### PR TITLE
bpo-35306: Handle '*' in pathlib.Path functions on Windows

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -34,8 +34,9 @@ __all__ = [
 # Internals
 #
 
-# EBADF - guard agains macOS `stat` throwing EBADF
-_IGNORED_ERROS = (ENOENT, ENOTDIR, EBADF)
+# EBADF - guard against macOS `stat` throwing EBADF
+# EINVAL - `stat` on Windows throws it for invalid paths 
+_IGNORED_ERROS = (ENOENT, ENOTDIR, EBADF, EINVAL)
 
 def _is_wildcard_pattern(pat):
     # Whether this pattern needs actual matching using fnmatch, or can

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -35,7 +35,7 @@ __all__ = [
 #
 
 # EBADF - guard against macOS `stat` throwing EBADF
-# EINVAL - `stat` on Windows throws it for invalid paths 
+# EINVAL - `stat` on Windows throws it for invalid paths
 _IGNORED_ERROS = (ENOENT, ENOTDIR, EBADF, EINVAL)
 
 def _is_wildcard_pattern(pat):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2242,6 +2242,9 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
         p = P(BASE, "dirC")
         self.assertEqual(set(p.rglob("FILEd")), { P(BASE, "dirC/dirD/fileD") })
 
+    def test_exists_for_invalid_path(self):
+        self.assertEqual(self.cls("*").exists(), False)
+
     def test_expanduser(self):
         P = self.cls
         with support.EnvironmentVarGuard() as env:

--- a/Misc/NEWS.d/next/Library/2018-12-12-12-09-27.bpo-35306.AzA3I6.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-12-12-09-27.bpo-35306.AzA3I6.rst
@@ -1,0 +1,1 @@
+Handle '*' in pathlib.Path.exists on Windows


### PR DESCRIPTION
Added EINVAL to the set of ignored errors as suggested in [comment](https://bugs.python.org/issue35306).

<!-- issue-number: [bpo-35306](https://bugs.python.org/issue35306) -->
https://bugs.python.org/issue35306
<!-- /issue-number -->
