### PR TITLE
subprocess: close pipes/fds by using ExitStack

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1115,6 +1115,7 @@ class Popen(object):
                 if p2cread is None:
                     p2cread, _ = _winapi.CreatePipe(None, 0)
                     p2cread = Handle(p2cread)
+                    _winapi.CloseHandle(_)
             elif stdin == PIPE:
                 p2cread, p2cwrite = _winapi.CreatePipe(None, 0)
                 p2cread, p2cwrite = Handle(p2cread), Handle(p2cwrite)
@@ -1132,6 +1133,7 @@ class Popen(object):
                 if c2pwrite is None:
                     _, c2pwrite = _winapi.CreatePipe(None, 0)
                     c2pwrite = Handle(c2pwrite)
+                    _winapi.CloseHandle(_)
             elif stdout == PIPE:
                 c2pread, c2pwrite = _winapi.CreatePipe(None, 0)
                 c2pread, c2pwrite = Handle(c2pread), Handle(c2pwrite)

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1114,10 +1114,7 @@ class Popen(object):
                 p2cread = _winapi.GetStdHandle(_winapi.STD_INPUT_HANDLE)
                 if p2cread is None:
                     p2cread, _ = _winapi.CreatePipe(None, 0)
-                    try:
-                        p2cread = Handle(p2cread)
-                    finally:
-                        _winapi.CloseHandle(_)
+                    p2cread = Handle(p2cread)
             elif stdin == PIPE:
                 p2cread, p2cwrite = _winapi.CreatePipe(None, 0)
                 p2cread, p2cwrite = Handle(p2cread), Handle(p2cwrite)
@@ -1134,10 +1131,7 @@ class Popen(object):
                 c2pwrite = _winapi.GetStdHandle(_winapi.STD_OUTPUT_HANDLE)
                 if c2pwrite is None:
                     _, c2pwrite = _winapi.CreatePipe(None, 0)
-                    try:
-                        c2pwrite = Handle(c2pwrite)
-                    finally:
-                        _winapi.CloseHandle(_)
+                    c2pwrite = Handle(c2pwrite)
             elif stdout == PIPE:
                 c2pread, c2pwrite = _winapi.CreatePipe(None, 0)
                 c2pread, c2pwrite = Handle(c2pread), Handle(c2pwrite)

--- a/Misc/NEWS.d/next/Library/2019-01-29-17-24-52.bpo-35537.Q0ktFC.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-29-17-24-52.bpo-35537.Q0ktFC.rst
@@ -1,0 +1,4 @@
+An ExitStack is now used internally within subprocess.POpen to clean up pipe
+file handles. No behavior change in normal operation. But if closing one
+handle were ever to cause an exception, the others will now be closed
+instead of leaked.  (patch by Giampaolo Rodola)


### PR DESCRIPTION
"In case of premature failure on X.Close() or os.close(X) the remaining pipes/fds will remain "open". Perhaps it makes sense to use contextlib.ExitStack."

This is a follow up of [bpo-35537](https://bugs.python.org/issue35537). Rationale of this change originated during code inspection in https://github.com/python/cpython/pull/11575#discussion_r250288394.