### PR TITLE
bpo-35283: Add a deprecated warning for the threading.Thread.isAlive

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -394,6 +394,8 @@ Deprecated
 
   (Contributed by Serhiy Storchaka in :issue:`33710`.)
 
+* The :meth:`~threading.Thread.isAlive()` method of :class:`threading.Thread` has been deprecated.
+  (Contributed by Dong-hee Na in :issue:`35283`.)
 
 API and Feature Removals
 ========================

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2264,14 +2264,14 @@ def start_threads(threads, unlock=None):
                 endtime += 60
                 for t in started:
                     t.join(max(endtime - time.monotonic(), 0.01))
-                started = [t for t in started if t.isAlive()]
+                started = [t for t in started if t.is_alive()]
                 if not started:
                     break
                 if verbose:
                     print('Unable to join %d threads during a period of '
                           '%d minutes' % (len(started), timeout))
         finally:
-            started = [t for t in started if t.isAlive()]
+            started = [t for t in started if t.is_alive()]
             if started:
                 faulthandler.dump_traceback(sys.stdout)
                 raise AssertionError('Unable to join %d threads' % len(started))

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -415,7 +415,8 @@ class ThreadTests(BaseTestCase):
         t.setDaemon(True)
         t.getName()
         t.setName("name")
-        t.isAlive()
+        with self.assertWarnsRegex(DeprecationWarning, 'use is_alive()'):
+            t.isAlive()
         e = threading.Event()
         e.isSet()
         threading.activeCount()

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1091,7 +1091,15 @@ class Thread:
         self._wait_for_tstate_lock(False)
         return not self._is_stopped
 
-    isAlive = is_alive
+    def isAlive(self):
+        """Return whether the thread is alive.
+
+        This method is deprecated, use is_alive() instead.
+        """
+        import warnings
+        warnings.warn('isAlive() is deprecated, use is_alive() instead',
+                      DeprecationWarning, stacklevel=2)
+        return self.is_alive()
 
     @property
     def daemon(self):

--- a/Misc/NEWS.d/next/Library/2019-01-07-17-17-16.bpo-35283.WClosC.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-07-17-17-16.bpo-35283.WClosC.rst
@@ -1,0 +1,2 @@
+Add a deprecated warning for the :meth:`threading.Thread.isAlive` method.
+Patch by Dong-hee Na.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35283](https://bugs.python.org/issue35283) -->
https://bugs.python.org/issue35283
<!-- /issue-number -->
