### PR TITLE
bpo-12707: deprecate info(), geturl(), getcode() methods in favor of headers, url, and status properties for HTTPResponse and addinfourl

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -460,6 +460,14 @@ statement.
 
    HTTP protocol version used by server.  10 for HTTP/1.0, 11 for HTTP/1.1.
 
+.. attribute:: HTTPResponse.url
+
+   URL of the resource retrieved, commonly used to determine if a redirect was followed
+
+.. attribute:: HTTPResponse.headers
+
+   Headers of the response in the form of an :meth:`email.message_from_string` instance
+
 .. attribute:: HTTPResponse.status
 
    Status code returned by server.
@@ -476,6 +484,24 @@ statement.
 .. attribute:: HTTPResponse.closed
 
    Is ``True`` if the stream is closed.
+
+.. method:: HTTPResponse.geturl()
+
+   .. deprecated:: 3.8
+
+      Returns the URL of the resource retrieved. Deprecated in favor of *HTTPResponse.url*.
+
+.. method:: HTTPResponse.info()
+
+   .. deprecated:: 3.8
+
+      Returns the response headers. Deprecated in favor of *HTTPResponse.headers*.
+
+.. method:: HTTPResponse.getstatus()
+
+   .. deprecated:: 3.8
+
+      Returns the status. Deprecated in favor of *HTTPResponse.status*.
 
 Examples
 --------

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -487,15 +487,15 @@ statement.
 
 .. method:: HTTPResponse.geturl()
 
-   Returns the URL of the resource retrieved. Recommended to use *HTTPResponse.url* instead.
+   Returns the URL of the resource retrieved. Recommended to use :attr:`~HTTPResponse.url` instead.
 
 .. method:: HTTPResponse.info()
 
-   Returns the response headers. Recommended to use *HTTPResponse.headers* instead.
+   Returns the response headers. Recommended to use :attr:`~HTTPResponse.headers` instead.
 
 .. method:: HTTPResponse.getstatus()
 
-   Returns the status. Recommended to use *HTTPResponse.status* instead.
+   Returns the status. Recommended to use :attr:`~HTTPResponse.status` instead.
 
 Examples
 --------

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -466,7 +466,7 @@ statement.
 
 .. attribute:: HTTPResponse.headers
 
-   Headers of the response in the form of an :meth:`email.message_from_string` instance.
+   Headers of the response in the form of an :class:`email.message.EmailMessage` instance.
 
 .. attribute:: HTTPResponse.status
 

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -487,21 +487,15 @@ statement.
 
 .. method:: HTTPResponse.geturl()
 
-   .. deprecated:: 3.8
-
-      Returns the URL of the resource retrieved. Deprecated in favor of *HTTPResponse.url*.
+   Returns the URL of the resource retrieved. Recommended to use *HTTPResponse.url* instead.
 
 .. method:: HTTPResponse.info()
 
-   .. deprecated:: 3.8
-
-      Returns the response headers. Deprecated in favor of *HTTPResponse.headers*.
+   Returns the response headers. Recommended to use *HTTPResponse.headers* instead.
 
 .. method:: HTTPResponse.getstatus()
 
-   .. deprecated:: 3.8
-
-      Returns the status. Deprecated in favor of *HTTPResponse.status*.
+   Returns the status. Recommended to use *HTTPResponse.status* instead.
 
 Examples
 --------

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -487,15 +487,15 @@ statement.
 
 .. method:: HTTPResponse.geturl()
 
-   Returns the URL of the resource retrieved. Recommended to use :attr:`~HTTPResponse.url` instead.
+   Deprecated method equivalent to :attr:`HTTPResponse.url`.
 
 .. method:: HTTPResponse.info()
 
-   Returns the response headers. Recommended to use :attr:`~HTTPResponse.headers` instead.
+   Deprecated method equivalent to :attr:`HTTPResponse.headers`.
 
 .. method:: HTTPResponse.getstatus()
 
-   Returns the status. Recommended to use :attr:`~HTTPResponse.status` instead.
+   Deprecated method equivalent to :attr:`~HTTPResponse.status`.
 
 Examples
 --------

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -462,11 +462,11 @@ statement.
 
 .. attribute:: HTTPResponse.url
 
