### PR TITLE
bpo-35406: Add validity check to prevmonth and nextmonth functions

### DIFF
--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -132,21 +132,21 @@ def monthlen(year, month):
 
 
 def prevmonth(year, month):
-    if not 1 <= month <= 12:
-        raise IllegalMonthError(month)
     if month == 1:
         return year-1, 12
-    else:
+    elif 1 < month <= 12:
         return year, month-1
+    else:
+        raise IllegalMonthError(month)
 
 
 def nextmonth(year, month):
-    if not 1 <= month <= 12:
-        raise IllegalMonthError(month)
     if month == 12:
         return year+1, 1
-    else:
+    elif 1 <= month < 12:
         return year, month+1
+    else:
+        raise IllegalMonthError(month)
 
 
 class Calendar(object):

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -132,6 +132,8 @@ def monthlen(year, month):
 
 
 def prevmonth(year, month):
+    if not 1 <= month <= 12:
+        raise IllegalMonthError(month)
     if month == 1:
         return year-1, 12
     else:
@@ -139,6 +141,8 @@ def prevmonth(year, month):
 
 
 def nextmonth(year, month):
+    if not 1 <= month <= 12:
+        raise IllegalMonthError(month)
     if month == 12:
         return year+1, 1
     else:

--- a/Misc/NEWS.d/next/Library/2018-12-04-15-05-23.bpo-35406.FhU5h.rst.
+++ b/Misc/NEWS.d/next/Library/2018-12-04-15-05-23.bpo-35406.FhU5h.rst.
@@ -1,0 +1,4 @@
+`calendar.prevmonth` and `calendar.nextmonth` functions 
+now checks if the given month is valid and raises
+`calendar.IllegalMonthError` for non-valid month values.
+Patch by Şahin Akkaya.


### PR DESCRIPTION
`calendar.nextmonth(2018, 10)` returns `(2018, 11)` but not checking if the month is valid. It should raise a `calendar.IllegalMonthError` if the month is not valid. Similarly, `calendar.prevmonth` should check it too.
Currently, they are accepting all integers as month values:
```
>>> import calendar
>>> calendar.nextmonth(2018, 13)
(2018, 14)
>>> calendar.nextmonth(2018, -5)
(2018, -4)
>>> calendar.prevmonth(2018, 80)
(2018, 79)
>>> calendar.prevmonth(2018, -2)
(2018, -3)
```

<!-- issue-number: [bpo-35406](https://bugs.python.org/issue35406) -->
https://bugs.python.org/issue35406
<!-- /issue-number -->
