### PR TITLE
bpo-31904: Add cross-build support for VxWorks RTOS

### DIFF
--- a/Include/osdefs.h
+++ b/Include/osdefs.h
@@ -14,6 +14,10 @@ extern "C" {
 #define DELIM L';'
 #endif
 
+#ifdef __VXWORKS__
+#define DELIM L';'
+#endif
+
 /* Filename separator */
 #ifndef SEP
 #define SEP L'/'

--- a/Misc/NEWS.d/next/Build/2019-02-21-14-48-31.bpo-31904.J82jY2.rst
+++ b/Misc/NEWS.d/next/Build/2019-02-21-14-48-31.bpo-31904.J82jY2.rst
@@ -1,1 +1,1 @@
-Enable cpython build system to cross-build for VxWorks RTOS.
+Enable build system to cross-build for VxWorks RTOS.

--- a/Misc/NEWS.d/next/Build/2019-02-21-14-48-31.bpo-31904.J82jY2.rst
+++ b/Misc/NEWS.d/next/Build/2019-02-21-14-48-31.bpo-31904.J82jY2.rst
@@ -1,0 +1,1 @@
+Enable cpython build system to cross-build for VxWorks RTOS.

--- a/configure
+++ b/configure
@@ -3268,6 +3268,9 @@ then
 	*-*-cygwin*)
 		ac_sys_system=Cygwin
 		;;
+	*-*-vxworks*)
+	    ac_sys_system=VxWorks
+	    ;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -3311,6 +3314,9 @@ if test "$cross_compiling" = yes; then
 		;;
 	*-*-cygwin*)
 		_host_cpu=
+		;;
+	*-*-vxworks*)
+		_host_cpu=$host_cpu
 		;;
 	*)
 		# for now, limit cross builds to known configurations
@@ -3397,6 +3403,11 @@ $as_echo "#define _BSD_SOURCE 1" >>confdefs.h
   # On QNX 6.3.2, defining _XOPEN_SOURCE prevents netdb.h from
   # defining NI_NUMERICHOST.
   QNX/6.3.2)
