### PR TITLE
bpo-13850: Add summary tables for argparse add_argument options

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -23,8 +23,48 @@ The :mod:`argparse` module makes it easy to write user-friendly command-line
 interfaces. The program defines what arguments it requires, and :mod:`argparse`
 will figure out how to parse those out of :data:`sys.argv`.  The :mod:`argparse`
 module also automatically generates help and usage messages and issues errors
-when users give the program invalid arguments.
+when users give the program invalid arguments.  See the `Quick Reference`_ for a
+summary table of applicable parameters for each action_ in
+:meth:`~ArgumentParser.add_argument`.
 
+Quick Reference
+---------------
+
+The table below provides a summary of applicable parameters (columns) of the
+add_argument() method for each functional action_ (rows).
+
++-----------------+---------+----------------+-----------+--------+-----------+------------+--------+-----------+--------+-----------+
+|                 |``nargs``|``const``       |``default``|``type``|``choices``|``required``|``help``|``metavar``|``dest``|``version``|
++=================+=========+================+===========+========+===========+============+========+===========+========+===========+
+|``store``        |x        |if ``nargs='?'``|x          |x       |x          |x           |x       |x          |x       |           |
++-----------------+---------+----------------+-----------+--------+-----------+------------+--------+-----------+--------+-----------+
+|``store_const``  |         |x               |x          |        |           |x           |x       |x          |x       |           |
++-----------------+---------+----------------+-----------+--------+-----------+------------+--------+-----------+--------+-----------+
+|``store_true``   |         |x               |x          |        |           |x           |x       |x          |x       |           |
++-----------------+---------+----------------+-----------+--------+-----------+------------+--------+-----------+--------+-----------+
+|``store_false``  |         |x               |x          |        |           |x           |x       |x          |x       |           |
++-----------------+---------+----------------+-----------+--------+-----------+------------+--------+-----------+--------+-----------+
+|``append``       |x        |if ``nargs='?'``|x          |x       |x          |x           |x       |x          |x       |           |
++-----------------+---------+----------------+-----------+--------+-----------+------------+--------+-----------+--------+-----------+
+|``append_const`` |         |x               |x          |        |           |x           |x       |x          |x       |           |
++-----------------+---------+----------------+-----------+--------+-----------+------------+--------+-----------+--------+-----------+
+|``count``        |         |                |           |        |           |            |x       |x          |x       |           |
++-----------------+---------+----------------+-----------+--------+-----------+------------+--------+-----------+--------+-----------+
+|``version``      |         |                |           |        |           |            |        |           |        |x          |
++-----------------+---------+----------------+-----------+--------+-----------+------------+--------+-----------+--------+-----------+
+
+.. note::
+
+    * ``default`` can be set to ``argparse.SUPPRESS`` to prevent the
+      attribute from being added
+
+    * ``nargs='?'`` will use ``default`` if the argument is not
+      specified, but ``const`` if the argument is specified with no
+      value provided
+
+    * list-type ``nargs`` (an ``int``, ``'*'`` or ``'+'``) causes a
+      list to be used: ``store`` becomes a list and ``append`` becomes
+      a list of lists
 
 Example
 -------

--- a/Misc/NEWS.d/next/Documentation/2019-02-27-14-48-15.bpo-13850.EykSI5.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-02-27-14-48-15.bpo-13850.EykSI5.rst
@@ -1,0 +1,3 @@
+Add asummary of applicable parameters of the
+:meth:`~ArgumentParser.add_argument`. Original patch by Xavier Morel,
+updated by Tina Zhang. Contributed by Stéphane Wirtel.


### PR DESCRIPTION
Co-authored-by: Xavier Morel <xavier.morel@masklinn.net>
Co-authored-by: Tina Zhang <tinazhang86@gmail.com>
Co-authored-by: Stéphane Wirtel <stephane@wirtel.be>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-13850](https://bugs.python.org/issue13850) -->
https://bugs.python.org/issue13850
<!-- /issue-number -->
