### PR TITLE
[3.7] bpo-28450: Fix and improve the documentation for unknown escapes in RE. (GH-11920).

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -570,7 +570,8 @@ accepted by the regular expression parser::
 only inside character classes.)
 
 ``'\u'`` and ``'\U'`` escape sequences are only recognized in Unicode
-patterns.  In bytes patterns they are errors.
+patterns.  In bytes patterns they are errors.  Unknown escapes of ASCII
+letters are reserved for future use and treated as errors.
 
 Octal escapes are included in a limited form.  If the first digit is a 0, or if
 there are three octal digits, it is considered an octal escape. Otherwise, it is
@@ -844,7 +845,9 @@ form.
    *string* is returned unchanged.  *repl* can be a string or a function; if it is
    a string, any backslash escapes in it are processed.  That is, ``\n`` is
    converted to a single newline character, ``\r`` is converted to a carriage return, and
-   so forth.  Unknown escapes such as ``\&`` are left alone.  Backreferences, such
+   so forth.  Unknown escapes of ASCII letters are reserved for future use and
+   treated as errors.  Other unknown escapes such as ``\&`` are left alone.
+   Backreferences, such
    as ``\6``, are replaced with the substring matched by group 6 in the pattern.
    For example::
 


### PR DESCRIPTION
(cherry picked from commit a180b007d96fe68b32f11dec720fbd0cd5b6758a)


<!-- issue-number: [bpo-28450](https://bugs.python.org/issue28450) -->
https://bugs.python.org/issue28450
<!-- /issue-number -->