-   URL of the resource retrieved, commonly used to determine if a redirect was followed
+   URL of the resource retrieved, commonly used to determine if a redirect was followed.
 
 .. attribute:: HTTPResponse.headers
 
-   Headers of the response in the form of an :meth:`email.message_from_string` instance
+   Headers of the response in the form of an :meth:`email.message_from_string` instance.
 
 .. attribute:: HTTPResponse.status
 

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -487,17 +487,17 @@ statement.
 
 .. method:: HTTPResponse.geturl()
 
-   ..deprecated:: 3.9
+   .. deprecated:: 3.9
       Deprecated in favor of :attr:`~HTTPResponse.url`.
 
 .. method:: HTTPResponse.info()
 
-   ..deprecated:: 3.9
+   .. deprecated:: 3.9
       Deprecated in favor of :attr:`~HTTPResponse.headers`.
 
 .. method:: HTTPResponse.getstatus()
 
-   ..deprecated:: 3.9
+   .. deprecated:: 3.9
       Deprecated in favor of :attr:`~HTTPResponse.status`.
 
 Examples

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -487,15 +487,18 @@ statement.
 
 .. method:: HTTPResponse.geturl()
 
-   Deprecated method equivalent to :attr:`HTTPResponse.url`.
+   ..deprecated:: 3.9
+      Deprecated in favor of :attr:`~HTTPResponse.url`.
 
 .. method:: HTTPResponse.info()
 
-   Deprecated method equivalent to :attr:`HTTPResponse.headers`.
+   ..deprecated:: 3.9
+      Deprecated in favor of :attr:`~HTTPResponse.headers`.
 
 .. method:: HTTPResponse.getstatus()
 
-   Deprecated method equivalent to :attr:`~HTTPResponse.status`.
+   ..deprecated:: 3.9
+      Deprecated in favor of :attr:`~HTTPResponse.status`.
 
 Examples
 --------

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -55,16 +55,8 @@ The :mod:`urllib.request` module defines the following functions:
    The *cadefault* parameter is ignored.
 
    This function always returns an object which can work as a
-   :term:`context manager` and has methods such as
-
-   * :meth:`~urllib.response.addinfourl.geturl` --- return the URL of the resource retrieved,
-     commonly used to determine if a redirect was followed
-
-   * :meth:`~urllib.response.addinfourl.info` --- return the meta-information of the page, such as headers,
-     in the form of an :func:`email.message_from_string` instance (see
-     `Quick Reference to HTTP Headers <http://jkorpela.fi/http.html>`_)
-
-   * :meth:`~urllib.response.addinfourl.getcode` -- return the HTTP status code of the response.
+   :term:`context manager` and has the properties `url`, `headers`, and `status`.
+   See :class:`urllib.response.addinfourl` for more detail on these properties.
 
    For HTTP and HTTPS URLs, this function returns a
    :class:`http.client.HTTPResponse` object slightly modified. In addition
@@ -1557,9 +1549,46 @@ some point in the future.
    :synopsis: Response classes used by urllib.
 
 The :mod:`urllib.response` module defines functions and classes which define a
-minimal file like interface, including ``read()`` and ``readline()``. The
-typical response object is an addinfourl instance, which defines an ``info()``
-method and that returns headers and a ``geturl()`` method that returns the url.
-Functions defined by this module are used internally by the
-:mod:`urllib.request` module.
+minimal file-like interface, including ``read()`` and ``readline()``.
+Functions defined by this module are used internally by the :mod:`urllib.request` module.
+The typical response object is a :class:`urllib.response.addinfourl` instance:
 
