### PR TITLE
bpo-35310: Clear select() lists before returning upon EINTR

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-12-03-19-45-00.bpo-35310.9k28gR.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-03-19-45-00.bpo-35310.9k28gR.rst
@@ -1,0 +1,4 @@
+Fix a bug in :func:`select.select` where, in some cases, the file descriptor
+sequences were returned unmodified after a signal interruption, even though the
+file descriptors might not be ready yet.  :func:`select.select` will now always
+return empty lists if a timeout has occurred.  Patch by Oran Avraham.

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -335,6 +335,10 @@ select_select_impl(PyObject *module, PyObject *rlist, PyObject *wlist,
         if (tvp) {
             timeout = deadline - _PyTime_GetMonotonicClock();
             if (timeout < 0) {
+                /* bpo-35310: lists were unmodified -- clear them explicitly */
+                FD_ZERO(&ifdset);
+                FD_ZERO(&ofdset);
+                FD_ZERO(&efdset);
                 n = 0;
                 break;
             }


### PR DESCRIPTION
select() calls are retried on EINTR (per PEP 475).  However, if a
timeout was provided and the deadline has passed after running the
signal handlers, we should clear rlist, wlist and xlist since select(2)
left them unmodified.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35310](https://bugs.python.org/issue35310) -->
https://bugs.python.org/issue35310
<!-- /issue-number -->
