### PR TITLE
bpo-33498: Add rmtree method to pathlib.Path

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -5,6 +5,7 @@ import ntpath
 import os
 import posixpath
 import re
+import shutil
 import sys
 from _collections_abc import Sequence
 from errno import EINVAL, ENOENT, ENOTDIR, EBADF
@@ -403,6 +404,8 @@ class _NormalAccessor(_Accessor):
     unlink = os.unlink
 
     rmdir = os.rmdir
+
+    rmtree = shutil.rmtree
 
     rename = os.rename
 
@@ -1283,6 +1286,14 @@ class Path(PurePath):
         if self._closed:
             self._raise_closed()
         self._accessor.rmdir(self)
+
+    def rmtree(self, ignore_errors=False, onerror=None):
+        """
+        Remove this directory tree.
+        """
+        if self._closed:
+            self._raise_closed()
+        shutil.rmtree(path=self, ignore_errors=ignore_errors, onerror=onerror)
 
     def lstat(self):
         """

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1643,6 +1643,33 @@ class _BasePathTest(object):
         self.assertFileNotFound(p.stat)
         self.assertFileNotFound(p.unlink)
 
+    def test_rmtree(self):
+        p = self.cls(BASE) / 'dirB'
+        q = self.cls(BASE) / 'dirC'
+        p.rmtree()
+        q.rmtree()
+        self.assertFileNotFound(p.stat)
+        self.assertFileNotFound(q.stat)
+        self.assertFileNotFound(p.unlink)
+        self.assertFileNotFound(q.unlink)
+
+    def test_rmtree_ignore_errors(self):
+        p = self.cls(BASE)
+        p.rmtree(ignore_errors=True)
+        self.assertListEqual(["dirE"], os.listdir(p))
+
+    def test_rmtree_onerror(self):
+        p = self.cls(BASE) / 'dirA/linkC'
+
+        errors = []
+        def onerror(*args):
+            errors.append(args)
+        p.rmtree(onerror=onerror)
+        self.assertEqual(len(errors), 1)
+        self.assertIs(errors[0][0], os.path.islink)
+        self.assertEqual(errors[0][1], p)
+        self.assertIsInstance(errors[0][2][1], OSError)
+
     def test_rename(self):
         P = self.cls(BASE)
         p = P / 'fileA'

--- a/Misc/NEWS.d/next/Library/2019-01-10-17-51-12.bpo-33498.GW14Xx.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-10-17-51-12.bpo-33498.GW14Xx.rst
@@ -1,0 +1,1 @@
+Add rmtree method to pathlib.Path


### PR DESCRIPTION
Attempted to mirror similar existing remove methods (i.e. pathlib.Path.rmdir and pathlib.Path.unlink)

Feedback very welcome.

<!-- issue-number: [bpo-33498](https://bugs.python.org/issue33498) -->
https://bugs.python.org/issue33498
<!-- /issue-number -->
