### PR TITLE
bpo-22577: in pdb, prevent changes to locals from being lost after a jump

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -217,7 +217,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         # The f_locals dictionary is updated from the actual frame
         # locals whenever the .f_locals accessor is called, so we
         # cache it here to ensure that modifications are not overwritten.
-        self.curframe_locals = self.curframe.f_locals
+        self.curframe_locals = dict(self.curframe.f_locals)
         return self.execRcLines()
 
     # Can be executed earlier than 'setup' if desired

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1079,7 +1079,17 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 # new position
                 self.curframe.f_lineno = arg
                 self.stack[self.curindex] = self.stack[self.curindex][0], arg
+
+                # Save copy of curframe_locals because print_stack_entry
+                # causes a .f_locals access.
+                curframe_locals_copy = dict(self.curframe_locals)
+
                 self.print_stack_entry(self.stack[self.curindex])
+
+                # In case user had deleted variable before jump
+                self.curframe_locals.clear()
+                # Restore from copy
+                self.curframe_locals.update(curframe_locals_copy)
             except ValueError as e:
                 self.error('Jump failed: %s' % e)
     do_j = do_jump

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1079,17 +1079,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 # new position
                 self.curframe.f_lineno = arg
                 self.stack[self.curindex] = self.stack[self.curindex][0], arg
-
-                # Save copy of curframe_locals because print_stack_entry
-                # causes a .f_locals access.
-                curframe_locals_copy = dict(self.curframe_locals)
-
                 self.print_stack_entry(self.stack[self.curindex])
-
-                # In case user had deleted variable before jump
-                self.curframe_locals.clear()
-                # Restore from copy
-                self.curframe_locals.update(curframe_locals_copy)
             except ValueError as e:
                 self.error('Jump failed: %s' % e)
     do_j = do_jump
@@ -1459,8 +1449,17 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             prefix = '> '
         else:
             prefix = '  '
+
+        # Save copy of curframe_locals because format_stack_entry
+        # causes a .f_locals access
+        curframe_locals_copy = dict(self.curframe_locals)
+
         self.message(prefix +
                      self.format_stack_entry(frame_lineno, prompt_prefix))
+
+        # Restore from copy
+        self.curframe_locals.clear()
+        self.curframe_locals.update(curframe_locals_copy)
 
     # Provide help
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -217,7 +217,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         # The f_locals dictionary is updated from the actual frame
         # locals whenever the .f_locals accessor is called, so we
         # cache it here to ensure that modifications are not overwritten.
-        self.curframe_locals = dict(self.curframe.f_locals)
+        self.curframe_locals = self.curframe.f_locals
         return self.execRcLines()
 
     # Can be executed earlier than 'setup' if desired

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1144,6 +1144,30 @@ def test_pdb_issue_20766():
     pdb 2: <built-in function default_int_handler>
     """
 
+def test_issue22577():
+    """Test that local variable change not lost after jump.
+
+    >>> def test_function(x):
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     lineno = 3
+    ...     lineno = 4
+
+    >>> with PdbTestInput(['x = 123',
+    ...                    'jump 4',
+    ...                    'x',
+    ...                    'continue']):
+    ...     test_function(1)
+    > <doctest test.test_pdb.test_issue22577[0]>(3)test_function()
+    -> lineno = 3
+    (Pdb) x = 123
+    (Pdb) jump 4
+    > <doctest test.test_pdb.test_issue22577[0]>(4)test_function()
+    -> lineno = 4
+    (Pdb) x
+    123
+    (Pdb) continue
+    """
+
 
 class PdbTestCase(unittest.TestCase):
     def tearDown(self):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1168,6 +1168,28 @@ def test_issue22577():
     (Pdb) continue
     """
 
+def test_local_variable_change():
+    """Test that local variable change persists after step.
+
+    >>> def test_function(x):
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     print(x)
+
+    >>> with PdbTestInput(['x = 123',
+    ...                   'step',
+    ...                   'continue']):
+    ...     test_function(1)
+    > <doctest test.test_pdb.test_local_variable_change[0]>(3)test_function()
+    -> print(x)
+    (Pdb) x = 123
+    (Pdb) step
+    123
+    --Return--
+    > <doctest test.test_pdb.test_local_variable_change[0]>(3)test_function()->None
+    -> print(x)
+    (Pdb) continue
+    """
+
 
 class PdbTestCase(unittest.TestCase):
     def tearDown(self):

--- a/Misc/NEWS.d/next/Library/2018-12-08-20-24-07.bpo-22577.5ggVNs.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-08-20-24-07.bpo-22577.5ggVNs.rst
@@ -1,0 +1,2 @@
+Fix the loss of changes to local variables after a jump command in a PDB
+session. Patch by Henry Chen.


### PR DESCRIPTION
The ``Pdb.setup`` method creates a ``curframe_locals`` attribute to prevent subsequent ``.f_locals`` access from undoing changes made during the debugging session. However, the existing implementation binds ``curframe_locals`` to ``.f_locals`` without making a copy, so changes are lost after a jump because it invokes the ``Bdb.format_stack_entry`` method which does contain an ``.f_locals`` access.

The proposed fix is to assign to ``curframe_locals`` a copy of ``.f_locals``.

I've added a test to ``test_pdb`` that reproduces the original issue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-22577](https://bugs.python.org/issue22577) -->
https://bugs.python.org/issue22577
<!-- /issue-number -->
