### PR TITLE
DOC: emphasize the need to always call PySequence_Fast

### DIFF
--- a/Doc/c-api/sequence.rst
+++ b/Doc/c-api/sequence.rst
@@ -130,25 +130,29 @@ Sequence Protocol
 
 .. c:function:: PyObject* PySequence_Fast(PyObject *o, const char *m)
 
-   Return the sequence or iterable *o* as a list, unless it is already a tuple or list, in
-   which case *o* is returned.  Use :c:func:`PySequence_Fast_GET_ITEM` to access
-   the members of the result.  Returns *NULL* on failure.  If the object is not
-   a sequence or iterable, raises :exc:`TypeError` with *m* as the message text.
+   Return the sequence or iterable *o* as an object usable by the other
+   ``PySequence_Fast*`` family of functions. On CPython, if *o* is already a
+   sequence or list, it will be returned, but this is an implementation detail.
+   Returns *NULL* on failure.  If the object is not a sequence or iterable,
+   raises :exc:`TypeError` with *m* as the message text.
+
+   This family of functions is labelled *Fast* since it can assume *o* is a
+   :c:type:`PyTupleObject` or a :c:type:`PyListObject`, and accesses the type's
+   data fields directly.
 
 
 .. c:function:: Py_ssize_t PySequence_Fast_GET_SIZE(PyObject *o)
 
    Returns the length of *o*, assuming that *o* was returned by
-   :c:func:`PySequence_Fast` and that *o* is not *NULL*.  The size can also be
-   gotten by calling :c:func:`PySequence_Size` on *o*, but
-   :c:func:`PySequence_Fast_GET_SIZE` is faster because it can assume *o* is a list
-   or tuple.
+   :c:func:`PySequence_Fast` and that *o* is not *NULL*.  Equivalent to
+   :c:func:`PySequence_Size` but faster.
 
 
 .. c:function:: PyObject* PySequence_Fast_GET_ITEM(PyObject *o, Py_ssize_t i)
 
    Return the *i*\ th element of *o*, assuming that *o* was returned by
    :c:func:`PySequence_Fast`, *o* is not *NULL*, and that *i* is within bounds.
+   Equivalent to :c:func:`PySequence_GetItem` but faster.
 
 
 .. c:function:: PyObject** PySequence_Fast_ITEMS(PyObject *o)
@@ -163,7 +167,7 @@ Sequence Protocol
 
 .. c:function:: PyObject* PySequence_ITEM(PyObject *o, Py_ssize_t i)
 
-   Return the *i*\ th element of *o* or *NULL* on failure. Macro form of
+   Return the *i*\ th element of *o* or *NULL* on failure. Faster form of
    :c:func:`PySequence_GetItem` but without checking that
    :c:func:`PySequence_Check` on *o* is true and without adjustment for negative
    indices.

--- a/Doc/c-api/sequence.rst
+++ b/Doc/c-api/sequence.rst
@@ -136,7 +136,7 @@ Sequence Protocol
    *NULL* on failure.
 
    The ``PySequence_Fast*`` functions are thus named because they assume
-   *o* is a :c:type:`PyTupleObject` or a :c:type:`PyListObject`, and access
+   *o* is a :c:type:`PyTupleObject` or a :c:type:`PyListObject` and access
    the data fields of *o* directly.
 
    As a CPython implementation detail, if *o* is already a sequence or list, it

--- a/Doc/c-api/sequence.rst
+++ b/Doc/c-api/sequence.rst
@@ -134,12 +134,11 @@ Sequence Protocol
    ``PySequence_Fast*`` family of functions. If the object is not a sequence or
    iterable, raises :exc:`TypeError` with *m* as the message text.
 
-   The ``PySequence_Fast*`` functions are thus named because they can assume
-   *o* is a :c:type:`PyTupleObject` or a :c:type:`PyListObject`, and accesses
-   the type's data fields directly.
+   The ``PySequence_Fast*`` functions are thus named because they assume
+   *o* is a :c:type:`PyTupleObject` or a :c:type:`PyListObject`, and access
+   the data fields of *o* directly.
 
