### PR TITLE
bpo-35609: Remove examples for deprecated decorators in the abc module.

### DIFF
--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -11,7 +11,8 @@ def abstractmethod(funcobj):
     class that has a metaclass derived from ABCMeta cannot be
     instantiated unless all of its abstract methods are overridden.
     The abstract methods can be called using any of the normal
-    'super' call mechanisms.
+    'super' call mechanisms.  abstractmethod() may be used to declare
+    abstract methods for properties and descriptors.
 
     Usage:
 
@@ -27,17 +28,7 @@ def abstractmethod(funcobj):
 class abstractclassmethod(classmethod):
     """A decorator indicating abstract classmethods.
 
-    Similar to abstractmethod.
-
-    Usage:
-
-        class C(metaclass=ABCMeta):
-            @abstractclassmethod
-            def my_abstract_classmethod(cls, ...):
-                ...
-
-    'abstractclassmethod' is deprecated. Use 'classmethod' with
-    'abstractmethod' instead.
+    Deprecated, use 'classmethod' with 'abstractmethod' instead.
     """
 
     __isabstractmethod__ = True
@@ -50,17 +41,7 @@ class abstractclassmethod(classmethod):
 class abstractstaticmethod(staticmethod):
     """A decorator indicating abstract staticmethods.
 
-    Similar to abstractmethod.
-
-    Usage:
-
-        class C(metaclass=ABCMeta):
-            @abstractstaticmethod
-            def my_abstract_staticmethod(...):
-                ...
-
-    'abstractstaticmethod' is deprecated. Use 'staticmethod' with
-    'abstractmethod' instead.
+    Deprecated, use 'staticmethod' with 'abstractmethod' instead.
     """
 
     __isabstractmethod__ = True
@@ -73,29 +54,7 @@ class abstractstaticmethod(staticmethod):
 class abstractproperty(property):
     """A decorator indicating abstract properties.
 
-    Requires that the metaclass is ABCMeta or derived from it.  A
-    class that has a metaclass derived from ABCMeta cannot be
-    instantiated unless all of its abstract properties are overridden.
-    The abstract properties can be called using any of the normal
-    'super' call mechanisms.
-
-    Usage:
-
-        class C(metaclass=ABCMeta):
-            @abstractproperty
-            def my_abstract_property(self):
-                ...
-
-    This defines a read-only property; you can also define a read-write
-    abstract property using the 'long' form of property declaration:
-
-        class C(metaclass=ABCMeta):
-            def getx(self): ...
-            def setx(self, value): ...
-            x = abstractproperty(getx, setx)
-
-    'abstractproperty' is deprecated. Use 'property' with 'abstractmethod'
-    instead.
+    Deprecated, use 'property' with 'abstractmethod' instead.
     """
 
     __isabstractmethod__ = True


### PR DESCRIPTION


<!-- issue-number: [bpo-35609](https://bugs.python.org/issue35609) -->
https://bugs.python.org/issue35609
<!-- /issue-number -->
