### PR TITLE
bpo-35402: Update Windows build to use Tcl and Tk 8.6.9

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-12-13-13-30-04.bpo-35402.n_mXb2.rst
+++ b/Misc/NEWS.d/next/Windows/2018-12-13-13-30-04.bpo-35402.n_mXb2.rst
@@ -1,0 +1,1 @@
+Update Windows build to use Tcl and Tk 8.6.9

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -51,8 +51,8 @@ set libraries=
 set libraries=%libraries%                                       bzip2-1.0.6
 if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.0j
 set libraries=%libraries%                                       sqlite-3.21.0.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.8.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.8.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.9.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.9.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tix-8.4.3.6
 set libraries=%libraries%                                       xz-5.2.2
 set libraries=%libraries%                                       zlib-1.2.11
@@ -73,7 +73,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.0j
-if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.8.0
+if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 
 for %%b in (%binaries%) do (

--- a/PCbuild/tcltk.props
+++ b/PCbuild/tcltk.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TclMajorVersion>8</TclMajorVersion>
     <TclMinorVersion>6</TclMinorVersion>
-    <TclPatchLevel>8</TclPatchLevel>
+    <TclPatchLevel>9</TclPatchLevel>
     <TclRevision>0</TclRevision>
     <TkMajorVersion>$(TclMajorVersion)</TkMajorVersion>
     <TkMinorVersion>$(TclMinorVersion)</TkMinorVersion>


### PR DESCRIPTION


<!-- issue-number: [bpo-35402](https://bugs.python.org/issue35402) -->
https://bugs.python.org/issue35402
<!-- /issue-number -->