+.. class:: urllib.response.addinfourl
+
+.. attribute:: addinfourl.url
+
+   URL of the resource retrieved, commonly used to determine if a redirect was followed
+
+.. attribute:: addinfourl.headers
+
+   Returns the meta-information of the page, such as headers,
+   in the form of an :func:`email.message_from_string` instance (see
+   `Quick Reference to HTTP Headers <http://jkorpela.fi/http.html>`_)
+
+.. attribute:: addinfourl.code
+
+   Status code returned by server.
+
+.. attribute:: addinfourl.status
+
+   .. deprecated:: 3.8
+
+      Status code returned by server. Deprecated in favor of *addinfourl.status*.
+
+.. method:: addinfourl.geturl()
+
+   .. deprecated:: 3.8
+
+      Returns the URL of the resource retrieved. Deprecated in favor of *addinfourl.url*.
+
+.. method:: addinfourl.info()
+
+   .. deprecated:: 3.8
+
+      Returns the response headers. Deprecated in favor of *addinfourl.headers*.
+
+.. method:: addinfourl.getstatus()
+
+   .. deprecated:: 3.8
+
+      Returns the status. Deprecated in favor of *addinfourl.status*.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -55,7 +55,7 @@ The :mod:`urllib.request` module defines the following functions:
    The *cadefault* parameter is ignored.
 
    This function always returns an object which can work as a
-   :term:`context manager` and has the properties `url`, `headers`, and `status`.
+   :term:`context manager` and has the properties *url*, *headers*, and *status*.
    See :class:`urllib.response.addinfourl` for more detail on these properties.
 
    For HTTP and HTTPS URLs, this function returns a

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1565,10 +1565,6 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
    in the form of an :func:`email.message_from_string` instance (see
    `Quick Reference to HTTP Headers <http://jkorpela.fi/http.html>`_)
 
-.. attribute:: addinfourl.code
-
-   Status code returned by server.
-
 .. attribute:: addinfourl.status
 
    .. versionadded:: 3.8
@@ -1582,6 +1578,10 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 .. method:: addinfourl.info()
 
    Returns the response headers. Recommended to use :attr:`~addinfourl.headers` instead.
+
+.. attribute:: addinfourl.code
+
+   Status code returned by server. Recommended to use :attr:`~addinfourl.status` instead.
 
 .. method:: addinfourl.getstatus()
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1571,16 +1571,16 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
 .. method:: addinfourl.geturl()
 
-   Returns the URL of the resource retrieved. Recommended to use :attr:`~addinfourl.url` instead.
+   Deprecated method equivalent to :attr:`~addinfourl.url`.
 
 .. method:: addinfourl.info()
 
-   Returns the response headers. Recommended to use :attr:`~addinfourl.headers` instead.
+   Deprecated method equivalent to :attr:`~addinfourl.headers`.
 
 .. attribute:: addinfourl.code
 
-   Status code returned by server. Recommended to use :attr:`~addinfourl.status` instead.
+   Deprecated attribute equivalent to :attr:`~addinfourl.status`.
 
 .. method:: addinfourl.getstatus()
 
-   Returns the status. Recommended to use :attr:`~addinfourl.status` instead.
+   Deprecated method equivalent to :attr:`~addinfourl.status`.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1571,15 +1571,15 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
 .. attribute:: addinfourl.status
 
-   Status code returned by server. Recommended to use :attr:`~addinfourl.status` instead.
+   Status code returned by server.
 
 .. method:: addinfourl.geturl()
 
-   Returns the URL of the resource retrieved. Recommended to use :attr:`~addinfourl.status` instead.
+   Returns the URL of the resource retrieved. Recommended to use :attr:`~addinfourl.url` instead.
 
 .. method:: addinfourl.info()
 
-   Returns the response headers. Recommended to use :attr:`~addinfourl.status` instead.
+   Returns the response headers. Recommended to use :attr:`~addinfourl.headers` instead.
 
 .. method:: addinfourl.getstatus()
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1571,6 +1571,8 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
 .. attribute:: addinfourl.status
 
+   .. versionadded:: 3.8
+   
    Status code returned by server.
 
 .. method:: addinfourl.geturl()

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1553,34 +1553,34 @@ minimal file-like interface, including ``read()`` and ``readline()``.
 Functions defined by this module are used internally by the :mod:`urllib.request` module.
 The typical response object is a :class:`urllib.response.addinfourl` instance:
 
-.. class:: urllib.response.addinfourl
+.. class:: addinfourl
 
-.. attribute:: addinfourl.url
+   .. attribute:: url
 
