### PR TITLE
bpo-35499: make profile-opt don't override CFLAGS_NODIST

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -496,7 +496,7 @@ profile-run-stamp:
 	touch $@
 
 build_all_generate_profile:
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS) $(PGO_PROF_GEN_FLAG)" LDFLAGS="$(LDFLAGS) $(PGO_PROF_GEN_FLAG)" LIBS="$(LIBS)"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS_NODIST) $(PGO_PROF_GEN_FLAG)" LDFLAGS="$(LDFLAGS) $(PGO_PROF_GEN_FLAG)" LIBS="$(LIBS)"
 
 run_profile_task:
 	@ # FIXME: can't run for a cross build
@@ -510,7 +510,7 @@ build_all_merge_profile:
 profile-opt: profile-run-stamp
 	@echo "Rebuilding with profile guided optimizations:"
 	-rm -f profile-clean-stamp
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS) $(PGO_PROF_USE_FLAG)" LDFLAGS="$(LDFLAGS)"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS_NODIST) $(PGO_PROF_USE_FLAG)" LDFLAGS="$(LDFLAGS)"
 
 # Compile and run with gcov
 .PHONY=coverage coverage-lcov coverage-report

--- a/Misc/NEWS.d/next/Build/2018-12-14-19-36-05.bpo-35499.9yAldM.rst
+++ b/Misc/NEWS.d/next/Build/2018-12-14-19-36-05.bpo-35499.9yAldM.rst
@@ -1,0 +1,3 @@
+``make profile-opt`` no longer replaces ``CFLAGS_NODIST`` with ``CFLAGS``. It
+now adds profile-guided optimization (PGO) flags to ``CFLAGS_NODIST``: existing
+``CFLAGS_NODIST`` flags are kept.


### PR DESCRIPTION
"make profile-opt" no longer replaces CFLAGS_NODIST with CFLAGS. It
now adds profile-guided optimization (PGO) flags to CFLAGS_NODIST,
existing CFLAGS_NODIST flags are kept.

<!-- issue-number: [bpo-35499](https://bugs.python.org/issue35499) -->
https://bugs.python.org/issue35499
<!-- /issue-number -->
