### PR TITLE
bpo-36117: Allow rich comparisons for real-valued complex objects.

### DIFF
--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -6050,8 +6050,9 @@ def _convert_for_comparison(self, other, equality_op=False):
 
     # Comparisons with float and complex types.  == and != comparisons
     # with complex numbers should succeed, returning either True or False
-    # as appropriate.  Other comparisons return NotImplemented.
-    if equality_op and isinstance(other, _numbers.Complex) and other.imag == 0:
+    # as appropriate.  Other comparisons return NotImplemented if the
+    # complex object has an imaginary component.
+    if isinstance(other, _numbers.Complex) and other.imag == 0:
         other = other.real
     if isinstance(other, float):
         context = getcontext()

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -593,9 +593,9 @@ class Fraction(numbers.Rational):
 
         Implement comparison between a Rational instance `self`, and
         either another Rational instance or a float `other`.  If
-        `other` is not a Rational instance, a float, or a real complex,
-        return NotImplemented. `op` should be one of the six standard
-        comparison operators.
+        `other` is not a Rational instance, a float, or a real-valued
+        complex, return NotImplemented. `op` should be one of the six
+        standard comparison operators.
 
         """
         # convert other to a Rational instance where reasonable.
@@ -606,7 +606,7 @@ class Fraction(numbers.Rational):
             if other.imag:
                 return NotImplemented
             else:
-                other = float(other.real)
+                other = other.real
         if isinstance(other, float):
             if math.isnan(other) or math.isinf(other):
                 return op(0.0, other)

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -593,8 +593,8 @@ class Fraction(numbers.Rational):
 
         Implement comparison between a Rational instance `self`, and
         either another Rational instance or a float `other`.  If
-        `other` is not a Rational instance or a float, return
-        NotImplemented. `op` should be one of the six standard
+        `other` is not a Rational instance, a float, or a real complex,
+        return NotImplemented. `op` should be one of the six standard
         comparison operators.
 
         """
@@ -602,6 +602,11 @@ class Fraction(numbers.Rational):
         if isinstance(other, numbers.Rational):
             return op(self._numerator * other.denominator,
                       self._denominator * other.numerator)
+        if isinstance(other, complex):
+            if other.imag:
+                return NotImplemented
+            else:
+                other = float(other.real)
         if isinstance(other, float):
             if math.isnan(other) or math.isinf(other):
                 return op(0.0, other)

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -140,6 +140,20 @@ class ComplexTest(unittest.TestCase):
         self.assertIs(operator.eq(1+1j, 2+2j), False)
         self.assertIs(operator.ne(1+1j, 1+1j), False)
         self.assertIs(operator.ne(1+1j, 2+2j), True)
+        for n in range(100):
+            for f in (int(n), float(n), complex(n)):
+                self.assertIs(complex.__lt__(complex(f), f), False)
+                self.assertIs(complex.__gt__(complex(f), f), False)
+                self.assertIs(complex.__le__(complex(f), f), True)
+                self.assertIs(complex.__ge__(complex(f), f), True)
+                self.assertIs(complex.__lt__(complex(f-1), f), True)
+                self.assertIs(complex.__gt__(complex(f-1), f), False)
+                self.assertIs(complex.__le__(complex(f-1), f), True)
+                self.assertIs(complex.__ge__(complex(f-1), f), False)
+                self.assertIs(complex.__lt__(complex(f), f-1), False)
+                self.assertIs(complex.__gt__(complex(f), f-1), True)
+                self.assertIs(complex.__le__(complex(f), f-1), False)
+                self.assertIs(complex.__ge__(complex(f), f-1), True)
 
     def test_richcompare_boundaries(self):
         def check(n, deltas, is_equal, imag = 0.0):

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1705,10 +1705,14 @@ class UsabilityTest(unittest.TestCase):
         self.assertNotEqual(db, (3.0+1j))
         self.assertNotEqual((3.0+1j), db)
 
