### PR TITLE
bpo-35310: Retry select() calls on EINTR even if deadline has passed

### DIFF
--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -39,8 +39,6 @@ class EINTRBaseTest(unittest.TestCase):
 
     # delay for initial signal delivery
     signal_delay = 0.1
-    # signal handler run time duration
-    signal_duration = 0.05
     # signal delivery periodicity
     signal_period = 0.1
     # default sleep time for tests - should obviously have:
@@ -48,7 +46,6 @@ class EINTRBaseTest(unittest.TestCase):
     sleep_time = 0.2
 
     def sighandler(self, signum, frame):
-        time.sleep(self.signal_duration)
         self.signals += 1
 
     def setUp(self):
@@ -443,16 +440,6 @@ class SelectEINTRTest(EINTRBaseTest):
         dt = time.monotonic() - t0
         self.stop_alarm()
         self.assertGreaterEqual(dt, self.sleep_time)
-
-    def test_select_long_signal(self):
-        rd, wr = os.pipe()
-        self.addCleanup(os.close, rd)
-        self.addCleanup(os.close, wr)
-        # timeout is enough for signal to fire, but not for it to return
-        timeout = self.signal_delay + self.signal_duration/2
-        rlist, _, _ = select.select([rd], [], [], timeout)
-        self.stop_alarm()
-        self.assertNotIn(rd, rlist)
 
     @unittest.skipIf(sys.platform == "darwin",
                      "poll may fail on macOS; see issue #28087")

--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -39,6 +39,8 @@ class EINTRBaseTest(unittest.TestCase):
 
     # delay for initial signal delivery
     signal_delay = 0.1
+    # signal handler run time duration
+    signal_duration = 0.05
     # signal delivery periodicity
     signal_period = 0.1
     # default sleep time for tests - should obviously have:
@@ -46,6 +48,7 @@ class EINTRBaseTest(unittest.TestCase):
     sleep_time = 0.2
 
     def sighandler(self, signum, frame):
+        time.sleep(self.signal_duration)
         self.signals += 1
 
     def setUp(self):
@@ -440,6 +443,16 @@ class SelectEINTRTest(EINTRBaseTest):
         dt = time.monotonic() - t0
         self.stop_alarm()
         self.assertGreaterEqual(dt, self.sleep_time)
+
+    def test_select_long_signal(self):
+        rd, wr = os.pipe()
+        self.addCleanup(os.close, rd)
+        self.addCleanup(os.close, wr)
+        # timeout is enough for signal to fire, but not for it to return
+        timeout = self.signal_delay + self.signal_duration/2
+        rlist, _, _ = select.select([rd], [], [], timeout)
+        self.stop_alarm()
+        self.assertNotIn(rd, rlist)
 
     @unittest.skipIf(sys.platform == "darwin",
                      "poll may fail on macOS; see issue #28087")

--- a/Misc/NEWS.d/next/Library/2018-11-25-14-53-00.bpo-35310.75QGfz.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-25-14-53-00.bpo-35310.75QGfz.rst
@@ -1,0 +1,3 @@
+Fix a bug in ``select.select()`` where a retry does not occur on EINTR if the
+deadline has already passed after running the signal handlers.  Patch by Oran
+Avraham.

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -335,8 +335,8 @@ select_select_impl(PyObject *module, PyObject *rlist, PyObject *wlist,
         if (tvp) {
             timeout = deadline - _PyTime_GetMonotonicClock();
             if (timeout < 0) {
-                n = 0;
-                break;
+                timeout = 0;
+                /* retry select() with a non-blocking call */
             }
             _PyTime_AsTimeval_noraise(timeout, &tv, _PyTime_ROUND_CEILING);
             /* retry select() with the recomputed timeout */


### PR DESCRIPTION
select() calls are retried on EINTR (per PEP 475).  However, if a
timeout was provided and the deadline has passed after running signal
handlers, we should still retry select() with a non-blocking call -- to
make sure rlist, wlist and xlist are initialized appropriately.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35310](https://bugs.python.org/issue35310) -->
https://bugs.python.org/issue35310
<!-- /issue-number -->
