### PR TITLE
bpo-35466: Use a linked list for the list of ceval pending calls.

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -19,6 +19,9 @@ struct _pending_call {
     struct _pending_call *next;
 };
 
+// We technically do not need this limit around any longer since we
+// moved from a circular queue to a linked list.  However, having a
+// size limit is still a good idea so we keep the one we already had.
 #define NPENDINGCALLS 32
 
 struct _pending_calls {

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -11,10 +11,15 @@ extern "C" {
 #include "pycore_atomic.h"
 #include "pythread.h"
 
+struct _pending_call;
+
 struct _pending_call {
     int (*func)(void *);
     void *arg;
+    struct _pending_call *next;
 };
+
+#define NPENDINGCALLS 32
 
 struct _pending_calls {
     unsigned long main_thread;
@@ -25,10 +30,9 @@ struct _pending_calls {
        thread state.
        Guarded by the GIL. */
     int async_exc;
-#define NPENDINGCALLS 32
-    struct _pending_call calls[NPENDINGCALLS];
-    int first;
-    int last;
+    int ncalls;
+    struct _pending_call *head;
+    struct _pending_call *last;
 };
 
 #include "pycore_gil.h"

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -11,6 +11,11 @@ extern "C" {
 #include "pycore_atomic.h"
 #include "pythread.h"
 
+struct _pending_call {
+    int (*func)(void *);
+    void *arg;
+};
+
 struct _pending_calls {
     unsigned long main_thread;
     PyThread_type_lock lock;
@@ -21,10 +26,7 @@ struct _pending_calls {
        Guarded by the GIL. */
     int async_exc;
 #define NPENDINGCALLS 32
-    struct {
-        int (*func)(void *);
-        void *arg;
-    } calls[NPENDINGCALLS];
+    struct _pending_call calls[NPENDINGCALLS];
     int first;
     int last;
 };

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-11-15-12-03.bpo-35466.5xu737.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-11-15-12-03.bpo-35466.5xu737.rst
@@ -1,0 +1,1 @@
+Simply the ceval pending calls list by using a linked list.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -325,6 +325,7 @@ _PyEval_SignalReceived(void)
 int
 _add_pending_call(int (*func)(void *), void *arg)
 {
+    // TODO: Drop the limit?
     if (_PyRuntime.ceval.pending.ncalls == NPENDINGCALLS) {
         return -1; /* Queue full */
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -322,7 +322,7 @@ _PyEval_SignalReceived(void)
     SIGNAL_PENDING_SIGNALS();
 }
 
-int
+static int
 _add_pending_call(int (*func)(void *), void *arg)
 {
     // TODO: Drop the limit?
@@ -349,7 +349,7 @@ _add_pending_call(int (*func)(void *), void *arg)
     return 0;
 }
 
-void
+static void
 _pop_pending_call(int (**func)(void *), void **arg)
 {
     struct _pending_call *call = _PyRuntime.ceval.pending.head;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -322,6 +322,34 @@ _PyEval_SignalReceived(void)
     SIGNAL_PENDING_SIGNALS();
 }
 
+int
+_add_pending_call(int (*func)(void *), void *arg)
+{
+    int i = _PyRuntime.ceval.pending.last;
+    int j = (i + 1) % NPENDINGCALLS;
+    if (j == _PyRuntime.ceval.pending.first) {
+        return -1; /* Queue full */
+    }
+    _PyRuntime.ceval.pending.calls[i].func = func;
+    _PyRuntime.ceval.pending.calls[i].arg = arg;
+    _PyRuntime.ceval.pending.last = j;
+    return 0;
+}
+
+void
+_pop_pending_call(int (**func)(void *), void **arg)
+{
+    /* pop one item off the queue while holding the lock */
+    int i = _PyRuntime.ceval.pending.first;
+    if (i == _PyRuntime.ceval.pending.last) {
+        return; /* Queue empty */
+    }
+
+    *func = _PyRuntime.ceval.pending.calls[i].func;
+    *arg = _PyRuntime.ceval.pending.calls[i].arg;
+    _PyRuntime.ceval.pending.first = (i + 1) % NPENDINGCALLS;
+}
+
 /* This implementation is thread-safe.  It allows
    scheduling to be made from any thread, and even from an executing
    callback.
@@ -330,7 +358,6 @@ _PyEval_SignalReceived(void)
 int
 Py_AddPendingCall(int (*func)(void *), void *arg)
 {
-    int i, j, result=0;
     PyThread_type_lock lock = _PyRuntime.ceval.pending.lock;
 
     /* try a few times for the lock.  Since this mechanism is used
@@ -345,6 +372,7 @@ Py_AddPendingCall(int (*func)(void *), void *arg)
      * this function is called before any bytecode evaluation takes place.
      */
     if (lock != NULL) {
+        int i;
         for (i = 0; i<100; i++) {
             if (PyThread_acquire_lock(lock, NOWAIT_LOCK))
                 break;
@@ -353,20 +381,13 @@ Py_AddPendingCall(int (*func)(void *), void *arg)
             return -1;
     }
 
-    i = _PyRuntime.ceval.pending.last;
-    j = (i + 1) % NPENDINGCALLS;
-    if (j == _PyRuntime.ceval.pending.first) {
-        result = -1; /* Queue full */
-    } else {
-        _PyRuntime.ceval.pending.calls[i].func = func;
-        _PyRuntime.ceval.pending.calls[i].arg = arg;
-        _PyRuntime.ceval.pending.last = j;
-    }
+    int res = _add_pending_call(func, arg);
+
     /* signal main loop */
     SIGNAL_PENDING_CALLS();
     if (lock != NULL)
         PyThread_release_lock(lock);
-    return result;
+    return res;
 }
 
 static int
@@ -420,24 +441,18 @@ make_pending_calls(void)
 
     /* perform a bounded number of calls, in case of recursion */
     for (int i=0; i<NPENDINGCALLS; i++) {
-        int j;
-        int (*func)(void *);
+        int (*func)(void *) = NULL;
         void *arg = NULL;
 
         /* pop one item off the queue while holding the lock */
         PyThread_acquire_lock(_PyRuntime.ceval.pending.lock, WAIT_LOCK);
-        j = _PyRuntime.ceval.pending.first;
-        if (j == _PyRuntime.ceval.pending.last) {
-            func = NULL; /* Queue empty */
-        } else {
-            func = _PyRuntime.ceval.pending.calls[j].func;
-            arg = _PyRuntime.ceval.pending.calls[j].arg;
-            _PyRuntime.ceval.pending.first = (j + 1) % NPENDINGCALLS;
-        }
+        _pop_pending_call(&func, &arg);
         PyThread_release_lock(_PyRuntime.ceval.pending.lock);
+
         /* having released the lock, perform the callback */
-        if (func == NULL)
+        if (func == NULL) {
             break;
+        }
         res = func(arg);
         if (res) {
             goto error;


### PR DESCRIPTION
Using a linked list instead of a circular array for the list of pending calls simplifies the code.

<!-- issue-number: [bpo-35466](https://bugs.python.org/issue35466) -->
https://bugs.python.org/issue35466
<!-- /issue-number -->
