### PR TITLE
bpo-35614: Fix pydoc help() on metaclasses

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1255,7 +1255,7 @@ location listed above.
 
         # List the built-in subclasses, if any:
         subclasses = sorted(
-            (str(cls.__name__) for cls in object.__subclasses__()
+            (str(cls.__name__) for cls in type.__subclasses__(object)
              if not cls.__name__.startswith("_") and cls.__module__ == "builtins"),
             key=str.lower
         )

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -636,6 +636,17 @@ class PydocDocTest(unittest.TestCase):
         # Testing that the subclasses section does not appear
         self.assertNotIn('Built-in subclasses', text)
 
+    def test_builtin_on_metaclasses(self):
+        """Tests help on metaclasses.
+
+        When running help() on a metaclasses such as type, it
+        should not contain any "Built-in subclasses" section.
+        """
+        doc = pydoc.TextDoc()
+        text = doc.docclass(type)
+        # Testing that the subclasses section does not appear
+        self.assertNotIn('Built-in subclasses', text)
+
     @unittest.skipIf(sys.flags.optimize >= 2,
                      'Docstrings are omitted with -O2 and above')
     @unittest.skipIf(hasattr(sys, 'gettrace') and sys.gettrace(),

--- a/Misc/NEWS.d/next/Library/2018-12-30-01-10-50.bpo-35614.cnkM4f.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-30-01-10-50.bpo-35614.cnkM4f.rst
@@ -1,0 +1,1 @@
+Fixed help() on metaclasses. Patch by Sanyam Khurana.


### PR DESCRIPTION


<!-- issue-number: [bpo-35614](https://bugs.python.org/issue35614) -->
https://bugs.python.org/issue35614
<!-- /issue-number -->
