### PR TITLE
bpo-24209: In http.server script, rely on getaddrinfo to bind to preferred address based on the bind parameter.

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1232,7 +1232,7 @@ def _get_best_family(address):
 
 def test(HandlerClass=BaseHTTPRequestHandler,
          ServerClass=ThreadingHTTPServer,
-         protocol="HTTP/1.0", port=8000, bind=""):
+         protocol="HTTP/1.0", port=8000, bind=None):
     """Test the HTTP request handler class.
 
     This runs an HTTP server on port 8000 (or the port argument).
@@ -1262,7 +1262,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--cgi', action='store_true',
                        help='Run as CGI Server')
-    parser.add_argument('--bind', '-b', default='', metavar='ADDRESS',
+    parser.add_argument('--bind', '-b', metavar='ADDRESS',
                         help='Specify alternate bind address '
                              '[default: all interfaces]')
     parser.add_argument('--directory', '-d', default=os.getcwd(),

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1244,9 +1244,12 @@ def test(HandlerClass=BaseHTTPRequestHandler,
 
     HandlerClass.protocol_version = protocol
     with ServerClass(server_address, HandlerClass) as httpd:
-        sa = httpd.socket.getsockname()
-        serve_message = "Serving HTTP on {host} port {port} (http://{host}:{port}/) ..."
-        print(serve_message.format(host=sa[0], port=sa[1]))
+        host, port = httpd.socket.getsockname()[:2]
+        url_host = f'[{host}]' if ':' in host else host
+        print(
+            f"Serving HTTP on {host} port {port} "
+            f"(http://{url_host}:{port}/) ..."
+        )
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1224,6 +1224,12 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
                 self.log_message("CGI script exited OK")
 
 
+def _get_best_family(address):
+    infos = socket.getaddrinfo(*address, type=socket.SOCK_STREAM)
+    family, type, proto, canonname, sockaddr = next(iter(infos))
+    return family
+
+
 def test(HandlerClass=BaseHTTPRequestHandler,
          ServerClass=ThreadingHTTPServer,
          protocol="HTTP/1.0", port=8000, bind=""):
@@ -1234,8 +1240,7 @@ def test(HandlerClass=BaseHTTPRequestHandler,
     """
     server_address = (bind, port)
 
-    if ':' in bind:
-        ServerClass.address_family = socket.AF_INET6
+    ServerClass.address_family = _get_best_family(server_address)
 
     HandlerClass.protocol_version = protocol
     with ServerClass(server_address, HandlerClass) as httpd:

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1156,12 +1156,12 @@ class ScriptTestCase(unittest.TestCase):
         server.test(ServerClass=mock_server, bind="::")
         self.assertEqual(mock_server.address_family, socket.AF_INET6)
 
-        mock_server.reset_mock()
+        mock_server = self.mock_server_class()
         server.test(ServerClass=mock_server,
                     bind="2001:0db8:85a3:0000:0000:8a2e:0370:7334")
         self.assertEqual(mock_server.address_family, socket.AF_INET6)
 
-        mock_server.reset_mock()
+        mock_server = self.mock_server_class()
         server.test(ServerClass=mock_server, bind="::1")
         self.assertEqual(mock_server.address_family, socket.AF_INET6)
 
@@ -1171,11 +1171,11 @@ class ScriptTestCase(unittest.TestCase):
         server.test(ServerClass=mock_server, bind="0.0.0.0")
         self.assertEqual(mock_server.address_family, socket.AF_INET)
 
-        mock_server.reset_mock()
+        mock_server = self.mock_server_class()
         server.test(ServerClass=mock_server, bind="8.8.8.8")
         self.assertEqual(mock_server.address_family, socket.AF_INET)
 
-        mock_server.reset_mock()
+        mock_server = self.mock_server_class()
         server.test(ServerClass=mock_server, bind="127.0.0.1")
         self.assertEqual(mock_server.address_family, socket.AF_INET)
 

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1135,7 +1135,7 @@ class ScriptTestCase(unittest.TestCase):
     @mock.patch('builtins.print')
     def test_server_test_unspec(self, _):
         mock_server = self.mock_server_class()
