### PR TITLE
bpo-35178: Ensure custom formatwarning function can receive line as positional argument

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -877,6 +877,18 @@ class WarningsDisplayTests(BaseTest):
                                 file_object, expected_file_line)
         self.assertEqual(expect, file_object.getvalue())
 
+        # bpo-35178: Test custom formatwarning can receive line as positional
+        def formatwarning(message, category, filename, lineno, text):
+            return text
+
+        file_object = StringIO()
+        original = self.module.formatwarning
+        self.module.formatwarning = formatwarning
+        self.module.showwarning(message, category, file_name, line_num,
+                                file_object, expected_file_line)
+        self.assertEqual(file_object.getvalue(), expected_file_line)
+        self.addCleanup(setattr, self.module, 'formatwarning', original)
+
 
 class CWarningsDisplayTests(WarningsDisplayTests, unittest.TestCase):
     module = c_warnings

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -878,7 +878,8 @@ class WarningsDisplayTests(BaseTest):
         self.assertEqual(expect, file_object.getvalue())
 
     def test_formatwarning_override(self):
-        # bpo-35178: Test custom formatwarning can receive line as positional
+        # bpo-35178: Test that a custom formatwarning function gets the 'line'
+        # argument as a positional argument, and not only as a keyword argument
         def myformatwarning(message, category, filename, lineno, text):
             return f'm={message}:c={category}:f={filename}:l={lineno}:t={text}'
 

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -124,7 +124,7 @@ def _formatwarnmsg(msg):
         if fw is not _formatwarning_orig:
             # warnings.formatwarning() was replaced
             return fw(msg.message, msg.category,
-                      msg.filename, msg.lineno, line=msg.line)
+                      msg.filename, msg.lineno, msg.line)
     return _formatwarnmsg_impl(msg)
 
 def filterwarnings(action, message="", category=Warning, module="", lineno=0,

--- a/Misc/NEWS.d/next/Library/2019-02-25-23-04-00.bpo-35178.NA_rXa.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-25-23-04-00.bpo-35178.NA_rXa.rst
@@ -1,0 +1,2 @@
+Ensure custom :func:`warnings.formatwarning` function can receive `line` as
+positional argument. Based on patch by Tashrif Billah.


### PR DESCRIPTION
Custom `warnings.formatwarning` function can receive `line` as positional argument.

Co-Authored-By: Tashrif Billah <tashrifbillah@gmail.com>
Co-Authored-By: Xtreak <tir.karthi@gmail.com>


<!-- issue-number: [bpo-35178](https://bugs.python.org/issue35178) -->
https://bugs.python.org/issue35178
<!-- /issue-number -->
