### PR TITLE
bpo-35506: Fix linking of `as` in documentation

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -223,6 +223,7 @@ returns the list ``[0, 1, 2]``.
 .. _try:
 .. _except:
 .. _finally:
+.. _try_as:
 
 The :keyword:`try` statement
 ============================
@@ -270,7 +271,7 @@ as if the entire :keyword:`try` statement raised the exception).
 .. index:: single: as; except clause
 
 When a matching except clause is found, the exception is assigned to the target
-specified after the :keyword:`as` keyword in that except clause, if present, and
+specified after the :keyword:`as <try_as>` keyword in that except clause, if present, and
 the except clause's suite is executed.  All except clauses must have an
 executable block.  When the end of this block is reached, execution continues
 normally after the entire try statement.  (This means that if two nested

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -707,6 +707,7 @@ really starting the next loop cycle.
 
 .. _import:
 .. _from:
+.. _import_as:
 
 The :keyword:`import` statement
 ===============================
@@ -755,8 +756,8 @@ available in the local namespace in one of three ways:
 
 .. index:: single: as; import statement
 
-* If the module name is followed by :keyword:`as`, then the name
-  following :keyword:`as` is bound directly to the imported module.
+* If the module name is followed by :keyword:`as <import_as>`, then the name
+  following :keyword:`as <import_as>` is bound directly to the imported module.
 * If no other name is specified, and the module being imported is a top
   level module, the module's name is bound in the local namespace as a
   reference to the imported module
@@ -781,7 +782,7 @@ The :keyword:`from` form uses a slightly more complex process:
       check the imported module again for that attribute
    #. if the attribute is not found, :exc:`ImportError` is raised.
    #. otherwise, a reference to that value is stored in the local namespace,
-      using the name in the :keyword:`as` clause if it is present,
+      using the name in the :keyword:`as <import_as>` clause if it is present,
       otherwise using the attribute name
 
 Examples::

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -112,8 +112,8 @@ Note that in general the practice of importing ``*`` from a module or package is
 frowned upon, since it often causes poorly readable code. However, it is okay to
 use it to save typing in interactive sessions.
 
-If the module name is followed by :keyword:`as`, then the name
-following :keyword:`as` is bound directly to the imported module.
+If the module name is followed by :keyword:`as <import_as>`, then the name
+following :keyword:`as <import_as>` is bound directly to the imported module.
 
 ::
 

--- a/Doc/whatsnew/3.0.rst
+++ b/Doc/whatsnew/3.0.rst
@@ -415,7 +415,7 @@ Changed Syntax
   the restrictions on ``None`` already.)
 
 * Change from :keyword:`except` *exc*, *var* to
-  :keyword:`except` *exc* :keyword:`as` *var*.  See :pep:`3110`.
+  :keyword:`except` *exc* :keyword:`as <try_as>` *var*.  See :pep:`3110`.
 
 * :pep:`3115`: New Metaclass Syntax.  Instead of::
 
@@ -507,9 +507,9 @@ consulted for longer descriptions.
 * :ref:`pep-3105`.  This is now a standard feature and no longer needs
   to be imported from :mod:`__future__`.  More details were given above.
 
-* :ref:`pep-3110`.  The :keyword:`except` *exc* :keyword:`as` *var*
+* :ref:`pep-3110`.  The :keyword:`except` *exc* :keyword:`as <try_as>` *var*
   syntax is now standard and :keyword:`except` *exc*, *var* is no
-  longer supported.  (Of course, the :keyword:`as` *var* part is still
+  longer supported.  (Of course, the :keyword:`as <try_as>` *var* part is still
   optional.)
 
 * :ref:`pep-3112`.  The ``b"..."`` string literal notation (and its

--- a/Misc/NEWS.d/next/Documentation/2018-12-14-20-39-23.bpo-35506.ylc-HE.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-12-14-20-39-23.bpo-35506.ylc-HE.rst
@@ -1,0 +1,1 @@
+Fix linking of :keyword:`as` for :keyword:`import` and :keyword:`try`.


### PR DESCRIPTION
Correct linking of `as` to the proper sections instead of always linking to `with`.


<!-- issue-number: [bpo-35506](https://bugs.python.org/issue35506) -->
https://bugs.python.org/issue35506
<!-- /issue-number -->
