### PR TITLE
bpo-18610: Update wsgiref.validate docstring for wsgi.input read()

### DIFF
--- a/Lib/wsgiref/validate.py
+++ b/Lib/wsgiref/validate.py
@@ -77,7 +77,7 @@ Some of the things this checks:
 
 * That wsgi.input is used properly:
 
-  - .read() is called with zero or one argument
+  - .read() is called with exactly one argument
 
   - That it returns a string
 


### PR DESCRIPTION
Update the docstring for `wsgiref.validate` to state that in `wsgi.input` `read()` is called with exactly one argument to match the edit in the code.


<!-- issue-number: [bpo-18610](https://bugs.python.org/issue18610) -->
https://bugs.python.org/issue18610
<!-- /issue-number -->
