### PR TITLE
bpo-33043: Add a Contributing to Docs link and Update the Found a Bug Page

### DIFF
--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -27,7 +27,7 @@ though it may take a while to be processed.
 .. seealso::
 
    `Documentation bugs`_
-      Link to the Python issue tracker. Provides a list of documentation bugs that have been submitted.
+      A list of documentation bugs that have been submitted to the Python issue tracker.
 
    `Issue Tracking <https://devguide.python.org/tracker/>`_
       Overview of the process involved in reporting an improvement on the tracker.

--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -25,7 +25,15 @@ docs@python.org (behavioral bugs can be sent to python-list@python.org).
 though it may take a while to be processed.
 
 .. seealso::
-   `Documentation bugs`_ on the Python issue tracker
+
+   `Documentation bugs`_
+      Link to the Python issue tracker. Provides a list of documentation bugs that have been submitted.
+
+   `Issue Tracking <https://devguide.python.org/tracker/>`_
+      Overview of the process involved in reporting an improvement on the tracker.
+
+   `Helping with Documentation <https://devguide.python.org/docquality/#helping-with-documentation>`_
+      Comprehensive guide for individuals that are interested in contributing to Python documentation.
 
 .. _using-the-tracker:
 

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -57,6 +57,7 @@
   <table class="contentstable" align="center"><tr>
     <td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("bugs") }}">{% trans %}Reporting bugs{% endtrans %}</a></p>
+      <p class="biglink"><a class="biglink" href="https://devguide.python.org/docquality/#helping-with-documentation">{% trans %}Contributing to Docs{% endtrans %}</a></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("about") }}">{% trans %}About the documentation{% endtrans %}</a></p>
     </td><td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("license") }}">{% trans %}History and License of Python{% endtrans %}</a></p>

--- a/Misc/NEWS.d/next/Documentation/2019-02-24-03-15-10.bpo-33043.8knWTS.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-02-24-03-15-10.bpo-33043.8knWTS.rst
@@ -1,0 +1,1 @@
+Updates the docs.python.org page with the addition of a 'Contributing to Docs' link at the end of the page (between 'Reporting Bugs' and 'About Documentation'). Updates the 'Found a Bug' page with additional links and information in the Documentation Bugs section.


### PR DESCRIPTION
A 'Contributing to Docs' link was added to the bottom of the docs.python.org page. Along with this, the 'Found a Bug' (https://docs.python.org/3/bugs.html) page was edited as the table in the Documentation Bugs section was changed (2 extra links were added and summaries were revised/added). 


<!-- issue-number: [bpo-33043](https://bugs.python.org/issue33043) -->
https://bugs.python.org/issue33043
<!-- /issue-number -->
