### PR TITLE
bpo-35933: Document/fix case when __getstate__ returns a tuple of 2 dictionnaries

### DIFF
--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -616,7 +616,7 @@ or both.
      the object's :attr:`~object.__dict__` attribute. If the object has
      attributes living outside of its :attr:`~object.__dict__` attribute (for
      instance if its class has :attr:`~object.__slots__`), the state must be a
-     tuple ``(state, slotstate)`` of two dictionnaries. Items of the first one
+     tuple ``(state, slotstate)`` of two dictionaries. Items of the first one
      will be added to the object's :attr:`~object.__dict__`, while items of the
      latter will try to update ``object``'s data members first.
 

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -613,7 +613,12 @@ or both.
    * Optionally, the object's state, which will be passed to the object's
      :meth:`__setstate__` method as previously described.  If the object has no
      such method then, the value must be a dictionary and it will be added to
-     the object's :attr:`~object.__dict__` attribute.
+     the object's :attr:`~object.__dict__` attribute. If the object has
+     attributes living outside of its :attr:`~object.__dict__` attribute (for
+     instance if its class has :attr:`~object.__slots__`), the state must be a
+     tuple ``(state, slotstate)`` of two dictionnaries. Items of the first one
+     will be added to the object's :attr:`~object.__dict__`, while items of the
+     latter will try to update ``object``'s data members first.
 
    * Optionally, an iterator (and not a sequence) yielding successive items.
      These items will be appended to the object either using

--- a/Misc/NEWS.d/next/Documentation/2019-02-20-15-35-00.bpo-35933.trRE3.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-02-20-15-35-00.bpo-35933.trRE3.rst
@@ -1,0 +1,3 @@
+* Mention in the documentation that ``pickle`` can natively preserve a class
+  ``__slots__`` if the state returned by a custom ``__getstate__`` or
+  ``__reduce__`` contains member descriptors attribute in a second dictionary.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6233,7 +6233,7 @@ load_build(UnpicklerObject *self)
         slotstate = NULL;
 
     /* Set inst.__dict__ from the state dict (if any). */
-    if (state != Py_None) {
+    if (PyObject_IsTrue(state)) {
         PyObject *dict;
         PyObject *d_key, *d_value;
         Py_ssize_t i;


### PR DESCRIPTION
[bpo-35933](https://bugs.python.org/issue35933): Document/fix case when __getstate__ returns a tuple of 2 dictionnaries

* [`test_descr.py`](https://github.com/python/cpython/blob/master/Lib/test/test_descr.py#L5111-L5176) already tests this functionality pretty thoroughly.
* the change in `_pickle.c` is simply for the sake of consistency between `pickle.py` and `_pickle.c`

<!-- issue-number: [bpo-35933](https://bugs.python.org/issue35933) -->
https://bugs.python.org/issue35933
<!-- /issue-number -->
