### PR TITLE
[2.7] bpo-35359: Add _CRT_SECURE_NO_WARNINGS to pythoncore project

### DIFF
--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -70,7 +70,7 @@
     <ClCompile>
       <AdditionalOptions>/Zm200  %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(PySourcePath)Python;$(PySourcePath)Modules\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_USRDLL;Py_BUILD_CORE;Py_ENABLE_SHARED;MS_DLL_ID="$(SysWinVer)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USRDLL;Py_BUILD_CORE;Py_ENABLE_SHARED;_CRT_SECURE_NO_WARNINGS;MS_DLL_ID="$(SysWinVer)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Define _CRT_SECURE_NO_WARNINGS in the Visual Studio pythoncore
project to make quiet security warnings when building zlib C files
(Modules\zlib\ subdirectory).

<!-- issue-number: [bpo-35359](https://bugs.python.org/issue35359) -->
https://bugs.python.org/issue35359
<!-- /issue-number -->