-   URL of the resource retrieved, commonly used to determine if a redirect was followed.
+      URL of the resource retrieved, commonly used to determine if a redirect was followed.
 
-.. attribute:: addinfourl.headers
+   .. attribute:: headers
 
-   Returns the headers of the response in the form of an :class:`~email.message.EmailMessage` instance.
+      Returns the headers of the response in the form of an :class:`~email.message.EmailMessage` instance.
 
-.. attribute:: addinfourl.status
+   .. attribute:: status
 
-   .. versionadded:: 3.8
+      .. versionadded:: 3.8
 
-   Status code returned by server.
+      Status code returned by server.
 
-.. method:: addinfourl.geturl()
+   .. method:: geturl()
 
-   Deprecated method equivalent to :attr:`~addinfourl.url`.
+      Deprecated method equivalent to :attr:`~addinfourl.url`.
 
-.. method:: addinfourl.info()
+   .. method:: info()
 
-   Deprecated method equivalent to :attr:`~addinfourl.headers`.
+      Deprecated method equivalent to :attr:`~addinfourl.headers`.
 
-.. attribute:: addinfourl.code
+   .. attribute:: code
 
-   Deprecated attribute equivalent to :attr:`~addinfourl.status`.
+      Deprecated attribute equivalent to :attr:`~addinfourl.status`.
 
-.. method:: addinfourl.getstatus()
+   .. method:: getstatus()
 
-   Deprecated method equivalent to :attr:`~addinfourl.status`.
+      Deprecated method equivalent to :attr:`~addinfourl.status`.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1571,24 +1571,16 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
 .. attribute:: addinfourl.status
 
-   .. deprecated:: 3.8
-
-      Status code returned by server. Deprecated in favor of *addinfourl.status*.
+   Status code returned by server. Recommended to use *addinfourl.status* instead.
 
 .. method:: addinfourl.geturl()
 
-   .. deprecated:: 3.8
-
-      Returns the URL of the resource retrieved. Deprecated in favor of *addinfourl.url*.
+   Returns the URL of the resource retrieved. Recommended to use *addinfourl.url* instead.
 
 .. method:: addinfourl.info()
 
-   .. deprecated:: 3.8
-
-      Returns the response headers. Deprecated in favor of *addinfourl.headers*.
+   Returns the response headers. Recommended to use *addinfourl.headers* instead.
 
 .. method:: addinfourl.getstatus()
 
-   .. deprecated:: 3.8
-
-      Returns the status. Deprecated in favor of *addinfourl.status*.
+   Returns the status. Deprecated in favor of *addinfourl.status* instead.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1571,16 +1571,16 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
 .. attribute:: addinfourl.status
 
-   Status code returned by server. Recommended to use *addinfourl.status* instead.
+   Status code returned by server. Recommended to use :attr:`~addinfourl.status` instead.
 
 .. method:: addinfourl.geturl()
 
-   Returns the URL of the resource retrieved. Recommended to use *addinfourl.url* instead.
+   Returns the URL of the resource retrieved. Recommended to use :attr:`~addinfourl.status` instead.
 
 .. method:: addinfourl.info()
 
-   Returns the response headers. Recommended to use *addinfourl.headers* instead.
+   Returns the response headers. Recommended to use :attr:`~addinfourl.status` instead.
 
 .. method:: addinfourl.getstatus()
 
-   Returns the status. Recommended to use *addinfourl.status* instead.
+   Returns the status. Recommended to use :attr:`~addinfourl.status` instead.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1557,7 +1557,7 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
 .. attribute:: addinfourl.url
 
-   URL of the resource retrieved, commonly used to determine if a redirect was followed
+   URL of the resource retrieved, commonly used to determine if a redirect was followed.
 
 .. attribute:: addinfourl.headers
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1561,13 +1561,12 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
 .. attribute:: addinfourl.headers
 
-   Returns the meta-information of the page, such as headers,
-   in the form of an :class:`~email.message.EmailMessage` instance.
+   Returns the headers of the response in the form of an :class:`~email.message.EmailMessage` instance.
 
 .. attribute:: addinfourl.status
 
    .. versionadded:: 3.8
