### PR TITLE
bpo-35704: Include correct NEWS entry

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-01-04-17-44-41.bpo-35633.wHfVop.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-04-17-44-41.bpo-35633.wHfVop.rst
@@ -1,2 +1,0 @@
-Add PermissionError to the Exception: list
-patch by Michael Felt, aixtools

--- a/Misc/NEWS.d/next/Tests/2019-01-10-09-14-58.bpo-35704.FLglYo.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-10-09-14-58.bpo-35704.FLglYo.rst
@@ -1,3 +1,4 @@
-Prevent ''test_shutil.test_unpack_archive_xztar'' from MemoryError on 32-bit AIX
-when MAXDATA setting is less than 0x20000000.
-patch by Michael Felt, aixtools
+Skip ``test_shutil.test_unpack_archive_xztar` to prevent a MemoryError
+on 32-bit AIX when MAXDATA setting is less than 0x20000000.
+
+Patch by Michael Felt (aixtools)

--- a/Misc/NEWS.d/next/Tests/2019-01-10-09-14-58.bpo-35704.FLglYo.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-10-09-14-58.bpo-35704.FLglYo.rst
@@ -1,4 +1,4 @@
-Skip ``test_shutil.test_unpack_archive_xztar` to prevent a MemoryError
+Skip ``test_shutil.test_unpack_archive_xztar`` to prevent a MemoryError
 on 32-bit AIX when MAXDATA setting is less than 0x20000000.
 
 Patch by Michael Felt (aixtools)

--- a/Misc/NEWS.d/next/Tests/2019-01-10-09-14-58.bpo-35704.FLglYo.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-10-09-14-58.bpo-35704.FLglYo.rst
@@ -1,0 +1,3 @@
+Prevent ''test_shutil.test_unpack_archive_xztar'' from MemoryError on 32-bit AIX
+when MAXDATA setting is less than 0x20000000.
+patch by Michael Felt, aixtools


### PR DESCRIPTION
The wrong NEWS snippet was inadvertently included in
GH-11500, this switches to the correct one.

<!-- issue-number: [bpo-35704](https://bugs.python.org/issue35704) -->
https://bugs.python.org/issue35704
<!-- /issue-number -->
