### PR TITLE
bpo-36015:  logging: handle StreamHandler representaton of stream with int name

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1120,6 +1120,8 @@ class StreamHandler(Handler):
     def __repr__(self):
         level = getLevelName(self.level)
         name = getattr(self.stream, 'name', '')
+        #  bpo-36015: name can be an int
+        name = str(name)
         if name:
             name += ' '
         return '<%s %s(%s)>' % (self.__class__.__name__, name, level)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -743,6 +743,10 @@ class TestStreamHandler(logging.StreamHandler):
     def handleError(self, record):
         self.error_record = record
 
+class StreamWithIntName(object):
+    level = logging.NOTSET
+    name = 2
+
 class StreamHandlerTest(BaseTest):
     def test_error_handling(self):
         h = TestStreamHandler(BadStream())
@@ -779,6 +783,10 @@ class StreamHandlerTest(BaseTest):
         # test that setting to existing value returns None
         actual = h.setStream(old)
         self.assertIsNone(actual)
+
+    def test_can_represent_stream_with_int_name(self):
+        h = logging.StreamHandler(StreamWithIntName())
+        self.assertEqual(repr(h), '<StreamHandler 2 (NOTSET)>')
 
 # -- The following section could be moved into a server_helper.py module
 # -- if it proves to be of wider utility than just test_logging


### PR DESCRIPTION
When debugging uwsgi logging issues with python3.7 i got this:
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/logging/__init__.py", line 269, in _after_at_fork_weak_calls
    _at_fork_weak_calls('release')
  File "/usr/lib/python3.7/logging/__init__.py", line 261, in _at_fork_weak_calls
    method_name, "method:", err, file=sys.stderr)
  File "/usr/lib/python3.7/logging/__init__.py", line 1066, in __repr__
    name = name + ' '
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```

<!-- issue-number: [bpo-36015](https://bugs.python.org/issue36015) -->
https://bugs.python.org/issue36015
<!-- /issue-number -->
