### PR TITLE
bpo-35502: Fix reference leaks in ElementTree.TreeBuilder.

### DIFF
--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -1,4 +1,5 @@
 # xml.etree test for cElementTree
+import io
 import struct
 from test import support
 from test.support import import_fresh_module
@@ -132,6 +133,22 @@ class MiscTests(unittest.TestCase):
         self.assertEqual(list(elem.attrib.items()), [('bar', 42)])
         self.assertEqual(len(elem), 1)
         self.assertEqual(elem[0].tag, 'child')
+
+    def test_iterparse_leaks(self):
+        # Test reference leaks in TreeBuilder (issue #35502).
+        XML = '<a></a></b>'
+        parser = cET.iterparse(io.StringIO(XML))
+        next(parser)
+        del parser
+        support.gc_collect()
+
+    def test_xmlpullparser_leaks(self):
+        # Test reference leaks in TreeBuilder (issue #35502).
+        XML = '<a></a></b>'
+        parser = cET.XMLPullParser()
+        parser.feed(XML)
+        del parser
+        support.gc_collect()
 
 
 @unittest.skipUnless(cET, 'requires _elementtree')

--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -136,6 +136,8 @@ class MiscTests(unittest.TestCase):
 
     def test_iterparse_leaks(self):
         # Test reference leaks in TreeBuilder (issue #35502).
+        # The test is written to be executed in the hunting reference leaks
+        # mode.
         XML = '<a></a></b>'
         parser = cET.iterparse(io.StringIO(XML))
         next(parser)
@@ -144,6 +146,8 @@ class MiscTests(unittest.TestCase):
 
     def test_xmlpullparser_leaks(self):
         # Test reference leaks in TreeBuilder (issue #35502).
+        # The test is written to be executed in the hunting reference leaks
+        # mode.
         XML = '<a></a></b>'
         parser = cET.XMLPullParser()
         parser.feed(XML)

--- a/Misc/NEWS.d/next/Library/2018-12-14-23-56-48.bpo-35502.gLHuFS.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-14-23-56-48.bpo-35502.gLHuFS.rst
@@ -1,0 +1,2 @@
+Fixed reference leaks in :class:`xml.etree.ElementTree.TreeBuilder` in case
+of unfinished building of the tree.

--- a/Misc/NEWS.d/next/Library/2018-12-14-23-56-48.bpo-35502.gLHuFS.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-14-23-56-48.bpo-35502.gLHuFS.rst
@@ -1,2 +1,3 @@
 Fixed reference leaks in :class:`xml.etree.ElementTree.TreeBuilder` in case
-of unfinished building of the tree.
+of unfinished building of the tree (in particular when an error was raised
+during parsing XML).

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -2447,6 +2447,11 @@ _elementtree_TreeBuilder___init___impl(TreeBuilderObject *self,
 static int
 treebuilder_gc_traverse(TreeBuilderObject *self, visitproc visit, void *arg)
 {
+    Py_VISIT(self->end_ns_event_obj);
+    Py_VISIT(self->start_ns_event_obj);
+    Py_VISIT(self->end_event_obj);
+    Py_VISIT(self->start_event_obj);
+    Py_VISIT(self->events_append);
     Py_VISIT(self->root);
     Py_VISIT(self->this);
     Py_VISIT(self->last);


### PR DESCRIPTION


<!-- issue-number: [bpo-35502](https://bugs.python.org/issue35502) -->
https://bugs.python.org/issue35502
<!-- /issue-number -->
