### PR TITLE
bpo-13497: Fix `broken nice` configure test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4727,6 +4727,8 @@ LIBS=$LIBS_no_readline
 AC_MSG_CHECKING(for broken nice())
 AC_CACHE_VAL(ac_cv_broken_nice, [
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <stdlib.h>
+#include <unistd.h>
 int main()
 {
 	int val1 = nice(1);


### PR DESCRIPTION
Per POSIX, `nice(3)` requires `unistd.h` and `exit(3)` requires `stdlib.h`.

Fixing the test will prevent false positives with pedantic compilers,
like clang.

[bpo-13497](https://bugs.python.org/issue13497)

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>

<!-- issue-number: [bpo-13497](https://bugs.python.org/issue13497) -->
https://bugs.python.org/issue13497
<!-- /issue-number -->
