### PR TITLE
Fast path for int inputs to math.dist() and math.hypot()

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -766,6 +766,9 @@ class MathTests(unittest.TestCase):
             hypot(x=1)
         with self.assertRaises(TypeError):         # Reject values without __float__
             hypot(1.1, 'string', 2.2)
+        int_too_big_for_float = 10 ** (sys.float_info.max_10_exp + 5)
+        with self.assertRaises((ValueError, OverflowError)):
+            hypot(1, int_too_big_for_float)
 
         # Any infinity gives positive infinity.
         self.assertEqual(hypot(INF), INF)
@@ -805,7 +808,8 @@ class MathTests(unittest.TestCase):
         dist = math.dist
         sqrt = math.sqrt
 
-        # Simple exact case
+        # Simple exact cases
+        self.assertEqual(dist((1.0, 2.0, 3.0), (4.0, 2.0, -1.0)), 5.0)
         self.assertEqual(dist((1, 2, 3), (4, 2, -1)), 5.0)
 
         # Test different numbers of arguments (from zero to nine)
@@ -869,6 +873,11 @@ class MathTests(unittest.TestCase):
             dist((1, 2, 3), (4, 5, 6, 7))
         with self.assertRaises(TypeError):         # Rejects invalid types
             dist("abc", "xyz")
+        int_too_big_for_float = 10 ** (sys.float_info.max_10_exp + 5)
+        with self.assertRaises((ValueError, OverflowError)):
+            dist((1, int_too_big_for_float), (2, 3))
+        with self.assertRaises((ValueError, OverflowError)):
+            dist((2, 3), (1, int_too_big_for_float))
 
         # Verify that the one dimensional case is equivalent to abs()
         for i in range(20):

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2144,7 +2144,14 @@ math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
         item = PyTuple_GET_ITEM(p, i);
         if (PyFloat_CheckExact(item)) {
             px = PyFloat_AS_DOUBLE(item);
-        } else {
+        }
+        else if (PyLong_CheckExact(item)) {
+            x = PyLong_AsDouble(item);
+            if (x == -1.0 && PyErr_Occurred()) {
+                goto error_exit;
+            }
+        }
+        else {
             px = PyFloat_AsDouble(item);
             if (px == -1.0 && PyErr_Occurred()) {
                 goto error_exit;
@@ -2153,7 +2160,14 @@ math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
         item = PyTuple_GET_ITEM(q, i);
         if (PyFloat_CheckExact(item)) {
             qx = PyFloat_AS_DOUBLE(item);
-        } else {
+        }
+        else if (PyLong_CheckExact(item)) {
+            x = PyLong_AsDouble(item);
+            if (x == -1.0 && PyErr_Occurred()) {
+                goto error_exit;
+            }
+        }
+        else {
             qx = PyFloat_AsDouble(item);
             if (qx == -1.0 && PyErr_Occurred()) {
                 goto error_exit;
@@ -2201,7 +2215,14 @@ math_hypot(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
         item = args[i];
         if (PyFloat_CheckExact(item)) {
             x = PyFloat_AS_DOUBLE(item);
-        } else {
+        }
+        else if (PyLong_CheckExact(item)) {
+            x = PyLong_AsDouble(item);
+            if (x == -1.0 && PyErr_Occurred()) {
+                goto error_exit;
+            }
+        }
+        else {
             x = PyFloat_AsDouble(item);
             if (x == -1.0 && PyErr_Occurred()) {
                 goto error_exit;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2146,8 +2146,8 @@ math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
             px = PyFloat_AS_DOUBLE(item);
         }
         else if (PyLong_CheckExact(item)) {
-            x = PyLong_AsDouble(item);
-            if (x == -1.0 && PyErr_Occurred()) {
+            px = PyLong_AsDouble(item);
+            if (px == -1.0 && PyErr_Occurred()) {
                 goto error_exit;
             }
         }
@@ -2162,8 +2162,8 @@ math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
             qx = PyFloat_AS_DOUBLE(item);
         }
         else if (PyLong_CheckExact(item)) {
-            x = PyLong_AsDouble(item);
-            if (x == -1.0 && PyErr_Occurred()) {
+            qx = PyLong_AsDouble(item);
+            if (qx == -1.0 && PyErr_Occurred()) {
                 goto error_exit;
             }
         }


### PR DESCRIPTION
Besides *float* which already has a fast path, *int* is the other common case.   Add a fast path that goes directly to a C double without creating a *PyFloat* object as an intermediate step.  

Timings with patch:
```
$ ./python.exe -m timeit -s 'from math import hypot' 'hypot(3, 4, 5, 6, 7, 8)'
5000000 loops, best of 5: 87.5 nsec per loop
$ ./python.exe -m timeit -s 'from math import dist' -s 'p=(3, 4, 5, 6, 7, 8)' -s 'q=(1, 2, 3, 4, 5, 6)' 'dist(p, q)'
2000000 loops, best of 5: 118 nsec per loop
```

Timings for the baseline version:
```
$ ./python.exe -m timeit -s 'from math import hypot' 'hypot(3, 4, 5, 6, 7, 8)'
2000000 loops, best of 5: 149 nsec per loop
$ ./python.exe -m timeit -s 'from math import dist' -s 'p=(3, 4, 5, 6, 7, 8)' -s 'q=(1, 2, 3, 4, 5, 6)' 'dist(p, q)'
1000000 loops, best of 5: 217 nsec per loop
```