### PR TITLE
[3.6] bpo-35499: make profile-opt don't override CFLAGS_NODIST (GH-11164)

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -472,7 +472,7 @@ profile-opt:
 	$(MAKE) profile-removal
 
 build_all_generate_profile:
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS) $(PGO_PROF_GEN_FLAG)" LDFLAGS="$(LDFLAGS) $(PGO_PROF_GEN_FLAG)" LIBS="$(LIBS)"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS_NODIST) $(PGO_PROF_GEN_FLAG)" LDFLAGS="$(LDFLAGS) $(PGO_PROF_GEN_FLAG)" LIBS="$(LIBS)"
 
 run_profile_task:
 	: # FIXME: can't run for a cross build
@@ -482,7 +482,7 @@ build_all_merge_profile:
 	$(LLVM_PROF_MERGER)
 
 build_all_use_profile:
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS) $(PGO_PROF_USE_FLAG)" LDFLAGS="$(LDFLAGS)"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS_NODIST) $(PGO_PROF_USE_FLAG)" LDFLAGS="$(LDFLAGS)"
 
 # Compile and run with gcov
 .PHONY=coverage coverage-lcov coverage-report

--- a/Misc/NEWS.d/next/Build/2018-12-14-19-36-05.bpo-35499.9yAldM.rst
+++ b/Misc/NEWS.d/next/Build/2018-12-14-19-36-05.bpo-35499.9yAldM.rst
@@ -1,0 +1,3 @@
+``make profile-opt`` no longer replaces ``CFLAGS_NODIST`` with ``CFLAGS``. It
+now adds profile-guided optimization (PGO) flags to ``CFLAGS_NODIST``: existing
+``CFLAGS_NODIST`` flags are kept.


### PR DESCRIPTION
"make profile-opt" no longer replaces CFLAGS_NODIST with CFLAGS. It
now adds profile-guided optimization (PGO) flags to CFLAGS_NODIST,
existing CFLAGS_NODIST flags are kept.

(cherry picked from commit 640ed520dd6a43a8bf470b79542f58b5d57af9de)

<!-- issue-number: [bpo-35499](https://bugs.python.org/issue35499) -->
https://bugs.python.org/issue35499
<!-- /issue-number -->
