### PR TITLE
bpo-35584: Incorrect description of ^

### DIFF
--- a/Doc/howto/regex.rst
+++ b/Doc/howto/regex.rst
@@ -98,7 +98,7 @@ You can match the characters not listed within the class by :dfn:`complementing`
 the set.  This is indicated by including a ``'^'`` as the first character of the
 class. For example, ``[^5]`` will match any character except ``'5'``.  If the
 caret appears elsewhere in a character class, it does not have special meaning.
-For example: ``[5^]`` will match either a ``'5'`` or a ``'^'``.The behaviour of
+For example: ``[5^]`` will match either a ``'5'`` or a ``'^'``. The behaviour of
 ``'^'`` outside of a character class will be introduced in
 section :ref:`more-metacharacters`.
 

--- a/Doc/howto/regex.rst
+++ b/Doc/howto/regex.rst
@@ -96,15 +96,12 @@ special nature.
 
 You can match the characters not listed within the class by :dfn:`complementing`
 the set.  This is indicated by including a ``'^'`` as the first character of the
-<<<<<<< HEAD
-class. For example, ``[^5]`` will match any character except ``'5'``.
-The behaviour of ``'^'`` outside of a character class will be introduced in
-section :ref:`more-metacharacters`.
-=======
 class. For example, ``[^5]`` will match any character except ``'5'``.  If the
 caret appears elsewhere in a character class, it does not have special meaning.
-For example: ``[5^]`` will match either a ``'5'`` or a ``'^'``.
->>>>>>> 3bacf6126522a9b3bcb6be0c4f3ee6a895dfe772
+For example: ``[5^]`` will match either a ``'5'`` or a ``'^'``.The behaviour of
+``'^'`` outside of a character class will be introduced in
+section :ref:`more-metacharacters`.
+
 
 Perhaps the most important metacharacter is the backslash, ``\``.   As in Python
 string literals, the backslash can be followed by various characters to signal

--- a/Doc/howto/regex.rst
+++ b/Doc/howto/regex.rst
@@ -96,8 +96,9 @@ special nature.
 
 You can match the characters not listed within the class by :dfn:`complementing`
 the set.  This is indicated by including a ``'^'`` as the first character of the
-class; ``'^'`` outside a character class will simply match the ``'^'``
-character.  For example, ``[^5]`` will match any character except ``'5'``.
+class. For example, ``[^5]`` will match any character except ``'5'``. 
+The behaviour of ``'^'`` outside of a character class will be introduced in 
+section :ref:`more-metacharacters`.  
 
 Perhaps the most important metacharacter is the backslash, ``\``.   As in Python
 string literals, the backslash can be followed by various characters to signal

--- a/Doc/howto/regex.rst
+++ b/Doc/howto/regex.rst
@@ -96,8 +96,8 @@ special nature.
 
 You can match the characters not listed within the class by :dfn:`complementing`
 the set.  This is indicated by including a ``'^'`` as the first character of the
-class. For example, ``[^5]`` will match any character except ``'5'``. 
-The behaviour of ``'^'`` outside of a character class will be introduced in 
+class. For example, ``[^5]`` will match any character except ``'5'``.
+The behaviour of ``'^'`` outside of a character class will be introduced in
 section :ref:`more-metacharacters`.
 
 Perhaps the most important metacharacter is the backslash, ``\``.   As in Python

--- a/Doc/howto/regex.rst
+++ b/Doc/howto/regex.rst
@@ -98,7 +98,7 @@ You can match the characters not listed within the class by :dfn:`complementing`
 the set.  This is indicated by including a ``'^'`` as the first character of the
 class. For example, ``[^5]`` will match any character except ``'5'``. 
 The behaviour of ``'^'`` outside of a character class will be introduced in 
-section :ref:`more-metacharacters`.  
+section :ref:`more-metacharacters`.
 
 Perhaps the most important metacharacter is the backslash, ``\``.   As in Python
 string literals, the backslash can be followed by various characters to signal

--- a/Misc/NEWS.d/next/Documentation/2019-02-19-18-38-23.bpo-35584.x4EQ9V.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-02-19-18-38-23.bpo-35584.x4EQ9V.rst
@@ -1,0 +1,1 @@
+Update regex howto to note ^ outside of character classes will not just match literal ^


### PR DESCRIPTION
The previous description of ^ was inaccurate since it will not match the literal ^ unescaped outside of a character class.  


<!-- issue-number: [bpo-35584](https://bugs.python.org/issue35584) -->
https://bugs.python.org/issue35584
<!-- /issue-number -->
