### PR TITLE
bpo-35603: Escape table header of make_table output that can cause potential XSS

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -2036,6 +2036,10 @@ class HtmlDiff(object):
                 s.append( fmt % (next_id[i],next_href[i],fromlist[i],
                                            next_href[i],tolist[i]))
         if fromdesc or todesc:
+            fromdesc = fromdesc.replace("&", "&amp;").replace(">", "&gt;") \
+                                                     .replace("<", "&lt;")
+            todesc = todesc.replace("&", "&amp;").replace(">", "&gt;") \
+                                                 .replace("<", "&lt;")
             header_row = '<thead><tr>%s%s%s%s</tr></thead>' % (
                 '<th class="diff_next"><br /></th>',
                 '<th colspan="2" class="diff_header">%s</th>' % fromdesc,

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -240,10 +240,10 @@ class TestSFpatches(unittest.TestCase):
 
     def test_make_table_escape_table_header(self):
         html_diff = difflib.HtmlDiff()
-        output = html_diff.make_file(patch914575_from1.splitlines(),
-                                     patch914575_to1.splitlines(),
-                                     fromdesc='<from>',
-                                     todesc='<to>')
+        output = html_diff.make_table(patch914575_from1.splitlines(),
+                                      patch914575_to1.splitlines(),
+                                      fromdesc='<from>',
+                                      todesc='<to>')
         self.assertIn('&lt;from&gt;', output)
         self.assertIn('&lt;to&gt;', output)
 

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -238,6 +238,15 @@ class TestSFpatches(unittest.TestCase):
         with open(findfile('test_difflib_expect.html')) as fp:
             self.assertEqual(actual, fp.read())
 
+    def test_make_table_escape_table_header(self):
+        html_diff = difflib.HtmlDiff()
+        output = html_diff.make_file(patch914575_from1.splitlines(),
+                                     patch914575_to1.splitlines(),
+                                     fromdesc='<from>',
+                                     todesc='<to>')
+        self.assertIn('&lt;from&gt;', output)
+        self.assertIn('&lt;to&gt;', output)
+
     def test_recursion_limit(self):
         # Check if the problem described in patch #1413711 exists.
         limit = sys.getrecursionlimit()

--- a/Misc/NEWS.d/next/Library/2018-12-28-14-53-22.bpo-35603.rVCZAE.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-28-14-53-22.bpo-35603.rVCZAE.rst
@@ -1,0 +1,2 @@
+Escape table header output of :meth:`difflib.HtmlDiff.make_table`.
+Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
* `fromdesc` and `todesc` should be escaped since rendering unescaped HTML might lead to code execution in the browser rendering them as tags.

<!-- issue-number: [bpo-35603](https://bugs.python.org/issue35603) -->
https://bugs.python.org/issue35603
<!-- /issue-number -->
