### PR TITLE
bpo-35732: Fix typo in documentation (library/warnings).

### DIFF
--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -400,7 +400,7 @@ Available Functions
    in which case *category* will be ignored and ``message.__class__`` will be used.
    In this case the message text will be ``str(message)``. This function raises an
    exception if the particular warning issued is changed into an error by the
-   warnings filter see above.  The *stacklevel* argument can be used by wrapper
+   warnings filter (see above).  The *stacklevel* argument can be used by wrapper
    functions written in Python, like this::
 
       def deprecation(message):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35732](https://bugs.python.org/issue35732) -->
https://bugs.python.org/issue35732
<!-- /issue-number -->
