### PR TITLE
[3.7] bpo-35214: Annotate posix calls for clang MSan. (GH-11389)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-30-15-36-23.bpo-35214.GWDQcv.rst
@@ -1,2 +1,2 @@
 clang Memory Sanitizer build instrumentation was added to work around false
-positives from socket, time, test_io, and test_faulthandler.
+positives from posix, socket, time, test_io, and test_faulthandler.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -393,6 +393,10 @@ static int win32_can_symlink = 0;
 #define HAVE_STRUCT_STAT_ST_FSTYPE 1
 #endif
 
+#ifdef _Py_MEMORY_SANITIZER
+# include <sanitizer/msan_interface.h>
+#endif
+
 #ifdef HAVE_FORK
 static void
 run_at_forkers(PyObject *lst, int reverse)
@@ -5689,6 +5693,9 @@ os_sched_rr_get_interval_impl(PyObject *module, pid_t pid)
         posix_error();
         return -1.0;
     }
+#ifdef _Py_MEMORY_SANITIZER
+    __msan_unpoison(&interval, sizeof(interval));
+#endif
     return (double)interval.tv_sec + 1e-9*interval.tv_nsec;
 }
 #endif /* HAVE_SCHED_RR_GET_INTERVAL */
@@ -6154,6 +6161,12 @@ posix_getgrouplist(PyObject *self, PyObject *args)
         PyMem_Del(groups);
         return posix_error();
     }
+
+#ifdef _Py_MEMORY_SANITIZER
+    /* Clang memory sanitizer libc intercepts don't know getgrouplist. */
+    __msan_unpoison(&ngroups, sizeof(ngroups));
+    __msan_unpoison(groups, ngroups*sizeof(*groups));
+#endif
 
     list = PyList_New(ngroups);
     if (list == NULL) {


### PR DESCRIPTION
It doesn't know the details of a few less common libc functions..
(cherry picked from commit 1d300ce1d8238136595c8fea76266a4755cd73a2)


<!-- issue-number: [bpo-35214](https://bugs.python.org/issue35214) -->
https://bugs.python.org/issue35214
<!-- /issue-number -->
