### PR TITLE
[2.7] bpo-29136: Fix from test_ssl test_default_ecdh_curve

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2860,6 +2860,9 @@ else:
             # should be enabled by default on SSL contexts.
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             context.load_cert_chain(CERTFILE)
+            # TLSv1.3 defaults to PFS key agreement and no longer has KEA in
+            # cipher name.
+            context.options |= ssl.OP_NO_TLSv1_3
             # Prior to OpenSSL 1.0.0, ECDH ciphers have to be enabled
             # explicitly using the 'ECCdraft' cipher alias.  Otherwise,
             # our default cipher list should prefer ECDH-based ciphers


### PR DESCRIPTION
Partial backport from cb5b68abdeb1b1d56c581d5b4d647018703d61e3

Co-authored-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-29136](https://bugs.python.org/issue29136) -->
https://bugs.python.org/issue29136
<!-- /issue-number -->
