### PR TITLE
bpo-35477: multiprocessing.Pool.__enter__() fails if called twice

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2561,6 +2561,22 @@ class _TestPool(BaseTestCase):
         # they were released too.
         self.assertEqual(CountedObject.n_instances, 0)
 
+    def test_enter(self):
+        if self.TYPE == 'manager':
+            self.skipTest("test not applicable to manager")
+
+        pool = self.Pool(1)
+        with pool:
+            pass
+            # call pool.terminate()
+        # pool is no longer running
+
+        with self.assertRaises(ValueError):
+            # bpo-35477: pool.__enter__() fails if the pool is not running
+            with pool:
+                pass
+        pool.join()
+
 
 def raising():
     raise KeyError("key")

--- a/Misc/NEWS.d/next/Library/2018-12-13-00-10-51.bpo-35477.hHyy06.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-13-00-10-51.bpo-35477.hHyy06.rst
@@ -1,0 +1,2 @@
+:meth:`multiprocessing.Pool.__enter__` now fails if the pool is not running:
+``with pool:`` fails if used more than once.


### PR DESCRIPTION
multiprocessing.Pool.__enter__() now fails if the pool is not
running: "with pool:" fails if used more than once.

<!-- issue-number: [bpo-35477](https://bugs.python.org/issue35477) -->
https://bugs.python.org/issue35477
<!-- /issue-number -->
