### PR TITLE
bpo-36150: Fix possible assertion failures due to _ctypes.c's PyCData_reduce()

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2735,12 +2735,8 @@ PyCData_reduce(PyObject *myself, PyObject *args)
     if (dict == NULL) {
         return NULL;
     }
-    PyObject *bytes = PyBytes_FromStringAndSize(self->b_ptr, self->b_size);
-    if (bytes == NULL) {
-        Py_DECREF(dict);
-        return NULL;
-    }
-    return Py_BuildValue("O(O(NN))", _unpickle, Py_TYPE(myself), dict, bytes);
+    return Py_BuildValue("O(O(NN))", _unpickle, Py_TYPE(myself), dict,
+                         PyBytes_FromStringAndSize(self->b_ptr, self->b_size));
 }
 
 static PyObject *

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2731,11 +2731,16 @@ PyCData_reduce(PyObject *myself, PyObject *args)
                         "ctypes objects containing pointers cannot be pickled");
         return NULL;
     }
-    return Py_BuildValue("O(O(NN))",
-                         _unpickle,
-                         Py_TYPE(myself),
-                         PyObject_GetAttrString(myself, "__dict__"),
-                         PyBytes_FromStringAndSize(self->b_ptr, self->b_size));
+    PyObject *dict = PyObject_GetAttrString(myself, "__dict__");
+    if (dict == NULL) {
+        return NULL;
+    }
+    PyObject *bytes = PyBytes_FromStringAndSize(self->b_ptr, self->b_size);
+    if (bytes == NULL) {
+        Py_DECREF(dict);
+        return NULL;
+    }
+    return Py_BuildValue("O(O(NN))", _unpickle, Py_TYPE(myself), dict, bytes);
 }
 
 static PyObject *


### PR DESCRIPTION
(This is a "skip news" PR.)

<!-- issue-number: [bpo-36150](https://bugs.python.org/issue36150) -->
https://bugs.python.org/issue36150
<!-- /issue-number -->
