### PR TITLE
bpo-36035: pathlib.Path().rglob() breaks with broken symlinks

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -7,7 +7,7 @@ import posixpath
 import re
 import sys
 from _collections_abc import Sequence
-from errno import EINVAL, ENOENT, ENOTDIR, EBADF
+from errno import EINVAL, ENOENT, ENOTDIR, EBADF, ELOOP
 from operator import attrgetter
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
@@ -35,7 +35,7 @@ __all__ = [
 #
 
 # EBADF - guard agains macOS `stat` throwing EBADF
-_IGNORED_ERROS = (ENOENT, ENOTDIR, EBADF)
+_IGNORED_ERROS = (ENOENT, ENOTDIR, EBADF, ELOOP)
 
 _IGNORED_WINERRORS = (
     21,  # ERROR_NOT_READY - drive exists but is not accessible

--- a/Misc/NEWS.d/next/Library/2019-02-20-22-04-20.bpo-36035.zJ0TEX.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-20-22-04-20.bpo-36035.zJ0TEX.rst
@@ -1,0 +1,2 @@
+Ignoring ELOOP error on pathlib to avoid raise exceptions when symlinks are
+broken.


### PR DESCRIPTION
[bpo-36035](https://bugs.python.org/issue36035): adding ELOOP variable to _IGNORED_ERROS 


Based on  Jörg Stucke suggestion


<!-- issue-number: [bpo-36035](https://bugs.python.org/issue36035) -->
https://bugs.python.org/issue36035
<!-- /issue-number -->
