### PR TITLE
bpo-35598: IDLE: Refactor globals in config_key.py

### DIFF
--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -81,7 +81,7 @@ The abstract event loop policy base class is defined as follows:
 
    .. method:: set_child_watcher(watcher)
 
-      Get the current child process watcher to *watcher*.
+      Set the current child process watcher to *watcher*.
 
       This function is Unix specific.
 

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -36,7 +36,17 @@
 #include <unistd.h>
 #endif
 #ifdef HAVE_CRYPT_H
+#if defined(HAVE_CRYPT_R) && !defined(_GNU_SOURCE)
+/* Required for glibc to expose the crypt_r() function prototype. */
+#  define _GNU_SOURCE
+#  define _Py_GNU_SOURCE_FOR_CRYPT
+#endif
 #include <crypt.h>
+#ifdef _Py_GNU_SOURCE_FOR_CRYPT
+/* Don't leak the _GNU_SOURCE define to other headers. */
+#  undef _GNU_SOURCE
+#  undef _Py_GNU_SOURCE_FOR_CRYPT
+#endif
 #endif
 
 /* For size_t? */

--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -11,7 +11,8 @@ def abstractmethod(funcobj):
     class that has a metaclass derived from ABCMeta cannot be
     instantiated unless all of its abstract methods are overridden.
     The abstract methods can be called using any of the normal
-    'super' call mechanisms.
+    'super' call mechanisms.  abstractmethod() may be used to declare
+    abstract methods for properties and descriptors.
 
     Usage:
 
@@ -27,17 +28,7 @@ def abstractmethod(funcobj):
 class abstractclassmethod(classmethod):
     """A decorator indicating abstract classmethods.
 
-    Similar to abstractmethod.
-
-    Usage:
-
-        class C(metaclass=ABCMeta):
-            @abstractclassmethod
-            def my_abstract_classmethod(cls, ...):
-                ...
-
-    'abstractclassmethod' is deprecated. Use 'classmethod' with
-    'abstractmethod' instead.
+    Deprecated, use 'classmethod' with 'abstractmethod' instead.
     """
 
     __isabstractmethod__ = True
@@ -50,17 +41,7 @@ class abstractclassmethod(classmethod):
 class abstractstaticmethod(staticmethod):
     """A decorator indicating abstract staticmethods.
 
-    Similar to abstractmethod.
-
-    Usage:
-
-        class C(metaclass=ABCMeta):
-            @abstractstaticmethod
-            def my_abstract_staticmethod(...):
-                ...
-
-    'abstractstaticmethod' is deprecated. Use 'staticmethod' with
-    'abstractmethod' instead.
+    Deprecated, use 'staticmethod' with 'abstractmethod' instead.
     """
 
     __isabstractmethod__ = True
@@ -73,29 +54,7 @@ class abstractstaticmethod(staticmethod):
 class abstractproperty(property):
     """A decorator indicating abstract properties.
 
-    Requires that the metaclass is ABCMeta or derived from it.  A
-    class that has a metaclass derived from ABCMeta cannot be
-    instantiated unless all of its abstract properties are overridden.
-    The abstract properties can be called using any of the normal
-    'super' call mechanisms.
-
-    Usage:
-
-        class C(metaclass=ABCMeta):
-            @abstractproperty
-            def my_abstract_property(self):
-                ...
-
-    This defines a read-only property; you can also define a read-write
-    abstract property using the 'long' form of property declaration:
-
-        class C(metaclass=ABCMeta):
-            def getx(self): ...
-            def setx(self, value): ...
-            x = abstractproperty(getx, setx)
-
-    'abstractproperty' is deprecated. Use 'property' with 'abstractmethod'
-    instead.
+    Deprecated, use 'property' with 'abstractmethod' instead.
     """
 
     __isabstractmethod__ = True

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -316,8 +316,6 @@ try:
 except ImportError:
     _tuplegetter = lambda index, doc: property(_itemgetter(index), doc=doc)
 
