### PR TITLE
[2.7] bpo-33023: Fix NotImplemented to NotImplementedError. (GH-10934). (GH-11001)

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -630,8 +630,8 @@ class SSLSocket(socket):
         self._sslobj.context = ctx
 
     def dup(self):
-        raise NotImplemented("Can't dup() %s instances" %
-                             self.__class__.__name__)
+        raise NotImplementedError("Can't dup() %s instances" %
+                                  self.__class__.__name__)
 
     def _checkClosed(self, msg=None):
         # raise an exception here if you wish to check for spurious closes

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -341,6 +341,7 @@ class BasicSocketTests(unittest.TestCase):
             self.assertRaises(socket.error, ss.recvfrom_into, bytearray(b'x'), 1)
             self.assertRaises(socket.error, ss.send, b'x')
             self.assertRaises(socket.error, ss.sendto, b'x', ('0.0.0.0', 0))
+            self.assertRaises(NotImplementedError, ss.dup)
 
     def test_timeout(self):
         # Issue #8524: when creating an SSL socket, the timeout of the
@@ -2645,6 +2646,7 @@ else:
                 self.assertEqual(s.read(-1, buffer), len(data))
                 self.assertEqual(buffer, data)
 
+                self.assertRaises(NotImplementedError, s.dup)
                 s.write(b"over\n")
 
                 self.assertRaises(ValueError, s.recv, -1)


### PR DESCRIPTION
(cherry picked from commit 42b1d6127bd8595522a78a75166ebb9fba74a6a2).
(cherry picked from commit 7a2cf1e7d3bf300e98c702589d405734f4a8fcf8)


<!-- issue-number: [bpo-33023](https://bugs.python.org/issue33023) -->
https://bugs.python.org/issue33023
<!-- /issue-number -->
