### PR TITLE
bpo-35189, bpo-35316: Make test_eintr less strict

### DIFF
--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -69,8 +69,6 @@ class EINTRBaseTest(unittest.TestCase):
         signal.signal(signal.SIGALRM, self.orig_handler)
         if hasattr(faulthandler, 'cancel_dump_traceback_later'):
             faulthandler.cancel_dump_traceback_later()
-        # make sure that at least one signal has been received
-        self.assertGreater(self.signals, 0)
 
     def subprocess(self, *args, **kw):
         cmd_args = (sys.executable, '-c') + args


### PR DESCRIPTION
test_eintr no longer fails if the signal handler has not been called.

<!-- issue-number: [bpo-35189](https://bugs.python.org/issue35189) -->
https://bugs.python.org/issue35189
<!-- /issue-number -->
