### PR TITLE
Revert "bpo-35402: Update macOS installer to use Tcl 8.6.9 / Tk 8.6.9.1 (GH-11101)"

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -227,9 +227,9 @@ def library_recipes():
     if internalTk():
         result.extend([
           dict(
-              name="Tcl 8.6.9",
-              url="ftp://ftp.tcl.tk/pub/tcl//tcl8_6/tcl8.6.9-src.tar.gz",
-              checksum='aa0a121d95a0e7b73a036f26028538d4',
+              name="Tcl 8.6.8",
+              url="ftp://ftp.tcl.tk/pub/tcl//tcl8_6/tcl8.6.8-src.tar.gz",
+              checksum='81656d3367af032e0ae6157eff134f89',
               buildDir="unix",
               configure_pre=[
                     '--enable-shared',
@@ -243,9 +243,12 @@ def library_recipes():
                   },
               ),
           dict(
-              name="Tk 8.6.9.1",
-              url="ftp://ftp.tcl.tk/pub/tcl//tcl8_6/tk8.6.9.1-src.tar.gz",
-              checksum='9efe3976468352dc894dae0c4e785a8e',
+              name="Tk 8.6.8",
+              url="ftp://ftp.tcl.tk/pub/tcl//tcl8_6/tk8.6.8-src.tar.gz",
+              checksum='5e0faecba458ee1386078fb228d008ba',
+              patches=[
+                  "tk868_on_10_8_10_9.patch",
+                   ],
               buildDir="unix",
               configure_pre=[
                     '--enable-aqua',
@@ -706,7 +709,6 @@ def extractArchive(builddir, archiveName):
     work for current Tcl and Tk source releases where the basename of
     the archive ends with "-src" but the uncompressed directory does not.
     For now, just special case Tcl and Tk tar.gz downloads.
-    Another special case: the tk8.6.9.1 tarball extracts to tk8.6.9.
     """
     curdir = os.getcwd()
     try:
@@ -716,8 +718,6 @@ def extractArchive(builddir, archiveName):
             if ((retval.startswith('tcl') or retval.startswith('tk'))
                     and retval.endswith('-src')):
                 retval = retval[:-4]
-                if retval == 'tk8.6.9.1':
-                    retval = 'tk8.6.9'
             if os.path.exists(retval):
                 shutil.rmtree(retval)
             fp = os.popen("tar zxf %s 2>&1"%(shellQuote(archiveName),), 'r')

--- a/Mac/BuildScript/tk868_on_10_8_10_9.patch
+++ b/Mac/BuildScript/tk868_on_10_8_10_9.patch
@@ -1,0 +1,18 @@
+Fix build failure with +quartz variant on OS X 10.8 and 10.9.
+Even though Gestalt was deprecated in OS X 10.8, it should work fine
+through OS X 10.9, and its replacement NSOperatingSystemVersion was
+not introduced until OS X 10.10.
+
+Patch from MacPorts project and reported upstream:
+https://trac.macports.org/ticket/55649
+--- tk8.6.8/macosx/tkMacOSXXStubs.c.orig	2017-12-06 09:25:08.000000000 -0600
++++ tk8.6.8-patched/macosx/tkMacOSXXStubs.c	2018-01-06 19:34:17.000000000 -0600
+@@ -175,7 +175,7 @@
+     {
+ 	int major, minor, patch;
+ 
+-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1080
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 101000
+ 	Gestalt(gestaltSystemVersionMajor, (SInt32*)&major);
+ 	Gestalt(gestaltSystemVersionMinor, (SInt32*)&minor);
+ 	Gestalt(gestaltSystemVersionBugFix, (SInt32*)&patch);

--- a/Misc/NEWS.d/next/macOS/2018-12-10-02-44-48.bpo-35402.xzn8qJ.rst
+++ b/Misc/NEWS.d/next/macOS/2018-12-10-02-44-48.bpo-35402.xzn8qJ.rst
@@ -1,1 +1,0 @@
-Update macOS installer to use Tcl/Tk 8.6.9.1.


### PR DESCRIPTION
This reverts commit 7cf3d8e25174c8871883e42f3240fd7f01efd3a8.

Due to regressions found with using Tk 8.6.9.1, build the python.org macOS installers with Tcl/Tk 8.6.8 as used in previous releases.


<!-- issue-number: [bpo-35402](https://bugs.python.org/issue35402) -->
https://bugs.python.org/issue35402
<!-- /issue-number -->
