### PR TITLE
[3.7] bpo-34921: Allow escaped NoReturn in get_type_hints (GH-9750)

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -130,7 +130,7 @@ def _type_check(arg, msg, is_argument=True):
     if (isinstance(arg, _GenericAlias) and
             arg.__origin__ in invalid_generic_forms):
         raise TypeError(f"{arg} is not valid as type argument")
-    if (isinstance(arg, _SpecialForm) and arg is not Any or
+    if (isinstance(arg, _SpecialForm) and arg not in (Any, NoReturn) or
             arg in (Generic, _Protocol)):
         raise TypeError(f"Plain {arg} is not valid as type argument")
     if isinstance(arg, (type, TypeVar, ForwardRef)):


### PR DESCRIPTION
Backport the bugfix from master to 3.7.
I ran into the problem at work today again and would love to have the fix in 3.7.2.

This bug only happens with `from __future__ import annotations`, so backporting to other branches won't make sense.

Original PR description:
[bpo-34921](https://bugs.python.org/issue34921): Modified line 133 in Lib/typing.py to fix get_type_hints(NoReturn)

https://bugs.python.org/issue34921

PS: Just signed CLA as well.

<!-- issue-number: [bpo-34921](https://bugs.python.org/issue34921) -->
https://bugs.python.org/issue34921
<!-- /issue-number -->
