### PR TITLE
bpo-30681: Support invalid date format or value in email Date header

### DIFF
--- a/Doc/library/email.utils.rst
+++ b/Doc/library/email.utils.rst
@@ -124,7 +124,10 @@ of the new API.
 .. function:: parsedate_to_datetime(date)
 
    The inverse of :func:`format_datetime`.  Performs the same function as
-   :func:`parsedate`, but on success returns a :mod:`~datetime.datetime`.  If
+   :func:`parsedate`, but on success returns a :mod:`~datetime.datetime`;
+   otherwise ``None`` may be returned if parsing fails, or a ``ValueError``
+   raised if *date* contains an invalid value such as an hour greater than
+   23 or a timezone offset not between -24 and 24 hours.  If
    the input date has a timezone of ``-0000``, the ``datetime`` will be a naive
    ``datetime``, and if the date is conforming to the RFCs it will represent a
    time in UTC but with no indication of the actual source timezone of the

--- a/Lib/email/errors.py
+++ b/Lib/email/errors.py
@@ -108,3 +108,6 @@ class NonASCIILocalPartDefect(HeaderDefect):
     """local_part contains non-ASCII characters"""
     # This defect only occurs during unicode parsing, not when
     # parsing messages decoded from binary.
+
+class InvalidDateDefect(HeaderDefect):
+    """Header has unparseable or invalid date"""

--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -307,7 +307,7 @@ class DateHeader:
             try:
                 value = utils.parsedate_to_datetime(value)
             except (ValueError, TypeError):
-                kwds['defects'].append(errors.InvalidHeaderDefect('Invalid date value or format'))
+                kwds['defects'].append(errors.InvalidDateDefect('Invalid date value or format'))
                 kwds['datetime'] = None
                 kwds['parse_tree'] = parser.TokenList()
                 return

--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -303,7 +303,14 @@ class DateHeader:
             kwds['parse_tree'] = parser.TokenList()
             return
         if isinstance(value, str):
-            value = utils.parsedate_to_datetime(value)
+            kwds['decoded'] = value
+            try:
+                value = utils.parsedate_to_datetime(value)
+            except (ValueError, TypeError):
+                kwds['defects'].append(errors.InvalidHeaderDefect('Invalid date value or format'))
+                kwds['datetime'] = None
+                kwds['parse_tree'] = parser.TokenList()
+                return
         kwds['datetime'] = value
         kwds['decoded'] = utils.format_datetime(kwds['datetime'])
         kwds['parse_tree'] = cls.value_parser(kwds['decoded'])

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -209,7 +209,7 @@ class TestDateHeader(TestHeaderBase):
         self.assertEqual(h, s)
         self.assertIsNone(h.datetime)
         self.assertEqual(len(h.defects), 1)
-        self.assertIsInstance(h.defects[0], errors.InvalidHeaderDefect)
+        self.assertIsInstance(h.defects[0], errors.InvalidDateDefect)
 
     def test_invalid_date_value(self):
         s = 'Tue, 06 Jun 2017 27:39:33 +0600'
@@ -217,7 +217,7 @@ class TestDateHeader(TestHeaderBase):
         self.assertEqual(h, s)
         self.assertIsNone(h.datetime)
         self.assertEqual(len(h.defects), 1)
-        self.assertIsInstance(h.defects[0], errors.InvalidHeaderDefect)
+        self.assertIsInstance(h.defects[0], errors.InvalidDateDefect)
 
     def test_datetime_read_only(self):
         h = self.make_header('date', self.datestring)

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -203,6 +203,22 @@ class TestDateHeader(TestHeaderBase):
         self.assertEqual(len(h.defects), 1)
         self.assertIsInstance(h.defects[0], errors.HeaderMissingRequiredValue)
 
+    def test_invalid_date_format(self):
+        s = 'Not a date header'
+        h = self.make_header('date', s)
+        self.assertEqual(h, s)
+        self.assertIsNone(h.datetime)
+        self.assertEqual(len(h.defects), 1)
+        self.assertIsInstance(h.defects[0], errors.InvalidHeaderDefect)
+
+    def test_invalid_date_value(self):
+        s = 'Tue, 06 Jun 2017 27:39:33 +0600'
+        h = self.make_header('date', s)
+        self.assertEqual(h, s)
+        self.assertIsNone(h.datetime)
+        self.assertEqual(len(h.defects), 1)
+        self.assertIsInstance(h.defects[0], errors.InvalidHeaderDefect)
+
     def test_datetime_read_only(self):
         h = self.make_header('date', self.datestring)
         with self.assertRaises(AttributeError):

--- a/Lib/test/test_email/test_inversion.py
+++ b/Lib/test/test_email/test_inversion.py
@@ -46,6 +46,14 @@ class TestInversion(TestEmailBase):
             foo
             """),),
 
+        'header_with_invalid_date': (dedent(b"""\
+            Date: Tue, 06 Jun 2017 27:39:33 +0600
+            From: abc@xyz.com
+            Subject: timezones
+
+            How do they work even?
+            """),),
+
             }
 
     payload_params = {

--- a/Lib/test/test_email/test_utils.py
+++ b/Lib/test/test_email/test_utils.py
@@ -48,6 +48,22 @@ class DateTimeTests(unittest.TestCase):
             utils.parsedate_to_datetime(self.datestring + ' -0000'),
             self.naive_dt)
 
+    def test_parsedate_to_datetime_with_invalid_raises_typeerror(self):
+        with self.assertRaises(TypeError):
+            utils.parsedate_to_datetime('')
+        with self.assertRaises(TypeError):
+            utils.parsedate_to_datetime('0')
+        with self.assertRaises(TypeError):
+            utils.parsedate_to_datetime('A Complete Waste of Time')
+
+    def test_parsedate_to_datetime_with_invalid_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            utils.parsedate_to_datetime('Tue, 06 Jun 2017 27:39:33 +0600')
+        with self.assertRaises(ValueError):
+            utils.parsedate_to_datetime('Tue, 06 Jun 2017 07:39:33 +2600')
+        with self.assertRaises(ValueError):
+            utils.parsedate_to_datetime('Tue, 06 Jun 2017 27:39:33')
+
 
 class LocaltimeTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2018-11-29-11-14-18.bpo-30681.04zEWG.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-29-11-14-18.bpo-30681.04zEWG.rst
@@ -1,0 +1,2 @@
+Handle exceptions caused by unparseable date headers when using email
+"default" policy.  Patch by Tim Bell.


### PR DESCRIPTION
In `email.utils.parsedate_to_datetime()`, a failure to parse the date, or invalid date components (such as hour outside 0..23) raises an exception. Document this behaviour, and add tests to test_email/test_utils.py to confirm this behaviour.

In `email.headerregistry.DateHeader.parse()`, check when `parsedate_to_datetime()` raises an exception and add a new defect `InvalidDateDefect`; preserve the invalid value as the string value of the header, but set the `datetime` attribute to `None`.

Add tests to test_email/test_headerregistry.py to confirm this behaviour; also added test to test_email/test_inversion.py to confirm emails with such defective date headers round trip successfully.

This pull request incorporates feedback gratefully received from @bitdancer, @brettcannon, @Mariatta and @warsaw, and replaces the earlier PR #2254.

<!-- issue-number: [bpo-30681](https://bugs.python.org/issue30681) -->
https://bugs.python.org/issue30681
<!-- /issue-number -->
