### PR TITLE
bpo-33725: skip test_multiprocessing_fork on macOS

### DIFF
--- a/Lib/test/test_multiprocessing_fork.py
+++ b/Lib/test/test_multiprocessing_fork.py
@@ -1,11 +1,14 @@
 import unittest
 import test._test_multiprocessing
 
+import sys
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
+if sys.platform == 'darwin':
+    raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
 test._test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
 

--- a/Misc/NEWS.d/next/Tests/2018-12-09-01-27-29.bpo-33725.TaGayj.rst
+++ b/Misc/NEWS.d/next/Tests/2018-12-09-01-27-29.bpo-33725.TaGayj.rst
@@ -1,0 +1,2 @@
+test_multiprocessing_fork may crash on recent versions of macOS.  Until the
+issue is resolved, skip the test on macOS.


### PR DESCRIPTION


<!-- issue-number: [bpo-33725](https://bugs.python.org/issue33725) -->
https://bugs.python.org/issue33725
<!-- /issue-number -->
