### PR TITLE
bpo-10320: Replace nonstandard sprintf() length modifier in ctypes' PyCArg_repr()

### DIFF
--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -484,7 +484,7 @@ PyCArg_repr(PyCArgObject *self)
 #ifdef MS_WIN32
             "<cparam '%c' (%I64d)>",
 #else
-            "<cparam '%c' (%qd)>",
+            "<cparam '%c' (%lld)>",
 #endif
             self->tag, self->value.q);
         break;


### PR DESCRIPTION

Use "ll" instead of the nonstandard "q".

<!-- issue-number: [bpo-10320](https://bugs.python.org/issue10320) -->
https://bugs.python.org/issue10320
<!-- /issue-number -->
