### PR TITLE
bpo-24412: Use assertEqual to fix DeprecationWarning

### DIFF
--- a/Lib/unittest/test/test_runner.py
+++ b/Lib/unittest/test/test_runner.py
@@ -256,7 +256,7 @@ class TestClassCleanup(unittest.TestCase):
         TestableTest.addClassCleanup(cleanup2)
         with self.assertRaises(Exception) as e:
             TestableTest.doClassCleanups()
-            self.assertEquals(e, 'cleanup1')
+            self.assertEqual(e, 'cleanup1')
 
     def test_with_errors_addCleanUp(self):
         ordering = []


### PR DESCRIPTION
Use `assertEqual` to fix `DeprecationWarning` in the test as noted in https://bugs.python.org/issue24412#msg330624

<!-- issue-number: [bpo-24412](https://bugs.python.org/issue24412) -->
https://bugs.python.org/issue24412
<!-- /issue-number -->
