### PR TITLE
bpo-35723: Proof of concept for tzidx cache

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1315,6 +1315,22 @@ Instance methods:
    complete list of formatting directives, see
    :ref:`strftime-strptime-behavior`.
 
+.. method:: datetime.tzidx()
+
+    This method is only intended to be called from :class:`tzinfo`
+    implementations that implement :meth:`tzinfo.utcoffset`, :meth:`tzinfo.dst`,
+    and :meth:`tzinfo.tzname` in such a way that caching a small amount of
+    information on the datetime object could speed up subsequent lookups.
+
+    This function returns the potentially-cached return value of
+    :meth:`tzinfo.tzidx`. If :meth:`tzinfo.tzidx` returns a value that fits
+    in the datetime object's cache, it will store the value and subsequent
+    calls to ``tzidx`` will not call :meth:`tzinfo.tzidx`. The size and type
+    of the cache is implementation-defined, and in CPython only integers in
+    the interval ``[0, 254]`` are cached.
+
+    .. versionadded:: 3.8
+
 
 Examples of working with datetime objects:
 
@@ -1861,6 +1877,25 @@ There is one more :class:`tzinfo` method that a subclass may wish to override:
               return dt + dtdst
           else:
               return dt
+
+Additionally, for ``tzinfo`` implementations that use an indexed container of
+time zone data (e.g. a ``list`` of offsets and abbreviations), implementing
+``tzidx`` may provide some performance improvements:
+
+
+.. method:: tzinfo.tzidx(dt):
+
+    This method is called whenever a :meth:`datetime.tzidx` call cannot return
+    a cached value. Though the size and type of cache is implementation-defined,
+    in CPython, if this function returns an integer in the interval
+    ``[0, 254]``, the value will be cached on subsequent calls to
+    :meth:`datetime.tzidx`.
+
+    In many situations, this can be used to improve performance by implementing
+    :meth:`tzinfo.utcoffset`, :meth:`tzinfo.dst`, :meth:`tzinfo.tzname` and
+    :meth:`tzinfo.fromutc` in terms of ``datetime.tzidx`` calls.
+
+    .. versionadded:: 3.8
 
 In the following :download:`tzinfo_examples.py
 <../includes/tzinfo_examples.py>` file there are some examples of

--- a/Include/datetime.h
+++ b/Include/datetime.h
@@ -82,6 +82,7 @@ typedef struct
 {
     _PyDateTime_TIMEHEAD
     unsigned char fold;
+    unsigned char tzidx;
     PyObject *tzinfo;
 } PyDateTime_Time;              /* hastzinfo true */
 
@@ -110,6 +111,7 @@ typedef struct
 {
     _PyDateTime_DATETIMEHEAD
     unsigned char fold;
+    unsigned char tzidx;
     PyObject *tzinfo;
 } PyDateTime_DateTime;          /* hastzinfo true */
 
@@ -128,6 +130,7 @@ typedef struct
      (((PyDateTime_DateTime*)o)->data[8] << 8)  |       \
       ((PyDateTime_DateTime*)o)->data[9])
 #define PyDateTime_DATE_GET_FOLD(o)        (((PyDateTime_DateTime*)o)->fold)
+#define PyDateTime_DATE_GET_TZIDX(o)       (((PyDateTime_DateTime*)o)->tzidx)
 
 /* Apply for time instances. */
 #define PyDateTime_TIME_GET_HOUR(o)        (((PyDateTime_Time*)o)->data[0])
@@ -138,6 +141,7 @@ typedef struct
      (((PyDateTime_Time*)o)->data[4] << 8)  |           \
       ((PyDateTime_Time*)o)->data[5])
 #define PyDateTime_TIME_GET_FOLD(o)        (((PyDateTime_Time*)o)->fold)
+#define PyDateTime_TIME_GET_TZIDX(o)       (((PyDateTime_Time*)o)->tzidx)
 
 /* Apply for time delta instances */
 #define PyDateTime_DELTA_GET_DAYS(o)         (((PyDateTime_Delta*)o)->days)

--- a/Include/datetime.h
+++ b/Include/datetime.h
@@ -82,7 +82,6 @@ typedef struct
 {
     _PyDateTime_TIMEHEAD
     unsigned char fold;
-    unsigned char tzidx;
     PyObject *tzinfo;
 } PyDateTime_Time;              /* hastzinfo true */
 
