### PR TITLE
bpo-31177: Fix reset_mock on mock with deleted children

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -544,6 +544,8 @@ class NonCallableMock(Base):
         for child in self._mock_children.values():
             if isinstance(child, _SpecState):
                 continue
+            if child is _deleted:
+                continue
             child.reset_mock(visited)
 
         ret = self._mock_return_value

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -202,11 +202,13 @@ class MockTest(unittest.TestCase):
 
     def test_reset_mock(self):
         parent = Mock()
-        spec = ["something"]
+        spec = ["something", "deleted"]
         mock = Mock(name="child", parent=parent, spec=spec)
         mock(sentinel.Something, something=sentinel.SomethingElse)
         something = mock.something
         mock.something()
+        mock.deleted
+        del mock.deleted
         mock.side_effect = sentinel.SideEffect
         return_value = mock.return_value
         return_value()
@@ -234,10 +236,12 @@ class MockTest(unittest.TestCase):
         self.assertEqual(mock.return_value, return_value,
                           "return_value incorrectly reset")
         self.assertFalse(return_value.called, "return value mock not reset")
-        self.assertEqual(mock._mock_children, {'something': something},
+        self.assertEqual(list(mock._mock_children), ['something', 'deleted'],
                           "children reset incorrectly")
         self.assertEqual(mock.something, something,
                           "children incorrectly cleared")
+        with self.assertRaises(AttributeError, msg="deleted attribute incorrectly restored"):
+            mock.deleted
         self.assertFalse(mock.something.called, "child not reset")
 
 

--- a/Misc/NEWS.d/next/Library/2018-11-30-03-23-06.bpo-31177.hp4sp9.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-30-03-23-06.bpo-31177.hp4sp9.rst
@@ -1,0 +1,2 @@
+unittest.mock: reset_mock() now works on Mock objects that had attributes
+deleted.


### PR DESCRIPTION
Currently, calling reset_mock() on a unittest.mock.Mock object after one of its attributes was deleted causes an exception.

This fixes the exception. Note deleted attributes stay deleted after a reset_mock() call, which might be surprising to the user.

https://bugs.python.org/issue31177

<!-- issue-number: [bpo-31177](https://bugs.python.org/issue31177) -->
https://bugs.python.org/issue31177
<!-- /issue-number -->
