### PR TITLE
bpo-36052: Raise a SyntaxError when we assign a value to __debug__

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -626,6 +626,9 @@ Corner-cases that used to crash:
     Traceback (most recent call last):
     SyntaxError: cannot assign to __debug__
 
+>>> (__debug__ := 'spam')
+Traceback (most recent call last):
+SyntaxError: cannot assign to __debug__
 """
 
 import re

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -629,6 +629,7 @@ Corner-cases that used to crash:
     >>> def f(*xx, __debug__): pass
     Traceback (most recent call last):
     SyntaxError: cannot assign to __debug__
+
 """
 
 import re

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -51,6 +51,10 @@ SyntaxError: cannot assign to __debug__
 Traceback (most recent call last):
 SyntaxError: cannot assign to __debug__
 
+>>> (__debug__ := 1)
+Traceback (most recent call last):
+SyntaxError: cannot assign to __debug__
+
 >>> f() = 1
 Traceback (most recent call last):
 SyntaxError: cannot assign to function call
@@ -625,10 +629,6 @@ Corner-cases that used to crash:
     >>> def f(*xx, __debug__): pass
     Traceback (most recent call last):
     SyntaxError: cannot assign to __debug__
-
->>> (__debug__ := 'spam')
-Traceback (most recent call last):
-SyntaxError: cannot assign to __debug__
 """
 
 import re

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-20-17-57-31.bpo-36052.l8lJSi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-20-17-57-31.bpo-36052.l8lJSi.rst
@@ -1,0 +1,2 @@
+Raise a SyntaxError when we try to assign a value to `__debug__` with the
+Assignment Operator. Contributed by Stéphane Wirtel.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-20-17-57-31.bpo-36052.l8lJSi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-20-17-57-31.bpo-36052.l8lJSi.rst
@@ -1,2 +1,2 @@
 Raise a SyntaxError when we try to assign a value to `__debug__` with the
-Assignment Operator. Contributed by Stéphane Wirtel.
+Assignment Operator. Contributed by Stéphane Wirtel and Pablo Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-20-17-57-31.bpo-36052.l8lJSi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-20-17-57-31.bpo-36052.l8lJSi.rst
@@ -1,2 +1,2 @@
-Raise a :exc:`SyntaxError` when we try to assign a value to `__debug__` with the
+Raise a :exc:`SyntaxError` when assigning a value to `__debug__` with the
 Assignment Operator. Contributed by Stéphane Wirtel and Pablo Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-20-17-57-31.bpo-36052.l8lJSi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-20-17-57-31.bpo-36052.l8lJSi.rst
@@ -1,2 +1,2 @@
-Raise a SyntaxError when we try to assign a value to `__debug__` with the
+Raise a :exc:`SyntaxError` when we try to assign a value to `__debug__` with the
 Assignment Operator. Contributed by Stéphane Wirtel and Pablo Galindo.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -1084,7 +1084,7 @@ set_context(struct compiling *c, expr_ty e, expr_context_ty ctx, const node *n)
                 return 0;
             break;
         case Name_kind:
-            if (ctx == Store) {
+            if (ctx == Store || ctx == NamedStore) {
                 if (forbidden_name(c, e->v.Name.id, n, 0))
                     return 0; /* forbidden_name() calls ast_error() */
             }


### PR DESCRIPTION
Co-authored-by: Stéphane Wirtel <stephane@wirtel.be>
Co-authored-by: Pablo Galindo <Pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36052](https://bugs.python.org/issue36052) -->
https://bugs.python.org/issue36052
<!-- /issue-number -->
