### PR TITLE
 bpo-22703: IDLE: Improve Code Context and Zoom Height menu labels

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -275,7 +275,7 @@ Configure IDLE
    menu. For more, see
    :ref:`Setting preferences <preferences>` under Help and preferences.
 
-Code Context (toggle)(Editor Window only)
+Show/Hide Code Context (Editor Window only)
    Open a pane at the top of the edit window which shows the block context
    of the code which has scrolled above the top of the window.  See
    :ref:`Code Context <code-context>` in the Editing and Navigation section below.

--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -275,7 +275,7 @@ Configure IDLE
    menu. For more, see
    :ref:`Setting preferences <preferences>` under Help and preferences.
 
-Zoom Height
+Zoom/Restore Height
    Toggles the window between normal size and maximum height. The initial size
    defaults to 40 lines by 80 chars unless changed on the General tab of the
    Configure IDLE dialog.

--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -275,6 +275,11 @@ Configure IDLE
    menu. For more, see
    :ref:`Setting preferences <preferences>` under Help and preferences.
 
+Zoom Height
+   Toggles the window between normal size and maximum height. The initial size
+   defaults to 40 lines by 80 chars unless changed on the General tab of the
+   Configure IDLE dialog.
+
 Show/Hide Code Context (Editor Window only)
    Open a pane at the top of the edit window which shows the block context
    of the code which has scrolled above the top of the window.  See
@@ -283,13 +288,8 @@ Show/Hide Code Context (Editor Window only)
 Window menu (Shell and Editor)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Zoom Height
-   Toggles the window between normal size and maximum height. The initial size
-   defaults to 40 lines by 80 chars unless changed on the General tab of the
-   Configure IDLE dialog.
-
-The rest of this menu lists the names of all open windows; select one to bring
-it to the foreground (deiconifying it if necessary).
+Lists the names of all open windows; select one to bring it to the foreground
+(deiconifying it if necessary).
 
 Help menu (Shell and Editor)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,10 +3,10 @@ Released on 2019-10-20?
 ======================================
 
 
-bpo-22703: Improve Code Context and Zoom Height menu labels.
-Code Context menu label now toggles between Show/Hide Code Context.
-Menu label for Zoom Height, moved from Window menu to Options menu,
-now toggles between Zoom/Restore Height.
+bpo-22703: Improve the Code Context and Zoom Height menu labels.
+The Code Context menu label now toggles between Show/Hide Code Context.
+The Zoom Height menu now toggles between Zoom/Restore Height.
+It has moved from the Window menu to the Options menu.
 
 bpo-35521: Document the editor code context feature.
 Add some internal references within the IDLE doc.

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -6,7 +6,7 @@ Released on 2019-10-20?
 bpo-22703: Improve the Code Context and Zoom Height menu labels.
 The Code Context menu label now toggles between Show/Hide Code Context.
 The Zoom Height menu now toggles between Zoom/Restore Height.
-It has moved from the Window menu to the Options menu.
+Zoom Height has moved from the Window menu to the Options menu.
 
 bpo-35521: Document the editor code context feature.
 Add some internal references within the IDLE doc.

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,11 @@ Released on 2019-10-20?
 ======================================
 
 
+bpo-22703: Improve Code Context and Zoom Height menu labels.
+Code Context menu label now toggles between Show/Hide Code Context.
+Menu label for Zoom Height, moved from Window menu to Options menu,
+now toggles between Zoom/Restore Height.
+
 bpo-35521: Document the editor code context feature.
 Add some internal references within the IDLE doc.
 

--- a/Lib/idlelib/codecontext.py
+++ b/Lib/idlelib/codecontext.py
@@ -122,9 +122,13 @@ class CodeContext:
             # thus ensuring that it will appear directly above text_frame.
             self.context.pack(side=TOP, fill=X, expand=False,
                             before=self.editwin.text_frame)
+            menu_status = 'Hide'
         else:
             self.context.destroy()
             self.context = None
+            menu_status = 'Show'
+        self.editwin.update_label(menu='options', index=3,
+                                  label=f'{menu_status} Code Context')
         return "break"
 
     def get_context(self, new_topvisible, stopline=1, stopindent=0):

--- a/Lib/idlelib/codecontext.py
+++ b/Lib/idlelib/codecontext.py
@@ -127,8 +127,8 @@ class CodeContext:
             self.context.destroy()
             self.context = None
             menu_status = 'Show'
-        self.editwin.update_label(menu='options', index=3,
-                                  label=f'{menu_status} Code Context')
+        self.editwin.update_menu_label(menu='options', index='* Code Context',
+                                       label=f'{menu_status} Code Context')
         return "break"
 
     def get_context(self, new_topvisible, stopline=1, stopindent=0):

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -446,6 +446,11 @@ class EditorWindow(object):
             menu.delete(self.wmenu_end+1, end)
         window.add_windows_to_menu(menu)
 
+    def update_label(self, menu, index, label):
+        "Update label for menu item at index ."
+        menuitem = self.menudict[menu]
+        menuitem.entryconfig(index, label=label)
+
     def handle_yview(self, event, *args):
         "Handle scrollbar."
         if event == 'moveto':

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -446,7 +446,7 @@ class EditorWindow(object):
             menu.delete(self.wmenu_end+1, end)
         window.add_windows_to_menu(menu)
 
-    def update_label(self, menu, index, label):
+    def update_menu_label(self, menu, index, label):
         "Update label for menu item at index ."
         menuitem = self.menudict[menu]
         menuitem.entryconfig(index, label=label)

