### PR TITLE
bpo-36052: Disallow assigning to __debug__ in named expressions

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -51,6 +51,10 @@ SyntaxError: cannot assign to __debug__
 Traceback (most recent call last):
 SyntaxError: cannot assign to __debug__
 
+>>> (__debug__ := 1)
+Traceback (most recent call last):
+SyntaxError: cannot assign to __debug__
+
 >>> f() = 1
 Traceback (most recent call last):
 SyntaxError: cannot assign to function call

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -1084,7 +1084,7 @@ set_context(struct compiling *c, expr_ty e, expr_context_ty ctx, const node *n)
                 return 0;
             break;
         case Name_kind:
-            if (ctx == Store) {
+            if (ctx == Store || ctx == NamedStore) {
                 if (forbidden_name(c, e->v.Name.id, n, 0))
                     return 0; /* forbidden_name() calls ast_error() */
             }


### PR DESCRIPTION


<!-- issue-number: [bpo-36052](https://bugs.python.org/issue36052) -->
https://bugs.python.org/issue36052
<!-- /issue-number -->
