### PR TITLE
bpo-21150: add quick link/summary table to the top of argparse documentation

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -750,7 +750,7 @@ The add_argument() method
 The following sections describe how each of these are used.
 
 
-.. ref:`name or flags`
+.. _name_or_flags:
 
 name or flags
 ^^^^^^^^^^^^^

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -32,11 +32,17 @@ Summary
 Core Functionality
 ^^^^^^^^^^^^^^^^^^
 
-.. csv-table::
-    :header: "Name", "Commonly Used Arguments", "Example"
+The :mod:`argparse` module's support for command-line interfaces is built from the following:
 
-    ":class:`argparse.ArgumentParser`", "`prog`_, `description`_, `formatter_class`_", "``parser = argparse.ArgumentParser(prog='PROG', description='DESC', formatter_class=argparse.RawDescriptionHelpFormatter)``"
-    ":func:`ArgumentParser.add_argument`", "`name or flags`_, `action`_, `default`_, `type`_, `required`_, `help`_", "``parser.add_argument('-v', '--verbose', action='store_true', help='Show various debugging information')``"
+The :class:`argparse.ArgumentParser` creates a new :class:`ArgumentParser` object. Commonly used arguments include `prog`_, `description`_, and `formatter_class`_. For example, the user can create an instance of :class:`ArgumentParser` through the following::
+
+   >>> parser = argparse.ArgumentParser(prog='PROG', description='DESC',
+   ...		   			formatter_class=argparse.RawDescriptionHelpFormatter)
+
+The :func:`ArgumentParser.add_argument` is a function that is used to define how a single command-line argument should be parsed. Commonly used arguments include `name or flags`_, `action`_, `default`_, `type`_, `required`_, and `help`_. An example of the function :func:`ArgumentParser.add_argument` is as follows::
+
+   >>> parser.add_argument('-v', '--verbose', action='store_true',
+   ...		   	   help='Show various debugging information')
 
 
 Basic Usage of :func:`add_argument`
@@ -744,7 +750,7 @@ The add_argument() method
 The following sections describe how each of these are used.
 
 
-.. _name or flags:
+.. ref:`name or flags`
 
 name or flags
 ^^^^^^^^^^^^^

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -26,6 +26,61 @@ module also automatically generates help and usage messages and issues errors
 when users give the program invalid arguments.
 
 
+Summary
+-------
+
+Core Functionality
+^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+    :header: "Name", "Commonly Used Arguments", "Example"
+
+    ":class:`argparse.ArgumentParser`", "`prog`_, `description`_, `formatter_class`_", "``parser = argparse.ArgumentParser(prog='PROG', description='DESC', formatter_class=argparse.RawDescriptionHelpFormatter)``"
+    ":func:`ArgumentParser.add_argument`", "`name or flags`_, `action`_, `default`_, `type`_, `required`_, `help`_", "``parser.add_argument('-v', '--verbose', action='store_true', help='Show various debugging information')``"
+
+
+Basic Usage of :func:`add_argument`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+**Name or Flags Type**
+
+====================== ===========================
+Type                   Example
+====================== ===========================
+Positional             ``'foo'``
+Optional               ``'-v'``, ``'--verbose'``
+====================== ===========================
+
+
+**Basic Arguments:**
+
+====================== =========================================================== =========================================================================================================================
+Name                   Description                                                 Keywords
+====================== =========================================================== =========================================================================================================================
+`action`_              Specifies how an argument should be handled                 ``'store'``, ``'store_const'``, ``'store_true'``, ``'append'``, ``'append_const'``, ``'count'``, ``'help'``, ``'version'``
+`default`_             Default value used when an argument is not provided
+`type`_                Automatically converts an argument to the given type        :class:`int`, :class:`float`, :class:`bool`, ``argparse.FileType('w')``, ``callable function``
+`help`_                Help message of an argument
+====================== =========================================================== =========================================================================================================================
+
+
+
+**Advanced Arguments:**
+
+====================== =========================================================== =======================================================================================================================
+Name                   Description                                                 Keywords
+====================== =========================================================== =======================================================================================================================
+`nargs`_               Associates a single action with the number of arguments     ``N`` (:class:`int`), ``'?'``, ``'*'``, ``'+'``, ``argparse.REMAINDER``
+`const`_               Stores constant values of names or flags
+`choices`_             A container that lists the possible values                  ``['foo', 'bar']``, ``range(1, 10)``, Any object that supports ``in`` operator
+`required`_            Indicates if an optional argument is required or not        ``True``, ``False``
+`metavar`_             An alternative display name for the argument
+`dest`_                Specifies name of attribute to be used in ``parse_args()``
+====================== =========================================================== =======================================================================================================================
+
+
+
 Example
 -------
 
