### PR TITLE
bpo-35458: Fix test_shutil.test_disk_usage()

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1363,12 +1363,16 @@ class TestShutil(unittest.TestCase):
                          "disk_usage not available on this platform")
     def test_disk_usage(self):
         usage = shutil.disk_usage(os.path.dirname(__file__))
-        self.assertEqual(usage, shutil.disk_usage(__file__))
+        for attr in ('total', 'used', 'free'):
+            self.assertIsInstance(getattr(usage, attr), int)
         self.assertGreater(usage.total, 0)
         self.assertGreater(usage.used, 0)
         self.assertGreaterEqual(usage.free, 0)
         self.assertGreaterEqual(usage.total, usage.used)
         self.assertGreater(usage.total, usage.free)
+
+        # bpo-32557: Check that disk_usage() also accepts a filename
+        shutil.disk_usage(__file__)
 
     @unittest.skipUnless(UID_GID_SUPPORT, "Requires grp and pwd support")
     @unittest.skipUnless(hasattr(os, 'chown'), 'requires os.chown')


### PR DESCRIPTION
The following test fails if a different process creates or removes
data disk on the same disk partition:

    usage = shutil.disk_usage(os.path.dirname(__file__))
    self.assertEqual(usage, shutil.disk_usage(__file__))

Only test that disk_usage() succeed on a filename, but check the
result.

Add also tests on the fields type (must be int).

<!-- issue-number: [bpo-35458](https://bugs.python.org/issue35458) -->
https://bugs.python.org/issue35458
<!-- /issue-number -->
