### PR TITLE
bpo-23078:  Add support for staticmethod and classmethod to mock created with autospec

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -29,7 +29,7 @@ import inspect
 import pprint
 import sys
 import builtins
-from types import ModuleType
+from types import ModuleType, MethodType
 from unittest.util import safe_repr
 from functools import wraps, partial
 
@@ -122,6 +122,8 @@ def _copy_func_details(func, funcopy):
 def _callable(obj):
     if isinstance(obj, type):
         return True
+    if isinstance(obj, (staticmethod, classmethod, MethodType)):
+        return _callable(obj.__func__)
     if getattr(obj, '__call__', None) is not None:
         return True
     return False

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -1009,33 +1009,33 @@ class TestCallablePredicate(unittest.TestCase):
             self.assertTrue(_callable(obj))
 
     def test_call_magic_method(self):
-        class Callable(object):
+        class Callable:
             def __call__(self):
                 pass
         instance = Callable()
         self.assertTrue(_callable(instance))
 
     def test_staticmethod(self):
-        class WithStaticMethod(object):
+        class WithStaticMethod:
             @staticmethod
             def staticfunc():
                 pass
         self.assertTrue(_callable(WithStaticMethod.staticfunc))
 
     def test_non_callable_staticmethod(self):
-        class BadStaticMethod(object):
+        class BadStaticMethod:
             not_callable = staticmethod(None)
         self.assertFalse(_callable(BadStaticMethod.not_callable))
 
     def test_classmethod(self):
-        class WithClassMethod(object):
+        class WithClassMethod:
             @classmethod
             def classfunc(cls):
                 pass
         self.assertTrue(_callable(WithClassMethod.classfunc))
 
     def test_non_callable_classmethod(self):
-        class BadClassMethod(object):
+        class BadClassMethod:
             not_callable = classmethod(None)
         self.assertFalse(_callable(BadClassMethod.not_callable))
 

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -5,7 +5,7 @@ import unittest
 
 from unittest.mock import (
     call, _Call, create_autospec, MagicMock,
-    Mock, ANY, _CallList, patch, PropertyMock
+    Mock, ANY, _CallList, patch, PropertyMock, _callable
 )
 
 from datetime import datetime
@@ -1000,6 +1000,44 @@ class TestCallList(unittest.TestCase):
         p.assert_called_once_with()
         self.assertIsInstance(returned, MagicMock)
         self.assertNotIsInstance(returned, PropertyMock)
+
+
+class TestCallablePredicate(unittest.TestCase):
+
+    def test_type(self):
+        for obj in [str, bytes, int, list, tuple, SomeClass]:
+            self.assertTrue(_callable(obj))
+
+    def test_call_magic_method(self):
+        class Callable(object):
+            def __call__(self):
+                pass
+        instance = Callable()
+        self.assertTrue(_callable(instance))
+
+    def test_staticmethod(self):
+        class WithStaticMethod(object):
+            @staticmethod
+            def staticfunc():
+                pass
+        self.assertTrue(_callable(WithStaticMethod.staticfunc))
+
+    def test_non_callable_staticmethod(self):
+        class BadStaticMethod(object):
+            not_callable = staticmethod(None)
+        self.assertFalse(_callable(BadStaticMethod.not_callable))
+
+    def test_classmethod(self):
+        class WithClassMethod(object):
+            @classmethod
+            def classfunc(cls):
+                pass
+        self.assertTrue(_callable(WithClassMethod.classfunc))
+
+    def test_non_callable_classmethod(self):
+        class BadClassMethod(object):
+            not_callable = classmethod(None)
+        self.assertFalse(_callable(BadClassMethod.not_callable))
 
 
 if __name__ == '__main__':

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1414,26 +1414,21 @@ class MockTest(unittest.TestCase):
         self.assertIn('sweet_func', repr(m))
 
     #Issue23078
-    def test_create_autospec_classmethod(self):
+    def test_create_autospec_classmethod_and_staticmethod(self):
         class TestClass:
             @classmethod
-            def method(cls):
+            def class_method(cls):
                 pass
-        mock_bound_meth = mock.create_autospec(TestClass.method)
-        mock_bound_meth()
-        mock_bound_meth.assert_called_once_with()
-        self.assertRaises(TypeError, mock_bound_meth, 'extra_arg')
 
-    #Issue23078
-    def test_create_autospec_staticmethod(self):
-        class TestClass:
             @staticmethod
-            def method():
+            def static_method():
                 pass
