### PR TITLE
bpo-24780:  unittest assertEqual difference output foiled by newlines

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1238,6 +1238,11 @@ class TestCase(object):
             msg = self._formatMessage(msg, standardMsg)
             self.fail(msg)
 
+    def addTrailingNewLine(self, line):
+        if line != '' and line[-1] != '\n':
+            line = line + '\n'
+        return line
+
     def assertMultiLineEqual(self, first, second, msg=None):
         """Assert that two multi-line strings are equal."""
         self.assertIsInstance(first, str, 'First argument is not a string')
@@ -1248,13 +1253,16 @@ class TestCase(object):
             if (len(first) > self._diffThreshold or
                 len(second) > self._diffThreshold):
                 self._baseAssertEqual(first, second, msg)
-            firstlines = first.splitlines(keepends=True)
+            firstlines = first.splitlines(keepends=True) 
             secondlines = second.splitlines(keepends=True)
             if len(firstlines) == 1 and first.strip('\r\n') == first:
                 firstlines = [first + '\n']
                 secondlines = [second + '\n']
             standardMsg = '%s != %s' % _common_shorten_repr(first, second)
-            diff = '\n' + ''.join(difflib.ndiff(firstlines, secondlines))
+            difflines = list(difflib.ndiff(firstlines, secondlines))
+            if len(difflines) > 1:
+                difflines = [self.addTrailingNewLine(line) for line in difflines]
+            diff = '\n' + ''.join(difflines)
             standardMsg = self._truncateMessage(standardMsg, diff)
             self.fail(self._formatMessage(msg, standardMsg))
 

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1253,7 +1253,7 @@ class TestCase(object):
             if (len(first) > self._diffThreshold or
                 len(second) > self._diffThreshold):
                 self._baseAssertEqual(first, second, msg)
-            firstlines = first.splitlines(keepends=True) 
+            firstlines = first.splitlines(keepends=True)
             secondlines = second.splitlines(keepends=True)
             if len(firstlines) == 1 and first.strip('\r\n') == first:
                 firstlines = [first + '\n']

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -1839,5 +1839,20 @@ test case
             self.assertEqual(MyException.ninstance, 0)
 
 
+class testAssertEqualSingleLine(unittest.TestCase):
+
+    def test_trailing_new_line_at_end(self):
+        self.assertEqual("abc\n", "abc\n")
+    def test_trailing_space_at_end(self):
+        self.assertEqual("abc ", "abc ")
+    def test_no_trailing_new_line(self):
+        self.assertEqual("abc", "abc")
+    def test_new_line_at_beginning(self):
+        self.assertEqual("\nabc", "\nabc")
+    def test_new_line_at_start_and_end(self):
+        self.assertEqual("\nabc\n", "\nabc\n")
+    def test_with_space_at_start_and_end(self):
+        self.assertEqual(" abc ", " abc ")
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2019-01-16-09-11-29.bpo-24780.69AB4h.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-16-09-11-29.bpo-24780.69AB4h.rst
@@ -1,0 +1,1 @@
+unittest assertEqual difference output now not foiled by newlines.


### PR DESCRIPTION
I have created a fix for this issue and relevant tests.

<!-- issue-number: [bpo-24780](https://bugs.python.org/issue24780) -->
https://bugs.python.org/issue24780
<!-- /issue-number -->
