### PR TITLE
bpo-35493: Use Process.sentinel instead of sleeping for polling worker status in multiprocessing.Pool

### DIFF
--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -265,6 +265,8 @@ class Pool(object):
         if self._state == RUN:
             _warn(f"unclosed running multiprocessing pool {self!r}",
                   ResourceWarning, source=self)
+            if getattr(self, '_change_notifier') is not None:
+                self._change_notifier.put(None)
 
     def __repr__(self):
         cls = self.__class__

--- a/Misc/NEWS.d/next/Library/2019-01-09-23-43-08.bpo-35493.kEcRGE.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-09-23-43-08.bpo-35493.kEcRGE.rst
@@ -1,0 +1,3 @@
+Use :func:`multiprocessing.connection.wait` instead of polling each 0.2
+seconds for worker updates in :class:`multiprocessing.Pool`. Patch by Pablo
+Galindo.


### PR DESCRIPTION
This is a very simple fix for this problem using `Process.sentinel`. If you want a more sophisticated solution, please advice.

```python

import multiprocessing
import time
CONCURRENCY = 1
NTASK = 100
def noop():
    pass
with multiprocessing.Pool(CONCURRENCY, maxtasksperchild=1) as pool:
    start_time = time.monotonic()
    results = [pool.apply_async(noop, ()) for _ in range(NTASK)]
    for result in results:
        result.get()
    dt = time.monotonic() - start_time
    pool.terminate()
    pool.join()
print("Total: %.1f sec" % dt)
```

Before this PR
```
Total: 10.2 sec
```

After this PR:

```
Total: 0.5 sec
```

<!-- issue-number: [bpo-35493](https://bugs.python.org/issue35493) -->
https://bugs.python.org/issue35493
<!-- /issue-number -->
