### PR TITLE
bpo-21269: Provide args and kwargs attributes on mock call objects

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -609,10 +609,11 @@ the *new_callable* argument to :func:`patch`.
 
         This is either ``None`` (if the mock hasn't been called), or the
         arguments that the mock was last called with. This will be in the
-        form of a tuple: the first member is ``args`` which will be any ordered
-        arguments the mock was called with (or an empty tuple) and the
-        second member is ``kwargs`` which will be any keyword arguments
-        (or an empty dictionary).
+        form of a tuple: the first member, which can also be accessed through
+        the ``args`` property, is any ordered arguments the mock was
+        called with (or an empty tuple) and the second member, which can
+        also be accessed through the ``kwargs`` property, is any keyword
+        arguments (or an empty dictionary).
 
             >>> mock = Mock(return_value=None)
             >>> print(mock.call_args)

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -609,9 +609,10 @@ the *new_callable* argument to :func:`patch`.
 
         This is either ``None`` (if the mock hasn't been called), or the
         arguments that the mock was last called with. This will be in the
-        form of a tuple: the first member is any ordered arguments the mock
-        was called with (or an empty tuple) and the second member is any
-        keyword arguments (or an empty dictionary).
+        form of a tuple: the first member is ``args`` which will be any ordered
+        arguments the mock was called with (or an empty tuple) and the
+        second member is ``kwargs`` which will be any keyword arguments
+        (or an empty dictionary).
 
             >>> mock = Mock(return_value=None)
             >>> print(mock.call_args)
@@ -626,9 +627,17 @@ the *new_callable* argument to :func:`patch`.
             call(3, 4)
             >>> mock.call_args == ((3, 4),)
             True
+            >>> mock.call_args.args
+            (3, 4)
+            >>> mock.call_args.kwargs
+            {}
             >>> mock(3, 4, 5, key='fish', next='w00t!')
             >>> mock.call_args
             call(3, 4, 5, key='fish', next='w00t!')
+            >>> mock.call_args.args
+            (3, 4, 5)
+            >>> mock.call_args.kwargs
+            {'key': 'fish', 'next': 'w00t!'}
 
         :attr:`call_args`, along with members of the lists :attr:`call_args_list`,
         :attr:`method_calls` and :attr:`mock_calls` are :data:`call` objects.
@@ -1987,14 +1996,13 @@ arguments are a dictionary:
     >>> m = MagicMock(return_value=None)
     >>> m(1, 2, 3, arg='one', arg2='two')
     >>> kall = m.call_args
-    >>> args, kwargs = kall
-    >>> args
+    >>> kall.args
     (1, 2, 3)
-    >>> kwargs
+    >>> kall.kwargs
     {'arg': 'one', 'arg2': 'two'}
-    >>> args is kall[0]
+    >>> kall.args is kall[0]
     True
-    >>> kwargs is kall[1]
+    >>> kall.kwargs is kall[1]
     True
 
     >>> m = MagicMock()

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2124,6 +2124,22 @@ class _Call(tuple):
     def index(self, *args, **kwargs):
         return self.__getattr__('index')(*args, **kwargs)
 
+    def _get_call_arguments(self):
+        if len(self) == 2:
+            args, kwargs = self
+        else:
+            name, args, kwargs = self
+
+        return args, kwargs
+
+    @property
+    def args(self):
+        return self._get_call_arguments()[0]
+
+    @property
+    def kwargs(self):
+        return self._get_call_arguments()[1]
+
     def __repr__(self):
         if not self._mock_from_kall:
             name = self._mock_name or 'call'

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -146,6 +146,8 @@ class CallTest(unittest.TestCase):
         self.assertEqual(args, ('foo', (1, 2, 3)))
         self.assertEqual(args, ('foo', (1, 2, 3), {}))
         self.assertEqual(args, ((1, 2, 3), {}))
+        self.assertEqual(args.args, (1, 2, 3))
+        self.assertEqual(args.kwargs, {})
 
 
     def test_named_call_with_args(self):
@@ -153,6 +155,8 @@ class CallTest(unittest.TestCase):
 
         self.assertEqual(args, ('foo', (1, 2, 3)))
         self.assertEqual(args, ('foo', (1, 2, 3), {}))
+        self.assertEqual(args.args, (1, 2, 3))
+        self.assertEqual(args.kwargs, {})
 
         self.assertNotEqual(args, ((1, 2, 3),))
         self.assertNotEqual(args, ((1, 2, 3), {}))
@@ -165,6 +169,8 @@ class CallTest(unittest.TestCase):
         self.assertEqual(args, ('foo', dict(a=3, b=4)))
         self.assertEqual(args, ('foo', (), dict(a=3, b=4)))
         self.assertEqual(args, ((), dict(a=3, b=4)))
+        self.assertEqual(args.args, ())
+        self.assertEqual(args.kwargs, dict(a=3, b=4))
 
 
     def test_named_call_with_kwargs(self):
@@ -172,6 +178,8 @@ class CallTest(unittest.TestCase):
 
         self.assertEqual(args, ('foo', dict(a=3, b=4)))
         self.assertEqual(args, ('foo', (), dict(a=3, b=4)))
+        self.assertEqual(args.args, ())
+        self.assertEqual(args.kwargs, dict(a=3, b=4))
 
         self.assertNotEqual(args, (dict(a=3, b=4),))
         self.assertNotEqual(args, ((), dict(a=3, b=4)))
@@ -179,6 +187,7 @@ class CallTest(unittest.TestCase):
 
     def test_call_with_args_call_empty_name(self):
         args = _Call(((1, 2, 3), {}))
+
         self.assertEqual(args, call(1, 2, 3))
         self.assertEqual(call(1, 2, 3), args)
         self.assertIn(call(1, 2, 3), [args])

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -267,6 +267,10 @@ class MockTest(unittest.TestCase):
         self.assertEqual(mock.call_count, 1, "call_count incoreect")
         self.assertEqual(mock.call_args, ((sentinel.Arg,), {}),
                          "call_args not set")
+        self.assertEqual(mock.call_args.args, (sentinel.Arg,),
+                         "call_args not set")
+        self.assertEqual(mock.call_args.kwargs, {},
+                         "call_args not set")
         self.assertEqual(mock.call_args_list, [((sentinel.Arg,), {})],
                          "call_args_list not initialised correctly")
 
@@ -300,6 +304,8 @@ class MockTest(unittest.TestCase):
         ])
         self.assertEqual(mock.call_args,
                          ((sentinel.Arg,), {"kw": sentinel.Kwarg}))
