### PR TITLE
[Skip Issue] Include the highest pickle protocol in a couple of tests

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -248,7 +248,7 @@ class BaseTest:
         a = array.array(self.typecode, self.example)
         for protocol in range(3):
             self.assertIs(a.__reduce_ex__(protocol)[0], array.array)
-        for protocol in range(3, pickle.HIGHEST_PROTOCOL):
+        for protocol in range(3, pickle.HIGHEST_PROTOCOL + 1):
             self.assertIs(a.__reduce_ex__(protocol)[0], array_reconstructor)
 
     def test_pickle(self):

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1112,7 +1112,7 @@ class DictTest(unittest.TestCase):
             self.assertEqual(dict(it), data)
 
     def test_reversevaluesiterator_pickling(self):
-        for proto in range(pickle.HIGHEST_PROTOCOL):
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             data = {1:"a", 2:"b", 3:"c"}
             # data.values() isn't picklable, only its iterator
             it = reversed(data.values())


### PR DESCRIPTION
test_reduce_ex() in test_array.py and
test_reversevaluesiterator_pickling() in test_dict.py weren't using
the highest pickle protocol.