+    define_xopen_source=no
+    ;;
+  # On VxWorks, defining _XOPEN_SOURCE causes compile failures
+  # in network headers still using system V types.
+  VxWorks/*)
     define_xopen_source=no
     ;;
 
@@ -5283,6 +5294,8 @@ cat >> conftest.c <<EOF
         i386-gnu
 #elif defined(__APPLE__)
         darwin
+#elif defined(__VXWORKS__)
+        vxworks
 #else
 # error unknown platform triplet
 #endif
@@ -9391,7 +9404,7 @@ then
 			BLDSHARED="$LDSHARED"
 		fi
 		;;
-	Linux*|GNU*|QNX*)
+	Linux*|GNU*|QNX*|VxWorks*)
 		LDSHARED='$(CC) -shared'
 		LDCXXSHARED='$(CXX) -shared';;
 	FreeBSD*)
@@ -9472,6 +9485,8 @@ then
 		then CCSHARED="-fPIC"
 		else CCSHARED="-Kpic -belf"
 		fi;;
+	VxWorks*)
+		CCSHARED="-fpic -D__SO_PICABILINUX__  -ftls-model=global-dynamic"
 	esac
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CCSHARED" >&5
@@ -9530,6 +9545,8 @@ then
 		# to 2048 kilobytes so that the stack doesn't overflow
 		# when running test_compile.py.
 		LINKFORSHARED='-Wl,-E -N 2048K';;
+	VxWorks*)
+		LINKFORSHARED='--export-dynamic';;
 	esac
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LINKFORSHARED" >&5
@@ -11459,7 +11476,7 @@ for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  sigtimedwait sigwait sigwaitinfo snprintf strftime strlcpy strsignal symlinkat sync \
  sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile tmpnam tmpnam_r \
  truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \
- wcscoll wcsftime wcsxfrm wmemcmp writev _getpty
+ wcscoll wcsftime wcsxfrm wmemcmp writev _getpty rtpSpawn
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
@@ -15079,7 +15096,7 @@ $as_echo "$SOABI" >&6; }
 
 
 case $ac_sys_system in
-    Linux*|GNU*|Darwin)
+    Linux*|GNU*|Darwin|VxWorks)
 	EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX};;
     *)
 	EXT_SUFFIX=${SHLIB_SUFFIX};;

--- a/configure
+++ b/configure
@@ -11476,7 +11476,7 @@ for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  sigtimedwait sigwait sigwaitinfo snprintf strftime strlcpy strsignal symlinkat sync \
  sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile tmpnam tmpnam_r \
  truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \
- wcscoll wcsftime wcsxfrm wmemcmp writev _getpty rtpSpawn
+ wcscoll wcsftime wcsxfrm wmemcmp writev _getpty
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -3534,7 +3534,7 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  sigtimedwait sigwait sigwaitinfo snprintf strftime strlcpy strsignal symlinkat sync \
  sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile tmpnam tmpnam_r \
  truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \
- wcscoll wcsftime wcsxfrm wmemcmp writev _getpty rtpSpawn)
+ wcscoll wcsftime wcsxfrm wmemcmp writev _getpty)
 
 # Force lchmod off for Linux. Linux disallows changing the mode of symbolic
 # links. Some libc implementations have a stub lchmod implementation that always

--- a/configure.ac
+++ b/configure.ac
@@ -379,6 +379,9 @@ then
 	*-*-cygwin*)
 		ac_sys_system=Cygwin
 		;;
+	*-*-vxworks*)
+	    ac_sys_system=VxWorks
+	    ;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -422,6 +425,9 @@ if test "$cross_compiling" = yes; then
 		;;
 	*-*-cygwin*)
 		_host_cpu=
+		;;
+	*-*-vxworks*)
+		_host_cpu=$host_cpu
 		;;
 	*)
 		# for now, limit cross builds to known configurations
@@ -505,6 +511,11 @@ case $ac_sys_system/$ac_sys_release in
   # On QNX 6.3.2, defining _XOPEN_SOURCE prevents netdb.h from
   # defining NI_NUMERICHOST.
   QNX/6.3.2)
+    define_xopen_source=no
+    ;;
+  # On VxWorks, defining _XOPEN_SOURCE causes compile failures
+  # in network headers still using system V types.
+  VxWorks/*)
     define_xopen_source=no
     ;;
 
@@ -829,6 +840,8 @@ cat >> conftest.c <<EOF
         i386-gnu
 #elif defined(__APPLE__)
         darwin
+#elif defined(__VXWORKS__)
+        vxworks
 #else
 # error unknown platform triplet
 #endif
@@ -2555,7 +2568,7 @@ then
 			BLDSHARED="$LDSHARED"
 		fi
 		;;
-	Linux*|GNU*|QNX*)
+	Linux*|GNU*|QNX*|VxWorks*)
 		LDSHARED='$(CC) -shared'
 		LDCXXSHARED='$(CXX) -shared';;
 	FreeBSD*)
@@ -2634,6 +2647,8 @@ then
 		then CCSHARED="-fPIC"
 		else CCSHARED="-Kpic -belf"
 		fi;;
+	VxWorks*)
+		CCSHARED="-fpic -D__SO_PICABILINUX__  -ftls-model=global-dynamic"
 	esac
 fi
 AC_MSG_RESULT($CCSHARED)
@@ -2690,6 +2705,8 @@ then
 		# to 2048 kilobytes so that the stack doesn't overflow
 		# when running test_compile.py.
 		LINKFORSHARED='-Wl,-E -N 2048K';;
+	VxWorks*)
+		LINKFORSHARED='--export-dynamic';;		
 	esac
 fi
 AC_MSG_RESULT($LINKFORSHARED)
@@ -3517,7 +3534,7 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  sigtimedwait sigwait sigwaitinfo snprintf strftime strlcpy strsignal symlinkat sync \
  sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile tmpnam tmpnam_r \
  truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \
- wcscoll wcsftime wcsxfrm wmemcmp writev _getpty)
+ wcscoll wcsftime wcsxfrm wmemcmp writev _getpty rtpSpawn)
 
 # Force lchmod off for Linux. Linux disallows changing the mode of symbolic
 # links. Some libc implementations have a stub lchmod implementation that always
@@ -4578,7 +4595,7 @@ AC_MSG_RESULT($SOABI)
 
 AC_SUBST(EXT_SUFFIX)
 case $ac_sys_system in
-    Linux*|GNU*|Darwin)
+    Linux*|GNU*|Darwin|VxWorks)
 	EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX};;
     *)
 	EXT_SUFFIX=${SHLIB_SUFFIX};;

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -144,18 +144,6 @@
 /* Define to 1 if you have the `copysign' function. */
 #undef HAVE_COPYSIGN
 
