### PR TITLE
bpo-35353: Added 'frame' command to pdb

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -269,6 +269,10 @@ by the local file.
    Move the current frame *count* (default one) levels up in the stack trace (to
    an older frame).
 
+.. pdbcommand:: fr(ame) [index]
+
+   Switch to frame *index* in the stack trace.
+
 .. pdbcommand:: b(reak) [([filename:]lineno | function) [, condition]]
 
    With a *lineno* argument, set a break there in the current file.  With a

--- a/Misc/NEWS.d/next/Library/2018-11-29-09-12-45.bpo-35353.pviesm.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-29-09-12-45.bpo-35353.pviesm.rst
@@ -1,0 +1,2 @@
+Added `fr(ame)` command to pdb to directly jump to stack frame.
+Frame indexes are shown in stack trace.


### PR DESCRIPTION
[bpo-35353](https://bugs.python.org/issue35353): Added frame command to pdb

Added `fr(ame)` command to pdb that lets you directly jump to a stack frame.
Frames are prefixed by index in stack trace.

https://bugs.python.org/issue35353


<!-- issue-number: [bpo-35353](https://bugs.python.org/issue35353) -->
https://bugs.python.org/issue35353
<!-- /issue-number -->
