### PR TITLE
bpo-35758: Fix building on ARM + MSVC

### DIFF
--- a/Include/internal/pycore_atomic.h
+++ b/Include/internal/pycore_atomic.h
@@ -19,7 +19,9 @@ extern "C" {
 
 #if defined(_MSC_VER)
 #include <intrin.h>
-#include <immintrin.h>
+#if defined(_M_IX86) || defined(_M_X64)
+#  include <immintrin.h>
+#endif
 #endif
 
 /* This is modeled after the atomics interface from C1x, according to

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -406,7 +406,7 @@ extern "C" {
 #endif
 
 /* get and set x87 control word for VisualStudio/x86 */
-#if defined(_MSC_VER) && !defined(_WIN64) /* x87 not supported in 64-bit */
+#if defined(_MSC_VER) && defined(_M_IX86) /* x87 only supported in x86 */
 #define HAVE_PY_SET_53BIT_PRECISION 1
 #define _Py_SET_53BIT_PRECISION_HEADER \
     unsigned int old_387controlword, new_387controlword, out_387controlword

--- a/Misc/NEWS.d/next/Windows/2019-01-21-05-18-14.bpo-35758.8LsY3l.rst
+++ b/Misc/NEWS.d/next/Windows/2019-01-21-05-18-14.bpo-35758.8LsY3l.rst
@@ -1,0 +1,1 @@
+On msvc, x87 control word is only available on x86 target. Need to disable it for other targets to prevent compiling problems.

--- a/Misc/NEWS.d/next/Windows/2019-01-21-05-18-14.bpo-35758.8LsY3l.rst
+++ b/Misc/NEWS.d/next/Windows/2019-01-21-05-18-14.bpo-35758.8LsY3l.rst
@@ -1,1 +1,1 @@
-Allow building on ARM + MSVC.
+Allow building on ARM with MSVC.

--- a/Misc/NEWS.d/next/Windows/2019-01-21-05-18-14.bpo-35758.8LsY3l.rst
+++ b/Misc/NEWS.d/next/Windows/2019-01-21-05-18-14.bpo-35758.8LsY3l.rst
@@ -1,1 +1,1 @@
-On msvc, x87 control word is only available on x86 target. Need to disable it for other targets to prevent compiling problems.
+Allow building on ARM + MSVC.


### PR DESCRIPTION
Msvc defines _M_ARM for arm target, but it doesn't have x87 control word. Need to disable it to prevent some compiling problems.

<!-- issue-number: [bpo-14802](https://bugs.python.org/issue14802) -->
https://bugs.python.org/issue14802
<!-- /issue-number -->
