### PR TITLE
bpo-35363: test_eintr runs eintr_tester.py in verbose mode

### DIFF
--- a/Lib/test/test_eintr.py
+++ b/Lib/test/test_eintr.py
@@ -1,5 +1,7 @@
 import os
 import signal
+import subprocess
+import sys
 import unittest
 
 from test import support
@@ -15,7 +17,19 @@ class EINTRTests(unittest.TestCase):
         # thread (for reliable signal delivery).
         tester = support.findfile("eintr_tester.py", subdir="eintrdata")
         # use -u to try to get the full output if the test hangs or crash
-        script_helper.assert_python_ok("-u", tester)
+        args = ["-u", tester, "-v"]
+        if support.verbose:
+            print()
+            print("--- run eintr_tester.py ---")
+            # In verbose mode, the child process inherit stdout and stdout,
+            # to see output in realtime and reduce the risk of loosing output.
+            args = [sys.executable, "-E", "-X", "faulthandler", *args]
+            proc = subprocess.run(args)
+            print(f"--- eintr_tester.py completed: exit code {proc.returncode} ---")
+            if proc.returncode:
+                self.fail("eintr_tester.py failed")
+        else:
+            script_helper.assert_python_ok("-u", tester, "-v")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Moreover, "python3 -m test test_eintr -v" now avoids redirecting
stdout/stderr to a pipe, the child process inherits stdout/stderr
from the parent.

<!-- issue-number: [bpo-35363](https://bugs.python.org/issue35363) -->
https://bugs.python.org/issue35363
<!-- /issue-number -->
