### PR TITLE
[2.7] bpo-35441: Remove dead and buggy code related to PyList_SetItem(). (GH-11033)

### DIFF
--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -73,19 +73,12 @@ copy_grouping(char* s)
     do {
         i++;
         val = PyInt_FromLong(s[i]);
-        if (!val)
-            break;
-        if (PyList_SetItem(result, i, val)) {
-            Py_DECREF(val);
-            val = NULL;
-            break;
+        if (val == NULL) {
+            Py_DECREF(result);
+            return NULL;
         }
+        PyList_SET_ITEM(result, i, val);
     } while (s[i] != '\0' && s[i] != CHAR_MAX);
-
-    if (!val) {
-        Py_DECREF(result);
-        return NULL;
-    }
 
     return result;
 }

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -792,8 +792,7 @@ on_completion_display_matches_hook(char **matches,
         s = PyString_FromString(matches[i+1]);
         if (s == NULL)
             goto error;
-        if (PyList_SetItem(m, i, s) == -1)
-            goto error;
+        PyList_SET_ITEM(m, i, s);
     }
 
     r = PyObject_CallFunction(completion_display_matches_hook,

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -601,10 +601,7 @@ poll_poll(pollObject *self, PyObject *args)
                 goto error;
             }
             PyTuple_SET_ITEM(value, 1, num);
-            if ((PyList_SetItem(result_list, j, value)) == -1) {
-                Py_DECREF(value);
-                goto error;
-            }
+            PyList_SET_ITEM(result_list, j, value);
             i++;
         }
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5247,7 +5247,7 @@ getarray(long a[256])
             Py_DECREF(l);
             return NULL;
         }
-        PyList_SetItem(l, i, x);
+        PyList_SET_ITEM(l, i, x);
     }
     for (i = 0; i < 256; i++)
         a[i] = 0;
@@ -5269,7 +5269,7 @@ _Py_GetDXProfile(PyObject *self, PyObject *args)
             Py_DECREF(l);
             return NULL;
         }
-        PyList_SetItem(l, i, x);
+        PyList_SET_ITEM(l, i, x);
     }
     return l;
 #endif

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1555,7 +1555,7 @@ makepathobject(char *path, int delim)
             Py_DECREF(v);
             return NULL;
         }
-        PyList_SetItem(v, i, w);
+        PyList_SET_ITEM(v, i, w);
         if (*p == '\0')
             break;
         path = p+1;


### PR DESCRIPTION
In _localemodule.c and selectmodule.c, remove dead code that would
cause double decrefs if run.

In addition, replace PyList_SetItem() with PyList_SET_ITEM() in cases
where a new list is populated and there is no possibility of an error.

In addition, check if the list changed size in the loop in array_array_fromlist().
(cherry picked from commit 99d56b53560b3867844472ae381fb3f858760621)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>


<!-- issue-number: [bpo-35441](https://bugs.python.org/issue35441) -->
https://bugs.python.org/issue35441
<!-- /issue-number -->
