### PR TITLE
bpo-35523: Remove ctypes callback workaround

### DIFF
--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -266,11 +266,6 @@ def _reset_cache():
     # _SimpleCData.c_char_p_from_param
     POINTER(c_char).from_param = c_char_p.from_param
     _pointer_type_cache[None] = c_void_p
-    # XXX for whatever reasons, creating the first instance of a callback
-    # function is needed for the unittests on Win64 to succeed.  This MAY
-    # be a compiler bug, since the problem occurs only when _ctypes is
-    # compiled with the MS SDK compiler.  Or an uninitialized variable?
-    CFUNCTYPE(c_int)(lambda: None)
 
 def create_unicode_buffer(init, size=None):
     """create_unicode_buffer(aString) -> character array

--- a/Misc/NEWS.d/next/Library/2018-12-18-13-52-13.bpo-35523.SkoMno.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-18-13-52-13.bpo-35523.SkoMno.rst
@@ -1,0 +1,2 @@
+Remove :mod:`ctypes` callback workaround: no longer create a callback at
+startup. Avoid SELinux alert on ``import ctypes`` and ``import uuid``.


### PR DESCRIPTION
Remove ctypes callback workaround: no longer create a callback at startup.

<!-- issue-number: [bpo-35523](https://bugs.python.org/issue35523) -->
https://bugs.python.org/issue35523
<!-- /issue-number -->
