### PR TITLE
bpo-35452: Make PySys_HasWarnOptions() never raising an exception.

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1846,7 +1846,7 @@ PySys_HasWarnOptions(void)
 {
     PyObject *warnoptions = _PySys_GetObjectId(&PyId_warnoptions);
     return (warnoptions != NULL && PyList_Check(warnoptions)
-            && PyList_GET_SIZE(warnoptions));
+            && PyList_GET_SIZE(warnoptions) > 0);
 }
 
 static PyObject *

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1845,7 +1845,8 @@ int
 PySys_HasWarnOptions(void)
 {
     PyObject *warnoptions = _PySys_GetObjectId(&PyId_warnoptions);
-    return (warnoptions != NULL && (PyList_Size(warnoptions) > 0)) ? 1 : 0;
+    return (warnoptions != NULL && PyList_Check(warnoptions)
+            && PyList_GET_SIZE(warnoptions));
 }
 
 static PyObject *


### PR DESCRIPTION


<!-- issue-number: [bpo-35452](https://bugs.python.org/issue35452) -->
https://bugs.python.org/issue35452
<!-- /issue-number -->
