### PR TITLE
bpo-35727: Use exit code 0 on sys.exit() in multiprocessing.Process.

### DIFF
--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -315,12 +315,12 @@ class BaseProcess(object):
             finally:
                 util._exit_function()
         except SystemExit as e:
-            if not e.args:
-                exitcode = 1
-            elif isinstance(e.args[0], int):
-                exitcode = e.args[0]
+            if e.code is None:
+                exitcode = 0
+            elif isinstance(e.code, int):
+                exitcode = e.code
             else:
-                sys.stderr.write(str(e.args[0]) + '\n')
+                sys.stderr.write(str(e.code) + '\n')
                 exitcode = 1
         except:
             exitcode = 1

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -857,11 +857,12 @@ class _TestSubclassingProcess(BaseTestCase):
             ]
 
         for args, expected in cases:
-            p = self.Process(target=sys.exit, args=args)
-            p.daemon = True
-            p.start()
-            join_process(p)
-            self.assertEqual(p.exitcode, expected)
+            with self.subTest(args=args):
+                p = self.Process(target=sys.exit, args=args)
+                p.daemon = True
+                p.start()
+                join_process(p)
+                self.assertEqual(p.exitcode, expected)
 
 #
 #

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -848,19 +848,20 @@ class _TestSubclassingProcess(BaseTestCase):
 
             os.unlink(testfn)
 
-        for reason in (True, False, 8):
-            p = self.Process(target=sys.exit, args=(reason,))
-            p.daemon = True
-            p.start()
-            join_process(p)
-            self.assertEqual(p.exitcode, reason)
+        cases = [
+            ((True,), 1),
+            ((False,), 0),
+            ((8,), 8),
+            ((None,), 0),
+            ((), 0),
+            ]
 
-        for args in ((None,), (),):
+        for args, expected in cases:
             p = self.Process(target=sys.exit, args=args)
             p.daemon = True
             p.start()
             join_process(p)
-            self.assertEqual(p.exitcode, 0)
+            self.assertEqual(p.exitcode, expected)
 
 #
 #

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -855,6 +855,13 @@ class _TestSubclassingProcess(BaseTestCase):
             join_process(p)
             self.assertEqual(p.exitcode, reason)
 
+        for args in ((None,), (),):
+            p = self.Process(target=sys.exit, args=args)
+            p.daemon = True
+            p.start()
+            join_process(p)
+            self.assertEqual(p.exitcode, 0)
+
 #
 #
 #

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -735,6 +735,7 @@ Lawrence Hudson
 Michael Hudson
 Jim Hugunin
 Greg Humphreys
+Chris Hunt
 Eric Huss
 Nehal Hussain
 Taihyun Hwang

--- a/Misc/NEWS.d/next/Library/2019-01-12-20-39-34.bpo-35727.FWrbHn.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-12-20-39-34.bpo-35727.FWrbHn.rst
@@ -1,0 +1,1 @@
+Fix sys.exit() and sys.exit(None) exit code propagation when used in multiprocessing.Process.


### PR DESCRIPTION
<!-- issue-number: [bpo-35727](https://bugs.python.org/issue35727) -->
https://bugs.python.org/issue35727
<!-- /issue-number -->
