### PR TITLE
bpo-35718: Cannot initialize the "force" Command-option in initialize_options()

### DIFF
--- a/Lib/distutils/cmd.py
+++ b/Lib/distutils/cmd.py
@@ -59,7 +59,6 @@ class Command:
             raise RuntimeError("Command is an abstract class")
 
         self.distribution = dist
-        self.initialize_options()
 
         # Per-command versions of the global flags, so that the user can
         # customize Distutils' behaviour command-by-command and let some
@@ -90,6 +89,8 @@ class Command:
         # this flag: it is the business of 'ensure_finalized()', which
         # always calls 'finalize_options()', to respect/update it.
         self.finalized = 0
+
+        self.initialize_options()
 
     # XXX A more explicit way to customize dry_run would be better.
     def __getattr__(self, attr):

--- a/Lib/distutils/command/build_clib.py
+++ b/Lib/distutils/command/build_clib.py
@@ -61,7 +61,7 @@ class build_clib(Command):
         self.define = None
         self.undef = None
         self.debug = None
-        self.force = 0
+        self.force = None
         self.compiler = None
 
 

--- a/Lib/distutils/command/install_data.py
+++ b/Lib/distutils/command/install_data.py
@@ -28,7 +28,7 @@ class install_data(Command):
         self.install_dir = None
         self.outfiles = []
         self.root = None
-        self.force = 0
+        self.force = None
         self.data_files = self.distribution.data_files
         self.warn_dir = 1
 

--- a/Lib/distutils/command/install_headers.py
+++ b/Lib/distutils/command/install_headers.py
@@ -21,7 +21,7 @@ class install_headers(Command):
 
     def initialize_options(self):
         self.install_dir = None
-        self.force = 0
+        self.force = None
         self.outfiles = []
 
     def finalize_options(self):

--- a/Lib/distutils/command/install_lib.py
+++ b/Lib/distutils/command/install_lib.py
@@ -52,7 +52,7 @@ class install_lib(Command):
         # let the 'install' command dictate our installation directory
         self.install_dir = None
         self.build_dir = None
-        self.force = 0
+        self.force = None
         self.compile = None
         self.optimize = None
         self.skip_build = None

--- a/Lib/distutils/command/install_scripts.py
+++ b/Lib/distutils/command/install_scripts.py
@@ -26,7 +26,7 @@ class install_scripts(Command):
 
     def initialize_options(self):
         self.install_dir = None
-        self.force = 0
+        self.force = None
         self.build_dir = None
         self.skip_build = None
 


### PR DESCRIPTION
See [Issue 35718](https://bugs.python.org/issue35718).
In this `build_py` subclass I initialize `force` to `1`, but when reaching `byte_compile()` we find out it was reset to `None`.
```python
from setuptools.command.build_py import build_py as _build_py

class build_py(_build_py):
    def initialize_options(self):
        _build_py.initialize_options(self)
        self.force = 1
        self.compile = 1

    def byte_compile(self, files):
        # self.compile == 1
        # self.force == None
        _build_py.byte_compile(self, files)
        # do stuff...
```

<!-- issue-number: [bpo-35718](https://bugs.python.org/issue35718) -->
https://bugs.python.org/issue35718
<!-- /issue-number -->
