### PR TITLE
bpo-35770: IDLE macosx deletes Options => Configure IDLE

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,11 @@ Released on 2019-10-20?
 ======================================
 
 
+bpo-35770: IDLE macosx deletes Options => Configure IDLE.
+It previously deleted Window => Zoom Height by mistake.
+(Zoom Height is now on the Options menu).  On Mac, the settings
+dialog is accessed via Preferences on the IDLE menu.
+
 bpo-35769: Change new file name from 'Untitled' to 'untitled'.
 
 bpo-35660: Fix imports in window module.

--- a/Lib/idlelib/macosx.py
+++ b/Lib/idlelib/macosx.py
@@ -178,7 +178,7 @@ def overrideRootMenu(root, flist):
     del mainmenu.menudefs[-1][1][0:2]
     # Remove the 'Configure Idle' entry from the options menu, it is in the
     # application menu as 'Preferences'
-    del mainmenu.menudefs[-2][1][0]
+    del mainmenu.menudefs[-3][1][0:1]
     menubar = Menu(root)
     root.configure(menu=menubar)
     menudict = {}

--- a/Misc/NEWS.d/next/IDLE/2019-01-18-13-04-30.bpo-35770.2LxJGu.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-01-18-13-04-30.bpo-35770.2LxJGu.rst
@@ -1,0 +1,3 @@
+IDLE macosx deletes Options => Configure IDLE. It previously deleted Window
+=> Zoom Height by mistake. (Zoom Height is now on the Options menu).  On
+Mac, the settings dialog is accessed via Preferences on the IDLE menu.


### PR DESCRIPTION
It previously deleted Window => Zoom Height by mistake.
(Zoom Height is now on the Options menu).  On Mac, the settings
dialog is accessed via Preferences on the IDLE menu.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35770](https://bugs.python.org/issue35770) -->
https://bugs.python.org/issue35770
<!-- /issue-number -->
