### PR TITLE
Remove empty Dictionaries section from FAQ

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1317,9 +1317,6 @@ The ``__iadd__`` succeeds, and thus the list is extended, but even though
 that final assignment still results in an error, because tuples are immutable.
 
 
-Dictionaries
-============
-
 I want to do a complicated sort: can you do a Schwartzian Transform in Python?
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Doesn't have any use since 396ecb9c3e7fb150eace7bfc733d5b9d0263d697.

Before that commit, these two questions were below that title when they shouldn't have:

- I want to do a complicated sort: can you do a Schwartzian Transform in Python?
- How can I sort one list by values from another list?