### PR TITLE
bpo-35890 : Fix some API calling consistency

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-02-02-22-12-23.bpo-35890.ccIjHH.rst
+++ b/Misc/NEWS.d/next/Windows/2019-02-02-22-12-23.bpo-35890.ccIjHH.rst
@@ -1,0 +1,1 @@
+Call unicode version GetVersionExW in Python/sysmodule.c, and add a WCSTOK macro to Python/pathconfig.c to wrap the wcstok_s.

--- a/Misc/NEWS.d/next/Windows/2019-02-02-22-12-23.bpo-35890.ccIjHH.rst
+++ b/Misc/NEWS.d/next/Windows/2019-02-02-22-12-23.bpo-35890.ccIjHH.rst
@@ -1,1 +1,1 @@
-Call unicode version GetVersionExW in Python/sysmodule.c, and add a WCSTOK macro to Python/pathconfig.c to wrap the wcstok_s.
+Fix API calling consistency of GetVersionEx and wcstok.

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -675,6 +675,12 @@ _PyPathConfig_ComputeArgv0(int argc, wchar_t **argv)
 }
 
 
+#ifdef MS_WINDOWS
+#define WCSTOK wcstok_s
+#else
+#define WCSTOK wcstok
+#endif
+
 /* Search for a prefix value in an environment file (pyvenv.cfg).
    If found, copy it into the provided buffer. */
 int
@@ -705,11 +711,11 @@ _Py_FindEnvConfigValue(FILE *env_file, const wchar_t *key,
         wchar_t *tmpbuffer = _Py_DecodeUTF8_surrogateescape(buffer, n);
         if (tmpbuffer) {
             wchar_t * state;
-            wchar_t * tok = wcstok(tmpbuffer, L" \t\r\n", &state);
+            wchar_t * tok = WCSTOK(tmpbuffer, L" \t\r\n", &state);
             if ((tok != NULL) && !wcscmp(tok, key)) {
-                tok = wcstok(NULL, L" \t", &state);
+                tok = WCSTOK(NULL, L" \t", &state);
                 if ((tok != NULL) && !wcscmp(tok, L"=")) {
-                    tok = wcstok(NULL, L"\r\n", &state);
+                    tok = WCSTOK(NULL, L"\r\n", &state);
                     if (tok != NULL) {
                         wcsncpy(value, tok, MAXPATHLEN);
                         result = 1;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1145,7 +1145,7 @@ sys_getwindowsversion_impl(PyObject *module)
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.dwMinorVersion));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.dwBuildNumber));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.dwPlatformId));
-    PyStructSequence_SET_ITEM(version, pos++, PyUnicode_FromUnicode(ver.szCSDVersion, wcslen(ver.szCSDVersion)));
+    PyStructSequence_SET_ITEM(version, pos++, PyUnicode_FromWideChar(ver.szCSDVersion, -1));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.wServicePackMajor));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.wServicePackMinor));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.wSuiteMask));

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1126,7 +1126,7 @@ sys_getwindowsversion_impl(PyObject *module)
 {
     PyObject *version;
     int pos = 0;
-    OSVERSIONINFOEX ver;
+    OSVERSIONINFOEXW ver;
     DWORD realMajor, realMinor, realBuild;
     HANDLE hKernel32;
     wchar_t kernel32_path[MAX_PATH];
@@ -1134,7 +1134,7 @@ sys_getwindowsversion_impl(PyObject *module)
     DWORD verblock_size;
 
     ver.dwOSVersionInfoSize = sizeof(ver);
-    if (!GetVersionEx((OSVERSIONINFO*) &ver))
+    if (!GetVersionExW((OSVERSIONINFOW*) &ver))
         return PyErr_SetFromWindowsErr(0);
 
     version = PyStructSequence_New(&WindowsVersionType);
@@ -1145,7 +1145,7 @@ sys_getwindowsversion_impl(PyObject *module)
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.dwMinorVersion));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.dwBuildNumber));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.dwPlatformId));
-    PyStructSequence_SET_ITEM(version, pos++, PyUnicode_FromString(ver.szCSDVersion));
+    PyStructSequence_SET_ITEM(version, pos++, PyUnicode_FromUnicode(ver.szCSDVersion, wcslen(ver.szCSDVersion)));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.wServicePackMajor));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.wServicePackMinor));
     PyStructSequence_SET_ITEM(version, pos++, PyLong_FromLong(ver.wSuiteMask));


### PR DESCRIPTION
1. Unicode version of Windows APIs are used in places, but not for GetVersionEx in Python/sysmodule.c
2. The wcstok_s is called on Windows in Modules/main.c and PC/launcher.c, but not in Python/pathconfig.c

This change fixes these 2 callings by calling unicode version GetVersionExW, and add a WCSTOK macro to wrap wcstok_s.

<!-- issue-number: [bpo-35890](https://bugs.python.org/issue35890) -->
https://bugs.python.org/issue35890
<!-- /issue-number -->
