### PR TITLE
Fix bpo-19217: Calling assertEquals for moderately long list takes too long

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1187,9 +1187,8 @@ def unified_diff(a, b, fromfile='', tofile='', fromfiledate='',
         first, last = group[0], group[-1]
         file1_range = _format_range_unified(first[1], last[2])
         file2_range = _format_range_unified(first[3], last[4])
-        if isinstance(a, list) or isinstance(a, tuple) and \
-            isinstance(b, list) or isinstance(b, tuple):
-            yield '{}'.format(lineterm)
+        if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
+            yield lineterm
         else:
             yield '@@ -{} +{} @@{}'.format(file1_range, file2_range, lineterm)
 

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1187,7 +1187,11 @@ def unified_diff(a, b, fromfile='', tofile='', fromfiledate='',
         first, last = group[0], group[-1]
         file1_range = _format_range_unified(first[1], last[2])
         file2_range = _format_range_unified(first[3], last[4])
-        yield '@@ -{} +{} @@{}'.format(file1_range, file2_range, lineterm)
+        if isinstance(a, list) or isinstance(a, tuple) and \
+            isinstance(b, list) or isinstance(b, tuple):
+            yield '{}'.format(lineterm)
+        else:
+            yield '@@ -{} +{} @@{}'.format(file1_range, file2_range, lineterm)
 
         for tag, i1, i2, j1, j2 in group:
             if tag == 'equal':

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1058,9 +1058,9 @@ class TestCase(object):
                                   'of second %s\n' % (len1, seq_type_name))
         standardMsg = differing
         diffMsg = difflib.unified_diff(pprint.pformat(seq1).splitlines(),
-                                        pprint.pformat(seq2).splitlines(),
-                                        fromfile='expected', tofile='got',
-                                        lineterm='')
+                                       pprint.pformat(seq2).splitlines(),
+                                       fromfile='expected', tofile='got',
+                                       lineterm='')
         diffMsg = '\n' + '\n'.join(diffMsg)
 
         standardMsg = self._truncateMessage(standardMsg, diffMsg)

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1057,9 +1057,11 @@ class TestCase(object):
                     differing += ('Unable to index element %d '
                                   'of second %s\n' % (len1, seq_type_name))
         standardMsg = differing
-        diffMsg = '\n' + '\n'.join(
-            difflib.ndiff(pprint.pformat(seq1).splitlines(),
-                          pprint.pformat(seq2).splitlines()))
+        diffMsg = difflib.unified_diff(pprint.pformat(seq1).splitlines(),
+                                        pprint.pformat(seq2).splitlines(),
+                                        fromfile='expected', tofile='got',
+                                        lineterm='')
+        diffMsg = '\n' + '\n'.join(diffMsg)
 
         standardMsg = self._truncateMessage(standardMsg, diffMsg)
         msg = self._formatMessage(msg, standardMsg)

--- a/Lib/unittest/test/test_assertions.py
+++ b/Lib/unittest/test/test_assertions.py
@@ -242,8 +242,8 @@ class TestLongMessage(unittest.TestCase):
         # Error messages are multiline so not testing on full message
         # assertTupleEqual and assertListEqual delegate to this method
         self.assertMessages('assertSequenceEqual', ([], [None]),
-                            [r"\+ \[None\]$", "^oops$", r"\+ \[None\]$",
-                             r"\+ \[None\] : oops$"])
+                            [r"\+\[None\]$", "^oops$", r"\+\[None\]$",
+                             r"\+\[None\] : oops$"])
 
     def testAssertSetEqual(self):
         self.assertMessages('assertSetEqual', (set(), set([None])),

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -790,8 +790,8 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         seq1 = 'a' + 'x' * 80**2
         seq2 = 'b' + 'x' * 80**2
         diff = difflib.unified_diff(pprint.pformat(seq1).splitlines(),
-                                     pprint.pformat(seq2).splitlines(),
-                                     lineterm='')
+                                    pprint.pformat(seq2).splitlines(),
+                                    lineterm='')
         diff = '\n'.join(diff)
         # the +1 is the leading \n added by assertSequenceEqual
         omitted = unittest.case.DIFF_OMITTED % (len(diff) + 1,)

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -789,8 +789,10 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertEqual(self.maxDiff, 80*8)
         seq1 = 'a' + 'x' * 80**2
         seq2 = 'b' + 'x' * 80**2
-        diff = '\n'.join(difflib.ndiff(pprint.pformat(seq1).splitlines(),
-                                       pprint.pformat(seq2).splitlines()))
+        diff = difflib.unified_diff(pprint.pformat(seq1).splitlines(),
+                                     pprint.pformat(seq2).splitlines(),
+                                     lineterm='')
+        diff = '\n'.join(diff)
         # the +1 is the leading \n added by assertSequenceEqual
         omitted = unittest.case.DIFF_OMITTED % (len(diff) + 1,)
 


### PR DESCRIPTION
# Fix [bpo-19217](https://bugs.python.org/issue19217): Calling assertEquals for moderately long list takes too long
Fix https://bugs.python.org/issue19217
Related: https://github.com/python/cpython/pull/10034


<!-- issue-number: [bpo-19217](https://bugs.python.org/issue19217) -->
https://bugs.python.org/issue19217
<!-- /issue-number -->
