### PR TITLE
bpo-33671: allow setting shutil.copyfile() bufsize globally

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -187,9 +187,11 @@ def _copyfileobj_readinto(fsrc, fdst, length=COPY_BUFSIZE):
             else:
                 fdst_write(mv)
 
-def copyfileobj(fsrc, fdst, length=COPY_BUFSIZE):
+def copyfileobj(fsrc, fdst, length=0):
     """copy data from file-like object fsrc to file-like object fdst"""
     # Localize variable access to minimize overhead.
+    if not length:
+        length = COPY_BUFSIZE
     fsrc_read = fsrc.read
     fdst_write = fdst.write
     while True:


### PR DESCRIPTION
Looking back at [BPO-33671](https://bugs.python.org/issue33671) / PR #7160: since `copyfileobj()` is used by all `copy*` functions one may want to set `file.read()` bufsize globally as `shutil.COPY_BUFSIZE = ...`. This may be useful on Windows where bufsize defaults to 1 MiB. I decided not to document `shutil.COPY_BUFSIZE` because I consider it a corner case.

<!-- issue-number: [bpo-33671](https://bugs.python.org/issue33671) -->
https://bugs.python.org/issue33671
<!-- /issue-number -->
