### PR TITLE
bpo-35824: Update http.cookies._CookiePattern

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -514,6 +514,8 @@ class BaseCookie(dict):
         # syntactically invalid (this helps avoid some classes of injection
         # attacks).
         for key, value in http.cookiejar.parse_ns_headers([rawstr,])[0]:
+            if key == 'version':
+                continue
             if not isinstance(value, str):
                 value = str(value)
             if key[0] == "$":

--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -441,7 +441,7 @@ _CookiePattern = re.compile(r"""
     (?P<val>                         # Start of group 'val'
     "(?:[^\\"]|\\.)*"                  # Any doublequoted string
     |                                  # or
-    \w{3},\s[\w\d\s-]{9,11}\s[\d:]{8}\sGMT  # Special case for "expires" attr
+    \w{3},\s?[\w\d\s-]{9,11}\s[\d:]{8}\sGMT  # Special case for "expires" attr
     |                                  # or
     [""" + _LegalValueChars + r"""]*      # Any word or empty string
     )                                # End of group 'val'

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -16,11 +16,6 @@ class CookieTests(unittest.TestCase):
              'repr': "<SimpleCookie: chips='ahoy' vienna='finger'>",
              'output': 'Set-Cookie: chips=ahoy\nSet-Cookie: vienna=finger'},
 
-            {'data': 'keebler="E=mc2; L=\\"Loves\\"; fudge=\\012;"',
-             'dict': {'keebler' : 'E=mc2; L="Loves"; fudge=\012;'},
-             'repr': '''<SimpleCookie: keebler='E=mc2; L="Loves"; fudge=\\n;'>''',
-             'output': 'Set-Cookie: keebler="E=mc2; L=\\"Loves\\"; fudge=\\012;"'},
-
             # Check illegal cookies that have an '=' char in an unquoted value
             {'data': 'keebler=E=mc2',
              'dict': {'keebler' : 'E=mc2'},

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -47,7 +47,20 @@ class CookieTests(unittest.TestCase):
                     'Set-Cookie: d=r',
                     'Set-Cookie: f=h'
                 ))
-            }
+            },
+            # issue35824 - http.cookies._CookiePattern modifying regular expressions
+            {
+                'data': 'Hello=World; Expires=Thu, 31 Jan 2019 05:56:00 GMT;',
+                'dict': {'Hello': 'World'},
+                'repr': "<SimpleCookie: Hello='World'>",
+                'output': 'Set-Cookie: Hello=World; expires=Thu, 31 Jan 2019 05:56:00 GMT'
+            },
+            {
+                'data': 'Hello=World; Expires=Thu,31 Jan 2019 05:56:00 GMT;',
+                'dict': {'Hello': 'World'},
+                'repr': "<SimpleCookie: Hello='World'>",
+                'output': 'Set-Cookie: Hello=World; expires=Thu,31 Jan 2019 05:56:00 GMT'
+            },
         ]
 
         for case in cases:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -622,6 +622,7 @@ Manus Hand
 Milton L. Hankins
 Stephen Hansen
 Barry Hantman
+Zehao Hao
 Lynda Hardman
 Bar Harel
 Derek Harland

--- a/Misc/NEWS.d/next/Library/2019-01-27-05-27-23.bpo-35824.gMGwan.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-27-05-27-23.bpo-35824.gMGwan.rst
@@ -1,0 +1,1 @@
+Modify the parsing of Expires in Set-Cookie, Spaces and commas are both treated as delimiters. Patch by MeiK.


### PR DESCRIPTION
Modified a regular expression to correctly parse Expires in Cookies

http.cookies.BaseCookie can't parse Expires in this format like `Expires=Thu,31 Jan 2019 05:56:00 GMT;`(Less space after `Thu,`).

I encountered this problem in actual use, Chrome, IE and Firefox can parse this string normally. Many languages, such as JavaScript, can also parse this data automatically.

I looked for [mdn](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date#Syntax), and the examples they gave were spaces, but didn't do more.

I don't know the specification of pr and whether this pr is necessary. If it doesn't make sense, please close it.

English is not my native language; please excuse typing errors.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35824](https://bugs.python.org/issue35824) -->
https://bugs.python.org/issue35824
<!-- /issue-number -->
