### PR TITLE
bpo-35730: Disable IDLE test_reload assertion.

### DIFF
--- a/Lib/idlelib/idle_test/test_squeezer.py
+++ b/Lib/idlelib/idle_test/test_squeezer.py
@@ -307,7 +307,9 @@ class SqueezerTest(unittest.TestCase):
             str(new_auto_squeeze_min_lines))
 
         Squeezer.reload()
-        self.assertGreater(squeezer.zero_char_width, orig_zero_char_width)
+        # The following failed on Gentoo buildbots.  Issue title will be
+        # IDLE: Fix squeezer test_reload.
+        #self.assertGreater(squeezer.zero_char_width, orig_zero_char_width)
         self.assertEqual(squeezer.auto_squeeze_min_lines,
                          new_auto_squeeze_min_lines)
 


### PR DESCRIPTION
IDLE's test_squeezer.SqueezerTest.test_reload, added for issue 35196,
failed on both Gentoo buildbots.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35730](https://bugs.python.org/issue35730) -->
https://bugs.python.org/issue35730
<!-- /issue-number -->
