### PR TITLE
bpo-36003: change socketserver.TCPServer reuse_addr and backlog default options

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -277,8 +277,10 @@ Server Objects
    .. attribute:: allow_reuse_address
 
       Whether the server will allow the reuse of an address.  This defaults to
-      :const:`False`, and can be set in subclasses to change the policy.
+      :const:`True` on POSIX, and can be set in subclasses to change the policy.
 
+      .. versionchanged:: 3.8
+         default changed from :const:`False` to :const:`True` on POSIX
 
    .. attribute:: request_queue_size
 
@@ -286,8 +288,11 @@ Server Objects
       request, any requests that arrive while the server is busy are placed into a
       queue, up to :attr:`request_queue_size` requests.  Once the queue is full,
       further requests from clients will get a "Connection denied" error.  The default
-      value is usually 5, but this can be overridden by subclasses.
+      value is 0, meaning a default reasonable value is chosen, but this can be
+      overridden by subclasses.
 
+      .. versionchanged:: 3.8
+         default changed from 5 to 0
 
    .. attribute:: socket_type
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -546,6 +546,13 @@ Changes in the Python API
   :exc:`dbm.gnu.error` or :exc:`dbm.ndbm.error`) instead of :exc:`KeyError`.
   (Contributed by Xiang Zhang in :issue:`33106`.)
 
+* :class:`socketserver.TCPServer` `allow_reuse_address` default changed from
+  ``False`` to ``True`` on POSIX.
+  :attr:`socketserver.TCPServer` `request_queue_size` default changed from
+  ``5`` to ``None`` in order to choose a default reasonable value (usually 128).
+  :class:`http.server.HTTPServer` and :class:`xmlrpc.server.SimpleXMLRPCServer`
+  also inherited this change.
+  (Contributed by Giampaolo Rodola in :issue:`36003`)
 
 CPython bytecode changes
 ------------------------

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -546,9 +546,9 @@ Changes in the Python API
   :exc:`dbm.gnu.error` or :exc:`dbm.ndbm.error`) instead of :exc:`KeyError`.
   (Contributed by Xiang Zhang in :issue:`33106`.)
 
-* :class:`socketserver.TCPServer` `allow_reuse_address` default changed from
+* :class:`socketserver.TCPServer` ``allow_reuse_address`` default changed from
   ``False`` to ``True`` on POSIX.
-  :attr:`socketserver.TCPServer` `request_queue_size` default changed from
+  :attr:`socketserver.TCPServer` ``request_queue_size`` default changed from
   ``5`` to ``None`` in order to choose a default reasonable value (usually 128).
   :class:`http.server.HTTPServer` and :class:`xmlrpc.server.SimpleXMLRPCServer`
   also inherited this change.

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -130,8 +130,6 @@ DEFAULT_ERROR_CONTENT_TYPE = "text/html;charset=utf-8"
 
 class HTTPServer(socketserver.TCPServer):
 
-    allow_reuse_address = 1    # Seems to make sense in testing environment
-
     def server_bind(self):
         """Override server_bind to store the server name."""
         socketserver.TCPServer.server_bind(self)

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -878,8 +878,6 @@ def listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None):
         A simple TCP socket-based logging config receiver.
         """
 
-        allow_reuse_address = 1
-
         def __init__(self, host='localhost', port=DEFAULT_LOGGING_CONFIG_PORT,
                      handler=None, ready=None, verify=None):
             ThreadingTCPServer.__init__(self, (host, port), handler)

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -438,9 +438,10 @@ class TCPServer(BaseServer):
 
     socket_type = socket.SOCK_STREAM
 
-    request_queue_size = 5
+    request_queue_size = 0
 
-    allow_reuse_address = False
+    allow_reuse_address = \
+        os.name not in ('nt', 'cygwin') and hasattr(socket, 'SO_REUSEADDR')
 
     def __init__(self, server_address, RequestHandlerClass, bind_and_activate=True):
         """Constructor.  May be extended, do not override."""
@@ -472,7 +473,7 @@ class TCPServer(BaseServer):
         May be overridden.
 
         """
-        self.socket.listen(self.request_queue_size)
+        self.socket.listen(self.request_queue_size or 0)
 
     def server_close(self):
         """Called to clean-up the server.

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -473,7 +473,7 @@ class TCPServer(BaseServer):
         May be overridden.
 
         """
-        self.socket.listen(self.request_queue_size or 0)
+        self.socket.listen(self.request_queue_size)
 
     def server_close(self):
         """Called to clean-up the server.

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -966,8 +966,6 @@ class TestTCPServer(ControlMixin, ThreadingTCPServer):
                         the server will set up the socket and listen on it.
     """
 
-    allow_reuse_address = True
-
     def __init__(self, addr, handler, poll_interval=0.5,
                  bind_and_activate=True):
         class DelegatingTCPRequestHandler(StreamRequestHandler):

--- a/Lib/xmlrpc/server.py
+++ b/Lib/xmlrpc/server.py
@@ -587,8 +587,6 @@ class SimpleXMLRPCServer(socketserver.TCPServer,
     from SimpleXMLRPCDispatcher to change this behavior.
     """
 
-    allow_reuse_address = True
-
     # Warning: this is for debugging purposes only! Never set this to True in
     # production code, as will be sending out sensitive information (exception
     # and stack trace details) when exceptions are raised inside

--- a/Misc/NEWS.d/next/Library/2019-02-15-15-12-32.bpo-36003.D5t4_b.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-15-15-12-32.bpo-36003.D5t4_b.rst
@@ -1,0 +1,6 @@
+`socketserver.TCPServer.allow_reuse_address` default changed from ``False``
+to ``True`` on POSIX. `socketserver.TCPServer.request_queue_size` default
+changed from ``5`` to ``None`` in order to choose a default reasonable value
+(usually 128). `http.server.HTTPServer` and
+`xmlrpc.server.SimpleXMLRPCServer` also inherited this change.  (Contributed
+by Giampaolo Rodola in :issue:`36003`)


### PR DESCRIPTION


<!-- issue-number: [bpo-36003](https://bugs.python.org/issue36003) -->
https://bugs.python.org/issue36003
<!-- /issue-number -->
