### PR TITLE
bpo-20239: Allow repeated deletion of unittest.mock.Mock attributes

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -727,11 +727,10 @@ class NonCallableMock(Base):
                 # not set on the instance itself
                 return
 
-        if name in self.__dict__:
-            object.__delattr__(self, name)
-
         obj = self._mock_children.get(name, _missing)
-        if obj is _deleted:
+        if name in self.__dict__:
+            super().__delattr__(name)
+        elif obj is _deleted:
             raise AttributeError(name)
         if obj is not _missing:
             del self._mock_children[name]

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1779,7 +1779,6 @@ class MockTest(unittest.TestCase):
 
             del mock.foo
             self.assertFalse(hasattr(mock, 'foo'))
-            self.assertRaises(AttributeError, getattr, mock, 'foo')
 
             mock.foo = 4
             self.assertTrue(hasattr(mock, 'foo'))
@@ -1787,14 +1786,13 @@ class MockTest(unittest.TestCase):
 
             del mock.foo
             self.assertFalse(hasattr(mock, 'foo'))
-            self.assertRaises(AttributeError, getattr, mock, 'foo')
 
 
-    def test_mock_raises_when_deleting_inexistent_attribute(self):
+    def test_mock_raises_when_deleting_nonexistent_attribute(self):
         for mock in (Mock(), MagicMock(), NonCallableMagicMock(),
                      NonCallableMock()):
+            del mock.foo
             with self.assertRaises(AttributeError):
-                del mock.foo
                 del mock.foo
 
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1769,6 +1769,27 @@ class MockTest(unittest.TestCase):
             self.assertRaises(AttributeError, getattr, mock, 'f')
 
 
+    def test_mock_does_not_raise_on_repeated_attribute_deletion(self):
+        # bpo-20239: Assigning and deleting twice an attribute raises.
+        for mock in (Mock(), MagicMock(), NonCallableMagicMock(),
+                     NonCallableMock()):
+            mock.foo = 3
+            self.assertTrue(hasattr(mock, 'foo'))
+            self.assertEqual(mock.foo, 3)
+
+            del mock.foo
+            self.assertFalse(hasattr(mock, 'foo'))
+            self.assertRaises(AttributeError, getattr, mock, 'foo')
+
+            mock.foo = 4
+            self.assertTrue(hasattr(mock, 'foo'))
+            self.assertEqual(mock.foo, 4)
+
+            del mock.foo
+            self.assertFalse(hasattr(mock, 'foo'))
+            self.assertRaises(AttributeError, getattr, mock, 'foo')
+
+
     def test_reset_mock_does_not_raise_on_attr_deletion(self):
         # bpo-31177: reset_mock should not raise AttributeError when attributes
         # were deleted in a mock instance

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1790,6 +1790,14 @@ class MockTest(unittest.TestCase):
             self.assertRaises(AttributeError, getattr, mock, 'foo')
 
 
+    def test_mock_raises_when_deleting_inexistent_attribute(self):
+        for mock in (Mock(), MagicMock(), NonCallableMagicMock(),
+                     NonCallableMock()):
+            with self.assertRaises(AttributeError):
+                del mock.foo
+                del mock.foo
+
+
     def test_reset_mock_does_not_raise_on_attr_deletion(self):
         # bpo-31177: reset_mock should not raise AttributeError when attributes
         # were deleted in a mock instance

--- a/Misc/NEWS.d/next/Library/2018-12-09-21-35-49.bpo-20239.V4mWBL.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-09-21-35-49.bpo-20239.V4mWBL.rst
@@ -1,0 +1,2 @@
+Allow repeated assignment deletion of ``unittest.mock.Mock`` attributes.
+Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Library/2018-12-09-21-35-49.bpo-20239.V4mWBL.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-09-21-35-49.bpo-20239.V4mWBL.rst
@@ -1,2 +1,2 @@
-Allow repeated assignment deletion of ``unittest.mock.Mock`` attributes.
+Allow repeated assignment deletion of :class:`unittest.mock.Mock` attributes.
 Patch by Pablo Galindo.


### PR DESCRIPTION


<!-- issue-number: [bpo-20239](https://bugs.python.org/issue20239) -->
https://bugs.python.org/issue20239
<!-- /issue-number -->
