### PR TITLE
bpo-32627: Fix compile error when `_uuid` headers conflicting included

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-02-03-19-13-08.bpo-32627.b68f64.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-03-19-13-08.bpo-32627.b68f64.rst
@@ -1,0 +1,1 @@
+Fix compile error when ``_uuid`` headers conflicting included.

--- a/Modules/_uuidmodule.c
+++ b/Modules/_uuidmodule.c
@@ -1,13 +1,16 @@
+/*
+ * Python UUID module that wraps libuuid -
+ * DCE compatible Universally Unique Identifier library.
+ */
+
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
 #ifdef HAVE_UUID_UUID_H
 #include <uuid/uuid.h>
-#endif
-#ifdef HAVE_UUID_H
+#elif defined(HAVE_UUID_H)
 #include <uuid.h>
 #endif
-
 
 static PyObject *
 py_uuid_generate_time_safe(PyObject *Py_UNUSED(context),


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
A compile error occurred when operating system both have `uuid.h` and `uuid/uuid.h`.

- Versions: *Python 3.8*, *Python 3.7*

<!-- issue-number: [bpo-32627](https://bugs.python.org/issue32627) -->
https://bugs.python.org/issue32627
<!-- /issue-number -->
