### PR TITLE
[3.6] bpo-33023: Fix NotImplemented to NotImplementedError. (GH-10934).

### DIFF
--- a/Lib/idlelib/debugger_r.py
+++ b/Lib/idlelib/debugger_r.py
@@ -157,7 +157,7 @@ class IdbAdapter:
     #----------called by a DictProxy----------
 
     def dict_keys(self, did):
-        raise NotImplemented("dict_keys not public or pickleable")
+        raise NotImplementedError("dict_keys not public or pickleable")
 ##         dict = dicttable[did]
 ##         return dict.keys()
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -848,8 +848,8 @@ class SSLSocket(socket):
             return self._sslobj.session_reused
 
     def dup(self):
-        raise NotImplemented("Can't dup() %s instances" %
-                             self.__class__.__name__)
+        raise NotImplementedError("Can't dup() %s instances" %
+                                  self.__class__.__name__)
 
     def _checkClosed(self, msg=None):
         # raise an exception here if you wish to check for spurious closes

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -408,6 +408,12 @@ class BasicSocketTests(unittest.TestCase):
             self.assertRaises(OSError, ss.recvfrom_into, bytearray(b'x'), 1)
             self.assertRaises(OSError, ss.send, b'x')
             self.assertRaises(OSError, ss.sendto, b'x', ('0.0.0.0', 0))
+            self.assertRaises(NotImplementedError, ss.dup)
+            self.assertRaises(NotImplementedError, ss.sendmsg,
+                              [b'x'], (), 0, ('0.0.0.0', 0))
+            self.assertRaises(NotImplementedError, ss.recvmsg, 100)
+            self.assertRaises(NotImplementedError, ss.recvmsg_into,
+                              [bytearray(100)])
 
     def test_timeout(self):
         # Issue #8524: when creating an SSL socket, the timeout of the
@@ -2942,11 +2948,11 @@ if _have_threads:
                 # Make sure sendmsg et al are disallowed to avoid
                 # inadvertent disclosure of data and/or corruption
                 # of the encrypted data stream
+                self.assertRaises(NotImplementedError, s.dup)
                 self.assertRaises(NotImplementedError, s.sendmsg, [b"data"])
                 self.assertRaises(NotImplementedError, s.recvmsg, 100)
                 self.assertRaises(NotImplementedError,
-                                  s.recvmsg_into, bytearray(100))
-
+                                  s.recvmsg_into, [bytearray(100)])
                 s.write(b"over\n")
 
                 self.assertRaises(ValueError, s.recv, -1)


### PR DESCRIPTION
(cherry picked from commit 42b1d6127bd8595522a78a75166ebb9fba74a6a2)


<!-- issue-number: [bpo-33023](https://bugs.python.org/issue33023) -->
https://bugs.python.org/issue33023
<!-- /issue-number -->
