### PR TITLE
[3.7] bpo-34523, bpo-35322: Fix unicode_encode_locale() (GH-10759)

### DIFF
--- a/Misc/NEWS.d/next/C API/2018-11-28-03-20-36.bpo-35322.Qcqsag.rst
+++ b/Misc/NEWS.d/next/C API/2018-11-28-03-20-36.bpo-35322.Qcqsag.rst
@@ -1,0 +1,2 @@
+Fix memory leak in :c:func:`PyUnicode_EncodeLocale` and
+:c:func:`PyUnicode_EncodeFSDefault` on error handling.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3391,10 +3391,9 @@ unicode_encode_locale(PyObject *unicode, const char *errors,
         return NULL;
     }
 
-    Py_ssize_t wlen2 = wcslen(wstr);
-    if (wlen2 != wlen) {
-        PyMem_Free(wstr);
+    if ((size_t)wlen != wcslen(wstr)) {
         PyErr_SetString(PyExc_ValueError, "embedded null character");
+        PyMem_Free(wstr);
         return NULL;
     }
 
@@ -3403,6 +3402,8 @@ unicode_encode_locale(PyObject *unicode, const char *errors,
     const char *reason;
     int res = _Py_EncodeLocaleEx(wstr, &str, &error_pos, &reason,
                                  current_locale, surrogateescape);
+    PyMem_Free(wstr);
+
     if (res != 0) {
         if (res == -2) {
             PyObject *exc;
@@ -3415,15 +3416,12 @@ unicode_encode_locale(PyObject *unicode, const char *errors,
                 PyCodec_StrictErrors(exc);
                 Py_DECREF(exc);
             }
-            return NULL;
         }
         else {
             PyErr_NoMemory();
-            PyMem_Free(wstr);
-            return NULL;
         }
+        return NULL;
     }
-    PyMem_Free(wstr);
 
     PyObject *bytes = PyBytes_FromString(str);
     PyMem_RawFree(str);


### PR DESCRIPTION
Fix memory leak in PyUnicode_EncodeLocale() and
PyUnicode_EncodeFSDefault() on error handling.

Fix unicode_encode_locale() error handling.

(cherry picked from commit bde9d6bbb46ca59bcee5d5060adaa33c3ffee3a6)

<!-- issue-number: [bpo-34523](https://bugs.python.org/issue34523) -->
https://bugs.python.org/issue34523
<!-- /issue-number -->
