### PR TITLE
bpo-35537: use os.posix_spawn in subprocess

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1392,8 +1392,7 @@ class Popen(object):
 
         def _posix_spawn(self, args, executable):
             """Execute program using os.posix_spawn()."""
-            env = os.environ
-            self.pid = os.posix_spawn(executable, args, env)
+            self.pid = os.posix_spawn(executable, args, os.environ)
 
         def _execute_child(self, args, executable, preexec_fn, close_fds,
                            pass_fds, cwd, env,
@@ -1420,15 +1419,17 @@ class Popen(object):
             if executable is None:
                 executable = args[0]
 
-            if (preexec_fn is None
+            if (os.path.dirname(executable)
+                    and preexec_fn is None
                     and not close_fds
                     and not pass_fds
                     and cwd is None
                     and env is None
+                    and p2cread == p2cwrite == -1
+                    and c2pread == c2pwrite == -1
+                    and errread == errwrite == -1
                     and not restore_signals
-                    and not start_new_session
-                    and os.path.dirname(executable)
-                    and self.stdin is self.stdout is self.stderr is None):
+                    and not start_new_session):
                 self._posix_spawn(args, executable)
                 return
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1392,7 +1392,7 @@ class Popen(object):
 
         def _posix_spawn(self, args, executable):
             """Execute program using os.posix_spawn()."""
-            env = dict(os.environ)
+            env = os.environ
             self.pid = os.posix_spawn(executable, args, env)
 
         def _execute_child(self, args, executable, preexec_fn, close_fds,
@@ -1425,9 +1425,12 @@ class Popen(object):
                     and not pass_fds
                     and cwd is None
                     and env is None
-                    and restore_signals is False
-                    and not start_new_session):
-                return self._posix_spawn(args, executable)
+                    and not restore_signals
+                    and not start_new_session
+                    and os.path.dirname(executable)
+                    and self.stdin is self.stdout is self.stderr is None):
+                self._posix_spawn(args, executable)
+                return
 
             orig_executable = executable
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1390,6 +1390,11 @@ class Popen(object):
                     errread, errwrite)
 
 
+        def _posix_spawn(self, args, executable):
+            """Execute program using os.posix_spawn()."""
+            env = dict(os.environ)
+            self.pid = os.posix_spawn(executable, args, env)
+
         def _execute_child(self, args, executable, preexec_fn, close_fds,
                            pass_fds, cwd, env,
                            startupinfo, creationflags, shell,
@@ -1414,6 +1419,16 @@ class Popen(object):
 
             if executable is None:
                 executable = args[0]
+
+            if (preexec_fn is None
+                    and not close_fds
+                    and not pass_fds
+                    and cwd is None
+                    and env is None
+                    and restore_signals is False
+                    and not start_new_session):
+                return self._posix_spawn(args, executable)
+
             orig_executable = executable
 
             # For transferring possible exec failure from child to parent.

--- a/Misc/NEWS.d/next/Library/2018-12-20-16-24-51.bpo-35537.z4E7aA.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-20-16-24-51.bpo-35537.z4E7aA.rst
@@ -1,0 +1,1 @@
+subprocess.Popen can now use posix_spawn() in some cases.


### PR DESCRIPTION
This patch uses os.posix_spawn in subprocess.

posix_spawn() is faster but it's also safer: it allows us to do a lot of "actions" before exec(), before executing the new program. For example, you can close files and control signals. 

@vstinner this is the patch without any options.


<!-- issue-number: [bpo-35537](https://bugs.python.org/issue35537) -->
https://bugs.python.org/issue35537
<!-- /issue-number -->
