### PR TITLE
bpo-35401: Update Windows build to OpenSSL 1.1.0j

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-12-10-15-01-13.bpo-35401.9L1onG.rst
+++ b/Misc/NEWS.d/next/Windows/2018-12-10-15-01-13.bpo-35401.9L1onG.rst
@@ -1,0 +1,1 @@
+Updates Windows build to OpenSSL 1.1.0j

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -49,7 +49,7 @@ echo.Fetching external libraries...
 
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.6
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.0i
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.0j
 set libraries=%libraries%                                       sqlite-3.21.0.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.8.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.8.0
@@ -72,7 +72,7 @@ for %%e in (%libraries%) do (
 echo.Fetching external binaries...
 
 set binaries=
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.0i
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.0j
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.8.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/prepare_ssl.bat
+++ b/PCbuild/prepare_ssl.bat
@@ -32,19 +32,12 @@ if "%~1"=="-h" shift & goto Usage
 if "%~1"=="--certificate" (set SigningCertificate=%~2) && shift && shift & goto CheckOpts
 if "%~1"=="-c" (set SigningCertificate=%~2) && shift && shift & goto CheckOpts
 if "%~1"=="--organization" (set ORG_SETTING=--organization "%~2") && shift && shift && goto CheckOpts
-if "%~1"=="-i" (SET SRC=$~2) && shift && shift && goto CheckOpts
-if "%~1"=="--in" (SET SRC=$~2) && shift && shift && goto CheckOpts
-if "%~1"=="-o" (set OUT=$~2) && shift && shift && goto CheckOpts
-if "%~1"=="--out" (set OUT=$~2) && shift && shift && goto CheckOpts
 
 if "%~1"=="" goto Build
 echo Unrecognized option: %1
 goto Usage
 
 :Build
-if not defined SRC (echo --in directory is required & exit /b 1)
-if not defined OUT (echo --out directory is required & exit /b 1)
-
 call "%PCBUILD%\find_msbuild.bat" %MSBUILD%
 if ERRORLEVEL 1 (echo Cannot locate MSBuild.exe on PATH or as MSBUILD variable & exit /b 2)
 

--- a/PCbuild/prepare_ssl.bat
+++ b/PCbuild/prepare_ssl.bat
@@ -23,8 +23,6 @@ setlocal
 if "%PCBUILD%"=="" (set PCBUILD=%~dp0)
 if "%EXTERNALS_DIR%"=="" (set EXTERNALS_DIR=%PCBUILD%\..\externals)
 
-set OUT=
-set SRC=
 set ORG_SETTING=
 
 :CheckOpts

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -49,8 +49,8 @@
     <sqlite3Dir>$(ExternalsDir)sqlite-3.21.0.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.0i\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.0i\$(ArchName)\</opensslOutDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.0j\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.0j\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>


### PR DESCRIPTION
Also removes some unnecessary lines from the `prepare_ssl.bat` file.

<!-- issue-number: [bpo-35401](https://bugs.python.org/issue35401) -->
https://bugs.python.org/issue35401
<!-- /issue-number -->
