### PR TITLE
bpo-35441: Remove dead and buggy code related to PyList_SetItem()

### DIFF
--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -71,15 +71,12 @@ copy_grouping(const char* s)
     do {
         i++;
         val = PyLong_FromLong(s[i]);
-        if (!val)
-            break;
+        if (val == NULL) {
+            Py_DECREF(result);
+            return NULL;
+        }
         PyList_SET_ITEM(result, i, val);
     } while (s[i] != '\0' && s[i] != CHAR_MAX);
-
-    if (!val) {
-        Py_DECREF(result);
-        return NULL;
-    }
 
     return result;
 }

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -73,11 +73,7 @@ copy_grouping(const char* s)
         val = PyLong_FromLong(s[i]);
         if (!val)
             break;
-        if (PyList_SetItem(result, i, val)) {
-            Py_DECREF(val);
-            val = NULL;
-            break;
-        }
+        PyList_SET_ITEM(result, i, val);
     } while (s[i] != '\0' && s[i] != CHAR_MAX);
 
     if (!val) {

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1544,7 +1544,7 @@ array_array_fromlist(arrayobject *self, PyObject *list)
         if (array_resize(self, old_size + n) == -1)
             return NULL;
         for (i = 0; i < n; i++) {
-            PyObject *v = PyList_GetItem(list, i);
+            PyObject *v = PyList_GET_ITEM(list, i);
             if ((*self->ob_descr->setitem)(self,
                             Py_SIZE(self) - n + i, v) != 0) {
                 array_resize(self, old_size);
@@ -1574,8 +1574,7 @@ array_array_tolist_impl(arrayobject *self)
         PyObject *v = getarrayitem((PyObject *)self, i);
         if (v == NULL)
             goto error;
-        if (PyList_SetItem(list, i, v) < 0)
-            goto error;
+        PyList_SET_ITEM(list, i, v);
     }
     return list;
 

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1550,6 +1550,12 @@ array_array_fromlist(arrayobject *self, PyObject *list)
                 array_resize(self, old_size);
                 return NULL;
             }
+            if (n != PyList_GET_SIZE(list)) {
+                PyErr_SetString(PyExc_RuntimeError,
+                                "list changed size during iteration");
+                array_resize(self, old_size);
+                return NULL;
+            }
         }
     }
     Py_RETURN_NONE;

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -936,8 +936,7 @@ on_completion_display_matches_hook(char **matches,
         s = decode(matches[i+1]);
         if (s == NULL)
             goto error;
-        if (PyList_SetItem(m, i, s) == -1)
-            goto error;
+        PyList_SET_ITEM(m, i, s);
     }
     sub = decode(matches[0]);
     r = PyObject_CallFunction(readlinestate_global->completion_display_matches_hook,

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -693,10 +693,7 @@ select_poll_poll_impl(pollObject *self, PyObject *timeout_obj)
             goto error;
         }
         PyTuple_SET_ITEM(value, 1, num);
-        if ((PyList_SetItem(result_list, j, value)) == -1) {
-            Py_DECREF(value);
-            goto error;
-        }
+        PyList_SET_ITEM(result_list, j, value);
         i++;
     }
     return result_list;
@@ -986,10 +983,7 @@ select_devpoll_poll_impl(devpollObject *self, PyObject *timeout_obj)
         Py_DECREF(num2);
         if (value == NULL)
             goto error;
-        if ((PyList_SetItem(result_list, i, value)) == -1) {
-            Py_DECREF(value);
-            goto error;
-        }
+        PyList_SET_ITEM(result_list, i, value);
     }
 
     return result_list;

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -756,9 +756,13 @@ Reg2Py(BYTE *retDataBuf, DWORD retDataSize, DWORD typ)
                         PyMem_Free(str);
                         return NULL;
                     }
-                    PyList_SetItem(obData,
-                                   index,
-                                   PyUnicode_FromWideChar(str[index], len));
+                    PyObject *uni = PyUnicode_FromWideChar(str[index], len);
+                    if (uni == NULL) {
+                        Py_DECREF(obData);
+                        PyMem_Free(str);
+                        return NULL;
+                    }
+                    PyList_SET_ITEM(obData, index, uni);
                 }
                 PyMem_Free(str);
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5124,7 +5124,7 @@ getarray(long a[256])
             Py_DECREF(l);
             return NULL;
         }
-        PyList_SetItem(l, i, x);
+        PyList_SET_ITEM(l, i, x);
     }
     for (i = 0; i < 256; i++)
         a[i] = 0;
@@ -5146,7 +5146,7 @@ _Py_GetDXProfile(PyObject *self, PyObject *args)
             Py_DECREF(l);
             return NULL;
         }
-        PyList_SetItem(l, i, x);
+        PyList_SET_ITEM(l, i, x);
     }
     return l;
 #endif

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2594,7 +2594,7 @@ makepathobject(const wchar_t *path, wchar_t delim)
             Py_DECREF(v);
             return NULL;
         }
-        PyList_SetItem(v, i, w);
+        PyList_SET_ITEM(v, i, w);
         if (*p == '\0')
             break;
         path = p+1;


### PR DESCRIPTION
In _localemodule.c and selectmodule.c, remove dead code that would
cause double decrefs if run.

In addition, replace PyList_SetItem() with PyList_SET_ITEM() in cases
where a new list is populated and there is no possibility of an error.


<!-- issue-number: [bpo-35441](https://bugs.python.org/issue35441) -->
https://bugs.python.org/issue35441
<!-- /issue-number -->
