### PR TITLE
bpo-35781: Changed references to deprecated 'warn' method in logging documentation in favour of 'warning'

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -186,7 +186,7 @@ previous simple module-based configuration example::
     # 'application' code
     logger.debug('debug message')
     logger.info('info message')
-    logger.warn('warn message')
+    logger.warning('warn message')
     logger.error('error message')
     logger.critical('critical message')
 
@@ -295,7 +295,7 @@ Here is an example of a module using the logging configuration server::
         while True:
             logger.debug('debug message')
             logger.info('info message')
-            logger.warn('warn message')
+            logger.warning('warn message')
             logger.error('error message')
             logger.critical('critical message')
             time.sleep(5)

--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -610,7 +610,7 @@ logger, a console handler, and a simple formatter using Python code::
     # 'application' code
     logger.debug('debug message')
     logger.info('info message')
-    logger.warn('warn message')
+    logger.warning('warn message')
     logger.error('error message')
     logger.critical('critical message')
 
@@ -640,7 +640,7 @@ the names of the objects::
     # 'application' code
     logger.debug('debug message')
     logger.info('info message')
-    logger.warn('warn message')
+    logger.warning('warn message')
     logger.error('error message')
     logger.critical('critical message')
 

--- a/Misc/NEWS.d/next/Documentation/2019-01-23-01-43-42.bpo-35781.i_Qa7D.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-01-23-01-43-42.bpo-35781.i_Qa7D.rst
@@ -1,0 +1,2 @@
+Modify `logger.warn` to `logger.warning`.
+Because `logger.warn` method is deprecated.

--- a/Misc/NEWS.d/next/Documentation/2019-01-23-01-43-42.bpo-35781.i_Qa7D.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-01-23-01-43-42.bpo-35781.i_Qa7D.rst
@@ -1,2 +1,0 @@
-Modify `logger.warn` to `logger.warning`.
-Because `logger.warn` method is deprecated.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35781](https://bugs.python.org/issue35781) -->
https://bugs.python.org/issue35781
<!-- /issue-number -->
