### PR TITLE
bpo-35431: Implemented math.comb

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -237,7 +237,7 @@ Number-theoretic and representation functions
    Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
 
    It is the coefficient of kth term in polynomial expansion of the expression
-   (1 + x)^n. It is also termed as the number of ways to choose an unordered
+   (1 + x)^n. It is also known as the number of ways to choose an unordered
    subset of k elements from a fixed set of n elements, usually called
    *n choose k*.
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -234,15 +234,15 @@ Number-theoretic and representation functions
 
 .. function:: comb(n, k)
 
-   Return the number of ways to choose k items from n items without repetition
-   and without order. Also called binomial coefficient.
+   Return the number of ways to choose *k* items from *n( items without repetition
+   and without order.
 
-   It is mathematically equal to the expression (n!)/(k! * (n - k)!). It is
-   equivalent to the the coefficient of kth term in polynomial expansion of
-   the expression (1 + x)^n.
+   Also called the binomial coefficient. It is mathematically equal to the expression
+   ``n! / (k! (n - k)!)``. It is equivalent to the coefficient of k-th term in
+   polynomial expansion of the expression ``(1 + x) ** n``.
 
-   Raises :exc:`TypeError` if argument(s) are non-integer and :exc:`ValueError`
-   if argument(s) are negative or k > n.
+   Raises :exc:`TypeError` if the arguments not integers.
+   Raises :exc:`ValueError` if the arguments are negative or if k > n.
 
    .. versionadded:: 3.8
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -232,6 +232,21 @@ Number-theoretic and representation functions
    :meth:`x.__trunc__() <object.__trunc__>`.
 
 
+.. function:: comb(n, k)
+
+   Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
+
+   It is the coefficient of kth term in polynomial expansion of the expression
+   (1 + x)^n. It is also termed as the number of ways to choose an unordered
+   subset of k elements from a fixed set of n elements, usually called
+   *n choose k*.
+
+   Raises :exc:`TypeError` if argument(s) are non-integer and :exc:`ValueError`
+   if argument(s) are negative or k > n.
+
+   .. versionadded:: 3.8
+
+
 Note that :func:`frexp` and :func:`modf` have a different call/return pattern
 than their C equivalents: they take a single argument and return a pair of
 values, rather than returning their second return value through an 'output

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -234,12 +234,12 @@ Number-theoretic and representation functions
 
 .. function:: comb(n, k)
 
-   Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
+   Return the number of ways to choose k items from n items without repetition
+   and without order. Also called binomial coefficient.
 
-   It is the coefficient of kth term in polynomial expansion of the expression
-   (1 + x)^n. It is also known as the number of ways to choose an unordered
-   subset of k elements from a fixed set of n elements, usually called
-   *n choose k*.
+   It is mathematically equal to the expression (n!)/(k! * (n - k)!). It is
+   equivalent to the the coefficient of kth term in polynomial expansion of
+   the expression (1 + x)^n.
 
    Raises :exc:`TypeError` if argument(s) are non-integer and :exc:`ValueError`
    if argument(s) are negative or k > n.

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -234,7 +234,7 @@ Number-theoretic and representation functions
 
 .. function:: comb(n, k)
 
-   Return the number of ways to choose *k* items from *n( items without repetition
+   Return the number of ways to choose *k* items from *n* items without repetition
    and without order.
 
    Also called the binomial coefficient. It is mathematically equal to the expression

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1876,7 +1876,7 @@ class IsCloseTests(unittest.TestCase):
             for k in range(1, n):
                 self.assertEqual(comb(n, k), comb(n - 1, k - 1) + comb(n - 1, k))
 
-        # Test corner case
+        # Test corner cases
         for n in range(100):
             self.assertEqual(comb(n, 0), 1)
             self.assertEqual(comb(n, n), 1)
@@ -1890,10 +1890,6 @@ class IsCloseTests(unittest.TestCase):
             for k in range(n // 2):
                 self.assertEqual(comb(n, k), comb(n, n - k))
 
-        # Test OverflowError (For current implementation occurs when
-        # minimum(k, n - k) > LLONG_MAX)
-        self.assertRaises(OverflowError, comb, 10**400, 10**200)
-
         # Raises TypeError if any argument is non-integer or argument count is
         # not 2
         self.assertRaises(TypeError, comb, 10, 1.0)
@@ -1905,13 +1901,20 @@ class IsCloseTests(unittest.TestCase):
         self.assertRaises(TypeError, comb, 10, 1, 3)
         self.assertRaises(TypeError, comb)
 
-        # Raises Value error if not 0 <= k <= n
+        # Raises Value error if not k or n are negative numbers
         self.assertRaises(ValueError, comb, -1, 1)
+        self.assertRaises(ValueError, comb, -10*10, 1)
         self.assertRaises(ValueError, comb, 1, -1)
-        self.assertRaises(ValueError, comb, 1, 2)
+        self.assertRaises(ValueError, comb, 1, -10*10)
 
-        # ValueError instead of OverflowError if k is negative and overflowing
-        self.assertRaises(ValueError, comb, 10**400, -10**200)
+        # Raises value error if k is greater than n
+        self.assertRaises(ValueError, comb, 1, 10**10)
+        self.assertRaises(ValueError, comb, 0, 1)
+
+        # Raises OverflowError if n or k is greater than LLONG_MAX
+        self.assertRaises(OverflowError, comb, 10**400, 10**200)
+        self.assertRaises(OverflowError, comb, 10**400, -10**200)
+
 
 
 def test_main():

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1862,6 +1862,49 @@ class IsCloseTests(unittest.TestCase):
         self.assertAllClose(fraction_examples, rel_tol=1e-8)
         self.assertAllNotClose(fraction_examples, rel_tol=1e-9)
 
+    def testComb(self):
+        comb = math.comb
+        factorial = math.factorial
+        # Test if factorial defintion is staisfied
+        for n in range(100):
+            for k in range(n + 1):
+                self.assertEqual(comb(n, k), factorial(n) // (factorial(k) * factorial(n - k)))
+
+        # Test for pascal's identity
+        for n in range(1, 100):
+            for k in range(1, n):
+                self.assertEqual(comb(n, k), comb(n - 1, k - 1) + comb(n - 1, k))
+
+        # Test corner case
+        for n in range(100):
+            self.assertEqual(comb(n, 0), 1)
+            self.assertEqual(comb(n, n), 1)
+
+        # Test Symmetry
+        for n in range(100):
+            for k in range(n // 2):
+                self.assertEqual(comb(n, k), comb(n, n - k))
+
+        # Test OverflowError (For current implementation occurs when
+        # minimum(k, n - k) > LLONG_MAX)
+        self.assertRaises(OverflowError, comb, 10**400, 10**200)
+
+        # Raises TypeError if any argument is non-integer or argument count is
+        # not 2
+        self.assertRaises(TypeError, comb, 10, 1.0)
+        self.assertRaises(TypeError, comb, 10, "1")
+        self.assertRaises(TypeError, comb, "10", 1)
+        self.assertRaises(TypeError, comb, 10.0, 1)
+
+        self.assertRaises(TypeError, comb, 10)
+        self.assertRaises(TypeError, comb, 10, 1, 3)
+        self.assertRaises(TypeError, comb)
+
+        # Raises Value error if not 0 <= k <= n
+        self.assertRaises(ValueError, comb, -1, 1)
+        self.assertRaises(ValueError, comb, 1, -1)
+        self.assertRaises(ValueError, comb, 1, 2)
+
 
 def test_main():
     from doctest import DocFileSuite

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1865,13 +1865,13 @@ class IsCloseTests(unittest.TestCase):
     def testComb(self):
         comb = math.comb
         factorial = math.factorial
-        # Test if factorial defintion is staisfied
+        # Test if factorial defintion is satisfied
         for n in range(100):
             for k in range(n + 1):
                 self.assertEqual(comb(n, k), factorial(n)
                     // (factorial(k) * factorial(n - k)))
 
-        # Test for pascal's identity
+        # Test for Pascal's identity
         for n in range(1, 100):
             for k in range(1, n):
                 self.assertEqual(comb(n, k), comb(n - 1, k - 1) + comb(n - 1, k))

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1911,9 +1911,6 @@ class IsCloseTests(unittest.TestCase):
         self.assertRaises(ValueError, comb, 1, 10**10)
         self.assertRaises(ValueError, comb, 0, 1)
 
-        # Raises OverflowError if n or k is greater than LLONG_MAX
-        self.assertRaises(OverflowError, comb, 10**400, 10**200)
-        self.assertRaises(OverflowError, comb, 10**400, -10**200)
 
 
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1868,7 +1868,8 @@ class IsCloseTests(unittest.TestCase):
         # Test if factorial defintion is staisfied
         for n in range(100):
             for k in range(n + 1):
-                self.assertEqual(comb(n, k), factorial(n) // (factorial(k) * factorial(n - k)))
+                self.assertEqual(comb(n, k), factorial(n)
+                    // (factorial(k) * factorial(n - k)))
 
         # Test for pascal's identity
         for n in range(1, 100):
@@ -1879,6 +1880,10 @@ class IsCloseTests(unittest.TestCase):
         for n in range(100):
             self.assertEqual(comb(n, 0), 1)
             self.assertEqual(comb(n, n), 1)
+
+        for n in range(1, 100):
+            self.assertEqual(comb(n, 1), n)
+            self.assertEqual(comb(n, n - 1), n)
 
         # Test Symmetry
         for n in range(100):
@@ -1904,6 +1909,9 @@ class IsCloseTests(unittest.TestCase):
         self.assertRaises(ValueError, comb, -1, 1)
         self.assertRaises(ValueError, comb, 1, -1)
         self.assertRaises(ValueError, comb, 1, 2)
+
+        # ValueError instead of OverflowError if k is negative and overflowing
+        self.assertRaises(ValueError, comb, 10**400, -10**200)
 
 
 def test_main():

--- a/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
@@ -1,0 +1,3 @@
+Implement :func:`math.comb` that returns binomial coefficient, that is the
+coefficient of kth term in expansion of polynomial (1 + x)^n.
+Patch by Yash Aggarwal.

--- a/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-02-19-48-23.bpo-35431.FhG6QA.rst
@@ -1,3 +1,4 @@
-Implement :func:`math.comb` that returns binomial coefficient, that is the
-coefficient of kth term in expansion of polynomial (1 + x)^n.
-Patch by Yash Aggarwal.
+Implement :func:`math.comb` that returns binomial coefficient, that computes
+the number of ways to choose k items from n items without repetition and
+without order.
+Patch by Yash Aggarwal and Keller Fuchs.

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -633,8 +633,46 @@ math_prod(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *k
     start = args[1];
 skip_optional_kwonly:
     return_value = math_prod_impl(module, iterable, start);
+=======
+PyDoc_STRVAR(math_comb__doc__,
+"comb($module, /, a, b)\n"
+"--\n"
+"\n"
+"Return the binomial coefficient indexed by the pair of integers n >= k >= 0.\n"
+"\n"
+"It is the coefficient of kth term in polynomial expansion of the expression\n"
+"(1 + x)^n. It is also termed as the number of ways to choose an unordered\n"
+"subset of k elements from a fixed set of n elements, usually called\n"
+"*n choose k*.\n"
+"\n"
+"Raises a TypeError if argument(s) are non-integer and ValueError\n"
+"if argument(s) are negative or k > n.");
+
+#define MATH_COMB_METHODDEF    \
+    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL|METH_KEYWORDS, math_comb__doc__},
+
+static PyObject *
+math_comb_impl(PyObject *module, PyObject *a, PyObject *b);
+
+static PyObject *
+math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"a", "b", NULL};
+    static _PyArg_Parser _parser = {"OO:comb", _keywords, 0};
+    PyObject *a;
+    PyObject *b;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &a, &b)) {
+        goto exit;
+    }
+    return_value = math_comb_impl(module, a, b);
+>>>>>>> implemented math.comb function
 
 exit:
     return return_value;
 }
+
 /*[clinic end generated code: output=aeed62f403b90199 input=a9049054013a1b77]*/
+

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -672,61 +672,44 @@ exit:
     return return_value;
 }
 
-<<<<<<< HEAD
 /*[clinic end generated code: output=66c5583e59c57e47 input=a9049054013a1b77]*/
 
-=======
 PyDoc_STRVAR(math_comb__doc__,
-"comb($module, N, K, /)\n"
+"comb($module, /, n, k)\n"
 "--\n"
 "\n"
-"Return the number of ways to choose k items from n items without repetition.\n"
+"Return the number of ways to choose *k* items from *n* items without repetition.\n"
 "\n"
 "Also called binomial coefficient. It is mathematically equal to the expression\n"
-"(n!)/(k! * (n - k)!). It is equivalent to the the coefficient of kth term in\n"
-"polynomial expansion of the expression (1 + x)^n.\n"
+"(n!) / (k! * (n - k)!). It is equivalent to the coefficient of kth term in\n"
+"polynomial expansion of the expression (1 + x)**n.\n"
 "\n"
-"Raises :exc:`TypeError` if argument(s) are non-integer and :exc:`ValueError`\n"
-"if argument(s) are negative or k > n.");
+"Raises :exc:`TypeError` if the arguments are not integers.\n"
+"Raises :exc:`ValueError` if the arguments are negative or if k > n.");
 
 #define MATH_COMB_METHODDEF    \
-    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL, math_comb__doc__},
+    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL|METH_KEYWORDS, math_comb__doc__},
 
 static PyObject *
