### PR TITLE
bpo-35598: IDLE: Update config_key.py with PEP8 names

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -2,6 +2,7 @@ What's New in IDLE 3.8.0 (since 3.7.0)
 Released on 2019-10-20?
 ======================================
 
+bpo-35598: Improve config_key with PEP8 names.
 
 bpo-35208: Squeezer now counts wrapped lines before newlines.
 

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -2,7 +2,6 @@ What's New in IDLE 3.8.0 (since 3.7.0)
 Released on 2019-10-20?
 ======================================
 
-bpo-35598: Improve config_key with PEP8 names.
 
 bpo-35208: Squeezer now counts wrapped lines before newlines.
 

--- a/Lib/idlelib/config_key.py
+++ b/Lib/idlelib/config_key.py
@@ -234,7 +234,7 @@ class GetKeysDialog(Toplevel):
         self.move_keys = ('Home', 'End', 'Page Up', 'Page Down', 'Left Arrow',
                           'Right Arrow', 'Up Arrow', 'Down Arrow')
         # Make a tuple of most of the useful common 'final' keys.
-        keys = (self.alphanum_keys + self.punctuation_keys + self.function_keys + 
+        keys = (self.alphanum_keys + self.punctuation_keys + self.function_keys +
                 self.whitespace_keys + self.edit_keys + self.move_keys)
         self.list_keys_final.insert(END, *keys)
 

--- a/Lib/idlelib/config_key.py
+++ b/Lib/idlelib/config_key.py
@@ -39,7 +39,8 @@ class GetKeysDialog(Toplevel):
         self.result = ''
         self.key_string = StringVar(self)
         self.key_string.set('')
-        self.set_modifiers_for_platform()  # Set self.modifiers, self.modifier_label
+        # Set self.modifiers, self.modifier_label.
+        self.set_modifiers_for_platform()
         self.modifier_vars = []
         for modifier in self.modifiers:
             variable = StringVar(self)

--- a/Lib/idlelib/config_key.py
+++ b/Lib/idlelib/config_key.py
@@ -13,39 +13,41 @@ class GetKeysDialog(Toplevel):
     # Dialog title for invalid key sequence
     keyerror_title = 'Key Sequence Error'
 
-    def __init__(self, parent, title, action, currentKeySequences,
+    def __init__(self, parent, title, action, current_key_sequences,
                  *, _htest=False, _utest=False):
         """
+        parent - parent of this dialog
+        title - string which is the title of the popup dialog
         action - string, the name of the virtual event these keys will be
                  mapped to
-        currentKeys - list, a list of all key sequence lists currently mapped
-                 to virtual events, for overlap checking
-        _utest - bool, do not wait when running unittest
+        current_key_sequences - list, a list of all key sequence lists
+                 currently mapped to virtual events, for overlap checking
         _htest - bool, change box location when running htest
+        _utest - bool, do not wait when running unittest
         """
         Toplevel.__init__(self, parent)
-        self.withdraw() #hide while setting geometry
+        self.withdraw()  # Hide while setting geometry.
         self.configure(borderwidth=5)
-        self.resizable(height=FALSE, width=FALSE)
+        self.resizable(height=False, width=False)
         self.title(title)
         self.transient(parent)
         self.grab_set()
-        self.protocol("WM_DELETE_WINDOW", self.Cancel)
+        self.protocol("WM_DELETE_WINDOW", self.cancel)
         self.parent = parent
-        self.action=action
-        self.currentKeySequences = currentKeySequences
+        self.action = action
+        self.current_key_sequences = current_key_sequences
         self.result = ''
-        self.keyString = StringVar(self)
-        self.keyString.set('')
-        self.SetModifiersForPlatform() # set self.modifiers, self.modifier_label
+        self.key_string = StringVar(self)
+        self.key_string.set('')
+        self.set_modifiers_for_platform()  # Set self.modifiers, self.modifier_label
         self.modifier_vars = []
         for modifier in self.modifiers:
             variable = StringVar(self)
             variable.set('')
             self.modifier_vars.append(variable)
         self.advanced = False
-        self.CreateWidgets()
-        self.LoadFinalKeyList()
+        self.create_widgets()
+        self.load_final_key_list()
         self.update_idletasks()
         self.geometry(
                 "+%d+%d" % (
@@ -54,83 +56,99 @@ class GetKeysDialog(Toplevel):
                     parent.winfo_rooty() +
                     ((parent.winfo_height()/2 - self.winfo_reqheight()/2)
                     if not _htest else 150)
-                ) )  #centre dialog over parent (or below htest box)
+                ) )  # Center dialog over parent (or below htest box).
         if not _utest:
