### PR TITLE
bpo-34323: Enhance IocpProactor.close() log

### DIFF
--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -812,7 +812,7 @@ class IocpProactor:
         while self._cache:
             if next_msg <= time.monotonic():
                 logger.debug('IocpProactor.close(): '
-                             'loop is still running since %.1f sec',
+                             'loop is running after closing for %.1f seconds',
                              time.monotonic() - start_time)
                 next_msg = time.monotonic() + msg_update
 

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -7,6 +7,7 @@ import math
 import msvcrt
 import socket
 import struct
+import time
 import weakref
 
 from . import events
@@ -802,10 +803,21 @@ class IocpProactor:
                             context['source_traceback'] = fut._source_traceback
                         self._loop.call_exception_handler(context)
 
-        # wait until all cancelled overlapped future complete
+        # Wait until all cancelled overlapped complete: don't exit with running
+        # overlapped to prevent a crash. Display progress every second if the
+        # loop is still running.
+        msg_update = 1.0
+        start_time = time.monotonic()
+        next_msg = start_time + msg_update
         while self._cache:
-            if not self._poll(1):
-                logger.debug('taking long time to close proactor')
+            if next_msg <= time.monotonic():
+                logger.debug('IocpProactor.close(): '
+                             'loop is still running since %.1f sec',
+                             time.monotonic() - start_time)
+                next_msg = time.monotonic() + msg_update
+
+            # handle a few events, or timeout
+            self._poll(msg_update)
 
         self._results = []
 

--- a/Misc/NEWS.d/next/Library/2019-01-14-17-34-36.bpo-34323.CRErrt.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-14-17-34-36.bpo-34323.CRErrt.rst
@@ -1,0 +1,3 @@
+:mod:`asyncio`: Enhance ``IocpProactor.close()`` log: wait 1 second before
+the first log, then log every second. Log also the number of seconds since
+``close()`` was called.


### PR DESCRIPTION
IocpProactor.close() now uses time to decide when to log: wait 1
second before the first log, then log every second. Log also the
number of seconds since close() is running.

<!-- issue-number: [bpo-34323](https://bugs.python.org/issue34323) -->
https://bugs.python.org/issue34323
<!-- /issue-number -->
