### PR TITLE
bpo-35588: Speed up mod, divmod and floordiv operations for Fraction type

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -436,13 +436,9 @@ class Fraction(numbers.Rational):
 
     def _divmod(a, b):
         """(a // b, a % b)"""
-        # div = a // b
         da, db = a.denominator, b.denominator
-        n_div, d_div = a.numerator * db, da * b.numerator
-        div = n_div // d_div
-        # mod = a - b * div == (na*db - da*nb * div) / (da*db)
-        n_mod, d_mod = n_div - d_div * div, da * db
-        return div, Fraction(n_mod, d_mod)
+        div, n_mod = divmod(a.numerator * db, da * b.numerator)
+        return div, Fraction(n_mod, da * db)
 
     __divmod__, __rdivmod__ = _operator_fallbacks(_divmod, divmod)
 

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -440,7 +440,7 @@ class Fraction(numbers.Rational):
 
     def _floordiv(a, b):
         """a // b"""
-        return math.floor(a / b)
+        return (a.numerator * b.denominator) // (a.denominator * b.numerator)
 
     __floordiv__, __rfloordiv__ = _operator_fallbacks(_floordiv, operator.floordiv)
 

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -35,7 +35,6 @@ def _gcd(a, b):
         a, b = b, a%b
     return a
 
-
 # Constants related to the hash implementation;  hash(x) is based
 # on the reduction of x modulo the prime _PyHASH_MODULUS.
 _PyHASH_MODULUS = sys.hash_info.modulus

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -42,7 +42,7 @@ def _flat_divmod(na, da, nb, db):
     n_div, d_div = na * db, da * nb
     div = n_div // d_div
     # mod = a - b * div == (na*db - da*nb * div) / (da*db)
-    n_mod, d_mod = n_div - d_div * div, da*db
+    n_mod, d_mod = n_div - d_div * div, da * db
     return div, n_mod, d_mod
 
 

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -36,16 +36,6 @@ def _gcd(a, b):
     return a
 
 
-def _flat_divmod(na, da, nb, db):
-    """(a // b, a % b)"""
-    # div = a // b
-    n_div, d_div = na * db, da * nb
-    div = n_div // d_div
-    # mod = a - b * div == (na*db - da*nb * div) / (da*db)
-    n_mod, d_mod = n_div - d_div * div, da * db
-    return div, n_mod, d_mod
-
-
 # Constants related to the hash implementation;  hash(x) is based
 # on the reduction of x modulo the prime _PyHASH_MODULUS.
 _PyHASH_MODULUS = sys.hash_info.modulus
@@ -446,17 +436,20 @@ class Fraction(numbers.Rational):
 
     def _divmod(a, b):
         """(a // b, a % b)"""
-        div, n_mod, d_mod = _flat_divmod(
-            a.numerator, a.denominator, b.numerator, b.denominator)
+        # div = a // b
+        da, db = a.denominator, b.denominator
+        n_div, d_div = a.numerator * db, da * b.numerator
+        div = n_div // d_div
+        # mod = a - b * div == (na*db - da*nb * div) / (da*db)
+        n_mod, d_mod = n_div - d_div * div, da * db
         return div, Fraction(n_mod, d_mod)
 
     __divmod__, __rdivmod__ = _operator_fallbacks(_divmod, divmod)
 
     def _mod(a, b):
         """a % b"""
-        _, n_mod, d_mod = _flat_divmod(
-            a.numerator, a.denominator, b.numerator, b.denominator)
-        return Fraction(n_mod, d_mod)
+        da, db = a.denominator, b.denominator
+        return Fraction((a.numerator * db) % (b.numerator * da), da * db)
 
     __mod__, __rmod__ = _operator_fallbacks(_mod, operator.mod)
 

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -35,6 +35,17 @@ def _gcd(a, b):
         a, b = b, a%b
     return a
 
+
+def _flat_divmod(na, da, nb, db):
+    """(a // b, a % b)"""
+    # div = a // b
+    n_div, d_div = na * db, da * nb
+    div = n_div // d_div
+    # mod = a - b * div == (na*db - da*nb * div) / (da*db)
+    n_mod, d_mod = n_div - d_div * div, da*db
+    return div, n_mod, d_mod
+
+
 # Constants related to the hash implementation;  hash(x) is based
 # on the reduction of x modulo the prime _PyHASH_MODULUS.
 _PyHASH_MODULUS = sys.hash_info.modulus
@@ -433,10 +444,19 @@ class Fraction(numbers.Rational):
 
     __floordiv__, __rfloordiv__ = _operator_fallbacks(_floordiv, operator.floordiv)
 
