### PR TITLE
bpo-36029: Use title-case HTTP header fields

### DIFF
--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -410,7 +410,7 @@ redirect. The URL of the page fetched may not be the same as the URL requested.
 fetched, particularly the headers sent by the server. It is currently an
 :class:`http.client.HTTPMessage` instance.
 
-Typical headers include 'Content-length', 'Content-type', and so on. See the
+Typical headers include 'Content-Length', 'Content-Type', and so on. See the
 `Quick Reference to HTTP Headers <http://jkorpela.fi/http.html>`_
 for a useful listing of HTTP headers with brief explanations of their meaning
 and use.

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -543,7 +543,7 @@ Here is an example session that shows how to ``POST`` requests::
 
    >>> import http.client, urllib.parse
    >>> params = urllib.parse.urlencode({'@number': 12524, '@type': 'issue', '@action': 'show'})
-   >>> headers = {"Content-type": "application/x-www-form-urlencoded",
+   >>> headers = {"Content-Type": "application/x-www-form-urlencoded",
    ...            "Accept": "text/plain"}
    >>> conn = http.client.HTTPConnection("bugs.python.org")
    >>> conn.request("POST", "", params, headers)

--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -372,7 +372,7 @@ provides three different variants:
       type is guessed by calling the :meth:`guess_type` method, which in turn
       uses the *extensions_map* variable, and the file contents are returned.
 
-      A ``'Content-type:'`` header with the guessed content type is output,
+      A ``'Content-Type:'`` header with the guessed content type is output,
       followed by a ``'Content-Length:'`` header with the file's size and a
       ``'Last-Modified:'`` header with the file's modification time.
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1210,7 +1210,7 @@ The code for the sample CGI used in the above example is::
    #!/usr/bin/env python
    import sys
    data = sys.stdin.read()
-   print('Content-type: text/plain\n\nGot Data: "%s"' % data)
+   print('Content-Type: text/plain\n\nGot Data: "%s"' % data)
 
 Here is an example of doing a ``PUT`` request using :class:`Request`::
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1270,7 +1270,7 @@ every :class:`Request`.  To change this::
 
    import urllib.request
    opener = urllib.request.build_opener()
-   opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+   opener.addheaders = [('User-Agent', 'Mozilla/5.0')]
    opener.open('http://www.example.com/')
 
 Also, remember that a few standard headers (:mailheader:`Content-Length`,

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -125,7 +125,7 @@ parameter expect a WSGI-compliant dictionary to be supplied; please see
           setup_testing_defaults(environ)
 
           status = '200 OK'
-          headers = [('Content-type', 'text/plain; charset=utf-8')]
+          headers = [('Content-Type', 'text/plain; charset=utf-8')]
 
           start_response(status, headers)
 
@@ -424,7 +424,7 @@ Paste" library.
       # standard, so the validator is going to break
       def simple_app(environ, start_response):
           status = '200 OK'  # HTTP Status
-          headers = [('Content-type', 'text/plain')]  # HTTP Headers
+          headers = [('Content-Type', 'text/plain')]  # HTTP Headers
           start_response(status, headers)
 
           # This is going to break because we need to return a list, and
@@ -770,7 +770,7 @@ This is a working "Hello World" WSGI application::
    # second variable is the callable object (see PEP 333).
    def hello_world_app(environ, start_response):
        status = '200 OK'  # HTTP Status
-       headers = [('Content-type', 'text/plain; charset=utf-8')]  # HTTP Headers
+       headers = [('Content-Type', 'text/plain; charset=utf-8')]  # HTTP Headers
        start_response(status, headers)
 
        # The returned object is going to be printed

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -750,8 +750,8 @@ supply compound field names that read attributes or access dictionary keys::
     [GCC 4.0.1 (Apple Computer, Inc. build 5367)]'
 
     >>> import mimetypes
-    >>> 'Content-type: {0[.mp4]}'.format(mimetypes.types_map)
-    'Content-type: video/mp4'
+    >>> 'Content-Type: {0[.mp4]}'.format(mimetypes.types_map)
+    'Content-Type: video/mp4'
 
 Note that when using dictionary-style notation such as ``[.mp4]``, you
 don't need to put any quotation marks around the string; it will look

--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -218,7 +218,7 @@ def _parseparam(s):
         s = s[end:]
 
 def parse_header(line):
-    """Parse a Content-type like header.
+    """Parse a Content-Type like header.
 
     Return the main content-type and a dictionary of options.
 
@@ -835,7 +835,7 @@ def test(environ=os.environ):
     the script in HTML form.
 
     """
-    print("Content-type: text/html")
+    print("Content-Type: text/html")
     print()
     sys.stderr = sys.stdout
     try:

--- a/Lib/distutils/command/register.py
+++ b/Lib/distutils/command/register.py
@@ -276,8 +276,8 @@ Your selection [default 1]: ''', log.INFO)
 
         # build the Request
         headers = {
-            'Content-type': 'multipart/form-data; boundary=%s; charset=utf-8'%boundary,
-            'Content-length': str(len(body))
+            'Content-Type': 'multipart/form-data; boundary=%s; charset=utf-8'%boundary,
+            'Content-Length': str(len(body))
         }
         req = urllib.request.Request(self.repository, body, headers)
 

--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -162,8 +162,8 @@ class upload(PyPIRCCommand):
 
         # build the Request
         headers = {
-            'Content-type': 'multipart/form-data; boundary=%s' % boundary,
-            'Content-length': str(len(body)),
+            'Content-Type': 'multipart/form-data; boundary=%s' % boundary,
+            'Content-Length': str(len(body)),
             'Authorization': auth,
         }
 

--- a/Lib/distutils/tests/test_register.py
+++ b/Lib/distutils/tests/test_register.py
@@ -152,8 +152,8 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         req1 = dict(self.conn.reqs[0].headers)
         req2 = dict(self.conn.reqs[1].headers)
 
-        self.assertEqual(req1['Content-length'], '1374')
-        self.assertEqual(req2['Content-length'], '1374')
+        self.assertEqual(req1['Content-Length'], '1374')
+        self.assertEqual(req2['Content-Length'], '1374')
         self.assertIn(b'xxx', self.conn.reqs[1].data)
 
     def test_password_not_in_file(self):
@@ -183,7 +183,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         self.assertEqual(len(self.conn.reqs), 1)
         req = self.conn.reqs[0]
         headers = dict(req.headers)
-        self.assertEqual(headers['Content-length'], '608')
+        self.assertEqual(headers['Content-Length'], '608')
         self.assertIn(b'tarek', req.data)
 
     def test_password_reset(self):
@@ -201,7 +201,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         self.assertEqual(len(self.conn.reqs), 1)
         req = self.conn.reqs[0]
         headers = dict(req.headers)
-        self.assertEqual(headers['Content-length'], '290')
+        self.assertEqual(headers['Content-Length'], '290')
         self.assertIn(b'tarek', req.data)
 
     @unittest.skipUnless(docutils is not None, 'needs docutils')

--- a/Lib/distutils/tests/test_register.py
+++ b/Lib/distutils/tests/test_register.py
@@ -152,8 +152,8 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         req1 = dict(self.conn.reqs[0].headers)
         req2 = dict(self.conn.reqs[1].headers)
 
-        self.assertEqual(req1['Content-Length'], '1374')
-        self.assertEqual(req2['Content-Length'], '1374')
+        self.assertEqual(req1['Content-length'], '1374')
+        self.assertEqual(req2['Content-length'], '1374')
         self.assertIn(b'xxx', self.conn.reqs[1].data)
 
     def test_password_not_in_file(self):
@@ -183,7 +183,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         self.assertEqual(len(self.conn.reqs), 1)
         req = self.conn.reqs[0]
         headers = dict(req.headers)
-        self.assertEqual(headers['Content-Length'], '608')
+        self.assertEqual(headers['Content-length'], '608')
         self.assertIn(b'tarek', req.data)
 
     def test_password_reset(self):
@@ -201,7 +201,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         self.assertEqual(len(self.conn.reqs), 1)
         req = self.conn.reqs[0]
         headers = dict(req.headers)
-        self.assertEqual(headers['Content-Length'], '290')
+        self.assertEqual(headers['Content-length'], '290')
         self.assertIn(b'tarek', req.data)
 
     @unittest.skipUnless(docutils is not None, 'needs docutils')

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -130,8 +130,8 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
 
         # what did we send ?
         headers = dict(self.last_open.req.headers)
-        self.assertEqual(headers['Content-length'], '2162')
-        content_type = headers['Content-type']
+        self.assertEqual(headers['Content-Length'], '2162')
+        content_type = headers['Content-Type']
         self.assertTrue(content_type.startswith('multipart/form-data'))
         self.assertEqual(self.last_open.req.get_method(), 'POST')
         expected_url = 'https://upload.pypi.org/legacy/'
@@ -166,7 +166,7 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
         cmd.run()
 
         headers = dict(self.last_open.req.headers)
-        self.assertEqual(headers['Content-length'], '2172')
+        self.assertEqual(headers['Content-Length'], '2172')
         self.assertIn(b'long description\r', self.last_open.req.data)
 
     def test_upload_fails(self):

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -130,8 +130,8 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
 
         # what did we send ?
         headers = dict(self.last_open.req.headers)
-        self.assertEqual(headers['Content-Length'], '2162')
-        content_type = headers['Content-Type']
+        self.assertEqual(headers['Content-length'], '2162')
+        content_type = headers['Content-type']
         self.assertTrue(content_type.startswith('multipart/form-data'))
         self.assertEqual(self.last_open.req.get_method(), 'POST')
         expected_url = 'https://upload.pypi.org/legacy/'
@@ -166,7 +166,7 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
         cmd.run()
 
         headers = dict(self.last_open.req.headers)
-        self.assertEqual(headers['Content-Length'], '2172')
+        self.assertEqual(headers['Content-length'], '2172')
         self.assertIn(b'long description\r', self.last_open.req.data)
 
     def test_upload_fails(self):

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -241,7 +241,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
     the command executed by the server; in most cases, when data is
     returned, there should be at least one header line of the form
 
-    Content-type: <type>/<subtype>
+    Content-Type: <type>/<subtype>
 
     where <type> and <subtype> should be registered MIME types,
     e.g. "text/html" or "text/plain".
@@ -737,7 +737,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                             return None
 
             self.send_response(HTTPStatus.OK)
-            self.send_header("Content-type", ctype)
+            self.send_header("Content-Type", ctype)
             self.send_header("Content-Length", str(fs[6]))
             self.send_header("Last-Modified",
                 self.date_time_string(fs.st_mtime))
@@ -800,7 +800,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         f.write(encoded)
         f.seek(0)
         self.send_response(HTTPStatus.OK)
-        self.send_header("Content-type", "text/html; charset=%s" % enc)
+        self.send_header("Content-Type", "text/html; charset=%s" % enc)
         self.send_header("Content-Length", str(len(encoded)))
         self.end_headers()
         return f
@@ -857,7 +857,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         Argument is a PATH (a filename).
 
         Return value is a string of the form type/subtype,
-        usable for a MIME Content-type header.
+        usable for a MIME Content-Type header.
 
         The default implementation looks the file's extension
         up in the table self.extensions_map, using application/octet-stream

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1185,9 +1185,9 @@ class HTTPHandler(logging.Handler):
             # on Python 3.x.
             # h.putheader("Host", host)
             if self.method == "POST":
-                h.putheader("Content-type",
+                h.putheader("Content-Type",
                             "application/x-www-form-urlencoded")
-                h.putheader("Content-length", str(len(data)))
+                h.putheader("Content-Length", str(len(data)))
             if self.credentials:
                 import base64
                 s = ('%s:%s' % self.credentials).encode('utf-8')

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -99,7 +99,7 @@ class MimeTypes:
 
         Return value is a tuple (type, encoding) where type is None if
         the type can't be guessed (no or unknown suffix) or a string
-        of the form type/subtype, usable for a MIME Content-type
+        of the form type/subtype, usable for a MIME Content-Type
         header; and encoding is None for no encoding or the name of
         the program used to encode (e.g. compress or gzip).  The
         mappings are table driven.  Encoding suffixes are case
@@ -274,7 +274,7 @@ def guess_type(url, strict=True):
 
     Return value is a tuple (type, encoding) where type is None if the
     type can't be guessed (no or unknown suffix) or a string of the
-    form type/subtype, usable for a MIME Content-type header; and
+    form type/subtype, usable for a MIME Content-Type header; and
     encoding is None for no encoding or the name of the program used
     to encode (e.g. compress or gzip).  The mappings are table
     driven.  Encoding suffixes are case sensitive; type suffixes are

--- a/Lib/test/ssl_servers.py
+++ b/Lib/test/ssl_servers.py
@@ -101,7 +101,7 @@ class StatsRequestHandler(BaseHTTPRequestHandler):
         body = pprint.pformat(stats)
         body = body.encode('utf-8')
         self.send_response(200)
-        self.send_header("Content-type", "text/plain; charset=utf-8")
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         if send_body:

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -183,7 +183,7 @@ def _run_test_server(*, address, use_ssl=False, server_cls, server_ssl_cls):
 
     def app(environ, start_response):
         status = '200 OK'
-        headers = [('Content-type', 'text/plain')]
+        headers = [('Content-Type', 'text/plain')]
         start_response(status, headers)
         if environ['PATH_INFO'] == '/loop':
             return loop(environ)

--- a/Lib/test/test_docxmlrpc.py
+++ b/Lib/test/test_docxmlrpc.py
@@ -90,7 +90,7 @@ class DocXMLRPCHTTPGETServer(unittest.TestCase):
         response = self.client.getresponse()
 
         self.assertEqual(response.status, 200)
-        self.assertEqual(response.getheader("Content-type"), "text/html")
+        self.assertEqual(response.getheader("Content-Type"), "text/html")
 
         # Server raises an exception if we don't start to read the data
         response.read()
@@ -100,7 +100,7 @@ class DocXMLRPCHTTPGETServer(unittest.TestCase):
         response = self.client.getresponse()
 
         self.assertEqual(response.status, 404)
-        self.assertEqual(response.getheader("Content-type"), "text/plain")
+        self.assertEqual(response.getheader("Content-Type"), "text/plain")
 
         response.read()
 

--- a/Lib/test/test_email/data/msg_02.txt
+++ b/Lib/test/test_email/data/msg_02.txt
@@ -9,8 +9,8 @@ X-Mailman-Version: 2.0.4
 Content-Type: multipart/mixed; boundary="192.168.1.2.889.32614.987812255.500.21814"
 
 --192.168.1.2.889.32614.987812255.500.21814
-Content-type: text/plain; charset=us-ascii
-Content-description: Masthead (Ppp digest, Vol 1 #2)
+Content-Type: text/plain; charset=us-ascii
+Content-Description: Masthead (Ppp digest, Vol 1 #2)
 
 Send Ppp mailing list submissions to
 	ppp@zzz.org
@@ -28,8 +28,8 @@ than "Re: Contents of Ppp digest..."
 
 
 --192.168.1.2.889.32614.987812255.500.21814
-Content-type: text/plain; charset=us-ascii
-Content-description: Today's Topics (5 msgs)
+Content-Type: text/plain; charset=us-ascii
+Content-Description: Today's Topics (5 msgs)
 
 Today's Topics:
 
@@ -121,8 +121,8 @@ hello
 --__--__----
 
 --192.168.1.2.889.32614.987812255.500.21814
-Content-type: text/plain; charset=us-ascii
-Content-description: Digest Footer
+Content-Type: text/plain; charset=us-ascii
+Content-Description: Digest Footer
 
 _______________________________________________
 Ppp mailing list

--- a/Lib/test/test_email/data/msg_15.txt
+++ b/Lib/test/test_email/data/msg_15.txt
@@ -5,26 +5,26 @@ Subject: XX
 From: xx@xx.dk
 To: XX
 Message-ID: <xxxx>
-Mime-version: 1.0
-Content-type: multipart/mixed;
+MIME-version: 1.0
+Content-Type: multipart/mixed;
    boundary="MS_Mac_OE_3071477847_720252_MIME_Part"
 
 > Denne meddelelse er i MIME-format. Da dit postl
 
 --MS_Mac_OE_3071477847_720252_MIME_Part
-Content-type: multipart/alternative;
+Content-Type: multipart/alternative;
    boundary="MS_Mac_OE_3071477847_720252_MIME_Part"
 
 
 --MS_Mac_OE_3071477847_720252_MIME_Part
-Content-type: text/plain; charset="ISO-8859-1"
-Content-transfer-encoding: quoted-printable
+Content-Type: text/plain; charset="ISO-8859-1"
+Content-Transfer-Encoding: quoted-printable
 
-Some removed test. 
+Some removed test.
 
 --MS_Mac_OE_3071477847_720252_MIME_Part
-Content-type: text/html; charset="ISO-8859-1"
-Content-transfer-encoding: quoted-printable
+Content-Type: text/html; charset="ISO-8859-1"
+Content-Transfer-Encoding: quoted-printable
 
 <HTML>
 <HEAD>
@@ -40,11 +40,11 @@ Some removed text.
 
 
 --MS_Mac_OE_3071477847_720252_MIME_Part
-Content-type: image/gif; name="xx.gif";
+Content-Type: image/gif; name="xx.gif";
  x-mac-creator="6F676C65";
  x-mac-type="47494666"
-Content-disposition: attachment
-Content-transfer-encoding: base64
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
 
 Some removed base64 encoded chars.
 

--- a/Lib/test/test_email/data/msg_16.txt
+++ b/Lib/test/test_email/data/msg_16.txt
@@ -33,7 +33,7 @@ Content-Type: multipart/report; boundary="Boundary_(ID_PGS2F2a+z+/jL7hupKgRhA)"
 
 
 --Boundary_(ID_PGS2F2a+z+/jL7hupKgRhA)
-Content-type: text/plain; charset=ISO-8859-1
+Content-Type: text/plain; charset=ISO-8859-1
 
 This report relates to a message you sent with the following header fields:
 
@@ -50,7 +50,7 @@ Your message cannot be delivered to the following recipients:
 
 
 --Boundary_(ID_PGS2F2a+z+/jL7hupKgRhA)
-Content-type: message/DELIVERY-STATUS
+Content-Type: message/DELIVERY-STATUS
 
 Original-envelope-id: 0GK500B4HD0888@cougar.noc.ucla.edu
 Reporting-MTA: dns; cougar.noc.ucla.edu
@@ -61,7 +61,7 @@ Original-recipient: rfc822;jangel1@cougar.noc.ucla.edu
 Final-recipient: rfc822;jangel1@cougar.noc.ucla.edu
 
 --Boundary_(ID_PGS2F2a+z+/jL7hupKgRhA)
-Content-type: MESSAGE/RFC822
+Content-Type: MESSAGE/RFC822
 
 Return-path: scr-admin@socal-raves.org
 Received: from sims-ms-daemon by cougar.noc.ucla.edu
@@ -94,7 +94,7 @@ Errors-to: scr-admin@socal-raves.org
 Message-id: <002001c144a6$8752e060$56104586@oxy.edu>
 MIME-version: 1.0
 X-Mailer: Microsoft Outlook Express 5.50.4522.1200
-Content-type: text/plain; charset=us-ascii
+Content-Type: text/plain; charset=us-ascii
 Precedence: bulk
 Delivered-to: scr-post@babylon.socal-raves.org
 Delivered-to: scr@socal-raves.org

--- a/Lib/test/test_email/test_defect_handling.py
+++ b/Lib/test/test_email/test_defect_handling.py
@@ -20,32 +20,32 @@ class TestDefectsBase:
             Subject: XX
             From: xx@xx.dk
             To: XX
-            Mime-version: 1.0
-            Content-type: multipart/mixed;
+            MIME-Version: 1.0
+            Content-Type: multipart/mixed;
                boundary="MS_Mac_OE_3071477847_720252_MIME_Part"
 
             --MS_Mac_OE_3071477847_720252_MIME_Part
-            Content-type: multipart/alternative;
+            Content-Type: multipart/alternative;
                boundary="MS_Mac_OE_3071477847_720252_MIME_Part"
 
             --MS_Mac_OE_3071477847_720252_MIME_Part
-            Content-type: text/plain; charset="ISO-8859-1"
-            Content-transfer-encoding: quoted-printable
+            Content-Type: text/plain; charset="ISO-8859-1"
+            Content-Transfer-Encoding: quoted-printable
 
             text
 
             --MS_Mac_OE_3071477847_720252_MIME_Part
-            Content-type: text/html; charset="ISO-8859-1"
-            Content-transfer-encoding: quoted-printable
+            Content-Type: text/html; charset="ISO-8859-1"
+            Content-Transfer-Encoding: quoted-printable
 
             <HTML></HTML>
 
             --MS_Mac_OE_3071477847_720252_MIME_Part--
 
             --MS_Mac_OE_3071477847_720252_MIME_Part
-            Content-type: image/gif; name="xx.gif";
-            Content-disposition: attachment
-            Content-transfer-encoding: base64
+            Content-Type: image/gif; name="xx.gif";
+            Content-Disposition: attachment
+            Content-Transfer-Encoding: base64
 
             Some removed base64 encoded chars.
 

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -143,7 +143,7 @@ class HeaderTests(TestCase):
                 list.append(self, item)
 
         for explicit_header in True, False:
-            for header in 'Content-length', 'Host', 'Accept-encoding':
+            for header in 'Content-Length', 'Host', 'Accept-Encoding':
                 conn = client.HTTPConnection('example.com')
                 conn.sock = FakeSocket('blahblahblah')
                 conn._buffer = HeaderCountingBuffer()
@@ -225,8 +225,8 @@ class HeaderTests(TestCase):
         conn = client.HTTPConnection('example.com')
         conn.sock = FakeSocket(None)
         conn.putrequest('GET','/')
-        conn.putheader('Content-length', 42)
-        self.assertIn(b'Content-length: 42', conn._buffer)
+        conn.putheader('Content-Length', 42)
+        self.assertIn(b'Content-Length: 42', conn._buffer)
 
         conn.putheader('Foo', ' bar ')
         self.assertIn(b'Foo:  bar ', conn._buffer)
@@ -946,7 +946,7 @@ class BasicTest(TestCase):
     def test_epipe(self):
         sock = EPipeSocket(
             "HTTP/1.0 401 Authorization Required\r\n"
-            "Content-type: text/html\r\n"
+            "Content-Type: text/html\r\n"
             "WWW-Authenticate: Basic realm=\"example\"\r\n",
             b"Content-Length")
         conn = client.HTTPConnection("example.com")

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -514,7 +514,7 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         """
         response = self.request(self.base_url + '/test')
         self.check_status_and_reason(response, HTTPStatus.OK, data=self.data)
-        last_modif_header = response.headers['Last-modified']
+        last_modif_header = response.headers['Last-Modified']
         self.assertEqual(last_modif_header, self.last_modif_header)
 
     def test_path_without_leading_slash(self):
@@ -558,7 +558,7 @@ class SimpleHTTPServerTestCase(BaseTestCase):
 cgi_file1 = """\
 #!%s
 
-print("Content-type: text/html")
+print("Content-Type: text/html")
 print()
 print("Hello World")
 """
@@ -567,7 +567,7 @@ cgi_file2 = """\
 #!%s
 import cgi
 
-print("Content-type: text/html")
+print("Content-Type: text/html")
 print()
 
 form = cgi.FieldStorage()
@@ -579,7 +579,7 @@ cgi_file4 = """\
 #!%s
 import os
 
-print("Content-type: text/html")
+print("Content-Type: text/html")
 print()
 
 print(os.environ["%s"])
@@ -718,7 +718,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
     def test_headers_and_content(self):
         res = self.request('/cgi-bin/file1.py')
         self.assertEqual(
-            (res.read(), res.getheader('Content-type'), res.status),
+            (res.read(), res.getheader('Content-Type'), res.status),
             (b'Hello World' + self.linesep, 'text/html', HTTPStatus.OK))
 
     def test_issue19435(self):
@@ -728,7 +728,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
     def test_post(self):
         params = urllib.parse.urlencode(
             {'spam' : 1, 'eggs' : 'python', 'bacon' : 123456})
-        headers = {'Content-type' : 'application/x-www-form-urlencoded'}
+        headers = {'Content-Type' : 'application/x-www-form-urlencoded'}
         res = self.request('/cgi-bin/file2.py', 'POST', params, headers)
 
         self.assertEqual(res.read(), b'1, python, 123456' + self.linesep)
@@ -744,14 +744,14 @@ class CGIHTTPServerTestCase(BaseTestCase):
         res = self.request('/cgi-bin/file1.py', 'GET', headers=headers)
         self.assertEqual(
             (b'Hello World' + self.linesep, 'text/html', HTTPStatus.OK),
-            (res.read(), res.getheader('Content-type'), res.status))
+            (res.read(), res.getheader('Content-Type'), res.status))
 
     def test_no_leading_slash(self):
         # http://bugs.python.org/issue2254
         res = self.request('cgi-bin/file1.py')
         self.assertEqual(
             (b'Hello World' + self.linesep, 'text/html', HTTPStatus.OK),
-            (res.read(), res.getheader('Content-type'), res.status))
+            (res.read(), res.getheader('Content-Type'), res.status))
 
     def test_os_environ_is_not_altered(self):
         signature = "Test CGI Server"
