### PR TITLE
Minor refactoring to use enumerate in loops

### DIFF
--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -353,8 +353,8 @@ class Cmd:
             self.stdout.write("<empty>\n")
             return
 
-        nonstrings = [i for i in range(len(list))
-                        if not isinstance(list[i], str)]
+        nonstrings = [i for i, val in enumerate(list)
+                      if not isinstance(val, str)]
         if nonstrings:
             raise TypeError("list[i] not a string for i in %s"
                             % ", ".join(map(str, nonstrings)))
@@ -396,6 +396,6 @@ class Cmd:
                 texts.append(x)
             while texts and not texts[-1]:
                 del texts[-1]
-            for col in range(len(texts)):
-                texts[col] = texts[col].ljust(colwidths[col])
+            texts = [line.ljust(width)
+                     for line, width in zip(texts, colwidths)]
             self.stdout.write("%s\n"%str("  ".join(texts)))

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -2026,8 +2026,8 @@ class HtmlDiff(object):
         s = []
         fmt = '            <tr><td class="diff_next"%s>%s</td>%s' + \
               '<td class="diff_next">%s</td>%s</tr>\n'
-        for i in range(len(flaglist)):
-            if flaglist[i] is None:
+        for i, flag in enumerate(flaglist):
+            if flag is None:
                 # mdiff yields None on separator lines skip the bogus ones
                 # generated for the first line
                 if i > 0:

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -341,9 +341,7 @@ class CCompiler:
         pp_opts = gen_preprocess_options(macros, incdirs)
 
         build = {}
-        for i in range(len(sources)):
-            src = sources[i]
-            obj = objects[i]
+        for src, obj in zip(sources, objects):
             ext = os.path.splitext(src)[1]
             self.mkpath(os.path.dirname(obj))
             build[obj] = (src, ext)

--- a/Lib/distutils/command/bdist.py
+++ b/Lib/distutils/command/bdist.py
@@ -125,11 +125,10 @@ class bdist(Command):
                 raise DistutilsOptionError("invalid format '%s'" % format)
 
         # Reinitialize and run each command.
-        for i in range(len(self.formats)):
-            cmd_name = commands[i]
+        for i, (cmd_name, format_) in zip(self.formats, commands):
             sub_cmd = self.reinitialize_command(cmd_name)
             if cmd_name not in self.no_format_option:
-                sub_cmd.format = self.formats[i]
+                sub_cmd.format = format_
 
             # passing the owner and group names for tar archiving
             if cmd_name == 'bdist_dumb':

--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -564,8 +564,8 @@ class install(Command):
             outputs = self.get_outputs()
             if self.root:               # strip any package prefix
                 root_len = len(self.root)
