### PR TITLE
bpo-35504: Fix a SystemError when delete the characters_written attribute of an OSError.

### DIFF
--- a/Lib/test/test_exception_hierarchy.py
+++ b/Lib/test/test_exception_hierarchy.py
@@ -150,10 +150,15 @@ class AttributesTest(unittest.TestCase):
             e = BlockingIOError(*args[:n])
             with self.assertRaises(AttributeError):
                 e.characters_written
+            with self.assertRaises(AttributeError):
+                del e.characters_written
         e = BlockingIOError("a", "b", 3)
         self.assertEqual(e.characters_written, 3)
         e.characters_written = 5
         self.assertEqual(e.characters_written, 5)
+        del e.characters_written
+        with self.assertRaises(AttributeError):
+            e.characters_written
 
 
 class ExplicitSubclassingTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-15-00-47-41.bpo-35504.9gVuen.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-15-00-47-41.bpo-35504.9gVuen.rst
@@ -1,0 +1,1 @@
+Fixed a SystemError when delete the characters_written attribute of an OSError.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1196,6 +1196,14 @@ OSError_written_get(PyOSErrorObject *self, void *context)
 static int
 OSError_written_set(PyOSErrorObject *self, PyObject *arg, void *context)
 {
+    if (arg == NULL) {
+        if (self->written == -1) {
+            PyErr_SetString(PyExc_AttributeError, "characters_written");
+            return -1;
+        }
+        self->written = -1;
+        return 0;
+    }
     Py_ssize_t n;
     n = PyNumber_AsSsize_t(arg, PyExc_ValueError);
     if (n == -1 && PyErr_Occurred())


### PR DESCRIPTION


<!-- issue-number: [bpo-35504](https://bugs.python.org/issue35504) -->
https://bugs.python.org/issue35504
<!-- /issue-number -->