-_nt_itemgetters = {}
-
 def namedtuple(typename, field_names, *, rename=False, defaults=None, module=None):
     """Returns a new subclass of tuple with named fields.
 
@@ -456,16 +454,9 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
         '_asdict': _asdict,
         '__getnewargs__': __getnewargs__,
     }
-    cache = _nt_itemgetters
     for index, name in enumerate(field_names):
-        try:
-            doc = cache[index]
-        except KeyError:
-            doc = f'Alias for field number {index}'
-            cache[index] = doc
-
-        tuplegetter_object = _tuplegetter(index, doc)
-        class_namespace[name] = tuplegetter_object
+        doc = _sys.intern(f'Alias for field number {index}')
+        class_namespace[name] = _tuplegetter(index, doc)
 
     result = type(typename, (tuple,), class_namespace)
 

--- a/Lib/idlelib/config_key.py
+++ b/Lib/idlelib/config_key.py
@@ -8,6 +8,38 @@ import string
 import sys
 
 
+FUNCTION_KEYS = ('F1', 'F2' ,'F3' ,'F4' ,'F5' ,'F6',
+                 'F7', 'F8' ,'F9' ,'F10' ,'F11' ,'F12')
+ALPHANUM_KEYS = tuple(string.ascii_lowercase + string.digits)
+PUNCTUATION_KEYS = tuple('~!@#%^&*()_-+={}[]|;:,.<>/?')
+WHITESPACE_KEYS = ('Tab', 'Space', 'Return')
+EDIT_KEYS = ('BackSpace', 'Delete', 'Insert')
+MOVE_KEYS = ('Home', 'End', 'Page Up', 'Page Down', 'Left Arrow',
+             'Right Arrow', 'Up Arrow', 'Down Arrow')
+AVAILABLE_KEYS = (ALPHANUM_KEYS + PUNCTUATION_KEYS + FUNCTION_KEYS +
+                  WHITESPACE_KEYS + EDIT_KEYS + MOVE_KEYS)
+
+
+def translate_key(key, modifiers):
+    "Translate from keycap symbol to the Tkinter keysym."
+    mapping = {'Space':'space',
+            '~':'asciitilde', '!':'exclam', '@':'at', '#':'numbersign',
+            '%':'percent', '^':'asciicircum', '&':'ampersand',
+            '*':'asterisk', '(':'parenleft', ')':'parenright',
+            '_':'underscore', '-':'minus', '+':'plus', '=':'equal',
+            '{':'braceleft', '}':'braceright',
+            '[':'bracketleft', ']':'bracketright', '|':'bar',
+            ';':'semicolon', ':':'colon', ',':'comma', '.':'period',
+            '<':'less', '>':'greater', '/':'slash', '?':'question',
+            'Page Up':'Prior', 'Page Down':'Next',
+            'Left Arrow':'Left', 'Right Arrow':'Right',
+            'Up Arrow':'Up', 'Down Arrow': 'Down', 'Tab':'Tab'}
+    key = mapping.get(key, key)
+    if 'Shift' in modifiers and key in string.ascii_lowercase:
+        key = key.upper()
+    return f'Key-{key}'
+
+
 class GetKeysDialog(Toplevel):
 
     # Dialog title for invalid key sequence
@@ -206,7 +238,7 @@ class GetKeysDialog(Toplevel):
         keylist = modifiers = self.get_modifiers()
         final_key = self.list_keys_final.get('anchor')
         if final_key:
-            final_key = self.translate_key(final_key, modifiers)
+            final_key = translate_key(final_key, modifiers)
             keylist.append(final_key)
         self.key_string.set(f"<{'-'.join(keylist)}>")
 
@@ -225,40 +257,7 @@ class GetKeysDialog(Toplevel):
 
     def load_final_key_list(self):
         "Populate listbox of available keys."
-        # These tuples are also available for use in validity checks.
-        self.function_keys = ('F1', 'F2' ,'F3' ,'F4' ,'F5' ,'F6',
-                              'F7', 'F8' ,'F9' ,'F10' ,'F11' ,'F12')
-        self.alphanum_keys = tuple(string.ascii_lowercase + string.digits)
-        self.punctuation_keys = tuple('~!@#%^&*()_-+={}[]|;:,.<>/?')
-        self.whitespace_keys = ('Tab', 'Space', 'Return')
-        self.edit_keys = ('BackSpace', 'Delete', 'Insert')
-        self.move_keys = ('Home', 'End', 'Page Up', 'Page Down', 'Left Arrow',
-                          'Right Arrow', 'Up Arrow', 'Down Arrow')
-        # Make a tuple of most of the useful common 'final' keys.
-        keys = (self.alphanum_keys + self.punctuation_keys + self.function_keys +
-                self.whitespace_keys + self.edit_keys + self.move_keys)
-        self.list_keys_final.insert('end', *keys)
-
-    @staticmethod
-    def translate_key(key, modifiers):
-        "Translate from keycap symbol to the Tkinter keysym."
-        translate_dict = {'Space':'space',
-                '~':'asciitilde', '!':'exclam', '@':'at', '#':'numbersign',
-                '%':'percent', '^':'asciicircum', '&':'ampersand',
-                '*':'asterisk', '(':'parenleft', ')':'parenright',
-                '_':'underscore', '-':'minus', '+':'plus', '=':'equal',
-                '{':'braceleft', '}':'braceright',
-                '[':'bracketleft', ']':'bracketright', '|':'bar',
-                ';':'semicolon', ':':'colon', ',':'comma', '.':'period',
-                '<':'less', '>':'greater', '/':'slash', '?':'question',
-                'Page Up':'Prior', 'Page Down':'Next',
-                'Left Arrow':'Left', 'Right Arrow':'Right',
-                'Up Arrow':'Up', 'Down Arrow': 'Down', 'Tab':'Tab'}
-        if key in translate_dict:
-            key = translate_dict[key]
-        if 'Shift' in modifiers and key in string.ascii_lowercase:
-            key = key.upper()
-        return f'Key-{key}'
+        self.list_keys_final.insert('end', *AVAILABLE_KEYS)
 
     def ok(self, event=None):
         keys = self.key_string.get().strip()
@@ -291,12 +290,12 @@ class GetKeysDialog(Toplevel):
             self.showerror(title, parent=self,
                            message='Missing the final Key')
         elif (not modifiers
-              and final_key not in self.function_keys + self.move_keys):
+              and final_key not in FUNCTION_KEYS + MOVE_KEYS):
             self.showerror(title=title, parent=self,
                            message='No modifier key(s) specified.')
         elif (modifiers == ['Shift']) \
                  and (final_key not in
-                      self.function_keys + self.move_keys + ('Tab', 'Space')):
+                      FUNCTION_KEYS + MOVE_KEYS + ('Tab', 'Space')):
             msg = 'The shift modifier by itself may not be used with'\
                   ' this key symbol.'
             self.showerror(title=title, parent=self, message=msg)

--- a/Lib/idlelib/idle_test/test_config_key.py
+++ b/Lib/idlelib/idle_test/test_config_key.py
@@ -206,25 +206,6 @@ class KeySelectionTest(unittest.TestCase):
         dialog.modifier_checkbuttons['foo'].invoke()
         eq(gm(), ['BAZ'])
 
-    def test_translate_key(self):
-        dialog = self.dialog
-        tr = dialog.translate_key
-        eq = self.assertEqual
-
-        # Letters return unchanged with no 'Shift'.
-        eq(tr('q', []), 'Key-q')
-        eq(tr('q', ['Control', 'Alt']), 'Key-q')
-
-        # 'Shift' uppercases single lowercase letters.
-        eq(tr('q', ['Shift']), 'Key-Q')
-        eq(tr('q', ['Control', 'Shift']), 'Key-Q')
-        eq(tr('q', ['Control', 'Alt', 'Shift']), 'Key-Q')
-
-        # Convert key name to keysym.
-        eq(tr('Page Up', []), 'Key-Prior')
-        # 'Shift' doesn't change case.
-        eq(tr('Page Down', ['Shift']), 'Key-Next')
-
     @mock.patch.object(gkd, 'get_modifiers')
     def test_build_key_string(self, mock_modifiers):
         dialog = self.dialog
@@ -282,6 +263,28 @@ class CancelTest(unittest.TestCase):
         with self.assertRaises(TclError):
             self.dialog.winfo_class()
         self.assertEqual(self.dialog.result, '')
+
+
+class HelperTest(unittest.TestCase):
+    "Test module level helper functions."
+
+    def test_translate_key(self):
+        tr = config_key.translate_key
+        eq = self.assertEqual
+
+        # Letters return unchanged with no 'Shift'.
+        eq(tr('q', []), 'Key-q')
+        eq(tr('q', ['Control', 'Alt']), 'Key-q')
+
+        # 'Shift' uppercases single lowercase letters.
+        eq(tr('q', ['Shift']), 'Key-Q')
+        eq(tr('q', ['Control', 'Shift']), 'Key-Q')
+        eq(tr('q', ['Control', 'Alt', 'Shift']), 'Key-Q')
+
+        # Convert key name to keysym.
+        eq(tr('Page Up', []), 'Key-Prior')
+        # 'Shift' doesn't change case when it's not a single char.
+        eq(tr('*', ['Shift']), 'Key-asterisk')
 
 
 if __name__ == '__main__':

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1255,7 +1255,7 @@ location listed above.
 
         # List the built-in subclasses, if any:
         subclasses = sorted(
-            (str(cls.__name__) for cls in object.__subclasses__()
+            (str(cls.__name__) for cls in type.__subclasses__(object)
              if not cls.__name__.startswith("_") and cls.__module__ == "builtins"),
             key=str.lower
         )

--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -68,7 +68,7 @@ typically try to ascertain containers keep working when containing more than
 2 billion objects, which only works on 64-bit systems. There are also some
 tests that try to exhaust the address space of the process, which only makes
 sense on 32-bit systems with at least 2Gb of memory. The passed-in memlimit,
-which is a string in the form of '2.5Gb', determines howmuch memory the
+which is a string in the form of '2.5Gb', determines how much memory the
 tests will limit themselves to (but they may go slightly over.) The number
 shouldn't be more memory than the machine has (including swap memory). You
 should also keep in mind that swap memory is generally much, much slower

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -3,6 +3,7 @@
 import collections
 import copy
 import doctest
+import inspect
 import operator
 import pickle
 from random import choice, randrange
@@ -281,20 +282,50 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(Point(1), (1, 20))
         self.assertEqual(Point(), (10, 20))
 
+    def test_readonly(self):
+        Point = namedtuple('Point', 'x y')
+        p = Point(11, 22)
+        with self.assertRaises(AttributeError):
+            p.x = 33
+        with self.assertRaises(AttributeError):
+            del p.x
+        with self.assertRaises(TypeError):
+            p[0] = 33
+        with self.assertRaises(TypeError):
+            del p[0]
+        self.assertEqual(p.x, 11)
+        self.assertEqual(p[0], 11)
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
     def test_factory_doc_attr(self):
         Point = namedtuple('Point', 'x y')
         self.assertEqual(Point.__doc__, 'Point(x, y)')
+        Point.__doc__ = '2D point'
+        self.assertEqual(Point.__doc__, '2D point')
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
-    def test_doc_writable(self):
+    def test_field_doc(self):
         Point = namedtuple('Point', 'x y')
         self.assertEqual(Point.x.__doc__, 'Alias for field number 0')
+        self.assertEqual(Point.y.__doc__, 'Alias for field number 1')
         Point.x.__doc__ = 'docstring for Point.x'
         self.assertEqual(Point.x.__doc__, 'docstring for Point.x')
+        # namedtuple can mutate doc of descriptors independently
+        Vector = namedtuple('Vector', 'x y')
+        self.assertEqual(Vector.x.__doc__, 'Alias for field number 0')
+        Vector.x.__doc__ = 'docstring for Vector.x'
+        self.assertEqual(Vector.x.__doc__, 'docstring for Vector.x')
+
+    @support.cpython_only
+    @unittest.skipIf(sys.flags.optimize >= 2,
+                     "Docstrings are omitted with -O2 and above")
+    def test_field_doc_reuse(self):
+        P = namedtuple('P', ['m', 'n'])
+        Q = namedtuple('Q', ['o', 'p'])
+        self.assertIs(P.m.__doc__, Q.o.__doc__)
+        self.assertIs(P.n.__doc__, Q.p.__doc__)
 
     def test_name_fixer(self):
         for spec, renamed in [
@@ -319,16 +350,18 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(p, Point(y=22, x=11))
         self.assertEqual(p, Point(*(11, 22)))
         self.assertEqual(p, Point(**dict(x=11, y=22)))
-        self.assertRaises(TypeError, Point, 1)                              # too few args
-        self.assertRaises(TypeError, Point, 1, 2, 3)                        # too many args
-        self.assertRaises(TypeError, eval, 'Point(XXX=1, y=2)', locals())   # wrong keyword argument
-        self.assertRaises(TypeError, eval, 'Point(x=1)', locals())          # missing keyword argument
+        self.assertRaises(TypeError, Point, 1)          # too few args
+        self.assertRaises(TypeError, Point, 1, 2, 3)    # too many args
+        with self.assertRaises(TypeError):              # wrong keyword argument
+            Point(XXX=1, y=2)
+        with self.assertRaises(TypeError):              # missing keyword argument
+            Point(x=1)
         self.assertEqual(repr(p), 'Point(x=11, y=22)')
         self.assertNotIn('__weakref__', dir(p))
-        self.assertEqual(p, Point._make([11, 22]))                          # test _make classmethod
-        self.assertEqual(p._fields, ('x', 'y'))                             # test _fields attribute
-        self.assertEqual(p._replace(x=1), (1, 22))                          # test _replace method
-        self.assertEqual(p._asdict(), dict(x=11, y=22))                     # test _asdict method
+        self.assertEqual(p, Point._make([11, 22]))      # test _make classmethod
+        self.assertEqual(p._fields, ('x', 'y'))         # test _fields attribute
+        self.assertEqual(p._replace(x=1), (1, 22))      # test _replace method
+        self.assertEqual(p._asdict(), dict(x=11, y=22)) # test _asdict method
 
         try:
             p._replace(x=1, error=2)
@@ -360,11 +393,15 @@ class TestNamedTuple(unittest.TestCase):
         x, y = p
         self.assertEqual(p, (x, y))                                         # unpacks like a tuple
         self.assertEqual((p[0], p[1]), (11, 22))                            # indexable like a tuple
-        self.assertRaises(IndexError, p.__getitem__, 3)
+        with self.assertRaises(IndexError):
+            p[3]
+        self.assertEqual(p[-1], 22)
+        self.assertEqual(hash(p), hash((11, 22)))
 
         self.assertEqual(p.x, x)
         self.assertEqual(p.y, y)
-        self.assertRaises(AttributeError, eval, 'p.z', locals())
+        with self.assertRaises(AttributeError):
+            p.z
 
     def test_odd_sizes(self):
         Zero = namedtuple('Zero', '')
@@ -514,13 +551,13 @@ class TestNamedTuple(unittest.TestCase):
         a.w = 5
         self.assertEqual(a.__dict__, {'w': 5})
 
-    def test_namedtuple_can_mutate_doc_of_descriptors_independently(self):
-        A = namedtuple('A', 'x y')
-        B = namedtuple('B', 'x y')
-        A.x.__doc__ = 'foo'
-        B.x.__doc__ = 'bar'
-        self.assertEqual(A.x.__doc__, 'foo')
-        self.assertEqual(B.x.__doc__, 'bar')
+    def test_field_descriptor(self):
+        Point = namedtuple('Point', 'x y')
+        p = Point(11, 22)
+        self.assertTrue(inspect.isdatadescriptor(Point.x))
+        self.assertEqual(Point.x.__get__(p), 11)
+        self.assertRaises(AttributeError, Point.x.__set__, p, 33)
+        self.assertRaises(AttributeError, Point.x.__delete__, p)
 
 
 ################################################################################

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -23,11 +23,11 @@ MS_WINDOWS = (os.name == 'nt')
 _cflags = sysconfig.get_config_var('CFLAGS') or ''
 _config_args = sysconfig.get_config_var('CONFIG_ARGS') or ''
 UB_SANITIZER = (
-    '-fsanitizer=undefined' in _cflags or
+    '-fsanitize=undefined' in _cflags or
     '--with-undefined-behavior-sanitizer' in _config_args
 )
 MEMORY_SANITIZER = (
-    '-fsanitizer=memory' in _cflags or
+    '-fsanitize=memory' in _cflags or
     '--with-memory-sanitizer' in _config_args
 )
 
@@ -265,7 +265,7 @@ class FaultHandlerTests(unittest.TestCase):
             'Segmentation fault')
 
     @unittest.skipIf(UB_SANITIZER or MEMORY_SANITIZER,
-                     "sanizer builds change crashing process output.")
+                     "sanitizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_file(self):
         with temporary_filename() as filename:
@@ -282,7 +282,7 @@ class FaultHandlerTests(unittest.TestCase):
     @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
     @unittest.skipIf(UB_SANITIZER or MEMORY_SANITIZER,
-                     "sanizer builds change crashing process output.")
+                     "sanitizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -5,6 +5,7 @@ import os
 import signal
 import subprocess
 import sys
+import sysconfig
 from test import support
 from test.support import script_helper, is_android
 import tempfile
@@ -19,6 +20,10 @@ except ImportError:
 
 TIMEOUT = 0.5
 MS_WINDOWS = (os.name == 'nt')
+MEMORY_SANITIZER = (
+    sysconfig.get_config_var("CONFIG_ARGS") and
+    ("--with-memory-sanitizer" in sysconfig.get_config_var("CONFIG_ARGS"))
+)
 
 def expected_traceback(lineno1, lineno2, header, min_count=1):
     regex = header
@@ -252,6 +257,8 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'Segmentation fault')
 
+    @unittest.skipIf(MEMORY_SANITIZER,
+                     "memory-sanizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_file(self):
         with temporary_filename() as filename:
@@ -267,6 +274,8 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
+    @unittest.skipIf(MEMORY_SANITIZER,
+                     "memory-sanizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -20,10 +20,17 @@ except ImportError:
 
 TIMEOUT = 0.5
 MS_WINDOWS = (os.name == 'nt')
-MEMORY_SANITIZER = (
-    sysconfig.get_config_var("CONFIG_ARGS") and
-    ("--with-memory-sanitizer" in sysconfig.get_config_var("CONFIG_ARGS"))
+_cflags = sysconfig.get_config_var('CFLAGS') or ''
+_config_args = sysconfig.get_config_var('CONFIG_ARGS') or ''
+UB_SANITIZER = (
+    '-fsanitizer=undefined' in _cflags or
+    '--with-undefined-behavior-sanitizer' in _config_args
 )
+MEMORY_SANITIZER = (
+    '-fsanitizer=memory' in _cflags or
+    '--with-memory-sanitizer' in _config_args
+)
+
 
 def expected_traceback(lineno1, lineno2, header, min_count=1):
     regex = header
@@ -99,7 +106,7 @@ class FaultHandlerTests(unittest.TestCase):
         else:
             header = 'Stack'
         regex = r"""
