### PR TITLE
bpo-35722: Specify in the docs that disable_existing_loggers does not affect the root logger

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -695,15 +695,15 @@ noncoders to easily modify the logging properties.
 .. warning:: The :func:`fileConfig` function takes a default parameter,
    ``disable_existing_loggers``, which defaults to ``True`` for reasons of
    backward compatibility. This may or may not be what you want, since it
-   will cause any loggers existing before the :func:`fileConfig` call to
-   be disabled unless they (or an ancestor) are explicitly named in the
-   configuration.  Please refer to the reference documentation for more
+   will cause any non-root loggers existing before the :func:`fileConfig`
+   call to be disabled unless they (or an ancestor) are explicitly named in
+   the configuration. Please refer to the reference documentation for more
    information, and specify ``False`` for this parameter if you wish.
 
    The dictionary passed to :func:`dictConfig` can also specify a Boolean
    value with key ``disable_existing_loggers``, which if not specified
    explicitly in the dictionary also defaults to being interpreted as
-   ``True``.  This leads to the logger-disabling behaviour described above,
+   ``True``. This leads to the logger-disabling behaviour described above,
    which may not be what you want - in which case, provide the key
    explicitly with a value of ``False``.
 
@@ -749,7 +749,7 @@ the new dictionary-based approach:
       simpleExample:
         level: DEBUG
         handlers: [console]
-        propagate: no
+        propagate: false
     root:
       level: DEBUG
       handlers: [console]
@@ -802,7 +802,7 @@ the best default behaviour.
 If for some reason you *don't* want these messages printed in the absence of
 any logging configuration, you can attach a do-nothing handler to the top-level
 logger for your library. This avoids the message being printed, since a handler
-will be always be found for the library's events: it just doesn't produce any
+will always be found for the library's events: it just doesn't produce any
 output. If the library user configures logging for application use, presumably
 that configuration will add some handlers, and if levels are suitably
 configured then logging calls made in library code will send output to those

--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -749,7 +749,7 @@ the new dictionary-based approach:
       simpleExample:
         level: DEBUG
         handlers: [console]
-        propagate: false
+        propagate: no
     root:
       level: DEBUG
       handlers: [console]

--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -107,9 +107,9 @@ in :mod:`logging` itself) and defining handlers which are declared either in
                                     enabled. The default is ``True`` because this
                                     enables old behaviour in a
                                     backward-compatible way. This behaviour is to
-                                    disable any existing loggers unless they or
-                                    their ancestors are explicitly named in the
-                                    logging configuration.
+                                    disable any existing non-root loggers unless
+                                    they or their ancestors are explicitly named
+                                    in the logging configuration.
 
    .. versionchanged:: 3.4
       An instance of a subclass of :class:`~configparser.RawConfigParser` is
@@ -313,8 +313,8 @@ otherwise, the context is used to determine what to instantiate.
   If the specified value is ``True``, the configuration is processed
   as described in the section on :ref:`logging-config-dict-incremental`.
 
-* *disable_existing_loggers* - whether any existing loggers are to be
-  disabled. This setting mirrors the parameter of the same name in
+* *disable_existing_loggers* - whether any existing non-root loggers are
+  to be disabled. This setting mirrors the parameter of the same name in
   :func:`fileConfig`. If absent, this parameter defaults to ``True``.
   This value is ignored if *incremental* is ``True``.
 


### PR DESCRIPTION
In the package `logging`, the parameter `disable_existing_loggers` used in the functions `logging.config.dictConfig` and `logging.config.fileConfig` does not affect the root logger. More precisely, calling those functions with the parameter `disable_existing_loggers` set to `True` or `False` leaves the attribute `disabled` of the root logger unchanged (while it sets it to `True` for non-root loggers). So it is either a bug or the documentation should be updated. This PR updates the documentation.

Illustration:

```
import logging.config

assert logging.getLogger().disabled is False
assert logging.getLogger("foo").disabled is False

logging.config.dictConfig({"version": 1})

assert logging.getLogger().disabled is False
assert logging.getLogger("foo").disabled is True
```

<!-- issue-number: [bpo-35722](https://bugs.python.org/issue35722) -->
https://bugs.python.org/issue35722
<!-- /issue-number -->