### PR TITLE
bpo-35716: CLOCK_MONOTONIC_RAW available on macOS

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -772,7 +772,7 @@ These constants are used as parameters for :func:`clock_getres` and
    Similar to :data:`CLOCK_MONOTONIC`, but provides access to a raw
    hardware-based time that is not subject to NTP adjustments.
 
-   Availability: Linux 2.6.28 or later.
+   Availability: Availability: Linux 2.6.28 or later, macOS 10.12 and newer.
 
    .. versionadded:: 3.3
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -772,7 +772,7 @@ These constants are used as parameters for :func:`clock_getres` and
    Similar to :data:`CLOCK_MONOTONIC`, but provides access to a raw
    hardware-based time that is not subject to NTP adjustments.
 
-   Availability: Availability: Linux 2.6.28 or later, macOS 10.12 and newer.
+   .. availability:: Linux 2.6.28 and newer, macOS 10.12 and newer.
 
    .. versionadded:: 3.3
 
@@ -799,7 +799,7 @@ These constants are used as parameters for :func:`clock_getres` and
 
    Thread-specific CPU-time clock.
 
-   Availability: Unix.
+   .. availability::  Unix.
 
    .. versionadded:: 3.3
 


### PR DESCRIPTION
Add macOS among supported versions for the CLOCK_MONOTONIC_RAW  identifier in the description because it is already available since 10.12.

Co-authored-by: Ricardo Fraile rfraile@rfraile.eu

<!-- issue-number: [bpo-35716](https://bugs.python.org/issue35716) -->
https://bugs.python.org/issue35716
<!-- /issue-number -->