@@ -759,33 +759,33 @@ class CGIHTTPServerTestCase(BaseTestCase):
         res = self.request('/cgi-bin/file1.py')
         self.assertEqual(
             (b'Hello World' + self.linesep, 'text/html', HTTPStatus.OK),
-            (res.read(), res.getheader('Content-type'), res.status))
+            (res.read(), res.getheader('Content-Type'), res.status))
         self.assertEqual(os.environ['SERVER_SOFTWARE'], signature)
 
     def test_urlquote_decoding_in_cgi_check(self):
         res = self.request('/cgi-bin%2ffile1.py')
         self.assertEqual(
             (b'Hello World' + self.linesep, 'text/html', HTTPStatus.OK),
-            (res.read(), res.getheader('Content-type'), res.status))
+            (res.read(), res.getheader('Content-Type'), res.status))
 
     def test_nested_cgi_path_issue21323(self):
         res = self.request('/cgi-bin/child-dir/file3.py')
         self.assertEqual(
             (b'Hello World' + self.linesep, 'text/html', HTTPStatus.OK),
-            (res.read(), res.getheader('Content-type'), res.status))
+            (res.read(), res.getheader('Content-Type'), res.status))
 
     def test_query_with_multiple_question_mark(self):
         res = self.request('/cgi-bin/file4.py?a=b?c=d')
         self.assertEqual(
             (b'a=b?c=d' + self.linesep, 'text/html', HTTPStatus.OK),
-            (res.read(), res.getheader('Content-type'), res.status))
+            (res.read(), res.getheader('Content-Type'), res.status))
 
     def test_query_with_continuous_slashes(self):
         res = self.request('/cgi-bin/file4.py?k=aa%2F%2Fbb&//q//p//=//a//b//')
         self.assertEqual(
             (b'k=aa%2F%2Fbb&//q//p//=//a//b//' + self.linesep,
              'text/html', HTTPStatus.OK),
-            (res.read(), res.getheader('Content-type'), res.status))
+            (res.read(), res.getheader('Content-Type'), res.status))
 
 
 class SocketlessRequestHandler(SimpleHTTPRequestHandler):

