### PR TITLE
bpo-33927: Pass stdin and stdout are default arguments to argpars infile/outfile

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -21,17 +21,19 @@ def main():
                    'to validate and pretty-print JSON objects.')
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('infile', nargs='?', type=argparse.FileType(),
-                        help='a JSON file to be validated or pretty-printed')
+                        help='a JSON file to be validated or pretty-printed',
+                        default=sys.stdin)
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
-                        help='write the output of infile to outfile')
+                        help='write the output of infile to outfile',
+                        default=sys.stdout)
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
     parser.add_argument('--json-lines', action='store_true', default=False,
                         help='parse input using the jsonlines format')
     options = parser.parse_args()
 
-    infile = options.infile or sys.stdin
-    outfile = options.outfile or sys.stdout
+    infile = options.infile
+    outfile = options.outfile
     sort_keys = options.sort_keys
     json_lines = options.json_lines
     with infile, outfile:


### PR DESCRIPTION
Argparse can handle default value as stdin and stdout for parameters
as a file type (infile, outfile).

- No issue just a minor improvement on args handeling.
- Not a backport




<!-- issue-number: [bpo-33927](https://bugs.python.org/issue33927) -->
https://bugs.python.org/issue33927
<!-- /issue-number -->