+    def _divmod(a, b):
+        """(a // b, a % b)"""
+        div, n_mod, d_mod = _flat_divmod(
+            a.numerator, a.denominator, b.numerator, b.denominator)
+        return Fraction(div), Fraction(n_mod, d_mod)
+
+    __divmod__, __rdivmod__ = _operator_fallbacks(_divmod, divmod)
+
     def _mod(a, b):
         """a % b"""
-        div = a // b
-        return a - b * div
+        _, n_mod, d_mod = _flat_divmod(
+            a.numerator, a.denominator, b.numerator, b.denominator)
+        return Fraction(n_mod, d_mod)
 
     __mod__, __rmod__ = _operator_fallbacks(_mod, operator.mod)
 

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -448,7 +448,7 @@ class Fraction(numbers.Rational):
         """(a // b, a % b)"""
         div, n_mod, d_mod = _flat_divmod(
             a.numerator, a.denominator, b.numerator, b.denominator)
-        return Fraction(div), Fraction(n_mod, d_mod)
+        return div, Fraction(n_mod, d_mod)
 
     __divmod__, __rdivmod__ = _operator_fallbacks(_divmod, divmod)
 

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -119,9 +119,8 @@ class FractionTest(unittest.TestCase):
 
     def assertTypedTupleEquals(self, expected, actual):
         """Asserts that both the types and values in the tuples are the same."""
-        self.assertIsInstance(actual, tuple)
-        self.assertEqual(list(map(type, expected)), list(map(type, actual)))
-        self.assertEqual(expected, actual)
+        self.assertTupleEqual(expected, actual)
+        self.assertListEqual(list(map(type, expected)), list(map(type, actual)))
 
     def assertRaisesMessage(self, exc_type, message,
                             callable, *args, **kwargs):

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -380,6 +380,40 @@ class FractionTest(unittest.TestCase):
         self.assertEqual(p.numerator, 4)
         self.assertEqual(p.denominator, 1)
 
+    def testLargeArithmetic(self):
+        self.assertTypedEquals(
+            F(10101010100808080808080808101010101010000000000000000,
+              1010101010101010101010101011111111101010101010101010101010101),
+            F(10**35+1, 10**27+1) % F(10**27+1, 10**35-1)
+        )
+        self.assertTypedEquals(
+            F(7, 1901475900342344102245054808064),
+            F(-2**100, 3) % F(5, 2**100)
+        )
+        self.assertTypedTupleEquals(
+            (9999999999999999,
+             F(10101010100808080808080808101010101010000000000000000,
+               1010101010101010101010101011111111101010101010101010101010101)),
+            divmod(F(10**35+1, 10**27+1), F(10**27+1, 10**35-1))
+        )
+        self.assertTypedEquals(
+            -2 ** 200 // 15,
+            F(-2**100, 3) // F(5, 2**100)
+        )
+        self.assertTypedEquals(
+            1,
+            F(5, 2**100) // F(3, 2**100)
+        )
+        self.assertTypedEquals(
+            (1, F(2, 2**100)),
+            divmod(F(5, 2**100), F(3, 2**100))
+        )
+        self.assertTypedTupleEquals(
+            (-2 ** 200 // 15,
+             F(7, 1901475900342344102245054808064)),
+            divmod(F(-2**100, 3), F(5, 2**100))
+        )
+
     def testMixedArithmetic(self):
         self.assertTypedEquals(F(11, 10), F(1, 10) + 1)
         self.assertTypedEquals(1.1, F(1, 10) + 1.0)

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -117,6 +117,12 @@ class FractionTest(unittest.TestCase):
         self.assertEqual(type(expected), type(actual))
         self.assertEqual(expected, actual)
 
+    def assertTypedTupleEquals(self, expected, actual):
+        """Asserts that both the types and values in the tuples are the same."""
+        self.assertIsInstance(actual, tuple)
+        self.assertEqual(list(map(type, expected)), list(map(type, actual)))
+        self.assertEqual(expected, actual)
+
     def assertRaisesMessage(self, exc_type, message,
                             callable, *args, **kwargs):
         """Asserts that callable(*args, **kwargs) raises exc_type(message)."""
