### PR TITLE
bpo-35682: Fix _ProactorBasePipeTransport._force_close()

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -111,7 +111,7 @@ class _ProactorBasePipeTransport(transports._FlowControlMixin,
             self._force_close(exc)
 
     def _force_close(self, exc):
-        if self._empty_waiter is not None:
+        if self._empty_waiter is not None and not self._empty_waiter.done():
             if exc is None:
                 self._empty_waiter.set_result(None)
             else:

--- a/Misc/NEWS.d/next/Library/2019-01-08-01-54-02.bpo-35682.KDM9lk.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-08-01-54-02.bpo-35682.KDM9lk.rst
@@ -1,0 +1,2 @@
+Fix ``asyncio.ProactorEventLoop.sendfile()``: don't attempt to set the result
+of an internal future if it's already done.


### PR DESCRIPTION
[bpo-32622](https://bugs.python.org/issue32622), [bpo-35682](https://bugs.python.org/issue35682): Fix a bug in the sendfile() implementation of
asyncio.ProactorEventLoop: don't attempt to the result of an internal
future if it's already done.

Fix asyncio _ProactorBasePipeTransport._force_close(): don't set the
result of _empty_waiter if it's already done.

<!-- issue-number: [bpo-35682](https://bugs.python.org/issue35682) -->
https://bugs.python.org/issue35682
<!-- /issue-number -->
