### PR TITLE
[3.7] get_gmtoff() now returns time_t (GH-10838)

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -994,7 +994,7 @@ of the timezone or altzone attributes on the time module.");
 #endif /* HAVE_MKTIME */
 
 #ifdef HAVE_WORKING_TZSET
-static void PyInit_timezone(PyObject *module);
+static int PyInit_timezone(PyObject *module);
 
 static PyObject *
 time_tzset(PyObject *self, PyObject *unused)
@@ -1009,7 +1009,9 @@ time_tzset(PyObject *self, PyObject *unused)
     tzset();
 
     /* Reset timezone, altzone, daylight and tzname */
-    PyInit_timezone(m);
+    if (PyInit_timezone(m) < 0) {
+         return NULL;
+    }
     Py_DECREF(m);
     if (PyErr_Occurred())
         return NULL;
@@ -1510,7 +1512,7 @@ get_zone(char *zone, int n, struct tm *p)
 #endif
 }
 
-static int
+static time_t
 get_gmtoff(time_t t, struct tm *p)
 {
 #ifdef HAVE_STRUCT_TM_TM_ZONE
@@ -1521,8 +1523,11 @@ get_gmtoff(time_t t, struct tm *p)
 }
 #endif /* !defined(HAVE_TZNAME) || defined(__GLIBC__) || defined(__CYGWIN__) */
 
-static void
-PyInit_timezone(PyObject *m) {
+static int
+PyInit_timezone(PyObject *m)
+{
+    assert(!PyErr_Occurred());
+
     /* This code moved from PyInit_time wholesale to allow calling it from
     time_tzset. In the future, some parts of it can be moved back
     (for platforms that don't HAVE_WORKING_TZSET, when we know what they
@@ -1557,18 +1562,30 @@ PyInit_timezone(PyObject *m) {
 #define YEAR ((time_t)((365 * 24 + 6) * 3600))
         time_t t;
         struct tm p;
-        long janzone, julyzone;
+        time_t janzone_t, julyzone_t;
         char janname[10], julyname[10];
         t = (time((time_t *)0) / YEAR) * YEAR;
         _PyTime_localtime(t, &p);
         get_zone(janname, 9, &p);
-        janzone = -get_gmtoff(t, &p);
+        janzone_t = -get_gmtoff(t, &p);
         janname[9] = '\0';
         t += YEAR/2;
         _PyTime_localtime(t, &p);
         get_zone(julyname, 9, &p);
-        julyzone = -get_gmtoff(t, &p);
+        julyzone_t = -get_gmtoff(t, &p);
         julyname[9] = '\0';
+
+        /* Sanity check, don't check for the validity of timezones.
+           In practice, it should be more in range -12 hours .. +14 hours. */
+#define MAX_TIMEZONE (48 * 3600)
+        if (janzone_t < -MAX_TIMEZONE || janzone_t > MAX_TIMEZONE
+            || julyzone_t < -MAX_TIMEZONE || julyzone_t > MAX_TIMEZONE)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "invalid GMT offset");
+            return -1;
+        }
+        int janzone = (int)janzone_t;
+        int julyzone = (int)julyzone_t;
 
         if( janzone < julyzone ) {
             /* DST is reversed in the southern hemisphere */
@@ -1598,6 +1615,7 @@ PyInit_timezone(PyObject *m) {
                        Py_BuildValue("(zz)", _tzname[0], _tzname[1]));
 #endif /* __CYGWIN__ */
 #endif /* !HAVE_TZNAME || __GLIBC__ || __CYGWIN__*/
+    return 0;
 }
 
 
@@ -1698,7 +1716,9 @@ PyInit_time(void)
         return NULL;
 
     /* Set, or reset, module variables like time.timezone */
-    PyInit_timezone(m);
+    if (PyInit_timezone(m) < 0) {
+        return NULL;
+    }
 
 #if defined(HAVE_CLOCK_GETTIME) || defined(HAVE_CLOCK_SETTIME) || defined(HAVE_CLOCK_GETRES)
 


### PR DESCRIPTION
get_gmtoff() now returns time_t instead of int to fix the following
Visual Studio warning:

    Modules\timemodule.c(1183): warning C4244: 'return':
    conversion from 'time_t' to 'int', possible loss of data

(cherry picked from commit 503ce5c482cb267b0770bc46c315d5cf822bdca9)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
