### PR TITLE
[2.7] bpo-35746: Credit Colin Read and Nicolas Edet

### DIFF
--- a/Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst
+++ b/Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst
@@ -1,3 +1,4 @@
 [CVE-2019-5010] Fix a NULL pointer deref in ssl module. The cert parser did
 not handle CRL distribution points with empty DP or URI correctly. A
-malicious or buggy certificate can result into segfault.
+malicious or buggy certificate can result into segfault. Vulnerability
+(TALOS-2018-0758) reported by Colin Read and Nicolas Edet of Cisco.


### PR DESCRIPTION
Add credit for the cert parser vulnerability. Mention also Cisco
TALOS-2018-0758 identifier.

<!-- issue-number: [bpo-35746](https://bugs.python.org/issue35746) -->
https://bugs.python.org/issue35746
<!-- /issue-number -->
