### PR TITLE
bpo-35798: Add test.support.check_syntax_warning().

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -936,9 +936,22 @@ The :mod:`test.support` module defines the following functions:
 
    Test for syntax errors in *statement* by attempting to compile *statement*.
    *testcase* is the :mod:`unittest` instance for the test.  *errtext* is the
-   text of the error raised by :exc:`SyntaxError`.  If *lineno* is not None,
-   compares to the line of the :exc:`SyntaxError`.  If *offset* is not None,
-   compares to the offset of the :exc:`SyntaxError`.
+   regular expression which should match the string representation of the
+   raised :exc:`SyntaxError`.  If *lineno* is not ``None``, compares to
+   the line of the exception.  If *offset* is not ``None``, compares to
+   the offset of the exception.
+
+
+.. function:: check_syntax_warning(testcase, statement, errtext='', *, lineno=1, offset=None)
+
+   Test for syntax warning in *statement* by attempting to compile *statement*.
+   Test also that the :exc:`SyntaxWarning` is emitted only once, and that it
+   will be converted to a :exc:`SyntaxError` when turned into error.
+   *testcase* is the :mod:`unittest` instance for the test.  *errtext* is the
+   regular expression which should match the string representation of the
+   emitted :exc:`SyntaxWarning` and raised :exc:`SyntaxError`.  If *lineno*
+   is not ``None``, compares to the line of the warning and exception.
+   If *offset* is not ``None``, compares to the offset of the exception.
 
 
 .. function:: open_urlresource(url, *args, **kw)

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -953,6 +953,8 @@ The :mod:`test.support` module defines the following functions:
    is not ``None``, compares to the line of the warning and exception.
    If *offset* is not ``None``, compares to the offset of the exception.
 
+   .. versionadded:: 3.8
+
 
 .. function:: open_urlresource(url, *args, **kw)
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -86,6 +86,7 @@ __all__ = [
     # unittest
     "is_resource_enabled", "requires", "requires_freebsd_version",
     "requires_linux_version", "requires_mac_ver", "check_syntax_error",
+    "check_syntax_warning",
     "TransientResource", "time_out", "socket_peer_reset", "ioerror_peer_reset",
     "transient_internet", "BasicTestRunner", "run_unittest", "run_doctest",
     "skip_unless_symlink", "requires_gzip", "requires_bz2", "requires_lzma",

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1113,6 +1113,7 @@ def make_bad_fd():
         file.close()
         unlink(TESTFN)
 
+
 def check_syntax_error(testcase, statement, errtext='', *, lineno=None, offset=None):
     with testcase.assertRaisesRegex(SyntaxError, errtext) as cm:
         compile(statement, '<test string>', 'exec')
@@ -1123,6 +1124,33 @@ def check_syntax_error(testcase, statement, errtext='', *, lineno=None, offset=N
     testcase.assertIsNotNone(err.offset)
     if offset is not None:
         testcase.assertEqual(err.offset, offset)
+
+def check_syntax_warning(testcase, statement, errtext='', *, lineno=1, offset=None):
+    # Test also that a warning is emitted only once.
+    with warnings.catch_warnings(record=True) as warns:
+        warnings.simplefilter('always', SyntaxWarning)
+        compile(statement, '<testcase>', 'exec')
+    testcase.assertEqual(len(warns), 1, warns)
+
+    warn, = warns
+    testcase.assertTrue(issubclass(warn.category, SyntaxWarning), warn.category)
+    if errtext:
+        testcase.assertRegex(str(warn.message), errtext)
+    testcase.assertEqual(warn.filename, '<testcase>')
+    testcase.assertIsNotNone(warn.lineno)
+    if lineno is not None:
+        testcase.assertEqual(warn.lineno, lineno)
+
+    # SyntaxWarning should be converted to SyntaxError when raised,
+    # since the latter contains more information and provides better
+    # error report.
+    with warnings.catch_warnings(record=True) as warns:
+        warnings.simplefilter('error', SyntaxWarning)
+        check_syntax_error(testcase, statement, errtext,
+                           lineno=lineno, offset=offset)
+    # No warnings are leaked when a SyntaxError is raised.
+    testcase.assertEqual(warns, [])
+
 
 def open_urlresource(url, *args, **kw):
     import urllib.request, urllib.parse

--- a/Lib/test/test_string_literals.py
+++ b/Lib/test/test_string_literals.py
@@ -63,6 +63,8 @@ def byte(i):
 
 class TestLiterals(unittest.TestCase):
 
+    from test.support import check_syntax_warning
+
     def setUp(self):
         self.save_path = sys.path[:]
         self.tmpdir = tempfile.mkdtemp()
@@ -112,21 +114,7 @@ class TestLiterals(unittest.TestCase):
             with self.assertWarns(SyntaxWarning):
                 self.assertEqual(eval(r"'\%c'" % b), '\\' + chr(b))
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=SyntaxWarning)
-            eval("'''\n\\z'''")
-        self.assertEqual(len(w), 1)
-        self.assertEqual(w[0].filename, '<string>')
-        self.assertEqual(w[0].lineno, 1)
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('error', category=SyntaxWarning)
-            with self.assertRaises(SyntaxError) as cm:
-                eval("'''\n\\z'''")
-            exc = cm.exception
-        self.assertEqual(w, [])
-        self.assertEqual(exc.filename, '<string>')
-        self.assertEqual(exc.lineno, 1)
+        self.check_syntax_warning("'''\n\\z'''")
 
     def test_eval_str_raw(self):
         self.assertEqual(eval(""" r'x' """), 'x')
@@ -161,21 +149,7 @@ class TestLiterals(unittest.TestCase):
             with self.assertWarns(SyntaxWarning):
                 self.assertEqual(eval(r"b'\%c'" % b), b'\\' + bytes([b]))
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=SyntaxWarning)
-            eval("b'''\n\\z'''")
-        self.assertEqual(len(w), 1)
-        self.assertEqual(w[0].filename, '<string>')
-        self.assertEqual(w[0].lineno, 1)
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('error', category=SyntaxWarning)
-            with self.assertRaises(SyntaxError) as cm:
-                eval("b'''\n\\z'''")
-            exc = cm.exception
-        self.assertEqual(w, [])
-        self.assertEqual(exc.filename, '<string>')
-        self.assertEqual(exc.lineno, 1)
+        self.check_syntax_warning("b'''\n\\z'''")
 
     def test_eval_bytes_raw(self):
         self.assertEqual(eval(""" br'x' """), b'x')

--- a/Misc/NEWS.d/next/Tests/2019-02-16-15-19-31.bpo-35798.JF16MP.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-16-15-19-31.bpo-35798.JF16MP.rst
@@ -1,0 +1,1 @@
+Added :func:`test.support.check_syntax_warning`.


### PR DESCRIPTION
It checks that a SyntaxWarning is raised when compile specified
statement, that it is raised only once, that it is converted to
a SyntaxError when raised as exception, and that both warning and
exception objects have corresponding attributes.


<!-- issue-number: [bpo-35798](https://bugs.python.org/issue35798) -->
https://bugs.python.org/issue35798
<!-- /issue-number -->
