### PR TITLE
bpo-35720: Fixing a memory leak in Modules/main.c:pymain_parse_cmdline_impl

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-01-12-23-33-04.bpo-35720.LELKQx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-01-12-23-33-04.bpo-35720.LELKQx.rst
@@ -1,0 +1,1 @@
+Fixed a minor memory leak in pymain_parse_cmdline_impl function in Modules/main.c

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1376,6 +1376,7 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
             goto done;
         }
         pymain_clear_cmdline(pymain, cmdline);
+        pymain_clear_pymain(pymain);
         memset(cmdline, 0, sizeof(*cmdline));
         config->utf8_mode = new_utf8_mode;
         config->coerce_c_locale = new_coerce_c_locale;


### PR DESCRIPTION
When the loop in the pymain_read_conf function in this same file
calls pymain_init_cmdline_argv a 2nd time, the pymain->command
buffer of wchar_t is overriden and the previously allocated memory
is never freed.

<!-- issue-number: [bpo-35720](https://bugs.python.org/issue35720) -->
https://bugs.python.org/issue35720
<!-- /issue-number -->
