### PR TITLE
bpo-36152: IDLE: Remove unused parameter from colorizer

### DIFF
--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -66,8 +66,6 @@ class ColorDelegator(Delegator):
         colorizing: Boolean flag when colorizing is in process.
         stop_colorizing: Boolean flag to end an active colorizing
                 process.
-        close_when_done: Widget to destroy after colorizing process
-                completes (doesn't seem to be used by IDLE).
     """
 
     def __init__(self):
@@ -157,9 +155,7 @@ class ColorDelegator(Delegator):
             self.after_id = self.after(1, self.recolorize)
         return
 
-    close_when_done = None  # Window to be closed when done colorizing.
-
-    def close(self, close_when_done=None):
+    def close(self):
         if self.after_id:
             after_id = self.after_id
             self.after_id = None
@@ -167,11 +163,6 @@ class ColorDelegator(Delegator):
             self.after_cancel(after_id)
         self.allow_colorizing = False
         self.stop_colorizing = True
-        if close_when_done:
-            if not self.colorizing:
-                close_when_done.destroy()
-            else:
-                self.close_when_done = close_when_done
 
     def toggle_colorize_event(self, event=None):
         """Toggle colorizing on and off.
@@ -205,9 +196,7 @@ class ColorDelegator(Delegator):
         process is not already running.
 
         After colorizing is complete, some cleanup is done to
-        make sure that all the text has been colorized and to close
-        the window if the close event had been called while the
-        process was running.
+        make sure that all the text has been colorized.
         """
         self.after_id = None
         if not self.delegate:
@@ -232,10 +221,6 @@ class ColorDelegator(Delegator):
         if self.allow_colorizing and self.tag_nextrange("TODO", "1.0"):
             if DEBUG: print("reschedule colorizing")
             self.after_id = self.after(1, self.recolorize)
-        if self.close_when_done:
-            top = self.close_when_done
-            self.close_when_done = None
-            top.destroy()
 
     def recolorize_main(self):
         "Evaluate text and apply colorizing tags."

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1033,7 +1033,7 @@ class EditorWindow(object):
         self.io = None
         self.undo = None
         if self.color:
-            self.color.close(False)
+            self.color.close()
             self.color = None
         self.text = None
         self.tkinter_vars = None

--- a/Misc/NEWS.d/next/IDLE/2019-02-28-18-52-40.bpo-36152.9pkHIU.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-02-28-18-52-40.bpo-36152.9pkHIU.rst
@@ -1,1 +1,3 @@
-Remove unused close_when_done parameter from colorizer close() method.
+Remove colorizer.ColorDelegator.close_when_done and the
+corresponding argument of .close().  In IDLE, both have
+always been None or False since 2007.

--- a/Misc/NEWS.d/next/IDLE/2019-02-28-18-52-40.bpo-36152.9pkHIU.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-02-28-18-52-40.bpo-36152.9pkHIU.rst
@@ -1,0 +1,1 @@
+Remove unused close_when_done parameter from colorizer close() method.


### PR DESCRIPTION
Remove unused `close_when_done` parameter from ColorDelegator's `close()` method.


<!-- issue-number: [bpo-36152](https://bugs.python.org/issue36152) -->
https://bugs.python.org/issue36152
<!-- /issue-number -->
