### PR TITLE
bpo-21478: Autospec functions should propagate mock calls to parent

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -321,6 +321,14 @@ class _CallList(list):
 
 
 def _check_and_set_parent(parent, value, name, new_name):
+    # function passed to create_autospec will have mock
+    # attribute attached to which parent must be set
+    if isinstance(value, FunctionTypes):
+        try:
+            value = value.mock
+        except AttributeError:
+            pass
+
     if not _is_instance_mock(value):
         return False
     if ((value._mock_name or value._mock_new_name) or

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1802,5 +1802,18 @@ class MockTest(unittest.TestCase):
         self.assertEqual(type(call.parent().parent), _Call)
 
 
+    def test_parent_propagation_with_create_autospec(self):
+
+        def foo(a, b):
+            pass
+
+        mock = Mock()
+        mock.child = create_autospec(foo)
+        mock.child(1, 2)
+
+        self.assertRaises(TypeError, mock.child, 1)
+        self.assertEqual(mock.mock_calls, [call.child(1, 2)])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-12-21-09-54-30.bpo-21478.5gsXtc.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-21-09-54-30.bpo-21478.5gsXtc.rst
@@ -1,0 +1,2 @@
+Calls to a child function created with :func:`unittest.mock.create_autospec`
+should propagate to the parent. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
When a function is passed to `create_autospec` then a function object is returned where the mock is attached to the object with the attribute name `mock` . Set parent against the mock attribute so that calls to children are propagated to the parent.

<!-- issue-number: [bpo-21478](https://bugs.python.org/issue21478) -->
https://bugs.python.org/issue21478
<!-- /issue-number -->
