### PR TITLE
bpo-35344: platform.platform() uses mac_ver() on macOS

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -79,6 +79,11 @@ Cross Platform
    Setting *terse* to true causes the function to return only the absolute minimum
    information needed to identify the platform.
 
+   .. versionchanged:: 3.8
+      On macOS, the function now uses :func:`mac_ver`, if it returns a
+      non-empty release string, to get the macOS version rather than the darwin
+      version.
+
 
 .. function:: processor()
 

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -1167,6 +1167,14 @@ def platform(aliased=0, terse=0):
     if aliased:
         system, release, version = system_alias(system, release, version)
 
+    if system == 'Darwin':
+        # macOS (darwin kernel)
+        macos_release = mac_ver()[0]
+        if macos_release:
+            # note: 'macOS' is different than 'MacOS' used below
+            system = 'macOS'
+            release = macos_release
+
     if system == 'Windows':
         # MS platforms
         rel, vers, csd, ptype = win32_ver(version)

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -4,10 +4,16 @@ import subprocess
 import sys
 import sysconfig
 import unittest
+from unittest import mock
 
 from test import support
 
 class PlatformTest(unittest.TestCase):
+    def clear_caches(self):
+        platform._platform_cache.clear()
+        platform._sys_version_cache.clear()
+        platform._uname_cache = None
+
     def test_architecture(self):
         res = platform.architecture()
 
@@ -313,6 +319,34 @@ class PlatformTest(unittest.TestCase):
         self.assertLess(V('0.4'), V('0.4.0'))
         self.assertLess(V('1.13++'), V('5.5.kw'))
         self.assertLess(V('0.960923'), V('2.2beta29'))
+
+
+    def test_macos(self):
+        self.addCleanup(self.clear_caches)
+
+        uname = ('Darwin', 'hostname', '17.7.0',
+                 ('Darwin Kernel Version 17.7.0: '
+                  'Thu Jun 21 22:53:14 PDT 2018; '
+                  'root:xnu-4570.71.2~1/RELEASE_X86_64'),
+                 'x86_64', 'i386')
+        arch = ('64bit', '')
+        with mock.patch.object(platform, 'uname', return_value=uname), \
+             mock.patch.object(platform, 'architecture', return_value=arch):
+            for mac_ver, expected_terse, expected in [
+                # darwin: mac_ver() returns empty strings
+                (('', '', ''),
+                 'Darwin-17.7.0',
+                 'Darwin-17.7.0-x86_64-i386-64bit'),
+                # macOS: mac_ver() returns macOS version
+                (('10.13.6', ('', '', ''), 'x86_64'),
+                 'macOS-10.13.6',
+                 'macOS-10.13.6-x86_64-i386-64bit'),
+            ]:
+                with mock.patch.object(platform, 'mac_ver',
+                                       return_value=mac_ver):
+                    self.clear_caches()
+                    self.assertEqual(platform.platform(terse=1), expected_terse)
+                    self.assertEqual(platform.platform(), expected)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2018-11-29-00-23-25.bpo-35344.4QOPJQ.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-29-00-23-25.bpo-35344.4QOPJQ.rst
@@ -1,0 +1,3 @@
+On macOS, :func:`platform.platform` now uses :func:`platform.mac_ver`, if it
+returns a non-empty release string, to get the macOS version rather than the
+darwin version.


### PR DESCRIPTION
On macOS, platform.platform() now uses mac_ver(), if it returns a
non-empty release string, to get the macOS version rather than darwin
version.

<!-- issue-number: [bpo-35344](https://bugs.python.org/issue35344) -->
https://bugs.python.org/issue35344
<!-- /issue-number -->
