### PR TITLE
bpo-35861: test_named_expressions raises SyntaxWarning

### DIFF
--- a/Lib/test/test_named_expressions.py
+++ b/Lib/test/test_named_expressions.py
@@ -165,7 +165,7 @@ class NamedExpressionAssignmentTest(unittest.TestCase):
         else: self.fail("variable was not assigned using named expression")
 
     def test_named_expression_assignment_10(self):
-        if (match := 10) is 10:
+        if (match := 10) == 10:
             pass
         else: self.fail("variable was not assigned using named expression")
 

--- a/Misc/NEWS.d/next/Tests/2019-02-01-12-44-56.bpo-35861.HJePPm.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-01-12-44-56.bpo-35861.HJePPm.rst
@@ -1,1 +1,0 @@
-There is now a fix for a SyntaxWarning recently added for comparison using "is" over literals on master for a PEP 572 related test.

--- a/Misc/NEWS.d/next/Tests/2019-02-01-12-44-56.bpo-35861.HJePPm.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-01-12-44-56.bpo-35861.HJePPm.rst
@@ -1,0 +1,1 @@
+There is now a fix for a SyntaxWarning recently added for comparison using "is" over literals on master for a PEP 572 related test.


### PR DESCRIPTION
I have added a fix for a SyntaxWarning  recently added for comparison using "is" over literals  on master for a PEP 572 related test.

The tests pass with this fix.

cc @emilyemorehouse @tirkarthi .

<!-- issue-number: [bpo-35861](https://bugs.python.org/issue35861) -->
https://bugs.python.org/issue35861
<!-- /issue-number -->