--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -43,7 +43,7 @@ class BaseRobotTest:
 
 class UserAgentWildcardTest(BaseRobotTest, unittest.TestCase):
     robots_txt = """\
-User-agent: *
+User-Agent: *
 Disallow: /cyberworld/map/ # This is an infinite virtual URL space
 Disallow: /tmp/ # these will soon disappear
 Disallow: /foo.html
@@ -56,13 +56,13 @@ class CrawlDelayAndCustomAgentTest(BaseRobotTest, unittest.TestCase):
     robots_txt = """\
 # robots.txt for http://www.example.com/
 
-User-agent: *
+User-Agent: *
 Crawl-delay: 1
 Request-rate: 3/15
 Disallow: /cyberworld/map/ # This is an infinite virtual URL space
 
 # Cybermapper knows where to go.
-User-agent: cybermapper
+User-Agent: cybermapper
 Disallow:
     """
     good = ['/', '/test.html', ('cybermapper', '/cyberworld/map/index.html')]
@@ -73,7 +73,7 @@ class SitemapTest(BaseRobotTest, unittest.TestCase):
     robots_txt = """\
 # robots.txt for http://www.example.com/
 
-User-agent: *
+User-Agent: *
 Sitemap: http://www.gstatic.com/s2/sitemaps/profiles-sitemap.xml
 Sitemap: http://www.google.com/hostednews/sitemap_index.xml
 Request-rate: 3/15
@@ -89,7 +89,7 @@ Disallow: /cyberworld/map/ # This is an infinite virtual URL space
 class RejectAllRobotsTest(BaseRobotTest, unittest.TestCase):
     robots_txt = """\
 # go away
-User-agent: *
+User-Agent: *
 Disallow: /
     """
     good = []
@@ -123,7 +123,7 @@ class BaseRequestRateTest(BaseRobotTest):
 
 class CrawlDelayAndRequestRateTest(BaseRequestRateTest, unittest.TestCase):
     robots_txt = """\
-User-agent: figtree
+User-Agent: figtree
 Crawl-delay: 3
 Request-rate: 9/30
 Disallow: /tmp
@@ -149,7 +149,7 @@ class DifferentAgentTest(CrawlDelayAndRequestRateTest):
 
 class InvalidRequestRateTest(BaseRobotTest, unittest.TestCase):
     robots_txt = """\
-User-agent: *
+User-Agent: *
 Disallow: /tmp/
 Disallow: /a%3Cd.html
 Disallow: /a/b.html
@@ -178,7 +178,7 @@ Crawl-delay: pears
 class AnotherInvalidRequestRateTest(BaseRobotTest, unittest.TestCase):
     # also test that Allow and Diasallow works well with each other
     robots_txt = """\
-User-agent: Googlebot
+User-Agent: Googlebot
 Allow: /folder1/myfile.html
 Disallow: /folder1/
 Request-rate: whale/banana
@@ -189,14 +189,14 @@ Request-rate: whale/banana
 
 
 class UserAgentOrderingTest(BaseRobotTest, unittest.TestCase):
-    # the order of User-agent should be correct. note
+    # the order of User-Agent should be correct. note
     # that this file is incorrect because "Googlebot" is a
     # substring of "Googlebot-Mobile"
     robots_txt = """\
-User-agent: Googlebot
+User-Agent: Googlebot
 Disallow: /
 
-User-agent: Googlebot-Mobile
+User-Agent: Googlebot-Mobile
 Allow: /
     """
     agent = 'Googlebot'
@@ -211,7 +211,7 @@ class GoogleURLOrderingTest(BaseRobotTest, unittest.TestCase):
     # Google also got the order wrong. You need
     # to specify the URLs from more specific to more general
     robots_txt = """\
