### PR TITLE
bpo-35499: Fix LDFLAGS in "make build_all_generate_profile"

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -496,7 +496,7 @@ profile-run-stamp:
 	touch $@
 
 build_all_generate_profile:
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS_NODIST) $(PGO_PROF_GEN_FLAG)" LDFLAGS="$(LDFLAGS) $(PGO_PROF_GEN_FLAG)" LIBS="$(LIBS)"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS_NODIST) $(PGO_PROF_GEN_FLAG)" LIBS="$(LIBS)"
 
 run_profile_task:
 	@ # FIXME: can't run for a cross build
@@ -510,7 +510,7 @@ build_all_merge_profile:
 profile-opt: profile-run-stamp
 	@echo "Rebuilding with profile guided optimizations:"
 	-rm -f profile-clean-stamp
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS_NODIST) $(PGO_PROF_USE_FLAG)" LDFLAGS="$(LDFLAGS)"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS_NODIST) $(PGO_PROF_USE_FLAG)"
 
 # Compile and run with gcov
 .PHONY=coverage coverage-lcov coverage-report

--- a/Misc/NEWS.d/next/Build/2018-12-18-21-56-55.bpo-35499.CBdeX0.rst
+++ b/Misc/NEWS.d/next/Build/2018-12-18-21-56-55.bpo-35499.CBdeX0.rst
@@ -1,0 +1,2 @@
+``make build_all_generate_profile`` doesn't add ``PGO_PROF_GEN_FLAG`` flags
+to ``LDFLAGS`` anymore.


### PR DESCRIPTION
"make build_all_generate_profile" doesn't add PGO_PROF_GEN_FLAG flags
to LDFLAGS anymore.

Remove also LDFLAGS="$(LDFLAGS)" from "make profile-opt".

<!-- issue-number: [bpo-35499](https://bugs.python.org/issue35499) -->
https://bugs.python.org/issue35499
<!-- /issue-number -->
