### PR TITLE
gh-79940: add introspection API for asynchronous generators

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -1439,8 +1439,8 @@ code execution::
            pass
 
 
-Current State of Generators and Coroutines
-------------------------------------------
+Current State of Generators, Coroutines, and Asynchronous Generators
+--------------------------------------------------------------------
 
 When implementing coroutine schedulers and for other advanced uses of
 generators, it is useful to determine whether a generator is currently
@@ -1475,6 +1475,22 @@ generator to be determined easily.
 
    .. versionadded:: 3.5
 
+.. function:: getasyncgenstate(agen)
+
+   Get current state of an asynchronous generator object.  The function is
+   intended to be used with asynchronous iterator objects created by
+   :keyword:`async def` functions which use the :keyword:`yield` statement,
+   but will accept any asynchronous generator-like object that has
+   ``ag_running`` and ``ag_frame`` attributes.
+
+   Possible states are:
+    * AGEN_CREATED: Waiting to start execution.
+    * AGEN_RUNNING: Currently being executed by the interpreter.
+    * AGEN_SUSPENDED: Currently suspended at a yield expression.
+    * AGEN_CLOSED: Execution has completed.
+
+   .. versionadded:: 3.12
+
 The current internal state of the generator can also be queried. This is
 mostly useful for testing purposes, to ensure that internal state is being
 updated as expected:
@@ -1505,6 +1521,14 @@ updated as expected:
    works for coroutine objects created by :keyword:`async def` functions.
 
    .. versionadded:: 3.5
+
+.. function:: getasyncgenlocals(agen)
+
+   This function is analogous to :func:`~inspect.getgeneratorlocals`, but
+   works for asynchronous generator objects created by :keyword:`async def`
+   functions which use the :keyword:`yield` statement.
+
+   .. versionadded:: 3.12
 
 
 .. _inspect-module-co-flags:

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -242,6 +242,10 @@ inspect
   a :term:`coroutine` for use with :func:`iscoroutinefunction`.
   (Contributed Carlton Gibson in :gh:`99247`.)
 
+* Add :func:`inspect.getasyncgenstate` and :func:`inspect.getasyncgenlocals`
+  for determining the current state of asynchronous generators.
+  (Contributed by Thomas Krennwallner in :gh:`11590`.)
+
 pathlib
 -------
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -244,7 +244,7 @@ inspect
 
 * Add :func:`inspect.getasyncgenstate` and :func:`inspect.getasyncgenlocals`
   for determining the current state of asynchronous generators.
