### PR TITLE
Remove misleading sentence

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -726,7 +726,8 @@ than raw I/O does.
    :data:`DEFAULT_BUFFER_SIZE`.
 
    :class:`BufferedRandom` is capable of anything :class:`BufferedReader` or
-   :class:`BufferedWriter` can do.
+   :class:`BufferedWriter` can do.  In addition, :meth:`seek` and :meth:`tell`
+   are guaranteed to be implemented.
 
 
 .. class:: BufferedRWPair(reader, writer, buffer_size=DEFAULT_BUFFER_SIZE)

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -719,8 +719,7 @@ than raw I/O does.
 .. class:: BufferedRandom(raw, buffer_size=DEFAULT_BUFFER_SIZE)
 
    A buffered interface to random access streams.  It inherits
-   :class:`BufferedReader` and :class:`BufferedWriter`, and further supports
-   :meth:`seek` and :meth:`tell` functionality.
+   :class:`BufferedReader` and :class:`BufferedWriter`.
 
    The constructor creates a reader and writer for a seekable raw stream, given
    in the first argument.  If the *buffer_size* is omitted it defaults to


### PR DESCRIPTION
The sentence, “It inherits BufferedReader and BufferedWriter, and
further supports seek() and tell() functionality,” is misleading: it
suggests that BufferedRandom is special in that it is seekable, whereas
BufferedReader and BufferedWriter are not. However, this is not the
case: assuming the underlying raw stream is seekable (which is equally a
requirement of BufferedRandom), then BufferedReader and BufferedWriter
*are* seekable. Remove the misleading sentence.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
