### PR TITLE
bpo-33717: pythoninfo logs information of all clocks

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-01-07-23-22-44.bpo-33717.GhHXv8.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-07-23-22-44.bpo-33717.GhHXv8.rst
@@ -1,0 +1,2 @@
+test.pythoninfo now logs information of all clocks, not only time.time() and
+time.perf_counter().


### PR DESCRIPTION
test.pythoninfo now logs information of all clocks, not only time.time() and
time.perf_counter().

<!-- issue-number: [bpo-33717](https://bugs.python.org/issue33717) -->
https://bugs.python.org/issue33717
<!-- /issue-number -->
