### PR TITLE
bpo-20523: pdb searches for .pdbrc in ~ instead of $HOME

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -159,11 +159,11 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.allow_kbdint = False
         self.nosigint = nosigint
 
-        # Read $HOME/.pdbrc and ./.pdbrc
+        # Read ~/.pdbrc and ./.pdbrc
         self.rcLines = []
         if readrc:
-            if 'HOME' in os.environ:
-                envHome = os.environ['HOME']
+            envHome = os.path.expanduser('~')
+            if envHome != '~':
                 try:
                     with open(os.path.join(envHome, ".pdbrc")) as rcFile:
                         self.rcLines.extend(rcFile)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1333,6 +1333,18 @@ class PdbTestCase(unittest.TestCase):
             if save_home is not None:
                 os.environ['HOME'] = save_home
 
+    def test_readrc_homedir(self):
+        save_home = os.environ.pop("HOME", None)
+        with support.temp_dir() as temp_dir, patch("os.path.expanduser"):
+            os.path.expanduser.return_value = temp_dir
+            try:
+                with open(os.path.join(temp_dir, ".pdbrc"), "w") as f:
+                    f.write("invalid")
+                self.assertEqual(pdb.Pdb().rcLines[0], "invalid")
+            finally:
+                if save_home is not None:
+                    os.environ["HOME"] = save_home
+
     def test_header(self):
         stdout = StringIO()
         header = 'Nobody expects... blah, blah, blah'


### PR DESCRIPTION
Previously pdb checked the $HOME environmental variable
to find the user .pdbrc. If $HOME is not set, the user
.pdbrc would not be found.

Change pdb to use `os.path.expanduser('~')` to determine
the user's home directory. Thus, if $HOME is not set (as
in tox or on Windows), os.path.expanduser('~') falls
back on other techniques for locating the user's home
directory.

This follows pip's implementation for loading .piprc.

Co-authored-by: Dan Lidral-Porter <dlp@aperiodic.org>


<!-- issue-number: [bpo-20523](https://bugs.python.org/issue20523) -->
https://bugs.python.org/issue20523
<!-- /issue-number -->