+        self.assertEqual(mock.call_args.args, (sentinel.Arg,))
+        self.assertEqual(mock.call_args.kwargs, {"kw": sentinel.Kwarg})
 
         # Comparing call_args to a long sequence should not raise
         # an exception. See issue 24857.
@@ -1156,9 +1162,8 @@ class MockTest(unittest.TestCase):
         mock(2, b=4)
 
         self.assertEqual(len(mock.call_args), 2)
-        args, kwargs = mock.call_args
-        self.assertEqual(args, (2,))
-        self.assertEqual(kwargs, dict(b=4))
+        self.assertEqual(mock.call_args.args, (2,))
+        self.assertEqual(mock.call_args.kwargs, dict(b=4))
 
         expected_list = [((1,), dict(a=3)), ((2,), dict(b=4))]
         for expected, call_args in zip(expected_list, mock.call_args_list):

--- a/Misc/NEWS.d/next/Library/2019-02-10-16-49-16.bpo-21269.Fqi7VH.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-10-16-49-16.bpo-21269.Fqi7VH.rst
@@ -1,1 +1,1 @@
-Add ``args`` and ``kwargs`` property to mock call objects. Contributed by Kumar Akshay.
+Add ``args`` and ``kwargs`` properties to mock call objects. Contributed by Kumar Akshay.

--- a/Misc/NEWS.d/next/Library/2019-02-10-16-49-16.bpo-21269.Fqi7VH.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-10-16-49-16.bpo-21269.Fqi7VH.rst
@@ -1,2 +1,1 @@
-Add property method to provide args and kwargs attributes on mock call
-objects. Contributed by Kumar Akshay.
+Add args and kwards propery to mock call objects. Contributed by Kumar Akshay.

--- a/Misc/NEWS.d/next/Library/2019-02-10-16-49-16.bpo-21269.Fqi7VH.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-10-16-49-16.bpo-21269.Fqi7VH.rst
@@ -1,1 +1,1 @@
-Add args and kwards propery to mock call objects. Contributed by Kumar Akshay.
+Add ``args`` and ``kwargs`` property to mock call objects. Contributed by Kumar Akshay.

--- a/Misc/NEWS.d/next/Library/2019-02-10-16-49-16.bpo-21269.Fqi7VH.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-10-16-49-16.bpo-21269.Fqi7VH.rst
@@ -1,0 +1,2 @@
+Add property method to provide args and kwargs attributes on mock call
+objects. Contributed by Kumar Akshay.


### PR DESCRIPTION
This PR tries to add this functionality
```
➜  cpython git:(fix-issue-21269) ✗ ./python.exe
Python 3.8.0a0 (heads/fix-issue-21269-dirty:2433a2ab70, Feb 10 2019, 14:24:54)
[Clang 10.0.0 (clang-1000.10.44.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from unittest.mock import Mock
>>> m = Mock()
>>> m(1, a=23)
<Mock name='mock()' id='4552188368'>
>>> m.call_args
call(1, a=23)
>>> m.call_args.args     #after this patch
(1,)
>>> m.call_args.kwargs   #after this patch
{'a': 23}
>>> m.call_args_list[0].args    #after this patch
(1,)
>>> m.call_args_list[0].kwargs   #after this patch
{'a': 23}
```

<!-- issue-number: [bpo-21269](https://bugs.python.org/issue21269) -->
https://bugs.python.org/issue21269
<!-- /issue-number -->
