### PR TITLE
bpo-33012: Add _Py_CAST_FUNC() to cast function ptr

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -792,4 +792,9 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 #define WITH_THREAD
 #endif
 
+/* Cast a function pointer to new_type.
+
+   Use a temporary cast to (void*) see avoid compiler warning (bpo-33012). */
+#define _Py_CAST_FUNC(new_type, func) ((new_type)(void *)(func))
+
 #endif /* Py_PYPORT_H */

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1398,16 +1398,16 @@ static PyMethodDef FutureType_methods[] = {
 };
 
 #define FUTURE_COMMON_GETSETLIST                                              \
-    {"_state", (getter)FutureObj_get_state, NULL, NULL},                      \
-    {"_asyncio_future_blocking", (getter)FutureObj_get_blocking,              \
-                                 (setter)FutureObj_set_blocking, NULL},       \
-    {"_loop", (getter)FutureObj_get_loop, NULL, NULL},                        \
-    {"_callbacks", (getter)FutureObj_get_callbacks, NULL, NULL},              \
-    {"_result", (getter)FutureObj_get_result, NULL, NULL},                    \
-    {"_exception", (getter)FutureObj_get_exception, NULL, NULL},              \
-    {"_log_traceback", (getter)FutureObj_get_log_traceback,                   \
-                       (setter)FutureObj_set_log_traceback, NULL},            \
-    {"_source_traceback", (getter)FutureObj_get_source_traceback, NULL, NULL},
+    {"_state", _Py_CAST_FUNC(getter, FutureObj_get_state), NULL, NULL},                      \
+    {"_asyncio_future_blocking", _Py_CAST_FUNC(getter, FutureObj_get_blocking),              \
+                                 _Py_CAST_FUNC(setter, FutureObj_set_blocking), NULL},       \
+    {"_loop", _Py_CAST_FUNC(getter, FutureObj_get_loop), NULL, NULL},                        \
+    {"_callbacks", _Py_CAST_FUNC(getter, FutureObj_get_callbacks), NULL, NULL},              \
+    {"_result", _Py_CAST_FUNC(getter, FutureObj_get_result), NULL, NULL},                    \
+    {"_exception", _Py_CAST_FUNC(getter, FutureObj_get_exception), NULL, NULL},              \
+    {"_log_traceback", _Py_CAST_FUNC(getter, FutureObj_get_log_traceback),                   \
+                       _Py_CAST_FUNC(setter, FutureObj_set_log_traceback), NULL},            \
+    {"_source_traceback", _Py_CAST_FUNC(getter, FutureObj_get_source_traceback), NULL, NULL},
 
 static PyGetSetDef FutureType_getsetlist[] = {
     FUTURE_COMMON_GETSETLIST
@@ -1724,7 +1724,7 @@ TaskStepMethWrapper_get___self__(TaskStepMethWrapper *o)
 }
 
 static PyGetSetDef TaskStepMethWrapper_getsetlist[] = {
-    {"__self__", (getter)TaskStepMethWrapper_get___self__, NULL, NULL},
+    {"__self__", _Py_CAST_FUNC(getter, TaskStepMethWrapper_get___self__), NULL, NULL},
     {NULL} /* Sentinel */
 };
 
