### PR TITLE
bpo-36060: Document how collections.ChainMap() determines iteration order

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -100,6 +100,22 @@ The class can be used to simulate nested scopes and is useful in templating.
         :func:`super` function.  A reference to ``d.parents`` is equivalent to:
         ``ChainMap(*d.maps[1:])``.
 
+    Note, the iteration order of a :class:`ChainMap()` is determined by
+    scanning the mappings last to first::
+
+
+        >>> baseline = {'music': 'bach', 'art': 'rembrandt'}
+        >>> adjustments = {'art': 'van gogh', 'opera': 'carmen'}
+        >>> list(ChainMap(adjustments, baseline))
+        ['music', 'art', 'opera']
+
+    This gives the same ordering as a series of :meth:`dict.update` calls
+    starting with the last mapping::
+
+        >>> combined = baseline.copy()
+        >>> combined.update(adjustments)
+        >>> list(combined)
+        ['music', 'art', 'opera']
 
 .. seealso::
 

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -103,7 +103,6 @@ The class can be used to simulate nested scopes and is useful in templating.
     Note, the iteration order of a :class:`ChainMap()` is determined by
     scanning the mappings last to first::
 
-
         >>> baseline = {'music': 'bach', 'art': 'rembrandt'}
         >>> adjustments = {'art': 'van gogh', 'opera': 'carmen'}
         >>> list(ChainMap(adjustments, baseline))

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -116,7 +116,7 @@ class TestChainMap(unittest.TestCase):
     def test_ordering(self):
         # The combined order is the same a series of dict updates from last to first.
         # This test relies on the ordering of the underlying dicts.
-        
+
         baseline = {'music': 'bach', 'art': 'rembrandt'}
         adjustments = {'art': 'van gogh', 'opera': 'carmen'}
 

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -113,6 +113,20 @@ class TestChainMap(unittest.TestCase):
         self.assertEqual(f['b'], 5)                                    # find first in chain
         self.assertEqual(f.parents['b'], 2)                            # look beyond maps[0]
 
+    def test_ordering(self):
+        # The combined order is the same a series of dict updates from last to first.
+        # This test relies on the ordering of the underlying dicts.
+        
+        baseline = {'music': 'bach', 'art': 'rembrandt'}
+        adjustments = {'art': 'van gogh', 'opera': 'carmen'}
+
+        cm = ChainMap(adjustments, baseline)
+
+        combined = baseline.copy()
+        combined.update(adjustments)
+
+        self.assertEqual(list(combined.items()), list(cm.items()))
+
     def test_constructor(self):
         self.assertEqual(ChainMap().maps, [{}])                        # no-args --> one new dict
         self.assertEqual(ChainMap({1:2}).maps, [{1:2}])                # 1 arg --> list

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -114,7 +114,7 @@ class TestChainMap(unittest.TestCase):
         self.assertEqual(f.parents['b'], 2)                            # look beyond maps[0]
 
     def test_ordering(self):
-        # The combined order is the same a series of dict updates from last to first.
+        # Combined order matches a series of dict updates from last to first.
         # This test relies on the ordering of the underlying dicts.
 
         baseline = {'music': 'bach', 'art': 'rembrandt'}


### PR DESCRIPTION


<!-- issue-number: [bpo-36060](https://bugs.python.org/issue36060) -->
https://bugs.python.org/issue36060
<!-- /issue-number -->
