### PR TITLE
bpo-35767: Fix unittest.loader to allow partials as test_functions [3.7]

### DIFF
--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -229,7 +229,9 @@ class TestLoader(object):
             testFunc = getattr(testCaseClass, attrname)
             if not callable(testFunc):
                 return False
-            fullName = '%s.%s' % (testCaseClass.__module__, testFunc.__qualname__)
+            fullName = f'%s.%s.%s' % (
+                testCaseClass.__module__, testCaseClass.__qualname__, attrname
+            )
             return self.testNamePatterns is None or \
                 any(fnmatchcase(fullName, pattern) for pattern in self.testNamePatterns)
         testFnNames = list(filter(shouldIncludeMethod, dir(testCaseClass)))

--- a/Lib/unittest/test/test_loader.py
+++ b/Lib/unittest/test/test_loader.py
@@ -1,3 +1,4 @@
+import functools
 import sys
 import types
 import warnings
@@ -1573,6 +1574,22 @@ class Test_TestLoader(unittest.TestCase):
     def test_suiteClass__default_value(self):
         loader = unittest.TestLoader()
         self.assertIs(loader.suiteClass, unittest.TestSuite)
+
+
+    def test_partial_functions(self):
+        def noop(arg):
+            pass
+
+        class Foo(unittest.TestCase):
+            pass
+
+        setattr(Foo, 'test_partial', functools.partial(noop, None))
+
+        loader = unittest.TestLoader()
+
+        test_names = ['test_partial']
+        self.assertEqual(loader.getTestCaseNames(Foo), test_names)
+
 
 
 if __name__ == "__main__":

--- a/Lib/unittest/test/test_loader.py
+++ b/Lib/unittest/test/test_loader.py
@@ -1591,6 +1591,5 @@ class Test_TestLoader(unittest.TestCase):
         self.assertEqual(loader.getTestCaseNames(Foo), test_names)
 
 
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This was a regression I first noticed in 3.7 branch.  


<!-- issue-number: [bpo-35767](https://bugs.python.org/issue35767) -->
https://bugs.python.org/issue35767
<!-- /issue-number -->
