### PR TITLE
bpo-35377:  fix incorrect urls produced by urlunsplit

### DIFF
--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -471,7 +471,8 @@ def urlunsplit(components):
     scheme, netloc, url, query, fragment, _coerce_result = (
                                           _coerce_args(*components))
     if netloc or (scheme and scheme in uses_netloc and url[:2] != '//'):
-        if url and url[:1] != '/': url = '/' + url
+        if netloc or scheme == 'file':
+            if url and url[:1] != '/': url = '/' + url
         url = '//' + (netloc or '') + url
     if scheme:
         url = scheme + ':' + url


### PR DESCRIPTION
see bugreport for discussion.


<!-- issue-number: [bpo-35377](https://bugs.python.org/issue35377) -->
https://bugs.python.org/issue35377
<!-- /issue-number -->
