### PR TITLE
bpo-35431: Add a function computing binomial numbers to the math module

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -218,6 +218,21 @@ Number-theoretic and representation functions
    :meth:`x.__trunc__() <object.__trunc__>`.
 
 
+.. function:: comb(n, k)
+
+   Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
+
+   It is the coefficient of kth term in polynomial expansion of the expression
+   (1 + x)^n. It is also known as the number of ways to choose an unordered
+   subset of k elements from a fixed set of n elements, usually called
+   *n choose k*.
+
+   Raises :exc:`TypeError` if argument(s) are non-integer and :exc:`ValueError`
+   if argument(s) are negative or k > n.
+
+   .. versionadded:: 3.8
+
+
 Note that :func:`frexp` and :func:`modf` have a different call/return pattern
 than their C equivalents: they take a single argument and return a pair of
 values, rather than returning their second return value through an 'output

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -227,8 +227,9 @@ Number-theoretic and representation functions
    subset of k elements from a fixed set of n elements, usually called
    *n choose k*.
 
-   Raises :exc:`TypeError` if argument(s) are non-integer and :exc:`ValueError`
-   if argument(s) are negative or k > n.
+   Raises :exc:`TypeError` if argument(s) are non-integer, :exc:`ValueError`
+   if argument(s) are negative or k > n, and :exc:`OverflowError` if k and (n-k)
+   are too large (beyond `LLONG_MAX`).
 
    .. versionadded:: 3.8
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -218,7 +218,7 @@ Number-theoretic and representation functions
    :meth:`x.__trunc__() <object.__trunc__>`.
 
 
-.. function:: comb(n, k)
+.. function:: combinations(n, k)
 
    Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -218,7 +218,7 @@ Number-theoretic and representation functions
    :meth:`x.__trunc__() <object.__trunc__>`.
 
 
-.. function:: combinations(n, k)
+.. function:: comb(n, k)
 
    Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -548,24 +548,24 @@ class MathTests(unittest.TestCase):
             self.assertEqual(1, math.binomial(n, n))
 
     def testBinomialValueErrors(self):
-        """Test math.binomial raises ValueError on negative or non-integral inputs."""
+        """Test that math.binomial raises ValueError on negative inputs."""
         self.assertRaises(ValueError, math.binomial, 0, -1)
-        self.assertRaises(ValueError, math.binomial, 0, -1.0)
         self.assertRaises(ValueError, math.binomial, 0, -10**100)
-        self.assertRaises(ValueError, math.binomial, 0, -1e100)
-        self.assertRaises(ValueError, math.binomial, 0, math.pi)
 
         self.assertRaises(ValueError, math.binomial, -1,       0)
-        self.assertRaises(ValueError, math.binomial, -1.0,     0)
         self.assertRaises(ValueError, math.binomial, -10**100, 0)
-        self.assertRaises(ValueError, math.binomial, -1e100,   0)
-        self.assertRaises(ValueError, math.binomial, math.pi,  0)
 
     def testBinomialTypeErrors(self):
-        """Test math.binomial raises TypeError on non-int, non-float inputs."""
+        """Test math.binomial raises TypeError on non-int inputs."""
+        self.assertRaises(TypeError, math.binomial, 0, -1e100)
+        self.assertRaises(TypeError, math.binomial, 0, -1.0)
+        self.assertRaises(TypeError, math.binomial, 0, math.pi)
         self.assertRaises(TypeError, math.binomial, 0, decimal.Decimal(5.2))
         self.assertRaises(TypeError, math.binomial, 0, "5")
 
+        self.assertRaises(TypeError, math.binomial, -1e100,   0)
+        self.assertRaises(ValueError, math.binomial, -1.0,     0)
+        self.assertRaises(TypeError, math.binomial, math.pi,  0)
         self.assertRaises(TypeError, math.binomial, decimal.Decimal(5.2), 0)
         self.assertRaises(TypeError, math.binomial, "5",                  0)
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -523,41 +523,41 @@ class MathTests(unittest.TestCase):
         self.assertRaises(OverflowError, math.factorial, 10**100)
         self.assertRaises(OverflowError, math.factorial, 1e100)
 
-    def testBinomialFactorial(self):
+    def testCombinationsFactorial(self):
         """Test (n choose k) = n! / (k! (n-k)!) when 0 <= k <= n."""
         for n in range(100):
             for k in range(n+1):
