### PR TITLE
bpo-36232: Improve error message on dbm.open() when the db doesn't exist

### DIFF
--- a/Lib/dbm/__init__.py
+++ b/Lib/dbm/__init__.py
@@ -82,7 +82,8 @@ def open(file, flag='r', mode=0o666):
             # file doesn't exist and the new flag was used so use default type
             mod = _defaultmod
         else:
-            raise error[0]("need 'c' or 'n' flag to open new db")
+            raise error[0]("db file doesn't exist; "
+                           "use 'c' or 'n' flag to create a new db")
     elif result == "":
         # db type cannot be determined
         raise error[0]("db type could not be determined")

--- a/Misc/NEWS.d/next/Library/2019-03-20-15-13-18.bpo-36366.n0eav_.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-20-15-13-18.bpo-36366.n0eav_.rst
@@ -1,4 +1,4 @@
 Calling ``stop()`` on an unstarted or stopped :func:`unittest.mock.patch`
 object will now return `None` instead of raising :exc:`RuntimeError`,
 making the method idempotent.
-Patch byKarthikeyan Singaravelan.
+Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Library/2019-04-06-20-25-25.bpo-36232.SClmhb.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-06-20-25-25.bpo-36232.SClmhb.rst
@@ -1,0 +1,2 @@
+Improve error message when trying to open existing DBM database that
+actually doesn't exist. Patch by Marco Rougeth.


### PR DESCRIPTION


<!-- issue-number: [bpo-36232](https://bugs.python.org/issue36232) -->
https://bugs.python.org/issue36232
<!-- /issue-number -->
