### PR TITLE
bpo-35490: Remove the DecodeFSDefault return converter in AC.

### DIFF
--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -176,7 +176,7 @@ PyDoc_STRVAR(os_ttyname__doc__,
 #define OS_TTYNAME_METHODDEF    \
     {"ttyname", (PyCFunction)os_ttyname, METH_O, os_ttyname__doc__},
 
-static char *
+static PyObject *
 os_ttyname_impl(PyObject *module, int fd);
 
 static PyObject *
@@ -184,16 +184,11 @@ os_ttyname(PyObject *module, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int fd;
-    char *_return_value;
 
     if (!PyArg_Parse(arg, "i:ttyname", &fd)) {
         goto exit;
     }
-    _return_value = os_ttyname_impl(module, fd);
-    if (_return_value == NULL) {
-        goto exit;
-    }
-    return_value = PyUnicode_DecodeFSDefault(_return_value);
+    return_value = os_ttyname_impl(module, fd);
 
 exit:
     return return_value;
@@ -6758,4 +6753,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=7ebb53d872bab149 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=87a3ebadb91bc46b input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2647,7 +2647,7 @@ os_access_impl(PyObject *module, path_t *path, int mode, int dir_fd,
 
 #ifdef HAVE_TTYNAME
 /*[clinic input]
-os.ttyname -> DecodeFSDefault
+os.ttyname
 
     fd: int
         Integer file descriptor handle.
@@ -2657,16 +2657,17 @@ os.ttyname -> DecodeFSDefault
 Return the name of the terminal device connected to 'fd'.
 [clinic start generated code]*/
 
-static char *
+static PyObject *
 os_ttyname_impl(PyObject *module, int fd)
-/*[clinic end generated code: output=ed16ad216d813591 input=5f72ca83e76b3b45]*/
+/*[clinic end generated code: output=c424d2e9d1cd636a input=9ff5a58b08115c55]*/
 {
     char *ret;
 
     ret = ttyname(fd);
-    if (ret == NULL)
-        posix_error();
-    return ret;
+    if (ret == NULL) {
+        return posix_error();
+    }
+    return PyUnicode_DecodeFSDefault(ret);
 }
 #endif
 

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -3166,16 +3166,6 @@ class float_return_converter(double_return_converter):
     cast = '(double)'
 
 
-class DecodeFSDefault_return_converter(CReturnConverter):
-    type = 'char *'
-
-    def render(self, function, data):
-        self.declare(data)
-        self.err_occurred_if_null_pointer("_return_value", data)
-        data.return_conversion.append(
-            'return_value = PyUnicode_DecodeFSDefault(_return_value);\n')
-
-
 def eval_ast_expr(node, globals, *, filename='-'):
     """
     Takes an ast.Expr node.  Compiles and evaluates it.


### PR DESCRIPTION


<!-- issue-number: [bpo-35490](https://bugs.python.org/issue35490) -->
https://bugs.python.org/issue35490
<!-- /issue-number -->
