### PR TITLE
bpo-28235: fix *xml.etree.ElementTree.fromstring* docs

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -494,10 +494,12 @@ Functions
       by the user.
 
 
-.. function:: fromstring(text)
+.. function:: fromstring(text, parser=None)
 
    Parses an XML section from a string constant.  Same as :func:`XML`.  *text*
-   is a string containing XML data.  Returns an :class:`Element` instance.
+   is a string containing XML data.  *parser* is an optional parser instance.  
+   If not given, the standard :class:`XMLParser` parser is used.  
+   Returns an :class:`Element` instance.
 
 
 .. function:: fromstringlist(sequence, parser=None)

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -497,8 +497,8 @@ Functions
 .. function:: fromstring(text, parser=None)
 
    Parses an XML section from a string constant.  Same as :func:`XML`.  *text*
-   is a string containing XML data.  *parser* is an optional parser instance.  
-   If not given, the standard :class:`XMLParser` parser is used.  
+   is a string containing XML data.  *parser* is an optional parser instance.
+   If not given, the standard :class:`XMLParser` parser is used.
    Returns an :class:`Element` instance.
 
 


### PR DESCRIPTION
https://bugs.python.org/issue28235

<!-- issue-number: [bpo-28235](https://bugs.python.org/issue28235) -->
https://bugs.python.org/issue28235
<!-- /issue-number -->
