### PR TITLE
bpo-35429: Use raise NotImplementedError instead of NotImplemented

### DIFF
--- a/Lib/idlelib/debugger_r.py
+++ b/Lib/idlelib/debugger_r.py
@@ -157,7 +157,7 @@ class IdbAdapter:
     #----------called by a DictProxy----------
 
     def dict_keys(self, did):
-        raise NotImplemented("dict_keys not public or pickleable")
+        raise NotImplementedError("dict_keys not public or pickleable")
 ##         dict = dicttable[did]
 ##         return dict.keys()
 

--- a/Lib/idlelib/idle_test/test_debugger_r.py
+++ b/Lib/idlelib/idle_test/test_debugger_r.py
@@ -25,7 +25,7 @@ class Test(unittest.TestCase):
         adapter = debugger_r.IdbAdapter(None)
 
         with self.assertRaises(NotImplementedError):
-            adapter.dict_keys()
+            adapter.dict_keys(None)
 
 
 # Classes GUIProxy, IdbAdapter, FrameProxy, CodeProxy, DictProxy,

--- a/Lib/idlelib/idle_test/test_debugger_r.py
+++ b/Lib/idlelib/idle_test/test_debugger_r.py
@@ -21,6 +21,12 @@ class Test(unittest.TestCase):
     def test_init(self):
         self.assertTrue(True)  # Get coverage of import
 
+    def test_idbadapter_dict_keys(self):
+        adapter = debugger_r.IdbAdapter(None)
+
+        with self.assertRaises(NotImplementedError):
+            adapter.dict_keys()
+
 
 # Classes GUIProxy, IdbAdapter, FrameProxy, CodeProxy, DictProxy,
 # GUIAdapter, IdbProxy plus 7 module functions.

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -884,8 +884,8 @@ class SSLSocket(socket):
             return self._sslobj.session_reused
 
     def dup(self):
-        raise NotImplemented("Can't dup() %s instances" %
-                             self.__class__.__name__)
+        raise NotImplementedError("Can't dup() %s instances" %
+                                  self.__class__.__name__)
 
     def _checkClosed(self, msg=None):
         # raise an exception here if you wish to check for spurious closes

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3531,6 +3531,10 @@ class ThreadedTests(unittest.TestCase):
         server.close()
         # Sanity checks.
         self.assertIsInstance(remote, ssl.SSLSocket)
+
+        with self.assertRaises(NotImplementedError):
+            remote.dup()
+
         self.assertEqual(peer, client_addr)
 
     def test_getpeercert_enotconn(self):


### PR DESCRIPTION
Closes https://bugs.python.org/issue35429

In two places in stdlib, `raise NotImplemented` was used instead of `raise NotImplementedError`. The former is not valid and produces,

```
>>> raise NotImplemented('message')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'NotImplementedType' object is not callable
```


<!-- issue-number: [bpo-35429](https://bugs.python.org/issue35429) -->
https://bugs.python.org/issue35429
<!-- /issue-number -->
