### PR TITLE
bpo-35685: Add examples of unittest.mock.patch.dict usage

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1578,7 +1578,7 @@ decorator. When used as a class decorator :func:`patch.dict` honours
 
     >>> foo = {}
     >>> @patch.dict(foo, {'newkey': 'newvalue'})
-    >>> def test():
+    ... def test():
     ...     assert foo == {'newkey': 'newvalue'}
     >>> test()
     >>> assert foo == {}

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1572,6 +1572,11 @@ patch.dict
     :func:`patch.dict` can also be called with arbitrary keyword arguments to set
     values in the dictionary.
 
+    .. versionchanged:: 3.8
+
+        :func:`patch.dict` now returns the patched dictionary when used as a context
+        manager.
+
 :func:`patch.dict` can be used as a context manager, decorator or class
 decorator:
 
@@ -1596,11 +1601,6 @@ When used as a class decorator :func:`patch.dict` honours
 If you want to use a different prefix for your test, you can inform the
 patchers of the different prefix by setting ``patch.TEST_PREFIX``. For
 more details about how to change the value of see :ref:`test-prefix`.
-
-    .. versionchanged:: 3.8
-
-        :func:`patch.dict` now returns the patched dictionary when used as a context
-        manager.
 
 :func:`patch.dict` can be used to add members to a dictionary, or simply let a test
 change a dictionary, and ensure the dictionary is restored when the test

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1573,8 +1573,9 @@ patch.dict
     values in the dictionary.
 
 :func:`patch.dict` can be used as a context manager, decorator or class
-decorator.
+decorator:
 
+    >>> import patch
     >>> foo = {}
     >>> @patch.dict(foo, {'newkey': 'newvalue'})
     ... def test():
@@ -1583,21 +1584,19 @@ decorator.
     >>> assert foo == {}
 
 When used as a class decorator :func:`patch.dict` honours
-``patch.TEST_PREFIX`` for choosing which methods to wrap. The patchers
-recognise methods that start with ``'test'`` as being test methods.
-If you want to use a different prefix for your test, you can inform the
-patchers of the different prefix by setting ``patch.TEST_PREFIX``.
+``patch.TEST_PREFIX`` (default to ``'test'``) for choosing which methods to wrap:
 
     >>> import os
     >>> import unittest
-    >>> patch.TEST_PREFIX = 'foo'
+    >>> from unittest.mock import patch
     >>> @patch.dict('os.environ', {'newkey': 'newvalue'})
     ... class TestSample(unittest.TestCase):
-    ...     def foo_sample(self):
+    ...     def test_sample(self):
     ...         self.assertEqual(os.environ['newkey'], 'newvalue')
-    ...
-    ...     def test_sample2(self):
-    ...         self.assertNotIn('newkey', os.environ.keys())
+
+If you want to use a different prefix for your test, you can inform the
+patchers of the different prefix by setting ``patch.TEST_PREFIX``. For
+more details about how to change the value of see :ref:`test-prefix`.
 
     .. versionchanged:: 3.8
 
@@ -1815,6 +1814,8 @@ builtin :func:`ord`::
     >>> test()
     101
 
+
+.. _test-prefix:
 
 TEST_PREFIX
 ~~~~~~~~~~~

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1573,8 +1573,7 @@ patch.dict
     values in the dictionary.
 
 :func:`patch.dict` can be used as a context manager, decorator or class
-decorator. When used as a class decorator :func:`patch.dict` honours
-``patch.TEST_PREFIX`` for choosing which methods to wrap.
+decorator.
 
     >>> foo = {}
     >>> @patch.dict(foo, {'newkey': 'newvalue'})
@@ -1583,12 +1582,22 @@ decorator. When used as a class decorator :func:`patch.dict` honours
     >>> test()
     >>> assert foo == {}
 
