### PR TITLE
bpo-20523: pdb searches for .pdbrc in ~ instead of $HOME

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -159,16 +159,14 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.allow_kbdint = False
         self.nosigint = nosigint
 
-        # Read $HOME/.pdbrc and ./.pdbrc
+        # Read ~/.pdbrc and ./.pdbrc
         self.rcLines = []
         if readrc:
-            if 'HOME' in os.environ:
-                envHome = os.environ['HOME']
-                try:
-                    with open(os.path.join(envHome, ".pdbrc")) as rcFile:
-                        self.rcLines.extend(rcFile)
-                except OSError:
-                    pass
+            try:
+                with open(os.path.expanduser('~/.pdbrc')) as rcFile:
+                    self.rcLines.extend(rcFile)
+            except OSError:
+                pass
             try:
                 with open(".pdbrc") as rcFile:
                     self.rcLines.extend(rcFile)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1337,6 +1337,19 @@ class PdbTestCase(unittest.TestCase):
             if save_home is not None:
                 os.environ['HOME'] = save_home
 
+    def test_readrc_homedir(self):
+        save_home = os.environ.pop("HOME", None)
+        with support.temp_dir() as temp_dir, patch("os.path.expanduser"):
+            rc_path = os.path.join(temp_dir, ".pdbrc")
+            os.path.expanduser.return_value = rc_path
+            try:
+                with open(rc_path, "w") as f:
+                    f.write("invalid")
+                self.assertEqual(pdb.Pdb().rcLines[0], "invalid")
+            finally:
+                if save_home is not None:
+                    os.environ["HOME"] = save_home
+
     def test_header(self):
         stdout = StringIO()
         header = 'Nobody expects... blah, blah, blah'

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-15-20-42-36.bpo-20523.rRLrvr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-15-20-42-36.bpo-20523.rRLrvr.rst
@@ -1,0 +1,2 @@
+``pdb.Pdb`` supports ~/.pdbrc in Windows 7. Patch by Tim Hopper and Dan 
+Lidral-Porter.


### PR DESCRIPTION
Previously pdb checked the $HOME environmental variable
to find the user .pdbrc. If $HOME is not set, the user
.pdbrc would not be found.

Change pdb to use `os.path.expanduser('~')` to determine
the user's home directory. Thus, if $HOME is not set (as
in tox or on Windows), os.path.expanduser('~') falls
back on other techniques for locating the user's home
directory.

This follows pip's implementation for loading .piprc.

Co-authored-by: Dan Lidral-Porter <dlp@aperiodic.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-20523](https://bugs.python.org/issue20523) -->
https://bugs.python.org/issue20523
<!-- /issue-number -->
