### PR TITLE
bpo-32417: Add What's New entry for date subclass behavior

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -115,6 +115,14 @@ Other Language Changes
   a :exc:`SyntaxWarning` instead.
   (Contributed by Serhiy Storchaka in :issue:`32912`.)
 
+* Arithmetic operations between subclasses of :class:`datetime.date` or
+  :class:`datetime.datetime` and :class:`datetime.timedelta` objects now return
+  an instance of the subclass, rather than the base class. This also affects
+  the return type of operations whose implementation (directly or indirectly)
+  uses :class:`datetime.timedelta` arithmetic, such as
+  :meth:`datetime.datetime.astimezone`.
+  (Contributed by Paul Ganssle in :issue:`32417`.)
+
 
 New Modules
 ===========


### PR DESCRIPTION
This was a backwards incompatible change and should be clearly noted.

Original PR was #10902.

News can be skipped on this, and both related bugs should be closed.

CC: @abalkin @vstinner @ambv 

Related bugs:
[bpo-32417](https://bugs.python.org/issue32417)
[bpo-35364](https://bugs.python.org/issue35364)