### PR TITLE
bpo-36064: Fix the encoding when sending an iterable object via urllib.request.Request

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1050,6 +1050,8 @@ class HTTPConnection:
 
                 if encode_chunked and self._http_vsn == 11:
                     # chunked encoding
+                    if isinstance(chunk, str):
+                        chunk = chunk.encode('ascii')
                     chunk = f'{len(chunk):X}\r\n'.encode('ascii') + chunk \
                         + b'\r\n'
                 self.send(chunk)

--- a/Misc/NEWS.d/next/Library/2019-02-21-13-39-45.bpo-36064.n5nRxN.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-21-13-39-45.bpo-36064.n5nRxN.rst
@@ -1,0 +1,2 @@
+Fix the encoding when sending an iterable object via urllib.request.Request.
+Contributed by Stéphane Wirtel.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36064](https://bugs.python.org/issue36064) -->
https://bugs.python.org/issue36064
<!-- /issue-number -->
