### PR TITLE
bpo-35994: add sub dir for sub2_tree in os.walk test if symlink is not supported

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -923,7 +923,7 @@ class WalkTests(unittest.TestCase):
                               ["broken_link", "broken_link2", "broken_link3",
                                "tmp3"])
         else:
-            self.sub2_tree = (sub2_path, [], ["tmp3"])
+            self.sub2_tree = (sub2_path, ["SUB21"], ["tmp3"])
 
         os.chmod(sub21_path, 0)
         try:

--- a/Misc/NEWS.d/next/Tests/2019-02-14-08-49-05.bpo-35994.h_Erws.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-14-08-49-05.bpo-35994.h_Erws.rst
@@ -1,1 +1,0 @@
-test_so.py: add sub dir for sub2_tree in os.walk test if symlink is not supported.

--- a/Misc/NEWS.d/next/Tests/2019-02-14-08-49-05.bpo-35994.h_Erws.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-14-08-49-05.bpo-35994.h_Erws.rst
@@ -1,0 +1,1 @@
+test_so.py: add sub dir for sub2_tree in os.walk test if symlink is not supported.


### PR DESCRIPTION


<!-- issue-number: [bpo-35994](https://bugs.python.org/issue35994) -->
https://bugs.python.org/issue35994
<!-- /issue-number -->
