### PR TITLE
[3.7] bpo-35472: Allow sphinx 3.6.6 to build Python 3.7 documentation.

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -34,8 +34,8 @@ today_fmt = '%B %d, %Y'
 # By default, highlight as Python 3.
 highlight_language = 'python3'
 
-# Require Sphinx 1.7 for build.
-needs_sphinx = '1.7'
+# Require Sphinx 1.6.6 for build.
+needs_sphinx = "1.6.6"
 
 # Ignore any .rst files in the venv/ directory.
 venvdir = os.getenv('VENVDIR', 'venv')


### PR DESCRIPTION
This is not a backport, nor a change I'm willing to do on master, this is intentionally only for the 3.7 branch, so requirements will look like this:

- python 3.6 needs sphinx 1.2
- python 3.7 needs sphinx 1.6.6
- python 3.8 needs sphinx 1.7 (and will ultimately need sphinx 2 for colspan and rowspan)


<!-- issue-number: [bpo-35472](https://bugs.python.org/issue35472) -->
https://bugs.python.org/issue35472
<!-- /issue-number -->
