### PR TITLE
bpo-35623: Fix integer overflow when sorting large lists

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-31-02-37-20.bpo-35623.24AQhY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-31-02-37-20.bpo-35623.24AQhY.rst
@@ -1,0 +1,1 @@
+Fix a crash when sorting very long lists

--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-31-02-37-20.bpo-35623.24AQhY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-31-02-37-20.bpo-35623.24AQhY.rst
@@ -1,1 +1,1 @@
-Fix a crash when sorting very long lists
+Fix a crash when sorting very long lists. Patch by Stephan Hohe.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2283,7 +2283,6 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
         int ints_are_bounded = 1;
 
         /* Prove that assumption by checking every key. */
-        int i;
         for (i=0; i < saved_ob_size; i++) {
 
             if (keys_are_in_tuples &&


### PR DESCRIPTION
In `list_sort_impl()` in one case an `int i` is used to track the number of elements while sorting. With a large list this can lead to an integer overflow. This happens when running `test_bigmem` with enough memory.

There is already a `Py_ssize_t i` defined at function scope that is used
for similar loops. By removing the local `int i` declaration that `i` from function scope is
used, which has the appropriate type.

<!-- issue-number: [bpo-35623](https://bugs.python.org/issue35623) -->
https://bugs.python.org/issue35623
<!-- /issue-number -->