@@ -2434,11 +2434,11 @@ static PyMethodDef TaskType_methods[] = {
 
 static PyGetSetDef TaskType_getsetlist[] = {
     FUTURE_COMMON_GETSETLIST
-    {"_log_destroy_pending", (getter)TaskObj_get_log_destroy_pending,
-                             (setter)TaskObj_set_log_destroy_pending, NULL},
-    {"_must_cancel", (getter)TaskObj_get_must_cancel, NULL, NULL},
-    {"_coro", (getter)TaskObj_get_coro, NULL, NULL},
-    {"_fut_waiter", (getter)TaskObj_get_fut_waiter, NULL, NULL},
+    {"_log_destroy_pending", _Py_CAST_FUNC(getter, TaskObj_get_log_destroy_pending),
+                             _Py_CAST_FUNC(setter, TaskObj_set_log_destroy_pending), NULL},
+    {"_must_cancel", _Py_CAST_FUNC(getter, TaskObj_get_must_cancel), NULL, NULL},
+    {"_coro", _Py_CAST_FUNC(getter, TaskObj_get_coro), NULL, NULL},
+    {"_fut_waiter", _Py_CAST_FUNC(getter, TaskObj_get_fut_waiter), NULL, NULL},
     {NULL} /* Sentinel */
 };
 

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1519,7 +1519,7 @@ deque_get_maxlen(dequeobject *deque)
 /* deque object ********************************************************/
 
 static PyGetSetDef deque_getset[] = {
-    {"maxlen", (getter)deque_get_maxlen, (setter)NULL,
+    {"maxlen", _Py_CAST_FUNC(getter, deque_get_maxlen), (setter)NULL,
      "maximum size of a deque or None if unbounded"},
     {0}
 };

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -300,11 +300,11 @@ static struct PyMemberDef Dialect_memberlist[] = {
 };
 
 static PyGetSetDef Dialect_getsetlist[] = {
-    { "delimiter",          (getter)Dialect_get_delimiter},
-    { "escapechar",             (getter)Dialect_get_escapechar},
-    { "lineterminator",         (getter)Dialect_get_lineterminator},
-    { "quotechar",              (getter)Dialect_get_quotechar},
-    { "quoting",                (getter)Dialect_get_quoting},
+    { "delimiter",          _Py_CAST_FUNC(getter, Dialect_get_delimiter)},
+    { "escapechar",             _Py_CAST_FUNC(getter, Dialect_get_escapechar)},
+    { "lineterminator",         _Py_CAST_FUNC(getter, Dialect_get_lineterminator)},
+    { "quotechar",              _Py_CAST_FUNC(getter, Dialect_get_quotechar)},
+    { "quoting",                _Py_CAST_FUNC(getter, Dialect_get_quoting)},
     {NULL},
 };
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1240,9 +1240,9 @@ CharArray_set_value(CDataObject *self, PyObject *value)
 }
 
 static PyGetSetDef CharArray_getsets[] = {
-    { "raw", (getter)CharArray_get_raw, (setter)CharArray_set_raw,
+    { "raw", _Py_CAST_FUNC(getter, CharArray_get_raw), _Py_CAST_FUNC(setter, CharArray_set_raw),
       "value", NULL },
-    { "value", (getter)CharArray_get_value, (setter)CharArray_set_value,
+    { "value", _Py_CAST_FUNC(getter, CharArray_get_value), _Py_CAST_FUNC(setter, CharArray_set_value),
       "string value"},
     { NULL, NULL }
 };
@@ -1300,7 +1300,7 @@ WCharArray_set_value(CDataObject *self, PyObject *value)
 }
 
 static PyGetSetDef WCharArray_getsets[] = {
-    { "value", (getter)WCharArray_get_value, (setter)WCharArray_set_value,
+    { "value", _Py_CAST_FUNC(getter, WCharArray_get_value), _Py_CAST_FUNC(setter, WCharArray_set_value),
       "string value"},
     { NULL, NULL }
 };
@@ -3159,12 +3159,12 @@ PyCFuncPtr_get_argtypes(PyCFuncPtrObject *self)
 }
 
 static PyGetSetDef PyCFuncPtr_getsets[] = {
-    { "errcheck", (getter)PyCFuncPtr_get_errcheck, (setter)PyCFuncPtr_set_errcheck,
+    { "errcheck", _Py_CAST_FUNC(getter, PyCFuncPtr_get_errcheck), _Py_CAST_FUNC(setter, PyCFuncPtr_set_errcheck),
       "a function to check for errors", NULL },
-    { "restype", (getter)PyCFuncPtr_get_restype, (setter)PyCFuncPtr_set_restype,
+    { "restype", _Py_CAST_FUNC(getter, PyCFuncPtr_get_restype), _Py_CAST_FUNC(setter, PyCFuncPtr_set_restype),
       "specify the result type", NULL },
-    { "argtypes", (getter)PyCFuncPtr_get_argtypes,
-      (setter)PyCFuncPtr_set_argtypes,
+    { "argtypes", _Py_CAST_FUNC(getter, PyCFuncPtr_get_argtypes),
+      _Py_CAST_FUNC(setter, PyCFuncPtr_set_argtypes),
       "specify the argument types", NULL },
     { NULL, NULL }
 };
@@ -4727,7 +4727,7 @@ Simple_get_value(CDataObject *self)
 }
 
 static PyGetSetDef Simple_getsets[] = {
-    { "value", (getter)Simple_get_value, (setter)Simple_set_value,
+    { "value", _Py_CAST_FUNC(getter, Simple_get_value), _Py_CAST_FUNC(setter, Simple_set_value),
       "current value", NULL },
     { NULL, NULL }
 };
@@ -4969,8 +4969,8 @@ Pointer_set_contents(CDataObject *self, PyObject *value, void *closure)
 }
 
 static PyGetSetDef Pointer_getsets[] = {
-    { "contents", (getter)Pointer_get_contents,
-      (setter)Pointer_set_contents,
+    { "contents", _Py_CAST_FUNC(getter, Pointer_get_contents),
+      _Py_CAST_FUNC(setter, Pointer_set_contents),
       "the object this pointer points to (read-write)", NULL },
     { NULL, NULL }
 };

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2409,8 +2409,8 @@ static PyMethodDef PyCursesWindow_Methods[] = {
 
 static PyGetSetDef PyCursesWindow_getsets[] = {
     {"encoding",
-     (getter)PyCursesWindow_get_encoding,
-     (setter)PyCursesWindow_set_encoding,
+     _Py_CAST_FUNC(getter, PyCursesWindow_get_encoding),
+     _Py_CAST_FUNC(setter, PyCursesWindow_set_encoding),
      "the typecode character used to create the array"},
     {NULL, NULL, NULL, NULL }  /* sentinel */
 };

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -966,7 +966,7 @@ bytesio_clear(bytesio *self)
 #include "clinic/bytesio.c.h"
 
 static PyGetSetDef bytesio_getsetlist[] = {
-    {"closed",  (getter)bytesio_get_closed, NULL,
+    {"closed",  _Py_CAST_FUNC(getter, bytesio_get_closed), NULL,
      "True if the file is closed."},
     {NULL},            /* sentinel */
 };

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4667,10 +4667,10 @@ static PyMemberDef Pickler_members[] = {
 };
 
 static PyGetSetDef Pickler_getsets[] = {
-    {"memo",          (getter)Pickler_get_memo,
-                      (setter)Pickler_set_memo},
-    {"persistent_id", (getter)Pickler_get_persid,
-                      (setter)Pickler_set_persid},
+    {"memo",          _Py_CAST_FUNC(getter, Pickler_get_memo),
+                      _Py_CAST_FUNC(setter, Pickler_set_memo)},
+    {"persistent_id", _Py_CAST_FUNC(getter, Pickler_get_persid),
+                      _Py_CAST_FUNC(setter, Pickler_set_persid)},
     {NULL}
 };
 
@@ -7114,9 +7114,9 @@ Unpickler_set_persload(UnpicklerObject *self, PyObject *value)
 }
 
 static PyGetSetDef Unpickler_getsets[] = {
-    {"memo", (getter)Unpickler_get_memo, (setter)Unpickler_set_memo},
-    {"persistent_load", (getter)Unpickler_get_persload,
-                        (setter)Unpickler_set_persload},
+    {"memo", _Py_CAST_FUNC(getter, Unpickler_get_memo), _Py_CAST_FUNC(setter, Unpickler_set_memo)},
+    {"persistent_load", _Py_CAST_FUNC(getter, Unpickler_get_persload),
+                        _Py_CAST_FUNC(setter, Unpickler_set_persload)},
     {NULL}
 };
 

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1757,9 +1757,9 @@ static const char connection_doc[] =
 PyDoc_STR("SQLite database connection object.");
 
 static PyGetSetDef connection_getset[] = {
-    {"isolation_level",  (getter)pysqlite_connection_get_isolation_level, (setter)pysqlite_connection_set_isolation_level},
-    {"total_changes",  (getter)pysqlite_connection_get_total_changes, (setter)0},
-    {"in_transaction",  (getter)pysqlite_connection_get_in_transaction, (setter)0},
+    {"isolation_level",  _Py_CAST_FUNC(getter, pysqlite_connection_get_isolation_level), _Py_CAST_FUNC(setter, pysqlite_connection_set_isolation_level)},
+    {"total_changes",  _Py_CAST_FUNC(getter, pysqlite_connection_get_total_changes), _Py_CAST_FUNC(setter, 0)},
+    {"in_transaction",  _Py_CAST_FUNC(getter, pysqlite_connection_get_in_transaction), _Py_CAST_FUNC(setter, 0)},
     {NULL}
 };
 

--- a/Modules/_sqlite/row.c
+++ b/Modules/_sqlite/row.c
@@ -204,13 +204,13 @@ static PyObject* pysqlite_row_richcompare(pysqlite_Row *self, PyObject *_other, 
 }
 
 PyMappingMethods pysqlite_row_as_mapping = {
-    /* mp_length        */ (lenfunc)pysqlite_row_length,
-    /* mp_subscript     */ (binaryfunc)pysqlite_row_subscript,
+    /* mp_length        */ _Py_CAST_FUNC(lenfunc, pysqlite_row_length),
+    /* mp_subscript     */ _Py_CAST_FUNC(binaryfunc, pysqlite_row_subscript),
     /* mp_ass_subscript */ (objobjargproc)0,
 };
 
 static PySequenceMethods pysqlite_row_as_sequence = {
-   /* sq_length */         (lenfunc)pysqlite_row_length,
+   /* sq_length */         _Py_CAST_FUNC(lenfunc, pysqlite_row_length),
    /* sq_concat */         0,
    /* sq_repeat */         0,
    /* sq_item */           (ssizeargfunc)pysqlite_row_item,
@@ -229,7 +229,7 @@ PyTypeObject pysqlite_RowType = {
         MODULE_NAME ".Row",                             /* tp_name */
         sizeof(pysqlite_Row),                           /* tp_basicsize */
         0,                                              /* tp_itemsize */
-        (destructor)pysqlite_row_dealloc,               /* tp_dealloc */
+        _Py_CAST_FUNC(destructor, pysqlite_row_dealloc),               /* tp_dealloc */
         0,                                              /* tp_print */
         0,                                              /* tp_getattr */
         0,                                              /* tp_setattr */

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -2579,7 +2579,7 @@ static PyMethodDef pattern_methods[] = {
 };
 
 static PyGetSetDef pattern_getset[] = {
-    {"groupindex", (getter)pattern_groupindex, (setter)NULL,
+    {"groupindex", _Py_CAST_FUNC(getter, pattern_groupindex), (setter)NULL,
       "A dictionary mapping group names to group numbers."},
     {NULL}  /* Sentinel */
 };
@@ -2649,11 +2649,11 @@ static PyMethodDef match_methods[] = {
 };
 
 static PyGetSetDef match_getset[] = {
-    {"lastindex", (getter)match_lastindex_get, (setter)NULL,
+    {"lastindex", _Py_CAST_FUNC(getter, match_lastindex_get), (setter)NULL,
      "The integer index of the last matched capturing group."},
-    {"lastgroup", (getter)match_lastgroup_get, (setter)NULL,
+    {"lastgroup", _Py_CAST_FUNC(getter, match_lastgroup_get), (setter)NULL,
      "The name of the last matched capturing group."},
-    {"regs",      (getter)match_regs_get,      (setter)NULL},
+    {"regs",      _Py_CAST_FUNC(getter, match_regs_get),      (setter)NULL},
     {NULL}
 };
 

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -1544,8 +1544,8 @@ ndarray_releasebuf(NDArrayObject *self, Py_buffer *view)
 }
 
 static PyBufferProcs ndarray_as_buffer = {
-    (getbufferproc)ndarray_getbuf,        /* bf_getbuffer */
-    (releasebufferproc)ndarray_releasebuf /* bf_releasebuffer */
+    _Py_CAST_FUNC(getbufferproc, ndarray_getbuf),        /* bf_getbuffer */
+    _Py_CAST_FUNC(releasebufferproc, ndarray_releasebuf) /* bf_releasebuffer */
 };
 
 
@@ -2130,21 +2130,21 @@ ndarray_contig(PyObject *self, PyObject *dummy)
 static PyGetSetDef ndarray_getset [] =
 {
   /* ndbuf */
-  { "flags",        (getter)ndarray_get_flags,      NULL, NULL, NULL},
-  { "offset",       (getter)ndarray_get_offset,     NULL, NULL, NULL},
+  { "flags",        _Py_CAST_FUNC(getter, ndarray_get_flags),      NULL, NULL, NULL},
+  { "offset",       _Py_CAST_FUNC(getter, ndarray_get_offset),     NULL, NULL, NULL},
   /* ndbuf.base */
-  { "obj",          (getter)ndarray_get_obj,        NULL, NULL, NULL},
-  { "nbytes",       (getter)ndarray_get_nbytes,     NULL, NULL, NULL},
-  { "readonly",     (getter)ndarray_get_readonly,   NULL, NULL, NULL},
-  { "itemsize",     (getter)ndarray_get_itemsize,   NULL, NULL, NULL},
-  { "format",       (getter)ndarray_get_format,     NULL, NULL, NULL},
-  { "ndim",         (getter)ndarray_get_ndim,       NULL, NULL, NULL},
-  { "shape",        (getter)ndarray_get_shape,      NULL, NULL, NULL},
-  { "strides",      (getter)ndarray_get_strides,    NULL, NULL, NULL},
-  { "suboffsets",   (getter)ndarray_get_suboffsets, NULL, NULL, NULL},
-  { "c_contiguous", (getter)ndarray_c_contig,       NULL, NULL, NULL},
-  { "f_contiguous", (getter)ndarray_fortran_contig, NULL, NULL, NULL},
-  { "contiguous",   (getter)ndarray_contig,         NULL, NULL, NULL},
+  { "obj",          _Py_CAST_FUNC(getter, ndarray_get_obj),        NULL, NULL, NULL},
+  { "nbytes",       _Py_CAST_FUNC(getter, ndarray_get_nbytes),     NULL, NULL, NULL},
+  { "readonly",     _Py_CAST_FUNC(getter, ndarray_get_readonly),   NULL, NULL, NULL},
+  { "itemsize",     _Py_CAST_FUNC(getter, ndarray_get_itemsize),   NULL, NULL, NULL},
+  { "format",       _Py_CAST_FUNC(getter, ndarray_get_format),     NULL, NULL, NULL},
+  { "ndim",         _Py_CAST_FUNC(getter, ndarray_get_ndim),       NULL, NULL, NULL},
+  { "shape",        _Py_CAST_FUNC(getter, ndarray_get_shape),      NULL, NULL, NULL},
+  { "strides",      _Py_CAST_FUNC(getter, ndarray_get_strides),    NULL, NULL, NULL},
+  { "suboffsets",   _Py_CAST_FUNC(getter, ndarray_get_suboffsets), NULL, NULL, NULL},
+  { "c_contiguous", _Py_CAST_FUNC(getter, ndarray_c_contig),       NULL, NULL, NULL},
+  { "f_contiguous", _Py_CAST_FUNC(getter, ndarray_fortran_contig), NULL, NULL, NULL},
+  { "contiguous",   _Py_CAST_FUNC(getter, ndarray_contig),         NULL, NULL, NULL},
   {NULL}
 };
 
@@ -2758,7 +2758,7 @@ staticarray_getbuf(StaticArrayObject *self, Py_buffer *view, int flags)
 }
 
 static PyBufferProcs staticarray_as_buffer = {
-    (getbufferproc)staticarray_getbuf, /* bf_getbuffer */
+    _Py_CAST_FUNC(getbufferproc, staticarray_getbuf), /* bf_getbuffer */
     NULL,                              /* bf_releasebuffer */
 };
 

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -899,16 +899,16 @@ get_typename(PyTclObject* obj, void* ignored)
 
 
 static PyGetSetDef PyTclObject_getsetlist[] = {
-    {"typename", (getter)get_typename, NULL, get_typename__doc__},
-    {"string", (getter)PyTclObject_string, NULL,
+    {"typename", _Py_CAST_FUNC(getter, get_typename), NULL, get_typename__doc__},
+    {"string", _Py_CAST_FUNC(getter, PyTclObject_string), NULL,
      PyTclObject_string__doc__},
     {0},
 };
 
 static PyType_Slot PyTclObject_Type_slots[] = {
-    {Py_tp_dealloc, (destructor)PyTclObject_dealloc},
-    {Py_tp_repr, (reprfunc)PyTclObject_repr},
-    {Py_tp_str, (reprfunc)PyTclObject_str},
+    {Py_tp_dealloc, _Py_CAST_FUNC(destructor, PyTclObject_dealloc)},
+    {Py_tp_repr, _Py_CAST_FUNC(reprfunc, PyTclObject_repr)},
+    {Py_tp_str, _Py_CAST_FUNC(reprfunc, PyTclObject_str)},
     {Py_tp_getattro, PyObject_GenericGetAttr},
     {Py_tp_richcompare, PyTclObject_richcompare},
     {Py_tp_getset, PyTclObject_getsetlist},

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -153,8 +153,8 @@ codecctx_errors_set(MultibyteStatefulCodecContext *self, PyObject *value,
 
 /* This getset handlers list is used by all the stateful codec objects */
 static PyGetSetDef codecctx_getsets[] = {
-    {"errors",          (getter)codecctx_errors_get,
-                    (setter)codecctx_errors_set,
+    {"errors",          _Py_CAST_FUNC(getter, codecctx_errors_get),
+                    _Py_CAST_FUNC(setter, codecctx_errors_set),
                     PyDoc_STR("how to treat errors")},
     {NULL,}
 };
@@ -706,7 +706,7 @@ static PyTypeObject MultibyteCodec_Type = {
     sizeof(MultibyteCodecObject),       /* tp_basicsize */
     0,                                  /* tp_itemsize */
     /* methods */
-    (destructor)multibytecodec_dealloc, /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, multibytecodec_dealloc), /* tp_dealloc */
     0,                                  /* tp_print */
     0,                                  /* tp_getattr */
     0,                                  /* tp_setattr */
@@ -1083,7 +1083,7 @@ static PyTypeObject MultibyteIncrementalEncoder_Type = {
     sizeof(MultibyteIncrementalEncoderObject), /* tp_basicsize */
     0,                                  /* tp_itemsize */
     /*  methods  */
-    (destructor)mbiencoder_dealloc, /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, mbiencoder_dealloc), /* tp_dealloc */
     0,                                  /* tp_print */
     0,                                  /* tp_getattr */
     0,                                  /* tp_setattr */
@@ -1382,7 +1382,7 @@ static PyTypeObject MultibyteIncrementalDecoder_Type = {
     sizeof(MultibyteIncrementalDecoderObject), /* tp_basicsize */
     0,                                  /* tp_itemsize */
     /*  methods  */
-    (destructor)mbidecoder_dealloc, /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, mbidecoder_dealloc), /* tp_dealloc */
     0,                                  /* tp_print */
     0,                                  /* tp_getattr */
     0,                                  /* tp_setattr */
@@ -1729,7 +1729,7 @@ static PyTypeObject MultibyteStreamReader_Type = {
     sizeof(MultibyteStreamReaderObject), /* tp_basicsize */
     0,                                  /* tp_itemsize */
     /*  methods  */
-    (destructor)mbstreamreader_dealloc, /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, mbstreamreader_dealloc), /* tp_dealloc */
     0,                                  /* tp_print */
     0,                                  /* tp_getattr */
     0,                                  /* tp_setattr */
@@ -1975,7 +1975,7 @@ static PyTypeObject MultibyteStreamWriter_Type = {
     sizeof(MultibyteStreamWriterObject), /* tp_basicsize */
     0,                                  /* tp_itemsize */
     /*  methods  */
-    (destructor)mbstreamwriter_dealloc, /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, mbstreamwriter_dealloc), /* tp_dealloc */
     0,                                  /* tp_print */
     0,                                  /* tp_getattr */
     0,                                  /* tp_setattr */

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -719,7 +719,7 @@ static struct PyMethodDef mmap_object_methods[] = {
 };
 
 static PyGetSetDef mmap_object_getset[] = {
-    {"closed", (getter) mmap_closed_get, NULL, NULL},
+    {"closed", _Py_CAST_FUNC(getter, mmap_closed_get), NULL, NULL},
     {NULL}
 };
 
@@ -949,8 +949,8 @@ static PyMappingMethods mmap_as_mapping = {
 };
 
 static PyBufferProcs mmap_as_buffer = {
-    (getbufferproc)mmap_buffer_getbuf,
-    (releasebufferproc)mmap_buffer_releasebuf,
+    _Py_CAST_FUNC(getbufferproc, mmap_buffer_getbuf),
+    _Py_CAST_FUNC(releasebufferproc, mmap_buffer_releasebuf),
 };
 
 static PyObject *

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1055,7 +1055,7 @@ select_devpoll_fileno_impl(devpollObject *self)
 }
 
 static PyGetSetDef devpoll_getsetlist[] = {
-    {"closed", (getter)devpoll_get_closed, NULL,
+    {"closed", _Py_CAST_FUNC(getter, devpoll_get_closed), NULL,
      "True if the devpoll object is closed"},
     {0},
 };
@@ -1638,7 +1638,7 @@ select_epoll___exit___impl(pyEpoll_Object *self, PyObject *exc_type,
 }
 
 static PyGetSetDef pyepoll_getsetlist[] = {
-    {"closed", (getter)pyepoll_get_closed, NULL,
+    {"closed", _Py_CAST_FUNC(getter, pyepoll_get_closed), NULL,
      "True if the epoll handler is closed"},
     {0},
 };
@@ -2188,7 +2188,7 @@ select_kqueue_control_impl(kqueue_queue_Object *self, PyObject *changelist,
 }
 
 static PyGetSetDef kqueue_queue_getsetlist[] = {
-    {"closed", (getter)kqueue_queue_get_closed, NULL,
+    {"closed", _Py_CAST_FUNC(getter, kqueue_queue_get_closed), NULL,
      "True if the kqueue handler is closed"},
     {0},
 };
@@ -2218,7 +2218,7 @@ static PyTypeObject poll_Type = {
     sizeof(pollObject),         /*tp_basicsize*/
     0,                          /*tp_itemsize*/
     /* methods */
-    (destructor)poll_dealloc, /*tp_dealloc*/
+    _Py_CAST_FUNC(destructor, poll_dealloc), /*tp_dealloc*/
     0,                          /*tp_print*/
     0,                          /*tp_getattr*/
     0,                      /*tp_setattr*/
@@ -2264,7 +2264,7 @@ static PyTypeObject devpoll_Type = {
     sizeof(devpollObject),      /*tp_basicsize*/
     0,                          /*tp_itemsize*/
     /* methods */
-    (destructor)devpoll_dealloc, /*tp_dealloc*/
+    _Py_CAST_FUNC(destructor, devpoll_dealloc), /*tp_dealloc*/
     0,                          /*tp_print*/
     0,                          /*tp_getattr*/
     0,                          /*tp_setattr*/
@@ -2316,7 +2316,7 @@ static PyTypeObject pyEpoll_Type = {
     "select.epoll",                                     /* tp_name */
     sizeof(pyEpoll_Object),                             /* tp_basicsize */
     0,                                                  /* tp_itemsize */
-    (destructor)pyepoll_dealloc,                        /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, pyepoll_dealloc),                        /* tp_dealloc */
     0,                                                  /* tp_print */
     0,                                                  /* tp_getattr */
     0,                                                  /* tp_setattr */
@@ -2367,7 +2367,7 @@ static PyTypeObject kqueue_event_Type = {
     0,                                                  /* tp_getattr */
     0,                                                  /* tp_setattr */
     0,                                                  /* tp_reserved */
-    (reprfunc)kqueue_event_repr,                        /* tp_repr */
+    _Py_CAST_FUNC(reprfunc, kqueue_event_repr),                        /* tp_repr */
     0,                                                  /* tp_as_number */
     0,                                                  /* tp_as_sequence */
     0,                                                  /* tp_as_mapping */
@@ -2412,7 +2412,7 @@ static PyTypeObject kqueue_queue_Type = {
     "select.kqueue",                                    /* tp_name */
     sizeof(kqueue_queue_Object),                        /* tp_basicsize */
     0,                                                  /* tp_itemsize */
-    (destructor)kqueue_queue_dealloc,                   /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, kqueue_queue_dealloc),                   /* tp_dealloc */
     0,                                                  /* tp_print */
     0,                                                  /* tp_getattr */
     0,                                                  /* tp_setattr */

--- a/Modules/xxsubtype.c
+++ b/Modules/xxsubtype.c
@@ -95,7 +95,7 @@ spamlist_state_get(spamlistobject *self)
 }
 
 static PyGetSetDef spamlist_getsets[] = {
-    {"state", (getter)spamlist_state_get, NULL,
+    {"state", _Py_CAST_FUNC(getter, spamlist_state_get), NULL,
      PyDoc_STR("an int variable for demonstration purposes")},
     {0}
 };

--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -121,7 +121,7 @@ cell_set_contents(PyCellObject *op, PyObject *obj)
 
 static PyGetSetDef cell_getsetlist[] = {
     {"cell_contents", (getter)cell_get_contents,
-                      (setter)cell_set_contents, NULL},
+                      _Py_CAST_FUNC(setter, cell_set_contents), NULL},
     {NULL} /* sentinel */
 };
 

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -346,7 +346,7 @@ wrapperdescr_raw_call(PyWrapperDescrObject *descr, PyObject *self,
     wrapperfunc wrapper = descr->d_base->wrapper;
 
     if (descr->d_base->flags & PyWrapperFlag_KEYWORDS) {
-        wrapperfunc_kwds wk = (wrapperfunc_kwds)wrapper;
+        wrapperfunc_kwds wk = _Py_CAST_FUNC(wrapperfunc_kwds, wrapper);
         return (*wk)(self, args, descr->d_wrapped, kwds);
     }
 
@@ -474,9 +474,9 @@ static PyMemberDef descr_members[] = {
 };
 
 static PyGetSetDef method_getset[] = {
-    {"__doc__", (getter)method_get_doc},
-    {"__qualname__", (getter)descr_get_qualname},
-    {"__text_signature__", (getter)method_get_text_signature},
+    {"__doc__", _Py_CAST_FUNC(getter, method_get_doc)},
+    {"__qualname__", _Py_CAST_FUNC(getter, descr_get_qualname)},
+    {"__text_signature__", _Py_CAST_FUNC(getter, method_get_text_signature)},
     {0}
 };
 
@@ -490,8 +490,8 @@ member_get_doc(PyMemberDescrObject *descr, void *closure)
 }
 
 static PyGetSetDef member_getset[] = {
-    {"__doc__", (getter)member_get_doc},
-    {"__qualname__", (getter)descr_get_qualname},
+    {"__doc__", _Py_CAST_FUNC(getter, member_get_doc)},
+    {"__qualname__", _Py_CAST_FUNC(getter, descr_get_qualname)},
     {0}
 };
 
@@ -505,8 +505,8 @@ getset_get_doc(PyGetSetDescrObject *descr, void *closure)
 }
 
 static PyGetSetDef getset_getset[] = {
-    {"__doc__", (getter)getset_get_doc},
-    {"__qualname__", (getter)descr_get_qualname},
+    {"__doc__", _Py_CAST_FUNC(getter, getset_get_doc)},
+    {"__qualname__", _Py_CAST_FUNC(getter, descr_get_qualname)},
     {0}
 };
 
@@ -523,9 +523,9 @@ wrapperdescr_get_text_signature(PyWrapperDescrObject *descr, void *closure)
 }
 
 static PyGetSetDef wrapperdescr_getset[] = {
-    {"__doc__", (getter)wrapperdescr_get_doc},
-    {"__qualname__", (getter)descr_get_qualname},
-    {"__text_signature__", (getter)wrapperdescr_get_text_signature},
+    {"__doc__", _Py_CAST_FUNC(getter, wrapperdescr_get_doc)},
+    {"__qualname__", _Py_CAST_FUNC(getter, descr_get_qualname)},
+    {"__text_signature__", _Py_CAST_FUNC(getter, wrapperdescr_get_text_signature)},
     {0}
 };
 
@@ -1142,11 +1142,11 @@ wrapper_qualname(wrapperobject *wp)
 }
 
 static PyGetSetDef wrapper_getsets[] = {
-    {"__objclass__", (getter)wrapper_objclass},
-    {"__name__", (getter)wrapper_name},
-    {"__qualname__", (getter)wrapper_qualname},
-    {"__doc__", (getter)wrapper_doc},
-    {"__text_signature__", (getter)wrapper_text_signature},
+    {"__objclass__", _Py_CAST_FUNC(getter, wrapper_objclass)},
+    {"__name__", _Py_CAST_FUNC(getter, wrapper_name)},
+    {"__qualname__", _Py_CAST_FUNC(getter, wrapper_qualname)},
+    {"__doc__", _Py_CAST_FUNC(getter, wrapper_doc)},
+    {"__text_signature__", _Py_CAST_FUNC(getter, wrapper_text_signature)},
     {0}
 };
 
@@ -1534,7 +1534,7 @@ property_get___isabstractmethod__(propertyobject *prop, void *closure)
 
 static PyGetSetDef property_getsetlist[] = {
     {"__isabstractmethod__",
-     (getter)property_get___isabstractmethod__, NULL,
+     _Py_CAST_FUNC(getter, property_get___isabstractmethod__), NULL,
      NULL,
      NULL},
     {NULL} /* Sentinel */

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -291,12 +291,12 @@ BaseException_set_cause(PyObject *self, PyObject *arg) {
 
 static PyGetSetDef BaseException_getset[] = {
     {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict},
-    {"args", (getter)BaseException_get_args, (setter)BaseException_set_args},
-    {"__traceback__", (getter)BaseException_get_tb, (setter)BaseException_set_tb},
-    {"__context__", (getter)BaseException_get_context,
-     (setter)BaseException_set_context, PyDoc_STR("exception context")},
-    {"__cause__", (getter)BaseException_get_cause,
-     (setter)BaseException_set_cause, PyDoc_STR("exception cause")},
+    {"args", _Py_CAST_FUNC(getter, BaseException_get_args), _Py_CAST_FUNC(setter, BaseException_set_args)},
+    {"__traceback__", _Py_CAST_FUNC(getter, BaseException_get_tb), _Py_CAST_FUNC(setter, BaseException_set_tb)},
+    {"__context__", _Py_CAST_FUNC(getter, BaseException_get_context),
+     _Py_CAST_FUNC(setter, BaseException_set_context), PyDoc_STR("exception context")},
+    {"__cause__", _Py_CAST_FUNC(getter, BaseException_get_cause),
+     _Py_CAST_FUNC(setter, BaseException_set_cause), PyDoc_STR("exception cause")},
     {NULL},
 };
 
@@ -363,18 +363,18 @@ static PyTypeObject _PyExc_BaseException = {
     "BaseException", /*tp_name*/
     sizeof(PyBaseExceptionObject), /*tp_basicsize*/
     0,                          /*tp_itemsize*/
-    (destructor)BaseException_dealloc, /*tp_dealloc*/
+    _Py_CAST_FUNC(destructor, BaseException_dealloc), /*tp_dealloc*/
     0,                          /*tp_print*/
     0,                          /*tp_getattr*/
     0,                          /*tp_setattr*/
     0,                          /* tp_reserved; */
-    (reprfunc)BaseException_repr, /*tp_repr*/
+    _Py_CAST_FUNC(reprfunc, BaseException_repr), /*tp_repr*/
     0,                          /*tp_as_number*/
     0,                          /*tp_as_sequence*/
     0,                          /*tp_as_mapping*/
     0,                          /*tp_hash */
     0,                          /*tp_call*/
-    (reprfunc)BaseException_str,  /*tp_str*/
+    _Py_CAST_FUNC(reprfunc, BaseException_str),  /*tp_str*/
     PyObject_GenericGetAttr,    /*tp_getattro*/
     PyObject_GenericSetAttr,    /*tp_setattro*/
     0,                          /*tp_as_buffer*/
@@ -412,7 +412,7 @@ static PyTypeObject _PyExc_ ## EXCNAME = { \
     PyVarObject_HEAD_INIT(NULL, 0) \
     # EXCNAME, \
     sizeof(PyBaseExceptionObject), \
-    0, (destructor)BaseException_dealloc, 0, 0, 0, 0, 0, 0, 0, \
+    0, _Py_CAST_FUNC(destructor, BaseException_dealloc), 0, 0, 0, 0, 0, 0, 0, \
     0, 0, 0, 0, 0, 0, 0, \
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, \
     PyDoc_STR(EXCDOC), (traverseproc)BaseException_traverse, \
@@ -427,7 +427,7 @@ static PyTypeObject _PyExc_ ## EXCNAME = { \
     PyVarObject_HEAD_INIT(NULL, 0) \
     # EXCNAME, \
     sizeof(Py ## EXCSTORE ## Object), \
-    0, (destructor)EXCSTORE ## _dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+    0, _Py_CAST_FUNC(destructor, EXCSTORE ## _dealloc), 0, 0, 0, 0, 0, 0, 0, 0, 0, \
     0, 0, 0, 0, 0, \
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, \
     PyDoc_STR(EXCDOC), (traverseproc)EXCSTORE ## _traverse, \
@@ -444,8 +444,8 @@ static PyTypeObject _PyExc_ ## EXCNAME = { \
     PyVarObject_HEAD_INIT(NULL, 0) \
     # EXCNAME, \
     sizeof(Py ## EXCSTORE ## Object), 0, \
-    (destructor)EXCSTORE ## _dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
-    (reprfunc)EXCSTR, 0, 0, 0, \
+    _Py_CAST_FUNC(destructor, EXCSTORE ## _dealloc), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+    _Py_CAST_FUNC(reprfunc, EXCSTR), 0, 0, 0, \
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, \
     PyDoc_STR(EXCDOC), (traverseproc)EXCSTORE ## _traverse, \
     (inquiry)EXCSTORE ## _clear, 0, 0, 0, 0, EXCMETHODS, \
@@ -1948,8 +1948,8 @@ static PyTypeObject _PyExc_UnicodeEncodeError = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "UnicodeEncodeError",
     sizeof(PyUnicodeErrorObject), 0,
-    (destructor)UnicodeError_dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    (reprfunc)UnicodeEncodeError_str, 0, 0, 0,
+    _Py_CAST_FUNC(destructor, UnicodeError_dealloc), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    _Py_CAST_FUNC(reprfunc, UnicodeEncodeError_str), 0, 0, 0,
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
     PyDoc_STR("Unicode encoding error."), (traverseproc)UnicodeError_traverse,
     (inquiry)UnicodeError_clear, 0, 0, 0, 0, 0, UnicodeError_members,
@@ -2064,8 +2064,8 @@ static PyTypeObject _PyExc_UnicodeDecodeError = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "UnicodeDecodeError",
     sizeof(PyUnicodeErrorObject), 0,
-    (destructor)UnicodeError_dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    (reprfunc)UnicodeDecodeError_str, 0, 0, 0,
+    _Py_CAST_FUNC(destructor, UnicodeError_dealloc), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    _Py_CAST_FUNC(reprfunc, UnicodeDecodeError_str), 0, 0, 0,
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
     PyDoc_STR("Unicode decoding error."), (traverseproc)UnicodeError_traverse,
     (inquiry)UnicodeError_clear, 0, 0, 0, 0, 0, UnicodeError_members,
@@ -2161,8 +2161,8 @@ static PyTypeObject _PyExc_UnicodeTranslateError = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "UnicodeTranslateError",
     sizeof(PyUnicodeErrorObject), 0,
-    (destructor)UnicodeError_dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    (reprfunc)UnicodeTranslateError_str, 0, 0, 0,
+    _Py_CAST_FUNC(destructor, UnicodeError_dealloc), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    _Py_CAST_FUNC(reprfunc, UnicodeTranslateError_str), 0, 0, 0,
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
     PyDoc_STR("Unicode translation error."), (traverseproc)UnicodeError_traverse,
     (inquiry)UnicodeError_clear, 0, 0, 0, 0, 0, UnicodeError_members,
@@ -2320,7 +2320,7 @@ static PyTypeObject _PyExc_MemoryError = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "MemoryError",
     sizeof(PyBaseExceptionObject),
-    0, (destructor)MemoryError_dealloc, 0, 0, 0, 0, 0, 0, 0,
+    0, _Py_CAST_FUNC(destructor, MemoryError_dealloc), 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0,
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
     PyDoc_STR("Out of memory."), (traverseproc)BaseException_traverse,

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -347,10 +347,10 @@ frame_settrace(PyFrameObject *f, PyObject* v, void *closure)
 
 
 static PyGetSetDef frame_getsetlist[] = {
-    {"f_locals",        (getter)frame_getlocals, NULL, NULL},
-    {"f_lineno",        (getter)frame_getlineno,
-                    (setter)frame_setlineno, NULL},
-    {"f_trace",         (getter)frame_gettrace, (setter)frame_settrace, NULL},
+    {"f_locals",        _Py_CAST_FUNC(getter, frame_getlocals), NULL, NULL},
+    {"f_lineno",        _Py_CAST_FUNC(getter, frame_getlineno),
+                    _Py_CAST_FUNC(setter, frame_setlineno), NULL},
+    {"f_trace",         _Py_CAST_FUNC(getter, frame_gettrace), _Py_CAST_FUNC(setter, frame_settrace), NULL},
     {0}
 };
 
@@ -559,12 +559,12 @@ PyTypeObject PyFrame_Type = {
     "frame",
     sizeof(PyFrameObject),
     sizeof(PyObject *),
-    (destructor)frame_dealloc,                  /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, frame_dealloc),                  /* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_reserved */
-    (reprfunc)frame_repr,                       /* tp_repr */
+    _Py_CAST_FUNC(reprfunc, frame_repr),                       /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
@@ -577,7 +577,7 @@ PyTypeObject PyFrame_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
     0,                                          /* tp_doc */
     (traverseproc)frame_traverse,               /* tp_traverse */
-    (inquiry)frame_tp_clear,                    /* tp_clear */
+    _Py_CAST_FUNC(inquiry, frame_tp_clear),                    /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -407,16 +407,16 @@ func_set_annotations(PyFunctionObject *op, PyObject *value)
 }
 
 static PyGetSetDef func_getsetlist[] = {
-    {"__code__", (getter)func_get_code, (setter)func_set_code},
-    {"__defaults__", (getter)func_get_defaults,
-     (setter)func_set_defaults},
-    {"__kwdefaults__", (getter)func_get_kwdefaults,
-     (setter)func_set_kwdefaults},
-    {"__annotations__", (getter)func_get_annotations,
-     (setter)func_set_annotations},
+    {"__code__", _Py_CAST_FUNC(getter, func_get_code), _Py_CAST_FUNC(setter, func_set_code)},
+    {"__defaults__", _Py_CAST_FUNC(getter, func_get_defaults),
+     _Py_CAST_FUNC(setter, func_set_defaults)},
+    {"__kwdefaults__", _Py_CAST_FUNC(getter, func_get_kwdefaults),
+     _Py_CAST_FUNC(setter, func_set_kwdefaults)},
+    {"__annotations__", _Py_CAST_FUNC(getter, func_get_annotations),
+     _Py_CAST_FUNC(setter, func_set_annotations)},
     {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict},
-    {"__name__", (getter)func_get_name, (setter)func_set_name},
-    {"__qualname__", (getter)func_get_qualname, (setter)func_set_qualname},
+    {"__name__", _Py_CAST_FUNC(getter, func_get_name), _Py_CAST_FUNC(setter, func_set_name)},
+    {"__qualname__", _Py_CAST_FUNC(getter, func_get_qualname), _Py_CAST_FUNC(setter, func_set_qualname)},
     {NULL} /* Sentinel */
 };
 
@@ -604,12 +604,12 @@ PyTypeObject PyFunction_Type = {
     "function",
     sizeof(PyFunctionObject),
     0,
-    (destructor)func_dealloc,                   /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, func_dealloc),                   /* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_reserved */
-    (reprfunc)func_repr,                        /* tp_repr */
+    _Py_CAST_FUNC(reprfunc, func_repr),                        /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
@@ -622,7 +622,7 @@ PyTypeObject PyFunction_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
     func_new__doc__,                            /* tp_doc */
     (traverseproc)func_traverse,                /* tp_traverse */
-    (inquiry)func_clear,                        /* tp_clear */
+    _Py_CAST_FUNC(inquiry, func_clear),                        /* tp_clear */
     0,                                          /* tp_richcompare */
     offsetof(PyFunctionObject, func_weakreflist), /* tp_weaklistoffset */
     0,                                          /* tp_iter */
@@ -743,7 +743,7 @@ cm_get___isabstractmethod__(classmethod *cm, void *closure)
 
 static PyGetSetDef cm_getsetlist[] = {
     {"__isabstractmethod__",
-     (getter)cm_get___isabstractmethod__, NULL,
+     _Py_CAST_FUNC(getter, cm_get___isabstractmethod__), NULL,
      NULL,
      NULL},
     {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict, NULL, NULL},
@@ -777,7 +777,7 @@ PyTypeObject PyClassMethod_Type = {
     "classmethod",
     sizeof(classmethod),
     0,
-    (destructor)cm_dealloc,                     /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, cm_dealloc),                     /* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
@@ -795,7 +795,7 @@ PyTypeObject PyClassMethod_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
     classmethod_doc,                            /* tp_doc */
     (traverseproc)cm_traverse,                  /* tp_traverse */
-    (inquiry)cm_clear,                          /* tp_clear */
+    _Py_CAST_FUNC(inquiry, cm_clear),                          /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */
@@ -924,7 +924,7 @@ sm_get___isabstractmethod__(staticmethod *sm, void *closure)
 
 static PyGetSetDef sm_getsetlist[] = {
     {"__isabstractmethod__",
-     (getter)sm_get___isabstractmethod__, NULL,
+     _Py_CAST_FUNC(getter, sm_get___isabstractmethod__), NULL,
      NULL,
      NULL},
     {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict, NULL, NULL},
@@ -955,7 +955,7 @@ PyTypeObject PyStaticMethod_Type = {
     "staticmethod",
     sizeof(staticmethod),
     0,
-    (destructor)sm_dealloc,                     /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, sm_dealloc),                     /* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
@@ -973,7 +973,7 @@ PyTypeObject PyStaticMethod_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
     staticmethod_doc,                           /* tp_doc */
     (traverseproc)sm_traverse,                  /* tp_traverse */
-    (inquiry)sm_clear,                          /* tp_clear */
+    _Py_CAST_FUNC(inquiry, sm_clear),                          /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -698,11 +698,11 @@ gen_getyieldfrom(PyGenObject *gen)
 }
 
 static PyGetSetDef gen_getsetlist[] = {
-    {"__name__", (getter)gen_get_name, (setter)gen_set_name,
+    {"__name__", _Py_CAST_FUNC(getter, gen_get_name), _Py_CAST_FUNC(setter, gen_set_name),
      PyDoc_STR("name of the generator")},
-    {"__qualname__", (getter)gen_get_qualname, (setter)gen_set_qualname,
+    {"__qualname__", _Py_CAST_FUNC(getter, gen_get_qualname), _Py_CAST_FUNC(setter, gen_set_qualname),
      PyDoc_STR("qualified name of the generator")},
-    {"gi_yieldfrom", (getter)gen_getyieldfrom, NULL,
+    {"gi_yieldfrom", _Py_CAST_FUNC(getter, gen_getyieldfrom), NULL,
      PyDoc_STR("object being iterated by yield from, or None")},
     {NULL} /* Sentinel */
 };
@@ -935,11 +935,11 @@ coro_get_cr_await(PyCoroObject *coro)
 }
 
 static PyGetSetDef coro_getsetlist[] = {
-    {"__name__", (getter)gen_get_name, (setter)gen_set_name,
+    {"__name__", _Py_CAST_FUNC(getter, gen_get_name), _Py_CAST_FUNC(setter, gen_set_name),
      PyDoc_STR("name of the coroutine")},
-    {"__qualname__", (getter)gen_get_qualname, (setter)gen_set_qualname,
+    {"__qualname__", _Py_CAST_FUNC(getter, gen_get_qualname), _Py_CAST_FUNC(setter, gen_set_qualname),
      PyDoc_STR("qualified name of the coroutine")},
-    {"cr_await", (getter)coro_get_cr_await, NULL,
+    {"cr_await", _Py_CAST_FUNC(getter, coro_get_cr_await), NULL,
      PyDoc_STR("object being awaited on, or None")},
     {NULL} /* Sentinel */
 };
@@ -1333,11 +1333,11 @@ async_gen_athrow(PyAsyncGenObject *o, PyObject *args)
 
 
 static PyGetSetDef async_gen_getsetlist[] = {
-    {"__name__", (getter)gen_get_name, (setter)gen_set_name,
+    {"__name__", _Py_CAST_FUNC(getter, gen_get_name), _Py_CAST_FUNC(setter, gen_set_name),
      PyDoc_STR("name of the async generator")},
-    {"__qualname__", (getter)gen_get_qualname, (setter)gen_set_qualname,
+    {"__qualname__", _Py_CAST_FUNC(getter, gen_get_qualname), _Py_CAST_FUNC(setter, gen_set_qualname),
      PyDoc_STR("qualified name of the async generator")},
-    {"ag_await", (getter)coro_get_cr_await, NULL,
+    {"ag_await", _Py_CAST_FUNC(getter, coro_get_cr_await), NULL,
      PyDoc_STR("object being awaited on, or None")},
     {NULL} /* Sentinel */
 };

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -140,7 +140,7 @@ PyTypeObject _PyManagedBuffer_Type = {
     "managedbuffer",
     sizeof(_PyManagedBufferObject),
     0,
-    (destructor)mbuf_dealloc,                /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, mbuf_dealloc),                /* tp_dealloc */
     0,                                       /* tp_print */
     0,                                       /* tp_getattr */
     0,                                       /* tp_setattr */
@@ -158,7 +158,7 @@ PyTypeObject _PyManagedBuffer_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
     0,                                       /* tp_doc */
     (traverseproc)mbuf_traverse,             /* tp_traverse */
-    (inquiry)mbuf_clear                      /* tp_clear */
+    _Py_CAST_FUNC(inquiry, mbuf_clear)                      /* tp_clear */
 };
 
 
@@ -1507,8 +1507,8 @@ memory_releasebuf(PyMemoryViewObject *self, Py_buffer *view)
 
 /* Buffer methods */
 static PyBufferProcs memory_as_buffer = {
-    (getbufferproc)memory_getbuf,         /* bf_getbuffer */
-    (releasebufferproc)memory_releasebuf, /* bf_releasebuffer */
+    _Py_CAST_FUNC(getbufferproc, memory_getbuf),         /* bf_getbuffer */
+    _Py_CAST_FUNC(releasebufferproc, memory_releasebuf), /* bf_releasebuffer */
 };
 
 
@@ -3041,18 +3041,18 @@ PyDoc_STRVAR(memory_contiguous_doc,
 
 
 static PyGetSetDef memory_getsetlist[] = {
-    {"obj",             (getter)memory_obj_get,        NULL, memory_obj_doc},
-    {"nbytes",          (getter)memory_nbytes_get,     NULL, memory_nbytes_doc},
-    {"readonly",        (getter)memory_readonly_get,   NULL, memory_readonly_doc},
-    {"itemsize",        (getter)memory_itemsize_get,   NULL, memory_itemsize_doc},
-    {"format",          (getter)memory_format_get,     NULL, memory_format_doc},
-    {"ndim",            (getter)memory_ndim_get,       NULL, memory_ndim_doc},
-    {"shape",           (getter)memory_shape_get,      NULL, memory_shape_doc},
-    {"strides",         (getter)memory_strides_get,    NULL, memory_strides_doc},
-    {"suboffsets",      (getter)memory_suboffsets_get, NULL, memory_suboffsets_doc},
-    {"c_contiguous",    (getter)memory_c_contiguous,   NULL, memory_c_contiguous_doc},
-    {"f_contiguous",    (getter)memory_f_contiguous,   NULL, memory_f_contiguous_doc},
-    {"contiguous",      (getter)memory_contiguous,     NULL, memory_contiguous_doc},
+    {"obj",             _Py_CAST_FUNC(getter, memory_obj_get),        NULL, memory_obj_doc},
+    {"nbytes",          _Py_CAST_FUNC(getter, memory_nbytes_get),     NULL, memory_nbytes_doc},
+    {"readonly",        _Py_CAST_FUNC(getter, memory_readonly_get),   NULL, memory_readonly_doc},
+    {"itemsize",        _Py_CAST_FUNC(getter, memory_itemsize_get),   NULL, memory_itemsize_doc},
+    {"format",          _Py_CAST_FUNC(getter, memory_format_get),     NULL, memory_format_doc},
+    {"ndim",            _Py_CAST_FUNC(getter, memory_ndim_get),       NULL, memory_ndim_doc},
+    {"shape",           _Py_CAST_FUNC(getter, memory_shape_get),      NULL, memory_shape_doc},
+    {"strides",         _Py_CAST_FUNC(getter, memory_strides_get),    NULL, memory_strides_doc},
+    {"suboffsets",      _Py_CAST_FUNC(getter, memory_suboffsets_get), NULL, memory_suboffsets_doc},
+    {"c_contiguous",    _Py_CAST_FUNC(getter, memory_c_contiguous),   NULL, memory_c_contiguous_doc},
+    {"f_contiguous",    _Py_CAST_FUNC(getter, memory_f_contiguous),   NULL, memory_f_contiguous_doc},
+    {"contiguous",      _Py_CAST_FUNC(getter, memory_contiguous),     NULL, memory_contiguous_doc},
     {NULL, NULL, NULL, NULL},
 };
 
@@ -3099,12 +3099,12 @@ PyTypeObject PyMemoryView_Type = {
     "memoryview",                             /* tp_name */
     offsetof(PyMemoryViewObject, ob_array),   /* tp_basicsize */
     sizeof(Py_ssize_t),                       /* tp_itemsize */
-    (destructor)memory_dealloc,               /* tp_dealloc */
+    _Py_CAST_FUNC(destructor, memory_dealloc),               /* tp_dealloc */
     0,                                        /* tp_print */
     0,                                        /* tp_getattr */
     0,                                        /* tp_setattr */
     0,                                        /* tp_reserved */
-    (reprfunc)memory_repr,                    /* tp_repr */
+    _Py_CAST_FUNC(reprfunc, memory_repr),                    /* tp_repr */
     0,                                        /* tp_as_number */
     &memory_as_sequence,                      /* tp_as_sequence */
     &memory_as_mapping,                       /* tp_as_mapping */
@@ -3117,7 +3117,7 @@ PyTypeObject PyMemoryView_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,  /* tp_flags */
     memory_doc,                               /* tp_doc */
     (traverseproc)memory_traverse,            /* tp_traverse */
-    (inquiry)memory_clear,                    /* tp_clear */
+    _Py_CAST_FUNC(inquiry, memory_clear),                    /* tp_clear */
     memory_richcompare,                       /* tp_richcompare */
     offsetof(PyMemoryViewObject, weakreflist),/* tp_weaklistoffset */
     0,                                        /* tp_iter */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6822,7 +6822,7 @@ static slotdef slotdefs[] = {
            "__repr__($self, /)\n--\n\nReturn repr(self)."),
     TPSLOT("__hash__", tp_hash, slot_tp_hash, wrap_hashfunc,
            "__hash__($self, /)\n--\n\nReturn hash(self)."),
-    FLSLOT("__call__", tp_call, slot_tp_call, (wrapperfunc)wrap_call,
+    FLSLOT("__call__", tp_call, slot_tp_call, _Py_CAST_FUNC(wrapperfunc, wrap_call),
            "__call__($self, /, *args, **kwargs)\n--\n\nCall self as a function.",
            PyWrapperFlag_KEYWORDS),
     TPSLOT("__str__", tp_str, slot_tp_str, wrap_unaryfunc,
@@ -6858,7 +6858,7 @@ static slotdef slotdefs[] = {
     TPSLOT("__delete__", tp_descr_set, slot_tp_descr_set,
            wrap_descr_delete,
            "__delete__($self, instance, /)\n--\n\nDelete an attribute of instance."),
-    FLSLOT("__init__", tp_init, slot_tp_init, (wrapperfunc)wrap_init,
+    FLSLOT("__init__", tp_init, slot_tp_init, _Py_CAST_FUNC(wrapperfunc, wrap_init),
            "__init__($self, /, *args, **kwargs)\n--\n\n"
            "Initialize self.  See help(type(self)) for accurate signature.",
            PyWrapperFlag_KEYWORDS),

--- a/Python/context.c
+++ b/Python/context.c
@@ -1159,8 +1159,8 @@ token_get_old_value(PyContextToken *self)
 }
 
 static PyGetSetDef PyContextTokenType_getsetlist[] = {
-    {"var", (getter)token_get_var, NULL, NULL},
-    {"old_value", (getter)token_get_old_value, NULL, NULL},
+    {"var", _Py_CAST_FUNC(getter, token_get_var), NULL, NULL},
+    {"old_value", _Py_CAST_FUNC(getter, token_get_old_value), NULL, NULL},
     {NULL}
 };
 

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -194,7 +194,7 @@ PyThread_start_new_thread(void (*func)(void *), void *arg)
 #else
                              (pthread_attr_t*)NULL,
 #endif
-                             (void* (*)(void *))func,
+                             _Py_CAST_FUNC(void* (*)(void *), func),
                              (void *)arg
                              );
 

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -155,7 +155,7 @@ static PyMemberDef tb_memberlist[] = {
 };
 
 static PyGetSetDef tb_getsetters[] = {
-    {"tb_next", (getter)tb_next_get, (setter)tb_next_set, NULL, NULL},
+    {"tb_next", _Py_CAST_FUNC(getter, tb_next_get), _Py_CAST_FUNC(setter, tb_next_set), NULL, NULL},
     {NULL}      /* Sentinel */
 };
 
@@ -190,7 +190,7 @@ PyTypeObject PyTraceBack_Type = {
     "traceback",
     sizeof(PyTracebackObject),
     0,
-    (destructor)tb_dealloc, /*tp_dealloc*/
+    _Py_CAST_FUNC(destructor, tb_dealloc), /*tp_dealloc*/
     0,                  /*tp_print*/
     0,    /*tp_getattr*/
     0,                  /*tp_setattr*/
@@ -208,7 +208,7 @@ PyTypeObject PyTraceBack_Type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
     tb_new__doc__,                              /* tp_doc */
     (traverseproc)tb_traverse,                  /* tp_traverse */
-    (inquiry)tb_clear,                          /* tp_clear */
+    _Py_CAST_FUNC(inquiry, tb_clear),                          /* tp_clear */
     0,                                          /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */


### PR DESCRIPTION
Use _Py_CAST_FUNC() to cast functions pointers to getter, setter,
destructor, etc.

Change mostly written in gvim using the command:

    :%s!(\(inquiry\|destructor\|reprfunc\|getter\|setter
     \|releasebufferproc\|getbufferproc\))
     \([A-Za-z0-9_]\+\)
     !_Py_CAST_FUNC(\1, \2)!g

<!--

<!-- issue-number: [bpo-33012](https://bugs.python.org/issue33012) -->
https://bugs.python.org/issue33012
<!-- /issue-number -->
