### PR TITLE
bpo-35389: platform.libc_ver() uses os.confstr()

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -169,7 +169,7 @@ _libc_search = re.compile(b'(__libc_init)'
                           b'|'
                           br'(libc(_\w+)?\.so(?:\.(\d[0-9.]*))?)', re.ASCII)
 
-def libc_ver(executable=sys.executable, lib='', version='', chunksize=16384):
+def libc_ver(executable=None, lib='', version='', chunksize=16384):
 
     """ Tries to determine the libc version that the file executable
         (which defaults to the Python interpreter) is linked against.
@@ -184,6 +184,19 @@ def libc_ver(executable=sys.executable, lib='', version='', chunksize=16384):
         The file is read and scanned in chunks of chunksize bytes.
 
     """
+    if executable is None:
+        try:
+            ver = os.confstr('CS_GNU_LIBC_VERSION')
+            # parse 'glibc 2.28' as ('glibc', '2.28')
+            parts = ver.split(maxsplit=1)
+            if len(parts) == 2:
+                return tuple(parts)
+        except (AttributeError, ValueError, OSError):
+            # os.confstr() or CS_GNU_LIBC_VERSION value not available
+            pass
+
+        executable = sys.executable
+
     V = _comparable_version
     if hasattr(os.path, 'realpath'):
         # Python 2.2 introduced os.path.realpath(); it is used

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -265,19 +265,46 @@ class PlatformTest(unittest.TestCase):
             self.assertEqual(sts, 0)
 
     def test_libc_ver(self):
+        # check that libc_ver(executable) doesn't raise an exception
         if os.path.isdir(sys.executable) and \
            os.path.exists(sys.executable+'.exe'):
             # Cygwin horror
             executable = sys.executable + '.exe'
         else:
             executable = sys.executable
-        res = platform.libc_ver(executable)
+        platform.libc_ver(executable)
 
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, 'wb') as f:
-            f.write(b'x'*(16384-10))
+        filename = support.TESTFN
+        self.addCleanup(support.unlink, filename)
+
+        with mock.patch('os.confstr', create=True, return_value='mock 1.0'):
+            # test os.confstr() code path
+            self.assertEqual(platform.libc_ver(), ('mock', '1.0'))
+
+            # test the different regular expressions
+            for data, expected in (
+                (b'__libc_init', ('libc', '')),
+                (b'GLIBC_2.9', ('glibc', '2.9')),
+                (b'libc.so.1.2.5', ('libc', '1.2.5')),
+                (b'libc_pthread.so.1.2.5', ('libc', '1.2.5_pthread')),
+                (b'', ('', '')),
+            ):
+                with open(filename, 'wb') as fp:
+                    fp.write(b'[xxx%sxxx]' % data)
+                    fp.flush()
+
+                # os.confstr() must not be used if executable is set
+                self.assertEqual(platform.libc_ver(executable=filename),
+                                 expected)
+
+        # binary containing multiple versions: get the most recent,
+        # make sure that 1.9 is seen as older than 1.23.4
+        chunksize = 16384
+        with open(filename, 'wb') as f:
+            # test match at chunk boundary
+            f.write(b'x'*(chunksize - 10))
             f.write(b'GLIBC_1.23.4\0GLIBC_1.9\0GLIBC_1.21\0')
-        self.assertEqual(platform.libc_ver(support.TESTFN),
+        self.assertEqual(platform.libc_ver(filename, chunksize=chunksize),
                          ('glibc', '1.23.4'))
 
     @support.cpython_only
@@ -315,29 +342,6 @@ class PlatformTest(unittest.TestCase):
         self.assertLess(V('0.4'), V('0.4.0'))
         self.assertLess(V('1.13++'), V('5.5.kw'))
         self.assertLess(V('0.960923'), V('2.2beta29'))
-
-    def test_libc_ver(self):
-        with mock.patch('os.confstr', create=True, return_value='mock 1.0'):
-            self.assertEqual(platform.libc_ver(), ('mock', '1.0'))
-
-            tmpname = tempfile.mktemp()
-            try:
-                for data, expected in (
-                    (b'__libc_init', ('libc', '')),
-                    (b'GLIBC_2.9xxxGLIBC_2.10', ('glibc', '2.10')),
-                    (b'libc.so.1.2.5', ('libc', '1.2.5')),
-                    (b'libc_pthread.so.1.2.5', ('libc', '1.2.5_pthread')),
-                    (b'', ('', '')),
-                ):
-                    with open(tmpname, 'wb') as fp:
-                        fp.write(b'[xxx%sxxx]' % data)
-                        fp.flush()
-
-                    # os.confstr() must not be used if executable is set
-                    self.assertEqual(platform.libc_ver(executable=tmpname),
-                                     expected)
-            finally:
-                support.unlink(tmpname)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2018-12-04-12-46-05.bpo-35389.CTZ9iA.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-04-12-46-05.bpo-35389.CTZ9iA.rst
@@ -1,0 +1,2 @@
+:func:`platform.libc_ver` now uses ``os.confstr('CS_GNU_LIBC_VERSION')`` if
+available and the *executable* parameter is not set.


### PR DESCRIPTION
platform.libc_ver() now uses os.confstr('CS_GNU_LIBC_VERSION') if
available.

Quick benchmark on Fedora 29:

python3 -m perf command ./python -S -c 'import platform; platform.libc_ver()'
94.9 ms +- 4.3 ms -> 33.2 ms +- 1.4 ms: 2.86x faster (-65%)

<!-- issue-number: [bpo-35389](https://bugs.python.org/issue35389) -->
https://bugs.python.org/issue35389
<!-- /issue-number -->
