### PR TITLE
[2.7] Fix DeprecationWarning in test_bytes

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -161,13 +161,13 @@ class BaseBytesTest(unittest.TestCase):
         # exceptions.
         class BadInt:
             def __index__(self):
-                1/0
+                1//0
         self.assertRaises(ZeroDivisionError, self.type2test, BadInt())
         self.assertRaises(ZeroDivisionError, self.type2test, [BadInt()])
 
         class BadIterable:
             def __iter__(self):
-                1/0
+                1//0
         self.assertRaises(ZeroDivisionError, self.type2test, BadIterable())
 
     def test_compare(self):


### PR DESCRIPTION
Running test_bytes with python -3 -Wd emits two DeprecationWarning on
"1/0". Use "1//0" to prevent the warning.