### PR TITLE
bpo-35356: Fix a possible reference leak in nis.maps()

### DIFF
--- a/Modules/nismodule.c
+++ b/Modules/nismodule.c
@@ -412,6 +412,7 @@ nis_maps (PyObject *self, PyObject *args, PyObject *kwdict)
         PyObject *str = PyUnicode_FromString(maps->map);
         if (!str || PyList_Append(list, str) < 0)
         {
+            Py_XDECREF(str);
             Py_DECREF(list);
             list = NULL;
             break;


### PR DESCRIPTION


<!-- issue-number: [bpo-35356](https://bugs.python.org/issue35356) -->
https://bugs.python.org/issue35356
<!-- /issue-number -->
