### PR TITLE
Fix Lib/posixmodule.c compilation with clang on OSX

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2386,18 +2386,18 @@ class TextIOWrapper(TextIOBase):
             raise ValueError("tell on closed file")
         if not self._seekable:
             raise UnsupportedOperation("underlying stream is not seekable")
-        if whence == 1: # seek relative to current position
+        if whence == SEEK_CUR:
             if cookie != 0:
                 raise UnsupportedOperation("can't do nonzero cur-relative seeks")
             # Seeking to the current position should attempt to
             # sync the underlying buffer with the current position.
             whence = 0
             cookie = self.tell()
-        if whence == 2: # seek relative to end of file
+        elif whence == SEEK_END:
             if cookie != 0:
                 raise UnsupportedOperation("can't do nonzero end-relative seeks")
             self.flush()
-            position = self.buffer.seek(0, 2)
+            position = self.buffer.seek(0, whence)
             self._set_decoded_chars('')
             self._snapshot = None
             if self._decoder:

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2344,7 +2344,8 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
         goto fail;
     }
 
-    if (whence == 1) {
+    switch (whence) {
+    case SEEK_CUR:
         /* seek relative to current position */
         cmp = PyObject_RichCompareBool(cookieObj, _PyLong_Zero, Py_EQ);
         if (cmp < 0)
@@ -2362,8 +2363,7 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
         cookieObj = _PyObject_CallMethodId((PyObject *)self, &PyId_tell, NULL);
         if (cookieObj == NULL)
             goto fail;
-    }
-    else if (whence == 2) {
+    case SEEK_END:
         /* seek relative to end of file */
         cmp = PyObject_RichCompareBool(cookieObj, _PyLong_Zero, Py_EQ);
         if (cmp < 0)
@@ -2401,10 +2401,12 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
             }
         }
         return res;
-    }
-    else if (whence != 0) {
+    case SEEK_SET:
+        break;
+    default:
         PyErr_Format(PyExc_ValueError,
-                     "invalid whence (%d, should be 0, 1 or 2)", whence);
+                     "invalid whence (%d, should be %d, %d or %d)", whence,
+                     SEEK_SET, SEEK_CUR, SEEK_END);
         goto fail;
     }
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -20,6 +20,8 @@
 #  pragma weak statvfs
 #  pragma weak fstatvfs
 
+#include <util.h> /* needed for forkpty() and openpty(). */
+
 #endif /* __APPLE__ */
 
 #define PY_SSIZE_T_CLEAN
@@ -1260,7 +1262,7 @@ _Py_Sigset_Converter(PyObject *obj, void *addr)
     long signum;
     int overflow;
 
-    if (sigemptyset(mask)) {
+    if (sigemptyset(mask) == -1) {
         /* Probably only if mask == NULL. */
         PyErr_SetFromErrno(PyExc_OSError);
         return 0;

--- a/configure.ac
+++ b/configure.ac
@@ -121,9 +121,13 @@ VERSION=PYTHON_VERSION
 AC_SUBST(SOVERSION)
 SOVERSION=1.0
 
-# The later defininition of _XOPEN_SOURCE disables certain features
-# on Linux, so we need _GNU_SOURCE to re-enable them (makedev, tm_zone).
-AC_DEFINE(_GNU_SOURCE, 1, [Define on Linux to activate all library features])
+ifdef([AC_USE_SYSTEM_EXTENSIONS], [
+AC_USE_SYSTEM_EXTENSIONS
+], [
+AC_AIX
+AC_GNU_SOURCE
+AC_MINIX
+])
 
 # The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on NetBSD, so we need _NETBSD_SOURCE to re-enable


### PR DESCRIPTION
This commit fixes building Lib/posixmodule.c with clang on OSX.

Due to a combination of bugs and environment quirks, I was unable to compile posixmodule.c for 2 reasons.

1. It was using an improper util.h header. I assume this occurred due to a bad/stale header from a previous version of the libevent Homebrew package that was never cleaned up, but I'm not 100% sure of this hypothesis. Even though my environment was buggy/off, it's best to define `_GNU_SOURCE` only when necessary and in a manner consistent with the autoconf definition to avoid conflicts between projects.
2. clang was complaining about `forkpty(..)`/`openpty(..)`'s definitions not being found. I suspect that what was happening was that it was finding it via configure, but failing because the header was not included for util.h. Regardless, for correctness, it's best to include util.h on OSX. This should no doubt be extended to other platforms where util.h is present, e.g., NetBSD and OpenBSD, but I will do that in another future commit.