### PR TITLE
bpo-35479: Optimize multiprocessing.Pool.join()

### DIFF
--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -214,7 +214,7 @@ class Pool(object):
         self._terminate = util.Finalize(
             self, self._terminate_pool,
             args=(self._taskqueue, self._inqueue, self._outqueue, self._pool,
-                  self._worker_handler, self._task_handler,
+                  self._worker_handler, self._worker_state_event, self._task_handler,
                   self._result_handler, self._cache),
             exitpriority=15
             )
@@ -597,11 +597,13 @@ class Pool(object):
 
     @classmethod
     def _terminate_pool(cls, taskqueue, inqueue, outqueue, pool,
-                        worker_handler, task_handler, result_handler, cache):
+                        worker_handler, worker_state_event, task_handler,
+                        result_handler, cache):
         # this is guaranteed to only be called once
         util.debug('finalizing pool')
 
         worker_handler._state = TERMINATE
+        worker_state_event.set()
         task_handler._state = TERMINATE
 
         util.debug('helping task handler/workers to finish')

--- a/Misc/NEWS.d/next/Library/2018-12-13-01-50-29.bpo-35479.hjsDJN.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-13-01-50-29.bpo-35479.hjsDJN.rst
@@ -1,0 +1,2 @@
+The :meth:`multiprocessing.Pool.join` method now completes as soon as possible.
+Previously, it always had to wait at least 100 ms.


### PR DESCRIPTION
The multiprocessing.Pool.join() method now completes as soon as
possible. Previously, it always had to wait at least 100 ms.

multiprocessing.Pool._worker_handler() now waits on threading events
rather than using naive time.sleep(0.1).

When the pool is closed, a delay of 100 ms is still needed because of
[bpo-35478](https://bugs.python.org/issue35478) bug (pending results never complete if the pool is
terminated) to check if thread._state has been set to TERMINATE in
the meanwhile.

<!-- issue-number: [bpo-35479](https://bugs.python.org/issue35479) -->
https://bugs.python.org/issue35479
<!-- /issue-number -->
