### PR TITLE
bpo-35560: Remove incorrect assert statement that caused segfault in debug builds

### DIFF
--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -701,6 +701,12 @@ class FormatTestCase(unittest.TestCase):
         self.assertEqual(format(1234.56, '.4'), '1.235e+03')
         self.assertEqual(format(12345.6, '.4'), '1.235e+04')
 
+    def test_issue35560(self):
+        self.assertEqual(format(123.0, '00'), '123.0')
+        self.assertEqual(format(float(123), '00'), '123.0')
+        self.assertEqual("{0:00f}".format(float(123)), '123.000000')
+        self.assertEqual(f"{123:00f}", '123.000000')
+
 class ReprTestCase(unittest.TestCase):
     def test_repr(self):
         floats_file = open(os.path.join(os.path.split(__file__)[0],

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -703,9 +703,18 @@ class FormatTestCase(unittest.TestCase):
 
     def test_issue35560(self):
         self.assertEqual(format(123.0, '00'), '123.0')
-        self.assertEqual(format(float(123), '00'), '123.0')
-        self.assertEqual("{0:00f}".format(float(123)), '123.000000')
-        self.assertEqual(f"{123:00f}", '123.000000')
+        self.assertEqual(format(123.34, '00f'), '123.340000')
+        self.assertEqual(format(123.34, '00e'), '1.233400e+02')
+        self.assertEqual(format(123.340, '00g'), '123.34')
+        self.assertEqual(format(123.340, '00.10f'), '123.3400000000')
+        self.assertEqual(format(123.340, '0010f'), '123.340000')
+
+        self.assertEqual(format(-123.0, '00'), '-123.0')
+        self.assertEqual(format(-123.34, '00f'), '-123.340000')
+        self.assertEqual(format(-123.34, '00e'), '-1.233400e+02')
+        self.assertEqual(format(-123.340, '00g'), '-123.34')
+        self.assertEqual(format(-123.340, '00.10f'), '-123.3400000000')
+        self.assertEqual(format(-123.340, '0010f'), '-123.340000')
 
 class ReprTestCase(unittest.TestCase):
     def test_repr(self):

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -705,16 +705,20 @@ class FormatTestCase(unittest.TestCase):
         self.assertEqual(format(123.0, '00'), '123.0')
         self.assertEqual(format(123.34, '00f'), '123.340000')
         self.assertEqual(format(123.34, '00e'), '1.233400e+02')
-        self.assertEqual(format(123.340, '00g'), '123.34')
-        self.assertEqual(format(123.340, '00.10f'), '123.3400000000')
-        self.assertEqual(format(123.340, '0010f'), '123.340000')
+        self.assertEqual(format(123.34, '00g'), '123.34')
+        self.assertEqual(format(123.34, '00.10f'), '123.3400000000')
+        self.assertEqual(format(123.34, '00.10e'), '1.2334000000e+02')
+        self.assertEqual(format(123.34, '00.10g'), '123.34')
+        self.assertEqual(format(123.34, '01f'), '123.340000')
 
         self.assertEqual(format(-123.0, '00'), '-123.0')
         self.assertEqual(format(-123.34, '00f'), '-123.340000')
         self.assertEqual(format(-123.34, '00e'), '-1.233400e+02')
-        self.assertEqual(format(-123.340, '00g'), '-123.34')
-        self.assertEqual(format(-123.340, '00.10f'), '-123.3400000000')
-        self.assertEqual(format(-123.340, '0010f'), '-123.340000')
+        self.assertEqual(format(-123.34, '00g'), '-123.34')
+        self.assertEqual(format(-123.34, '00.10f'), '-123.3400000000')
+        self.assertEqual(format(-123.34, '00.10f'), '-123.3400000000')
+        self.assertEqual(format(-123.34, '00.10e'), '-1.2334000000e+02')
+        self.assertEqual(format(-123.34, '00.10g'), '-123.34')
 
 class ReprTestCase(unittest.TestCase):
     def test_repr(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-22-22-19-51.bpo-35560.9vMWSP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-22-22-19-51.bpo-35560.9vMWSP.rst
@@ -1,2 +1,3 @@
-Removed incorrect assert statement that caused segfault in debug builds.
-Patch by Karthikeyan Singaravelan.
+Removed an incorrect assert statement expecting `min_width`  >= 0 in
+`_PyUnicode_InsertThousandsGrouping` that caused segfault in :func:`format`
+in debug builds for certain cases. Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-22-22-19-51.bpo-35560.9vMWSP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-22-22-19-51.bpo-35560.9vMWSP.rst
@@ -1,3 +1,3 @@
-Removed an incorrect assert statement that caused segfault in :func:`format`
-in debug builds for floating point formatting with zero padding and small width.
-Patch by Karthikeyan Singaravelan.
+Fix an assertion error in :func:`format` in debug build for floating point
+formatting with "n" format, zero padding and small width. Release build is
+not impacted. Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-22-22-19-51.bpo-35560.9vMWSP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-22-22-19-51.bpo-35560.9vMWSP.rst
@@ -1,3 +1,3 @@
-Removed an incorrect assert statement expecting `min_width`  >= 0 in
-`_PyUnicode_InsertThousandsGrouping` that caused segfault in :func:`format`
-in debug builds for certain cases. Patch by Karthikeyan Singaravelan.
+Removed an incorrect assert statement that caused segfault in :func:`format`
+in debug builds for floating point formatting with zero padding and small width.
+Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-22-22-19-51.bpo-35560.9vMWSP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-22-22-19-51.bpo-35560.9vMWSP.rst
@@ -1,0 +1,2 @@
+Removed incorrect assert statement that caused segfault in debug builds.
+Patch by Karthikeyan Singaravelan.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9391,7 +9391,6 @@ _PyUnicode_InsertThousandsGrouping(
     }
     assert(0 <= d_pos);
     assert(0 <= n_digits);
-    assert(0 <= min_width);
     assert(grouping != NULL);
 
     if (digits != NULL) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9381,6 +9381,7 @@ _PyUnicode_InsertThousandsGrouping(
     PyObject *thousands_sep,
     Py_UCS4 *maxchar)
 {
+    min_width = Py_MAX(0, min_width);
     if (writer) {
         assert(digits != NULL);
         assert(maxchar == NULL);


### PR DESCRIPTION
* Removed assert statement checking for negative `min_width`. This caused segfault in debug builds for some format string in float. Reference for negative `min_width` : https://github.com/python/cpython/blob/59423e3ddd736387cef8f7632c71954c1859bed0/Python/formatter_unicode.c#L529
* Add tests from https://bugs.python.org/msg99839

<!-- issue-number: [bpo-35560](https://bugs.python.org/issue35560) -->
https://bugs.python.org/issue35560
<!-- /issue-number -->
