### PR TITLE
[2.7] bpo-35126: Fix a mistake in FAQ about converting number to string

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1009,7 +1009,7 @@ the division result if the arguments are floats or complex::
 
 In Python 3, the default behaviour of the division operator (see :pep:`238`) has
 been changed but you can have the same behaviour in Python 2 if you import
-`division` from :mod:`__future__`::
+``division`` from :mod:`__future__` ::
 
    >>> from __future__ import division
    >>> print('{:.3f}'.format(1/3))

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1009,7 +1009,7 @@ the division result if the arguments are floats or complex::
 
 In Python 3, the default behaviour of the division operator (see :pep:`238`) has
 been changed but you can have the same behaviour in Python 2 if you import
-``division`` from :mod:`__future__` ::
+``division`` from :mod:`__future__`::
 
    >>> from __future__ import division
    >>> print('{:.3f}'.format(1/3))

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -997,9 +997,27 @@ To convert, e.g., the number 144 to the string '144', use the built-in type
 constructor :func:`str`.  If you want a hexadecimal or octal representation, use
 the built-in functions :func:`hex` or :func:`oct`.  For fancy formatting, see
 the :ref:`formatstrings` section, e.g. ``"{:04d}".format(144)`` yields
-``'0144'`` and ``"{:.3f}".format(1/3)`` yields ``'0.333'``.  You may also use
-:ref:`the % operator <string-formatting>` on strings.  See the library reference
-manual for details.
+``'0144'`` and ``"{:.3f}".format(1.0/3.0)`` yields ``'0.333'``. In Python 2, the
+division (/) operator returns the floor of the mathematical result of division
+if the arguments are ints or longs, but it returns a reasonable approximation of
+the division result if the arguments are floats or complex::
+
+   >>> print('{:.3f}'.format(1/3))
+   0.000
+   >>> print('{:.3f}'.format(1.0/3))
+   0.333
+
+In Python 3, the default behaviour of the division operator (see :pep:`238`) has
+been changed but you can have the same behaviour in Python 2 if you import
+`division` from :mod:`__future__`::
+
+   >>> from __future__ import division
+   >>> print('{:.3f}'.format(1/3))
+   0.333
+
+
+You may also use :ref:`the % operator <string-formatting>` on strings.  See the
+library reference manual for details.
 
 
 How do I modify a string in place?

--- a/Misc/NEWS.d/next/Documentation/2019-02-18-10-01-07.bpo-35126.LWwl8X.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-02-18-10-01-07.bpo-35126.LWwl8X.rst
@@ -1,0 +1,2 @@
+Improve the examples in the "How do I convert a number to string?" question
+of the "Programming" section of the FAQ.  Contributed by Stéphane Wirtel.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35126](https://bugs.python.org/issue35126) -->
https://bugs.python.org/issue35126
<!-- /issue-number -->
