### PR TITLE
bpo-35134: Don't define types twice in header files

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -175,8 +175,12 @@ typedef int (*initproc)(PyObject *, PyObject *, PyObject *);
 typedef PyObject *(*newfunc)(struct _typeobject *, PyObject *, PyObject *);
 typedef PyObject *(*allocfunc)(struct _typeobject *, Py_ssize_t);
 
+#ifdef Py_LIMITED_API
 /* In Py_LIMITED_API, PyTypeObject is an opaque structure. */
 typedef struct _typeobject PyTypeObject;
+#else
+/* PyTypeObject is defined in cpython/object.h */
+#endif
 
 typedef struct{
     int slot;    /* slot id, see below */
@@ -196,30 +200,30 @@ PyAPI_FUNC(PyObject*) PyType_FromSpec(PyType_Spec*);
 PyAPI_FUNC(PyObject*) PyType_FromSpecWithBases(PyType_Spec*, PyObject*);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03040000
-PyAPI_FUNC(void*) PyType_GetSlot(PyTypeObject*, int);
+PyAPI_FUNC(void*) PyType_GetSlot(struct _typeobject*, int);
 #endif
 
 /* Generic type check */
-PyAPI_FUNC(int) PyType_IsSubtype(PyTypeObject *, PyTypeObject *);
+PyAPI_FUNC(int) PyType_IsSubtype(struct _typeobject *, struct _typeobject *);
 #define PyObject_TypeCheck(ob, tp) \
     (Py_TYPE(ob) == (tp) || PyType_IsSubtype(Py_TYPE(ob), (tp)))
 
-PyAPI_DATA(PyTypeObject) PyType_Type; /* built-in 'type' */
-PyAPI_DATA(PyTypeObject) PyBaseObject_Type; /* built-in 'object' */
-PyAPI_DATA(PyTypeObject) PySuper_Type; /* built-in 'super' */
+PyAPI_DATA(struct _typeobject) PyType_Type; /* built-in 'type' */
+PyAPI_DATA(struct _typeobject) PyBaseObject_Type; /* built-in 'object' */
+PyAPI_DATA(struct _typeobject) PySuper_Type; /* built-in 'super' */
 
-PyAPI_FUNC(unsigned long) PyType_GetFlags(PyTypeObject*);
+PyAPI_FUNC(unsigned long) PyType_GetFlags(struct _typeobject*);
 
 #define PyType_Check(op) \
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_TYPE_SUBCLASS)
 #define PyType_CheckExact(op) (Py_TYPE(op) == &PyType_Type)
 
