### PR TITLE
bpo-35346, platform: replace os.popen() with subprocess

### DIFF
--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -222,16 +222,16 @@ class PlatformTest(unittest.TestCase):
         res = platform.mac_ver()
 
         if platform.uname().system == 'Darwin':
-            # We're on a MacOSX system, check that
-            # the right version information is returned
-            fd = os.popen('sw_vers', 'r')
-            real_ver = None
-            for ln in fd:
-                if ln.startswith('ProductVersion:'):
-                    real_ver = ln.strip().split()[-1]
+            # We are on a macOS system, check that the right version
+            # information is returned
+            output = subprocess.check_output(['sw_vers'], text=True)
+            for line in output.splitlines():
+                if line.startswith('ProductVersion:'):
+                    real_ver = line.strip().split()[-1]
                     break
-            fd.close()
-            self.assertFalse(real_ver is None)
+            else:
+                self.fail(f"failed to parse sw_vers output: {output!r}")
+
             result_list = res[0].split('.')
             expect_list = real_ver.split('.')
             len_diff = len(result_list) - len(expect_list)

--- a/Misc/NEWS.d/next/Library/2018-11-29-12-42-13.bpo-35346.OmTY5c.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-29-12-42-13.bpo-35346.OmTY5c.rst
@@ -1,0 +1,2 @@
+:func:`platform.uname` now redirects ``stderr`` to :data:`os.devnull` when
+running external programs like ``cmd /c ver``.


### PR DESCRIPTION
Replace os.popen() with subprocess.Popen in the platform module:

* Pass the command as a list of strings, not as as a string;
* Don't use a shell;
* _syscmd_ver() now redirects errors to DEVNULL.

<!-- issue-number: [bpo-35346](https://bugs.python.org/issue35346) -->
https://bugs.python.org/issue35346
<!-- /issue-number -->
