### PR TITLE
bpo-36006: Fix versionchanged directive alignment in io module documentation

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -349,8 +349,8 @@ I/O Base Classes
       (on most systems, additional bytes are zero-filled).  The new file size
       is returned.
 
-   .. versionchanged:: 3.5
-      Windows will now zero-fill files when extending.
+      .. versionchanged:: 3.5
+         Windows will now zero-fill files when extending.
 
    .. method:: writable()
 


### PR DESCRIPTION
<!-- issue-number: [bpo-36006](https://bugs.python.org/issue36006) -->
https://bugs.python.org/issue36006
<!-- /issue-number -->