-User-agent: Googlebot
+User-Agent: Googlebot
 Allow: /folder1/myfile.html
 Disallow: /folder1/
     """
@@ -223,7 +223,7 @@ Disallow: /folder1/
 class DisallowQueryStringTest(BaseRobotTest, unittest.TestCase):
     # see issue #6325 for details
     robots_txt = """\
-User-agent: *
+User-Agent: *
 Disallow: /some/path?name=value
     """
     good = ['/some/path']
@@ -233,10 +233,10 @@ Disallow: /some/path?name=value
 class UseFirstUserAgentWildcardTest(BaseRobotTest, unittest.TestCase):
     # obey first * entry (#4108)
     robots_txt = """\
-User-agent: *
+User-Agent: *
 Disallow: /some/path
 
-User-agent: *
+User-Agent: *
 Disallow: /another/path
     """
     good = ['/another/path']
@@ -246,7 +246,7 @@ Disallow: /another/path
 class EmptyQueryStringTest(BaseRobotTest, unittest.TestCase):
     # normalize the URL first (#17403)
     robots_txt = """\
-User-agent: *
+User-Agent: *
 Allow: /some/path?
 Disallow: /another/path?
     """
@@ -256,7 +256,7 @@ Disallow: /another/path?
 
 class DefaultEntryTest(BaseRequestRateTest, unittest.TestCase):
     robots_txt = """\
-User-agent: *
+User-Agent: *
 Crawl-delay: 1
 Request-rate: 3/15
 Disallow: /cyberworld/map/
@@ -269,21 +269,21 @@ Disallow: /cyberworld/map/
 
 class StringFormattingTest(BaseRobotTest, unittest.TestCase):
     robots_txt = """\
-User-agent: *
+User-Agent: *
 Crawl-delay: 1
 Request-rate: 3/15
 Disallow: /cyberworld/map/ # This is an infinite virtual URL space
 
 # Cybermapper knows where to go.
-User-agent: cybermapper
+User-Agent: cybermapper
 Disallow: /some/path
     """
 
     expected_output = """\
-User-agent: cybermapper
+User-Agent: cybermapper
 Disallow: /some/path
 
-User-agent: *
+User-Agent: *
 Crawl-delay: 1
 Request-rate: 3/15
 Disallow: /cyberworld/map/\

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -492,7 +492,7 @@ class MockHTTPHandler(urllib.request.BaseHandler):
 
 
 class MockHTTPSHandler(urllib.request.AbstractHTTPHandler):
-    # Useful for testing the Proxy-Authorization request by verifying the
+    # Useful for testing the Proxy-authorization request by verifying the
     # properties of httpcon
 
     def __init__(self, debuglevel=0):
@@ -760,8 +760,8 @@ class HandlerTests(unittest.TestCase):
             self.assertEqual(h.ftpwrapper.filename, filename)
             self.assertEqual(h.ftpwrapper.filetype, type_)
             headers = r.info()
-            self.assertEqual(headers.get("Content-Type"), mimetype)
-            self.assertEqual(int(headers["Content-Length"]), len(data))
+            self.assertEqual(headers.get("Content-type"), mimetype)
+            self.assertEqual(int(headers["Content-length"]), len(data))
 
     def test_file(self):
         import email.utils
@@ -803,9 +803,9 @@ class HandlerTests(unittest.TestCase):
             finally:
                 os.remove(TESTFN)
             self.assertEqual(data, towrite)
-            self.assertEqual(headers["Content-Type"], "text/plain")
-            self.assertEqual(headers["Content-Length"], "13")
-            self.assertEqual(headers["Last-Modified"], modified)
+            self.assertEqual(headers["Content-type"], "text/plain")
+            self.assertEqual(headers["Content-length"], "13")
+            self.assertEqual(headers["Last-modified"], modified)
             self.assertEqual(respurl, url)
 
         for url in [
@@ -900,24 +900,24 @@ class HandlerTests(unittest.TestCase):
             r = MockResponse(200, "OK", {}, "")
             newreq = h.do_request_(req)
             if data is None:  # GET
-                self.assertNotIn("Content-Length", req.unredirected_hdrs)
-                self.assertNotIn("Content-Type", req.unredirected_hdrs)
+                self.assertNotIn("Content-length", req.unredirected_hdrs)
+                self.assertNotIn("Content-type", req.unredirected_hdrs)
             else:  # POST
-                self.assertEqual(req.unredirected_hdrs["Content-Length"], "0")
-                self.assertEqual(req.unredirected_hdrs["Content-Type"],
+                self.assertEqual(req.unredirected_hdrs["Content-length"], "0")
+                self.assertEqual(req.unredirected_hdrs["Content-type"],
                              "application/x-www-form-urlencoded")
             # XXX the details of Host could be better tested
             self.assertEqual(req.unredirected_hdrs["Host"], "example.com")
             self.assertEqual(req.unredirected_hdrs["Spam"], "eggs")
 
             # don't clobber existing headers
-            req.add_unredirected_header("Content-Length", "foo")
-            req.add_unredirected_header("Content-Type", "bar")
+            req.add_unredirected_header("Content-length", "foo")
+            req.add_unredirected_header("Content-type", "bar")
             req.add_unredirected_header("Host", "baz")
             req.add_unredirected_header("Spam", "foo")
             newreq = h.do_request_(req)
-            self.assertEqual(req.unredirected_hdrs["Content-Length"], "foo")
-            self.assertEqual(req.unredirected_hdrs["Content-Type"], "bar")
+            self.assertEqual(req.unredirected_hdrs["Content-length"], "foo")
+            self.assertEqual(req.unredirected_hdrs["Content-type"], "bar")
             self.assertEqual(req.unredirected_hdrs["Host"], "baz")
             self.assertEqual(req.unredirected_hdrs["Spam"], "foo")
 
@@ -936,15 +936,15 @@ class HandlerTests(unittest.TestCase):
         with open(file_path, "rb") as f:
             req = Request("http://example.com/", f, {})
             newreq = h.do_request_(req)
-            te = newreq.get_header('Transfer-Encoding')
+            te = newreq.get_header('Transfer-encoding')
             self.assertEqual(te, "chunked")
-            self.assertFalse(newreq.has_header('Content-Length'))
+            self.assertFalse(newreq.has_header('Content-length'))
 
         with open(file_path, "rb") as f:
-            req = Request("http://example.com/", f, {"Content-Length": 30})
+            req = Request("http://example.com/", f, {"Content-length": 30})
             newreq = h.do_request_(req)
-            self.assertEqual(int(newreq.get_header('Content-Length')), 30)
-            self.assertFalse(newreq.has_header("Transfer-Encoding"))
+            self.assertEqual(int(newreq.get_header('Content-length')), 30)
+            self.assertFalse(newreq.has_header("Transfer-encoding"))
 
     def test_http_body_fileobj(self):
         # A file object - chunked encoding is used
@@ -958,14 +958,14 @@ class HandlerTests(unittest.TestCase):
 
         req = Request("http://example.com/", file_obj, {})
         newreq = h.do_request_(req)
-        self.assertEqual(newreq.get_header('Transfer-Encoding'), 'chunked')
-        self.assertFalse(newreq.has_header('Content-Length'))
+        self.assertEqual(newreq.get_header('Transfer-encoding'), 'chunked')
+        self.assertFalse(newreq.has_header('Content-length'))
 
-        headers = {"Content-Length": 30}
+        headers = {"Content-length": 30}
         req = Request("http://example.com/", file_obj, headers)
         newreq = h.do_request_(req)
-        self.assertEqual(int(newreq.get_header('Content-Length')), 30)
-        self.assertFalse(newreq.has_header("Transfer-Encoding"))
+        self.assertEqual(int(newreq.get_header('Content-length')), 30)
+        self.assertFalse(newreq.has_header("Transfer-encoding"))
 
         file_obj.close()
 
@@ -973,27 +973,27 @@ class HandlerTests(unittest.TestCase):
         # A file reading from a pipe.
         # A pipe cannot be seek'ed.  There is no way to determine the
         # content length up front.  Thus, do_request_() should fall
-        # back to Transfer-Encoding chunked.
+        # back to Transfer-encoding chunked.
 
         h = urllib.request.AbstractHTTPHandler()
         o = h.parent = MockOpener()
 
         cmd = [sys.executable, "-c", r"pass"]
-        for headers in {}, {"Content-Length": 30}:
+        for headers in {}, {"Content-length": 30}:
             with subprocess.Popen(cmd, stdout=subprocess.PIPE) as proc:
                 req = Request("http://example.com/", proc.stdout, headers)
                 newreq = h.do_request_(req)
                 if not headers:
-                    self.assertEqual(newreq.get_header('Content-Length'), None)
-                    self.assertEqual(newreq.get_header('Transfer-Encoding'),
+                    self.assertEqual(newreq.get_header('Content-length'), None)
+                    self.assertEqual(newreq.get_header('Transfer-encoding'),
                                      'chunked')
                 else:
-                    self.assertEqual(int(newreq.get_header('Content-Length')),
+                    self.assertEqual(int(newreq.get_header('Content-length')),
                                      30)
 
     def test_http_body_iterable(self):
         # Generic iterable.  There is no way to determine the content
-        # length up front.  Fall back to Transfer-Encoding chunked.
+        # length up front.  Fall back to Transfer-encoding chunked.
 
         h = urllib.request.AbstractHTTPHandler()
         o = h.parent = MockOpener()
@@ -1001,23 +1001,23 @@ class HandlerTests(unittest.TestCase):
         def iterable_body():
             yield b"one"
 
-        for headers in {}, {"Content-Length": 11}:
+        for headers in {}, {"Content-length": 11}:
             req = Request("http://example.com/", iterable_body(), headers)
             newreq = h.do_request_(req)
             if not headers:
-                self.assertEqual(newreq.get_header('Content-Length'), None)
-                self.assertEqual(newreq.get_header('Transfer-Encoding'),
+                self.assertEqual(newreq.get_header('Content-length'), None)
+                self.assertEqual(newreq.get_header('Transfer-encoding'),
                                  'chunked')
             else:
-                self.assertEqual(int(newreq.get_header('Content-Length')), 11)
+                self.assertEqual(int(newreq.get_header('Content-length')), 11)
 
     def test_http_body_empty_seq(self):
         # Zero-length iterable body should be treated like any other iterable
         h = urllib.request.AbstractHTTPHandler()
         h.parent = MockOpener()
         req = h.do_request_(Request("http://example.com/", ()))
-        self.assertEqual(req.get_header("Transfer-Encoding"), "chunked")
-        self.assertFalse(req.has_header("Content-Length"))
+        self.assertEqual(req.get_header("Transfer-encoding"), "chunked")
+        self.assertFalse(req.has_header("Content-length"))
 
     def test_http_body_array(self):
         # array.array Iterable - Content Length is calculated
@@ -1027,10 +1027,10 @@ class HandlerTests(unittest.TestCase):
 
         iterable_array = array.array("I",[1,2,3,4])
 
-        for headers in {}, {"Content-Length": 16}:
+        for headers in {}, {"Content-length": 16}:
             req = Request("http://example.com/", iterable_array, headers)
             newreq = h.do_request_(req)
-            self.assertEqual(int(newreq.get_header('Content-Length')),16)
+            self.assertEqual(int(newreq.get_header('Content-length')),16)
 
     def test_http_handler_debuglevel(self):
         o = OpenerDirector()
@@ -1171,7 +1171,7 @@ class HandlerTests(unittest.TestCase):
                 req.timeout = socket._GLOBAL_DEFAULT_TIMEOUT
                 req.add_header("Nonsense", "viking=withhold")
                 if data is not None:
-                    req.add_header("Content-Length", str(len(data)))
+                    req.add_header("Content-length", str(len(data)))
                 req.add_unredirected_header("Spam", "spam")
                 try:
                     method(req, MockFile(), code, "Blah",
@@ -1316,7 +1316,7 @@ class HandlerTests(unittest.TestCase):
                 # Set up a normal response for the next request
                 self.connection = test_urllib.fakehttp(
                     b'HTTP/1.1 200 OK\r\n'
-                    b'Content-Length: 3\r\n'
+                    b'Content-length: 3\r\n'
                     b'\r\n'
                     b'123'
                 )
@@ -1407,13 +1407,13 @@ class HandlerTests(unittest.TestCase):
         https_handler = MockHTTPSHandler()
         o.add_handler(https_handler)
         req = Request("https://www.example.com/")
-        req.add_header("Proxy-Authorization", "FooBar")
-        req.add_header("User-Agent", "Grail")
+        req.add_header("Proxy-authorization", "FooBar")
+        req.add_header("User-agent", "Grail")
         self.assertEqual(req.host, "www.example.com")
         self.assertIsNone(req._tunnel_host)
         o.open(req)
-        # Verify Proxy-Authorization gets tunneled to request.
-        # httpsconn req_headers do not have the Proxy-Authorization header but
+        # Verify Proxy-authorization gets tunneled to request.
+        # httpsconn req_headers do not have the Proxy-authorization header but
         # the req will have.
         self.assertNotIn(("Proxy-Authorization", "FooBar"),
                          https_handler.httpconn.req_headers)
@@ -1421,7 +1421,7 @@ class HandlerTests(unittest.TestCase):
                       https_handler.httpconn.req_headers)
         self.assertIsNotNone(req._tunnel_host)
         self.assertEqual(req.host, "proxy.example.com:3128")
-        self.assertEqual(req.get_header("Proxy-Authorization"), "FooBar")
+        self.assertEqual(req.get_header("Proxy-authorization"), "FooBar")
 
     @unittest.skipUnless(sys.platform == 'darwin', "only relevant for OSX")
     def test_osx_proxy_bypass(self):
@@ -1488,10 +1488,10 @@ class HandlerTests(unittest.TestCase):
         auth_handler = urllib.request.ProxyBasicAuthHandler(password_manager)
         realm = "ACME Networks"
         http_handler = MockHTTPHandler(
-            407, 'Proxy-Authenticate: Basic realm="%s"\r\n\r\n' % realm)
+            407, 'Proxy-authenticate: Basic realm="%s"\r\n\r\n' % realm)
         opener.add_handler(auth_handler)
         opener.add_handler(http_handler)
-        self._test_basic_auth(opener, auth_handler, "Proxy-Authorization",
+        self._test_basic_auth(opener, auth_handler, "Proxy-authorization",
                               realm, http_handler, password_manager,
                               "http://acme.example.com:3128/protected",
                               "proxy.example.com:3128",
@@ -1594,8 +1594,6 @@ class HandlerTests(unittest.TestCase):
             base64.encodebytes(userpass).strip().decode())
         self.assertEqual(http_handler.requests[1].get_header(auth_header),
                          auth_hdr_value)
-        self.assertEqual(http_handler.requests[1].unredirected_hdrs[auth_header],
-                         auth_hdr_value)
         # if the password manager can't find a password, the handler won't
         # handle the HTTP auth error
         password_manager.user = password_manager.password = None
@@ -1674,8 +1672,8 @@ class HandlerTests(unittest.TestCase):
         """Test the connection is cleaned up when the response is closed"""
         for (transfer, data) in (
             ("Connection: close", b"data"),
-            ("Transfer-Encoding: chunked", b"4\r\ndata\r\n0\r\n\r\n"),
-            ("Content-Length: 4", b"data"),
+            ("Transfer-encoding: chunked", b"4\r\ndata\r\n0\r\n\r\n"),
+            ("Content-length: 4", b"data"),
         ):
             header = "HTTP/1.1 200 OK\r\n{}\r\n\r\n".format(transfer)
             conn = test_urllib.fakehttp(header.encode() + data)
@@ -1758,11 +1756,11 @@ class MiscTests(unittest.TestCase):
 
             opener.open(request, "1".encode("us-ascii"))
             self.assertEqual(b"1", request.data)
-            self.assertEqual("1", request.get_header("Content-Length"))
+            self.assertEqual("1", request.get_header("Content-length"))
 
             opener.open(request, "1234567890".encode("us-ascii"))
             self.assertEqual(b"1234567890", request.data)
-            self.assertEqual("10", request.get_header("Content-Length"))
+            self.assertEqual("10", request.get_header("Content-length"))
 
     def test_HTTPError_interface(self):
         """
