### PR TITLE
bpo-35697, decimal: Fix locale formatting

### DIFF
--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -4,8 +4,8 @@
 extern "C" {
 #endif
 
-#ifndef Py_BUILD_CORE
-#  error "Py_BUILD_CORE must be defined to include this header"
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN defined"
 #endif
 
 #include <locale.h>   /* struct lconv */

--- a/Misc/NEWS.d/next/Library/2019-01-09-12-35-57.bpo-35697._TAUNc.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-09-12-35-57.bpo-35697._TAUNc.rst
@@ -1,0 +1,7 @@
+The :mod:`decimal` module now supports formatting number to the "n" type
+when the ``LC_NUMERIC`` locale uses a different encoding than the
+``LC_CTYPE`` locale. It now sets temporarily the ``LC_CTYPE`` locale to the
+``LC_NUMERIC`` locale to decode ``decimal_point`` and ``thousands_sep`` byte
+strings if they are non-ASCII or longer than 1 byte, and the ``LC_NUMERIC``
+locale is different than the ``LC_CTYPE`` locale.  This temporary change
+affects other threads.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -34,6 +34,7 @@
 #include "mpdecimal.h"
 #include "pycore_fileutils.h"
 
+#include <locale.h>
 #include <stdlib.h>
 
 #include "docstrings.h"

--- a/Modules/_decimal/libmpdec/io.c
+++ b/Modules/_decimal/libmpdec/io.c
@@ -784,6 +784,7 @@ mpd_parse_fmt_str(mpd_spec_t *spec, const char *fmt, int caps)
     spec->dot = "";
     spec->sep = "";
     spec->grouping = "";
+    spec->locale = 0;
 
 
     /* presume that the first character is a UTF-8 fill character */
@@ -871,6 +872,7 @@ mpd_parse_fmt_str(mpd_spec_t *spec, const char *fmt, int caps)
         if (*spec->sep) {
             return 0;
         }
+        spec->locale = 1;
         spec->type = *cp++;
         spec->type = (spec->type == 'N') ? 'G' : 'g';
         lc = localeconv();

--- a/Modules/_decimal/libmpdec/mpdecimal.h
+++ b/Modules/_decimal/libmpdec/mpdecimal.h
@@ -397,6 +397,7 @@ typedef struct mpd_spec_t {
     const char *dot;       /* decimal point */
     const char *sep;       /* thousands separator */
     const char *grouping;  /* grouping of digits */
+    int locale;            /* use localeconv() */
 } mpd_spec_t;
 
 /* output to a string */

--- a/PCbuild/_decimal.vcxproj
+++ b/PCbuild/_decimal.vcxproj
@@ -61,7 +61,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;MASM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;MASM;Py_BUILD_CORE_BUILTIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)' == 'Win32'">CONFIG_32;PPRO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)' == 'x64'">CONFIG_64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\Modules\_decimal;..\Modules\_decimal\libmpdec;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/setup.py
+++ b/setup.py
@@ -2002,7 +2002,7 @@ class PyBuildExt(build_ext):
             ext.libraries.append('dl')
 
     def _decimal_ext(self):
-        extra_compile_args = []
+        extra_compile_args = ['-DPy_BUILD_CORE_BUILTIN']
         undef_macros = []
         if '--with-system-libmpdec' in sysconfig.get_config_var("CONFIG_ARGS"):
             include_dirs = []


### PR DESCRIPTION
The decimal module now supports formatting number to the "n" type
when the LC_NUMERIC locale uses a different encoding than the
LC_CTYPE locale. It now sets temporarily the LC_CTYPE locale to the
LC_NUMERIC locale to decode decimal_point and thousands_sep byte
strings if they are non-ASCII or longer than 1 byte, and the
LC_NUMERIC locale is different than the LC_CTYPE locale. This
temporary change affects other threads.

Fix also #define guard of pycore_fileutils.h: allow also
Py_BUILD_CORE_BUILTIN.

<!-- issue-number: [bpo-35697](https://bugs.python.org/issue35697) -->
https://bugs.python.org/issue35697
<!-- /issue-number -->
