### PR TITLE
bpo-35755: Remove current directory from posixpath.defpath

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -18,7 +18,7 @@ pardir = '..'
 extsep = '.'
 sep = '/'
 pathsep = ':'
-defpath = ':/bin:/usr/bin'
+defpath = '/bin:/usr/bin'
 altsep = None
 devnull = '/dev/null'
 

--- a/Misc/NEWS.d/next/Security/2019-01-17-10-03-48.bpo-35755.GmllIs.rst
+++ b/Misc/NEWS.d/next/Security/2019-01-17-10-03-48.bpo-35755.GmllIs.rst
@@ -1,0 +1,5 @@
+:func:`shutil.which` now uses ``os.confstr("CS_PATH")`` if available and if the
+:envvar:`PATH` environment variable is not set. Remove also the current
+directory from :data:`posixpath.defpath`. On Unix, :func:`shutil.which` and the
+:mod:`subprocess` module no longer search the executable in the current
+directory if the :envvar:`PATH` environment variable is not set.


### PR DESCRIPTION
Document the change in a NEWS entry of the Security category.

<!-- issue-number: [bpo-35755](https://bugs.python.org/issue35755) -->
https://bugs.python.org/issue35755
<!-- /issue-number -->
