### PR TITLE
bpo-35550 fix incorrect Solaris define guards

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-12-29-10-19-43.bpo-35550.BTuu8e.rst
+++ b/Misc/NEWS.d/next/Build/2018-12-29-10-19-43.bpo-35550.BTuu8e.rst
@@ -1,0 +1,1 @@
+Fix incorrect Solaris #ifdef checks to look for __sun && __SVR4 instead of sun when compiling.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -30,7 +30,7 @@
 # define SYS_getdents64  __NR_getdents64
 #endif
 
-#if defined(sun)
+#if defined(__sun) && defined(__SVR4)
 /* readdir64 is used to work around Solaris 9 bug 6395699. */
 # define readdir readdir64
 # define dirent dirent64

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6334,7 +6334,7 @@ os_openpty_impl(PyObject *module)
 #endif
 #if defined(HAVE_DEV_PTMX) && !defined(HAVE_OPENPTY) && !defined(HAVE__GETPTY)
     PyOS_sighandler_t sig_saved;
-#ifdef sun
+#ifdef defined(__sun) && defined(__SVR4)
     extern char *ptsname(int fildes);
 #endif
 #endif

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6334,7 +6334,7 @@ os_openpty_impl(PyObject *module)
 #endif
 #if defined(HAVE_DEV_PTMX) && !defined(HAVE_OPENPTY) && !defined(HAVE__GETPTY)
     PyOS_sighandler_t sig_saved;
-#ifdef defined(__sun) && defined(__SVR4)
+#if defined(__sun) && defined(__SVR4)
     extern char *ptsname(int fildes);
 #endif
 #endif

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -263,7 +263,7 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
 #endif
 
 /* Solaris fails to define this variable at all. */
-#if defined(sun) && !defined(INET_ADDRSTRLEN)
+#if (defined(__sun) && defined(__SVR4)) && !defined(INET_ADDRSTRLEN)
 #define INET_ADDRSTRLEN 16
 #endif
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -743,7 +743,7 @@ time_strftime(PyObject *self, PyObject *args)
         return NULL;
     }
 
-#if defined(_MSC_VER) || defined(sun) || defined(_AIX)
+#if defined(_MSC_VER) || (defined(__sun) && defined(__SVR4)) || defined(_AIX)
     if (buf.tm_year + 1900 < 1 || 9999 < buf.tm_year + 1900) {
         PyErr_SetString(PyExc_ValueError,
                         "strftime() requires year in [1; 9999]");
@@ -789,7 +789,7 @@ time_strftime(PyObject *self, PyObject *args)
             return NULL;
         }
     }
-#elif (defined(_AIX) || defined(sun)) && defined(HAVE_WCSFTIME)
+#elif (defined(_AIX) || (defined(__sun) && defined(__SVR4))) && defined(HAVE_WCSFTIME)
     for (outbuf = wcschr(fmt, '%');
         outbuf != NULL;
         outbuf = wcschr(outbuf+2, '%'))

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -114,7 +114,7 @@ py_getrandom(void *buffer, Py_ssize_t size, int blocking, int raise)
     flags = blocking ? 0 : GRND_NONBLOCK;
     dest = buffer;
     while (0 < size) {
-#ifdef sun
+#if defined(__sun) && defined(__SVR4)
         /* Issue #26735: On Solaris, getrandom() is limited to returning up
            to 1024 bytes. Call it multiple times if more bytes are
            requested. */
@@ -264,7 +264,7 @@ py_getentropy(char *buffer, Py_ssize_t size, int raise)
     }
     return 1;
 }
-#endif /* defined(HAVE_GETENTROPY) && !defined(sun) */
+#endif /* defined(HAVE_GETENTROPY) && !(defined(__sun) && defined(__SVR4)) */
 
 
 static struct {


### PR DESCRIPTION
Python source code uses on several places ifdef sun or defined(sun) without the underscores, which is not standard compliant and shouldn't be used.

Defines should check for __sun instead.  Reference: http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system#Solaris

<!-- issue-number: [bpo-35550](https://bugs.python.org/issue35550) -->
https://bugs.python.org/issue35550
<!-- /issue-number -->
