### PR TITLE
bpo-35567: Convert dict of constants to a set

### DIFF
--- a/Lib/wsgiref/util.py
+++ b/Lib/wsgiref/util.py
@@ -162,9 +162,9 @@ def setup_testing_defaults(environ):
 
 
 _hoppish = {
-    'connection':1, 'keep-alive':1, 'proxy-authenticate':1,
-    'proxy-authorization':1, 'te':1, 'trailers':1, 'transfer-encoding':1,
-    'upgrade':1
+    'connection', 'keep-alive', 'proxy-authenticate',
+    'proxy-authorization', 'te', 'trailers', 'transfer-encoding',
+    'upgrade'
 }.__contains__
 
 def is_hop_by_hop(header_name):


### PR DESCRIPTION
* Dictionary ``_hoppish`` is used to check if the header name exists, but only the key is used and not the value.  This converts it to a set.
* Tests already exist for the function that uses ``_hoppish`` and they still pass after the change.

<!-- issue-number: [bpo-35567](https://bugs.python.org/issue35567) -->
https://bugs.python.org/issue35567
<!-- /issue-number -->
