### PR TITLE
[2.7] bpo-15663: the 10.6+ macOS installers for 3.6/2.7 now provide a private Tcl/Tk 8.6

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -2,6 +2,8 @@
 """
 This script is used to build "official" universal installers on macOS.
 
+NEW for 3.6.8 / 2.7.16:
+- also build and use Tk 8.6 for 10.6+ installers
 NEW for 3.6.5:
 - support Intel 64-bit-only () and 32-bit-only installer builds
 - build and link with private Tcl/Tk 8.6 for 10.9+ builds
@@ -20,8 +22,8 @@ Sphinx and dependencies are installed into a venv using the python3's pip
 so will fetch them from PyPI if necessary.  Since python3 is now used for
 Sphinx, build-installer.py should also be converted to use python3!
 
-For 10.9 or greater deployment targets, build-installer builds and links
-with its own copy of Tcl/Tk 8.5 and the rest of this paragraph does not
+For 10.6 or greater deployment targets, build-installer builds and links
+with its own copy of Tcl/Tk 8.6 and the rest of this paragraph does not
 apply.  Otherwise, build-installer requires an installed third-party version
 of Tcl/Tk 8.4 (for OS X 10.4 and 10.5 deployment targets) or Tcl/TK 8.5
 (for 10.6 or later) installed in /Library/Frameworks.  When installed,
@@ -188,9 +190,9 @@ USAGE = textwrap.dedent("""\
 EXPECTED_SHARED_LIBS = {}
 
 # Are we building and linking with our own copy of Tcl/TK?
-#   For now, do so if deployment target is 10.9+.
+#   For now, do so if deployment target is 10.6+.
 def internalTk():
-    return getDeptargetTuple() >= (10, 9)
+    return getDeptargetTuple() >= (10, 6)
 
 # List of names of third party software built with this installer.
 # The names will be inserted into the rtf version of the License.

--- a/Mac/BuildScript/resources/ReadMe.rtf
+++ b/Mac/BuildScript/resources/ReadMe.rtf
@@ -1,5 +1,6 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1561\cocoasubrtf400
-{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fmodern\fcharset0 CourierNewPSMT;}
+{\rtf1\ansi\ansicpg1252\cocoartf1671\cocoasubrtf100
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fswiss\fcharset0 Helvetica-Bold;\f2\fswiss\fcharset0 Helvetica-Oblique;
+\f3\fmodern\fcharset0 CourierNewPSMT;}
 {\colortbl;\red255\green255\blue255;}
 {\*\expandedcolortbl;;}
 \margl1440\margr1440\vieww15240\viewh15540\viewkind0
@@ -9,145 +10,143 @@
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\b \cf0 \ul \ulc0 Which installer variant should I use? [CHANGED in 2.7.15]
-\b0 \ulnone \
+\f1\b \cf0 \ul \ulc0 Which installer variant should I use? [CHANGED in 2.7.15]
+\f0\b0 \ulnone \
 \
-
-\b **NEW**
-\b0  With Python 2.7.15, the python.org website now provides two installer variants for download: one that installs a 
-\i 64-bit-only 
-\i0 Python capable of running on 
-\i macOS 10.9 (Mavericks)
-\i0  or later; and one that installs a 
-\i 64-bit/32-bit Intel
-\i0  Python capable of running on 
-\i macOS 10.6 (Snow Leopard)
-\i0  or later.  (This ReadMe was installed with the 
-\i $MACOSX_DEPLOYMENT_TARGET
-\i0  variant.)  Previous Python 2.7.x releases provided the 10.6 or later installer and a 10.5 or later 32-bit-only variant. If you are running on macOS 10.9 or later and if you have no need for compatibility with older systems, use the 10.9 variant.  Use the 10.6 variant if you are running on macOS 10.6 through 10.8, if you need to maintain compatibility with previous 2.7.x releases, or if you want to produce standalone applications that can run on systems from 10.6.  The Pythons installed by these installers are built with private copies of some third-party libraries not included with or newer than those in macOS itself.  The list of these libraries varies by installer variant and is included at the end of the 
-\f1 License.rtf
+With Python 2.7.15, the python.org website now provides two installer variants for download: one that installs a 
+\f2\i 64-bit-only 
+\f0\i0 Python capable of running on 
+\f2\i macOS 10.9 (Mavericks)
+\f0\i0  or later; and one that installs a 
+\f2\i 64-bit/32-bit Intel
+\f0\i0  Python capable of running on 
+\f2\i macOS 10.6 (Snow Leopard)
+\f0\i0  or later.  (This ReadMe was installed with the 
+\f2\i $MACOSX_DEPLOYMENT_TARGET
+\f0\i0  variant.)  Previous Python 2.7.x releases provided the 10.6 or later installer and a 10.5 or later 32-bit-only variant. If you are running on macOS 10.9 or later and if you have no need for compatibility with older systems, use the 10.9 variant.  Use the 10.6 variant if you are running on macOS 10.6 through 10.8, if you need to maintain compatibility with previous 2.7.x releases, or if you want to produce standalone applications that can run on systems from 10.6.  The Pythons installed by these installers are built with private copies of some third-party libraries not included with or newer than those in macOS itself.  The list of these libraries varies by installer variant and is included at the end of the 
+\f3 License.rtf
 \f0  file.\
 
