### PR TITLE
gh-80170: Forbid a netmask > 32 for ipaddress.IPv4Network

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1520,7 +1520,7 @@ class IPv4Network(_BaseV4, _BaseNetwork):
         elif isinstance(address, tuple):
             addr = address[0]
             if len(address) > 1:
-                if isinstance(address[1], int) and 0 < address[1] > 32:
+                if isinstance(address[1], int) and address[1] > 32:
                     raise NetmaskValueError(f"The netmask is not valid {address[1]}")
                 mask = address[1]
             else:

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1519,7 +1519,13 @@ class IPv4Network(_BaseV4, _BaseNetwork):
         # Constructing from a tuple (addr, [mask])
         elif isinstance(address, tuple):
             addr = address[0]
-            mask = address[1] if len(address) > 1 else self._max_prefixlen
+            if len(address) > 1:
+                if isinstance(address[1], int) and 0 < address[1] > 32:
+                    raise NetmaskValueError("The netmask should be isn't valid")
+                mask = address[1]
+            else:
+                mask = self._max_prefixlen
+            #mask = address[1] if len(address) > 1 else self._max_prefixlen
         # Assume input argument to be string or any object representation
         # which converts into a formatted IP prefix string.
         else:

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1521,7 +1521,7 @@ class IPv4Network(_BaseV4, _BaseNetwork):
             addr = address[0]
             if len(address) > 1:
                 if isinstance(address[1], int) and 0 < address[1] > 32:
-                    raise NetmaskValueError("The netmask should be isn't valid")
+                    raise NetmaskValueError(f"The netmask is not valid {address[1]}")
                 mask = address[1]
             else:
                 mask = self._max_prefixlen

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -840,6 +840,8 @@ class IpaddrUnitTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             ipaddress.IPv4Network(('192.0.2.1', 24))
         with self.assertRaises(ValueError):
+            ipaddress.IPv4Network(('192.0.2.1', 33))
+        with self.assertRaises(ValueError):
             ipaddress.IPv4Network((ip, 24))
         with self.assertRaises(ValueError):
             ipaddress.IPv4Network((3221225985, 24))

--- a/Misc/NEWS.d/next/Library/2019-02-13-21-43-31.bpo-35989.8L9aBw.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-13-21-43-31.bpo-35989.8L9aBw.rst
@@ -1,0 +1,2 @@
+IPv4Network raises a ``NetmaskValueError`` exception if the netmask is not
+between 0 and 32. Contributed by Stéphane Wirtel.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35989](https://bugs.python.org/issue35989) -->
https://bugs.python.org/issue35989
<!-- /issue-number -->

<!-- gh-issue-number: gh-80170 -->
* Issue: gh-80170
<!-- /gh-issue-number -->
