### PR TITLE
Fix mock_open docstring to use readline

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2376,7 +2376,7 @@ def mock_open(mock=None, read_data=''):
     default) then a `MagicMock` will be created for you, with the API limited
     to methods or attributes available on standard file handles.
 
-    `read_data` is a string for the `read` methoddline`, and `readlines` of the
+    `read_data` is a string for the `read`, `readline` and `readlines` of the
     file handle to return.  This is an empty string by default.
     """
     def _readlines_side_effect(*args, **kwargs):


### PR DESCRIPTION
This should be `readline` instead of `methoddline`. I think this is trivial and doesn't need a bpo and NEWS entry.