### PR TITLE
bpo-35368: Add assertions in pymalloc to check GIL

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -20,6 +20,8 @@ extern "C" {
 /* GIL state */
 
 struct _gilstate_runtime_state {
+    /* Issue #26558: Flag to disable PyGILState_Check().
+       If set to non-zero, PyGILState_Check() always return 1. */
     int check_enabled;
     /* Assuming the current thread holds the GIL, this is the
        PyThreadState for the current thread. */
@@ -35,10 +37,6 @@ struct _gilstate_runtime_state {
 
 /* hook for PyEval_GetFrame(), requested for Psyco */
 #define _PyThreadState_GetFrame _PyRuntime.gilstate.getframe
-
-/* Issue #26558: Flag to disable PyGILState_Check().
-   If set to non-zero, PyGILState_Check() always return 1. */
-#define _PyGILState_check_enabled _PyRuntime.gilstate.check_enabled
 
 
 /* interpreter state */

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1358,6 +1358,9 @@ pymalloc_alloc(void *ctx, void **ptr_p, size_t nbytes)
     poolp next;
     uint size;
 
+    /* pymalloc is protected by the GIL */
+    assert(PyGILState_Check());
+
 #ifdef WITH_VALGRIND
     if (UNLIKELY(running_on_valgrind == -1)) {
         running_on_valgrind = RUNNING_ON_VALGRIND;
@@ -1589,6 +1592,9 @@ pymalloc_free(void *ctx, void *p)
     uint size;
 
     assert(p != NULL);
+
+    /* pymalloc is protected by the GIL */
+    assert(PyGILState_Check());
 
 #ifdef WITH_VALGRIND
     if (UNLIKELY(running_on_valgrind > 0)) {
@@ -1823,6 +1829,9 @@ pymalloc_realloc(void *ctx, void **newptr_p, void *p, size_t nbytes)
     size_t size;
 
     assert(p != NULL);
+
+    /* pymalloc is protected by the GIL */
+    assert(PyGILState_Check());
 
 #ifdef WITH_VALGRIND
     /* Treat running_on_valgrind == -1 the same as 0 */
@@ -2193,9 +2202,10 @@ _PyMem_DebugRawRealloc(void *ctx, void *p, size_t nbytes)
 static void
 _PyMem_DebugCheckGIL(void)
 {
-    if (!PyGILState_Check())
+    if (!PyGILState_Check()) {
         Py_FatalError("Python memory allocator called "
                       "without holding the GIL");
+    }
 }
 
 static void *

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1232,7 +1232,7 @@ new_interpreter(PyThreadState **tstate_p)
 
     /* Issue #10915, #15751: The GIL API doesn't work with multiple
        interpreters: disable PyGILState_Check(). */
-    _PyGILState_check_enabled = 0;
+    _PyRuntime.gilstate.check_enabled = 0;
 
     interp = PyInterpreterState_New();
     if (interp == NULL) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1078,8 +1078,9 @@ PyGILState_Check(void)
 {
     PyThreadState *tstate;
 
-    if (!_PyGILState_check_enabled)
+    if (!_PyRuntime.gilstate.check_enabled) {
         return 1;
+    }
 
     if (!PyThread_tss_is_created(&_PyRuntime.gilstate.autoTSSkey)) {
         return 1;


### PR DESCRIPTION
Add "assert(PyGILState_Check());" assertion to pymalloc functions
like pymalloc_alloc() to ensure that the GIL is held.

Remove also _PyGILState_check_enabled define: use directly
_PyRuntime.gilstate.check_enabled.

Note: The debug hook already uses _PyMem_DebugCheckGIL() to check
that the GIL is held.

<!-- issue-number: [bpo-35368](https://bugs.python.org/issue35368) -->
https://bugs.python.org/issue35368
<!-- /issue-number -->
