### PR TITLE
bpo-35617: Fix for unittest discover not working with implicit namespace packages

### DIFF
--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -290,11 +290,11 @@ class TestLoader(object):
         if os.path.isdir(os.path.abspath(start_dir)):
             if os.path.abspath(start_dir) != top_level_dir:
                 try:
-                    __import__(start_dir)
+                    __import__(os.path.relpath(start_dir, top_level_dir))
                 except ImportError:
                     raise ImportError('Start directory is not importable: %r' % start_dir)
 
-            if not os.path.isfile(os.path.join(os.path.abspath(start_dir), '__init__.py')):
+            if not os.path.isfile(os.path.join(start_dir, '__init__.py')):
                 is_namespace = True
 
             tests = list(self._find_tests(start_dir, pattern, is_namespace))

--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -290,7 +290,11 @@ class TestLoader(object):
         if os.path.isdir(os.path.abspath(start_dir)):
             if os.path.abspath(start_dir) != top_level_dir:
                 try:
-                    __import__(os.path.relpath(start_dir, top_level_dir))
+                    # Convert to dot import
+                    dot_import = '.'.join(
+                        os.path.relpath(start_dir, top_level_dir).split(os.sep)
+                    )
+                    __import__(dot_import)
                 except ImportError:
                     raise ImportError('Start directory is not importable: %r' % start_dir)
 


### PR DESCRIPTION
If the startdir is considered a path, then the discover function does not look for implicit namespace packages. I fixed this.
Now if the startdir is not the topdir its checked for importability (if they are the same, then it should always be importable).
If the startdir does not contain a __init__.py file, then its considered a implicit namespace package.
To make sure that the directories are importable I changed the code so that ImportError is raised directly when problem is discovered instead of waiting.

The PR seems to fix the problem with this, but might affect other parts that I'm not aware of.

<!-- issue-number: [bpo-35617](https://bugs.python.org/issue35617) -->
https://bugs.python.org/issue35617
<!-- /issue-number -->
