### PR TITLE
bpo-36086: Split IDLE into separate feature in Windows installer

### DIFF
--- a/Tools/msi/bundle/Default.thm
+++ b/Tools/msi/bundle/Default.thm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Theme xmlns="http://wixtoolset.org/schemas/thmutil/2010">
-    <Window Width="670" Height="412" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
+    <Window Width="670" Height="425" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
     <Font Id="0" Height="-14" Weight="500" Foreground="000000" Background="ffffff">Segoe UI</Font>
     <Font Id="1" Height="-26" Weight="500" Foreground="000000" Background="ffffff">Segoe UI</Font>
     <Font Id="2" Height="-24" Weight="500" Foreground="808080" Background="ffffff">Segoe UI</Font>
@@ -60,13 +60,16 @@
         
         <Checkbox Name="Include_tcltk" X="185" Y="151" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.Include_tcltkLabel)</Checkbox>
         <Text X="205" Y="176" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_tcltkHelpLabel)</Text>
-        
-        <Checkbox Name="Include_test" X="185" Y="201" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.Include_testLabel)</Checkbox>
-        <Text X="205" Y="226" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_testHelpLabel)</Text>
 
-        <Checkbox Name="Include_launcher" X="185" Y="251" Width="100" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="no">#(loc.Include_launcherLabel)</Checkbox>
-        <Checkbox Name="CustomInstallLauncherAllUsers" X="285" Y="251" Width="-11" Height="24" TabStop="yes" FontId="3">#(loc.InstallLauncherAllUsersLabel)</Checkbox>
-        <Text Name="Include_launcherHelp" X="205" Y="276" Width="-11" Height="24" TabStop="no" FontId="5"></Text>
+        <Checkbox Name="Include_idle" X="185" Y="201" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.Include_idleLabel)</Checkbox>
+        <Text X="205" Y="226" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_idleHelpLabel)</Text>
+        
+        <Checkbox Name="Include_test" X="185" Y="251" Width="-11" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.Include_testLabel)</Checkbox>
+        <Text X="205" Y="276" Width="-11" Height="24" TabStop="no" FontId="5">#(loc.Include_testHelpLabel)</Text>
+
+        <Checkbox Name="Include_launcher" X="185" Y="301" Width="100" Height="24" TabStop="yes" FontId="3" HideWhenDisabled="no">#(loc.Include_launcherLabel)</Checkbox>
+        <Checkbox Name="CustomInstallLauncherAllUsers" X="285" Y="301" Width="-11" Height="24" TabStop="yes" FontId="3">#(loc.InstallLauncherAllUsersLabel)</Checkbox>
+        <Text Name="Include_launcherHelp" X="205" Y="326" Width="-11" Height="24" TabStop="no" FontId="5"></Text>
 
         <Button Name="Custom1BackButton" X="185" Y="-11" Width="85" Height="27" TabStop="yes" FontId="0">#(loc.CustomBackButton)</Button>
         <Button Name="CustomNextButton" X="-101" Y="-11" Width="85" Height="27" TabStop="yes" FontId="0">#(loc.CustomNextButton)</Button>

--- a/Tools/msi/bundle/Default.wxl
+++ b/Tools/msi/bundle/Default.wxl
@@ -71,8 +71,10 @@ Select Customize to review current options.</String>
   <String Id="Include_docHelpLabel">Installs the Python documentation file.</String>
   <String Id="Include_pipLabel">&amp;pip</String>
   <String Id="Include_pipHelpLabel">Installs pip, which can download and install other Python packages.</String>