-\b \ul \
+\f1\b \ul \
 Certificate verification and OpenSSL_[CHANGED in 2.7.15]\
 
-\b0 \ulnone \
+\f0\b0 \ulnone \
 This variant of Python 2.7 now includes its own private copy of OpenSSL 1.0.2.  Unlike previous releases, the deprecated Apple-supplied OpenSSL libraries are no longer used.  This also means that the trust certificates in system and user keychains managed by the 
-\i Keychain Access 
-\i0 application and the 
-\i security
-\i0  command line utility are no longer used as defaults by the Python 
-\f1 ssl
+\f2\i Keychain Access 
+\f0\i0 application and the 
+\f2\i security
+\f0\i0  command line utility are no longer used as defaults by the Python 
+\f3 ssl
 \f0  module.  A sample command script is included in 
-\f1 /Applications/Python 2.7
+\f3 /Applications/Python 2.7
 \f0  to install a curated bundle of default root certificates from the third-party 
-\f1 certifi
+\f3 certifi
 \f0  package ({\field{\*\fldinst{HYPERLINK "https://pypi.python.org/pypi/certifi"}}{\fldrslt https://pypi.python.org/pypi/certifi}}).  Click on 
-\f1 Install Certificates
+\f3 Install Certificates
 \f0  to run it.  If you choose to use 
-\f1 certifi
+\f3 certifi
 \f0 , you should consider subscribing to the{\field{\*\fldinst{HYPERLINK "https://certifi.io/en/latest/"}}{\fldrslt  project's email update service}} to be notified when the certificate bundle is updated.\
 \
 The bundled 
-\f1 pip
+\f3 pip
 \f0  included with the Python 2.7 installer has its own default certificate store for verifying download connections.\
 \
 
-\b \ul Using IDLE or other Tk applications [NEW/CHANGED in 2.7.15] 
-\b0 \ulnone \
+\f1\b \ul Using IDLE or other Tk applications [NEW/CHANGED in 2.7.15] 
+\f0\b0 \ulnone \
 \
-The 10.9+ installer variant comes with its own private version of Tcl/Tk 8.6. It does not use system-supplied or third-party supplied versions of Tcl/Tk.\
+As of 2.7.15, the 10.9+ installer variant comes with its own private version of Tcl/Tk 8.6. It does not use system-supplied or third-party supplied versions of Tcl/Tk.\
 \
-For the 10.6+ variant, you continue to need to install a newer third-party version of the 
-\i Tcl/Tk
-\i0  8.5 (not 8.6) frameworks to use IDLE or other programs that use the Tkinter graphical user interface toolkit.  Visit {\field{\*\fldinst{HYPERLINK "https://www.python.org/download/mac/tcltk/"}}{\fldrslt https://www.python.org/download/mac/tcltk/}} for current information about supported and recommended versions of 
-\i Tcl/Tk
-\i0  for this version of Python and of macOS.\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\b \ul \
+\f1\b \cf0 CHANGED in 2.7.16: 
+\f0\b0 The 10.6+ variant now also uses a private version of Tcl/Tk 8.6.\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f1\b \cf0 \ul \ulc0 \
 Binary installer support for Mac OS X 10.5 and earlier discontinued [CHANGED for Python 2.7.15]
-\b0 \ulnone \
+\f0\b0 \ulnone \
 \
 As of Python 2.7.15, binary installers from python.org no longer support Mac OS X 10.5 (Leopard) systems.   Binary installer support for Mac OS X 10.3.9 (Panther) and 10.4.x (Tiger) systems was previously dropped in Python 2.7.9.  Mac OS X 10.5 was originally released by Apple in 2007 and last updated in 2009 and was the last OS X release for PPC machines (G4 and G5).  If needed, it is still possible to build Python from source for 10.3.9, 10.4, or 10.5.\
 \
 
-\b \ul Packages installed with the system Python 2.7 are no longer searched for [CHANGED for Python 2.7.13]
-\b0 \ulnone \
+\f1\b \ul Packages installed with the system Python 2.7 are no longer searched for [CHANGED for Python 2.7.13]
+\f0\b0 \ulnone \
 \
 As of Python 2.7.0, user-installed Python 2.7 versions from python.org installers added the system-wide site-packages directory for the Apple-supplied Python 2.7 to the end of their search path.  This meant that packages installed with the system Python 2.7 could also be used by the user-installed Python 2.7.  While sometimes convenient, this also often caused confusion with the implicit coupling between the two Python instances.  Separately, as of macOS 10.12, Apple changed the layout of the system site-packages directory, 
-\f1 /Library/Python/2.7/site-packages
+\f3 /Library/Python/2.7/site-packages
 \f0 , in a way that can now cause installation of 
-\f1 pip
+\f3 pip
 \f0  components to fail.  To avoid the confusion and the installation failures, as of 2.7.13 user-installed Pythons no longer add 
-\f1 /Library/Python/2.7/site-packages
+\f3 /Library/Python/2.7/site-packages
 \f0  to 
-\f1 sys.path
+\f3 sys.path
 \f0 .  If you are using a package with both a user-installed Python 2.7 and the system Python 2.7, you will now need to ensure that separate copies of the package are installed for each instance.\
 \
 
-\b \ul Installing on OS X 10.8 (Mountain Lion) or later systems [CHANGED for Python 2.7.9]
-\b0 \ulnone \
+\f1\b \ul Installing on OS X 10.8 (Mountain Lion) or later systems [CHANGED for Python 2.7.9]
+\f0\b0 \ulnone \
 \
 As of Python 2.7.9, installer packages from python.org are now compatible with the Gatekeeper security feature introduced in OS X 10.8.   Downloaded packages can now be directly installed by double-clicking with the default system security settings.  Python.org installer packages for macOS are signed with the Developer ID of the builder, as identified on {\field{\*\fldinst{HYPERLINK "https://www.python.org/downloads/"}}{\fldrslt the download page}} for this release.  To inspect the digital signature of the package, click on the lock icon in the upper right corner of the 
-\i Install Python
-\i0  installer window.  Refer to Apple\'92s support pages for {\field{\*\fldinst{HYPERLINK "http://support.apple.com/kb/ht5290"}}{\fldrslt more information on Gatekeeper}}.\
+\f2\i Install Python
+\f0\i0  installer window.  Refer to Apple\'92s support pages for {\field{\*\fldinst{HYPERLINK "http://support.apple.com/kb/ht5290"}}{\fldrslt more information on Gatekeeper}}.\
 \
 
-\b \ul Simplified web-based installs [NEW for Python 2.7.9]
-\b0 \ulnone \
+\f1\b \ul Simplified web-based installs [NEW for Python 2.7.9]
+\f0\b0 \ulnone \
 \
 With the change to the newer flat format installer package, the download file now has a 
-\f1 .pkg
+\f3 .pkg
 \f0  extension as it is no longer necessary to embed the installer within a disk image (
-\f1 .dmg
+\f3 .dmg
 \f0 ) container.   If you download the Python installer through a web browser, the macOS installer application may open automatically to allow you to perform the install.  If your browser settings do not allow automatic open, double click on the downloaded installer file.\
 \
 
-\b \ul New Installation Options and Defaults [NEW for Python 2.7.9]
-\b0 \ulnone \
+\f1\b \ul New Installation Options and Defaults [NEW for Python 2.7.9]
+\f0\b0 \ulnone \
 \
 The Python installer now includes an option to automatically install or upgrade 
-\f1 pip
+\f3 pip
 \f0 , a tool for installing and managing Python packages.  This option is enabled by default and no Internet access is required.  If you do not want the installer to do this, select the 
-\i Customize
-\i0  option at the 
-\i Installation Type
-\i0  step and uncheck the 
-\i Install or upgrade pip
-\i0  option.  For other changes in this release, see the 
-\i Release Notes
-\i0  link for this release at {\field{\*\fldinst{HYPERLINK "https://www.python.org/downloads/"}}{\fldrslt https://www.python.org/downloads/}}.\
+\f2\i Customize
+\f0\i0  option at the 
+\f2\i Installation Type
+\f0\i0  step and uncheck the 
+\f2\i Install or upgrade pip
+\f0\i0  option.  For other changes in this release, see the 
+\f2\i Release Notes
+\f0\i0  link for this release at {\field{\*\fldinst{HYPERLINK "https://www.python.org/downloads/"}}{\fldrslt https://www.python.org/downloads/}}.\
 \
 
-\b \ul Python 3 and Python 2 Co-existence\
+\f1\b \ul Python 3 and Python 2 Co-existence\
 
-\b0 \ulnone \
+\f0\b0 \ulnone \
 Python.org Python 2.7 and 3.x versions can both be installed on your system and will not conflict.  Python 2.7 command names contain a 2 or no digit: 
-\f1 python2
+\f3 python2
 \f0  (or 
-\f1 python2.7
+\f3 python2.7
 \f0  or 
-\f1 python
+\f3 python
 \f0 ), 
-\f1 idle2
+\f3 idle2
 \f0  (or 
-\f1 idle2.7
+\f3 idle2.7
 \f0  or 
-\f1 idle
+\f3 idle
 \f0 ), 
-\f1 pip2
+\f3 pip2
 \f0  (or 
-\f1 pip2.7
+\f3 pip2.7
 \f0  or 
-\f1 pip
+\f3 pip
 \f0 ), etc.  Command names for Python 3 contain a 3 in them, 
-\f1 python3
+\f3 python3
 \f0 , 
-\f1 idle3
+\f3 idle3
 \f0 , 
-\f1 pip3
+\f3 pip3
 \f0 , etc.  Also, installing a python.org Python 2.7 does not alter or remove any Apple-supplied system Pythons, found in 
-\f1 /usr/bin
+\f3 /usr/bin
 \f0 .\
 \
 \

--- a/Mac/BuildScript/resources/Welcome.rtf
+++ b/Mac/BuildScript/resources/Welcome.rtf
@@ -1,28 +1,33 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1561\cocoasubrtf400
-\cocoascreenfonts1{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fmodern\fcharset0 CourierNewPSMT;}
+{\rtf1\ansi\ansicpg1252\cocoartf1671\cocoasubrtf100
+\cocoascreenfonts1{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fswiss\fcharset0 Helvetica-Bold;\f2\fmodern\fcharset0 CourierNewPSMT;
+}
 {\colortbl;\red255\green255\blue255;}
 {\*\expandedcolortbl;;}
 \paperw11905\paperh16837\margl1440\margr1440\vieww13360\viewh10920\viewkind0
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
 \f0\fs24 \cf0 This package will install 
-\b Python $FULL_VERSION
-\b0  for 
-\b macOS $MACOSX_DEPLOYMENT_TARGET
-\b0 .\
+\f1\b Python $FULL_VERSION
+\f0\b0  for 
+\f1\b macOS $MACOSX_DEPLOYMENT_TARGET
+\f0\b0 .\
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
 
-\b Python for macOS
-\b0  consists of the Python programming language interpreter, plus a set of programs to allow easy access to it for macOS users including an integrated development environment 
-\b IDLE
-\b0 .\
+\f1\b Python for macOS
+\f0\b0  consists of the Python programming language interpreter, plus a set of programs to allow easy access to it for macOS users including an integrated development environment 
+\f1\b IDLE
+\f0\b0 .\
 \
 
-\b NEW in 2.7.15: 
-\b0 two installer variants (10.9+ 64-bit-only, 10.6+ 64-/32-bit), built-in Tcl/Tk 8.6 support in the 10.9+ variant (no additional third-party downloads!), updated  
-\f1 pip,
+\f1\b NEW in 2.7.15: 
+\f0\b0 two installer variants (10.9+ 64-bit-only, 10.6+ 64-/32-bit), built-in Tcl/Tk 8.6 support in the 10.9+ variant (no additional third-party downloads!), updated  
+\f2 pip,
 \f0  built-in OpenSSL 1.0.2 (click on 
-\f1 Install Certificates
+\f2 Install Certificates
 \f0  for root certificates)\
+\
+
+\f1\b CHANGED in 2.7.16:
+\f0\b0   the 10.6+ variant now also uses a built-in Tcl/Tk 8.6\
 }

--- a/Misc/NEWS.d/next/macOS/2018-12-11-02-50-35.bpo-15663.6tnyd2.rst
+++ b/Misc/NEWS.d/next/macOS/2018-12-11-02-50-35.bpo-15663.6tnyd2.rst
@@ -1,0 +1,2 @@
+The macOS 10.6+ installer now provides a private copy of Tcl/Tk 8.6, like
+the 10.9+ installer does.


### PR DESCRIPTION


<!-- issue-number: [bpo-15663](https://bugs.python.org/issue15663) -->
https://bugs.python.org/issue15663
<!-- /issue-number -->