-/* Define to 1 if you must link with -lrt for shm_open(). */
-#undef SHM_NEEDS_LIBRT
-
-/* Define to 1 if you have the <sys/mman.h> header file. */
-#undef HAVE_SYS_MMAN_H
-
-/* Define to 1 if you have the shm_open syscall */
-#undef HAVE_SHM_OPEN
-
-/* Define to 1 if you have the shm_unlink syscall */
-#undef HAVE_SHM_UNLINK
-
 /* Define to 1 if you have the <crypt.h> header file. */
 #undef HAVE_CRYPT_H
 
@@ -843,9 +831,6 @@
 /* Define to 1 if you have the `round' function. */
 #undef HAVE_ROUND
 
-/* Define to 1 if you have the `rtpSpawn' function. */
-#undef HAVE_RTPSPAWN
-
 /* Define to 1 if you have the `sched_get_priority_max' function. */
 #undef HAVE_SCHED_GET_PRIORITY_MAX
 
@@ -932,6 +917,12 @@
 
 /* Define to 1 if you have the <shadow.h> header file. */
 #undef HAVE_SHADOW_H
+
+/* Define to 1 if you have the `shm_open' function. */
+#undef HAVE_SHM_OPEN
+
+/* Define to 1 if you have the `shm_unlink' function. */
+#undef HAVE_SHM_UNLINK
 
 /* Define to 1 if you have the `sigaction' function. */
 #undef HAVE_SIGACTION
@@ -1111,6 +1102,9 @@
 
 /* Define to 1 if you have the <sys/mkdev.h> header file. */
 #undef HAVE_SYS_MKDEV_H
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#undef HAVE_SYS_MMAN_H
 
 /* Define to 1 if you have the <sys/modem.h> header file. */
 #undef HAVE_SYS_MODEM_H
@@ -1385,6 +1379,9 @@
 
 /* Define if setpgrp() must be called as setpgrp(0, 0). */
 #undef SETPGRP_HAVE_ARG
+
+/* Define to 1 if you must link with -lrt for shm_open(). */
+#undef SHM_NEEDS_LIBRT
 
 /* Define if i>>j for signed int i does not extend the sign bit when i < 0 */
 #undef SIGNED_RIGHT_SHIFT_ZERO_FILLS

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -843,6 +843,9 @@
 /* Define to 1 if you have the `round' function. */
 #undef HAVE_ROUND
 
+/* Define to 1 if you have the `rtpSpawn' function. */
+#undef HAVE_RTPSPAWN
+
 /* Define to 1 if you have the `sched_get_priority_max' function. */
 #undef HAVE_SCHED_GET_PRIORITY_MAX
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ def get_platform():
     return sys.platform
 host_platform = get_platform()
 
+_vxworks = ('vxworks' in host_platform)
+
 # Were we compiled --with-pydebug or with #define Py_DEBUG?
 COMPILED_WITH_PYDEBUG = ('--with-pydebug' in sysconfig.get_config_var("CONFIG_ARGS"))
 
@@ -509,12 +511,12 @@ class PyBuildExt(build_ext):
         finally:
             os.unlink(tmpfile)
 
