### PR TITLE
bpo-35724: Explicitly require the main interpreter for signal-handling.

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -133,6 +133,7 @@ PyAPI_FUNC(PyObject *) _PyErr_TrySetFromCause(
 /* In signalmodule.c */
 
 int PySignal_SetWakeupFd(int fd);
+PyAPI_FUNC(int) _PyErr_CheckSignals(void);
 
 /* Support for adding program text to SyntaxErrors */
 

--- a/Misc/NEWS.d/next/Core and Builtins/2019-01-11-14-46-08.bpo-35724.Wv79MG.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-01-11-14-46-08.bpo-35724.Wv79MG.rst
@@ -1,0 +1,2 @@
+Signal-handling is now guaranteed to happen relative to the main
+interpreter.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -186,7 +186,7 @@ itimer_retval(struct itimerval *iv)
 }
 #endif
 
-int
+static int
 is_main(void)
 {
     return PyThread_get_thread_ident() == main_thread &&

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -99,6 +99,7 @@ class sigset_t_converter(CConverter):
 #include "pythread.h"
 static unsigned long main_thread;
 static pid_t main_pid;
+static PyInterpreterState *main_interp;
 
 static volatile struct {
     _Py_atomic_int tripped;
@@ -188,7 +189,8 @@ itimer_retval(struct itimerval *iv)
 int
 is_main(void)
 {
-    return PyThread_get_thread_ident() == main_thread;
+    return PyThread_get_thread_ident() == main_thread &&
+        _PyInterpreterState_Get() == main_interp;
 }
 
 static PyObject *
@@ -1320,6 +1322,7 @@ PyInit__signal(void)
 
     main_thread = PyThread_get_thread_ident();
     main_pid = getpid();
+    main_interp = _PyInterpreterState_Get();
 
     /* Create the module and add the functions */
     m = PyModule_Create(&signalmodule);
@@ -1732,6 +1735,7 @@ _PySignal_AfterFork(void)
     _clear_pending_signals();
     main_thread = PyThread_get_thread_ident();
     main_pid = getpid();
+    main_interp = _PyInterpreterState_Get();
 }
 
 int

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -381,7 +381,7 @@ handle_signals(void)
     }
 
     UNSIGNAL_PENDING_SIGNALS();
-    if (PyErr_CheckSignals() < 0) {
+    if (_PyErr_CheckSignals() < 0) {
         SIGNAL_PENDING_SIGNALS(); /* We're not done yet */
         return -1;
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -379,6 +379,13 @@ handle_signals(void)
     {
         return 0;
     }
+    /*
+     * Ensure that the thread isn't currently running some other
+     * interpreter.
+     */
+    if (_PyInterpreterState_GET_UNSAFE() != _PyRuntime.interpreters.main) {
+        return 0;
+    }
 
     UNSIGNAL_PENDING_SIGNALS();
     if (_PyErr_CheckSignals() < 0) {


### PR DESCRIPTION
Ensure that the main interpreter is active (in the main thread) for signal-handling operations.  This is increasingly relevant as people use subinterpreters more.

<!-- issue-number: [bpo-35724](https://bugs.python.org/issue35724) -->
https://bugs.python.org/issue35724
<!-- /issue-number -->
