### PR TITLE
bpo-35749: Don't log exception if event loop wakeup pipe is full

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -490,7 +490,7 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         proactor.set_loop(self)
         self._make_self_pipe()
         self_no = self._csock.fileno()
-        signal.set_wakeup_fd(self_no)
+        signal.set_wakeup_fd(self_no, warn_on_full_buffer=False)
 
     def _make_socket_transport(self, sock, protocol, waiter=None,
                                extra=None, server=None):
@@ -639,10 +639,9 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         try:
             self._csock.send(b'\0')
         except OSError:
-            if self._debug:
-                logger.debug("Fail to write a null byte into the "
-                             "self-pipe socket",
-                             exc_info=True)
+            # Ignore the error,
+            # See https://bugs.python.org/issue35749
+            pass
 
     def _start_serving(self, protocol_factory, sock,
                        sslcontext=None, server=None, backlog=100,

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -105,7 +105,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         self._internal_fds += 1
         self._add_reader(self._ssock.fileno(), self._read_from_self)
 
-    def _process_self_data(self, data):
+    def _process_self_data(self):
         pass
 
     def _read_from_self(self):
@@ -114,7 +114,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
                 data = self._ssock.recv(4096)
                 if not data:
                     break
-                self._process_self_data(data)
+                self._process_self_data()
             except InterruptedError:
                 continue
             except BlockingIOError:
@@ -131,10 +131,9 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
             try:
                 csock.send(b'\0')
             except OSError:
-                if self._debug:
-                    logger.debug("Fail to write a null byte into the "
-                                 "self-pipe socket",
-                                 exc_info=True)
+                # Ignore the error,
+                # See https://bugs.python.org/issue35749
+                pass
 
     def _start_serving(self, protocol_factory, sock,
                        sslcontext=None, server=None, backlog=100,

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -109,16 +109,20 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         pass
 
     def _read_from_self(self):
+        wakeup = False
         while True:
             try:
                 data = self._ssock.recv(4096)
                 if not data:
                     break
-                self._process_self_data()
+                else:
+                    wakeup = True
             except InterruptedError:
                 continue
             except BlockingIOError:
                 break
+        if wakeup:
+            self._process_self_data()
 
     def _write_to_self(self):
         # This may be called from a different thread, possibly after

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -114,9 +114,11 @@ class SelectorEventLoopSignalTests(test_utils.TestCase):
         m_signal.NSIG = signal.NSIG
         m_signal.valid_signals = signal.valid_signals
 
-        def set_wakeup_fd(fd):
+        def set_wakeup_fd(fd, *, warn_on_full_buffer=True):
             if fd == -1:
                 raise ValueError()
+            else:
+                self.assertFalse(warn_on_full_buffer)
         m_signal.set_wakeup_fd = set_wakeup_fd
 
         class Err(OSError):

--- a/Misc/NEWS.d/next/Library/2019-01-16-11-45-55.bpo-35749.AfgbrZ.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-16-11-45-55.bpo-35749.AfgbrZ.rst
@@ -1,0 +1,1 @@
+Don't log exception if event loop wakeup pipe is full


### PR DESCRIPTION


<!-- issue-number: [bpo-35749](https://bugs.python.org/issue35749) -->
https://bugs.python.org/issue35749
<!-- /issue-number -->
