### PR TITLE
Fix syntax warnings in tests introduced in bpo-15248.

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -852,9 +852,10 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
     type2test = bytes
 
     def test_getitem_error(self):
+        b = b'python'
         msg = "byte indices must be integers or slices"
         with self.assertRaisesRegex(TypeError, msg):
-            b'python'['a']
+            b['a']
 
     def test_buffer_is_readonly(self):
         fd = os.open(__file__, os.O_RDONLY)
@@ -1042,14 +1043,15 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
     type2test = bytearray
 
     def test_getitem_error(self):
+        b = bytearray(b'python')
         msg = "bytearray indices must be integers or slices"
         with self.assertRaisesRegex(TypeError, msg):
-            bytearray(b'python')['a']
+            b['a']
 
     def test_setitem_error(self):
+        b = bytearray(b'python')
         msg = "bytearray indices must be integers or slices"
         with self.assertRaisesRegex(TypeError, msg):
-            b = bytearray(b'python')
             b['a'] = "python"
 
     def test_nohash(self):

--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -264,7 +264,8 @@ What about willful misconduct?
       ...
     TypeError: dir() argument after * must be an iterable, not function
 
-    >>> None(*h)
+    >>> nothing = None
+    >>> nothing(*h)
     Traceback (most recent call last):
       ...
     TypeError: NoneType object argument after * must be an iterable, \
@@ -305,7 +306,7 @@ not function
       ...
     TypeError: dir() argument after ** must be a mapping, not function
 
-    >>> None(**h)
+    >>> nothing(**h)
     Traceback (most recent call last):
       ...
     TypeError: NoneType object argument after ** must be a mapping, \

--- a/Lib/test/test_tuple.py
+++ b/Lib/test/test_tuple.py
@@ -19,9 +19,10 @@ class TupleTest(seq_tests.CommonTest):
     type2test = tuple
 
     def test_getitem_error(self):
+        t = ()
         msg = "tuple indices must be integers or slices"
         with self.assertRaisesRegex(TypeError, msg):
-            ()['a']
+            t['a']
 
     def test_constructors(self):
         super().test_constructors()


### PR DESCRIPTION
<!-- issue-number: [bpo-15248](https://bugs.python.org/issue15248) -->
https://bugs.python.org/issue15248
<!-- /issue-number -->
