### PR TITLE
bpo-35081: Add Include/internal/pycore_tupleobject.h

### DIFF
--- a/Include/internal/pycore_tupleobject.h
+++ b/Include/internal/pycore_tupleobject.h
@@ -1,0 +1,18 @@
+#ifndef Py_INTERNAL_TUPLEOBJECT_H
+#define Py_INTERNAL_TUPLEOBJECT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
+
+#include "tupleobject.h"
+
+#define _PyTuple_ITEMS(op) (_PyTuple_CAST(op)->ob_item)
+
+#ifdef __cplusplus
+}
+#endif
+#endif   /* !Py_INTERNAL_TUPLEOBJECT_H */

--- a/Include/tupleobject.h
+++ b/Include/tupleobject.h
@@ -61,10 +61,6 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 #define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
 #define PyTuple_GET_SIZE(op)    (assert(PyTuple_Check(op)), Py_SIZE(op))
 
-#ifdef Py_BUILD_CORE
-#  define _PyTuple_ITEMS(op) (_PyTuple_CAST(op)->ob_item)
-#endif
-
 /* Macro, *only* to be used to fill in brand new tuples */
 #define PyTuple_SET_ITEM(op, i, v) (_PyTuple_CAST(op)->ob_item[i] = v)
 #endif

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1043,6 +1043,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_pylifecycle.h \
 		$(srcdir)/Include/internal/pycore_pymem.h \
 		$(srcdir)/Include/internal/pycore_pystate.h \
+		$(srcdir)/Include/internal/pycore_tupleobject.h \
 		$(srcdir)/Include/internal/pycore_warnings.h \
 		$(DTRACE_HEADERS)
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1,7 +1,7 @@
-
 #include "Python.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
+#include "pycore_tupleobject.h"
 #include "structmember.h"
 
 /* _functools module written and maintained

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 #include "pycore_object.h"
 #include "pycore_pystate.h"
+#include "pycore_tupleobject.h"
 #include "frameobject.h"
 
 

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -4,6 +4,7 @@
 #include "code.h"
 #include "structmember.h"
 #include "pycore_pystate.h"
+#include "pycore_tupleobject.h"
 
 /* Holder for co_extra information */
 typedef struct {

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -3,6 +3,7 @@
 #include "Python.h"
 #include "pycore_object.h"
 #include "pycore_pystate.h"
+#include "pycore_tupleobject.h"
 #include "structmember.h" /* Why is this not included in Python.h? */
 
 /*[clinic input]

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -5,6 +5,7 @@
 #include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
+#include "pycore_tupleobject.h"
 #include "code.h"
 #include "structmember.h"
 

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -127,6 +127,7 @@
     <ClInclude Include="..\Include\internal\pycore_pylifecycle.h" />
     <ClInclude Include="..\Include\internal\pycore_pymem.h" />
     <ClInclude Include="..\Include\internal\pycore_pystate.h" />
+    <ClInclude Include="..\Include\internal\pycore_tupleobject.h" />
     <ClInclude Include="..\Include\internal\pycore_warnings.h" />
     <ClInclude Include="..\Include\intrcheck.h" />
     <ClInclude Include="..\Include\iterobject.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -180,6 +180,9 @@
     <ClInclude Include="..\Include\internal\pycore_pystate.h">
       <Filter>Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_tupleobject.h">
+      <Filter>Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_warnings.h">
       <Filter>Include</Filter>
     </ClInclude>

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -12,6 +12,7 @@
 #include "Python.h"
 #include "pycore_object.h"
 #include "pycore_pystate.h"
+#include "pycore_tupleobject.h"
 
 #include "code.h"
 #include "dictobject.h"

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2,6 +2,7 @@
 /* New getargs implementation */
 
 #include "Python.h"
+#include "pycore_tupleobject.h"
 
 #include <ctype.h>
 #include <float.h>


### PR DESCRIPTION
Move _PyTuple_ITEMS() to a new header file:
Include/internal/pycore_tupleobject.h

<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
