### PR TITLE
[2.7] bpo-36106: resolve sinpi name clash with libm (IEEE-754 violation) (GH-12027)

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-02-25-13-21-43.bpo-36106.VuhEiQ.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-25-13-21-43.bpo-36106.VuhEiQ.rst
@@ -1,0 +1,1 @@
+Resolve potential name clash with libm's sinpi(). Patch by Dmitrii Pasechnik.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -71,7 +71,7 @@ static const double pi = 3.141592653589793238462643383279502884197;
 static const double sqrtpi = 1.772453850905516027298167483341145182798;
 
 static double
-sinpi(double x)
+m_sinpi(double x)
 {
     double y, r;
     int n;
@@ -270,7 +270,7 @@ m_tgamma(double x)
        integer. */
     if (absx > 200.0) {
         if (x < 0.0) {
-            return 0.0/sinpi(x);
+            return 0.0/m_sinpi(x);
         }
         else {
             errno = ERANGE;
@@ -294,7 +294,7 @@ m_tgamma(double x)
     }
     z = z * lanczos_g / y;
     if (x < 0.0) {
-        r = -pi / sinpi(absx) / absx * exp(y) / lanczos_sum(absx);
+        r = -pi / m_sinpi(absx) / absx * exp(y) / lanczos_sum(absx);
         r -= z * r;
         if (absx < 140.0) {
             r /= pow(y, absx - 0.5);
@@ -366,7 +366,7 @@ m_lgamma(double x)
             (x-0.5)*(log(x+lanczos_g-0.5)-1);
     }
     else {
-        r = log(pi) - log(fabs(sinpi(absx))) - log(absx) -
+        r = log(pi) - log(fabs(m_sinpi(absx))) - log(absx) -
             (log(lanczos_sum(absx)) - lanczos_g +
              (absx-0.5)*(log(absx+lanczos_g-0.5)-1));
     }


### PR DESCRIPTION
the standard math library (libm) may follow IEEE-754 recommendation to
include an implementation of sinPi(), i.e. sinPi(x):=sin(pi*x).
And this triggers a name clash, found by FreeBSD developer
Steve Kargl, who worked on putting sinpi into libm used on FreeBSD
(it has to be named "sinpi", not "sinPi", cf. e.g.
https://en.cppreference.com/w/c/experimental/fpext4)

https://bugs.python.org/issue36106

this is a backport of https://github.com/python/cpython/pull/12027 to
2.7 branch.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36106](https://bugs.python.org/issue36106) -->
https://bugs.python.org/issue36106
<!-- /issue-number -->
