### PR TITLE
bpo-35811: Avoid propagating venv settings when launching via py.exe

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-01-25-12-46-36.bpo-35811.2hU-mm.rst
+++ b/Misc/NEWS.d/next/Windows/2019-01-25-12-46-36.bpo-35811.2hU-mm.rst
@@ -1,0 +1,1 @@
+Avoid propagating venv settings when launching via py.exe

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -1707,6 +1707,17 @@ process(int argc, wchar_t ** argv)
     command = skip_me(GetCommandLineW());
     debug(L"Called with command line: %ls\n", command);
 
+#if !defined(VENV_REDIRECT)
+    /* bpo-35811: The __PYVENV_LAUNCHER__ variable is used to
+     * override sys.executable and locate the original prefix path. 
+     * However, if it is silently inherited by a non-venv Python
+     * process, that process will believe it is running in the venv
+     * still. This is the only place where *we* can clear it (that is,
+     * when py.exe is being used to launch Python), so we do.
+     */
+    SetEnvironmentVariableW(L"__PYVENV_LAUNCHER__", NULL);
+#endif
+
 #if defined(SCRIPT_WRAPPER)
     /* The launcher is being used in "script wrapper" mode.
      * There should therefore be a Python script named <exename>-script.py in


### PR DESCRIPTION


<!-- issue-number: [bpo-35811](https://bugs.python.org/issue35811) -->
https://bugs.python.org/issue35811
<!-- /issue-number -->
