### PR TITLE
bpo-35702: Add new identifier CLOCK_UPTIME_RAW for Darwin

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -821,14 +821,13 @@ These constants are used as parameters for :func:`clock_getres` and
    point, unaffected by frequency or time adjustments and not increment while 
    the system is asleep.
 
-   .. availability:: Unix.
+   .. availability:: macOS 10.12 and newer.
 
-   .. versionadded:: 3.7
+   .. versionadded:: 3.8
 
 
 The following constant is the only parameter that can be sent to
 :func:`clock_settime`.
-
 
 .. data:: CLOCK_REALTIME
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -818,7 +818,7 @@ These constants are used as parameters for :func:`clock_getres` and
 .. data:: CLOCK_UPTIME_RAW
 
    Clock that increments monotonically, tracking the time since an arbitrary 
-   point, unaffected by frequency or time adjustments and not increment while 
+   point, unaffected by frequency or time adjustments and not incremented while 
    the system is asleep.
 
    .. availability:: macOS 10.12 and newer.

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -815,6 +815,17 @@ These constants are used as parameters for :func:`clock_getres` and
    .. versionadded:: 3.7
 
 
+.. data:: CLOCK_UPTIME_RAW
+
+   Clock that increments monotonically, tracking the time since an arbitrary 
+   point, unaffected by frequency or time adjustments and not increment while 
+   the system is asleep.
+
+   .. availability:: Unix.
+
+   .. versionadded:: 3.7
+
+
 The following constant is the only parameter that can be sent to
 :func:`clock_settime`.
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -829,6 +829,7 @@ These constants are used as parameters for :func:`clock_getres` and
 The following constant is the only parameter that can be sent to
 :func:`clock_settime`.
 
+
 .. data:: CLOCK_REALTIME
 
    System-wide real-time clock.  Setting this clock requires appropriate

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -817,8 +817,8 @@ These constants are used as parameters for :func:`clock_getres` and
 
 .. data:: CLOCK_UPTIME_RAW
 
-   Clock that increments monotonically, tracking the time since an arbitrary 
-   point, unaffected by frequency or time adjustments and not incremented while 
+   Clock that increments monotonically, tracking the time since an arbitrary
+   point, unaffected by frequency or time adjustments and not incremented while
    the system is asleep.
 
    .. availability:: macOS 10.12 and newer.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -237,11 +237,8 @@ in the :class:`tkinter.Canvas` class.
 time
 ----
 
-Added new clock :data:`~time.CLOCK_UPTIME_RAW` for macOS 10.12 that
-increments monotonically, tracking the time since an arbitrary point,
-unaffected by frequency or time adjustments and not incremented while the
-system is asleep.
-(Contributed by Ricardo Fraile in :issue:`35702`.)
+Added new clock :data:`~time.CLOCK_UPTIME_RAW` for macOS 10.12.
+(Contributed by Joannah Nanjekye in :issue:`35702`.)
 
 unicodedata
 -----------

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -237,9 +237,9 @@ in the :class:`tkinter.Canvas` class.
 time
 ----
 
-Added new clock :data:`~time.CLOCK_UPTIME_RAW` for macOS 10.12 that 
-increments monotonically, tracking the time since an arbitrary point, 
-unaffected by frequency or time adjustments and not incremented while the 
+Added new clock :data:`~time.CLOCK_UPTIME_RAW` for macOS 10.12 that
+increments monotonically, tracking the time since an arbitrary point,
+unaffected by frequency or time adjustments and not incremented while the
 system is asleep.
 (Contributed by Ricardo Fraile in :issue:`35702`.)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -234,6 +234,14 @@ Added method :meth:`~tkinter.Canvas.moveto`
 in the :class:`tkinter.Canvas` class.
 (Contributed by Juliette Monsel in :issue:`23831`.)
 
+time
+-------
+
+Added a new clock identifier `~time.CLOCK_UPTIME_RAW` for Darwin that increments
+monotonically, tracking the time since an arbitrary point, unaffected by 
+frequency or time adjustments and not increment while the system is asleep.
+(Contributed by Ricardo Fraile in :issue:`35702`.)
+
 unicodedata
 -----------
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -235,11 +235,12 @@ in the :class:`tkinter.Canvas` class.
 (Contributed by Juliette Monsel in :issue:`23831`.)
 
 time
--------
+----
 
-Added a new clock identifier `~time.CLOCK_UPTIME_RAW` for Darwin that increments
-monotonically, tracking the time since an arbitrary point, unaffected by 
-frequency or time adjustments and not increment while the system is asleep.
+Added new clock :data:`~time.CLOCK_UPTIME_RAW` for macOS 10.12 that 
+increments monotonically, tracking the time since an arbitrary point, 
+unaffected by frequency or time adjustments and not incremented while the 
+system is asleep.
 (Contributed by Ricardo Fraile in :issue:`35702`.)
 
 unicodedata

--- a/Misc/NEWS.d/next/Library/2019-01-10-14-03-12.bpo-35702._ct_0H.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-10-14-03-12.bpo-35702._ct_0H.rst
@@ -1,1 +1,1 @@
-The CLOCK_UPTIME_RAW constant is now available for Darwin.
+The :data:`time.CLOCK_UPTIME_RAW` constant is now available for macOS 10.12.

--- a/Misc/NEWS.d/next/Library/2019-01-10-14-03-12.bpo-35702._ct_0H.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-10-14-03-12.bpo-35702._ct_0H.rst
@@ -1,0 +1,1 @@
+The CLOCK_UPTIME_RAW constant is now available for Darwin.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1806,6 +1806,9 @@ PyInit_time(void)
 #ifdef CLOCK_UPTIME
     PyModule_AddIntMacro(m, CLOCK_UPTIME);
 #endif
+#ifdef CLOCK_UPTIME_RAW
+    PyModule_AddIntMacro(m, CLOCK_UPTIME_RAW);
+#endif
 
 #endif  /* defined(HAVE_CLOCK_GETTIME) || defined(HAVE_CLOCK_SETTIME) || defined(HAVE_CLOCK_GETRES) */
 


### PR DESCRIPTION
I have added a clock constant,  CLOCK_UPTIME_RAW for Darwin.

<!-- issue-number: [bpo-35702](https://bugs.python.org/issue35702) -->
https://bugs.python.org/issue35702
<!-- /issue-number -->
