### PR TITLE
[2.7] bpo-26386: Re-enable missing widget testcases in test_ttk_guionly.

### DIFF
--- a/Lib/lib-tk/test/test_ttk/test_widgets.py
+++ b/Lib/lib-tk/test/test_ttk/test_widgets.py
@@ -1675,9 +1675,5 @@ tests_gui = (
         SizegripTest, TreeviewTest, WidgetTest,
         )
 
-tests_gui = (
-        TreeviewTest,
-        )
-
 if __name__ == "__main__":
     run_unittest(*tests_gui)

--- a/Misc/NEWS.d/next/Tests/2019-02-24-02-44-52.bpo-26386.YZylPP.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-24-02-44-52.bpo-26386.YZylPP.rst
@@ -1,0 +1,1 @@
+Re-enable missing widget testcases in test_ttk_guionly.


### PR DESCRIPTION
It looks like some testing code was inadvertently committed in d8b5942f7cce0743e1ac522a1aa9475272d4506f for [bpo-26386](https://bugs.python.org/issue26386) causing only the Treeview testcases to be executed when test_ttk_gui_only is run on 2.7.  (I noticed this because a testcase was failing on other branches but not 2.7 although the tests are virtually identical.) 

<!-- issue-number: [bpo-26386](https://bugs.python.org/issue26386) -->
https://bugs.python.org/issue26386
<!-- /issue-number -->
