### PR TITLE
Add versionadded directives to ssl.minimum_version and ssl.maximum_version

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1922,6 +1922,8 @@ to speed up repeated connections from the same clients.
      This attribute is not available unless the ssl module is compiled
      with OpenSSL 1.1.0g or newer.
 
+   .. versionadded:: 3.7
+
 .. attribute:: SSLContext.minimum_version
 
    Like :attr:`SSLContext.maximum_version` except it is the lowest
@@ -1931,6 +1933,8 @@ to speed up repeated connections from the same clients.
 
      This attribute is not available unless the ssl module is compiled
      with OpenSSL 1.1.0g or newer.
+
+   .. versionadded:: 3.7
 
 .. attribute:: SSLContext.options
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1328,11 +1328,11 @@ SSL sockets also have the following additional methods and attributes:
    If any precondition isn't met (e.g. not TLS 1.3, PHA not enabled), an
    :exc:`SSLError` is raised.
 
-   .. versionadded:: 3.8
-
    .. note::
       Only available with OpenSSL 1.1.1 and TLS 1.3 enabled. Without TLS 1.3
       support, the method raises :exc:`NotImplementedError`.
+
+   .. versionadded:: 3.8
 
 .. method:: SSLSocket.version()
 
@@ -1965,11 +1965,11 @@ to speed up repeated connections from the same clients.
    :meth:`SSLSocket.verify_client_post_handshake` is called and some I/O is
    performed.
 
-   .. versionadded:: 3.8
-
    .. note::
       Only available with OpenSSL 1.1.1 and TLS 1.3 enabled. Without TLS 1.3
       support, the property value is None and can't be modified
+
+   .. versionadded:: 3.8
 
 .. attribute:: SSLContext.protocol
 
@@ -1982,10 +1982,10 @@ to speed up repeated connections from the same clients.
    subject common name in the absence of a subject alternative name
    extension (default: true).
 
-   .. versionadded:: 3.7
-
    .. note::
       Only writeable with OpenSSL 1.1.0 or higher.
+
+   .. versionadded:: 3.7
 
 .. attribute:: SSLContext.verify_flags
 


### PR DESCRIPTION
`ssl.minimum_version` and `ssl.maximum_version` were introduced in Python 3.7, alongside `ssl.TLSVersion` and such. Not having `versionadded` directives is somewhat confusing.

This is trivial enough and warrants skip issue and skip news.