### PR TITLE
bpo-36012: Avoid linear slot search when it's easy to know that we are not looking for a slot name

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -378,7 +378,7 @@ Optimizations
 * Doubled the speed of class variable writes.  When a non-dunder attribute
   was updated, there was an unnecessary call to update slots.
   (Contributed by Stefan Behnel, Pablo Galindo Salgado, Raymond Hettinger,
-  and Serhiy Storchaka in :issue:`36012`.)
+  Neil Schemenauer, and Serhiy Storchaka in :issue:`36012`.)
 
 
 Build and C API Changes

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -379,7 +379,7 @@ Optimizations
   was updated, there was an unnecessary call to update slots.
   (Contributed by Stefan Behnel, Pablo Galindo Salgado, Raymond Hettinger,
   and Serhiy Storchaka in :issue:`36012`.)
-  
+
 
 Build and C API Changes
 =======================

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -375,6 +375,11 @@ Optimizations
   This makes the created list 12% smaller on average. (Contributed by
   Raymond Hettinger and Pablo Galindo in :issue:`33234`.)
 
+* Doubled the speed of class variable writes.  When a non-dunder attribute
+  was updated, there was an unnecessary call to update slots.
+  (Contributed by Stefan Behnel, Pablo Galindo Salgado, Raymond Hettinger,
+  and Serhiy Storchaka in :issue:`36012`.)
+  
 
 Build and C API Changes
 =======================

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-19-10-47-51.bpo-36012.xq7C9E.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-19-10-47-51.bpo-36012.xq7C9E.rst
@@ -1,0 +1,2 @@
+Doubled the speed of class variable writes.  When a non-dunder attribute was
+updated, there was an unnecessary call to update slots.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7013,15 +7013,17 @@ static int name_looks_like_slot(PyObject *name) {
     Py_ssize_t length = PyUnicode_GET_LENGTH(name);
     /* The longest slot name is currently "__getattribute__": 16 characters */
     if (length >= 6 && length <= 16) {
+        /* All slot names are pure ASCII. */
         int kind = PyUnicode_KIND(name);
-        void *data = PyUnicode_DATA(name);
-        if (PyUnicode_READ(kind, data, 0) == '_') {
-            if (PyUnicode_READ(kind, data, 1) == '_') {
-                if (PyUnicode_READ(kind, data, length-2) == '_') {
-                    if (PyUnicode_READ(kind, data, length-1) == '_') {
-                        /* Might be a slot name: "__x...y__" */
-                        return 1;
-                    }
+        if (kind == PyUnicode_1BYTE_KIND) {
+            void *data = PyUnicode_DATA(name);
+            /* Allow the C compiler to read 2 bytes instead of two times 1 byte. */
+            if ((PyUnicode_READ(kind, data, 0) == '_') &
+                    (PyUnicode_READ(kind, data, 1) == '_')) {
+                if ((PyUnicode_READ(kind, data, length-2) == '_') &
+                        (PyUnicode_READ(kind, data, length-1) == '_')) {
+                    /* Might be a slot name: "__x...y__" */
+                    return 1;
                 }
             }
         }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3175,8 +3175,8 @@ is_dunder_name(PyObject *name)
     if (length > 4 && kind == PyUnicode_1BYTE_KIND) {
         Py_UCS1 *characters = PyUnicode_1BYTE_DATA(name);
         return (
-            ((characters[0] == '_') && (characters[1] == '_')) &&
-            ((characters[length-2] == '_') && (characters[length-1] == '_'))
+            ((characters[length-2] == '_') && (characters[length-1] == '_')) &&
+            ((characters[0] == '_') && (characters[1] == '_'))
         );
     }
     return 0;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7027,7 +7027,6 @@ static slotdef slotdefs[] = {
     {NULL}
 };
 
-
 /* Given a type pointer and an offset gotten from a slotdef entry, return a
    pointer to the actual slot.  This is not quite the same as simply adding
    the offset to the type pointer, since it takes care to indirect through the

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3174,10 +3174,9 @@ is_dunder_name(PyObject *name)
     /* Special names contain at least "__x__" and are always ASCII. */
     if (length > 4 && kind == PyUnicode_1BYTE_KIND) {
         Py_UCS1 *characters = PyUnicode_1BYTE_DATA(name);
-        /* Allow the C compiler to read 2 bytes instead of two times 1 byte. */
         return (
-            ((characters[0] == '_') & (characters[1] == '_')) &
-            ((characters[length-2] == '_') & (characters[length-1] == '_'))
+            ((characters[0] == '_') && (characters[1] == '_')) &&
+            ((characters[length-2] == '_') && (characters[length-1] == '_'))
         );
     }
     return 0;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7240,6 +7240,11 @@ update_slot(PyTypeObject *type, PyObject *name)
        recursing into subclasses. */
     PyType_Modified(type);
 
+    if (PyUnicode_READ_CHAR(name, 0) != '_') {
+        /* Definitely not a slot name. */
+        return 0;
+    }
+
     init_slotdefs();
     pp = ptrs;
     for (p = slotdefs; p->name; p++) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3293,12 +3293,14 @@ type_setattro(PyTypeObject *type, PyObject *name, PyObject *value)
             if (name == NULL)
                 return -1;
         }
-        PyUnicode_InternInPlace(&name);
         if (!PyUnicode_CHECK_INTERNED(name)) {
-            PyErr_SetString(PyExc_MemoryError,
-                            "Out of memory interning an attribute name");
-            Py_DECREF(name);
-            return -1;
+            PyUnicode_InternInPlace(&name);
+            if (!PyUnicode_CHECK_INTERNED(name)) {
+                PyErr_SetString(PyExc_MemoryError,
+                                "Out of memory interning an attribute name");
+                Py_DECREF(name);
+                return -1;
+            }
         }
     }
     else {


### PR DESCRIPTION
Speeds up class attribute setting for non-slot names by 50%.

<!-- issue-number: [bpo-36012](https://bugs.python.org/issue36012) -->
https://bugs.python.org/issue36012
<!-- /issue-number -->