-        server.test(ServerClass=mock_server, bind="")
+        server.test(ServerClass=mock_server, bind=None)
         self.assertIn(
             mock_server.address_family,
             (socket.AF_INET6, socket.AF_INET),

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1118,6 +1118,25 @@ class MiscTestCase(unittest.TestCase):
 
 
 class ScriptTestCase(unittest.TestCase):
+
+    @mock.patch('builtins.print')
+    def test_server_test_unspec(self, _):
+        mock_server = mock.MagicMock()
+        server.test(ServerClass=mock_server, bind="")
+        self.assertIn(
+            mock_server.address_family,
+            (socket.AF_INET6, socket.AF_INET),
+        )
+
+    @mock.patch('builtins.print')
+    def test_server_test_localhost(self, _):
+        mock_server = mock.MagicMock()
+        server.test(ServerClass=mock_server, bind="localhost")
+        self.assertIn(
+            mock_server.address_family,
+            (socket.AF_INET6, socket.AF_INET),
+        )
+
     @mock.patch('builtins.print')
     def test_server_test_ipv6(self, _):
         mock_server = mock.MagicMock()
@@ -1130,9 +1149,22 @@ class ScriptTestCase(unittest.TestCase):
         self.assertEqual(mock_server.address_family, socket.AF_INET6)
 
         mock_server.reset_mock()
-        server.test(ServerClass=mock_server,
-                    bind="::1")
+        server.test(ServerClass=mock_server, bind="::1")
         self.assertEqual(mock_server.address_family, socket.AF_INET6)
+
+    @mock.patch('builtins.print')
+    def test_server_test_ipv4(self, _):
+        mock_server = mock.MagicMock()
+        server.test(ServerClass=mock_server, bind="0.0.0.0")
+        self.assertEqual(mock_server.address_family, socket.AF_INET)
+
+        mock_server.reset_mock()
+        server.test(ServerClass=mock_server, bind="8.8.8.8")
+        self.assertEqual(mock_server.address_family, socket.AF_INET)
+
+        mock_server.reset_mock()
+        server.test(ServerClass=mock_server, bind="127.0.0.1")
+        self.assertEqual(mock_server.address_family, socket.AF_INET)
 
 
 def test_main(verbose=None):

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1119,9 +1119,22 @@ class MiscTestCase(unittest.TestCase):
 
 class ScriptTestCase(unittest.TestCase):
 
+    def mock_server_class(self):
+        return mock.MagicMock(
+            return_value=mock.MagicMock(
+                __enter__=mock.MagicMock(
+                    return_value=mock.MagicMock(
+                        socket=mock.MagicMock(
+                            getsockname=lambda: ('', 0),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
     @mock.patch('builtins.print')
     def test_server_test_unspec(self, _):
-        mock_server = mock.MagicMock()
+        mock_server = self.mock_server_class()
         server.test(ServerClass=mock_server, bind="")
         self.assertIn(
             mock_server.address_family,
@@ -1130,7 +1143,7 @@ class ScriptTestCase(unittest.TestCase):
 
     @mock.patch('builtins.print')
     def test_server_test_localhost(self, _):
-        mock_server = mock.MagicMock()
+        mock_server = self.mock_server_class()
         server.test(ServerClass=mock_server, bind="localhost")
         self.assertIn(
             mock_server.address_family,
@@ -1139,7 +1152,7 @@ class ScriptTestCase(unittest.TestCase):
 
     @mock.patch('builtins.print')
     def test_server_test_ipv6(self, _):
-        mock_server = mock.MagicMock()
+        mock_server = self.mock_server_class()
         server.test(ServerClass=mock_server, bind="::")
         self.assertEqual(mock_server.address_family, socket.AF_INET6)
 
@@ -1154,7 +1167,7 @@ class ScriptTestCase(unittest.TestCase):
 
     @mock.patch('builtins.print')
     def test_server_test_ipv4(self, _):
-        mock_server = mock.MagicMock()
+        mock_server = self.mock_server_class()
         server.test(ServerClass=mock_server, bind="0.0.0.0")
         self.assertEqual(mock_server.address_family, socket.AF_INET)
 

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1150,34 +1150,31 @@ class ScriptTestCase(unittest.TestCase):
             (socket.AF_INET6, socket.AF_INET),
         )
 
+    ipv6_addrs = (
+        "::",
+        "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+        "::1",
+    )
+
+    ipv4_addrs = (
+        "0.0.0.0",
+        "8.8.8.8",
+        "127.0.0.1",
+    )
+
     @mock.patch('builtins.print')
     def test_server_test_ipv6(self, _):
-        mock_server = self.mock_server_class()
-        server.test(ServerClass=mock_server, bind="::")
-        self.assertEqual(mock_server.address_family, socket.AF_INET6)
-
-        mock_server = self.mock_server_class()
-        server.test(ServerClass=mock_server,
-                    bind="2001:0db8:85a3:0000:0000:8a2e:0370:7334")
-        self.assertEqual(mock_server.address_family, socket.AF_INET6)
-
-        mock_server = self.mock_server_class()
-        server.test(ServerClass=mock_server, bind="::1")
-        self.assertEqual(mock_server.address_family, socket.AF_INET6)
+        for bind in self.ipv6_addrs:
+            mock_server = self.mock_server_class()
+            server.test(ServerClass=mock_server, bind=bind)
+            self.assertEqual(mock_server.address_family, socket.AF_INET6)
 
     @mock.patch('builtins.print')
     def test_server_test_ipv4(self, _):
-        mock_server = self.mock_server_class()
-        server.test(ServerClass=mock_server, bind="0.0.0.0")
-        self.assertEqual(mock_server.address_family, socket.AF_INET)
-
-        mock_server = self.mock_server_class()
-        server.test(ServerClass=mock_server, bind="8.8.8.8")
-        self.assertEqual(mock_server.address_family, socket.AF_INET)
-
-        mock_server = self.mock_server_class()
-        server.test(ServerClass=mock_server, bind="127.0.0.1")
-        self.assertEqual(mock_server.address_family, socket.AF_INET)
+        for bind in self.ipv4_addrs:
+            mock_server = self.mock_server_class()
+            server.test(ServerClass=mock_server, bind=bind)
+            self.assertEqual(mock_server.address_family, socket.AF_INET)
 
 
 def test_main(verbose=None):

--- a/Misc/NEWS.d/next/Library/2019-02-06-01-40-55.bpo-24209.awtwPD.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-06-01-40-55.bpo-24209.awtwPD.rst
@@ -1,0 +1,1 @@
+In http.server script, rely on getaddrinfo to bind to preferred address based on the bind parameter. Now default bind or binding to a name may bind to IPv6 or dual-stack, depending on the environment.


### PR DESCRIPTION


<!-- issue-number: [bpo-24209](https://bugs.python.org/issue24209) -->
https://bugs.python.org/issue24209
<!-- /issue-number -->
