### PR TITLE
[2.7] bpo-25872: fix KeyError on race in linecache.checkcache()

### DIFF
--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -63,10 +63,12 @@ def checkcache(filename=None):
         try:
             stat = os.stat(fullname)
         except os.error:
-            del cache[filename]
+            # Use pop instead of del because in a multithreaded case, this
+            # could have been deleted by another thread.
+            cache.pop(filename, None)
             continue
         if size != stat.st_size or mtime != stat.st_mtime:
-            del cache[filename]
+            cache.pop(filename, None)   # likewise
 
 
 def updatecache(filename, module_globals=None):

--- a/Misc/NEWS.d/next/Library/2019-02-27-15-00-22.bpo-25872.ItVO2B.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-27-15-00-22.bpo-25872.ItVO2B.rst
@@ -1,2 +1,3 @@
 Fixed a race condition in linecache.checkcache() that sometimes caused an
 exception if two threads generated a traceback simultaneously.
+Patch by Christopher Unkel.

--- a/Misc/NEWS.d/next/Library/2019-02-27-15-00-22.bpo-25872.ItVO2B.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-27-15-00-22.bpo-25872.ItVO2B.rst
@@ -1,0 +1,2 @@
+Fixed a race condition in linecache.checkcache() that sometimes caused an
+exception if two threads generated a traceback simultaneously.


### PR DESCRIPTION
If two threads generating a traceback run checkcache() at the same time,
they may both try to delete the same entries in the line cache,
resulting in a KeyError in one.  Use .pop(filename, None) instead of
del, as it will not raise the KeyError.

https://bugs.python.org/issue25872


<!-- issue-number: [bpo-25872](https://bugs.python.org/issue25872) -->
https://bugs.python.org/issue25872
<!-- /issue-number -->
