### PR TITLE
bpo-35267: warning deadlock in multiprocessing.Pool

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2141,6 +2141,12 @@ with the :class:`Pool` class.
       Callbacks should complete immediately since otherwise the thread which
       handles the results will get blocked.
 
+      .. warning::
+
+         If function *function* send too many data to the PIPE_BUF in os.pipe()
+         (>= 512 bytes in POSIX, >= 4096 bytes in Linux), it may block the os.pipe()
+         function then cause deadlock.
+
    .. method:: map(func, iterable[, chunksize])
 
       A parallel equivalent of the :func:`map` built-in function (it supports only


### PR DESCRIPTION
We also discussed in https://python.zulipchat.com/#narrow/stream/116742-core.2Fhelp/topic/issue35267

<!-- issue-number: [[bpo-35267](https://bugs.python.org/issue35267)](https://bugs.python.org/issue35367) -->
https://bugs.python.org/issue35267
<!-- /issue-number -->
