### PR TITLE
bpo-36074: Result of  `asyncio.Server.sockets` after `Server.close()` after  is not clear

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1394,14 +1394,12 @@ Do not instantiate the class directly.
 
    .. attribute:: sockets
 
-      List of :class:`socket.socket` objects the server is listening on,
-      or ``None`` if the server is closed.
+      List of :class:`socket.socket` objects the server is listening on.
 
       .. versionchanged:: 3.7
          Prior to Python 3.7 ``Server.sockets`` used to return an
          internal list of server sockets directly.  In 3.7 a copy
-         of that list is returned. `None` is still returned when
-         the server is closed.
+         of that list is returned.
 
 
 .. _asyncio-event-loops:

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1400,7 +1400,8 @@ Do not instantiate the class directly.
       .. versionchanged:: 3.7
          Prior to Python 3.7 ``Server.sockets`` used to return an
          internal list of server sockets directly.  In 3.7 a copy
-         of that list is returned.
+         of that list is returned. `None` is still returned when
+         the server is closed.
 
 
 .. _asyncio-event-loops:


### PR DESCRIPTION
[bpo-36074](https://bugs.python.org/issue36074): It becomes clear on  that the None is still return for server closed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36074](https://bugs.python.org/issue36074) -->
https://bugs.python.org/issue36074
<!-- /issue-number -->
