### PR TITLE
bpo-35134: Create Include/cpython/tupleobject.h

### DIFF
--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -1,0 +1,36 @@
+#ifndef Py_CPYTHON_TUPLEOBJECT_H
+#  error "this header file must not be included directly"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    PyObject_VAR_HEAD
+    /* ob_item contains space for 'ob_size' elements.
+       Items must normally not be NULL, except during construction when
+       the tuple is not yet visible outside the function that builds it. */
+    PyObject *ob_item[1];
+} PyTupleObject;
+
+PyAPI_FUNC(int) _PyTuple_Resize(PyObject **, Py_ssize_t);
+PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
+
+/* Macros trading safety for speed */
+
+/* Cast argument to PyTupleObject* type. */
+#define _PyTuple_CAST(op) (assert(PyTuple_Check(op)), (PyTupleObject *)(op))
+
+#define PyTuple_GET_SIZE(op)    Py_SIZE(_PyTuple_CAST(op))
+
+#define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
+
+/* Macro, *only* to be used to fill in brand new tuples */
+#define PyTuple_SET_ITEM(op, i, v) (_PyTuple_CAST(op)->ob_item[i] = v)
+
+PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Include/tupleobject.h
+++ b/Include/tupleobject.h
@@ -1,4 +1,3 @@
-
 /* Tuple object interface */
 
 #ifndef Py_TUPLEOBJECT_H
@@ -21,18 +20,6 @@ inserted in the tuple.  Similarly, PyTuple_GetItem does not increment the
 returned item's reference count.
 */
 
-#ifndef Py_LIMITED_API
-typedef struct {
-    PyObject_VAR_HEAD
-    PyObject *ob_item[1];
-
-    /* ob_item contains space for 'ob_size' elements.
-     * Items must normally not be NULL, except during construction when
-     * the tuple is not yet visible outside the function that builds it.
-     */
-} PyTupleObject;
-#endif
-
 PyAPI_DATA(PyTypeObject) PyTuple_Type;
 PyAPI_DATA(PyTypeObject) PyTupleIter_Type;
 
@@ -45,30 +32,15 @@ PyAPI_FUNC(Py_ssize_t) PyTuple_Size(PyObject *);
 PyAPI_FUNC(PyObject *) PyTuple_GetItem(PyObject *, Py_ssize_t);
 PyAPI_FUNC(int) PyTuple_SetItem(PyObject *, Py_ssize_t, PyObject *);
 PyAPI_FUNC(PyObject *) PyTuple_GetSlice(PyObject *, Py_ssize_t, Py_ssize_t);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(int) _PyTuple_Resize(PyObject **, Py_ssize_t);
-#endif
 PyAPI_FUNC(PyObject *) PyTuple_Pack(Py_ssize_t, ...);
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
-#endif
-
-/* Macro, trading safety for speed */
-#ifndef Py_LIMITED_API
-/* Cast argument to PyTupleObject* type. */
-#define _PyTuple_CAST(op) (assert(PyTuple_Check(op)), (PyTupleObject *)(op))
-
-#define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
-#define PyTuple_GET_SIZE(op)    Py_SIZE(_PyTuple_CAST(op))
-
-/* Macro, *only* to be used to fill in brand new tuples */
-#define PyTuple_SET_ITEM(op, i, v) (_PyTuple_CAST(op)->ob_item[i] = v)
-#endif
 
 PyAPI_FUNC(int) PyTuple_ClearFreeList(void);
+
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);
-#endif /* Py_LIMITED_API */
+#  define Py_CPYTHON_TUPLEOBJECT_H
+#  include  "cpython/tupleobject.h"
+#  undef Py_CPYTHON_TUPLEOBJECT_H
+#endif
 
 #ifdef __cplusplus
 }

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1027,7 +1027,15 @@ PYTHON_HEADERS= \
 		$(PARSER_HEADERS) \
 		$(srcdir)/Include/Python-ast.h \
 		\
+		$(srcdir)/Include/cpython/abstract.h \
+		$(srcdir)/Include/cpython/dictobject.h \
+		$(srcdir)/Include/cpython/object.h \
 		$(srcdir)/Include/cpython/objimpl.h \
+		$(srcdir)/Include/cpython/pyerrors.h \
+		$(srcdir)/Include/cpython/pylifecycle.h \
+		$(srcdir)/Include/cpython/pystate.h \
+		$(srcdir)/Include/cpython/tupleobject.h \
+		$(srcdir)/Include/cpython/unicodeobject.h \
 		\
 		$(srcdir)/Include/internal/pycore_accu.h \
 		$(srcdir)/Include/internal/pycore_atomic.h \

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -95,7 +95,15 @@
     <ClInclude Include="..\Include\complexobject.h" />
     <ClInclude Include="..\Include\context.h" />
     <ClInclude Include="..\Include\coreconfig.h" />
+    <ClInclude Include="..\Include\cpython\abstract.h" />
+    <ClInclude Include="..\Include\cpython\dictobject.h" />
+    <ClInclude Include="..\Include\cpython\object.h" />
     <ClInclude Include="..\Include\cpython\objimpl.h" />
+    <ClInclude Include="..\Include\cpython\pyerrors.h" />
+    <ClInclude Include="..\Include\cpython\pylifecycle.h" />
+    <ClInclude Include="..\Include\cpython\pystate.h" />
+    <ClInclude Include="..\Include\cpython\tupleobject.h" />
+    <ClInclude Include="..\Include\cpython\unicodeobject.h" />
     <ClInclude Include="..\Include\datetime.h" />
     <ClInclude Include="..\Include\descrobject.h" />
     <ClInclude Include="..\Include\dictobject.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -84,7 +84,31 @@
     <ClInclude Include="..\Include\coreconfig.h">
       <Filter>Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\cpython\abstract.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\cpython\dictobject.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\cpython\object.h">
+      <Filter>Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\cpython\objimpl.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\cpython\pyerrors.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\cpython\pylifecycle.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\cpython\pystate.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\cpython\tupleobject.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\cpython\unicodeobject.h">
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\datetime.h">


### PR DESCRIPTION
Move tupleobject.h code surrounded by "#ifndef Py_LIMITED_API"
to a new Include/cpython/tupleobject.h header file.

Add cpython/ header files to Makefile.pre.in and pythoncore project
of PCbuild.

<!-- issue-number: [bpo-35134](https://bugs.python.org/issue35134) -->
https://bugs.python.org/issue35134
<!-- /issue-number -->
