### PR TITLE
Remove unused function in `testmock/support.py`

### DIFF
--- a/Lib/unittest/test/testmock/support.py
+++ b/Lib/unittest/test/testmock/support.py
@@ -12,10 +12,3 @@ class SomeClass(object):
 
 class X(object):
     pass
-
-
-def examine_warnings(func):
-    def wrapper():
-        with catch_warnings(record=True) as ws:
-            func(ws)
-    return wrapper


### PR DESCRIPTION
An easy way to raise coverage!

The function is never imported and the implementation is actually buggy.
As `warnings.catch_warnings` is not imported here.

Let me know if you want me to create an issue/news entry for this, though I think it is not worth it.