### PR TITLE
bpo-34855: Correct Windows-native variables

### DIFF
--- a/.azure-pipelines/windows-appx-test.yml
+++ b/.azure-pipelines/windows-appx-test.yml
@@ -36,7 +36,7 @@ jobs:
       Write-Host '##vso[task.setvariable variable=Py_IntDir]$(Build.BinariesDirectory)\obj'
       # UNDONE: Do not build to a different directory because of broken tests
       Write-Host '##vso[task.setvariable variable=Py_OutDir]$(Build.SourcesDirectory)\PCbuild'
-      Write-Host '##vso[task.setvariable variable=EXTERNAL_DIR]$(Build.BinariesDirectory)\externals'
+      Write-Host '##vso[task.setvariable variable=EXTERNALS_DIR]$(Build.BinariesDirectory)\externals'
     displayName: Update build locations
 
   - script: PCbuild\build.bat -e $(buildOpt)

--- a/.azure-pipelines/windows-steps.yml
+++ b/.azure-pipelines/windows-steps.yml
@@ -8,7 +8,7 @@ steps:
     Write-Host '##vso[task.setvariable variable=Py_IntDir]$(Build.BinariesDirectory)\obj'
     # UNDONE: Do not build to a different directory because of broken tests
     Write-Host '##vso[task.setvariable variable=Py_OutDir]$(Build.SourcesDirectory)\PCbuild'
-    Write-Host '##vso[task.setvariable variable=EXTERNAL_DIR]$(Build.BinariesDirectory)\externals'
+    Write-Host '##vso[task.setvariable variable=EXTERNALS_DIR]$(Build.BinariesDirectory)\externals'
   displayName: Update build locations
 
 - script: PCbuild\build.bat -e $(buildOpt)

--- a/PCbuild/find_python.bat
+++ b/PCbuild/find_python.bat
@@ -24,7 +24,7 @@
 :begin_search
 @set PYTHON=
 
-@set _Py_EXTERNALS_DIR=%EXTERNAL_DIR%
+@set _Py_EXTERNALS_DIR=%EXTERNALS_DIR%
 @if "%_Py_EXTERNALS_DIR%"=="" (set _Py_EXTERNALS_DIR=%~dp0\..\externals)
 
 @rem If we have Python in externals, use that one


### PR DESCRIPTION
Adding an extra S to "EXTERNAL_DIR" (line 27).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34855](https://bugs.python.org/issue34855) -->
https://bugs.python.org/issue34855
<!-- /issue-number -->
