### PR TITLE
bpo-35991: Fix a potential double free in Modules/_randommodule.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-14-00-00-30.bpo-35991.xlbfSk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-14-00-00-30.bpo-35991.xlbfSk.rst
@@ -1,0 +1,1 @@
+Fix a potential double free in Modules/_randommodule.c.

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -292,7 +292,6 @@ random_seed(RandomObject *self, PyObject *args)
                               PY_LITTLE_ENDIAN,
                               0); /* unsigned */
     if (res == -1) {
-        PyMem_Free(key);
         goto Done;
     }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-35991](https://bugs.python.org/issue35991) -->
https://bugs.python.org/issue35991
<!-- /issue-number -->
