### PR TITLE
bpo-35214: MSan workarounds for socket, time, and test_faulthandler.

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -5,6 +5,7 @@ import os
 import signal
 import subprocess
 import sys
+import sysconfig
 from test import support
 from test.support import script_helper, is_android
 import tempfile
@@ -252,6 +253,8 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'Segmentation fault')
 
+    @unittest.skipIf("--with-memory-sanitizer" in sysconfig.get_config_var("CONFIG_ARGS"),
+                     "memory-sanizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_file(self):
         with temporary_filename() as filename:
@@ -267,6 +270,8 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
+    @unittest.skipIf("--with-memory-sanitizer" in sysconfig.get_config_var("CONFIG_ARGS"),
+                     "memory-sanizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -20,6 +20,10 @@ except ImportError:
 
 TIMEOUT = 0.5
 MS_WINDOWS = (os.name == 'nt')
+MEMORY_SANITIZER = (
+    sysconfig.get_config_var("CONFIG_ARGS") and
+    ("--with-memory-sanitizer" in sysconfig.get_config_var("CONFIG_ARGS"))
+)
 
 def expected_traceback(lineno1, lineno2, header, min_count=1):
     regex = header
@@ -253,7 +257,7 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'Segmentation fault')
 
-    @unittest.skipIf("--with-memory-sanitizer" in sysconfig.get_config_var("CONFIG_ARGS"),
+    @unittest.skipIf(MEMORY_SANITIZER,
                      "memory-sanizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_file(self):
@@ -270,7 +274,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
-    @unittest.skipIf("--with-memory-sanitizer" in sysconfig.get_config_var("CONFIG_ARGS"),
+    @unittest.skipIf(MEMORY_SANITIZER,
                      "memory-sanizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_fd(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
@@ -1,0 +1,2 @@
+Clang Memory Sanitizer build instrumentation was added to work around false
+positives from socket, time, and test_faulthandler.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
@@ -1,2 +1,2 @@
-Clang Memory Sanitizer build instrumentation was added to work around false
+clang Memory Sanitizer build instrumentation was added to work around false
 positives from socket, time, and test_faulthandler.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -102,6 +102,10 @@ Local naming conventions:
 #include "Python.h"
 #include "structmember.h"
 
+#ifdef _Py_MEMORY_SANITIZER
+# include <sanitizer/msan_interface.h>
+#endif
+
 /* Socket object documentation */
 PyDoc_STRVAR(sock_doc,
 "socket(family=AF_INET, type=SOCK_STREAM, proto=0) -> socket object\n\
@@ -6571,7 +6575,23 @@ socket_if_nameindex(PyObject *self, PyObject *arg)
         return NULL;
     }
 
+#ifdef _Py_MEMORY_SANITIZER
+    __msan_unpoison(ni, sizeof(ni));
+    __msan_unpoison(&ni[0], sizeof(ni[0]));
+#endif
     for (i = 0; ni[i].if_index != 0 && i < INT_MAX; i++) {
+#ifdef _Py_MEMORY_SANITIZER
+        /* This one isn't the end sentinel, the next one must exist. */
+        __msan_unpoison(&ni[i+1], sizeof(ni[0]));
+        /* Otherwise Py_BuildValue internals are flagged by MSan when
+           they access the not-msan-tracked if_name string data. */
+        {
+            char *to_sanitize = ni[i].if_name;
+            do {
+                __msan_unpoison(to_sanitize, 1);
+            } while (*to_sanitize++ != '\0');
+        }
+#endif
         PyObject *ni_tuple = Py_BuildValue("IO&",
                 ni[i].if_index, PyUnicode_DecodeFSDefault, ni[i].if_name);
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -34,6 +34,10 @@
 #endif /* MS_WINDOWS */
 #endif /* !__WATCOMC__ || __QNX__ */
 
+#ifdef _Py_MEMORY_SANITIZER
+# include <sanitizer/msan_interface.h>
+#endif
+
 #define SEC_TO_NS (1000 * 1000 * 1000)
 
 /* Forward declarations */
@@ -336,6 +340,9 @@ time_pthread_getcpuclockid(PyObject *self, PyObject *args)
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
+#ifdef _Py_MEMORY_SANITIZER
+    __msan_unpoison(&clk_id, sizeof(clk_id));
+#endif
     return PyLong_FromLong(clk_id);
 }
 


### PR DESCRIPTION
Add Clang Memory Sanitizer build instrumentation to work around
false positives from the socket and time modules as well as skipping
a couple test_faulthandler tests.

<!-- issue-number: [bpo-35214](https://bugs.python.org/issue35214) -->
https://bugs.python.org/issue35214
<!-- /issue-number -->
