### PR TITLE
bpo-35940: Do not retain references to processes and managers in TestSyncManagerTypes to avoid dangling processes

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4740,6 +4740,8 @@ class TestSyncManagerTypes(unittest.TestCase):
             self.proc.terminate()
             self.proc.join()
         self.manager.shutdown()
+        self.manager = None
+        self.proc = None
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION


<!-- issue-number: [bpo-35940](https://bugs.python.org/issue35940) -->
https://bugs.python.org/issue35940
<!-- /issue-number -->
