### PR TITLE
bpo-35345: Remove platform.popen()

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -212,20 +212,6 @@ Windows Platform
       only runs on Win32 compatible platforms.
 
 
-Win95/98 specific
-^^^^^^^^^^^^^^^^^
-
-.. function:: popen(cmd, mode='r', bufsize=-1)
-
-   Portable :func:`popen` interface.  Find a working popen implementation
-   preferring :func:`win32pipe.popen`.  On Windows NT, :func:`win32pipe.popen`
-   should work; on Windows 9x it hangs due to bugs in the MS C library.
-
-   .. deprecated:: 3.3
-      This function is obsolete.  Use the :mod:`subprocess` module.  Check
-      especially the :ref:`subprocess-replacements` section.
-
-
 Mac OS Platform
 ---------------
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -175,6 +175,13 @@ characters or bytes unrepresentable at the OS level.
 (Contributed by Serhiy Storchaka in :issue:`33721`.)
 
 
+platform
+--------
+
+The function `platform.popen` has been removed, it was deprecated since Python
+3.3: use :func:`os.popen` instead.
+
+
 ncurses
 -------
 
@@ -413,6 +420,9 @@ Changes in Python behavior
 
 Changes in the Python API
 -------------------------
+
+* The function `platform.popen` has been removed, it was deprecated since
+  Python 3.3: use :func:`os.popen` instead.
 
 * The :meth:`~tkinter.ttk.Treeview.selection` method of the
   :class:`tkinter.ttk.Treeview` class no longer takes arguments.  Using it with

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -175,13 +175,6 @@ characters or bytes unrepresentable at the OS level.
 (Contributed by Serhiy Storchaka in :issue:`33721`.)
 
 
-platform
---------
-
-The function :func:`platform.popen` has been removed, it was deprecated since
-Python 3.3: use :func:`os.popen` instead.
-
-
 ncurses
 -------
 
@@ -380,8 +373,13 @@ Deprecated
   (Contributed by Serhiy Storchaka in :issue:`33710`.)
 
 
-Removed
-=======
+API and Feature Removals
+========================
+
+The following features and APIs have been removed from Python 3.8:
+
+* The function :func:`platform.popen` has been removed, it was deprecated since
+  Python 3.3: use :func:`os.popen` instead.
 
 * The ``pyvenv`` script has been removed in favor of ``python3.8 -m venv``
   to help eliminate confusion as to what Python interpreter the ``pyvenv``

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -178,8 +178,8 @@ characters or bytes unrepresentable at the OS level.
 platform
 --------
 
-The function `platform.popen` has been removed, it was deprecated since Python
-3.3: use :func:`os.popen` instead.
+The function :func:`platform.popen` has been removed, it was deprecated since
+Python 3.3: use :func:`os.popen` instead.
 
 
 ncurses
@@ -421,7 +421,7 @@ Changes in Python behavior
 Changes in the Python API
 -------------------------
 
-* The function `platform.popen` has been removed, it was deprecated since
+* The function :func:`platform.popen` has been removed, it was deprecated since
   Python 3.3: use :func:`os.popen` instead.
 
 * The :meth:`~tkinter.ttk.Treeview.selection` method of the

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -275,15 +275,6 @@ def _dist_try_harder(distname, version, id):
 
     return distname, version, id
 
-def popen(cmd, mode='r', bufsize=-1):
-
-    """ Portable popen() interface.
-    """
-    import warnings
-    warnings.warn('use os.popen instead', DeprecationWarning, stacklevel=2)
-    return os.popen(cmd, mode, bufsize)
-
-
 def _norm_version(version, build=''):
 
     """ Normalize the version and build strings and return a single

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -3,9 +3,7 @@ import platform
 import subprocess
 import sys
 import sysconfig
-import tempfile
 import unittest
-import warnings
 
 from test import support
 
@@ -316,37 +314,6 @@ class PlatformTest(unittest.TestCase):
         self.assertLess(V('1.13++'), V('5.5.kw'))
         self.assertLess(V('0.960923'), V('2.2beta29'))
 
-    def test_popen(self):
-        mswindows = (sys.platform == "win32")
-
-        if mswindows:
-            command = '"{}" -c "print(\'Hello\')"'.format(sys.executable)
-        else:
-            command = "'{}' -c 'print(\"Hello\")'".format(sys.executable)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            with platform.popen(command) as stdout:
-                hello = stdout.read().strip()
-                stdout.close()
-                self.assertEqual(hello, "Hello")
-
-        data = 'plop'
-        if mswindows:
-            command = '"{}" -c "import sys; data=sys.stdin.read(); exit(len(data))"'
-        else:
-            command = "'{}' -c 'import sys; data=sys.stdin.read(); exit(len(data))'"
-        command = command.format(sys.executable)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            with platform.popen(command, 'w') as stdin:
-                stdout = stdin.write(data)
-                ret = stdin.close()
-                self.assertIsNotNone(ret)
-                if os.name == 'nt':
-                    returncode = ret
-                else:
-                    returncode = ret >> 8
-                self.assertEqual(returncode, len(data))
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-11-29-00-55-33.bpo-35345.vepCSJ.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-29-00-55-33.bpo-35345.vepCSJ.rst
@@ -1,0 +1,2 @@
+The function `platform.popen` has been removed, it was deprecated since Python
+3.3: use :func:`os.popen` instead.


### PR DESCRIPTION
Remove platform.popen() function, it was deprecated since Python 3.3:
use os.popen() instead.

<!-- issue-number: [bpo-35345](https://bugs.python.org/issue35345) -->
https://bugs.python.org/issue35345
<!-- /issue-number -->
