### PR TITLE
bpo-35455: Fix thread_time for Solaris OS

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-11-02-14-10-48.bpo-35455.Q1xTIo.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-02-14-10-48.bpo-35455.Q1xTIo.rst
@@ -1,0 +1,3 @@
+On Solaris, :func:`~time.thread_time` is now implemented with
+``gethrvtime()`` because ``clock_gettime(CLOCK_THREAD_CPUTIME_ID)`` is not
+always available. Patch by Jakub Kulik.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1371,6 +1371,25 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
     return 0;
 }
 
+#elif defined(__sun) && defined(__SVR4)
+#define HAVE_THREAD_TIME
+static int
+_PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
+{
+    _PyTime_t t;
+
+    if (info) {
+        info->implementation = "gethrvtime()";
+        info->resolution = 1e-9;
+        info->monotonic = 1;
+        info->adjustable = 0;
+    }
+
+    t = _PyTime_FromNanoseconds(gethrvtime());
+    *tp = t;
+    return 0;
+}
+
 #elif defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_PROCESS_CPUTIME_ID)
 #define HAVE_THREAD_TIME
 static int

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1378,17 +1378,13 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 {
     /* bpo-35455: On Solaris, CLOCK_THREAD_CPUTIME_ID clock is not always
        available; use gethrvtime() to substitute this functionality. */
-    _PyTime_t t;
-
     if (info) {
         info->implementation = "gethrvtime()";
         info->resolution = 1e-9;
         info->monotonic = 1;
         info->adjustable = 0;
     }
-
-    t = _PyTime_FromNanoseconds(gethrvtime());
-    *tp = t;
+    *tp = _PyTime_FromNanoseconds(gethrvtime());
     return 0;
 }
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1376,6 +1376,8 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 static int
 _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 {
+    /* bpo-35455: On Solaris, CLOCK_THREAD_CPUTIME_ID clock is not always
+       available; use gethrvtime() to substitute this functionality. */
     _PyTime_t t;
 
     if (info) {


### PR DESCRIPTION
Implementation of time.thread_time() doesn't work on Solaris because clock_id CLOCK_THREAD_CPUTIME_ID is not known (it is defined, but clock_gettime() returns EINVAL error). Solaris, however, has function gethrvtime() which can substitute this functionality.

<!-- issue-number: [bpo-35455](https://bugs.python.org/issue35455) -->
https://bugs.python.org/issue35455
<!-- /issue-number -->
