### PR TITLE
[3.7] bpo-35336: Fix PYTHONCOERCECLOCALE=1 (GH-10806)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-29-23-59-52.bpo-35336.8LOz4F.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-29-23-59-52.bpo-35336.8LOz4F.rst
@@ -1,0 +1,2 @@
+Fix PYTHONCOERCECLOCALE=1 environment variable: only coerce the C locale
+if the LC_CTYPE locale is "C".

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -2191,10 +2191,16 @@ done:
 static void
 config_init_locale(_PyCoreConfig *config)
 {
-    if (config->coerce_c_locale < 0) {
+    /* Test also if coerce_c_locale equals 1: PYTHONCOERCECLOCALE=1 doesn't
+       imply that the C locale is always coerced. It is only coerced if
+       if the LC_CTYPE locale is "C". */
+    if (config->coerce_c_locale != 0) {
         /* The C locale enables the C locale coercion (PEP 538) */
         if (_Py_LegacyLocaleDetected()) {
             config->coerce_c_locale = 1;
+        }
+        else {
+            config->coerce_c_locale = 0;
         }
     }
 
@@ -2376,7 +2382,7 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         }
     }
 
-    if (config->utf8_mode < 0 || config->coerce_c_locale < 0) {
+    if (config->coerce_c_locale != 0 || config->utf8_mode < 0) {
         config_init_locale(config);
     }
 


### PR DESCRIPTION
Fix PYTHONCOERCECLOCALE=1 environment variable: only coerce the C
locale if the LC_CTYPE locale is "C".

(cherry picked from commit 55e498058faf8c97840556f6d791c2c392732dc3)

<!-- issue-number: [bpo-35336](https://bugs.python.org/issue35336) -->
https://bugs.python.org/issue35336
<!-- /issue-number -->
