### PR TITLE
bpo-35699: fix distuils cannot detect Build Tools 2017 anymore

### DIFF
--- a/Lib/distutils/_msvccompiler.py
+++ b/Lib/distutils/_msvccompiler.py
@@ -78,6 +78,7 @@ def _find_vc2017():
             "-prerelease",
             "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
             "-property", "installationPath",
+            "-products", "*",
         ], encoding="mbcs", errors="strict").strip()
     except (subprocess.CalledProcessError, OSError, UnicodeDecodeError):
         return None, None

--- a/Misc/NEWS.d/next/Library/2019-01-11-07-09-25.bpo-35699.VDiENF.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-11-07-09-25.bpo-35699.VDiENF.rst
@@ -1,0 +1,1 @@
+Fixed detection of Visual Studio Build Tools 2017 in distutils


### PR DESCRIPTION


<!-- issue-number: [bpo-35699](https://bugs.python.org/issue35699) -->
https://bugs.python.org/issue35699
<!-- /issue-number -->
