### PR TITLE
bpo-34148: Dont log exception traceback when TimeoutError is occurred in asyncio transports

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -59,7 +59,8 @@ _MIN_CANCELLED_TIMER_HANDLES_FRACTION = 0.5
 # Exceptions which must not call the exception handler in fatal error
 # methods (_fatal_error())
 _FATAL_ERROR_IGNORE = (BrokenPipeError,
-                       ConnectionResetError, ConnectionAbortedError)
+                       ConnectionResetError, ConnectionAbortedError,
+                       TimeoutError)
 
 if ssl is not None:
     _FATAL_ERROR_IGNORE = _FATAL_ERROR_IGNORE + (ssl.SSLCertVerificationError,)

--- a/Misc/NEWS.d/next/Library/2019-01-16-09-55-05.bpo-34148.J5A1QC.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-16-09-55-05.bpo-34148.J5A1QC.rst
@@ -1,0 +1,2 @@
+Don't log exception traceback when :exc:`TimeoutError` is occurred in
+asyncio transport.


### PR DESCRIPTION
The exception is normal behavior, `ETIMEDOUT` can be set by NAT gateways and IP bridge hardware for example.

<!-- issue-number: [bpo-34148](https://bugs.python.org/issue34148) -->
https://bugs.python.org/issue34148
<!-- /issue-number -->
