### PR TITLE
Make b64decode with validate=True faster by compiling regex

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -28,8 +28,16 @@ __all__ = [
     'urlsafe_b64encode', 'urlsafe_b64decode',
     ]
 
-VALID_BASE64_REGEX = re.compile(b'^[A-Za-z0-9+/]*={0,2}$')
+VALID_BASE64_REGEX = None
 bytes_types = (bytes, bytearray)  # Types acceptable as binary data
+
+def _get_valid_base64_regex():
+    global VALID_BASE64_REGEX
+    if VALID_BASE64_REGEX:
+        return VALID_BASE64_REGEX
+
+    VALID_BASE64_REGEX = re.compile(b'^[A-Za-z0-9+/]*={0,2}$')
+    return VALID_BASE64_REGEX
 
 def _bytes_from_decode_data(s):
     if isinstance(s, str):
@@ -82,7 +90,7 @@ def b64decode(s, altchars=None, validate=False):
         altchars = _bytes_from_decode_data(altchars)
         assert len(altchars) == 2, repr(altchars)
         s = s.translate(bytes.maketrans(altchars, b'+/'))
-    if validate and not VALID_BASE64_REGEX.match(s):
+    if validate and not _get_valid_base64_regex().match(s):
         raise binascii.Error('Non-base64 digit found')
     return binascii.a2b_base64(s)
 

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -28,7 +28,7 @@ __all__ = [
     'urlsafe_b64encode', 'urlsafe_b64decode',
     ]
 
-
+VALID_BASE64_REGEX = re.compile(b'^[A-Za-z0-9+/]*={0,2}$')
 bytes_types = (bytes, bytearray)  # Types acceptable as binary data
 
 def _bytes_from_decode_data(s):
@@ -82,7 +82,7 @@ def b64decode(s, altchars=None, validate=False):
         altchars = _bytes_from_decode_data(altchars)
         assert len(altchars) == 2, repr(altchars)
         s = s.translate(bytes.maketrans(altchars, b'+/'))
-    if validate and not re.match(b'^[A-Za-z0-9+/]*={0,2}$', s):
+    if validate and not VALID_BASE64_REGEX.match(s):
         raise binascii.Error('Non-base64 digit found')
     return binascii.a2b_base64(s)
 


### PR DESCRIPTION
Hi there, I was running some code that had to de code a lot of base64 encoded data and
I was using `validate=True` to also make sure it had valida data but it seemed to be way
slower than `validate=False` and I saw that it uses a regex without compiling it and
thought of sending a PR.
I didn't put any issue number because I didn't find any and the docs
say that for trivial changes there is no need to do it. Let me know if it would be needed.
And I also didn't create a test because `Lib/test/test_base64.py` already covers `validate=True`.

With the following benchmark the change goes from `15.174073122` to `8.906353553999999`.


```python
import timeit

import re
import binascii
from base64 import _bytes_from_decode_data

def original_base64(s, altchars=None, validate=False):
    s = _bytes_from_decode_data(s)
    if altchars is not None:
        altchars = _bytes_from_decode_data(altchars)
        assert len(altchars) == 2, repr(altchars)
        s = s.translate(bytes.maketrans(altchars, b'+/'))
    if validate and not re.match(b'^[A-Za-z0-9+/]*={0,2}$', s):
        raise binascii.Error('Non-base64 digit found')
    return binascii.a2b_base64(s)

VALID_BASE64_REGEX = re.compile(b'^[A-Za-z0-9+/]*={0,2}$')

def changed_base64(s, altchars=None, validate=False):
    s = _bytes_from_decode_data(s)
    if altchars is not None:
        altchars = _bytes_from_decode_data(altchars)
        assert len(altchars) == 2, repr(altchars)
        s = s.translate(bytes.maketrans(altchars, b'+/'))
    if validate and not VALID_BASE64_REGEX.match(s):
        raise binascii.Error('Non-base64 digit found')
    return binascii.a2b_base64(s)

for b64 in (original_base64, changed_base64):
    print(b64)
    print(timeit.timeit('assert b64(b"UHl0aG9u", validate=True) == b"Python"', globals={'b64': b64}, number=10_000_000))
```