### PR TITLE
add Timestamp option in _iterencode_dict

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -370,10 +370,13 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             elif isinstance(key, int):
                 # see comment for int/float in _make_iterencode
                 key = _intstr(key)
+            elif type(key).__name__=='Timestamp':
+                # this works for pandas.datetime objects and doesn't require importing pandas.
+                key = str(key)
             elif _skipkeys:
                 continue
             else:
-                raise TypeError(f'keys must be str, int, float, bool or None, '
+                raise TypeError(f'keys must be str, int, float, bool, Timestamp or None, '
                                 f'not {key.__class__.__name__}')
             if first:
                 first = False
@@ -395,6 +398,9 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             elif isinstance(value, float):
                 # see comment for int/float in _make_iterencode
                 yield _floatstr(value)
+            elif type(key).__name__=='Timestamp':
+                # this works for pandas.datetime objects and doesn't require importing pandas.
+                key = str(key)
             else:
                 if isinstance(value, (list, tuple)):
                     chunks = _iterencode_list(value, _current_indent_level)


### PR DESCRIPTION
convert keys and values of type Timestamp (works for pandas.datetime) of dictionaries into strings.

Cheers.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
