### PR TITLE
bpo-35780: Add link guards to the lru_cache() C code

### DIFF
--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -844,6 +844,9 @@ infinite_lru_cache_wrapper(lru_cache_object *self, PyObject *args, PyObject *kwd
     return result;
 }
 
+/* Mark a link as unused when it is created or when it is extracted
+   from the doubly-linked list.  Use this marker to avoid being
+   updated by two threads at the same time. */
 #define MARK_UNUSED(link)  {link->prev = NULL; link->next = NULL;}
 #define IS_USED(link) (link != NULL && link->prev != NULL && link->next != NULL)
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1006,10 +1006,13 @@ bounded_lru_cache_wrapper(lru_cache_object *self, PyObject *args, PyObject *kwds
             Py_DECREF(link);
             return NULL;
         }
+        Py_INCREF(result); /* for return */
         if (!IS_USED(link)) {
             lru_cache_append_link(self, link);
         }
-        Py_INCREF(result); /* for return */
+        else {
+            Py_DECREF(link);
+        }
         return result;
     }
     /* Since the cache is full, we need to evict an old key and add

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1059,7 +1059,12 @@ bounded_lru_cache_wrapper(lru_cache_object *self, PyObject *args, PyObject *kwds
            original position as the oldest link.  Then we allow the
            error propagate upward; treating it the same as an error
            arising in the user function. */
-        lru_cache_prepend_link(self, link);
+        if (!IS_USED(link)) {
+            lru_cache_prepend_link(self, link);
+        }
+        else {
+            Py_DECREF(link);
+        }
         Py_DECREF(key);
         Py_DECREF(result);
         return NULL;

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1085,7 +1085,11 @@ bounded_lru_cache_wrapper(lru_cache_object *self, PyObject *args, PyObject *kwds
     lru_cache_extract_link(link);
     /* Remove it from the cache.
        The cache dict holds one reference to the link,
-       and the linked list holds yet one reference to it. */
+       and the linked list holds yet one reference to it.
+
+       XXX Double check this statement.  The linked list
+       is documented above to only have borrowed references.
+    */
     popresult = _PyDict_Pop_KnownHash(self->cache, link->key,
                                       link->hash, Py_None);
     if (popresult == Py_None) {

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -661,6 +661,25 @@ sequence is empty.");
 
 /* lru_cache object **********************************************************/
 
+/* There are four principal algorithmic differences from the pure python version:
+
+   1). The C version relies on the GIL instead of having its own reentrant lock.
+
+   2). The prev/next link fields use borrowed references.
+
+   3). For a full cache, the pure python version rotates the location of the
+       root entry so that it never has to move individual links and it can
+       limit updates to just the key and result fields.  However, in the C
+       version, links are temporarily removed while the cache dict updates are
+       occurring. Afterwards, they are appended or prepended back into the
+       doubly-linked lists.
+
+   4)  In the Python version, a _HashSeq class is used to prevent __hash__
+       from being called more than once.  In the C version, the "known hash"
+       variants of dictionary calls as used to the same effect.
+
+*/
+
 /* this object is used delimit args and keywords in the cache keys */
 static PyObject *kwd_mark = NULL;
 


### PR DESCRIPTION
Hello Tim, if you have the time can you give your thoughts on this?

I've been through the code a few times and can't convince myself that the existing code won't fail in exotic cases (ones where the `__eq__` call triggers arbitrary code).  My thought is to mark links as unused when they are new or have been extracted from the doubly linked list, and then to use that information to skip invalid actions if another thread or reentrant call is also modifying the same link or the cache dictionary.

In the last PR, GH-11623, I fixed-up the more obvious bugs and added extensive commentary that may help with the analysis. 

<!-- issue-number: [bpo-35780](https://bugs.python.org/issue35780) -->
https://bugs.python.org/issue35780
<!-- /issue-number -->
