### PR TITLE
bpo-35797: Fix default executable used by the multiprocessing module

### DIFF
--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -29,20 +29,19 @@ __all__ = ['_main', 'freeze_support', 'set_executable', 'get_executable',
 if sys.platform != 'win32':
     WINEXE = False
     WINSERVICE = False
+    _WINENV = False
 else:
-    WINEXE = (sys.platform == 'win32' and getattr(sys, 'frozen', False))
+    WINEXE = getattr(sys, 'frozen', False)
     WINSERVICE = sys.executable.lower().endswith("pythonservice.exe")
+    _WINENV = '__PYVENV_LAUNCHER__' in os.environ
 
 if WINSERVICE:
     _python_exe = os.path.join(sys.exec_prefix, 'python.exe')
-elif (sys.platform == 'win32' and sys.base_exec_prefix != sys.exec_prefix
-      and '__PYVENV_LAUNCHER__' in os.environ):
+elif _WINENV:
     # bpo-35797: When running in a venv, we need to bypass the redirect
-    # executor and launch our original Python.
-    _python_exe = os.path.join(
-        sys.base_exec_prefix,
-        os.path.split(sys.executable)[-1]
-    )
+    # executor and launch our base Python.
+    import _winapi
+    _python_exe = _winapi.GetModuleFileName(0)
 else:
     _python_exe = sys.executable
 

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -35,6 +35,14 @@ else:
 
 if WINSERVICE:
     _python_exe = os.path.join(sys.exec_prefix, 'python.exe')
+elif (sys.platform == 'win32' and sys.base_exec_prefix != sys.exec_prefix
+      and '__PYVENV_LAUNCHER__' in os.environ):
+    # bpo-35797: When running in a venv, we need to bypass the redirect
+    # executor and launch our original Python.
+    _python_exe = os.path.join(
+        sys.base_exec_prefix,
+        os.path.split(sys.executable)[-1]
+    )
 else:
     _python_exe = sys.executable
 

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -306,6 +306,19 @@ class BasicTest(BaseTest):
         )
         self.assertEqual(out.strip(), '0')
 
+    def test_multiprocessing(self):
+        """
+        Test that the multiprocessing is able to spawn.
+        """
+        rmtree(self.env_dir)
+        self.run_with_capture(venv.create, self.env_dir)
+        envpy = os.path.join(os.path.realpath(self.env_dir),
+                             self.bindir, self.exe)
+        out, err = check_output([envpy, '-c',
+            'from multiprocessing import Pool; ' +
+            'print(Pool(1).apply_async("Python".lower).get(3))'])
+        self.assertEqual(out.strip(), "python".encode())
+
 @skipInVenv
 class EnsurePipTest(BaseTest):
     """Test venv module installation of pip."""

--- a/Misc/NEWS.d/next/Windows/2019-01-25-12-29-14.bpo-35797.MzyOK9.rst
+++ b/Misc/NEWS.d/next/Windows/2019-01-25-12-29-14.bpo-35797.MzyOK9.rst
@@ -1,0 +1,1 @@
+Fix default executable used by the multiprocessing module


### PR DESCRIPTION


<!-- issue-number: [bpo-35797](https://bugs.python.org/issue35797) -->
https://bugs.python.org/issue35797
<!-- /issue-number -->
