### PR TITLE
bpo-35434 Fix wrong issue number in what's new in 3.8

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -275,7 +275,7 @@ Optimizations
   +26% on Linux, +50% on macOS and +40% on Windows. Also, much less CPU cycles
   are consumed.
   See :ref:`shutil-platform-dependent-efficient-copy-operations` section.
-  (Contributed by Giampaolo Rodola' in :issue:`25427`.)
+  (Contributed by Giampaolo Rodola' in :issue:`33671`.)
 
 * :func:`shutil.copytree` uses :func:`os.scandir` function and all copy
   functions depending from it use cached :func:`os.stat` values. The speedup


### PR DESCRIPTION


<!-- issue-number: [bpo-35434](https://bugs.python.org/issue35434) -->
https://bugs.python.org/issue35434
<!-- /issue-number -->
