### PR TITLE
Fixed typo

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1602,7 +1602,7 @@ using the :meth:`loop.add_signal_handler` method::
     import os
     import signal
 
-    def ask_exit(signame):
+    def ask_exit(signame, loop):
         print("got signal %s: exit" % signame)
         loop.stop()
 
@@ -1612,7 +1612,7 @@ using the :meth:`loop.add_signal_handler` method::
         for signame in {'SIGINT', 'SIGTERM'}:
             loop.add_signal_handler(
                 getattr(signal, signame),
-                functools.partial(ask_exit, signame))
+                functools.partial(ask_exit, signame, loop))
 
         await asyncio.sleep(3600)
 


### PR DESCRIPTION
Given example does not run, loop variable is missing.

Secondly, this is bad example how to handle shutdown signal, because it would cause `RuntimeError: Event loop stopped before Future completed.`

Perhaps it would be better to cancel all tasks instead of closing loop directly?

Did not create issue, because question is quite simple.