### PR TITLE
bpo-35337: PyTuple_GET_ITEM() now checks the index

### DIFF
--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -62,7 +62,8 @@ Tuple Objects
 
 .. c:function:: PyObject* PyTuple_GET_ITEM(PyObject *p, Py_ssize_t pos)
 
-   Like :c:func:`PyTuple_GetItem`, but does no checking of its arguments.
+   Like :c:func:`PyTuple_GetItem`, but does no checking of its arguments (in
+   release mode).
 
 
 .. c:function:: PyObject* PyTuple_GetSlice(PyObject *p, Py_ssize_t low, Py_ssize_t high)
@@ -83,12 +84,15 @@ Tuple Objects
 
 .. c:function:: void PyTuple_SET_ITEM(PyObject *p, Py_ssize_t pos, PyObject *o)
 
-   Like :c:func:`PyTuple_SetItem`, but does no error checking, and should *only* be
-   used to fill in brand new tuples.
+   Like :c:func:`PyTuple_SetItem`, but does no error checking (in release
+   mode), and should *only* be used to fill in brand new tuples.
 
    .. note::
 
       This function "steals" a reference to *o*.
+
+   .. versionchanged:: 3.8
+      Arguments are now checked in debug mode.
 
 
 .. c:function:: int _PyTuple_Resize(PyObject **p, Py_ssize_t newsize)
@@ -196,6 +200,9 @@ type.
 .. c:function:: PyObject* PyStructSequence_GET_ITEM(PyObject *p, Py_ssize_t pos)
 
    Macro equivalent of :c:func:`PyStructSequence_GetItem`.
+
+   .. versionchanged:: 3.8
+      Arguments are now checked in debug mode.
 
 
 .. c:function:: void PyStructSequence_SetItem(PyObject *p, Py_ssize_t pos, PyObject *o)

--- a/Include/cpython/tupleobject.h
+++ b/Include/cpython/tupleobject.h
@@ -17,17 +17,29 @@ typedef struct {
 PyAPI_FUNC(int) _PyTuple_Resize(PyObject **, Py_ssize_t);
 PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 
-/* Macros trading safety for speed */
+/* Macros and inline functions trading safety for speed */
 
 /* Cast argument to PyTupleObject* type. */
 #define _PyTuple_CAST(op) (assert(PyTuple_Check(op)), (PyTupleObject *)(op))
 
 #define PyTuple_GET_SIZE(op)    Py_SIZE(_PyTuple_CAST(op))
 
-#define PyTuple_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
+static inline PyObject* _PyTuple_GET_ITEM(PyTupleObject *op, Py_ssize_t i)
+{
+    assert(0 <= i && i < Py_SIZE(op));
+    return op->ob_item[i];
+}
+
+#define PyTuple_GET_ITEM(op, i) _PyTuple_GET_ITEM(_PyTuple_CAST(op), i)
+
+static inline void _PyTuple_SET_ITEM(PyTupleObject *op, Py_ssize_t i, PyObject *item)
+{
+    assert(0 <= i && i < Py_SIZE(op));
+    op->ob_item[i] = item;
+}
 
 /* Macro, *only* to be used to fill in brand new tuples */
-#define PyTuple_SET_ITEM(op, i, v) (_PyTuple_CAST(op)->ob_item[i] = v)
+#define PyTuple_SET_ITEM(op, i, v) _PyTuple_SET_ITEM(_PyTuple_CAST(op), i, v)
 
 PyAPI_FUNC(void) _PyTuple_DebugMallocStats(FILE *out);
 

--- a/Include/structseq.h
+++ b/Include/structseq.h
@@ -34,10 +34,15 @@ PyAPI_FUNC(PyObject *) PyStructSequence_New(PyTypeObject* type);
 #ifndef Py_LIMITED_API
 typedef PyTupleObject PyStructSequence;
 
-/* Macro, *only* to be used to fill in brand new objects */
-#define PyStructSequence_SET_ITEM(op, i, v) PyTuple_SET_ITEM(op, i, v)
+/* Macro, *only* to be used to fill in brand new objects.
 
-#define PyStructSequence_GET_ITEM(op, i) PyTuple_GET_ITEM(op, i)
+   PyTuple_SET_ITEM() checks the size and so cannot be used here, since a
+   structseq with unnamed fields can be smaller size than the real size. */
+#define PyStructSequence_SET_ITEM(op, i, v) (_PyTuple_CAST(op)->ob_item[i] = v)
+
+/* PyTuple_GET_ITEM() checks the size and so cannot be used here, since a
+   structseq with unnamed fields can be smaller size than the real size. */
+#define PyStructSequence_GET_ITEM(op, i) (_PyTuple_CAST(op)->ob_item[i])
 #endif
 
 PyAPI_FUNC(void) PyStructSequence_SetItem(PyObject*, Py_ssize_t, PyObject*);

--- a/Misc/NEWS.d/next/C API/2018-11-28-16-24-00.bpo-35337.Z55QFz.rst
+++ b/Misc/NEWS.d/next/C API/2018-11-28-16-24-00.bpo-35337.Z55QFz.rst
@@ -1,0 +1,2 @@
+:c:func:`PyTuple_GET_ITEM` and :c:func:`PyTuple_SET_ITEM` now check the
+index using an assertion.


### PR DESCRIPTION
PyTuple_GET_ITEM() and PyTuple_SET_ITEM() now check the index using
an assertion.

<!-- issue-number: [bpo-35337](https://bugs.python.org/issue35337) -->
https://bugs.python.org/issue35337
<!-- /issue-number -->
