### PR TITLE
bpo-36094: Fix a bug in smtplib module

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -1038,7 +1038,7 @@ if _have_ssl:
             new_socket = socket.create_connection((host, port), timeout,
                     self.source_address)
             new_socket = self.context.wrap_socket(new_socket,
-                                                  server_hostname=self._host)
+                                                  server_hostname=host)
             return new_socket
 
     __all__.append("SMTP_SSL")

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -319,6 +319,7 @@ class SMTP:
         specified during instantiation.
 
         """
+        self._host = host
 
         if source_address:
             self.source_address = source_address
@@ -1038,7 +1039,7 @@ if _have_ssl:
             new_socket = socket.create_connection((host, port), timeout,
                     self.source_address)
             new_socket = self.context.wrap_socket(new_socket,
-                                                  server_hostname=host)
+                                                  server_hostname=self._host)
             return new_socket
 
     __all__.append("SMTP_SSL")


### PR DESCRIPTION
The following bug occurs when you connect after creating an instance of SMTP_SSL:
```
import smtplib


smtp_server = "smtp.163.com"
con2 = smtplib.SMTP_SSL()
con2.connect(smtp_server, 465)
```
ValueError:
server_hostname cannot be an empty string or start with a leading dot.
  File "E:\code\noUse.py", line 8, in <module>
    con2.connect(smtp_server, 465)

![1](https://user-images.githubusercontent.com/37615298/53289900-80358c00-37d7-11e9-834d-8353a3262a1c.png)
![2](https://user-images.githubusercontent.com/37615298/53289901-80358c00-37d7-11e9-9027-15839698b51e.png)
![3](https://user-images.githubusercontent.com/37615298/53289902-80358c00-37d7-11e9-8051-dad74a166326.png)
![4](https://user-images.githubusercontent.com/37615298/53289903-80358c00-37d7-11e9-93b5-cf375970e81e.png)
![5](https://user-images.githubusercontent.com/37615298/53289904-80ce2280-37d7-11e9-909d-2d2348be01e7.png)


<!-- issue-number: [bpo-36094](https://bugs.python.org/issue36094) -->
https://bugs.python.org/issue36094
<!-- /issue-number -->
