### PR TITLE
bpo-35514:  Enhanced the explanation on reference count details

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -271,9 +271,11 @@ borrowed reference.
 
 Conversely, when a calling function passes in a reference to an  object, there
 are two possibilities: the function *steals* a  reference to the object, or it
-does not.  *Stealing a reference* means that when you pass a reference to a
-function, that function assumes that it now owns that reference, and you are not
-responsible for it any longer.
+does not. If a called function decreases the reference count of an object, it
+is said to *steal* the ownership of the reference from its caller. *Stealing a
+reference* means that when you pass a reference to a stealing function, that
+function assumes that it now owns that reference, and you are not responsible
+for it any longer.
 
 .. index::
    single: PyList_SetItem()

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -251,17 +251,22 @@ they are done with the result; this soon becomes second nature.
 Reference Count Details
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The reference count behavior of functions in the Python/C API is best  explained
+The reference count behavior of functions in the Python/C API is best explained
 in terms of *ownership of references*.  Ownership pertains to references, never
 to objects (objects are not owned: they are always shared).  "Owning a
-reference" means being responsible for calling Py_DECREF on it when the
+reference" means being responsible for calling :c:func:`Py_DECREF` on it when the
 reference is no longer needed.  Ownership can also be transferred, meaning that
 the code that receives ownership of the reference then becomes responsible for
 eventually decref'ing it by calling :c:func:`Py_DECREF` or :c:func:`Py_XDECREF`
 when it's no longer needed---or passing on this responsibility (usually to its
-caller). When a function passes ownership of a reference on to its caller, the
-caller is said to receive a *new* reference.  When no ownership is transferred,
-the caller is said to *borrow* the reference. Nothing needs to be done for a
+caller). Let's look at different types of reference ownership passings in more
+detail.
+
+When a function returns an object and effectively increases the
+reference count of it, the function is said to *give* ownership of a new
+reference to its caller and the caller is said to *own* the reference. When a
+function returns an object without changing the reference count of it, the
+caller is said to *borrow* the reference. Nothing needs to be done for a
 borrowed reference.
 
 Conversely, when a calling function passes in a reference to an  object, there

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -269,8 +269,8 @@ function returns an object without changing the reference count of it, the
 caller is said to *borrow* the reference. Nothing needs to be done for a
 borrowed reference.
 
-Conversely, when a calling function passes in a reference to an  object, there
-are two possibilities: the function *steals* a  reference to the object, or it
+Conversely, when a calling function passes in a reference to an object, there
+are two possibilities: the function *steals* a reference to the object, or it
 does not. If a called function decreases the reference count of an object, it
 is said to *steal* the ownership of the reference from its caller. *Stealing a
 reference* means that when you pass a reference to a stealing function, that

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -259,23 +259,22 @@ reference is no longer needed.  Ownership can also be transferred, meaning that
 the code that receives ownership of the reference then becomes responsible for
 eventually decref'ing it by calling :c:func:`Py_DECREF` or :c:func:`Py_XDECREF`
 when it's no longer needed---or passing on this responsibility (usually to its
-caller). Let's look at different types of reference ownership passings in more
-detail.
+caller).
 
-When a function returns an object and effectively increases the
-reference count of it, the function is said to *give* ownership of a new
-reference to its caller and the caller is said to *own* the reference. When a
-function returns an object without changing the reference count of it, the
-caller is said to *borrow* the reference. Nothing needs to be done for a
-borrowed reference.
+When a function returns an object whose reference count has been increased by
+the function, the caller of the function is said to *receive a new reference*.
+It means the ownership of the reference is transferred to the caller.
+When a function returns an object without having changed its reference count,
+the caller of the function is said to *borrow* the reference. No ownership is
+transferred and nothing needs to be done for the borrowed reference.
 
 Conversely, when a calling function passes in a reference to an object, there
-are two possibilities: the function *steals* a reference to the object, or it
-does not. If a called function decreases the reference count of an object, it
-is said to *steal* the ownership of the reference from its caller. *Stealing a
-reference* means that when you pass a reference to a stealing function, that
-function assumes that it now owns that reference, and you are not responsible
-for it any longer.
+are two possibilities: the called function *steals* the reference,
+or it does not. *Stealing a reference* means that when you pass a reference
+to a stealing function, that function assumes that it now owns that reference,
+and you are not responsible for the reference any longer.
+Note that *stealing a reference* does not result in instant decrement in
+the reference count of the object in most cases.
 
 .. index::
    single: PyList_SetItem()
@@ -283,7 +282,7 @@ for it any longer.
 
 Few functions steal references; the two notable exceptions are
 :c:func:`PyList_SetItem` and :c:func:`PyTuple_SetItem`, which  steal a reference
-to the item (but not to the tuple or list into which the item is put!).  These
+to the item (but not to the tuple or list into which the item is put!). These
 functions were designed to steal a reference because of a common idiom for
 populating a tuple or list with newly created objects; for example, the code to
 create the tuple ``(1, 2, "three")`` could look like this (forgetting about

--- a/Misc/NEWS.d/next/Documentation/2018-12-21-22-46-16.bpo-35514.lj3s9s.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-12-21-22-46-16.bpo-35514.lj3s9s.rst
@@ -1,0 +1,1 @@
+Enhanced the explanation on reference count details


### PR DESCRIPTION
@birkenfeld 

When I read the reference count details section of the docs first time, I found it hard to grasp what transferring of ownership means concretely, which is an important and repeating concept throughout the docs. Some parts were confusing. For example,

> When a function passes ownership of a reference on to its caller, the
> caller is said to receive a new reference

This part seems to explain what is to receive a new reference, in terms of ownership passing. It may have had to do the opposite, which is to explain what a transferring of ownership is in terms of reference count changes because transferring of ownership is a high level concept and changing a reference count is a concrete operation. I fixed the documentation based on this idea.

<!-- issue-number: [bpo-35514](https://bugs.python.org/issue35514) -->
https://bugs.python.org/issue35514
<!-- /issue-number -->
