### PR TITLE
Fixed missing colun in library/sys.po

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -703,7 +703,7 @@ always available.
 .. function:: get_coroutine_origin_tracking_depth()
 
    Get the current coroutine origin tracking depth, as set by
-   func:`set_coroutine_origin_tracking_depth`.
+   :func:`set_coroutine_origin_tracking_depth`.
 
    .. versionadded:: 3.7
 


### PR DESCRIPTION
# Fixed missing colun in library/sys.po


[bpo-35492](https://bugs.python.org/issue35492): Fixed missing colun in library/sys.po

