### PR TITLE
bpo-35972: _xxsubinterpreters: Fix potential integer truncation in channel_send()

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -393,7 +393,19 @@ class ShareableTypeTests(unittest.TestCase):
                             for i in range(-1, 258))
 
     def test_int(self):
-        self._assert_values(range(-1, 258))
+        self._assert_values(itertools.chain(range(-1, 258),
+                                            [sys.maxsize, -sys.maxsize - 1]))
+
+    def test_non_shareable_int(self):
+        ints = [
+            sys.maxsize + 1,
+            -sys.maxsize - 2,
+            2**1000,
+        ]
+        for i in ints:
+            with self.subTest(i):
+                with self.assertRaises(OverflowError):
+                    interpreters.channel_send(self.cid, i)
 
 
 ##################################

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1473,6 +1473,10 @@ _new_long_object(_PyCrossInterpreterData *data)
 static int
 _long_shared(PyObject *obj, _PyCrossInterpreterData *data)
 {
+    /* Note that this means the size of shareable ints is bounded by
+     * sys.maxsize.  Hence on 32-bit architectures that is half the
+     * size of maximum shareable ints on 64-bit.
+     */
     Py_ssize_t value = PyLong_AsSsize_t(obj);
     if (value == -1 && PyErr_Occurred()) {
         if (PyErr_ExceptionMatches(PyExc_OverflowError)) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1467,13 +1467,13 @@ _str_shared(PyObject *obj, _PyCrossInterpreterData *data)
 static PyObject *
 _new_long_object(_PyCrossInterpreterData *data)
 {
-    return PyLong_FromLongLong((intptr_t)(data->data));
+    return PyLong_FromSsize_t((Py_ssize_t)(data->data));
 }
 
 static int
 _long_shared(PyObject *obj, _PyCrossInterpreterData *data)
 {
-    int64_t value = PyLong_AsLongLong(obj);
+    Py_ssize_t value = PyLong_AsSsize_t(obj);
     if (value == -1 && PyErr_Occurred()) {
         if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
             PyErr_SetString(PyExc_OverflowError, "try sending as bytes");


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35972](https://bugs.python.org/issue35972) -->
https://bugs.python.org/issue35972
<!-- /issue-number -->
