### PR TITLE
bpo-35643: Fix a SyntaxWarning: invalid escape sequence in Modules/_sha3/cleanup.py

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-01-02-20-04-49.bpo-35643.DaMiaV.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-02-20-04-49.bpo-35643.DaMiaV.rst
@@ -1,0 +1,2 @@
+Fixed a SyntaxWarning: invalid escape sequence in Modules/_sha3/cleanup.py.
+Patch by Mickaël Schoentgen.

--- a/Modules/_sha3/cleanup.py
+++ b/Modules/_sha3/cleanup.py
@@ -8,7 +8,7 @@ import os
 import re
 
 CPP1 = re.compile("^//(.*)")
-CPP2 = re.compile("\ //(.*)")
+CPP2 = re.compile(r"\ //(.*)")
 
 STATICS = ("void ", "int ", "HashReturn ",
            "const UINT64 ", "UINT16 ", "    int prefix##")


### PR DESCRIPTION


<!-- issue-number: [bpo-35643](https://bugs.python.org/issue35643) -->
https://bugs.python.org/issue35643
<!-- /issue-number -->
