### PR TITLE
bpo-35348: Fix platform.architecture() on macOS

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -35,10 +35,9 @@ Cross Platform
    ``sizeof(long)`` on Python version < 1.5.2) is used as indicator for the
    supported pointer size.
 
-   The function relies on the system's :file:`file` command to do the actual work.
-   This is available on most if not all Unix  platforms and some non-Unix platforms
-   and then only if the executable points to the Python interpreter.  Reasonable
-   defaults are used when the above needs are not met.
+   If the *executable* parameter is set, the function relies on the system's
+   :file:`file` command to do the actual work. This is available on most Unix
+   platforms.
 
    .. note::
 
@@ -49,6 +48,10 @@ Cross Platform
       reliable to query the :attr:`sys.maxsize` attribute::
 
          is_64bits = sys.maxsize > 2**32
+
+   .. versionchanged:: 3.8
+      The system's :file:`file` command is now longer used if the *executable*
+      parameter is not set.
 
 
 .. function:: machine()

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -618,6 +618,8 @@ def _syscmd_file(target, default=''):
 
 ### Information about the used architecture
 
+_DEFAULT_LINKAGE = {'win32': 'WindowsPE'}
+
 def architecture(executable=None, bits='', linkage=''):
 
     """ Queries the given executable (defaults to the Python interpreter
@@ -646,8 +648,7 @@ def architecture(executable=None, bits='', linkage=''):
 
     # bpo-35348: For Python executable, don't use the file command
     if executable is None or executable == sys.executable:
-        if sys.platform == 'win32':
-            linkage = 'WindowsPE'
+        linkage = _DEFAULT_LINKAGE.get(sys.platform, linkage)
         return bits, linkage
 
     # Get data from the 'file' system command

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -16,7 +16,13 @@ class PlatformTest(unittest.TestCase):
         platform._uname_cache = None
 
     def test_architecture(self):
-        res = platform.architecture()
+        with mock.patch('struct.calcsize', return_value=10):
+            bits, linkage = platform.architecture()
+            self.assertEqual(bits, '80bit')
+            if sys.platform == 'win32':
+                self.assertEqual(linkage, 'WindowsPE')
+            else:
+                self.assertEqual(linkage, '')
 
     @support.skip_unless_symlink
     def test_architecture_via_symlink(self): # issue3762

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import struct
 import subprocess
 import sys
 import sysconfig
@@ -16,13 +17,13 @@ class PlatformTest(unittest.TestCase):
         platform._uname_cache = None
 
     def test_architecture(self):
-        with mock.patch('struct.calcsize', return_value=10):
-            bits, linkage = platform.architecture()
-            self.assertEqual(bits, '80bit')
-            if sys.platform == 'win32':
-                self.assertEqual(linkage, 'WindowsPE')
-            else:
-                self.assertEqual(linkage, '')
+        bits, linkage = platform.architecture()
+        pointer_bits = struct.calcsize('P') * 8
+        self.assertEqual(bits, f"{pointer_bits}bit")
+        if sys.platform == 'win32':
+            self.assertEqual(linkage, 'WindowsPE')
+        else:
+            self.assertEqual(linkage, '')
 
     @support.skip_unless_symlink
     def test_architecture_via_symlink(self): # issue3762

--- a/Misc/NEWS.d/next/Library/2018-12-17-10-01-15.bpo-35348.rUPsJI.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-17-10-01-15.bpo-35348.rUPsJI.rst
@@ -1,0 +1,2 @@
+Fix :func:`platform.architecture` for macOS universal binaries: it no longer
+uses the system's ``file`` command if the *executable* parameter is not set.


### PR DESCRIPTION
Fix platform.architecture() for macOS universal binaries: it no
longer uses the system's "file" command if the executable parameter
is not set.

<!-- issue-number: [bpo-35348](https://bugs.python.org/issue35348) -->
https://bugs.python.org/issue35348
<!-- /issue-number -->
