### PR TITLE
Test with OpenSSL 1.1.0j

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 env:
   global:
-    - OPENSSL=1.1.0i
+    - OPENSSL=1.1.0j
     - OPENSSL_DIR="$HOME/multissl/openssl/${OPENSSL}"
     - PATH="${OPENSSL_DIR}/bin:$PATH"
     # Use -O3 because we don't use debugger on Travis-CI

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -45,16 +45,17 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "1.0.2p",
-    "1.1.0i",
-    "1.1.1",
+    "1.0.2r",
+    "1.1.0j",
+    "1.1.1b",
 ]
 
 LIBRESSL_OLD_VERSIONS = [
+    "2.7.5",
 ]
 
 LIBRESSL_RECENT_VERSIONS = [
-    "2.7.4",
+    "2.8.3",
 ]
 
 # store files in ../multissl


### PR DESCRIPTION
Also update multissl test script to use latest OpenSSL 1.0.2, 1.1.0, and
1.1.1, as well as latest LibreSSL 2.7 and 2.8.

Signed-off-by: Christian Heimes <christian@python.org>