### PR TITLE
bpo-36123:race condition in test_socket

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5603,7 +5603,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
         support.unlink(support.TESTFN)
 
     def accept_conn(self):
-        self.serv.settimeout(self.TIMEOUT)
+        self.serv.settimeout(MAIN_TIMEOUT)
         conn, addr = self.serv.accept()
         conn.settimeout(self.TIMEOUT)
         self.addCleanup(conn.close)

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5788,7 +5788,8 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
     def _testWithTimeoutTriggeredSend(self):
         address = self.serv.getsockname()
         with open(support.TESTFN, 'rb') as file:
-            with socket.create_connection(address, timeout=0.01) as sock:
+            with socket.create_connection(address) as sock:
+                sock.settimeout(0.01)
                 meth = self.meth_from_sock(sock)
                 self.assertRaises(socket.timeout, meth, file)
 

--- a/Misc/NEWS.d/next/Tests/2019-02-26-12-51-35.bpo-36123.QRhhRS.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-26-12-51-35.bpo-36123.QRhhRS.rst
@@ -1,0 +1,2 @@
+timeout is now set once the socket is created in :_testWithTimeoutTriggeredSend(self) rather than on the
+connection.

--- a/Misc/NEWS.d/next/Tests/2019-02-26-12-51-35.bpo-36123.QRhhRS.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-26-12-51-35.bpo-36123.QRhhRS.rst
@@ -1,2 +1,1 @@
-timeout is now set once the socket is created in :_testWithTimeoutTriggeredSend(self) rather than on the
-connection.
+Fix race condition in test_socket.


### PR DESCRIPTION
I have set timeout  once the socket is created rather than setting timeout on the
connection.

cc @vstinner 

<!-- issue-number: [bpo-36123](https://bugs.python.org/issue36123) -->
https://bugs.python.org/issue36123
<!-- /issue-number -->
