### PR TITLE
bpo-36004: Add date.fromisocalendar

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -458,6 +458,13 @@ Other constructors, all class methods:
   .. versionadded:: 3.7
 
 
+.. classmethod:: date.fromisocalendar(year, week, day)
+
+   Return a :class:`date` corresponding to the ISO calendar date specified by
+   year, week and day. This is the inverse of the function :meth:`date.isocalendar`.
+
+   .. versionadded:: 3.8
+
 
 Class attributes:
 
@@ -853,6 +860,16 @@ Other constructors, all class methods:
     as the inverse operation of :meth:`datetime.isoformat`.
 
   .. versionadded:: 3.7
+
+
+.. classmethod:: datetime.fromisocalendar(year, week, day)
+
+   Return a :class:`datetime` corresponding to the ISO calendar date specified
+   by year, week and day. The non-date components of the datetime are populated
+   with their normal default values. This is the inverse of the function
+   :meth:`datetime.isocalendar`.
+
+   .. versionadded:: 3.8
 
 .. classmethod:: datetime.strptime(date_string, format)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -219,6 +219,16 @@ where the DLL is stored (if a full or partial path is used to load the initial
 DLL) and paths added by :func:`~os.add_dll_directory`.
 
 
+datetime
+--------
+
+Added new alternate constructors :meth:`datetime.date.fromisocalendar` and
+:meth:`datetime.datetime.fromisocalendar`, which construct :class:`date` and
+:class:`datetime` objects respectively from ISO year, week number and weekday;
+these are the inverse of each class's ``isocalendar`` method.
+(Contributed by Paul Ganssle in :issue:`36004`.)
+
+
 gettext
 -------
 

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -890,7 +890,7 @@ class date:
 
         This is the inverse of the date.isocalendar() function"""
         # Year is bounded this way because 9999-12-31 is (9999, 52, 5)
-        if not 0 < year < 10000:
+        if not MINYEAR <= year <= MAXYEAR:
             raise ValueError(f"Year is out of range: {year}")
 
         if not 0 < week < 53:

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -884,6 +884,22 @@ class date:
         except Exception:
             raise ValueError(f'Invalid isoformat string: {date_string!r}')
 
+    @classmethod
+    def fromisocalendar(cls, year, week, day):
+        if not 0 < week < 54:
+            raise ValueError(f"Invalid week: {week}")
+
+        if not 0 < day < 8:
+            raise ValueError(f"Invalid weekday: {day} (range is [1, 7])")
+
+        # Now compute the offset from (Y, 1, 1) in days:
+        day_offset = (week - 1) * 7 + (day - 1)
+
+        # Calculate the ordinal day for monday, week 1
+        day_1 = _isoweek1monday(year)
+        ord_day = day_1 + day_offset
+
+        return cls(*_ord2ymd(ord_day))
 
     # Conversions to string
 

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -890,8 +890,11 @@ class date:
         if not 0 < year < 10000:
             raise ValueError(f"Year is out of range: {year}")
 
-        if not 0 < week < 54:
-            raise ValueError(f"Invalid week: {week}")
+        if not 0 < week < 53:
+            if not (week == 53 and
+                    _iso_long_year_helper(year) == 4 or
+                    _iso_long_year_helper(year - 1) == 3):
+                raise ValueError(f"Invalid week: {week}")
 
         if not 0 < day < 8:
             raise ValueError(f"Invalid weekday: {day} (range is [1, 7])")
@@ -2150,6 +2153,10 @@ datetime.max = datetime(9999, 12, 31, 23, 59, 59, 999999)
 datetime.resolution = timedelta(microseconds=1)
 
 
+def _iso_long_year_helper(year):
+    return (year + (year // 4) - (year // 100) + (year // 400)) % 7
+
+
 def _isoweek1monday(year):
     # Helper to calculate the day number of the Monday starting week 1
     # XXX This could be done more efficiently
@@ -2160,6 +2167,7 @@ def _isoweek1monday(year):
     if firstweekday > THURSDAY:
         week1monday += 7
     return week1monday
+
 
 class timezone(tzinfo):
     __slots__ = '_offset', '_name'
@@ -2492,7 +2500,7 @@ else:
          _format_time, _format_offset, _is_leap, _isoweek1monday, _math,
          _ord2ymd, _time, _time_class, _tzinfo_class, _wrap_strftime, _ymd2ord,
          _divide_and_round, _parse_isoformat_date, _parse_isoformat_time,
-         _parse_hh_mm_ss_ff)
+         _parse_hh_mm_ss_ff, _iso_long_year_helper)
     # XXX Since import * above excludes names that start with _,
     # docstring does not get overwritten. In the future, it may be
     # appropriate to maintain a single module level docstring and

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -886,6 +886,9 @@ class date:
 
     @classmethod
     def fromisocalendar(cls, year, week, day):
+        """Construct a date from the ISO year, week number and weekday.
+
+        This is the inverse of the date.isocalendar() function"""
         # Year is bounded this way because 9999-12-31 is (9999, 52, 5)
         if not 0 < year < 10000:
             raise ValueError(f"Year is out of range: {year}")

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -886,6 +886,10 @@ class date:
 
     @classmethod
     def fromisocalendar(cls, year, week, day):
+        # Year is bounded this way because 9999-12-31 is (9999, 52, 5)
+        if not 0 < year < 10000:
+            raise ValueError(f"Year is out of range: {year}")
+
         if not 0 < week < 54:
             raise ValueError(f"Invalid week: {week}")
 

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -891,9 +891,17 @@ class date:
             raise ValueError(f"Year is out of range: {year}")
 
         if not 0 < week < 53:
-            if not (week == 53 and
-                    _iso_long_year_helper(year) == 4 or
-                    _iso_long_year_helper(year - 1) == 3):
+            out_of_range = True
+
+            if week == 53:
+                # ISO years have 53 weeks in them on years starting with a
+                # Thursday and leap years starting on a Wednesday
+                first_weekday = _ymd2ord(year, 1, 1) % 7
+                if (first_weekday == 4 or (first_weekday == 3 and
+                                           _is_leap(year))):
+                    out_of_range = False
+
+            if out_of_range:
                 raise ValueError(f"Invalid week: {week}")
 
         if not 0 < day < 8:
@@ -2153,10 +2161,6 @@ datetime.max = datetime(9999, 12, 31, 23, 59, 59, 999999)
 datetime.resolution = timedelta(microseconds=1)
 
 
-def _iso_long_year_helper(year):
-    return (year + (year // 4) - (year // 100) + (year // 400)) % 7
-
-
 def _isoweek1monday(year):
     # Helper to calculate the day number of the Monday starting week 1
     # XXX This could be done more efficiently
@@ -2500,7 +2504,7 @@ else:
          _format_time, _format_offset, _is_leap, _isoweek1monday, _math,
          _ord2ymd, _time, _time_class, _tzinfo_class, _wrap_strftime, _ymd2ord,
          _divide_and_round, _parse_isoformat_date, _parse_isoformat_time,
-         _parse_hh_mm_ss_ff, _iso_long_year_helper)
+         _parse_hh_mm_ss_ff)
     # XXX Since import * above excludes names that start with _,
     # docstring does not get overwritten. In the future, it may be
     # appropriate to maintain a single module level docstring and

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1848,17 +1848,22 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
                     self.theclass.fromisocalendar(*isocal)
 
     def test_fromisocalendar_type_errors(self):
-        isocals = [
-            ("2019", 1, 1),
-            (2019, "1", 1),
-            (2019, 1, "1"),
-            (None, 1, 1),
-            (2019, None, 1),
-            (2019, 1, None),
-            (2019.0, 1, 1),
-            (2019, 1.0, 1),
-            (2019, 1, 1.0),
+        err_txformers = [
+            str,
+            float,
+            lambda x: None,
         ]
+
+        # Take a valid base tuple and transform it to contain one argument
+        # with the wrong type. Repeat this for each argument, e.g.
+        # [("2019", 1, 1), (2019, "1", 1), (2019, 1, "1"), ...]
+        isocals = []
+        base = (2019, 1, 1)
+        for i in range(3):
+            for txformer in err_txformers:
+                err_val = list(base)
+                err_val[i] = txformer(err_val[i])
+                isocals.append(tuple(err_val))
 
         for isocal in isocals:
             with self.subTest(isocal=isocal):

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1815,9 +1815,6 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
                 self.assertEqual(dobj, d_roundtrip)
 
     def test_fromisocalendar_value_errors(self):
-        class KnownFailure(tuple):
-            pass
-
         isocals = [
             (2019, 0, 1),
             (2019, -1, 1),
@@ -1829,20 +1826,15 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
             (10000, 1, 1),
             (0, 1, 1),
             (9999999, 1, 1),
+            (2<<32, 1, 1),
+            (2019, 2<<32, 1),
+            (2019, 1, 2<<32),
         ]
 
         for isocal in isocals:
             with self.subTest(isocal=isocal):
                 with self.assertRaises(ValueError):
-                    known_failure = isinstance(isocal, KnownFailure)
                     self.theclass.fromisocalendar(*isocal)
-
-                    if isinstance(isocal, KnownFailure):
-                        known_failure = False
-                        raise ValueError()
-
-                if known_failure:
-                    raise Exception("XPASS: Known failure condition not met")
 
 
 #############################################################################

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1800,9 +1800,18 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         # inverse of the isocalendar function
         dates = [
             (2016, 4, 3),
-            (2005, 1, 2),
-            (2008, 12, 30),
-            (2010, 1, 2),
+            (2005, 1, 2),       # (2004, 53, 7)
+            (2008, 12, 30),     # (2009, 1, 2)
+            (2010, 1, 2),       # (2009, 53, 6)
+            (2009, 12, 31),     # (2009, 53, 4)
+            (1900, 1, 1),       # Unusual non-leap year (year % 100 == 0)
+            (1900, 12, 31),
+            (2000, 1, 1),       # Unusual leap year (year % 400 == 0)
+            (2000, 12, 31),
+            (2004, 1, 1),       # Leap year
+            (2004, 12, 31),
+            (1, 1, 1),
+            (9999, 12, 31),
         ]
 
         for datecomps in dates:

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1795,6 +1795,56 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
             with self.assertRaises(TypeError):
                 self.theclass.fromisoformat(bad_type)
 
+    def test_fromisocalendar(self):
+        # For each test case, assert that fromisocalendar is the
+        # inverse of the isocalendar function
+        dates = [
+            (2016, 4, 3),
+            (2005, 1, 2),
+            (2008, 12, 30),
+            (2010, 1, 2),
+        ]
+
+        for datecomps in dates:
+            with self.subTest(datecomps=datecomps):
+                dobj = self.theclass(*datecomps)
+                isocal = dobj.isocalendar()
+
+                d_roundtrip = self.theclass.fromisocalendar(*isocal)
+
+                self.assertEqual(dobj, d_roundtrip)
+
+    def test_fromisocalendar_value_errors(self):
+        class KnownFailure(tuple):
+            pass
+
+        isocals = [
+            (2019, 0, 1),
+            (2019, -1, 1),
+            (2019, 54, 1),
+            (2019, 1, 0),
+            (2019, 1, -1),
+            (2019, 1, 8),
+            KnownFailure([2019, 53, 1]),
+        ]
+
+        for isocal in isocals:
+            with self.subTest(isocal=isocal):
+                with self.assertRaises(ValueError):
+                    known_failure = isinstance(isocal, KnownFailure)
+                    self.theclass.fromisocalendar(*isocal)
+
+                    if isinstance(isocal, KnownFailure):
+                        known_failure = False
+                        raise ValueError()
+
+                if known_failure:
+                    raise Exception("XPASS: Known failure condition not met")
+
+
+
+
+
 #############################################################################
 # datetime tests
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1822,7 +1822,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
             (2019, 1, 0),
             (2019, 1, -1),
             (2019, 1, 8),
-            KnownFailure([2019, 53, 1]),
+            (2019, 53, 1),
             (10000, 1, 1),
             (0, 1, 1),
             (9999999, 1, 1),

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1845,6 +1845,24 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
                 with self.assertRaises(ValueError):
                     self.theclass.fromisocalendar(*isocal)
 
+    def test_fromisocalendar_type_errors(self):
+        isocals = [
+            ("2019", 1, 1),
+            (2019, "1", 1),
+            (2019, 1, "1"),
+            (None, 1, 1),
+            (2019, None, 1),
+            (2019, 1, None),
+            (2019.0, 1, 1),
+            (2019, 1.0, 1),
+            (2019, 1, 1.0),
+        ]
+
+        for isocal in isocals:
+            with self.subTest(isocal=isocal):
+                with self.assertRaises(TypeError):
+                    self.theclass.fromisocalendar(*isocal)
+
 
 #############################################################################
 # datetime tests

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1826,6 +1826,9 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
             (2019, 1, -1),
             (2019, 1, 8),
             KnownFailure([2019, 53, 1]),
+            (10000, 1, 1),
+            (0, 1, 1),
+            (9999999, 1, 1),
         ]
 
         for isocal in isocals:
@@ -1840,9 +1843,6 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
 
                 if known_failure:
                     raise Exception("XPASS: Known failure condition not met")
-
-
-
 
 
 #############################################################################

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1812,6 +1812,8 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
             (2004, 12, 31),
             (1, 1, 1),
             (9999, 12, 31),
+            (MINYEAR, 1, 1),
+            (MAXYEAR, 12, 31),
         ]
 
         for datecomps in dates:

--- a/Misc/NEWS.d/next/Library/2019-02-17-12-55-51.bpo-36004.hCt_KK.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-17-12-55-51.bpo-36004.hCt_KK.rst
@@ -1,0 +1,4 @@
+Added new alternate constructors :meth:`datetime.date.fromisocalendar` and
+:meth:`datetime.datetime.fromisocalendar`, which construct date objects from
+ISO year, week number and weekday; these are the inverse of each class's
+``isocalendar`` method. Patch by Paul Ganssle.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3025,6 +3025,11 @@ date_fromisocalendar(PyObject *cls, PyObject *args, PyObject *kw) {
     if (PyArg_ParseTupleAndKeywords(args, kw, "iii:fromisocalendar",
                 keywords,
                 &year, &week, &day) == 0) {
+        if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+            PyErr_Format(PyExc_ValueError,
+                    "ISO calendar component out of range");
+
+        }
         return NULL;
     }
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3028,6 +3028,12 @@ date_fromisocalendar(PyObject *cls, PyObject *args, PyObject *kw) {
         return NULL;
     }
 
+    // Year is bounded to 0 < year < 10000 because 9999-12-31 is (9999, 52, 5)
+    if (year <= 0 || year >= 10000) {
+        PyErr_Format(PyExc_ValueError, "Year is out of range: %d", year);
+        return NULL;
+    }
+
     if (week <= 0 || week >= 54) {
         PyErr_Format(PyExc_ValueError, "Invalid week: %d", week);
         return NULL;
@@ -3037,6 +3043,7 @@ date_fromisocalendar(PyObject *cls, PyObject *args, PyObject *kw) {
         PyErr_Format(PyExc_ValueError, "Invalid day: %d (range is [1, 7])");
         return NULL;
     }
+
 
     int month = week;
     isocalendar_to_ymd(&year, &month, &day);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3024,7 +3024,7 @@ date_fromisocalendar(PyObject *cls, PyObject *args, PyObject *kw)
     }
 
     // Year is bounded to 0 < year < 10000 because 9999-12-31 is (9999, 52, 5)
-    if (year <= 0 || year >= 10000) {
+    if (year < MINYEAR || year > MAXYEAR) {
         PyErr_Format(PyExc_ValueError, "Year is out of range: %d", year);
         return NULL;
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3359,8 +3359,9 @@ static PyMethodDef date_methods[] = {
 
      {"fromisocalendar", (PyCFunction)(void(*)(void))date_fromisocalendar,
       METH_VARARGS | METH_KEYWORDS | METH_CLASS,
-      PyDoc_STR("int, int, int -> Construct a date from the "
-                "output of date.isocalendar()")},
+      PyDoc_STR("int, int, int -> Construct a date from the ISO year, week "
+                "number and weekday.\n\n"
+                "This is the inverse of the date.isocalendar() function")},
 
     {"today",         (PyCFunction)date_today,   METH_NOARGS | METH_CLASS,
      PyDoc_STR("Current date or datetime:  same as "

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3047,7 +3047,8 @@ date_fromisocalendar(PyObject *cls, PyObject *args, PyObject *kw)
     }
 
     if (day <= 0 || day >= 8) {
-        PyErr_Format(PyExc_ValueError, "Invalid day: %d (range is [1, 7])");
+        PyErr_Format(PyExc_ValueError, "Invalid day: %d (range is [1, 7])",
+                     day);
         return NULL;
     }
 


### PR DESCRIPTION
This commit implements the first version of `date.fromisocalendar`, the inverse function for `date.isocalendar`. It is currently missing error checking for the case of of invalid ISO dates in week 53.

To Do:
- [x]  Validate ISO datetimes
- [x] Test for `TypeError`
- [x] Add documentation
- [x] Add news entry

~~Other than these known errors, the existing code can be reviewed.~~ Ready to go.

[bpo-36004](https://bugs.python.org/issue36004)


<!-- issue-number: [bpo-36004](https://bugs.python.org/issue36004) -->
https://bugs.python.org/issue36004
<!-- /issue-number -->
