### PR TITLE
Fix the versionadded info for typing.NoReturn

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -958,7 +958,7 @@ The module defines the following classes, functions and decorators:
       def stop() -> NoReturn:
           raise RuntimeError('no way')
 
-   .. versionadded:: 3.6.5
+   .. versionadded:: 3.5.4
 
 .. data:: Union
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

The earliest version that `typing.NoReturn` appears in is [3.5.4rc1](https://docs.python.org/3/whatsnew/changelog.html#python-3-5-4-release-candidate-1), also being ported to these later versions;

* [3.7.0a1](https://docs.python.org/3/whatsnew/changelog.html#python-3-7-0-alpha-1)
* [3.6.2rc1](https://docs.python.org/3/whatsnew/changelog.html#python-3-6-2-release-candidate-1)
