### PR TITLE
bpo-35837 Take kwargs and string in PureProxy's process_message

### DIFF
--- a/Lib/smtpd.py
+++ b/Lib/smtpd.py
@@ -738,7 +738,7 @@ class PureProxy(SMTPServer):
             raise ValueError("PureProxy does not support SMTPUTF8.")
         super(PureProxy, self).__init__(*args, **kwargs)
 
-    def process_message(self, peer, mailfrom, rcpttos, data):
+    def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
         lines = data.split('\n')
         # Look for the last header
         i = 0
@@ -783,7 +783,7 @@ class MailmanProxy(PureProxy):
             raise ValueError("MailmanProxy does not support SMTPUTF8.")
         super(PureProxy, self).__init__(*args, **kwargs)
 
-    def process_message(self, peer, mailfrom, rcpttos, data):
+    def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
         from io import StringIO
         from Mailman import Utils
         from Mailman import Message

--- a/Lib/smtpd.py
+++ b/Lib/smtpd.py
@@ -736,7 +736,7 @@ class PureProxy(SMTPServer):
     def __init__(self, *args, **kwargs):
         if 'enable_SMTPUTF8' in kwargs and kwargs['enable_SMTPUTF8']:
             raise ValueError("PureProxy does not support SMTPUTF8.")
-        super(PureProxy, self).__init__(*args, **kwargs)
+        super(PureProxy, self).__init__(*args, decode_data=True, **kwargs)
 
     def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
         lines = data.split('\n')


### PR DESCRIPTION
# [bpo-35837](https://bugs.python.org/issue35837) Take kwargs and string in PureProxy's process_message

This makes smtpd's PureProxy work again.

<!-- issue-number: [bpo-35837](https://bugs.python.org/issue35837) -->
https://bugs.python.org/issue35837
<!-- /issue-number -->