--- a/Lib/idlelib/idle_test/test_codecontext.py
+++ b/Lib/idlelib/idle_test/test_codecontext.py
@@ -40,6 +40,10 @@ class DummyEditwin:
         self.top = root
         self.text_frame = frame
         self.text = text
+        self.label = ''
+
+    def update_label(self, **kwargs):
+        self.label = kwargs['label']
 
 
 class CodeContextTest(unittest.TestCase):
@@ -127,10 +131,12 @@ class CodeContextTest(unittest.TestCase):
         eq(cc.context['fg'], cc.colors['foreground'])
         eq(cc.context['bg'], cc.colors['background'])
         eq(cc.context.get('1.0', 'end-1c'), '')
+        eq(cc.editwin.label, 'Hide Code Context')
 
         # Toggle off.
         eq(toggle(), 'break')
         self.assertIsNone(cc.context)
+        eq(cc.editwin.label, 'Show Code Context')
 
     def test_get_context(self):
         eq = self.assertEqual

--- a/Lib/idlelib/idle_test/test_codecontext.py
+++ b/Lib/idlelib/idle_test/test_codecontext.py
@@ -42,7 +42,7 @@ class DummyEditwin:
         self.text = text
         self.label = ''
 
-    def update_label(self, **kwargs):
+    def update_menu_label(self, **kwargs):
         self.label = kwargs['label']
 
 

--- a/Lib/idlelib/mainmenu.py
+++ b/Lib/idlelib/mainmenu.py
@@ -94,11 +94,12 @@ menudefs = [
 
  ('options', [
    ('Configure _IDLE', '<<open-config-dialog>>'),
-   ('_Code Context', '<<toggle-code-context>>'),
+   None,
+   ('Zoom Height', '<<zoom-height>>'),
+   ('Show _Code Context', '<<toggle-code-context>>'),
    ]),
 
  ('window', [
-   ('Zoom Height', '<<zoom-height>>'),
    ]),
 
  ('help', [

--- a/Lib/idlelib/mainmenu.py
+++ b/Lib/idlelib/mainmenu.py
@@ -95,8 +95,8 @@ menudefs = [
  ('options', [
    ('Configure _IDLE', '<<open-config-dialog>>'),
    None,
-   ('Zoom Height', '<<zoom-height>>'),
    ('Show _Code Context', '<<toggle-code-context>>'),
+   ('Zoom Height', '<<zoom-height>>'),
    ]),
 
  ('window', [

--- a/Lib/idlelib/zoomheight.py
+++ b/Lib/idlelib/zoomheight.py
@@ -13,7 +13,10 @@ class ZoomHeight:
 
     def zoom_height_event(self, event=None):
         top = self.editwin.top
-        zoom_height(top)
+        zoomed = zoom_height(top)
+        menu_status = 'Restore' if zoomed else 'Zoom'
+        self.editwin.update_menu_label(menu='options', index='* Height',
+                                       label=f'{menu_status} Height')
         return "break"
 
 
@@ -46,6 +49,7 @@ def zoom_height(top):
     else:
         newgeom = "%dx%d+%d+%d" % (width, newheight, x, newy)
     top.wm_geometry(newgeom)
+    return newgeom != ""
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/IDLE/2018-12-18-13-56-31.bpo-22703.UlsjKQ.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-12-18-13-56-31.bpo-22703.UlsjKQ.rst
@@ -1,3 +1,3 @@
-Code Context menu label now toggles between Show/Hide Code Context.
-Menu label for Zoom Height, moved from Window menu to Options menu,
-now toggles between Zoom/Restore Height.
+The Code Context menu label now toggles between Show/Hide Code Context.
+The Zoom Height menu now toggles between Zoom/Restore Height.
+Zoom Height has moved from the Window menu to the Options menu.

--- a/Misc/NEWS.d/next/IDLE/2018-12-18-13-56-31.bpo-22703.UlsjKQ.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-12-18-13-56-31.bpo-22703.UlsjKQ.rst
@@ -1,0 +1,1 @@
+Change menu label for Code Context to toggle between Show/Hide Code Context.

--- a/Misc/NEWS.d/next/IDLE/2018-12-18-13-56-31.bpo-22703.UlsjKQ.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-12-18-13-56-31.bpo-22703.UlsjKQ.rst
@@ -1,2 +1,3 @@
-Change menu label for Code Context to toggle between Show/Hide Code Context.
-Move Zoom Height from Window menu to Options menu.
+Code Context menu label now toggles between Show/Hide Code Context.
+Menu label for Zoom Height, moved from Window menu to Options menu,
+now toggles between Zoom/Restore Height.

--- a/Misc/NEWS.d/next/IDLE/2018-12-18-13-56-31.bpo-22703.UlsjKQ.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-12-18-13-56-31.bpo-22703.UlsjKQ.rst
@@ -1,1 +1,2 @@
 Change menu label for Code Context to toggle between Show/Hide Code Context.
+Move Zoom Height from Window menu to Options menu.


### PR DESCRIPTION
 The Code Context menu label now toggles between Show/Hide Code Context. 
 The Zoom Height menu now toggles between Zoom/Restore Height. 
 Zoom Height has moved from the Window menu to the Options menu. 

 <!-- issue-number: [bpo-22703](https://bugs.python.org/issue22703) -->
https://bugs.python.org/issue22703
<!-- /issue-number -->
