### PR TITLE
bpo-35884: Add string-keys-only microbenchmark for dict access to var_access_benchmark.py

### DIFF
--- a/Tools/scripts/var_access_benchmark.py
+++ b/Tools/scripts/var_access_benchmark.py
@@ -196,6 +196,14 @@ def read_dict(trials=trials, a={0: 1}):
         a[0];   a[0];   a[0];   a[0];   a[0]
         a[0];   a[0];   a[0];   a[0];   a[0]
 
+def read_strdict(trials=trials, a={'key': 1}):
+    for t in trials:
+        a['key'];   a['key'];   a['key'];   a['key'];   a['key']
+        a['key'];   a['key'];   a['key'];   a['key'];   a['key']
+        a['key'];   a['key'];   a['key'];   a['key'];   a['key']
+        a['key'];   a['key'];   a['key'];   a['key'];   a['key']
+        a['key'];   a['key'];   a['key'];   a['key'];   a['key']
+
 def list_append_pop(trials=trials, a=[1]):
     ap, pop = a.append, a.pop
     for t in trials:
@@ -247,6 +255,14 @@ def write_dict(trials=trials, a={0: 1}):
         a[0]=1; a[0]=1; a[0]=1; a[0]=1; a[0]=1
         a[0]=1; a[0]=1; a[0]=1; a[0]=1; a[0]=1
 
+def write_strdict(trials=trials, a={'key': 1}):
+    for t in trials:
+        a['key']=1; a['key']=1; a['key']=1; a['key']=1; a['key']=1
+        a['key']=1; a['key']=1; a['key']=1; a['key']=1; a['key']=1
+        a['key']=1; a['key']=1; a['key']=1; a['key']=1; a['key']=1
+        a['key']=1; a['key']=1; a['key']=1; a['key']=1; a['key']=1
+        a['key']=1; a['key']=1; a['key']=1; a['key']=1; a['key']=1
+
 def loop_overhead(trials=trials):
     for t in trials:
         pass
@@ -266,9 +282,9 @@ if __name__=='__main__':
             write_local, write_nonlocal, write_global,
             write_classvar, write_instancevar, write_instancevar_slots,
             '\nData structure read access:',
-            read_list, read_deque, read_dict,
+            read_list, read_deque, read_dict, read_strdict,
             '\nData structure write access:',
-            write_list, write_deque, write_dict,
+            write_list, write_deque, write_dict, write_strdict,
             '\nStack (or queue) operations:',
             list_append_pop, deque_append_pop, deque_append_popleft,
             '\nTiming loop overhead:',

--- a/Tools/scripts/var_access_benchmark.py
+++ b/Tools/scripts/var_access_benchmark.py
@@ -207,20 +207,20 @@ def read_strdict(trials=trials, a={'key': 1}):
 def list_append_pop(trials=trials, a=[1]):
     ap, pop = a.append, a.pop
     for t in trials:
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
 
 def deque_append_pop(trials=trials, a=deque([1])):
     ap, pop = a.append, a.pop
     for t in trials:
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
-        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop();
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
+        ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop(); ap(1); pop()
 
 def deque_append_popleft(trials=trials, a=deque([1])):
     ap, pop = a.append, a.popleft


### PR DESCRIPTION
String-only key dicts are special in CPython and I think they merit their own micro benchmark.
```
Data structure read access:
  23.6 ns       read_list
  23.4 ns       read_deque
  26.2 ns       read_dict
  23.2 ns       read_strdict

Data structure write access:
  25.6 ns       write_list
  27.1 ns       write_deque
  33.7 ns       write_dict
  29.1 ns       write_strdict
```
(I hope this is not worth creating a ticket…)

<!-- issue-number: [bpo-35884](https://bugs.python.org/issue35884) -->
https://bugs.python.org/issue35884
<!-- /issue-number -->