-math_comb_impl(PyObject *module, long long N, long long K);
+math_comb_impl(PyObject *module, PyObject *n, PyObject *k);
 
 static PyObject *
-math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
-    long long N;
-    long long K;
+    static const char * const _keywords[] = {"n", "k", NULL};
+    static _PyArg_Parser _parser = {"O!O!:comb", _keywords, 0};
+    PyObject *n;
+    PyObject *k;
 
-    if (!_PyArg_CheckPositional("comb", nargs, 2, 2)) {
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &PyLong_Type, &n, &PyLong_Type, &k)) {
         goto exit;
     }
-    if (PyFloat_Check(args[0])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
-    N = PyLong_AsLongLong(args[0]);
-    if (N == (PY_LONG_LONG)-1 && PyErr_Occurred()) {
-        goto exit;
-    }
-    if (PyFloat_Check(args[1])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
-    K = PyLong_AsLongLong(args[1]);
-    if (K == (PY_LONG_LONG)-1 && PyErr_Occurred()) {
-        goto exit;
-    }
-    return_value = math_comb_impl(module, N, K);
+    return_value = math_comb_impl(module, n, k);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0084c36fc1963ba8 input=a9049054013a1b77]*/
->>>>>>> Replicated some changes from KellerFuchs' PR and made requested changes.
+/*[clinic end generated code: output=c91fa426b9d913d2 input=a9049054013a1b77]*/
+

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -635,7 +635,7 @@ skip_optional_kwonly:
     return_value = math_prod_impl(module, iterable, start);
 =======
 PyDoc_STRVAR(math_comb__doc__,
-"comb($module, /, a, b)\n"
+"comb($module, n, k, /)\n"
 "--\n"
 "\n"
 "Return the binomial coefficient indexed by the pair of integers n >= k >= 0.\n"
@@ -649,25 +649,24 @@ PyDoc_STRVAR(math_comb__doc__,
 "if argument(s) are negative or k > n.");
 
 #define MATH_COMB_METHODDEF    \
-    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL|METH_KEYWORDS, math_comb__doc__},
+    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL, math_comb__doc__},
 
 static PyObject *
