### PR TITLE
Correct 416 status code enum name

### DIFF
--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -96,7 +96,7 @@ Code    Enum Name                           Details
 ``413`` ``REQUEST_ENTITY_TOO_LARGE``        HTTP/1.1 :rfc:`7231`, Section 6.5.11
 ``414`` ``REQUEST_URI_TOO_LONG``            HTTP/1.1 :rfc:`7231`, Section 6.5.12
 ``415`` ``UNSUPPORTED_MEDIA_TYPE``          HTTP/1.1 :rfc:`7231`, Section 6.5.13
-``416`` ``REQUEST_RANGE_NOT_SATISFIABLE``   HTTP/1.1 Range Requests :rfc:`7233`, Section 4.4
+``416`` ``REQUESTED_RANGE_NOT_SATISFIABLE`` HTTP/1.1 Range Requests :rfc:`7233`, Section 4.4
 ``417`` ``EXPECTATION_FAILED``              HTTP/1.1 :rfc:`7231`, Section 6.5.14
 ``421`` ``MISDIRECTED_REQUEST``             HTTP/2 :rfc:`7540`, Section 9.1.2
 ``422`` ``UNPROCESSABLE_ENTITY``            WebDAV :rfc:`4918`, Section 11.2


### PR DESCRIPTION
See [`Lib/http/__init__.py#L97`](https://github.com/python/cpython/blob/master/Lib/http/__init__.py#L97), it is `REQUESTED_RANGE_NOT_SATISFIABLE` 
rather than `REQUEST_RANGE_NOT_SATISFIABLE`.

I think this is a trivial change that doesn't need an issue (`Trivial changes, like fixing a typo, do not need an issue.`).