### PR TITLE
bpo-35412: Skip test_multiprocessing_fork and test_multiprocessing_forkserver on Windows

### DIFF
--- a/Lib/test/test_multiprocessing_fork.py
+++ b/Lib/test/test_multiprocessing_fork.py
@@ -7,6 +7,9 @@ from test import support
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
+if sys.platform == "win32":
+    raise unittest.SkipTest("fork is not available on Windows")
+
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 

--- a/Lib/test/test_multiprocessing_forkserver.py
+++ b/Lib/test/test_multiprocessing_forkserver.py
@@ -1,10 +1,14 @@
 import unittest
 import test._test_multiprocessing
 
+import sys
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
+
+if sys.platform == "win32":
+    raise unittest.SkipTest("forkserver is not available on Windows")
 
 test._test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
 


### PR DESCRIPTION


<!-- issue-number: [bpo-35412](https://bugs.python.org/issue35412) -->
https://bugs.python.org/issue35412
<!-- /issue-number -->
