### PR TITLE
bpo-35559: Use compiled regex in base64.b16decode

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -30,6 +30,7 @@ __all__ = [
 
 
 bytes_types = (bytes, bytearray)  # Types acceptable as binary data
+_B16DECODE_PAT = re.compile(b'[^0-9A-F]')
 
 def _bytes_from_decode_data(s):
     if isinstance(s, str):
@@ -263,7 +264,7 @@ def b16decode(s, casefold=False):
     s = _bytes_from_decode_data(s)
     if casefold:
         s = s.upper()
-    if re.search(b'[^0-9A-F]', s):
+    if _B16DECODE_PAT.search(s):
         raise binascii.Error('Non-base16 digit found')
     return binascii.unhexlify(s)
 

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -30,7 +30,7 @@ __all__ = [
 
 
 bytes_types = (bytes, bytearray)  # Types acceptable as binary data
-_B16DECODE_PAT = re.compile(b'[^0-9A-F]')
+_has_non_base16_digits = re.compile(b'[^0-9A-F]').search
 
 def _bytes_from_decode_data(s):
     if isinstance(s, str):
@@ -264,7 +264,7 @@ def b16decode(s, casefold=False):
     s = _bytes_from_decode_data(s)
     if casefold:
         s = s.upper()
-    if _B16DECODE_PAT.search(s):
+    if _has_non_base16_digits(s):
         raise binascii.Error('Non-base16 digit found')
     return binascii.unhexlify(s)
 

--- a/Misc/NEWS.d/next/Library/2018-12-22-13-05-27.bpo-35559.RlGyr2.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-22-13-05-27.bpo-35559.RlGyr2.rst
@@ -1,0 +1,2 @@
+Use compiled regex in :func:`base64.b16decode` for validation.
+Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
Using a compiled regex instead of compiling it for every run improves performance. 

```
$ python3 -m perf compare_to default.json optimized.json --table
+--------------------+---------+------------------------------+
| Benchmark          | default | optimized                    |
+====================+=========+==============================+
| b16decode          | 2.97 us | 2.03 us: 1.46x faster (-32%) |
+--------------------+---------+------------------------------+
| b16decode_casefold | 3.18 us | 2.19 us: 1.45x faster (-31%) |
+--------------------+---------+------------------------------+
```

Benchmark script : 

```python
import perf
import re
import binascii
import base64

_B16DECODE_PAT = re.compile(b'[^0-9A-F]')

def b16decode_re_compiled_search(s, casefold=False):
    s = base64._bytes_from_decode_data(s)
    if casefold:
        s = s.upper()
    if _B16DECODE_PAT.search(s):
        raise binascii.Error('Non-base16 digit found')
    return binascii.unhexlify(s)

if __name__ == "__main__":
    hex_data = "806903d098eb50957b1b376385f233bb3a5d54f54191c8536aefee21fc9ba3ca"
    hex_data_upper = hex_data.upper()

    assert base64.b16decode(hex_data_upper) == b16decode_re_compiled_search(hex_data_upper)
    assert base64.b16decode(hex_data, casefold=True) == b16decode_re_compiled_search(hex_data, casefold=True)

    runner = perf.Runner()
    if True: # toggle to False for default.json
        runner.timeit(name="b16decode",
                      stmt="b16decode_re_compiled_search(hex_data_upper)",
                      setup="from __main__ import b16decode_re_compiled_search, hex_data, hex_data_upper")
        runner.timeit(name="b16decode_casefold",
                      stmt="b16decode_re_compiled_search(hex_data, casefold=True)",
                      setup="from __main__ import b16decode_re_compiled_search, hex_data, hex_data_upper")
    else:
        runner.timeit(name="b16decode",
                      stmt="base64.b16decode(hex_data_upper)",
                      setup="from __main__ import hex_data, hex_data_upper; import base64")
        runner.timeit(name="b16decode_casefold",
                      stmt="base64.b16decode(hex_data, casefold=True)",
                      setup="from __main__ import hex_data, hex_data_upper; import base64")
```

<!-- issue-number: [bpo-35559](https://bugs.python.org/issue35559) -->
https://bugs.python.org/issue35559
<!-- /issue-number -->
