### PR TITLE
bpo-35582: Argument Clinic: Optimize the "all boring objects" case.

### DIFF
--- a/Lib/test/clinic.test
+++ b/Lib/test/clinic.test
@@ -106,11 +106,15 @@ test_objects_converter(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *a;
     PyObject *b = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "test_objects_converter",
-        1, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("test_objects_converter", nargs, 1, 2)) {
         goto exit;
     }
+    a = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    b = args[1];
+skip_optional:
     return_value = test_objects_converter_impl(module, a, b);
 
 exit:
@@ -119,7 +123,7 @@ exit:
 
 static PyObject *
 test_objects_converter_impl(PyObject *module, PyObject *a, PyObject *b)
-/*[clinic end generated code: output=068c25d6ae8cd1ef input=4cbb3d9edd2a36f3]*/
+/*[clinic end generated code: output=58009c0e42b4834e input=4cbb3d9edd2a36f3]*/
 
 /*[clinic input]
 test_object_converter_subclass_of

--- a/Modules/_io/clinic/bufferedio.c.h
+++ b/Modules/_io/clinic/bufferedio.c.h
@@ -389,11 +389,14 @@ _io__Buffered_truncate(buffered *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *pos = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "truncate",
-        0, 1,
-        &pos)) {
+    if (!_PyArg_CheckPositional("truncate", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    pos = args[0];
+skip_optional:
     return_value = _io__Buffered_truncate_impl(self, pos);
 
 exit:
@@ -591,4 +594,4 @@ _io_BufferedRandom___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a85f61f495feff5c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b7f51040defff318 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/bytesio.c.h
+++ b/Modules/_io/clinic/bytesio.c.h
@@ -282,11 +282,14 @@ _io_BytesIO_readlines(bytesio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "readlines",
-        0, 1,
-        &arg)) {
+    if (!_PyArg_CheckPositional("readlines", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    arg = args[0];
+skip_optional:
     return_value = _io_BytesIO_readlines_impl(self, arg);
 
 exit:
@@ -503,4 +506,4 @@ _io_BytesIO___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5c68eb481fa960bf input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a6b47dd7921abfcd input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/fileio.c.h
+++ b/Modules/_io/clinic/fileio.c.h
@@ -368,11 +368,14 @@ _io_FileIO_truncate(fileio *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *posobj = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "truncate",
-        0, 1,
-        &posobj)) {
+    if (!_PyArg_CheckPositional("truncate", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    posobj = args[0];
+skip_optional:
     return_value = _io_FileIO_truncate_impl(self, posobj);
 
 exit:
@@ -402,4 +405,4 @@ _io_FileIO_isatty(fileio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO_FILEIO_TRUNCATE_METHODDEF
     #define _IO_FILEIO_TRUNCATE_METHODDEF
 #endif /* !defined(_IO_FILEIO_TRUNCATE_METHODDEF) */
-/*[clinic end generated code: output=4cf4e5f0cd656b11 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b6f327457938d4dd input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/textio.c.h
+++ b/Modules/_io/clinic/textio.c.h
@@ -419,11 +419,14 @@ _io_TextIOWrapper_truncate(textio *self, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     PyObject *pos = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "truncate",
-        0, 1,
-        &pos)) {
+    if (!_PyArg_CheckPositional("truncate", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    pos = args[0];
+skip_optional:
     return_value = _io_TextIOWrapper_truncate_impl(self, pos);
 
 exit:
@@ -548,4 +551,4 @@ _io_TextIOWrapper_close(textio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_TextIOWrapper_close_impl(self);
 }
-/*[clinic end generated code: output=8bdd1035bf878d6f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c3d1b2a5d2d2d429 input=a9049054013a1b77]*/

