### PR TITLE
gh-79888: support __index__ and __float__ in time functions

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -46,6 +46,19 @@ ROUNDING_MODES = (
 )
 
 
+class IndexLike:
+    def __init__(self, value):
+        self.value = int(value)
+    def __index__(self):
+        return self.value
+
+class FloatLike:
+    def __init__(self, value):
+        self.value = float(value)
+    def __float__(self):
+        return self.value
+
+
 class TimeTestCase(unittest.TestCase):
 
     def setUp(self):
@@ -151,6 +164,8 @@ class TimeTestCase(unittest.TestCase):
         self.assertRaises(ValueError, time.sleep, -2)
         self.assertRaises(ValueError, time.sleep, -1)
         time.sleep(1.2)
+        time.sleep(IndexLike(0))
+        time.sleep(FloatLike(0))
 
     def test_strftime(self):
         tt = time.gmtime(self.t)
@@ -839,13 +854,22 @@ class CPyTimeTestCase:
                     pytime_converter(value, time_rnd)
 
     def check_int_rounding(self, pytime_converter, expected_func,
-                           unit_to_sec=1, value_filter=None):
+                           unit_to_sec=1, value_filter=None, *, index=True):
         self._check_rounding(pytime_converter, expected_func,
                              False, unit_to_sec, value_filter)
+        if index:
+            def convert_IndexLike(x, rnd):
+                return pytime_converter(IndexLike(x), rnd)
+            self._check_rounding(convert_IndexLike, expected_func,
+                                 False, unit_to_sec, value_filter)
 
     def check_float_rounding(self, pytime_converter, expected_func,
                              unit_to_sec=1, value_filter=None):
         self._check_rounding(pytime_converter, expected_func,
+                             True, unit_to_sec, value_filter)
+        def convert_FloatLike(x, rnd):
+            return pytime_converter(FloatLike(x), rnd)
+        self._check_rounding(convert_FloatLike, expected_func,
                              True, unit_to_sec, value_filter)
 
     def decimal_round(self, x):
@@ -870,7 +894,7 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
 
         self.check_int_rounding(lambda secs, rnd: PyTime_FromSeconds(secs),
                                 lambda secs: secs * SEC_TO_NS,
-                                value_filter=c_int_filter)
+                                value_filter=c_int_filter, index=False)
 
         # test nan
         for time_rnd, _ in ROUNDING_MODES:
@@ -904,7 +928,7 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
 
         self.check_int_rounding(lambda ns, rnd: PyTime_AsSecondsDouble(ns),
                                 float_converter,
-                                NS_TO_SEC)
+                                NS_TO_SEC, index=False)
 
         # test nan
         for time_rnd, _ in ROUNDING_MODES:
@@ -941,7 +965,7 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
         self.check_int_rounding(PyTime_AsTimeval,
                                 timeval_converter,
                                 NS_TO_SEC,
-                                value_filter=seconds_filter)
+                                value_filter=seconds_filter, index=False)
 
     @unittest.skipUnless(hasattr(_testcapi, 'PyTime_AsTimespec'),
                          'need _testcapi.PyTime_AsTimespec')
@@ -954,21 +978,21 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
         self.check_int_rounding(lambda ns, rnd: PyTime_AsTimespec(ns),
                                 timespec_converter,
                                 NS_TO_SEC,
-                                value_filter=self.time_t_filter)
+                                value_filter=self.time_t_filter, index=False)
 
     def test_AsMilliseconds(self):
         from _testcapi import PyTime_AsMilliseconds
 
         self.check_int_rounding(PyTime_AsMilliseconds,
                                 self.create_decimal_converter(MS_TO_NS),
-                                NS_TO_SEC)
+                                NS_TO_SEC, index=False)
 
     def test_AsMicroseconds(self):
         from _testcapi import PyTime_AsMicroseconds
 
         self.check_int_rounding(PyTime_AsMicroseconds,
                                 self.create_decimal_converter(US_TO_NS),
-                                NS_TO_SEC)
+                                NS_TO_SEC, index=False)
 
 
 class TestOldPyTime(CPyTimeTestCase, unittest.TestCase):
@@ -1016,7 +1040,7 @@ class TestOldPyTime(CPyTimeTestCase, unittest.TestCase):
                                   self.create_converter(SEC_TO_US),
                                   value_filter=self.time_t_filter)
 
-         # test nan
+        # test nan
         for time_rnd, _ in ROUNDING_MODES:
             with self.assertRaises(ValueError):
                 pytime_object_to_timeval(float('nan'), time_rnd)

--- a/Misc/NEWS.d/next/C API/2019-01-21-14-44-42.bpo-35707.3wB7XC.rst
+++ b/Misc/NEWS.d/next/C API/2019-01-21-14-44-42.bpo-35707.3wB7XC.rst
@@ -1,0 +1,3 @@
+Various time-related functions now use the ``__index__`` and ``__float__``
+methods to convert objects to time. This affects in particular
+``time.sleep()``.


### PR DESCRIPTION
<!-- issue-number: [bpo-35707](https://bugs.python.org/issue35707) -->
https://bugs.python.org/issue35707
<!-- /issue-number -->

Note that there is substantial code duplication in my patch, but that is only because the existing code already had substantial duplication. It would be possible to fix that, at the expense of a slightly more complicated (and therefore probably slightly slower) implementation.

<!-- gh-issue-number: gh-79888 -->
* Issue: gh-79888
<!-- /gh-issue-number -->
