### PR TITLE
bpo-35589: Prevent buffer copy in sock_sendall()

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -438,13 +438,13 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
                         memoryview(data), [n])
         return await fut
 
-    def _sock_sendall(self, fut, sock, data, pos):
+    def _sock_sendall(self, fut, sock, view, pos):
         if fut.done():
             # Future cancellation can be scheduled on previous loop iteration
             return
         start = pos[0]
         try:
-            n = sock.send(data[start:])
+            n = sock.send(view[start:])
         except (BlockingIOError, InterruptedError):
             return
         except Exception as exc:
@@ -453,7 +453,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
 
         start += n
 
-        if start == len(data):
+        if start == len(view):
             fut.set_result(None)
         else:
             pos[0] = start

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -434,7 +434,8 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         fut.add_done_callback(
             functools.partial(self._sock_write_done, fd))
         # use a trick with a list in closure to store a mutable state
-        self.add_writer(fd, self._sock_sendall, fut, sock, data, [n])
+        self.add_writer(fd, self._sock_sendall, fut, sock,
+                        memoryview(data), [n])
         return await fut
 
     def _sock_sendall(self, fut, sock, data, pos):

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -428,32 +428,34 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         if n == len(data):
             # all data sent
             return
-        else:
-            data = bytearray(memoryview(data)[n:])
 
         fut = self.create_future()
         fd = sock.fileno()
         fut.add_done_callback(
             functools.partial(self._sock_write_done, fd))
-        self.add_writer(fd, self._sock_sendall, fut, sock, data)
+        # use a trick with a list in closure to store a mutable state
+        self.add_writer(fd, self._sock_sendall, fut, sock, data, [n])
         return await fut
 
-    def _sock_sendall(self, fut, sock, data):
+    def _sock_sendall(self, fut, sock, data, pos):
         if fut.done():
             # Future cancellation can be scheduled on previous loop iteration
             return
+        start = pos[0]
         try:
-            n = sock.send(data)
+            n = sock.send(data[start:])
         except (BlockingIOError, InterruptedError):
             return
         except Exception as exc:
             fut.set_exception(exc)
             return
 
-        if n == len(data):
+        start += n
+
+        if start == len(data):
             fut.set_result(None)
         else:
-            del data[:n]
+            pos[0] = start
 
     async def sock_connect(self, sock, address):
         """Connect to a remote socket at address.


### PR DESCRIPTION
No NEWs is needed since the problem was introduced on master only and never released.

<!-- issue-number: [bpo-35589](https://bugs.python.org/issue35589) -->
https://bugs.python.org/issue35589
<!-- /issue-number -->
