### PR TITLE
[2.7] bpo-24746: Fix doctest failures when running the testsuite with -R

### DIFF
--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -2355,8 +2355,7 @@ def test_unittest_reportflags():
     Then the default eporting options are ignored:
 
       >>> result = suite.run(unittest.TestResult())
-    """
-    """
+
     *NOTE*: These doctest are intentionally not placed in raw string to depict
     the trailing whitespace using `\x20` in the diff below.
 


### PR DESCRIPTION
```
[bpo-24746](https://bugs.python.org/issue24746): Fix doctest failures when running the testsuite with -R 
```

Cherry-pick: [bpo-24746](https://bugs.python.org/issue24746): https://github.com/python/cpython/commit/c5dc60ea858b8ccf78e8d26db81c307a8f9b2314 to 2.7 branch

<!-- issue-number: [bpo-24746](https://bugs.python.org/issue24746) -->
https://bugs.python.org/issue24746
<!-- /issue-number -->

```
$ ./python -m test test_doctest test_doctest
Run tests sequentially
0:00:00 load avg: 0.55 [1/2] test_doctest
0:00:00 load avg: 0.55 [2/2] test_doctest

== Tests result: SUCCESS ==

All 2 tests OK.

Total duration: 327 ms
Tests result: SUCCESS


```
