### PR TITLE
bpo-35700: Added a much-needed functionality to Place, Pack and Grid

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2141,6 +2141,7 @@ class Pack:
         self.tk.call(
               ('pack', 'configure', self._w)
               + self._options(cnf, kw))
+        return self
     pack = configure = config = pack_configure
     def pack_forget(self):
         """Unmap this widget and do not use it for the packing order."""
@@ -2186,6 +2187,7 @@ class Place:
         self.tk.call(
               ('place', 'configure', self._w)
               + self._options(cnf, kw))
+        return self
     place = configure = config = place_configure
     def place_forget(self):
         """Unmap this widget."""
@@ -2224,6 +2226,7 @@ class Grid:
         self.tk.call(
               ('grid', 'configure', self._w)
               + self._options(cnf, kw))
+        return self
     grid = configure = config = grid_configure
     bbox = grid_bbox = Misc.grid_bbox
     columnconfigure = grid_columnconfigure = Misc.grid_columnconfigure


### PR DESCRIPTION
With this commit Place, Pack and Grid now return the widget they place on a window, which makes it much easier to use these functions. When you want to simply place a widget on a window and you also want to store the reference for that widget in a variable you can't do that in one line, which is really unpleasant, because when you create a new widget these things are usually the first what you want to do with a widget and breaking it two line is just making things more complicated.

For example, if you want to create 3 label, place it next to each other and store their reference:
```
import tkinter as tk
root = tk.Tk()

# you can't do that:
# here the variables assigned to None, since grid() returns 'nothing'
label1 = tk.Label(root).grid(row=0, column=0)
label2 = tk.Label(root).grid(row=0, column=1)
label3 = tk.Label(root).grid(row=0, column=2)

# actually, you must do this:
label1 = tk.Label(root)
label1.grid(row=0, column=0)
label2 = tk.Label(root)
label2.grid(row=0, column=1)
label3 = tk.Label(root)
label3.grid(row=0, column=2)
```

<!-- issue-number: [bpo-35700](https://bugs.python.org/issue35700) -->
https://bugs.python.org/issue35700
<!-- /issue-number -->
