### PR TITLE
[Docs] Fix Default Argument Values of xml.dom.minidom.Document.toprettyxml

### DIFF
--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -163,7 +163,7 @@ module documentation.  This section lists the differences between the API and
       The :meth:`toxml` method now preserves the attribute order specified
       by the user.
 
-.. method:: Node.toprettyxml(indent="", newl="", encoding="")
+.. method:: Node.toprettyxml(indent="\t", newl="\n", encoding=None)
 
    Return a pretty-printed version of the document. *indent* specifies the
    indentation string and defaults to a tabulator; *newl* specifies the string


### PR DESCRIPTION
The document is inconsistent with
https://github.com/python/cpython/blob/55e498058faf8c97840556f6d791c2c392732dc3/Lib/xml/dom/minidom.py#L49