### PR TITLE
bpo-36140: Fix an incorrect check in msidb_getsummaryinformation()

### DIFF
--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -916,7 +916,7 @@ msidb_getsummaryinformation(msiobj *db, PyObject *args)
         return msierror(status);
 
     oresult = PyObject_NEW(struct msiobj, &summary_Type);
-    if (!result) {
+    if (!oresult) {
         MsiCloseHandle(result);
         return NULL;
     }


### PR DESCRIPTION
(This is a "skip news" PR.)

<!-- issue-number: [bpo-36140](https://bugs.python.org/issue36140) -->
https://bugs.python.org/issue36140
<!-- /issue-number -->
