### PR TITLE
bpo-35633: test_lockf() fails with "PermissionError: [Errno 13] Permission denied" on AIX

### DIFF
--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -12,6 +12,7 @@ import contextlib
 import faulthandler
 import fcntl
 import os
+import platform
 import select
 import signal
 import socket
@@ -507,7 +508,7 @@ class FNTLEINTRTest(EINTRBaseTest):
                         lock_func(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
                         lock_func(f, fcntl.LOCK_UN)
                         time.sleep(0.01)
-                    except (BlockingIOError, PermissionError):
+                    except BlockingIOError:
                         break
                 # the child locked the file just a moment ago for 'sleep_time' seconds
                 # that means that the lock below will block for 'sleep_time' minus some
@@ -518,6 +519,9 @@ class FNTLEINTRTest(EINTRBaseTest):
                 self.stop_alarm()
             proc.wait()
 
+    # Issue 35633: See https://bugs.python.org/issue35633#msg333662
+    # skip test rather than accept PermissionError from all platforms
+    @unittest.skipIf(platform.system() == "AIX", "AIX returns PermissionError")
     def test_lockf(self):
         self._lock(fcntl.lockf, "lockf")
 

--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -507,7 +507,7 @@ class FNTLEINTRTest(EINTRBaseTest):
                         lock_func(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
                         lock_func(f, fcntl.LOCK_UN)
                         time.sleep(0.01)
-                    except BlockingIOError:
+                    except (BlockingIOError, PermissionError):
                         break
                 # the child locked the file just a moment ago for 'sleep_time' seconds
                 # that means that the lock below will block for 'sleep_time' minus some

--- a/Misc/NEWS.d/next/Tests/2019-01-04-17-44-41.bpo-35633.wHfVop.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-04-17-44-41.bpo-35633.wHfVop.rst
@@ -1,0 +1,2 @@
+Add PermissionError to the Exception: list
+patch by Michael Felt, aixtools

--- a/Misc/NEWS.d/next/Tests/2019-01-04-17-44-41.bpo-35633.wHfVop.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-04-17-44-41.bpo-35633.wHfVop.rst
@@ -1,2 +1,0 @@
-Add PermissionError to the Exception: list
-patch by Michael Felt, aixtools


### PR DESCRIPTION
[bpo-35633](https://bugs.python.org/issue35633): Fix a test regression introduced with [bpo-35189](https://bugs.python.org/issue35189) (PEP 475: fnctl functions are not retried if interrupted (EINTR)).

Not only a blocking IO error needs to be ignored - permission errors also need to be ignored.

p.s. - iirc as a "test" only correction a NEWS item is not required. If this is not correct - just mention, and I'll add a NEWS blurb.

<!-- issue-number: [bpo-35633](https://bugs.python.org/issue35633) -->
https://bugs.python.org/issue35633
<!-- /issue-number -->
