### PR TITLE
[2.7] bpo-8765: Deprecate writing unicode to binary streams in Py3k mode.

### DIFF
--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -12,7 +12,7 @@ from functools import wraps
 from UserList import UserList
 
 from test.test_support import TESTFN, check_warnings, run_unittest, make_bad_fd
-from test.test_support import py3k_bytes as bytes, cpython_only
+from test.test_support import py3k_bytes as bytes, cpython_only, check_py3k_warnings
 from test.script_helper import run_python
 
 from _io import FileIO as _FileIO
@@ -100,6 +100,10 @@ class AutoFileTests(unittest.TestCase):
         self.f.seek(0)
         self.assertEqual(self.f.readline(None), b"hi\n")
         self.assertEqual(self.f.readlines(None), [b"bye\n", b"abc"])
+
+    def testWriteUnicode(self):
+        with check_py3k_warnings():
+            self.f.write('')
 
     def testRepr(self):
         self.assertEqual(repr(self.f), "<_io.FileIO name=%r mode='%s'>"
@@ -210,7 +214,7 @@ class AutoFileTests(unittest.TestCase):
 
     @ClosedFDRaises
     def testErrnoOnClosedWrite(self, f):
-        f.write('a')
+        f.write(b'a')
 
     @ClosedFDRaises
     def testErrnoOnClosedSeek(self, f):

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -103,7 +103,7 @@ class AutoFileTests(unittest.TestCase):
 
     def testWriteUnicode(self):
         with check_py3k_warnings():
-            self.f.write('')
+            self.f.write(u'')
 
     def testRepr(self):
         self.assertEqual(repr(self.f), "<_io.FileIO name=%r mode='%s'>"

--- a/Misc/NEWS.d/next/Library/2018-12-12-09-59-41.bpo-8765.IFupT2.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-12-09-59-41.bpo-8765.IFupT2.rst
@@ -1,0 +1,2 @@
+The write() method of buffered and unbuffered binary streams in the io
+module emits now a DeprecationWarning in Py3k mode for unicode argument.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1807,8 +1807,19 @@ bufferedwriter_write(buffered *self, PyObject *args)
     Py_buffer buf;
     Py_ssize_t written, avail, remaining;
     Py_off_t offset;
+    PyObject *arg;
 
     CHECK_INITIALIZED(self)
+
+    if (!PyArg_ParseTuple(args, "O:write", &arg)) {
+        return NULL;
+    }
+    if (PyUnicode_Check(arg) &&
+        PyErr_WarnPy3k("write() argument must be string or buffer, "
+                       "not 'unicode'", 1) < 0)
+    {
+        return NULL;
+    }
     if (!PyArg_ParseTuple(args, "s*:write", &buf)) {
         return NULL;
     }

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1807,20 +1807,16 @@ bufferedwriter_write(buffered *self, PyObject *args)
     Py_buffer buf;
     Py_ssize_t written, avail, remaining;
     Py_off_t offset;
-    PyObject *arg;
 
     CHECK_INITIALIZED(self)
-
-    if (!PyArg_ParseTuple(args, "O:write", &arg)) {
+    if (!PyArg_ParseTuple(args, "s*:write", &buf)) {
         return NULL;
     }
-    if (PyUnicode_Check(arg) &&
+    if (PyUnicode_Check(PyTuple_GET_ITEM(args, 0)) &&
         PyErr_WarnPy3k("write() argument must be string or buffer, "
                        "not 'unicode'", 1) < 0)
     {
-        return NULL;
-    }
-    if (!PyArg_ParseTuple(args, "s*:write", &buf)) {
+        PyBuffer_Release(&buf);
         return NULL;
     }
 

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -710,14 +710,25 @@ fileio_write(fileio *self, PyObject *args)
 {
     Py_buffer pbuf;
     Py_ssize_t n, len;
+    PyObject *arg;
 
     if (self->fd < 0)
         return err_closed();
     if (!self->writable)
         return err_mode("writing");
 
-    if (!PyArg_ParseTuple(args, "s*", &pbuf))
+    if (!PyArg_ParseTuple(args, "O:write", &arg)) {
         return NULL;
+    }
+    if (PyUnicode_Check(arg) &&
+        PyErr_WarnPy3k("write() argument must be string or buffer, "
+                       "not 'unicode'", 1) < 0)
+    {
+        return NULL;
+    }
+    if (!PyArg_ParseTuple(args, "s*:write", &pbuf)) {
+        return NULL;
+    }
 
     if (_PyVerify_fd(self->fd)) {
         Py_BEGIN_ALLOW_THREADS

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -710,23 +710,20 @@ fileio_write(fileio *self, PyObject *args)
 {
     Py_buffer pbuf;
     Py_ssize_t n, len;
-    PyObject *arg;
 
     if (self->fd < 0)
         return err_closed();
     if (!self->writable)
         return err_mode("writing");
 
-    if (!PyArg_ParseTuple(args, "O:write", &arg)) {
+    if (!PyArg_ParseTuple(args, "s*:write", &pbuf)) {
         return NULL;
     }
-    if (PyUnicode_Check(arg) &&
+    if (PyUnicode_Check(PyTuple_GET_ITEM(args, 0)) &&
         PyErr_WarnPy3k("write() argument must be string or buffer, "
                        "not 'unicode'", 1) < 0)
     {
-        return NULL;
-    }
-    if (!PyArg_ParseTuple(args, "s*:write", &pbuf)) {
+        PyBuffer_Release(&pbuf);
         return NULL;
     }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-8765](https://bugs.python.org/issue8765) -->
https://bugs.python.org/issue8765
<!-- /issue-number -->
