### PR TITLE
bpo-NNNN:  Trivial change. Enhance the flexibility of calling functions. 

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3792,6 +3792,7 @@ _PyEval_EvalCodeWithName(PyObject *_co, PyObject *globals, PyObject *locals,
             }
         }
 
+		/*
         assert(j >= total_args);
         if (kwdict == NULL) {
             PyErr_Format(PyExc_TypeError,
@@ -3799,8 +3800,9 @@ _PyEval_EvalCodeWithName(PyObject *_co, PyObject *globals, PyObject *locals,
                          co->co_name, keyword);
             goto fail;
         }
+		*/
 
-        if (PyDict_SetItem(kwdict, keyword, value) == -1) {
+        if (kwdict && PyDict_SetItem(kwdict, keyword, value) == -1) {
             goto fail;
         }
         continue;


### PR DESCRIPTION
--------------
Modification: When function arguments are passed in the form of keyword, they are thought valid as long as all the callee's needed args exist. If extra args exist, no error would be raised. This would increases the flexibility of Python and  bring more freedom.
For example:

def f(x, y):
        print(x, y)

def call_f():
        f(x = 7, y = 9, z = 9)

Before, the extra argument 'z' would be thought as invalid and the python interpreter would raise an exception.
Now, no error would be raised because all the args that function 'f' needs, which are 'x' and 'y', are completely provided and 'f' can rightly do its job. It is not very reasonable to stop the interpreter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
