### PR TITLE
 bpo-35960: Fix dataclasses.field throwing away empty metadata. 

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -241,7 +241,7 @@ class Field:
         self.hash = hash
         self.compare = compare
         self.metadata = (_EMPTY_METADATA
-                         if metadata is None or len(metadata) == 0 else
+                         if metadata is None else
                          types.MappingProxyType(metadata))
         self._field_type = None
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1741,9 +1741,12 @@ class TestCase(unittest.TestCase):
         @dataclass
         class C:
             i: int = field(metadata=d)
-        self.assertEqual(fields(C)[0].metadata, d)
+        self.assertFalse(fields(C)[0].metadata)
+        self.assertEqual(len(fields(C)[0].metadata), 0)
+        # Update should work (see bpo-35960).
         d['foo'] = 1
-        self.assertEqual(fields(C)[0].metadata, d)
+        self.assertEqual(len(fields(C)[0].metadata), 1)
+        self.assertEqual(fields(C)[0].metadata['foo'], 1)
         with self.assertRaisesRegex(TypeError,
                                     'does not support item assignment'):
             fields(C)[0].metadata['test'] = 3
@@ -1753,9 +1756,14 @@ class TestCase(unittest.TestCase):
         @dataclass
         class C:
             i: int = field(metadata=d)
-        self.assertEqual(fields(C)[0].metadata, d)
+        self.assertEqual(len(fields(C)[0].metadata), 3)
+        self.assertEqual(fields(C)[0].metadata['test'], 10)
+        self.assertEqual(fields(C)[0].metadata['bar'], '42')
+        self.assertEqual(fields(C)[0].metadata[3], 'three')
+        # Update should work.
         d['foo'] = 1
-        self.assertEqual(fields(C)[0].metadata, d)
+        self.assertEqual(len(fields(C)[0].metadata), 4)
+        self.assertEqual(fields(C)[0].metadata['foo'], 1)
         with self.assertRaises(KeyError):
             # Non-existent key.
             fields(C)[0].metadata['baz']

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1737,23 +1737,25 @@ class TestCase(unittest.TestCase):
                 i: int = field(metadata=0)
 
         # Make sure an empty dict works.
+        d = {}
         @dataclass
         class C:
-            i: int = field(metadata={})
-        self.assertFalse(fields(C)[0].metadata)
-        self.assertEqual(len(fields(C)[0].metadata), 0)
+            i: int = field(metadata=d)
+        self.assertEqual(fields(C)[0].metadata, d)
+        d['foo'] = 1
+        self.assertEqual(fields(C)[0].metadata, d)
         with self.assertRaisesRegex(TypeError,
                                     'does not support item assignment'):
             fields(C)[0].metadata['test'] = 3
 
         # Make sure a non-empty dict works.
+        d = {'test': 10, 'bar': '42', 3: 'three'}
         @dataclass
         class C:
-            i: int = field(metadata={'test': 10, 'bar': '42', 3: 'three'})
-        self.assertEqual(len(fields(C)[0].metadata), 3)
-        self.assertEqual(fields(C)[0].metadata['test'], 10)
-        self.assertEqual(fields(C)[0].metadata['bar'], '42')
-        self.assertEqual(fields(C)[0].metadata[3], 'three')
+            i: int = field(metadata=d)
+        self.assertEqual(fields(C)[0].metadata, d)
+        d['foo'] = 1
+        self.assertEqual(fields(C)[0].metadata, d)
         with self.assertRaises(KeyError):
             # Non-existent key.
             fields(C)[0].metadata['baz']

--- a/Misc/NEWS.d/next/Library/2019-02-10-20-57-12.bpo-35960.bh-6Ja.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-10-20-57-12.bpo-35960.bh-6Ja.rst
@@ -1,0 +1,2 @@
+Fix :func:`dataclasses.field` throwing away empty mapping objects passed as
+metadata.


### PR DESCRIPTION


<!-- issue-number: [bpo-35960](https://bugs.python.org/issue35960) -->
https://bugs.python.org/issue35960
<!-- /issue-number -->
