### PR TITLE
bpo-22005: Document the reality of pickle compatibility.

### DIFF
--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -71,7 +71,9 @@ The :mod:`pickle` module differs from :mod:`marshal` in several significant ways
   :file:`.pyc` files, the Python implementers reserve the right to change the
   serialization format in non-backwards compatible ways should the need arise.
   The :mod:`pickle` serialization format is guaranteed to be backwards compatible
-  across Python releases.
+  across Python releases provided a compatible pickle protocol is chosen and
+  pickling and unpickling code deals with Python 2 to Python 3 type differences
+  if your data is crossing that unique breaking change language boundary.
 
 Comparison with ``json``
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
People still seem surprised that pickle can't magically send bytes/str/unicode values back and forth from Python 2 and Python 3 processes without a lot of hand holding despite the underlying fundamental types of the language changing.  This should clarify that there is no such free lunch.

It has always has been, impossible to guarantee such compatibility. That the docs were not updated to reflect this in 3.0 was an oversight.

<!-- issue-number: [bpo-22005](https://bugs.python.org/issue22005) -->
https://bugs.python.org/issue22005
<!-- /issue-number -->
