### PR TITLE
bpo-35491, multiprocessing: replace "RUN" with RUN

### DIFF
--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -486,7 +486,7 @@ class Pool(object):
                 util.debug('result handler got EOFError/OSError -- exiting')
                 return
 
-            if thread._state != "RUN":
+            if thread._state != RUN:
                 assert thread._state == TERMINATE, "Thread not in TERMINATE"
                 util.debug('result handler found thread._state=TERMINATE')
                 break


### PR DESCRIPTION


<!-- issue-number: [bpo-35491](https://bugs.python.org/issue35491) -->
https://bugs.python.org/issue35491
<!-- /issue-number -->
