### PR TITLE
bpo-35800: Deprecate smtpd.MailmanProxy

### DIFF
--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -148,7 +148,7 @@ MailmanProxy Objects
 
 .. class:: MailmanProxy(localaddr, remoteaddr)
 
-   .. deprecated-removed:: 3.8 3.10
+   .. deprecated-removed:: 3.9 3.11
 
       :class:`MailmanProxy` is deprecated, it depends on a ``Mailman``
       module which no longer exists and therefore is already broken.

--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -148,7 +148,7 @@ MailmanProxy Objects
 
 .. class:: MailmanProxy(localaddr, remoteaddr)
 
-   .. deprecated-removed:: 3.8 3.9
+   .. deprecated-removed:: 3.8 3.10
 
       :class:`MailmanProxy` is deprecated, it depends on a ``Mailman``
       module which no long exists and therefore is already broken.

--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -148,6 +148,12 @@ MailmanProxy Objects
 
 .. class:: MailmanProxy(localaddr, remoteaddr)
 
+   .. deprecated-removed:: 3.8 3.9
+
+      :class:`MailmanProxy` is deprecated, it depends on a ``Mailman``
+      module which no long exists and therefore is already broken.
+
+
    Create a new pure proxy server. Arguments are as per :class:`SMTPServer`.
    Everything will be relayed to *remoteaddr*, unless local mailman configurations
    knows about an address, in which case it will be handled via mailman.  Note that

--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -151,7 +151,7 @@ MailmanProxy Objects
    .. deprecated-removed:: 3.8 3.10
 
       :class:`MailmanProxy` is deprecated, it depends on a ``Mailman``
-      module which no long exists and therefore is already broken.
+      module which no longer exists and therefore is already broken.
 
 
    Create a new pure proxy server. Arguments are as per :class:`SMTPServer`.

--- a/Lib/smtpd.py
+++ b/Lib/smtpd.py
@@ -779,6 +779,8 @@ class PureProxy(SMTPServer):
 
 class MailmanProxy(PureProxy):
     def __init__(self, *args, **kwargs):
+        warn('MailmanProxy is deprecated and will be removed '
+             'in future', DeprecationWarning, 2)
         if 'enable_SMTPUTF8' in kwargs and kwargs['enable_SMTPUTF8']:
             raise ValueError("MailmanProxy does not support SMTPUTF8.")
         super(PureProxy, self).__init__(*args, **kwargs)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -313,6 +313,7 @@ Benjamin Collar
 Jeffery Collins
 Robert Collins
 Paul Colomiets
+Samuel Colvin
 Christophe Combelles
 Geremy Condra
 Denver Coneybeare

--- a/Misc/NEWS.d/next/Library/2019-01-25-17-12-17.bpo-35800.MCGJdQ.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-25-17-12-17.bpo-35800.MCGJdQ.rst
@@ -1,0 +1,1 @@
+Deprecate ``smtpd.MailmanProxy`` ready for future removal.


### PR DESCRIPTION
Since `smtpd.MailmanProxy` is already broken, it is not formally deprecated in 3.9. It will be removed in 3.10.

<!-- issue-number: [bpo-35800](https://bugs.python.org/issue35800) -->
https://bugs.python.org/issue35800
<!-- /issue-number -->


Automerge-Triggered-By: @maxking