### PR TITLE
[WIP] _PyTuple_ITEMS() now requires PyTupleObject*

### DIFF
--- a/Include/internal/pycore_tupleobject.h
+++ b/Include/internal/pycore_tupleobject.h
@@ -10,7 +10,10 @@ extern "C" {
 
 #include "tupleobject.h"
 
-#define _PyTuple_ITEMS(op) (_PyTuple_CAST(op)->ob_item)
+static inline PyObject** _PyTuple_ITEMS(PyTupleObject *op)
+{
+    return op->ob_item;
+}
 
 #ifdef __cplusplus
 }

--- a/Include/tupleobject.h
+++ b/Include/tupleobject.h
@@ -56,7 +56,7 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 /* Macro, trading safety for speed */
 #ifndef Py_LIMITED_API
 /* Cast argument to PyTupleObject* type. */
-#define _PyTuple_CAST(op) ((PyTupleObject *)(op))
+#define _PyTuple_CAST(op) (assert(PyTuple_Check(op)), (PyTupleObject *)(op))
 
 #define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
 #define PyTuple_GET_SIZE(op)    (assert(PyTuple_Check(op)), Py_SIZE(op))

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -134,15 +134,16 @@ partial_fastcall(partialobject *pto, PyObject **args, Py_ssize_t nargs,
     PyObject *ret;
     PyObject **stack, **stack_buf = NULL;
     Py_ssize_t nargs2, pto_nargs;
+    PyTupleObject *pto_args_tuple = _PyTuple_CAST(pto->args);
 
-    pto_nargs = PyTuple_GET_SIZE(pto->args);
+    pto_nargs = PyTuple_GET_SIZE(pto_args_tuple);
     nargs2 = pto_nargs + nargs;
 
     if (pto_nargs == 0) {
         stack = args;
     }
     else if (nargs == 0) {
-        stack = _PyTuple_ITEMS(pto->args);
+        stack = _PyTuple_ITEMS(pto_args_tuple);
     }
     else {
         if (nargs2 <= (Py_ssize_t)Py_ARRAY_LENGTH(small_stack)) {
@@ -159,7 +160,7 @@ partial_fastcall(partialobject *pto, PyObject **args, Py_ssize_t nargs,
 
         /* use borrowed references */
         memcpy(stack,
-               _PyTuple_ITEMS(pto->args),
+               _PyTuple_ITEMS(pto_args_tuple),
                pto_nargs * sizeof(PyObject*));
         memcpy(&stack[pto_nargs],
                args,
@@ -221,9 +222,10 @@ partial_call(partialobject *pto, PyObject *args, PyObject *kwargs)
 
 
     if (pto->use_fastcall) {
+        PyTupleObject *args_tuple = _PyTuple_CAST(args);
         res = partial_fastcall(pto,
-                               _PyTuple_ITEMS(args),
-                               PyTuple_GET_SIZE(args),
+                               _PyTuple_ITEMS(args_tuple),
+                               PyTuple_GET_SIZE(args_tuple),
                                kwargs2);
     }
     else {

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -31,7 +31,7 @@ all_name_chars(PyObject *o)
 }
 
 static void
-intern_strings(PyObject *tuple)
+intern_strings(PyTupleObject *tuple)
 {
     Py_ssize_t i;
 
@@ -126,10 +126,10 @@ PyCode_New(int argcount, int kwonlyargcount,
     if (PyUnicode_READY(filename) < 0)
         return NULL;
 
-    intern_strings(names);
-    intern_strings(varnames);
-    intern_strings(freevars);
-    intern_strings(cellvars);
+    intern_strings(_PyTuple_CAST(names));
+    intern_strings(_PyTuple_CAST(varnames));
+    intern_strings(_PyTuple_CAST(freevars));
+    intern_strings(_PyTuple_CAST(cellvars));
     intern_string_constants(consts);
 
     /* Check for any inner or outer closure references */

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -226,7 +226,8 @@ methoddescr_call(PyMethodDescrObject *descr, PyObject *args, PyObject *kwargs)
 
     /* Make sure that the first argument is acceptable as 'self' */
     assert(PyTuple_Check(args));
-    nargs = PyTuple_GET_SIZE(args);
+    PyTupleObject *args_tuple = _PyTuple_CAST(args);
+    nargs = PyTuple_GET_SIZE(args_tuple);
     if (nargs < 1) {
         PyErr_Format(PyExc_TypeError,
                      "descriptor '%V' of '%.100s' "
@@ -235,7 +236,7 @@ methoddescr_call(PyMethodDescrObject *descr, PyObject *args, PyObject *kwargs)
                      PyDescr_TYPE(descr)->tp_name);
         return NULL;
     }
-    self = PyTuple_GET_ITEM(args, 0);
+    self = PyTuple_GET_ITEM(args_tuple, 0);
     if (!_PyObject_RealIsSubclass((PyObject *)Py_TYPE(self),
                                   (PyObject *)PyDescr_TYPE(descr))) {
         PyErr_Format(PyExc_TypeError,
@@ -249,7 +250,8 @@ methoddescr_call(PyMethodDescrObject *descr, PyObject *args, PyObject *kwargs)
     }
 
     result = _PyMethodDef_RawFastCallDict(descr->d_method, self,
-                                          &_PyTuple_ITEMS(args)[1], nargs - 1,
+                                          &_PyTuple_ITEMS(args_tuple)[1],
+                                          nargs - 1,
                                           kwargs);
     result = _Py_CheckFunctionResult((PyObject *)descr, result, NULL);
     return result;
@@ -302,7 +304,8 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
 
     /* Make sure that the first argument is acceptable as 'self' */
     assert(PyTuple_Check(args));
-    argc = PyTuple_GET_SIZE(args);
+    PyTupleObject *args_tuple = _PyTuple_CAST(args);
+    argc = PyTuple_GET_SIZE(args_tuple);
     if (argc < 1) {
         PyErr_Format(PyExc_TypeError,
                      "descriptor '%V' of '%.100s' "
@@ -311,7 +314,7 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
                      PyDescr_TYPE(descr)->tp_name);
         return NULL;
     }
-    self = PyTuple_GET_ITEM(args, 0);
+    self = PyTuple_GET_ITEM(args_tuple, 0);
     if (!PyType_Check(self)) {
         PyErr_Format(PyExc_TypeError,
                      "descriptor '%V' requires a type "
@@ -333,7 +336,8 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
     }
 
     result = _PyMethodDef_RawFastCallDict(descr->d_method, self,
-                                          &_PyTuple_ITEMS(args)[1], argc - 1,
+                                          &_PyTuple_ITEMS(args_tuple)[1],
+                                          argc - 1,
                                           kwds);
     result = _Py_CheckFunctionResult((PyObject *)descr, result, NULL);
     return result;

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -580,11 +580,9 @@ func_traverse(PyFunctionObject *f, visitproc visit, void *arg)
 static PyObject *
 function_call(PyObject *func, PyObject *args, PyObject *kwargs)
 {
-    PyObject **stack;
-    Py_ssize_t nargs;
-
-    stack = _PyTuple_ITEMS(args);
-    nargs = PyTuple_GET_SIZE(args);
+    PyTupleObject *args_tuple = _PyTuple_CAST(args);
+    PyObject **stack = _PyTuple_ITEMS(args_tuple);
+    Py_ssize_t nargs = PyTuple_GET_SIZE(args_tuple);
     return _PyFunction_FastCallDict(func, stack, nargs, kwargs);
 }
 

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -422,9 +422,9 @@ vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
                 "new style getargs format but argument is not a tuple");
             return 0;
         }
-
-        stack = _PyTuple_ITEMS(args);
-        nargs = PyTuple_GET_SIZE(args);
+        PyTupleObject *args_tuple = (PyTupleObject *)args;
+        stack = _PyTuple_ITEMS(args_tuple);
+        nargs = PyTuple_GET_SIZE(args_tuple);
     }
     else {
         stack = NULL;
@@ -2244,9 +2244,6 @@ static int
 vgetargskeywordsfast(PyObject *args, PyObject *keywords,
                      struct _PyArg_Parser *parser, va_list *p_va, int flags)
 {
-    PyObject **stack;
-    Py_ssize_t nargs;
-
     if (args == NULL
         || !PyTuple_Check(args)
         || (keywords != NULL && !PyDict_Check(keywords)))
@@ -2254,9 +2251,9 @@ vgetargskeywordsfast(PyObject *args, PyObject *keywords,
         PyErr_BadInternalCall();
         return 0;
     }
-
-    stack = _PyTuple_ITEMS(args);
-    nargs = PyTuple_GET_SIZE(args);
+    PyTupleObject *args_tuple = (PyTupleObject *)args;
+    PyObject **stack = _PyTuple_ITEMS(args_tuple);
+    Py_ssize_t nargs = PyTuple_GET_SIZE(args_tuple);
     return vgetargskeywordsfast_impl(stack, nargs, keywords, NULL,
                                      parser, p_va, flags);
 }
@@ -2462,8 +2459,9 @@ PyArg_UnpackTuple(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t m
             "PyArg_UnpackTuple() argument list is not a tuple");
         return 0;
     }
-    stack = _PyTuple_ITEMS(args);
-    nargs = PyTuple_GET_SIZE(args);
+    PyTupleObject *args_tuple = (PyTupleObject *)args;
+    stack = _PyTuple_ITEMS(args_tuple);
+    nargs = PyTuple_GET_SIZE(args_tuple);
 
 #ifdef HAVE_STDARG_PROTOTYPES
     va_start(vargs, max);


### PR DESCRIPTION
* Convert _PyTuple_ITEMS() to a static function which requires
  a PyTupleObject* argument.
* Add an assertion to _PyTuple_CAST() to ensure that the argument is
  a tuple object.