### PR TITLE
[2.7] Replace 1/0 with 1//0 in tests to avoid Python 3 warns

### DIFF
--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -868,7 +868,7 @@ class BreakpointTestCase(BaseTestCase):
         with create_modules(modules):
             self.expect_set = [
                 ('line', 2, 'tfunc_import'),
-                    break_in_func('func', TEST_MODULE_FNAME, False, '1 / 0'),
+                    break_in_func('func', TEST_MODULE_FNAME, False, '1 // 0'),
                 ('None', 2, 'tfunc_import'),       ('continue', ),
                 ('line', 3, 'func', ({1:1}, [])),  ('quit', ),
             ]

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -423,7 +423,7 @@ except RuntimeError, e:
         # Test division by zero:
         gdb_repr, gdb_output = self.get_gdb_repr('''
 try:
-    a = 1 / 0
+    a = 1 // 0
 except ZeroDivisionError, e:
     print e
 ''')

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -1053,7 +1053,7 @@ output.append(4)
                "can only jump from a 'line' trace event"))
     def test_no_jump_from_exception_event(output):
         output.append(1)
-        1 / 0
+        1 // 0
 
     @jump_test(3, 2, [2], event='return', error=(ValueError,
                "can't jump from a yield statement"))


### PR DESCRIPTION
Fix DeprecationWarning when tests are run using python -3.