### PR TITLE
bpo-35148: fix resetting codepage in activate.bat

### DIFF
--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem This file is UTF-8 encoded, so we need to update the current code page while executing it
-for /f "tokens=2 delims=:" %%a in ('"%SystemRoot%\System32\chcp.com"') do (
+for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\System32\chcp.com"') do (
     set "_OLD_CODEPAGE=%%a"
 )
 if defined _OLD_CODEPAGE (

--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -1,9 +1,14 @@
 @echo off
 
 rem This file is UTF-8 encoded, so we need to update the current code page while executing it
-for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\System32\chcp.com"') do (
+for /f "tokens=2 delims=:" %%a in ('"%SystemRoot%\System32\chcp.com"') do (
     set "_OLD_CODEPAGE=%%a"
 )
+
+rem Some international Windows versions put a period at the end of the codepage number,
+rem so erase it if existent.
+set "_OLD_CODEPAGE=%_OLD_CODEPAGE:.=%"
+
 if defined _OLD_CODEPAGE (
     "%SystemRoot%\System32\chcp.com" 65001 > nul
 )

--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -4,11 +4,6 @@ rem This file is UTF-8 encoded, so we need to update the current code page while
 for /f "tokens=2 delims=:" %%a in ('"%SystemRoot%\System32\chcp.com"') do (
     set "_OLD_CODEPAGE=%%a"
 )
-
-rem Some international Windows versions put a period at the end of the codepage number,
-rem so erase it if existent.
-set "_OLD_CODEPAGE=%_OLD_CODEPAGE:.=%"
-
 if defined _OLD_CODEPAGE (
     "%SystemRoot%\System32\chcp.com" 65001 > nul
 )
@@ -45,6 +40,8 @@ set "PATH=%VIRTUAL_ENV%\__VENV_BIN_NAME__;%PATH%"
 
 :END
 if defined _OLD_CODEPAGE (
-    "%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE% > nul
+    rem Some Windows versions put a period at the end of the codepage number,
+    rem so erase it if existent.
+    "%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE:.=% > nul
     set "_OLD_CODEPAGE="
 )

--- a/Misc/NEWS.d/next/Windows/2018-11-25-14-17-32.bpo-35148.Y_mvPW.rst
+++ b/Misc/NEWS.d/next/Windows/2018-11-25-14-17-32.bpo-35148.Y_mvPW.rst
@@ -1,0 +1,3 @@
+On international Windows versions, venv script ``activate.bat`` was fixed to
+correctly reset original codepage and prevent corresponding user-facing
+error message.


### PR DESCRIPTION
The current version of the Windows `activate.bat` activation script unfortunately does not work well in some international versions of Windows.

E.g. on a German Windows 10 version (or the bug reporter's Swiss version) the output of `chcp` is something like this:

```
Aktive Codepage: 850.
```

Unlike the US version, the statement ends with a period, unexpected by the activation script, leading to an unsuccessful attempt to reset the codepage after venv installation. While the venv is set up correctly, the codepage is not reset. In addition a user-visible error message appears, confusing users and giving the doubt whether venv actually worked:

```
Parameterformat falsch - 850.
```

 (English: "wrong parameter format")

The fix leaves the original approach in place, but deletes any periods from the CP number string, if they exist, which means it simply cleans up the CP string. This should have minimal side effects.


<!-- issue-number: [bpo-35148](https://bugs.python.org/issue35148) -->
https://bugs.python.org/issue35148
<!-- /issue-number -->
