### PR TITLE
bpo-35715: Liberate return value of _process_worker

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -239,6 +239,7 @@ def _process_worker(call_queue, result_queue, initializer, initargs):
         # Liberate the resource as soon as possible, to avoid holding onto
         # open files or shared memory that is not needed anymore
         del call_item
+        del r
 
 
 def _add_call_item_to_queue(pending_work_items,

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -235,11 +235,11 @@ def _process_worker(call_queue, result_queue, initializer, initargs):
             _sendback_result(result_queue, call_item.work_id, exception=exc)
         else:
             _sendback_result(result_queue, call_item.work_id, result=r)
+            del r
 
         # Liberate the resource as soon as possible, to avoid holding onto
         # open files or shared memory that is not needed anymore
         del call_item
-        del r
 
 
 def _add_call_item_to_queue(pending_work_items,

--- a/Misc/NEWS.d/next/Library/2019-01-11-08-47-58.bpo-35715.Wi3gl0.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-11-08-47-58.bpo-35715.Wi3gl0.rst
@@ -1,0 +1,1 @@
+Librates the return value of a ProcessPoolExecutor _process_worker after it's no longer needed to free memory


### PR DESCRIPTION
ProcessPoolExecutor workers will hold the return value of their last task in memory until the next task is received. Since the return value has already been propagated to the parent process's `Future` or else effectively discarded by this point, the memory can be safely released.

Simple case to reproduce:

    import concurrent.futures
    import time

    executor = concurrent.futures.ProcessPoolExecutor(max_workers=1)

    def big_val():
        return [{1:1} for i in range(1, 1000000)]

    executor.submit(big_val)

    # Observe the memory usage of the process worker during the sleep interval
    time.sleep(10)


This should be easily addressed by having the worker explicitly `del r` after calling `_sendback_result` as it already does this for `call_item`.

<!-- issue-number: [bpo-35715](https://bugs.python.org/issue35715) -->
https://bugs.python.org/issue35715
<!-- /issue-number -->