-   
+
    Status code returned by server.
 
 .. method:: addinfourl.geturl()

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1583,4 +1583,4 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
 .. method:: addinfourl.getstatus()
 
-   Returns the status. Deprecated in favor of *addinfourl.status* instead.
+   Returns the status. Recommended to use *addinfourl.status* instead.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1562,8 +1562,7 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 .. attribute:: addinfourl.headers
 
    Returns the meta-information of the page, such as headers,
-   in the form of an :func:`email.message_from_string` instance (see
-   `Quick Reference to HTTP Headers <http://jkorpela.fi/http.html>`_)
+   in the form of an :class:`~email.message.EmailMessage` instance.
 
 .. attribute:: addinfourl.status
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1565,22 +1565,26 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
    .. attribute:: status
 
-      .. versionadded:: 3.8
+      .. versionadded:: 3.9
 
       Status code returned by server.
 
    .. method:: geturl()
 
-      Deprecated method equivalent to :attr:`~addinfourl.url`.
+      ..deprecated:: 3.9
+         Deprecated in favor of :attr:`~addinfourl.url`.
 
    .. method:: info()
 
-      Deprecated method equivalent to :attr:`~addinfourl.headers`.
+      ..deprecated:: 3.9
+         Deprecated in favor of :attr:`~addinfourl.headers`.
 
    .. attribute:: code
 
-      Deprecated attribute equivalent to :attr:`~addinfourl.status`.
+      ..deprecated:: 3.9
+         Deprecated in favor of :attr:`~addinfourl.status`.
 
    .. method:: getstatus()
 
-      Deprecated method equivalent to :attr:`~addinfourl.status`.
+      ..deprecated:: 3.9
+         Deprecated in favor of :attr:`~addinfourl.status`.

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1571,20 +1571,20 @@ The typical response object is a :class:`urllib.response.addinfourl` instance:
 
    .. method:: geturl()
 
-      ..deprecated:: 3.9
+      .. deprecated:: 3.9
          Deprecated in favor of :attr:`~addinfourl.url`.
 
    .. method:: info()
 
-      ..deprecated:: 3.9
+      .. deprecated:: 3.9
          Deprecated in favor of :attr:`~addinfourl.headers`.
 
    .. attribute:: code
 
-      ..deprecated:: 3.9
+      .. deprecated:: 3.9
          Deprecated in favor of :attr:`~addinfourl.status`.
 
    .. method:: getstatus()
 
-      ..deprecated:: 3.9
+      .. deprecated:: 3.9
          Deprecated in favor of :attr:`~addinfourl.status`.

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -755,6 +755,10 @@ class HTTPResponse(io.BufferedIOBase):
         description of the mimetools module.
 
         '''
+        import warnings
+        warnings.warn("HTTPResponse.info() is deprecated"
+                "use HTTPResponse.headers instead",
+                DeprecationWarning, stacklevel=2)
         return self.headers
 
     def geturl(self):
@@ -767,6 +771,10 @@ class HTTPResponse(io.BufferedIOBase):
         redirected URL.
 
         '''
+        import warnings
+        warnings.warn("HTTPResponse.geturl() is deprecated"
+                "use HTTPResponse.url instead",
+                DeprecationWarning, stacklevel=2)
         return self.url
 
     def getcode(self):
@@ -774,6 +782,14 @@ class HTTPResponse(io.BufferedIOBase):
         or None if the URL is not an HTTP URL.
 
         '''
+        import warnings
+        warnings.warn("HTTPResponse.getcode() is deprecated"
+                "use HTTPResponse.code instead",
+                DeprecationWarning, stacklevel=2)
+        return self.status
+    
+    @property
+    def code(self):
         return self.status
 
 class HTTPConnection:

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -784,12 +784,8 @@ class HTTPResponse(io.BufferedIOBase):
         '''
         import warnings
         warnings.warn("HTTPResponse.getcode() is deprecated"
-                "use HTTPResponse.code instead",
+                "use HTTPResponse.status instead",
                 DeprecationWarning, stacklevel=2)
