### PR TITLE
[3.6] bpo-32947: Fixes for TLS 1.3 and OpenSSL 1.1.1

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-01-18-17-46-10.bpo-32947.Hk0KnM.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-18-17-46-10.bpo-32947.Hk0KnM.rst
@@ -1,0 +1,1 @@
+test_ssl fixes for TLS 1.3 and OpenSSL 1.1.1.


### PR DESCRIPTION
Backport partially commit 529525fb5a8fd9b96ab4021311a598c77588b918:
complete the previous partial backport (commit
2a4ee8aa01d61b6a9c8e9c65c211e61bdb471826.

Co-Authored-By: Christian Heimes <christian@python.org>

<!-- issue-number: [bpo-32947](https://bugs.python.org/issue32947) -->
https://bugs.python.org/issue32947
<!-- /issue-number -->
