### PR TITLE
bpo-32299: Return patched dict when using patch.dict as a context manager

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1343,15 +1343,24 @@ patch.dict
     decorator. When used as a class decorator :func:`patch.dict` honours
     ``patch.TEST_PREFIX`` for choosing which methods to wrap.
 
+    .. versionchanged:: 3.8
+
+        :func:`patch.dict` now returns the patched dictionary when used as a context
+        manager.
+
 :func:`patch.dict` can be used to add members to a dictionary, or simply let a test
 change a dictionary, and ensure the dictionary is restored when the test
 ends.
 
     >>> foo = {}
-    >>> with patch.dict(foo, {'newkey': 'newvalue'}):
+    >>> with patch.dict(foo, {'newkey': 'newvalue'}) as patched_foo:
     ...     assert foo == {'newkey': 'newvalue'}
+    ...     assert patched_foo == {'newkey': 'newvalue'}
+    ...     patched_foo['spam'] = 'eggs'
+    ...     assert patched_foo['spam'] == 'eggs'
     ...
     >>> assert foo == {}
+    >>> assert patched_foo == {}
 
     >>> import os
     >>> with patch.dict('os.environ', {'newkey': 'newvalue'}):

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1356,8 +1356,8 @@ ends.
     >>> with patch.dict(foo, {'newkey': 'newvalue'}) as patched_foo:
     ...     assert foo == {'newkey': 'newvalue'}
     ...     assert patched_foo == {'newkey': 'newvalue'}
+    ...     # You can add, update or delete keys of foo (or patched_foo, it's the same dict)
     ...     patched_foo['spam'] = 'eggs'
-    ...     assert patched_foo['spam'] == 'eggs'
     ...
     >>> assert foo == {}
     >>> assert patched_foo == {}

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1664,6 +1664,7 @@ class _patch_dict(object):
     def __enter__(self):
         """Patch the dict."""
         self._patch_dict()
+        return self.in_dict
 
 
     def _patch_dict(self):

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -627,6 +627,13 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(foo.values, original)
 
 
+    def test_patch_dict_as_context_manager(self):
+        foo = {'a': 'b'}
+        with patch.dict(foo, a='c') as patched:
+            self.assertEqual(patched, {'a': 'c'})
+        self.assertEqual(foo, {'a': 'b'})
+
+
     def test_name_preserved(self):
         foo = {}
 

--- a/Misc/NEWS.d/next/Library/2017-12-13-17-49-56.bpo-32299.eqAPWs.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-13-17-49-56.bpo-32299.eqAPWs.rst
@@ -1,0 +1,2 @@
+Changed :func:`unittest.mock.patch.dict` to return the patched
+dictionary when used as context manager. Patch by Vadim Tsander.


### PR DESCRIPTION
Return the patched version of the dict when `unittest.mock.patch.dict` is used as a context manager. This change mirrors the rest of the APIs that patch objects in `unittest.mock`

Closes: #4834

This PR brings the commit from the abandoned PR #4834 with the comments addressed. See https://github.com/python/cpython/pull/4834#issuecomment-436744393


<!-- issue-number: [bpo-32299](https://bugs.python.org/issue32299) -->
https://bugs.python.org/issue32299
<!-- /issue-number -->
