### PR TITLE
bpo-35557 - Allow base64.b16decode() to accept lowercase hexadecimal characters by default

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -241,9 +241,6 @@ def b32decode(s, casefold=False, map01=None):
     return bytes(decoded)
 
 
-# RFC 3548, Base 16 Alphabet specifies uppercase, but hexlify() returns
-# lowercase.  The RFC also recommends against accepting input case
-# insensitively.
 def b16encode(s):
     """Encode the bytes-like object s using Base16 and return a bytes object.
     """

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -252,10 +252,7 @@ def b16encode(s):
 
 def b16decode(s):
     """Decode the Base16 encoded bytes-like object or ASCII string s.
-
-    Optional casefold is a flag specifying whether a lowercase alphabet is
-    acceptable as input.  For security purposes, the default is False.
-
+    
     The result is returned as a bytes object.  A binascii.Error is raised if
     s is incorrectly padded or if there are non-alphabet characters present
     in the input.

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -250,7 +250,7 @@ def b16encode(s):
     return binascii.hexlify(s).upper()
 
 
-def b16decode(s, casefold=False):
+def b16decode(s):
     """Decode the Base16 encoded bytes-like object or ASCII string s.
 
     Optional casefold is a flag specifying whether a lowercase alphabet is
@@ -261,9 +261,7 @@ def b16decode(s, casefold=False):
     in the input.
     """
     s = _bytes_from_decode_data(s)
-    if casefold:
-        s = s.upper()
-    if re.search(b'[^0-9A-F]', s):
+    if re.search(b'[^0-9A-Fa-f]', s):
         raise binascii.Error('Non-base16 digit found')
     return binascii.unhexlify(s)
 

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -250,7 +250,7 @@ def b16encode(s):
 def b16decode(s):
     """Decode the Base16 encoded bytes-like object or ASCII string s.
     
-    The result is returned as a bytes object.  A binascii.Error is raised if
+    The result is returned as a bytes object. A binascii.Error is raised if
     s is incorrectly padded or if there are non-alphabet characters present
     in the input.
     """

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -249,7 +249,6 @@ def b16encode(s):
 
 def b16decode(s):
     """Decode the Base16 encoded bytes-like object or ASCII string s.
-    
     The result is returned as a bytes object. A binascii.Error is raised if
     s is incorrectly padded or if there are non-alphabet characters present
     in the input.

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -373,21 +373,15 @@ class BaseXYTestCase(unittest.TestCase):
         eq(base64.b16decode('0102ABCDEF'), b'\x01\x02\xab\xcd\xef')
         eq(base64.b16decode(b'00'), b'\x00')
         eq(base64.b16decode('00'), b'\x00')
-        # Lower case is not allowed without a flag
-        self.assertRaises(binascii.Error, base64.b16decode, b'0102abcdef')
-        self.assertRaises(binascii.Error, base64.b16decode, '0102abcdef')
-        # Case fold
-        eq(base64.b16decode(b'0102abcdef', True), b'\x01\x02\xab\xcd\xef')
-        eq(base64.b16decode('0102abcdef', True), b'\x01\x02\xab\xcd\xef')
         # Non-bytes
         self.check_other_types(base64.b16decode, b"0102ABCDEF",
                                b'\x01\x02\xab\xcd\xef')
         self.check_decode_type_errors(base64.b16decode)
-        eq(base64.b16decode(bytearray(b"0102abcdef"), True),
+        eq(base64.b16decode(bytearray(b"0102abcdef")),
            b'\x01\x02\xab\xcd\xef')
-        eq(base64.b16decode(memoryview(b"0102abcdef"), True),
+        eq(base64.b16decode(memoryview(b"0102abcdef")),
            b'\x01\x02\xab\xcd\xef')
-        eq(base64.b16decode(array('B', b"0102abcdef"), True),
+        eq(base64.b16decode(array('B', b"0102abcdef")),
            b'\x01\x02\xab\xcd\xef')
         # Non-alphabet characters
         self.assertRaises(binascii.Error, base64.b16decode, '0102AG')


### PR DESCRIPTION
Hello,

This pull request addresses the proposed changes in [issue 35557](https://bugs.python.org/issue35557). Namely, it refactors `base64.b16decode()` to accept both lowercase and uppercase hexadecimal strings without requiring the use of the `casefold` parameter. The motivating reasons for this change are outlined in the corresponding issue.

Specifically, the code changes to the two files are as follows:

1. Expand the regular expression matching string from `0-9A-F` to `0-9A-Fa-f`;

2. Remove the `casefold` argument, its default value, and the conditional check for its value within the method;

3. Remove the tests under `test_base64.py` which check the `casefold` conditional checking behavior (and only those tests!).

This change passes all other tests for `base64.py`. I also attached a file on the corresponding issue which demonstrates a ~9.4% performance improvement on decoding hexadecimal strings due to the removal of the `casefold` parameter.

<!-- issue-number: [bpo-35557](https://bugs.python.org/issue35557) -->
https://bugs.python.org/issue35557
<!-- /issue-number -->
