### PR TITLE
bpo-35348: Fix platform.architecture()

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -610,7 +610,7 @@ def _syscmd_file(target, default=''):
     target = _follow_symlinks(target)
     # "file" output is locale dependent: force the usage of the C locale
     # to get deterministic behavior.
-    env = dict(os.environ, LC_ALL='c')
+    env = dict(os.environ, LC_ALL='C')
     try:
         # -b: do not prepend filenames to output lines (brief mode)
         output = subprocess.check_output(['file', '-b', target],

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -608,13 +608,21 @@ def _syscmd_file(target, default=''):
 
     import subprocess
     target = _follow_symlinks(target)
+    # "file" output is locale dependent: force the usage of the C locale
+    # to get deterministic behavior.
+    env = dict(os.environ, LC_ALL='c')
     try:
-        output = subprocess.check_output(['file', target],
+        # -b: do not prepend filenames to output lines (brief mode)
+        output = subprocess.check_output(['file', '-b', target],
                                          stderr=subprocess.DEVNULL,
-                                         encoding='latin-1')
+                                         env=env)
     except (OSError, subprocess.CalledProcessError):
         return default
-    return (output or default)
+    if not output:
+        return default
+    # With the C locale, the output should be mostly ASCII-compatible.
+    # Decode from Latin-1 to prevent Unicode decode error.
+    return output.decode('latin-1')
 
 ### Information about the used architecture
 
@@ -676,7 +684,7 @@ def architecture(executable=sys.executable, bits='', linkage=''):
                 linkage = l
         return bits, linkage
 
-    if 'executable' not in fileout:
+    if 'executable' not in fileout and 'shared object' not in fileout:
         # Format not supported
         return bits, linkage
 

--- a/Misc/NEWS.d/next/Library/2018-12-14-13-27-45.bpo-35348.u3Y2an.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-14-13-27-45.bpo-35348.u3Y2an.rst
@@ -1,0 +1,3 @@
+Make :func:`platform.architecture` parsing of ``file`` command output more
+reliable: add the ``-b`` option to the ``file`` command to omit the filename,
+force the usage of the C locale, and search also the "shared object" pattern.


### PR DESCRIPTION
Fix platform.architecture(): add the -b option to the "file" command.

<!-- issue-number: [bpo-35348](https://bugs.python.org/issue35348) -->
https://bugs.python.org/issue35348
<!-- /issue-number -->
