### PR TITLE
bpo-35942: Improve the error message if __fspath__ returns invalid types in path_converter

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3344,7 +3344,7 @@ class PathTConverterTests(unittest.TestCase):
                             cleanup_fn(result)
 
                 with self.assertRaisesRegex(
-                        TypeError, 'should be string, bytes'):
+                        TypeError, 'to return str or bytes'):
                     fn(int_fspath, *extra_args)
 
                 if allow_fd:
@@ -3356,6 +3356,23 @@ class PathTConverterTests(unittest.TestCase):
                             TypeError,
                             'os.PathLike'):
                         fn(fd, *extra_args)
+
+    def test_path_t_converter_and_custom_class(self):
+        with self.assertRaisesRegex(
+                TypeError,
+                '__fspath__\(\) to return str or bytes, not int'
+            ):
+            os.stat(FakePath(2))
+        with self.assertRaisesRegex(
+                TypeError,
+                '__fspath__\(\) to return str or bytes, not float'
+            ):
+            os.stat(FakePath(2.34))
+        with self.assertRaisesRegex(
+                TypeError,
+                '__fspath__\(\) to return str or bytes, not object'
+            ):
+            os.stat(FakePath(object()))
 
 
 @unittest.skipUnless(hasattr(os, 'get_blocking'),

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -601,7 +601,7 @@ class PosixTester(unittest.TestCase):
             self.assertTrue(posix.stat(fp.fileno()))
 
             self.assertRaisesRegex(TypeError,
-                    'should be string, bytes, os.PathLike or integer, not',
+                    'expected str, bytes or os.PathLike object, not',
                     posix.stat, float(fp.fileno()))
         finally:
             fp.close()
@@ -616,13 +616,13 @@ class PosixTester(unittest.TestCase):
                 'should be string, bytes, os.PathLike or integer, not',
                 posix.stat, bytearray(os.fsencode(support.TESTFN)))
         self.assertRaisesRegex(TypeError,
-                'should be string, bytes, os.PathLike or integer, not',
+                'expected str, bytes or os.PathLike object, not',
                 posix.stat, None)
         self.assertRaisesRegex(TypeError,
-                'should be string, bytes, os.PathLike or integer, not',
+                'expected str, bytes or os.PathLike object, not',
                 posix.stat, list(support.TESTFN))
         self.assertRaisesRegex(TypeError,
-                'should be string, bytes, os.PathLike or integer, not',
+                'expected str, bytes or os.PathLike object, not',
                 posix.stat, list(os.fsencode(support.TESTFN)))
 
     @unittest.skipUnless(hasattr(posix, 'mkfifo'), "don't have mkfifo()")

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -601,7 +601,7 @@ class PosixTester(unittest.TestCase):
             self.assertTrue(posix.stat(fp.fileno()))
 
             self.assertRaisesRegex(TypeError,
-                    'expected str, bytes or os.PathLike object, not',
+                    'should be string, bytes, os.PathLike or integer, not',
                     posix.stat, float(fp.fileno()))
         finally:
             fp.close()
@@ -616,13 +616,13 @@ class PosixTester(unittest.TestCase):
                 'should be string, bytes, os.PathLike or integer, not',
                 posix.stat, bytearray(os.fsencode(support.TESTFN)))
         self.assertRaisesRegex(TypeError,
-                'expected str, bytes or os.PathLike object, not',
+                'should be string, bytes, os.PathLike or integer, not',
                 posix.stat, None)
         self.assertRaisesRegex(TypeError,
-                'expected str, bytes or os.PathLike object, not',
+                'should be string, bytes, os.PathLike or integer, not',
                 posix.stat, list(support.TESTFN))
         self.assertRaisesRegex(TypeError,
-                'expected str, bytes or os.PathLike object, not',
+                'should be string, bytes, os.PathLike or integer, not',
                 posix.stat, list(os.fsencode(support.TESTFN)))
 
     @unittest.skipUnless(hasattr(posix, 'mkfifo'), "don't have mkfifo()")

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-18-09-30-55.bpo-35942.oLhL2v.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-18-09-30-55.bpo-35942.oLhL2v.rst
@@ -1,0 +1,3 @@
+The error message emmited when returning invalid types from ``__fspath__``
+in interfaces that allow passing :class:`~os.PathLike` objects has been
+improved and now it does explain the origin of the error.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -954,20 +954,15 @@ path_converter(PyObject *o, void *p)
     if (!is_index && !is_buffer && !is_unicode && !is_bytes) {
         /* Inline PyOS_FSPath() for better error messages. */
         _Py_IDENTIFIER(__fspath__);
-        PyObject *func = NULL;
+        PyObject *res = NULL;
 
-        func = _PyObject_LookupSpecial(o, &PyId___fspath__);
-        if (NULL == func) {
-            goto error_format;
-        }
-        /* still owns a reference to the original object */
-        Py_DECREF(o);
-        o = _PyObject_CallNoArg(func);
-        Py_DECREF(func);
-        if (NULL == o) {
+        res = PyOS_FSPath(o);
+        if (res == NULL) {
             goto error_exit;
         }
-        else if (PyUnicode_Check(o)) {
+        Py_DECREF(o);
+        o = res;
+        if (PyUnicode_Check(o)) {
             is_unicode = 1;
         }
         else if (PyBytes_Check(o)) {


### PR DESCRIPTION

<!-- issue-number: [bpo-36942](https://bugs.python.org/issue36942) -->
https://bugs.python.org/issue35942
<!-- /issue-number -->