@@ -141,7 +140,6 @@ typedef struct
      (((PyDateTime_Time*)o)->data[4] << 8)  |           \
       ((PyDateTime_Time*)o)->data[5])
 #define PyDateTime_TIME_GET_FOLD(o)        (((PyDateTime_Time*)o)->fold)
-#define PyDateTime_TIME_GET_TZIDX(o)       (((PyDateTime_Time*)o)->tzidx)
 
 /* Apply for time delta instances */
 #define PyDateTime_DELTA_GET_DAYS(o)         (((PyDateTime_Delta*)o)->days)

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1983,7 +1983,7 @@ class datetime(date):
         _check_utc_offset("dst", offset)
         return offset
 
-    def tzidx(self, callback):
+    def tzidx(self):
         """Retrieve the time zone index of the datetime, either from the cache
         or from the return value of the passed callback.
 
@@ -1997,7 +1997,14 @@ class datetime(date):
         if self._tzidx != 0xff:
             return self._tzidx
 
-        tzidx = callback(self)
+        if self.tzinfo is None:
+            raise TypeError("tzidx must not be called on naive datetimes")
+
+        if not hasattr(self.tzinfo, "tzidx"):
+            raise TypeError("datetime.tzidx must only be called from tzinfo " +
+                            "objects which have implemented the tzidx method")
+
+        tzidx = self.tzinfo.tzidx(self)
         if isinstance(tzidx, int) and 0 <= tzidx < 0xff:
             self._tzidx = tzidx
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -4679,6 +4679,12 @@ class TestDateTimeTZ(TestDateTime, TZInfoBase, unittest.TestCase):
                 self.assertEqual(dt0.utcoffset(), offset)
                 self.assertEqual(tz.calls, i)
 
+                # Create a new datetime with replace, clearing the cache
+                dt0 = dt0.replace(microsecond=1)
+                self.assertEqual(dt0.utcoffset(), offset)
+                i += 1
+                self.assertEqual(tz.calls, i)
+
     def test_tzidx_misses(self):
         class CachableTZInfo(tzinfo):
             """Fixed DST offset time zone class intended to test tzidx_cache"""

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -4619,7 +4619,7 @@ class TestDateTimeTZ(TestDateTime, TZInfoBase, unittest.TestCase):
             def __repr__(self):
                 return f"{self.__class__.__name__}()"
 
-            def get_tzidx(self, dt):
+            def tzidx(self, dt):
                 self.calls += 1
 
                 dst_start = (3, 15, 2, 0, 0, 0)      # DST starts March 15 at 2AM
@@ -4635,13 +4635,13 @@ class TestDateTimeTZ(TestDateTime, TZInfoBase, unittest.TestCase):
                     return 0
 
             def dst(self, dt):
-                return self.dsts[dt.tzidx(self.get_tzidx)]
+                return self.dsts[dt.tzidx()]
 
             def utcoffset(self, dt):
-                return self.offsets[dt.tzidx(self.get_tzidx)]
+                return self.offsets[dt.tzidx()]
 
             def tzname(self, dt):
-                return self.names[dt.tzidx(self.get_tzidx)]
+                return self.names[dt.tzidx()]
 
         STD_TUPLE = (timedelta(hours=0), '+00:00', timedelta(hours=0))
         DST_TUPLE = (timedelta(hours=1), '+01:00', timedelta(hours=1))

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1012,7 +1012,7 @@ pylong_to_tzidx(PyObject* tzidx_obj) {
 
 
 static PyObject*
-datetime_get_tzidx(PyObject* self, PyObject* callback) {
+datetime_tzidx(PyObject* self, PyObject* callback) {
     unsigned char tzidx = DATE_GET_TZIDX(self);
 
     if (tzidx != 0xff) {
@@ -6320,7 +6320,7 @@ static PyMethodDef datetime_methods[] = {
     {"dst",             (PyCFunction)datetime_dst, METH_NOARGS,
      PyDoc_STR("Return self.tzinfo.dst(self).")},
 
-    {"get_tzidx", (PyCFunction)datetime_get_tzidx,    METH_O,
+    {"tzidx", (PyCFunction)datetime_tzidx,    METH_O,
      PyDoc_STR("Get the cached time zone index")},
 
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -96,7 +96,6 @@ class datetime.date "PyDateTime_Date *" "&PyDateTime_DateType"
 #define TIME_GET_SECOND         PyDateTime_TIME_GET_SECOND
 #define TIME_GET_MICROSECOND    PyDateTime_TIME_GET_MICROSECOND
 #define TIME_GET_FOLD           PyDateTime_TIME_GET_FOLD
-#define TIME_GET_TZIDX          PyDateTime_TIME_GET_TZIDX
 #define TIME_SET_HOUR(o, v)     (PyDateTime_TIME_GET_HOUR(o) = (v))
 #define TIME_SET_MINUTE(o, v)   (PyDateTime_TIME_GET_MINUTE(o) = (v))
 #define TIME_SET_SECOND(o, v)   (PyDateTime_TIME_GET_SECOND(o) = (v))
@@ -105,7 +104,6 @@ class datetime.date "PyDateTime_Date *" "&PyDateTime_DateType"
      ((o)->data[4] = ((v) & 0x00ff00) >> 8), \
      ((o)->data[5] = ((v) & 0x0000ff)))
 #define TIME_SET_FOLD(o, v)   (PyDateTime_TIME_GET_FOLD(o) = (v))
-#define TIME_SET_TZIDX(o, v)  (PyDateTime_TIME_GET_TZIDX(o) = (v))
 
 /* Delta accessors for timedelta. */
 #define GET_TD_DAYS(o)          (((PyDateTime_Delta *)(o))->days)
@@ -1074,24 +1072,6 @@ new_time_ex(int hour, int minute, int second, int usecond,
 #define new_time(hh, mm, ss, us, tzinfo, fold)                       \
     new_time_ex2(hh, mm, ss, us, tzinfo, fold, &PyDateTime_TimeType)
 
-
-static PyObject*
-time_get_tzidx(PyObject* self, PyObject* callback) {
-    unsigned char tzidx = TIME_GET_TZIDX(self);
-
-    if (tzidx != 0xff) {
-        return PyLong_FromLong((long)tzidx);
-    }
-
-    PyObject *obj = _load_valid_tzidx(self, callback);
-
-    if (PyLong_Check(obj)) {
-        tzidx = pylong_to_tzidx(obj);
-        TIME_SET_TZIDX(self, tzidx);
-    };
-
-    return obj;
-}
 
 /* Create a timedelta instance.  Normalize the members iff normalize is
  * true.  Passing false is a speed optimization, if you know for sure
@@ -4633,9 +4613,6 @@ static PyMethodDef time_methods[] = {
 
     {"dst",             (PyCFunction)time_dst,          METH_NOARGS,
      PyDoc_STR("Return self.tzinfo.dst(self).")},
-
-    {"get_tzidx",       (PyCFunction)time_get_tzidx,    METH_O,
-     PyDoc_STR("Retrieve the tzidx cache")},
 
     {"replace",     (PyCFunction)(void(*)(void))time_replace,          METH_VARARGS | METH_KEYWORDS,
      PyDoc_STR("Return time with new specified fields.")},


### PR DESCRIPTION
When examining the performance characteristics of pytz, I realized that pytz's eager calculation of tzname, offset and DST gives it an implicit cache that makes it much faster for repeated queries to .utcoffset(), .dst() and/or .tzname(), see my blog post ["pytz: The Fastest Footgun in the West"](https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html), though the eager calculation means that it's slower to create an aware datetime that never calculates those functions.

This proof of concept introduces a "set once" cache to the `datetime` object that `tzinfo` implementations can use to cache offset and name lookups per datetime. A more thorough discussion of the rationale for this change is available on the associated issue, [bpo-35723](https://bugs.python.org/issue35723).

I will note that this is currently a WIP, it still needs:

- [x] Proper handling of what happens when this function is called in an infinite recursive loop (currently segfaults)
- [x] Tests for the situation where `tzidx` is not an integer, or outside the interval [0, 254]
- [ ] Documentation of the API
- [ ] News entry

<!-- issue-number: [bpo-35723](https://bugs.python.org/issue35723) -->
https://bugs.python.org/issue35723
<!-- /issue-number -->
