### PR TITLE
Doc: Be explicit that Pathlib resolve was strict before 3.6.

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -976,7 +976,7 @@ call fails (for example because the path doesn't exist).
    is raised.
 
    .. versionadded:: 3.6
-      The *strict* argument.
+      The *strict* argument (pre-3.6 behavior is strict).
 
 .. method:: Path.rglob(pattern)
 


### PR DESCRIPTION
From: https://mail.python.org/pipermail/docs/2018-December/038529.html

Not sure about the wording, can a native-english proofread this? :)