### PR TITLE
[DOC] urllib.request: Explain how works Basic HTTP Authentication

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1236,6 +1236,40 @@ Use of Basic HTTP Authentication::
    urllib.request.install_opener(opener)
    urllib.request.urlopen('http://www.example.com/login.html')
 
+.. note::
+
+   Normally, when you first try to access to a protected page, the server should
+   send back a ``401 Unauthorized`` response, with a ``WWW-Authenticate`` header,
+   containing the authentication scheme in use, and the realm of the page
+   (e.g., ``WWW-Authenticate: Basic realm="Python Documentation"``). After what,
+   you can perform a new request with a ``Authorization`` header, containing
+   your credentials encoded in base64 (e.g., ``Authorization: Basic <CREDENTIALS>``).
+
+   This is what :class:`HTTPBasicAuthHandler` is automatically doing for you by default.
+
+However, when the server doesn't properly implement Basic HTTP Authentication, you should
+instead use :class:`HTTPBasicAuthHandler` with :class:`HTTPPasswordMgrWithPriorAuth`::
+
+   import urllib.request
+
+   # Set-up an authentication handler.
+   pwd_mgr = urllib.request.HTTPPasswordMgrWithPriorAuth()
+   pwd_mgr.add_password(
+      # No realm returned by the server.
+      realm=None,
+      uri='http://www.example.com/,
+      user='jdoe',
+      passwd='foobar',
+      # No WWW-Authenticate header returned by the server.
+      is_authenticated=True,
+   )
+   auth_handler = urllib.request.HTTPBasicAuthHandler(pwd_mgr)
+
+   # And use it globally.
+   opener = urllib.request.build_opener(auth_handler)
+   urllib.request.install_opener(opener)
+   urllib.request.urlopen('http://www.example.com/something.html')
+
 :func:`build_opener` provides many handlers by default, including a
 :class:`ProxyHandler`.  By default, :class:`ProxyHandler` uses the environment
 variables named ``<scheme>_proxy``, where ``<scheme>`` is the URL scheme


### PR DESCRIPTION
The original example given in the doc, to manage Basic HTTP Authentication,
only works when the authentication mechanism is properly implemented by
the server.

However, very often, this is not the case. And the top-answers on Stackoverflow
recommend to bypass using password managers from ``urllib.request``, and instead,
to manually encode the credentials in base64.

These answers have mostly been written before the introduction of
``HTTPPasswordMgrWithPriorAuth``, which is aimed to solve this problem.

By giving more explanations, directly in the Python documentation, about how
the Basic HTTP Authentication mechanism is working, we will avoid people to
copy/paste some outdated code snippet from Stackoverflow.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
