### PR TITLE
bpo-35826: Fix typo in equivalent code of `async with cond`

### DIFF
--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -180,11 +180,11 @@ Condition
        cond = asyncio.Condition()
 
        # ... later
-       await lock.acquire()
+       await cond.acquire()
        try:
            await cond.wait()
        finally:
-           lock.release()
+           cond.release()
 
    .. coroutinemethod:: acquire()
 


### PR DESCRIPTION
#### Issues
The equivalent example code of `async with` statement with `asyncio.Condition` has a typo. `lock.xxx` should be changed to `cond.xxx`.

#### Changes
- `lock.acquire` to `cond.acquire`
- `lock.release` to `cond.release`


<!-- issue-number: [bpo-35826](https://bugs.python.org/issue35826) -->
https://bugs.python.org/issue35826
<!-- /issue-number -->
