### PR TITLE
bpo-35470: Fix a reference counting bug in _PyImport_FindExtensionObjectEx()

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -749,7 +749,6 @@ _PyImport_FindExtensionObjectEx(PyObject *name, PyObject *filename,
     }
     if (_PyState_AddModule(mod, def) < 0) {
         PyMapping_DelItem(modules, name);
-        Py_DECREF(mod);
         return NULL;
     }
     if (Py_VerboseFlag)


### PR DESCRIPTION


<!-- issue-number: [bpo-35470](https://bugs.python.org/issue35470) -->
https://bugs.python.org/issue35470
<!-- /issue-number -->