--- a/Modules/cjkcodecs/clinic/multibytecodec.c.h
+++ b/Modules/cjkcodecs/clinic/multibytecodec.c.h
@@ -296,11 +296,14 @@ _multibytecodec_MultibyteStreamReader_read(MultibyteStreamReaderObject *self, Py
     PyObject *return_value = NULL;
     PyObject *sizeobj = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "read",
-        0, 1,
-        &sizeobj)) {
+    if (!_PyArg_CheckPositional("read", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    sizeobj = args[0];
+skip_optional:
     return_value = _multibytecodec_MultibyteStreamReader_read_impl(self, sizeobj);
 
 exit:
@@ -325,11 +328,14 @@ _multibytecodec_MultibyteStreamReader_readline(MultibyteStreamReaderObject *self
     PyObject *return_value = NULL;
     PyObject *sizeobj = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "readline",
-        0, 1,
-        &sizeobj)) {
+    if (!_PyArg_CheckPositional("readline", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    sizeobj = args[0];
+skip_optional:
     return_value = _multibytecodec_MultibyteStreamReader_readline_impl(self, sizeobj);
 
 exit:
@@ -354,11 +360,14 @@ _multibytecodec_MultibyteStreamReader_readlines(MultibyteStreamReaderObject *sel
     PyObject *return_value = NULL;
     PyObject *sizehintobj = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "readlines",
-        0, 1,
-        &sizehintobj)) {
+    if (!_PyArg_CheckPositional("readlines", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    sizehintobj = args[0];
+skip_optional:
     return_value = _multibytecodec_MultibyteStreamReader_readlines_impl(self, sizehintobj);
 
 exit:
@@ -422,4 +431,4 @@ PyDoc_STRVAR(_multibytecodec___create_codec__doc__,
 
 #define _MULTIBYTECODEC___CREATE_CODEC_METHODDEF    \
     {"__create_codec", (PyCFunction)_multibytecodec___create_codec, METH_O, _multibytecodec___create_codec__doc__},
-/*[clinic end generated code: output=2ed7030b28a79029 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bcd6311010557faf input=a9049054013a1b77]*/

--- a/Modules/clinic/_abc.c.h
+++ b/Modules/clinic/_abc.c.h
@@ -65,11 +65,11 @@ _abc__abc_register(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *self;
     PyObject *subclass;
 
-    if (!_PyArg_UnpackStack(args, nargs, "_abc_register",
-        2, 2,
-        &self, &subclass)) {
+    if (!_PyArg_CheckPositional("_abc_register", nargs, 2, 2)) {
         goto exit;
     }
+    self = args[0];
+    subclass = args[1];
     return_value = _abc__abc_register_impl(module, self, subclass);
 
 exit:
@@ -96,11 +96,11 @@ _abc__abc_instancecheck(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *self;
     PyObject *instance;
 
-    if (!_PyArg_UnpackStack(args, nargs, "_abc_instancecheck",
-        2, 2,
-        &self, &instance)) {
+    if (!_PyArg_CheckPositional("_abc_instancecheck", nargs, 2, 2)) {
         goto exit;
     }
+    self = args[0];
+    instance = args[1];
     return_value = _abc__abc_instancecheck_impl(module, self, instance);
 
 exit:
@@ -127,11 +127,11 @@ _abc__abc_subclasscheck(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *self;
     PyObject *subclass;
 
-    if (!_PyArg_UnpackStack(args, nargs, "_abc_subclasscheck",
-        2, 2,
-        &self, &subclass)) {
+    if (!_PyArg_CheckPositional("_abc_subclasscheck", nargs, 2, 2)) {
         goto exit;
     }
+    self = args[0];
+    subclass = args[1];
     return_value = _abc__abc_subclasscheck_impl(module, self, subclass);
 
 exit:
@@ -159,4 +159,4 @@ _abc_get_cache_token(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _abc_get_cache_token_impl(module);
 }
-/*[clinic end generated code: output=606db3cb658d9240 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2544b4b5ae50a089 input=a9049054013a1b77]*/

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -468,11 +468,42 @@ _curses_window_border(PyCursesWindowObject *self, PyObject *const *args, Py_ssiz
     PyObject *bl = NULL;
     PyObject *br = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "border",
-        0, 8,
-        &ls, &rs, &ts, &bs, &tl, &tr, &bl, &br)) {
+    if (!_PyArg_CheckPositional("border", nargs, 0, 8)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    ls = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    rs = args[1];
+    if (nargs < 3) {
+        goto skip_optional;
+    }
+    ts = args[2];
+    if (nargs < 4) {
+        goto skip_optional;
+    }
+    bs = args[3];
+    if (nargs < 5) {
+        goto skip_optional;
+    }
+    tl = args[4];
+    if (nargs < 6) {
+        goto skip_optional;
+    }
+    tr = args[5];
+    if (nargs < 7) {
+        goto skip_optional;
+    }
+    bl = args[6];
+    if (nargs < 8) {
+        goto skip_optional;
+    }
+    br = args[7];
+skip_optional:
     return_value = _curses_window_border_impl(self, ls, rs, ts, bs, tl, tr, bl, br);
 
 exit:
@@ -4500,4 +4531,4 @@ _curses_use_default_colors(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef _CURSES_USE_DEFAULT_COLORS_METHODDEF
     #define _CURSES_USE_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_USE_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=ceb2e32ee1370033 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5305982cb312a911 input=a9049054013a1b77]*/

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -504,11 +504,11 @@ _elementtree_Element_makeelement(ElementObject *self, PyObject *const *args, Py_
     PyObject *tag;
     PyObject *attrib;
 
-    if (!_PyArg_UnpackStack(args, nargs, "makeelement",
-        2, 2,
-        &tag, &attrib)) {
+    if (!_PyArg_CheckPositional("makeelement", nargs, 2, 2)) {
         goto exit;
     }
+    tag = args[0];
+    attrib = args[1];
     return_value = _elementtree_Element_makeelement_impl(self, tag, attrib);
 
 exit:
@@ -562,11 +562,11 @@ _elementtree_Element_set(ElementObject *self, PyObject *const *args, Py_ssize_t 
     PyObject *key;
     PyObject *value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "set",
-        2, 2,
-        &key, &value)) {
+    if (!_PyArg_CheckPositional("set", nargs, 2, 2)) {
         goto exit;
     }
+    key = args[0];
+    value = args[1];
     return_value = _elementtree_Element_set_impl(self, key, value);
 
 exit:
@@ -647,11 +647,15 @@ _elementtree_TreeBuilder_start(TreeBuilderObject *self, PyObject *const *args, P
     PyObject *tag;
     PyObject *attrs = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "start",
-        1, 2,
-        &tag, &attrs)) {
+    if (!_PyArg_CheckPositional("start", nargs, 1, 2)) {
         goto exit;
     }
+    tag = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    attrs = args[1];
+skip_optional:
     return_value = _elementtree_TreeBuilder_start_impl(self, tag, attrs);
 
 exit:
@@ -734,14 +738,18 @@ _elementtree_XMLParser__setevents(XMLParserObject *self, PyObject *const *args, 
     PyObject *events_queue;
     PyObject *events_to_report = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "_setevents",
-        1, 2,
-        &events_queue, &events_to_report)) {
+    if (!_PyArg_CheckPositional("_setevents", nargs, 1, 2)) {
         goto exit;
     }
+    events_queue = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    events_to_report = args[1];
+skip_optional:
     return_value = _elementtree_XMLParser__setevents_impl(self, events_queue, events_to_report);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6bbedd24b709dc00 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0c15c41e03a7829f input=a9049054013a1b77]*/

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -21,11 +21,15 @@ _gdbm_gdbm_get(dbmobject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "get",
-        1, 2,
-        &key, &default_value)) {
+    if (!_PyArg_CheckPositional("get", nargs, 1, 2)) {
         goto exit;
     }
+    key = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    default_value = args[1];
+skip_optional:
     return_value = _gdbm_gdbm_get_impl(self, key, default_value);
 
 exit:
@@ -52,11 +56,15 @@ _gdbm_gdbm_setdefault(dbmobject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "setdefault",
-        1, 2,
-        &key, &default_value)) {
+    if (!_PyArg_CheckPositional("setdefault", nargs, 1, 2)) {
         goto exit;
     }
+    key = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    default_value = args[1];
+skip_optional:
     return_value = _gdbm_gdbm_setdefault_impl(self, key, default_value);
 
 exit:
@@ -290,4 +298,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=05f06065d2dc1f9e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0a72598e5a3acd60 input=a9049054013a1b77]*/

--- a/Modules/clinic/_heapqmodule.c.h
+++ b/Modules/clinic/_heapqmodule.c.h
@@ -21,11 +21,11 @@ _heapq_heappush(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *heap;
     PyObject *item;
 
-    if (!_PyArg_UnpackStack(args, nargs, "heappush",
-        2, 2,
-        &heap, &item)) {
+    if (!_PyArg_CheckPositional("heappush", nargs, 2, 2)) {
         goto exit;
     }
+    heap = args[0];
+    item = args[1];
     return_value = _heapq_heappush_impl(module, heap, item);
 
 exit:
@@ -68,11 +68,11 @@ _heapq_heapreplace(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *heap;
     PyObject *item;
 
-    if (!_PyArg_UnpackStack(args, nargs, "heapreplace",
-        2, 2,
-        &heap, &item)) {
+    if (!_PyArg_CheckPositional("heapreplace", nargs, 2, 2)) {
         goto exit;
     }
+    heap = args[0];
+    item = args[1];
     return_value = _heapq_heapreplace_impl(module, heap, item);
 
 exit:
@@ -101,11 +101,11 @@ _heapq_heappushpop(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *heap;
     PyObject *item;
 
-    if (!_PyArg_UnpackStack(args, nargs, "heappushpop",
-        2, 2,
-        &heap, &item)) {
+    if (!_PyArg_CheckPositional("heappushpop", nargs, 2, 2)) {
         goto exit;
     }
+    heap = args[0];
+    item = args[1];
     return_value = _heapq_heappushpop_impl(module, heap, item);
 
 exit:
@@ -150,11 +150,11 @@ _heapq__heapreplace_max(PyObject *module, PyObject *const *args, Py_ssize_t narg
     PyObject *heap;
     PyObject *item;
 
-    if (!_PyArg_UnpackStack(args, nargs, "_heapreplace_max",
-        2, 2,
-        &heap, &item)) {
+    if (!_PyArg_CheckPositional("_heapreplace_max", nargs, 2, 2)) {
         goto exit;
     }
+    heap = args[0];
+    item = args[1];
     return_value = _heapq__heapreplace_max_impl(module, heap, item);
 
 exit:
@@ -169,4 +169,4 @@ PyDoc_STRVAR(_heapq__heapify_max__doc__,
 
 #define _HEAPQ__HEAPIFY_MAX_METHODDEF    \
     {"_heapify_max", (PyCFunction)_heapq__heapify_max, METH_O, _heapq__heapify_max__doc__},
-/*[clinic end generated code: output=b73e874eeb9977b6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=37ef2a3319971c8d input=a9049054013a1b77]*/

--- a/Modules/clinic/_operator.c.h
+++ b/Modules/clinic/_operator.c.h
@@ -49,11 +49,11 @@ _operator_add(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "add",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("add", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_add_impl(module, a, b);
 
 exit:
@@ -79,11 +79,11 @@ _operator_sub(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "sub",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("sub", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_sub_impl(module, a, b);
 
 exit:
@@ -109,11 +109,11 @@ _operator_mul(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "mul",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("mul", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_mul_impl(module, a, b);
 
 exit:
@@ -139,11 +139,11 @@ _operator_matmul(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "matmul",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("matmul", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_matmul_impl(module, a, b);
 
 exit:
@@ -169,11 +169,11 @@ _operator_floordiv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "floordiv",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("floordiv", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_floordiv_impl(module, a, b);
 
 exit:
@@ -199,11 +199,11 @@ _operator_truediv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "truediv",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("truediv", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_truediv_impl(module, a, b);
 
 exit:
@@ -229,11 +229,11 @@ _operator_mod(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "mod",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("mod", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_mod_impl(module, a, b);
 
 exit:
@@ -304,11 +304,11 @@ _operator_lshift(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lshift",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("lshift", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_lshift_impl(module, a, b);
 
 exit:
@@ -334,11 +334,11 @@ _operator_rshift(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "rshift",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("rshift", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_rshift_impl(module, a, b);
 
 exit:
@@ -392,11 +392,11 @@ _operator_and_(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "and_",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("and_", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_and__impl(module, a, b);
 
 exit:
@@ -422,11 +422,11 @@ _operator_xor(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "xor",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("xor", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_xor_impl(module, a, b);
 
 exit:
@@ -452,11 +452,11 @@ _operator_or_(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "or_",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("or_", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_or__impl(module, a, b);
 
 exit:
@@ -482,11 +482,11 @@ _operator_iadd(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "iadd",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("iadd", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_iadd_impl(module, a, b);
 
 exit:
@@ -512,11 +512,11 @@ _operator_isub(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "isub",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("isub", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_isub_impl(module, a, b);
 
 exit:
@@ -542,11 +542,11 @@ _operator_imul(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "imul",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("imul", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_imul_impl(module, a, b);
 
 exit:
@@ -572,11 +572,11 @@ _operator_imatmul(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "imatmul",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("imatmul", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_imatmul_impl(module, a, b);
 
 exit:
@@ -602,11 +602,11 @@ _operator_ifloordiv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ifloordiv",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("ifloordiv", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_ifloordiv_impl(module, a, b);
 
 exit:
@@ -632,11 +632,11 @@ _operator_itruediv(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "itruediv",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("itruediv", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_itruediv_impl(module, a, b);
 
 exit:
@@ -662,11 +662,11 @@ _operator_imod(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "imod",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("imod", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_imod_impl(module, a, b);
 
 exit:
@@ -692,11 +692,11 @@ _operator_ilshift(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ilshift",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("ilshift", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_ilshift_impl(module, a, b);
 
 exit:
@@ -722,11 +722,11 @@ _operator_irshift(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "irshift",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("irshift", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_irshift_impl(module, a, b);
 
 exit:
@@ -752,11 +752,11 @@ _operator_iand(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "iand",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("iand", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_iand_impl(module, a, b);
 
 exit:
@@ -782,11 +782,11 @@ _operator_ixor(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ixor",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("ixor", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_ixor_impl(module, a, b);
 
 exit:
@@ -812,11 +812,11 @@ _operator_ior(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ior",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("ior", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_ior_impl(module, a, b);
 
 exit:
@@ -842,11 +842,11 @@ _operator_concat(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "concat",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("concat", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_concat_impl(module, a, b);
 
 exit:
@@ -872,11 +872,11 @@ _operator_iconcat(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "iconcat",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("iconcat", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_iconcat_impl(module, a, b);
 
 exit:
@@ -903,11 +903,11 @@ _operator_contains(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *b;
     int _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "contains",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("contains", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     _return_value = _operator_contains_impl(module, a, b);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
@@ -938,11 +938,11 @@ _operator_indexOf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *b;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "indexOf",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("indexOf", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     _return_value = _operator_indexOf_impl(module, a, b);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
@@ -973,11 +973,11 @@ _operator_countOf(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *b;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "countOf",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("countOf", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     _return_value = _operator_countOf_impl(module, a, b);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
@@ -1007,11 +1007,11 @@ _operator_getitem(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "getitem",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("getitem", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_getitem_impl(module, a, b);
 
 exit:
@@ -1039,11 +1039,12 @@ _operator_setitem(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *b;
     PyObject *c;
 
-    if (!_PyArg_UnpackStack(args, nargs, "setitem",
-        3, 3,
-        &a, &b, &c)) {
+    if (!_PyArg_CheckPositional("setitem", nargs, 3, 3)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
+    c = args[2];
     return_value = _operator_setitem_impl(module, a, b, c);
 
 exit:
@@ -1069,11 +1070,11 @@ _operator_delitem(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "delitem",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("delitem", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_delitem_impl(module, a, b);
 
 exit:
@@ -1099,11 +1100,11 @@ _operator_eq(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "eq",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("eq", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_eq_impl(module, a, b);
 
 exit:
@@ -1129,11 +1130,11 @@ _operator_ne(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ne",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("ne", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_ne_impl(module, a, b);
 
 exit:
@@ -1159,11 +1160,11 @@ _operator_lt(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lt",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("lt", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_lt_impl(module, a, b);
 
 exit:
@@ -1189,11 +1190,11 @@ _operator_le(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "le",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("le", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_le_impl(module, a, b);
 
 exit:
@@ -1219,11 +1220,11 @@ _operator_gt(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "gt",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("gt", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_gt_impl(module, a, b);
 
 exit:
@@ -1249,11 +1250,11 @@ _operator_ge(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ge",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("ge", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_ge_impl(module, a, b);
 
 exit:
@@ -1279,11 +1280,11 @@ _operator_pow(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "pow",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("pow", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_pow_impl(module, a, b);
 
 exit:
@@ -1309,11 +1310,11 @@ _operator_ipow(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ipow",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("ipow", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_ipow_impl(module, a, b);
 
 exit:
@@ -1348,11 +1349,11 @@ _operator_is_(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "is_",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("is_", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_is__impl(module, a, b);
 
 exit:
@@ -1378,11 +1379,11 @@ _operator_is_not(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "is_not",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("is_not", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator_is_not_impl(module, a, b);
 
 exit:
@@ -1480,14 +1481,14 @@ _operator__compare_digest(PyObject *module, PyObject *const *args, Py_ssize_t na
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "_compare_digest",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("_compare_digest", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = _operator__compare_digest_impl(module, a, b);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b382bece80a5a254 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e7ed71a8c475a901 input=a9049054013a1b77]*/

--- a/Modules/clinic/_pickle.c.h
+++ b/Modules/clinic/_pickle.c.h
@@ -213,11 +213,11 @@ _pickle_Unpickler_find_class(UnpicklerObject *self, PyObject *const *args, Py_ss
     PyObject *module_name;
     PyObject *global_name;
 
-    if (!_PyArg_UnpackStack(args, nargs, "find_class",
-        2, 2,
-        &module_name, &global_name)) {
+    if (!_PyArg_CheckPositional("find_class", nargs, 2, 2)) {
         goto exit;
     }
+    module_name = args[0];
+    global_name = args[1];
     return_value = _pickle_Unpickler_find_class_impl(self, module_name, global_name);
 
 exit:
@@ -562,4 +562,4 @@ _pickle_loads(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4b32d63ff58b64d8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=225f06abcf27ed2b input=a9049054013a1b77]*/

--- a/Modules/clinic/_sre.c.h
+++ b/Modules/clinic/_sre.c.h
@@ -653,11 +653,14 @@ _sre_SRE_Match_start(MatchObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *group = NULL;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "start",
-        0, 1,
-        &group)) {
+    if (!_PyArg_CheckPositional("start", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    group = args[0];
+skip_optional:
     _return_value = _sre_SRE_Match_start_impl(self, group);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
@@ -687,11 +690,14 @@ _sre_SRE_Match_end(MatchObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *group = NULL;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "end",
-        0, 1,
-        &group)) {
+    if (!_PyArg_CheckPositional("end", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    group = args[0];
+skip_optional:
     _return_value = _sre_SRE_Match_end_impl(self, group);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
@@ -720,11 +726,14 @@ _sre_SRE_Match_span(MatchObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *group = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "span",
-        0, 1,
-        &group)) {
+    if (!_PyArg_CheckPositional("span", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    group = args[0];
+skip_optional:
     return_value = _sre_SRE_Match_span_impl(self, group);
 
 exit:
@@ -789,4 +798,4 @@ _sre_SRE_Scanner_search(ScannerObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _sre_SRE_Scanner_search_impl(self);
 }
-/*[clinic end generated code: output=7992634045212b26 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8d19359d6a4a3a7e input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -124,11 +124,10 @@ itertools__tee(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("_tee", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "_tee",
-        1, 1,
-        &iterable)) {
+    if (!_PyArg_CheckPositional("_tee", PyTuple_GET_SIZE(args), 1, 1)) {
         goto exit;
     }
+    iterable = PyTuple_GET_ITEM(args, 0);
     return_value = itertools__tee_impl(type, iterable);
 
 exit:
@@ -204,11 +203,10 @@ itertools_cycle(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("cycle", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "cycle",
-        1, 1,
-        &iterable)) {
+    if (!_PyArg_CheckPositional("cycle", PyTuple_GET_SIZE(args), 1, 1)) {
         goto exit;
     }
+    iterable = PyTuple_GET_ITEM(args, 0);
     return_value = itertools_cycle_impl(type, iterable);
 
 exit:
@@ -237,11 +235,11 @@ itertools_dropwhile(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("dropwhile", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "dropwhile",
-        2, 2,
-        &func, &seq)) {
+    if (!_PyArg_CheckPositional("dropwhile", PyTuple_GET_SIZE(args), 2, 2)) {
         goto exit;
     }
+    func = PyTuple_GET_ITEM(args, 0);
+    seq = PyTuple_GET_ITEM(args, 1);
     return_value = itertools_dropwhile_impl(type, func, seq);
 
 exit:
@@ -268,11 +266,11 @@ itertools_takewhile(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("takewhile", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "takewhile",
-        2, 2,
-        &func, &seq)) {
+    if (!_PyArg_CheckPositional("takewhile", PyTuple_GET_SIZE(args), 2, 2)) {
         goto exit;
     }
+    func = PyTuple_GET_ITEM(args, 0);
+    seq = PyTuple_GET_ITEM(args, 1);
     return_value = itertools_takewhile_impl(type, func, seq);
 
 exit:
@@ -299,11 +297,11 @@ itertools_starmap(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("starmap", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "starmap",
-        2, 2,
-        &func, &seq)) {
+    if (!_PyArg_CheckPositional("starmap", PyTuple_GET_SIZE(args), 2, 2)) {
         goto exit;
     }
+    func = PyTuple_GET_ITEM(args, 0);
+    seq = PyTuple_GET_ITEM(args, 1);
     return_value = itertools_starmap_impl(type, func, seq);
 
 exit:
@@ -496,11 +494,11 @@ itertools_filterfalse(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("filterfalse", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "filterfalse",
-        2, 2,
-        &func, &seq)) {
+    if (!_PyArg_CheckPositional("filterfalse", PyTuple_GET_SIZE(args), 2, 2)) {
         goto exit;
     }
+    func = PyTuple_GET_ITEM(args, 0);
+    seq = PyTuple_GET_ITEM(args, 1);
     return_value = itertools_filterfalse_impl(type, func, seq);
 
 exit:
@@ -542,4 +540,4 @@ itertools_count(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f289354f54e04c13 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3d0ca69707b60715 input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -21,11 +21,11 @@ math_gcd(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "gcd",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_CheckPositional("gcd", nargs, 2, 2)) {
         goto exit;
     }
+    a = args[0];
+    b = args[1];
     return_value = math_gcd_impl(module, a, b);
 
 exit:
@@ -307,11 +307,11 @@ math_dist(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *p;
     PyObject *q;
 
-    if (!_PyArg_UnpackStack(args, nargs, "dist",
-        2, 2,
-        &p, &q)) {
+    if (!_PyArg_CheckPositional("dist", nargs, 2, 2)) {
         goto exit;
     }
+    p = args[0];
+    q = args[1];
     return_value = math_dist_impl(module, p, q);
 
 exit:
@@ -548,4 +548,4 @@ math_isclose(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2fe4fecd85585313 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f3264ab0ef57ba0a input=a9049054013a1b77]*/

--- a/Modules/clinic/selectmodule.c.h
+++ b/Modules/clinic/selectmodule.c.h
@@ -45,11 +45,17 @@ select_select(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *xlist;
     PyObject *timeout_obj = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "select",
-        3, 4,
-        &rlist, &wlist, &xlist, &timeout_obj)) {
+    if (!_PyArg_CheckPositional("select", nargs, 3, 4)) {
         goto exit;
     }
+    rlist = args[0];
+    wlist = args[1];
+    xlist = args[2];
+    if (nargs < 4) {
+        goto skip_optional;
+    }
+    timeout_obj = args[3];
+skip_optional:
     return_value = select_select_impl(module, rlist, wlist, xlist, timeout_obj);
 
 exit:
@@ -201,11 +207,14 @@ select_poll_poll(pollObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *timeout_obj = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "poll",
-        0, 1,
-        &timeout_obj)) {
+    if (!_PyArg_CheckPositional("poll", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    timeout_obj = args[0];
+skip_optional:
     return_value = select_poll_poll_impl(self, timeout_obj);
 
 exit:
@@ -366,11 +375,14 @@ select_devpoll_poll(devpollObject *self, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     PyObject *timeout_obj = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "poll",
-        0, 1,
-        &timeout_obj)) {
+    if (!_PyArg_CheckPositional("poll", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    timeout_obj = args[0];
+skip_optional:
     return_value = select_devpoll_poll_impl(self, timeout_obj);
 
 exit:
@@ -808,11 +820,22 @@ select_epoll___exit__(pyEpoll_Object *self, PyObject *const *args, Py_ssize_t na
     PyObject *exc_value = Py_None;
     PyObject *exc_tb = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "__exit__",
-        0, 3,
-        &exc_type, &exc_value, &exc_tb)) {
+    if (!_PyArg_CheckPositional("__exit__", nargs, 0, 3)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    exc_type = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    exc_value = args[1];
+    if (nargs < 3) {
+        goto skip_optional;
+    }
+    exc_tb = args[2];
+skip_optional:
     return_value = select_epoll___exit___impl(self, exc_type, exc_value, exc_tb);
 
 exit:
@@ -1105,4 +1128,4 @@ exit:
 #ifndef SELECT_KQUEUE_CONTROL_METHODDEF
     #define SELECT_KQUEUE_CONTROL_METHODDEF
 #endif /* !defined(SELECT_KQUEUE_CONTROL_METHODDEF) */
-/*[clinic end generated code: output=20da8f9c050e1b65 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3e40b33a3294d03d input=a9049054013a1b77]*/

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -545,11 +545,14 @@ bytearray_strip(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "strip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_CheckPositional("strip", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    bytes = args[0];
+skip_optional:
     return_value = bytearray_strip_impl(self, bytes);
 
 exit:
@@ -576,11 +579,14 @@ bytearray_lstrip(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t narg
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_CheckPositional("lstrip", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    bytes = args[0];
+skip_optional:
     return_value = bytearray_lstrip_impl(self, bytes);
 
 exit:
@@ -607,11 +613,14 @@ bytearray_rstrip(PyByteArrayObject *self, PyObject *const *args, Py_ssize_t narg
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_CheckPositional("rstrip", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    bytes = args[0];
+skip_optional:
     return_value = bytearray_rstrip_impl(self, bytes);
 
 exit:
@@ -815,4 +824,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=010e281b823d7df1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f4353c27dcb4a13d input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -203,11 +203,14 @@ bytes_strip(PyBytesObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "strip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_CheckPositional("strip", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    bytes = args[0];
+skip_optional:
     return_value = bytes_strip_impl(self, bytes);
 
 exit:
@@ -234,11 +237,14 @@ bytes_lstrip(PyBytesObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_CheckPositional("lstrip", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    bytes = args[0];
+skip_optional:
     return_value = bytes_lstrip_impl(self, bytes);
 
 exit:
@@ -265,11 +271,14 @@ bytes_rstrip(PyBytesObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_CheckPositional("rstrip", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    bytes = args[0];
+skip_optional:
     return_value = bytes_rstrip_impl(self, bytes);
 
 exit:
@@ -559,4 +568,4 @@ bytes_fromhex(PyTypeObject *type, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=810c8dfc72520ca4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c6621bda84e63e51 input=a9049054013a1b77]*/

--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -21,11 +21,15 @@ dict_fromkeys(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs)
     PyObject *iterable;
     PyObject *value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "fromkeys",
-        1, 2,
-        &iterable, &value)) {
+    if (!_PyArg_CheckPositional("fromkeys", nargs, 1, 2)) {
         goto exit;
     }
+    iterable = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    value = args[1];
+skip_optional:
     return_value = dict_fromkeys_impl(type, iterable, value);
 
 exit:
@@ -60,11 +64,15 @@ dict_get(PyDictObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "get",
-        1, 2,
-        &key, &default_value)) {
+    if (!_PyArg_CheckPositional("get", nargs, 1, 2)) {
         goto exit;
     }
+    key = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    default_value = args[1];
+skip_optional:
     return_value = dict_get_impl(self, key, default_value);
 
 exit:
@@ -93,11 +101,15 @@ dict_setdefault(PyDictObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "setdefault",
-        1, 2,
-        &key, &default_value)) {
+    if (!_PyArg_CheckPositional("setdefault", nargs, 1, 2)) {
         goto exit;
     }
+    key = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    default_value = args[1];
+skip_optional:
     return_value = dict_setdefault_impl(self, key, default_value);
 
 exit:
@@ -121,4 +133,4 @@ dict___reversed__(PyDictObject *self, PyObject *Py_UNUSED(ignored))
 {
     return dict___reversed___impl(self);
 }
-/*[clinic end generated code: output=193e08cb8099fe22 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=12c21ce3552d9617 input=a9049054013a1b77]*/

--- a/Objects/clinic/enumobject.c.h
+++ b/Objects/clinic/enumobject.c.h
@@ -58,14 +58,13 @@ reversed_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("reversed", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "reversed",
-        1, 1,
-        &seq)) {
+    if (!_PyArg_CheckPositional("reversed", PyTuple_GET_SIZE(args), 1, 1)) {
         goto exit;
     }
+    seq = PyTuple_GET_ITEM(args, 0);
     return_value = reversed_new_impl(type, seq);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9008c36999c57218 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=831cec3db0e987c9 input=a9049054013a1b77]*/

--- a/Objects/clinic/floatobject.c.h
+++ b/Objects/clinic/floatobject.c.h
@@ -58,11 +58,14 @@ float___round__(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *o_ndigits = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "__round__",
-        0, 1,
-        &o_ndigits)) {
+    if (!_PyArg_CheckPositional("__round__", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    o_ndigits = args[0];
+skip_optional:
     return_value = float___round___impl(self, o_ndigits);
 
 exit:
@@ -173,11 +176,14 @@ float_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("float", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "float",
-        0, 1,
-        &x)) {
+    if (!_PyArg_CheckPositional("float", PyTuple_GET_SIZE(args), 0, 1)) {
         goto exit;
     }
+    if (PyTuple_GET_SIZE(args) < 1) {
+        goto skip_optional;
+    }
+    x = PyTuple_GET_ITEM(args, 0);
+skip_optional:
     return_value = float_new_impl(type, x);
 
 exit:
@@ -345,4 +351,4 @@ float___format__(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2631a60701a8f7d4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c183029d87dd41fa input=a9049054013a1b77]*/

--- a/Objects/clinic/listobject.c.h
+++ b/Objects/clinic/listobject.c.h
@@ -289,11 +289,14 @@ list___init__(PyObject *self, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("list", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "list",
-        0, 1,
-        &iterable)) {
+    if (!_PyArg_CheckPositional("list", PyTuple_GET_SIZE(args), 0, 1)) {
         goto exit;
     }
+    if (PyTuple_GET_SIZE(args) < 1) {
+        goto skip_optional;
+    }
+    iterable = PyTuple_GET_ITEM(args, 0);
+skip_optional:
     return_value = list___init___impl((PyListObject *)self, iterable);
 
 exit:
@@ -335,4 +338,4 @@ list___reversed__(PyListObject *self, PyObject *Py_UNUSED(ignored))
 {
     return list___reversed___impl(self);
 }
-/*[clinic end generated code: output=1f641f5aef3f886f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4a835f9880a72273 input=a9049054013a1b77]*/

--- a/Objects/clinic/tupleobject.c.h
+++ b/Objects/clinic/tupleobject.c.h
@@ -81,11 +81,14 @@ tuple_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("tuple", kwargs)) {
         goto exit;
     }
-    if (!PyArg_UnpackTuple(args, "tuple",
-        0, 1,
-        &iterable)) {
+    if (!_PyArg_CheckPositional("tuple", PyTuple_GET_SIZE(args), 0, 1)) {
         goto exit;
     }
+    if (PyTuple_GET_SIZE(args) < 1) {
+        goto skip_optional;
+    }
+    iterable = PyTuple_GET_ITEM(args, 0);
+skip_optional:
     return_value = tuple_new_impl(type, iterable);
 
 exit:
@@ -108,4 +111,4 @@ tuple___getnewargs__(PyTupleObject *self, PyObject *Py_UNUSED(ignored))
 {
     return tuple___getnewargs___impl(self);
 }
-/*[clinic end generated code: output=5312868473a41cfe input=a9049054013a1b77]*/
+/*[clinic end generated code: output=56fab9b7368aba49 input=a9049054013a1b77]*/

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -546,11 +546,14 @@ unicode_strip(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *chars = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "strip",
-        0, 1,
-        &chars)) {
+    if (!_PyArg_CheckPositional("strip", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    chars = args[0];
+skip_optional:
     return_value = unicode_strip_impl(self, chars);
 
 exit:
@@ -577,11 +580,14 @@ unicode_lstrip(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *chars = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
-        0, 1,
-        &chars)) {
+    if (!_PyArg_CheckPositional("lstrip", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    chars = args[0];
+skip_optional:
     return_value = unicode_lstrip_impl(self, chars);
 
 exit:
@@ -608,11 +614,14 @@ unicode_rstrip(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *chars = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
-        0, 1,
-        &chars)) {
+    if (!_PyArg_CheckPositional("rstrip", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    chars = args[0];
+skip_optional:
     return_value = unicode_rstrip_impl(self, chars);
 
 exit:
@@ -1098,4 +1107,4 @@ unicode_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return unicode_sizeof_impl(self);
 }
-/*[clinic end generated code: output=73ad9670e00a2490 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=087ff163a10505ae input=a9049054013a1b77]*/

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -217,11 +217,11 @@ builtin_divmod(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *x;
     PyObject *y;
 
-    if (!_PyArg_UnpackStack(args, nargs, "divmod",
-        2, 2,
-        &x, &y)) {
+    if (!_PyArg_CheckPositional("divmod", nargs, 2, 2)) {
         goto exit;
     }
+    x = args[0];
+    y = args[1];
     return_value = builtin_divmod_impl(module, x, y);
 
 exit:
@@ -255,11 +255,19 @@ builtin_eval(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *globals = Py_None;
     PyObject *locals = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "eval",
-        1, 3,
-        &source, &globals, &locals)) {
+    if (!_PyArg_CheckPositional("eval", nargs, 1, 3)) {
         goto exit;
     }
+    source = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    globals = args[1];
+    if (nargs < 3) {
+        goto skip_optional;
+    }
+    locals = args[2];
+skip_optional:
     return_value = builtin_eval_impl(module, source, globals, locals);
 
 exit:
@@ -293,11 +301,19 @@ builtin_exec(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *globals = Py_None;
     PyObject *locals = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "exec",
-        1, 3,
-        &source, &globals, &locals)) {
+    if (!_PyArg_CheckPositional("exec", nargs, 1, 3)) {
         goto exit;
     }
+    source = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    globals = args[1];
+    if (nargs < 3) {
+        goto skip_optional;
+    }
+    locals = args[2];
+skip_optional:
     return_value = builtin_exec_impl(module, source, globals, locals);
 
 exit:
@@ -346,11 +362,11 @@ builtin_hasattr(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *obj;
     PyObject *name;
 
-    if (!_PyArg_UnpackStack(args, nargs, "hasattr",
-        2, 2,
-        &obj, &name)) {
+    if (!_PyArg_CheckPositional("hasattr", nargs, 2, 2)) {
         goto exit;
     }
+    obj = args[0];
+    name = args[1];
     return_value = builtin_hasattr_impl(module, obj, name);
 
 exit:
@@ -392,11 +408,12 @@ builtin_setattr(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *name;
     PyObject *value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "setattr",
-        3, 3,
-        &obj, &name, &value)) {
+    if (!_PyArg_CheckPositional("setattr", nargs, 3, 3)) {
         goto exit;
     }
+    obj = args[0];
+    name = args[1];
+    value = args[2];
     return_value = builtin_setattr_impl(module, obj, name, value);
 
 exit:
@@ -424,11 +441,11 @@ builtin_delattr(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *obj;
     PyObject *name;
 
-    if (!_PyArg_UnpackStack(args, nargs, "delattr",
-        2, 2,
-        &obj, &name)) {
+    if (!_PyArg_CheckPositional("delattr", nargs, 2, 2)) {
         goto exit;
     }
+    obj = args[0];
+    name = args[1];
     return_value = builtin_delattr_impl(module, obj, name);
 
 exit:
@@ -534,11 +551,16 @@ builtin_pow(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *y;
     PyObject *z = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "pow",
-        2, 3,
-        &x, &y, &z)) {
+    if (!_PyArg_CheckPositional("pow", nargs, 2, 3)) {
         goto exit;
     }
+    x = args[0];
+    y = args[1];
+    if (nargs < 3) {
+        goto skip_optional;
+    }
+    z = args[2];
+skip_optional:
     return_value = builtin_pow_impl(module, x, y, z);
 
 exit:
@@ -569,11 +591,14 @@ builtin_input(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *prompt = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "input",
-        0, 1,
-        &prompt)) {
+    if (!_PyArg_CheckPositional("input", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    prompt = args[0];
+skip_optional:
     return_value = builtin_input_impl(module, prompt);
 
 exit:
@@ -684,11 +709,11 @@ builtin_isinstance(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *obj;
     PyObject *class_or_tuple;
 
-    if (!_PyArg_UnpackStack(args, nargs, "isinstance",
-        2, 2,
-        &obj, &class_or_tuple)) {
+    if (!_PyArg_CheckPositional("isinstance", nargs, 2, 2)) {
         goto exit;
     }
+    obj = args[0];
+    class_or_tuple = args[1];
     return_value = builtin_isinstance_impl(module, obj, class_or_tuple);
 
 exit:
@@ -719,14 +744,14 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *cls;
     PyObject *class_or_tuple;
 
-    if (!_PyArg_UnpackStack(args, nargs, "issubclass",
-        2, 2,
-        &cls, &class_or_tuple)) {
+    if (!_PyArg_CheckPositional("issubclass", nargs, 2, 2)) {
         goto exit;
     }
+    cls = args[0];
+    class_or_tuple = args[1];
     return_value = builtin_issubclass_impl(module, cls, class_or_tuple);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=11b5cd918bd7eb18 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=54e5e33dcc2659e0 input=a9049054013a1b77]*/

--- a/Python/clinic/context.c.h
+++ b/Python/clinic/context.c.h
@@ -25,11 +25,15 @@ _contextvars_Context_get(PyContext *self, PyObject *const *args, Py_ssize_t narg
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "get",
-        1, 2,
-        &key, &default_value)) {
+    if (!_PyArg_CheckPositional("get", nargs, 1, 2)) {
         goto exit;
     }
+    key = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    default_value = args[1];
+skip_optional:
     return_value = _contextvars_Context_get_impl(self, key, default_value);
 
 exit:
@@ -134,11 +138,14 @@ _contextvars_ContextVar_get(PyContextVar *self, PyObject *const *args, Py_ssize_
     PyObject *return_value = NULL;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "get",
-        0, 1,
-        &default_value)) {
+    if (!_PyArg_CheckPositional("get", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    default_value = args[0];
+skip_optional:
     return_value = _contextvars_ContextVar_get_impl(self, default_value);
 
 exit:
@@ -170,4 +177,4 @@ PyDoc_STRVAR(_contextvars_ContextVar_reset__doc__,
 
 #define _CONTEXTVARS_CONTEXTVAR_RESET_METHODDEF    \
     {"reset", (PyCFunction)_contextvars_ContextVar_reset, METH_O, _contextvars_ContextVar_reset__doc__},
-/*[clinic end generated code: output=9c93e22bcadbaa2b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=67c3a8f76b6cf4e7 input=a9049054013a1b77]*/

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -318,11 +318,15 @@ _imp_create_dynamic(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *spec;
     PyObject *file = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "create_dynamic",
-        1, 2,
-        &spec, &file)) {
+    if (!_PyArg_CheckPositional("create_dynamic", nargs, 1, 2)) {
         goto exit;
     }
+    spec = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    file = args[1];
+skip_optional:
     return_value = _imp_create_dynamic_impl(module, spec, file);
 
 exit:
@@ -433,4 +437,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=22062cee6e8ba7f3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2409b8feeafe7c4b input=a9049054013a1b77]*/

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -32,11 +32,12 @@ sys_excepthook(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *value;
     PyObject *traceback;
 
-    if (!_PyArg_UnpackStack(args, nargs, "excepthook",
-        3, 3,
-        &exctype, &value, &traceback)) {
+    if (!_PyArg_CheckPositional("excepthook", nargs, 3, 3)) {
         goto exit;
     }
+    exctype = args[0];
+    value = args[1];
+    traceback = args[2];
     return_value = sys_excepthook_impl(module, exctype, value, traceback);
 
 exit:
@@ -87,11 +88,14 @@ sys_exit(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *return_value = NULL;
     PyObject *status = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "exit",
-        0, 1,
-        &status)) {
+    if (!_PyArg_CheckPositional("exit", nargs, 0, 1)) {
         goto exit;
     }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    status = args[0];
+skip_optional:
     return_value = sys_exit_impl(module, status);
 
 exit:
@@ -1046,4 +1050,4 @@ sys_getandroidapilevel(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=6a5202e5bfe5e6bd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=109787af3401cd27 input=a9049054013a1b77]*/


### PR DESCRIPTION
Use _PyArg_CheckPositional() and inlined code instead of
PyArg_UnpackTuple() and _PyArg_UnpackStack() if all parameters
are positional and use the "object" converter.


<!-- issue-number: [bpo-35582](https://bugs.python.org/issue35582) -->
https://bugs.python.org/issue35582
<!-- /issue-number -->
