### PR TITLE
bpo-35641: IDLE - calltip not properly formatted if no docstring

### DIFF
--- a/Lib/idlelib/calltip.py
+++ b/Lib/idlelib/calltip.py
@@ -155,6 +155,7 @@ def get_argspec(ob):
     lines = (textwrap.wrap(argspec, _MAX_COLS, subsequent_indent=_INDENT)
              if len(argspec) > _MAX_COLS else [argspec] if argspec else [])
 
+    print(lines)
     if isinstance(ob_call, types.MethodType):
         doc = ob_call.__doc__
     else:
@@ -167,7 +168,7 @@ def get_argspec(ob):
             if len(line) > _MAX_COLS:
                 line = line[: _MAX_COLS - 3] + '...'
             lines.append(line)
-        argspec = '\n'.join(lines)
+    argspec = '\n'.join(lines)
     if not argspec:
         argspec = _default_callable_argspec
     return argspec

--- a/Lib/idlelib/calltip.py
+++ b/Lib/idlelib/calltip.py
@@ -155,7 +155,6 @@ def get_argspec(ob):
     lines = (textwrap.wrap(argspec, _MAX_COLS, subsequent_indent=_INDENT)
              if len(argspec) > _MAX_COLS else [argspec] if argspec else [])
 
-    print(lines)
     if isinstance(ob_call, types.MethodType):
         doc = ob_call.__doc__
     else:

--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -99,6 +99,35 @@ non-overlapping occurrences o...''')
     drop_whitespace=True, break_on_hyphens=True, tabsize=8, *, max_lines=None,
     placeholder=' [...]')''')
 
+    def test_properly_formated(self):
+        def foo(s='a'*100):
+            pass
+
+        def bar(s='a'*100):
+            """Hello Guido"""
+            pass
+
+        def baz(s='a'*100, z='b'*100):
+            pass
+
+        indent = calltip._INDENT
+
+        str_foo = "(s='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" + indent + "aaaaaaaaa"\
+                  "aaaaaaaaaa')"
+        str_bar = "(s='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" + indent + "aaaaaaaaa"\
+                  "aaaaaaaaaa')\nHello Guido"
+        str_baz = "(s='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\
+                  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" + indent + "aaaaaaaaa"\
+                  "aaaaaaaaaa', z='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"\
+                  "bbbbbbbbbbbbbbbbb\n" + indent + "bbbbbbbbbbbbbbbbbbbbbb"\
+                  "bbbbbbbbbbbbbbbbbbbbbb')"
+
+        self.assertEqual(calltip.get_argspec(foo), str_foo)
+        self.assertEqual(calltip.get_argspec(bar), str_bar)
+        self.assertEqual(calltip.get_argspec(baz), str_baz)
+
     def test_docline_truncation(self):
         def f(): pass
         f.__doc__ = 'a'*300

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -60,6 +60,7 @@ Heidi Annexstad
 Ramchandra Apte
 Éric Araujo
 Alexandru Ardelean
+Emmanuel Arias
 Alicia Arlen
 Jeffrey Armstrong
 Jason Asbahr

--- a/Misc/NEWS.d/next/Library/2019-01-02-22-15-01.bpo-35641.QEaANl.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-02-22-15-01.bpo-35641.QEaANl.rst
@@ -1,1 +1,1 @@
-`calltip` get signature properly formated for function with not docstring
+Proper format `calltip` when the function has no docstring.

--- a/Misc/NEWS.d/next/Library/2019-01-02-22-15-01.bpo-35641.QEaANl.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-02-22-15-01.bpo-35641.QEaANl.rst
@@ -1,0 +1,1 @@
+`calltip` get signature properly formated for function with not docstring


### PR DESCRIPTION
[bpo-35641](https://bugs.python.org/issue35641): IDLE: calltips not properly formatted for functions without doc-strings

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35641](https://bugs.python.org/issue35641) -->
https://bugs.python.org/issue35641
<!-- /issue-number -->
