### PR TITLE
bpo-35677: Do not automount directories by os.stat() on Linux.

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-01-07-11-25-05.bpo-35677.2I_ZC5.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-07-11-25-05.bpo-35677.2I_ZC5.rst
@@ -1,0 +1,4 @@
+:func:`os.stat` and :meth:`os.DirEntry.stat` no longer automount the
+terminal ("basename") component of pathname if it is a directory that is an
+automount point on Linux when *dir_fd* or *follow_symlinks* arguments are
+passed.


### PR DESCRIPTION
Unlike to stat() and lstat(), fstatat() automounts directories
by default.


<!-- issue-number: [bpo-35677](https://bugs.python.org/issue35677) -->
https://bugs.python.org/issue35677
<!-- /issue-number -->
