### PR TITLE
[2.7] bpo-35552: Fix reading past the end in PyString_FromFormat(). (GH-11276)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-21-13-29-30.bpo-35552.1DzQQc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-21-13-29-30.bpo-35552.1DzQQc.rst
@@ -1,0 +1,2 @@
+Format character ``%s`` in :c:func:`PyString_FromFormat` no longer read
+memory past the limit if *precision* is specified.

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -360,9 +360,15 @@ PyString_FromFormatV(const char *format, va_list vargs)
                 break;
             case 's':
                 p = va_arg(vargs, char*);
-                i = strlen(p);
-                if (n > 0 && i > n)
-                    i = n;
+                if (n <= 0) {
+                    i = strlen(p);
+                }
+                else {
+                    i = 0;
+                    while (i < n && p[i]) {
+                        i++;
+                    }
+                }
                 Py_MEMCPY(s, p, i);
                 s += i;
                 break;


### PR DESCRIPTION
Format character "%s" in PyString_FromFormat() no longer read memory
past the limit if precision is specified.
(cherry picked from commit d586ccb04f79863c819b212ec5b9d873964078e4)


<!-- issue-number: [bpo-35552](https://bugs.python.org/issue35552) -->
https://bugs.python.org/issue35552
<!-- /issue-number -->
