### PR TITLE
bpo-2661: Make mapping tests better usable for custom mapping classes.

### DIFF
--- a/Lib/test/mapping_tests.py
+++ b/Lib/test/mapping_tests.py
@@ -448,7 +448,7 @@ class TestMappingProtocol(BasicTestMappingProtocol):
         class Exc(Exception): pass
 
         class baddict1(self.type2test):
-            def __init__(self):
+            def __init__(self, *args, **kwargs):
                 raise Exc()
 
         self.assertRaises(Exc, baddict1.fromkeys, [1])
@@ -595,12 +595,14 @@ class TestHashMappingProtocol(TestMappingProtocol):
         d = self._empty_mapping()
         d[1] = 1
         try:
+            count = 0
             for i in d:
                 d[i+1] = 1
+                if count >= 1:
+                    self.fail("changing dict size during iteration doesn't raise Error")
+                count += 1
         except RuntimeError:
             pass
-        else:
-            self.fail("changing dict size during iteration doesn't raise Error")
 
     def test_repr(self):
         d = self._empty_mapping()


### PR DESCRIPTION
In test_fromkeys() the derived test class now supports all arguments in its
constructor so that the class to be tested can use its own constructor in its
fromkeys() implementation.

In test_mutatingiteration() the test fails as soon as iterating over a
dictionary with one entry and adding new entries in the loop iterates more
than once (to avoid endless loops in faulty implementations).


<!-- issue-number: [bpo-2661](https://bugs.python.org/issue2661) -->
https://bugs.python.org/issue2661
<!-- /issue-number -->
