### PR TITLE
[3.7] bpo-35296: make install now installs the internal API (GH-10665)

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1443,10 +1443,20 @@ inclinstall:
 		else	true; \
 		fi; \
 	done
+	@if test ! -d $(DESTDIR)$(INCLUDEPY)/internal; then \
+		echo "Creating directory $(DESTDIR)$(INCLUDEPY)/internal"; \
+		$(INSTALL) -d -m $(DIRMODE) $(DESTDIR)$(INCLUDEPY)/internal; \
+	else	true; \
+	fi
 	@for i in $(srcdir)/Include/*.h; \
 	do \
 		echo $(INSTALL_DATA) $$i $(INCLUDEPY); \
 		$(INSTALL_DATA) $$i $(DESTDIR)$(INCLUDEPY); \
+	done
+	@for i in $(srcdir)/Include/internal/*.h; \
+	do \
+		echo $(INSTALL_DATA) $$i $(INCLUDEPY)/internal; \
+		$(INSTALL_DATA) $$i $(DESTDIR)$(INCLUDEPY)/internal; \
 	done
 	$(INSTALL_DATA) pyconfig.h $(DESTDIR)$(CONFINCLUDEPY)/pyconfig.h
 

--- a/Misc/NEWS.d/next/Build/2018-12-04-17-10-17.bpo-35296.2ktH40.rst
+++ b/Misc/NEWS.d/next/Build/2018-12-04-17-10-17.bpo-35296.2ktH40.rst
@@ -1,0 +1,2 @@
+The Windows installer (MSI) now also install internal header files
+(``Include/internal/`` subdirectory).

--- a/Misc/NEWS.d/next/C API/2018-11-22-18-34-23.bpo-35296.nxrIQt.rst
+++ b/Misc/NEWS.d/next/C API/2018-11-22-18-34-23.bpo-35296.nxrIQt.rst
@@ -1,0 +1,2 @@
+``make install`` now also installs the internal API:
+``Include/internal/*.h`` header files.

--- a/Tools/msi/dev/dev.wixproj
+++ b/Tools/msi/dev/dev.wixproj
@@ -21,7 +21,7 @@
         <EmbeddedResource Include="*.wxl" />
     </ItemGroup>
     <ItemGroup>
-        <InstallFiles Include="$(PySourcePath)include\*.h">
+        <InstallFiles Include="$(PySourcePath)include\**\*.h">
             <SourceBase>$(PySourcePath)</SourceBase>
             <Source>!(bindpath.src)</Source>
             <TargetBase>$(PySourcePath)</TargetBase>
@@ -29,7 +29,7 @@
             <Group>dev_include</Group>
         </InstallFiles>
     </ItemGroup>
-    
+
     <Target Name="BuildMinGWLib"
             Inputs="$(BuildPath)$(PyDllName).dll"
             Outputs="$(BuildPath)lib$(PyDllName).a"


### PR DESCRIPTION
* [bpo-35296](https://bugs.python.org/issue35296): make install now installs the internal API (GH-10665)
* Windows installer now also install Include/internal/


<!-- issue-number: [bpo-35296](https://bugs.python.org/issue35296) -->
https://bugs.python.org/issue35296
<!-- /issue-number -->
