### PR TITLE
bpo-35899: Fix Enum handling of empty and weird strings

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -19,18 +19,19 @@ def _is_descriptor(obj):
 
 def _is_dunder(name):
     """Returns True if a __dunder__ name, False otherwise."""
-    return (name[:2] == name[-2:] == '__' and
-            name[2:3] != '_' and
-            name[-3:-2] != '_' and
-            len(name) > 4)
+    return (len(name) > 4 and
+            name[:2] == name[-2:] == '__' and
+            name[2] != '_' and
+            name[-3] != '_')
 
 
 def _is_sunder(name):
     """Returns True if a _sunder_ name, False otherwise."""
-    return (name[0] == name[-1] == '_' and
+    return (len(name) > 2 and
+            name[0] == name[-1] == '_' and
             name[1:2] != '_' and
-            name[-2:-1] != '_' and
-            len(name) > 2)
+            name[-2:-1] != '_')
+
 
 def _make_class_unpicklable(cls):
     """Make the given class un-picklable."""

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -151,7 +151,7 @@ class EnumMeta(type):
         _order_ = classdict.pop('_order_', None)
 
         # check for illegal enum names (any others?)
-        invalid_names = set(enum_members) & {'mro', }
+        invalid_names = set(enum_members) & {'mro', ''}
         if invalid_names:
             raise ValueError('Invalid enum member name: {0}'.format(
                 ','.join(invalid_names)))

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2730,16 +2730,20 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(256, len(seen), 'too many composite members created')
 
 
-class TestEmptyAndWeirdString(unittest.TestCase):
+class TestEmptyAndNonLatinStrings(unittest.TestCase):
 
     def test_empty_string(self):
-        empty_abc = Enum('empty_abc', ('', 'B', 'C'))
-        item = getattr(empty_abc, '')
+        with self.assertRaises(ValueError):
+            empty_abc = Enum('empty_abc', ('', 'B', 'C'))
+
+    def test_non_latin_character_string(self):
+        greek_abc = Enum('greek_abc', ('α', 'B', 'C'))
+        item = getattr(greek_abc, 'α')
         self.assertEqual(item.value, 1)
 
-    def test_weird_character_string(self):
-        weird_abc = Enum('weird_abc', ('!', 'B', 'C'))
-        item = getattr(weird_abc, '!')
+    def test_non_latin_number_string(self):
+        hebrew_123 = Enum('hebrew_123', ('א', '2', '3'))
+        item = getattr(hebrew_123, 'א')
         self.assertEqual(item.value, 1)
 
 

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2737,13 +2737,13 @@ class TestEmptyAndNonLatinStrings(unittest.TestCase):
             empty_abc = Enum('empty_abc', ('', 'B', 'C'))
 
     def test_non_latin_character_string(self):
-        greek_abc = Enum('greek_abc', ('α', 'B', 'C'))
-        item = getattr(greek_abc, 'α')
+        greek_abc = Enum('greek_abc', ('\u03B1', 'B', 'C'))
+        item = getattr(greek_abc, '\u03B1')
         self.assertEqual(item.value, 1)
 
     def test_non_latin_number_string(self):
-        hebrew_123 = Enum('hebrew_123', ('א', '2', '3'))
-        item = getattr(hebrew_123, 'א')
+        hebrew_123 = Enum('hebrew_123', ('\u05D0', '2', '3'))
+        item = getattr(hebrew_123, '\u05D0')
         self.assertEqual(item.value, 1)
 
 

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2730,6 +2730,19 @@ class TestIntFlag(unittest.TestCase):
         self.assertEqual(256, len(seen), 'too many composite members created')
 
 
+class TestEmptyAndWeirdString(unittest.TestCase):
+
+    def test_empty_string(self):
+        empty_abc = Enum('empty_abc', ('', 'B', 'C'))
+        item = getattr(empty_abc, '')
+        self.assertEqual(item.value, 1)
+
+    def test_weird_character_string(self):
+        weird_abc = Enum('weird_abc', ('!', 'B', 'C'))
+        item = getattr(weird_abc, '!')
+        self.assertEqual(item.value, 1)
+
+
 class TestUnique(unittest.TestCase):
 
     def test_unique_clean(self):

--- a/Misc/NEWS.d/next/Library/2019-02-16-07-11-02.bpo-35899.cjfn5a.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-16-07-11-02.bpo-35899.cjfn5a.rst
@@ -1,0 +1,1 @@
+Enum has been fixed to correctly handle empty strings and strings with "weird" characters (ie. '!') without crashing. Original patch contributed by Maxwell. Assisted by Stéphane Wirtel.

--- a/Misc/NEWS.d/next/Library/2019-02-16-07-11-02.bpo-35899.cjfn5a.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-16-07-11-02.bpo-35899.cjfn5a.rst
@@ -1,1 +1,1 @@
-Enum has been fixed to correctly handle empty strings and strings with "weird" characters (ie. '!') without crashing. Original patch contributed by Maxwell. Assisted by Stéphane Wirtel.
+Enum has been fixed to correctly handle empty strings and strings with non-Latin characters (ie. 'α', 'א') without crashing. Original patch contributed by Maxwell. Assisted by Stéphane Wirtel.


### PR DESCRIPTION
Co-authored-by: Maxwell <maxwellpxt@gmail.com>
Co-authored-by: Stéphane Wirtel <stephane@wirtel.be>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35899](https://bugs.python.org/issue35899) -->
https://bugs.python.org/issue35899
<!-- /issue-number -->
