### PR TITLE
bpo-32592: Remove Vista code from os.cpu_count()

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11820,22 +11820,7 @@ os_cpu_count_impl(PyObject *module)
 {
     int ncpu = 0;
 #ifdef MS_WINDOWS
-    /* Vista is supported and the GetMaximumProcessorCount API is Win7+
-       Need to fallback to Vista behavior if this call isn't present */
-    HINSTANCE hKernel32;
-    hKernel32 = GetModuleHandleW(L"KERNEL32");
-
-    static DWORD(CALLBACK *_GetMaximumProcessorCount)(WORD) = NULL;
-    *(FARPROC*)&_GetMaximumProcessorCount = GetProcAddress(hKernel32,
-        "GetMaximumProcessorCount");
-    if (_GetMaximumProcessorCount != NULL) {
-        ncpu = _GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS);
-    }
-    else {
-        SYSTEM_INFO sysinfo;
-        GetSystemInfo(&sysinfo);
-        ncpu = sysinfo.dwNumberOfProcessors;
-    }
+    ncpu = GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS);
 #elif defined(__hpux)
     ncpu = mpctl(MPC_GETNUMSPUS, NULL, NULL);
 #elif defined(HAVE_SYSCONF) && defined(_SC_NPROCESSORS_ONLN)


### PR DESCRIPTION
Remove code specific to Windows Vista from os.cpu_count(): Python
requires Windows 7 or newer.

<!-- issue-number: [bpo-32592](https://bugs.python.org/issue32592) -->
https://bugs.python.org/issue32592
<!-- /issue-number -->
