### PR TITLE
bpo-35373: Fix PyInit_timezone() if HAVE_DECL_TZNAME is defined

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1581,16 +1581,17 @@ PyInit_timezone(PyObject *m)
     PyModule_AddIntConstant(m, "daylight", daylight);
     otz0 = PyUnicode_DecodeLocale(tzname[0], "surrogateescape");
     if (otz0 == NULL) {
-        return;
+        return -1;
     }
     otz1 = PyUnicode_DecodeLocale(tzname[1], "surrogateescape");
     if (otz1 == NULL) {
         Py_DECREF(otz0);
-        return;
+        return -1;
     }
     PyObject *tzname_obj = Py_BuildValue("(NN)", otz0, otz1);
-    if (tzname_obj == NULL)
-        return;
+    if (tzname_obj == NULL) {
+        return -1;
+    }
     PyModule_AddObject(m, "tzname", tzname_obj);
 #else // !HAVE_DECL_TZNAME
     static const time_t YEAR = (365 * 24 + 6) * 3600;


### PR DESCRIPTION
If HAVE_DECL_TZNAME, PyInit_timezone() now returns -1 on error.

<!-- issue-number: [bpo-35373](https://bugs.python.org/issue35373) -->
https://bugs.python.org/issue35373
<!-- /issue-number -->
