### PR TITLE
Micro-optimization for random.choices().  Convert range() to repeat().

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -43,7 +43,7 @@ from math import sqrt as _sqrt, acos as _acos, cos as _cos, sin as _sin
 from os import urandom as _urandom
 from _collections_abc import Set as _Set, Sequence as _Sequence
 from hashlib import sha512 as _sha512
-from itertools import accumulate as _accumulate
+from itertools import accumulate as _accumulate, repeat as _repeat
 from bisect import bisect as _bisect
 import os as _os
 
@@ -389,7 +389,7 @@ class Random(_random.Random):
             if weights is None:
                 _int = int
                 n += 0.0    # convert to float for a small speed improvement
-                return [population[_int(random() * n)] for i in range(k)]
+                return [population[_int(random() * n)] for i in _repeat(None, k)]
             cum_weights = list(_accumulate(weights))
         elif weights is not None:
             raise TypeError('Cannot specify both weights and cumulative weights')
@@ -399,7 +399,7 @@ class Random(_random.Random):
         total = cum_weights[-1] + 0.0   # convert to float
         hi = n - 1
         return [population[bisect(cum_weights, random() * total, 0, hi)]
-                for i in range(k)]
+                for i in _repeat(None, k)]
 
 ## -------------------- real-valued distributions  -------------------
 


### PR DESCRIPTION
Borrowing from the technique used in the *timeit* module, loop with *repeat()* instead of *range()* to avoid unnecessary creation and destruction of integer objects.  Gives a modest speed-up (in the 5% range).

Patched:
```
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, cum_weights=w, k=2)'
200000 loops, best of 11: 1.82 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, cum_weights=w, k=1000)'
1000 loops, best of 11: 388 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, cum_weights=w, k=1000)'
500 loops, best of 11: 390 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, k=2)'
200000 loops, best of 11: 1.43 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' 'choices(p, k=1000)'
1000 loops, best of 11: 255 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' 'choices(p, k=1000)'
1000 loops, best of 11: 255 usec per loop
```

Baseline:
```
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, cum_weights=w, k=2)'
200000 loops, best of 11: 1.95 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, cum_weights=w, k=1000)'
500 loops, best of 11: 398 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, cum_weights=w, k=1000)'
500 loops, best of 11: 402 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, k=2)'
200000 loops, best of 11: 1.5 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, k=1000)'
1000 loops, best of 11: 271 usec per loop
$ ./python.exe -m timeit -r11 -s 'from random import choices' -s'p=range(20)' -s'w=list(map(float, range(20)))' 'choices(p, k=1000)'
1000 loops, best of 11: 272 usec per loop
```