### PR TITLE
[3.7] Fix typo in xml.dom.minidom documentation (GH-10956)

### DIFF
--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -156,8 +156,8 @@ module documentation.  This section lists the differences between the API and
    encoding. Encoding this string in an encoding other than UTF-8 is
    likely incorrect, since UTF-8 is the default encoding of XML.
 
-.. method:: Node.toprettyxml(indent="\t", newl="\n", encoding=None)
-
+.. method:: Node.toprettyxml(indent="\\t", newl="\n", encoding=None)
+\
    Return a pretty-printed version of the document. *indent* specifies the
    indentation string and defaults to a tabulator; *newl* specifies the string
    emitted at the end of each line and defaults to ``\n``.

--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -156,8 +156,8 @@ module documentation.  This section lists the differences between the API and
    encoding. Encoding this string in an encoding other than UTF-8 is
    likely incorrect, since UTF-8 is the default encoding of XML.
 
-.. method:: Node.toprettyxml(indent="\\t", newl="\n", encoding=None)
-\
+.. method:: Node.toprettyxml(indent="\\t", newl="\\n", encoding=None)
+
    Return a pretty-printed version of the document. *indent* specifies the
    indentation string and defaults to a tabulator; *newl* specifies the string
    emitted at the end of each line and defaults to ``\n``.


### PR DESCRIPTION
Escape the \t and \n.
Follow up from https://github.com/python/cpython/pull/10814..
(cherry picked from commit 2d8f976cde4794d174b44ff7d5fd970aa89c65e8)

Co-authored-by: E Kawashima <e-kwsm@users.noreply.github.com>