### PR TITLE
bpo-11555: Enhance IocpProactor.close() log again

### DIFF
--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -811,9 +811,8 @@ class IocpProactor:
         next_msg = start_time + msg_update
         while self._cache:
             if next_msg <= time.monotonic():
-                logger.debug('IocpProactor.close(): '
-                             'loop is running after closing for %.1f seconds',
-                             time.monotonic() - start_time)
+                logger.debug('%r is running after closing for %.1f seconds',
+                             self, time.monotonic() - start_time)
                 next_msg = time.monotonic() + msg_update
 
             # handle a few events, or timeout


### PR DESCRIPTION
Add repr(self) to the log to display the number of pending overlapped
in the log.

<!-- issue-number: [bpo-11555](https://bugs.python.org/issue11555) -->
https://bugs.python.org/issue11555
<!-- /issue-number -->