-            ^{fatal_error}
+            (?m)^{fatal_error}
 
             {header} \(most recent call first\):
               File "<string>", line {lineno} in <module>
@@ -257,8 +264,8 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'Segmentation fault')
 
-    @unittest.skipIf(MEMORY_SANITIZER,
-                     "memory-sanizer builds change crashing process output.")
+    @unittest.skipIf(UB_SANITIZER or MEMORY_SANITIZER,
+                     "sanizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_file(self):
         with temporary_filename() as filename:
@@ -274,8 +281,8 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
-    @unittest.skipIf(MEMORY_SANITIZER,
-                     "memory-sanizer builds change crashing process output.")
+    @unittest.skipIf(UB_SANITIZER or MEMORY_SANITIZER,
+                     "sanizer builds change crashing process output.")
     @skip_segfault_on_android
     def test_enable_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -687,6 +687,16 @@ class PydocDocTest(unittest.TestCase):
         finally:
             pydoc.getpager = getpager_old
 
+    def test_namedtuple_fields(self):
+        Person = namedtuple('Person', ['nickname', 'firstname'])
+        with captured_stdout() as help_io:
+            pydoc.help(Person)
+        helptext = help_io.getvalue()
+        self.assertIn("nickname", helptext)
+        self.assertIn("firstname", helptext)
+        self.assertIn("Alias for field number 0", helptext)
+        self.assertIn("Alias for field number 1", helptext)
+
     def test_namedtuple_public_underscore(self):
         NT = namedtuple('NT', ['abc', 'def'], rename=True)
         with captured_stdout() as help_io:

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -636,6 +636,17 @@ class PydocDocTest(unittest.TestCase):
         # Testing that the subclasses section does not appear
         self.assertNotIn('Built-in subclasses', text)
 
+    def test_builtin_on_metaclasses(self):
+        """Tests help on metaclasses.
+
+        When running help() on a metaclasses such as type, it
+        should not contain any "Built-in subclasses" section.
+        """
+        doc = pydoc.TextDoc()
+        text = doc.docclass(type)
+        # Testing that the subclasses section does not appear
+        self.assertNotIn('Built-in subclasses', text)
+
     @unittest.skipIf(sys.flags.optimize >= 2,
                      'Docstrings are omitted with -O2 and above')
     @unittest.skipIf(hasattr(sys, 'gettrace') and sys.gettrace(),

--- a/Misc/NEWS.d/next/Build/2018-12-29-10-19-43.bpo-35550.BTuu8e.rst
+++ b/Misc/NEWS.d/next/Build/2018-12-29-10-19-43.bpo-35550.BTuu8e.rst
@@ -1,0 +1,1 @@
+Fix incorrect Solaris #ifdef checks to look for __sun && __SVR4 instead of sun when compiling.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
@@ -1,0 +1,2 @@
+clang Memory Sanitizer build instrumentation was added to work around false
+positives from socket, time, and test_faulthandler.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
@@ -1,2 +1,2 @@
 clang Memory Sanitizer build instrumentation was added to work around false
-positives from socket, time, and test_faulthandler.
+positives from socket, time, test_io, and test_faulthandler.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
@@ -1,2 +1,2 @@
 clang Memory Sanitizer build instrumentation was added to work around false
-positives from socket, time, test_io, and test_faulthandler.
+positives from posix, socket, time, test_io, and test_faulthandler.

--- a/Misc/NEWS.d/next/Library/2018-12-30-01-10-50.bpo-35614.cnkM4f.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-30-01-10-50.bpo-35614.cnkM4f.rst
@@ -1,0 +1,1 @@
+Fixed help() on metaclasses. Patch by Sanyam Khurana.

--- a/Misc/NEWS.d/next/Library/2018-12-30-14-56-33.bpo-28503.V4kNN3.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-30-14-56-33.bpo-28503.V4kNN3.rst
@@ -1,0 +1,2 @@
+The `crypt` module now internally uses the `crypt_r()` library function
+instead of `crypt()` when available.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2336,7 +2336,7 @@ done:
     Py_RETURN_NONE;
 }
 
-/* Helper functions for namedtuples */
+/* Helper function for namedtuple() ************************************/
 
 typedef struct {
     PyObject_HEAD
@@ -2369,9 +2369,11 @@ tuplegetter_new_impl(PyTypeObject *type, Py_ssize_t index, PyObject *doc)
 }
 
 static PyObject *
-tuplegetterdescr_get(PyObject *self, PyObject *obj, PyObject *type)
+tuplegetter_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 {
+    Py_ssize_t index = ((_tuplegetterobject*)self)->index;
     PyObject *result;
+
     if (obj == NULL) {
         Py_INCREF(self);
         return self;
@@ -2384,12 +2386,10 @@ tuplegetterdescr_get(PyObject *self, PyObject *obj, PyObject *type)
         PyErr_Format(PyExc_TypeError,
                      "descriptor for index '%d' for tuple subclasses "
                      "doesn't apply to '%s' object",
-                     ((_tuplegetterobject*)self)->index,
+                     index,
                      obj->ob_type->tp_name);
         return NULL;
     }
-
-    Py_ssize_t index = ((_tuplegetterobject*)self)->index;
 
     if (!valid_index(index, PyTuple_GET_SIZE(obj))) {
         PyErr_SetString(PyExc_IndexError, "tuple index out of range");
@@ -2402,7 +2402,7 @@ tuplegetterdescr_get(PyObject *self, PyObject *obj, PyObject *type)
 }
 
 static int
-tuplegetter_set(PyObject *self, PyObject *obj, PyObject *value)
+tuplegetter_descr_set(PyObject *self, PyObject *obj, PyObject *value)
 {
     if (value == NULL) {
         PyErr_SetString(PyExc_AttributeError, "can't delete attribute");
@@ -2476,8 +2476,8 @@ static PyTypeObject tuplegetter_type = {
     0,                                          /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */
-    tuplegetterdescr_get,                       /* tp_descr_get */
-    tuplegetter_set,                            /* tp_descr_set */
+    tuplegetter_descr_get,                      /* tp_descr_get */
+    tuplegetter_descr_set,                      /* tp_descr_set */
     0,                                          /* tp_dictoffset */
     0,                                          /* tp_init */
     0,                                          /* tp_alloc */

--- a/Modules/_cryptmodule.c
+++ b/Modules/_cryptmodule.c
@@ -34,7 +34,15 @@ static PyObject *
 crypt_crypt_impl(PyObject *module, const char *word, const char *salt)
 /*[clinic end generated code: output=0512284a03d2803c input=0e8edec9c364352b]*/
 {
-    return Py_BuildValue("s", crypt(word, salt));
+    char *crypt_result;
+#ifdef HAVE_CRYPT_R
+    struct crypt_data data;
+    memset(&data, 0, sizeof(data));
+    crypt_result = crypt_r(word, salt, &data);
+#else
+    crypt_result = crypt(word, salt);
+#endif
+    return Py_BuildValue("s", crypt_result);
 }
 
 

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -28,10 +28,6 @@
 
 #define MUNCH_SIZE INT_MAX
 
-#ifndef HASH_OBJ_CONSTRUCTOR
-#define HASH_OBJ_CONSTRUCTOR 0
-#endif
-
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 /* OpenSSL < 1.1.0 */
 #define EVP_MD_CTX_new EVP_MD_CTX_create
@@ -345,76 +341,23 @@ EVP_repr(EVPobject *self)
     return PyUnicode_FromFormat("<%U HASH object @ %p>", self->name, self);
 }
 
-/*[clinic input]
-_hashlib.HASH.__init__ as EVP_tp_init
-
-    name as name_obj: object
-    string as data_obj: object(py_default="b''") = NULL
-
-A hash is an object used to calculate a checksum of a string of information.
-
-Methods:
-
-update() -- updates the current digest with an additional string
-digest() -- return the current digest value
-hexdigest() -- return the current digest as a string of hexadecimal digits
-copy() -- return a copy of the current hash object
-
-Attributes:
-
-name -- the hash algorithm being used by this object
-digest_size -- number of bytes in this hashes output
-[clinic start generated code]*/
-
-static int
-EVP_tp_init_impl(EVPobject *self, PyObject *name_obj, PyObject *data_obj)
-/*[clinic end generated code: output=44766d27757cf851 input=dac22658387f9b5d]*/
-{
-    Py_buffer view;
-    char *nameStr;
-    const EVP_MD *digest;
-
-    if (data_obj)
-        GET_BUFFER_VIEW_OR_ERROR(data_obj, &view, return -1);
-
-    if (!PyArg_Parse(name_obj, "s", &nameStr)) {
-        PyErr_SetString(PyExc_TypeError, "name must be a string");
-        if (data_obj)
-            PyBuffer_Release(&view);
-        return -1;
-    }
-
-    digest = EVP_get_digestbyname(nameStr);
-    if (!digest) {
-        PyErr_SetString(PyExc_ValueError, "unknown hash function");
-        if (data_obj)
-            PyBuffer_Release(&view);
-        return -1;
-    }
-    if (!EVP_DigestInit(self->ctx, digest)) {
-        _setException(PyExc_ValueError);
-        if (data_obj)
-            PyBuffer_Release(&view);
-        return -1;
-    }
-
-    Py_INCREF(name_obj);
-    Py_XSETREF(self->name, name_obj);
-
-    if (data_obj) {
-        if (view.len >= HASHLIB_GIL_MINSIZE) {
-            Py_BEGIN_ALLOW_THREADS
-            EVP_hash(self, view.buf, view.len);
-            Py_END_ALLOW_THREADS
-        } else {
-            EVP_hash(self, view.buf, view.len);
-        }
-        PyBuffer_Release(&view);
-    }
-
-    return 0;
-}
-
+PyDoc_STRVAR(hashtype_doc,
+"HASH(name, string=b\'\')\n"
+"--\n"
+"\n"
+"A hash is an object used to calculate a checksum of a string of information.\n"
+"\n"
+"Methods:\n"
+"\n"
+"update() -- updates the current digest with an additional string\n"
+"digest() -- return the current digest value\n"
+"hexdigest() -- return the current digest as a string of hexadecimal digits\n"
+"copy() -- return a copy of the current hash object\n"
+"\n"
+"Attributes:\n"
+"\n"
+"name -- the hash algorithm being used by this object\n"
+"digest_size -- number of bytes in this hashes output");
 
 static PyTypeObject EVPtype = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -438,7 +381,7 @@ static PyTypeObject EVPtype = {
     0,                  /*tp_setattro*/
     0,                  /*tp_as_buffer*/
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-    EVP_tp_init__doc__, /*tp_doc*/
+    hashtype_doc,       /*tp_doc*/
     0,                  /*tp_traverse*/
     0,                  /*tp_clear*/
     0,                  /*tp_richcompare*/
@@ -448,16 +391,11 @@ static PyTypeObject EVPtype = {
     EVP_methods,        /* tp_methods */
     EVP_members,        /* tp_members */
     EVP_getseters,      /* tp_getset */
-#if 1
     0,                  /* tp_base */
     0,                  /* tp_dict */
     0,                  /* tp_descr_get */
     0,                  /* tp_descr_set */
     0,                  /* tp_dictoffset */
-#endif
-#if HASH_OBJ_CONSTRUCTOR
-    (initproc)EVP_tp_init, /* tp_init */
-#endif
 };
 
 static PyObject *

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -30,7 +30,7 @@
 # define SYS_getdents64  __NR_getdents64
 #endif
 
-#if defined(sun)
+#if defined(__sun) && defined(__SVR4)
 /* readdir64 is used to work around Solaris 9 bug 6395699. */
 # define readdir readdir64
 # define dirent dirent64

--- a/Modules/clinic/_hashopenssl.c.h
+++ b/Modules/clinic/_hashopenssl.c.h
@@ -65,46 +65,6 @@ PyDoc_STRVAR(EVP_update__doc__,
 #define EVP_UPDATE_METHODDEF    \
     {"update", (PyCFunction)EVP_update, METH_O, EVP_update__doc__},
 
-PyDoc_STRVAR(EVP_tp_init__doc__,
-"HASH(name, string=b\'\')\n"
-"--\n"
-"\n"
-"A hash is an object used to calculate a checksum of a string of information.\n"
-"\n"
-"Methods:\n"
-"\n"
-"update() -- updates the current digest with an additional string\n"
-"digest() -- return the current digest value\n"
-"hexdigest() -- return the current digest as a string of hexadecimal digits\n"
-"copy() -- return a copy of the current hash object\n"
-"\n"
-"Attributes:\n"
-"\n"
-"name -- the hash algorithm being used by this object\n"
-"digest_size -- number of bytes in this hashes output");
-
-static int
-EVP_tp_init_impl(EVPobject *self, PyObject *name_obj, PyObject *data_obj);
-
-static int
-EVP_tp_init(PyObject *self, PyObject *args, PyObject *kwargs)
-{
-    int return_value = -1;
-    static const char * const _keywords[] = {"name", "string", NULL};
-    static _PyArg_Parser _parser = {"O|O:HASH", _keywords, 0};
-    PyObject *name_obj;
-    PyObject *data_obj = NULL;
-
-    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
-        &name_obj, &data_obj)) {
-        goto exit;
-    }
-    return_value = EVP_tp_init_impl((EVPobject *)self, name_obj, data_obj);
-
-exit:
-    return return_value;
-}
-
 PyDoc_STRVAR(EVP_new__doc__,
 "new($module, /, name, string=b\'\')\n"
 "--\n"
@@ -292,4 +252,4 @@ exit:
 #ifndef _HASHLIB_SCRYPT_METHODDEF
     #define _HASHLIB_SCRYPT_METHODDEF
 #endif /* !defined(_HASHLIB_SCRYPT_METHODDEF) */
-/*[clinic end generated code: output=cae09468e2cdbefe input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fe5931d2b301ca12 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -367,6 +367,10 @@ static int win32_can_symlink = 0;
 #define HAVE_STRUCT_STAT_ST_FSTYPE 1
 #endif
 
+#ifdef _Py_MEMORY_SANITIZER
+# include <sanitizer/msan_interface.h>
+#endif
+
 #ifdef HAVE_FORK
 static void
 run_at_forkers(PyObject *lst, int reverse)
@@ -5493,6 +5497,9 @@ os_posix_spawn_impl(PyObject *module, path_t *path, PyObject *argv,
         PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, path->object);
         goto exit;
     }
+#ifdef _Py_MEMORY_SANITIZER
+    __msan_unpoison(&pid, sizeof(pid));
+#endif
     result = PyLong_FromPid(pid);
 
 exit:
@@ -6098,6 +6105,9 @@ os_sched_rr_get_interval_impl(PyObject *module, pid_t pid)
         posix_error();
         return -1.0;
     }
+#ifdef _Py_MEMORY_SANITIZER
+    __msan_unpoison(&interval, sizeof(interval));
+#endif
     return (double)interval.tv_sec + 1e-9*interval.tv_nsec;
 }
 #endif /* HAVE_SCHED_RR_GET_INTERVAL */
@@ -6567,6 +6577,12 @@ posix_getgrouplist(PyObject *self, PyObject *args)
         PyMem_Del(groups);
         return posix_error();
     }
+
+#ifdef _Py_MEMORY_SANITIZER
+    /* Clang memory sanitizer libc intercepts don't know getgrouplist. */
+    __msan_unpoison(&ngroups, sizeof(ngroups));
+    __msan_unpoison(groups, ngroups*sizeof(*groups));
+#endif
 
     list = PyList_New(ngroups);
     if (list == NULL) {

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6335,7 +6335,7 @@ os_openpty_impl(PyObject *module)
 #endif
 #if defined(HAVE_DEV_PTMX) && !defined(HAVE_OPENPTY) && !defined(HAVE__GETPTY)
     PyOS_sighandler_t sig_saved;
-#ifdef sun
+#if defined(__sun) && defined(__SVR4)
     extern char *ptsname(int fildes);
 #endif
 #endif

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -267,7 +267,7 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
 #endif
 
 /* Solaris fails to define this variable at all. */
-#if defined(sun) && !defined(INET_ADDRSTRLEN)
+#if (defined(__sun) && defined(__SVR4)) && !defined(INET_ADDRSTRLEN)
 #define INET_ADDRSTRLEN 16
 #endif
 

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -102,6 +102,10 @@ Local naming conventions:
 #include "Python.h"
 #include "structmember.h"
 
+#ifdef _Py_MEMORY_SANITIZER
+# include <sanitizer/msan_interface.h>
+#endif
+
 /* Socket object documentation */
 PyDoc_STRVAR(sock_doc,
 "socket(family=AF_INET, type=SOCK_STREAM, proto=0) -> socket object\n\
@@ -6571,7 +6575,23 @@ socket_if_nameindex(PyObject *self, PyObject *arg)
         return NULL;
     }
 
+#ifdef _Py_MEMORY_SANITIZER
+    __msan_unpoison(ni, sizeof(ni));
+    __msan_unpoison(&ni[0], sizeof(ni[0]));
+#endif
     for (i = 0; ni[i].if_index != 0 && i < INT_MAX; i++) {
+#ifdef _Py_MEMORY_SANITIZER
+        /* This one isn't the end sentinel, the next one must exist. */
+        __msan_unpoison(&ni[i+1], sizeof(ni[0]));
+        /* Otherwise Py_BuildValue internals are flagged by MSan when
+           they access the not-msan-tracked if_name string data. */
+        {
+            char *to_sanitize = ni[i].if_name;
+            do {
+                __msan_unpoison(to_sanitize, 1);
+            } while (*to_sanitize++ != '\0');
+        }
+#endif
         PyObject *ni_tuple = Py_BuildValue("IO&",
                 ni[i].if_index, PyUnicode_DecodeFSDefault, ni[i].if_name);
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -755,7 +755,7 @@ time_strftime(PyObject *self, PyObject *args)
         return NULL;
     }
 
-#if defined(_MSC_VER) || defined(sun) || defined(_AIX)
+#if defined(_MSC_VER) || (defined(__sun) && defined(__SVR4)) || defined(_AIX)
     if (buf.tm_year + 1900 < 1 || 9999 < buf.tm_year + 1900) {
         PyErr_SetString(PyExc_ValueError,
                         "strftime() requires year in [1; 9999]");
@@ -801,7 +801,7 @@ time_strftime(PyObject *self, PyObject *args)
             return NULL;
         }
     }
-#elif (defined(_AIX) || defined(sun)) && defined(HAVE_WCSFTIME)
+#elif (defined(_AIX) || (defined(__sun) && defined(__SVR4))) && defined(HAVE_WCSFTIME)
     for (outbuf = wcschr(fmt, '%');
         outbuf != NULL;
         outbuf = wcschr(outbuf+2, '%'))

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -34,6 +34,10 @@
 #endif /* MS_WINDOWS */
 #endif /* !__WATCOMC__ || __QNX__ */
 
+#ifdef _Py_MEMORY_SANITIZER
+# include <sanitizer/msan_interface.h>
+#endif
+
 #define SEC_TO_NS (1000 * 1000 * 1000)
 
 /* Forward declarations */
@@ -336,6 +340,9 @@ time_pthread_getcpuclockid(PyObject *self, PyObject *args)
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
+#ifdef _Py_MEMORY_SANITIZER
+    __msan_unpoison(&clk_id, sizeof(clk_id));
+#endif
     return PyLong_FromLong(clk_id);
 }
 

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -114,7 +114,7 @@ py_getrandom(void *buffer, Py_ssize_t size, int blocking, int raise)
     flags = blocking ? 0 : GRND_NONBLOCK;
     dest = buffer;
     while (0 < size) {
-#ifdef sun
+#if defined(__sun) && defined(__SVR4)
         /* Issue #26735: On Solaris, getrandom() is limited to returning up
            to 1024 bytes. Call it multiple times if more bytes are
            requested. */
@@ -264,7 +264,7 @@ py_getentropy(char *buffer, Py_ssize_t size, int raise)
     }
     return 1;
 }
-#endif /* defined(HAVE_GETENTROPY) && !defined(sun) */
+#endif /* defined(HAVE_GETENTROPY) && !(defined(__sun) && defined(__SVR4)) */
 
 
 static struct {

--- a/configure
+++ b/configure
@@ -12677,6 +12677,150 @@ fi
 done
 
 
+# We search for both crypt and crypt_r as one or the other may be defined
+# This gets us our -lcrypt in LIBS when required on the target platform.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing crypt" >&5
+$as_echo_n "checking for library containing crypt... " >&6; }
+if ${ac_cv_search_crypt+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char crypt ();
+int
+main ()
+{
+return crypt ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' crypt; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_crypt=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_crypt+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_crypt+:} false; then :
+
+else
+  ac_cv_search_crypt=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_crypt" >&5
+$as_echo "$ac_cv_search_crypt" >&6; }
+ac_res=$ac_cv_search_crypt
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing crypt_r" >&5
+$as_echo_n "checking for library containing crypt_r... " >&6; }
+if ${ac_cv_search_crypt_r+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char crypt_r ();
+int
+main ()
+{
+return crypt_r ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' crypt; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_crypt_r=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_crypt_r+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_crypt_r+:} false; then :
+
+else
+  ac_cv_search_crypt_r=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_crypt_r" >&5
+$as_echo "$ac_cv_search_crypt_r" >&6; }
+ac_res=$ac_cv_search_crypt_r
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+
+ac_fn_c_check_func "$LINENO" "crypt_r" "ac_cv_func_crypt_r"
+if test "x$ac_cv_func_crypt_r" = xyes; then :
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#define _GNU_SOURCE  /* Required for crypt_r()'s prototype in glibc. */
+#include <crypt.h>
+
+int
+main ()
+{
+
+struct crypt_data d;
+char *r = crypt_r("", "", &d);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+$as_echo "#define HAVE_CRYPT_R 1" >>confdefs.h
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+
+
 for ac_func in clock_gettime
 do :
   ac_fn_c_check_func "$LINENO" "clock_gettime" "ac_cv_func_clock_gettime"

--- a/configure.ac
+++ b/configure.ac
@@ -3818,6 +3818,23 @@ AC_CHECK_FUNCS(gettimeofday,
     ])
 )
 
+# We search for both crypt and crypt_r as one or the other may be defined
+# This gets us our -lcrypt in LIBS when required on the target platform.
+AC_SEARCH_LIBS(crypt, crypt)
+AC_SEARCH_LIBS(crypt_r, crypt)
+
+AC_CHECK_FUNC(crypt_r,
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#define _GNU_SOURCE  /* Required for crypt_r()'s prototype in glibc. */
+#include <crypt.h>
+]], [[
+struct crypt_data d;
+char *r = crypt_r("", "", &d);
+]])],
+    [AC_DEFINE(HAVE_CRYPT_R, 1, [Define if you have the crypt_r() function.])],
+    [])
+)
+
 AC_CHECK_FUNCS(clock_gettime, [], [
     AC_CHECK_LIB(rt, clock_gettime, [
         LIBS="$LIBS -lrt"

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -147,6 +147,9 @@
 /* Define to 1 if you have the <crypt.h> header file. */
 #undef HAVE_CRYPT_H
 
+/* Define if you have the crypt_r() function. */
+#undef HAVE_CRYPT_R
+
 /* Define to 1 if you have the `ctermid' function. */
 #undef HAVE_CTERMID
 


### PR DESCRIPTION
* Move translate_key to module level and rename some variables.  Also refactor check for key in dictionary.
* Move key tuples to module level



<!-- issue-number: [bpo-35598](https://bugs.python.org/issue35598) -->
https://bugs.python.org/issue35598
<!-- /issue-number -->
