### PR TITLE
Trivial: Distutils must no longer remain compatible with 2.3

### DIFF
--- a/Lib/distutils/README
+++ b/Lib/distutils/README
@@ -8,6 +8,4 @@ The Distutils-SIG web page is also a good starting point:
 
     http://www.python.org/sigs/distutils-sig/
 
-WARNING : Distutils must remain compatible with 2.3
-
 $Id$


### PR DESCRIPTION
The line was most likely bogus.

(Trivial changes, like fixing a typo, do not need an issue.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