+When used as a class decorator :func:`patch.dict` honours
+``patch.TEST_PREFIX`` for choosing which methods to wrap. The patchers
+recognise methods that start with ``'test'`` as being test methods.
+If you want to use a different prefix for your test, you can inform the
+patchers of the different prefix by setting ``patch.TEST_PREFIX``.
+
     >>> import os
     >>> import unittest
+    >>> patch.TEST_PREFIX = 'foo'
     >>> @patch.dict('os.environ', {'newkey': 'newvalue'})
     ... class TestSample(unittest.TestCase):
-    ...     def test_sample(self):
+    ...     def foo_sample(self):
     ...         self.assertEqual(os.environ['newkey'], 'newvalue')
+    ...
+    ...     def test_sample2(self):
+    ...         self.assertNotIn('newkey', os.environ.keys())
 
     .. versionchanged:: 3.8
 

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1586,7 +1586,7 @@ decorator. When used as a class decorator :func:`patch.dict` honours
     >>> import os
     >>> import unittest
     >>> @patch.dict('os.environ', {'newkey': 'newvalue'})
-    >>> class TestSample(unittest.TestCase):
+    ... class TestSample(unittest.TestCase):
     ...     def test_sample(self):
     ...         self.assertEqual(os.environ['newkey'], 'newvalue')
 

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1575,7 +1575,6 @@ patch.dict
 :func:`patch.dict` can be used as a context manager, decorator or class
 decorator:
 
-    >>> import patch
     >>> foo = {}
     >>> @patch.dict(foo, {'newkey': 'newvalue'})
     ... def test():

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1572,9 +1572,23 @@ patch.dict
     :func:`patch.dict` can also be called with arbitrary keyword arguments to set
     values in the dictionary.
 
-    :func:`patch.dict` can be used as a context manager, decorator or class
-    decorator. When used as a class decorator :func:`patch.dict` honours
-    ``patch.TEST_PREFIX`` for choosing which methods to wrap.
+:func:`patch.dict` can be used as a context manager, decorator or class
+decorator. When used as a class decorator :func:`patch.dict` honours
+``patch.TEST_PREFIX`` for choosing which methods to wrap.
+
+    >>> foo = {}
+    >>> @patch.dict(foo, {'newkey': 'newvalue'})
+    >>> def test():
+    ...     assert foo == {'newkey': 'newvalue'}
+    >>> test()
+    >>> assert foo == {}
+
+    >>> import os
+    >>> import unittest
+    >>> @patch.dict('os.environ', {'newkey': 'newvalue'}):
+    >>> class TestSample(unittest.TestCase):
+    ...     def test_sample(self):
+    ...         self.assertEqual(os.environ['newkey'], 'newvalue') 
 
     .. versionchanged:: 3.8
 

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1585,7 +1585,7 @@ decorator. When used as a class decorator :func:`patch.dict` honours
 
     >>> import os
     >>> import unittest
-    >>> @patch.dict('os.environ', {'newkey': 'newvalue'}):
+    >>> @patch.dict('os.environ', {'newkey': 'newvalue'})
     >>> class TestSample(unittest.TestCase):
     ...     def test_sample(self):
     ...         self.assertEqual(os.environ['newkey'], 'newvalue')

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1588,7 +1588,7 @@ decorator. When used as a class decorator :func:`patch.dict` honours
     >>> @patch.dict('os.environ', {'newkey': 'newvalue'}):
     >>> class TestSample(unittest.TestCase):
     ...     def test_sample(self):
-    ...         self.assertEqual(os.environ['newkey'], 'newvalue') 
+    ...         self.assertEqual(os.environ['newkey'], 'newvalue')
 
     .. versionchanged:: 3.8
 


### PR DESCRIPTION
Add examples of the use of mock.path.dict with decorator and in class. Currently there are examples only with the use on context manager.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35685](https://bugs.python.org/issue35685) -->
https://bugs.python.org/issue35685
<!-- /issue-number -->