-math_comb_impl(PyObject *module, PyObject *a, PyObject *b);
+math_comb_impl(PyObject *module, PyObject *n, PyObject *k);
 
 static PyObject *
-math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"a", "b", NULL};
-    static _PyArg_Parser _parser = {"OO:comb", _keywords, 0};
-    PyObject *a;
-    PyObject *b;
+    PyObject *n;
+    PyObject *k;
 
-    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
-        &a, &b)) {
+    if (!_PyArg_UnpackStack(args, nargs, "comb",
+        2, 2,
+        &n, &k)) {
         goto exit;
     }
-    return_value = math_comb_impl(module, a, b);
+    return_value = math_comb_impl(module, n, k);
 
 exit:
     return return_value;

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -633,46 +633,10 @@ math_prod(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *k
     start = args[1];
 skip_optional_kwonly:
     return_value = math_prod_impl(module, iterable, start);
-=======
-PyDoc_STRVAR(math_comb__doc__,
-"comb($module, n, k, /)\n"
-"--\n"
-"\n"
-"Return the binomial coefficient indexed by the pair of integers n >= k >= 0.\n"
-"\n"
-"It is the coefficient of kth term in polynomial expansion of the expression\n"
-"(1 + x)^n. It is also known as the number of ways to choose an unordered\n"
-"subset of k elements from a fixed set of n elements, usually called\n"
-"*n choose k*.\n"
-"\n"
-"Raises a TypeError if argument(s) are non-integer and ValueError\n"
-"if argument(s) are negative or k > n.");
-
-#define MATH_COMB_METHODDEF    \
-    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL, math_comb__doc__},
-
-static PyObject *
-math_comb_impl(PyObject *module, PyObject *n, PyObject *k);
-
-static PyObject *
-math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
-{
-    PyObject *return_value = NULL;
-    PyObject *n;
-    PyObject *k;
-
-    if (!_PyArg_CheckPositional("comb", nargs, 2, 2)) {
-        goto exit;
-    }
-    n = args[0];
-    k = args[1];
-    return_value = math_comb_impl(module, n, k);
 
 exit:
     return return_value;
 }
-
-/*[clinic end generated code: output=66c5583e59c57e47 input=a9049054013a1b77]*/
 
 PyDoc_STRVAR(math_comb__doc__,
 "comb($module, /, n, k)\n"
@@ -698,18 +662,28 @@ math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *k
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"n", "k", NULL};
-    static _PyArg_Parser _parser = {"O!O!:comb", _keywords, 0};
+    static _PyArg_Parser _parser = {NULL, _keywords, "comb", 0};
+    PyObject *argsbuf[2];
     PyObject *n;
     PyObject *k;
 
-    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
-        &PyLong_Type, &n, &PyLong_Type, &k)) {
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 2, 2, 0, argsbuf);
+    if (!args) {
         goto exit;
     }
