### PR TITLE
bpo-35555: Create function to update IDLE menu item state

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -447,9 +447,14 @@ class EditorWindow(object):
         window.add_windows_to_menu(menu)
 
     def update_menu_label(self, menu, index, label):
-        "Update label for menu item at index ."
+        "Update label for menu item at index."
         menuitem = self.menudict[menu]
         menuitem.entryconfig(index, label=label)
+
+    def update_menu_state(self, menu, index, state):
+        "Update state for menu item at index."
+        menuitem = self.menudict[menu]
+        menuitem.entryconfig(index, state=state)
 
     def handle_yview(self, event, *args):
         "Handle scrollbar."

--- a/Lib/idlelib/outwin.py
+++ b/Lib/idlelib/outwin.py
@@ -78,8 +78,7 @@ class OutputWindow(EditorWindow):
         EditorWindow.__init__(self, *args)
         self.text.bind("<<goto-file-line>>", self.goto_file_line)
         self.text.unbind("<<toggle-code-context>>")
-        self.menudict['options'].entryconfig('*Code Context',
-                                             state='disabled')
+        self.update_menu_state('options', '*Code Context', 'disabled')
 
     # Customize EditorWindow
     def ispythonsource(self, filename):


### PR DESCRIPTION
* Instead of updating menu state directly, create function to update the state.
* Change outwin to call new function instead of updating menu directly.



<!-- issue-number: [bpo-35555](https://bugs.python.org/issue35555) -->
https://bugs.python.org/issue35555
<!-- /issue-number -->
