### PR TITLE
[3.7] bpo-35283: Add deprecation warning for Thread.isAlive (GH-11454)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2224,14 +2224,14 @@ def start_threads(threads, unlock=None):
                 endtime += 60
                 for t in started:
                     t.join(max(endtime - time.monotonic(), 0.01))
-                started = [t for t in started if t.isAlive()]
+                started = [t for t in started if t.is_alive()]
                 if not started:
                     break
                 if verbose:
                     print('Unable to join %d threads during a period of '
                           '%d minutes' % (len(started), timeout))
         finally:
-            started = [t for t in started if t.isAlive()]
+            started = [t for t in started if t.is_alive()]
             if started:
                 faulthandler.dump_traceback(sys.stdout)
                 raise AssertionError('Unable to join %d threads' % len(started))

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -415,7 +415,8 @@ class ThreadTests(BaseTestCase):
         t.setDaemon(True)
         t.getName()
         t.setName("name")
-        t.isAlive()
+        with self.assertWarnsRegex(PendingDeprecationWarning, 'use is_alive()'):
+            t.isAlive()
         e = threading.Event()
         e.isSet()
         threading.activeCount()

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1007,7 +1007,7 @@ class Thread:
         When the timeout argument is present and not None, it should be a
         floating point number specifying a timeout for the operation in seconds
         (or fractions thereof). As join() always returns None, you must call
-        isAlive() after join() to decide whether a timeout happened -- if the
+        is_alive() after join() to decide whether a timeout happened -- if the
         thread is still alive, the join() call timed out.
 
         When the timeout argument is not present or None, the operation will

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1091,7 +1091,15 @@ class Thread:
         self._wait_for_tstate_lock(False)
         return not self._is_stopped
 
-    isAlive = is_alive
+    def isAlive(self):
+        """Return whether the thread is alive.
+
+        This method is deprecated, use is_alive() instead.
+        """
+        import warnings
+        warnings.warn('isAlive() is deprecated, use is_alive() instead',
+                      PendingDeprecationWarning, stacklevel=2)
+        return self.is_alive()
 
     @property
     def daemon(self):

--- a/Misc/NEWS.d/next/Library/2019-01-07-17-17-16.bpo-35283.WClosC.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-07-17-17-16.bpo-35283.WClosC.rst
@@ -1,0 +1,2 @@
+Add a pending deprecated warning for the :meth:`threading.Thread.isAlive` method.
+Patch by Dong-hee Na.


### PR DESCRIPTION
Add a pending deprecated warning for the threading.Thread.isAlive() method..
(cherry picked from commit 89669ffe10a9db6343f6ee42239e412c8ad96bde)

Co-authored-by: Dong-hee Na <donghee.na92@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35283](https://bugs.python.org/issue35283) -->
https://bugs.python.org/issue35283
<!-- /issue-number -->