+    if (!PyLong_Check(args[0])) {
+        _PyArg_BadArgument("comb", 1, "int", args[0]);
+        goto exit;
+    }
+    n = args[0];
+    if (!PyLong_Check(args[1])) {
+        _PyArg_BadArgument("comb", 2, "int", args[1]);
+        goto exit;
+    }
+    k = args[1];
     return_value = math_comb_impl(module, n, k);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c91fa426b9d913d2 input=a9049054013a1b77]*/
-
+/*[clinic end generated code: output=b48cc0f0594fe74f input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -672,5 +672,61 @@ exit:
     return return_value;
 }
 
+<<<<<<< HEAD
 /*[clinic end generated code: output=66c5583e59c57e47 input=a9049054013a1b77]*/
 
+=======
+PyDoc_STRVAR(math_comb__doc__,
+"comb($module, N, K, /)\n"
+"--\n"
+"\n"
+"Return the number of ways to choose k items from n items without repetition.\n"
+"\n"
+"Also called binomial coefficient. It is mathematically equal to the expression\n"
+"(n!)/(k! * (n - k)!). It is equivalent to the the coefficient of kth term in\n"
+"polynomial expansion of the expression (1 + x)^n.\n"
+"\n"
+"Raises :exc:`TypeError` if argument(s) are non-integer and :exc:`ValueError`\n"
+"if argument(s) are negative or k > n.");
+
+#define MATH_COMB_METHODDEF    \
+    {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL, math_comb__doc__},
+
+static PyObject *
+math_comb_impl(PyObject *module, long long N, long long K);
+
+static PyObject *
+math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    long long N;
+    long long K;
+
+    if (!_PyArg_CheckPositional("comb", nargs, 2, 2)) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[0])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    N = PyLong_AsLongLong(args[0]);
+    if (N == (PY_LONG_LONG)-1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[1])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    K = PyLong_AsLongLong(args[1]);
+    if (K == (PY_LONG_LONG)-1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = math_comb_impl(module, N, K);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=0084c36fc1963ba8 input=a9049054013a1b77]*/
+>>>>>>> Replicated some changes from KellerFuchs' PR and made requested changes.

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -642,14 +642,14 @@ PyDoc_STRVAR(math_comb__doc__,
 "comb($module, /, n, k)\n"
 "--\n"
 "\n"
-"Return the number of ways to choose *k* items from *n* items without repetition.\n"
+"Number of ways to choose *k* items from *n* items without repetition and without order.\n"
 "\n"
-"Also called binomial coefficient. It is mathematically equal to the expression\n"
-"(n!) / (k! * (n - k)!). It is equivalent to the coefficient of kth term in\n"
+"Also called the binomial coefficient. It is mathematically equal to the expression\n"
+"n! / (k! * (n - k)!). It is equivalent to the coefficient of k-th term in\n"
 "polynomial expansion of the expression (1 + x)**n.\n"
 "\n"
-"Raises :exc:`TypeError` if the arguments are not integers.\n"
-"Raises :exc:`ValueError` if the arguments are negative or if k > n.");
+"Raises TypeError if the arguments are not integers.\n"
+"Raises ValueError if the arguments are negative or if k > n.");
 
 #define MATH_COMB_METHODDEF    \
     {"comb", (PyCFunction)(void(*)(void))math_comb, METH_FASTCALL|METH_KEYWORDS, math_comb__doc__},