-    def add_gcc_paths(self):
-        gcc = sysconfig.get_config_var('CC')
-        tmpfile = os.path.join(self.build_temp, 'gccpaths')
+    def add_cross_compiling_paths(self):
+        cc = sysconfig.get_config_var('CC')
+        tmpfile = os.path.join(self.build_temp, 'ccpaths')
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        ret = os.system('%s -E -v - </dev/null 2>%s 1>/dev/null' % (gcc, tmpfile))
+        ret = os.system('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
         is_gcc = False
         is_clang = False
         in_incdirs = False
@@ -526,7 +528,7 @@ class PyBuildExt(build_ext):
                     for line in fp.readlines():
                         if line.startswith("gcc version"):
                             is_gcc = True
-                        if line.startswith("clang version"):
+                        elif line.startswith("clang version"):
                             is_clang = True
                         elif line.startswith("#include <...>"):
                             in_incdirs = True
@@ -553,7 +555,7 @@ class PyBuildExt(build_ext):
             add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
         # only change this for cross builds for 3.3, issues on Mageia
         if cross_compiling:
-            self.add_gcc_paths()
+            self.add_cross_compiling_paths()
         self.add_multiarch_paths()
 
         # Add paths specified in the environment variables LDFLAGS and
@@ -725,7 +727,7 @@ class PyBuildExt(build_ext):
         # pwd(3)
         exts.append( Extension('pwd', ['pwdmodule.c']) )
         # grp(3)
-        if 'vxworks' not in host_platform:
+        if not _vxworks:
             exts.append( Extension('grp', ['grpmodule.c']) )
         # spwd, shadow passwords
         if (config_h_vars.get('HAVE_GETSPNAM', False) or
@@ -864,7 +866,7 @@ class PyBuildExt(build_ext):
         else:
             libs = []
 
-        if 'vxworks' not in host_platform:
+        if not _vxworks:
             exts.append( Extension('_crypt', ['_cryptmodule.c'], libraries=libs) )
         elif self.compiler.find_library_file(lib_dirs, 'OPENSSL'):
             libs = ['OPENSSL']
@@ -877,7 +879,7 @@ class PyBuildExt(build_ext):
         exts.append( Extension('_posixsubprocess', ['_posixsubprocess.c']) )
 
         # socket(2)
-        if 'vxworks' not in host_platform :
+        if not _vxworks:
             exts.append( Extension('_socket', ['socketmodule.c'],
                                    depends = ['socketmodule.h']) )
         elif self.compiler.find_library_file(lib_dirs, 'net'):
@@ -1334,7 +1336,7 @@ class PyBuildExt(build_ext):
 
         # Unix-only modules
         if host_platform != 'win32':
-            if 'vxworks' not in host_platform :
+            if not _vxworks:
                 # Steen Lumholt's termios module
                 exts.append( Extension('termios', ['termios.c']) )
                 # Jeremy Hylton's rlimit interface

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def get_platform():
     return sys.platform
 host_platform = get_platform()
 
-_vxworks = ('vxworks' in host_platform)
+VXWORKS = ('vxworks' in host_platform)
 
 # Were we compiled --with-pydebug or with #define Py_DEBUG?
 COMPILED_WITH_PYDEBUG = ('--with-pydebug' in sysconfig.get_config_var("CONFIG_ARGS"))
@@ -727,7 +727,7 @@ class PyBuildExt(build_ext):
         # pwd(3)
         exts.append( Extension('pwd', ['pwdmodule.c']) )
         # grp(3)
-        if not _vxworks:
+        if not VXWORKS:
             exts.append( Extension('grp', ['grpmodule.c']) )
         # spwd, shadow passwords
         if (config_h_vars.get('HAVE_GETSPNAM', False) or
@@ -866,7 +866,7 @@ class PyBuildExt(build_ext):
         else:
             libs = []
 
-        if not _vxworks:
+        if not VXWORKS:
             exts.append( Extension('_crypt', ['_cryptmodule.c'], libraries=libs) )
         elif self.compiler.find_library_file(lib_dirs, 'OPENSSL'):
             libs = ['OPENSSL']
@@ -879,7 +879,7 @@ class PyBuildExt(build_ext):
         exts.append( Extension('_posixsubprocess', ['_posixsubprocess.c']) )
 
         # socket(2)
-        if not _vxworks:
+        if not VXWORKS:
             exts.append( Extension('_socket', ['socketmodule.c'],
                                    depends = ['socketmodule.h']) )
         elif self.compiler.find_library_file(lib_dirs, 'net'):
@@ -1336,7 +1336,7 @@ class PyBuildExt(build_ext):
 
         # Unix-only modules
         if host_platform != 'win32':
-            if not _vxworks:
+            if not VXWORKS:
                 # Steen Lumholt's termios module
                 exts.append( Extension('termios', ['termios.c']) )
                 # Jeremy Hylton's rlimit interface

--- a/setup.py
+++ b/setup.py
@@ -874,10 +874,7 @@ class PyBuildExt(build_ext):
         exts.append( Extension('_csv', ['_csv.c']) )
 
         # POSIX subprocess module helper.
-        if 'vxworks' in host_platform :
-            exts.append( Extension('_vxwapi', ['_vxwapi.c']) )
-        else:
-            exts.append( Extension('_posixsubprocess', ['_posixsubprocess.c']) )
+        exts.append( Extension('_posixsubprocess', ['_posixsubprocess.c']) )
 
         # socket(2)
         if 'vxworks' not in host_platform :


### PR DESCRIPTION
This PR enables cpython build system to cross-build for VxWorks RTOS. More and full support on modules for VxWorks will continuously be added by the coming PRs.
VxWorks is a product developed and owned by Wind River. For VxWorks introduction or more details, go to https://www.windriver.com/products/vxworks/
Wind River will have a dedicated engineering team to contribute to the support as maintainers.
We already have a working buildbot worker internally, but has not bound to master. We will check the process for the buildbot, then add it.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
