### PR TITLE
bpo-17185: Add __signature__ to mock that can be used by inspect for signature

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -69,22 +69,23 @@ def _get_signature_object(func, as_instance, eat_self):
     signature object.
     Return a (reduced func, signature) tuple, or None.
     """
-    if not isinstance(func, functools.partial):
-        if isinstance(func, type) and not as_instance:
-            # If it's a type and should be modelled as a type, use __init__.
-            try:
-                func = func.__init__
-            except AttributeError:
-                return None
-            # Skip the `self` argument in __init__
-            eat_self = True
-        elif not isinstance(func, FunctionTypes):
-            # If we really want to model an instance of the passed type,
-            # __call__ should be looked up, not __init__.
-            try:
-                func = func.__call__
-            except AttributeError:
-                return None
+    if isinstance(func, functools.partial):
+        pass
+    elif isinstance(func, type) and not as_instance:
+        # If it's a type and should be modelled as a type, use __init__.
+        try:
+            func = func.__init__
+        except AttributeError:
+            return None
+        # Skip the `self` argument in __init__
+        eat_self = True
+    elif not isinstance(func, FunctionTypes):
+        # If we really want to model an instance of the passed type,
+        # __call__ should be looked up, not __init__.
+        try:
+            func = func.__call__
+        except AttributeError:
+            return None
     if eat_self:
         sig_func = partial(func, None)
     else:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -25,7 +25,6 @@ __all__ = (
 __version__ = '1.0'
 
 
-import functools
 import inspect
 import pprint
 import sys
@@ -69,9 +68,7 @@ def _get_signature_object(func, as_instance, eat_self):
     signature object.
     Return a (reduced func, signature) tuple, or None.
     """
-    if isinstance(func, functools.partial):
-        pass
-    elif isinstance(func, type) and not as_instance:
+    if isinstance(func, type) and not as_instance:
         # If it's a type and should be modelled as a type, use __init__.
         try:
             func = func.__init__
@@ -2308,8 +2305,6 @@ def _must_skip(spec, entry, is_type):
             # Normal method => skip if looked up on type
             # (if looked up on instance, self is already skipped)
             return is_type
-        elif isinstance(result, functools.partialmethod):
-            return True
         else:
             return False
 

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -907,7 +907,7 @@ class SpecSignatureTest(unittest.TestCase):
             pass
 
         mock = create_autospec(myfunc)
-        assert inspect.getfullargspec(mock) == inspect.getfullargspec(myfunc)
+        self.assertEqual(inspect.getfullargspec(mock), inspect.getfullargspec(myfunc))
         mock(1, 2)
         mock(x=1, y=2)
         self.assertRaises(TypeError, mock, 1)
@@ -916,7 +916,7 @@ class SpecSignatureTest(unittest.TestCase):
             return a + b + c
 
         mock = create_autospec(foo)
-        assert inspect.getfullargspec(mock) == inspect.getfullargspec(foo)
+        self.assertEqual(inspect.getfullargspec(mock), inspect.getfullargspec(foo))
         mock(1, 2, c=3)
         mock(1, c=3)
         self.assertRaises(TypeError, mock, 1)
@@ -933,7 +933,7 @@ class SpecSignatureTest(unittest.TestCase):
         mock = create_autospec(partial_object)
         mock(1, c=1)
         mock(c=1)
-        assert inspect.getfullargspec(mock) == inspect.getfullargspec(partial_object)
+        self.assertEqual(inspect.getfullargspec(mock), inspect.getfullargspec(partial_object))
         self.assertRaises(TypeError, partial_object)
 
         class Bar:

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -918,6 +918,7 @@ class SpecSignatureTest(unittest.TestCase):
         mock = create_autospec(foo)
         assert inspect.getfullargspec(mock) == inspect.getfullargspec(foo)
         mock(1, 2, c=3)
+        mock(1, c=3)
         self.assertRaises(TypeError, mock, 1)
         self.assertRaises(TypeError, mock, 1, 2, 3, c=4)
 
@@ -930,6 +931,8 @@ class SpecSignatureTest(unittest.TestCase):
 
         partial_object = functools.partial(foo, 1)
         mock = create_autospec(partial_object)
+        mock(1, c=1)
+        mock(c=1)
         assert inspect.getfullargspec(mock) == inspect.getfullargspec(partial_object)
         self.assertRaises(TypeError, partial_object)
 
@@ -942,6 +945,7 @@ class SpecSignatureTest(unittest.TestCase):
 
         mock = create_autospec(Bar)
         mock.baz(1, c=2)
