### PR TITLE
bpo-35862: Spawn processes with a modified environment

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -449,7 +449,7 @@ The :mod:`multiprocessing` package mostly replicates the API of the
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. class:: Process(group=None, target=None, name=None, args=(), kwargs={}, \
-                   *, daemon=None)
+                   *, env=None, daemon=None)
 
    Process objects represent activity that is run in a separate process. The
    :class:`Process` class has equivalents of all the methods of
@@ -461,9 +461,11 @@ The :mod:`multiprocessing` package mostly replicates the API of the
    the :meth:`run()` method.  It defaults to ``None``, meaning nothing is
    called. *name* is the process name (see :attr:`name` for more details).
    *args* is the argument tuple for the target invocation.  *kwargs* is a
-   dictionary of keyword arguments for the target invocation.  If provided,
-   the keyword-only *daemon* argument sets the process :attr:`daemon` flag
-   to ``True`` or ``False``.  If ``None`` (the default), this flag will be
+   dictionary of keyword arguments for the target invocation.  The optional
+   argument *env* can be used to change the environment for the new process
+   similar to :class:`subprocess.Popen` (Windows only).  If provided, the
+   keyword-only *daemon* argument sets the process :attr:`daemon` flag to
+   ``True`` or ``False``.  If ``None`` (the default), this flag will be
    inherited from the creating process.
 
    By default, no arguments are passed to *target*.
@@ -474,6 +476,9 @@ The :mod:`multiprocessing` package mostly replicates the API of the
 
    .. versionchanged:: 3.3
       Added the *daemon* argument.
+
+   .. versionchanged:: 3.8
+      Added the *env* argument.
 
    .. method:: run()
 

--- a/Lib/multiprocessing/popen_spawn_win32.py
+++ b/Lib/multiprocessing/popen_spawn_win32.py
@@ -55,7 +55,7 @@ class Popen(object):
             try:
                 hp, ht, pid, tid = _winapi.CreateProcess(
                     spawn.get_executable(), cmd,
-                    None, None, False, 0, None, None, None)
+                    None, None, False, 0, process_obj._env, None, None)
                 _winapi.CloseHandle(ht)
             except:
                 _winapi.CloseHandle(rhandle)

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -70,7 +70,7 @@ class BaseProcess(object):
         raise NotImplementedError
 
     def __init__(self, group=None, target=None, name=None, args=(), kwargs={},
-                 *, daemon=None):
+                 *, env=None, daemon=None):
         assert group is None, 'group argument must be None for now'
         count = next(_process_counter)
         self._identity = _current_process._identity + (count,)
@@ -83,6 +83,7 @@ class BaseProcess(object):
         self._kwargs = dict(kwargs)
         self._name = name or type(self).__name__ + '-' + \
                      ':'.join(str(i) for i in self._identity)
+        self._env = env
         if daemon is not None:
             self.daemon = daemon
         _dangling.add(self)


### PR DESCRIPTION

This adds support for spawning a python process with a changed environment, which is very helpful in certain cases.

Currently implemented for win32, I'm not sure how useful it would be for other systems. The inspiration is from the subprocess module.

Tests are already included!

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35862](https://bugs.python.org/issue35862) -->
https://bugs.python.org/issue35862
<!-- /issue-number -->
