### PR TITLE
bpo-35438: Remove the usage of _PyObject_LookupSpecial from Modules

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1991,10 +1991,7 @@ order (MRO) for bases """
             ("__exit__", run_context, swallow, set(), {"__enter__" : iden}),
             ("__complex__", complex, complex_num, set(), {}),
             ("__format__", format, format_impl, set(), {}),
-            ("__floor__", math.floor, zero, set(), {}),
-            ("__trunc__", math.trunc, zero, set(), {}),
             ("__trunc__", int, zero, set(), {}),
-            ("__ceil__", math.ceil, zero, set(), {}),
             ("__dir__", dir, empty_seq, set(), {}),
             ("__round__", round, zero, set(), {}),
             ]

--- a/Misc/NEWS.d/next/C API/2018-12-10-10-54-23.bpo-35438.-MWdoM.rst
+++ b/Misc/NEWS.d/next/C API/2018-12-10-10-54-23.bpo-35438.-MWdoM.rst
@@ -1,0 +1,2 @@
+Modify extension modules to remove the usage of the non-public
+`_PyObject_LookupSpecial` function

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3180,8 +3180,7 @@ test_pytime_object_to_timespec(PyObject *self, PyObject *args)
 static void
 slot_tp_del(PyObject *self)
 {
-    _Py_IDENTIFIER(__tp_del__);
-    PyObject *del, *res;
+    PyObject *res, *type;
     PyObject *error_type, *error_value, *error_traceback;
 
     /* Temporarily resurrect the object. */
@@ -3192,14 +3191,10 @@ slot_tp_del(PyObject *self)
     PyErr_Fetch(&error_type, &error_value, &error_traceback);
 
     /* Execute __del__ method, if any. */
-    del = _PyObject_LookupSpecial(self, &PyId___tp_del__);
-    if (del != NULL) {
-        res = _PyObject_CallNoArg(del);
-        if (res == NULL)
-            PyErr_WriteUnraisable(del);
-        else
-            Py_DECREF(res);
-        Py_DECREF(del);
+    type = (PyObject *)Py_TYPE(self);
+    if (PyObject_HasAttrString(type, "__tp_del__") == 1) {
+        res = PyObject_CallMethod(type, "__tp_del__", "(O)", self);
+        Py_XDECREF(res);
     }
 
     /* Restore the saved exception. */

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1726,9 +1726,9 @@ math_trunc(PyObject *module, PyObject *x)
 
     number_type = (PyObject *)Py_TYPE(x);
     if (PyObject_HasAttrString(number_type, "__trunc__") == 0) {
-				PyErr_Format(PyExc_TypeError,
-										 "type %.100s doesn't define __trunc__ method",
-										 Py_TYPE(x)->tp_name);
+                                PyErr_Format(PyExc_TypeError,
+                                                                                 "type %.100s doesn't define __trunc__ method",
+                                                                                 Py_TYPE(x)->tp_name);
         return NULL;
     }
     return PyObject_CallMethod(number_type, "__trunc__", "(O)", x);

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1085,18 +1085,13 @@ static PyObject *
 math_ceil(PyObject *module, PyObject *number)
 /*[clinic end generated code: output=6c3b8a78bc201c67 input=2725352806399cab]*/
 {
-    _Py_IDENTIFIER(__ceil__);
-    PyObject *method, *result;
+    PyObject *number_type;
 
-    method = _PyObject_LookupSpecial(number, &PyId___ceil__);
-    if (method == NULL) {
-        if (PyErr_Occurred())
-            return NULL;
+    number_type = (PyObject *)Py_TYPE(number);
+    if (PyObject_HasAttrString(number_type, "__ceil__") == 0) {
         return math_1_to_int(number, ceil, 0);
     }
-    result = _PyObject_CallNoArg(method);
-    Py_DECREF(method);
-    return result;
+    return PyObject_CallMethod(number_type, "__ceil__", "(O)", number);
 }
 
 FUNC2(copysign, copysign,
@@ -1143,18 +1138,13 @@ static PyObject *
 math_floor(PyObject *module, PyObject *number)
 /*[clinic end generated code: output=c6a65c4884884b8a input=63af6b5d7ebcc3d6]*/
 {
-    _Py_IDENTIFIER(__floor__);
-    PyObject *method, *result;
+    PyObject *number_type;
 
-    method = _PyObject_LookupSpecial(number, &PyId___floor__);
-    if (method == NULL) {
-        if (PyErr_Occurred())
-            return NULL;
+    number_type = (PyObject *)Py_TYPE(number);
+    if (PyObject_HasAttrString(number_type, "__floor__") == 0) {
         return math_1_to_int(number, floor, 0);
     }
-    result = _PyObject_CallNoArg(method);
-    Py_DECREF(method);
-    return result;
+    return PyObject_CallMethod(number_type, "__floor__", "(O)", number);
 }
 
 FUNC1A(gamma, m_tgamma,
@@ -1732,25 +1722,16 @@ static PyObject *
 math_trunc(PyObject *module, PyObject *x)
 /*[clinic end generated code: output=34b9697b707e1031 input=2168b34e0a09134d]*/
 {
-    _Py_IDENTIFIER(__trunc__);
-    PyObject *trunc, *result;
+    PyObject *number_type;
 
-    if (Py_TYPE(x)->tp_dict == NULL) {
-        if (PyType_Ready(Py_TYPE(x)) < 0)
-            return NULL;
-    }
-
-    trunc = _PyObject_LookupSpecial(x, &PyId___trunc__);
-    if (trunc == NULL) {
-        if (!PyErr_Occurred())
-            PyErr_Format(PyExc_TypeError,
-                         "type %.100s doesn't define __trunc__ method",
-                         Py_TYPE(x)->tp_name);
+    number_type = (PyObject *)Py_TYPE(x);
+    if (PyObject_HasAttrString(number_type, "__trunc__") == 0) {
+				PyErr_Format(PyExc_TypeError,
+										 "type %.100s doesn't define __trunc__ method",
+										 Py_TYPE(x)->tp_name);
         return NULL;
     }
-    result = _PyObject_CallNoArg(trunc);
-    Py_DECREF(trunc);
-    return result;
+    return PyObject_CallMethod(number_type, "__trunc__", "(O)", x);
 }
 
 


### PR DESCRIPTION
Cleanup the use of the internal API _PyObject_LookupSpecial in CPython Modules. This function is just a wrapper around _PyType_Lookup which as the implementation says it's an: "Internal API".

This is a nice cleanup on a bad use of the C-API (more on that documented here: https://pythoncapi.readthedocs.io/bad_api.html).

<!-- issue-number: [bpo-35438](https://bugs.python.org/issue35438) -->
https://bugs.python.org/issue35438
<!-- /issue-number -->
