### PR TITLE
bpo-35899: Support of empty and weird strings by Enum

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -19,18 +19,19 @@ def _is_descriptor(obj):
 
 def _is_dunder(name):
     """Returns True if a __dunder__ name, False otherwise."""
-    return (name[:2] == name[-2:] == '__' and
-            name[2:3] != '_' and
-            name[-3:-2] != '_' and
-            len(name) > 4)
+    return (len(name) > 4 and
+            name[:2] == name[-2:] == '__' and
+            name[2] != '_' and
+            name[-3] != '_')
 
 
 def _is_sunder(name):
     """Returns True if a _sunder_ name, False otherwise."""
-    return (name[0] == name[-1] == '_' and
+    return (len(name) > 2 and
+            name[0] == name[-1] == '_' and
             name[1:2] != '_' and
-            name[-2:-1] != '_' and
-            len(name) > 2)
+            name[-2:-1] != '_')
+
 
 def _make_class_unpicklable(cls):
     """Make the given class un-picklable."""

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2730,7 +2730,12 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(256, len(seen), 'too many composite members created')
 
 
-class TestWeirdString(unittest.TestCase):
+class TestEmptyWeirdString(unittest.TestCase):
+    def test_empty_string(self):
+        Yay = Enum('Yay', ('', 'B', 'C'))
+        item = getattr(Yay, '')
+        self.assertEqual(item.value, 1)
+
     def test_weird_character(self):
         Yay = Enum('Yay', ('!', 'B', 'C'))
         item = getattr(Yay, '!')

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2730,6 +2730,13 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(256, len(seen), 'too many composite members created')
 
 
+class TestWeirdString(unittest.TestCase):
+    def test_weird_character(self):
+        Yay = Enum('Yay', ('!', 'B', 'C'))
+        item = getattr(Yay, '!')
+        self.assertEqual(item.value, 1)
+
+
 class TestUnique(unittest.TestCase):
 
     def test_unique_clean(self):

--- a/Misc/NEWS.d/next/Library/2019-02-13-13-18-32.bpo-35899.sFrRfw.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-13-13-18-32.bpo-35899.sFrRfw.rst
@@ -1,0 +1,1 @@
+Enum supports empty and weird strings for the items. Contributed by Maxwell.


### PR DESCRIPTION
Co-authored-by: Maxwell <maxwellpxt@gmail.com>
Co-authored-by: Stéphane Wirtel <stephane@wirtel.be>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35899](https://bugs.python.org/issue35899) -->
https://bugs.python.org/issue35899
<!-- /issue-number -->
