### PR TITLE
bpo-36091: remove reference to async generator in Lib/types.py

### DIFF
--- a/Lib/types.py
+++ b/Lib/types.py
@@ -62,7 +62,7 @@ except TypeError:
 GetSetDescriptorType = type(FunctionType.__code__)
 MemberDescriptorType = type(FunctionType.__globals__)
 
-del sys, _f, _g, _C, _c,                           # Not for export
+del sys, _f, _g, _C, _c, _ag  # Not for export
 
 
 # Provide a PEP 3115 compliant mechanism for class creation

--- a/Misc/NEWS.d/next/Library/2019-02-23-06-49-06.bpo-36091.26o4Lc.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-23-06-49-06.bpo-36091.26o4Lc.rst
@@ -1,0 +1,1 @@
+Clean up reference to async generator in Lib/types. Patch by Henry Chen.


### PR DESCRIPTION
The types module creates an async generator `_ag` for the purpose of extracting its type. This causes a GeneratorExit exception upon program exit, as can be seen by running the following script:
```
import sys, types

def tr(frame, event, arg):
    print(frame, event, arg)
    return tr

sys.settrace(tr)
```
which outputs
```
<frame object at 0x106c5cd48> call None
<frame object at 0x106c5cd48> exception (<class 'GeneratorExit'>, GeneratorExit(), <traceback object at 0x106cc1f88>)
<frame object at 0x106c5cd48> return None
```
To preempt this, this PR proposes to delete `_ag` after getting its type, which is its sole purpose, like several other objects in the types module.

<!-- issue-number: [bpo-36091](https://bugs.python.org/issue36091) -->
https://bugs.python.org/issue36091
<!-- /issue-number -->
