### PR TITLE
bpo-35451: Fix reference counting for sys.warnoptions and sys._xoptions.

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1774,7 +1774,6 @@ get_warnoptions(void)
          * call optional for embedding applications, thus making this
          * reachable again.
          */
-        Py_XDECREF(warnoptions);
         warnoptions = PyList_New(0);
         if (warnoptions == NULL)
             return NULL;
@@ -1864,7 +1863,6 @@ get_xoptions(void)
          * call optional for embedding applications, thus making this
          * reachable again.
          */
-        Py_XDECREF(xoptions);
         xoptions = PyDict_New();
         if (xoptions == NULL)
             return NULL;


### PR DESCRIPTION


<!-- issue-number: [bpo-35451](https://bugs.python.org/issue35451) -->
https://bugs.python.org/issue35451
<!-- /issue-number -->
