### PR TITLE
bpo-35838: Fix duplicate optionxform calls on a section's option

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -745,13 +745,13 @@ class RawConfigParser(MutableMapping):
                     raise
             elements_added.add(section)
             for key, value in keys.items():
-                key = self.optionxform(str(key))
+                option_key = self.optionxform(str(key))
                 if value is not None:
                     value = str(value)
-                if self._strict and (section, key) in elements_added:
-                    raise DuplicateOptionError(section, key, source)
-                elements_added.add((section, key))
-                self.set(section, key, value)
+                if self._strict and (section, option_key) in elements_added:
+                    raise DuplicateOptionError(section, option_key, source)
+                elements_added.add((section, option_key))
+                self.set(section, str(key), value)
 
     def readfp(self, fp, filename=None):
         """Deprecated, use read_file instead."""

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -428,6 +428,20 @@ boolean {0[0]} NO
                 },
             })
 
+    def test_read_dict_optionxform(self):
+        config = {
+            "foo": {
+                "bar": "baz",
+            }
+        }
+
+        cf = self.newconfig()
+        cf.optionxform = lambda x: f"({x})"
+        cf.read_dict(config)
+        self.assertEqual(cf.get("foo", "bar"), "baz")
+        with self.assertRaises(KeyError):
+            cf['foo']['(bar)']
+
     def test_case_sensitivity(self):
         cf = self.newconfig()
         cf.add_section("A")

--- a/Misc/NEWS.d/next/Library/2019-02-05-15-12-53.bpo-35838.1fpfc0.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-05-15-12-53.bpo-35838.1fpfc0.rst
@@ -1,0 +1,3 @@
+Fix duplicate calls to :meth:`configparser.ConfigParser.optionxform` on option
+while using :meth:`configparser.ConfigParser.read_dict`. Patch by Karthikeyan
+Singaravelan.


### PR DESCRIPTION
`optionxform` is called to check for duplicates and the transformed key is passed to `set` which again calls `optionxform` making two transformations to the key. This can be a problem when `optionxform` is not idempotent.

<!-- issue-number: [bpo-35838](https://bugs.python.org/issue35838) -->
https://bugs.python.org/issue35838
<!-- /issue-number -->
