### PR TITLE
bpo-35516: Add macOS support to platform.system_alias()

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -155,6 +155,11 @@ Cross Platform
    for some systems.  It also does some reordering of the information in some cases
    where it would otherwise cause confusion.
 
+   .. versionchanged:: 3.8
+      On macOS, the function now uses :func:`mac_ver`, if it returns a
+      non-empty release string, to get the macOS version rather than the darwin
+      version.
+
 
 .. function:: version()
 

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -478,7 +478,14 @@ def system_alias(system, release, version):
         where it would otherwise cause confusion.
 
     """
-    if system == 'SunOS':
+    if system == 'Darwin':
+        # macOS (darwin kernel)
+        macos_release = mac_ver()[0]
+        if macos_release:
+            system = 'macOS'
+            release = macos_release
+
+    elif system == 'SunOS':
         # Sun's OS
         if release < '5':
             # These releases use the old name SunOS

--- a/Misc/NEWS.d/next/Library/2018-12-17-10-34-05.bpo-35516.0g2Vn4.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-17-10-34-05.bpo-35516.0g2Vn4.rst
@@ -1,0 +1,2 @@
+On macOS, :func:`platform.system_alias` now returns macOS and macOS release,
+rather than Darwin and Darwin release.


### PR DESCRIPTION
On macOS, platform.system_alias() now returns macOS and macOS
version, rather than Darwin and Darwin release.

<!-- issue-number: [bpo-35516](https://bugs.python.org/issue35516) -->
https://bugs.python.org/issue35516
<!-- /issue-number -->
