### PR TITLE
bpo-35384: The repr of ctypes.CArgObject no longer fail for non-ascii character.

### DIFF
--- a/Lib/ctypes/test/test_bytes.py
+++ b/Lib/ctypes/test/test_bytes.py
@@ -12,6 +12,7 @@ class BytesTest(unittest.TestCase):
             x.value = "y"
         c_char.from_param(b"x")
         self.assertRaises(TypeError, c_char.from_param, "x")
+        self.assertIn('xbd', repr(c_char.from_param(b"\xbd")))
         (c_char * 3)(b"a", b"b", b"c")
         self.assertRaises(TypeError, c_char * 3, "a", "b", "c")
 

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -510,6 +510,7 @@ PyCArg_repr(PyCArgObject *self)
             sprintf(buffer, "<cparam '%c' ('\\x%02x')>",
                 self->tag, (unsigned char)self->value.c);
         }
+        break;
 
 /* Hm, are these 'z' and 'Z' codes useful at all?
    Shouldn't they be replaced by the functionality of c_string

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -499,7 +499,8 @@ PyCArg_repr(PyCArgObject *self)
 
     case 'c':
         if ((unsigned char)self->value.c < 128
-            && _PyUnicode_IsPrintable(self->value.c)
+            && _PyUnicode_IsPrintable((unsigned char)self->value.c)
+            && self->value.c != '\\'
             && self->value.c != '\'')
         {
             sprintf(buffer, "<cparam '%c' ('%c')>",
@@ -522,7 +523,7 @@ PyCArg_repr(PyCArgObject *self)
         break;
 
     default:
-        sprintf(buffer, "<cparam %02x' at %p>",
+        sprintf(buffer, "<cparam 0x%02x at %p>",
             (unsigned char)self->tag, self);
         break;
     }

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -498,9 +498,17 @@ PyCArg_repr(PyCArgObject *self)
         break;
 
     case 'c':
-        sprintf(buffer, "<cparam '%c' (%c)>",
-            self->tag, self->value.c);
-        break;
+        if ((unsigned char)self->value.c < 128
+            && _PyUnicode_IsPrintable(self->value.c)
+            && self->value.c != '\'')
+        {
+            sprintf(buffer, "<cparam '%c' ('%c')>",
+                self->tag, self->value.c);
+        }
+        else {
+            sprintf(buffer, "<cparam '%c' ('\\x%02x')>",
+                self->tag, (unsigned char)self->value.c);
+        }
 
 /* Hm, are these 'z' and 'Z' codes useful at all?
    Shouldn't they be replaced by the functionality of c_string
@@ -514,8 +522,8 @@ PyCArg_repr(PyCArgObject *self)
         break;
 
     default:
-        sprintf(buffer, "<cparam '%c' at %p>",
-            self->tag, self);
+        sprintf(buffer, "<cparam %02x' at %p>",
+            (unsigned char)self->tag, self);
         break;
     }
     return PyUnicode_FromString(buffer);


### PR DESCRIPTION


<!-- issue-number: [bpo-35384](https://bugs.python.org/issue35384) -->
https://bugs.python.org/issue35384
<!-- /issue-number -->
