### PR TITLE
Updated argparse version

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -61,7 +61,7 @@ considered public as object names -- the API of the formatter objects is
 still considered an implementation detail.)
 """
 
-__version__ = '1.1'
+__version__ = '1.2'
 __all__ = [
     'ArgumentParser',
     'ArgumentError',


### PR DESCRIPTION
In the Python 3.7 the argparse module was updated, for example inserting parse_intermixed_args method.
Even though the module was changed the version was not. Therefore I suggest to change from version 1.1 to version 1.2. Avoiding conflict when the person just check the module version.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
