### PR TITLE
[3.6] Fix typos in concurrent.Futures documentation (GH-10920)

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -137,6 +137,12 @@ And::
    An :class:`Executor` subclass that uses a pool of at most *max_workers*
    threads to execute calls asynchronously.
 
+   *initializer* is an optional callable that is called at the start of
+   each worker thread; *initargs* is a tuple of arguments passed to the
+   initializer.  Should *initializer* raise an exception, all currently
+   pending jobs will raise a :exc:`~concurrent.futures.thread.BrokenThreadPool`,
+   as well any attempt to submit more jobs to the pool.
+
    .. versionchanged:: 3.5
       If *max_workers* is ``None`` or
       not given, it will default to the number of processors on the machine,
@@ -147,7 +153,7 @@ And::
 
    .. versionadded:: 3.6
       The *thread_name_prefix* argument was added to allow users to
-      control the threading.Thread names for worker threads created by
+      control the :class:`threading.Thread` names for worker threads created by
       the pool for easier debugging.
 
 .. _threadpoolexecutor-example:


### PR DESCRIPTION
Add a missing word `as` in `as well as an`.
Linkify `threading.Thread`..
(cherry picked from commit 40a61da40d252626f8b9ff524d76c1f0ccb3a4f7)

Co-authored-by: Matt Wheeler <m@funkyhat.org>
