### PR TITLE
bpo-35398: Improve DDL statement detection for SQLite

### DIFF
--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -85,7 +85,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
         if (single_line_comment && (*p == '\n')) {
             single_line_comment = 0;
             continue;
-        } else if (multi_line_comment && strcmp(p, "*/") == 0) {
+        } else if (multi_line_comment && strncmp(p, "*/", 2) == 0) {
             multi_line_comment = 0;
             p++;
             continue;
@@ -94,10 +94,10 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
             continue;
         }
         // detect leading comments
-        if (strcmp(p, "--") == 0) {
+        if (strncmp(p, "--", 2) == 0) {
             single_line_comment = 1;
             continue;
-        } else if (strcmp(p, "/*") == 0) {
+        } else if (strncmp(p, "/*", 2) == 0) {
             multi_line_comment = 1;
             p++;
             continue;

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -85,7 +85,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
         if (single_line_comment && (*p == '\n')) {
             single_line_comment = 0;
             continue;
-        } else if (multi_line_comment && PyOS_strnicmp(p, "*/", 2) == 0) {
+        } else if (multi_line_comment && strcmp(p, "*/") == 0) {
             multi_line_comment = 0;
             p++;
             continue;
@@ -94,10 +94,10 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
             continue;
         }
         // detect leading comments
-        if (PyOS_strnicmp(p, "--", 2) == 0) {
+        if (strcmp(p, "--") == 0) {
             single_line_comment = 1;
             continue;
-        } else if (PyOS_strnicmp(p, "/*", 2) == 0) {
+        } else if (strcmp(p, "/*") == 0) {
             multi_line_comment = 1;
             p++;
             continue;

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -81,7 +81,7 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
     single_line_comment = 0;
     multi_line_comment = 0;
     for (p = sql_cstr; *p != 0; p++) {
-		// skip leading comments
+        // skip leading comments
         if (single_line_comment && (*p == '\n')) {
             single_line_comment = 0;
             continue;

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -55,8 +55,8 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
     const char* sql_cstr;
     Py_ssize_t sql_cstr_len;
     const char* p;
-	unsigned char multi_line_comment;
-	unsigned char single_line_comment;
+    unsigned char multi_line_comment;
+    unsigned char single_line_comment;
 
     self->st = NULL;
     self->in_use = 0;
@@ -78,31 +78,31 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
     /* Determine if the statement is a DML statement.
        SELECT is the only exception. See #9924. */
     self->is_dml = 0;
-	single_line_comment = 0;
-	multi_line_comment = 0;
+    single_line_comment = 0;
+    multi_line_comment = 0;
     for (p = sql_cstr; *p != 0; p++) {
 		// skip leading comments
-		if (single_line_comment && (*p == '\n')) {
-			single_line_comment = 0;
-			continue;
-	    } else if (multi_line_comment && PyOS_strnicmp(p, "*/", 2) == 0) {
-		    multi_line_comment = 0;
-			p++;
-			continue;
-	    }
-		if (single_line_comment || multi_line_comment) {
-			continue;
-		}
-		// detect leading comments
-		if (PyOS_strnicmp(p, "--", 2) == 0) {
-		    single_line_comment = 1;
-			continue;
-	    } else if (PyOS_strnicmp(p, "/*", 2) == 0) {
-		    multi_line_comment = 1;
-			p++;			
-			continue;
-	    }
-		// skip leading whitespace 
+        if (single_line_comment && (*p == '\n')) {
+            single_line_comment = 0;
+            continue;
+        } else if (multi_line_comment && PyOS_strnicmp(p, "*/", 2) == 0) {
+            multi_line_comment = 0;
+            p++;
+            continue;
+        }
+        if (single_line_comment || multi_line_comment) {
+            continue;
+        }
+        // detect leading comments
+        if (PyOS_strnicmp(p, "--", 2) == 0) {
+            single_line_comment = 1;
+            continue;
+        } else if (PyOS_strnicmp(p, "/*", 2) == 0) {
+            multi_line_comment = 1;
+            p++;
+            continue;
+        }
+        // skip leading whitespace 
         switch (*p) {
             case ' ':
             case '\r':


### PR DESCRIPTION
SQLite driver depends on DDL detection to return an accurate row count for a statement. SQL statements that begin with comments currently break DDL detection, which results in incorrect row counts being returned.

<!-- issue-number: [bpo-35398](https://bugs.python.org/issue35398) -->
https://bugs.python.org/issue35398
<!-- /issue-number -->
