### PR TITLE
bpo-35348: Make parsing the output of the file command in platform.architecture() more reliable.

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -610,11 +610,13 @@ def _syscmd_file(target, default=''):
     target = _follow_symlinks(target)
     try:
         output = subprocess.check_output(['file', target],
-                                         stderr=subprocess.DEVNULL,
-                                         encoding='latin-1')
+                                         stderr=subprocess.DEVNULL)
     except (OSError, subprocess.CalledProcessError):
         return default
-    return (output or default)
+    prefix = os.fsencode(target) + b': '
+    if output.startswith(prefix):
+        output = output[len(prefix):]
+    return (os.fsdecode(output) or default)
 
 ### Information about the used architecture
 
@@ -676,7 +678,7 @@ def architecture(executable=sys.executable, bits='', linkage=''):
                 linkage = l
         return bits, linkage
 
-    if 'executable' not in fileout:
+    if 'executable' not in fileout and 'shared object' not in fileout:
         # Format not supported
         return bits, linkage
 

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -610,7 +610,8 @@ def _syscmd_file(target, default=''):
     target = _follow_symlinks(target)
     try:
         output = subprocess.check_output(['file', target],
-                                         stderr=subprocess.DEVNULL)
+                                         stderr=subprocess.DEVNULL,
+                                         env={'LC_ALL': 'C'})
     except (OSError, subprocess.CalledProcessError):
         return default
     prefix = os.fsencode(target) + b': '

--- a/Misc/NEWS.d/next/Library/2018-12-14-16-52-00.bpo-35348.z4sCtb.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-14-16-52-00.bpo-35348.z4sCtb.rst
@@ -1,0 +1,2 @@
+Make parsing the output of the ``file`` command in
+:func:`platform.architecture`: more reliable.


### PR DESCRIPTION


<!-- issue-number: [bpo-35348](https://bugs.python.org/issue35348) -->
https://bugs.python.org/issue35348
<!-- /issue-number -->
