### PR TITLE
bpo-31823 - subprocess.rst: remove outdated changes

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -473,10 +473,6 @@ functions.
    child process unless explicitly passed in the ``handle_list`` element of
    :attr:`STARTUPINFO.lpAttributeList`, or by standard handle redirection.
 
-   .. versionchanged:: 3.2
-      The default for *close_fds* was changed from :const:`False` to
-      what is described above.
-
    .. versionchanged:: 3.7
       On Windows the default for *close_fds* was changed from :const:`False` to
       :const:`True` when redirecting the standard handles. It's now possible to


### PR DESCRIPTION
```
[bpo-31823](https://bugs.python.org/issue31823): remove outdated changes from `subprocess.__init__` doc
```


<!-- issue-number: [bpo-31823](https://bugs.python.org/issue31823) -->
https://bugs.python.org/issue31823
<!-- /issue-number -->