@@ -1771,12 +1769,12 @@ class MiscTests(unittest.TestCase):
         """
         msg = 'something bad happened'
         url = code = fp = None
-        hdrs = 'Content-Length: 42'
+        hdrs = 'Content-length: 42'
         err = urllib.error.HTTPError(url, code, msg, hdrs, fp)
         self.assertTrue(hasattr(err, 'reason'))
         self.assertEqual(err.reason, 'something bad happened')
         self.assertTrue(hasattr(err, 'headers'))
-        self.assertEqual(err.headers, 'Content-Length: 42')
+        self.assertEqual(err.headers, 'Content-length: 42')
         expected_errmsg = 'HTTP Error %s: %s' % (err.code, err.msg)
         self.assertEqual(str(err), expected_errmsg)
         expected_errmsg = '<HTTPError %s: %r>' % (err.code, err.msg)
@@ -1861,20 +1859,20 @@ class RequestTests(unittest.TestCase):
     # if we change data we need to remove content-length header
     # (cause it's most probably calculated for previous value)
     def test_setting_data_should_remove_content_length(self):
-        self.assertNotIn("Content-Length", self.get.unredirected_hdrs)
-        self.get.add_unredirected_header("Content-Length", 42)
-        self.assertEqual(42, self.get.unredirected_hdrs["Content-Length"])
+        self.assertNotIn("Content-length", self.get.unredirected_hdrs)
+        self.get.add_unredirected_header("Content-length", 42)
+        self.assertEqual(42, self.get.unredirected_hdrs["Content-length"])
         self.get.data = "spam"
-        self.assertNotIn("Content-Length", self.get.unredirected_hdrs)
+        self.assertNotIn("Content-length", self.get.unredirected_hdrs)
 
     # issue 17485 same for deleting data.
     def test_deleting_data_should_remove_content_length(self):
-        self.assertNotIn("Content-Length", self.get.unredirected_hdrs)
+        self.assertNotIn("Content-length", self.get.unredirected_hdrs)
         self.get.data = 'foo'
-        self.get.add_unredirected_header("Content-Length", 3)
-        self.assertEqual(3, self.get.unredirected_hdrs["Content-Length"])
+        self.get.add_unredirected_header("Content-length", 3)
+        self.assertEqual(3, self.get.unredirected_hdrs["Content-length"])
         del self.get.data
-        self.assertNotIn("Content-Length", self.get.unredirected_hdrs)
+        self.assertNotIn("Content-length", self.get.unredirected_hdrs)
 
     def test_get_full_url(self):
         self.assertEqual("http://www.python.org/~jeremy/",

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -760,8 +760,8 @@ class HandlerTests(unittest.TestCase):
             self.assertEqual(h.ftpwrapper.filename, filename)
             self.assertEqual(h.ftpwrapper.filetype, type_)
             headers = r.info()
-            self.assertEqual(headers.get("Content-type"), mimetype)
-            self.assertEqual(int(headers["Content-length"]), len(data))
+            self.assertEqual(headers.get("Content-Type"), mimetype)
+            self.assertEqual(int(headers["Content-Length"]), len(data))
 
     def test_file(self):
         import email.utils
@@ -803,9 +803,9 @@ class HandlerTests(unittest.TestCase):
             finally:
                 os.remove(TESTFN)
             self.assertEqual(data, towrite)
-            self.assertEqual(headers["Content-type"], "text/plain")
-            self.assertEqual(headers["Content-length"], "13")
-            self.assertEqual(headers["Last-modified"], modified)
+            self.assertEqual(headers["Content-Type"], "text/plain")
+            self.assertEqual(headers["Content-Length"], "13")
+            self.assertEqual(headers["Last-Modified"], modified)
             self.assertEqual(respurl, url)
 
         for url in [
@@ -900,24 +900,24 @@ class HandlerTests(unittest.TestCase):
             r = MockResponse(200, "OK", {}, "")
             newreq = h.do_request_(req)
             if data is None:  # GET
-                self.assertNotIn("Content-length", req.unredirected_hdrs)
-                self.assertNotIn("Content-type", req.unredirected_hdrs)
+                self.assertNotIn("Content-Length", req.unredirected_hdrs)
+                self.assertNotIn("Content-Type", req.unredirected_hdrs)
             else:  # POST
-                self.assertEqual(req.unredirected_hdrs["Content-length"], "0")
-                self.assertEqual(req.unredirected_hdrs["Content-type"],
+                self.assertEqual(req.unredirected_hdrs["Content-Length"], "0")
+                self.assertEqual(req.unredirected_hdrs["Content-Type"],
                              "application/x-www-form-urlencoded")
             # XXX the details of Host could be better tested
             self.assertEqual(req.unredirected_hdrs["Host"], "example.com")
             self.assertEqual(req.unredirected_hdrs["Spam"], "eggs")
 
             # don't clobber existing headers
-            req.add_unredirected_header("Content-length", "foo")
-            req.add_unredirected_header("Content-type", "bar")
+            req.add_unredirected_header("Content-Length", "foo")
+            req.add_unredirected_header("Content-Type", "bar")
             req.add_unredirected_header("Host", "baz")
             req.add_unredirected_header("Spam", "foo")
             newreq = h.do_request_(req)
-            self.assertEqual(req.unredirected_hdrs["Content-length"], "foo")
-            self.assertEqual(req.unredirected_hdrs["Content-type"], "bar")
+            self.assertEqual(req.unredirected_hdrs["Content-Length"], "foo")
+            self.assertEqual(req.unredirected_hdrs["Content-Type"], "bar")
             self.assertEqual(req.unredirected_hdrs["Host"], "baz")
             self.assertEqual(req.unredirected_hdrs["Spam"], "foo")
 
@@ -936,15 +936,15 @@ class HandlerTests(unittest.TestCase):
         with open(file_path, "rb") as f:
             req = Request("http://example.com/", f, {})
             newreq = h.do_request_(req)
-            te = newreq.get_header('Transfer-encoding')
+            te = newreq.get_header('Transfer-Encoding')
             self.assertEqual(te, "chunked")
-            self.assertFalse(newreq.has_header('Content-length'))
+            self.assertFalse(newreq.has_header('Content-Length'))
 
         with open(file_path, "rb") as f:
             req = Request("http://example.com/", f, {"Content-Length": 30})
             newreq = h.do_request_(req)
-            self.assertEqual(int(newreq.get_header('Content-length')), 30)
-            self.assertFalse(newreq.has_header("Transfer-encoding"))
+            self.assertEqual(int(newreq.get_header('Content-Length')), 30)
+            self.assertFalse(newreq.has_header("Transfer-Encoding"))
 
     def test_http_body_fileobj(self):
         # A file object - chunked encoding is used
@@ -958,14 +958,14 @@ class HandlerTests(unittest.TestCase):
 
         req = Request("http://example.com/", file_obj, {})
         newreq = h.do_request_(req)
-        self.assertEqual(newreq.get_header('Transfer-encoding'), 'chunked')
-        self.assertFalse(newreq.has_header('Content-length'))
+        self.assertEqual(newreq.get_header('Transfer-Encoding'), 'chunked')
+        self.assertFalse(newreq.has_header('Content-Length'))
 
         headers = {"Content-Length": 30}
         req = Request("http://example.com/", file_obj, headers)
         newreq = h.do_request_(req)
-        self.assertEqual(int(newreq.get_header('Content-length')), 30)
-        self.assertFalse(newreq.has_header("Transfer-encoding"))
+        self.assertEqual(int(newreq.get_header('Content-Length')), 30)
+        self.assertFalse(newreq.has_header("Transfer-Encoding"))
 
         file_obj.close()
 
@@ -973,7 +973,7 @@ class HandlerTests(unittest.TestCase):
         # A file reading from a pipe.
         # A pipe cannot be seek'ed.  There is no way to determine the
         # content length up front.  Thus, do_request_() should fall
-        # back to Transfer-encoding chunked.
+        # back to Transfer-Encoding chunked.
 
         h = urllib.request.AbstractHTTPHandler()
         o = h.parent = MockOpener()
@@ -984,16 +984,16 @@ class HandlerTests(unittest.TestCase):
                 req = Request("http://example.com/", proc.stdout, headers)
                 newreq = h.do_request_(req)
                 if not headers:
-                    self.assertEqual(newreq.get_header('Content-length'), None)
-                    self.assertEqual(newreq.get_header('Transfer-encoding'),
+                    self.assertEqual(newreq.get_header('Content-Length'), None)
+                    self.assertEqual(newreq.get_header('Transfer-Encoding'),
                                      'chunked')
                 else:
-                    self.assertEqual(int(newreq.get_header('Content-length')),
+                    self.assertEqual(int(newreq.get_header('Content-Length')),
                                      30)
 
     def test_http_body_iterable(self):
         # Generic iterable.  There is no way to determine the content
-        # length up front.  Fall back to Transfer-encoding chunked.
+        # length up front.  Fall back to Transfer-Encoding chunked.
 
         h = urllib.request.AbstractHTTPHandler()
         o = h.parent = MockOpener()
@@ -1005,19 +1005,19 @@ class HandlerTests(unittest.TestCase):
             req = Request("http://example.com/", iterable_body(), headers)
             newreq = h.do_request_(req)
             if not headers:
-                self.assertEqual(newreq.get_header('Content-length'), None)
-                self.assertEqual(newreq.get_header('Transfer-encoding'),
+                self.assertEqual(newreq.get_header('Content-Length'), None)
+                self.assertEqual(newreq.get_header('Transfer-Encoding'),
                                  'chunked')
             else:
-                self.assertEqual(int(newreq.get_header('Content-length')), 11)
+                self.assertEqual(int(newreq.get_header('Content-Length')), 11)
 
     def test_http_body_empty_seq(self):
         # Zero-length iterable body should be treated like any other iterable
         h = urllib.request.AbstractHTTPHandler()
         h.parent = MockOpener()
         req = h.do_request_(Request("http://example.com/", ()))
-        self.assertEqual(req.get_header("Transfer-encoding"), "chunked")
-        self.assertFalse(req.has_header("Content-length"))
+        self.assertEqual(req.get_header("Transfer-Encoding"), "chunked")
+        self.assertFalse(req.has_header("Content-Length"))
 
     def test_http_body_array(self):
         # array.array Iterable - Content Length is calculated
@@ -1030,7 +1030,7 @@ class HandlerTests(unittest.TestCase):
         for headers in {}, {"Content-Length": 16}:
             req = Request("http://example.com/", iterable_array, headers)
             newreq = h.do_request_(req)
-            self.assertEqual(int(newreq.get_header('Content-length')),16)
+            self.assertEqual(int(newreq.get_header('Content-Length')),16)
 
     def test_http_handler_debuglevel(self):
         o = OpenerDirector()
@@ -1421,7 +1421,7 @@ class HandlerTests(unittest.TestCase):
                       https_handler.httpconn.req_headers)
         self.assertIsNotNone(req._tunnel_host)
         self.assertEqual(req.host, "proxy.example.com:3128")
-        self.assertEqual(req.get_header("Proxy-authorization"), "FooBar")
+        self.assertEqual(req.get_header("Proxy-Authorization"), "FooBar")
 
     @unittest.skipUnless(sys.platform == 'darwin', "only relevant for OSX")
     def test_osx_proxy_bypass(self):
@@ -1491,7 +1491,7 @@ class HandlerTests(unittest.TestCase):
             407, 'Proxy-Authenticate: Basic realm="%s"\r\n\r\n' % realm)
         opener.add_handler(auth_handler)
         opener.add_handler(http_handler)
-        self._test_basic_auth(opener, auth_handler, "Proxy-authorization",
+        self._test_basic_auth(opener, auth_handler, "Proxy-Authorization",
                               realm, http_handler, password_manager,
                               "http://acme.example.com:3128/protected",
                               "proxy.example.com:3128",
@@ -1758,11 +1758,11 @@ class MiscTests(unittest.TestCase):
 
             opener.open(request, "1".encode("us-ascii"))
             self.assertEqual(b"1", request.data)
-            self.assertEqual("1", request.get_header("Content-length"))
+            self.assertEqual("1", request.get_header("Content-Length"))
 
             opener.open(request, "1234567890".encode("us-ascii"))
             self.assertEqual(b"1234567890", request.data)
-            self.assertEqual("10", request.get_header("Content-length"))
+            self.assertEqual("10", request.get_header("Content-Length"))
 
     def test_HTTPError_interface(self):
         """
