### PR TITLE
bpo-35864: fix namedtuple._asdict() docstring

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -429,7 +429,7 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
     _dict, _zip = dict, zip
 
     def _asdict(self):
-        'Return a new OrderedDict which maps field names to their values.'
+        'Return a new dict which maps field names to their values.'
         return _dict(_zip(self._fields, self))
 
     def __getnewargs__(self):


### PR DESCRIPTION
Commit 0bb4bdf0d93b301407774c4ffd6df54cff947df8 replaced `OrderedDict` with regular dict in `namedtuple()`. This patch just updates the `_asdict()` docstring.

<!-- issue-number: [bpo-35864](https://bugs.python.org/issue35864) -->
https://bugs.python.org/issue35864
<!-- /issue-number -->
