### PR TITLE
bpo-35931: Gracefully handle SyntaxError in pdb debug command

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1093,10 +1093,16 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         sys.settrace(None)
         globals = self.curframe.f_globals
         locals = self.curframe_locals
+        try:
+            code = compile(arg, "<string>", "exec")
+        except SyntaxError:
+            exc_info = sys.exc_info()[:2]
+            self.error(traceback.format_exception_only(*exc_info)[-1].strip())
+            return
         p = Pdb(self.completekey, self.stdin, self.stdout)
         p.prompt = "(%s) " % self.prompt.strip()
         self.message("ENTERING RECURSIVE DEBUGGER")
-        sys.call_tracing(p.run, (arg, globals, locals))
+        sys.call_tracing(p.run, (code, globals, locals))
         self.message("LEAVING RECURSIVE DEBUGGER")
         sys.settrace(self.trace_dispatch)
         self.lastcmd = p.lastcmd

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1486,6 +1486,14 @@ class PdbTestCase(unittest.TestCase):
         stdout, _ = self._run_pdb(['-m', self.module_name + '.runme'], commands)
         self.assertTrue(any("VAR from module" in l for l in stdout.splitlines()), stdout)
 
+    def test_syntaxerror(self):
+        stdout, _ = self.run_pdb_module("", "print(")
+        self.assertIn('(Pdb) *** SyntaxError: unexpected EOF while parsing\n(Pdb) ', stdout)
+
+    def test_syntaxerror_debug(self):
+        stdout, _ = self.run_pdb_module("", "debug print(")
+        self.assertIn('(Pdb) *** SyntaxError: unexpected EOF while parsing\n(Pdb) ', stdout)
+
 
 def load_tests(*args):
     from test import test_pdb

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1486,14 +1486,14 @@ class PdbTestCase(unittest.TestCase):
         stdout, _ = self._run_pdb(['-m', self.module_name + '.runme'], commands)
         self.assertTrue(any("VAR from module" in l for l in stdout.splitlines()), stdout)
 
-    def test_syntaxerror(self):
-        stdout, _ = self.run_pdb_module("", "print(")
-        self.assertIn('(Pdb) *** SyntaxError: unexpected EOF while parsing\n(Pdb) ', stdout)
-
-    def test_syntaxerror_debug(self):
-        stdout, _ = self.run_pdb_module("", "debug print(")
-        self.assertIn('(Pdb) *** SyntaxError: unexpected EOF while parsing\n(Pdb) ', stdout)
-
+    def test_syntaxerror_in_command(self):
+        commands = "print(\ndebug print("
+        stdout, _ = self.run_pdb_script("", commands)
+        self.assertEqual(stdout.splitlines()[1:], [
+            '(Pdb) *** SyntaxError: unexpected EOF while parsing',
+            '(Pdb) *** SyntaxError: unexpected EOF while parsing',
+            '(Pdb) ',
+        ])
 
 def load_tests(*args):
     from test import test_pdb

--- a/Misc/NEWS.d/next/Library/2019-02-07-16-22-50.bpo-35931._63i7B.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-07-16-22-50.bpo-35931._63i7B.rst
@@ -1,1 +1,1 @@
-pdb: handle SyntaxError with ``debug``.
+The :mod:`pdb` ``debug`` command now gracefully handles syntax errors.

--- a/Misc/NEWS.d/next/Library/2019-02-07-16-22-50.bpo-35931._63i7B.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-07-16-22-50.bpo-35931._63i7B.rst
@@ -1,0 +1,1 @@
+pdb: handle SyntaxError with ``debug``.


### PR DESCRIPTION
Previously, `debug print(` would cause the interpreter to exit on a SyntaxError whereas `print(` would properly display the error and return to the pdb prompt.

This patch fixes this by pre-compiling the code before passing it to `Pdb.run`.

<!-- issue-number: [bpo-35931](https://bugs.python.org/issue35931) -->
https://bugs.python.org/issue35931
<!-- /issue-number -->
