### PR TITLE
bpo-35134: Update "make tags": add Include/cpython/

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1667,7 +1667,7 @@ autoconf:
 
 # Create a tags file for vi
 tags::
-	ctags -w $(srcdir)/Include/*.h $(srcdir)/Include/internal/*.h
+	ctags -w $(srcdir)/Include/*.h $(srcdir)/Include/cpython/*.h $(srcdir)/Include/internal/*.h
 	for i in $(SRCDIRS); do ctags -f tags -w -a $(srcdir)/$$i/*.[ch]; done
 	ctags -f tags -w -a $(srcdir)/Modules/_ctypes/*.[ch]
 	LC_ALL=C sort -o tags tags
@@ -1675,7 +1675,7 @@ tags::
 # Create a tags file for GNU Emacs
 TAGS::
 	cd $(srcdir); \
-	etags Include/*.h Include/internal/*.h; \
+	etags Include/*.h Include/cpython/*.h Include/internal/*.h; \
 	for i in $(SRCDIRS); do etags -a $$i/*.[ch]; done
 
 # Sanitation targets -- clean leaves libraries, executables and tags


### PR DESCRIPTION
"make tags" and "make TAGS" now also parse Include/cpython/ header
files.

<!-- issue-number: [bpo-35134](https://bugs.python.org/issue35134) -->
https://bugs.python.org/issue35134
<!-- /issue-number -->