@@ -185,6 +240,8 @@ ArgumentParser objects
 The following sections describe how each of these are used.
 
 
+.. _prog:
+
 prog
 ^^^^
 
@@ -282,6 +339,8 @@ The ``%(prog)s`` format specifier is available to fill in the program name in
 your usage messages.
 
 
+.. _description:
+
 description
 ^^^^^^^^^^^
 
@@ -361,6 +420,8 @@ and one in the child) and raise an error.
    If you change the parent parsers after the child parser, those changes will
    not be reflected in the child.
 
+
+.. _formatter_class:
 
 formatter_class
 ^^^^^^^^^^^^^^^
@@ -683,6 +744,8 @@ The add_argument() method
 The following sections describe how each of these are used.
 
 
+.. _name or flags:
+
 name or flags
 ^^^^^^^^^^^^^
 
@@ -714,6 +777,8 @@ be positional::
    usage: PROG [-h] [-f FOO] bar
    PROG: error: the following arguments are required: bar
 
+
+.. _action:
 
 action
 ^^^^^^
@@ -824,6 +889,9 @@ An example of a custom action::
 
 For more details, see :class:`Action`.
 
+
+.. _nargs:
+	
 nargs
 ^^^^^
 
@@ -924,6 +992,8 @@ is determined by the action_.  Generally this means a single command-line argume
 will be consumed and a single item (not a list) will be produced.
 
 
+.. _const:
+
 const
 ^^^^^
 
@@ -946,6 +1016,8 @@ the various :class:`ArgumentParser` actions.  The two most common uses of it are
 With the ``'store_const'`` and ``'append_const'`` actions, the ``const``
 keyword argument must be given.  For other actions, it defaults to ``None``.
 
+
+.. _default:
 
 default
 ^^^^^^^
@@ -996,6 +1068,8 @@ command-line argument was not present::
    >>> parser.parse_args(['--foo', '1'])
    Namespace(foo='1')
 
+
+.. _type:
 
 type
 ^^^^
@@ -1059,6 +1133,8 @@ simply check against a range of values::
 See the choices_ section for more details.
 
 
+.. _choices:
+
 choices
 ^^^^^^^
 
@@ -1093,7 +1169,9 @@ Any object that supports the ``in`` operator can be passed as the *choices*
 value, so :class:`dict` objects, :class:`set` objects, custom containers,
 etc. are all supported.
 
-
+		      
+.. _required:
+		       
 required
 ^^^^^^^^
 
@@ -1119,6 +1197,8 @@ present at the command line.
     Required options are generally considered bad form because users expect
     *options* to be *optional*, and thus they should be avoided when possible.
 
+
+.. _help:
 
 help
 ^^^^
@@ -1174,6 +1254,8 @@ setting the ``help`` value to ``argparse.SUPPRESS``::
    optional arguments:
      -h, --help  show this help message and exit
 
+
+.. _metavar:
 
 metavar
 ^^^^^^^
@@ -1238,6 +1320,8 @@ arguments::
     -x X X
     --foo bar baz
 
+
+.. _dest:
 
 dest
 ^^^^

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -32,14 +32,22 @@ Summary
 Core Functionality
 ^^^^^^^^^^^^^^^^^^
 
-The :mod:`argparse` module's support for command-line interfaces is built from the following:
+The :mod:`argparse` module's support for command-line interfaces is built
+from the following:
 
-The :class:`argparse.ArgumentParser` creates a new :class:`ArgumentParser` object. Commonly used arguments include `prog`_, `description`_, and `formatter_class`_. For example, the user can create an instance of :class:`ArgumentParser` through the following::
+The :class:`argparse.ArgumentParser` creates a new :class:`ArgumentParser`
+object. Commonly used arguments include prog_, description_, and
+formatter_class_. For example, the user can create an instance of
+:class:`ArgumentParser` through the following::
 
    >>> parser = argparse.ArgumentParser(prog='PROG', description='DESC',
    ...                                  formatter_class=argparse.RawDescriptionHelpFormatter)
 
-The :func:`ArgumentParser.add_argument` is a function that is used to define how a single command-line argument should be parsed. Commonly used arguments include `name or flags`_, `action`_, `default`_, `type`_, `required`_, and `help`_. An example of the function :func:`ArgumentParser.add_argument` is as follows::
+The :func:`ArgumentParser.add_argument` is a function that is used
+to define how a single command-line argument should be parsed. Commonly used
+arguments include `name or flags`_, action_, default_, type_, required_,
+and help_. An example of the function :func:`ArgumentParser.add_argument`
+is as follows::
 
    >>> parser.add_argument('-v', '--verbose', action='store_true',
    ...                     help='Show various debugging information')
