### PR TITLE
bpo-35692: pathlib no longer raises when checking file and directory existence

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -37,6 +37,15 @@ __all__ = [
 # EBADF - guard agains macOS `stat` throwing EBADF
 _IGNORED_ERROS = (ENOENT, ENOTDIR, EBADF)
 
+_IGNORED_WINERRORS = (
+    21,  # ERROR_NOT_READY - drive exists but is not accessible
+)
+
+def _ignore_error(exception):
+    return (getattr(exception, 'errno', None) in _IGNORED_ERROS or
+            getattr(exception, 'winerror', None) in _IGNORED_WINERRORS)
+
+
 def _is_wildcard_pattern(pat):
     # Whether this pattern needs actual matching using fnmatch, or can
     # be looked up directly as a file.
@@ -535,7 +544,7 @@ class _RecursiveWildcardSelector(_Selector):
                 try:
                     entry_is_dir = entry.is_dir()
                 except OSError as e:
-                    if e.errno not in _IGNORED_ERROS:
+                    if not _ignore_error(e):
                         raise
                 if entry_is_dir and not entry.is_symlink():
                     path = parent_path._make_child_relpath(entry.name)
@@ -1328,7 +1337,7 @@ class Path(PurePath):
         try:
             self.stat()
         except OSError as e:
-            if e.errno not in _IGNORED_ERROS:
+            if not _ignore_error(e):
                 raise
             return False
         except ValueError:
@@ -1343,7 +1352,7 @@ class Path(PurePath):
         try:
             return S_ISDIR(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in _IGNORED_ERROS:
+            if not _ignore_error(e):
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1360,7 +1369,7 @@ class Path(PurePath):
         try:
             return S_ISREG(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in _IGNORED_ERROS:
+            if not _ignore_error(e):
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1397,7 +1406,7 @@ class Path(PurePath):
         try:
             return S_ISLNK(self.lstat().st_mode)
         except OSError as e:
-            if e.errno not in _IGNORED_ERROS:
+            if not _ignore_error(e):
                 raise
             # Path doesn't exist
             return False
@@ -1412,7 +1421,7 @@ class Path(PurePath):
         try:
             return S_ISBLK(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in _IGNORED_ERROS:
+            if not _ignore_error(e):
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1428,7 +1437,7 @@ class Path(PurePath):
         try:
             return S_ISCHR(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in _IGNORED_ERROS:
+            if not _ignore_error(e):
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1444,7 +1453,7 @@ class Path(PurePath):
         try:
             return S_ISFIFO(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in _IGNORED_ERROS:
+            if not _ignore_error(e):
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1460,7 +1469,7 @@ class Path(PurePath):
         try:
             return S_ISSOCK(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in _IGNORED_ERROS:
+            if not _ignore_error(e):
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)

--- a/Misc/NEWS.d/next/Windows/2019-02-02-16-23-57.bpo-35692.cIiiE9.rst
+++ b/Misc/NEWS.d/next/Windows/2019-02-02-16-23-57.bpo-35692.cIiiE9.rst
@@ -1,0 +1,2 @@
+``pathlib`` no longer raises when checking file and directory existence on
+drives that are not ready


### PR DESCRIPTION
pathlib no longer raises when checking file and directory existence on drives that are not ready

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35692](https://bugs.python.org/issue35692) -->
https://bugs.python.org/issue35692
<!-- /issue-number -->
