### PR TITLE
bpo-35376: Fix modulefinder skipping some nested modules

### DIFF
--- a/Lib/modulefinder.py
+++ b/Lib/modulefinder.py
@@ -326,14 +326,14 @@ class ModuleFinder:
         else:
             if fromlist:
                 for sub in fromlist:
-                    if sub in self.badmodules:
-                        self._add_badmodule(sub, caller)
+                    fullname = name + "." + sub
+                    if fullname in self.badmodules:
+                        self._add_badmodule(fullname, caller)
                         continue
                     try:
                         self.import_hook(name, caller, [sub], level=level)
                     except ImportError as msg:
                         self.msg(2, "ImportError:", str(msg))
-                        fullname = name + "." + sub
                         self._add_badmodule(fullname, caller)
 
     def scan_opcodes(self, co):


### PR DESCRIPTION
If modulefinder finds a nested module import (eg. 'import a.b.c') while there is a top-level module with the same name (eg. 'c') that failed to import and got added to the badmodules list, it will skip it entirely without even trying to import it.

The right thing to do is clearly to check it by fqname in the badmodules dict since that's also what it expects in other locations.

Should I make additional PRs for other branches or is this OK as-is?

https://bugs.python.org/issue35376

<!-- issue-number: [bpo-35376](https://bugs.python.org/issue35376) -->
https://bugs.python.org/issue35376
<!-- /issue-number -->