-  <String Id="Include_tcltkLabel">tcl/tk and &amp;IDLE</String>
-  <String Id="Include_tcltkHelpLabel">Installs tkinter and the IDLE development environment.</String>
+  <String Id="Include_tcltkLabel">tcl/tk</String>
+  <String Id="Include_tcltkHelpLabel">Installs tkinter.</String>
+  <String Id="Include_idleLabel">&amp;IDLE</String>
+  <String Id="Include_idleHelpLabel">Installs the IDLE development environment (requires tcl/tk).</String>
   <String Id="Include_testLabel">Python &amp;test suite</String>
   <String Id="Include_testHelpLabel">Installs the standard library test suite.</String>
   <String Id="Include_launcherLabel">py &amp;launcher</String>

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -207,6 +207,7 @@ static struct { LPCWSTR regName; LPCWSTR variableName; } OPTIONAL_FEATURES[] = {
     { L"path", L"PrependPath" },
     { L"pip", L"Include_pip" },
     { L"tcltk", L"Include_tcltk" },
+	{ L"idle", L"Include_idle" },
     { L"test", L"Include_test" },
     { L"tools", L"Include_tools" },
     { L"Shortcuts", L"Shortcuts" },

--- a/Tools/msi/bundle/bundle.targets
+++ b/Tools/msi/bundle/bundle.targets
@@ -69,6 +69,7 @@
         <Package Include="..\path\path*.wixproj" />
         <Package Include="..\pip\pip*.wixproj" />
         <Package Include="..\tcltk\tcltk*.wixproj" />
+        <Package Include="..\idle\idle*.wixproj" />
         <Package Include="..\test\test*.wixproj" />
         <Package Include="..\tools\tools*.wixproj" />
         <Package Include="..\ucrt\ucrt*.wixproj" />

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -70,6 +70,7 @@
     <Variable Name="Include_doc" Value="1" bal:Overridable="yes" />
     <Variable Name="Include_tools" Value="1" bal:Overridable="yes" />
     <Variable Name="Include_tcltk" Value="1" bal:Overridable="yes" />
+    <Variable Name="Include_idle" Value="1" bal:Overridable="yes" />
     <Variable Name="Include_pip" Value="1" bal:Overridable="yes" />
     <?if "$(var.PyTestExt)"="" ?>
     <Variable Name="Include_launcher" Value="1" bal:Overridable="yes" />
@@ -103,6 +104,7 @@
       <PackageGroupRef Id="doc" />
       <PackageGroupRef Id="tools" />
       <PackageGroupRef Id="tcltk" />
+      <PackageGroupRef Id="idle" />
       <PackageGroupRef Id="launcher" />
       <PackageGroupRef Id="pip" />
       <PackageGroupRef Id="packageinstall" />

--- a/Tools/msi/bundle/packagegroups/idle.wxs
+++ b/Tools/msi/bundle/packagegroups/idle.wxs
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <PackageGroup Id="idle">
+            <MsiPackage Id="idle_AllUsers"
+                        SourceFile="idle.msi"
+                        Compressed="$(var.CompressMSI)"
+                        DownloadUrl="$(var.DownloadUrl)"
+                        ForcePerMachine="yes"
+                        EnableFeatureSelection="yes"
+                        InstallCondition="InstallAllUsers and Include_idle and not LauncherOnly">
+                <MsiProperty Name="TARGETDIR" Value="[TargetDir]" />
+                <MsiProperty Name="OPTIONALFEATURESREGISTRYKEY" Value="[OptionalFeaturesRegistryKey]" />
+            </MsiPackage>
+
+            <MsiPackage Id="idle_JustForMe"
+                        SourceFile="idle.msi"
+                        Compressed="$(var.CompressMSI)"
+                        DownloadUrl="$(var.DownloadUrl)"
+                        ForcePerMachine="no"
+                        EnableFeatureSelection="yes"
+                        InstallCondition="not InstallAllUsers and Include_idle and not LauncherOnly">
+                <MsiProperty Name="TARGETDIR" Value="[TargetDir]" />
+                <MsiProperty Name="OPTIONALFEATURESREGISTRYKEY" Value="[OptionalFeaturesRegistryKey]" />
+            </MsiPackage>
+        </PackageGroup>
+    </Fragment>
+</Wix>

--- a/Tools/msi/idle/idle.wixproj
+++ b/Tools/msi/idle/idle.wixproj
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <ProjectGuid>{DB350600-186C-4E52-BA98-26A7CECB067F}</ProjectGuid>
+        <ProjectGuid>{F43264F7-05DF-4F8B-9E41-85E7165E732C}</ProjectGuid>
         <SchemaVersion>2.0</SchemaVersion>
-        <OutputName>tcltk</OutputName>
+        <OutputName>idle</OutputName>
         <OutputType>Package</OutputType>
     </PropertyGroup>
     <PropertyGroup>
@@ -12,28 +12,21 @@
     </PropertyGroup>
     <Import Project="..\msi.props" />
     <ItemGroup>
-        <Compile Include="tcltk.wxs" />
-        <Compile Include="tcltk_files.wxs" />
+        <Compile Include="idle.wxs" />
+        <Compile Include="idle_reg.wxs" />
     </ItemGroup>
     <ItemGroup>
         <WxlTemplate Include="*.wxl_template" />
     </ItemGroup>
     <ItemGroup>
-        <InstallFiles Include="$(tcltkDir)lib\**\*">
-            <SourceBase>$(tcltkDir)</SourceBase>
-            <Source>!(bindpath.tcltk)</Source>
-            <TargetBase>$(tcltkDir)lib</TargetBase>
-            <Target_>tcl\</Target_>
-            <Group>tcltk_lib</Group>
-        </InstallFiles>
 
-        <InstallFiles Include="$(PySourcePath)Lib\tkinter\**\*;$(PySourcePath)Lib\turtledemo\**\*"
+        <InstallFiles Include="$(PySourcePath)Lib\idlelib\**\*"
                       Exclude="$(PySourcePath)Lib\**\*.pyc;$(PySourcePath)Lib\**\*.pyo">
             <SourceBase>$(PySourcePath)</SourceBase>
             <Source>!(bindpath.src)</Source>
             <TargetBase>$(PySourcePath)</TargetBase>
             <Target_></Target_>
-            <Group>tkinter_lib</Group>
+            <Group>idle_lib</Group>
         </InstallFiles>
     </ItemGroup>
     

--- a/Tools/msi/idle/idle.wxs
+++ b/Tools/msi/idle/idle.wxs
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product Id="*" Language="!(loc.LCID)" Name="!(loc.Title)" Version="$(var.Version)" Manufacturer="!(loc.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
+        <Package InstallerVersion="300" Compressed="yes" InstallScope="perUser" Platform="$(var.Platform)" />
+        <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+        
+        <PropertyRef Id="UpgradeTable" />
+        <PropertyRef Id="REGISTRYKEY" />
+        
+        <Property Id="PYTHON_EXE" Secure="yes">
+            <ComponentSearch Id="PythonExe" Guid="$(var.PythonExeComponentGuid)">
+                <FileSearch Name="python.exe" />
+            </ComponentSearch>
+        </Property>
+        
+        <Property Id="PYTHONW_EXE" Secure="yes">
+            <ComponentSearch Id="PythonwExe" Guid="$(var.PythonwExeComponentGuid)">
+                <FileSearch Name="pythonw.exe" />
+            </ComponentSearch>
+        </Property>
+        
+        <Condition Message="!(loc.NoPython)">PYTHON_EXE and PYTHONW_EXE</Condition>
+      
+        <!-- TODO: Introduce dependency on tcltk, probably using <Requires> or <Condition>
+        <Condition Message="!(loc.NoTcltk)">!tcltk = 3</Condition>
+        -->
+
+        <Feature Id="DefaultFeature" AllowAdvertise="no" Title="!(loc.Title)" Description="!(loc.Description)">
+            <ComponentGroupRef Id="idle_lib" Primary="yes" />
+            
+            <Component Id="idle_reg" Directory="InstallDirectory">
+                <RegistryValue KeyPath="yes" Root="HKMU" Key="[REGISTRYKEY]\Idle" Type="string" Value="[#Lib_idlelib_idle.pyw]" />
+            </Component>
+            <ComponentRef Id="OptionalFeature" />
+        </Feature>
+        <Feature Id="AssociateFiles" AllowAdvertise="no" Title="!(loc.Title)" Description="!(loc.Description)">
+            <ComponentGroupRef Id="idle_lib" />
+            <ComponentGroupRef Id="idle_reg" />
+        </Feature>
+        <Feature Id="Shortcuts" AllowAdvertise="no" Title="!(loc.Title)" Description="!(loc.Description)">
+            <ComponentGroupRef Id="idle_lib" />
+            
+            <Component Id="idle_shortcut" Directory="MenuDir">
+                <RegistryValue Root="HKMU" Key="[REGISTRYKEY]\IdleShortcuts" Type="integer" Value="1" KeyPath="yes" />
+                <RemoveFolder Id="Remove_MenuDir" On="uninstall" />
+
+                <Shortcut Id="IDLE"
+                          Directory="MenuDir"
+                          Name="!(loc.ShortcutName)"
+                          Description="!(loc.ShortcutDescription)"
+                          Target="[PYTHONW_EXE]"
+                          Arguments='"[#Lib_idlelib_idle.pyw]"'
+                          Icon="idle.exe"
+                          WorkingDirectory="InstallDirectory">
+                    <Icon Id="idle.exe" SourceFile="!(bindpath.src)Lib\idlelib\Icons\idle.ico" />
+                </Shortcut>
+                <Shortcut Id="pydoc.py"
+                          Target="[PYTHON_EXE]"
+                          Arguments='-m pydoc -b'
+                          Name="!(loc.PyDocShortcutName)"
+                          Description="!(loc.PyDocShortcutDescription)"
+                          Icon="idle.exe"
+                          WorkingDirectory="InstallDirectory" />
+            </Component>
+        </Feature>
+    </Product>
+</Wix>

--- a/Tools/msi/idle/idle_en-US.wxl_template
+++ b/Tools/msi/idle/idle_en-US.wxl_template
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
+    <String Id="Descriptor">IDLE development environment</String>
+    <String Id="ShortDescriptor">IDLE</String>
+    <String Id="NoPython">No !(loc.ProductName) installation was detected.</String>
+    <String Id="NoTcltk">No tck/tk installation was detected.</String>
+    <String Id="ShortcutName">IDLE (Python {{ShortVersion}} {{Bitness}})</String>
+    <String Id="ShortcutDescription">Launches IDLE, the interactive environment for !(loc.ProductName).</String>
+    <String Id="PyDocShortcutName">Python {{ShortVersion}} Module Docs ({{Bitness}})</String>
+    <String Id="PyDocShortcutDescription">Start the !(loc.ProductName) documentation server.</String>
+    <String Id="EditMenu">&amp;Edit with IDLE</String>
+    <String Id="EditSubMenu">Edit with IDLE {{ShortVersion}} ({{Bitness}})</String>
+</WixLocalization>

--- a/Tools/msi/idle/idle_reg.wxs
+++ b/Tools/msi/idle/idle_reg.wxs
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <ComponentGroup Id="idle_reg">
+            <!-- We fix the guid of the Subcommands key so that it is correctly reference counted -->
+            <Component Id="assoc_subcommands" Directory="InstallDirectory" Guid="{57D47B4C-96E6-40A0-A958-57083D74423F}">
+                <Condition>VersionNT > 600</Condition>
+                <RegistryValue Root="HKCR" Key="Python.File\Shell\editwithidle$(var.PyTestExt)" Name="MUIVerb" Value="!(loc.EditMenu)" Type="string" KeyPath="yes" />
+                <RegistryValue Root="HKCR" Key="Python.File\Shell\editwithidle$(var.PyTestExt)" Name="Subcommands" Value="" Type="string" KeyPath="no" />
+            </Component>
+            <Component Id="assoc_subcommands_nocon" Directory="InstallDirectory" Guid="{07061D85-9151-4FC4-BB78-13628020D026}">
+                <Condition>VersionNT > 600</Condition>
+                <RegistryValue Root="HKCR" Key="Python.NoConFile\Shell\editwithidle$(var.PyTestExt)" Name="MUIVerb" Value="!(loc.EditMenu)" Type="string" KeyPath="yes" />
+                <RegistryValue Root="HKCR" Key="Python.NoConFile\Shell\editwithidle$(var.PyTestExt)" Name="Subcommands" Value="" Type="string" KeyPath="no" />
+            </Component>
+            
+            <Component Id="assoc_editwithidle" Directory="InstallDirectory">
+                <Condition>VersionNT > 600</Condition>
+                <RegistryKey Root="HKCR" Key="Python.File\Shell\editwithidle\shell\edit$(var.MajorVersionNumber)$(var.MinorVersionNumber)$(var.PyArchExt)$(var.PyTestExt)">
+                    <RegistryValue Name="MUIVerb" Value="!(loc.EditSubMenu)" Type="string" KeyPath="yes" />
+                    <RegistryValue Key="command" Value='"[PYTHONW_EXE]" -m idlelib "%L" %*' Type="string" />
+                </RegistryKey>
+            </Component>
+            <Component Id="assoc_editwithidle_nocon" Directory="InstallDirectory">
+                <Condition>VersionNT > 600</Condition>
+                <RegistryKey Root="HKCR" Key="Python.NoConFile\Shell\editwithidle\shell\edit$(var.MajorVersionNumber)$(var.MinorVersionNumber)$(var.PyArchExt)$(var.PyTestExt)">
+                    <RegistryValue Name="MUIVerb" Value="!(loc.EditSubMenu)" Type="string" KeyPath="yes" />
+                    <RegistryValue Key="command" Value='"[PYTHONW_EXE]" -m idlelib "%L" %*' Type="string" />
+                </RegistryKey>
+            </Component>
+            
+            <Component Id="assoc_editwithidle_vista" Directory="InstallDirectory">
+                <Condition>VersionNT = 600</Condition>
+                <RegistryKey Root="HKCR" Key="Python.File\Shell\editwithidle$(var.MajorVersionNumber)$(var.MinorVersionNumber)$(var.PyArchExt)$(var.PyTestExt)">
+                    <RegistryValue Value="!(loc.EditSubMenu)" Type="string" KeyPath="yes" />
+                    <RegistryValue Key="command" Value='"[PYTHONW_EXE]" -m idlelib "%L" %*' Type="string" />
+                </RegistryKey>
+            </Component>
+            <Component Id="assoc_editwithidle_nocon_vista" Directory="InstallDirectory">
+                <Condition>VersionNT = 600</Condition>
+                <RegistryKey Root="HKCR" Key="Python.NoConFile\Shell\editwithidle$(var.MajorVersionNumber)$(var.MinorVersionNumber)$(var.PyArchExt)$(var.PyTestExt)">
+                    <RegistryValue Value="!(loc.EditSubMenu)" Type="string" KeyPath="yes" />
+                    <RegistryValue Key="command" Value='"[PYTHONW_EXE]" -m idlelib "%L" %*' Type="string" />
+                </RegistryKey>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/Tools/msi/purge.py
+++ b/Tools/msi/purge.py
@@ -46,6 +46,7 @@ FILES = [
     "tcltk.msi",
     "tcltk_d.msi",
     "tcltk_pdb.msi",
+    "idle.msi",
     "test.msi",
     "test_d.msi",
     "test_pdb.msi",

--- a/Tools/msi/tcltk/tcltk.wxs
+++ b/Tools/msi/tcltk/tcltk.wxs
@@ -26,41 +26,10 @@
             <ComponentGroupRef Id="tcltk_dlls" />
             <ComponentGroupRef Id="tcltk_lib" />
             <ComponentGroupRef Id="tkinter_lib" Primary="yes" />
-            
-            <Component Id="idle_reg" Directory="InstallDirectory">
-                <RegistryValue KeyPath="yes" Root="HKMU" Key="[REGISTRYKEY]\Idle" Type="string" Value="[#Lib_idlelib_idle.pyw]" />
-            </Component>
             <ComponentRef Id="OptionalFeature" />
         </Feature>
         <Feature Id="AssociateFiles" AllowAdvertise="no" Title="!(loc.Title)" Description="!(loc.Description)">
             <ComponentGroupRef Id="tkinter_lib" />
-            <ComponentGroupRef Id="idle_reg" />
-        </Feature>
-        <Feature Id="Shortcuts" AllowAdvertise="no" Title="!(loc.Title)" Description="!(loc.Description)">
-            <ComponentGroupRef Id="tkinter_lib" />
-            
-            <Component Id="idle_shortcut" Directory="MenuDir">
-                <RegistryValue Root="HKMU" Key="[REGISTRYKEY]\IdleShortcuts" Type="integer" Value="1" KeyPath="yes" />
-                <RemoveFolder Id="Remove_MenuDir" On="uninstall" />
-
-                <Shortcut Id="IDLE"
-                          Directory="MenuDir"
-                          Name="!(loc.ShortcutName)"
-                          Description="!(loc.ShortcutDescription)"
-                          Target="[PYTHONW_EXE]"
-                          Arguments='"[#Lib_idlelib_idle.pyw]"'
-                          Icon="idle.exe"
-                          WorkingDirectory="InstallDirectory">
-                    <Icon Id="idle.exe" SourceFile="!(bindpath.src)Lib\idlelib\Icons\idle.ico" />
-                </Shortcut>
-                <Shortcut Id="pydoc.py"
-                          Target="[PYTHON_EXE]"
-                          Arguments='-m pydoc -b'
-                          Name="!(loc.PyDocShortcutName)"
-                          Description="!(loc.PyDocShortcutDescription)"
-                          Icon="idle.exe"
-                          WorkingDirectory="InstallDirectory" />
-            </Component>
         </Feature>
     </Product>
 </Wix>

--- a/Tools/msi/tcltk/tcltk_en-US.wxl_template
+++ b/Tools/msi/tcltk/tcltk_en-US.wxl_template
@@ -3,10 +3,4 @@
     <String Id="Descriptor">Tcl/Tk Support</String>
     <String Id="ShortDescriptor">tcltk</String>
     <String Id="NoPython">No !(loc.ProductName) installation was detected.</String>
-    <String Id="ShortcutName">IDLE (Python {{ShortVersion}} {{Bitness}})</String>
-    <String Id="ShortcutDescription">Launches IDLE, the interactive environment for !(loc.ProductName).</String>
-    <String Id="PyDocShortcutName">Python {{ShortVersion}} Module Docs ({{Bitness}})</String>
-    <String Id="PyDocShortcutDescription">Start the !(loc.ProductName) documentation server.</String>
-    <String Id="EditMenu">&amp;Edit with IDLE</String>
-    <String Id="EditSubMenu">Edit with IDLE {{ShortVersion}} ({{Bitness}})</String>
 </WixLocalization>

--- a/Tools/msi/testrelease.bat
+++ b/Tools/msi/testrelease.bat
@@ -89,7 +89,13 @@ exit /B 0
 @if not errorlevel 1 (
     @echo Testing Tcl/tk
     @set TCL_LIBRARY=%~2\Python\tcl\tcl8.6
-    "%~2\Python\python.exe" -m test -uall -v test_ttk_guionly test_tk test_idle > "%~2\tcltk.txt" 2>&1
+    "%~2\Python\python.exe" -m test -uall -v test_ttk_guionly test_tk > "%~2\tcltk.txt" 2>&1
+    @set TCL_LIBRARY=
+)
+@if not errorlevel 1 (
+    @echo Testing IDLE
+    @set TCL_LIBRARY=%~2\Python\tcl\tcl8.6
+    "%~2\Python\python.exe" -m test -uall -v test_idle > "%~2\idle.txt" 2>&1
     @set TCL_LIBRARY=
 )
 


### PR DESCRIPTION
Two to-do's before this can be merged:

- Introduce a dependency from the IDLE package to the Tcl/Tk package which prevents installing IDLE without Tcl/Tk and uninstalling Tcl/Tk without IDLE.
- Ensure that when upgrading from an installation with Tcl/Tk installed, the IDLE package will also be installed, and that reversely, when upgrading from an installation without Tcl/Tk, IDLE won't be installed.

Unfortunately, I can't find proper documentation on how to do either in WIX.

<!-- issue-number: [bpo-36086](https://bugs.python.org/issue36086) -->
https://bugs.python.org/issue36086
<!-- /issue-number -->
