### PR TITLE
Fix the compiler warning after bpo-35444.

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -17,7 +17,6 @@ _Py_IDENTIFIER(Py_Repr);
 _Py_IDENTIFIER(__bytes__);
 _Py_IDENTIFIER(__dir__);
 _Py_IDENTIFIER(__isabstractmethod__);
-_Py_IDENTIFIER(builtins);
 
 #ifdef Py_REF_DEBUG
 Py_ssize_t _Py_RefTotal;


### PR DESCRIPTION


<!-- issue-number: [bpo-35444](https://bugs.python.org/issue35444) -->
https://bugs.python.org/issue35444
<!-- /issue-number -->
