### PR TITLE
bpo-33817: Fix _PyBytes_Resize() for empty bytes object.

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1001,6 +1001,12 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
         self.assertRaises(OverflowError,
                           PyBytes_FromFormat, b'%c', c_int(256))
 
+        # Issue #33817: empty strings
+        self.assertEqual(PyBytes_FromFormat(b''),
+                         b'')
+        self.assertEqual(PyBytes_FromFormat(b'%s', b''),
+                         b'')
+
     def test_bytes_blocking(self):
         class IterationBlocked(list):
             __bytes__ = None

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -2680,6 +2680,12 @@ class CAPITest(unittest.TestCase):
         check_format('%.%s',
                      b'%.%s', b'abc')
 
+        # Issue #33817: empty strings
+        check_format('',
+                     b'')
+        check_format('',
+                     b'%s', b'')
+
     # Test PyUnicode_AsWideChar()
     @support.cpython_only
     def test_aswidechar(self):

--- a/Misc/NEWS.d/next/C API/2019-01-11-11-16-16.bpo-33817.nJ4yIj.rst
+++ b/Misc/NEWS.d/next/C API/2019-01-11-11-16-16.bpo-33817.nJ4yIj.rst
@@ -1,0 +1,1 @@
+Fixed :c:func:`_PyBytes_Resize` for empty bytes objects.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2991,8 +2991,21 @@ _PyBytes_Resize(PyObject **pv, Py_ssize_t newsize)
         /* return early if newsize equals to v->ob_size */
         return 0;
     }
+    if (Py_SIZE(v) == 0) {
+        if (newsize == 0) {
+            return 0;
+        }
+        *pv = _PyBytes_FromSize(newsize, 0);
+        Py_DECREF(v);
+        return (*pv == NULL) ? -1 : 0;
+    }
     if (Py_REFCNT(v) != 1) {
         goto error;
+    }
+    if (newsize == 0) {
+        *pv = _PyBytes_FromSize(0, 0);
+        Py_DECREF(v);
+        return (*pv == NULL) ? -1 : 0;
     }
     /* XXX UNREF/NEWREF interface should be more symmetrical */
     _Py_DEC_REFTOTAL;


### PR DESCRIPTION
Add also tests for PyUnicode_FromFormat() and PyBytes_FromFormat()
with empty result.


<!-- issue-number: [bpo-33817](https://bugs.python.org/issue33817) -->
https://bugs.python.org/issue33817
<!-- /issue-number -->
