### PR TITLE
bpo-35961: Fix a crash in slice_richcompare()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-12-19-21-54.bpo-35961.7f7Sne.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-12-19-21-54.bpo-35961.7f7Sne.rst
@@ -1,0 +1,3 @@
+Fix a crash in slice_richcompare(): ensure that the 2 temporary internal
+tuples used for the comparison are not tracked by the garbage collector,
+since they use borrowed references.

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -590,13 +590,17 @@ slice_richcompare(PyObject *v, PyObject *w, int op)
     }
 
     t1 = PyTuple_New(3);
-    if (t1 == NULL)
+    if (t1 == NULL) {
         return NULL;
+    }
+    PyObject_GC_UnTrack(t1);
+
     t2 = PyTuple_New(3);
     if (t2 == NULL) {
         Py_DECREF(t1);
         return NULL;
     }
+    PyObject_GC_UnTrack(t2);
 
     PyTuple_SET_ITEM(t1, 0, ((PySliceObject *)v)->start);
     PyTuple_SET_ITEM(t1, 1, ((PySliceObject *)v)->stop);


### PR DESCRIPTION
Fix a crash in slice_richcompare(): ensure that the 2 temporary
internal tuples used for the comparison are not tracked by the
garbage collector, since they use borrowed references.

The crash (or assertion error) occurred if a garbage collection
occurred during slice_richcompare(), especially while calling
PyObject_RichCompare(t1, t2, op).

<!-- issue-number: [bpo-35961](https://bugs.python.org/issue35961) -->
https://bugs.python.org/issue35961
<!-- /issue-number -->