-   Returns *NULL* on failure.  If the object is not a sequence or iterable,
-   raises :exc:`TypeError` with *m* as the message text.
+   Returns *NULL* on failure.
 
    As a CPython implementation detail, if *o* is already a sequence or list, it
    will be returned.

--- a/Doc/c-api/sequence.rst
+++ b/Doc/c-api/sequence.rst
@@ -132,13 +132,12 @@ Sequence Protocol
 
    Return the sequence or iterable *o* as an object usable by the other
    ``PySequence_Fast*`` family of functions. If the object is not a sequence or
-   iterable, raises :exc:`TypeError` with *m* as the message text.
+   iterable, raises :exc:`TypeError` with *m* as the message text. Returns
+   *NULL* on failure.
 
    The ``PySequence_Fast*`` functions are thus named because they assume
    *o* is a :c:type:`PyTupleObject` or a :c:type:`PyListObject`, and access
    the data fields of *o* directly.
-
-   Returns *NULL* on failure.
 
    As a CPython implementation detail, if *o* is already a sequence or list, it
    will be returned.

--- a/Doc/c-api/sequence.rst
+++ b/Doc/c-api/sequence.rst
@@ -131,28 +131,33 @@ Sequence Protocol
 .. c:function:: PyObject* PySequence_Fast(PyObject *o, const char *m)
 
    Return the sequence or iterable *o* as an object usable by the other
-   ``PySequence_Fast*`` family of functions. On CPython, if *o* is already a
-   sequence or list, it will be returned, but this is an implementation detail.
+   ``PySequence_Fast*`` family of functions. If the object is not a sequence or
+   iterable, raises :exc:`TypeError` with *m* as the message text.
+
+   The ``PySequence_Fast*`` functions are thus named because they can assume
+   *o* is a :c:type:`PyTupleObject` or a :c:type:`PyListObject`, and accesses
+   the type's data fields directly.
+
    Returns *NULL* on failure.  If the object is not a sequence or iterable,
    raises :exc:`TypeError` with *m* as the message text.
 
-   This family of functions is labelled *Fast* since it can assume *o* is a
-   :c:type:`PyTupleObject` or a :c:type:`PyListObject`, and accesses the type's
-   data fields directly.
+   As a CPython implementation detail, if *o* is already a sequence or list, it
+   will be returned.
 
 
 .. c:function:: Py_ssize_t PySequence_Fast_GET_SIZE(PyObject *o)
 
    Returns the length of *o*, assuming that *o* was returned by
-   :c:func:`PySequence_Fast` and that *o* is not *NULL*.  Equivalent to
-   :c:func:`PySequence_Size` but faster.
+   :c:func:`PySequence_Fast` and that *o* is not *NULL*.  The size can also be
+   gotten by calling :c:func:`PySequence_Size` on *o*, but
+   :c:func:`PySequence_Fast_GET_SIZE` is faster because it can assume *o* is a
+   list or tuple.
 
 
 .. c:function:: PyObject* PySequence_Fast_GET_ITEM(PyObject *o, Py_ssize_t i)
 
    Return the *i*\ th element of *o*, assuming that *o* was returned by
    :c:func:`PySequence_Fast`, *o* is not *NULL*, and that *i* is within bounds.
-   Equivalent to :c:func:`PySequence_GetItem` but faster.
 
 
 .. c:function:: PyObject** PySequence_Fast_ITEMS(PyObject *o)


### PR DESCRIPTION
`PySequence_Fast()` should always be used (and the result checked) before any of the other `PySequence_Fast*` family of functions. As an implementation detail, CPython can circumvent this if `PyTuple_CheckExact()` passes, but that does not work on PyPy. 

xref numpy/numpy#12524