-            self.deiconify() #geometry set, unhide
+            self.deiconify()  # Geometry set, unhide.
             self.wait_window()
 
     def showerror(self, *args, **kwargs):
         # Make testing easier.  Replace in #30751.
         messagebox.showerror(*args, **kwargs)
 
-    def CreateWidgets(self):
-        frameMain = Frame(self,borderwidth=2,relief=SUNKEN)
-        frameMain.pack(side=TOP,expand=TRUE,fill=BOTH)
-        frameButtons=Frame(self)
-        frameButtons.pack(side=BOTTOM,fill=X)
-        self.buttonOK = Button(frameButtons,text='OK',
-                width=8,command=self.OK)
-        self.buttonOK.grid(row=0,column=0,padx=5,pady=5)
-        self.buttonCancel = Button(frameButtons,text='Cancel',
-                width=8,command=self.Cancel)
-        self.buttonCancel.grid(row=0,column=1,padx=5,pady=5)
-        self.frameKeySeqBasic = Frame(frameMain)
-        self.frameKeySeqAdvanced = Frame(frameMain)
-        self.frameControlsBasic = Frame(frameMain)
-        self.frameHelpAdvanced = Frame(frameMain)
-        self.frameKeySeqAdvanced.grid(row=0,column=0,sticky=NSEW,padx=5,pady=5)
-        self.frameKeySeqBasic.grid(row=0,column=0,sticky=NSEW,padx=5,pady=5)
-        self.frameKeySeqBasic.lift()
-        self.frameHelpAdvanced.grid(row=1,column=0,sticky=NSEW,padx=5)
-        self.frameControlsBasic.grid(row=1,column=0,sticky=NSEW,padx=5)
-        self.frameControlsBasic.lift()
-        self.buttonLevel = Button(frameMain,command=self.ToggleLevel,
-                text='Advanced Key Binding Entry >>')
-        self.buttonLevel.grid(row=2,column=0,stick=EW,padx=5,pady=5)
-        labelTitleBasic = Label(self.frameKeySeqBasic,
-                text="New keys for  '"+self.action+"' :")
-        labelTitleBasic.pack(anchor=W)
-        labelKeysBasic = Label(self.frameKeySeqBasic,justify=LEFT,
-                textvariable=self.keyString,relief=GROOVE,borderwidth=2)
-        labelKeysBasic.pack(ipadx=5,ipady=5,fill=X)
+    def create_widgets(self):
+        frame = Frame(self, borderwidth=2, relief=SUNKEN)
+        frame.pack(side=TOP, expand=True, fill=BOTH)
+
+        frame_buttons = Frame(self)
+        frame_buttons.pack(side=BOTTOM, fill=X)
+
+        self.button_ok = Button(frame_buttons, text='OK',
+                                width=8, command=self.ok)
+        self.button_ok.grid(row=0, column=0, padx=5, pady=5)
+        self.button_cancel = Button(frame_buttons, text='Cancel',
+                                   width=8, command=self.cancel)
+        self.button_cancel.grid(row=0, column=1, padx=5, pady=5)
+
+        # Basic entry key sequence.
+        self.frame_keyseq_basic = Frame(frame)
+        self.frame_keyseq_basic.grid(row=0, column=0, sticky=NSEW,
+                                      padx=5, pady=5)
+        basic_title = Label(self.frame_keyseq_basic,
+                            text=f"New keys for '{self.action}' :")
+        basic_title.pack(anchor=W)
+
+        basic_keys = Label(self.frame_keyseq_basic, justify=LEFT,
+                           textvariable=self.key_string, relief=GROOVE,
+                           borderwidth=2)
+        basic_keys.pack(ipadx=5, ipady=5, fill=X)
+
+        # Basic entry controls.
+        self.frame_controls_basic = Frame(frame)
+        self.frame_controls_basic.grid(row=1, column=0, sticky=NSEW, padx=5)
+
+        # Basic entry modifiers.
         self.modifier_checkbuttons = {}
         column = 0
         for modifier, variable in zip(self.modifiers, self.modifier_vars):
             label = self.modifier_label.get(modifier, modifier)
