### PR TITLE
bpo-31784: Use time.time_ns() in uuid.uuid1()

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -9,6 +9,7 @@ import pickle
 import shutil
 import subprocess
 import sys
+from unittest import mock
 
 py_uuid = support.import_fresh_module('uuid', blocked=['_uuid'])
 c_uuid = support.import_fresh_module('uuid', fresh=['_uuid'])
@@ -566,6 +567,23 @@ class BaseTestUUID:
         with self.mock_generate_time_safe(3):
             u = self.uuid.uuid1()
             self.assertEqual(u.is_safe, self.uuid.SafeUUID.unknown)
+
+    def test_uuid1_time(self):
+        with mock.patch.object(self.uuid, '_has_uuid_generate_time_safe', False), \
+             mock.patch.object(self.uuid, '_generate_time_safe', None), \
+             mock.patch.object(self.uuid, '_last_timestamp', None), \
+             mock.patch.object(self.uuid, 'getnode', return_value=93328246233727), \
+             mock.patch('time.time_ns', return_value=1545052026752910643), \
+             mock.patch('random.getrandbits', return_value=5317): # guaranteed to be random
+            u = self.uuid.uuid1()
+            self.assertEqual(u, self.uuid.UUID('a7a55b92-01fc-11e9-94c5-54e1acf6da7f'))
+
+        with mock.patch.object(self.uuid, '_has_uuid_generate_time_safe', False), \
+             mock.patch.object(self.uuid, '_generate_time_safe', None), \
+             mock.patch.object(self.uuid, '_last_timestamp', None), \
+             mock.patch('time.time_ns', return_value=1545052026752910643):
+            u = self.uuid.uuid1(node=93328246233727, clock_seq=5317)
+            self.assertEqual(u, self.uuid.UUID('a7a55b92-01fc-11e9-94c5-54e1acf6da7f'))
 
     def test_uuid3(self):
         equal = self.assertEqual

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -728,10 +728,10 @@ def uuid1(node=None, clock_seq=None):
 
     global _last_timestamp
     import time
-    nanoseconds = int(time.time() * 1e9)
+    nanoseconds = time.time_ns()
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
-    timestamp = int(nanoseconds/100) + 0x01b21dd213814000
+    timestamp = nanoseconds // 100 + 0x01b21dd213814000
     if _last_timestamp is not None and timestamp <= _last_timestamp:
         timestamp = _last_timestamp + 1
     _last_timestamp = timestamp

--- a/Misc/NEWS.d/next/Library/2018-12-17-11-43-11.bpo-31784.W0gDjC.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-17-11-43-11.bpo-31784.W0gDjC.rst
@@ -1,0 +1,2 @@
+:func:`uuid.uuid1` now calls :func:`time.time_ns` rather than
+``int(time.time() * 1e9)``.


### PR DESCRIPTION
Replace int(time.time() * 1e9) with time.time_ns().

<!-- issue-number: [bpo-31784](https://bugs.python.org/issue31784) -->
https://bugs.python.org/issue31784
<!-- /issue-number -->
