### PR TITLE
bpo-36130: Fix stepping into a frame without a __name__

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -190,6 +190,8 @@ class Bdb:
 
     def is_skipped_module(self, module_name):
         "Return True if module_name matches any skip pattern."
+        if module_name is None:  # some modules do not have names
+            return False
         for pattern in self.skip:
             if fnmatch.fnmatch(module_name, pattern):
                 return True

--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -730,6 +730,13 @@ class StateTestCase(BaseTestCase):
             with TracerRun(self, skip=skip) as tracer:
                 tracer.runcall(tfunc_import)
 
+    def test_skip_with_no_name_module(self):
+        # some frames have `globals` with no `__name__`
+        # for instance the second frame in this traceback
+        # exec(compile('raise ValueError()', '', 'exec'), {})
+        bdb = Bdb(skip=['anything*'])
+        self.assertIs(bdb.is_skipped_module(None), False)
+
     def test_down(self):
         # Check that set_down() raises BdbError at the newest frame.
         self.expect_set = [

--- a/Misc/NEWS.d/next/Library/2019-02-26-22-41-38.bpo-36130._BnZOo.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-26-22-41-38.bpo-36130._BnZOo.rst
@@ -1,0 +1,2 @@
+Fix ``pdb`` with ``skip=...`` when stepping into a frame without a
+``__name__`` global.  Patch by Anthony Sottile.


### PR DESCRIPTION


<!-- issue-number: [bpo-36130](https://bugs.python.org/issue36130) -->
https://bugs.python.org/issue36130
<!-- /issue-number -->
