### PR TITLE
bpo-24643: Fix "#define timezone _timezone" clashes on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-02-24-07-52-39.bpo-24643.PofyiS.rst
+++ b/Misc/NEWS.d/next/Windows/2019-02-24-07-52-39.bpo-24643.PofyiS.rst
@@ -1,0 +1,1 @@
+Fix name collisions due to ``#define timezone _timezone`` in PC/pyconfig.h.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -38,6 +38,16 @@
 # include <sanitizer/msan_interface.h>
 #endif
 
+#ifdef _MSC_VER
+#define _Py_timezone _timezone
+#define _Py_daylight _daylight
+#define _Py_tzname _tzname
+#else
+#define _Py_timezone timezone
+#define _Py_daylight daylight
+#define _Py_tzname tzname
+#endif
+
 #define SEC_TO_NS (1000 * 1000 * 1000)
 
 /* Forward declarations */
@@ -1600,18 +1610,18 @@ init_timezone(PyObject *m)
 #ifdef HAVE_DECL_TZNAME
     PyObject *otz0, *otz1;
     tzset();
-    PyModule_AddIntConstant(m, "timezone", timezone);
+    PyModule_AddIntConstant(m, "timezone", _Py_timezone);
 #ifdef HAVE_ALTZONE
     PyModule_AddIntConstant(m, "altzone", altzone);
 #else
-    PyModule_AddIntConstant(m, "altzone", timezone-3600);
+    PyModule_AddIntConstant(m, "altzone", _Py_timezone-3600);
 #endif
-    PyModule_AddIntConstant(m, "daylight", daylight);
-    otz0 = PyUnicode_DecodeLocale(tzname[0], "surrogateescape");
+    PyModule_AddIntConstant(m, "daylight", _Py_daylight);
+    otz0 = PyUnicode_DecodeLocale(_Py_tzname[0], "surrogateescape");
     if (otz0 == NULL) {
         return -1;
     }
-    otz1 = PyUnicode_DecodeLocale(tzname[1], "surrogateescape");
+    otz1 = PyUnicode_DecodeLocale(_Py_tzname[1], "surrogateescape");
     if (otz1 == NULL) {
         Py_DECREF(otz0);
         return -1;

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -192,13 +192,6 @@ typedef int pid_t;
 #define Py_IS_FINITE(X) _finite(X)
 #define copysign _copysign
 
-/* VS 2015 defines these names with a leading underscore */
-#if _MSC_VER >= 1900
-#define timezone _timezone
-#define daylight _daylight
-#define tzname _tzname
-#endif
-
 /* Side by Side assemblies supported in VS 2005 and VS 2008 but not 2010*/
 #if _MSC_VER >= 1400 && _MSC_VER < 1600
 #define HAVE_SXS 1


### PR DESCRIPTION
Several solutions were proposed on the bug tracker.

<!-- issue-number: [bpo-24643](https://bugs.python.org/issue24643) -->
https://bugs.python.org/issue24643
<!-- /issue-number -->
