### PR TITLE
bpo-35596: Fix vcruntime140.dll being added to embeddable distro multiple times.

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-12-28-07-25-47.bpo-35596.P9CEY2.rst
+++ b/Misc/NEWS.d/next/Windows/2018-12-28-07-25-47.bpo-35596.P9CEY2.rst
@@ -1,0 +1,1 @@
+Fix vcruntime140.dll being added to embeddable distro multiple times.

--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -46,7 +46,7 @@ TCLTK_FILES_ONLY = FileNameSet("turtle.py")
 
 VENV_DIRS_ONLY = FileNameSet("venv", "ensurepip")
 
-EXCLUDE_FROM_PYDS = FileStemSet("python*", "pyshellext")
+EXCLUDE_FROM_PYDS = FileStemSet("python*", "pyshellext", "vcruntime*")
 EXCLUDE_FROM_LIB = FileNameSet("*.pyc", "__pycache__", "*.pickle")
 EXCLUDE_FROM_PACKAGED_LIB = FileNameSet("readme.txt")
 EXCLUDE_FROM_COMPILE = FileNameSet("badsyntax_*", "bad_*")


### PR DESCRIPTION


<!-- issue-number: [bpo-35596](https://bugs.python.org/issue35596) -->
https://bugs.python.org/issue35596
<!-- /issue-number -->
