### PR TITLE
[2.7] Fix url to core-mentorship mailing list (GH-11775).

### DIFF
--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -84,5 +84,5 @@ the `core-mentorship mailing list`_ is a friendly place to get answers to
 any and all questions pertaining to the process of fixing issues in Python.
 
 .. _Documentation bugs: https://bugs.python.org/issue?@filter=status&@filter=components&components=4&status=1&@columns=id,activity,title,status&@sort=-activity
-.. _Python Developer's Guide: https://docs.python.org/devguide/
-.. _core-mentorship mailing list: https://mail.python.org/mailman/listinfo/core-mentorship/
+.. _Python Developer's Guide: https://devguide.python.org/
+.. _core-mentorship mailing list: https://mail.python.org/mailman3/lists/core-mentorship.python.org/


### PR DESCRIPTION
(cherry picked from commit e9bc4172d18db9c182d8e04dd7b033097a994c06)

Co-authored-by: Mariatta <Mariatta@users.noreply.github.com>

