### PR TITLE
Fix typo in xml.dom.minidom documentation

### DIFF
--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -163,7 +163,7 @@ module documentation.  This section lists the differences between the API and
       The :meth:`toxml` method now preserves the attribute order specified
       by the user.
 
-.. method:: Node.toprettyxml(indent="\t", newl="\n", encoding=None)
+.. method:: Node.toprettyxml(indent="\\t", newl="\\n", encoding=None)
 
    Return a pretty-printed version of the document. *indent* specifies the
    indentation string and defaults to a tabulator; *newl* specifies the string


### PR DESCRIPTION
Escape the \t and \n.
Follow up from https://github.com/python/cpython/pull/10814.