-PyAPI_FUNC(int) PyType_Ready(PyTypeObject *);
-PyAPI_FUNC(PyObject *) PyType_GenericAlloc(PyTypeObject *, Py_ssize_t);
-PyAPI_FUNC(PyObject *) PyType_GenericNew(PyTypeObject *,
+PyAPI_FUNC(int) PyType_Ready(struct _typeobject *);
+PyAPI_FUNC(PyObject *) PyType_GenericAlloc(struct _typeobject *, Py_ssize_t);
+PyAPI_FUNC(PyObject *) PyType_GenericNew(struct _typeobject *,
                                                PyObject *, PyObject *);
 PyAPI_FUNC(unsigned int) PyType_ClearCache(void);
-PyAPI_FUNC(void) PyType_Modified(PyTypeObject *);
+PyAPI_FUNC(void) PyType_Modified(struct _typeobject *);
 
 /* Generic operations on objects */
 PyAPI_FUNC(PyObject *) PyObject_Repr(PyObject *);
@@ -397,8 +401,8 @@ PyAPI_FUNC(void) _PyDebug_PrintTotalRefs(void);
 #endif /* Py_REF_DEBUG */
 
 #ifdef COUNT_ALLOCS
-PyAPI_FUNC(void) _Py_inc_count(PyTypeObject *);
-PyAPI_FUNC(void) _Py_dec_count(PyTypeObject *);
+PyAPI_FUNC(void) _Py_inc_count(struct _typeobject *);
+PyAPI_FUNC(void) _Py_dec_count(struct _typeobject *);
 #define _Py_INC_TPALLOCS(OP)    _Py_inc_count(Py_TYPE(OP))
 #define _Py_INC_TPFREES(OP)     _Py_dec_count(Py_TYPE(OP))
 #define _Py_DEC_TPFREES(OP)     Py_TYPE(OP)->tp_frees--

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -14,25 +14,28 @@ extern "C" {
 removed (with effort). */
 #define MAX_CO_EXTRA_USERS 255
 
-/* State shared between threads */
+/* Forward declarations for PyFrameObject, PyThreadState
+   and PyInterpreterState */
+struct _frame;
+struct _ts;
+struct _is;
 
-struct _ts; /* Forward */
-struct _is; /* Forward */
-struct _frame; /* Forward declaration for PyFrameObject. */
-
+#ifdef Py_LIMITED_API
+typedef struct _ts PyThreadState;
 typedef struct _is PyInterpreterState;
+#else
+/* PyThreadState and PyInterpreterState are defined in cpython/pystate.h */
+#endif
 
 /* State unique per thread */
 
-typedef struct _ts PyThreadState;
-
-PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_New(void);
-PyAPI_FUNC(void) PyInterpreterState_Clear(PyInterpreterState *);
-PyAPI_FUNC(void) PyInterpreterState_Delete(PyInterpreterState *);
+PyAPI_FUNC(struct _is *) PyInterpreterState_New(void);
+PyAPI_FUNC(void) PyInterpreterState_Clear(struct _is *);
+PyAPI_FUNC(void) PyInterpreterState_Delete(struct _is *);
 
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
 /* New in 3.7 */
-PyAPI_FUNC(int64_t) PyInterpreterState_GetID(PyInterpreterState *);
+PyAPI_FUNC(int64_t) PyInterpreterState_GetID(struct _is *);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 /* New in 3.3 */
@@ -41,9 +44,9 @@ PyAPI_FUNC(int) PyState_RemoveModule(struct PyModuleDef*);
 #endif
 PyAPI_FUNC(PyObject*) PyState_FindModule(struct PyModuleDef*);
 
-PyAPI_FUNC(PyThreadState *) PyThreadState_New(PyInterpreterState *);
-PyAPI_FUNC(void) PyThreadState_Clear(PyThreadState *);
-PyAPI_FUNC(void) PyThreadState_Delete(PyThreadState *);
+PyAPI_FUNC(struct _ts *) PyThreadState_New(struct _is *);
+PyAPI_FUNC(void) PyThreadState_Clear(struct _ts *);
+PyAPI_FUNC(void) PyThreadState_Delete(struct _ts *);
 PyAPI_FUNC(void) PyThreadState_DeleteCurrent(void);
 
 /* Get the current thread state.
@@ -54,7 +57,7 @@ PyAPI_FUNC(void) PyThreadState_DeleteCurrent(void);
    The caller must hold the GIL.
 
    See also PyThreadState_GET() and _PyThreadState_GET(). */
-PyAPI_FUNC(PyThreadState *) PyThreadState_Get(void);
+PyAPI_FUNC(struct _ts *) PyThreadState_Get(void);
 
 /* Get the current Python thread state.
 
@@ -67,7 +70,7 @@ PyAPI_FUNC(PyThreadState *) PyThreadState_Get(void);
    See also PyThreadState_Get() and _PyThreadState_GET(). */
 #define PyThreadState_GET() PyThreadState_Get()
 
-PyAPI_FUNC(PyThreadState *) PyThreadState_Swap(PyThreadState *);
+PyAPI_FUNC(struct _ts *) PyThreadState_Swap(struct _ts *);
 PyAPI_FUNC(PyObject *) PyThreadState_GetDict(void);
 PyAPI_FUNC(int) PyThreadState_SetAsyncExc(unsigned long, PyObject *);
 
@@ -115,7 +118,7 @@ PyAPI_FUNC(void) PyGILState_Release(PyGILState_STATE);
    thread-state, even if no auto-thread-state call has been made
    on the main thread.
 */
-PyAPI_FUNC(PyThreadState *) PyGILState_GetThisThreadState(void);
+PyAPI_FUNC(struct _ts *) PyGILState_GetThisThreadState(void);
 
 
 #ifndef Py_LIMITED_API


### PR DESCRIPTION
Fix the following clang warning:

    Include/cpython/pystate.h:217:3: warning: redefinition of
    typedef 'PyThreadState' is a C11 feature [-Wtypedef-redefinition]

<!-- issue-number: [bpo-35134](https://bugs.python.org/issue35134) -->
https://bugs.python.org/issue35134
<!-- /issue-number -->
