### PR TITLE
bpo-35500: align expected and actual calls on mock.assert_called_with error message.

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -814,7 +814,10 @@ class NonCallableMock(Base):
         self = _mock_self
         if self.call_args is None:
             expected = self._format_mock_call_signature(args, kwargs)
-            raise AssertionError('Expected call: %s\nNot called' % (expected,))
+            actual = 'not called.'
+            error_message = ('expected call not found.\nExpected: %s\nActual: %s'
+                    % (expected, actual))
+            raise AssertionError(error_message)
 
         def _error_message():
             msg = self._format_mock_failure_message(args, kwargs)

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -745,7 +745,7 @@ class NonCallableMock(Base):
 
 
     def _format_mock_failure_message(self, args, kwargs):
-        message = 'Expected call: %s\nActual call: %s'
+        message = 'expected call not found.\nExpected: %s\nActual: %s'
         expected_string = self._format_mock_call_signature(args, kwargs)
         call_args = self.call_args
         if len(call_args) == 3:

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -724,7 +724,7 @@ class MockTest(unittest.TestCase):
 
     def test_assert_called_with_message(self):
         mock = Mock()
-        self.assertRaisesRegex(AssertionError, 'Not called',
+        self.assertRaisesRegex(AssertionError, 'not called',
                                 mock.assert_called_with)
 
 
@@ -917,10 +917,11 @@ class MockTest(unittest.TestCase):
     def test_assert_called_with_failure_message(self):
         mock = NonCallableMock()
 
+        actual = 'not called.'
         expected = "mock(1, '2', 3, bar='foo')"
-        message = 'Expected call: %s\nNot called'
+        message = 'expected call not found.\nExpected: %s\nActual: %s'
         self.assertRaisesWithMsg(
-            AssertionError, message % (expected,),
+            AssertionError, message % (expected, actual),
             mock.assert_called_with, 1, '2', 3, bar='foo'
         )
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -933,7 +933,7 @@ class MockTest(unittest.TestCase):
         for meth in asserters:
             actual = "foo(1, '2', 3, foo='foo')"
             expected = "foo(1, '2', 3, bar='foo')"
-            message = 'Expected call: %s\nActual call: %s'
+            message = 'expected call not found.\nExpected: %s\nActual: %s'
             self.assertRaisesWithMsg(
                 AssertionError, message % (expected, actual),
                 meth, 1, '2', 3, bar='foo'
@@ -943,7 +943,7 @@ class MockTest(unittest.TestCase):
         for meth in asserters:
             actual = "foo(1, '2', 3, foo='foo')"
             expected = "foo(bar='foo')"
-            message = 'Expected call: %s\nActual call: %s'
+            message = 'expected call not found.\nExpected: %s\nActual: %s'
             self.assertRaisesWithMsg(
                 AssertionError, message % (expected, actual),
                 meth, bar='foo'
@@ -953,7 +953,7 @@ class MockTest(unittest.TestCase):
         for meth in asserters:
             actual = "foo(1, '2', 3, foo='foo')"
             expected = "foo(1, 2, 3)"
-            message = 'Expected call: %s\nActual call: %s'
+            message = 'expected call not found.\nExpected: %s\nActual: %s'
             self.assertRaisesWithMsg(
                 AssertionError, message % (expected, actual),
                 meth, 1, 2, 3
@@ -963,7 +963,7 @@ class MockTest(unittest.TestCase):
         for meth in asserters:
             actual = "foo(1, '2', 3, foo='foo')"
             expected = "foo()"
-            message = 'Expected call: %s\nActual call: %s'
+            message = 'expected call not found.\nExpected: %s\nActual: %s'
             self.assertRaisesWithMsg(
                 AssertionError, message % (expected, actual), meth
             )

--- a/Misc/NEWS.d/next/Library/2019-02-10-00-00-13.bpo-35500.1HOMmo.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-10-00-00-13.bpo-35500.1HOMmo.rst
@@ -1,0 +1,1 @@
+When mock.assert_called_with is called, the error message that is generated currently does not possess a newline between the AssertionError and the Expected field. Now, the message "expected call not found." will follow the AssertionError. In the next lines, the Expected and Actual values will be displayed.

--- a/Misc/NEWS.d/next/Library/2019-02-10-00-00-13.bpo-35500.1HOMmo.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-10-00-00-13.bpo-35500.1HOMmo.rst
@@ -1,1 +1,1 @@
-Write expected and actual call parameters on separate lines in mock.assert_called_wtih() assertion errors.  Contributed by Susan Su.
+Write expected and actual call parameters on separate lines in mock.assert_called_with() assertion errors.  Contributed by Susan Su.

--- a/Misc/NEWS.d/next/Library/2019-02-10-00-00-13.bpo-35500.1HOMmo.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-10-00-00-13.bpo-35500.1HOMmo.rst
@@ -1,1 +1,1 @@
-When mock.assert_called_with is called, the error message that is generated currently does not possess a newline between the AssertionError and the Expected field. Now, the message "expected call not found." will follow the AssertionError. In the next lines, the Expected and Actual values will be displayed.
+Write expected and actual call parameters on separate lines in mock.assert_called_wtih() assertion errors.  Contributed by Susan Su.

--- a/Misc/NEWS.d/next/Library/2019-02-10-00-00-13.bpo-35500.1HOMmo.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-10-00-00-13.bpo-35500.1HOMmo.rst
@@ -1,1 +1,1 @@
-Write expected and actual call parameters on separate lines in mock.assert_called_with() assertion errors.  Contributed by Susan Su.
+Write expected and actual call parameters on separate lines in :meth:`unittest.mock.Mock.assert_called_with` assertion errors.  Contributed by Susan Su.


### PR DESCRIPTION
This patch adds an enhancement to the unittest module by adding a newline between the Assertion Error and Expected fields of the error messages generated by mock.assert_called_with. With this addition, the output is clearer as it is easier to read. 

<!-- issue-number: [bpo-35500](https://bugs.python.org/issue35500) -->
https://bugs.python.org/issue35500
<!-- /issue-number -->
