### PR TITLE
bpo-20182: remove doc-string declaration no longer used after AC conversion

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1594,10 +1594,6 @@ sys__clear_type_cache_impl(PyObject *module)
     Py_RETURN_NONE;
 }
 
-PyDoc_STRVAR(sys_clear_type_cache__doc__,
-"_clear_type_cache() -> None\n\
-Clear the internal type lookup cache.");
-
 /*[clinic input]
 sys.is_finalizing
 


### PR DESCRIPTION


<!-- issue-number: [bpo-20182](https://bugs.python.org/issue20182) -->
https://bugs.python.org/issue20182
<!-- /issue-number -->
