### PR TITLE
Clarify file-closing example in tutorial

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -323,9 +323,7 @@ equivalent :keyword:`try`\ -\ :keyword:`finally` blocks::
     >>> with open('workfile') as f:
     ...     read_data = f.read()
 
-After the :keyword:`with` statement, we can see that the file has been
-automatically closed::
-
+    >>> # We can check that the file has been automatically closed.
     >>> f.closed
     True
 

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -323,7 +323,7 @@ equivalent :keyword:`try`\ -\ :keyword:`finally` blocks::
     >>> with open('workfile') as f:
     ...     read_data = f.read()
 
-After this :keyword:`with` statement, we can see that the file has been
+After the :keyword:`with` statement, we can see that the file has been
 automatically closed::
 
     >>> f.closed

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -322,6 +322,10 @@ equivalent :keyword:`try`\ -\ :keyword:`finally` blocks::
 
     >>> with open('workfile') as f:
     ...     read_data = f.read()
+
+After this :keyword:`with` statement, we can see that the file has been
+automatically closed::
+
     >>> f.closed
     True
 


### PR DESCRIPTION
I was helping a new Python user who was slightly confused by the
tutorial's example of using the `with` keyword with file objects,
because it seemed to them as though `f.closed` was something you needed
to do in order to close the file.  I think it's worth a brief clarifying
sentence here to explain that `f.closed` is just here to demonstrate
that the file object has been closed.