### PR TITLE
bpo-35959: Fix division by 0 when checking for overflow

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1756,6 +1756,10 @@ class IsCloseTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             prod([10, 20], [30, 40])     # start is a keyword-only argument
 
+        self.assertEqual(prod([0, 1, 2, 3]), 0)
+        self.assertEqual(prod([1, 0, 2, 3]), 0)
+        self.assertEqual(prod(range(10)), 0)
+
 def test_main():
     from doctest import DocFileSuite
     suite = unittest.TestSuite()

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2561,8 +2561,8 @@ math_prod_impl(PyObject *module, PyObject *iterable, PyObject *start)
                 long x = i_result * b;
                 /* Continue if there is no overflow */
                 if (overflow == 0
-                    && x < INT_MAX && x > INT_MIN
-                    && !(b != 0 && x / i_result != b)) {
+                    && x < LONG_MAX && x > LONG_MIN
+                    && !(b != 0 && x / b != i_result)) {
                     i_result = x;
                     Py_DECREF(item);
                     continue;


### PR DESCRIPTION


<!-- issue-number: [bpo-35959](https://bugs.python.org/issue35959) -->
https://bugs.python.org/issue35959
<!-- /issue-number -->
