### PR TITLE
bpo-35312: Make `lib2to3.pgen2.parse.ParseError` round-trip pickle-able

### DIFF
--- a/Lib/lib2to3/pgen2/parse.py
+++ b/Lib/lib2to3/pgen2/parse.py
@@ -24,6 +24,9 @@ class ParseError(Exception):
         self.value = value
         self.context = context
 
+    def __reduce__(self):
+        return type(self), (self.msg, self.type, self.value, self.context)
+
 class Parser(object):
     """Parser engine.
 

--- a/Lib/lib2to3/tests/test_parser.py
+++ b/Lib/lib2to3/tests/test_parser.py
@@ -622,6 +622,18 @@ class TestLiterals(GrammarTest):
         self.validate(s)
 
 
+class TestPickleableException(unittest.TestCase):
+    def test_ParseError(self):
+        err = ParseError('msg', 2, None, (1, 'context'))
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            err2 = pickle.loads(pickle.dumps(err, protocol=proto))
+            self.assertEqual(err.args, err2.args)
+            self.assertEqual(err.msg, err2.msg)
+            self.assertEqual(err.type, err2.type)
+            self.assertEqual(err.value, err2.value)
+            self.assertEqual(err.context, err2.context)
+
+
 def diff_texts(a, b, filename):
     a = a.splitlines()
     b = b.splitlines()

--- a/Misc/NEWS.d/next/Library/2018-11-25-20-05-33.bpo-35312.wbw0zO.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-25-20-05-33.bpo-35312.wbw0zO.rst
@@ -1,0 +1,1 @@
+Make ``lib2to3.pgen2.parse.ParseError`` round-trip pickle-able.  Patch by Anthony Sottile.


### PR DESCRIPTION


<!-- issue-number: [bpo-35312](https://bugs.python.org/issue35312) -->
https://bugs.python.org/issue35312
<!-- /issue-number -->
