### PR TITLE
bpo-35292: Lazily inject system mime.types into SimpleHTTPRequestHandler.extensions_map

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -639,6 +639,11 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
     server_version = "SimpleHTTP/" + __version__
 
+    extensions_map = {
+        '': 'application/octet-stream', # Default,
+        **mimetypes.types_map
+    }
+
     def __init__(self, *args, directory=None, **kwargs):
         if directory is None:
             directory = os.getcwd()
@@ -857,6 +862,9 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         slow) to look inside the data to make a better guess.
 
         """
+        if not mimetypes.inited:
+            mimetypes.init() # try to read system mime.types
+            self.extensions_map.update(mimetypes.types_map)
 
         base, ext = posixpath.splitext(path)
         if ext in self.extensions_map:
@@ -866,16 +874,6 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             return self.extensions_map[ext]
         else:
             return self.extensions_map['']
-
-    if not mimetypes.inited:
-        mimetypes.init() # try to read system mime.types
-    extensions_map = mimetypes.types_map.copy()
-    extensions_map.update({
-        '': 'application/octet-stream', # Default
-        '.py': 'text/plain',
-        '.c': 'text/plain',
-        '.h': 'text/plain',
-        })
 
 
 # Utilities for CGIHTTPRequestHandler


### PR DESCRIPTION
### Important changes

* When http.server is imported, the `extension_map` class attribute of `SimpleHTTPRequestHandler` is initialized with a default mapping, **and** some static mapping already available in `mimetypes.types_map`.
* The time delay in importing the aforementioned module is now deferred to the first call of `SimpleHTTPRequestHandler.guess_type` method.
* The mimetype for `.py` extension is now `text/x-python` instead of `text/plain`.

<!-- issue-number: [bpo-35292](https://bugs.python.org/issue35292) -->
https://bugs.python.org/issue35292
<!-- /issue-number -->
