### PR TITLE
bpo-35134: Add Include/cpython/pyerrors.h

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -1,0 +1,176 @@
+#ifndef Py_CPYTHON_ERRORS_H
+#  error "this header file must not be included directly"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Error objects */
+
+/* PyException_HEAD defines the initial segment of every exception class. */
+#define PyException_HEAD PyObject_HEAD PyObject *dict;\
+             PyObject *args; PyObject *traceback;\
+             PyObject *context; PyObject *cause;\
+             char suppress_context;
+
+typedef struct {
+    PyException_HEAD
+} PyBaseExceptionObject;
+
+typedef struct {
+    PyException_HEAD
+    PyObject *msg;
+    PyObject *filename;
+    PyObject *lineno;
+    PyObject *offset;
+    PyObject *text;
+    PyObject *print_file_and_line;
+} PySyntaxErrorObject;
+
+typedef struct {
+    PyException_HEAD
+    PyObject *msg;
+    PyObject *name;
+    PyObject *path;
+} PyImportErrorObject;
+
+typedef struct {
+    PyException_HEAD
+    PyObject *encoding;
+    PyObject *object;
+    Py_ssize_t start;
+    Py_ssize_t end;
+    PyObject *reason;
+} PyUnicodeErrorObject;
+
+typedef struct {
+    PyException_HEAD
+    PyObject *code;
+} PySystemExitObject;
+
+typedef struct {
+    PyException_HEAD
+    PyObject *myerrno;
+    PyObject *strerror;
+    PyObject *filename;
+    PyObject *filename2;
+#ifdef MS_WINDOWS
+    PyObject *winerror;
+#endif
+    Py_ssize_t written;   /* only for BlockingIOError, -1 otherwise */
+} PyOSErrorObject;
+
+typedef struct {
+    PyException_HEAD
+    PyObject *value;
+} PyStopIterationObject;
+
+/* Compatibility typedefs */
+typedef PyOSErrorObject PyEnvironmentErrorObject;
+#ifdef MS_WINDOWS
+typedef PyOSErrorObject PyWindowsErrorObject;
+#endif
+
+/* Error handling definitions */
+
+PyAPI_FUNC(void) _PyErr_SetKeyError(PyObject *);
+_PyErr_StackItem *_PyErr_GetTopmostException(PyThreadState *tstate);
+
+/* Context manipulation (PEP 3134) */
+
+PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
+
+/* */
+
+#define PyExceptionClass_Name(x)  (((PyTypeObject*)(x))->tp_name)
+
+/* Convenience functions */
+
+#ifdef MS_WINDOWS
+PyAPI_FUNC(PyObject *) PyErr_SetFromErrnoWithUnicodeFilename(
+    PyObject *, const Py_UNICODE *) Py_DEPRECATED(3.3);
+#endif /* MS_WINDOWS */
+
+/* Like PyErr_Format(), but saves current exception as __context__ and
+   __cause__.
+ */
+PyAPI_FUNC(PyObject *) _PyErr_FormatFromCause(
+    PyObject *exception,
+    const char *format,   /* ASCII-encoded string  */
+    ...
+    );
+
+#ifdef MS_WINDOWS
+/* XXX redeclare to use WSTRING */
+PyAPI_FUNC(PyObject *) PyErr_SetFromWindowsErrWithUnicodeFilename(
+    int, const Py_UNICODE *) Py_DEPRECATED(3.3);
+
+PyAPI_FUNC(PyObject *) PyErr_SetExcFromWindowsErrWithUnicodeFilename(
+    PyObject *,int, const Py_UNICODE *) Py_DEPRECATED(3.3);
+#endif
+
+/* In exceptions.c */
+
+/* Helper that attempts to replace the current exception with one of the
+ * same type but with a prefix added to the exception text. The resulting
+ * exception description looks like:
+ *
+ *     prefix (exc_type: original_exc_str)
+ *
+ * Only some exceptions can be safely replaced. If the function determines
+ * it isn't safe to perform the replacement, it will leave the original
+ * unmodified exception in place.
+ *
+ * Returns a borrowed reference to the new exception (if any), NULL if the
+ * existing exception was left in place.
+ */
+PyAPI_FUNC(PyObject *) _PyErr_TrySetFromCause(
+    const char *prefix_format,   /* ASCII-encoded string  */
+    ...
+    );
+
+/* In signalmodule.c */
+
+int PySignal_SetWakeupFd(int fd);
+
+/* Support for adding program text to SyntaxErrors */
+
+PyAPI_FUNC(void) PyErr_SyntaxLocationObject(
+    PyObject *filename,
+    int lineno,
+    int col_offset);
+
+PyAPI_FUNC(PyObject *) PyErr_ProgramTextObject(
+    PyObject *filename,
+    int lineno);
+
+/* Create a UnicodeEncodeError object */
+PyAPI_FUNC(PyObject *) PyUnicodeEncodeError_Create(
+    const char *encoding,       /* UTF-8 encoded string */
+    const Py_UNICODE *object,
+    Py_ssize_t length,
+    Py_ssize_t start,
+    Py_ssize_t end,
+    const char *reason          /* UTF-8 encoded string */
+    ) Py_DEPRECATED(3.3);
+
+/* Create a UnicodeTranslateError object */
+PyAPI_FUNC(PyObject *) PyUnicodeTranslateError_Create(
+    const Py_UNICODE *object,
+    Py_ssize_t length,
+    Py_ssize_t start,
+    Py_ssize_t end,
+    const char *reason          /* UTF-8 encoded string */
+    ) Py_DEPRECATED(3.3);
+PyAPI_FUNC(PyObject *) _PyUnicodeTranslateError_Create(
+    PyObject *object,
+    Py_ssize_t start,
+    Py_ssize_t end,
+    const char *reason          /* UTF-8 encoded string */
+    );
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -4,82 +4,10 @@
 extern "C" {
 #endif
 
-/* Error objects */
-
-#ifndef Py_LIMITED_API
-/* PyException_HEAD defines the initial segment of every exception class. */
-#define PyException_HEAD PyObject_HEAD PyObject *dict;\
-             PyObject *args; PyObject *traceback;\
-             PyObject *context; PyObject *cause;\
-             char suppress_context;
-
-typedef struct {
-    PyException_HEAD
-} PyBaseExceptionObject;
-
-typedef struct {
-    PyException_HEAD
-    PyObject *msg;
-    PyObject *filename;
-    PyObject *lineno;
-    PyObject *offset;
-    PyObject *text;
-    PyObject *print_file_and_line;
-} PySyntaxErrorObject;
-
-typedef struct {
-    PyException_HEAD
-    PyObject *msg;
-    PyObject *name;
-    PyObject *path;
-} PyImportErrorObject;
-
-typedef struct {
-    PyException_HEAD
-    PyObject *encoding;
-    PyObject *object;
-    Py_ssize_t start;
-    Py_ssize_t end;
-    PyObject *reason;
-} PyUnicodeErrorObject;
-
-typedef struct {
-    PyException_HEAD
-    PyObject *code;
-} PySystemExitObject;
-
-typedef struct {
-    PyException_HEAD
-    PyObject *myerrno;
-    PyObject *strerror;
-    PyObject *filename;
-    PyObject *filename2;
-#ifdef MS_WINDOWS
-    PyObject *winerror;
-#endif
-    Py_ssize_t written;   /* only for BlockingIOError, -1 otherwise */
-} PyOSErrorObject;
-
-typedef struct {
-    PyException_HEAD
-    PyObject *value;
-} PyStopIterationObject;
-
-/* Compatibility typedefs */
-typedef PyOSErrorObject PyEnvironmentErrorObject;
-#ifdef MS_WINDOWS
-typedef PyOSErrorObject PyWindowsErrorObject;
-#endif
-#endif /* !Py_LIMITED_API */
-
 /* Error handling definitions */
 
 PyAPI_FUNC(void) PyErr_SetNone(PyObject *);
 PyAPI_FUNC(void) PyErr_SetObject(PyObject *, PyObject *);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _PyErr_SetKeyError(PyObject *);
-_PyErr_StackItem *_PyErr_GetTopmostException(PyThreadState *tstate);
-#endif
 PyAPI_FUNC(void) PyErr_SetString(
     PyObject *exception,
     const char *string   /* decoded from utf-8 */
@@ -129,9 +57,6 @@ PyAPI_FUNC(void) PyException_SetCause(PyObject *, PyObject *);
 /* Context manipulation (PEP 3134) */
 PyAPI_FUNC(PyObject *) PyException_GetContext(PyObject *);
 PyAPI_FUNC(void) PyException_SetContext(PyObject *, PyObject *);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
-#endif
 
 /* */
 
@@ -143,9 +68,6 @@ PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
     PyType_FastSubclass((x)->ob_type, Py_TPFLAGS_BASE_EXC_SUBCLASS)
 
 PyAPI_FUNC(const char *) PyExceptionClass_Name(PyObject *);
-#ifndef Py_LIMITED_API
-#define PyExceptionClass_Name(x)  (((PyTypeObject*)(x))->tp_name)
-#endif
 
 #define PyExceptionInstance_Class(x) ((PyObject*)((x)->ob_type))
 
@@ -253,10 +175,6 @@ PyAPI_FUNC(PyObject *) PyErr_SetFromErrnoWithFilename(
     PyObject *exc,
     const char *filename   /* decoded from the filesystem encoding */
     );
-#if defined(MS_WINDOWS) && !defined(Py_LIMITED_API)
-PyAPI_FUNC(PyObject *) PyErr_SetFromErrnoWithUnicodeFilename(
-    PyObject *, const Py_UNICODE *) Py_DEPRECATED(3.3);
-#endif /* MS_WINDOWS */
 
 PyAPI_FUNC(PyObject *) PyErr_Format(
     PyObject *exception,
@@ -270,27 +188,11 @@ PyAPI_FUNC(PyObject *) PyErr_FormatV(
     va_list vargs);
 #endif
 
-#ifndef Py_LIMITED_API
-/* Like PyErr_Format(), but saves current exception as __context__ and
-   __cause__.
- */
-PyAPI_FUNC(PyObject *) _PyErr_FormatFromCause(
-    PyObject *exception,
-    const char *format,   /* ASCII-encoded string  */
-    ...
-    );
-#endif
-
 #ifdef MS_WINDOWS
 PyAPI_FUNC(PyObject *) PyErr_SetFromWindowsErrWithFilename(
     int ierr,
     const char *filename        /* decoded from the filesystem encoding */
     );
-#ifndef Py_LIMITED_API
-/* XXX redeclare to use WSTRING */
-PyAPI_FUNC(PyObject *) PyErr_SetFromWindowsErrWithUnicodeFilename(
-    int, const Py_UNICODE *) Py_DEPRECATED(3.3);
-#endif
 PyAPI_FUNC(PyObject *) PyErr_SetFromWindowsErr(int);
 PyAPI_FUNC(PyObject *) PyErr_SetExcFromWindowsErrWithFilenameObject(
     PyObject *,int, PyObject *);
@@ -303,10 +205,6 @@ PyAPI_FUNC(PyObject *) PyErr_SetExcFromWindowsErrWithFilename(
     int ierr,
     const char *filename        /* decoded from the filesystem encoding */
     );
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) PyErr_SetExcFromWindowsErrWithUnicodeFilename(
-    PyObject *,int, const Py_UNICODE *) Py_DEPRECATED(3.3);
-#endif
 PyAPI_FUNC(PyObject *) PyErr_SetExcFromWindowsErr(PyObject *, int);
 #endif /* MS_WINDOWS */
 
@@ -333,36 +231,10 @@ PyAPI_FUNC(PyObject *) PyErr_NewExceptionWithDoc(
     const char *name, const char *doc, PyObject *base, PyObject *dict);
 PyAPI_FUNC(void) PyErr_WriteUnraisable(PyObject *);
 
-/* In exceptions.c */
-#ifndef Py_LIMITED_API
-/* Helper that attempts to replace the current exception with one of the
- * same type but with a prefix added to the exception text. The resulting
- * exception description looks like:
- *
- *     prefix (exc_type: original_exc_str)
- *
- * Only some exceptions can be safely replaced. If the function determines
- * it isn't safe to perform the replacement, it will leave the original
- * unmodified exception in place.
- *
- * Returns a borrowed reference to the new exception (if any), NULL if the
- * existing exception was left in place.
- */
-PyAPI_FUNC(PyObject *) _PyErr_TrySetFromCause(
-    const char *prefix_format,   /* ASCII-encoded string  */
-    ...
-    );
-#endif
-
 
 /* In signalmodule.c */
 PyAPI_FUNC(int) PyErr_CheckSignals(void);
 PyAPI_FUNC(void) PyErr_SetInterrupt(void);
-
-/* In signalmodule.c */
-#ifndef Py_LIMITED_API
-int PySignal_SetWakeupFd(int fd);
-#endif
 
 /* Support for adding program text to SyntaxErrors */
 PyAPI_FUNC(void) PyErr_SyntaxLocation(
@@ -372,20 +244,9 @@ PyAPI_FUNC(void) PyErr_SyntaxLocationEx(
     const char *filename,       /* decoded from the filesystem encoding */
     int lineno,
     int col_offset);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(void) PyErr_SyntaxLocationObject(
-    PyObject *filename,
-    int lineno,
-    int col_offset);
-#endif
 PyAPI_FUNC(PyObject *) PyErr_ProgramText(
     const char *filename,       /* decoded from the filesystem encoding */
     int lineno);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) PyErr_ProgramTextObject(
-    PyObject *filename,
-    int lineno);
-#endif
 
 /* The following functions are used to create and modify unicode
    exceptions from C */
@@ -399,35 +260,6 @@ PyAPI_FUNC(PyObject *) PyUnicodeDecodeError_Create(
     Py_ssize_t end,
     const char *reason          /* UTF-8 encoded string */
     );
-
-/* create a UnicodeEncodeError object */
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) PyUnicodeEncodeError_Create(
-    const char *encoding,       /* UTF-8 encoded string */
-    const Py_UNICODE *object,
-    Py_ssize_t length,
-    Py_ssize_t start,
-    Py_ssize_t end,
-    const char *reason          /* UTF-8 encoded string */
-    ) Py_DEPRECATED(3.3);
-#endif
-
-/* create a UnicodeTranslateError object */
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) PyUnicodeTranslateError_Create(
-    const Py_UNICODE *object,
-    Py_ssize_t length,
-    Py_ssize_t start,
-    Py_ssize_t end,
-    const char *reason          /* UTF-8 encoded string */
-    ) Py_DEPRECATED(3.3);
-PyAPI_FUNC(PyObject *) _PyUnicodeTranslateError_Create(
-    PyObject *object,
-    Py_ssize_t start,
-    Py_ssize_t end,
-    const char *reason          /* UTF-8 encoded string */
-    );
-#endif
 
 /* get the encoding attribute */
 PyAPI_FUNC(PyObject *) PyUnicodeEncodeError_GetEncoding(PyObject *);
@@ -501,6 +333,12 @@ PyAPI_FUNC(int) PyOS_snprintf(char *str, size_t size, const char  *format, ...)
                         Py_GCC_ATTRIBUTE((format(printf, 3, 4)));
 PyAPI_FUNC(int) PyOS_vsnprintf(char *str, size_t size, const char  *format, va_list va)
                         Py_GCC_ATTRIBUTE((format(printf, 3, 0)));
+
+#ifndef Py_LIMITED_API
+#  define Py_CPYTHON_ERRORS_H
+#  include  "cpython/pyerrors.h"
+#  undef Py_CPYTHON_ERRORS_H
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Move pyerrors.h code surrounded by "#ifndef Py_LIMITED_API"
to a new Include/cpython/pyerrors.h header file.

<!-- issue-number: [bpo-35134](https://bugs.python.org/issue35134) -->
https://bugs.python.org/issue35134
<!-- /issue-number -->
