### PR TITLE
bpo-33723: Remove busy loop from test_time

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -495,24 +495,6 @@ class TimeTestCase(unittest.TestCase):
         # on Windows
         self.assertLess(stop - start, 0.020)
 
-        # bpo-33723: A busy loop of 100 ms should increase process_time()
-        # by at least 15 ms
-        min_time = 0.015
-        busy_time = 0.100
-
-        # process_time() should include CPU time spent in any thread
-        start = time.process_time()
-        busy_wait(busy_time)
-        stop = time.process_time()
-        self.assertGreaterEqual(stop - start, min_time)
-
-        t = threading.Thread(target=busy_wait, args=(busy_time,))
-        start = time.process_time()
-        t.start()
-        t.join()
-        stop = time.process_time()
-        self.assertGreaterEqual(stop - start, min_time)
-
         info = time.get_clock_info('process_time')
         self.assertTrue(info.monotonic)
         self.assertFalse(info.adjustable)
@@ -532,25 +514,6 @@ class TimeTestCase(unittest.TestCase):
         # use 20 ms because thread_time() has usually a resolution of 15 ms
         # on Windows
         self.assertLess(stop - start, 0.020)
-
-        # bpo-33723: A busy loop of 100 ms should increase thread_time()
-        # by at least 15 ms
-        min_time = 0.015
-        busy_time = 0.100
-
-        # thread_time() should include CPU time spent in current thread...
-        start = time.thread_time()
-        busy_wait(busy_time)
-        stop = time.thread_time()
-        self.assertGreaterEqual(stop - start, min_time)
-
-        # ...but not in other threads
-        t = threading.Thread(target=busy_wait, args=(busy_time,))
-        start = time.thread_time()
-        t.start()
-        t.join()
-        stop = time.thread_time()
-        self.assertLess(stop - start, min_time)
 
         info = time.get_clock_info('thread_time')
         self.assertTrue(info.monotonic)


### PR DESCRIPTION
The "busy loops" of test_process_time() and test_thread_time() are
not reliable and fail randomly on different CIs. Remove the tests
to make the CIs more reliable.

<!-- issue-number: [bpo-33723](https://bugs.python.org/issue33723) -->
https://bugs.python.org/issue33723
<!-- /issue-number -->
