### PR TITLE
bpo-35579: Fix typo in in asyncio-task documentation

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -610,7 +610,7 @@ Scheduling From Other Threads
    See the :ref:`concurrency and multithreading <asyncio-multithreading>`
    section of the documentation.
 
-   Unlike other asyncio functions this functions requires the *loop*
+   Unlike other asyncio functions this function requires the *loop*
    argument to be passed explicitly.
 
    .. versionadded:: 3.5.1


### PR DESCRIPTION
https://bugs.python.org/issue35579

<!-- issue-number: [bpo-35579](https://bugs.python.org/issue35579) -->
https://bugs.python.org/issue35579
<!-- /issue-number -->
