### PR TITLE
bpo-35995: update logging.handlers.SMTPHandler to support smtp server which just in TLS mode

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1023,7 +1023,7 @@ class SMTPHandler(logging.Handler):
         except Exception:
             self.handleError(record)
 
-class SMTPSSLHandler(SMTPHandler):
+class SMTPSSLhandler(SMTPHandler):
     """
     A handler sends an email by smtplib.SMTP_SSL for each logging event.
     """

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -961,7 +961,7 @@ class SMTPHandler(logging.Handler):
         only be used when authentication credentials are supplied. The tuple
         will be either an empty tuple, or a single-value tuple with the name
         of a keyfile, or a 2-value tuple with the names of the keyfile and
-        certificate file. (This tuple is passed to the `starttls` method).
+        certificate file. (This tuple is passed to the `ssl._create_stdlib_context` method).
         A timeout in seconds can be specified for the SMTP connection (the
         default is one second).
         """

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1005,19 +1005,19 @@ class SMTPHandler(logging.Handler):
             port = self.mailport
             if not port:
                 port = smtplib.SMTP_PORT
-            smtp = smtplib.SMTP(self.mailhost, port, timeout=self.timeout)
+            if self.username and self.secure is not None:
+                smtp = smtplib.SMTP_SSL(self.mailhost, port, timeout=self.timeout)
+            else:
+                smtp = smtplib.SMTP(self.mailhost, port, timeout=self.timeout)
+            if self.username:
+                smtp.login(self.username, self.password)
+
             msg = EmailMessage()
             msg['From'] = self.fromaddr
             msg['To'] = ','.join(self.toaddrs)
             msg['Subject'] = self.getSubject(record)
             msg['Date'] = email.utils.localtime()
             msg.set_content(self.format(record))
-            if self.username:
-                if self.secure is not None:
-                    smtp.ehlo()
-                    smtp.starttls(*self.secure)
-                    smtp.ehlo()
-                smtp.login(self.username, self.password)
             smtp.send_message(msg)
             smtp.quit()
         except Exception:

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1008,7 +1008,8 @@ class SMTPHandler(logging.Handler):
             if self.username and self.secure is not None:
                 keyfile = self.secure[0] if len(self.secure) >= 1 else None
                 certfile = self.secure[1] if len(self.secure) >= 2 else None
-                smtp = smtplib.SMTP_SSL(self.mailhost, port, timeout=self.timeout, keyfile=keyfile, certfile=certfile)
+                smtp = smtplib.SMTP_SSL(self.mailhost, port, timeout=self.timeout,
+                                        keyfile=keyfile, certfile=certfile)
             else:
                 smtp = smtplib.SMTP(self.mailhost, port, timeout=self.timeout)
             if self.username:
@@ -1055,7 +1056,7 @@ class NTEventLogHandler(logging.Handler):
                 logging.WARNING : win32evtlog.EVENTLOG_WARNING_TYPE,
                 logging.ERROR   : win32evtlog.EVENTLOG_ERROR_TYPE,
                 logging.CRITICAL: win32evtlog.EVENTLOG_ERROR_TYPE,
-         }
+            }
         except ImportError:
             print("The Python Win32 extensions for NT (service, event "\
                         "logging) appear not to be available.")

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -961,7 +961,7 @@ class SMTPHandler(logging.Handler):
         only be used when authentication credentials are supplied. The tuple
         will be either an empty tuple, or a single-value tuple with the name
         of a keyfile, or a 2-value tuple with the names of the keyfile and
-        certificate file. (This tuple is passed to the `ssl._create_stdlib_context` method).
+        certificate file. (This tuple is passed to the `starttls` method).
         A timeout in seconds can be specified for the SMTP connection (the
         default is one second).
         """
@@ -1005,16 +1005,60 @@ class SMTPHandler(logging.Handler):
             port = self.mailport
             if not port:
                 port = smtplib.SMTP_PORT