@@ -64,10 +72,10 @@ Optional               ``'-v'``, ``'--verbose'``
 ====================== =========================================================== =========================================================================================================================
 Name                   Description                                                 Keywords
 ====================== =========================================================== =========================================================================================================================
-`action`_              Specifies how an argument should be handled                 ``'store'``, ``'store_const'``, ``'store_true'``, ``'append'``, ``'append_const'``, ``'count'``, ``'help'``, ``'version'``
-`default`_             Default value used when an argument is not provided
-`type`_                Automatically converts an argument to the given type        :class:`int`, :class:`float`, :class:`bool`, ``argparse.FileType('w')``, ``callable function``
-`help`_                Help message of an argument
+action_                Specifies how an argument should be handled                 ``'store'``, ``'store_const'``, ``'store_true'``, ``'append'``, ``'append_const'``, ``'count'``, ``'help'``, ``'version'``
+default_               Default value used when an argument is not provided
+type_                  Automatically converts an argument to the given type        :class:`int`, :class:`float`, :class:`bool`, ``argparse.FileType('w')``, ``callable function``
+help_                  Help message of an argument
 ====================== =========================================================== =========================================================================================================================
 
 
@@ -77,12 +85,12 @@ Name                   Description                                              
 ====================== =========================================================== =======================================================================================================================
 Name                   Description                                                 Keywords
 ====================== =========================================================== =======================================================================================================================
-`nargs`_               Associates a single action with the number of arguments     ``N`` (:class:`int`), ``'?'``, ``'*'``, ``'+'``, ``argparse.REMAINDER``
-`const`_               Stores constant values of names or flags
-`choices`_             A container that lists the possible values                  ``['foo', 'bar']``, ``range(1, 10)``, Any object that supports ``in`` operator
-`required`_            Indicates if an optional argument is required or not        ``True``, ``False``
-`metavar`_             An alternative display name for the argument
-`dest`_                Specifies name of attribute to be used in ``parse_args()``
+nargs_                 Associates a single action with the number of arguments     ``N`` (:class:`int`), ``'?'``, ``'*'``, ``'+'``, ``argparse.REMAINDER``
+const_                 Stores constant values of names or flags
+choices_               A container that lists the possible values                  ``['foo', 'bar']``, ``range(1, 10)``, Any object that supports ``in`` operator
+required_              Indicates if an optional argument is required or not        ``True``, ``False``
+metavar_               An alternative display name for the argument
+dest_                  Specifies name of attribute to be used in ``parse_args()``
 ====================== =========================================================== =======================================================================================================================
 
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -37,12 +37,12 @@ The :mod:`argparse` module's support for command-line interfaces is built from t
 The :class:`argparse.ArgumentParser` creates a new :class:`ArgumentParser` object. Commonly used arguments include `prog`_, `description`_, and `formatter_class`_. For example, the user can create an instance of :class:`ArgumentParser` through the following::
 
    >>> parser = argparse.ArgumentParser(prog='PROG', description='DESC',
-   ...		   			formatter_class=argparse.RawDescriptionHelpFormatter)
+   ...                                  formatter_class=argparse.RawDescriptionHelpFormatter)
 
 The :func:`ArgumentParser.add_argument` is a function that is used to define how a single command-line argument should be parsed. Commonly used arguments include `name or flags`_, `action`_, `default`_, `type`_, `required`_, and `help`_. An example of the function :func:`ArgumentParser.add_argument` is as follows::
 
    >>> parser.add_argument('-v', '--verbose', action='store_true',
-   ...		   	   help='Show various debugging information')
+   ...                     help='Show various debugging information')
 
 
 Basic Usage of :func:`add_argument`

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -891,7 +891,7 @@ For more details, see :class:`Action`.
 
 
 .. _nargs:
-	
+
 nargs
 ^^^^^
 
@@ -1169,9 +1169,9 @@ Any object that supports the ``in`` operator can be passed as the *choices*
 value, so :class:`dict` objects, :class:`set` objects, custom containers,
 etc. are all supported.
 
-		      
+
 .. _required:
-		       
+
 required
 ^^^^^^^^
 

--- a/Misc/NEWS.d/next/Documentation/2019-02-24-03-06-59.bpo-21150.Vqv8Yc.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-02-24-03-06-59.bpo-21150.Vqv8Yc.rst
@@ -1,0 +1,1 @@
+Place summary/quick links table at the top of the documentation for the argparse module to benefit ease of use.


### PR DESCRIPTION
A few summary/quick links tables were added to the argparse module documentation in hopes of helping the user to better understand the module. These changes were based on the ones made by Louie Lu in the past, with a couple of revisions. 


<!-- issue-number: [bpo-21150](https://bugs.python.org/issue21150) -->
https://bugs.python.org/issue21150
<!-- /issue-number -->
