### PR TITLE
bpo-35552: Fix reading past the end in PyUnicode_FromFormat() and PyBytes_FromFormat().

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-21-13-29-30.bpo-35552.1DzQQc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-21-13-29-30.bpo-35552.1DzQQc.rst
@@ -1,0 +1,3 @@
+Format characters ``%s`` and ``%V`` in :c:func:`PyUnicode_FromFormat` and
+``%s`` in :c:func:`PyBytes_FromFormat` no longer read memory past the
+limit if *precision* is specified.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -312,9 +312,15 @@ PyBytes_FromFormatV(const char *format, va_list vargs)
             Py_ssize_t i;
 
             p = va_arg(vargs, const char*);
-            i = strlen(p);
-            if (prec > 0 && i > prec)
-                i = prec;
+            if (prec <= 0) {
+                i = strlen(p);
+            }
+            else {
+                i = 0;
+                while (i < prec && p[i]) {
+                    i++;
+                }
+            }
             s = _PyBytesWriter_WriteBytes(&writer, s, p, i);
             if (s == NULL)
                 goto error;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2578,9 +2578,15 @@ unicode_fromformat_write_cstr(_PyUnicodeWriter *writer, const char *str,
     PyObject *unicode;
     int res;
 
-    length = strlen(str);
-    if (precision != -1)
-        length = Py_MIN(length, precision);
+    if (precision == -1) {
+        length = strlen(str);
+    }
+    else {
+        length = 0;
+        while (length < precision && str[length]) {
+            length++;
+        }
+    }
     unicode = PyUnicode_DecodeUTF8Stateful(str, length, "replace", NULL);
     if (unicode == NULL)
         return -1;


### PR DESCRIPTION
Format characters "%s" and "%V" in PyUnicode_FromFormat() and "%s" in PyBytes_FromFormat()
no longer read memory past the limit if precision is specified.


<!-- issue-number: [bpo-35552](https://bugs.python.org/issue35552) -->
https://bugs.python.org/issue35552
<!-- /issue-number -->
