### PR TITLE
bpo-35602: Make sure the transport is always closed in SelectorEventLoopUnixSockSendfileTests

### DIFF
--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -504,12 +504,9 @@ class SelectorEventLoopUnixSockSendfileTests(test_utils.TestCase):
             lambda: proto, sock=srv_sock))
         self.run_loop(self.loop.sock_connect(sock, (support.HOST, port)))
 
-        def cleanup():
-            if proto.transport is not None:
-                # can be None if the task was cancelled before
-                # connection_made callback
-                proto.transport.close()
-                self.run_loop(proto.wait_closed())
+        def cleanup(transport=proto.transport):
+            transport.close()
+            self.run_loop(proto.wait_closed())
 
             server.close()
             self.run_loop(server.wait_closed())

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -449,10 +449,12 @@ class SelectorEventLoopUnixSockSendfileTests(test_utils.TestCase):
             self.data = bytearray()
             self.fut = loop.create_future()
             self.transport = None
+            self._ready = loop.create_future()
 
         def connection_made(self, transport):
             self.started = True
             self.transport = transport
+            self._ready.set_result(None)
 
         def data_received(self, data):
             self.data.extend(data)
@@ -503,9 +505,10 @@ class SelectorEventLoopUnixSockSendfileTests(test_utils.TestCase):
         server = self.run_loop(self.loop.create_server(
             lambda: proto, sock=srv_sock))
         self.run_loop(self.loop.sock_connect(sock, (support.HOST, port)))
+        self.run_loop(proto._ready)
 
-        def cleanup(transport=proto.transport):
-            transport.close()
+        def cleanup():
+            proto.transport.close()
             self.run_loop(proto.wait_closed())
 
             server.close()


### PR DESCRIPTION


<!-- issue-number: [bpo-35602](https://bugs.python.org/issue35602) -->
https://bugs.python.org/issue35602
<!-- /issue-number -->