-        return self.status
-    
-    @property
-    def code(self):
         return self.status
 
 class HTTPConnection:

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -755,10 +755,6 @@ class HTTPResponse(io.BufferedIOBase):
         description of the mimetools module.
 
         '''
-        import warnings
-        warnings.warn("HTTPResponse.info() is deprecated"
-                "use HTTPResponse.headers instead",
-                DeprecationWarning, stacklevel=2)
         return self.headers
 
     def geturl(self):
@@ -771,10 +767,6 @@ class HTTPResponse(io.BufferedIOBase):
         redirected URL.
 
         '''
-        import warnings
-        warnings.warn("HTTPResponse.geturl() is deprecated"
-                "use HTTPResponse.url instead",
-                DeprecationWarning, stacklevel=2)
         return self.url
 
     def getcode(self):
@@ -782,10 +774,6 @@ class HTTPResponse(io.BufferedIOBase):
         or None if the URL is not an HTTP URL.
 
         '''
-        import warnings
-        warnings.warn("HTTPResponse.getcode() is deprecated"
-                "use HTTPResponse.status instead",
-                DeprecationWarning, stacklevel=2)
         return self.status
 
 class HTTPConnection:

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -185,17 +185,23 @@ class urlopen_FileTests(unittest.TestCase):
         # by the tearDown() method for the test
         self.returned_obj.close()
 
+    def test_headers(self):
+        self.assertIsInstance(self.returned_obj.headers, email.message.Message)
+
+    def test_url(self):
+        self.assertEqual(self.returned_obj.url, self.pathname)
+
+    def test_status(self):
+        self.assertIsNone(self.returned_obj.status)
+
     def test_info(self):
         self.assertIsInstance(self.returned_obj.info(), email.message.Message)
-        self.assertIsInstance(self.returned_obj.headers, email.message.Message)
 
     def test_geturl(self):
         self.assertEqual(self.returned_obj.geturl(), self.pathname)
-        self.assertEqual(self.returned_obj.url, self.pathname)
 
     def test_getcode(self):
         self.assertIsNone(self.returned_obj.getcode())
-        self.assertIsNone(self.returned_obj.status)
 
     def test_iter(self):
         # Test iterator

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -187,12 +187,15 @@ class urlopen_FileTests(unittest.TestCase):
 
     def test_info(self):
         self.assertIsInstance(self.returned_obj.info(), email.message.Message)
+        self.assertIsInstance(self.returned_obj.info, email.message.Message)
 
     def test_geturl(self):
         self.assertEqual(self.returned_obj.geturl(), self.pathname)
+        self.assertEqual(self.returned_obj.url, self.pathname)
 
     def test_getcode(self):
         self.assertIsNone(self.returned_obj.getcode())
+        self.assertIsNone(self.returned_obj.code)
 
     def test_iter(self):
         # Test iterator

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -195,7 +195,7 @@ class urlopen_FileTests(unittest.TestCase):
 
     def test_getcode(self):
         self.assertIsNone(self.returned_obj.getcode())
-        self.assertIsNone(self.returned_obj.code)
+        self.assertIsNone(self.returned_obj.status)
 
     def test_iter(self):
         # Test iterator

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -187,7 +187,7 @@ class urlopen_FileTests(unittest.TestCase):
 
     def test_info(self):
         self.assertIsInstance(self.returned_obj.info(), email.message.Message)
-        self.assertIsInstance(self.returned_obj.info, email.message.Message)
+        self.assertIsInstance(self.returned_obj.headers, email.message.Message)
 
     def test_geturl(self):
         self.assertEqual(self.returned_obj.geturl(), self.pathname)

--- a/Lib/test/test_urllib_response.py
+++ b/Lib/test/test_urllib_response.py
@@ -42,7 +42,7 @@ class TestResponse(unittest.TestCase):
     def test_addinfo(self):
         info = urllib.response.addinfo(self.fp, self.test_headers)
         self.assertEqual(info.info(), self.test_headers)
-        self.assertEqual(info.info, self.test_headers)
+        self.assertEqual(info.headers, self.test_headers)
 
     def test_addinfourl(self):
         url = "http://www.python.org"
@@ -52,7 +52,7 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(infourl.info(), self.test_headers)
         self.assertEqual(infourl.geturl(), url)
         self.assertEqual(infourl.getcode(), code)
-        self.assertEqual(infourl.info, self.test_headers)
+        self.assertEqual(infourl.headers, self.test_headers)
         self.assertEqual(infourl.url, url)
         self.assertEqual(infourl.status, code)
 

--- a/Lib/test/test_urllib_response.py
+++ b/Lib/test/test_urllib_response.py
@@ -42,6 +42,7 @@ class TestResponse(unittest.TestCase):
     def test_addinfo(self):
         info = urllib.response.addinfo(self.fp, self.test_headers)
         self.assertEqual(info.info(), self.test_headers)
+        self.assertEqual(info.info, self.test_headers)
 
     def test_addinfourl(self):
         url = "http://www.python.org"
@@ -51,6 +52,9 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(infourl.info(), self.test_headers)
         self.assertEqual(infourl.geturl(), url)
         self.assertEqual(infourl.getcode(), code)
+        self.assertEqual(infourl.info, self.test_headers)
+        self.assertEqual(infourl.url, url)
+        self.assertEqual(infourl.code, code)
 
     def tearDown(self):
         self.sock.close()

--- a/Lib/test/test_urllib_response.py
+++ b/Lib/test/test_urllib_response.py
@@ -54,7 +54,7 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(infourl.getcode(), code)
         self.assertEqual(infourl.info, self.test_headers)
         self.assertEqual(infourl.url, url)
-        self.assertEqual(infourl.code, code)
+        self.assertEqual(infourl.status, code)
 
     def tearDown(self):
         self.sock.close()

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -165,8 +165,8 @@ def urlopen(url, data=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
 
 
     This function always returns an object which can work as a
-    :term:`context manager` and has the properties `url`, `headers`, and `status`.
-    See :class:`urllib.response.addinfourl` for more detail on these properties.
+    context manager and has the properties url, headers, and status.
+    See urllib.response.addinfourl for more detail on these properties.
 
     For HTTP and HTTPS URLs, this function returns a http.client.HTTPResponse
     object slightly modified. In addition to the three new methods above, the

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -164,9 +164,9 @@ def urlopen(url, data=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     The *cadefault* parameter is ignored.
 
 
-   This function always returns an object which can work as a
-   :term:`context manager` and has the properties `url`, `headers`, and `status`.
-   See :class:`urllib.response.addinfourl` for more detail on these properties.
+    This function always returns an object which can work as a
+    :term:`context manager` and has the properties `url`, `headers`, and `status`.
+    See :class:`urllib.response.addinfourl` for more detail on these properties.
 
     For HTTP and HTTPS URLs, this function returns a http.client.HTTPResponse
     object slightly modified. In addition to the three new methods above, the

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -163,18 +163,10 @@ def urlopen(url, data=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
 
     The *cadefault* parameter is ignored.
 
-    This function always returns an object which can work as a context
-    manager and has methods such as
 
-    * geturl() - return the URL of the resource retrieved, commonly used to
-      determine if a redirect was followed
-
-    * info() - return the meta-information of the page, such as headers, in the
-      form of an email.message_from_string() instance (see Quick Reference to
-      HTTP Headers)
-
-    * getcode() - return the HTTP status code of the response.  Raises URLError
-      on errors.
+   This function always returns an object which can work as a
+   :term:`context manager` and has the properties `url`, `headers`, and `status`.
+   See `urllib.response.addinfourl` for more detail on these properties.
 
     For HTTP and HTTPS URLs, this function returns a http.client.HTTPResponse
     object slightly modified. In addition to the three new methods above, the

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -166,7 +166,7 @@ def urlopen(url, data=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
 
    This function always returns an object which can work as a
    :term:`context manager` and has the properties `url`, `headers`, and `status`.
-   See `urllib.response.addinfourl` for more detail on these properties.
+   See :class:`urllib.response.addinfourl` for more detail on these properties.
 
     For HTTP and HTTPS URLs, this function returns a http.client.HTTPResponse
     object slightly modified. In addition to the three new methods above, the

--- a/Lib/urllib/response.py
+++ b/Lib/urllib/response.py
@@ -75,7 +75,7 @@ class addinfourl(addinfo):
     @property
     def status(self):
         return self.code
-    
+
     def getcode(self):
         return self.code
 

--- a/Lib/urllib/response.py
+++ b/Lib/urllib/response.py
@@ -64,6 +64,7 @@ class addinfo(addbase):
     def info(self):
         return self.headers
 
+
 class addinfourl(addinfo):
     """class to add info() and geturl() methods to an open file."""
 

--- a/Lib/urllib/response.py
+++ b/Lib/urllib/response.py
@@ -76,10 +76,14 @@ class addinfourl(addinfo):
         self.url = url
         self.code = code
 
+    @property
+    def status(self):
+        return self.code
+    
     def getcode(self):
         import warnings
         warnings.warn("addinfourl.getcode() is deprecated"
-                "use addinfourl.code instead",
+                "use addinfourl.status instead",
                 DeprecationWarning, stacklevel=2)
         return self.code
 

--- a/Lib/urllib/response.py
+++ b/Lib/urllib/response.py
@@ -62,8 +62,11 @@ class addinfo(addbase):
         self.headers = headers
 
     def info(self):
+        import warnings
+        warnings.warn("addinfo.info() is deprecated"
+                "use addinfo.headers instead",
+                DeprecationWarning, stacklevel=2)
         return self.headers
-
 
 class addinfourl(addinfo):
     """class to add info() and geturl() methods to an open file."""
@@ -74,7 +77,15 @@ class addinfourl(addinfo):
         self.code = code
 
     def getcode(self):
+        import warnings
+        warnings.warn("addinfourl.getcode() is deprecated"
+                "use addinfourl.code instead",
+                DeprecationWarning, stacklevel=2)
         return self.code
 
     def geturl(self):
+        import warnings
+        warnings.warn("addinfourl.geturl() is deprecated"
+                "use addinfourl.url instead",
+                DeprecationWarning, stacklevel=2)
         return self.url

--- a/Lib/urllib/response.py
+++ b/Lib/urllib/response.py
@@ -62,10 +62,6 @@ class addinfo(addbase):
         self.headers = headers
 
     def info(self):
-        import warnings
-        warnings.warn("addinfo.info() is deprecated"
-                "use addinfo.headers instead",
-                DeprecationWarning, stacklevel=2)
         return self.headers
 
 class addinfourl(addinfo):
@@ -81,15 +77,7 @@ class addinfourl(addinfo):
         return self.code
     
     def getcode(self):
-        import warnings
-        warnings.warn("addinfourl.getcode() is deprecated"
-                "use addinfourl.status instead",
-                DeprecationWarning, stacklevel=2)
         return self.code
 
     def geturl(self):
-        import warnings
-        warnings.warn("addinfourl.geturl() is deprecated"
-                "use addinfourl.url instead",
-                DeprecationWarning, stacklevel=2)
         return self.url

--- a/Misc/NEWS.d/next/Documentation/2019-08-27-01-14-59.bpo-12707.Yj3_7_.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-08-27-01-14-59.bpo-12707.Yj3_7_.rst
@@ -1,0 +1,1 @@
+Deprecate info(), geturl(), getcode() methods in favor of headers, url, and status properties for HTTPResponse and addinfourl. Patch by Ashwin Ramaswami

--- a/Misc/NEWS.d/next/Documentation/2019-08-27-01-14-59.bpo-12707.Yj3_7_.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-08-27-01-14-59.bpo-12707.Yj3_7_.rst
@@ -1,1 +1,1 @@
-Deprecate info(), geturl(), getcode() methods in favor of headers, url, and status properties for HTTPResponse and addinfourl. Patch by Ashwin Ramaswami
+Deprecate info(), geturl(), getcode() methods in favor of the headers, url, and status properties, respectively, for HTTPResponse and addinfourl. Also deprecate the code attribute of addinfourl in favor of the status attribute. Patch by Ashwin Ramaswami


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-12707](https://bugs.python.org/issue12707) -->
https://bugs.python.org/issue12707
<!-- /issue-number -->
