### PR TITLE
bpo-35045: Accept TLSv1 default in min max test

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1066,8 +1066,11 @@ class ContextTests(unittest.TestCase):
                          "required OpenSSL 1.1.0g")
     def test_min_max_version(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        self.assertEqual(
-            ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
+        # OpenSSL default is MINIMUM_SUPPORTED, however some vendors like
+        # Fedora override the setting to TLS 1.0.
+        self.assertIn(
+            ctx.minimum_version,
+            {ssl.TLSVersion.MINIMUM_SUPPORTED, ssl.TLSVersion.TLSv1}
         )
         self.assertEqual(
             ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED

--- a/Misc/NEWS.d/next/Tests/2019-01-10-18-35-42.bpo-35045.qdd6d9.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-10-18-35-42.bpo-35045.qdd6d9.rst
@@ -1,0 +1,2 @@
+Make ssl tests less strict and also accept TLSv1 as system default. The
+changes unbreaks test_min_max_version on Fedora 29.


### PR DESCRIPTION
Make ssl tests less strict and also accept TLSv1 as system default. The
changes unbreaks test_min_max_version on Fedora 29.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-35045](https://bugs.python.org/issue35045) -->
https://bugs.python.org/issue35045
<!-- /issue-number -->
