### PR TITLE
bpo-35903: Use autoconfig to probe for shm_open() and shm_unlink().

### DIFF
--- a/configure
+++ b/configure
@@ -16920,10 +16920,13 @@ ac_res=$ac_cv_search_shm_open
 if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
+fi
+
+if test "$ac_cv_search_shm_open" = "-lrt"; then
+
 $as_echo "#define HAVE_RT_SHM_OPEN 1" >>confdefs.h
 
 fi
-
 for ac_header in sys/mman.h
 do :
   ac_fn_c_check_header_mongrel "$LINENO" "sys/mman.h" "ac_cv_header_sys_mman_h" "$ac_includes_default"

--- a/configure
+++ b/configure
@@ -16924,7 +16924,7 @@ fi
 
 if test "$ac_cv_search_shm_open" = "-lrt"; then
 
-$as_echo "#define HAVE_RT_SHM_OPEN 1" >>confdefs.h
+$as_echo "#define SHM_NEEDS_LIBRT 1" >>confdefs.h
 
 fi
 for ac_header in sys/mman.h
@@ -16939,6 +16939,7 @@ fi
 
 done
 
+# temporarily override ac_includes_default for AC_CHECK_FUNCS below
 ac_includes_default="\
 ${ac_includes_default}
 #ifndef __cplusplus

--- a/configure
+++ b/configure
@@ -16862,6 +16862,104 @@ $as_echo "#define HAVE_GETRANDOM 1" >>confdefs.h
 
 fi
 
+# checks for POSIX shared memory, used by Modules/_multiprocessing/posixshmem.c
+# shm_* may only be available if linking against librt
+save_LIBS="$LIBS"
+save_includes_default="$ac_includes_default"
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing shm_open" >&5
+$as_echo_n "checking for library containing shm_open... " >&6; }
+if ${ac_cv_search_shm_open+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char shm_open ();
+int
+main ()
+{
+return shm_open ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' rt; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_shm_open=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_shm_open+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_shm_open+:} false; then :
+
+else
+  ac_cv_search_shm_open=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_shm_open" >&5
+$as_echo "$ac_cv_search_shm_open" >&6; }
+ac_res=$ac_cv_search_shm_open
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+$as_echo "#define HAVE_RT_SHM_OPEN 1" >>confdefs.h
+
+fi
+
+for ac_header in sys/mman.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "sys/mman.h" "ac_cv_header_sys_mman_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_mman_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SYS_MMAN_H 1
+_ACEOF
+
+fi
+
+done
+
+ac_includes_default="\
+${ac_includes_default}
+#ifndef __cplusplus
+#  ifdef HAVE_SYS_MMAN_H
+#    include <sys/mman.h>
+#  endif
+#endif
+"
+for ac_func in shm_open shm_unlink
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+done
+
+# we don't want to link with librt always, restore LIBS
+LIBS="$save_LIBS"
+ac_includes_default="$save_includes_default"
+
 # Check for usable OpenSSL
 
     found=false

--- a/configure.ac
+++ b/configure.ac
@@ -5443,6 +5443,27 @@ if test "$have_getrandom" = yes; then
               [Define to 1 if the getrandom() function is available])
 fi
 
+# checks for POSIX shared memory, used by Modules/_multiprocessing/posixshmem.c
+# shm_* may only be available if linking against librt
+save_LIBS="$LIBS"
+save_includes_default="$ac_includes_default"
+AC_SEARCH_LIBS(shm_open, rt,
+	       AC_DEFINE(HAVE_RT_SHM_OPEN, 1,
+			 [Define to 1 if librt contains shm_open().]))
+AC_CHECK_HEADERS(sys/mman.h)
+ac_includes_default="\
+${ac_includes_default}
+#ifndef __cplusplus
+#  ifdef HAVE_SYS_MMAN_H
+#    include <sys/mman.h>
+#  endif
+#endif
+"
+AC_CHECK_FUNCS([shm_open shm_unlink])
+# we don't want to link with librt always, restore LIBS
+LIBS="$save_LIBS"
+ac_includes_default="$save_includes_default"
+
 # Check for usable OpenSSL
 AX_CHECK_OPENSSL([have_openssl=yes],[have_openssl=no])
 

--- a/configure.ac
+++ b/configure.ac
@@ -5449,10 +5449,11 @@ save_LIBS="$LIBS"
 save_includes_default="$ac_includes_default"
 AC_SEARCH_LIBS(shm_open, rt)
 if test "$ac_cv_search_shm_open" = "-lrt"; then
-    AC_DEFINE(HAVE_RT_SHM_OPEN, 1,
-              [Define to 1 if librt contains shm_open().])
+    AC_DEFINE(SHM_NEEDS_LIBRT, 1,
+              [Define to 1 if you must link with -lrt for shm_open().])
 fi
 AC_CHECK_HEADERS(sys/mman.h)
