### PR TITLE
bpo-17088: Fix handling of XML attributes when serializing with default namespace

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1627,10 +1627,9 @@ class BugsTest(unittest.TestCase):
         e = ET.Element("{default}elem")
         s = ET.SubElement(e, "{default}elem")
         s = ET.SubElement(e, "elem") # unprefixed name
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaisesRegex(ValueError,
+                'cannot use non-qualified name.* with default_namespace option'):
             serialize(e, default_namespace="default") # 3
-        self.assertEqual(str(cm.exception),
-                'cannot use non-qualified names with default_namespace option')
 
     def test_bug_200709_register_namespace(self):
         e = ET.Element("{http://namespace.invalid/does/not/exist/}title")

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1619,9 +1619,9 @@ class BugsTest(unittest.TestCase):
         s = ET.SubElement(e, "{default}elem")
         s = ET.SubElement(e, "{not-default}elem")
         self.assertEqual(serialize(e, default_namespace="default"), # 2
-            '<elem xmlns="default" xmlns:ns1="not-default">'
+            '<elem xmlns="default" xmlns:ns0="not-default">'
             '<elem />'
-            '<ns1:elem />'
+            '<ns0:elem />'
             '</elem>')
 
         e = ET.Element("{default}elem")

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -173,7 +173,7 @@ class ElementTestCase:
 # --------------------------------------------------------------------
 # element tree tests
 
-class ElementTreeTest(unittest.TestCase):
+class ElementTreeTest(ElementTestCase, unittest.TestCase):
 
     def serialize_check(self, elem, expected):
         self.assertEqual(serialize(elem), expected)
@@ -971,6 +971,79 @@ class ElementTreeTest(unittest.TestCase):
         self.assertNotEqual(q1, q2)
         self.assertNotEqual(q1, 'ns:tag')
         self.assertEqual(q1, '{ns}tag')
+
+    def test_namespace_attribs(self):
+        # Unprefixed attributes are unqualified even if a default
+        # namespace is in effect. (This is a little unclear in some
+        # versions of the XML TR but is clarified in errata and other
+        # versions.) See bugs.python.org issue 17088.
+        #
+        # The reasoning behind this, alluded to in the spec, is that
+        # attribute meanings already depend on the element they're
+        # attached to; attributes have always lived in per-element
+        # namespaces even before explicit XML namespaces were
+        # introduced.  For that reason qualified attribute names are
+        # only really needed when one XML module defines attributes
+        # that can be placed on elements defined in a different module
+        # (such as happens with XLINK or, for that matter, the XML
+        # namespace spec itself).
+        e = ET.XML(
+            '<pf:elt xmlns:pf="space1" xmlns:pf2="space2" foo="value">'
+            '<pf:foo foo="value2" pf2:foo="value3"/>'
+            '<pf2:foo foo="value4" pf:foo="value5" pf2:foo="value6"/>'
+            '<foo foo="value7" pf:foo="value8"/>'
+            '</pf:elt>')
+        self.assertEqual(e.tag, '{space1}elt')
+        self.assertEqual(e.get('foo'), 'value')
+        self.assertIsNone(e.get('{space1}foo'))
+        self.assertIsNone(e.get('{space2}foo'))
+        self.assertEqual(e[0].tag, '{space1}foo')
+        self.assertEqual(e[0].attrib, { 'foo': 'value2',
+                                        '{space2}foo': 'value3' })
+        self.assertEqual(e[1].tag, '{space2}foo')
+        self.assertEqual(e[1].attrib, { 'foo': 'value4',
+                                        '{space1}foo': 'value5',
+                                        '{space2}foo': 'value6' })
+        self.assertEqual(e[2].tag, 'foo')
+        self.assertEqual(e[2].attrib, { 'foo': 'value7',
+                                        '{space1}foo': 'value8' })
+
+        serialized1 = (
+            '<ns0:elt xmlns:ns0="space1" xmlns:ns1="space2" foo="value">'
+            '<ns0:foo foo="value2" ns1:foo="value3" />'
+            '<ns1:foo foo="value4" ns0:foo="value5" ns1:foo="value6" />'
+            '<foo foo="value7" ns0:foo="value8" />'
+            '</ns0:elt>')
+        self.assertEqual(serialize(e), serialized1)
+        self.assertEqualElements(e, ET.XML(serialized1))
+
+        # Test writing with a default namespace.
+        with self.assertRaisesRegex(ValueError,
+                'cannot use non-qualified name.* with default_namespace option'):
+            serialize(e, default_namespace="space1")
+
+        # Remove the unqualified element from the tree so we can test
+        # further.
+        del e[2]
+
+        # Serialization can require a namespace prefix to be declared for
+        # space1 even if no elements use that prefix, in order to
+        # write an attribute name in that namespace.
+        serialized2 = (
+            '<ns0:elt xmlns="space2" xmlns:ns0="space1" xmlns:ns1="space2" foo="value">'
+            '<ns0:foo foo="value2" ns1:foo="value3" />'
+            '<foo foo="value4" ns0:foo="value5" ns1:foo="value6" />'
+            '</ns0:elt>')
+        self.assertEqual(serialize(e, default_namespace="space2"), serialized2)
+        self.assertEqualElements(e, ET.XML(serialized2))
+
+        serialized3 = (
+            '<elt xmlns="space1" xmlns:ns0="space2" xmlns:ns1="space1" foo="value">'
+            '<foo foo="value2" ns0:foo="value3" />'
+            '<ns0:foo foo="value4" ns1:foo="value5" ns0:foo="value6" />'
+            '</elt>')
+        self.assertEqual(serialize(e, default_namespace="space1"), serialized3)
+        self.assertEqualElements(e, ET.XML(serialized3))
 
     def test_doctype_public(self):
         # Test PUBLIC doctype.

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -870,10 +870,16 @@ def _namespaces(elem, default_namespace=None):
                     )
             return qname
 
