### PR TITLE
Revert "bpo-35537: subprocess can now use os.posix_spawnp (GH-11579)"

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -281,7 +281,8 @@ Optimizations
 
   * *close_fds* is false;
   * *preexec_fn*, *pass_fds*, *cwd*, *stdin*, *stdout*, *stderr* and
-    *start_new_session* parameters are not set.
+    *start_new_session* parameters are not set;
+  * the *executable* path contains a directory.
 
 * :func:`shutil.copyfile`, :func:`shutil.copy`, :func:`shutil.copy2`,
   :func:`shutil.copytree` and :func:`shutil.move` use platform-specific

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -655,7 +655,6 @@ def _use_posix_spawn():
 
 
 _USE_POSIX_SPAWN = _use_posix_spawn()
-_HAVE_POSIX_SPAWNP = hasattr(os, 'posix_spawnp')
 
 
 class Popen(object):
@@ -1443,10 +1442,7 @@ class Popen(object):
 
 
         def _posix_spawn(self, args, executable, env, restore_signals):
-            """Execute program using os.posix_spawnp().
-
-            Or use os.posix_spawn() if os.posix_spawnp() is not available.
-            """
+            """Execute program using os.posix_spawn()."""
             if env is None:
                 env = os.environ
 
@@ -1460,10 +1456,7 @@ class Popen(object):
                         sigset.append(signum)
                 kwargs['setsigdef'] = sigset
 
-            if _HAVE_POSIX_SPAWNP:
-                self.pid = os.posix_spawnp(executable, args, env, **kwargs)
-            else:
-                self.pid = os.posix_spawn(executable, args, env, **kwargs)
+            self.pid = os.posix_spawn(executable, args, env, **kwargs)
 
         def _execute_child(self, args, executable, preexec_fn, close_fds,
                            pass_fds, cwd, env,
@@ -1491,7 +1484,7 @@ class Popen(object):
                 executable = args[0]
 
             if (_USE_POSIX_SPAWN
-                    and (_HAVE_POSIX_SPAWNP or os.path.dirname(executable))
+                    and os.path.dirname(executable)
                     and preexec_fn is None
                     and not close_fds
                     and not pass_fds

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -612,8 +612,7 @@ def collect_get_config(info_add):
 
 def collect_subprocess(info_add):
     import subprocess
-    attrs = ('_USE_POSIX_SPAWN', '_HAVE_POSIX_SPAWNP')
-    copy_attributes(info_add, subprocess, 'subprocess.%s', attrs)
+    copy_attributes(info_add, subprocess, 'subprocess.%s', ('_USE_POSIX_SPAWN',))
 
 
 def collect_info(info):


### PR DESCRIPTION
This reverts commit 07858894689047c77f9c12ddc061d30681368d19.

<!-- issue-number: [bpo-35537](https://bugs.python.org/issue35537) -->
https://bugs.python.org/issue35537
<!-- /issue-number -->
