### PR TITLE
bpo-36013: Fix the interactive shell SIGINT test.

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -83,7 +83,9 @@ class PosixTests(unittest.TestCase):
         """KeyboardInterrupt triggers exit via SIGINT."""
         process = subprocess.run(
                 [sys.executable, "-c",
-                 "import os,signal; os.kill(os.getpid(), signal.SIGINT)"],
+                 "import os, signal, time\n"
+                 "os.kill(os.getpid(), signal.SIGINT)\n"
+                 "for _ in range(999): time.sleep(0.01)"],
                 stderr=subprocess.PIPE)
         self.assertIn(b"KeyboardInterrupt", process.stderr)
         self.assertEqual(process.returncode, -signal.SIGINT)


### PR DESCRIPTION
First attempt: switch shell interupt test to zsh.

if this doesn't work out, i'll just delete this test.  it's a nice bonus integration test to avoid a regression of the actual interactive mode ^C'd process detection rather than the weak test that looks only at exit status (not what shells do).

<!-- issue-number: [bpo-36013](https://bugs.python.org/issue36013) -->
https://bugs.python.org/issue36013
<!-- /issue-number -->
