### PR TITLE
bpo-36095: Better NaN sorting.

### DIFF
--- a/Lib/test/test_sort.py
+++ b/Lib/test/test_sort.py
@@ -259,6 +259,23 @@ class TestDecorateSortUndecorate(unittest.TestCase):
         copy2.sort(key=lambda x: x[0], reverse=True)
         self.assertEqual(data, copy2)
 
+    def test_stable_nan_sorting(self):
+
+        nan = float('nan')
+
+        data = (3, 1, 2, nan, 2.0, 2, 2.0)
+        correct = (1, 2, 2.0, 2, 2.0, 3, nan)
+
+        nestings = (
+                lambda x: x,
+                lambda x: (x,), lambda x: ((x,),),
+                lambda x: [x], lambda x: [[x]],
+                lambda x: ([x],), lambda x: [(x,)], 
+        )
+
+        for nesting in nestings:
+            self.assertEqual(sorted(map(nesting, data)), list(map(nesting, correct)))
+
 #==============================================================================
 def check_against_PyObject_RichCompareBool(self, L):
     ## The idea here is to exploit the fact that unsafe_tuple_compare uses

--- a/Lib/test/test_sort.py
+++ b/Lib/test/test_sort.py
@@ -270,7 +270,7 @@ class TestDecorateSortUndecorate(unittest.TestCase):
                 lambda x: x,
                 lambda x: (x,), lambda x: ((x,),),
                 lambda x: [x], lambda x: [[x]],
-                lambda x: ([x],), lambda x: [(x,)], 
+                lambda x: ([x],), lambda x: [(x,)],
         )
 
         for nesting in nestings:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -222,6 +222,7 @@ Ian Bruntlett
 Floris Bruynooghe
 Matt Bryant
 Stan Bubrouski
+Brandt Bucher
 Colm Buckley
 Erik de Bueger
 Jan-Hein Bührman

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-23-22-50-43.bpo-36095.ALiiiB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-23-22-50-43.bpo-36095.ALiiiB.rst
@@ -1,0 +1,2 @@
+Sorting is no longer mangled by ``NaN`` values; they are now stably pushed to the end of the fully-sorted list.
+Patch by Brandt Bucher.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2053,12 +2053,12 @@ safe_object_compare(PyObject *v, PyObject *w, MergeState *ms)
         if (v->ob_type == &PyFloat_Type)
             return unsafe_float_compare(v, w, ms);
 
-        if (v->ob_type == &PyTuple_Type) {
+        if (v->ob_type == &PyTuple_Type && Py_SIZE(v) && Py_SIZE(w)) {
             ms->elem_compare = safe_object_compare;
             return unsafe_tuple_compare(v, w, ms);
         }
 
-        if (v->ob_type == &PyList_Type) {
+        if (v->ob_type == &PyList_Type && Py_SIZE(v) && Py_SIZE(w)) {
             ms->elem_compare = safe_object_compare;
             return unsafe_list_compare(v, w, ms);
         }


### PR DESCRIPTION
Sorting sequences containing `NaN` values produces an incompletely sorted result. Further, because of the complexity of the timsort, this incomplete sort often silently produces unintuitive, unstable-seeming results that are extremely sensitive to the ordering of the inputs:

```py
>>> sorted([3, 1, 2, float('nan'), 2.0, 2, 2.0])
[1, 2, 2.0, 2.0, 3, nan, 2]
>>> sorted(reversed([3, 1, 2, float('nan'), 2.0, 2, 2.0]))
[1, 2.0, 2, 2.0, nan, 2, 3]
```

The patch I have provided addresses these issues, including for lists containing nested lists/tuples with `NaN` values. Specifically, it stably sorts `NaN`s to the end of the list with no changes to the timsort itself (just the element-wise comparison functions):

```py
>>> sorted([3, 1, 2, float('nan'), 2.0, 2, 2.0])
[1, 2, 2.0, 2, 2.0, 3, nan]
>>> sorted([[3], [1], [2], [float('nan')], [2.0], [2], [2.0]])
[[1], [2], [2.0], [2], [2.0], [3], [nan]]
```

It also includes a new regression test for this behavior.

Some other benefits to this patch:

* These changes generally result in a sorting performance improvement across data types. The largest increases here are for nested lists, since we add a new `unsafe_list_compare` function. Other speed increases are due to `safe_object_compare`'s delegation to unsafe comparison functions for objects of the same type. Specifically, the speed impact (positive is faster, negative is slower) is between:

    * -3% and +3% (10 elements, no PGO)
    * 0% and +4% (10 elements, PGO)
    * 0% and +9% (1000 elements, no PGO)
    * -1% and +9% (1000 elements, PGO)

* The current weird `NaN`-sorting behavior is not documented, so this is not a breaking change.

* IEEE754 compliance is maintained. The result is still a stable (arguably, more stable), nondecreasing ordering of the original list.

<!-- issue-number: [bpo-36095](https://bugs.python.org/issue36095) -->
https://bugs.python.org/issue36095
<!-- /issue-number -->
