### PR TITLE
bpo-35414: Add a missing Py_INCREF(Py_None) in PyState_RemoveModule()

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -592,6 +592,7 @@ PyState_RemoveModule(struct PyModuleDef* def)
         Py_FatalError("PyState_RemoveModule: Module index out of bounds.");
         return -1;
     }
+    Py_INCREF(Py_None);
     return PyList_SetItem(state->modules_by_index, index, Py_None);
 }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-35414](https://bugs.python.org/issue35414) -->
https://bugs.python.org/issue35414
<!-- /issue-number -->
