### PR TITLE
[2.7] bpo-36089: Fix formatting and spelling of SimpleHTTPServer docs

### DIFF
--- a/Doc/library/simplehttpserver.rst
+++ b/Doc/library/simplehttpserver.rst
@@ -13,7 +13,7 @@
 
 .. warning::
 
-   mod:`SimpleHTTServer` is not recommended for production. It only implements
+   :mod:`SimpleHTTPServer` is not recommended for production. It only implements
    basic security checks.
 
 The :mod:`SimpleHTTPServer` module defines a single class,


### PR DESCRIPTION
Improperly formatted rst is bleeding onto the page and the module name is misspelled.

https://docs.python.org/2/library/simplehttpserver.html
<!-- issue-number: [bpo-36089](https://bugs.python.org/issue36089) -->
https://bugs.python.org/issue36089
<!-- /issue-number -->
