### PR TITLE
[3.6] Revert "bpo-24746: Avoid stripping trailing whitespace in doctest fan…

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1691,6 +1691,8 @@ class OutputChecker:
                 kind = 'ndiff with -expected +actual'
             else:
                 assert 0, 'Bad diff option'
+            # Remove trailing whitespace on diff output.
+            diff = [line.rstrip() + '\n' for line in diff]
             return 'Differences (%s):\n' % kind + _indent(''.join(diff))
 
         # If we're not using diff, then simply list the expected

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -2431,11 +2431,6 @@ def test_unittest_reportflags():
     Then the default eporting options are ignored:
 
       >>> result = suite.run(unittest.TestResult())
-    """
-    """
-    *NOTE*: These doctest are intentionally not placed in raw string to depict
-    the trailing whitespace using `\x20` in the diff below.
-
       >>> print(result.failures[0][1]) # doctest: +ELLIPSIS
       Traceback ...
       Failed example:
@@ -2449,7 +2444,7 @@ def test_unittest_reportflags():
       Differences (ndiff with -expected +actual):
             a
           - <BLANKLINE>
-          +\x20
+          +
             b
       <BLANKLINE>
       <BLANKLINE>
@@ -2937,47 +2932,6 @@ Invalid doctest option:
     usage...invalid...nosuchoption...
 
 """
-
-def test_no_trailing_whitespace_stripping():
-    r"""
-    The fancy reports had a bug for a long time where any trailing whitespace on
-    the reported diff lines was stripped, making it impossible to see the
-    differences in line reported as different that differed only in the amount of
-    trailing whitespace.  The whitespace still isn't particularly visible unless
-    you use NDIFF, but at least it is now there to be found.
-
-    *NOTE*: This snippet was intentionally put inside a raw string to get rid of
-    leading whitespace error in executing the example below
-
-    >>> def f(x):
-    ...     r'''
-    ...     >>> print('\n'.join(['a    ', 'b']))
-    ...     a
-    ...     b
-    ...     '''
-    """
-    """
-    *NOTE*: These doctest are not placed in raw string to depict the trailing whitespace
-    using `\x20`
-
-    >>> test = doctest.DocTestFinder().find(f)[0]
-    >>> flags = doctest.REPORT_NDIFF
-    >>> doctest.DocTestRunner(verbose=False, optionflags=flags).run(test)
-    ... # doctest: +ELLIPSIS
-    **********************************************************************
-    File ..., line 3, in f
-    Failed example:
-        print('\n'.join(['a    ', 'b']))
-    Differences (ndiff with -expected +actual):
-        - a
-        + a
-          b
-    TestResults(failed=1, attempted=1)
-
-    *NOTE*: `\x20` is for checking the trailing whitespace on the +a line above.
-    We cannot use actual spaces there, as a commit hook prevents from committing
-    patches that contain trailing whitespace. More info on Issue 24746.
-    """
 
 ######################################################################
 ## Main

--- a/Misc/NEWS.d/next/Library/2018-11-22-15-22-56.bpo-24746.eSLKBE.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-22-15-22-56.bpo-24746.eSLKBE.rst
@@ -1,2 +1,0 @@
-Avoid stripping trailing whitespace in doctest fancy diff. Orignial patch by
-R. David Murray & Jairo Trad. Enhanced by Sanyam Khurana.


### PR DESCRIPTION
…cy diff (GH-10639) (#11477)"

This reverts commit 5d9ae8b9df8371dd65514e0d60b561fd37056986.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-24746](https://bugs.python.org/issue24746) -->
https://bugs.python.org/issue24746
<!-- /issue-number -->
