### PR TITLE
bpo-35537: subprocess can use posix_spawn with pipes

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -280,8 +280,8 @@ Optimizations
   and Linux (using glibc 2.24 or newer) if all these conditions are met:
 
   * *close_fds* is false;
-  * *preexec_fn*, *pass_fds*, *cwd*, *stdin*, *stdout*, *stderr* and
-    *start_new_session* parameters are not set;
+  * *preexec_fn*, *pass_fds*, *cwd* and *start_new_session* parameters
+    are not set;
   * the *executable* path contains a directory.
 
 * :func:`shutil.copyfile`, :func:`shutil.copy`, :func:`shutil.copy2`,


### PR DESCRIPTION
* subprocess.Popen can now also use os.posix_spawn() with pipes if
  pipe file descriptors are greater than 2.
* Fix Popen._posix_spawn(): set _child_created to True.
* Add Popen._close_pipe_fds() helper function to factorize the code.

<!-- issue-number: [bpo-35537](https://bugs.python.org/issue35537) -->
https://bugs.python.org/issue35537
<!-- /issue-number -->
