### PR TITLE
[3.6] bpo-35433: Properly detect installed SDK versions (GH-11009)

### DIFF
--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -141,4 +141,5 @@ goto :eof
 
 :Version
 rem Display the current build version information
-%MSBUILD% "%dir%python.props" /t:ShowVersionInfo /v:m /nologo %1 %2 %3 %4 %5 %6 %7 %8 %9
+call "%dir%find_msbuild.bat" %MSBUILD%
+if not ERRORLEVEL 1 %MSBUILD% "%dir%pythoncore.vcxproj" /t:ShowVersionInfo /v:m /nologo %1 %2 %3 %4 %5 %6 %7 %8 %9

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -76,10 +76,16 @@
     -->
     <_RegistryVersion>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</_RegistryVersion>
     <_RegistryVersion Condition="$(_RegistryVersion) == ''">$(Registry:HKEY_LOCAL_MACHINE\WOW6432Node\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</_RegistryVersion>
-    <DefaultWindowsSDKVersion>10.0.15063.0</DefaultWindowsSDKVersion>
-    <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.14393'">10.0.14393.0</DefaultWindowsSDKVersion>
-    <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.10586'">10.0.10586.0</DefaultWindowsSDKVersion>
-    <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.10240'">10.0.10240.0</DefaultWindowsSDKVersion>
+    <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
+    <_RegistryVersion Condition="$(_RegistryVersion) != '' and !$(_RegistryVersion.EndsWith('.0'))">$(_RegistryVersion).0</_RegistryVersion>
+
+    <!-- The minimum allowed SDK version to use for building -->
+    <DefaultWindowsSDKVersion>10.0.10586.0</DefaultWindowsSDKVersion>
+    <DefaultWindowsSDKVersion Condition="$([System.Version]::Parse($(_RegistryVersion))) > $([System.Version]::Parse($(DefaultWindowsSDKVersion)))">$(_RegistryVersion)</DefaultWindowsSDKVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="$(WindowsTargetPlatformVersion) == ''">
+    <WindowsTargetPlatformVersion>$(DefaultWindowsSDKVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OverrideVersion)' == ''">
@@ -187,5 +193,6 @@
     <Message Importance="high" Text="Field3Value:         $(Field3Value)" />
     <Message Importance="high" Text="SysWinVer:           $(SysWinVer)" />
     <Message Importance="high" Text="PyDllName:           $(PyDllName)" />
+    <Message Importance="high" Text="WindowsSdkVersion:   $(TargetPlatformVersion)" />
   </Target>
 </Project>


### PR DESCRIPTION
(cherry picked from commit f46eccd0ffe65333035c3820886295b71c41ab6e)


Co-authored-by: Jeremy Kloth <jeremy.kloth@gmail.com>

<!-- issue-number: [bpo-35433](https://bugs.python.org/issue35433) -->
https://bugs.python.org/issue35433
<!-- /issue-number -->
