### PR TITLE
bpo-35395: fix typos in asyncio eventloop documentation

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -756,7 +756,7 @@ Watching file descriptors
    writing.
 
    Use :func:`functools.partial` :ref:`to pass keyword arguments
-   <asyncio-pass-keywords>` to *func*.
+   <asyncio-pass-keywords>` to *callback*.
 
 .. method:: loop.remove_writer(fd)
 
@@ -970,7 +970,7 @@ Unix signals
    Raise :exc:`RuntimeError` if there is a problem setting up the handler.
 
    Use :func:`functools.partial` :ref:`to pass keyword arguments
-   <asyncio-pass-keywords>` to *func*.
+   <asyncio-pass-keywords>` to *callback*.
 
 .. method:: loop.remove_signal_handler(sig)
 


### PR DESCRIPTION
Fixes `loop.add_writer` and `loop.add_signal_handler` method documentation to correctly reference the callback parameter from method signature.

<!-- issue-number: [bpo-35395](https://bugs.python.org/issue35395) -->
https://bugs.python.org/issue35395
<!-- /issue-number -->
