### PR TITLE
bpo-32710: Fix leak in Overlapped_WSASend()

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-01-08-14-00-52.bpo-32710.Sn5Ujj.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-08-14-00-52.bpo-32710.Sn5Ujj.rst
@@ -1,0 +1,3 @@
+Fix a memory leak in asyncio in the ProactorEventLoop when ``ReadFile()`` or
+``WSASend()`` overlapped operation fail immediately: release the internal
+buffer.

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -723,6 +723,7 @@ do_ReadFile(OverlappedObject *self, HANDLE handle,
         case ERROR_IO_PENDING:
             Py_RETURN_NONE;
         default:
+            PyBuffer_Release(&self->user_buffer);
             self->type = TYPE_NOT_STARTED;
             return SetFromWindowsErr(err);
     }
@@ -1011,6 +1012,7 @@ Overlapped_WSASend(OverlappedObject *self, PyObject *args)
         case ERROR_IO_PENDING:
             Py_RETURN_NONE;
         default:
+            PyBuffer_Release(&self->user_buffer);
             self->type = TYPE_NOT_STARTED;
             return SetFromWindowsErr(err);
     }


### PR DESCRIPTION
Fix a memory leak in asyncio in the ProactorEventLoop when ReadFile()
or WSASend() overlapped operation fail immediately: release the
internal buffer.

<!-- issue-number: [bpo-32710](https://bugs.python.org/issue32710) -->
https://bugs.python.org/issue32710
<!-- /issue-number -->
