### PR TITLE
bpo-34279: regrtest consider that skipped tests are ran

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1937,7 +1937,7 @@ def _run_suite(suite):
     if junit_xml_list is not None:
         junit_xml_list.append(result.get_xml_element())
 
-    if not result.testsRun:
+    if not result.testsRun and not result.skipped:
         raise TestDidNotRun
     if not result.wasSuccessful():
         if len(result.errors) == 1 and not result.failures:

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1004,6 +1004,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("-w", testname, exitcode=2)
         self.check_executed_tests(output, [testname],
                                   failed=testname, rerun=testname)
+
     def test_no_tests_ran(self):
         code = textwrap.dedent("""
             import unittest
@@ -1016,6 +1017,19 @@ class ArgsTestCase(BaseTestCase):
 
         output = self.run_tests(testname, "-m", "nosuchtest", exitcode=0)
         self.check_executed_tests(output, [testname], no_test_ran=testname)
+
+    def test_no_tests_ran_skip(self):
+        code = textwrap.dedent("""
+            import unittest
+
+            class Tests(unittest.TestCase):
+                def test_skipped(self):
+                    self.skipTest("because")
+        """)
+        testname = self.create_test(code=code)
+
+        output = self.run_tests(testname, exitcode=0)
+        self.check_executed_tests(output, [testname])
 
     def test_no_tests_ran_multiple_tests_nonexistent(self):
         code = textwrap.dedent("""

--- a/Misc/NEWS.d/next/Tests/2018-12-12-18-20-18.bpo-34279.DhKcuP.rst
+++ b/Misc/NEWS.d/next/Tests/2018-12-12-18-20-18.bpo-34279.DhKcuP.rst
@@ -1,0 +1,3 @@
+:func:`test.support.run_unittest` no longer raise :exc:`TestDidNotRun` if
+the test result contains skipped tests. The exception is now only raised if
+no test have been run and no test have been skipped.


### PR DESCRIPTION
[bpo-34279](https://bugs.python.org/issue34279), [bpo-35412](https://bugs.python.org/issue35412): support.run_unittest() no longer raise
TestDidNotRun if the test result contains skipped tests. The
exception is now only raised if no test have been run and no test
have been skipped.