### PR TITLE
bpo-35537: Skip test_start_new_session() of posix_spawn

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1624,6 +1624,8 @@ class _PosixSpawnMixin:
                             os.environ, setsigmask=[signal.NSIG,
                                                     signal.NSIG+1])
 
+    @unittest.skipIf(True,
+                     "FIXME: bpo-35537: test fails is setsid is supported")
     def test_start_new_session(self):
         # For code coverage of calling setsid().  We don't care if we get an
         # EPERM error from it depending on the test execution environment, that


### PR DESCRIPTION
The test fails. Skip the test until a fix can be found.

<!-- issue-number: [bpo-35537](https://bugs.python.org/issue35537) -->
https://bugs.python.org/issue35537
<!-- /issue-number -->
