### PR TITLE
[2.7] bpo-10320: Use PY_FORMAT_LONG_LONG in ctypes' PyCArg_repr()

### DIFF
--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -485,11 +485,7 @@ PyCArg_repr(PyCArgObject *self)
     case 'q':
     case 'Q':
         sprintf(buffer,
-#ifdef MS_WIN32
-            "<cparam '%c' (%I64d)>",
-#else
-            "<cparam '%c' (%lld)>",
-#endif
+            "<cparam '%c' (%" PY_FORMAT_LONG_LONG "d)>",
             self->tag, self->value.q);
         break;
 #endif


### PR DESCRIPTION


<!-- issue-number: [bpo-10320](https://bugs.python.org/issue10320) -->
https://bugs.python.org/issue10320
<!-- /issue-number -->
