### PR TITLE
bpo-36322: Fix parameter name at dbm.gnu.open docs

### DIFF
--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -264,12 +264,12 @@ to locate the appropriate header file to simplify building this module.
    Name of the ``ndbm`` implementation library used.
 
 
-.. function:: open(filename[, flag[, mode]])
+.. function:: open(filename[, flags[, mode]])
 
    Open a dbm database and return a ``ndbm`` object.  The *filename* argument is the
    name of the database file (without the :file:`.dir` or :file:`.pag` extensions).
 
-   The optional *flag* argument must be one of these values:
+   The optional *flags* argument must be one of these values:
 
    +---------+-------------------------------------------+
    | Value   | Meaning                                   |

--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -149,12 +149,12 @@ supported.
    raised for general mapping errors like specifying an incorrect key.
 
 
-.. function:: open(filename[, flag[, mode]])
+.. function:: open(filename[, flags[, mode]])
 
    Open a ``gdbm`` database and return a :class:`gdbm` object.  The *filename*
    argument is the name of the database file.
 
-   The optional *flag* argument can be:
+   The optional *flags* argument can be:
 
    +---------+-------------------------------------------+
    | Value   | Meaning                                   |
@@ -172,8 +172,8 @@ supported.
    |         | for reading and writing                   |
    +---------+-------------------------------------------+
 
-   The following additional characters may be appended to the flag to control
-   how the database is opened:
+   The following additional characters may be appended to the *flags* argument
+   to control how the database is opened:
 
    +---------+--------------------------------------------+
    | Value   | Meaning                                    |
@@ -382,4 +382,3 @@ The module defines the following:
    .. method:: dumbdbm.close()
 
       Close the ``dumbdbm`` database.
-


### PR DESCRIPTION
There's a missing `s` in the `flags` parameter at the [docs](https://docs.python.org/3/library/dbm.html#dbm.gnu.open) for `dbm.gnu.open`.

Reference: https://github.com/python/cpython/blob/master/Modules/_gdbmmodule.c#L533

<!-- issue-number: [bpo-36322](https://bugs.python.org/issue36322) -->
https://bugs.python.org/issue36322
<!-- /issue-number -->