-                self.assertEqual(math.binomial(n, k), factorial(n) // factorial(k) // factorial(n-k))
+                self.assertEqual(math.combinations(n, k), factorial(n) // factorial(k) // factorial(n-k))
 
-    def testBinomialTriangle(self):
+    def testCombinationsTriangle(self):
         """Test (n+1 choose k+1) = (n choose k) + (n choose k+1)"""
         for n in range(100):
             for k in range(100):
-                self.assertEqual(math.binomial(n + 1, k + 1), math.binomial(n, k) + math.binomial(n, k + 1))
+                self.assertEqual(math.combinations(n + 1, k + 1), math.combinations(n, k) + math.combinations(n, k + 1))
 
-    def testBinomialZero(self):
+    def testCombinationsZero(self):
         """Test (n choose k) = 0 when k>n"""
         for k in range(100):
             for n in range(k):
-                self.assertEqual(0, math.binomial(n, k))
+                self.assertEqual(0, math.combinations(n, k))
 
-    def testBinomialOne(self):
+    def testCombinationsOne(self):
         """Test (n choose 0) = (n choose n) = 1"""
         for n in range(100):
-            self.assertEqual(1, math.binomial(n, 0))
-            self.assertEqual(1, math.binomial(n, n))
+            self.assertEqual(1, math.combinations(n, 0))
+            self.assertEqual(1, math.combinations(n, n))
 
-    def testBinomialValueErrors(self):
-        """Test that math.binomial raises ValueError on negative inputs."""
+    def testCombinationsValueErrors(self):
+        """Test that math.combinations raises ValueError on negative inputs."""
         for neg in [-1, -10**100]:
-            self.assertRaises(ValueError, math.binomial, 0, neg)
-            self.assertRaises(ValueError, math.binomial, neg, 0)
+            self.assertRaises(ValueError, math.combinations, 0, neg)
+            self.assertRaises(ValueError, math.combinations, neg, 0)
 
-    def testBinomialTypeErrors(self):
-        """Test math.binomial raises TypeError on non-int inputs."""
+    def testCombinationsTypeErrors(self):
+        """Test math.combinations raises TypeError on non-int inputs."""
         for non_int in [-1e100, -1.0, math.pi, decimal.Decimal(5.2), "5"]:
-            self.assertRaises(TypeError, math.binomial, 0, non_int)
-            self.assertRaises(TypeError, math.binomial, non_int, 0)
+            self.assertRaises(TypeError, math.combinations, 0, non_int)
+            self.assertRaises(TypeError, math.combinations, non_int, 0)
 
     def testFloor(self):
         self.assertRaises(TypeError, math.floor)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -532,7 +532,7 @@ class MathTests(unittest.TestCase):
     def testCombinationsTriangle(self):
         """Test (n+1 choose k+1) = (n choose k) + (n choose k+1)"""
         for n in range(100):
-            for k in range(100):
+            for k in range(n):
                 self.assertEqual(math.combinations(n + 1, k + 1), math.combinations(n, k) + math.combinations(n, k + 1))
 
     def testCombinationsZero(self):
@@ -548,10 +548,14 @@ class MathTests(unittest.TestCase):
             self.assertEqual(1, math.combinations(n, n))
 
     def testCombinationsValueErrors(self):
-        """Test that math.combinations raises ValueError on negative inputs."""
+        """Test that math.combinations raises ValueError on negative inputs or k>n."""
         for neg in [-1, -10**100]:
             self.assertRaises(ValueError, math.combinations, 0, neg)
             self.assertRaises(ValueError, math.combinations, neg, 0)
+
+        for n in range(100):
+            for k in range(n+1, 100):
+                self.assertRaises(ValueError, math.combinations, n, k)
 
     def testCombinationsOverflow(self):
         """math.combinations raises OverflowError on inputs too large for C longs."""

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -527,7 +527,8 @@ class MathTests(unittest.TestCase):
         """Test (n choose k) = n! / (k! (n-k)!) when 0 <= k <= n."""
         for n in range(100):
             for k in range(n+1):
-                self.assertEqual(math.combinations(n, k), factorial(n) // factorial(k) // factorial(n-k))
+                self.assertEqual(math.combinations(n, k),
+                                 math.factorial(n) // math.factorial(k) // math.factorial(n-k))
 
     def testCombinationsTriangle(self):
         """Test (n+1 choose k+1) = (n choose k) + (n choose k+1)"""

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -560,7 +560,7 @@ class MathTests(unittest.TestCase):
 
     def testCombinationsOverflow(self):
         """math.combinations raises OverflowError on inputs too large for C longs."""
-        # minimum(k, n - k) > LLONG_MAX)
+        # min(k, n - k) > LLONG_MAX)
         self.assertRaises(OverflowError, math.combinations, 10**400, 10**200)
 
     def testCombinationsTypeErrors(self):

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -523,32 +523,32 @@ class MathTests(unittest.TestCase):
         self.assertRaises(OverflowError, math.factorial, 10**100)
         self.assertRaises(OverflowError, math.factorial, 1e100)
 
-    def testCombinationsFactorial(self):
+    def testCombFactorial(self):
         """Test (n choose k) = n! / (k! (n-k)!) when 0 <= k <= n."""
         for n in range(100):
             for k in range(n+1):
                 self.assertEqual(math.comb(n, k),
                                  math.factorial(n) // math.factorial(k) // math.factorial(n-k))
 
-    def testCombinationsTriangle(self):
+    def testCombTriangle(self):
         """Test (n+1 choose k+1) = (n choose k) + (n choose k+1)"""
         for n in range(100):
             for k in range(n):
                 self.assertEqual(math.comb(n + 1, k + 1), math.comb(n, k) + math.comb(n, k + 1))
 
-    def testCombinationsZero(self):
+    def testCombZero(self):
         """(n choose k) raises ValueError when k>n"""
         for k in range(100):
             for n in range(k):
                 self.assertRaises(ValueError, math.comb, n, k)
 
-    def testCombinationsOne(self):
+    def testCombOne(self):
         """Test (n choose 0) = (n choose n) = 1"""
         for n in range(100):
             self.assertEqual(1, math.comb(n, 0))
             self.assertEqual(1, math.comb(n, n))
 
-    def testCombinationsValueErrors(self):
+    def testCombValueErrors(self):
         """Test that math.comb raises ValueError on negative inputs or k>n."""
         for neg in [-1, -10**100]:
             self.assertRaises(ValueError, math.comb, 0, neg)
@@ -558,12 +558,12 @@ class MathTests(unittest.TestCase):
             for k in range(n+1, 100):
                 self.assertRaises(ValueError, math.comb, n, k)
 
-    def testCombinationsOverflow(self):
+    def testCombOverflow(self):
         """math.comb raises OverflowError on inputs too large for C longs."""
         # min(k, n - k) > LLONG_MAX)
         self.assertRaises(OverflowError, math.comb, 10**400, 10**200)
 
-    def testCombinationsTypeErrors(self):
+    def testCombTypeErrors(self):
         """Test math.comb raises TypeError on non-int inputs."""
         for non_int in [-1e100, -1.0, math.pi, decimal.Decimal(5.2), "5"]:
             self.assertRaises(TypeError, math.comb, 0, non_int)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -537,10 +537,10 @@ class MathTests(unittest.TestCase):
                 self.assertEqual(math.combinations(n + 1, k + 1), math.combinations(n, k) + math.combinations(n, k + 1))
 
     def testCombinationsZero(self):
-        """Test (n choose k) = 0 when k>n"""
+        """(n choose k) raises ValueError when k>n"""
         for k in range(100):
             for n in range(k):
-                self.assertEqual(0, math.combinations(n, k))
+                self.assertRaises(ValueError, math.combinations, n, k)
 
     def testCombinationsOne(self):
         """Test (n choose 0) = (n choose n) = 1"""

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -523,6 +523,52 @@ class MathTests(unittest.TestCase):
         self.assertRaises(OverflowError, math.factorial, 10**100)
         self.assertRaises(OverflowError, math.factorial, 1e100)
 
+    def testBinomialFactorial(self):
+        """Test (n choose k) = n! / (k! (n-k)!) when 0 <= k <= n."""
+        for n in range(100):
+            for k in range(n+1):
+                self.assertEqual(math.binomial(n, k), factorial(n) // factorial(k) // factorial(n-k))
+
+    def testBinomialTriangle(self):
+        """Test (n+1 choose k+1) = (n choose k) + (n choose k+1)"""
+        for n in range(100):
+            for k in range(100):
+                self.assertEqual(math.binomial(n + 1, k + 1), math.binomial(n, k) + math.binomial(n, k + 1))
+
+    def testBinomialZero(self):
+        """Test (n choose k) = 0 when k>n"""
+        for k in range(100):
+            for n in range(k):
+                self.assertEqual(0, math.binomial(n, k))
+
+    def testBinomialOne(self):
+        """Test (n choose 0) = (n choose n) = 1"""
+        for n in range(100):
+            self.assertEqual(1, math.binomial(n, 0))
+            self.assertEqual(1, math.binomial(n, n))
+
+    def testBinomialValueErrors(self):
+        """Test math.binomial raises ValueError on negative or non-integral inputs."""
+        self.assertRaises(ValueError, math.binomial, 0, -1)
+        self.assertRaises(ValueError, math.binomial, 0, -1.0)
+        self.assertRaises(ValueError, math.binomial, 0, -10**100)
+        self.assertRaises(ValueError, math.binomial, 0, -1e100)
+        self.assertRaises(ValueError, math.binomial, 0, math.pi)
+
+        self.assertRaises(ValueError, math.binomial, -1,       0)
+        self.assertRaises(ValueError, math.binomial, -1.0,     0)
+        self.assertRaises(ValueError, math.binomial, -10**100, 0)
+        self.assertRaises(ValueError, math.binomial, -1e100,   0)
+        self.assertRaises(ValueError, math.binomial, math.pi,  0)
+
+    def testBinomialTypeErrors(self):
+        """Test math.binomial raises TypeError on non-int, non-float inputs."""
+        self.assertRaises(TypeError, math.binomial, 0, decimal.Decimal(5.2))
+        self.assertRaises(TypeError, math.binomial, 0, "5")
+
+        self.assertRaises(TypeError, math.binomial, decimal.Decimal(5.2), 0)
+        self.assertRaises(TypeError, math.binomial, "5",                  0)
+
     def testFloor(self):
         self.assertRaises(TypeError, math.floor)
         self.assertEqual(int, type(math.floor(0.5)))

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -549,25 +549,15 @@ class MathTests(unittest.TestCase):
 
     def testBinomialValueErrors(self):
         """Test that math.binomial raises ValueError on negative inputs."""
-        self.assertRaises(ValueError, math.binomial, 0, -1)
-        self.assertRaises(ValueError, math.binomial, 0, -10**100)
-
-        self.assertRaises(ValueError, math.binomial, -1,       0)
-        self.assertRaises(ValueError, math.binomial, -10**100, 0)
+        for neg in [-1, -10**100]:
+            self.assertRaises(ValueError, math.binomial, 0, neg)
+            self.assertRaises(ValueError, math.binomial, neg, 0)
 
     def testBinomialTypeErrors(self):
         """Test math.binomial raises TypeError on non-int inputs."""
-        self.assertRaises(TypeError, math.binomial, 0, -1e100)
-        self.assertRaises(TypeError, math.binomial, 0, -1.0)
-        self.assertRaises(TypeError, math.binomial, 0, math.pi)
-        self.assertRaises(TypeError, math.binomial, 0, decimal.Decimal(5.2))
-        self.assertRaises(TypeError, math.binomial, 0, "5")
-
-        self.assertRaises(TypeError, math.binomial, -1e100,   0)
-        self.assertRaises(ValueError, math.binomial, -1.0,     0)
-        self.assertRaises(TypeError, math.binomial, math.pi,  0)
-        self.assertRaises(TypeError, math.binomial, decimal.Decimal(5.2), 0)
-        self.assertRaises(TypeError, math.binomial, "5",                  0)
+        for non_int in [-1e100, -1.0, math.pi, decimal.Decimal(5.2), "5"]:
+            self.assertRaises(TypeError, math.binomial, 0, non_int)
+            self.assertRaises(TypeError, math.binomial, non_int, 0)
 
     def testFloor(self):
         self.assertRaises(TypeError, math.floor)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -527,47 +527,47 @@ class MathTests(unittest.TestCase):
         """Test (n choose k) = n! / (k! (n-k)!) when 0 <= k <= n."""
         for n in range(100):
             for k in range(n+1):
-                self.assertEqual(math.combinations(n, k),
+                self.assertEqual(math.comb(n, k),
                                  math.factorial(n) // math.factorial(k) // math.factorial(n-k))
 
     def testCombinationsTriangle(self):
         """Test (n+1 choose k+1) = (n choose k) + (n choose k+1)"""
         for n in range(100):
             for k in range(n):
-                self.assertEqual(math.combinations(n + 1, k + 1), math.combinations(n, k) + math.combinations(n, k + 1))
+                self.assertEqual(math.comb(n + 1, k + 1), math.comb(n, k) + math.comb(n, k + 1))
 
     def testCombinationsZero(self):
         """(n choose k) raises ValueError when k>n"""
         for k in range(100):
             for n in range(k):
-                self.assertRaises(ValueError, math.combinations, n, k)
+                self.assertRaises(ValueError, math.comb, n, k)
 
     def testCombinationsOne(self):
         """Test (n choose 0) = (n choose n) = 1"""
         for n in range(100):
-            self.assertEqual(1, math.combinations(n, 0))
-            self.assertEqual(1, math.combinations(n, n))
+            self.assertEqual(1, math.comb(n, 0))
+            self.assertEqual(1, math.comb(n, n))
 
     def testCombinationsValueErrors(self):
-        """Test that math.combinations raises ValueError on negative inputs or k>n."""
+        """Test that math.comb raises ValueError on negative inputs or k>n."""
         for neg in [-1, -10**100]:
-            self.assertRaises(ValueError, math.combinations, 0, neg)
-            self.assertRaises(ValueError, math.combinations, neg, 0)
+            self.assertRaises(ValueError, math.comb, 0, neg)
+            self.assertRaises(ValueError, math.comb, neg, 0)
 
         for n in range(100):
             for k in range(n+1, 100):
-                self.assertRaises(ValueError, math.combinations, n, k)
+                self.assertRaises(ValueError, math.comb, n, k)
 
     def testCombinationsOverflow(self):
-        """math.combinations raises OverflowError on inputs too large for C longs."""
+        """math.comb raises OverflowError on inputs too large for C longs."""
         # min(k, n - k) > LLONG_MAX)
-        self.assertRaises(OverflowError, math.combinations, 10**400, 10**200)
+        self.assertRaises(OverflowError, math.comb, 10**400, 10**200)
 
     def testCombinationsTypeErrors(self):
-        """Test math.combinations raises TypeError on non-int inputs."""
+        """Test math.comb raises TypeError on non-int inputs."""
         for non_int in [-1e100, -1.0, math.pi, decimal.Decimal(5.2), "5"]:
-            self.assertRaises(TypeError, math.combinations, 0, non_int)
-            self.assertRaises(TypeError, math.combinations, non_int, 0)
+            self.assertRaises(TypeError, math.comb, 0, non_int)
+            self.assertRaises(TypeError, math.comb, non_int, 0)
 
     def testFloor(self):
         self.assertRaises(TypeError, math.floor)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -553,6 +553,11 @@ class MathTests(unittest.TestCase):
             self.assertRaises(ValueError, math.combinations, 0, neg)
             self.assertRaises(ValueError, math.combinations, neg, 0)
 
+    def testCombinationsOverflow(self):
+        """math.combinations raises OverflowError on inputs too large for C longs."""
+        # minimum(k, n - k) > LLONG_MAX)
+        self.assertRaises(OverflowError, math.combinations, 10**400, 10**200)
+
     def testCombinationsTypeErrors(self):
         """Test math.combinations raises TypeError on non-int inputs."""
         for non_int in [-1e100, -1.0, math.pi, decimal.Decimal(5.2), "5"]:
@@ -1845,57 +1850,6 @@ class IsCloseTests(unittest.TestCase):
             (Fraction(10**8 + 1, 10**28), Fraction(1, 10**20))]
         self.assertAllClose(fraction_examples, rel_tol=1e-8)
         self.assertAllNotClose(fraction_examples, rel_tol=1e-9)
-
-    def testComb(self):
-        comb = math.comb
-        factorial = math.factorial
-        # Test if factorial defintion is satisfied
-        for n in range(100):
-            for k in range(n + 1):
-                self.assertEqual(comb(n, k), factorial(n)
-                    // (factorial(k) * factorial(n - k)))
-
-        # Test for Pascal's identity
-        for n in range(1, 100):
-            for k in range(1, n):
-                self.assertEqual(comb(n, k), comb(n - 1, k - 1) + comb(n - 1, k))
-
-        # Test corner case
-        for n in range(100):
-            self.assertEqual(comb(n, 0), 1)
-            self.assertEqual(comb(n, n), 1)
-
-        for n in range(1, 100):
-            self.assertEqual(comb(n, 1), n)
-            self.assertEqual(comb(n, n - 1), n)
-
-        # Test Symmetry
-        for n in range(100):
-            for k in range(n // 2):
-                self.assertEqual(comb(n, k), comb(n, n - k))
-
-        # Test OverflowError (For current implementation occurs when
-        # minimum(k, n - k) > LLONG_MAX)
-        self.assertRaises(OverflowError, comb, 10**400, 10**200)
-
-        # Raises TypeError if any argument is non-integer or argument count is
-        # not 2
-        self.assertRaises(TypeError, comb, 10, 1.0)
-        self.assertRaises(TypeError, comb, 10, "1")
-        self.assertRaises(TypeError, comb, "10", 1)
-        self.assertRaises(TypeError, comb, 10.0, 1)
-
-        self.assertRaises(TypeError, comb, 10)
-        self.assertRaises(TypeError, comb, 10, 1, 3)
-        self.assertRaises(TypeError, comb)
-
-        # Raises Value error if not 0 <= k <= n
-        self.assertRaises(ValueError, comb, -1, 1)
-        self.assertRaises(ValueError, comb, 1, -1)
-        self.assertRaises(ValueError, comb, 1, 2)
-
-        # ValueError instead of OverflowError if k is negative and overflowing
-        self.assertRaises(ValueError, comb, 10**400, -10**200)
 
 
 def test_main():

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1846,6 +1846,57 @@ class IsCloseTests(unittest.TestCase):
         self.assertAllClose(fraction_examples, rel_tol=1e-8)
         self.assertAllNotClose(fraction_examples, rel_tol=1e-9)
 
+    def testComb(self):
+        comb = math.comb
+        factorial = math.factorial
+        # Test if factorial defintion is satisfied
+        for n in range(100):
+            for k in range(n + 1):
+                self.assertEqual(comb(n, k), factorial(n)
+                    // (factorial(k) * factorial(n - k)))
+
+        # Test for Pascal's identity
+        for n in range(1, 100):
+            for k in range(1, n):
+                self.assertEqual(comb(n, k), comb(n - 1, k - 1) + comb(n - 1, k))
+
+        # Test corner case
+        for n in range(100):
+            self.assertEqual(comb(n, 0), 1)
+            self.assertEqual(comb(n, n), 1)
+
+        for n in range(1, 100):
+            self.assertEqual(comb(n, 1), n)
+            self.assertEqual(comb(n, n - 1), n)
+
+        # Test Symmetry
+        for n in range(100):
+            for k in range(n // 2):
+                self.assertEqual(comb(n, k), comb(n, n - k))
+
+        # Test OverflowError (For current implementation occurs when
+        # minimum(k, n - k) > LLONG_MAX)
+        self.assertRaises(OverflowError, comb, 10**400, 10**200)
+
+        # Raises TypeError if any argument is non-integer or argument count is
+        # not 2
+        self.assertRaises(TypeError, comb, 10, 1.0)
+        self.assertRaises(TypeError, comb, 10, "1")
+        self.assertRaises(TypeError, comb, "10", 1)
+        self.assertRaises(TypeError, comb, 10.0, 1)
+
+        self.assertRaises(TypeError, comb, 10)
+        self.assertRaises(TypeError, comb, 10, 1, 3)
+        self.assertRaises(TypeError, comb)
+
+        # Raises Value error if not 0 <= k <= n
+        self.assertRaises(ValueError, comb, -1, 1)
+        self.assertRaises(ValueError, comb, 1, -1)
+        self.assertRaises(ValueError, comb, 1, 2)
+
+        # ValueError instead of OverflowError if k is negative and overflowing
+        self.assertRaises(ValueError, comb, 10**400, -10**200)
+
 
 def test_main():
     from doctest import DocFileSuite

--- a/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
@@ -1,3 +1,3 @@
-Implement :func:`math.comb` that returns binomial coefficient, that is the
+Implement :func:`math.combinations` that returns binomial coefficient, that is the
 coefficient of kth term in expansion of polynomial (1 + x)^n.
-Patch by Yash Aggarwal.
+Patch by Keller Fuchs and Yash Aggarwal.

--- a/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
@@ -1,0 +1,3 @@
+Implement :func:`math.comb` that returns binomial coefficient, that is the
+coefficient of kth term in expansion of polynomial (1 + x)^n.
+Patch by Yash Aggarwal.

--- a/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
@@ -1,3 +1,3 @@
-Implement :func:`math.combinations` that returns binomial coefficient, that is the
+Implement :func:`math.comb` that returns binomial coefficient, that is the
 coefficient of kth term in expansion of polynomial (1 + x)^n.
 Patch by Keller Fuchs and Yash Aggarwal.

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -629,8 +629,8 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(math_comb__doc__,
-"comb($module, n, k, /)\n"
+PyDoc_STRVAR(math_combinations__doc__,
+"combinations($module, n, k, /)\n"
 "--\n"
 "\n"
 "Return the binomial coefficient indexed by the pair of integers n >= k >= 0.\n"
@@ -643,27 +643,27 @@ PyDoc_STRVAR(math_comb__doc__,
 "Raises a TypeError if argument(s) are non-integer and ValueError\n"
 "if argument(s) are negative or k > n.");
 
-#define MATH_COMB_METHODDEF    \
-    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL, math_comb__doc__},
+#define MATH_COMBINATIONS_METHODDEF    \
+    {"combinations", (PyCFunction)(void(*)(void))math_combinations, METH_FASTCALL, math_combinations__doc__},
 
 static PyObject *
-math_comb_impl(PyObject *module, PyObject *n, PyObject *k);
+math_combinations_impl(PyObject *module, PyObject *n, PyObject *k);
 
 static PyObject *
-math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+math_combinations(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *n;
     PyObject *k;
 
-    if (!_PyArg_CheckPositional("comb", nargs, 2, 2)) {
+    if (!_PyArg_CheckPositional("combinations", nargs, 2, 2)) {
         goto exit;
     }
     n = args[0];
     k = args[1];
-    return_value = math_comb_impl(module, n, k);
+    return_value = math_combinations_impl(module, n, k);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=333afdbd248d74d1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=62f06df6c20b08ef input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -628,4 +628,42 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=96e71135dce41c48 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(math_comb__doc__,
+"comb($module, n, k, /)\n"
+"--\n"
+"\n"
+"Return the binomial coefficient indexed by the pair of integers n >= k >= 0.\n"
+"\n"
+"It is the coefficient of kth term in polynomial expansion of the expression\n"
+"(1 + x)^n. It is also known as the number of ways to choose an unordered\n"
+"subset of k elements from a fixed set of n elements, usually called\n"
+"*n choose k*.\n"
+"\n"
+"Raises a TypeError if argument(s) are non-integer and ValueError\n"
+"if argument(s) are negative or k > n.");
+
+#define MATH_COMB_METHODDEF    \
+    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL, math_comb__doc__},
+
+static PyObject *
+math_comb_impl(PyObject *module, PyObject *n, PyObject *k);
+
+static PyObject *
+math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *n;
+    PyObject *k;
+
+    if (!_PyArg_CheckPositional("comb", nargs, 2, 2)) {
+        goto exit;
+    }
+    n = args[0];
+    k = args[1];
+    return_value = math_comb_impl(module, n, k);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=333afdbd248d74d1 input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -629,8 +629,8 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(math_combinations__doc__,
-"combinations($module, n, k, /)\n"
+PyDoc_STRVAR(math_comb__doc__,
+"comb($module, n, k, /)\n"
 "--\n"
 "\n"
 "Return the binomial coefficient indexed by the pair of integers n >= k >= 0.\n"
@@ -643,27 +643,27 @@ PyDoc_STRVAR(math_combinations__doc__,
 "Raises a TypeError if argument(s) are non-integer and ValueError\n"
 "if argument(s) are negative or k > n.");
 
-#define MATH_COMBINATIONS_METHODDEF    \
-    {"combinations", (PyCFunction)(void(*)(void))math_combinations, METH_FASTCALL, math_combinations__doc__},
+#define MATH_COMB_METHODDEF    \
+    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL, math_comb__doc__},
 
 static PyObject *
-math_combinations_impl(PyObject *module, PyObject *n, PyObject *k);
+math_comb_impl(PyObject *module, PyObject *n, PyObject *k);
 
 static PyObject *
-math_combinations(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *n;
     PyObject *k;
 
-    if (!_PyArg_CheckPositional("combinations", nargs, 2, 2)) {
+    if (!_PyArg_CheckPositional("comb", nargs, 2, 2)) {
         goto exit;
     }
     n = args[0];
     k = args[1];
-    return_value = math_combinations_impl(module, n, k);
+    return_value = math_comb_impl(module, n, k);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=62f06df6c20b08ef input=a9049054013a1b77]*/
+/*[clinic end generated code: output=333afdbd248d74d1 input=a9049054013a1b77]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2755,7 +2755,7 @@ math_combinations_impl(PyObject *module, PyObject *n, PyObject *k)
     cmp = PyObject_RichCompareBool(n, k, Py_LT);
     if (cmp == 1) {
         PyErr_Format(PyExc_ValueError,
-                     "n must be an integer >= k");
+                     "n must be an integer greater or equal to k");
         goto fail_comb;
     }
     else if (cmp == -1) {
@@ -2787,13 +2787,13 @@ math_combinations_impl(PyObject *module, PyObject *n, PyObject *k)
     }
     else if (overflow == 1) {
         PyErr_Format(PyExc_OverflowError,
-                     "minimum(n - k, k) must not exceed %lld",
+                     "(n - k) and k must not exceed %lld",
                      LLONG_MAX);
         goto fail_comb;
     }
     else if (overflow == -1 || terms < 0) {
         PyErr_Format(PyExc_ValueError,
-                     "k must be an integer >= 0");
+                     "k must be a positive integer");
         goto fail_comb;
     }
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2732,7 +2732,7 @@ math_combinations_impl(PyObject *module, PyObject *n, PyObject *k)
 {
     if (!(PyLong_Check(n) && PyLong_Check(k))) {
         PyErr_SetString(PyExc_TypeError,
-            "comb() only accepts integer arguments");
+            "combinations() only accepts integer arguments");
         return NULL;
     }
     n = PyNumber_Long(n);
@@ -2899,7 +2899,7 @@ static PyMethodDef math_methods[] = {
     {"tanh",            math_tanh,      METH_O,         math_tanh_doc},
     MATH_TRUNC_METHODDEF
     MATH_PROD_METHODDEF
-    MATH_COMB_METHODDEF
+    MATH_COMBINATIONS_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2707,7 +2707,7 @@ math_prod_impl(PyObject *module, PyObject *iterable, PyObject *start)
 
 
 /*[clinic input]
-math.comb
+math.combinations
 
     n: object
 
@@ -2727,8 +2727,8 @@ if argument(s) are negative or k > n.
 [clinic start generated code]*/
 
 static PyObject *
-math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
-/*[clinic end generated code: output=bd2cec8d854f3493 input=75e1a19623bae7dc]*/
+math_combinations_impl(PyObject *module, PyObject *n, PyObject *k)
+/*[clinic end generated code: output=19e8a448a1be51e0 input=a1334a4fbeb72a00]*/
 {
     if (!(PyLong_Check(n) && PyLong_Check(k))) {
         PyErr_SetString(PyExc_TypeError,

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2707,7 +2707,7 @@ math_prod_impl(PyObject *module, PyObject *iterable, PyObject *start)
 
 
 /*[clinic input]
-math.combinations
+math.comb
 
     n: object
 
@@ -2727,12 +2727,12 @@ if argument(s) are negative or k > n.
 [clinic start generated code]*/
 
 static PyObject *
-math_combinations_impl(PyObject *module, PyObject *n, PyObject *k)
-/*[clinic end generated code: output=19e8a448a1be51e0 input=a1334a4fbeb72a00]*/
+math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
+/*[clinic end generated code: output=bd2cec8d854f3493 input=75e1a19623bae7dc]*/
 {
     if (!(PyLong_Check(n) && PyLong_Check(k))) {
         PyErr_SetString(PyExc_TypeError,
-            "combinations() only accepts integer arguments");
+            "comb() only accepts integer arguments");
         return NULL;
     }
     n = PyNumber_Long(n);
@@ -2899,7 +2899,7 @@ static PyMethodDef math_methods[] = {
     {"tanh",            math_tanh,      METH_O,         math_tanh_doc},
     MATH_TRUNC_METHODDEF
     MATH_PROD_METHODDEF
-    MATH_COMBINATIONS_METHODDEF
+    MATH_COMB_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2787,7 +2787,7 @@ math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
     }
     else if (overflow == 1) {
         PyErr_Format(PyExc_OverflowError,
-                     "(n - k) and k must not exceed %lld",
+                     "Either (n - k) or k must not exceed %lld",
                      LLONG_MAX);
         goto fail_comb;
     }


### PR DESCRIPTION
- Add tests specifying the behaviour of `math.binomial(k, n)`:
  - [x] when `0 <= k <= n`;
  - [x] when `k > n`;
  - [x] when `k` or `n` are negative or non-integral;
  - [x] when `k` or `n` are neither `int` nor `float`.
- [x] Implement `math.binomial` in C; done by @FR4NKESTI3N 
- [x] ~Profile/benchmark and optimize if needed.~
      @rhettinger suggested optimizing this, if needed, in a later PR.

<!-- issue-number: [bpo-35431](https://bugs.python.org/issue35431) -->
https://bugs.python.org/issue35431
<!-- /issue-number -->
