### PR TITLE
bpo-35512: Resolve string target to patch.dict decorator during function call

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1662,8 +1662,6 @@ class _patch_dict(object):
         values = self.values
         if isinstance(self.in_dict, str):
             self.in_dict = _importer(self.in_dict)
-        else:
-            self.in_dict = self.in_dict
         in_dict = self.in_dict
         clear = self.clear
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1620,8 +1620,6 @@ class _patch_dict(object):
     """
 
     def __init__(self, in_dict, values=(), clear=False, **kwargs):
-        if isinstance(in_dict, str):
-            in_dict = _importer(in_dict)
         self.in_dict = in_dict
         # support any argument supported by dict(...) constructor
         self.values = dict(values)
@@ -1662,6 +1660,10 @@ class _patch_dict(object):
 
     def _patch_dict(self):
         values = self.values
+        if isinstance(self.in_dict, str):
+            self.in_dict = _importer(self.in_dict)
+        else:
+            self.in_dict = self.in_dict
         in_dict = self.in_dict
         clear = self.clear
 

--- a/Lib/unittest/test/testmock/support.py
+++ b/Lib/unittest/test/testmock/support.py
@@ -1,3 +1,6 @@
+target = {'foo': 'FOO'}
+
+
 def is_instance(obj, klass):
     """Version of is_instance that doesn't access __class__"""
     return issubclass(type(obj), klass)

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -676,6 +676,7 @@ class PatchTest(unittest.TestCase):
         try:
             support.target = {'foo': 'BAZ'}
             test()
+            self.assertEqual(support.target, {'foo': 'BAZ'})
         finally:
             support.target = original
 

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -667,16 +667,17 @@ class PatchTest(unittest.TestCase):
     def test_patch_dict_decorator_resolution(self):
         # bpo-35512: Ensure that patch with a string target resolves to
         # the new dictionary during function call
+        original = support.target.copy()
+
         @patch.dict('unittest.test.testmock.support.target', {'bar': 'BAR'})
         def test():
-            self.assertEqual(support.target['foo'], 'BAZ')
-            self.assertEqual(support.target['bar'], 'BAR')
+            self.assertEqual(support.target, {'foo': 'BAZ', 'bar': 'BAR'})
 
-        support.target = {'foo': 'BAZ'}
-        test()
-
-        self.assertEqual(support.target['foo'], 'BAZ')
-        self.assertNotIn('bar', support.target)
+        try:
+            support.target = {'foo': 'BAZ'}
+            test()
+        finally:
+            support.target = original
 
 
     def test_patch_descriptor(self):

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -664,6 +664,21 @@ class PatchTest(unittest.TestCase):
         test()
 
 
+    def test_patch_dict_decorator_resolution(self):
+        # bpo-35512: Ensure that patch with a string target resolves to
+        # the new dictionary during function call
+        @patch.dict('unittest.test.testmock.support.target', {'bar': 'BAR'})
+        def test():
+            self.assertEqual(support.target['foo'], 'BAZ')
+            self.assertEqual(support.target['bar'], 'BAR')
+
+        support.target = {'foo': 'BAZ'}
+        test()
+
+        self.assertEqual(support.target['foo'], 'BAZ')
+        self.assertNotIn('bar', support.target)
+
+
     def test_patch_descriptor(self):
         # would be some effort to fix this - we could special case the
         # builtin descriptors: classmethod, property, staticmethod

--- a/Misc/NEWS.d/next/Library/2019-02-24-00-04-10.bpo-35512.eWDjCJ.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-24-00-04-10.bpo-35512.eWDjCJ.rst
@@ -1,0 +1,3 @@
+:func:`unittest.mock.patch.dict` used as a decorator with string target
+resolves the target during function call instead of during decorator
+construction. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
String target provided to `patch.dict` can be reassigned after the decorator decorates the function. So resolve the target before function call to ensure the new reference is patched instead of patching the old reference stored in the constructor.

<!-- issue-number: [bpo-35512](https://bugs.python.org/issue35512) -->
https://bugs.python.org/issue35512
<!-- /issue-number -->
