### PR TITLE
bpo-36042 Check for methods, make them classmethod

### DIFF
--- a/Lib/test/test_genericclass.py
+++ b/Lib/test/test_genericclass.py
@@ -264,6 +264,13 @@ class TestClassGetitem(unittest.TestCase):
                 return 'from __class_getitem__'
         self.assertEqual(C[int], 'from metaclass')
 
+    def test_class_getitem_in_runtime(self):
+        class C:
+            pass
+
+        C.__class_getitem__ = lambda cls, item: f'{cls.__name__}[{item.__name__}]'
+
+        self.assertEqual(C[int], 'C[int]')
 
 @support.cpython_only
 class CAPITest(unittest.TestCase):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1847,3 +1847,4 @@ Doug Zongker
 Peter Åstrand
 Zheao Li
 Carsten Klein
+Batuhan Taskaya

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3264,6 +3264,16 @@ type_setattro(PyTypeObject *type, PyObject *name, PyObject *value)
             type->tp_name);
         return -1;
     }
+    
+    if (PyUnicode_Check (name)
+        && (!strcmp (PyUnicode_AsUTF8 (name), "__init_subclass__")
+        || !strcmp (PyUnicode_AsUTF8 (name), "__class_getitem__"))
+        && PyFunction_Check (value))
+    {
+        value = PyClassMethod_New (value);
+    } 
+
+    
     if (PyUnicode_Check(name)) {
         if (PyUnicode_CheckExact(name)) {
             if (PyUnicode_READY(name) == -1)


### PR DESCRIPTION
In each setattr operation check if name is __init_subclass__ or
__class_getitem__ and make them classmethod.

<!-- issue-number: [bpo-36042](https://bugs.python.org/issue36042) -->
https://bugs.python.org/issue36042
<!-- /issue-number -->
