### PR TITLE
Speed-up common cases for deque.__init__()

### DIFF
--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1463,9 +1463,13 @@ deque_init(dequeobject *deque, PyObject *args, PyObject *kwdargs)
     Py_ssize_t maxlen = -1;
     char *kwlist[] = {"iterable", "maxlen", 0};
 
-    if (kwdargs == NULL) {
-        if (!PyArg_UnpackTuple(args, "deque()", 0, 2, &iterable, &maxlenobj))
-            return -1;
+    if (kwdargs == NULL && PyTuple_GET_SIZE(args) <= 2) {
+        if (PyTuple_GET_SIZE(args) > 0) {
+            iterable = PyTuple_GET_ITEM(args, 0);
+        }
+        if (PyTuple_GET_SIZE(args) > 1) {
+            maxlenobj = PyTuple_GET_ITEM(args, 1);
+        }
     } else {
         if (!PyArg_ParseTupleAndKeywords(args, kwdargs, "|OO:deque", kwlist,
                                          &iterable, &maxlenobj))


### PR DESCRIPTION
Timings with patch:

```
$ ./python.exe -m timeit -r11 -s 'from collections import deque' 'deque()'
5000000 loops, best of 11: 77.2 nsec per loop
$ ./python.exe -m timeit -r11 -s 'from collections import deque' 'deque("abc")'
2000000 loops, best of 11: 157 nsec per loop
$ ./python.exe -m timeit -r11 -s 'from collections import deque' 'deque("abc", 2)'
2000000 loops, best of 11: 166 nsec per loop
```

Baseline timings:
```
$ ./python.exe -m timeit -r11 -s 'from collections import deque' 'deque()'
5000000 loops, best of 11: 81.4 nsec per loop
$ ./python.exe -m timeit -r11 -s 'from collections import deque' 'deque("abc")'
2000000 loops, best of 11: 171 nsec per loop
$ ./python.exe -m timeit -r11 -s 'from collections import deque' 'deque("abc", 2)'
2000000 loops, best of 11: 181 nsec per loop
```