### PR TITLE
Add 2 missing commas

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -101,7 +101,7 @@ accidentally creating a ``UserId`` in an invalid way::
    # 'output' is of type 'int', not 'UserId'
    output = UserId(23413) + UserId(54341)
 
-Note that these checks are enforced only by the static type checker. At runtime
+Note that these checks are enforced only by the static type checker. At runtime,
 the statement ``Derived = NewType('Derived', Base)`` will make ``Derived`` a
 function that immediately returns whatever parameter you pass it. That means
 the expression ``Derived(some_value)`` does not create a new class or introduce
@@ -110,7 +110,7 @@ any overhead beyond that of a regular function call.
 More precisely, the expression ``some_value is Derived(some_value)`` is always
 true at runtime.
 
-This also means that it is not possible to create a subtype of ``Derived``
+This also means that it is not possible to create a subtype of ``Derived``,
 since it is an identity function at runtime, not an actual type::
 
    from typing import NewType

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -110,7 +110,7 @@ any overhead beyond that of a regular function call.
 More precisely, the expression ``some_value is Derived(some_value)`` is always
 true at runtime.
 
-This also means that it is not possible to create a subtype of ``Derived``,
+This also means that it is not possible to create a subtype of ``Derived``
 since it is an identity function at runtime, not an actual type::
 
    from typing import NewType


### PR DESCRIPTION
Fixed the typing docs by adding 2 missing commas.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
