### PR TITLE
bpo-32805: Fix compiler warnings in gcmodule.c

### DIFF
--- a/Include/pydtrace.h
+++ b/Include/pydtrace.h
@@ -29,7 +29,7 @@ static inline void PyDTrace_LINE(const char *arg0, const char *arg1, int arg2) {
 static inline void PyDTrace_FUNCTION_ENTRY(const char *arg0, const char *arg1, int arg2)  {}
 static inline void PyDTrace_FUNCTION_RETURN(const char *arg0, const char *arg1, int arg2) {}
 static inline void PyDTrace_GC_START(int arg0) {}
-static inline void PyDTrace_GC_DONE(int arg0) {}
+static inline void PyDTrace_GC_DONE(Py_ssize_t arg0) {}
 static inline void PyDTrace_INSTANCE_NEW_START(int arg0) {}
 static inline void PyDTrace_INSTANCE_NEW_DONE(int arg0) {}
 static inline void PyDTrace_INSTANCE_DELETE_START(int arg0) {}


### PR DESCRIPTION
Use a C data type that matches DTrace's data type size for `long`.

<!-- issue-number: [bpo-32805](https://bugs.python.org/issue32805) -->
https://bugs.python.org/issue32805
<!-- /issue-number -->
