### PR TITLE
bpo-23846: Fix ProactorEventLoop._write_to_self()

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -636,7 +636,13 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
             f.add_done_callback(self._loop_self_reading)
 
     def _write_to_self(self):
-        self._csock.send(b'\0')
+        try:
+            self._csock.send(b'\0')
+        except OSError:
+            if self._debug:
+                logger.debug("Fail to write a null byte into the "
+                             "self-pipe socket",
+                             exc_info=True)
 
     def _start_serving(self, protocol_factory, sock,
                        sslcontext=None, server=None, backlog=100,

--- a/Misc/NEWS.d/next/Library/2019-01-15-13-31-30.bpo-23846.LT_qL8.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-15-13-31-30.bpo-23846.LT_qL8.rst
@@ -1,0 +1,2 @@
+:class:`asyncio.ProactorEventLoop` now catchs and logs send errors when the
+self-pipe is full.


### PR DESCRIPTION
asyncio.ProactorEventLoop now catchs and logs send errors when the
self-pipe is full: BaseProactorEventLoop._write_to_self() now catchs
and logs OSError exceptions, as done by
BaseSelectorEventLoop._write_to_self().

<!-- issue-number: [bpo-23846](https://bugs.python.org/issue23846) -->
https://bugs.python.org/issue23846
<!-- /issue-number -->
