### PR TITLE
bpo-35394: Add empty slots to abstract asyncio protocols

### DIFF
--- a/Lib/asyncio/protocols.py
+++ b/Lib/asyncio/protocols.py
@@ -16,6 +16,8 @@ class BaseProtocol:
     write-only transport like write pipe
     """
 
+    __slots__ = ()
+
     def connection_made(self, transport):
         """Called when a connection is made.
 
@@ -87,6 +89,8 @@ class Protocol(BaseProtocol):
     * CL: connection_lost()
     """
 
+    __slots__ = ()
+
     def data_received(self, data):
         """Called when some data is received.
 
@@ -130,6 +134,8 @@ class BufferedProtocol(BaseProtocol):
     * CL: connection_lost()
     """
 
+    __slots__ = ()
+
     def get_buffer(self, sizehint):
         """Called to allocate a new receive buffer.
 
@@ -160,6 +166,8 @@ class BufferedProtocol(BaseProtocol):
 class DatagramProtocol(BaseProtocol):
     """Interface for datagram protocol."""
 
+    __slots__ = ()
+
     def datagram_received(self, data, addr):
         """Called when some datagram is received."""
 
@@ -172,6 +180,8 @@ class DatagramProtocol(BaseProtocol):
 
 class SubprocessProtocol(BaseProtocol):
     """Interface for protocol for subprocess calls."""
+
+    __slots__ = ()
 
     def pipe_data_received(self, fd, data):
         """Called when the subprocess writes data into stdout/stderr pipe.

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2486,30 +2486,6 @@ class AbstractEventLoopTests(unittest.TestCase):
         loop.close()
 
 
-class ProtocolsAbsTests(unittest.TestCase):
-
-    def test_empty(self):
-        f = mock.Mock()
-        p = asyncio.Protocol()
-        self.assertIsNone(p.connection_made(f))
-        self.assertIsNone(p.connection_lost(f))
-        self.assertIsNone(p.data_received(f))
-        self.assertIsNone(p.eof_received())
-
-        dp = asyncio.DatagramProtocol()
-        self.assertIsNone(dp.connection_made(f))
-        self.assertIsNone(dp.connection_lost(f))
-        self.assertIsNone(dp.error_received(f))
-        self.assertIsNone(dp.datagram_received(f, f))
-
-        sp = asyncio.SubprocessProtocol()
-        self.assertIsNone(sp.connection_made(f))
-        self.assertIsNone(sp.connection_lost(f))
-        self.assertIsNone(sp.pipe_data_received(1, f))
-        self.assertIsNone(sp.pipe_connection_lost(1, f))
-        self.assertIsNone(sp.process_exited())
-
-
 class PolicyTests(unittest.TestCase):
 
     def test_event_loop_policy(self):

--- a/Lib/test/test_asyncio/test_protocols.py
+++ b/Lib/test/test_asyncio/test_protocols.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest import mock
+
+import asyncio
+
+
+class ProtocolsAbsTests(unittest.TestCase):
+
+    def test_base_protocol(self):
+        f = mock.Mock()
+        p = asyncio.BaseProtocol()
+        self.assertIsNone(p.connection_made(f))
+        self.assertIsNone(p.connection_lost(f))
+        self.assertIsNone(p.pause_writing())
+        self.assertIsNone(p.resume_writing())
+        self.assertFalse(hasattr(p, '__dict__'))
+
+    def test_protocol(self):
+        f = mock.Mock()
+        p = asyncio.Protocol()
+        self.assertIsNone(p.connection_made(f))
+        self.assertIsNone(p.connection_lost(f))
+        self.assertIsNone(p.data_received(f))
+        self.assertIsNone(p.eof_received())
+        self.assertIsNone(p.pause_writing())
+        self.assertIsNone(p.resume_writing())
+        self.assertFalse(hasattr(p, '__dict__'))
+
+    def test_buffered_protocol(self):
+        f = mock.Mock()
+        p = asyncio.BufferedProtocol()
+        self.assertIsNone(p.connection_made(f))
+        self.assertIsNone(p.connection_lost(f))
+        self.assertIsNone(p.get_buffer(100))
+        self.assertIsNone(p.buffer_updated(150))
+        self.assertIsNone(p.pause_writing())
+        self.assertIsNone(p.resume_writing())
+        self.assertFalse(hasattr(p, '__dict__'))
+
+    def test_datagram_protocol(self):
+        f = mock.Mock()
+        dp = asyncio.DatagramProtocol()
+        self.assertIsNone(dp.connection_made(f))
+        self.assertIsNone(dp.connection_lost(f))
+        self.assertIsNone(dp.error_received(f))
+        self.assertIsNone(dp.datagram_received(f, f))
+        self.assertFalse(hasattr(dp, '__dict__'))
+
+    def test_subprocess_protocol(self):
+        f = mock.Mock()
+        sp = asyncio.SubprocessProtocol()
+        self.assertIsNone(sp.connection_made(f))
+        self.assertIsNone(sp.connection_lost(f))
+        self.assertIsNone(sp.pipe_data_received(1, f))
+        self.assertIsNone(sp.pipe_connection_lost(1, f))
+        self.assertIsNone(sp.process_exited())
+        self.assertFalse(hasattr(sp, '__dict__'))

--- a/Misc/NEWS.d/next/Library/2018-12-04-12-17-08.bpo-35394.fuTVDk.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-04-12-17-08.bpo-35394.fuTVDk.rst
@@ -1,0 +1,1 @@
+Add empty slots to asyncio abstract protocols.


### PR DESCRIPTION


<!-- issue-number: [bpo-35394](https://bugs.python.org/issue35394) -->
https://bugs.python.org/issue35394
<!-- /issue-number -->
