### PR TITLE
bpo-35482: Fix creating the CHM file.

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -442,8 +442,6 @@ declaration; it is UTF-8 if no encoding declaration is given in the source file;
 see section :ref:`encodings`.
 
 .. index:: triple-quoted string, Unicode Consortium, raw string
-   single: """; string literal
-   single: '''; string literal
 
 In plain English: Both types of literals can be enclosed in matching single quotes
 (``'``) or double quotes (``"``).  They can also be enclosed in matching groups

--- a/Misc/NEWS.d/next/Documentation/2018-12-18-12-47-07.bpo-35482.9TD9QD.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-12-18-12-47-07.bpo-35482.9TD9QD.rst
@@ -1,0 +1,1 @@
+Fixed creating the CHM file.


### PR DESCRIPTION
The Microsoft HTML Help Compiler creates broken CHM file if
the index contains an entry for `'''` (triple single quote).


<!-- issue-number: [bpo-35482](https://bugs.python.org/issue35482) -->
https://bugs.python.org/issue35482
<!-- /issue-number -->
