### PR TITLE
bpo-34631: Update test infra to OpenSSL 1.1.1b

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -59,7 +59,7 @@ jobs:
   variables:
     testRunTitle: '$(build.sourceBranchName)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.0j
+    openssl_version: 1.1.1b
 
   steps:
   - template: ./posix-steps.yml
@@ -116,7 +116,7 @@ jobs:
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.0j
+    openssl_version: 1.1.1b
 
   steps:
   - template: ./posix-steps.yml

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -59,7 +59,7 @@ jobs:
   variables:
     testRunTitle: '$(system.pullRequest.TargetBranch)-linux'
     testRunPlatform: linux
-    openssl_version: 1.1.0j
+    openssl_version: 1.1.1b
 
   steps:
   - template: ./posix-steps.yml
@@ -116,7 +116,7 @@ jobs:
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
     testRunPlatform: linux-coverage
-    openssl_version: 1.1.0j
+    openssl_version: 1.1.1b
 
   steps:
   - template: ./posix-steps.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 env:
   global:
-    - OPENSSL=1.1.0i
+    - OPENSSL=1.1.1b
     - OPENSSL_DIR="$HOME/multissl/openssl/${OPENSSL}"
     - PATH="${OPENSSL_DIR}/bin:$PATH"
     # Use -O3 because we don't use debugger on Travis-CI

--- a/Misc/NEWS.d/next/Library/2019-02-28-17-08-47.bpo-34631.KgLT8q.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-28-17-08-47.bpo-34631.KgLT8q.rst
@@ -1,0 +1,1 @@
+Update test infrastructure to use OpenSSL 1.1.1b


### PR DESCRIPTION
OpenSSL 1.1.0 will reach EOL in September 2019. Update tests to use
OpenSSL 1.1.1b.

Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: [bpo-34631](https://bugs.python.org/issue34631) -->
https://bugs.python.org/issue34631
<!-- /issue-number -->
