### PR TITLE
bpo-35652: shutil.copytree(copy_function=...): pass DirEntry instead of path str 

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -472,7 +472,7 @@ def _copytree(entries, src, dst, symlinks, ignore, copy_function,
                          dirs_exist_ok=dirs_exist_ok)
             else:
                 # Will raise a SpecialFileError for unsupported file types
-                copy_function(srcentry, dstname)
+                copy_function(srcobj, dstname)
         # catch the Error from the recursive copytree so that we can
         # continue with other files
         except Error as err:

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -861,6 +861,24 @@ class TestShutil(unittest.TestCase):
         with self.assertRaises(shutil.Error):
             shutil.copytree(src_dir, dst_dir)
 
+    def test_copytree_custom_copy_function(self):
+        # See: https://bugs.python.org/issue35648
+        def custom_cpfun(a, b):
+            flag.append(None)
+            self.assertIsInstance(a, str)
+            self.assertIsInstance(b, str)
+            self.assertEqual(a, os.path.join(src, 'foo'))
+            self.assertEqual(b, os.path.join(dst, 'foo'))
+
+        flag = []
+        src = tempfile.mkdtemp()
+        dst = tempfile.mktemp()
+        self.addCleanup(shutil.rmtree, src)
+        with open(os.path.join(src, 'foo'), 'w') as f:
+            f.close()
+        shutil.copytree(src, dst, copy_function=custom_cpfun)
+        self.assertEqual(len(flag), 1)
+
     @unittest.skipIf(os.name == 'nt', 'temporarily disabled on Windows')
     @unittest.skipUnless(hasattr(os, 'link'), 'requires os.link')
     def test_dont_copy_file_onto_link_to_itself(self):

--- a/Misc/NEWS.d/next/Library/2019-02-26-11-34-44.bpo-35652.6KRJu_.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-26-11-34-44.bpo-35652.6KRJu_.rst
@@ -1,0 +1,2 @@
+shutil.copytree(copy_function=...) erroneously pass DirEntry instead of a
+path string.


### PR DESCRIPTION
This is related to the work I made in [BPO-33695](https://bugs.python.org/issue33695) and https://github.com/python/cpython/pull/7874 in which I inadvertently introduced a bug: if `copy_function` is specified src argument is a `DirEntry` instead of a `path` string. This PR fixes that issue.

<!-- issue-number: [bpo-35652](https://bugs.python.org/issue35652) -->
https://bugs.python.org/issue35652
<!-- /issue-number -->
