### PR TITLE
bpo-35647: Fix path check in cookiejar

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -1190,10 +1190,11 @@ class DefaultCookiePolicy(CookiePolicy):
     def path_return_ok(self, path, request):
         _debug("- checking cookie path=%s", path)
         req_path = request_path(request)
+        pathlen = len(path)
         if req_path == path:
             return True
         elif (req_path.startswith(path) and
-              (path.endswith("/") or req_path[len(path)] == "/")):
+              (path.endswith("/") or req_path[pathlen:pathlen+1] == "/")):
             return True
 
         _debug("  %s does not path-match %s", req_path, path)

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -992,7 +992,7 @@ class DefaultCookiePolicy(CookiePolicy):
             req_path = request_path(request)
             if ((cookie.version > 0 or
                  (cookie.version == 0 and self.strict_ns_set_path)) and
-                not req_path.startswith(cookie.path)):
+                not self.path_return_ok(cookie.path, request)):
                 _debug("   path attribute %s is not a prefix of request "
                        "path %s", cookie.path, req_path)
                 return False

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -1190,11 +1190,14 @@ class DefaultCookiePolicy(CookiePolicy):
     def path_return_ok(self, path, request):
         _debug("- checking cookie path=%s", path)
         req_path = request_path(request)
-        if not req_path.startswith(path):
-            _debug("  %s does not path-match %s", req_path, path)
-            return False
-        return True
+        if req_path == path:
+            return True
+        elif (req_path.startswith(path) and
+              (path.endswith("/") or req_path[len(path)] == "/")):
+            return True
 
+        _debug("  %s does not path-match %s", req_path, path)
+        return False
 
 def vals_sorted_by_key(adict):
     keys = sorted(adict.keys())

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -692,6 +692,28 @@ class CookieTests(unittest.TestCase):
         req = urllib.request.Request("http://www.example.com")
         self.assertEqual(request_path(req), "/")
 
+    def test_path_prefix_match(self):
+        pol = DefaultCookiePolicy()
+
+        c = CookieJar(pol)
+        url = "http://bar.com/foo"
+        interact_netscape(c, url, 'spam=eggs; Path=/foo')
+
+        h = interact_netscape(c, url)
+        self.assertIn('spam=eggs', h, "path not returned")
+
+        h = interact_netscape(c, "http://bar.com/foo/bar")
+        self.assertIn('spam=eggs', h, "path not returned")
+
+        h = interact_netscape(c, "http://bar.com/foo/bar/")
+        self.assertIn('spam=eggs', h, "path not returned")
+
+        h = interact_netscape(c, "http://bar.com/")
+        self.assertNotIn('spam=eggs', h, "path returned with /")
+
+        h = interact_netscape(c, "http://bar.com/foobad/foo")
+        self.assertNotIn('spam=eggs', h, "path returned with invalid prefix")
+
     def test_request_port(self):
         req = urllib.request.Request("http://www.acme.com:1234/",
                                      headers={"Host": "www.acme.com:4321"})

--- a/Misc/NEWS.d/next/Library/2018-12-30-14-35-19.bpo-35121.oWmiGU.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-30-14-35-19.bpo-35121.oWmiGU.rst
@@ -1,0 +1,3 @@
+Don't set cookie for a request when the request path is a prefix match of
+the cookie's path attribute but doesn't end with "/". Patch by Karthikeyan
+Singaravelan.


### PR DESCRIPTION
* Fixes `path_return_ok` to use [RFC 6265](https://tools.ietf.org/html/rfc6265#section-5.1.4) path-match algorithm. Fix `set_ok_path` which also had similar bug in prefix check which now uses `path_return_ok` itself.
* NEWS entry might need rewording. Any suggestions would be helpful since I am not a native speaker.

<!-- issue-number: [bpo-35647](https://bugs.python.org/issue35647) -->
https://bugs.python.org/issue35647
<!-- /issue-number -->