-    def add_qname(qname):
-        if qname not in qnames:
-            serialized = serialize_qname(qname)
-            qnames[qname] = (serialized, serialized)
+    def add_qname(qname, is_attr=False):
+        ser_tag, ser_attr = qnames.get(qname, (None, None))
+        if is_attr:
+            if ser_attr is None:
+                ser_attr = serialize_qname(qname)
+                qnames[qname] = (ser_tag, ser_attr)
+        else:
+            if ser_tag is None:
+                ser_tag = serialize_qname(qname)
+                qnames[qname] = (ser_tag, ser_attr)
 
     # populate qname and namespaces table
     for elem in elem.iter():
@@ -889,7 +895,7 @@ def _namespaces(elem, default_namespace=None):
                 key = key.text
             elif not isinstance(key, str):
                 _raise_serialization_error(key)
-            add_qname(key)
+            add_qname(key, is_attr=True)
             if isinstance(value, QName):
                 add_qname(value.text)
         text = elem.text

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -876,10 +876,14 @@ def _namespaces(elem, default_namespace=None):
         if is_attr:
             if ser_attr is None:
                 ser_attr = serialize_qname(qname, True)
+                if not default_namespace:
+                    ser_tag = ser_attr
                 qnames[qname] = (ser_tag, ser_attr)
         else:
             if ser_tag is None:
                 ser_tag = serialize_qname(qname, False)
+                if not default_namespace:
+                    ser_attr = ser_tag
                 qnames[qname] = (ser_tag, ser_attr)
 
     # populate qname and namespaces table

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -848,7 +848,7 @@ def _namespaces(elem, default_namespace=None):
         # calculate serialized qname representation
         try:
             if qname[:1] == "{":
-                uri, tag = qname[1:].rsplit("}", 1)
+                uri, local = qname[1:].rsplit("}", 1)
                 prefix = namespaces.get(uri)
                 if prefix is None:
                     prefix = _namespace_map.get(uri)
@@ -857,9 +857,9 @@ def _namespaces(elem, default_namespace=None):
                     if prefix != "xml":
                         namespaces[uri] = prefix
                 if prefix:
-                    qnames[qname] = "%s:%s" % (prefix, tag)
+                    qnames[qname] = "%s:%s" % (prefix, local)
                 else:
-                    qnames[qname] = tag # default element
+                    qnames[qname] = local # default element
             else:
                 if default_namespace:
                     # FIXME: can this be handled in XML 1.0?

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -843,20 +843,21 @@ def _namespaces(elem, default_namespace=None):
 
     # maps uri:s to prefixes
     namespaces = {}
-    if default_namespace:
-        namespaces[default_namespace] = ""
 
     def serialize_qname(qname):
         # calculate serialized qname representation
         if qname[:1] == "{":
             uri, local = qname[1:].rsplit("}", 1)
-            prefix = namespaces.get(uri)
-            if prefix is None:
-                prefix = _namespace_map.get(uri)
+            if uri == default_namespace:
+                prefix = ""
+            else:
+                prefix = namespaces.get(uri)
                 if prefix is None:
-                    prefix = "ns%d" % len(namespaces)
-                if prefix != "xml":
-                    namespaces[uri] = prefix
+                    prefix = _namespace_map.get(uri)
+                    if prefix is None:
+                        prefix = "ns%d" % len(namespaces)
+                    if prefix != "xml":
+                        namespaces[uri] = prefix
             if prefix:
                 return "%s:%s" % (prefix, local)
             else:
@@ -901,6 +902,9 @@ def _namespaces(elem, default_namespace=None):
         text = elem.text
         if isinstance(text, QName):
             add_qname(text.text)
