### PR TITLE
bpo-36109: Fix random test_descr failure.

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4325,7 +4325,11 @@ order (MRO) for bases """
             def __hash__(self):
                 return hash('attr')
             def __eq__(self, other):
-                del C.attr
+                try:
+                    del C.attr
+                except AttributeError:
+                    # possible race condition
+                    pass
                 return 0
 
         class Descr(object):


### PR DESCRIPTION


<!-- issue-number: [bpo-36109](https://bugs.python.org/issue36109) -->
https://bugs.python.org/issue36109
<!-- /issue-number -->
