### PR TITLE
bpo-31506: Clarify error messages for object.__new__ and object.__init__

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -602,19 +602,21 @@ class ClassTests(unittest.TestCase):
         class C:
             pass
 
+        error_msg = r'C.__init__\(\) takes exactly one argument \(the instance to initialize\)'
+
         with self.assertRaisesRegex(TypeError, r'C\(\) takes no arguments'):
             C(42)
 
         with self.assertRaisesRegex(TypeError, r'C\(\) takes no arguments'):
             C.__new__(C, 42)
 
-        with self.assertRaisesRegex(TypeError, r'C\(\).__init__\(\) takes no arguments'):
+        with self.assertRaisesRegex(TypeError, error_msg):
             C().__init__(42)
 
         with self.assertRaisesRegex(TypeError, r'C\(\) takes no arguments'):
             object.__new__(C, 42)
 
-        with self.assertRaisesRegex(TypeError, r'C\(\).__init__\(\) takes no arguments'):
+        with self.assertRaisesRegex(TypeError, error_msg):
             object.__init__(C(), 42)
 
         # Class with both `__init__` & `__new__` method overridden
@@ -624,13 +626,15 @@ class ClassTests(unittest.TestCase):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
 
-        with self.assertRaisesRegex(TypeError, r'object.__new__\(\) takes no argument'):
+        error_msg =  r'object.__new__\(\) takes exactly one argument \(the type to instantiate\)'
+
+        with self.assertRaisesRegex(TypeError, error_msg):
             D(42)
 
-        with self.assertRaisesRegex(TypeError, r'object.__new__\(\) takes no argument'):
+        with self.assertRaisesRegex(TypeError, error_msg):
             D.__new__(D, 42)
 
-        with self.assertRaisesRegex(TypeError, r'object.__new__\(\) takes no argument'):
+        with self.assertRaisesRegex(TypeError, error_msg):
             object.__new__(D, 42)
 
         # Class that only overrides __init__
@@ -638,10 +642,12 @@ class ClassTests(unittest.TestCase):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
 
-        with self.assertRaisesRegex(TypeError, r'object.__init__\(\) takes no argument'):
+        error_msg = r'object.__init__\(\) takes exactly one argument \(the instance to initialize\)'
+
+        with self.assertRaisesRegex(TypeError, error_msg):
             E().__init__(42)
 
-        with self.assertRaisesRegex(TypeError, r'object.__init__\(\) takes no argument'):
+        with self.assertRaisesRegex(TypeError, error_msg):
             object.__init__(E(), 42)
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Core and Builtins/2019-01-22-02-06-39.bpo-31506.eJ5FpV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-01-22-02-06-39.bpo-31506.eJ5FpV.rst
@@ -1,0 +1,2 @@
+Fix the error message logic for object.__new__ and object.__init__.
+Contributed by Sanyam Khurana.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-01-22-02-06-39.bpo-31506.eJ5FpV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-01-22-02-06-39.bpo-31506.eJ5FpV.rst
@@ -1,2 +1,3 @@
-Fix the error message logic for object.__new__ and object.__init__.
+Clarify the errors reported when ``object.__new__`` and ``object.__init__``
+receive more than one argument.
 Contributed by Sanyam Khurana.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3641,11 +3641,13 @@ object_init(PyObject *self, PyObject *args, PyObject *kwds)
     PyTypeObject *type = Py_TYPE(self);
     if (excess_args(args, kwds)) {
         if (type->tp_init != object_init) {
-            PyErr_SetString(PyExc_TypeError, "object.__init__() takes no arguments");
+            PyErr_SetString(PyExc_TypeError,
+                            "object.__init__() takes exactly one argument (the instance to initialize)");
             return -1;
         }
         if (type->tp_new == object_new) {
-            PyErr_Format(PyExc_TypeError, "%.200s().__init__() takes no arguments",
+            PyErr_Format(PyExc_TypeError,
+                         "%.200s.__init__() takes exactly one argument (the instance to initialize)",
                          type->tp_name);
             return -1;
         }
@@ -3658,7 +3660,8 @@ object_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     if (excess_args(args, kwds)) {
         if (type->tp_new != object_new) {
-            PyErr_SetString(PyExc_TypeError, "object.__new__() takes no arguments");
+            PyErr_SetString(PyExc_TypeError,
+                            "object.__new__() takes exactly one argument (the type to instantiate)");
             return NULL;
         }
         if (type->tp_init == object_init) {


### PR DESCRIPTION
``object.__new__`` and ``object.__init__`` do take one argument each,
they just don't take extra user supplied arguments.

<!-- issue-number: [bpo-31506](https://bugs.python.org/issue31506) -->
https://bugs.python.org/issue31506
<!-- /issue-number -->
