### PR TITLE
bpo-35566: Add links to annotation glossary term

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -51,9 +51,9 @@ Module-level decorators, classes, and functions
 
    The :func:`dataclass` decorator examines the class to find
    ``field``\s.  A ``field`` is defined as class variable that has a
-   type annotation.  With two exceptions described below, nothing in
-   :func:`dataclass` examines the type specified in the variable
-   annotation.
+   :term:`type annotation <variable annotation>`.  With two
+   exceptions described below, nothing in :func:`dataclass`
+   examines the type specified in the variable annotation.
 
    The order of the fields in all of the generated methods is the
    order in which they appear in the class definition.

--- a/Doc/library/pickletools.rst
+++ b/Doc/library/pickletools.rst
@@ -90,7 +90,7 @@ Programmatic Interface
    stream, are indented by *indentlevel* spaces.  If a nonzero value
    is given to *annotate*, each opcode in the output is annotated with
    a short description.  The value of *annotate* is used as a hint for
-   the column where :term:`annotation` should start.
+   the column where annotation should start.
 
    .. versionadded:: 3.2
       The *annotate* argument.

--- a/Doc/library/pickletools.rst
+++ b/Doc/library/pickletools.rst
@@ -90,7 +90,7 @@ Programmatic Interface
    stream, are indented by *indentlevel* spaces.  If a nonzero value
    is given to *annotate*, each opcode in the output is annotated with
    a short description.  The value of *annotate* is used as a hint for
-   the column where annotation should start.
+   the column where :term:`annotation` should start.
 
    .. versionadded:: 3.2
       The *annotate* argument.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -571,8 +571,8 @@ used keyword arguments.
    single: ->; function annotations
    single: : (colon); function annotations
 
-Parameters may have annotations of the form "``: expression``" following the
-parameter name.  Any parameter may have an annotation even those of the form
+Parameters may have an :term:`annotation <function annotation>` of the form "``: expression``"
+following the parameter name.  Any parameter may have an annotation, even those of the form
 ``*identifier`` or ``**identifier``.  Functions may have "return" annotation of
 the form "``-> expression``" after the parameter list.  These annotations can be
 any valid Python expression.  The presence of annotations does not change the

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -325,8 +325,8 @@ Annotated assignment statements
    single: statement; assignment, annotated
    single: : (colon); annotated variable
 
-Annotation assignment is the combination, in a single statement,
-of a variable or attribute annotation and an optional assignment statement:
+:term:`Annotation <variable annotation>` assignment is the combination, in a single
+statement, of a variable or attribute annotation and an optional assignment statement:
 
 .. productionlist::
    annotated_assignment_stmt: `augtarget` ":" `expression` ["=" `expression`]

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -682,10 +682,10 @@ Function Annotations
 information about the types used by user-defined functions (see :pep:`3107` and
 :pep:`484` for more information).
 
-Annotations are stored in the :attr:`__annotations__` attribute of the function
-as a dictionary and have no effect on any other part of the function.  Parameter
-annotations are defined by a colon after the parameter name, followed by an
-expression evaluating to the value of the annotation.  Return annotations are
+:term:`Annotations <function annotation>` are stored in the :attr:`__annotations__`
+attribute of the function as a dictionary and have no effect on any other part of the
+function.  Parameter annotations are defined by a colon after the parameter name, followed
+by an expression evaluating to the value of the annotation.  Return annotations are
 defined by a literal ``->``, followed by an expression, between the parameter
 list and the colon denoting the end of the :keyword:`def` statement.  The
 following example has a positional argument, a keyword argument, and the return


### PR DESCRIPTION


<!-- issue-number: [bpo-35566](https://bugs.python.org/issue35566) -->
https://bugs.python.org/issue35566
<!-- /issue-number -->
