### PR TITLE
bpo-34523, bpo-35322: Fix unicode_encode_locale()

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3290,9 +3290,9 @@ class LocaleCodecTest(unittest.TestCase):
                     expected = text.encode(self.ENCODING, errors)
                 except UnicodeEncodeError:
                     with self.assertRaises(RuntimeError) as cm:
-                        self.encode(self.SURROGATES)
+                        self.encode(text, errors)
                     errmsg = str(cm.exception)
-                    self.assertTrue(errmsg.startswith("encode error: pos=0, reason="), errmsg)
+                    self.assertRegex(errmsg, r"encode error: pos=[0-9]+, reason=")
                 else:
                     encoded = self.encode(text, errors)
                     self.assertEqual(encoded, expected)
@@ -3314,6 +3314,11 @@ class LocaleCodecTest(unittest.TestCase):
                 raise
 
         self.check_encode_strings("surrogatepass")
+
+    def test_encode_unsupported_error_handler(self):
+        with self.assertRaises(ValueError) as cm:
+            self.encode('', 'backslashreplace')
+        self.assertEqual(str(cm.exception), 'unsupported error handler')
 
     def decode(self, encoded, errors="strict"):
         return _testcapi.DecodeLocaleEx(encoded, 0, errors)
@@ -3369,6 +3374,11 @@ class LocaleCodecTest(unittest.TestCase):
                 raise
 
         self.check_decode_strings("surrogatepass")
+
+    def test_decode_unsupported_error_handler(self):
+        with self.assertRaises(ValueError) as cm:
+            self.decode(b'', 'backslashreplace')
+        self.assertEqual(str(cm.exception), 'unsupported error handler')
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/C API/2018-11-28-03-20-36.bpo-35322.Qcqsag.rst
+++ b/Misc/NEWS.d/next/C API/2018-11-28-03-20-36.bpo-35322.Qcqsag.rst
@@ -1,0 +1,2 @@
+Fix memory leak in :c:func:`PyUnicode_EncodeLocale` and
+:c:func:`PyUnicode_EncodeFSDefault` on error handling.


### PR DESCRIPTION
Fix memory leak in PyUnicode_EncodeLocale() and
PyUnicode_EncodeFSDefault() on error handling.

Changes:

* Fix unicode_encode_locale() error handling
* Fix test_codecs.LocaleCodecTest

<!-- issue-number: [bpo-34523](https://bugs.python.org/issue34523) -->
https://bugs.python.org/issue34523
<!-- /issue-number -->
