### PR TITLE
bpo-36146: Add TEST_EXTENSIONS to setup.py

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-03-01-17-49-22.bpo-36146.VeoyG7.rst
+++ b/Misc/NEWS.d/next/Build/2019-03-01-17-49-22.bpo-36146.VeoyG7.rst
@@ -1,0 +1,2 @@
+Add ``TEST_EXTENSIONS`` constant to ``setup.py`` to allow to not build test
+extensions like ``_testcapi``.


### PR DESCRIPTION
Add TEST_EXTENSIONS constant to setup.py to allow to not build test
extensions like _testcapi.

Changes:

* Add add_ldflags_cppflags() subfunction
* Rename add_compiler_directories() to configure_compiler().
* Remove unused COMPILED_WITH_PYDEBUG constant.
* Use self.add() rather than accessing directly self.extensions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36146](https://bugs.python.org/issue36146) -->
https://bugs.python.org/issue36146
<!-- /issue-number -->