-            check=Checkbutton(self.frameControlsBasic,
-                command=self.BuildKeyString,
-                text=label,variable=variable,onvalue=modifier,offvalue='')
-            check.grid(row=0,column=column,padx=2,sticky=W)
+            check = Checkbutton(self.frame_controls_basic,
+                                command=self.build_key_string, text=label,
+                                variable=variable, onvalue=modifier, offvalue='')
+            check.grid(row=0, column=column, padx=2, sticky=W)
             self.modifier_checkbuttons[modifier] = check
             column += 1
-        labelFnAdvice=Label(self.frameControlsBasic,justify=LEFT,
-                            text=\
-                            "Select the desired modifier keys\n"+
-                            "above, and the final key from the\n"+
-                            "list on the right.\n\n" +
-                            "Use upper case Symbols when using\n" +
-                            "the Shift modifier.  (Letters will be\n" +
-                            "converted automatically.)")
-        labelFnAdvice.grid(row=1,column=0,columnspan=4,padx=2,sticky=W)
-        self.listKeysFinal=Listbox(self.frameControlsBasic,width=15,height=10,
-                selectmode=SINGLE)
-        self.listKeysFinal.bind('<ButtonRelease-1>',self.FinalKeySelected)
-        self.listKeysFinal.grid(row=0,column=4,rowspan=4,sticky=NS)
-        scrollKeysFinal=Scrollbar(self.frameControlsBasic,orient=VERTICAL,
-                command=self.listKeysFinal.yview)
-        self.listKeysFinal.config(yscrollcommand=scrollKeysFinal.set)
-        scrollKeysFinal.grid(row=0,column=5,rowspan=4,sticky=NS)
-        self.buttonClear=Button(self.frameControlsBasic,
-                text='Clear Keys',command=self.ClearKeySeq)
-        self.buttonClear.grid(row=2,column=0,columnspan=4)
-        labelTitleAdvanced = Label(self.frameKeySeqAdvanced,justify=LEFT,
-                text="Enter new binding(s) for  '"+self.action+"' :\n"+
-                "(These bindings will not be checked for validity!)")
-        labelTitleAdvanced.pack(anchor=W)
-        self.entryKeysAdvanced=Entry(self.frameKeySeqAdvanced,
-                textvariable=self.keyString)
-        self.entryKeysAdvanced.pack(fill=X)
-        labelHelpAdvanced=Label(self.frameHelpAdvanced,justify=LEFT,
+
+        # Basic entry help text.
+        help_basic = Label(self.frame_controls_basic, justify=LEFT,
+                           text="Select the desired modifier keys\n"+
+                                "above, and the final key from the\n"+
+                                "list on the right.\n\n" +
+                                "Use upper case Symbols when using\n" +
+                                "the Shift modifier.  (Letters will be\n" +
+                                "converted automatically.)")
+        help_basic.grid(row=1, column=0, columnspan=4, padx=2, sticky=W)
+
+        # Basic entry key list.
+        self.list_keys_final = Listbox(self.frame_controls_basic, width=15,
+                                       height=10, selectmode=SINGLE)
+        self.list_keys_final.bind('<ButtonRelease-1>', self.final_key_selected)
+        self.list_keys_final.grid(row=0, column=4, rowspan=4, sticky=NS)
+        scroll_keys_final = Scrollbar(self.frame_controls_basic,
+                                      orient=VERTICAL,
+                                      command=self.list_keys_final.yview)
+        self.list_keys_final.config(yscrollcommand=scroll_keys_final.set)
+        scroll_keys_final.grid(row=0, column=5, rowspan=4, sticky=NS)
+        self.button_clear = Button(self.frame_controls_basic,
+                                   text='Clear Keys',
+                                   command=self.clear_key_seq)
+        self.button_clear.grid(row=2, column=0, columnspan=4)
+
+        # Advanced entry key sequence.
+        self.frame_keyseq_advanced = Frame(frame)
+        self.frame_keyseq_advanced.grid(row=0, column=0, sticky=NSEW,
+                                         padx=5, pady=5)
+        advanced_title = Label(self.frame_keyseq_advanced, justify=LEFT,
+                               text=f"Enter new binding(s) for '{self.action}' :\n" +
+                                     "(These bindings will not be checked for validity!)")
+        advanced_title.pack(anchor=W)
+        self.advanced_keys = Entry(self.frame_keyseq_advanced,
+                                   textvariable=self.key_string)
+        self.advanced_keys.pack(fill=X)
+
+        # Advanced entry help text.
+        self.frame_help_advanced = Frame(frame)
+        self.frame_help_advanced.grid(row=1, column=0, sticky=NSEW, padx=5)
+        help_advanced = Label(self.frame_help_advanced, justify=LEFT,
             text="Key bindings are specified using Tkinter keysyms as\n"+
                  "in these samples: <Control-f>, <Shift-F2>, <F12>,\n"
                  "<Control-space>, <Meta-less>, <Control-Alt-Shift-X>.\n"
@@ -140,13 +158,19 @@ class GetKeysDialog(Toplevel):
                  "is the 'do-nothing' keybinding.\n\n" +
                  "Multiple separate bindings for one action should be\n"+
                  "separated by a space, eg., <Alt-v> <Meta-v>." )
-        labelHelpAdvanced.grid(row=0,column=0,sticky=NSEW)
+        help_advanced.grid(row=0, column=0, sticky=NSEW)
 
-    def SetModifiersForPlatform(self):
+        # Switch between basic and advanced.
+        self.button_level = Button(frame, command=self.toggle_level,
+                                  text='<< Basic Key Binding Entry')
+        self.button_level.grid(row=2, column=0, stick=EW, padx=5, pady=5)
+        self.toggle_level()
+
+    def set_modifiers_for_platform(self):
         """Determine list of names of key modifiers for this platform.
 
         The names are used to build Tk bindings -- it doesn't matter if the
-        keyboard has these keys, it matters if Tk understands them. The
+        keyboard has these keys; it matters if Tk understands them.  The
         order is also important: key binding equality depends on it, so
         config-keys.def must use the same ordering.
         """
@@ -154,118 +178,124 @@ class GetKeysDialog(Toplevel):
             self.modifiers = ['Shift', 'Control', 'Option', 'Command']
         else:
             self.modifiers = ['Control', 'Alt', 'Shift']
-        self.modifier_label = {'Control': 'Ctrl'} # short name
+        self.modifier_label = {'Control': 'Ctrl'}  # Short name.
 
-    def ToggleLevel(self):
-        if  self.buttonLevel.cget('text')[:8]=='Advanced':
-            self.ClearKeySeq()
-            self.buttonLevel.config(text='<< Basic Key Binding Entry')
-            self.frameKeySeqAdvanced.lift()
-            self.frameHelpAdvanced.lift()
-            self.entryKeysAdvanced.focus_set()
+    def toggle_level(self):
+        "Toggle between basic and advanced keys."
+        if  self.button_level.cget('text').startswith('Advanced'):
+            self.clear_key_seq()
+            self.button_level.config(text='<< Basic Key Binding Entry')
+            self.frame_keyseq_advanced.lift()
+            self.frame_help_advanced.lift()
+            self.advanced_keys.focus_set()
             self.advanced = True
         else:
-            self.ClearKeySeq()
-            self.buttonLevel.config(text='Advanced Key Binding Entry >>')
-            self.frameKeySeqBasic.lift()
-            self.frameControlsBasic.lift()
+            self.clear_key_seq()
+            self.button_level.config(text='Advanced Key Binding Entry >>')
+            self.frame_keyseq_basic.lift()
+            self.frame_controls_basic.lift()
             self.advanced = False
 
-    def FinalKeySelected(self,event):
-        self.BuildKeyString()
+    def final_key_selected(self, event):
+        "Handler for clicking on key in basic settings list."
+        self.build_key_string()
 
-    def BuildKeyString(self):
-        keyList = modifiers = self.GetModifiers()
-        finalKey = self.listKeysFinal.get(ANCHOR)
-        if finalKey:
-            finalKey = self.TranslateKey(finalKey, modifiers)
-            keyList.append(finalKey)
-        self.keyString.set('<' + '-'.join(keyList) + '>')
+    def build_key_string(self):
+        "Create formatted string of modifiers plus the key."
+        keylist = modifiers = self.get_modifiers()
+        final_key = self.list_keys_final.get(ANCHOR)
+        if final_key:
+            final_key = self.translate_key(final_key, modifiers)
+            keylist.append(final_key)
+        self.key_string.set(f"<{'-'.join(keylist)}>")
 
-    def GetModifiers(self):
-        modList = [variable.get() for variable in self.modifier_vars]
-        return [mod for mod in modList if mod]
+    def get_modifiers(self):
+        "Return ordered list of modifiers that have been selected."
+        mod_list = [variable.get() for variable in self.modifier_vars]
+        return [mod for mod in mod_list if mod]
 
-    def ClearKeySeq(self):
-        self.listKeysFinal.select_clear(0,END)
-        self.listKeysFinal.yview(MOVETO, '0.0')
+    def clear_key_seq(self):
+        "Clear modifiers and keys selection."
+        self.list_keys_final.select_clear(0, END)
+        self.list_keys_final.yview(MOVETO, '0.0')
         for variable in self.modifier_vars:
             variable.set('')
-        self.keyString.set('')
+        self.key_string.set('')
 
-    def LoadFinalKeyList(self):
-        #these tuples are also available for use in validity checks
-        self.functionKeys=('F1','F2','F3','F4','F5','F6','F7','F8','F9',
-                'F10','F11','F12')
-        self.alphanumKeys=tuple(string.ascii_lowercase+string.digits)
-        self.punctuationKeys=tuple('~!@#%^&*()_-+={}[]|;:,.<>/?')
-        self.whitespaceKeys=('Tab','Space','Return')
-        self.editKeys=('BackSpace','Delete','Insert')
-        self.moveKeys=('Home','End','Page Up','Page Down','Left Arrow',
-                'Right Arrow','Up Arrow','Down Arrow')
-        #make a tuple of most of the useful common 'final' keys
-        keys=(self.alphanumKeys+self.punctuationKeys+self.functionKeys+
-                self.whitespaceKeys+self.editKeys+self.moveKeys)
-        self.listKeysFinal.insert(END, *keys)
+    def load_final_key_list(self):
+        "Populate listbox of available keys."
+        # These tuples are also available for use in validity checks.
+        self.function_keys = ('F1', 'F2' ,'F3' ,'F4' ,'F5' ,'F6',
+                              'F7', 'F8' ,'F9' ,'F10' ,'F11' ,'F12')
+        self.alphanum_keys = tuple(string.ascii_lowercase + string.digits)
+        self.punctuation_keys = tuple('~!@#%^&*()_-+={}[]|;:,.<>/?')
+        self.whitespace_keys = ('Tab', 'Space', 'Return')
+        self.edit_keys = ('BackSpace', 'Delete', 'Insert')
+        self.move_keys = ('Home', 'End', 'Page Up', 'Page Down', 'Left Arrow',
+                          'Right Arrow', 'Up Arrow', 'Down Arrow')
+        # Make a tuple of most of the useful common 'final' keys.
+        keys = (self.alphanum_keys + self.punctuation_keys + self.function_keys + 
+                self.whitespace_keys + self.edit_keys + self.move_keys)
+        self.list_keys_final.insert(END, *keys)
 
-    def TranslateKey(self, key, modifiers):
-        "Translate from keycap symbol to the Tkinter keysym"
-        translateDict = {'Space':'space',
-                '~':'asciitilde','!':'exclam','@':'at','#':'numbersign',
-                '%':'percent','^':'asciicircum','&':'ampersand','*':'asterisk',
-                '(':'parenleft',')':'parenright','_':'underscore','-':'minus',
-                '+':'plus','=':'equal','{':'braceleft','}':'braceright',
-                '[':'bracketleft',']':'bracketright','|':'bar',';':'semicolon',
-                ':':'colon',',':'comma','.':'period','<':'less','>':'greater',
-                '/':'slash','?':'question','Page Up':'Prior','Page Down':'Next',
-                'Left Arrow':'Left','Right Arrow':'Right','Up Arrow':'Up',
-                'Down Arrow': 'Down', 'Tab':'Tab'}
-        if key in translateDict:
-            key = translateDict[key]
+    @staticmethod
+    def translate_key(key, modifiers):
+        "Translate from keycap symbol to the Tkinter keysym."
+        translate_dict = {'Space':'space',
+                '~':'asciitilde', '!':'exclam', '@':'at', '#':'numbersign',
+                '%':'percent', '^':'asciicircum', '&':'ampersand',
+                '*':'asterisk', '(':'parenleft', ')':'parenright',
+                '_':'underscore', '-':'minus', '+':'plus', '=':'equal',
+                '{':'braceleft', '}':'braceright',
+                '[':'bracketleft', ']':'bracketright', '|':'bar',
+                ';':'semicolon', ':':'colon', ',':'comma', '.':'period',
+                '<':'less', '>':'greater', '/':'slash', '?':'question',
+                'Page Up':'Prior', 'Page Down':'Next',
+                'Left Arrow':'Left', 'Right Arrow':'Right',
+                'Up Arrow':'Up', 'Down Arrow': 'Down', 'Tab':'Tab'}
+        if key in translate_dict:
+            key = translate_dict[key]
         if 'Shift' in modifiers and key in string.ascii_lowercase:
             key = key.upper()
-        key = 'Key-' + key
-        return key
+        return f'Key-{key}'
 
-    def OK(self, event=None):
-        keys = self.keyString.get().strip()
+    def ok(self, event=None):
+        keys = self.key_string.get().strip()
         if not keys:
             self.showerror(title=self.keyerror_title, parent=self,
                            message="No key specified.")
             return
-        if (self.advanced or self.KeysOK(keys)) and self.bind_ok(keys):
+        if (self.advanced or self.keys_ok(keys)) and self.bind_ok(keys):
             self.result = keys
         self.grab_release()
         self.destroy()
 
-    def Cancel(self, event=None):
-        self.result=''
+    def cancel(self, event=None):
+        self.result = ''
         self.grab_release()
         self.destroy()
 
-    def KeysOK(self, keys):
-        '''Validity check on user's 'basic' keybinding selection.
+    def keys_ok(self, keys):
+        """Validity check on user's 'basic' keybinding selection.
 
         Doesn't check the string produced by the advanced dialog because
         'modifiers' isn't set.
-
-        '''
-        finalKey = self.listKeysFinal.get(ANCHOR)
-        modifiers = self.GetModifiers()
-        keysOK = False
+        """
+        final_key = self.list_keys_final.get(ANCHOR)
+        modifiers = self.get_modifiers()
         title = self.keyerror_title
-        key_sequences = [key for keylist in self.currentKeySequences
+        key_sequences = [key for keylist in self.current_key_sequences
                              for key in keylist]
         if not keys.endswith('>'):
             self.showerror(title, parent=self,
                            message='Missing the final Key')
         elif (not modifiers
-              and finalKey not in self.functionKeys + self.moveKeys):
+              and final_key not in self.function_keys + self.move_keys):
             self.showerror(title=title, parent=self,
                            message='No modifier key(s) specified.')
         elif (modifiers == ['Shift']) \
-                 and (finalKey not in
-                      self.functionKeys + self.moveKeys + ('Tab', 'Space')):
+                 and (final_key not in
+                      self.function_keys + self.move_keys + ('Tab', 'Space')):
             msg = 'The shift modifier by itself may not be used with'\
                   ' this key symbol.'
             self.showerror(title=title, parent=self, message=msg)
@@ -273,12 +303,11 @@ class GetKeysDialog(Toplevel):
             msg = 'This key combination is already in use.'
             self.showerror(title=title, parent=self, message=msg)
         else:
-            keysOK = True
-        return keysOK
+            return True
+        return False
 
     def bind_ok(self, keys):
         "Return True if Tcl accepts the new keys else show message."
-
         try:
             binding = self.bind(keys, lambda: None)
         except TclError as err:

--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -141,12 +141,11 @@ _editor_window_spec = {
            "Best to close editor first."
     }
 
-# Update once issue21519 is resolved.
 GetKeysDialog_spec = {
     'file': 'config_key',
     'kwds': {'title': 'Test keybindings',
              'action': 'find-again',
-             'currentKeySequences': [''] ,
+             'current_key_sequences': [['<Control-Key-g>', '<Key-F3>', '<Control-Key-G>']],
              '_htest': True,
              },
     'msg': "Test for different key modifier sequences.\n"

--- a/Lib/idlelib/idle_test/test_config_key.py
+++ b/Lib/idlelib/idle_test/test_config_key.py
@@ -9,15 +9,15 @@ from idlelib.idle_test.mock_tk import Mbox_func
 
 
 class ValidationTest(unittest.TestCase):
-    "Test validation methods: OK, KeysOK, bind_ok."
+    "Test validation methods: ok, keys_ok, bind_ok."
 
     class Validator(config_key.GetKeysDialog):
         def __init__(self, *args, **kwargs):
             config_key.GetKeysDialog.__init__(self, *args, **kwargs)
-            class listKeysFinal:
+            class list_keys_final:
                 get = Func()
-            self.listKeysFinal = listKeysFinal
-        GetModifiers = Func()
+            self.list_keys_final = list_keys_final
+        get_modifiers = Func()
         showerror = Mbox_func()
 
     @classmethod
@@ -31,7 +31,7 @@ class ValidationTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.dialog.Cancel()
+        cls.dialog.cancel()
         cls.root.update_idletasks()
         cls.root.destroy()
         del cls.dialog, cls.root
@@ -42,49 +42,49 @@ class ValidationTest(unittest.TestCase):
     # A test that sets a non-blank modifier list should reset it to [].
 
     def test_ok_empty(self):
-        self.dialog.keyString.set(' ')
-        self.dialog.OK()
+        self.dialog.key_string.set(' ')
+        self.dialog.ok()
         self.assertEqual(self.dialog.result, '')
         self.assertEqual(self.dialog.showerror.message, 'No key specified.')
 
     def test_ok_good(self):
-        self.dialog.keyString.set('<Key-F11>')
-        self.dialog.listKeysFinal.get.result = 'F11'
-        self.dialog.OK()
+        self.dialog.key_string.set('<Key-F11>')
+        self.dialog.list_keys_final.get.result = 'F11'
+        self.dialog.ok()
         self.assertEqual(self.dialog.result, '<Key-F11>')
         self.assertEqual(self.dialog.showerror.message, '')
 
     def test_keys_no_ending(self):
-        self.assertFalse(self.dialog.KeysOK('<Control-Shift'))
+        self.assertFalse(self.dialog.keys_ok('<Control-Shift'))
         self.assertIn('Missing the final', self.dialog.showerror.message)
 
     def test_keys_no_modifier_bad(self):
-        self.dialog.listKeysFinal.get.result = 'A'
-        self.assertFalse(self.dialog.KeysOK('<Key-A>'))
+        self.dialog.list_keys_final.get.result = 'A'
+        self.assertFalse(self.dialog.keys_ok('<Key-A>'))
         self.assertIn('No modifier', self.dialog.showerror.message)
 
     def test_keys_no_modifier_ok(self):
-        self.dialog.listKeysFinal.get.result = 'F11'
-        self.assertTrue(self.dialog.KeysOK('<Key-F11>'))
+        self.dialog.list_keys_final.get.result = 'F11'
+        self.assertTrue(self.dialog.keys_ok('<Key-F11>'))
         self.assertEqual(self.dialog.showerror.message, '')
 
     def test_keys_shift_bad(self):
-        self.dialog.listKeysFinal.get.result = 'a'
-        self.dialog.GetModifiers.result = ['Shift']
-        self.assertFalse(self.dialog.KeysOK('<a>'))
+        self.dialog.list_keys_final.get.result = 'a'
+        self.dialog.get_modifiers.result = ['Shift']
+        self.assertFalse(self.dialog.keys_ok('<a>'))
         self.assertIn('shift modifier', self.dialog.showerror.message)
-        self.dialog.GetModifiers.result = []
+        self.dialog.get_modifiers.result = []
 
     def test_keys_dup(self):
         for mods, final, seq in (([], 'F12', '<Key-F12>'),
                                  (['Control'], 'x', '<Control-Key-x>'),
                                  (['Control'], 'X', '<Control-Key-X>')):
             with self.subTest(m=mods, f=final, s=seq):
-                self.dialog.listKeysFinal.get.result = final
-                self.dialog.GetModifiers.result = mods
-                self.assertFalse(self.dialog.KeysOK(seq))
+                self.dialog.list_keys_final.get.result = final
+                self.dialog.get_modifiers.result = mods
+                self.assertFalse(self.dialog.keys_ok(seq))
                 self.assertIn('already in use', self.dialog.showerror.message)
-        self.dialog.GetModifiers.result = []
+        self.dialog.get_modifiers.result = []
 
     def test_bind_ok(self):
         self.assertTrue(self.dialog.bind_ok('<Control-Shift-Key-a>'))

--- a/Lib/idlelib/idle_test/test_config_key.py
+++ b/Lib/idlelib/idle_test/test_config_key.py
@@ -1,4 +1,4 @@
-"Test config_key, coverage 75%"
+"Test config_key, coverage 82%"
 
 from idlelib import config_key
 from test.support import requires

--- a/Misc/NEWS.d/next/IDLE/2018-12-27-15-29-11.bpo-35598.FWOOm8.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-12-27-15-29-11.bpo-35598.FWOOm8.rst
@@ -1,0 +1,1 @@
+Apply PEP8 naming convention to config_key.py.


### PR DESCRIPTION
For this first round of modernizing config_key, I tried to limit the changes to converting the existing names to PEP8 names, but there may be a few other changes included to help with following the source.

<!-- issue-number: [bpo-35598](https://bugs.python.org/issue35598) -->
https://bugs.python.org/issue35598
<!-- /issue-number -->