+# temporarily override ac_includes_default for AC_CHECK_FUNCS below
 ac_includes_default="\
 ${ac_includes_default}
 #ifndef __cplusplus

--- a/configure.ac
+++ b/configure.ac
@@ -5447,9 +5447,11 @@ fi
 # shm_* may only be available if linking against librt
 save_LIBS="$LIBS"
 save_includes_default="$ac_includes_default"
-AC_SEARCH_LIBS(shm_open, rt,
-	       AC_DEFINE(HAVE_RT_SHM_OPEN, 1,
-			 [Define to 1 if librt contains shm_open().]))
+AC_SEARCH_LIBS(shm_open, rt)
+if test "$ac_cv_search_shm_open" = "-lrt"; then
+    AC_DEFINE(HAVE_RT_SHM_OPEN, 1,
+              [Define to 1 if librt contains shm_open().])
+fi
 AC_CHECK_HEADERS(sys/mman.h)
 ac_includes_default="\
 ${ac_includes_default}

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -144,8 +144,8 @@
 /* Define to 1 if you have the `copysign' function. */
 #undef HAVE_COPYSIGN
 
-/* Define to 1 if librt contains shm_open(). */
-#undef HAVE_RT_SHM_OPEN
+/* Define to 1 if you must link with -lrt for shm_open(). */
+#undef SHM_NEEDS_LIBRT
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
 #undef HAVE_SYS_MMAN_H

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -144,6 +144,18 @@
 /* Define to 1 if you have the `copysign' function. */
 #undef HAVE_COPYSIGN
 
+/* Define to 1 if librt contains shm_open(). */
+#undef HAVE_RT_SHM_OPEN 1
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#undef HAVE_SYS_MMAN_H 1
+
+/* Define to 1 if you have the shm_open syscall */
+#undef HAVE_SHM_OPEN 1
+
+/* Define to 1 if you have the shm_unlink syscall */
+#undef HAVE_SHM_UNLINK 1
+
 /* Define to 1 if you have the <crypt.h> header file. */
 #undef HAVE_CRYPT_H
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -145,16 +145,16 @@
 #undef HAVE_COPYSIGN
 
 /* Define to 1 if librt contains shm_open(). */
-#undef HAVE_RT_SHM_OPEN 1
+#undef HAVE_RT_SHM_OPEN
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
-#undef HAVE_SYS_MMAN_H 1
+#undef HAVE_SYS_MMAN_H
 
 /* Define to 1 if you have the shm_open syscall */
-#undef HAVE_SHM_OPEN 1
+#undef HAVE_SHM_OPEN
 
 /* Define to 1 if you have the shm_unlink syscall */
-#undef HAVE_SHM_UNLINK 1
+#undef HAVE_SHM_UNLINK
 
 /* Define to 1 if you have the <crypt.h> header file. */
 #undef HAVE_CRYPT_H

--- a/setup.py
+++ b/setup.py
@@ -1592,12 +1592,13 @@ class PyBuildExt(build_ext):
             if (sysconfig.get_config_var('HAVE_SEM_OPEN') and not
                 sysconfig.get_config_var('POSIX_SEMAPHORES_NOT_ENABLED')):
                 multiprocessing_srcs.append('_multiprocessing/semaphore.c')
-            if (self.compiler.find_library_file(lib_dirs, 'rt') or
-                host_platform != 'cygwin'):
+            if (sysconfig.get_config_var('HAVE_SHM_OPEN') and
+                sysconfig.get_config_var('HAVE_SHM_UNLINK')):
                 posixshmem_srcs = [ '_multiprocessing/posixshmem.c',
                                   ]
                 libs = []
-                if self.compiler.find_library_file(lib_dirs, 'rt'):
+                if sysconfig.get_config_var('HAVE_RT_SHM_OPEN'):
+                    # need to link with librt to get shm_open()
                     libs.append('rt')
                 exts.append( Extension('_posixshmem', posixshmem_srcs,
                                        define_macros={},

--- a/setup.py
+++ b/setup.py
@@ -1597,7 +1597,7 @@ class PyBuildExt(build_ext):
                 posixshmem_srcs = [ '_multiprocessing/posixshmem.c',
                                   ]
                 libs = []
-                if sysconfig.get_config_var('HAVE_RT_SHM_OPEN'):
+                if sysconfig.get_config_var('SHM_NEEDS_LIBRT'):
                     # need to link with librt to get shm_open()
                     libs.append('rt')
                 exts.append( Extension('_posixshmem', posixshmem_srcs,


### PR DESCRIPTION

The logic in setup.py that determines if _multiprocessing/posixshmem.c should get built is not very robust.  I think it is better to use autoconfig to probe for the required functions and libraries.  My autoconfig brain cells are a bit fuzzy but I think my patch is correct.

I look for shm_open and shm_unlink.  I also check if librt is required for these functions.

<!-- issue-number: [bpo-35903](https://bugs.python.org/issue35903) -->
https://bugs.python.org/issue35903
<!-- /issue-number -->