@@ -1861,20 +1861,20 @@ class RequestTests(unittest.TestCase):
     # if we change data we need to remove content-length header
     # (cause it's most probably calculated for previous value)
     def test_setting_data_should_remove_content_length(self):
-        self.assertNotIn("Content-length", self.get.unredirected_hdrs)
-        self.get.add_unredirected_header("Content-length", 42)
-        self.assertEqual(42, self.get.unredirected_hdrs["Content-length"])
+        self.assertNotIn("Content-Length", self.get.unredirected_hdrs)
+        self.get.add_unredirected_header("Content-Length", 42)
+        self.assertEqual(42, self.get.unredirected_hdrs["Content-Length"])
         self.get.data = "spam"
-        self.assertNotIn("Content-length", self.get.unredirected_hdrs)
+        self.assertNotIn("Content-Length", self.get.unredirected_hdrs)
 
     # issue 17485 same for deleting data.
     def test_deleting_data_should_remove_content_length(self):
-        self.assertNotIn("Content-length", self.get.unredirected_hdrs)
+        self.assertNotIn("Content-Length", self.get.unredirected_hdrs)
         self.get.data = 'foo'
-        self.get.add_unredirected_header("Content-length", 3)
-        self.assertEqual(3, self.get.unredirected_hdrs["Content-length"])
+        self.get.add_unredirected_header("Content-Length", 3)
+        self.assertEqual(3, self.get.unredirected_hdrs["Content-Length"])
         del self.get.data
