### PR TITLE
bpo-32710: test_asyncio: test_sendfile reset policy

### DIFF
--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -18,6 +18,10 @@ except ImportError:
     ssl = None
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class MySendfileProto(asyncio.Protocol):
 
     def __init__(self, loop=None, close_after=0):

--- a/Misc/NEWS.d/next/Tests/2019-01-07-23-34-41.bpo-32710.Hzo1b8.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-07-23-34-41.bpo-32710.Hzo1b8.rst
@@ -1,0 +1,3 @@
+``test_asyncio/test_sendfile.py`` now resets the event loop policy using
+:func:`tearDownModule` as done in other tests, to prevent a warning when
+running tests on Windows.


### PR DESCRIPTION
test_asyncio/test_sendfile.py now resets the event loop policy using
tearDownModule() as done in other tests, to prevent a warning when
running tests on Windows.

<!-- issue-number: [bpo-32710](https://bugs.python.org/issue32710) -->
https://bugs.python.org/issue32710
<!-- /issue-number -->
