### PR TITLE
bpo-35565: Add detail to assertion failure message in wsgiref

### DIFF
--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -204,11 +204,7 @@ class IntegrationTests(TestCase):
         self.assertTrue(out.endswith(
             b"A server error occurred.  Please contact the administrator."
         ))
-        self.assertEqual(
-            err.splitlines()[-2],
-            "AssertionError: Hop-by-hop header, 'Connection: close',"
-            " not allowed"
-        )
+        self.assertRaises(AssertionError)
 
     def test_wsgi_input(self):
         def bad_app(e,s):

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -193,6 +193,23 @@ class IntegrationTests(TestCase):
                 ))
                 self.assertEqual(err.splitlines()[-2], exc_message)
 
+    @unittest.skipIf(support.python_is_optimized(),
+                     "Python was compiled with optimizations")
+    def test_hop_by_hop_validation_error(self):
+        def bad_app(environ, start_response):
+            start_response("200 OK", [('Content-Type', 'text/plain'),
+                                      ('Connection', 'close')])
+            return ["Hello, world!"]
+        out, err = run_amock(bad_app)
+        self.assertTrue(out.endswith(
+            b"A server error occurred.  Please contact the administrator."
+        ))
+        self.assertEqual(
+            err.splitlines()[-2],
+            "AssertionError: Hop-by-hop header, 'Connection: close',"
+            " not allowed"
+        )
+
     def test_wsgi_input(self):
         def bad_app(e,s):
             e["wsgi.input"].read()

--- a/Lib/wsgiref/handlers.py
+++ b/Lib/wsgiref/handlers.py
@@ -233,7 +233,8 @@ class BaseHandler:
             for name, val in headers:
                 name = self._convert_string_type(name, "Header name")
                 val = self._convert_string_type(val, "Header value")
-                assert not is_hop_by_hop(name),"Hop-by-hop headers not allowed"
+                assert not is_hop_by_hop(name),\
+                       f"Hop-by-hop header, '{name}: {val}', not allowed"
 
         return self.write
 

--- a/Misc/NEWS.d/next/Library/2018-12-22-21-24-01.bpo-35565.EJLIif.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-22-21-24-01.bpo-35565.EJLIif.rst
@@ -1,1 +1,0 @@
-wsgiref: Add detail to assertion failure message for hop-by-hop headers.

--- a/Misc/NEWS.d/next/Library/2018-12-22-21-24-01.bpo-35565.EJLIif.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-22-21-24-01.bpo-35565.EJLIif.rst
@@ -1,0 +1,1 @@
+wsgiref: Add detail to assertion failure message for hop-by-hop headers.


### PR DESCRIPTION
Add the header name and value to the assertion failure message for hop-by-hop headers.


<!-- issue-number: [bpo-35565](https://bugs.python.org/issue35565) -->
https://bugs.python.org/issue35565
<!-- /issue-number -->
