### PR TITLE
CI, FIX remove spurious quote in azure script

### DIFF
--- a/.azure-pipelines/posix-steps.yml
+++ b/.azure-pipelines/posix-steps.yml
@@ -26,7 +26,7 @@ steps:
       xvfb-run ./venv/bin/python -m coverage run --pylib -m test \
                 --fail-env-changed \
                 -uall,-cpu \
-                --junit-xml=$(build.binariesDirectory)/test-results.xml" \
+                --junit-xml=$(build.binariesDirectory)/test-results.xml \
                 -x test_multiprocessing_fork \
                 -x test_multiprocessing_forkserver \
                 -x test_multiprocessing_spawn \


### PR DESCRIPTION
# CI, FIX remove spurious quote in azure script
Does not deserve an issue to me, although it seems that this command would not run if actually executed (i.e coverage turned to `true` in this script)