-        self.assertNotIn("Content-length", self.get.unredirected_hdrs)
+        self.assertNotIn("Content-Length", self.get.unredirected_hdrs)
 
     def test_get_full_url(self):
         self.assertEqual("http://www.python.org/~jeremy/",

--- a/Lib/test/test_urllib2_localnet.py
+++ b/Lib/test/test_urllib2_localnet.py
@@ -216,13 +216,13 @@ class BasicAuthHandler(http.server.BaseHTTPRequestHandler):
 
     def do_HEAD(self):
         self.send_response(200)
-        self.send_header("Content-type", "text/html")
+        self.send_header("Content-Type", "text/html")
         self.end_headers()
 
     def do_AUTHHEAD(self):
         self.send_response(401)
         self.send_header("WWW-Authenticate", "Basic realm=\"%s\"" % self.REALM)
-        self.send_header("Content-type", "text/html")
+        self.send_header("Content-Type", "text/html")
         self.end_headers()
 
     def do_GET(self):
@@ -424,7 +424,7 @@ def GetRequestHandler(responses):
             for (header, value) in headers:
                 self.send_header(header, value % {'port':self.port})
             if body:
-                self.send_header("Content-type", "text/plain")
+                self.send_header("Content-Type", "text/plain")
                 self.end_headers()
                 return body
             self.end_headers()

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -180,10 +180,10 @@ class OtherNetworkTests(unittest.TestCase):
             self.assertFalse(request.header_items())
             opener.open(request)
             self.assertTrue(request.header_items())
-            self.assertTrue(request.has_header('User-agent'))
+            self.assertTrue(request.has_header('User-Agent'))
             request.add_header('User-Agent','Test-Agent')
             opener.open(request)
-            self.assertEqual(request.get_header('User-agent'),'Test-Agent')
+            self.assertEqual(request.get_header('User-Agent'),'Test-Agent')
 
     @unittest.skip('XXX: http://www.imdb.com is gone')
     def test_sites_no_connection_close(self):

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -180,10 +180,10 @@ class OtherNetworkTests(unittest.TestCase):
             self.assertFalse(request.header_items())
             opener.open(request)
             self.assertTrue(request.header_items())
-            self.assertTrue(request.has_header('User-Agent'))
-            request.add_header('User-Agent','Test-Agent')
+            self.assertTrue(request.has_header('User-agent'))
+            request.add_header('User-agent','Test-Agent')
             opener.open(request)
-            self.assertEqual(request.get_header('User-Agent'),'Test-Agent')
+            self.assertEqual(request.get_header('User-agent'),'Test-Agent')
 
     @unittest.skip('XXX: http://www.imdb.com is gone')
     def test_sites_no_connection_close(self):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -36,7 +36,7 @@ the Handler classes, while dealing with requests and responses.
 
 Request -- An object that encapsulates the state of a request.  The
 state can be as simple as the URL.  It can also include extra HTTP
-headers, e.g. a User-Agent.
+headers, e.g. a User-agent.
 
 BaseHandler --
 
@@ -132,7 +132,7 @@ __all__ = [
     'urlretrieve', 'urlcleanup', 'URLopener', 'FancyURLopener',
 ]
 
-# used in User-Agent header sent
+# used in User-agent header sent
 __version__ = '%d.%d' % sys.version_info[:2]
 
 _opener = None
@@ -267,7 +267,7 @@ def urlretrieve(url, filename=None, reporthook=None, data=None):
             read = 0
             blocknum = 0
             if "content-length" in headers:
-                size = int(headers["Content-Length"])
+                size = int(headers["Content-length"])
 
             if reporthook:
                 reporthook(blocknum, bs, size)
@@ -370,8 +370,8 @@ class Request:
             # issue 16464
             # if we change data we need to remove content-length header
             # (cause it's most probably calculated for previous value)
-            if self.has_header("Content-Length"):
-                self.remove_header("Content-Length")
+            if self.has_header("Content-length"):
+                self.remove_header("Content-length")
 
     @data.deleter
     def data(self):
@@ -433,7 +433,7 @@ class Request:
 class OpenerDirector:
     def __init__(self):
         client_version = "Python-urllib/%s" % __version__
-        self.addheaders = [('User-Agent', client_version)]
+        self.addheaders = [('User-agent', client_version)]
         # self.handlers is retained only for backward compatibility
         self.handlers = []
         # manage the individual handlers
@@ -817,7 +817,7 @@ class ProxyHandler(BaseHandler):
             user_pass = '%s:%s' % (unquote(user),
                                    unquote(password))
             creds = base64.b64encode(user_pass.encode()).decode("ascii")
-            req.add_header('Proxy-Authorization', 'Basic ' + creds)
+            req.add_header('Proxy-authorization', 'Basic ' + creds)
         hostport = unquote(hostport)
         req.set_proxy(hostport, proxy_type)
         if orig_type == proxy_type or orig_type == 'https':
@@ -1030,7 +1030,7 @@ class HTTPBasicAuthHandler(AbstractBasicAuthHandler, BaseHandler):
 
 class ProxyBasicAuthHandler(AbstractBasicAuthHandler, BaseHandler):
 
-    auth_header = 'Proxy-Authorization'
+    auth_header = 'Proxy-authorization'
 
     def http_error_407(self, req, fp, code, msg, headers):
         # http_error_auth_reqed requires that there is no userinfo component in
@@ -1211,7 +1211,7 @@ class HTTPDigestAuthHandler(BaseHandler, AbstractDigestAuthHandler):
 
 class ProxyDigestAuthHandler(BaseHandler, AbstractDigestAuthHandler):
 
-    auth_header = 'Proxy-Authorization'
+    auth_header = 'Proxy-authorization'
     handler_order = 490  # before Basic auth
 
     def http_error_407(self, req, fp, code, msg, headers):
@@ -1245,19 +1245,19 @@ class AbstractHTTPHandler(BaseHandler):
                 msg = "POST data should be bytes, an iterable of bytes, " \
                       "or a file object. It cannot be of type str."
                 raise TypeError(msg)
-            if not request.has_header('Content-Type'):
+            if not request.has_header('Content-type'):
                 request.add_unredirected_header(
-                    'Content-Type',
+                    'Content-type',
                     'application/x-www-form-urlencoded')
-            if (not request.has_header('Content-Length')
-                    and not request.has_header('Transfer-Encoding')):
+            if (not request.has_header('Content-length')
+                    and not request.has_header('Transfer-encoding')):
                 content_length = self._get_content_length(request)
                 if content_length is not None:
                     request.add_unredirected_header(
-                            'Content-Length', str(content_length))
+                            'Content-length', str(content_length))
                 else:
                     request.add_unredirected_header(
-                            'Transfer-Encoding', 'chunked')
+                            'Transfer-encoding', 'chunked')
 
         sel_host = host
         if request.has_proxy():
@@ -1314,7 +1314,7 @@ class AbstractHTTPHandler(BaseHandler):
         try:
             try:
                 h.request(req.get_method(), req.selector, req.data, headers,
-                          encode_chunked=req.has_header('Transfer-Encoding'))
+                          encode_chunked=req.has_header('Transfer-encoding'))
             except OSError as err: # timeout error
                 raise URLError(err)
             r = h.getresponse()
@@ -1475,7 +1475,7 @@ class FileHandler(BaseHandler):
             modified = email.utils.formatdate(stats.st_mtime, usegmt=True)
             mtype = mimetypes.guess_type(filename)[0]
             headers = email.message_from_string(
-                'Content-Type: %s\nContent-Length: %d\nLast-Modified: %s\n' %
+                'Content-type: %s\nContent-length: %d\nLast-modified: %s\n' %
                 (mtype or 'text/plain', size, modified))
             if host:
                 host, port = _splitport(host)
@@ -1541,9 +1541,9 @@ class FTPHandler(BaseHandler):
             headers = ""
             mtype = mimetypes.guess_type(req.full_url)[0]
             if mtype:
-                headers += "Content-Type: %s\n" % mtype
+                headers += "Content-type: %s\n" % mtype
             if retrlen is not None and retrlen >= 0:
-                headers += "Content-Length: %d\n" % retrlen
+                headers += "Content-length: %d\n" % retrlen
             headers = email.message_from_string(headers)
             return addinfourl(fp, headers, req.full_url)
         except ftplib.all_errors as exp:
@@ -1632,7 +1632,7 @@ class DataHandler(BaseHandler):
         if not mediatype:
             mediatype = "text/plain;charset=US-ASCII"
 
-        headers = email.message_from_string("Content-Type: %s\nContent-Length: %d\n" %
+        headers = email.message_from_string("Content-type: %s\nContent-length: %d\n" %
             (mediatype, len(data)))
 
         return addinfourl(io.BytesIO(data), headers, url)
@@ -1683,7 +1683,7 @@ class URLopener:
         self.proxies = proxies
         self.key_file = x509.get('key_file')
         self.cert_file = x509.get('cert_file')
-        self.addheaders = [('User-Agent', self.version), ('Accept', '*/*')]
+        self.addheaders = [('User-agent', self.version), ('Accept', '*/*')]
         self.__tempfiles = []
         self.__unlink = os.unlink # See cleanup()
         self.tempcache = None
@@ -1810,7 +1810,7 @@ class URLopener:
                 read = 0
                 blocknum = 0
                 if "content-length" in headers:
-                    size = int(headers["Content-Length"])
+                    size = int(headers["Content-length"])
                 if reporthook:
                     reporthook(blocknum, bs, size)
                 while 1:
@@ -1893,7 +1893,7 @@ class URLopener:
         http_conn = connection_factory(host)
         headers = {}
         if proxy_auth:
-            headers["Proxy-Authorization"] = "Basic %s" % proxy_auth
+            headers["Proxy-authorization"] = "Basic %s" % proxy_auth
         if auth:
             headers["Authorization"] =  "Basic %s" % auth
         if realhost:
@@ -1908,7 +1908,7 @@ class URLopener:
             headers[header] = value
 
         if data is not None:
-            headers["Content-Type"] = "application/x-www-form-urlencoded"
+            headers["Content-type"] = "application/x-www-form-urlencoded"
             http_conn.request("POST", selector, data, headers)
         else:
             http_conn.request("GET", selector, headers=headers)
@@ -1987,7 +1987,7 @@ class URLopener:
         modified = email.utils.formatdate(stats.st_mtime, usegmt=True)
         mtype = mimetypes.guess_type(url)[0]
         headers = email.message_from_string(
-            'Content-Type: %s\nContent-Length: %d\nLast-Modified: %s\n' %
+            'Content-type: %s\nContent-length: %d\nLast-modified: %s\n' %
             (mtype or 'text/plain', size, modified))
         if not host:
             urlfile = file
@@ -2055,9 +2055,9 @@ class URLopener:
             mtype = mimetypes.guess_type("ftp:" + url)[0]
             headers = ""
             if mtype:
-                headers += "Content-Type: %s\n" % mtype
+                headers += "Content-type: %s\n" % mtype
             if retrlen is not None and retrlen >= 0:
-                headers += "Content-Length: %d\n" % retrlen
+                headers += "Content-length: %d\n" % retrlen
             headers = email.message_from_string(headers)
             return addinfourl(fp, headers, "ftp:" + url)
         except ftperrors() as exp:
@@ -2089,13 +2089,13 @@ class URLopener:
         msg = []
         msg.append('Date: %s'%time.strftime('%a, %d %b %Y %H:%M:%S GMT',
                                             time.gmtime(time.time())))
-        msg.append('Content-Type: %s' % type)
+        msg.append('Content-type: %s' % type)
         if encoding == 'base64':
             # XXX is this encoding/decoding ok?
             data = base64.decodebytes(data.encode('ascii')).decode('latin-1')
         else:
             data = unquote(data)
-        msg.append('Content-Length: %d' % len(data))
+        msg.append('Content-length: %d' % len(data))
         msg.append('')
         msg.append(data)
         msg = '\n'.join(msg)

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -433,7 +433,7 @@ class Request:
 class OpenerDirector:
     def __init__(self):
         client_version = "Python-urllib/%s" % __version__
-        self.addheaders = [('User-agent', client_version)]
+        self.addheaders = [('User-Agent', client_version)]
         # self.handlers is retained only for backward compatibility
         self.handlers = []
         # manage the individual handlers

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -370,8 +370,8 @@ class Request:
             # issue 16464
             # if we change data we need to remove content-length header
             # (cause it's most probably calculated for previous value)
-            if self.has_header("Content-length"):
-                self.remove_header("Content-length")
+            if self.has_header("Content-Length"):
+                self.remove_header("Content-Length")
 
     @data.deleter
     def data(self):
@@ -817,7 +817,7 @@ class ProxyHandler(BaseHandler):
             user_pass = '%s:%s' % (unquote(user),
                                    unquote(password))
             creds = base64.b64encode(user_pass.encode()).decode("ascii")
-            req.add_header('Proxy-authorization', 'Basic ' + creds)
+            req.add_header('Proxy-Authorization', 'Basic ' + creds)
         hostport = unquote(hostport)
         req.set_proxy(hostport, proxy_type)
         if orig_type == proxy_type or orig_type == 'https':
@@ -1030,7 +1030,7 @@ class HTTPBasicAuthHandler(AbstractBasicAuthHandler, BaseHandler):
 
 class ProxyBasicAuthHandler(AbstractBasicAuthHandler, BaseHandler):
 
-    auth_header = 'Proxy-authorization'
+    auth_header = 'Proxy-Authorization'
 
     def http_error_407(self, req, fp, code, msg, headers):
         # http_error_auth_reqed requires that there is no userinfo component in
@@ -1245,19 +1245,19 @@ class AbstractHTTPHandler(BaseHandler):
                 msg = "POST data should be bytes, an iterable of bytes, " \
                       "or a file object. It cannot be of type str."
                 raise TypeError(msg)
-            if not request.has_header('Content-type'):
+            if not request.has_header('Content-Type'):
                 request.add_unredirected_header(
-                    'Content-type',
+                    'Content-Type',
                     'application/x-www-form-urlencoded')
-            if (not request.has_header('Content-length')
-                    and not request.has_header('Transfer-encoding')):
+            if (not request.has_header('Content-Length')
+                    and not request.has_header('Transfer-Encoding')):
                 content_length = self._get_content_length(request)
                 if content_length is not None:
                     request.add_unredirected_header(
-                            'Content-length', str(content_length))
+                            'Content-Length', str(content_length))
                 else:
                     request.add_unredirected_header(
-                            'Transfer-encoding', 'chunked')
+                            'Transfer-Encoding', 'chunked')
 
         sel_host = host
         if request.has_proxy():
