### PR TITLE
bpo-35642: Remove asynciomodule.c from pythoncore.vcxproj

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-01-02-11-23-33.bpo-35642.pjkhJe.rst
+++ b/Misc/NEWS.d/next/Build/2019-01-02-11-23-33.bpo-35642.pjkhJe.rst
@@ -1,0 +1,1 @@
+Remove asynciomodule.c from pythoncore.vcxproj

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -247,7 +247,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Modules\_abc.c" />
-    <ClCompile Include="..\Modules\_asynciomodule.c" />
     <ClCompile Include="..\Modules\_bisectmodule.c" />
     <ClCompile Include="..\Modules\_blake2\blake2module.c" />
     <ClCompile Include="..\Modules\_blake2\blake2b_impl.c" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -1073,9 +1073,6 @@
     <ClCompile Include="..\PC\_findvs.cpp">
       <Filter>PC</Filter>
     </ClCompile>
-    <ClCompile Include="..\Modules\_asynciomodule.c">
-      <Filter>Modules</Filter>
-    </ClCompile>
     <ClCompile Include="..\Modules\_contextvarsmodule.c">
       <Filter>Modules</Filter>
     </ClCompile>


### PR DESCRIPTION
Before this patch, asynciomodule.c was compiled by both the
pythoncore and _asyncio projects.

asynciomodule.c defines the _asyncio extension module.

The PC\config.c does not reference the _asyncio module. And the
official CPython distributions today are shipping _asyncio as a
standalone extension module (_asyncio.pyd) - not a built-in
as part of libpythonXY.dll.

I think the presence of asynciomodule.c in the pythoncore project
is incorrect.

Using dumpbin.exe, the distributed python37.dll does contain
some symbols from asynciomodule.c. I'm not an expert on Windows
loader semantics, so I'm not sure whether the symbols from
pythonXY.dll or _asyncio.pyd will be used when _asyncio.pyd is
loaded. Whatever the case, having symbols provided by 2 binaries
is probably not a good idea.

This commit removes asynciomodule.c from the pythoncore project
and reinforces that _asyncio is a standalone extension module and
not a built-in.

Because public symbols (at least PyInit__asyncio) are being dropped
from pythonXY.dll, this change is backwards incompatible at the API
layer. There is a possibility someone, somewhere is relying on
PyInit__asyncio being exported from pythonXY.dll. So caution may
be warranted before backporting.


<!-- issue-number: [bpo-35642](https://bugs.python.org/issue35642) -->
https://bugs.python.org/issue35642
<!-- /issue-number -->
