### PR TITLE
bpo-33608: Factor out a private, per-interpreter _Py_AddPendingCall().

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -221,7 +221,7 @@ PyAPI_FUNC(Py_ssize_t) _PyEval_RequestCodeExtraIndex(freefunc);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyEval_SliceIndex(PyObject *, Py_ssize_t *);
 PyAPI_FUNC(int) _PyEval_SliceIndexNotNone(PyObject *, Py_ssize_t *);
-PyAPI_FUNC(void) _PyEval_SignalAsyncExc(void);
+PyAPI_FUNC(void) _PyEval_SignalAsyncExc(PyInterpreterState *);
 #endif
 
 /* Masks and values used by FORMAT_VALUE opcode. */

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -13,7 +13,7 @@ extern "C" {
 
 struct _is;  // See PyInterpreterState in cpython/pystate.h.
 
-PyAPI_FUNC(int) _Py_AddPendingCall(struct _is*, int (*)(void *), void *);
+PyAPI_FUNC(int) _Py_AddPendingCall(struct _is*, unsigned long, int (*)(void *), void *);
 PyAPI_FUNC(int) _Py_MakePendingCalls(struct _is*);
 
 struct _pending_calls {
@@ -26,6 +26,7 @@ struct _pending_calls {
     int async_exc;
 #define NPENDINGCALLS 32
     struct {
+        unsigned long thread_id;
         int (*func)(void *);
         void *arg;
     } calls[NPENDINGCALLS];

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -11,8 +11,12 @@ extern "C" {
 #include "pycore_atomic.h"
 #include "pythread.h"
 
+struct _is;  // See PyInterpreterState in cpython/pystate.h.
+
+PyAPI_FUNC(int) _Py_AddPendingCall(struct _is*, int (*)(void *), void *);
+PyAPI_FUNC(int) _Py_MakePendingCalls(struct _is*);
+
 struct _pending_calls {
-    unsigned long main_thread;
     PyThread_type_lock lock;
     /* Request for running pending calls. */
     _Py_atomic_int calls_to_do;
@@ -39,12 +43,8 @@ struct _ceval_runtime_state {
        c_tracefunc.  This speeds up the if statement in
        PyEval_EvalFrameEx() after fast_next_opcode. */
     int tracing_possible;
-    /* This single variable consolidates all requests to break out of
-       the fast path in the eval loop. */
-    _Py_atomic_int eval_breaker;
     /* Request for dropping the GIL */
     _Py_atomic_int gil_drop_request;
-    struct _pending_calls pending;
     /* Request for checking signals. */
     _Py_atomic_int signals_pending;
     struct _gil_runtime_state gil;

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -34,6 +34,13 @@ struct _pending_calls {
     int last;
 };
 
+struct _ceval_interpreter_state {
+    /* This single variable consolidates all requests to break out of
+       the fast path in the eval loop. */
+    _Py_atomic_int eval_breaker;
+    struct _pending_calls pending;
+};
+
 #include "pycore_gil.h"
 
 struct _ceval_runtime_state {

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -207,6 +207,8 @@ typedef struct pyruntimestate {
         struct _xidregitem *head;
     } xidregistry;
 
+    unsigned long main_thread;
+
 #define NEXITFUNCS 32
     void (*exitfuncs[NEXITFUNCS])(void);
     int nexitfuncs;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -43,15 +43,6 @@ struct _is {
     /* Used in Python/sysmodule.c. */
     int check_interval;
 
-#ifdef Py_BUILD_CORE
-    struct _ceval {
-        /* This single variable consolidates all requests to break out of
-           the fast path in the eval loop. */
-        _Py_atomic_int eval_breaker;
-        struct _pending_calls pending;
-    } ceval;
-#endif
-
     /* Used in Modules/_threadmodule.c. */
     long num_threads;
     /* Support for runtime thread stack size tuning.
@@ -90,6 +81,13 @@ struct _is {
     PyObject *pyexitmodule;
 
     uint64_t tstate_next_unique_id;
+
+    struct _ceval {
+        /* This single variable consolidates all requests to break out of
+           the fast path in the eval loop. */
+        _Py_atomic_int eval_breaker;
+        struct _pending_calls pending;
+    } ceval;
 };
 
 PyAPI_FUNC(struct _is*) _PyInterpreterState_LookUpID(PY_INT64_T);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -32,6 +32,8 @@ struct _is {
     int64_t id_refcount;
     PyThread_type_lock id_mutex;
 
+    int finalizing;
+
     PyObject *modules;
     PyObject *modules_by_index;
     PyObject *sysdict;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -11,6 +11,7 @@ extern "C" {
 #include "pystate.h"
 #include "pythread.h"
 
+#include "pycore_atomic.h"
 #include "pycore_ceval.h"
 #include "pycore_pathconfig.h"
 #include "pycore_pymem.h"
@@ -39,6 +40,15 @@ struct _is {
 
     /* Used in Python/sysmodule.c. */
     int check_interval;
+
+#ifdef Py_BUILD_CORE
+    struct _ceval {
+        /* This single variable consolidates all requests to break out of
+           the fast path in the eval loop. */
+        _Py_atomic_int eval_breaker;
+        struct _pending_calls pending;
+    } ceval;
+#endif
 
     /* Used in Modules/_threadmodule.c. */
     long num_threads;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -82,12 +82,7 @@ struct _is {
 
     uint64_t tstate_next_unique_id;
 
-    struct _ceval {
-        /* This single variable consolidates all requests to break out of
-           the fast path in the eval loop. */
-        _Py_atomic_int eval_breaker;
-        struct _pending_calls pending;
-    } ceval;
+    struct _ceval_interpreter_state ceval;
 };
 
 PyAPI_FUNC(struct _is*) _PyInterpreterState_LookUpID(PY_INT64_T);

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-15-12-13-46.bpo-33608.avmvVP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-15-12-13-46.bpo-33608.avmvVP.rst
@@ -1,0 +1,5 @@
+We added a new internal _Py_AddPendingCall() that operates relative to the
+provided interpreter.  This allows us to use the existing implementation to
+ask another interpreter to do work that cannot be done in the current
+interpreter, like decref an object the other interpreter owns.  The existing
+Py_AddPendingCall() only operates relative to the main interpreter.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2445,6 +2445,7 @@ pending_threadfunc(PyObject *self, PyObject *arg)
     Py_INCREF(callable);
 
     Py_BEGIN_ALLOW_THREADS
+    /* XXX Use the internal _Py_AddPendingCall(). */
     r = Py_AddPendingCall(&_pending_callback, callable);
     Py_END_ALLOW_THREADS
 

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -289,6 +289,7 @@ trip_signal(int sig_num)
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
                     _Py_AddPendingCall(_PyRuntime.interpreters.main,
+                                       main_thread,
                                        report_wakeup_send_error,
                                        (void *)(intptr_t) last_error);
                 }
@@ -308,6 +309,7 @@ trip_signal(int sig_num)
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
                     _Py_AddPendingCall(_PyRuntime.interpreters.main,
+                                       main_thread,
                                        report_wakeup_write_error,
                                        (void *)(intptr_t)errno);
                 }

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -19,6 +19,7 @@
 #include <process.h>
 #endif
 #endif
+#include "internal/pycore_pystate.h"
 
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
@@ -287,8 +288,9 @@ trip_signal(int sig_num)
                 {
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
-                    Py_AddPendingCall(report_wakeup_send_error,
-                                      (void *)(intptr_t) last_error);
+                    _Py_AddPendingCall(_PyRuntime.interpreters.main,
+                                       report_wakeup_send_error,
+                                       (void *)(intptr_t) last_error);
                 }
             }
         }
@@ -305,8 +307,9 @@ trip_signal(int sig_num)
                 {
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
-                    Py_AddPendingCall(report_wakeup_write_error,
-                                      (void *)(intptr_t)errno);
+                    _Py_AddPendingCall(_PyRuntime.interpreters.main,
+                                       report_wakeup_write_error,
+                                       (void *)(intptr_t)errno);
                 }
             }
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -96,37 +96,37 @@ static long dxp[256];
 /* This can set eval_breaker to 0 even though gil_drop_request became
    1.  We believe this is all right because the eval loop will release
    the GIL eventually anyway. */
-#define COMPUTE_EVAL_BREAKER() \
+#define COMPUTE_EVAL_BREAKER(interp) \
     _Py_atomic_store_relaxed( \
-        &PyThreadState_Get()->interp->ceval.eval_breaker, \
+        &interp->ceval.eval_breaker, \
         GIL_REQUEST | \
         _Py_atomic_load_relaxed(&_PyRuntime.ceval.signals_pending) | \
-        _Py_atomic_load_relaxed(&PyThreadState_Get()->interp->ceval.pending.calls_to_do) | \
-        PyThreadState_Get()->interp->ceval.pending.async_exc)
+        _Py_atomic_load_relaxed(&interp->ceval.pending.calls_to_do) | \
+        interp->ceval.pending.async_exc)
 
-#define SET_GIL_DROP_REQUEST() \
+#define SET_GIL_DROP_REQUEST(interp) \
     do { \
         _Py_atomic_store_relaxed(&_PyRuntime.ceval.gil_drop_request, 1); \
-        _Py_atomic_store_relaxed(&PyThreadState_Get()->interp->ceval.eval_breaker, 1); \
+        _Py_atomic_store_relaxed(&interp->ceval.eval_breaker, 1); \
     } while (0)
 
-#define RESET_GIL_DROP_REQUEST() \
+#define RESET_GIL_DROP_REQUEST(interp) \
     do { \
         _Py_atomic_store_relaxed(&_PyRuntime.ceval.gil_drop_request, 0); \
-        COMPUTE_EVAL_BREAKER(); \
+        COMPUTE_EVAL_BREAKER(interp); \
     } while (0)
 
 /* Pending calls are only modified under pending_lock */
-#define SIGNAL_PENDING_CALLS() \
+#define SIGNAL_PENDING_CALLS(interp) \
     do { \
-        _Py_atomic_store_relaxed(&PyThreadState_Get()->interp->ceval.pending.calls_to_do, 1); \
-        _Py_atomic_store_relaxed(&PyThreadState_Get()->interp->ceval.eval_breaker, 1); \
+        _Py_atomic_store_relaxed(&interp->ceval.pending.calls_to_do, 1); \
+        _Py_atomic_store_relaxed(&interp->ceval.eval_breaker, 1); \
     } while (0)
 
-#define UNSIGNAL_PENDING_CALLS() \
+#define UNSIGNAL_PENDING_CALLS(interp) \
     do { \
-        _Py_atomic_store_relaxed(&PyThreadState_Get()->interp->ceval.pending.calls_to_do, 0); \
-        COMPUTE_EVAL_BREAKER(); \
+        _Py_atomic_store_relaxed(&interp->ceval.pending.calls_to_do, 0); \
+        COMPUTE_EVAL_BREAKER(interp); \
     } while (0)
 
 #define SIGNAL_PENDING_SIGNALS() \
@@ -138,19 +138,19 @@ static long dxp[256];
 #define UNSIGNAL_PENDING_SIGNALS() \
     do { \
         _Py_atomic_store_relaxed(&_PyRuntime.ceval.signals_pending, 0); \
-        COMPUTE_EVAL_BREAKER(); \
+        COMPUTE_EVAL_BREAKER(_PyRuntime.interpreters.main); \
     } while (0)
 
-#define SIGNAL_ASYNC_EXC() \
+#define SIGNAL_ASYNC_EXC(interp) \
     do { \
-        PyThreadState_Get()->interp->ceval.pending.async_exc = 1; \
-        _Py_atomic_store_relaxed(&PyThreadState_Get()->interp->ceval.eval_breaker, 1); \
+        interp->ceval.pending.async_exc = 1; \
+        _Py_atomic_store_relaxed(&interp->ceval.eval_breaker, 1); \
     } while (0)
 
-#define UNSIGNAL_ASYNC_EXC() \
+#define UNSIGNAL_ASYNC_EXC(interp) \
     do { \
-        PyThreadState_Get()->interp->ceval.pending.async_exc = 0; \
-        COMPUTE_EVAL_BREAKER(); \
+        interp->ceval.pending.async_exc = 0; \
+        COMPUTE_EVAL_BREAKER(interp); \
     } while (0)
 
 
@@ -253,9 +253,9 @@ PyEval_ReInitThreads(void)
    raised. */
 
 void
-_PyEval_SignalAsyncExc(void)
+_PyEval_SignalAsyncExc(PyInterpreterState *interp)
 {
-    SIGNAL_ASYNC_EXC();
+    SIGNAL_ASYNC_EXC(interp);
 }
 
 PyThreadState *
@@ -388,7 +388,7 @@ _Py_AddPendingCall(PyInterpreterState *interp, int (*func)(void *), void *arg)
 
     int result = _add_pending_call(interp, func, arg);
     /* signal main loop */
-    SIGNAL_PENDING_CALLS();
+    SIGNAL_PENDING_CALLS(interp);
 
     if (lock != NULL)
         PyThread_release_lock(lock);
@@ -423,7 +423,7 @@ make_pending_calls(PyInterpreterState *interp)
     busy = 1;
     /* unsignal before starting to call callbacks, so that any callback
        added in-between re-signals */
-    UNSIGNAL_PENDING_CALLS();
+    UNSIGNAL_PENDING_CALLS(interp);
     int res = 0;
 
     if (!interp->ceval.pending.lock) {
@@ -460,7 +460,7 @@ make_pending_calls(PyInterpreterState *interp)
 
 error:
     busy = 0;
-    SIGNAL_PENDING_CALLS();
+    SIGNAL_PENDING_CALLS(interp); /* We're not done yet */
     return res;
 }
 
@@ -1063,7 +1063,7 @@ main_loop:
             if (tstate->async_exc != NULL) {
                 PyObject *exc = tstate->async_exc;
                 tstate->async_exc = NULL;
-                UNSIGNAL_ASYNC_EXC();
+                UNSIGNAL_ASYNC_EXC(tstate->interp);
                 PyErr_SetNone(exc);
                 Py_DECREF(exc);
                 goto error;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -240,10 +240,11 @@ PyEval_ReInitThreads(void)
     if (!gil_created())
         return;
     recreate_gil();
-    _PyRuntime.main_thread = PyThread_get_thread_ident();
-    // XXX Set for every interpreter.
-    current_tstate->interp->ceval.pending.lock = PyThread_allocate_lock();
+    // This will be reset in make_pending_calls() below.
+    current_tstate->interp->ceval.pending.lock = NULL;
+
     take_gil(current_tstate);
+    _PyRuntime.main_thread = PyThread_get_thread_ident();
 
     /* Destroy all threads except the current one */
     _PyThreadState_DeleteExcept(current_tstate);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -243,6 +243,7 @@ PyEval_ReInitThreads(void)
     if (!gil_created())
         return;
     recreate_gil();
+    _PyRuntime.main_thread = PyThread_get_thread_ident();
     _PyRuntime.ceval.pending.lock = PyThread_allocate_lock();
     take_gil(current_tstate);
     _PyRuntime.ceval.pending.main_thread = PyThread_get_thread_ident();

--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -176,7 +176,7 @@ static void drop_gil(PyThreadState *tstate)
                     &_PyRuntime.ceval.gil.last_holder)
             ) == tstate)
         {
-        RESET_GIL_DROP_REQUEST();
+        RESET_GIL_DROP_REQUEST(tstate->interp);
             /* NOTE: if COND_WAIT does not atomically start waiting when
                releasing the mutex, another thread can run through, take
                the GIL and drop it again, and reset the condition
@@ -213,7 +213,7 @@ static void take_gil(PyThreadState *tstate)
         if (timed_out &&
             _Py_atomic_load_relaxed(&_PyRuntime.ceval.gil.locked) &&
             _PyRuntime.ceval.gil.switch_number == saved_switchnum) {
-            SET_GIL_DROP_REQUEST();
+            SET_GIL_DROP_REQUEST(tstate->interp);
         }
     }
 _ready:
@@ -239,10 +239,10 @@ _ready:
     MUTEX_UNLOCK(_PyRuntime.ceval.gil.switch_mutex);
 #endif
     if (_Py_atomic_load_relaxed(&_PyRuntime.ceval.gil_drop_request)) {
-        RESET_GIL_DROP_REQUEST();
+        RESET_GIL_DROP_REQUEST(tstate->interp);
     }
     if (tstate->async_exc != NULL) {
-        _PyEval_SignalAsyncExc();
+        _PyEval_SignalAsyncExc(tstate->interp);
     }
 
     MUTEX_UNLOCK(_PyRuntime.ceval.gil.mutex);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -189,8 +189,6 @@ void
 PyInterpreterState_Clear(PyInterpreterState *interp)
 {
     PyThreadState *p;
-    // XXX Also ensure that all pending calls have been made.  Disallow
-    // registration of more pending calls.
     HEAD_LOCK();
     for (p = interp->tstate_head; p != NULL; p = p->next)
         PyThreadState_Clear(p);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -189,6 +189,8 @@ void
 PyInterpreterState_Clear(PyInterpreterState *interp)
 {
     PyThreadState *p;
+    // XXX Also ensure that all pending calls have been made.  Disallow
+    // registration of more pending calls.
     HEAD_LOCK();
     for (p = interp->tstate_head; p != NULL; p = p->next)
         PyThreadState_Clear(p);
@@ -210,6 +212,9 @@ PyInterpreterState_Clear(PyInterpreterState *interp)
     Py_CLEAR(interp->after_forkers_parent);
     Py_CLEAR(interp->after_forkers_child);
 #endif
+    // XXX Once we have one allocator per interpreter (i.e.
+    // per-interpreter GC) we must ensure that all of the interpreter's
+    // objects have been cleaned up at the point.
 }
 
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -135,6 +135,13 @@ PyInterpreterState_New(void)
     memset(interp, 0, sizeof(*interp));
     interp->id_refcount = -1;
     interp->check_interval = 100;
+
+    interp->ceval.pending.lock = PyThread_allocate_lock();
+    if (interp->ceval.pending.lock == NULL) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "failed to create interpreter ceval pending mutex");
+        return NULL;
+    }
     interp->core_config = _PyCoreConfig_INIT;
     interp->config = _PyMainInterpreterConfig_INIT;
     interp->eval_frame = _PyEval_EvalFrameDefault;
@@ -242,6 +249,9 @@ PyInterpreterState_Delete(PyInterpreterState *interp)
     HEAD_UNLOCK();
     if (interp->id_mutex != NULL) {
         PyThread_free_lock(interp->id_mutex);
+    }
+    if (interp->ceval.pending.lock != NULL) {
+        PyThread_free_lock(interp->ceval.pending.lock);
     }
     PyMem_RawFree(interp);
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -132,28 +132,12 @@ PyInterpreterState_New(void)
         return NULL;
     }
 
+    memset(interp, 0, sizeof(*interp));
     interp->id_refcount = -1;
-    interp->id_mutex = NULL;
-    interp->modules = NULL;
-    interp->modules_by_index = NULL;
-    interp->sysdict = NULL;
-    interp->builtins = NULL;
-    interp->builtins_copy = NULL;
-    interp->tstate_head = NULL;
     interp->check_interval = 100;
-    interp->num_threads = 0;
-    interp->pythread_stacksize = 0;
-    interp->codec_search_path = NULL;
-    interp->codec_search_cache = NULL;
-    interp->codec_error_registry = NULL;
-    interp->codecs_initialized = 0;
-    interp->fscodec_initialized = 0;
     interp->core_config = _PyCoreConfig_INIT;
     interp->config = _PyMainInterpreterConfig_INIT;
-    interp->importlib = NULL;
-    interp->import_func = NULL;
     interp->eval_frame = _PyEval_EvalFrameDefault;
-    interp->co_extra_user_count = 0;
 #ifdef HAVE_DLOPEN
 #if HAVE_DECL_RTLD_NOW
     interp->dlopenflags = RTLD_NOW;
@@ -161,13 +145,6 @@ PyInterpreterState_New(void)
     interp->dlopenflags = RTLD_LAZY;
 #endif
 #endif
-#ifdef HAVE_FORK
-    interp->before_forkers = NULL;
-    interp->after_forkers_parent = NULL;
-    interp->after_forkers_child = NULL;
-#endif
-    interp->pyexitfunc = NULL;
-    interp->pyexitmodule = NULL;
 
     HEAD_LOCK();
     if (_PyRuntime.interpreters.next_id < 0) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -146,6 +146,10 @@ PyInterpreterState_New(void)
 #endif
 #endif
 
+    if (_PyRuntime.main_thread == 0) {
+        _PyRuntime.main_thread = PyThread_get_thread_ident();
+    }
+
     HEAD_LOCK();
     if (_PyRuntime.interpreters.next_id < 0) {
         /* overflow or Py_Initialize() not called! */

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -862,7 +862,7 @@ PyThreadState_SetAsyncExc(unsigned long id, PyObject *exc)
             p->async_exc = exc;
             HEAD_UNLOCK();
             Py_XDECREF(old_exc);
-            _PyEval_SignalAsyncExc();
+            _PyEval_SignalAsyncExc(interp);
             return 1;
         }
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1332,6 +1332,7 @@ _PyCrossInterpreterData_Release(_PyCrossInterpreterData *data)
     }
 
     // "Release" the data and/or the object.
+    // XXX Use _Py_AddPendingCall().
     _call_in_interpreter(interp, _release_xidata, data);
 }
 


### PR DESCRIPTION
This is part of the work to improve isolation between subinterpreters. We need a way for one interpreter to ask another interpreter to do small low-level tasks, like safely decref an object owned by the other interpreter. The existing Py_AddPendingCall() (part of the public C-API) is specific to the main interpreter, so we factor out a private per-interpreter _Py_AddPendingCall(). This involves moving the global "pending calls" state to PyInterpreterState.

As part of this change, we start tracking if each interpreter is "active" or finalizing. "Active" means that the interpreter is currently running the eval loop. We also start tracking the per-interpreter "active" thread ID rather than the global "main" thread ID.

<!-- issue-number: [bpo-33608](https://bugs.python.org/issue33608) -->
https://bugs.python.org/issue33608
<!-- /issue-number -->
