### PR TITLE
bpo-23057: add loop self socket as wakeup fd for signals

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -490,7 +490,9 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         self._accept_futures = {}   # socket file descriptor => Future
         proactor.set_loop(self)
         self._make_self_pipe()
-        signal.set_wakeup_fd(self._csock.fileno())
+        self_no = self._csock.fileno()
+        if isinstance(self_no, int):
+            signal.set_wakeup_fd(self_no)
 
     def _make_socket_transport(self, sock, protocol, waiter=None,
                                extra=None, server=None):

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -10,6 +10,7 @@ import io
 import os
 import socket
 import warnings
+import signal
 
 from . import base_events
 from . import constants
@@ -489,6 +490,7 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         self._accept_futures = {}   # socket file descriptor => Future
         proactor.set_loop(self)
         self._make_self_pipe()
+        signal.set_wakeup_fd(self._csock.fileno())
 
     def _make_socket_transport(self, sock, protocol, waiter=None,
                                extra=None, server=None):
@@ -529,6 +531,7 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         if self.is_closed():
             return
 
+        signal.set_wakeup_fd(-1)
         # Call these methods before closing the event loop (before calling
         # BaseEventLoop.close), because they can schedule callbacks with
         # call_soon(), which is forbidden when the event loop is closed.

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -617,7 +617,6 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         self._ssock.setblocking(False)
         self._csock.setblocking(False)
         self._internal_fds += 1
-        self.call_soon(self._loop_self_reading)
 
     def _loop_self_reading(self, f=None):
         try:

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -491,8 +491,7 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         proactor.set_loop(self)
         self._make_self_pipe()
         self_no = self._csock.fileno()
-        if isinstance(self_no, int):
-            signal.set_wakeup_fd(self_no)
+        signal.set_wakeup_fd(self_no)
 
     def _make_socket_transport(self, sock, protocol, waiter=None,
                                extra=None, server=None):

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -308,6 +308,22 @@ class ProactorEventLoop(proactor_events.BaseProactorEventLoop):
             proactor = IocpProactor()
         super().__init__(proactor)
 
+    def run_forever(self):
+        try:
+            # if _self_reading_future is cancelled -
+            # this might indicate that event loop was interrupted before
+            # and self-reading routine is not hooked up now and needs 
+            # to be restarted
+            if (self._self_reading_future is not None and 
+                self._self_reading_future.cancelled()):
+                self._self_reading_future = None
+                self.call_soon(self._loop_self_reading)
+            super().run_forever()
+        except KeyboardInterrupt:
+            if self._self_reading_future is not None:
+                self._self_reading_future.cancel()
+            raise
+
     async def create_pipe_connection(self, protocol_factory, address):
         f = self._proactor.connect_pipe(address)
         pipe = await f

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -310,19 +310,13 @@ class ProactorEventLoop(proactor_events.BaseProactorEventLoop):
 
     def run_forever(self):
         try:
-            # if _self_reading_future is cancelled -
-            # this might indicate that event loop was interrupted before
-            # and self-reading routine is not hooked up now and needs
-            # to be restarted
-            if (self._self_reading_future is not None and
-                self._self_reading_future.cancelled()):
-                self._self_reading_future = None
-                self.call_soon(self._loop_self_reading)
+            assert self._self_reading_future is None
+            self.call_soon(self._loop_self_reading)
             super().run_forever()
-        except KeyboardInterrupt:
+        finally:
             if self._self_reading_future is not None:
                 self._self_reading_future.cancel()
-            raise
+                self._self_reading_future = None
 
     async def create_pipe_connection(self, protocol_factory, address):
         f = self._proactor.connect_pipe(address)

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -312,9 +312,9 @@ class ProactorEventLoop(proactor_events.BaseProactorEventLoop):
         try:
             # if _self_reading_future is cancelled -
             # this might indicate that event loop was interrupted before
-            # and self-reading routine is not hooked up now and needs 
+            # and self-reading routine is not hooked up now and needs
             # to be restarted
