### PR TITLE
bpo-36061: Fix arcname bug in zipfile module on Windows

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1088,6 +1088,8 @@ class ZipFile(object):
             # remove trailing dots
             arcname = (x.rstrip('.') for x in arcname.split(os.path.sep))
             arcname = os.path.sep.join(x for x in arcname if x)
+            # Filename encodings use cp437 on Windows
+            arcname = arcname.decode('cp437')
 
         targetpath = os.path.join(targetpath, arcname)
         targetpath = os.path.normpath(targetpath)


### PR DESCRIPTION
Fixes an issue that occurs on Windows when the file names inside a zipfile contain non-ascii characters.

Filenames inside zipfiles in Windows are encoded using the cp437 codepage. In order to extract files that contain non-ascii characters the filename needs to be decoded properly. There may be some additional work to do for adding files to a zip that have non-ascii characters, but I don't know where that code is.

I'm not sure this is the best fix as I'm not familiar with the inner workings of Python. But this worked in scenario I was testing. I'm happy to make any changes or updates to this fix.

<!-- issue-number: [bpo-36061](https://bugs.python.org/issue36061) -->
https://bugs.python.org/issue36061
<!-- /issue-number -->
