### PR TITLE
bpo-35660: Fix imports in idlelib.window

### DIFF
--- a/Lib/idlelib/window.py
+++ b/Lib/idlelib/window.py
@@ -1,4 +1,5 @@
-from tkinter import *
+from tkinter import Toplevel, TclError
+import sys
 
 
 class WindowList:

--- a/Misc/NEWS.d/next/IDLE/2019-01-04-19-14-29.bpo-35660.hMxI7N.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-01-04-19-14-29.bpo-35660.hMxI7N.rst
@@ -1,1 +1,1 @@
-Remove use of `from tkinter import *` from window.py.
+Fix imports in idlelib.window.

--- a/Misc/NEWS.d/next/IDLE/2019-01-04-19-14-29.bpo-35660.hMxI7N.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-01-04-19-14-29.bpo-35660.hMxI7N.rst
@@ -1,0 +1,1 @@
+Remove use of `from tkinter import *` from window.py.


### PR DESCRIPTION
* sys was being imported through the `*`, so also added an `import sys`.


<!-- issue-number: [bpo-35660](https://bugs.python.org/issue35660) -->
https://bugs.python.org/issue35660
<!-- /issue-number -->
