### PR TITLE
bpo-34886: Fix subprocess.run handling of exclusive arguments

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -460,12 +460,12 @@ def run(*popenargs,
     The other arguments are the same as for the Popen constructor.
     """
     if input is not None:
-        if 'stdin' in kwargs:
+        if kwargs.get('stdin') is not None:
             raise ValueError('stdin and input arguments may not both be used.')
         kwargs['stdin'] = PIPE
 
     if capture_output:
-        if ('stdout' in kwargs) or ('stderr' in kwargs):
+        if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
             raise ValueError('stdout and stderr arguments may not be used '
                              'with capture_output.')
         kwargs['stdout'] = PIPE

--- a/Misc/NEWS.d/next/Library/2019-06-08-16-03-19.bpo-34886.Ov-pc9.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-08-16-03-19.bpo-34886.Ov-pc9.rst
@@ -1,0 +1,5 @@
+Fix an unintended ValueError from :func:`subprocess.run` when checking for
+conflicting `input` and `stdin` or `capture_output` and `stdout` or `stderr`
+args when they were explicitly provided but with `None` values within a
+passed in `**kwargs` dict rather than as passed directly by name. Patch
+contributed by Rémi Lapeyre.


### PR DESCRIPTION
I think we can skip news for this one.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34886](https://bugs.python.org/issue34886) -->
https://bugs.python.org/issue34886
<!-- /issue-number -->
