### PR TITLE
bpo-35307: Included --prompt flag in help output 

### DIFF
--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -34,7 +34,7 @@ your :ref:`Python installation <using-on-windows>`::
 The command, if run with ``-h``, will show the available options::
 
     usage: venv [-h] [--system-site-packages] [--symlinks | --copies] [--clear]
-                [--upgrade] [--without-pip]
+                [--upgrade] [--without-pip] [--prompt PROMPT]
                 ENV_DIR [ENV_DIR ...]
 
     Creates virtual Python environments in one or more target directories.
@@ -57,6 +57,8 @@ The command, if run with ``-h``, will show the available options::
                             of Python, assuming Python has been upgraded in-place.
       --without-pip         Skips installing or upgrading pip in the virtual
                             environment (pip is bootstrapped by default)
+      --prompt PROMPT       Provides an alternative prompt prefix for this
+                            environment.
 
     Once an environment has been created, you may wish to activate it, e.g. by
     sourcing an activate script in its bin directory.


### PR DESCRIPTION
In the output of "python -m venv --h" the "--prompt" flag was missing in the usage description and the optionals arguments section.



<!-- issue-number: [bpo-35307](https://bugs.python.org/issue35307) -->
https://bugs.python.org/issue35307
<!-- /issue-number -->
