### PR TITLE
bpo-35445: Do not ignore memory errors when create posix.environ.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-12-09-14-35-49.bpo-35445.LjvtsC.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-09-14-35-49.bpo-35445.LjvtsC.rst
@@ -1,0 +1,1 @@
+Memory errors during creating posix.environ no longer ignored.


### PR DESCRIPTION


<!-- issue-number: [bpo-35445](https://bugs.python.org/issue35445) -->
https://bugs.python.org/issue35445
<!-- /issue-number -->
