### PR TITLE
bpo-35337: Fix gettmarg(): use PyStructSequence_GET_ITEM()

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -568,7 +568,7 @@ gettmarg(PyObject *args, struct tm *p, const char *format)
 #ifdef HAVE_STRUCT_TM_TM_ZONE
     if (Py_TYPE(args) == &StructTimeType) {
         PyObject *item;
-        item = PyTuple_GET_ITEM(args, 9);
+        item = PyStructSequence_GET_ITEM(args, 9);
         if (item != Py_None) {
             p->tm_zone = (char *)PyUnicode_AsUTF8(item);
             if (p->tm_zone == NULL) {
@@ -589,7 +589,7 @@ gettmarg(PyObject *args, struct tm *p, const char *format)
             }
 #endif
         }
-        item = PyTuple_GET_ITEM(args, 10);
+        item = PyStructSequence_GET_ITEM(args, 10);
         if (item != Py_None) {
             p->tm_gmtoff = PyLong_AsLong(item);
             if (PyErr_Occurred())


### PR DESCRIPTION
PyStructSequence_GET_ITEM() must be used instead of
PyTuple_GET_ITEM() on a StructTimeType.

<!-- issue-number: [bpo-35337](https://bugs.python.org/issue35337) -->
https://bugs.python.org/issue35337
<!-- /issue-number -->
