### PR TITLE
[3.6] bpo-33012: Fix more invalid function cast warnings with gcc 8. (GH-10751)

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6596,7 +6596,7 @@ static slotdef slotdefs[] = {
            "__repr__($self, /)\n--\n\nReturn repr(self)."),
     TPSLOT("__hash__", tp_hash, slot_tp_hash, wrap_hashfunc,
            "__hash__($self, /)\n--\n\nReturn hash(self)."),
-    FLSLOT("__call__", tp_call, slot_tp_call, (wrapperfunc)wrap_call,
+    FLSLOT("__call__", tp_call, slot_tp_call, (wrapperfunc)(void(*)(void))wrap_call,
            "__call__($self, /, *args, **kwargs)\n--\n\nCall self as a function.",
            PyWrapperFlag_KEYWORDS),
     TPSLOT("__str__", tp_str, slot_tp_str, wrap_unaryfunc,
@@ -6632,7 +6632,7 @@ static slotdef slotdefs[] = {
     TPSLOT("__delete__", tp_descr_set, slot_tp_descr_set,
            wrap_descr_delete,
            "__delete__($self, instance, /)\n--\n\nDelete an attribute of instance."),
-    FLSLOT("__init__", tp_init, slot_tp_init, (wrapperfunc)wrap_init,
+    FLSLOT("__init__", tp_init, slot_tp_init, (wrapperfunc)(void(*)(void))wrap_init,
            "__init__($self, /, *args, **kwargs)\n--\n\n"
            "Initialize self.  See help(type(self)) for accurate signature.",
            PyWrapperFlag_KEYWORDS),


### PR DESCRIPTION
Fix warnings with gcc 8 for wrapperfunc <-> wrapperfunc_kwds casts.

(cherry picked from commit 1c607155c9e363489036ae6258b165a3fae75134)

<!-- issue-number: [bpo-33012](https://bugs.python.org/issue33012) -->
https://bugs.python.org/issue33012
<!-- /issue-number -->
