### PR TITLE
bpo-33987: IDLE: Use ttk Frame on help.py

### DIFF
--- a/Lib/idlelib/help.py
+++ b/Lib/idlelib/help.py
@@ -28,8 +28,8 @@ from html.parser import HTMLParser
 from os.path import abspath, dirname, isfile, join
 from platform import python_version
 
-from tkinter import Toplevel, Frame, Text, Menu
-from tkinter.ttk import Menubutton, Scrollbar
+from tkinter import Toplevel, Text, Menu
+from tkinter.ttk import Frame, Menubutton, Scrollbar, Style
 from tkinter import font as tkfont
 
 from idlelib.config import idleConf
@@ -212,7 +212,9 @@ class HelpFrame(Frame):
     def __init__(self, parent, filename):
         Frame.__init__(self, parent)
         self.text = text = HelpText(self, filename)
-        self['background'] = text['background']
+        self.style = Style(parent)
+        self['style'] = 'helpframe.TFrame'
+        self.style.configure('helpframe.TFrame', background=text['background'])
         self.toc = toc = self.toc_menu(text)
         self.scroll = scroll = Scrollbar(self, command=text.yview)
         text['yscrollcommand'] = scroll.set

--- a/Lib/idlelib/statusbar.py
+++ b/Lib/idlelib/statusbar.py
@@ -1,4 +1,5 @@
-from tkinter import Frame, Label
+from tkinter import Label
+from tkinter.ttk import Frame
 
 
 class MultiStatusBar(Frame):
@@ -20,7 +21,8 @@ class MultiStatusBar(Frame):
 
 
 def _multistatus_bar(parent):  # htest #
-    from tkinter import Toplevel, Frame, Text, Button
+    from tkinter import Toplevel, Text
+    from tkinter.ttk import Frame, Button
     top = Toplevel(parent)
     x, y = map(int, parent.geometry().split('+')[1:])
     top.geometry("+%d+%d" %(x, y + 175))


### PR DESCRIPTION
* Convert help.py to ttk frame.
* Use of ttk Style is similar to configdialog.py.  Without having to introduce ttk styles and themes too much, this is basically a specific replacement to the old usage of background on Label.
* I left off the blurb since I used the same ticket number.  Since you did all the other screens under one ticket, I didn't know if you wanted to reuse that or create a new ticket for this.


<!-- issue-number: [bpo-33987](https://bugs.python.org/issue33987) -->
https://bugs.python.org/issue33987
<!-- /issue-number -->
