### PR TITLE
[2.7] bpo-16039: CVE-2013-1752: Limit imaplib.IMAP4_SSL.readline()

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -1182,16 +1182,6 @@ else:
             self.file = self.sslobj.makefile('rb')
 
 
-        def read(self, size):
-            """Read 'size' bytes from remote."""
-            return self.file.read(size)
-
-
-        def readline(self):
-            """Read line from remote."""
-            return self.file.readline()
-
-
         def send(self, data):
             """Send data to remote."""
             bytes = len(data)

--- a/Misc/NEWS.d/next/Security/2018-12-11-16-00-57.bpo-16039.PCj2n4.rst
+++ b/Misc/NEWS.d/next/Security/2018-12-11-16-00-57.bpo-16039.PCj2n4.rst
@@ -1,0 +1,2 @@
+CVE-2013-1752: Change use of ``readline()`` in :class:`imaplib.IMAP4_SSL` to
+limit line length.


### PR DESCRIPTION
* [bpo-16039](https://bugs.python.org/issue16039): CVE-2013-1752: Change use of readline() in
  imaplib.IMAP4_SSL to limit line length. Remove IMAP4_SSL.readline()
  and IMAP4_SSL.read() to inherit IMAP4 implementation.
* [bpo-20118](https://bugs.python.org/issue20118): reenable ThreadedNetworkedTests.test_linetoolong()
  of test_imaplib. The test now sets the _MAXLINE limit to 10
  characters.

<!-- issue-number: [bpo-20118](https://bugs.python.org/issue20118) -->
https://bugs.python.org/issue16039
https://bugs.python.org/issue20118
<!-- /issue-number -->
