### PR TITLE
[2.7] bpo-34279: regrtest consider that skipped tests are ran (GH-11132)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1543,7 +1543,7 @@ def _run_suite(suite):
         runner = BasicTestRunner()
 
     result = runner.run(suite)
-    if not result.testsRun:
+    if not result.testsRun and not result.skipped:
         raise TestDidNotRun
     if not result.wasSuccessful():
         if len(result.errors) == 1 and not result.failures:

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -734,6 +734,19 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("-m", "nosuchtest", testname, exitcode=0)
         self.check_executed_tests(output, [testname], no_test_ran=testname)
 
+    def test_no_tests_ran_skip(self):
+        code = textwrap.dedent("""
+            import unittest
+
+            class Tests(unittest.TestCase):
+                def test_skipped(self):
+                    self.skipTest("because")
+        """)
+        testname = self.create_test(code=code)
+
+        output = self.run_tests(testname, exitcode=0)
+        self.check_executed_tests(output, [testname])
+
     def test_no_tests_ran_multiple_tests_nonexistent(self):
         code = textwrap.dedent("""
             import unittest

--- a/Misc/NEWS.d/next/Tests/2018-12-12-18-20-18.bpo-34279.DhKcuP.rst
+++ b/Misc/NEWS.d/next/Tests/2018-12-12-18-20-18.bpo-34279.DhKcuP.rst
@@ -1,0 +1,3 @@
+:func:`test.support.run_unittest` no longer raise :exc:`TestDidNotRun` if
+the test result contains skipped tests. The exception is now only raised if
+no test have been run and no test have been skipped.


### PR DESCRIPTION
[bpo-34279](https://bugs.python.org/issue34279), [bpo-35412](https://bugs.python.org/issue35412): support.run_unittest() no longer raises
TestDidNotRun if a test result contains skipped tests. The
exception is now only raised if no test have been run and no test
have been skipped.

(cherry picked from commit 3a8f4fef4a4dd0e4a800545468eef9542e126181)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34279](https://bugs.python.org/issue34279) -->
https://bugs.python.org/issue34279
<!-- /issue-number -->
