### PR TITLE
bpo-13927: time.ctime and time.asctime return string explantion

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -131,8 +131,8 @@ Functions
    and is space padded if the day is a single digit,
    e.g.: ``'Wed Jun  9 04:26:40 1993'``.
 
-   If *t* is not provided, the current time as returned by
-   :func:`localtime` is used. Locale information is not used by :func:`asctime`.
+   If *t* is not provided, the current time as returned by :func:`localtime`
+   is used. Locale information is not used by :func:`asctime`.
 
    .. note::
 
@@ -211,10 +211,10 @@ Functions
    is two characters long and is space padded if the day is a single digit,
    e.g.: ``'Wed Jun  9 04:26:40 1993'``.
 
-   If *secs* is not provided or
-   :const:`None`, the current time as returned by :func:`.time` is used.
-   ``ctime(secs)`` is equivalent to ``asctime(localtime(secs))``.
-   Locale information is not used by :func:`ctime`.
+   If *secs* is not provided or :const:`None`, the current time as
+   returned by :func:`.time` is used. ``ctime(secs)`` is equivalent to
+   ``asctime(localtime(secs))``. Locale information is not used by
+   :func:`ctime`.
 
 
 .. function:: get_clock_info(name)

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -127,13 +127,15 @@ Functions
 
    Convert a tuple or :class:`struct_time` representing a time as returned by
    :func:`gmtime` or :func:`localtime` to a string of the following
-   form: ``'Sun Jun 20 23:21:05 1993'``.  If *t* is not provided, the current time
-   as returned by :func:`localtime` is used. Locale information is not used by
-   :func:`asctime`.
+   form: ``'Sun Jun 20 23:21:05 1993'``. The day field is two characters long
+   and is space padded if the day is a single digit,
+   e.g.: ``'Wed Jun  9 04:26:40 1993'``.
+
+   If *t* is not provided, the current time as returned by
+   :func:`localtime` is used. Locale information is not used by :func:`asctime`.
 
    .. note::
 
-      The date field is two characters long, and is space padded.
       Unlike the C function of the same name, :func:`asctime` does not add a
       trailing newline.
 
@@ -204,14 +206,15 @@ Functions
 
 .. function:: ctime([secs])
 
-   Convert a time expressed in seconds since the epoch to a string representing
-   local time. If *secs* is not provided or :const:`None`, the current time as
-   returned by :func:`.time` is used.  ``ctime(secs)`` is equivalent to
-   ``asctime(localtime(secs))``. Locale information is not used by :func:`ctime`.
+   Convert a time expressed in seconds since the epoch to a string of a form:
+   ``'Sun Jun 20 23:21:05 1993'`` representing local time. The day field
+   is two characters long and is space padded if the day is a single digit,
+   e.g.: ``'Wed Jun  9 04:26:40 1993'``.
 
-   .. note::
-
-      The date field is two characters long, and is space padded. E.g. - 'Thu Jan  8 19:15:21 1970'
+   If *secs* is not provided or
+   :const:`None`, the current time as returned by :func:`.time` is used. 
+   ``ctime(secs)`` is equivalent to ``asctime(localtime(secs))``.
+   Locale information is not used by :func:`ctime`.
 
 
 .. function:: get_clock_info(name)

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -133,6 +133,7 @@ Functions
 
    .. note::
 
+      The date field is two characters long, and is space padded.
       Unlike the C function of the same name, :func:`asctime` does not add a
       trailing newline.
 
@@ -207,6 +208,18 @@ Functions
    local time. If *secs* is not provided or :const:`None`, the current time as
    returned by :func:`.time` is used.  ``ctime(secs)`` is equivalent to
    ``asctime(localtime(secs))``. Locale information is not used by :func:`ctime`.
+
+   .. note::
+
+      The date field is two characters long, and is space padded.
+
+   For example:
+
+      >>> import time
+      >>> time.ctime()
+      'Mon Dec 24 13:06:10 2018'
+      >>> time.ctime(654321)
+      'Thu Jan  8 19:15:21 1970'
 
 
 .. function:: get_clock_info(name)

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -212,7 +212,7 @@ Functions
    e.g.: ``'Wed Jun  9 04:26:40 1993'``.
 
    If *secs* is not provided or
-   :const:`None`, the current time as returned by :func:`.time` is used. 
+   :const:`None`, the current time as returned by :func:`.time` is used.
    ``ctime(secs)`` is equivalent to ``asctime(localtime(secs))``.
    Locale information is not used by :func:`ctime`.
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -211,15 +211,7 @@ Functions
 
    .. note::
 
-      The date field is two characters long, and is space padded.
-
-   For example:
-
-      >>> import time
-      >>> time.ctime(1545642769)
-      'Mon Dec 24 14:42:49 2018'
-      >>> time.ctime(654321)
-      'Thu Jan  8 19:15:21 1970'
+      The date field is two characters long, and is space padded. E.g. - 'Thu Jan  8 19:15:21 1970'
 
 
 .. function:: get_clock_info(name)

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -216,8 +216,8 @@ Functions
    For example:
 
       >>> import time
-      >>> time.ctime()
-      'Mon Dec 24 13:06:10 2018'
+      >>> time.ctime(1545642769)
+      'Mon Dec 24 14:42:49 2018'
       >>> time.ctime(654321)
       'Thu Jan  8 19:15:21 1970'
 


### PR DESCRIPTION
* Add note explaining that time.ctime and time.asctime returns a space padded date value in case it contains a single digit date
* Add example in date.ctime

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-13927](https://bugs.python.org/issue13927) -->
https://bugs.python.org/issue13927
<!-- /issue-number -->
