### PR TITLE
bpo-35330:  Don't call the wrapped object if `side_effect` is set

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1027,29 +1027,27 @@ class CallableMixin(Base):
                 break
             seen.add(_new_parent_id)
 
-        ret_val = DEFAULT
         effect = self.side_effect
         if effect is not None:
             if _is_exception(effect):
                 raise effect
-
-            if not _callable(effect):
+            elif not _callable(effect):
                 result = next(effect)
                 if _is_exception(result):
                     raise result
-                if result is DEFAULT:
-                    result = self.return_value
+            else:
+                result = effect(*args, **kwargs)
+
+            if result is not DEFAULT:
                 return result
 
-            ret_val = effect(*args, **kwargs)
+        if self._mock_return_value is not DEFAULT:
+            return self.return_value
 
-        elif (self._mock_wraps is not None and
-                self._mock_return_value is DEFAULT):
+        if self._mock_wraps is not None:
             return self._mock_wraps(*args, **kwargs)
 
-        if ret_val is DEFAULT:
-            ret_val = self.return_value
-        return ret_val
+        return self.return_value
 
 
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1043,9 +1043,10 @@ class CallableMixin(Base):
 
             ret_val = effect(*args, **kwargs)
 
-        if (self._mock_wraps is not None and
-             self._mock_return_value is DEFAULT):
+        elif (self._mock_wraps is not None and
+                self._mock_return_value is DEFAULT):
             return self._mock_wraps(*args, **kwargs)
+
         if ret_val is DEFAULT:
             ret_val = self.return_value
         return ret_val

--- a/Misc/NEWS.d/next/Library/2018-12-06-00-43-13.bpo-35330.abB4BN.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-06-00-43-13.bpo-35330.abB4BN.rst
@@ -1,0 +1,4 @@
+When a :class:`Mock` instance was used to wrap an object, if `side_effect`
+is used in one of the mocks of it methods, don't call the original
+implementation and return the result of using the side effect the same way
+that it is done with return_value.


### PR DESCRIPTION
When a `Mock` instance was used to wrap an object, if `side_effect` is used in one of the mocks of it methods, don't call the original implementation and return the result of using the side effect the same way
that it is done with return_value.

This PR also includes a refactor via commit 1a28aab, as after the change the code became even harder to read. The refactor (as it now uses common code), also fixes the test case `test_customize_wrapped_object_with_side_effect_iterable_with_default`, as when adding the tests I realized that if a mock has a side effect that is an iterable and one of the values returns `DEFAULT`, it will default to `return_value` if present but not to the value in `wraps`, which is surprising given that if instead of an iterable it is a callable the behaviour is as expected to call `wraps`.
Let me know if you want me to take this to a different PR and issue, as it might be worth properly explaining it. I can also get the fix without the refactor, but it'd get quite messy, basically copying the last lines into the iterator part of `side_effect`.

<!-- issue-number: [[bpo-3533](https://bugs.python.org/issue3533)](https://bugs.python.org/issue35330) -->
https://bugs.python.org/issue35330
<!-- /issue-number -->
