### PR TITLE
bpo-35766 follow-up: Kill half-support for FunctionType in PyAST_obj2mod

### DIFF
--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1187,19 +1187,18 @@ PyObject* PyAST_mod2obj(mod_ty t)
 }
 
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
-/* and 3 for "func_type" */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
     mod_ty res;
     PyObject *req_type[3];
-    char *req_name[] = {"Module", "Expression", "Interactive", "FunctionType"};
+    char *req_name[] = {"Module", "Expression", "Interactive"};
     int isinstance;
 
     req_type[0] = (PyObject*)Module_type;
     req_type[1] = (PyObject*)Expression_type;
     req_type[2] = (PyObject*)Interactive_type;
 
-    assert(0 <= mode && mode <= 3);
+    assert(0 <= mode && mode <= 2);
 
     if (!init_types())
         return NULL;

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -8917,19 +8917,18 @@ PyObject* PyAST_mod2obj(mod_ty t)
 }
 
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
-/* and 3 for "func_type" */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
     mod_ty res;
     PyObject *req_type[3];
-    char *req_name[] = {"Module", "Expression", "Interactive", "FunctionType"};
+    char *req_name[] = {"Module", "Expression", "Interactive"};
     int isinstance;
 
     req_type[0] = (PyObject*)Module_type;
     req_type[1] = (PyObject*)Expression_type;
     req_type[2] = (PyObject*)Interactive_type;
 
-    assert(0 <= mode && mode <= 3);
+    assert(0 <= mode && mode <= 2);
 
     if (!init_types())
         return NULL;


### PR DESCRIPTION
See https://github.com/python/cpython/pull/11645/files/229874c612df868e7ae3e997e159915f49d16542#r252631862

(Alternatively I could do what @ambv proposed, but I have no use for it.)

<!-- issue-number: [bpo-35766](https://bugs.python.org/issue35766) -->
https://bugs.python.org/issue35766
<!-- /issue-number -->
