### PR TITLE
[2.7] bpo-11617: Try to strengthen test_httpservers

### DIFF
--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -55,8 +55,8 @@ class TestServerThread(threading.Thread):
         self.test_object = test_object
 
     def run(self):
-        self.server = HTTPServer(('', 0), self.request_handler)
-        self.test_object.PORT = self.server.socket.getsockname()[1]
+        self.server = HTTPServer(('localhost', 0), self.request_handler)
+        self.test_object.HOST, self.test_object.PORT = self.server.socket.getsockname()
         self.test_object.server_started.set()
         self.test_object = None
         try:
@@ -84,7 +84,7 @@ class BaseTestCase(unittest.TestCase):
         test_support.threading_cleanup(*self._threads)
 
     def request(self, uri, method='GET', body=None, headers={}):
-        self.connection = httplib.HTTPConnection('localhost', self.PORT)
+        self.connection = httplib.HTTPConnection(self.HOST, self.PORT)
         self.connection.request(method, uri, body, headers)
         return self.connection.getresponse()
 
@@ -187,7 +187,7 @@ class BaseHTTPServerTestCase(BaseTestCase):
 
     def setUp(self):
         BaseTestCase.setUp(self)
-        self.con = httplib.HTTPConnection('localhost', self.PORT)
+        self.con = httplib.HTTPConnection(self.HOST, self.PORT)
         self.con.connect()
 
     def test_command(self):


### PR DESCRIPTION
(cherry picked from commit cb342182ee47c3e2c743de50d81aad60f4eebefd)

<!-- issue-number: [bpo-11617](https://bugs.python.org/issue11617) -->
https://bugs.python.org/issue11617
<!-- /issue-number -->
