### PR TITLE
Add whitespace before asterisk for consistency

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1190,7 +1190,7 @@ compiler_add_o(struct compiler *c, PyObject *dict, PyObject *o)
 }
 
 // Merge const *o* recursively and return constant key object.
-static PyObject*
+static PyObject *
 merge_consts_recursive(struct compiler *c, PyObject *o)
 {
     // None and Ellipsis are singleton, and key is the singleton.


### PR DESCRIPTION
Minor formatting improvement. Whitespace usually precedes asterisk.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
