### PR TITLE
bpo-35545: Fix mishandling of scoped IPv6 addresses

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -458,7 +458,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
     async def sock_connect(self, sock, address):
         """Connect to a remote socket at address.
 
-        address must be a socket address tuple(i.e. (ipv4_address, port) for
+        `address` must be a socket address tuple(i.e. (ipv4_address, port) for
         IPv4 or (ipv6_address, port, flowinfo, scopeid) for IPv6). It must
         not be a (host, port) tuple that still needs to be resolved.
 

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -458,15 +458,14 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
     async def sock_connect(self, sock, address):
         """Connect to a remote socket at address.
 
+        address must be a socket address tuple(i.e. (ipv4_address, port) for
+        IPv4 or (ipv6_address, port, flowinfo, scopeid) for IPv6). It must
+        not be a (host, port) tuple that still needs to be resolved.
+
         This method is a coroutine.
         """
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
-
-        if not hasattr(socket, 'AF_UNIX') or sock.family != socket.AF_UNIX:
-            resolved = await self._ensure_resolved(
-                address, family=sock.family, proto=sock.proto, loop=self)
-            _, _, _, _, address = resolved[0]
 
         fut = self.create_future()
         self._sock_connect(fut, sock, address)

--- a/Misc/NEWS.d/next/Library/2019-01-02-19-19-10.bpo-35545.lLbmO-.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-02-19-19-10.bpo-35545.lLbmO-.rst
@@ -1,0 +1,2 @@
+Fix mishandling of scoped IPv6 addresses in
+BaseEventLoop.create_connection().


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Make sure _ensure_resolved() is only called on user-provided (host, port), and not on already-resolved socket address tuples.

This should also fix [bpo-33678](https://bugs.python.org/issue33678).

<!-- issue-number: [bpo-35545](https://bugs.python.org/issue35545) -->
https://bugs.python.org/issue35545
<!-- /issue-number -->
