### PR TITLE
bpo-32129: Avoid blurry IDLE application icon on macOS with Tk 8.6.

### DIFF
--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -1495,7 +1495,7 @@ def main():
     if system() == 'Windows':
         iconfile = os.path.join(icondir, 'idle.ico')
         root.wm_iconbitmap(default=iconfile)
-    else:
+    elif not macosx.isAquaTk():
         ext = '.png' if TkVersion >= 8.6 else '.gif'
         iconfiles = [os.path.join(icondir, 'idle_%d%s' % (size, ext))
                      for size in (16, 32, 48)]

--- a/Misc/NEWS.d/next/IDLE/2019-02-25-11-40-14.bpo-32129.4qVCzD.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-02-25-11-40-14.bpo-32129.4qVCzD.rst
@@ -1,0 +1,2 @@
+Avoid blurry IDLE application icon on macOS with Tk 8.6. Patch by Kevin
+Walzer.


### PR DESCRIPTION
Patch by Kevin Walzer.


<!-- issue-number: [bpo-32129](https://bugs.python.org/issue32129) -->
https://bugs.python.org/issue32129
<!-- /issue-number -->
