### PR TITLE
bpo-35854: Fix EnvBuilder and ignore --symlinks in venv on Windows

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -199,6 +199,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
     .. versionchanged:: 3.7.3
        Windows copies the redirector scripts as part of :meth:`setup_python`
        instead of :meth:`setup_scripts`. This was not the case in 3.7.2.
+       When using symlinks, the original executables will be linked.
 
     In addition, :class:`EnvBuilder` provides this utility method that can be
     called from :meth:`setup_scripts` or :meth:`post_setup` in subclasses to

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -109,8 +109,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
       any existing target directory, before creating the environment.
 
     * ``symlinks`` -- a Boolean value indicating whether to attempt to symlink the
-      Python binary (and any necessary DLLs or other binaries,
-      e.g. ``pythonw.exe``), rather than copying.
+      Python binary rather than copying. This is not used on Windows.
 
     * ``upgrade`` -- a Boolean value which, if true, will upgrade an existing
       environment with the running Python - for use when that Python has been
@@ -176,15 +175,15 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
     .. method:: setup_python(context)
 
-        Creates a copy of the Python executable in the environment on POSIX
-        systems. If a specific executable ``python3.x`` was used, symlinks to
-        ``python`` and ``python3`` will be created pointing to that executable,
-        unless files with those names already exist.
+        Creates a copy or symlink to the Python executable in the environment.
+        If a specific executable ``python3.x`` was used, symlinks to ``python``
+        and ``python3`` will be created pointing to that executable, unless
+        files with those names already exist.
 
     .. method:: setup_scripts(context)
 
         Installs activation scripts appropriate to the platform into the virtual
-        environment. On Windows, also installs the ``python[w].exe`` scripts.
+        environment.
 
     .. method:: post_setup(context)
 
@@ -194,8 +193,12 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
     .. versionchanged:: 3.7.2
        Windows now uses redirector scripts for ``python[w].exe`` instead of
-       copying the actual binaries, and so :meth:`setup_python` does nothing
-       unless running from a build in the source tree.
+       copying the actual binaries. In 3.7.2 only :meth:`setup_python` does
+       nothing unless running from a build in the source tree.
+
+    .. versionchanged:: 3.7.3
+       Windows copies the redirector scripts as part of :meth:`setup_python`
+       instead of :meth:`setup_scripts`. This was not the case in 3.7.2.
 
     In addition, :class:`EnvBuilder` provides this utility method that can be
     called from :meth:`setup_scripts` or :meth:`post_setup` in subclasses to

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -109,7 +109,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
       any existing target directory, before creating the environment.
 
     * ``symlinks`` -- a Boolean value indicating whether to attempt to symlink the
-      Python binary rather than copying. This is not used on Windows.
+      Python binary rather than copying.
 
     * ``upgrade`` -- a Boolean value which, if true, will upgrade an existing
       environment with the running Python - for use when that Python has been
@@ -176,9 +176,9 @@ creation according to their needs, the :class:`EnvBuilder` class.
     .. method:: setup_python(context)
 
         Creates a copy or symlink to the Python executable in the environment.
-        If a specific executable ``python3.x`` was used, symlinks to ``python``
-        and ``python3`` will be created pointing to that executable, unless
-        files with those names already exist.
+        On POSIX systems, if a specific executable ``python3.x`` was used,
+        symlinks to ``python`` and ``python3`` will be created pointing to that
+        executable, unless files with those names already exist.
 
     .. method:: setup_scripts(context)
 

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -70,6 +70,11 @@ The command, if run with ``-h``, will show the available options::
    In earlier versions, if the target directory already existed, an error was
    raised, unless the ``--clear`` or ``--upgrade`` option was provided.
 
+.. note::
+   While symlinks are supported on Windows, they are not recommended. Of
+   particular note is that double-clicking ``python.exe`` in File Explorer
+   will resolve the symlink eagerly and ignore the virtual environment.
+
 The created ``pyvenv.cfg`` file also includes the
 ``include-system-site-packages`` key, set to ``true`` if ``venv`` is
 run with the ``--system-site-packages`` option, ``false`` otherwise.

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -243,7 +243,6 @@ class BasicTest(BaseTest):
             self.assertIn('include-system-site-packages = %s\n' % s, data)
 
     @unittest.skipUnless(can_symlink(), 'Needs symlinks')
-    @unittest.skipIf(os.name == 'nt', 'Symlinks are never used on Windows')
     def test_symlinking(self):
         """
         Test symlinking works as expected

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -293,7 +293,7 @@ class EnvBuilder:
         text = text.replace('__VENV_PYTHON__', context.env_exe)
         return text
 
-    def install_scripts(self, context, path, *, exe_scripts=False):
+    def install_scripts(self, context, path):
         """
         Install scripts into the created environment from a directory.
 
@@ -315,9 +315,9 @@ class EnvBuilder:
                         dirs.remove(d)
                 continue # ignore files in top level
             for f in files:
-                if os.name == 'nt':
-                    if f.startswith('python') and f.endswith(('.exe', '.pdb')):
-                        continue
+                if (os.name == 'nt' and f.startswith('python')
+                        and f.endswith(('.exe', '.pdb'))):
+                    continue
                 srcfile = os.path.join(root, f)
                 suffix = root[plen:].split(os.sep)[2:]
                 if not suffix:

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -241,7 +241,6 @@ class EnvBuilder:
                         shutil.copyfile(src, dst)
                         break
 
-
     def _setup_pip(self, context):
         """Installs or upgrades pip in a virtual environment"""
         # We run ensurepip in isolated mode to avoid side effects from

--- a/Misc/NEWS.d/next/Windows/2019-01-29-15-44-46.bpo-35854.Ww3z19.rst
+++ b/Misc/NEWS.d/next/Windows/2019-01-29-15-44-46.bpo-35854.Ww3z19.rst
@@ -1,0 +1,1 @@
+Fix EnvBuilder and ignore --symlinks in venv on Windows

--- a/Misc/NEWS.d/next/Windows/2019-01-29-15-44-46.bpo-35854.Ww3z19.rst
+++ b/Misc/NEWS.d/next/Windows/2019-01-29-15-44-46.bpo-35854.Ww3z19.rst
@@ -1,1 +1,1 @@
-Fix EnvBuilder and ignore --symlinks in venv on Windows
+Fix EnvBuilder and --symlinks in venv on Windows


### PR DESCRIPTION


<!-- issue-number: [bpo-35854](https://bugs.python.org/issue35854) -->
https://bugs.python.org/issue35854
<!-- /issue-number -->
