### PR TITLE
bpo-35788: fix smtpd.PureProxy and smtpd.MailmanProxy

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -313,6 +313,7 @@ Benjamin Collar
 Jeffery Collins
 Robert Collins
 Paul Colomiets
+Samuel Colvin
 Christophe Combelles
 Geremy Condra
 Denver Coneybeare

--- a/Misc/NEWS.d/next/Library/2019-01-20-12-37-52.bpo-35788.Kj6705.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-20-12-37-52.bpo-35788.Kj6705.rst
@@ -1,0 +1,1 @@
+Fix regressions in ``smtpd.PureProxy`` and ``smtpd.MailmanProxy``.


### PR DESCRIPTION
https://bugs.python.org/issue35788

~~WIP: still need to fix and test smtpd.MailmanProxy~~

I'm assuming this doesn't need to be backported, let me know what to do if that's not the case.

<!-- issue-number: [bpo-35788](https://bugs.python.org/issue35788) -->
https://bugs.python.org/issue35788
<!-- /issue-number -->
