### PR TITLE
bpo-35537: Change subprocess to use posix_spawnp instead of posix_spawn

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -323,7 +323,7 @@ Optimizations
 
   * *close_fds* is false;
   * *preexec_fn*, *pass_fds*, *cwd* and *start_new_session* parameters
-    are not set;
+    are not set.
 
 * :func:`shutil.copyfile`, :func:`shutil.copy`, :func:`shutil.copy2`,
   :func:`shutil.copytree` and :func:`shutil.move` use platform-specific

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -317,14 +317,13 @@ xml
 Optimizations
 =============
 
-* The :mod:`subprocess` module can now use the :func:`os.posix_spawn` function
+* The :mod:`subprocess` module can now use the :func:`os.posix_spawnp` function
   in some cases for better performance. Currently, it is only used on macOS
   and Linux (using glibc 2.24 or newer) if all these conditions are met:
 
   * *close_fds* is false;
   * *preexec_fn*, *pass_fds*, *cwd* and *start_new_session* parameters
     are not set;
-  * the *executable* path contains a directory.
 
 * :func:`shutil.copyfile`, :func:`shutil.copy`, :func:`shutil.copy2`,
   :func:`shutil.copytree` and :func:`shutil.move` use platform-specific

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1524,7 +1524,6 @@ class Popen(object):
                 executable = args[0]
 
             if (_USE_POSIX_SPAWNP
-                    and os.path.dirname(executable)
                     and preexec_fn is None
                     and not close_fds
                     and not pass_fds

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1532,10 +1532,8 @@ class Popen(object):
                     and (c2pwrite == -1 or c2pwrite > 2)
                     and (errwrite == -1 or errwrite > 2)
                     and not start_new_session):
-                self._posix_spawnp(args, executable, env, restore_signals,
-                                  p2cread, p2cwrite,
-                                  c2pread, c2pwrite,
-                                  errread, errwrite)
+                self._posix_spawnp(args, executable, env, restore_signals, p2cread,
+                                   p2cwrite, c2pread, c2pwrite, errread, errwrite)
                 return
 
             orig_executable = executable

--- a/Misc/NEWS.d/next/Library/2019-02-18-12-45-33.bpo-35537.xshtGJ.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-18-12-45-33.bpo-35537.xshtGJ.rst
@@ -1,0 +1,1 @@
+The :mod:`subprocess` now uses :func:`os.posix_spawnp` instead of :func:`os.posix_spawn`


### PR DESCRIPTION
I have added a change to make subprocess.py to use posix_spawnp instead of posix_spawn. 

cc @vstinner 

<!-- issue-number: [bpo-35537](https://bugs.python.org/issue35537) -->
https://bugs.python.org/issue35537
<!-- /issue-number -->
