### PR TITLE
bpo-29707: Document that os.path.ismount() is not able to detect bind mounts.

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -283,10 +283,11 @@ the :mod:`glob` module.)
 
    Return ``True`` if pathname *path* is a :dfn:`mount point`: a point in a
    file system where a different file system has been mounted.  On POSIX, the
-   function checks whether *path*'s parent, :file:`path/..`, is on a different
-   device than *path*, or whether :file:`path/..` and *path* point to the same
+   function checks whether *path*'s parent, :file:`{path}/..`, is on a different
+   device than *path*, or whether :file:`{path}/..` and *path* point to the same
    i-node on the same device --- this should detect mount points for all Unix
-   and POSIX variants.  On Windows, a drive letter root and a share UNC are
+   and POSIX variants.  It is not able to detect bind mounts on the same
+   filesystem.  On Windows, a drive letter root and a share UNC are
    always mount points, and for any other path ``GetVolumePathName`` is called
    to see if it is different from the input path.
 

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -286,8 +286,8 @@ the :mod:`glob` module.)
    function checks whether *path*'s parent, :file:`{path}/..`, is on a different
    device than *path*, or whether :file:`{path}/..` and *path* point to the same
    i-node on the same device --- this should detect mount points for all Unix
-   and POSIX variants.  It is not able to detect bind mounts on the same
-   filesystem.  On Windows, a drive letter root and a share UNC are
+   and POSIX variants.  It is not able to reliably detect bind mounts on the
+   same filesystem.  On Windows, a drive letter root and a share UNC are
    always mount points, and for any other path ``GetVolumePathName`` is called
    to see if it is different from the input path.
 


### PR DESCRIPTION


<!-- issue-number: [bpo-29707](https://bugs.python.org/issue29707) -->
https://bugs.python.org/issue29707
<!-- /issue-number -->
