### PR TITLE
bpo-35951: os.renames() creates directories if original name doesn't exist

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -263,8 +263,9 @@ def renames(old, new):
 
     """
     head, tail = path.split(new)
-    if head and tail and not path.exists(head):
-        makedirs(head)
+    if path.exists(old):
+        if head and tail and not path.exists(head):
+            makedirs(head)
     rename(old, new)
     head, tail = path.split(old)
     if head and tail:

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -135,8 +135,12 @@ class FileTests(unittest.TestCase):
     def test_rename_bad_dir(self):
         path1 = 'temp/not-exists'
         path1new = 'temp/test2/test3/test4'
-        os.rename(path1, path1new)
-        self.assertFalse(path.exists(path1new))
+        try:
+            os.rename(path1, path1new)
+            self.assertFalse(path.exists(path1new))
+        except FileNotFoundError:
+            pass
+
 
     def test_read(self):
         with open(support.TESTFN, "w+b") as fobj:

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -141,7 +141,6 @@ class FileTests(unittest.TestCase):
         except FileNotFoundError:
             pass
 
-
     def test_read(self):
         with open(support.TESTFN, "w+b") as fobj:
             fobj.write(b"spam")

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -126,10 +126,17 @@ class FileTests(unittest.TestCase):
     @support.cpython_only
     def test_rename(self):
         path = support.TESTFN
+        not_exists = 'temp2/test'
         old = sys.getrefcount(path)
         self.assertRaises(TypeError, os.rename, path, 0)
         new = sys.getrefcount(path)
         self.assertEqual(old, new)
+
+    def test_rename_bad_dir(self):
+        path1 = 'temp/not-exists'
+        path1new = 'temp/test2/test3/test4'
+        os.rename(path1, path1new)
+        self.assertFalse(path.exists(path1new))
 
     def test_read(self):
         with open(support.TESTFN, "w+b") as fobj:

--- a/Misc/NEWS.d/next/Library/2019-02-12-15-16-04.bpo-35951.GpZnMM.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-12-15-16-04.bpo-35951.GpZnMM.rst
@@ -1,0 +1,1 @@
+`os.rename()` now doesnt create directories when original directory doesn't exist.


### PR DESCRIPTION
I have added a fix to resolve `os.rename()` creating directories when original directory doesn't exist.

<!-- issue-number: [bpo-35951](https://bugs.python.org/issue35951) -->
https://bugs.python.org/issue35951
<!-- /issue-number -->