+
+    if default_namespace:
+        namespaces[default_namespace] = ""
     return qnames, namespaces
 
 def _serialize_xml(write, elem, qnames, namespaces,

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -864,8 +864,8 @@ def _namespaces(elem, default_namespace=None):
                 if default_namespace:
                     # FIXME: can this be handled in XML 1.0?
                     raise ValueError(
-                        "cannot use non-qualified names with "
-                        "default_namespace option"
+                        "cannot use non-qualified name (%s) with "
+                        "default_namespace option" % qname
                         )
                 qnames[qname] = qname
         except TypeError:

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -844,11 +844,11 @@ def _namespaces(elem, default_namespace=None):
     # maps uri:s to prefixes
     namespaces = {}
 
-    def serialize_qname(qname):
+    def serialize_qname(qname, is_attr):
         # calculate serialized qname representation
         if qname[:1] == "{":
             uri, local = qname[1:].rsplit("}", 1)
-            if uri == default_namespace:
+            if not is_attr and uri == default_namespace:
                 prefix = ""
             else:
                 prefix = namespaces.get(uri)
@@ -863,10 +863,10 @@ def _namespaces(elem, default_namespace=None):
             else:
                 return local # default element
         else:
-            if default_namespace:
+            if not is_attr and default_namespace:
                 # FIXME: can this be handled in XML 1.0?
                 raise ValueError(
-                    "cannot use non-qualified name (%s) with "
+                    "cannot use non-qualified name (<%s>) with "
                     "default_namespace option" % qname
                     )
             return qname
@@ -875,11 +875,11 @@ def _namespaces(elem, default_namespace=None):
         ser_tag, ser_attr = qnames.get(qname, (None, None))
         if is_attr:
             if ser_attr is None:
-                ser_attr = serialize_qname(qname)
+                ser_attr = serialize_qname(qname, True)
                 qnames[qname] = (ser_tag, ser_attr)
         else:
             if ser_tag is None:
-                ser_tag = serialize_qname(qname)
+                ser_tag = serialize_qname(qname, False)
                 qnames[qname] = (ser_tag, ser_attr)
 
     # populate qname and namespaces table

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -903,9 +903,10 @@ def _namespaces(elem, default_namespace=None):
         if isinstance(text, QName):
             add_qname(text.text)
 
+    prefix_map = {prefix: ns for ns, prefix in namespaces.items()}
     if default_namespace:
-        namespaces[default_namespace] = ""
-    return qnames, namespaces
+        prefix_map[""] = default_namespace
+    return qnames, prefix_map
 
 def _serialize_xml(write, elem, qnames, namespaces,
                    short_empty_elements, **kwargs):
@@ -928,8 +929,7 @@ def _serialize_xml(write, elem, qnames, namespaces,
             items = list(elem.items())
             if items or namespaces:
                 if namespaces:
-                    for v, k in sorted(namespaces.items(),
-                                       key=lambda x: x[1]):  # sort on prefix
+                    for k, v in sorted(namespaces.items()):
                         if k:
                             k = ":" + k
                         write(" xmlns%s=\"%s\"" % (
@@ -984,8 +984,7 @@ def _serialize_html(write, elem, qnames, namespaces, **kwargs):
             items = list(elem.items())
             if items or namespaces:
                 if namespaces:
-                    for v, k in sorted(namespaces.items(),
-                                       key=lambda x: x[1]):  # sort on prefix
+                    for k, v in sorted(namespaces.items()):
                         if k:
                             k = ":" + k
                         write(" xmlns%s=\"%s\"" % (

--- a/Misc/NEWS.d/next/Library/2018-12-09-14-58-08.bpo-17088.AHFvrn.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-09-14-58-08.bpo-17088.AHFvrn.rst
@@ -1,0 +1,5 @@
+ElementTree's serialization of attribute names when a default namespace is
+passed was corrected. Previously, unqualified attribute names would be
+rejected unnecessarily, while attributes in the default namespace would have
+their prefix stripped, which goes against the rules for namespace defaulting
+and uniqueness of attributes as specified in the XML namespaces spec.


### PR DESCRIPTION
I split the changes over several commits for easier reviewing. Feel free to squash some or all of them later.

I took the approach that Stefan Behnel suggested in the bug discussion: change the `qnames` cache values from a single serialized value shared by tag and attribute to a pair that contains a separate serialized value for tag and attribute. Often the two will be identical, but unqualified names interact differently with the default namespace depending on whether it's a tag name or an attribute name.

Many thanks to "wiml" for the detailed test case.


<!-- issue-number: [bpo-17088](https://bugs.python.org/issue17088) -->
https://bugs.python.org/issue17088
<!-- /issue-number -->
