### PR TITLE
bpo-35424: Fix test_multiprocessing_main_handling

### DIFF
--- a/Lib/test/test_multiprocessing_main_handling.py
+++ b/Lib/test/test_multiprocessing_main_handling.py
@@ -54,18 +54,21 @@ if "check_sibling" in __file__:
 if __name__ == '__main__':
     start_method = sys.argv[1]
     set_start_method(start_method)
-    p = Pool(5)
     results = []
-    p.map_async(f, [1, 2, 3], callback=results.extend)
-    start_time = time.monotonic()
-    while not results:
-        time.sleep(0.05)
-        # up to 1 min to report the results
-        dt = time.monotonic() - start_time
-        if dt > 60.0:
-            raise RuntimeError("Timed out waiting for results (%.1f sec)" % dt)
+    with Pool(5) as pool:
+        pool.map_async(f, [1, 2, 3], callback=results.extend)
+        start_time = time.monotonic()
+        while not results:
+            time.sleep(0.05)
+            # up to 1 min to report the results
+            dt = time.monotonic() - start_time
+            if dt > 60.0:
+                raise RuntimeError("Timed out waiting for results (%.1f sec)" % dt)
+
     results.sort()
     print(start_method, "->", results)
+
+    pool.join()
 """
 
 test_source_main_skipped_in_children = """\
@@ -84,18 +87,21 @@ from multiprocessing import Pool, set_start_method
 
 start_method = sys.argv[1]
 set_start_method(start_method)
-p = Pool(5)
 results = []
-p.map_async(int, [1, 4, 9], callback=results.extend)
-start_time = time.monotonic()
-while not results:
-    time.sleep(0.05)
-    # up to 1 min to report the results
-    dt = time.monotonic() - start_time
-    if dt > 60.0:
-        raise RuntimeError("Timed out waiting for results (%.1f sec)" % dt)
+with Pool(5) as pool:
+    pool.map_async(int, [1, 4, 9], callback=results.extend)
+    start_time = time.monotonic()
+    while not results:
+        time.sleep(0.05)
+        # up to 1 min to report the results
+        dt = time.monotonic() - start_time
+        if dt > 60.0:
+            raise RuntimeError("Timed out waiting for results (%.1f sec)" % dt)
+
 results.sort()
 print(start_method, "->", results)
+
+pool.join()
 """
 
 # These helpers were copied from test_cmd_line_script & tweaked a bit...

--- a/Misc/NEWS.d/next/Tests/2018-12-18-22-36-53.bpo-35424.1Pz4IS.rst
+++ b/Misc/NEWS.d/next/Tests/2018-12-18-22-36-53.bpo-35424.1Pz4IS.rst
@@ -1,0 +1,2 @@
+Fix test_multiprocessing_main_handling: use :class:`multiprocessing.Pool` with
+a context manager and then explicitly join the pool.


### PR DESCRIPTION
Fix test_multiprocessing_main_handling: use multiprocessing.Pool with
a context manager and then explicitly join the pool.

<!-- issue-number: [bpo-35424](https://bugs.python.org/issue35424) -->
https://bugs.python.org/issue35424
<!-- /issue-number -->
