### PR TITLE
[2.7] bpo-13096: Fix partial backport of issue 13096.

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-04-16-13-01.bpo-13096.SGPt_n.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-04-16-13-01.bpo-13096.SGPt_n.rst
@@ -1,0 +1,1 @@
+Fix memory leak in ctypes POINTER handling of large values.

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1831,6 +1831,7 @@ POINTER(PyObject *self, PyObject *cls)
                                        "s(O){}",
                                        buf,
                                        &PyCPointer_Type);
+        PyMem_Free(buf);
         if (result == NULL)
             return result;
         key = PyLong_FromVoidPtr(result);


### PR DESCRIPTION
Properly free the buf variable.

<!-- issue-number: [bpo-13096](https://bugs.python.org/issue13096) -->
https://bugs.python.org/issue13096
<!-- /issue-number -->
