### PR TITLE
bpo-35423: Stop using the "pending calls" machinery for signals.

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -45,6 +45,8 @@ struct _ceval_runtime_state {
     /* Request for dropping the GIL */
     _Py_atomic_int gil_drop_request;
     struct _pending_calls pending;
+    /* Request for checking signals. */
+    _Py_atomic_int signals_pending;
     struct _gil_runtime_state gil;
 };
 

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -13,6 +13,11 @@ extern "C" {
 
 struct _pending_calls {
     unsigned long main_thread;
+    /* "busy" is used to avoid reentrant triggering of pending call
+       handling, including signals.
+       coordinate between the eval loop and
+       Py_MakePendingCalls().  Consequently, it may be removed if the
+       latter is removed. */
     int busy;
     PyThread_type_lock lock;
     /* Request for running pending calls. */

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -13,6 +13,7 @@ extern "C" {
 
 struct _pending_calls {
     unsigned long main_thread;
+    int busy;
     PyThread_type_lock lock;
     /* Request for running pending calls. */
     _Py_atomic_int calls_to_do;

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -13,12 +13,6 @@ extern "C" {
 
 struct _pending_calls {
     unsigned long main_thread;
-    /* "busy" is used to avoid reentrant triggering of pending call
-       handling, including signals.
-       coordinate between the eval loop and
-       Py_MakePendingCalls().  Consequently, it may be removed if the
-       latter is removed. */
-    int busy;
     PyThread_type_lock lock;
     /* Request for running pending calls. */
     _Py_atomic_int calls_to_do;

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-05-16-24-05.bpo-35423.UIie_O.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-05-16-24-05.bpo-35423.UIie_O.rst
@@ -1,0 +1,3 @@
+Separate the signal handling trigger in the eval loop from the "pending
+calls" machinery. There is no semantic change and the difference in
+performance is insignificant.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -202,12 +202,15 @@ It raises KeyboardInterrupt.");
 static int
 report_wakeup_write_error(void *data)
 {
+    PyObject *exc, *val, *tb;
     int save_errno = errno;
     errno = (int) (intptr_t) data;
+    PyErr_Fetch(&exc, &val, &tb);
     PyErr_SetFromErrno(PyExc_OSError);
     PySys_WriteStderr("Exception ignored when trying to write to the "
                       "signal wakeup fd:\n");
     PyErr_WriteUnraisable(NULL);
+    PyErr_Restore(exc, val, tb);
     errno = save_errno;
     return 0;
 }
@@ -216,6 +219,8 @@ report_wakeup_write_error(void *data)
 static int
 report_wakeup_send_error(void* data)
 {
+    PyObject *exc, *val, *tb;
+    PyErr_Fetch(&exc, &val, &tb);
     /* PyErr_SetExcFromWindowsErr() invokes FormatMessage() which
        recognizes the error codes used by both GetLastError() and
        WSAGetLastError */
@@ -223,6 +228,7 @@ report_wakeup_send_error(void* data)
     PySys_WriteStderr("Exception ignored when trying to send to the "
                       "signal wakeup fd:\n");
     PyErr_WriteUnraisable(NULL);
+    PyErr_Restore(exc, val, tb);
     return 0;
 }
 #endif   /* MS_WINDOWS */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -372,7 +372,6 @@ Py_AddPendingCall(int (*func)(void *), void *arg)
 static int
 make_pending_calls(void)
 {
-    static int busy = 0;
     int i;
     int r = 0;
 
@@ -390,9 +389,9 @@ make_pending_calls(void)
         return 0;
     }
     /* don't perform recursive pending calls */
-    if (busy)
+    if (_PyRuntime.ceval.pending.busy)
         return 0;
-    busy = 1;
+    _PyRuntime.ceval.pending.busy = 1;
     /* unsignal before starting to call callbacks, so that any callback
        added in-between re-signals */
     UNSIGNAL_PENDING_CALLS();
@@ -429,11 +428,11 @@ make_pending_calls(void)
         }
     }
 
-    busy = 0;
+    _PyRuntime.ceval.pending.busy = 0;
     return r;
 
 error:
-    busy = 0;
+    _PyRuntime.ceval.pending.busy = 0;
     SIGNAL_PENDING_CALLS(); /* We're not done yet */
     return -1;
 }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -356,14 +356,12 @@ Py_AddPendingCall(int (*func)(void *), void *arg)
     return result;
 }
 
-int
-Py_MakePendingCalls(void)
+static int
+make_pending_calls(void)
 {
     static int busy = 0;
     int i;
     int r = 0;
-
-    assert(PyGILState_Check());
 
     if (!_PyRuntime.ceval.pending.lock) {
         /* initial allocation of the lock */
@@ -425,6 +423,13 @@ error:
     busy = 0;
     SIGNAL_PENDING_CALLS(); /* We're not done yet */
     return -1;
+}
+
+int
+Py_MakePendingCalls(void)
+{
+    assert(PyGILState_Check());
+    return make_pending_calls();
 }
 
 /* The interpreter's recursion limit */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -100,6 +100,7 @@ static long dxp[256];
     _Py_atomic_store_relaxed( \
         &_PyRuntime.ceval.eval_breaker, \
         GIL_REQUEST | \
+        _Py_atomic_load_relaxed(&_PyRuntime.ceval.signals_pending) | \
         _Py_atomic_load_relaxed(&_PyRuntime.ceval.pending.calls_to_do) | \
         _PyRuntime.ceval.pending.async_exc)
 
@@ -125,6 +126,18 @@ static long dxp[256];
 #define UNSIGNAL_PENDING_CALLS() \
     do { \
         _Py_atomic_store_relaxed(&_PyRuntime.ceval.pending.calls_to_do, 0); \
+        COMPUTE_EVAL_BREAKER(); \
+    } while (0)
+
+#define SIGNAL_PENDING_SIGNALS() \
+    do { \
+        _Py_atomic_store_relaxed(&_PyRuntime.ceval.signals_pending, 1); \
+        _Py_atomic_store_relaxed(&_PyRuntime.ceval.eval_breaker, 1); \
+    } while (0)
+
+#define UNSIGNAL_PENDING_SIGNALS() \
+    do { \
+        _Py_atomic_store_relaxed(&_PyRuntime.ceval.signals_pending, 0); \
         COMPUTE_EVAL_BREAKER(); \
     } while (0)
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -451,13 +451,11 @@ error:
 int
 Py_MakePendingCalls(void)
 {
-    int res = 0;
-
     assert(PyGILState_Check());
 
     /* Python signal handler doesn't really queue a callback: it only signals
        that a signal was received, see _PyEval_SignalReceived(). */
-    res = handle_signals();
+    int res = handle_signals();
     if (res != 0) {
         return res;
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -372,6 +372,13 @@ Py_AddPendingCall(int (*func)(void *), void *arg)
 static int
 handle_signals(void)
 {
+    /* Only handle signals on main thread. */
+    if (_PyRuntime.ceval.pending.main_thread &&
+        PyThread_get_thread_ident() != _PyRuntime.ceval.pending.main_thread)
+    {
+        return 0;
+    }
+
     UNSIGNAL_PENDING_SIGNALS();
     if (PyErr_CheckSignals() < 0) {
         SIGNAL_PENDING_SIGNALS(); /* We're not done yet */


### PR DESCRIPTION
This change separates the signal handling trigger in the eval loop from the "pending calls" machinery.  There is no semantic change and the difference in performance is insignificant.

The change makes both components less confusing.  It also eliminates the risk of changes to the pending calls affecting signal handling.  This is particularly relevant for some upcoming pending calls changes I have in the works.

<!-- issue-number: [bpo-35423](https://bugs.python.org/issue35423) -->
https://bugs.python.org/issue35423
<!-- /issue-number -->
