### PR TITLE
bpo-35240: Travis CI runs doctest without XVFB_RUN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,7 +161,7 @@ script:
     fi
     $XVFB_RUN make buildbottest TESTOPTS="-j4 -uall,-cpu"
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      $XVFB_RUN make PYTHON=../python SPHINXOPTS="-q -W -j4" -C Doc/ venv doctest
+      make PYTHON=../python SPHINXOPTS="-q -W -j4" -C Doc/ venv doctest
     fi
 notifications:
   email: false


### PR DESCRIPTION


<!-- issue-number: [bpo-35240](https://bugs.python.org/issue35240) -->
https://bugs.python.org/issue35240
<!-- /issue-number -->
