### PR TITLE
bpo-35526: make __future__.barry_as_FLUFL mandatory for Python 4.0

### DIFF
--- a/Lib/__future__.py
+++ b/Lib/__future__.py
@@ -134,7 +134,7 @@ unicode_literals = _Feature((2, 6, 0, "alpha", 2),
                             CO_FUTURE_UNICODE_LITERALS)
 
 barry_as_FLUFL = _Feature((3, 1, 0, "alpha", 2),
-                          (3, 9, 0, "alpha", 0),
+                          (4, 0, 0, "alpha", 0),
                           CO_FUTURE_BARRY_AS_BDFL)
 
 generator_stop = _Feature((3, 5, 0, "beta", 1),

--- a/Misc/NEWS.d/next/Library/2018-12-18-21-12-25.bpo-35526.fYvo6H.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-18-21-12-25.bpo-35526.fYvo6H.rst
@@ -1,0 +1,1 @@
+Delaying the 'joke' of barry_as_FLUFL.mandatory to Python version 4.0


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35526](https://bugs.python.org/issue35526) -->
https://bugs.python.org/issue35526
<!-- /issue-number -->
