### PR TITLE
bpo-35346, platform: import subprocess in _syscmd_file()

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -113,9 +113,9 @@ __copyright__ = """
 __version__ = '1.0.8'
 
 import collections
-import sys, os, re, subprocess
-
-import warnings
+import os
+import re
+import sys
 
 ### Globals & Constants
 
@@ -612,11 +612,13 @@ def _syscmd_file(target, default=''):
     if sys.platform in ('dos', 'win32', 'win16'):
         # XXX Others too ?
         return default
+
+    import subprocess
     target = _follow_symlinks(target)
     try:
         proc = subprocess.Popen(['file', target],
-                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
     except (AttributeError, OSError):
         return default
     output = proc.communicate()[0].decode('latin-1')


### PR DESCRIPTION
Only platform._syscmd_file() uses subprocess. Move subprocess import
inside this function to reduce the number of imports at Python
startup.

Remove also warnings import which is no longer needed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35346](https://bugs.python.org/issue35346) -->
https://bugs.python.org/issue35346
<!-- /issue-number -->
