### PR TITLE
Fix compiler warning in structseq_repr()

### DIFF
--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -182,9 +182,9 @@ structseq_repr(PyStructSequence *obj)
     endofbuf= &buf[REPR_BUFFER_SIZE-5];
 
     /* "typename(", limited to  TYPE_MAXSIZE */
-    len = strlen(typ->tp_name) > TYPE_MAXSIZE ? TYPE_MAXSIZE :
-                            strlen(typ->tp_name);
-    strncpy(pbuf, typ->tp_name, len);
+    len = strlen(typ->tp_name);
+    len = Py_MIN(len, TYPE_MAXSIZE);
+    memcpy(pbuf, typ->tp_name, len);
     pbuf += len;
     *pbuf++ = '(';
 


### PR DESCRIPTION
Replace strncpy() with memcpy() in structseq_repr() to fix the
following compiler warning:

Objects/structseq.c:187:5: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-overflow=]
     strncpy(pbuf, typ->tp_name, len);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Objects/structseq.c:185:11: note: length computed here
     len = strlen(typ->tp_name) > TYPE_MAXSIZE ? TYPE_MAXSIZE :

The function writes the terminating NUL byte later.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
