### PR TITLE
[3.7] bpo-35283: Add a deprecated warning for the threading.Thread.isAlive

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1091,7 +1091,15 @@ class Thread:
         self._wait_for_tstate_lock(False)
         return not self._is_stopped
 
-    isAlive = is_alive
+    def isAlive(self):
+        """Return whether the thread is alive.
+
+        This instance method is deprecated, use is_alive() instead.
+        """
+        import warnings
+        warnings.warn('isAlive() is deprecated, use is_alive() instead',
+                      PendingDeprecationWarning, stacklevel=2)
+        return self.is_alive()
 
     @property
     def daemon(self):

--- a/Misc/NEWS.d/next/Library/2019-01-07-17-17-16.bpo-35283.WClosC.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-07-17-17-16.bpo-35283.WClosC.rst
@@ -1,0 +1,2 @@
+Add a deprecated warning for the threading.Thread.isAlive.
+Patch by Dong-hee Na.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35283](https://bugs.python.org/issue35283) -->
https://bugs.python.org/issue35283
<!-- /issue-number -->
