### PR TITLE
closes bpo-36115: Fix some reference leaks in typeobject.c.

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4962,6 +4962,7 @@ add_getset(PyTypeObject *type, PyGetSetDef *gsp)
             return -1;
 
         if (PyDict_GetItemWithError(dict, PyDescr_NAME(descr))) {
+            Py_DECREF(descr);
             continue;
         }
         else if (PyErr_Occurred()) {
@@ -7689,6 +7690,7 @@ super_getattro(PyObject *self, PyObject *name)
             return res;
         }
         else if (PyErr_Occurred()) {
+            Py_DECREF(mro);
             return NULL;
         }
 


### PR DESCRIPTION
a24107b04c1277e3c1105f98aff5bfa3a98b33a0 introduced a few refleaks.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36115](https://bugs.python.org/issue36115) -->
https://bugs.python.org/issue36115
<!-- /issue-number -->
