### PR TITLE
bpo-35317: Fix mktime() error in test_email

### DIFF
--- a/Lib/test/test_email/test_utils.py
+++ b/Lib/test/test_email/test_utils.py
@@ -75,6 +75,7 @@ class LocaltimeTests(unittest.TestCase):
         t2 = utils.localtime(t1)
         self.assertEqual(t1, t2)
 
+    @test.support.run_with_tz('Europe/Minsk')
     def test_localtime_daylight_true_dst_true(self):
         test.support.patch(self, time, 'daylight', True)
         t0 = datetime.datetime(2012, 3, 12, 1, 1)
@@ -82,6 +83,7 @@ class LocaltimeTests(unittest.TestCase):
         t2 = utils.localtime(t1)
         self.assertEqual(t1, t2)
 
+    @test.support.run_with_tz('Europe/Minsk')
     def test_localtime_daylight_false_dst_true(self):
         test.support.patch(self, time, 'daylight', False)
         t0 = datetime.datetime(2012, 3, 12, 1, 1)

--- a/Misc/NEWS.d/next/Tests/2018-11-26-16-54-21.bpo-35317.jByGP2.rst
+++ b/Misc/NEWS.d/next/Tests/2018-11-26-16-54-21.bpo-35317.jByGP2.rst
@@ -1,0 +1,3 @@
+Fix ``mktime()`` overflow error in ``test_email``: run
+``test_localtime_daylight_true_dst_true()`` and
+``test_localtime_daylight_false_dst_true()`` with a specific timezone.


### PR DESCRIPTION
Fix mktime() overflow error in test_email: run
test_localtime_daylight_true_dst_true() and
test_localtime_daylight_false_dst_true() with a specific timezone.

<!-- issue-number: [bpo-35317](https://bugs.python.org/issue35317) -->
https://bugs.python.org/issue35317
<!-- /issue-number -->