@@ -686,4 +686,4 @@ math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *k
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b48cc0f0594fe74f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=00aa76356759617a input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -661,16 +661,16 @@ math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *n;
     PyObject *k;
 
-    if (!_PyArg_UnpackStack(args, nargs, "comb",
-        2, 2,
-        &n, &k)) {
+    if (!_PyArg_CheckPositional("comb", nargs, 2, 2)) {
         goto exit;
     }
+    n = args[0];
+    k = args[1];
     return_value = math_comb_impl(module, n, k);
 
 exit:
     return return_value;
 }
 
-/*[clinic end generated code: output=9bcf4b171e2ad3ec input=a9049054013a1b77]*/
+/*[clinic end generated code: output=66c5583e59c57e47 input=a9049054013a1b77]*/
 

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -641,7 +641,7 @@ PyDoc_STRVAR(math_comb__doc__,
 "Return the binomial coefficient indexed by the pair of integers n >= k >= 0.\n"
 "\n"
 "It is the coefficient of kth term in polynomial expansion of the expression\n"
-"(1 + x)^n. It is also termed as the number of ways to choose an unordered\n"
+"(1 + x)^n. It is also known as the number of ways to choose an unordered\n"
 "subset of k elements from a fixed set of n elements, usually called\n"
 "*n choose k*.\n"
 "\n"
@@ -668,11 +668,10 @@ math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *k
         goto exit;
     }
     return_value = math_comb_impl(module, a, b);
->>>>>>> implemented math.comb function
 
 exit:
     return return_value;
 }
 
-/*[clinic end generated code: output=aeed62f403b90199 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9bcf4b171e2ad3ec input=a9049054013a1b77]*/
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3001,37 +3001,30 @@ math_prod_impl(PyObject *module, PyObject *iterable, PyObject *start)
 /*[clinic input]
 math.comb
 
-    n: object
-
-    k: object
+    N: long_long
+    K: long_long
     /
 
-Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
+Return the number of ways to choose k items from n items without repetition.
 
-It is the coefficient of kth term in polynomial expansion of the expression
-(1 + x)^n. It is also known as the number of ways to choose an unordered
-subset of k elements from a fixed set of n elements, usually called
-*n choose k*.
+Also called binomial coefficient. It is mathematically equal to the expression
+(n!)/(k! * (n - k)!). It is equivalent to the the coefficient of kth term in
+polynomial expansion of the expression (1 + x)^n.
 
-Raises a TypeError if argument(s) are non-integer and ValueError
+Raises :exc:`TypeError` if argument(s) are non-integer and :exc:`ValueError`
 if argument(s) are negative or k > n.
 
 [clinic start generated code]*/
 
 static PyObject *
