### PR TITLE
bpo-35814: Allow same r.h.s. in annotated assignments as in normal ones

### DIFF
--- a/Grammar/Grammar
+++ b/Grammar/Grammar
@@ -40,7 +40,7 @@ small_stmt: (expr_stmt | del_stmt | pass_stmt | flow_stmt |
              import_stmt | global_stmt | nonlocal_stmt | assert_stmt)
 expr_stmt: testlist_star_expr (annassign | augassign (yield_expr|testlist) |
                      ('=' (yield_expr|testlist_star_expr))*)
-annassign: ':' test ['=' test]
+annassign: ':' test ['=' (yield_expr|testlist)]
 testlist_star_expr: (test|star_expr) (',' (test|star_expr))* [',']
 augassign: ('+=' | '-=' | '*=' | '@=' | '/=' | '%=' | '&=' | '|=' | '^=' |
             '<<=' | '>>=' | '**=' | '//=')

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -445,6 +445,15 @@ class GrammarTests(unittest.TestCase):
         exec('X: str', {}, CNS2())
         self.assertEqual(nonloc_ns['__annotations__']['x'], str)
 
+    def test_var_annot_rhs(self):
+        ns = {}
+        exec('x: tuple = 1, 2', ns)
+        self.assertEqual(ns['x'], (1, 2))
+        stmt = ('def f():\n'
+                '    x: int = yield')
+        exec(stmt, ns)
+        self.assertEqual(list(ns['f']()), [None])
+
     def test_funcdef(self):
         ### [decorators] 'def' NAME parameters ['->' test] ':' suite
         ### decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE

--- a/Lib/test/test_parser.py
+++ b/Lib/test/test_parser.py
@@ -165,8 +165,6 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             exec("x, *y, z: int = range(5)", {}, {})
         with self.assertRaises(SyntaxError):
-            exec("t: tuple = 1, 2", {}, {})
-        with self.assertRaises(SyntaxError):
             exec("u = v: int", {}, {})
         with self.assertRaises(SyntaxError):
             exec("False: int", {}, {})

--- a/Lib/test/test_parser.py
+++ b/Lib/test/test_parser.py
@@ -165,6 +165,8 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             exec("x, *y, z: int = range(5)", {}, {})
         with self.assertRaises(SyntaxError):
+            exec("x: int = 1, y = 2", {}, {})
+        with self.assertRaises(SyntaxError):
             exec("u = v: int", {}, {})
         with self.assertRaises(SyntaxError):
             exec("False: int", {}, {})

--- a/Misc/NEWS.d/next/Core and Builtins/2019-01-24-13-25-21.bpo-35814.r_MjA6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-01-24-13-25-21.bpo-35814.r_MjA6.rst
@@ -1,0 +1,2 @@
+Allow same right hand side expressions in annotated assignments as in normal ones.
+In particular, ``x: Tuple[int, int] = 1, 2`` (without parentheses on the right) is now allowed.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -3069,7 +3069,12 @@ ast_for_expr_stmt(struct compiling *c, const node *n)
         }
         else {
             ch = CHILD(ann, 3);
-            expr3 = ast_for_expr(c, ch);
+            if (TYPE(ch) == testlist) {
+                expr3 = ast_for_testlist(c, ch);
+            }
+            else {
+                expr3 = ast_for_expr(c, ch);
+            }
             if (!expr3) {
                 return NULL;
             }

--- a/Python/graminit.c
+++ b/Python/graminit.c
@@ -498,8 +498,9 @@ static arc arcs_17_2[2] = {
     {31, 3},
     {0, 2},
 };
-static arc arcs_17_3[1] = {
-    {26, 4},
+static arc arcs_17_3[2] = {
+    {50, 4},
+    {9, 4},
 };
 static arc arcs_17_4[1] = {
     {0, 4},
@@ -508,7 +509,7 @@ static state states_17[5] = {
     {1, arcs_17_0},
     {1, arcs_17_1},
     {2, arcs_17_2},
-    {1, arcs_17_3},
+    {2, arcs_17_3},
     {1, arcs_17_4},
 };
 static arc arcs_18_0[2] = {


### PR DESCRIPTION



<!-- issue-number: [bpo-35814](https://bugs.python.org/issue35814) -->
https://bugs.python.org/issue35814
<!-- /issue-number -->
