### PR TITLE
bpo-29571: Fix test_re.test_locale_flag()

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1552,8 +1552,7 @@ class ReTests(unittest.TestCase):
         self.assertRaises(re.error, re.compile, r'(?au)\w')
 
     def test_locale_flag(self):
-        import locale
-        _, enc = locale.getlocale(locale.LC_CTYPE)
+        enc = locale.getpreferredencoding()
         # Search non-ASCII letter
         for i in range(128, 256):
             try:

--- a/Misc/NEWS.d/next/Tests/2019-02-28-18-33-29.bpo-29571.r6b9fr.rst
+++ b/Misc/NEWS.d/next/Tests/2019-02-28-18-33-29.bpo-29571.r6b9fr.rst
@@ -1,0 +1,3 @@
+Fix ``test_re.test_locale_flag()``:  use ``locale.getpreferredencoding()``
+rather than ``locale.getlocale()`` to get the locale encoding. With some
+locales, ``locale.getlocale()`` returns the wrong encoding.


### PR DESCRIPTION
Use locale.getpreferredencoding() rather than locale.getlocale() to
get the locale encoding. With some locales, locale.getlocale()
returns the wrong encoding.

For example, on Fedora 29, locale.getlocale() returns ISO-8859-1
encoding for the "en_IN" locale, whereas
locale.getpreferredencoding() reports the correct encoding: UTF-8.

<!-- issue-number: [bpo-29571](https://bugs.python.org/issue29571) -->
https://bugs.python.org/issue29571
<!-- /issue-number -->
