### PR TITLE
bpo-36037: Fix test_ssl for strict OpenSSL policy

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2628,6 +2628,9 @@ def try_protocol_combo(server_protocol, client_protocol, expect_success,
 
     min_version = PROTOCOL_TO_TLS_VERSION.get(client_protocol, None)
     if (min_version is not None
+    # SSLContext.minimum_version is only available on recent OpenSSL
+    # (setter added in OpenSSL 1.1.0, getter added in OpenSSL 1.1.1)
+    and hasattr(server_context, 'minimum_version')
     and server_protocol == ssl.PROTOCOL_TLS
     and server_context.minimum_version > min_version):
         # If OpenSSL configuration is strict and requires more recent TLS

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -33,6 +33,19 @@ IS_OPENSSL_1_1_0 = not IS_LIBRESSL and ssl.OPENSSL_VERSION_INFO >= (1, 1, 0)
 IS_OPENSSL_1_1_1 = not IS_LIBRESSL and ssl.OPENSSL_VERSION_INFO >= (1, 1, 1)
 PY_SSL_DEFAULT_CIPHERS = sysconfig.get_config_var('PY_SSL_DEFAULT_CIPHERS')
 
+PROTOCOL_TO_TLS_VERSION = {}
+for proto, ver in (
+    ("PROTOCOL_SSLv23", "SSLv3"),
+    ("PROTOCOL_TLSv1", "TLSv1"),
+    ("PROTOCOL_TLSv1_1", "TLSv1_1"),
+):
+    try:
+        proto = getattr(ssl, proto)
+        ver = getattr(ssl.TLSVersion, ver)
+    except AttributeError:
+        continue
+    PROTOCOL_TO_TLS_VERSION[proto] = ver
+
 def data_file(*name):
     return os.path.join(os.path.dirname(__file__), *name)
 
@@ -1092,7 +1105,11 @@ class ContextTests(unittest.TestCase):
         # Fedora override the setting to TLS 1.0.
         self.assertIn(
             ctx.minimum_version,
-            {ssl.TLSVersion.MINIMUM_SUPPORTED, ssl.TLSVersion.TLSv1}
+            {ssl.TLSVersion.MINIMUM_SUPPORTED,
+             # Fedora 29 uses TLS 1.0 by default
+             ssl.TLSVersion.TLSv1,
+             # RHEL 8 uses TLS 1.2 by default
+             ssl.TLSVersion.TLSv1_2}
         )
         self.assertEqual(
             ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
@@ -2608,6 +2625,14 @@ def try_protocol_combo(server_protocol, client_protocol, expect_success,
     client_context.options |= client_options
     server_context = ssl.SSLContext(server_protocol)
     server_context.options |= server_options
+
+    min_version = PROTOCOL_TO_TLS_VERSION.get(client_protocol, None)
+    if (min_version is not None
+    and server_protocol == ssl.PROTOCOL_TLS
+    and server_context.minimum_version > min_version):
+        # If OpenSSL configuration is strict and requires more recent TLS
+        # version, we have to change the minimum to test old TLS versions.
+        server_context.minimum_version = min_version
 
     # NOTE: we must enable "ALL" ciphers on the client, otherwise an
     # SSLv23 client will send an SSLv3 hello (rather than SSLv2)

--- a/Misc/NEWS.d/next/Tests/2019-02-19-15-21-14.bpo-36037.75wG9_.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-19-15-21-14.bpo-36037.75wG9_.rst
@@ -1,0 +1,3 @@
+Fix test_ssl for strict OpenSSL configuration like RHEL8 strict crypto policy.
+Use older TLS version for minimum TLS version of the server SSL context if
+needed, to test TLS version older than default minimum TLS version.


### PR DESCRIPTION
Fix test_ssl for strict OpenSSL configuration like RHEL8 strict
crypto policy.

<!-- issue-number: [bpo-36037](https://bugs.python.org/issue36037) -->
https://bugs.python.org/issue36037
<!-- /issue-number -->
