### PR TITLE
bpo-36146: Fix inc_dirs in setup.py on macOS

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-02-28-18-09-01.bpo-36146.IwPJVT.rst
+++ b/Misc/NEWS.d/next/Build/2019-02-28-18-09-01.bpo-36146.IwPJVT.rst
@@ -1,0 +1,2 @@
+Fix setup.py on macOS: only add ``/usr/include/ffi`` to include
+directories of _ctypes, not for all extensions.

--- a/setup.py
+++ b/setup.py
@@ -2003,16 +2003,17 @@ class PyBuildExt(build_ext):
                      libraries=['m'])
         self.extensions.extend([ext, ext_test])
 
+        ffi_inc_dirs = inc_dirs.copy()
         if MACOS:
             if '--with-system-ffi' not in sysconfig.get_config_var("CONFIG_ARGS"):
                 return
             # OS X 10.5 comes with libffi.dylib; the include files are
             # in /usr/include/ffi
-            inc_dirs.append('/usr/include/ffi')
+            ffi_inc_dirs.append('/usr/include/ffi')
 
         ffi_inc = [sysconfig.get_config_var("LIBFFI_INCLUDEDIR")]
         if not ffi_inc or ffi_inc[0] == '':
-            ffi_inc = find_file('ffi.h', [], inc_dirs)
+            ffi_inc = find_file('ffi.h', [], ffi_inc_dirs)
         if ffi_inc is not None:
             ffi_h = ffi_inc[0] + '/ffi.h'
             if not os.path.exists(ffi_h):


### PR DESCRIPTION
Fix setup.py on macOS: only add /usr/include/ffi to include
directories of _ctypes, not for all extensions.

<!-- issue-number: [bpo-36146](https://bugs.python.org/issue36146) -->
https://bugs.python.org/issue36146
<!-- /issue-number -->
