### PR TITLE
bpo-10496: distutils check_environ() handles getpwuid() error

### DIFF
--- a/Lib/distutils/tests/test_util.py
+++ b/Lib/distutils/tests/test_util.py
@@ -237,24 +237,30 @@ class UtilTestCase(support.EnvironGuard, unittest.TestCase):
         util._environ_checked = 0
         os.environ.pop('HOME', None)
 
-        # posix without HOME
-        if os.name == 'posix':  # this test won't run on windows
-            check_environ()
-            import pwd
-            self.assertEqual(os.environ['HOME'], pwd.getpwuid(os.getuid())[5])
-        else:
-            check_environ()
+        check_environ()
 
         self.assertEqual(os.environ['PLAT'], get_platform())
         self.assertEqual(util._environ_checked, 1)
 
     @unittest.skipUnless(os.name == 'posix', 'specific to posix')
-    def test_check_environ_getpwuid_error(self):
+    def test_check_environ_getpwuid(self):
+        util._environ_checked = 0
+        os.environ.pop('HOME', None)
+
+        import pwd
+
+        # only set pw_dir field, other fields are not used
+        result = pwd.struct_passwd((None, None, None, None, None,
+                                    '/home/distutils', None))
+        with mock.patch.object(pwd, 'getpwuid', return_value=result):
+            check_environ()
+            self.assertEqual(os.environ['HOME'], '/home/distutils')
+
         util._environ_checked = 0
         os.environ.pop('HOME', None)
 
         # bpo-10496: Catch pwd.getpwuid() error
-        with mock.patch('pwd.getpwuid', side_effect=KeyError):
+        with mock.patch.object(pwd, 'getpwuid', side_effect=KeyError):
             check_environ()
             self.assertNotIn('HOME', os.environ)
 

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -157,8 +157,13 @@ def check_environ ():
         return
 
     if os.name == 'posix' and 'HOME' not in os.environ:
-        import pwd
-        os.environ['HOME'] = pwd.getpwuid(os.getuid())[5]
+        try:
+            import pwd
+            os.environ['HOME'] = pwd.getpwuid(os.getuid())[5]
+        except (ImportError, KeyError):
+            # bpo-10496: if the current user identifier doesn't exist in the
+            # password database, do nothing
+            pass
 
     if 'PLAT' not in os.environ:
         os.environ['PLAT'] = get_platform()

--- a/Misc/NEWS.d/next/Library/2018-12-05-17-42-49.bpo-10496.laV_IE.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-05-17-42-49.bpo-10496.laV_IE.rst
@@ -1,0 +1,3 @@
+:func:`~distutils.utils.check_environ` of :mod:`distutils.utils` now catchs
+:exc:`KeyError` on calling :func:`pwd.getpwuid`: don't create the ``HOME``
+environment variable in this case.


### PR DESCRIPTION
check_environ() of distutils.utils now catchs KeyError on calling
pwd.getpwuid(): don't create the HOME environment variable in this
case.

<!-- issue-number: [bpo-10496](https://bugs.python.org/issue10496) -->
https://bugs.python.org/issue10496
<!-- /issue-number -->
