### PR TITLE
bpo-35995: Fix some bug in logging module

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1005,19 +1005,19 @@ class SMTPHandler(logging.Handler):
             port = self.mailport
             if not port:
                 port = smtplib.SMTP_PORT
-            smtp = smtplib.SMTP(self.mailhost, port, timeout=self.timeout)
+            if self.username and self.secure is not None:
+                smtp = smtplib.SMTP_SSL(self.mailhost, port, timeout=self.timeout)
+            else:
+                smtp = smtplib.SMTP(self.mailhost, port, timeout=self.timeout)
+            if self.username:
+                smtp.login(self.username, self.password)
+
             msg = EmailMessage()
             msg['From'] = self.fromaddr
             msg['To'] = ','.join(self.toaddrs)
             msg['Subject'] = self.getSubject(record)
             msg['Date'] = email.utils.localtime()
             msg.set_content(self.format(record))
-            if self.username:
-                if self.secure is not None:
-                    smtp.ehlo()
-                    smtp.starttls(*self.secure)
-                    smtp.ehlo()
-                smtp.login(self.username, self.password)
             smtp.send_message(msg)
             smtp.quit()
         except Exception:


### PR DESCRIPTION
[[bpo-35995](https://bugs.python.org/issue35995)]: Summary of the changes made

just setting param secure=[] means use ssl socket with default certfile
but smtplib.SMTP() failed in self.connect --> self._get_socket. because it is not SMTP_SSL._get_socket


<!-- issue-number: [bpo-35995](https://bugs.python.org/issue35995) -->
https://bugs.python.org/issue35995
<!-- /issue-number -->
