### PR TITLE
bpo-35491: Enhance multiprocessing.BaseProcess.__repr__()

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -626,14 +626,14 @@ The :mod:`multiprocessing` package mostly replicates the API of the
        >>> import multiprocessing, time, signal
        >>> p = multiprocessing.Process(target=time.sleep, args=(1000,))
        >>> print(p, p.is_alive())
-       <Process(..., initial)> False
+       <Process ... initial> False
        >>> p.start()
        >>> print(p, p.is_alive())
-       <Process(..., started)> True
+       <Process ... started> True
        >>> p.terminate()
        >>> time.sleep(0.1)
        >>> print(p, p.is_alive())
-       <Process(..., stopped[SIGTERM])> False
+       <Process ... stopped exitcode=-SIGTERM> False
        >>> p.exitcode == -signal.SIGTERM
        True
 

--- a/Misc/NEWS.d/next/Library/2018-12-14-12-12-15.bpo-35491.jHsNOU.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-14-12-12-15.bpo-35491.jHsNOU.rst
@@ -1,0 +1,4 @@
+:mod:`multiprocessing`: Add ``Pool.__repr__()`` and enhance
+``BaseProcess.__repr__()`` (add pid and parent pid) to ease debugging. Pool
+state constant values are now strings instead of integers, for example ``RUN``
+value becomes ``'RUN'`` instead of ``0``.


### PR DESCRIPTION
Add the pid to multiprocessing.BaseProcess.__repr__(). Avoid also to
call _popen.poll() twice.

Example:
  <ForkProcess(ForkPoolWorker-1, started daemon)>
becomes:
  <ForkProcess(ForkPoolWorker-1, started[pid=28444] daemon)>

<!-- issue-number: [bpo-35491](https://bugs.python.org/issue35491) -->
https://bugs.python.org/issue35491
<!-- /issue-number -->
