### PR TITLE
bpo-31177: Fix reset_mock on mock with deleted children

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -541,6 +541,9 @@ class NonCallableMock(Base):
         if side_effect:
             self._mock_side_effect = None
 
+        # Forget that children were deleted
+        self._mock_children = {k: v for k, v in self._mock_children.items() if v is not _deleted}
+
         for child in self._mock_children.values():
             if isinstance(child, _SpecState):
                 continue

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -202,11 +202,13 @@ class MockTest(unittest.TestCase):
 
     def test_reset_mock(self):
         parent = Mock()
-        spec = ["something"]
+        spec = ["something", "deleted"]
         mock = Mock(name="child", parent=parent, spec=spec)
         mock(sentinel.Something, something=sentinel.SomethingElse)
         something = mock.something
         mock.something()
+        mock.deleted
+        del mock.deleted
         mock.side_effect = sentinel.SideEffect
         return_value = mock.return_value
         return_value()
@@ -234,10 +236,11 @@ class MockTest(unittest.TestCase):
         self.assertEqual(mock.return_value, return_value,
                           "return_value incorrectly reset")
         self.assertFalse(return_value.called, "return value mock not reset")
-        self.assertEqual(mock._mock_children, {'something': something},
+        self.assertEqual(list(mock._mock_children), ['something'],
                           "children reset incorrectly")
         self.assertEqual(mock.something, something,
                           "children incorrectly cleared")
+        mock.deleted  # available again
         self.assertFalse(mock.something.called, "child not reset")
 
 

--- a/Misc/NEWS.d/next/Library/2018-11-30-03-23-06.bpo-31177.hp4sp9.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-30-03-23-06.bpo-31177.hp4sp9.rst
@@ -1,0 +1,4 @@
+unittest.mock: reset_mock() now works on Mock objects that had attributes
+deleted. The deletion of an attribute is now forgotten after a reset_mock()
+call. Accessing the deleted attribute after a reset_mock() call behaves like
+its first access.


### PR DESCRIPTION
Currently, calling reset_mock() on a unittest.mock.Mock object after one of its attributes was deleted causes an exception.

This fixes the exception and introduces the behavior that the deletion of the attribute is reset, making it available again after the reset_mock() call.

<!-- issue-number: [bpo-31177](https://bugs.python.org/issue31177) -->
https://bugs.python.org/issue31177
<!-- /issue-number -->
