### PR TITLE
bpo-36083: Fix formatting of the manpage Synopsis

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2019-02-24-12-40-13.bpo-36083.JX7zbv.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-02-24-12-40-13.bpo-36083.JX7zbv.rst
@@ -1,0 +1,1 @@
+Fix formatting of --check-hash-based-pycs options in the manpage Synopsis.

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -75,7 +75,11 @@ python \- an interpreted, interactive, object-oriented programming language
 .br
        [
 .B \--check-hash-based-pycs
-\'default\'|\'always\'|\'never\'
+.I default
+|
+.I always
+|
+.I never
 ]
 .br
        [


### PR DESCRIPTION
More specifically, the options of --check-hash-based-pycs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36083](https://bugs.python.org/issue36083) -->
https://bugs.python.org/issue36083
<!-- /issue-number -->
