### PR TITLE
bpo-36096: IDLE: Refactor class variables in colorizer

### DIFF
--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -55,25 +55,34 @@ def color_config(text):
 class ColorDelegator(Delegator):
     """Delegator for syntax highlighting (text coloring).
 
-    Class variables:
-        after_id: Identifier for scheduled after event.
+    Instance variables:
+        delegate: Delegator below this one in the stack, meaning the
+                one this one delegates to.
+
+        Used to track state:
+        after_id: Identifier for scheduled after event, which is a
+                timer for colorizing the text.
         allow_colorizing: Boolean toggle for applying colorizing.
         colorizing: Boolean flag when colorizing is in process.
         stop_colorizing: Boolean flag to end an active colorizing
                 process.
         close_when_done: Widget to destroy after colorizing process
                 completes (doesn't seem to be used by IDLE).
-
-    Instance variables:
-        delegate: Delegator below this one in the stack, meaning the
-                one this one delegates to.
     """
 
     def __init__(self):
         Delegator.__init__(self)
+        self.init_state()
         self.prog = prog
         self.idprog = idprog
         self.LoadTagDefs()
+
+    def init_state(self):
+        "Initialize variables that track colorizing state."
+        self.after_id = None
+        self.allow_colorizing = True
+        self.stop_colorizing = False
+        self.colorizing = False
 
     def setdelegate(self, delegate):
         """Set the delegate for this instance.
@@ -133,11 +142,6 @@ class ColorDelegator(Delegator):
         index1 = self.index(index1)
         self.delegate.delete(index1, index2)
         self.notify_range(index1)
-
-    after_id = None
-    allow_colorizing = True
-    stop_colorizing = False
-    colorizing = False
 
     def notify_range(self, index1, index2=None):
         "Mark text changes for processing and restart colorizing, if active."

--- a/Lib/idlelib/idle_test/test_colorizer.py
+++ b/Lib/idlelib/idle_test/test_colorizer.py
@@ -100,6 +100,45 @@ class ColorConfigTest(unittest.TestCase):
         eq(text['inactiveselectbackground'], 'gray')
 
 
+class ColorDelegatorInstantiationTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        requires('gui')
+        root = cls.root = Tk()
+        root.withdraw()
+        text = cls.text = Text(root)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.text
+        cls.root.update_idletasks()
+        cls.root.destroy()
+        del cls.root
+
+    def setUp(self):
+        self.color = colorizer.ColorDelegator()
+
+    def tearDown(self):
+        self.color.close()
+        self.text.delete('1.0', 'end')
+        self.color.resetcache()
+        del self.color
+
+    def test_init(self):
+        color = self.color
+        self.assertIsInstance(color, colorizer.ColorDelegator)
+
+    def test_init_state(self):
+        # init_state() is called during the instantiation of
+        # ColorDelegator in setUp().
+        color = self.color
+        self.assertIsNone(color.after_id)
+        self.assertTrue(color.allow_colorizing)
+        self.assertFalse(color.colorizing)
+        self.assertFalse(color.stop_colorizing)
+
+
 class ColorDelegatorTest(unittest.TestCase):
 
     @classmethod
@@ -109,7 +148,7 @@ class ColorDelegatorTest(unittest.TestCase):
         root.withdraw()
         text = cls.text = Text(root)
         cls.percolator = Percolator(text)
-        # Delegator stack = [Delagator(text)]
+        # Delegator stack = [Delegator(text)]
 
     @classmethod
     def tearDownClass(cls):
@@ -122,7 +161,7 @@ class ColorDelegatorTest(unittest.TestCase):
     def setUp(self):
         self.color = colorizer.ColorDelegator()
         self.percolator.insertfilter(self.color)
-        # Calls color.setdelagate(Delagator(text)).
+        # Calls color.setdelegate(Delegator(text)).
 
     def tearDown(self):
         self.color.close()
@@ -131,15 +170,8 @@ class ColorDelegatorTest(unittest.TestCase):
         self.color.resetcache()
         del self.color
 
-    def test_init(self):
-        color = self.color
-        self.assertIsInstance(color, colorizer.ColorDelegator)
-        # The following are class variables.
-        self.assertTrue(color.allow_colorizing)
-        self.assertFalse(color.colorizing)
-
     def test_setdelegate(self):
-        # Called in setUp.
+        # Called in setUp when filter is attached to percolator.
         color = self.color
         self.assertIsInstance(color.delegate, colorizer.Delegator)
         # It is too late to mock notify_range, so test side effect.

--- a/Misc/NEWS.d/next/IDLE/2019-02-23-17-53-53.bpo-36096.mN5Ly3.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-02-23-17-53-53.bpo-36096.mN5Ly3.rst
@@ -1,0 +1,1 @@
+Refactor class variables to instance variables in colorizer.


### PR DESCRIPTION
Refactor class variables to instance variables in `colorizer.py`.


<!-- issue-number: [bpo-36096](https://bugs.python.org/issue36096) -->
https://bugs.python.org/issue36096
<!-- /issue-number -->
