### PR TITLE
bpo-35931: Gracefully handle any exception in pdb debug command

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1093,16 +1093,14 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         sys.settrace(None)
         globals = self.curframe.f_globals
         locals = self.curframe_locals
-        try:
-            code = compile(arg, "<string>", "exec")
-        except SyntaxError:
-            exc_info = sys.exc_info()[:2]
-            self.error(traceback.format_exception_only(*exc_info)[-1].strip())
-            return
         p = Pdb(self.completekey, self.stdin, self.stdout)
         p.prompt = "(%s) " % self.prompt.strip()
         self.message("ENTERING RECURSIVE DEBUGGER")
-        sys.call_tracing(p.run, (code, globals, locals))
+        try:
+            sys.call_tracing(p.run, (arg, globals, locals))
+        except Exception:
+            exc_info = sys.exc_info()[:2]
+            self.error(traceback.format_exception_only(*exc_info)[-1].strip())
         self.message("LEAVING RECURSIVE DEBUGGER")
         sys.settrace(self.trace_dispatch)
         self.lastcmd = p.lastcmd

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1486,12 +1486,26 @@ class PdbTestCase(unittest.TestCase):
         stdout, _ = self._run_pdb(['-m', self.module_name + '.runme'], commands)
         self.assertTrue(any("VAR from module" in l for l in stdout.splitlines()), stdout)
 
-    def test_syntaxerror_in_command(self):
-        commands = "print(\ndebug print("
-        stdout, _ = self.run_pdb_script("", commands)
+    def test_errors_in_command(self):
+        commands = "\n".join([
+            'print(',
+            'debug print(',
+            'debug doesnotexist',
+            'c',
+        ])
+        stdout, _ = self.run_pdb_script('', commands + '\n')
+
         self.assertEqual(stdout.splitlines()[1:], [
             '(Pdb) *** SyntaxError: unexpected EOF while parsing',
-            '(Pdb) *** SyntaxError: unexpected EOF while parsing',
+
+            '(Pdb) ENTERING RECURSIVE DEBUGGER',
+            '*** SyntaxError: unexpected EOF while parsing',
+            'LEAVING RECURSIVE DEBUGGER',
+
+            '(Pdb) ENTERING RECURSIVE DEBUGGER',
+            '> <string>(1)<module>()',
+            "((Pdb)) *** NameError: name 'doesnotexist' is not defined",
+            'LEAVING RECURSIVE DEBUGGER',
             '(Pdb) ',
         ])
 

--- a/Misc/NEWS.d/next/Library/2019-03-11-22-06-36.bpo-35931.Qp_Tbe.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-11-22-06-36.bpo-35931.Qp_Tbe.rst
@@ -1,0 +1,1 @@
+The :mod:`pdb` ``debug`` command now gracefully handles all exceptions.


### PR DESCRIPTION
This is relevant for `debug doesnotexist()`, which would crash with a
NameError otherwise.