### PR TITLE
bpo-35516: platform.system_alias() don't replace Darwin

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -514,6 +514,9 @@ def system_alias(system, release, version):
         # In case one of the other tricks
         system = 'Windows'
 
+    # bpo-35516: Don't replace Darwin with macOS since input release and
+    # version arguments can be different than the currently running version.
+
     return system, release, version
 
 ### Various internal helpers


### PR DESCRIPTION
Add a comment explaining why system_alias() doesn't alias Darwin to
macOS.

<!-- issue-number: [bpo-35516](https://bugs.python.org/issue35516) -->
https://bugs.python.org/issue35516
<!-- /issue-number -->
