### PR TITLE
bpo-34100: merge_consts_recursive() merges frozenset

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -615,6 +615,16 @@ if 1:
         self.check_constant(f1, Ellipsis)
         self.assertEqual(repr(f1()), repr(Ellipsis))
 
+        # Merge constants in tuple or frozenset
+        # NOTE: frozenset can't reuse previous const, but frozenset
+        # item can be reused later.
+        f3 = lambda x: x in {("not a name",)}
+        f1, f2 = lambda: "not a name", lambda: ("not a name",)
+        self.assertIs(next(iter(f3.__code__.co_consts[1])),
+                      f2.__code__.co_consts[1])
+        self.assertIs(f1.__code__.co_consts[1],
+                      f2.__code__.co_consts[1][0])
+
         # {0} is converted to a constant frozenset({0}) by the peephole
         # optimizer
         f1, f2 = lambda x: x in {0}, lambda x: x in {0}


### PR DESCRIPTION
merge_consts_recursive() now also merges frozenset. It now merges
items before merging containers (tuple and frozenset).

<!-- issue-number: [bpo-34100](https://bugs.python.org/issue34100) -->
https://bugs.python.org/issue34100
<!-- /issue-number -->
