### PR TITLE
Document that dict.fromkeys accepts any iterable for keys

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4245,7 +4245,8 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
 
    .. classmethod:: fromkeys(seq[, value])
 
-      Create a new dictionary with keys from *seq* and values set to *value*.
+      Create a new dictionary with keys from iterable *seq* and values set to
+      *value*.
 
       :meth:`fromkeys` is a class method that returns a new dictionary. *value*
       defaults to ``None``.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4245,7 +4245,7 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
 
    .. classmethod:: fromkeys(iterable[, value])
 
-      Create a new dictionary with keys from iterable and values set to *value*.
+      Create a new dictionary with keys from *iterable* and values set to *value*.
 
       :meth:`fromkeys` is a class method that returns a new dictionary. *value*
       defaults to ``None``.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4243,10 +4243,9 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
 
       Return a shallow copy of the dictionary.
 
-   .. classmethod:: fromkeys(seq[, value])
+   .. classmethod:: fromkeys(iterable[, value])
 
-      Create a new dictionary with keys from iterable *seq* and values set to
-      *value*.
+      Create a new dictionary with keys from iterable and values set to *value*.
 
       :meth:`fromkeys` is a class method that returns a new dictionary. *value*
       defaults to ``None``.


### PR DESCRIPTION
Parameter name "seq" is updated to "iterable" (the current name reported by help() on 3.7.1).