### PR TITLE
Update io.rst

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -171,22 +171,23 @@ separation between reading and writing to streams; implementations are allowed
 to raise :exc:`UnsupportedOperation` if they do not support a given operation.
 
 The :class:`RawIOBase` ABC extends :class:`IOBase`.  It deals with the reading
-and writing of bytes to a stream.  :class:`FileIO` subclasses :class:`RawIOBase`
-to provide an interface to files in the machine's file system.
+and writing of bytes to a stream.  :class:`FileIO` subclasses
+:class:`RawIOBase` to provide an interface to files in the machine's file
+system.
 
-The :class:`BufferedIOBase` ABC deals with buffering on a raw byte stream
-(:class:`RawIOBase`).  Its subclasses, :class:`BufferedWriter`,
-:class:`BufferedReader`, and :class:`BufferedRWPair` buffer streams that are
-readable, writable, and both readable and writable.  :class:`BufferedRandom`
-provides a buffered interface to random access streams.  Another
-:class:`BufferedIOBase` subclass, :class:`BytesIO`, is a stream of in-memory
-bytes.
+The :class:`BufferedIOBase` ABC extends :class:`IOBase`. It deals with
+buffering on a raw byte stream (:class:`RawIOBase`).  Its subclasses,
+:class:`BufferedWriter`, :class:`BufferedReader`, and :class:`BufferedRWPair`
+buffer streams that are readable, writable, and both readable and writable.
+:class:`BufferedRandom` provides a buffered interface to random access streams.
+Another :class:`BufferedIOBase` subclass, :class:`BytesIO`, is a stream of
+in-memory bytes.
 
-The :class:`TextIOBase` ABC, another subclass of :class:`IOBase`, deals with
-streams whose bytes represent text, and handles encoding and decoding to and
-from strings. :class:`TextIOWrapper`, which extends it, is a buffered text
-interface to a buffered raw stream (:class:`BufferedIOBase`). Finally,
-:class:`StringIO` is an in-memory stream for text.
+The :class:`TextIOBase` ABC extends :class:`IOBase`. It deals with streams
+whose bytes represent text, and handles encoding and decoding to and from
+strings. :class:`TextIOWrapper`, which extends it, is a buffered text interface
+to a buffered raw stream (:class:`BufferedIOBase`). Finally, :class:`StringIO`
+is an in-memory stream for text.
 
 Argument names are not part of the specification, and only the arguments of
 :func:`open` are intended to be used as keyword arguments.


### PR DESCRIPTION
This PR will apply the following changes to the [`io` module documentation](https://docs.python.org/3/library/io.html):

* add a missing sentence stating that the `BufferedIOBase` class extends  the `IOBase` class;
* use consistent phrasing.

So it replaces the start of these paragraphs:

> The `RawIOBase` ABC extends `IOBase`.  It deals with…
> The `BufferedIOBase` ABC deals with buffering on a raw byte stream (`RawIOBase`).
> The `TextIOBase` ABC, another subclass of `IOBase`, deals with…

with these:

> The `RawIOBase` ABC extends `IOBase`.  It deals with…
> The `BufferedIOBase` ABC extends `IOBase`.  It deals with buffering on a raw byte stream (`RawIOBase`)…
> The `TextIOBase` ABC extends `IOBase`.  It deals with…