### PR TITLE
[2.7] bpo-35907: Avoid file reading as disallowing the unnecessary URL scheme in urllib (GH-11842)

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1027,14 +1027,9 @@ class URLopener_Tests(unittest.TestCase):
         class DummyURLopener(urllib.URLopener):
             def open_local_file(self, url):
                 return url
-        self.assertEqual(DummyURLopener().open(
-            'local-file://example'), '//example')
-        self.assertEqual(DummyURLopener().open(
-            'local_file://example'), '//example')
-        self.assertRaises(IOError, urllib.urlopen,
-            'local-file://example')
-        self.assertRaises(IOError, urllib.urlopen,
-            'local_file://example')
+        for url in ('local_file://example', 'local-file://example'):
+            self.assertRaises(IOError, DummyURLopener().open, url)
+            self.assertRaises(IOError, urllib.urlopen, url)
 
 # Just commented them out.
 # Can't really tell why keep failing in windows and sparc.

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1023,6 +1023,18 @@ class URLopener_Tests(unittest.TestCase):
             "spam://c:|windows%/:=&?~#+!$,;'@()*[]|/path/"),
             "//c:|windows%/:=&?~#+!$,;'@()*[]|/path/")
 
+    def test_local_file_open(self):
+        class DummyURLopener(urllib.URLopener):
+            def open_local_file(self, url):
+                return url
+        self.assertEqual(DummyURLopener().open(
+            'local-file://example'), '//example')
+        self.assertEqual(DummyURLopener().open(
+            'local_file://example'), '//example')
+        self.assertRaises(IOError, urllib.urlopen,
+            'local-file://example')
+        self.assertRaises(IOError, urllib.urlopen,
+            'local_file://example')
 
 # Just commented them out.
 # Can't really tell why keep failing in windows and sparc.

--- a/Lib/urllib.py
+++ b/Lib/urllib.py
@@ -203,7 +203,10 @@ class URLopener:
         name = 'open_' + urltype
         self.type = urltype
         name = name.replace('-', '_')
-        if not hasattr(self, name):
+        
+        # bpo-35907: # disallow the file reading with the type not allowed
+        if not hasattr(self, name) or \
+            (self == _urlopener and name == 'open_local_file'):
             if proxy:
                 return self.open_unknown_proxy(proxy, fullurl, data)
             else:

--- a/Lib/urllib.py
+++ b/Lib/urllib.py
@@ -203,10 +203,10 @@ class URLopener:
         name = 'open_' + urltype
         self.type = urltype
         name = name.replace('-', '_')
-        
+
         # bpo-35907: # disallow the file reading with the type not allowed
         if not hasattr(self, name) or \
-            (self == _urlopener and name == 'open_local_file'):
+            getattr(self, name) == self.open_local_file:
             if proxy:
                 return self.open_unknown_proxy(proxy, fullurl, data)
             else:

--- a/Lib/urllib.py
+++ b/Lib/urllib.py
@@ -205,8 +205,7 @@ class URLopener:
         name = name.replace('-', '_')
 
         # bpo-35907: # disallow the file reading with the type not allowed
-        if not hasattr(self, name) or \
-            getattr(self, name) == self.open_local_file:
+        if not hasattr(self, name) or name == 'open_local_file':
             if proxy:
                 return self.open_unknown_proxy(proxy, fullurl, data)
             else:

--- a/Lib/urllib.py
+++ b/Lib/urllib.py
@@ -204,7 +204,7 @@ class URLopener:
         self.type = urltype
         name = name.replace('-', '_')
 
-        # bpo-35907: # disallow the file reading with the type not allowed
+        # bpo-35907: disallow the file reading with the type not allowed
         if not hasattr(self, name) or name == 'open_local_file':
             if proxy:
                 return self.open_unknown_proxy(proxy, fullurl, data)

--- a/Misc/NEWS.d/next/Library/2019-02-13-17-21-10.bpo-35907.ckk2zg.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-13-17-21-10.bpo-35907.ckk2zg.rst
@@ -1,1 +1,1 @@
-Avoid file reading as disallowing the unnecessary URL scheme in urllib.urlopen
+CVE-2019-9948: Avoid file reading as disallowing the unnecessary URL scheme in urllib.urlopen

--- a/Misc/NEWS.d/next/Library/2019-02-13-17-21-10.bpo-35907.ckk2zg.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-13-17-21-10.bpo-35907.ckk2zg.rst
@@ -1,0 +1,1 @@
+Avoid file reading as disallowing the unnecessary URL scheme in urllib.urlopen


### PR DESCRIPTION
https://bugs.python.org/issue35907

<!-- issue-number: [bpo-35907](https://bugs.python.org/issue35907) -->
<!-- /issue-number -->