-        self.assertIs(db.__lt__(3.0+0j), NotImplemented)
-        self.assertIs(db.__le__(3.0+0j), NotImplemented)
-        self.assertIs(db.__gt__(3.0+0j), NotImplemented)
-        self.assertIs(db.__le__(3.0+0j), NotImplemented)
+        self.assertIs(db.__lt__(0+3.0j), NotImplemented)
+        self.assertIs(db.__le__(0+3.0j), NotImplemented)
+        self.assertIs(db.__gt__(0+3.0j), NotImplemented)
+        self.assertIs(db.__le__(0+3.0j), NotImplemented)
+        self.assertIs(db.__lt__(3.0+0j), False)
+        self.assertIs(db.__le__(3.0+0j), True)
+        self.assertIs(db.__gt__(3.0+0j), False)
+        self.assertIs(db.__le__(3.0+0j), True)
 
     def test_decimal_fraction_comparison(self):
         D = self.decimal.Decimal

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -591,8 +591,6 @@ class FractionTest(unittest.TestCase):
 
     def testBigComplexComparisons(self):
         self.assertFalse(F(10**23) == complex(10**23))
-        self.assertRaises(TypeError, operator.gt, F(10**23), complex(10**23))
-        self.assertRaises(TypeError, operator.le, F(10**23), complex(10**23))
 
         x = F(3, 8)
         z = complex(0.375, 0.0)
@@ -601,9 +599,11 @@ class FractionTest(unittest.TestCase):
         self.assertFalse(x != z)
         self.assertFalse(x == w)
         self.assertTrue(x != w)
+        self.assertFalse(x > z)
+        self.assertFalse(x < z)
+        self.assertTrue(x >= z)
+        self.assertTrue(x <= z)
         for op in operator.lt, operator.le, operator.gt, operator.ge:
-            self.assertRaises(TypeError, op, x, z)
-            self.assertRaises(TypeError, op, z, x)
             self.assertRaises(TypeError, op, x, w)
             self.assertRaises(TypeError, op, w, x)
 

--- a/Lib/test/test_numeric_tower.py
+++ b/Lib/test/test_numeric_tower.py
@@ -177,7 +177,8 @@ class ComparisonTest(unittest.TestCase):
     def test_complex(self):
         # comparisons with complex are special:  equality and inequality
         # comparisons should always succeed, but order comparisons should
-        # raise TypeError.
+        # raise TypeError if the complex object has a nonzero imaginary
+        # component.
         z = 1.0 + 0j
         w = -3.14 + 2.7j
 
@@ -191,11 +192,17 @@ class ComparisonTest(unittest.TestCase):
             self.assertNotEqual(w, v)
             self.assertNotEqual(v, w)
 
-        for v in (1, 1.0, F(1), D(1), complex(1),
-                  2, 2.0, F(2), D(2), complex(2), w):
-            for op in operator.le, operator.lt, operator.ge, operator.gt:
-                self.assertRaises(TypeError, op, z, v)
-                self.assertRaises(TypeError, op, v, z)
+        for i in (1, 1.0, F(1), D(1), complex(1)):
+            for j in (2, 2.0, F(2), D(2), complex(2)):
+                for op in operator.le, operator.lt, operator.ge, operator.gt:
+                    self.assertLess(i, j)
+                    self.assertLessEqual(i, j)
+                    self.assertGreater(j, i)
+                    self.assertGreaterEqual(j, i)
+                    self.assertRaises(TypeError, op, w, i)
+                    self.assertRaises(TypeError, op, i, w)
+                    self.assertRaises(TypeError, op, w, j)
+                    self.assertRaises(TypeError, op, j, w)
 
 
 if __name__ == '__main__':

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -222,6 +222,7 @@ Ian Bruntlett
 Floris Bruynooghe
 Matt Bryant
 Stan Bubrouski
+Brandt Bucher
 Colm Buckley
 Erik de Bueger
 Jan-Hein Bührman

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-26-08-25-27.bpo-36117.VG0o8o.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-26-08-25-27.bpo-36117.VG0o8o.rst
@@ -1,0 +1,2 @@
+Rich comparisons of real-valued :class:`complex` objects with other numeric types no longer fail.
+Patch by Brandt Bucher.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -2875,7 +2875,7 @@ convert_op_cmp(PyObject **vcmp, PyObject **wcmp, PyObject *v, PyObject *w,
             *wcmp = PyDec_FromFloatExact(w, context);
         }
     }
-    else if (PyComplex_Check(w) && (op == Py_EQ || op == Py_NE)) {
+    else if (PyComplex_Check(w)) {
         Py_complex c = PyComplex_AsCComplex(w);
         if (c.real == -1.0 && PyErr_Occurred()) {
             *wcmp = NULL;


### PR DESCRIPTION



<!-- issue-number: [bpo-36117](https://bugs.python.org/issue36117) -->
https://bugs.python.org/issue36117
<!-- /issue-number -->
