### PR TITLE
Clarify expectedFailure in the unittest docs.

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -585,8 +585,8 @@ The following decorators implement test skipping and expected failures:
 
 .. decorator:: expectedFailure
 
-   Mark the test as an expected failure.  If the test fails when run, the test
-   is not counted as a failure.
+   Mark the test as an expected failure.  If the test fails it will be
+   considered a success.  If the test passes, it will be considered a failure.
 
 .. exception:: SkipTest(reason)
 


### PR DESCRIPTION
Some coworkers were wondering what `expectedFailure` was for as the documentation did not make it clear that the behavior was if the test passed.