### PR TITLE
bpo-35864: Replace OrderedDict with regular dict in namedtuple()

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -894,10 +894,17 @@ field names, the method and attribute names start with an underscore.
 
         >>> p = Point(x=11, y=22)
         >>> p._asdict()
-        OrderedDict([('x', 11), ('y', 22)])
+        {'x': 11, 'y': 22}
 
     .. versionchanged:: 3.1
         Returns an :class:`OrderedDict` instead of a regular :class:`dict`.
+
+    .. versionchanged:: 3.8
+        Returns a regular :class:`dict` instead of an :class:`OrderedDict`.
+        As of Python 3.7, regular dicts are guaranteed to be ordered.  If the
+        extra features of :class:`OrderedDict` are required, the suggested
+        remediation is to cast the result to the desired type:
+        ``OrderedDict(nt._asdict())``.
 
 .. method:: somenamedtuple._replace(**kwargs)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -125,6 +125,14 @@ New Modules
 Improved Modules
 ================
 
+* The :meth:`_asdict()` method for :func:`collections.namedtuple` now returns
+  a :class:`dict` instead of a :class:`collections.OrderedDict`.  This works because
+  regular dicts have guaranteed ordering in since Python 3.7.  If the extra
+  features of :class:`OrderedDict` are required, the suggested remediation is
+  to cast the result to the desired type: ``OrderedDict(nt._asdict())``.
+  (Contributed by Raymond Hettinger in :issue:`35864`.)
+
+
 asyncio
 -------
 

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -426,9 +426,11 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
         'Return a nicely formatted representation string'
         return self.__class__.__name__ + repr_fmt % self
 
+    _dict, _zip = dict, zip
+
     def _asdict(self):
         'Return a new OrderedDict which maps field names to their values.'
-        return OrderedDict(zip(self._fields, self))
+        return _dict(_zip(self._fields, self))
 
     def __getnewargs__(self):
         'Return self as a plain tuple.  Used by copy and pickle.'

--- a/Misc/NEWS.d/next/Library/2019-01-30-20-22-36.bpo-35864.ig9KnG.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-30-20-22-36.bpo-35864.ig9KnG.rst
@@ -1,0 +1,2 @@
+The _asdict() method for collections.namedtuple now returns a regular dict
+instead of an OrderedDict.


### PR DESCRIPTION


<!-- issue-number: [bpo-35864](https://bugs.python.org/issue35864) -->
https://bugs.python.org/issue35864
<!-- /issue-number -->
