### PR TITLE
[2.7] bpo-10496: distutils check_environ() handles getpwuid() error (GH-10931)

### DIFF
--- a/Lib/distutils/tests/test_util.py
+++ b/Lib/distutils/tests/test_util.py
@@ -1,11 +1,14 @@
 """Tests for distutils.util."""
+import os
 import sys
 import unittest
-from test.test_support import run_unittest
+from test.test_support import run_unittest, swap_attr
 
 from distutils.errors import DistutilsByteCompileError
 from distutils.tests import support
-from distutils.util import byte_compile, grok_environment_error
+from distutils import util # used to patch _environ_checked
+from distutils.util import (byte_compile, grok_environment_error,
+                            check_environ, get_platform)
 
 
 class UtilTestCase(support.EnvironGuard, unittest.TestCase):
@@ -25,6 +28,41 @@ class UtilTestCase(support.EnvironGuard, unittest.TestCase):
         exc = IOError("Unable to find batch file")
         msg = grok_environment_error(exc)
         self.assertEqual(msg, "error: Unable to find batch file")
+
+    def test_check_environ(self):
+        util._environ_checked = 0
+        os.environ.pop('HOME', None)
+
+        check_environ()
+
+        self.assertEqual(os.environ['PLAT'], get_platform())
+        self.assertEqual(util._environ_checked, 1)
+
+    @unittest.skipUnless(os.name == 'posix', 'specific to posix')
+    def test_check_environ_getpwuid(self):
+        util._environ_checked = 0
+        os.environ.pop('HOME', None)
+
+        import pwd
+
+        # only set pw_dir field, other fields are not used
+        def mock_getpwuid(uid):
+            return pwd.struct_passwd((None, None, None, None, None,
+                                      '/home/distutils', None))
+
+        with swap_attr(pwd, 'getpwuid', mock_getpwuid):
+            check_environ()
+            self.assertEqual(os.environ['HOME'], '/home/distutils')
+
+        util._environ_checked = 0
+        os.environ.pop('HOME', None)
+
+        # bpo-10496: Catch pwd.getpwuid() error
+        def getpwuid_err(uid):
+            raise KeyError
+        with swap_attr(pwd, 'getpwuid', getpwuid_err):
+            check_environ()
+            self.assertNotIn('HOME', os.environ)
 
 
 def test_suite():

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -178,8 +178,13 @@ def check_environ ():
         return
 
     if os.name == 'posix' and 'HOME' not in os.environ:
-        import pwd
-        os.environ['HOME'] = pwd.getpwuid(os.getuid())[5]
+        try:
+            import pwd
+            os.environ['HOME'] = pwd.getpwuid(os.getuid())[5]
+        except (ImportError, KeyError):
+            # bpo-10496: if the current user identifier doesn't exist in the
+            # password database, do nothing
+            pass
 
     if 'PLAT' not in os.environ:
         os.environ['PLAT'] = get_platform()

--- a/Misc/NEWS.d/next/Library/2018-12-05-17-42-49.bpo-10496.laV_IE.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-05-17-42-49.bpo-10496.laV_IE.rst
@@ -1,0 +1,3 @@
+:func:`~distutils.utils.check_environ` of :mod:`distutils.utils` now catchs
+:exc:`KeyError` on calling :func:`pwd.getpwuid`: don't create the ``HOME``
+environment variable in this case.


### PR DESCRIPTION
check_environ() of distutils.utils now catchs KeyError on calling
pwd.getpwuid(): don't create the HOME environment variable in this
case.

(cherry picked from commit 17d0c0595e101c4ce76b58e55de37e6b5083e6cd)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-10496](https://bugs.python.org/issue10496) -->
https://bugs.python.org/issue10496
<!-- /issue-number -->
