### PR TITLE
bpo-35593: Update webbrowser.py

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -518,7 +518,7 @@ def register_standard_browsers():
         # Detect some common Windows browsers, fallback to IE
         iexplore = os.path.join(os.environ.get("PROGRAMFILES", "C:\\Program Files"),
                                 "Internet Explorer\\IEXPLORE.EXE")
-        for browser in ("firefox", "firebird", "seamonkey", "mozilla",
+        for browser in ("firefox", "firebird", "seamonkey", "mozilla", "chrome"
                         "netscape", "opera", iexplore):
             if shutil.which(browser):
                 register(browser, None, BackgroundBrowser(browser))


### PR DESCRIPTION
# Register the Chrome Browser in the Windows Platform

Chrome is my favorite web browser, and I want to use it in Windows. Why do not register this browser in the `register_standard_browsers` function? Isn't it "standard"?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35593](https://bugs.python.org/issue35593) -->
https://bugs.python.org/issue35593
<!-- /issue-number -->
