### PR TITLE
bpo-35766 follow-up: Add an error check to new_type_comment()

### DIFF
--- a/Python/ast.c
+++ b/Python/ast.c
@@ -702,6 +702,8 @@ static string
 new_type_comment(const char *s, struct compiling *c)
 {
     PyObject *res = PyUnicode_DecodeUTF8(s, strlen(s), NULL);
+    if (res == NULL)
+        return NULL;
     if (PyArena_AddPyObject(c->c_arena, res) < 0) {
         Py_DECREF(res);
         return NULL;


### PR DESCRIPTION
If PyUnicode_DecodeUTF8() were to return `NULL`, `PyArena_AddPyObject()` would crash.
Found by @msullivan for https://github.com/python/typed_ast/pull/93.


<!-- issue-number: [bpo-35766](https://bugs.python.org/issue35766) -->
https://bugs.python.org/issue35766
<!-- /issue-number -->
