### PR TITLE
Clarify U-mode deprecation in open()

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1005,8 +1005,6 @@ are always available.  They are listed here in alphabetical order.
    ``'t'``   text mode (default)
    ``'+'``   open a disk file for updating (reading and writing)
    ``'U'``   :deprecated: :term:`universal newlines` is enabled by default
-             in text mode. See the :ref:` *newline* <open-newline-parameter>`
-             parameter documentation for more details.
    ========= ===============================================================
 
    The default mode is ``'r'`` (open for reading text, synonym of ``'rt'``).
@@ -1020,6 +1018,9 @@ are always available.  They are listed here in alphabetical order.
    the contents of the file are returned as :class:`str`, the bytes having been
    first decoded using a platform-dependent encoding or using the specified
    *encoding* if given.
+
+   :term:`universal newlines` is enabled by default in text mode, but can
+   be switched off with the :ref:`*newline* <open-newline-parameter>` parameter.
 
    .. note::
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1004,7 +1004,7 @@ are always available.  They are listed here in alphabetical order.
    ``'b'``   binary mode
    ``'t'``   text mode (default)
    ``'+'``   open a disk file for updating (reading and writing)
-   ``'U'``   equivalent to `newline=None` (deprecated, use *newline* option)
+   ``'U'``   equivalent to ``newline=None`` (deprecated, use *newline* option)
    ========= ===============================================================
 
    The default mode is ``'r'`` (open for reading text, synonym of ``'rt'``).

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1004,7 +1004,9 @@ are always available.  They are listed here in alphabetical order.
    ``'b'``   binary mode
    ``'t'``   text mode (default)
    ``'+'``   open a disk file for updating (reading and writing)
-   ``'U'``   equivalent to ``newline=None`` (deprecated, use *newline* option)
+   ``'U'``   :deprecated: :term:`universal newlines` is enabled by default
+             in text mode. See the :ref:` *newline* <open-newline-parameter>`
+             parameter documentation for more details.
    ========= ===============================================================
 
    The default mode is ``'r'`` (open for reading text, synonym of ``'rt'``).
@@ -1084,6 +1086,8 @@ are always available.  They are listed here in alphabetical order.
 
    .. index::
       single: universal newlines; open() built-in function
+
+   .. _open-newline-parameter:
 
    *newline* controls how :term:`universal newlines` mode works (it only
    applies to text mode).  It can be ``None``, ``''``, ``'\n'``, ``'\r'``, and

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1004,7 +1004,6 @@ are always available.  They are listed here in alphabetical order.
    ``'b'``   binary mode
    ``'t'``   text mode (default)
    ``'+'``   open a disk file for updating (reading and writing)
-   ``'U'``   :deprecated: :term:`universal newlines` is enabled by default
    ========= ===============================================================
 
    The default mode is ``'r'`` (open for reading text, synonym of ``'rt'``).
@@ -1019,8 +1018,11 @@ are always available.  They are listed here in alphabetical order.
    first decoded using a platform-dependent encoding or using the specified
    *encoding* if given.
 
-   :term:`universal newlines` is enabled by default in text mode, but can
-   be switched off with the :ref:`*newline* <open-newline-parameter>` parameter.
+   There is an additional mode character permitted, ``'U'``, which no longer
+   has any effect, and is considered deprecated. It previously enabled
+   :term:`universal newlines` in text mode, which became the default behaviour
+   in Python 3.0. Refer to the documentation of the
+   :ref:`newline <open-newline-parameter>` parameter for further details.
 
    .. note::
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1004,7 +1004,7 @@ are always available.  They are listed here in alphabetical order.
    ``'b'``   binary mode
    ``'t'``   text mode (default)
    ``'+'``   open a disk file for updating (reading and writing)
-   ``'U'``   :term:`universal newlines` mode (deprecated)
+   ``'U'``   equivalent to `newline=None` (deprecated, use *newline* option)
    ========= ===============================================================
 
    The default mode is ``'r'`` (open for reading text, synonym of ``'rt'``).


### PR DESCRIPTION
The previous wording could be read as saying that universal
newlines mode itself was deprecated, when it's only the 'U'
character in the mode field that should be avoided.