-  (Contributed by Thomas Krennwallner in :gh:`11590`.)
+  (Contributed by Thomas Krennwallner in :issue:`35759`.)
 
 pathlib
 -------

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1976,7 +1976,7 @@ def getasyncgenlocals(agen):
     bound values."""
 
     if not isasyncgen(agen):
-        raise TypeError("{!r} is not a Python async generator".format(agen))
+        raise TypeError(f"{agen!r} is not a Python async generator")
 
     frame = getattr(agen, "ag_frame", None)
     if frame is not None:

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -34,6 +34,10 @@ __author__ = ('Ka-Ping Yee <ping@lfw.org>',
               'Yury Selivanov <yselivanov@sprymix.com>')
 
 __all__ = [
+    "AGEN_CLOSED",
+    "AGEN_CREATED",
+    "AGEN_RUNNING",
+    "AGEN_SUSPENDED",
     "ArgInfo",
     "Arguments",
     "Attribute",
@@ -77,6 +81,8 @@ __all__ = [
     "getabsfile",
     "getargs",
     "getargvalues",
+    "getasyncgenlocals",
+    "getasyncgenstate",
     "getattr_static",
     "getblock",
     "getcallargs",
@@ -1931,6 +1937,50 @@ def getcoroutinelocals(coroutine):
     frame = getattr(coroutine, "cr_frame", None)
     if frame is not None:
         return frame.f_locals
+    else:
+        return {}
+
+
+# ----------------------------------- asynchronous generator introspection
+
+AGEN_CREATED = 'AGEN_CREATED'
+AGEN_RUNNING = 'AGEN_RUNNING'
+AGEN_SUSPENDED = 'AGEN_SUSPENDED'
+AGEN_CLOSED = 'AGEN_CLOSED'
+
+
+def getasyncgenstate(agen):
+    """Get current state of an asynchronous generator object.
+
+    Possible states are:
+      AGEN_CREATED: Waiting to start execution.
+      AGEN_RUNNING: Currently being executed by the interpreter.
+      AGEN_SUSPENDED: Currently suspended at a yield expression.
+      AGEN_CLOSED: Execution has completed.
+    """
+    if agen.ag_running:
+        return AGEN_RUNNING
+    if agen.ag_suspended:
+        return AGEN_SUSPENDED
+    if agen.ag_frame is None:
+        return AGEN_CLOSED
+    return AGEN_CREATED
+
+
+def getasyncgenlocals(agen):
+    """
+    Get the mapping of asynchronous generator local variables to their current
+    values.
+
+    A dict is returned, with the keys the local variable names and values the
+    bound values."""
+
+    if not isasyncgen(agen):
+        raise TypeError("{!r} is not a Python async generator".format(agen))
+
+    frame = getattr(agen, "ag_frame", None)
+    if frame is not None:
+        return agen.ag_frame.f_locals
     else:
         return {}
 

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -2343,7 +2343,7 @@ class TestGetAsyncGenState(unittest.TestCase):
 
     def test_suspended(self):
         try:
-            next(self.asyncgen.__anext__())
+            next(anext(self.asyncgen))
         except StopIteration as exc:
             self.assertEqual(self._asyncgenstate(), inspect.AGEN_SUSPENDED)
             self.assertEqual(exc.args, (0,))
@@ -2351,7 +2351,7 @@ class TestGetAsyncGenState(unittest.TestCase):
     def test_closed_after_exhaustion(self):
         while True:
             try:
-                next(self.asyncgen.__anext__())
+                next(anext(self.asyncgen))
             except StopAsyncIteration:
                 self.assertEqual(self._asyncgenstate(), inspect.AGEN_CLOSED)
                 break
@@ -2375,12 +2375,12 @@ class TestGetAsyncGenState(unittest.TestCase):
         self.asyncgen = running_check_asyncgen()
         # Running up to the first yield
         try:
-            next(self.asyncgen.__anext__())
+            next(anext(self.asyncgen))
         except StopIteration:
             pass
         # Running after the first yield
         try:
-            next(self.asyncgen.__anext__())
+            next(anext(self.asyncgen))
         except StopIteration:
             pass
 
@@ -2404,28 +2404,28 @@ class TestGetAsyncGenState(unittest.TestCase):
         self.assertEqual(inspect.getasyncgenlocals(numbers),
                          {'a': None, 'lst': [1, 2, 3]})
         try:
-            next(numbers.__anext__())
+            next(anext(numbers))
         except StopIteration:
             pass
         self.assertEqual(inspect.getasyncgenlocals(numbers),
                          {'a': None, 'lst': [1, 2, 3], 'v': 1,
                           'b': (1, 2, 3)})
         try:
-            next(numbers.__anext__())
+            next(anext(numbers))
         except StopIteration:
             pass
         self.assertEqual(inspect.getasyncgenlocals(numbers),
                          {'a': None, 'lst': [1, 2, 3], 'v': 2,
                           'b': (1, 2, 3)})
         try:
-            next(numbers.__anext__())
+            next(anext(numbers))
         except StopIteration:
             pass
         self.assertEqual(inspect.getasyncgenlocals(numbers),
                          {'a': None, 'lst': [1, 2, 3], 'v': 3,
                           'b': (1, 2, 3), 'c': 12})
         try:
-            next(numbers.__anext__())
+            next(anext(numbers))
         except StopAsyncIteration:
             pass
         self.assertEqual(inspect.getasyncgenlocals(numbers), {})
@@ -2436,12 +2436,12 @@ class TestGetAsyncGenState(unittest.TestCase):
         one = yield_one()
         self.assertEqual(inspect.getasyncgenlocals(one), {})
         try:
-            next(one.__anext__())
+            next(anext(one))
         except StopIteration:
             pass
         self.assertEqual(inspect.getasyncgenlocals(one), {})
         try:
-            next(one.__anext__())
+            next(anext(one))
         except StopAsyncIteration:
             pass
         self.assertEqual(inspect.getasyncgenlocals(one), {})

--- a/Misc/NEWS.d/next/Library/2023-02-26-17-29-57.gh-issue-79940.SAfmAy.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-26-17-29-57.gh-issue-79940.SAfmAy.rst
@@ -1,0 +1,2 @@
+Add :func:`inspect.getasyncgenstate` and :func:`inspect.getasyncgenlocals`.
+Patch by Thomas Krennwallner.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1552,6 +1552,15 @@ ag_getcode(PyGenObject *gen, void *Py_UNUSED(ignored))
     return _gen_getcode(gen, "ag__code");
 }
 
+static PyObject *
+ag_getsuspended(PyAsyncGenObject *ag, void *Py_UNUSED(ignored))
+{
+    if (ag->ag_frame_state == FRAME_SUSPENDED) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
 static PyGetSetDef async_gen_getsetlist[] = {
     {"__name__", (getter)gen_get_name, (setter)gen_set_name,
      PyDoc_STR("name of the async generator")},
@@ -1561,6 +1570,7 @@ static PyGetSetDef async_gen_getsetlist[] = {
      PyDoc_STR("object being awaited on, or None")},
      {"ag_frame",  (getter)ag_getframe, NULL, NULL},
      {"ag_code",  (getter)ag_getcode, NULL, NULL},
+     {"ag_suspended",  (getter)ag_getsuspended, NULL, NULL},
     {NULL} /* Sentinel */
 };
 


### PR DESCRIPTION
The `inspect` module does not contain functions for determining the current state of asynchronous generators. That is, there is no introspection API for asynchronous generators that match the API for generators and coroutines: https://docs.python.org/3.8/library/inspect.html#current-state-of-generators-and-coroutines.

The functions `inspect.getasyncgenstate` and `inspect.getasyncgenlocals` allow to determine the current state of asynchronous generators and mirror the introspection API for generators and coroutines.

https://bugs.python.org/issue35759

<!-- issue-number: [bpo-35759](https://bugs.python.org/issue35759) -->
https://bugs.python.org/issue35759
<!-- /issue-number -->


<!-- gh-issue-number: gh-79940 -->
* Issue: gh-79940
<!-- /gh-issue-number -->
