### PR TITLE
gh-80234: fix pkgutil.walk_packages

### DIFF
--- a/Lib/pkgutil.py
+++ b/Lib/pkgutil.py
@@ -88,8 +88,9 @@ def walk_packages(path=None, prefix='', onerror=None):
         yield info
 
         if info.ispkg:
+            loader = info.module_finder.find_module(info.name)
             try:
-                __import__(info.name)
+                module = loader.load_module(info.name)
             except ImportError:
                 if onerror is not None:
                     onerror(info.name)
@@ -99,7 +100,7 @@ def walk_packages(path=None, prefix='', onerror=None):
                 else:
                     raise
             else:
-                path = getattr(sys.modules[info.name], '__path__', None) or []
+                path = module.__path__
 
                 # don't traverse path items we've seen before
                 path = [p for p in path if not seen(p)]

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -176,6 +176,42 @@ class PkgutilTests(unittest.TestCase):
                 continue
             del sys.modules[pkg]
 
+    def test_walk_packages_with_same_package_name_in_pythonpath(self):
+        pkg1 = 'test_walk_packages_with_same_package_name_in_pythonpath'
+        pkg1_dir = os.path.join(self.dirname, pkg1)
+        os.mkdir(pkg1_dir)
+        f = open(os.path.join(pkg1_dir, '__init__.py'), "wb")
+        f.close()
+        os.mkdir(os.path.join(pkg1_dir, 'same_name'))
+        f = open(os.path.join(pkg1_dir, 'same_name', '__init__.py'), "wb")
+        f.close()
+        f = open(os.path.join(pkg1_dir, 'same_name', 'mod.py'), "wb")
+        f.close()
+
+        # Add another package in the path, with the same name as the one inside pkg1
+        pkg2 = 'same_name'
+        pkg2_dir = os.path.join(self.dirname, pkg2)
+        os.mkdir(pkg2_dir)
+        f = open(os.path.join(pkg2_dir, '__init__.py'), "wb")
+        f.close()
+        os.mkdir(os.path.join(pkg2_dir, 'test_same_name'))
+        f = open(os.path.join(pkg2_dir, 'test_same_name', '__init__.py'), "wb")
+        f.close()
+        f = open(os.path.join(pkg2_dir, 'test_same_name', 'another_mod.py'), "wb")
+        f.close()
+
+        expected = [
+            'same_name',
+            'same_name.mod'
+        ]
+        actual = [e[1] for e in pkgutil.walk_packages([os.path.join(self.dirname, pkg1)])]
+        self.assertEqual(actual, expected)
+
+        for pkg in expected:
+            if pkg.endswith('mod'):
+                continue
+            del sys.modules[pkg]
+
     def test_walk_packages_raises_on_string_or_bytes_input(self):
 
         str_input = 'test_dir'

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -1,4 +1,4 @@
-from test.support import run_unittest, unload, check_warnings, CleanImport
+from test.support import forget, run_unittest, unload, check_warnings, CleanImport
 import unittest
 import sys
 import importlib
@@ -204,13 +204,12 @@ class PkgutilTests(unittest.TestCase):
             'same_name',
             'same_name.mod'
         ]
-        actual = [e[1] for e in pkgutil.walk_packages([os.path.join(self.dirname, pkg1)])]
-        self.assertEqual(actual, expected)
 
         for pkg in expected:
-            if pkg.endswith('mod'):
-                continue
-            del sys.modules[pkg]
+            self.addCleanup(forget, pkg)
+
+        actual = [e[1] for e in pkgutil.walk_packages([os.path.join(self.dirname, pkg1)])]
+        self.assertEqual(actual, expected)
 
     def test_walk_packages_raises_on_string_or_bytes_input(self):
 

--- a/Misc/NEWS.d/next/Library/2019-02-20-17-44-00.bpo-36053.cER52b.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-20-17-44-00.bpo-36053.cER52b.rst
@@ -1,0 +1,1 @@
+Fix ``pkgutil.walk_packages()`` jumping outside given path if a package with the same name is available inside ``sys.path``. Patch by Piotr Karkut.


### PR DESCRIPTION
When walk_packages encounter a package with a name that is available in sys.path, it will abandon the current package, and start walking the package from the sys.path.

Consider this file layout:

```
PYTHONPATH/
├──package1/
|   ├──core   
|   |   ├──some_package/
|   |   |   ├──__init__.py
|   |   |   └──mod.py
|   |   └──__init__.py
|   └──__init__.py
└──some_package/
   |   ├──__init__.py
   |   └──another_mod.py
   └──__init__.py
```

The result of walking package1 will be:

```
>> pkgutil.walk_packages('PYTHONPATH/package1')

ModuleInfo(module_finder=FileFinder('PYTHONPATH/package1/core'), name='some_package', ispkg=True)
ModuleInfo(module_finder=FileFinder('PYTHONPATH/some_package), name='another_mod', ispkg=False)
```

I'm not sure if it is a security issue, but it definitely should not jump off the given path.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36053](https://bugs.python.org/issue36053) -->
https://bugs.python.org/issue36053
<!-- /issue-number -->

<!-- gh-issue-number: gh-80234 -->
* Issue: gh-80234
<!-- /gh-issue-number -->
