### PR TITLE
bpo-35701: Fixed documentation for UUID weak referencing and attributes.

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -316,8 +316,6 @@ Optimizations
   (Contributed by Inada Naoki in :issue:`33597`)
 
 * :class:`uuid.UUID` now uses ``__slots__`` to reduce its memory footprint.
-  Note that this means that instances can no longer be weak-referenced and
-  that arbitrary attributes can no longer be added to them.
 
 * The :class:`list` constructor does not overallocate the internal item buffer
   if the input iterable has a known length (the input implements ``__len__``).
@@ -509,9 +507,6 @@ Changes in the Python API
 
 * The function :func:`math.factorial` no longer accepts arguments that are not
   int-like. (Contributed by Pablo Galindo in :issue:`33083`.)
-
-* :class:`uuid.UUID` now uses ``__slots__``, therefore instances can no longer
-  be weak-referenced and attributes can no longer be added.
 
 * :mod:`xml.dom.minidom` and :mod:`xml.sax` modules no longer process
   external entities by default.


### PR DESCRIPTION
As of #11570, UUID can be weakly referenced once again, fixing a regression that would've been caused by release. The documentation needs to be fixed to no longer suggest that UUID cannot be weakly referenced. Not being able to add arbitrary attributes is not new, and was sufficiently documented before (see bpo issue).


<!-- issue-number: [bpo-35701](https://bugs.python.org/issue35701) -->
https://bugs.python.org/issue35701
<!-- /issue-number -->
