### PR TITLE
bpo-31374: Include pyconfig.h earlier in expat

### DIFF
--- a/Modules/expat/xmltok.c
+++ b/Modules/expat/xmltok.c
@@ -30,6 +30,7 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include <pyconfig.h>
 #include <stddef.h>
 #include <string.h>  /* memcpy */
 


### PR DESCRIPTION
Include <pyconfig.h> ealier in Modules/expat/xmltok.c to define
properly _POSIX_C_SOURCE. Python defines _POSIX_C_SOURCE as 200809L,
whereas <features.h> (included indirectly by <string.h>) defines
_POSIX_C_SOURCE as 199506L.

<!-- issue-number: [bpo-31374](https://bugs.python.org/issue31374) -->
https://bugs.python.org/issue31374
<!-- /issue-number -->
