### PR TITLE
bpo-35424: test_multiprocessing: join 3 pools

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2471,6 +2471,7 @@ class _TestPool(BaseTestCase):
             with self.Pool(2) as p:
                 r = p.map_async(sqr, L)
                 self.assertEqual(r.get(), expected)
+            p.join()
             self.assertRaises(ValueError, p.map_async, sqr, L)
 
     @classmethod
@@ -2488,6 +2489,7 @@ class _TestPool(BaseTestCase):
                     exc = e
                 else:
                     self.fail('expected RuntimeError')
+            p.join()
             self.assertIs(type(exc), RuntimeError)
             self.assertEqual(exc.args, (123,))
             cause = exc.__cause__
@@ -2512,6 +2514,7 @@ class _TestPool(BaseTestCase):
                     self.fail('expected SayWhenError')
                 self.assertIs(type(exc), SayWhenError)
                 self.assertIs(exc.__cause__, None)
+            p.join()
 
     @classmethod
     def _test_wrapped_exception(cls):


### PR DESCRIPTION
Join 3 pools in these tests:

* test.test_multiprocessing_spawn.WithProcessesTestPool.test_context
* test.test_multiprocessing_spawn.WithProcessesTestPool.test_traceback

<!-- issue-number: [bpo-35424](https://bugs.python.org/issue35424) -->
https://bugs.python.org/issue35424
<!-- /issue-number -->