-            if self.username and self.secure is not None:
-                keyfile = self.secure[0] if len(self.secure) >= 1 else None
-                certfile = self.secure[1] if len(self.secure) >= 2 else None
-                smtp = smtplib.SMTP_SSL(self.mailhost, port, timeout=self.timeout,
-                                        keyfile=keyfile, certfile=certfile)
-            else:
-                smtp = smtplib.SMTP(self.mailhost, port, timeout=self.timeout)
+            smtp = smtplib.SMTP(self.mailhost, port, timeout=self.timeout)
+            msg = EmailMessage()
+            msg['From'] = self.fromaddr
+            msg['To'] = ','.join(self.toaddrs)
+            msg['Subject'] = self.getSubject(record)
+            msg['Date'] = email.utils.localtime()
+            msg.set_content(self.format(record))
+            if self.username:
+                if self.secure is not None:
+                    smtp.ehlo()
+                    smtp.starttls(*self.secure)
+                    smtp.ehlo()
+                smtp.login(self.username, self.password)
+            smtp.send_message(msg)
+            smtp.quit()
+        except Exception:
+            self.handleError(record)
+
+class SMTPSSLhandler(SMTPHandler):
+    """
+    A handler sends an email by smtplib.SMTP_SSL for each logging event.
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize the handler.
+
+        Initialized by the super handler (SMTPHandler) and
+        default argument secure is a empty tuple
+        """
+        kwargs.setdefault('secure', ())
+        SMTPHandler.__init__(self, *args, **kwargs)
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        Format the record and send it to the specified addressees.
+        """
+        try:
+            import smtplib
+            from email.message import EmailMessage
+            import email.utils
+
+            port = self.mailport
+            if not port:
+                port = smtplib.SMTP_SSL_PORT
+            keyfile, certfile = None, None
+            if isinstance(self.secure, (tuple, list, set)):
+                keyfile = self.secure[0] if len(self.secure) > 0 else None
+                certfile = self.secure[1] if len(self.secure) > 1 else None
+            smtp = smtplib.SMTP_SSL(self.mailhost, port, timeout=self.timeout,
+                                    keyfile=keyfile, certfile=certfile)
             if self.username:
                 smtp.login(self.username, self.password)
-
             msg = EmailMessage()
             msg['From'] = self.fromaddr
             msg['To'] = ','.join(self.toaddrs)

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1023,7 +1023,7 @@ class SMTPHandler(logging.Handler):
         except Exception:
             self.handleError(record)
 
-class SMTPSSLhandler(SMTPHandler):
+class SMTPSSLHandler(SMTPHandler):
     """
     A handler sends an email by smtplib.SMTP_SSL for each logging event.
     """

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1006,7 +1006,9 @@ class SMTPHandler(logging.Handler):
             if not port:
                 port = smtplib.SMTP_PORT
             if self.username and self.secure is not None:
-                smtp = smtplib.SMTP_SSL(self.mailhost, port, timeout=self.timeout)
+                keyfile = self.secure[0] if len(self.secure) >= 1 else None
+                certfile = self.secure[1] if len(self.secure) >= 2 else None
+                smtp = smtplib.SMTP_SSL(self.mailhost, port, timeout=self.timeout, keyfile=keyfile, certfile=certfile)
             else:
                 smtp = smtplib.SMTP(self.mailhost, port, timeout=self.timeout)
             if self.username:

--- a/Misc/NEWS.d/next/Library/2019-02-15-09-55-45.bpo-35995.agBZEl.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-15-09-55-45.bpo-35995.agBZEl.rst
@@ -1,1 +1,1 @@
-add new LogHandler logging.handlers.SMTPSSLHandler to extends logging.handlers.SMTPHandler
+use "ssl._create_stdlib_context" and "SMTP_SSL._get_socket" when init smtp, just like startssl function.

--- a/Misc/NEWS.d/next/Library/2019-02-15-09-55-45.bpo-35995.agBZEl.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-15-09-55-45.bpo-35995.agBZEl.rst
@@ -1,0 +1,1 @@
+use "ssl._create_stdlib_context" and "SMTP_SSL._get_socket" when init smtp, just like startssl function.

--- a/Misc/NEWS.d/next/Library/2019-02-15-09-55-45.bpo-35995.agBZEl.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-15-09-55-45.bpo-35995.agBZEl.rst
@@ -1,1 +1,1 @@
-use "ssl._create_stdlib_context" and "SMTP_SSL._get_socket" when init smtp, just like startssl function.
+update logging.handlers.SMTPHandler to support smtp server which just in TLS mode

--- a/Misc/NEWS.d/next/Library/2019-02-15-09-55-45.bpo-35995.agBZEl.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-15-09-55-45.bpo-35995.agBZEl.rst
@@ -1,1 +1,1 @@
-use "ssl._create_stdlib_context" and "SMTP_SSL._get_socket" when init smtp, just like startssl function.
+add new LogHandler logging.handlers.SMTPSSLHandler to extends logging.handlers.SMTPHandler


### PR DESCRIPTION
[bpo-35995](https://bugs.python.org/issue35995): Fix some bug in logging module

just setting param secure=[] means use ssl socket with default certfile
but smtplib.SMTP() failed in self.connect --> self._get_socket. because it is not SMTP_SSL._get_socket

<!-- issue-number: [bpo-35995](https://bugs.python.org/issue35995) -->
https://bugs.python.org/issue35995
<!-- /issue-number -->