+        mock.baz(c=2)
         self.assertRaises(TypeError, mock.baz, 1)
         self.assertRaises(TypeError, mock.baz, 1, 2, c=2)
 

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -901,53 +901,34 @@ class SpecSignatureTest(unittest.TestCase):
         autospec = create_autospec(proxy)
         self.assertFalse(hasattr(autospec, '__name__'))
 
+
     def test_spec_inspect_signature(self):
 
         def myfunc(x, y):
             pass
 
         mock = create_autospec(myfunc)
-        self.assertEqual(inspect.getfullargspec(mock), inspect.getfullargspec(myfunc))
         mock(1, 2)
         mock(x=1, y=2)
+
+        self.assertEqual(inspect.getfullargspec(mock), inspect.getfullargspec(myfunc))
+        self.assertEqual(mock.mock_calls, [call(1, 2), call(x=1, y=2)])
         self.assertRaises(TypeError, mock, 1)
+
+
+    def test_spec_inspect_signature_annotations(self):
 
         def foo(a: int, b: int=10, *, c:int) -> int:
             return a + b + c
 
         mock = create_autospec(foo)
-        self.assertEqual(inspect.getfullargspec(mock), inspect.getfullargspec(foo))
         mock(1, 2, c=3)
         mock(1, c=3)
+
+        self.assertEqual(inspect.getfullargspec(mock), inspect.getfullargspec(foo))
+        self.assertEqual(mock.mock_calls, [call(1, 2, c=3), call(1, c=3)])
         self.assertRaises(TypeError, mock, 1)
         self.assertRaises(TypeError, mock, 1, 2, 3, c=4)
-
-    def test_spec_inspect_signature_partial(self):
-
-        import functools
-
-        def foo(a: int, b: int=10, *, c:int) -> int:
-            return a + b + c
-
-        partial_object = functools.partial(foo, 1)
-        mock = create_autospec(partial_object)
-        mock(1, c=1)
-        mock(c=1)
-        self.assertEqual(inspect.getfullargspec(mock), inspect.getfullargspec(partial_object))
-        self.assertRaises(TypeError, partial_object)
-
-        class Bar:
-
-            def foo(self, a: int, b: int=10, *, c:int) -> int:
-                return a + b + c
-
-            baz = functools.partialmethod(foo, 1)
-
-        mock = create_autospec(Bar)
-        mock.baz(1, c=2)
-        mock.baz(c=2)
-        self.assertRaises(TypeError, mock.baz, 1)
-        self.assertRaises(TypeError, mock.baz, 1, 2, c=2)
 
 
 class TestCallList(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-12-09-17-04-15.bpo-17185.SfSCJF.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-09-17-04-15.bpo-17185.SfSCJF.rst
@@ -1,3 +1,2 @@
-Set ``__signature__`` on mock for :mod:`inspect` to get signature. Fix signature
-check for :func:`functools.partial` and :func:`functools.partialmethod`.
+Set ``__signature__`` on mock for :mod:`inspect` to get signature.
 Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Library/2018-12-09-17-04-15.bpo-17185.SfSCJF.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-09-17-04-15.bpo-17185.SfSCJF.rst
@@ -1,0 +1,2 @@
+Set ``__signature__`` on mock for `inspect` to get signature. Fix signature
+check for partial and partialmethods. Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Library/2018-12-09-17-04-15.bpo-17185.SfSCJF.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-09-17-04-15.bpo-17185.SfSCJF.rst
@@ -1,2 +1,3 @@
 Set ``__signature__`` on mock for :mod:`inspect` to get signature. Fix signature
-check for partial and partialmethods. Patch by Karthikeyan Singaravelan.
+check for :func:`functools.partial` and :func:`functools.partialmethod`.
+Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Library/2018-12-09-17-04-15.bpo-17185.SfSCJF.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-09-17-04-15.bpo-17185.SfSCJF.rst
@@ -1,2 +1,2 @@
-Set ``__signature__`` on mock for `inspect` to get signature. Fix signature
+Set ``__signature__`` on mock for :mod:`inspect` to get signature. Fix signature
 check for partial and partialmethods. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
* Set `__signature__` that helps `inspect` module to detect the signature of the mock.

<!-- issue-number: [bpo-17185](https://bugs.python.org/issue17185) -->
https://bugs.python.org/issue17185
<!-- /issue-number -->

Edit : Removed partial bug into a separate issue
