### PR TITLE
[3.6] bpo-33954: Rewrite FILL() macro of unicodeobject.c

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -205,22 +205,30 @@ static PyObject *unicode_empty = NULL;
 
 #define FILL(kind, data, value, start, length) \
     do { \
-        Py_ssize_t i_ = 0; \
+        assert(0 <= start); \
         assert(kind != PyUnicode_WCHAR_KIND); \
-        switch ((kind)) { \
+        switch (kind) { \
         case PyUnicode_1BYTE_KIND: { \
-            unsigned char * to_ = (unsigned char *)((data)) + (start); \
-            memset(to_, (unsigned char)value, (length)); \
+            assert(value <= 0xff); \
+            Py_UCS1 ch = (unsigned char)value; \
+            Py_UCS1 *to = (Py_UCS1 *)data + start; \
+            memset(to, ch, length); \
             break; \
         } \
         case PyUnicode_2BYTE_KIND: { \
-            Py_UCS2 * to_ = (Py_UCS2 *)((data)) + (start); \
-            for (; i_ < (length); ++i_, ++to_) *to_ = (value); \
+            assert(value <= 0xffff); \
+            Py_UCS2 ch = (Py_UCS2)value; \
+            Py_UCS2 *to = (Py_UCS2 *)data + start; \
+            const Py_UCS2 *end = to + length; \
+            for (; to < end; ++to) *to = ch; \
             break; \
         } \
         case PyUnicode_4BYTE_KIND: { \
-            Py_UCS4 * to_ = (Py_UCS4 *)((data)) + (start); \
-            for (; i_ < (length); ++i_, ++to_) *to_ = (value); \
+            assert(value <= MAX_UNICODE); \
+            Py_UCS4 ch = value; \
+            Py_UCS4 * to = (Py_UCS4 *)data + start; \
+            const Py_UCS4 *end = to + length; \
+            for (; to < end; ++to) *to = ch; \
             break; \
         } \
         default: assert(0); \
@@ -10262,7 +10270,7 @@ _PyUnicode_FastFill(PyObject *unicode, Py_ssize_t start, Py_ssize_t length,
                     Py_UCS4 fill_char)
 {
     const enum PyUnicode_Kind kind = PyUnicode_KIND(unicode);
-    const void *data = PyUnicode_DATA(unicode);
+    void *data = PyUnicode_DATA(unicode);
     assert(PyUnicode_IS_READY(unicode));
     assert(unicode_modifiable(unicode));
     assert(fill_char <= PyUnicode_MAX_CHAR_VALUE(unicode));


### PR DESCRIPTION
Copy code from master: add assertions on start and value, replace 'i'
iterator with 'end' pointer for the loop stop condition.

_PyUnicode_FastFill(): fix type of 'data', it must not be constant,
since data is modified by FILL().

<!-- issue-number: [bpo-33954](https://bugs.python.org/issue33954) -->
https://bugs.python.org/issue33954
<!-- /issue-number -->