-            if (self._self_reading_future is not None and 
+            if (self._self_reading_future is not None and
                 self._self_reading_future.cancelled()):
                 self._self_reading_future = None
                 self.call_soon(self._loop_self_reading)

--- a/Lib/test/test_asyncio/test_ctrl_c_in_proactor_loop_helper.py
+++ b/Lib/test/test_asyncio/test_ctrl_c_in_proactor_loop_helper.py
@@ -1,0 +1,47 @@
+import sys
+
+
+def do_in_child_process():
+    import asyncio
+    asyncio.set_event_loop_policy(
+            asyncio.WindowsProactorEventLoopPolicy())
+    l = asyncio.get_event_loop()
+    try:
+        print("start")
+        sys.stdout.flush()
+        l.run_forever()
+    except KeyboardInterrupt:
+        # ok
+        sys.exit(255)
+    except:
+        # error - use default exit code
+        pass
+
+
+def do_in_main_process():
+    import os
+    import signal
+    import subprocess
+    from test.support.script_helper import spawn_python
+    
+    ok = False
+    with spawn_python(__file__, "--child") as p:
+        try:
+            ready = p.stdout.readline()
+            if ready != b"start\r\n":
+                raise Exception(f"Unexpected line: got {ready}, expected 'start'")
+            # ignore ctrl-c in current process
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            os.kill(p.pid, signal.CTRL_C_EVENT)
+            exit_code = p.wait(timeout=5)
+            ok = exit_code = 255
+        except Exception as e:
+            sys.stderr.write(repr(e))
+            p.kill()
+    sys.exit(255 if ok else 1)
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        do_in_main_process()
+    else:
+        do_in_child_process()

--- a/Lib/test/test_asyncio/test_ctrl_c_in_proactor_loop_helper.py
+++ b/Lib/test/test_asyncio/test_ctrl_c_in_proactor_loop_helper.py
@@ -3,8 +3,8 @@ import sys
 
 def do_in_child_process():
     import asyncio
-    asyncio.set_event_loop_policy(
-            asyncio.WindowsProactorEventLoopPolicy())
+
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
     l = asyncio.get_event_loop()
     try:
         print("start")
@@ -23,7 +23,7 @@ def do_in_main_process():
     import signal
     import subprocess
     from test.support.script_helper import spawn_python
-    
+
     ok = False
     with spawn_python(__file__, "--child") as p:
         try:
@@ -39,6 +39,7 @@ def do_in_main_process():
             sys.stderr.write(repr(e))
             p.kill()
     sys.exit(255 if ok else 1)
+
 
 if __name__ == "__main__":
     if len(sys.argv) == 1:

--- a/Lib/test/test_asyncio/test_ctrl_c_in_proactor_loop_helper.py
+++ b/Lib/test/test_asyncio/test_ctrl_c_in_proactor_loop_helper.py
@@ -6,33 +6,48 @@ def do_in_child_process():
 
     asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
     l = asyncio.get_event_loop()
-    try:
-        print("start")
-        sys.stdout.flush()
-        l.run_forever()
-    except KeyboardInterrupt:
-        # ok
-        sys.exit(255)
-    except:
-        # error - use default exit code
-        pass
+
+    def step(n):
+        try:
+            print(n)
+            sys.stdout.flush()
+            l.run_forever()
+            sys.exit(100)
+        except KeyboardInterrupt:
+            # ok
+            pass
+        except:
+            # error - use default exit code
+            sys.exit(200)
+
+    step(1)
+    step(2)
+    sys.exit(255)
 
 
 def do_in_main_process():
     import os
     import signal
     import subprocess
+    import time
     from test.support.script_helper import spawn_python
 
     ok = False
+
+    def step(p, expected):
+        s = p.stdout.readline()
+        if s != expected:
+            raise Exception(f"Unexpected line: got {s}, expected '{expected}'")
+        # ensure that child process gets to run_forever
+        time.sleep(0.5)
+        os.kill(p.pid, signal.CTRL_C_EVENT)
+
     with spawn_python(__file__, "--child") as p:
         try:
-            ready = p.stdout.readline()
-            if ready != b"start\r\n":
-                raise Exception(f"Unexpected line: got {ready}, expected 'start'")
             # ignore ctrl-c in current process
             signal.signal(signal.SIGINT, signal.SIG_IGN)
-            os.kill(p.pid, signal.CTRL_C_EVENT)
+            step(p, b"1\r\n")
+            step(p, b"2\r\n")
             exit_code = p.wait(timeout=5)
             ok = exit_code = 255
         except Exception as e:

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -741,9 +741,8 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
                 self.loop = BaseProactorEventLoop(self.proactor)
         self.set_event_loop(self.loop)
 
-    @mock.patch.object(BaseProactorEventLoop, 'call_soon')
     @mock.patch('asyncio.proactor_events.socket.socketpair')
-    def test_ctor(self, socketpair, call_soon):
+    def test_ctor(self, socketpair):
         ssock, csock = socketpair.return_value = (
             mock.Mock(), mock.Mock())
         with mock.patch('signal.set_wakeup_fd'):
@@ -751,7 +750,6 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
         self.assertIs(loop._ssock, ssock)
         self.assertIs(loop._csock, csock)
         self.assertEqual(loop._internal_fds, 1)
-        call_soon.assert_called_with(loop._loop_self_reading)
         loop.close()
 
     def test_close_self_pipe(self):

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -737,7 +737,8 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
 
         with mock.patch('asyncio.proactor_events.socket.socketpair',
                         return_value=(self.ssock, self.csock)):
-            self.loop = BaseProactorEventLoop(self.proactor)
+            with mock.patch('signal.set_wakeup_fd'):
+                self.loop = BaseProactorEventLoop(self.proactor)
         self.set_event_loop(self.loop)
 
     @mock.patch.object(BaseProactorEventLoop, 'call_soon')
@@ -745,7 +746,8 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
     def test_ctor(self, socketpair, call_soon):
         ssock, csock = socketpair.return_value = (
             mock.Mock(), mock.Mock())
-        loop = BaseProactorEventLoop(self.proactor)
+        with mock.patch('signal.set_wakeup_fd'):
+            loop = BaseProactorEventLoop(self.proactor)
         self.assertIs(loop._ssock, ssock)
         self.assertIs(loop._csock, csock)
         self.assertEqual(loop._internal_fds, 1)

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -40,7 +40,7 @@ class UpperProto(asyncio.Protocol):
 class ProactorLoopCtrlC(test_utils.TestCase):
     def test_ctrl_c(self):
         from .test_ctrl_c_in_proactor_loop_helper import __file__ as f
-        
+
         # ctrl-c will be sent to all processes that share the same console
         # in order to isolate the effect of raising ctrl-c we'll create
         # a process with a new console

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -18,6 +18,7 @@ from asyncio import windows_events
 from test.test_asyncio import utils as test_utils
 from test.support.script_helper import spawn_python
 
+
 def tearDownModule():
     asyncio.set_event_loop_policy(None)
 

--- a/Misc/NEWS.d/next/Library/2018-12-12-16-24-55.bpo-23057.OB4Z1Y.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-12-16-24-55.bpo-23057.OB4Z1Y.rst
@@ -1,0 +1,1 @@
+Unblock Proactor event loop when keyboard interrupt is received on Windows


### PR DESCRIPTION
When wakeup fd is set - receiving the signal will also write its number to a fd. This in turn will unblock the proactor and allow to process pending signal handler.

Is this approach valid in general and if yes - what is the best way to test changes like this? // cc @asvetlov 

<!-- issue-number: [bpo-23057](https://bugs.python.org/issue23057) -->
https://bugs.python.org/issue23057
<!-- /issue-number -->
