### PR TITLE
bpo-35713: Reorganize sys module initialization

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -27,8 +27,11 @@ extern int _PyLong_Init(void);
 extern _PyInitError _PyFaulthandler_Init(int enable);
 extern int _PyTraceMalloc_Init(int enable);
 extern PyObject * _PyBuiltin_Init(void);
-extern _PyInitError _PySys_BeginInit(PyObject **sysmod);
-extern int _PySys_EndInit(PyObject *sysdict, PyInterpreterState *interp);
+extern _PyInitError _PySys_Create(
+    PyInterpreterState *interp,
+    PyObject **sysmod_p);
+extern _PyInitError _PySys_SetPreliminaryStderr(PyObject *sysdict);
+extern int _PySys_InitMain(PyInterpreterState *interp);
 extern _PyInitError _PyImport_Init(PyInterpreterState *interp);
 extern _PyInitError _PyExc_Init(void);
 extern _PyInitError _PyBuiltins_AddExceptions(PyObject * bltinmod);
@@ -36,7 +39,7 @@ extern _PyInitError _PyImportHooks_Init(void);
 extern int _PyFloat_Init(void);
 extern _PyInitError _Py_HashRandomization_Init(const _PyCoreConfig *);
 
-extern _PyInitError _Py_ReadyTypes(void);
+extern _PyInitError _PyTypes_Init(void);
 
 /* Various internal finalizers */
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1717,7 +1717,7 @@ PyObject _Py_NotImplementedStruct = {
 };
 
 _PyInitError
-_Py_ReadyTypes(void)
+_PyTypes_Init(void)
 {
 #define INIT_TYPE(TYPE, NAME) \
     do { \


### PR DESCRIPTION
Reorganize Python initialization to get working exceptions and
sys.stderr earlier. Changes:

* Add _PySys_SetPreliminaryStderr(). Preliminary sys.stderr is now
  set earlier to get an usable sys.stderr ealier.
* Split _PyExc_Init(): create a new _PyBuiltins_AddExceptions()
  function.
* Call _PyExc_Init() earlier in _Py_InitializeCore_impl()
  and new_interpreter() to get working exceptions earlier.
* Split _Py_InitializeCore_impl() into subfunctions: add multiple
  pycore_init_xxx() functions
* Move code into _Py_Initialize_ReconfigureCore() to be able to call
  it from _Py_InitializeCore().
* Rename _Py_ReadyTypes() to _PyTypes_Init(). It now returns
  _PyInitError rather than calling Py_FatalError().
* Rename _PySys_BeginInit() to _PySys_InitCore()
* Rename _PySys_EndInit() to _PySys_InitMain()
* Add _PySys_Create(). It calls _PySys_InitCore() which becomes
  private.
* Misc code cleanup

<!-- issue-number: [bpo-35713](https://bugs.python.org/issue35713) -->
https://bugs.python.org/issue35713
<!-- /issue-number -->
