### PR TITLE
[2.7] bpo-35504: Fix segfaults and SystemErrors when deleting certain attrs. (GH-11175)

### DIFF
--- a/Lib/ctypes/test/test_strings.py
+++ b/Lib/ctypes/test/test_strings.py
@@ -61,6 +61,13 @@ class StringArrayTestCase(unittest.TestCase):
 ##        print BUF.from_param(c_char_p("python"))
 ##        print BUF.from_param(BUF(*"pyth"))
 
+    def test_del_segfault(self):
+        BUF = c_char * 4
+        buf = BUF()
+        with self.assertRaises(AttributeError):
+            del buf.raw
+
+
 @need_symbol('c_wchar')
 class WStringArrayTestCase(unittest.TestCase):
     def test(self):

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -361,6 +361,10 @@ class RegressionTests(unittest.TestCase):
         del ref
         support.gc_collect()
 
+    def CheckDelIsolation_levelSegfault(self):
+        with self.assertRaises(AttributeError):
+            del self.con.isolation_level
+
 
 class UnhashableFunc:
     def __hash__(self):

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2807,6 +2807,11 @@ class CTextIOWrapperTest(TextIOWrapperTest):
             t2.buddy = t1
         support.gc_collect()
 
+    def test_del__CHUNK_SIZE_SystemError(self):
+        t = self.TextIOWrapper(self.BytesIO(), encoding='ascii')
+        with self.assertRaises(AttributeError):
+            del t._CHUNK_SIZE
+
     maybeRaises = unittest.TestCase.assertRaises
 
 

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-15-14-01-45.bpo-35504.JtKczP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-15-14-01-45.bpo-35504.JtKczP.rst
@@ -1,0 +1,2 @@
+Fix segfaults and :exc:`SystemError`\ s when deleting certain attributes.
+Patch by Zackery Spytz.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1216,6 +1216,10 @@ CharArray_set_raw(CDataObject *self, PyObject *value)
 #if (PY_VERSION_HEX >= 0x02060000)
     Py_buffer view = { 0 };
 #endif
+    if (value == NULL) {
+        PyErr_SetString(PyExc_AttributeError, "cannot delete attribute");
+        return -1;
+    }
     if (PyBuffer_Check(value)) {
         size = Py_TYPE(value)->tp_as_buffer->bf_getreadbuffer(value, 0, (void *)&ptr);
         if (size < 0)

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2593,6 +2593,10 @@ textiowrapper_chunk_size_set(textio *self, PyObject *arg, void *context)
 {
     Py_ssize_t n;
     CHECK_ATTACHED_INT(self);
+    if (arg == NULL) {
+        PyErr_SetString(PyExc_AttributeError, "cannot delete attribute");
+        return -1;
+    }
     n = PyNumber_AsSsize_t(arg, PyExc_TypeError);
     if (n == -1 && PyErr_Occurred())
         return -1;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1131,6 +1131,10 @@ static int pysqlite_connection_set_isolation_level(pysqlite_Connection* self, Py
     PyObject* begin_statement;
     char* begin_statement_str;
 
+    if (isolation_level == NULL) {
+        PyErr_SetString(PyExc_AttributeError, "cannot delete attribute");
+        return -1;
+    }
     Py_XDECREF(self->isolation_level);
 
     if (self->begin_statement) {

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -138,6 +138,10 @@ codecctx_errors_set(MultibyteStatefulCodecContext *self, PyObject *value,
 {
     PyObject *cb;
 
+    if (value == NULL) {
+        PyErr_SetString(PyExc_AttributeError, "cannot delete attribute");
+        return -1;
+    }
     if (!PyString_Check(value)) {
         PyErr_SetString(PyExc_TypeError, "errors must be a string");
         return -1;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -118,6 +118,10 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno)
     int blockstack_top = 0;             /* (ditto) */
     unsigned char setup_op = 0;         /* (ditto) */
 
+    if (p_new_lineno == NULL) {
+        PyErr_SetString(PyExc_AttributeError, "cannot delete attribute");
+        return -1;
+    }
     /* f_lineno must be an integer. */
     if (!PyInt_Check(p_new_lineno)) {
         PyErr_SetString(PyExc_ValueError,


### PR DESCRIPTION

(cherry picked from commit 842acaab1376c5c84fd5966bb6070e289880e1ca)

<!-- issue-number: [bpo-35504](https://bugs.python.org/issue35504) -->
https://bugs.python.org/issue35504
<!-- /issue-number -->
