### PR TITLE
bpo-27313: Avoid test_ttk_guionly ComboboxTest fail with macOS Cocoa Tk

### DIFF
--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -329,7 +329,12 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
         self.entry.wait_visibility()
         self.entry.update_idletasks()
 
-        self.assertEqual(self.entry.identify(5, 5), "textarea")
+        # bpo-27313: macOS Cocoa widget differs from X, allow either
+        if sys.platform == 'darwin':
+            self.assertIn(self.entry.identify(5, 5),
+                ("textarea", "Combobox.button") )
+        else:
+            self.assertEqual(self.entry.identify(5, 5), "textarea")
         self.assertEqual(self.entry.identify(-1, -1), "")
 
         self.assertRaises(tkinter.TclError, self.entry.identify, None, 5)

--- a/Misc/NEWS.d/next/Tests/2019-02-24-01-58-38.bpo-27313.Sj9veH.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-24-01-58-38.bpo-27313.Sj9veH.rst
@@ -1,0 +1,1 @@
+Avoid test_ttk_guionly ComboboxTest failure with macOS Cocoa Tk.


### PR DESCRIPTION


<!-- issue-number: [bpo-27313](https://bugs.python.org/issue27313) -->
https://bugs.python.org/issue27313
<!-- /issue-number -->
