### PR TITLE
bpo-35603: Add a note on difflib table header interpreted as HTML

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -131,6 +131,10 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
          *charset* keyword-only argument was added.  The default charset of
          HTML document changed from ``'ISO-8859-1'`` to ``'utf-8'``.
 
+      .. note::
+         *fromdesc* and *todesc* are interpreted as HTML and should be properly escaped
+         while receiving input from untrusted sources.
+
    .. method:: make_table(fromlines, tolines, fromdesc='', todesc='', context=False, numlines=5)
 
       Compares *fromlines* and *tolines* (lists of strings) and returns a string which

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -132,8 +132,8 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
          HTML document changed from ``'ISO-8859-1'`` to ``'utf-8'``.
 
       .. note::
-         *fromdesc* and *todesc* are interpreted as HTML and should be properly escaped
-         while receiving input from untrusted sources.
+         *fromdesc* and *todesc* are interpreted as unescaped HTML and should be
+         properly escaped while receiving input from untrusted sources.
 
    .. method:: make_table(fromlines, tolines, fromdesc='', todesc='', context=False, numlines=5)
 

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -127,13 +127,13 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
       the next difference highlight at the top of the browser without any leading
       context).
 
-      .. versionchanged:: 3.5
-         *charset* keyword-only argument was added.  The default charset of
-         HTML document changed from ``'ISO-8859-1'`` to ``'utf-8'``.
-
       .. note::
          *fromdesc* and *todesc* are interpreted as unescaped HTML and should be
          properly escaped while receiving input from untrusted sources.
+
+      .. versionchanged:: 3.5
+         *charset* keyword-only argument was added.  The default charset of
+         HTML document changed from ``'ISO-8859-1'`` to ``'utf-8'``.
 
    .. method:: make_table(fromlines, tolines, fromdesc='', todesc='', context=False, numlines=5)
 


### PR DESCRIPTION
This adds a doc note on the difflib `make_file` output. Wording suggestions are welcome.

Output as note : 

![screen shot 2019-01-06 at 1 11 54 am](https://user-images.githubusercontent.com/3972343/50728530-30c8cd00-1151-11e9-92af-f2d98ad76b5d.png)

Output as warning : 

![screen shot 2019-01-06 at 1 12 38 am](https://user-images.githubusercontent.com/3972343/50728531-31616380-1151-11e9-9aa7-94990b1d59d9.png)


<!-- issue-number: [bpo-35603](https://bugs.python.org/issue35603) -->
https://bugs.python.org/issue35603
<!-- /issue-number -->