@@ -349,7 +355,10 @@ class FractionTest(unittest.TestCase):
         self.assertEqual(F(1, 4), F(1, 10) / F(2, 5))
         self.assertTypedEquals(2, F(9, 10) // F(2, 5))
         self.assertTypedEquals(10**23, F(10**23, 1) // F(1))
+        self.assertEqual(F(5, 6), F(7, 3) % F(3, 2))
         self.assertEqual(F(2, 3), F(-7, 3) % F(3, 2))
+        self.assertEqual((F(1), F(5, 6)), divmod(F(7, 3), F(3, 2)))
+        self.assertEqual((F(-2), F(2, 3)), divmod(F(-7, 3), F(3, 2)))
         self.assertEqual(F(8, 27), F(2, 3) ** F(3))
         self.assertEqual(F(27, 8), F(2, 3) ** F(-3))
         self.assertTypedEquals(2.0, F(4) ** F(1, 2))
@@ -415,7 +424,14 @@ class FractionTest(unittest.TestCase):
         self.assertTypedEquals(float('inf'), F(-1, 10) % float('inf'))
         self.assertTypedEquals(-0.1, F(-1, 10) % float('-inf'))
 
-        # No need for divmod since we don't override it.
+        self.assertTypedTupleEquals((F(0), F(1, 10)), divmod(F(1, 10), 1))
+        self.assertTypedTupleEquals(divmod(0.1, 1.0), divmod(F(1, 10), 1.0))
+        self.assertTypedTupleEquals((F(10, 1), F(0)), divmod(1, F(1, 10)))
+        self.assertTypedTupleEquals(divmod(1.0, 0.1), divmod(1.0, F(1, 10)))
+        self.assertTypedTupleEquals(divmod(0.1, float('inf')), divmod(F(1, 10), float('inf')))
+        self.assertTypedTupleEquals(divmod(0.1, float('-inf')), divmod(F(1, 10), float('-inf')))
+        self.assertTypedTupleEquals(divmod(-0.1, float('inf')), divmod(F(-1, 10), float('inf')))
+        self.assertTypedTupleEquals(divmod(-0.1, float('-inf')), divmod(F(-1, 10), float('-inf')))
 
         # ** has more interesting conversion rules.
         self.assertTypedEquals(F(100, 1), F(1, 10) ** -2)

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -424,9 +424,9 @@ class FractionTest(unittest.TestCase):
         self.assertTypedEquals(float('inf'), F(-1, 10) % float('inf'))
         self.assertTypedEquals(-0.1, F(-1, 10) % float('-inf'))
 
-        self.assertTypedTupleEquals((F(0), F(1, 10)), divmod(F(1, 10), 1))
+        self.assertTypedTupleEquals((0, F(1, 10)), divmod(F(1, 10), 1))
         self.assertTypedTupleEquals(divmod(0.1, 1.0), divmod(F(1, 10), 1.0))
-        self.assertTypedTupleEquals((F(10, 1), F(0)), divmod(1, F(1, 10)))
+        self.assertTypedTupleEquals((10, F(0)), divmod(1, F(1, 10)))
         self.assertTypedTupleEquals(divmod(1.0, 0.1), divmod(1.0, F(1, 10)))
         self.assertTypedTupleEquals(divmod(0.1, float('inf')), divmod(F(1, 10), float('inf')))
         self.assertTypedTupleEquals(divmod(0.1, float('-inf')), divmod(F(1, 10), float('-inf')))

--- a/Misc/NEWS.d/next/Library/2018-12-26-10-55-59.bpo-35588.PSR6Ez.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-26-10-55-59.bpo-35588.PSR6Ez.rst
@@ -1,0 +1,2 @@
+Mod and divmod operations on :class:`fractions.Fraction` types are 2-3x faster.
+Patch by Stefan Behnel.

--- a/Misc/NEWS.d/next/Library/2018-12-26-10-55-59.bpo-35588.PSR6Ez.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-26-10-55-59.bpo-35588.PSR6Ez.rst
@@ -1,2 +1,2 @@
-Mod, divmod and floordiv operations on :class:`fractions.Fraction` types are 2-4x faster.
+ The floor division and modulo operations and the :func:`divmod` function on :class:`fractions.Fraction` types are 2--4x faster.
 Patch by Stefan Behnel.

--- a/Misc/NEWS.d/next/Library/2018-12-26-10-55-59.bpo-35588.PSR6Ez.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-26-10-55-59.bpo-35588.PSR6Ez.rst
@@ -1,2 +1,2 @@
- The floor division and modulo operations and the :func:`divmod` function on :class:`fractions.Fraction` types are 2--4x faster.
+The floor division and modulo operations and the :func:`divmod` function on :class:`fractions.Fraction` types are 2--4x faster.
 Patch by Stefan Behnel.

--- a/Misc/NEWS.d/next/Library/2018-12-26-10-55-59.bpo-35588.PSR6Ez.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-26-10-55-59.bpo-35588.PSR6Ez.rst
@@ -1,2 +1,2 @@
-Mod and divmod operations on :class:`fractions.Fraction` types are 2-3x faster.
+Mod, divmod and floordiv operations on :class:`fractions.Fraction` types are 2-4x faster.
 Patch by Stefan Behnel.


### PR DESCRIPTION
Implement mod and divmod operations for Fraction type by spelling out the numerator/denominator calculation, instead of instantiating and normalising Fractions along the way. This speeds up '%' and divmod() by 2-3x.

<!-- issue-number: [bpo-35588](https://bugs.python.org/issue35588) -->
https://bugs.python.org/issue35588
<!-- /issue-number -->
