### PR TITLE
Fixes typo in asyncio.queue doc

### DIFF
--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -64,7 +64,7 @@ Queue
       Block until all items in the queue have been received and processed.
 
       The count of unfinished tasks goes up whenever an item is added
-      to the queue. The count goes down whenever a consumer thread calls
+      to the queue. The count goes down whenever a consumer coroutine calls
       :meth:`task_done` to indicate that the item was retrieved and all
       work on it is complete.  When the count of unfinished tasks drops
       to zero, :meth:`join` unblocks.


### PR DESCRIPTION
Typo fix for method doc, I'm pretty sure coro is meant, because there's no consumer threads for thread-unsafe queue.

Most probably this piece of doc was copied from `queue.Queue`

There's not BPO bug for this, afaik.