### PR TITLE
bpo-35045: Fix test_ssl.test_min_max_version()

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1066,9 +1066,9 @@ class ContextTests(unittest.TestCase):
                          "required OpenSSL 1.1.0g")
     def test_min_max_version(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        self.assertEqual(
-            ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
-        )
+        # bpo-35045: don't test the default minimum_version: it depends
+        # on the OpenSSL configuration, it is not always equal
+        # to TLSVersion.MINIMUM_SUPPORTED.
         self.assertEqual(
             ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
         )

--- a/Misc/NEWS.d/next/Tests/2019-01-10-18-03-22.bpo-35045.4VLUOt.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-10-18-03-22.bpo-35045.4VLUOt.rst
@@ -1,0 +1,2 @@
+Fix test_ssl.test_min_max_version(): no longer test the default
+minimum_version, it depends on the OpenSSL configuration.


### PR DESCRIPTION
test_ssl.test_min_max_version() no longer tests the default
minimum_version: it depends on the OpenSSL configuration, it is not
always equal to TLSVersion.MINIMUM_SUPPORTED.

<!-- issue-number: [bpo-35045](https://bugs.python.org/issue35045) -->
https://bugs.python.org/issue35045
<!-- /issue-number -->
