### PR TITLE
Remove unnecessary and over-restrictive type check in SystemRandom.getrandbits()

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -718,8 +718,6 @@ class SystemRandom(Random):
         """getrandbits(k) -> x.  Generates an int with k random bits."""
         if k <= 0:
             raise ValueError('number of bits must be greater than zero')
-        if k != int(k):
-            raise TypeError('number of bits should be an integer')
         numbytes = (k + 7) // 8                       # bits / 8 and rounded up
         x = int.from_bytes(_urandom(numbytes), 'big')
         return x >> (numbytes * 8 - k)                # trim excess bits


### PR DESCRIPTION
* The type check is over-restrictive (i.e. doesn't allow int subclasses).
* The type check is unnecessary:
  * We already that know *k* can be compared to *0*
  * In the subsequent step, urandom() verifies that (k + 7) // 8 is an instance of integer, and if not will raise a *TypeError* for us.
* The code is performance sensitive (called in the inner loops for *shuffle()*, *sample()*, and *choices()*).