### PR TITLE
bpo-32492: Tweak _collections._tuplegetter.

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -316,8 +316,6 @@ try:
 except ImportError:
     _tuplegetter = lambda index, doc: property(_itemgetter(index), doc=doc)
 
-_nt_itemgetters = {}
-
 def namedtuple(typename, field_names, *, rename=False, defaults=None, module=None):
     """Returns a new subclass of tuple with named fields.
 
@@ -456,16 +454,9 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
         '_asdict': _asdict,
         '__getnewargs__': __getnewargs__,
     }
-    cache = _nt_itemgetters
     for index, name in enumerate(field_names):
-        try:
-            doc = cache[index]
-        except KeyError:
-            doc = f'Alias for field number {index}'
-            cache[index] = doc
-
-        tuplegetter_object = _tuplegetter(index, doc)
-        class_namespace[name] = tuplegetter_object
+        doc = f'Alias for field number {index}'
+        class_namespace[name] = _tuplegetter(index, doc)
 
     result = type(typename, (tuple,), class_namespace)
 

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -455,7 +455,7 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
         '__getnewargs__': __getnewargs__,
     }
     for index, name in enumerate(field_names):
-        doc = f'Alias for field number {index}'
+        doc = _sys.intern(f'Alias for field number {index}')
         class_namespace[name] = _tuplegetter(index, doc)
 
     result = type(typename, (tuple,), class_namespace)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -3,6 +3,7 @@
 import collections
 import copy
 import doctest
+import inspect
 import operator
 import pickle
 from random import choice, randrange
@@ -552,6 +553,7 @@ class TestNamedTuple(unittest.TestCase):
     def test_attr_descr(self):
         Point = namedtuple('Point', 'x y')
         p = Point(11, 22)
+        self.assertTrue(inspect.isdatadescriptor(Point.x))
         self.assertEqual(Point.x.__get__(p), 11)
         self.assertRaises(AttributeError, Point.x.__set__, p, 33)
         self.assertRaises(AttributeError, Point.x.__delete__, p)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -551,7 +551,7 @@ class TestNamedTuple(unittest.TestCase):
         a.w = 5
         self.assertEqual(a.__dict__, {'w': 5})
 
-    def test_attr_descr(self):
+    def test_field_descriptor(self):
         Point = namedtuple('Point', 'x y')
         p = Point(11, 22)
         self.assertTrue(inspect.isdatadescriptor(Point.x))

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -3,6 +3,7 @@
 import collections
 import copy
 import doctest
+import inspect
 import operator
 import pickle
 from random import choice, randrange
@@ -305,7 +306,7 @@ class TestNamedTuple(unittest.TestCase):
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
-    def test_attr_doc(self):
+    def test_field_doc(self):
         Point = namedtuple('Point', 'x y')
         self.assertEqual(Point.x.__doc__, 'Alias for field number 0')
         self.assertEqual(Point.y.__doc__, 'Alias for field number 1')
@@ -544,6 +545,7 @@ class TestNamedTuple(unittest.TestCase):
     def test_attr_descr(self):
         Point = namedtuple('Point', 'x y')
         p = Point(11, 22)
+        self.assertTrue(inspect.isdatadescriptor(Point.x))
         self.assertEqual(Point.x.__get__(p), 11)
         self.assertRaises(AttributeError, Point.x.__set__, p, 33)
         self.assertRaises(AttributeError, Point.x.__delete__, p)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -3,7 +3,6 @@
 import collections
 import copy
 import doctest
-import inspect
 import operator
 import pickle
 from random import choice, randrange
@@ -306,7 +305,7 @@ class TestNamedTuple(unittest.TestCase):
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
-    def test_field_doc(self):
+    def test_attr_doc(self):
         Point = namedtuple('Point', 'x y')
         self.assertEqual(Point.x.__doc__, 'Alias for field number 0')
         self.assertEqual(Point.y.__doc__, 'Alias for field number 1')
@@ -317,6 +316,14 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(Vector.x.__doc__, 'Alias for field number 0')
         Vector.x.__doc__ = 'docstring for Vector.x'
         self.assertEqual(Vector.x.__doc__, 'docstring for Vector.x')
+
+    @unittest.skipIf(sys.flags.optimize >= 2,
+                     "Docstrings are omitted with -O2 and above")
+    def test_attr_doc_reuse(self):
+        P = namedtuple('P', ['m', 'n'])
+        Q = namedtuple('Q', ['o', 'p'])
+        self.assertIs(P.m.__doc__, Q.o.__doc__)
+        self.assertIs(P.n.__doc__, Q.p.__doc__)
 
     def test_name_fixer(self):
         for spec, renamed in [
@@ -545,7 +552,6 @@ class TestNamedTuple(unittest.TestCase):
     def test_attr_descr(self):
         Point = namedtuple('Point', 'x y')
         p = Point(11, 22)
-        self.assertTrue(inspect.isdatadescriptor(Point.x))
         self.assertEqual(Point.x.__get__(p), 11)
         self.assertRaises(AttributeError, Point.x.__set__, p, 33)
         self.assertRaises(AttributeError, Point.x.__delete__, p)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -306,7 +306,7 @@ class TestNamedTuple(unittest.TestCase):
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
-    def test_attr_doc(self):
+    def test_field_doc(self):
         Point = namedtuple('Point', 'x y')
         self.assertEqual(Point.x.__doc__, 'Alias for field number 0')
         self.assertEqual(Point.y.__doc__, 'Alias for field number 1')
@@ -318,9 +318,10 @@ class TestNamedTuple(unittest.TestCase):
         Vector.x.__doc__ = 'docstring for Vector.x'
         self.assertEqual(Vector.x.__doc__, 'docstring for Vector.x')
 
+    @support.cpython_only
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
-    def test_attr_doc_reuse(self):
+    def test_field_doc_reuse(self):
         P = namedtuple('P', ['m', 'n'])
         Q = namedtuple('Q', ['o', 'p'])
         self.assertIs(P.m.__doc__, Q.o.__doc__)
@@ -351,10 +352,10 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(p, Point(**dict(x=11, y=22)))
         self.assertRaises(TypeError, Point, 1)          # too few args
         self.assertRaises(TypeError, Point, 1, 2, 3)    # too many args
-        with self.assertRaises(TypeError):
-            Point(XXX=1, y=2)                           # wrong keyword argument
-        with self.assertRaises(TypeError):
-            Point(x=1)                                  # missing keyword argument
+        with self.assertRaises(TypeError):              # wrong keyword argument
+            Point(XXX=1, y=2)
+        with self.assertRaises(TypeError):              # missing keyword argument
+            Point(x=1)
         self.assertEqual(repr(p), 'Point(x=11, y=22)')
         self.assertNotIn('__weakref__', dir(p))
         self.assertEqual(p, Point._make([11, 22]))      # test _make classmethod

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -677,20 +677,14 @@ class PydocDocTest(unittest.TestCase):
             pydoc.getpager = getpager_old
 
     def test_namedtuple_fields(self):
-        NT = namedtuple('Box', ['width', 'heigh'])
+        Person = namedtuple('Person', ['nickname', 'firstname'])
         with captured_stdout() as help_io:
-            pydoc.help(NT)
+            pydoc.help(Person)
         helptext = help_io.getvalue()
-        self.assertIn("""
- |  Data descriptors defined here:
- |\x20\x20
- |  width
- |      Alias for field number 0
- |\x20\x20
- |  heigh
- |      Alias for field number 1
- |\x20\x20
-""", helptext)
+        self.assertIn("nickname", helptext)
+        self.assertIn("firstname", helptext)
+        self.assertIn("Alias for field number 0", helptext)
+        self.assertIn("Alias for field number 1", helptext)
 
     def test_namedtuple_public_underscore(self):
         NT = namedtuple('NT', ['abc', 'def'], rename=True)

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -676,6 +676,22 @@ class PydocDocTest(unittest.TestCase):
         finally:
             pydoc.getpager = getpager_old
 
+    def test_namedtuple_fields(self):
+        NT = namedtuple('Box', ['width', 'heigh'])
+        with captured_stdout() as help_io:
+            pydoc.help(NT)
+        helptext = help_io.getvalue()
+        self.assertIn("""
+ |  Data descriptors defined here:
+ |\x20\x20
+ |  width
+ |      Alias for field number 0
+ |\x20\x20
+ |  heigh
+ |      Alias for field number 1
+ |\x20\x20
+""", helptext)
+
     def test_namedtuple_public_underscore(self):
         NT = namedtuple('NT', ['abc', 'def'], rename=True)
         with captured_stdout() as help_io:

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2369,7 +2369,7 @@ tuplegetter_new_impl(PyTypeObject *type, Py_ssize_t index, PyObject *doc)
 }
 
 static PyObject *
-tuplegetterdescr_get(PyObject *self, PyObject *obj, PyObject *type)
+tuplegetter_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 {
     PyObject *result;
     if (obj == NULL) {
@@ -2402,7 +2402,7 @@ tuplegetterdescr_get(PyObject *self, PyObject *obj, PyObject *type)
 }
 
 static int
-tuplegetter_set(PyObject *self, PyObject *obj, PyObject *value)
+tuplegetter_descr_set(PyObject *self, PyObject *obj, PyObject *value)
 {
     if (value == NULL) {
         PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
@@ -2476,8 +2476,8 @@ static PyTypeObject tuplegetter_type = {
     0,                                          /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */
-    tuplegetterdescr_get,                       /* tp_descr_get */
-    tuplegetter_set,                            /* tp_descr_set */
+    tuplegetter_descr_get,                      /* tp_descr_get */
+    tuplegetter_descr_set,                      /* tp_descr_set */
     0,                                          /* tp_dictoffset */
     0,                                          /* tp_init */
     0,                                          /* tp_alloc */

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2336,7 +2336,7 @@ done:
     Py_RETURN_NONE;
 }
 
-/* Helper functions for namedtuples */
+/* Helper functions for namedtuples ************************************/
 
 typedef struct {
     PyObject_HEAD
@@ -2371,7 +2371,9 @@ tuplegetter_new_impl(PyTypeObject *type, Py_ssize_t index, PyObject *doc)
 static PyObject *
 tuplegetter_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 {
+    Py_ssize_t index = ((_tuplegetterobject*)self)->index;
     PyObject *result;
+
     if (obj == NULL) {
         Py_INCREF(self);
         return self;
@@ -2388,8 +2390,6 @@ tuplegetter_descr_get(PyObject *self, PyObject *obj, PyObject *type)
                      obj->ob_type->tp_name);
         return NULL;
     }
-
-    Py_ssize_t index = ((_tuplegetterobject*)self)->index;
 
     if (!valid_index(index, PyTuple_GET_SIZE(obj))) {
         PyErr_SetString(PyExc_IndexError, "tuple index out of range");

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2336,7 +2336,7 @@ done:
     Py_RETURN_NONE;
 }
 
-/* Helper functions for namedtuples ************************************/
+/* Helper function for namedtuple() ************************************/
 
 typedef struct {
     PyObject_HEAD

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2386,7 +2386,7 @@ tuplegetter_descr_get(PyObject *self, PyObject *obj, PyObject *type)
         PyErr_Format(PyExc_TypeError,
                      "descriptor for index '%d' for tuple subclasses "
                      "doesn't apply to '%s' object",
-                     ((_tuplegetterobject*)self)->index,
+                     index,
                      obj->ob_type->tp_name);
         return NULL;
     }


### PR DESCRIPTION
* Remove the docstrings cache.
* Improve tests.
* Unify names of tp_descr_get and tp_descr_set functions.


<!-- issue-number: [bpo-32492](https://bugs.python.org/issue32492) -->
https://bugs.python.org/issue32492
<!-- /issue-number -->
