### PR TITLE
bpo-35752: Fix memoryview for floats on ppc64

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-01-17-15-25-49.bpo-35752.IrKL6f.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-01-17-15-25-49.bpo-35752.IrKL6f.rst
@@ -1,0 +1,2 @@
+Fix memoryview on 64-bit PowerPC for floats: workaround a GCC bug when a
+64-bit double is casted to a 32-bit float followed by memcpy().

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1836,7 +1836,15 @@ pack_single(char *ptr, PyObject *item, const char *fmt)
         if (d == -1.0 && PyErr_Occurred())
             goto err_occurred;
         if (fmt[0] == 'f') {
+#if defined(__GNUC__) && defined(__powerpc64__)
+            /* bpo-35752: Workaround GCC bug on PPC64 using volatile:
+             * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88892*/
+            volatile float x;
+            x = (float)d;
+            memcpy(ptr, (char *)&x, sizeof x);
+#else
             PACK_SINGLE(ptr, d, float);
+#endif
         }
         else {
             PACK_SINGLE(ptr, d, double);


### PR DESCRIPTION
Fix memoryview on 64-bit PowerPC for floats: workaround a GCC bug
when a 64-bit double is casted to a 32-bit float followed by
memcpy().

The memoryview pack_single() function is miscompiled by GCC 8.2.1 on
PowerPC 64. Pseudo-code:

    void
    f (double d, char *target)
    {
      float f = d;
      __builtin_memcpy (target, &f, sizeof (f));
    }

When optimizations are enabled (-Og or -O1 at least), GCC rounds
towards zero rather than rounding to nearest:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88892

Use the volatile keyword to prevent the optimization which uses the
wrong rounding mode.

<!-- issue-number: [bpo-35752](https://bugs.python.org/issue35752) -->
https://bugs.python.org/issue35752
<!-- /issue-number -->
