### PR TITLE
[3.4] Max Workers is none for ThreadPoolExecutor bpo-36087 

### DIFF
--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -10,6 +10,7 @@ from concurrent.futures import _base
 import queue
 import threading
 import weakref
+import os
 
 # Workers are created as daemon threads. This is done to allow the interpreter
 # to exit when there are still idle threads in a ThreadPoolExecutor's thread
@@ -87,6 +88,13 @@ class ThreadPoolExecutor(_base.Executor):
             max_workers: The maximum number of threads that can be used to
                 execute the given calls.
         """
+        if max_workers is None:
+            # Use this number because ThreadPoolExecutor is often
+            # used to overlap I/O instead of CPU work.
+            max_workers = (os.cpu_count() or 1) * 5
+        if max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+
         self._max_workers = max_workers
         self._work_queue = queue.Queue()
         self._threads = set()


### PR DESCRIPTION
Handles the case when `max_workers=None`. Now, `ThreadPoolExecutor` has the same functionality as 3.5+, it will automatically create as many threads as cpus.

<!-- issue-number: [bpo-36087](https://bugs.python.org/issue36087) -->
https://bugs.python.org/issue36087
<!-- /issue-number -->
