### PR TITLE
bpo-35877: Make parenthesis optional for named expression in while statement

### DIFF
--- a/Grammar/Grammar
+++ b/Grammar/Grammar
@@ -72,7 +72,7 @@ assert_stmt: 'assert' test [',' test]
 compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | with_stmt | funcdef | classdef | decorated | async_stmt
 async_stmt: 'async' (funcdef | with_stmt | for_stmt)
 if_stmt: 'if' namedexpr_test ':' suite ('elif' namedexpr_test ':' suite)* ['else' ':' suite]
-while_stmt: 'while' test ':' suite ['else' ':' suite]
+while_stmt: 'while' namedexpr_test ':' suite ['else' ':' suite]
 for_stmt: 'for' exprlist 'in' testlist ':' [TYPE_COMMENT] suite ['else' ':' suite]
 try_stmt: ('try' ':' suite
            ((except_clause ':' suite)+

--- a/Lib/test/test_parser.py
+++ b/Lib/test/test_parser.py
@@ -426,6 +426,7 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
         self.check_suite("(a := 1)")
         self.check_suite("(a := a)")
         self.check_suite("if (match := pattern.search(data)) is None: pass")
+        self.check_suite("while match := pattern.search(f.read()): pass")
         self.check_suite("[y := f(x), y**2, y**3]")
         self.check_suite("filtered_data = [y for x in data if (y := f(x)) is None]")
         self.check_suite("(y := f(x))")

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-01-22-38-11.bpo-35877.Jrse8f.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-01-22-38-11.bpo-35877.Jrse8f.rst
@@ -1,0 +1,2 @@
+Make parenthesis optional for named expressions in while statement. Patch by
+Karthikeyan Singaravelan.

--- a/Python/graminit.c
+++ b/Python/graminit.c
@@ -971,7 +971,7 @@ static arc arcs_42_0[1] = {
     {103, 1},
 };
 static arc arcs_42_1[1] = {
-    {26, 2},
+    {99, 2},
 };
 static arc arcs_42_2[1] = {
     {27, 3},


### PR DESCRIPTION
Make parenthesis optional for named expressions used with while statement.

The following used to be a `SyntaxError` which should be valid according to PEP 572. This PR fixes the same.

```python
while match := pattern.search(f.read()): 
    pass
```

Feel free to rephrase NEWS entry if needed. I couldn't come up with a good test for an actual program for this case without reading a file or iteration. So I have added a test only to `test_parser` to make sure this is syntactically valid.

cc : @gvanrossum @emilyemorehouse

<!-- issue-number: [bpo-35877](https://bugs.python.org/issue35877) -->
https://bugs.python.org/issue35877
<!-- /issue-number -->
