### PR TITLE
bpo-22865: Expand on documentation for the pty.spawn function

### DIFF
--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -51,13 +51,18 @@ The :mod:`pty` module defines the following functions:
    which they should read from, and they should always return a byte
    string. Returning an empty byte string from either callback is interpreted as
    an end-of-file (EOF) condition, and that callback will not be called after
-   that.
+   that. This is not recommended. Instead, the graceful way to force the *spawn*
+   to return before the child process exits is to raise *OsError*.
 
-   In general, manually signaling EOF from one of the read callback will not
-   behave well. If *stdin_read* returns EOF the controlling terminal can no
-   longer communicate with.
+   In general, manually signaling EOF without receiving it from the underlying
+   file descriptor from one or both of the read callbacks will not behave
+   well. If *stdin_read* signals EOF the controlling terminal can no longer
+   communicate with the parent process OR the child process. Unless the child
+   process will quit without any input, *spawn* will then loop forever. If
+   *master_read* signals EOF the same behavior results (on linux at least).
 
-   If both callbacks signal EOF then *spawn* will block indefinitely. This
+   If both callbacks signal EOF then *spawn* will probably never return, unless
+   *select* throws an error on your platform when passed three empty lists. This
    is a bug, documented in `issue 26228 <https://bugs.python.org/issue26228>`_.
 
    The default implementation for both functions will read and return up to 1024

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -45,9 +45,12 @@ The :mod:`pty` module defines the following functions:
    process's standard io. This is often used to baffle programs which insist on
    reading from the controlling terminal.
 
-   The functions *master_read* and *stdin_read* should be functions which read from
-   a file descriptor. The defaults try to read 1024 bytes each time they are
-   called.
+   The functions *master_read* and *stdin_read* are passed a file
+   descriptor which they should read from, and should return a byte
+   string. The default implementation for both functions will read up
+   to 1024 bytes each time the function is called. Returning an empty
+   byte string is interpreted as an end of file (EOF) condition, and
+   that *_read* function will no longer be called.
 
    .. versionchanged:: 3.4
       :func:`spawn` now returns the status value from :func:`os.waitpid`

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -49,12 +49,12 @@ The :mod:`pty` module defines the following functions:
 
    The functions *master_read* and *stdin_read* are passed a file descriptor
    which they should read from, and they should always return a byte string. In
-   order to force spawn to return before the child process exits an *OsError*
-   should be thrown.
+   order to force spawn to return before the child process exits an
+   :exc:`OSError` should be thrown.
 
    The default implementation for both functions will read and return up to 1024
-   bytes each time the function is called. *Master_read* is passed the
-   pseudoterminal’s master file descriptor to read output from the child
+   bytes each time the function is called. The *master_read* callback is passed
+   the pseudoterminal’s master file descriptor to read output from the child
    process, and *stdin_read* is passed file descriptor 0, to read from the
    parent process's standard input.
 

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -48,15 +48,19 @@ The :mod:`pty` module defines the following functions:
    will return.
 
    The functions *master_read* and *stdin_read* are passed a file descriptor
-   which they should read from, and they should always return a byte
-   string. Returning an empty byte string from either callback is interpreted as
-   an end-of-file (EOF) condition, and that callback will not be called after
-   that. This is not recommended. Instead, the graceful way to force the *spawn*
-   to return before the child process exits is to raise *OsError*.
+   which they should read from, and they should always return a byte string. In
+   order to force spawn to return before the child process exits an *OsError*
+   should be thrown.
 
-   In general, manually signaling EOF without receiving it from the underlying
-   file descriptor from one or both of the read callbacks will not behave
-   well. If *stdin_read* signals EOF the controlling terminal can no longer
+   The default implementation for both functions will read and return up to 1024
+   bytes each time the function is called. *Master_read* is passed the
+   pseudoterminal’s master file descriptor to read output from the child
+   process, and *stdin_read* is passed file descriptor 0, to read from the
+   parent process's standard input.
+
+   Returning an empty byte string from either callback is interpreted as an
+   end-of-file (EOF) condition, and that callback will not be called after
+   that. If *stdin_read* signals EOF the controlling terminal can no longer
    communicate with the parent process OR the child process. Unless the child
    process will quit without any input, *spawn* will then loop forever. If
    *master_read* signals EOF the same behavior results (on linux at least).
@@ -65,11 +69,6 @@ The :mod:`pty` module defines the following functions:
    *select* throws an error on your platform when passed three empty lists. This
    is a bug, documented in `issue 26228 <https://bugs.python.org/issue26228>`_.
 
-   The default implementation for both functions will read and return up to 1024
-   bytes each time the function is called. *Master_read* is passed the
-   pseudoterminal’s master file descriptor to read output from the child
-   process, and *stdin_read* is passed file descriptor 0, to read from the
-   parent process's standard input.
 
    .. versionchanged:: 3.4
       :func:`spawn` now returns the status value from :func:`os.waitpid`

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -43,14 +43,28 @@ The :mod:`pty` module defines the following functions:
 
    Spawn a process, and connect its controlling terminal with the current
    process's standard io. This is often used to baffle programs which insist on
-   reading from the controlling terminal.
+   reading from the controlling terminal. It is expected that the process
+   spawned behind the pty will eventually terminate, and when it does *spawn*
+   will return.
 
-   The functions *master_read* and *stdin_read* are passed a file
-   descriptor which they should read from, and should return a byte
-   string. The default implementation for both functions will read up
-   to 1024 bytes each time the function is called. Returning an empty
-   byte string is interpreted as an end of file (EOF) condition, and
-   that *_read* function will no longer be called.
+   The functions *master_read* and *stdin_read* are passed a file descriptor
+   which they should read from, and they should always return a byte
+   string. Returning an empty byte string from either callback is interpreted as
+   an end-of-file (EOF) condition, and that callback will not be called after
+   that.
+
+   In general, manually signaling EOF from one of the read callback will not
+   behave well. If *stdin_read* returns EOF the controlling terminal can no
+   longer communicate with.
+
+   If both callbacks signal EOF then *spawn* will block indefinitely. This
+   is a bug, documented in `issue 26228 <https://bugs.python.org/issue26228>`_.
+
+   The default implementation for both functions will read and return up to 1024
+   bytes each time the function is called. *Master_read* is passed the
+   pseudoterminal’s master file descriptor to read output from the child
+   process, and *stdin_read* is passed file descriptor 0, to read from the
+   parent process's standard input.
 
    .. versionchanged:: 3.4
       :func:`spawn` now returns the status value from :func:`os.waitpid`

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1858,3 +1858,4 @@ Zheao Li
 Carsten Klein
 Diego Rojas
 Edison Abahurire
+Geoff Shannon

--- a/Misc/NEWS.d/next/Documentation/2019-02-21-18-13-50.bpo-22865.6hg6J8.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-02-21-18-13-50.bpo-22865.6hg6J8.rst
@@ -1,0 +1,1 @@
+Add detail to the documentation on the `pty.spawn` function.


### PR DESCRIPTION
Documentation enhancements for the `pyt.spawn` function as discussed in [issue 22865](https://bugs.python.org/issue22865).

<!-- issue-number: [bpo-22865](https://bugs.python.org/issue22865) -->
https://bugs.python.org/issue22865
<!-- /issue-number -->
