### PR TITLE
bpo-35742: Fix test_envar_unimportable in test_builtin.

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1608,6 +1608,7 @@ class TestBreakpoint(unittest.TestCase):
     def test_envar_unimportable(self):
         for envar in (
                 '.', '..', '.foo', 'foo.', '.int', 'int.',
+                '.foo.bar', '..foo.bar', '/./',
                 'nosuchbuiltin',
                 'nosuchmodule.nosuchcallable',
                 ):


### PR DESCRIPTION
Handle the case of an empty module name in PYTHONBREAKPOINT.

Fixes a regression introduced in [bpo-34756](https://bugs.python.org/issue34756).

<!-- issue-number: [bpo-35742](https://bugs.python.org/issue35742) -->
https://bugs.python.org/issue35742
<!-- /issue-number -->
