### PR TITLE
bpo-31374: expat doesn't include <pyconfig.h> on Windows

### DIFF
--- a/Modules/expat/xmltok.c
+++ b/Modules/expat/xmltok.c
@@ -30,7 +30,9 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <pyconfig.h>
+#if !defined(_WIN32) && defined(HAVE_EXPAT_CONFIG_H)
+#  include <pyconfig.h>
+#endif
 #include <stddef.h>
 #include <string.h>  /* memcpy */
 


### PR DESCRIPTION


<!-- issue-number: [bpo-31374](https://bugs.python.org/issue31374) -->
https://bugs.python.org/issue31374
<!-- /issue-number -->