-                for counter in range(len(outputs)):
-                    outputs[counter] = outputs[counter][root_len:]
+                outputs = [value[root_len:] for value in outputs]
+
             self.execute(write_file,
                          (self.record, outputs),
                          "writing list of installed files to '%s'" %

--- a/Lib/distutils/dep_util.py
+++ b/Lib/distutils/dep_util.py
@@ -41,10 +41,10 @@ def newer_pairwise (sources, targets):
     # build a pair of lists (sources, targets) where  source is newer
     n_sources = []
     n_targets = []
-    for i in range(len(sources)):
-        if newer(sources[i], targets[i]):
-            n_sources.append(sources[i])
-            n_targets.append(targets[i])
+    for src, targ in zip(sources, targets):
+        if newer(src, targ):
+            n_sources.append(src)
+            n_targets.append(targ)
 
     return (n_sources, n_targets)
 

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -980,8 +980,8 @@ def _get_ptext_to_endchars(value, endchars):
     vchars = []
     escape = False
     had_qp = False
-    for pos in range(len(fragment)):
-        if fragment[pos] == '\\':
+    for pos, value in enumerate(fragment):
+        if value == '\\':
             if escape:
                 escape = False
                 had_qp = True
@@ -990,9 +990,9 @@ def _get_ptext_to_endchars(value, endchars):
                 continue
         if escape:
             escape = False
-        elif fragment[pos] in endchars:
+        elif value in endchars:
             break
-        vchars.append(fragment[pos])
+        vchars.append(value)
     else:
         pos = pos + 1
     return ''.join(vchars), ''.join([fragment[pos:]] + remainder), had_qp

--- a/Lib/getopt.py
+++ b/Lib/getopt.py
@@ -205,8 +205,8 @@ def do_shorts(opts, optstring, shortopts, args):
     return opts, args
 
 def short_has_arg(opt, shortopts):
-    for i in range(len(shortopts)):
-        if opt == shortopts[i] != ':':
+    for i, value in enumerate(shortopts):
+        if opt == value != ':':
             return shortopts.startswith(':', i+1)
     raise GetoptError(_('option -%s not recognized') % opt, opt)
 

--- a/Lib/idlelib/debugger.py
+++ b/Lib/idlelib/debugger.py
@@ -389,8 +389,7 @@ class StackViewer(ScrolledList):
     def load_stack(self, stack, index=None):
         self.stack = stack
         self.clear()
-        for i in range(len(stack)):
-            frame, lineno = stack[i]
+        for i, (frame, lineno) in enumerate(stack):
             try:
                 modname = frame.f_globals["__name__"]
             except:

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -798,11 +798,11 @@ def findsource(object):
         # use the one with the least indentation, which is the one
         # that's most probably not inside a function definition.
         candidates = []
-        for i in range(len(lines)):
-            match = pat.match(lines[i])
+        for i, line in enumerate(lines):
+            match = pat.match(line)
             if match:
                 # if it's at toplevel, it's already the best one
-                if lines[i][0] == 'c':
+                if line[0] == 'c':
                     return lines, i
                 # else add whitespace to candidate list
                 candidates.append((match.group(1), i))
@@ -1279,9 +1279,7 @@ def formatargvalues(args, varargs, varkw, locals,
     def convert(name, locals=locals,
                 formatarg=formatarg, formatvalue=formatvalue):
         return formatarg(name) + formatvalue(locals[name])
-    specs = []
-    for i in range(len(args)):
-        specs.append(convert(args[i]))
+    specs = [convert(value) for value in args]
     if varargs:
         specs.append(formatvarargs(varargs) + formatvalue(locals[varargs]))
     if varkw:

--- a/Lib/mailcap.py
+++ b/Lib/mailcap.py
@@ -99,8 +99,7 @@ def _readmailcapfile(fp, lineno):
             lineno += 1
         # Normalize the key
         types = key.split('/')
-        for j in range(len(types)):
-            types[j] = types[j].strip()
+        types = [val.strip() for val in types]
         key = '/'.join(types).lower()
         # Update the database
         if key in caps:

--- a/Lib/modulefinder.py
+++ b/Lib/modulefinder.py
@@ -554,10 +554,9 @@ class ModuleFinder:
                                     % (original_filename,))
             self.processed_paths.append(original_filename)
 
-        consts = list(co.co_consts)
-        for i in range(len(consts)):
-            if isinstance(consts[i], type(co)):
-                consts[i] = self.replace_paths_in_code(consts[i])
+        consts = [self.replace_paths_in_code(value)
+                  if isinstance(value, type(co)) else value
+                  for value in co.co_consts]
 
         return types.CodeType(co.co_argcount, co.co_kwonlyargcount,
                               co.co_nlocals, co.co_stacksize, co.co_flags,

--- a/Lib/msilib/__init__.py
+++ b/Lib/msilib/__init__.py
@@ -86,12 +86,12 @@ class Table:
 class _Unspecified:pass
 def change_sequence(seq, action, seqno=_Unspecified, cond = _Unspecified):
     "Change the sequence number of an action in a sequence list"
-    for i in range(len(seq)):
-        if seq[i][0] == action:
+    for i, value in enumerate(seq):
+        if value[0] == action:
             if cond is _Unspecified:
-                cond = seq[i][1]
+                cond = value[1]
             if seqno is _Unspecified:
-                seqno = seq[i][2]
+                seqno = value[2]
             seq[i] = (action, cond, seqno)
             return
     raise ValueError("Action not found in sequence")

--- a/Lib/tkinter/simpledialog.py
+++ b/Lib/tkinter/simpledialog.py
@@ -49,8 +49,7 @@ class SimpleDialog:
         self.cancel = cancel
         self.default = default
         self.root.bind('<Return>', self.return_event)
-        for num in range(len(buttons)):
-            s = buttons[num]
+        for num, s in enumerate(buttons):
             b = Button(self.frame, text=s,
                        command=(lambda self=self, num=num: self.done(num)))
             if num == default:

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -386,8 +386,8 @@ def _find_mac(command, args, hw_identifiers, get_index):
         with proc:
             for line in proc.stdout:
                 words = line.lower().rstrip().split()
-                for i in range(len(words)):
-                    if words[i] in hw_identifiers:
+                for i, word in enumerate(words):
+                    if word in hw_identifiers:
                         try:
                             word = words[get_index(i)]
                             mac = int(word.replace(b':', b''), 16)


### PR DESCRIPTION
# Minor refactoring to use enumerate in loops

The overall goal is to replace code of the form,
```py
for i in range(len(x)):
   val = x[i]
```
with,
```py
for i, val in enumerate(x):
```

Which should be around 2x faster,
```
In [8]: x = list(range(10))                                                                                                                                  

In [9]: %timeit [(idx, x[idx]) for idx in range(len(x))]                                                                                                     
1.29 µs ± 11.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [10]: %timeit list(enumerate(x))                                                                                                                          
641 ns ± 12 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [5]: x = list(range(1000))                                                                                                                                

In [6]: %timeit [(idx, x[idx]) for idx in range(len(x))]                                                                                                     
80.7 µs ± 193 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [7]: %timeit list(enumerate(x))                                                                                                                           
42.8 µs ± 110 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
and a bit more readable.

Also refactored to use `zip` in places where it made sense instead.