### PR TITLE
bpo-36045: builtins.help() now prefixes `async` for async functions

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -947,6 +947,12 @@ class HTMLDoc(Doc):
                 else:
                     note = ' unbound %s method' % self.classlink(imclass,mod)
 
+        if (inspect.iscoroutinefunction(object) or
+                inspect.isasyncgenfunction(object)):
+            asyncqualifier = 'async '
+        else:
+            asyncqualifier = ''
+
         if name == realname:
             title = '<a name="%s"><strong>%s</strong></a>' % (anchor, realname)
         else:
@@ -975,8 +981,8 @@ class HTMLDoc(Doc):
         if not argspec:
             argspec = '(...)'
 
-        decl = title + self.escape(argspec) + (note and self.grey(
-               '<font face="helvetica, arial">%s</font>' % note))
+        decl = asyncqualifier + title + self.escape(argspec) + (note and
+               self.grey('<font face="helvetica, arial">%s</font>' % note))
 
         if skipdocs:
             return '<dl><dt>%s</dt></dl>\n' % decl
@@ -1376,6 +1382,12 @@ location listed above.
                 else:
                     note = ' unbound %s method' % classname(imclass,mod)
 
+        if (inspect.iscoroutinefunction(object) or
+                inspect.isasyncgenfunction(object)):
+            asyncqualifier = 'async '
+        else:
+            asyncqualifier = ''
+
         if name == realname:
             title = self.bold(realname)
         else:
@@ -1399,7 +1411,7 @@ location listed above.
                     argspec = argspec[1:-1] # remove parentheses
         if not argspec:
             argspec = '(...)'
-        decl = title + argspec + note
+        decl = asyncqualifier + title + argspec + note
 
         if skipdocs:
             return decl + '\n'

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1292,6 +1292,29 @@ foo
     Custom descriptor
 """)
 
+    def test_async_annotation(self):
+        async def coro_function(ign) -> int:
+            return 1
+
+        text = pydoc.plain(pydoc.plaintext.document(coro_function))
+        self.assertIn('async coro_function', text)
+
+        html = pydoc.HTMLDoc().document(coro_function)
+        self.assertIn(
+            'async <a name="-coro_function"><strong>coro_function',
+            html)
+
+    def test_async_generator_annotation(self):
+        async def an_async_generator():
+            yield 1
+
+        text = pydoc.plain(pydoc.plaintext.document(an_async_generator))
+        self.assertIn('async an_async_generator', text)
+
+        html = pydoc.HTMLDoc().document(an_async_generator)
+        self.assertIn(
+            'async <a name="-an_async_generator"><strong>an_async_generator',
+            html)
 
 class PydocServerTest(unittest.TestCase):
     """Tests for pydoc._start_server"""

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-24-12-44-46.bpo-36045.RO20OV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-24-12-44-46.bpo-36045.RO20OV.rst
@@ -1,0 +1,1 @@
+builtins.help() now prefixes `async` for async functions


### PR DESCRIPTION
Previously, it was hard to tell whether a function should be awaited. It was also incorrect (per PEP 484) to put this in the type hint for coroutine functions. Added this info to the output of builtins.help and pydoc.

<!-- issue-number: [bpo-36045](https://bugs.python.org/issue36045) -->
https://bugs.python.org/issue36045
<!-- /issue-number -->
