### PR TITLE
Doc: fix example for iter function

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -816,7 +816,7 @@ are always available.  They are listed here in alphabetical order.
 
       from functools import partial
       with open('mydata.db', 'rb') as f:
-          for block in iter(partial(f.read, 64), ''):
+          for block in iter(partial(f.read, 64), b''):
               process_block(block)
 
 


### PR DESCRIPTION
read returns bytes for a file opened in binary mode,
so b'' should be used as a sentinel instead of ''.
Otherwise the loop will be infinite.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
