### PR TITLE
[2.7] bpo-26544: Make platform.libc_ver() less slow

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -194,7 +194,10 @@ def libc_ver(executable=sys.executable,lib='',version='', chunksize=2048):
         binary = f.read(chunksize)
         pos = 0
         while pos < len(binary):
-            m = _libc_search.search(binary,pos)
+            if 'libc' in binary or 'GLIBC' in binary:
+                m = _libc_search.search(binary, pos)
+            else:
+                m = None
             if not m or m.end() == len(binary):
                 chunk = f.read(chunksize)
                 if chunk:


### PR DESCRIPTION
Coarse benchmark on Fedora 29: 1.6 sec => 0.1 sec.

Co-Authored-By: Antoine Pitrou <solipsis@pitrou.net>

(cherry-picked from commit ba7c226095703f63c78b00e56f1db8d99ac3a54a)

<!-- issue-number: [bpo-26544](https://bugs.python.org/issue26544) -->
https://bugs.python.org/issue26544
<!-- /issue-number -->
