### PR TITLE
[3.6] bpo-35401: Update macOS installer to OpenSSL 1.0.2q

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -211,9 +211,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.0.2p",
-              url="https://www.openssl.org/source/openssl-1.0.2p.tar.gz",
-              checksum='ac5eb30bf5798aa14b1ae6d0e7da58df',
+              name="OpenSSL 1.0.2q",
+              url="https://www.openssl.org/source/openssl-1.0.2q.tar.gz",
+              checksum='7563e1ce046cb21948eeb6ba1a0eb71c',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2018-12-10-02-37-11.bpo-35401.sFhD5z.rst
+++ b/Misc/NEWS.d/next/macOS/2018-12-10-02-37-11.bpo-35401.sFhD5z.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use OpenSSL 1.0.2q.


### PR DESCRIPTION


<!-- issue-number: [bpo-35401](https://bugs.python.org/issue35401) -->
https://bugs.python.org/issue35401
<!-- /issue-number -->