-        mock_meth = mock.create_autospec(TestClass.method)
-        mock_meth()
-        mock_meth.assert_called_once_with()
-        self.assertRaises(TypeError, mock_meth, 'extra_arg')
+        for method in ('class_method', 'static_method'):
+            with self.subTest(method=method):
+                mock_method = mock.create_autospec(getattr(TestClass, method))
+                mock_method()
+                mock_method.assert_called_once_with()
+                self.assertRaises(TypeError, mock_method, 'extra_arg')
 
     #Issue21238
     def test_mock_unsafe(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1416,7 +1416,9 @@ class MockTest(unittest.TestCase):
     #Issue23078
     def test_create_autospec_classmethod(self):
         class TestClass:
-            method = classmethod(lambda cls: None)
+            @classmethod
+            def method(cls):
+                pass
         mock_bound_meth = mock.create_autospec(TestClass.method)
         mock_bound_meth()
         mock_bound_meth.assert_called_once_with()
@@ -1425,7 +1427,9 @@ class MockTest(unittest.TestCase):
     #Issue23078
     def test_create_autospec_staticmethod(self):
         class TestClass:
-            method = staticmethod(lambda: None)
+            @staticmethod
+            def method():
+                pass
         mock_meth = mock.create_autospec(TestClass.method)
         mock_meth()
         mock_meth.assert_called_once_with()

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1413,6 +1413,24 @@ class MockTest(unittest.TestCase):
         m = mock.create_autospec(object(), name='sweet_func')
         self.assertIn('sweet_func', repr(m))
 
+    #Issue23078
+    def test_create_autospec_classmethod(self):
+        class TestClass:
+            method = classmethod(lambda cls: None)
+        mock_bound_meth = mock.create_autospec(TestClass.method)
+        mock_bound_meth()
+        mock_bound_meth.assert_called_once_with()
+        self.assertRaises(TypeError, mock_bound_meth, 'extra_arg')
+
+    #Issue23078
+    def test_create_autospec_staticmethod(self):
+        class TestClass:
+            method = staticmethod(lambda: None)
+        mock_meth = mock.create_autospec(TestClass.method)
+        mock_meth()
+        mock_meth.assert_called_once_with()
+        self.assertRaises(TypeError, mock_meth, 'extra_arg')
+
     #Issue21238
     def test_mock_unsafe(self):
         m = Mock()

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -52,11 +52,11 @@ class Foo(object):
     foo = 'bar'
 
     @staticmethod
-    def a_static():
+    def static_method():
         return 24
 
     @classmethod
-    def a_class(cls):
+    def class_method(cls):
         return 42
 
     class Bar(object):
@@ -1007,14 +1007,14 @@ class PatchTest(unittest.TestCase):
 
 
     def test_autospec_staticmethod(self):
-        with patch('%s.Foo.a_static' % __name__, autospec=True) as method:
-            Foo.a_static()
+        with patch('%s.Foo.static_method' % __name__, autospec=True) as method:
+            Foo.static_method()
             method.assert_called_once_with()
 
 
     def test_autospec_classmethod(self):
-        with patch('%s.Foo.a_class' % __name__, autospec=True) as method:
-            Foo.a_class()
+        with patch('%s.Foo.class_method' % __name__, autospec=True) as method:
+            Foo.class_method()
             method.assert_called_once_with()
 
 

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -51,6 +51,14 @@ class Foo(object):
         pass
     foo = 'bar'
 
+    @staticmethod
+    def a_static():
+        return 24
+
+    @classmethod
+    def a_class(cls):
+        return 42
+
     class Bar(object):
         def a(self):
             pass
@@ -996,6 +1004,18 @@ class PatchTest(unittest.TestCase):
 
         result = test()
         self.assertEqual(result, 3)
+
+
+    def test_autospec_staticmethod(self):
+        with patch('%s.Foo.a_static' % __name__, autospec=True) as method:
+            Foo.a_static()
+            method.assert_called_once_with()
+
+
+    def test_autospec_classmethod(self):
+        with patch('%s.Foo.a_class' % __name__, autospec=True) as method:
+            Foo.a_class()
+            method.assert_called_once_with()
 
 
     def test_autospec_with_new(self):

--- a/Misc/NEWS.d/next/Library/2019-01-18-23-10-10.bpo-23078.l4dFoj.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-18-23-10-10.bpo-23078.l4dFoj.rst
@@ -1,2 +1,2 @@
-Add support for staticmethod and classmethod with autospec. Based on patch
-by Felipe Ochoa. Improved by Karthikeyan Singaravelan.
+Add support for :func:`classmethod` and :func:`staticmethod` to
+:func:`unittest.mock.create_autospec`.  Initial patch by Felipe Ochoa.

--- a/Misc/NEWS.d/next/Library/2019-01-18-23-10-10.bpo-23078.l4dFoj.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-18-23-10-10.bpo-23078.l4dFoj.rst
@@ -1,0 +1,2 @@
+Add support for staticmethod and classmethod with autospec. Based on patch
+by Felipe.

--- a/Misc/NEWS.d/next/Library/2019-01-18-23-10-10.bpo-23078.l4dFoj.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-18-23-10-10.bpo-23078.l4dFoj.rst
@@ -1,2 +1,2 @@
 Add support for staticmethod and classmethod with autospec. Based on patch
-by Felipe.
+by Felipe Ochoa. Improved by Karthikeyan Singaravelan.


### PR DESCRIPTION
Add support for staticmethod and classmethod to mock created with autospec. Patch by @felipeochoa converted into a PR.

Co-authored-by: Felipe <felipe.nospam.ochoa@gmail.com>

<!-- issue-number: [bpo-23078](https://bugs.python.org/issue23078) -->
https://bugs.python.org/issue23078
<!-- /issue-number -->
