### PR TITLE
bpo-26243: data= is positional-only just on CPython

### DIFF
--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -165,6 +165,7 @@ class CompressTestCase(BaseCompressTestCase, unittest.TestCase):
         x = zlib.compress(HAMLET_SCENE)
         self.assertEqual(zlib.decompress(x), HAMLET_SCENE)
 
+    @support.cpython_only
     def test_keywords(self):
         x = zlib.compress(HAMLET_SCENE, level=3)
         self.assertEqual(zlib.decompress(x), HAMLET_SCENE)
@@ -245,6 +246,7 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
             self.assertIsInstance(dco.unconsumed_tail, bytes)
             self.assertIsInstance(dco.unused_data, bytes)
 
+    @support.cpython_only
     def test_keywords(self):
         level = 2
         method = zlib.DEFLATED


### PR DESCRIPTION
PyPy can take it as keyword just fine.

<!-- issue-number: [bpo-26243](https://bugs.python.org/issue26243) -->
https://bugs.python.org/issue26243
<!-- /issue-number -->
