### PR TITLE
bpo-13055: Fix empty version handling in disutils.version

### DIFF
--- a/Lib/distutils/tests/test_version.py
+++ b/Lib/distutils/tests/test_version.py
@@ -30,7 +30,9 @@ class VersionTestCase(unittest.TestCase):
                     ('1.2.2', '1.2', 1),
                     ('1.2', '1.2.2', -1),
                     ('0.4.0', '0.4', 0),
-                    ('1.13++', '5.5.kw', ValueError))
+                    ('1.13++', '5.5.kw', ValueError),
+                    ('', '1.1', ValueError),
+                    (None, '1.1', ValueError))
 
         for v1, v2, wanted in versions:
             try:
@@ -55,7 +57,8 @@ class VersionTestCase(unittest.TestCase):
                     ('3.2.pl0', '3.1.1.6', 1),
                     ('2g6', '11g', -1),
                     ('0.960923', '2.2beta29', -1),
-                    ('1.13++', '5.5.kw', -1))
+                    ('1.13++', '5.5.kw', -1),
+                    ('', '1.1', -1))
 
 
         for v1, v2, wanted in versions:

--- a/Lib/distutils/version.py
+++ b/Lib/distutils/version.py
@@ -36,7 +36,8 @@ class Version:
     """
 
     def __init__ (self, vstring=None):
-        if vstring:
+        self.version = None
+        if vstring is not None:
             self.parse(vstring)
 
     def __repr__ (self):
@@ -130,7 +131,6 @@ class StrictVersion (Version):
     version_re = re.compile(r'^(\d+) \. (\d+) (\. (\d+))? ([ab](\d+))?$',
                             re.VERBOSE | re.ASCII)
 
-
     def parse (self, vstring):
         match = self.version_re.match(vstring)
         if not match:
@@ -151,6 +151,8 @@ class StrictVersion (Version):
 
 
     def __str__ (self):
+        if self.version is None:
+            return 'None'
 
         if self.version[2] == 0:
             vstring = '.'.join(map(str, self.version[0:2]))
@@ -166,6 +168,9 @@ class StrictVersion (Version):
     def _cmp (self, other):
         if isinstance(other, str):
             other = StrictVersion(other)
+
+        if self.version is None:
+            raise ValueError("invalid version number 'None'")
 
         if self.version != other.version:
             # numeric versions don't match
@@ -299,9 +304,9 @@ class LooseVersion (Version):
 
     component_re = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
 
-    def __init__ (self, vstring=None):
-        if vstring:
-            self.parse(vstring)
+    def __init__(self, vstring=None):
+        self.vstring = None
+        super(LooseVersion, self).__init__(vstring)
 
 
     def parse (self, vstring):
@@ -321,16 +326,17 @@ class LooseVersion (Version):
 
 
     def __str__ (self):
+        if self.vstring is None:
+            return 'None'
         return self.vstring
-
-
-    def __repr__ (self):
-        return "LooseVersion ('%s')" % str(self)
 
 
     def _cmp (self, other):
         if isinstance(other, str):
             other = LooseVersion(other)
+
+        if self.version is None:
+            raise ValueError("invalid version number 'None'")
 
         if self.version == other.version:
             return 0

--- a/Misc/NEWS.d/next/Library/2019-03-01-15-42-52.bpo-13055.Xx2sK3.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-01-15-42-52.bpo-13055.Xx2sK3.rst
@@ -1,1 +1,1 @@
-Fix empty version handling in disutils.version
+Fix empty version handling in ``disutils.version``. Patch contributed by Matt Martz.

--- a/Misc/NEWS.d/next/Library/2019-03-01-15-42-52.bpo-13055.Xx2sK3.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-01-15-42-52.bpo-13055.Xx2sK3.rst
@@ -1,0 +1,1 @@
+Fix empty version handling in disutils.version


### PR DESCRIPTION
This PR aims to resolve a few problems in distutils.version empty version handling:

1. Use comparisons to `None` in `__init__` so that `''` can be treated as an actual version.
    1. `''` is a valid `LooseVersion`
    1. `''` isn't a valid `StrictVersion`
1. Guard `__str__` and `__repr__` so that they don't raise exceptions when instantiated with no version or `None` to avoid an `AttributeError`
1. Raise `ValueError` in `_cmp` if `parse` has not been called after instantiating with no version of `None`, to avoid an `AttributeError`
1. Add tests to assert the changed behavior

This issue was identified in an application that verifies a user specified version and compares it for accuracy. `StrictVersion('')` ended up causing tracebacks in the comparison, instead of in validating the version was correct.  In my specific case it has been worked around using:

```
try:
    version = StrictVersion()
    version.parse(user_version)
except ValueError:
    # Do something here
```

<!-- issue-number: [bpo-13055](https://bugs.python.org/issue13055) -->
https://bugs.python.org/issue13055
<!-- /issue-number -->
