### PR TITLE
[3.7] bpo-34604: Use %R because of invisible characters or trailing whitespaces. (GH-9165).

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-09-07-10-16-34.bpo-34604.xL7-kG.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-07-10-16-34.bpo-34604.xL7-kG.rst
@@ -1,0 +1,3 @@
+Fix possible mojibake in the error message of `pwd.getpwnam` and
+`grp.getgrnam` using string representation because of invisible characters
+or trailing whitespaces. Patch by William Grzybowski.

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -156,7 +156,7 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
         goto out;
 
     if ((p = getgrnam(name_chars)) == NULL) {
-        PyErr_Format(PyExc_KeyError, "getgrnam(): name not found: %S", name);
+        PyErr_Format(PyExc_KeyError, "getgrnam(): name not found: %R", name);
         goto out;
     }
     retval = mkgrent(p);

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -163,7 +163,7 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
         goto out;
     if ((p = getpwnam(name)) == NULL) {
         PyErr_Format(PyExc_KeyError,
-                     "getpwnam(): name not found: %S", arg);
+                     "getpwnam(): name not found: %R", arg);
         goto out;
     }
     retval = mkpwent(p);


### PR DESCRIPTION
(cherry picked from commit 34c7f0c04e2b4e715b2c3df1875af8939fbe7d0b)

Co-authored-by: William Grzybowski <wg@FreeBSD.org>


<!-- issue-number: [bpo-34604](https://bugs.python.org/issue34604) -->
https://bugs.python.org/issue34604
<!-- /issue-number -->