@@ -1314,7 +1314,7 @@ class AbstractHTTPHandler(BaseHandler):
         try:
             try:
                 h.request(req.get_method(), req.selector, req.data, headers,
-                          encode_chunked=req.has_header('Transfer-encoding'))
+                          encode_chunked=req.has_header('Transfer-Encoding'))
             except OSError as err: # timeout error
                 raise URLError(err)
             r = h.getresponse()
@@ -1475,7 +1475,7 @@ class FileHandler(BaseHandler):
             modified = email.utils.formatdate(stats.st_mtime, usegmt=True)
             mtype = mimetypes.guess_type(filename)[0]
             headers = email.message_from_string(
-                'Content-type: %s\nContent-length: %d\nLast-modified: %s\n' %
+                'Content-Type: %s\nContent-Length: %d\nLast-Modified: %s\n' %
                 (mtype or 'text/plain', size, modified))
             if host:
                 host, port = _splitport(host)
@@ -1541,9 +1541,9 @@ class FTPHandler(BaseHandler):
             headers = ""
             mtype = mimetypes.guess_type(req.full_url)[0]
             if mtype:
-                headers += "Content-type: %s\n" % mtype
+                headers += "Content-Type: %s\n" % mtype
             if retrlen is not None and retrlen >= 0:
-                headers += "Content-length: %d\n" % retrlen
+                headers += "Content-Length: %d\n" % retrlen
             headers = email.message_from_string(headers)
             return addinfourl(fp, headers, req.full_url)
         except ftplib.all_errors as exp:
@@ -1632,7 +1632,7 @@ class DataHandler(BaseHandler):
         if not mediatype:
             mediatype = "text/plain;charset=US-ASCII"
 
-        headers = email.message_from_string("Content-type: %s\nContent-length: %d\n" %
+        headers = email.message_from_string("Content-Type: %s\nContent-Length: %d\n" %
             (mediatype, len(data)))
 
         return addinfourl(io.BytesIO(data), headers, url)
@@ -1987,7 +1987,7 @@ class URLopener:
         modified = email.utils.formatdate(stats.st_mtime, usegmt=True)
         mtype = mimetypes.guess_type(url)[0]
         headers = email.message_from_string(
-            'Content-Type: %s\nContent-Length: %d\nLast-modified: %s\n' %
+            'Content-Type: %s\nContent-Length: %d\nLast-Modified: %s\n' %
             (mtype or 'text/plain', size, modified))
         if not host:
             urlfile = file
@@ -2089,7 +2089,7 @@ class URLopener:
         msg = []
         msg.append('Date: %s'%time.strftime('%a, %d %b %Y %H:%M:%S GMT',
                                             time.gmtime(time.time())))
-        msg.append('Content-type: %s' % type)
+        msg.append('Content-Type: %s' % type)
         if encoding == 'base64':
             # XXX is this encoding/decoding ok?
             data = base64.decodebytes(data.encode('ascii')).decode('latin-1')

--- a/Lib/urllib/robotparser.py
+++ b/Lib/urllib/robotparser.py
@@ -237,7 +237,7 @@ class Entry:
     def __str__(self):
         ret = []
         for agent in self.useragents:
-            ret.append(f"User-agent: {agent}")
+            ret.append(f"User-Agent: {agent}")
         if self.delay is not None:
             ret.append(f"Crawl-delay: {self.delay}")
         if self.req_rate is not None:

--- a/Lib/xmlrpc/server.py
+++ b/Lib/xmlrpc/server.py
@@ -526,11 +526,11 @@ class SimpleXMLRPCRequestHandler(BaseHTTPRequestHandler):
                 trace = str(trace.encode('ASCII', 'backslashreplace'), 'ASCII')
                 self.send_header("X-traceback", trace)
 
-            self.send_header("Content-length", "0")
+            self.send_header("Content-Length", "0")
             self.end_headers()
         else:
             self.send_response(200)
-            self.send_header("Content-type", "text/xml")
+            self.send_header("Content-Type", "text/xml")
             if self.encode_threshold is not None:
                 if len(response) > self.encode_threshold:
                     q = self.accept_encodings().get("gzip", 0)
@@ -540,7 +540,7 @@ class SimpleXMLRPCRequestHandler(BaseHTTPRequestHandler):
                             self.send_header("Content-Encoding", "gzip")
                         except NotImplementedError:
                             pass
-            self.send_header("Content-length", str(len(response)))
+            self.send_header("Content-Length", str(len(response)))
             self.end_headers()
             self.wfile.write(response)
 
@@ -558,15 +558,15 @@ class SimpleXMLRPCRequestHandler(BaseHTTPRequestHandler):
                 self.send_response(400, "error decoding gzip content")
         else:
             self.send_response(501, "encoding %r not supported" % encoding)
-        self.send_header("Content-length", "0")
+        self.send_header("Content-Length", "0")
         self.end_headers()
 
     def report_404 (self):
             # Report a 404 error
         self.send_response(404)
         response = b'No such page'
-        self.send_header("Content-type", "text/plain")
-        self.send_header("Content-length", str(len(response)))
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(response)))
         self.end_headers()
         self.wfile.write(response)
 
@@ -919,8 +919,8 @@ class DocXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
 
         response = self.server.generate_html_documentation().encode('utf-8')
         self.send_response(200)
-        self.send_header("Content-type", "text/html")
-        self.send_header("Content-length", str(len(response)))
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Length", str(len(response)))
         self.end_headers()
         self.wfile.write(response)
 

--- a/Misc/HISTORY
+++ b/Misc/HISTORY
@@ -7565,7 +7565,7 @@ Library
 - Issue #13152: Allow specifying a custom tabsize for expanding tabs in
   textwrap. Patch by John Feuerstein.
 
-- Issue #14721: Send the correct 'Content-length: 0' header when the body is an
+- Issue #14721: Send the correct 'Content-Length: 0' header when the body is an
   empty string ''. Initial Patch contributed by Arve Knudsen.
 
 - Issue #14072: Fix parsing of 'tel' URIs in urlparse by making the check for
@@ -13167,7 +13167,7 @@ Library
 - Issue #4179: In pdb, allow "list ." as a command to return to the currently
   debugged line.
 
-- Issue #4108: In urllib.robotparser, if there are multiple ``User-agent: *``
+- Issue #4108: In urllib.robotparser, if there are multiple ``User-Agent: *``
   entries, consider the first one.
 
 - Issue #6630: Allow customizing regex flags when subclassing the

--- a/Tools/scripts/highlight.py
+++ b/Tools/scripts/highlight.py
@@ -124,7 +124,7 @@ default_html = '''\
           "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
-<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
 <title> {title} </title>
 <style type="text/css">
 {css}


### PR DESCRIPTION
In Python 3.7, the class `http.server.SimpleHTTPRequestHandler` uses inconsistent case for HTTP header fields ("Content-type" instead of "Content-Type") in the generated responses. For instance here is the response to a HEAD request:

> $ curl -I localhost:8000
> HTTP/1.1 200 OK
> Server: SimpleHTTP/0.6 Python/3.7.0
> Date: Tue, 19 Feb 2019 08:22:30 GMT
> **Content-type: text/html**
> Content-Length: 6590
> Last-Modified: Wed, 02 Jan 2019 22:44:30 GMT

This PR uses title-case HTTP header fields, following [RFC 7231](https://tools.ietf.org/html/rfc7231).

https://bugs.python.org/issue36029