### PR TITLE
[2.7] bpo-34738: Add directory entries in ZIP files created by distutils. (GH-9419).

### DIFF
--- a/Lib/distutils/archive_util.py
+++ b/Lib/distutils/archive_util.py
@@ -162,7 +162,15 @@ def make_zipfile(base_name, base_dir, verbose=0, dry_run=0):
             zip = zipfile.ZipFile(zip_filename, "w",
                                   compression=zipfile.ZIP_DEFLATED)
 
+            if base_dir != os.curdir:
+                path = os.path.normpath(os.path.join(base_dir, ''))
+                zip.write(path, path)
+                log.info("adding '%s'", path)
             for dirpath, dirnames, filenames in os.walk(base_dir):
+                for name in dirnames:
+                    path = os.path.normpath(os.path.join(dirpath, name, ''))
+                    zip.write(path, path)
+                    log.info("adding '%s'", path)
                 for name in filenames:
                     path = os.path.normpath(os.path.join(dirpath, name))
                     if os.path.isfile(path):

--- a/Lib/distutils/tests/test_archive_util.py
+++ b/Lib/distutils/tests/test_archive_util.py
@@ -98,7 +98,7 @@ class ArchiveUtilTestCase(support.TempdirManager,
         try:
             names = tar.getnames()
             names.sort()
-            return tuple(names)
+            return names
         finally:
             tar.close()
 

--- a/Lib/distutils/tests/test_bdist_dumb.py
+++ b/Lib/distutils/tests/test_bdist_dumb.py
@@ -86,7 +86,7 @@ class BuildDumbTestCase(support.TempdirManager,
         finally:
             fp.close()
 
-        contents = sorted(os.path.basename(fn) for fn in contents)
+        contents = sorted(filter(None, map(os.path.basename, contents)))
         wanted = ['foo-0.1-py%s.%s.egg-info' % sys.version_info[:2], 'foo.py']
         if not sys.dont_write_bytecode:
             wanted.append('foo.pyc')

--- a/Lib/distutils/tests/test_sdist.py
+++ b/Lib/distutils/tests/test_sdist.py
@@ -130,7 +130,9 @@ class SDistTestCase(PyPIRCCommandTestCase):
             zip_file.close()
 
         # making sure everything has been pruned correctly
-        self.assertEqual(len(content), 4)
+        expected = ['', 'PKG-INFO', 'README', 'setup.py',
+                    'somecode/', 'somecode/__init__.py']
+        self.assertEqual(sorted(content), ['fake-1.0/' + x for x in expected])
 
     @unittest.skipUnless(zlib, "requires zlib")
     def test_make_distribution(self):
@@ -246,7 +248,13 @@ class SDistTestCase(PyPIRCCommandTestCase):
             zip_file.close()
 
         # making sure everything was added
-        self.assertEqual(len(content), 12)
+        expected = ['', 'PKG-INFO', 'README', 'buildout.cfg',
+                    'data/', 'data/data.dt', 'inroot.txt',
+                    'scripts/', 'scripts/script.py', 'setup.py',
+                    'some/', 'some/file.txt', 'some/other_file.txt',
+                    'somecode/', 'somecode/__init__.py', 'somecode/doc.dat',
+                    'somecode/doc.txt']
+        self.assertEqual(sorted(content), ['fake-1.0/' + x for x in expected])
 
         # checking the MANIFEST
         f = open(join(self.tmp_dir, 'MANIFEST'))

--- a/Misc/NEWS.d/next/Library/2018-09-19-16-51-04.bpo-34738.Pr3-iG.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-19-16-51-04.bpo-34738.Pr3-iG.rst
@@ -1,0 +1,2 @@
+ZIP files created by :mod:`distutils` will now include entries for
+directories.


### PR DESCRIPTION
(cherry picked from commit 67a93b3a0b3814e97ef9d077b21325fc8ce351b2)


<!-- issue-number: [bpo-34738](https://bugs.python.org/issue34738) -->
https://bugs.python.org/issue34738
<!-- /issue-number -->
