### PR TITLE
bpo-31731: Fix test_io.check_interrupted_write()

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4149,10 +4149,9 @@ class SignalsTest(unittest.TestCase):
         in the latter."""
         read_results = []
         def _read():
-            if hasattr(signal, 'pthread_sigmask'):
-                signal.pthread_sigmask(signal.SIG_BLOCK, [signal.SIGALRM])
             s = os.read(r, 1)
             read_results.append(s)
+
         t = threading.Thread(target=_read)
         t.daemon = True
         r, w = os.pipe()
@@ -4160,7 +4159,14 @@ class SignalsTest(unittest.TestCase):
         large_data = item * (support.PIPE_MAX_SIZE // len(item) + 1)
         try:
             wio = self.io.open(w, **fdopen_kwargs)
-            t.start()
+            if hasattr(signal, 'pthread_sigmask'):
+                # create the thread with SIGALRM signal blocked
+                signal.pthread_sigmask(signal.SIG_BLOCK, [signal.SIGALRM])
+                t.start()
+                signal.pthread_sigmask(signal.SIG_UNBLOCK, [signal.SIGALRM])
+            else:
+                t.start()
+
             # Fill the pipe enough that the write will be blocking.
             # It will be interrupted by the timer armed above.  Since the
             # other thread has read one byte, the low-level write will

--- a/Misc/NEWS.d/next/Tests/2018-12-18-23-20-39.bpo-31731.tcv85C.rst
+++ b/Misc/NEWS.d/next/Tests/2018-12-18-23-20-39.bpo-31731.tcv85C.rst
@@ -1,0 +1,4 @@
+Fix a race condition in ``check_interrupted_write()`` of test_io: create
+directly the thread with SIGALRM signal blocked, rather than blocking the
+signal later from the thread. Previously, it was possible that the thread gets
+the signal before the signal is blocked.


### PR DESCRIPTION
Fix a possible race condition in check_interrupted_write() of
test_io: create directly the thread with SIGALRM signal blocked,
rather than blocking the signal later from the thread. Previously, it
was possible that the thread gets the signal before the signal is
blocked.

<!-- issue-number: [bpo-31731](https://bugs.python.org/issue31731) -->
https://bugs.python.org/issue31731
<!-- /issue-number -->
