### PR TITLE
[2.7] bpo-31374: Include pyconfig.h earlier in expat

### DIFF
--- a/Modules/expat/xmlparse.c
+++ b/Modules/expat/xmlparse.c
@@ -30,6 +30,7 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include <pyconfig.h>
 #if !defined(_GNU_SOURCE)
 # define _GNU_SOURCE 1                  /* syscall prototype */
 #endif

--- a/Modules/expat/xmlparse.c
+++ b/Modules/expat/xmlparse.c
@@ -30,7 +30,9 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <pyconfig.h>
+#if !defined(_WIN32) && defined(HAVE_EXPAT_CONFIG_H)
+#  include <pyconfig.h>
+#endif
 #if !defined(_GNU_SOURCE)
 # define _GNU_SOURCE 1                  /* syscall prototype */
 #endif

--- a/Modules/expat/xmltok.c
+++ b/Modules/expat/xmltok.c
@@ -30,7 +30,9 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <pyconfig.h>
+#if !defined(_WIN32) && defined(HAVE_EXPAT_CONFIG_H)
+#  include <pyconfig.h>
+#endif
 #include <stddef.h>
 #include <string.h>  /* memcpy */
 


### PR DESCRIPTION
Include <pyconfig.h> ealier in Modules/expat/xmlparse.c to define
properly _POSIX_C_SOURCE and _XOPEN_SOURCE.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-31374](https://bugs.python.org/issue31374) -->
https://bugs.python.org/issue31374
<!-- /issue-number -->
