### PR TITLE
bpo-35746: Credit Colin Read and Nicolas Edet

### DIFF
--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -6,7 +6,8 @@
 
 [CVE-2019-5010] Fix a NULL pointer deref in ssl module. The cert parser did
 not handle CRL distribution points with empty DP or URI correctly. A
-malicious or buggy certificate can result into segfault.
+malicious or buggy certificate can result into segfault. Vulnerability
+(TALOS-2018-0758) reported by Colin Read and Nicolas Edet of Cisco.
 
 ..
 


### PR DESCRIPTION
Add credit for the cert parser vulnerability. Mention also Cisco
TALOS-2018-0758 identifier.

<!-- issue-number: [bpo-35746](https://bugs.python.org/issue35746) -->
https://bugs.python.org/issue35746
<!-- /issue-number -->
