### PR TITLE
bpo-26704: Add test for double patching instance methods

### DIFF
--- a/Lib/unittest/test/testmock/testwith.py
+++ b/Lib/unittest/test/testmock/testwith.py
@@ -126,6 +126,20 @@ class WithTest(unittest.TestCase):
 
         self.assertEqual(foo, {})
 
+    def test_double_patch_instance_method(self):
+        class C:
+            def f(self):
+                pass
+
+        c = C()
+
+        with patch.object(c, 'f', autospec=True) as patch1:
+            with patch.object(c, 'f', autospec=True) as patch2:
+                c.f()
+            self.assertEqual(patch2.call_count, 1)
+            self.assertEqual(patch1.call_count, 0)
+            c.f()
+        self.assertEqual(patch1.call_count, 1)
 
 
 class TestMockOpen(unittest.TestCase):

--- a/Misc/NEWS.d/next/Tests/2018-12-10-13-18-37.bpo-26704.DBAN4c.rst
+++ b/Misc/NEWS.d/next/Tests/2018-12-10-13-18-37.bpo-26704.DBAN4c.rst
@@ -1,0 +1,2 @@
+Added test demonstrating double-patching of an instance method.  Patch by
+Anthony Sottile.


### PR DESCRIPTION
(cannot be backported past python3.7 as the bugfix was not backported to python3.6)

<!-- issue-number: [bpo-26704](https://bugs.python.org/issue26704) -->
https://bugs.python.org/issue26704
<!-- /issue-number -->
