### PR TITLE
bpo-35701: Added '__weakref__' to UUID __slots__ list to prevent regression.

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -9,6 +9,7 @@ import pickle
 import shutil
 import subprocess
 import sys
+import weakref
 from unittest import mock
 
 py_uuid = support.import_fresh_module('uuid', blocked=['_uuid'])
@@ -657,6 +658,10 @@ class BaseTestUUID:
 
             self.assertNotEqual(parent_value, child_value)
 
+    def test_uuid_weakref(self):
+        strong = self.uuid.uuid4()
+        weak = weakref.ref(strong)
+        assert strong is weak()
 
 class TestUUIDWithoutExtModule(BaseTestUUID, unittest.TestCase):
     uuid = py_uuid

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -658,6 +658,7 @@ class BaseTestUUID:
 
             self.assertNotEqual(parent_value, child_value)
 
+    # bpo-35701: check that weak referencing to a UUID object can be created
     def test_uuid_weakref(self):
         strong = self.uuid.uuid4()
         weak = weakref.ref(strong)

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -658,11 +658,11 @@ class BaseTestUUID:
 
             self.assertNotEqual(parent_value, child_value)
 
-    # bpo-35701: check that weak referencing to a UUID object can be created
     def test_uuid_weakref(self):
+        # bpo-35701: check that weak referencing to a UUID object can be created
         strong = self.uuid.uuid4()
         weak = weakref.ref(strong)
-        assert strong is weak()
+        self.assertIs(strong, weak())
 
 class TestUUIDWithoutExtModule(BaseTestUUID, unittest.TestCase):
     uuid = py_uuid

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -118,7 +118,7 @@ class UUID:
                     uuid_generate_time_safe(3).
     """
 
-    __slots__ = 'int', 'is_safe', '__weakref__'
+    __slots__ = ('int', 'is_safe', '__weakref__')
 
     def __init__(self, hex=None, bytes=None, bytes_le=None, fields=None,
                        int=None, version=None,

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -118,7 +118,7 @@ class UUID:
                     uuid_generate_time_safe(3).
     """
 
-    __slots__ = ('int', 'is_safe')
+    __slots__ = 'int', 'is_safe', '__weakref__'
 
     def __init__(self, hex=None, bytes=None, bytes_le=None, fields=None,
                        int=None, version=None,

--- a/Misc/NEWS.d/next/Library/2019-01-15-17-45-45.bpo-35701.KFYngZ.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-15-17-45-45.bpo-35701.KFYngZ.rst
@@ -1,0 +1,1 @@
+Re-enable the ability to weakly reference a UUID object.

--- a/Misc/NEWS.d/next/Library/2019-01-15-17-45-45.bpo-35701.KFYngZ.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-15-17-45-45.bpo-35701.KFYngZ.rst
@@ -1,1 +1,0 @@
-Re-enable the ability to weakly reference a UUID object.


### PR DESCRIPTION
UUID objects don't currently allow for weak referencing with their new __slots__ implementation. This would cause regressions if people using weak referencing on these objects were to upgrade Python version. Also added a basic regression test that fails without the change implemented.

This is my first PR to cpython, so please let me know if there is something I forgot to do!


<!-- issue-number: [bpo-35701](https://bugs.python.org/issue35701) -->
https://bugs.python.org/issue35701
<!-- /issue-number -->
