### PR TITLE
[2.7] bpo-1104: msilib.SummaryInfo.GetProperty() truncates the string by one character (GH-4517)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2017-11-24-12-53-54.bpo-1104.1CWSZp.rst
+++ b/Misc/NEWS.d/next/Windows/2017-11-24-12-53-54.bpo-1104.1CWSZp.rst
@@ -1,0 +1,2 @@
+Correctly handle string length in ``msilib.SummaryInfo.GetProperty()`` to
+prevent it from truncating the last character.

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -539,7 +539,7 @@ summary_getproperty(msiobj* si, PyObject *args)
     FILETIME fval;
     char sbuf[1000];
     char *sval = sbuf;
-    DWORD ssize = sizeof(sval);
+    DWORD ssize = sizeof(sbuf);
 
     if (!PyArg_ParseTuple(args, "i:GetProperty", &field))
         return NULL;
@@ -547,6 +547,7 @@ summary_getproperty(msiobj* si, PyObject *args)
     status = MsiSummaryInfoGetProperty(si->h, field, &type, &ival,
         &fval, sval, &ssize);
     if (status == ERROR_MORE_DATA) {
+        ssize++;
         sval = malloc(ssize);
         if (sval == NULL) {
             return PyErr_NoMemory();
@@ -556,19 +557,29 @@ summary_getproperty(msiobj* si, PyObject *args)
     }
 
     switch(type) {
-        case VT_I2: case VT_I4:
-            return PyInt_FromLong(ival);
+        case VT_I2:
+        case VT_I4:
+            result = PyLong_FromLong(ival);
+            break;
         case VT_FILETIME:
             PyErr_SetString(PyExc_NotImplementedError, "FILETIME result");
-            return NULL;
+            result = NULL;
+            break;
         case VT_LPSTR:
-            result = PyString_FromStringAndSize(sval, ssize);
-            if (sval != sbuf)
-                free(sval);
-            return result;
+            result = PyBytes_FromStringAndSize(sval, ssize);
+            break;
+        case VT_EMPTY:
+            Py_INCREF(Py_None);
+            result = Py_None;
+            break;
+        default:
+            PyErr_Format(PyExc_NotImplementedError, "result of type %d", type);
+            result = NULL;
+            break;
     }
-    PyErr_Format(PyExc_NotImplementedError, "result of type %d", type);
-    return NULL;
+    if (sval != sbuf)
+        free(sval);
+    return result;
 }
 
 static PyObject*


### PR DESCRIPTION
Add one char to MsiSummaryInfoGetProperty() output
Based on the patch in [bpo-1104](https://bugs.python.org/issue1104) by Anthony Tuininga (atuining) and Mark McMahon (markm)
(cherry picked from commit 2de576e16d42ce43698d384d0dd46ba6cf165424)

Co-authored-by: Tzu-ping Chung <uranusjr@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1104](https://bugs.python.org/issue1104) -->
https://bugs.python.org/issue1104
<!-- /issue-number -->
