### PR TITLE
bpo-35396: Add support for __fspath__ in fnmatch.fnmatchcase and fnmatch.filter

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -72,12 +72,17 @@ patterns.
    :const:`False`; the comparison is case-sensitive and does not apply
    :func:`os.path.normcase`.
 
+   .. versionchanged:: 3.8
+      Accepts a :term:`path-like object` as *filename*.
 
 .. function:: filter(names, pattern)
 
    Return the subset of the list of *names* that match *pattern*. It is the same as
    ``[n for n in names if fnmatch(n, pattern)]``, but implemented more efficiently.
 
+   .. versionchanged:: 3.8
+      Accepts :term:`path-like objects <path-like object>` as items of the iterable
+      *names*.
 
 .. function:: translate(pattern)
 

--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -53,7 +53,7 @@ def filter(names, pat):
     if os.path is posixpath:
         # normcase on posix is NOP. Optimize it away from the loop.
         for name in names:
-            if match(name):
+            if match(os.fspath(name)):
                 result.append(name)
     else:
         for name in names:
@@ -68,7 +68,7 @@ def fnmatchcase(name, pat):
     its arguments.
     """
     match = _compile_pattern(pat)
-    return match(name) is not None
+    return match(os.fspath(name)) is not None
 
 
 def translate(pat):

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -6,6 +6,13 @@ import warnings
 
 from fnmatch import fnmatch, fnmatchcase, translate, filter
 
+class Path:
+    def __init__(self, path):
+        self.path = path
+
+    def __fspath__(self):
+        return self.path
+
 class FnmatchTestCase(unittest.TestCase):
 
     def check_match(self, filename, pattern, should_match=True, fn=fnmatch):
@@ -95,6 +102,11 @@ class FnmatchTestCase(unittest.TestCase):
             check(',', '[a-z+--A-Z]')
             check('.', '[a-z--/A-Z]')
 
+    def test_fspath(self):
+        check = self.check_match
+        check(Path('foo.txt'), '*.txt', fn=fnmatch)
+        check(Path('foo.txt'), '*.txt', fn=fnmatchcase)
+
 
 class TranslateTestCase(unittest.TestCase):
 
@@ -134,6 +146,12 @@ class FilterTestCase(unittest.TestCase):
                          ['usr/bin', 'usr\\lib'] if normsep else ['usr/bin'])
         self.assertEqual(filter(['usr/bin', 'usr', 'usr\\lib'], 'usr\\*'),
                          ['usr/bin', 'usr\\lib'] if normsep else ['usr\\lib'])
+
+    def test_fspath(self):
+        path = Path('foo.txt')
+
+        self.assertEqual(filter([path], '*.txt*'), [path])
+        self.assertEqual(filter([path, 'bar.txt'], '*.txt'), [path, 'bar.txt'])
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2018-12-04-07-02-57.bpo-35396.eXdRba.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-04-07-02-57.bpo-35396.eXdRba.rst
@@ -1,0 +1,3 @@
+Added support for :term:`path-like objects <path-like object>` to
+:func:`fnmatch.fnmatchcase` and :func:`fnmatch.filter`. Patch by
+Andrés Delfino.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35396](https://bugs.python.org/issue35396) -->
https://bugs.python.org/issue35396
<!-- /issue-number -->