-math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
-/*[clinic end generated code: output=bd2cec8d854f3493 input=75e1a19623bae7dc]*/
+math_comb_impl(PyObject *module, long long N, long long K)
+/*[clinic end generated code: output=07c14ebe36fef64f input=48c80dbbff4b2d8e]*/
 {
-    if (!(PyLong_Check(n) && PyLong_Check(k))) {
-        PyErr_SetString(PyExc_TypeError,
-            "comb() only accepts integer arguments");
-        return NULL;
-    }
-    n = PyNumber_Long(n);
+    PyObject* n = PyLong_FromLongLong(N);
     if (n == NULL) {
         return NULL;
     }
-    k = PyNumber_Long(k);
+    PyObject* k = PyLong_FromLongLong(K);
     if (k == NULL) {
         Py_DECREF(n);
         return NULL;
@@ -3045,12 +3038,12 @@ math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
     long long i, terms;
 
     cmp = PyObject_RichCompareBool(n, k, Py_LT);
-    if (cmp == 1) {
-        PyErr_Format(PyExc_ValueError,
-                     "n must be an integer >= k");
+    if (cmp < 0) {
         goto fail_comb;
     }
-    else if (cmp == -1) {
+    else if (cmp > 0) {
+        PyErr_Format(PyExc_ValueError,
+                     "n must be an integer greater than or equal to k");
         goto fail_comb;
     }
 
@@ -3060,13 +3053,13 @@ math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
         goto fail_comb;
     }
     cmp = PyObject_RichCompareBool(k, dump_var, Py_GT);
-    if (cmp == 1) {
+    if (cmp < 0) {
+        goto fail_comb;
+    }
+    else if (cmp > 0) {
         Py_DECREF(k);
         k = dump_var;
         dump_var = NULL;
-    }
-    else if (cmp == -1) {
-        goto fail_comb;
     }
     else {
         Py_DECREF(dump_var);
@@ -3074,18 +3067,18 @@ math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
     }
 
     terms = PyLong_AsLongLongAndOverflow(k, &overflow);
-    if (terms == -1 && PyErr_Occurred()) {
+    if (terms < 0 && PyErr_Occurred()) {
         goto fail_comb;
     }
-    else if (overflow == 1) {
+    else if (overflow > 0) {
         PyErr_Format(PyExc_OverflowError,
                      "minimum(n - k, k) must not exceed %lld",
                      LLONG_MAX);
         goto fail_comb;
     }
-    else if (overflow == -1 || terms < 0) {
+    else if (overflow < 0 || terms < 0) {
         PyErr_Format(PyExc_ValueError,
-                     "k must be an integer >= 0");
+                     "k must be a positive integer");
         goto fail_comb;
     }
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2998,6 +2998,92 @@ math_prod_impl(PyObject *module, PyObject *iterable, PyObject *start)
 }
 
 
+/*[clinic input]
+math.comb
+
+    a: object
+
+    b: object
+
+
+Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
+
+It is the coefficient of kth term in polynomial expansion of the expression
+(1 + x)^n. It is also termed as the number of ways to choose an unordered
+subset of k elements from a fixed set of n elements, usually called
+*n choose k*.
+
+Raises a TypeError if argument(s) are non-integer and ValueError
+if argument(s) are negative or k > n.
+
+[clinic start generated code]*/
+
+static PyObject *
+math_comb_impl(PyObject *module, PyObject *a, PyObject *b)
+/*[clinic end generated code: output=1343ae354f5dd2fa input=f5a3952a720899cf]*/
+{
+    if (!(PyLong_Check(a) && PyLong_Check(b))) {
+        PyErr_SetString(PyExc_TypeError,
+            "comb() only accepts integer arguments");
+        return NULL;
+    }
+    a = PyNumber_Long(a);
+    if (a == NULL)
+        return NULL;
+    b = PyNumber_Long(b);
+    if (b == NULL) {
+        Py_DECREF(a);
+        return NULL;
+    }
+
+    PyObject *val = PyLong_FromLong(1),
+        *temp_obj1, *temp_obj2,
+        *dump_var;
+    int overflow;
+    long long i, terms = PyLong_AsLongLongAndOverflow(b, &overflow);
+
+    if (overflow == 1) {
+        PyErr_Format(PyExc_OverflowError,
+                     "minimum(n - k, n) should not exceed %lld",
+                     LLONG_MAX);
+        return NULL;
+    }
+    dump_var = PyLong_FromLong(0);
+    if (PyObject_RichCompareBool(b, (PyObject *)dump_var, Py_LT)) {
+        PyErr_Format(PyExc_ValueError,
+                     "k must be an integer >= 0");
+        return NULL;
+    }
+    if (PyObject_RichCompareBool(a, b, Py_LT)) {
+        PyErr_Format(PyExc_ValueError,
+                     "n must be an integer >= k");
+        return NULL;
+    }
+
+    dump_var = PyNumber_Subtract(a, b);
+    if(PyObject_RichCompareBool(b, dump_var, Py_GT)){
+        b = dump_var;
+        dump_var = NULL;
+    }
+    for (i = 0; i < terms; ++i) {
+        temp_obj1 = PyLong_FromSsize_t(i);
+        temp_obj2 = PyNumber_Subtract(a, temp_obj1);
+        dump_var = val;
+        val = PyNumber_Multiply(val, temp_obj2);
+        Py_DECREF(dump_var);
+        Py_DECREF(temp_obj2);
+        temp_obj2 = PyLong_FromLong(PyLong_AsLong(temp_obj1) + 1);
+        dump_var = val;
+        val = PyNumber_FloorDivide(val, temp_obj2);
+        Py_DECREF(dump_var);
+        Py_DECREF(temp_obj1);
+        Py_DECREF(temp_obj2);
+    }
+
+    return val;
+}
+
+
 static PyMethodDef math_methods[] = {
     {"acos",            math_acos,      METH_O,         math_acos_doc},
     {"acosh",           math_acosh,     METH_O,         math_acosh_doc},
@@ -3047,6 +3133,7 @@ static PyMethodDef math_methods[] = {
     {"tanh",            math_tanh,      METH_O,         math_tanh_doc},
     MATH_TRUNC_METHODDEF
     MATH_PROD_METHODDEF
+    MATH_COMB_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3017,7 +3017,7 @@ Raises :exc:`ValueError` if the arguments are negative or if k > n.
 
 static PyObject *
 math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
-/*[clinic end generated code: output=bd2cec8d854f3493 input=8a54daf9f021f2d0]*/
+/*[clinic end generated code: output=bd2cec8d854f3493 input=e761869513577ae9]*/
 {
     PyObject *val = NULL,
         *temp_obj1 = NULL,

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3001,10 +3001,10 @@ math_prod_impl(PyObject *module, PyObject *iterable, PyObject *start)
 /*[clinic input]
 math.comb
 
-    a: object
+    n: object
 
-    b: object
-
+    k: object
+    /
 
 Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
 
@@ -3019,34 +3019,32 @@ if argument(s) are negative or k > n.
 [clinic start generated code]*/
 
 static PyObject *
-math_comb_impl(PyObject *module, PyObject *a, PyObject *b)
-/*[clinic end generated code: output=1343ae354f5dd2fa input=c7361e89712cfa3f]*/
+math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
+/*[clinic end generated code: output=bd2cec8d854f3493 input=75e1a19623bae7dc]*/
 {
-    if (!(PyLong_Check(a) && PyLong_Check(b))) {
+    if (!(PyLong_Check(n) && PyLong_Check(k))) {
         PyErr_SetString(PyExc_TypeError,
             "comb() only accepts integer arguments");
         return NULL;
     }
-    a = PyNumber_Long(a);
-    if (a == NULL)
+    n = PyNumber_Long(n);
+    if (n == NULL) {
         return NULL;
-    b = PyNumber_Long(b);
-    if (b == NULL) {
-        Py_DECREF(a);
+    }
+    k = PyNumber_Long(k);
+    if (k == NULL) {
+        Py_DECREF(n);
         return NULL;
     }
 
-    PyObject *val = PyLong_FromLong(1),
+    PyObject *val = NULL,
         *temp_obj1 = NULL,
         *temp_obj2 = NULL,
         *dump_var = NULL;
-    if (val == NULL) {
-        goto fail_comb;
-    }
     int overflow, cmp;
     long long i, terms;
 
-    cmp = PyObject_RichCompareBool(a, b, Py_LT);
+    cmp = PyObject_RichCompareBool(n, k, Py_LT);
     if (cmp == 1) {
         PyErr_Format(PyExc_ValueError,
                      "n must be an integer >= k");
@@ -3057,14 +3055,14 @@ math_comb_impl(PyObject *module, PyObject *a, PyObject *b)
     }
 
     /* b = min(b, a - b) */
-    dump_var = PyNumber_Subtract(a, b);
+    dump_var = PyNumber_Subtract(n, k);
     if (dump_var == NULL) {
         goto fail_comb;
     }
-    cmp = PyObject_RichCompareBool(b, dump_var, Py_GT);
+    cmp = PyObject_RichCompareBool(k, dump_var, Py_GT);
     if (cmp == 1) {
-        Py_DECREF(b);
-        b = dump_var;
+        Py_DECREF(k);
+        k = dump_var;
         dump_var = NULL;
     }
     else if (cmp == -1) {
@@ -3075,13 +3073,13 @@ math_comb_impl(PyObject *module, PyObject *a, PyObject *b)
         dump_var = NULL;
     }
 
-    terms = PyLong_AsLongLongAndOverflow(b, &overflow);
+    terms = PyLong_AsLongLongAndOverflow(k, &overflow);
     if (terms == -1 && PyErr_Occurred()) {
         goto fail_comb;
     }
     else if (overflow == 1) {
         PyErr_Format(PyExc_OverflowError,
-                     "minimum(n - k, n) should not exceed %lld",
+                     "minimum(n - k, k) must not exceed %lld",
                      LLONG_MAX);
         goto fail_comb;
     }
@@ -3091,12 +3089,19 @@ math_comb_impl(PyObject *module, PyObject *a, PyObject *b)
         goto fail_comb;
     }
 
-    for (i = 0; i < terms; ++i) {
+    if (terms == 0) {
+        Py_DECREF(n);
+        Py_DECREF(k);
+        return PyNumber_Long(_PyLong_One);
+    }
+
+    val = PyNumber_Long(n);
+    for (i = 1; i < terms; ++i) {
         temp_obj1 = PyLong_FromSsize_t(i);
         if (temp_obj1 == NULL) {
             goto fail_comb;
         }
-        temp_obj2 = PyNumber_Subtract(a, temp_obj1);
+        temp_obj2 = PyNumber_Subtract(n temp_obj1);
         if (temp_obj2 == NULL) {
             goto fail_comb;
         }
@@ -3121,14 +3126,14 @@ math_comb_impl(PyObject *module, PyObject *a, PyObject *b)
         Py_DECREF(temp_obj1);
         Py_DECREF(temp_obj2);
     }
-    Py_DECREF(a);
-    Py_DECREF(b);
+    Py_DECREF(n);
+    Py_DECREF(k);
 
     return val;
 
 fail_comb:
-    Py_XDECREF(a);
-    Py_XDECREF(b);
+    Py_XDECREF(n);
+    Py_XDECREF(k);
     Py_XDECREF(val);
     Py_XDECREF(dump_var);
     Py_XDECREF(temp_obj1);

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3101,7 +3101,7 @@ math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
         if (temp_obj1 == NULL) {
             goto fail_comb;
         }
-        temp_obj2 = PyNumber_Subtract(n temp_obj1);
+        temp_obj2 = PyNumber_Subtract(n, temp_obj1);
         if (temp_obj2 == NULL) {
             goto fail_comb;
         }

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3009,7 +3009,7 @@ math.comb
 Return the binomial coefficient indexed by the pair of integers n >= k >= 0.
 
 It is the coefficient of kth term in polynomial expansion of the expression
-(1 + x)^n. It is also termed as the number of ways to choose an unordered
+(1 + x)^n. It is also known as the number of ways to choose an unordered
 subset of k elements from a fixed set of n elements, usually called
 *n choose k*.
 
@@ -3020,7 +3020,7 @@ if argument(s) are negative or k > n.
 
 static PyObject *
 math_comb_impl(PyObject *module, PyObject *a, PyObject *b)
-/*[clinic end generated code: output=1343ae354f5dd2fa input=f5a3952a720899cf]*/
+/*[clinic end generated code: output=1343ae354f5dd2fa input=c7361e89712cfa3f]*/
 {
     if (!(PyLong_Check(a) && PyLong_Check(b))) {
         PyErr_SetString(PyExc_TypeError,

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3004,20 +3004,20 @@ math.comb
     n: object(subclass_of='&PyLong_Type')
     k: object(subclass_of='&PyLong_Type')
 
-Return the number of ways to choose *k* items from *n* items without repetition.
+Number of ways to choose *k* items from *n* items without repetition and without order.
 
-Also called binomial coefficient. It is mathematically equal to the expression
-(n!) / (k! * (n - k)!). It is equivalent to the coefficient of kth term in
+Also called the binomial coefficient. It is mathematically equal to the expression
+n! / (k! * (n - k)!). It is equivalent to the coefficient of k-th term in
 polynomial expansion of the expression (1 + x)**n.
 
-Raises :exc:`TypeError` if the arguments are not integers.
-Raises :exc:`ValueError` if the arguments are negative or if k > n.
+Raises TypeError if the arguments are not integers.
+Raises ValueError if the arguments are negative or if k > n.
 
 [clinic start generated code]*/
 
 static PyObject *
 math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
-/*[clinic end generated code: output=bd2cec8d854f3493 input=e761869513577ae9]*/
+/*[clinic end generated code: output=bd2cec8d854f3493 input=565f340f98efb5b5]*/
 {
     PyObject *val = NULL,
         *temp_obj1 = NULL,

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3001,35 +3001,24 @@ math_prod_impl(PyObject *module, PyObject *iterable, PyObject *start)
 /*[clinic input]
 math.comb
 
-    N: long_long
-    K: long_long
-    /
+    n: object(subclass_of='&PyLong_Type')
+    k: object(subclass_of='&PyLong_Type')
 
-Return the number of ways to choose k items from n items without repetition.
+Return the number of ways to choose *k* items from *n* items without repetition.
 
 Also called binomial coefficient. It is mathematically equal to the expression
-(n!)/(k! * (n - k)!). It is equivalent to the the coefficient of kth term in
-polynomial expansion of the expression (1 + x)^n.
+(n!) / (k! * (n - k)!). It is equivalent to the coefficient of kth term in
+polynomial expansion of the expression (1 + x)**n.
 
-Raises :exc:`TypeError` if argument(s) are non-integer and :exc:`ValueError`
-if argument(s) are negative or k > n.
+Raises :exc:`TypeError` if the arguments are not integers.
+Raises :exc:`ValueError` if the arguments are negative or if k > n.
 
 [clinic start generated code]*/
 
 static PyObject *
-math_comb_impl(PyObject *module, long long N, long long K)
-/*[clinic end generated code: output=07c14ebe36fef64f input=48c80dbbff4b2d8e]*/
+math_comb_impl(PyObject *module, PyObject *n, PyObject *k)
+/*[clinic end generated code: output=bd2cec8d854f3493 input=8a54daf9f021f2d0]*/
 {
-    PyObject* n = PyLong_FromLongLong(N);
-    if (n == NULL) {
-        return NULL;
-    }
-    PyObject* k = PyLong_FromLongLong(K);
-    if (k == NULL) {
-        Py_DECREF(n);
-        return NULL;
-    }
-
     PyObject *val = NULL,
         *temp_obj1 = NULL,
         *temp_obj2 = NULL,
@@ -3057,7 +3046,6 @@ math_comb_impl(PyObject *module, long long N, long long K)
         goto fail_comb;
     }
     else if (cmp > 0) {
-        Py_DECREF(k);
         k = dump_var;
         dump_var = NULL;
     }
@@ -3083,8 +3071,6 @@ math_comb_impl(PyObject *module, long long N, long long K)
     }
 
     if (terms == 0) {
-        Py_DECREF(n);
-        Py_DECREF(k);
         return PyNumber_Long(_PyLong_One);
     }
 
@@ -3119,14 +3105,10 @@ math_comb_impl(PyObject *module, long long N, long long K)
         Py_DECREF(temp_obj1);
         Py_DECREF(temp_obj2);
     }
-    Py_DECREF(n);
-    Py_DECREF(k);
 
     return val;
 
 fail_comb:
-    Py_XDECREF(n);
-    Py_XDECREF(k);
     Py_XDECREF(val);
     Py_XDECREF(dump_var);
     Py_XDECREF(temp_obj1);


### PR DESCRIPTION
Implemented the function math.comb to calculate binomial coefficient. Simple O(k) algorithm is used for now. ValueError if condition 0 <= k <= n is not satisfied and TypeError if non-integer arguments passed to function.


<!-- issue-number: [bpo-35431](https://bugs.python.org/issue35431) -->
https://bugs.python.org/issue35431
<!-- /issue-number -->
