### PR TITLE
bpo-36164: add sys.setinspectflag()

### DIFF
--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -1019,6 +1019,34 @@ sys_getandroidapilevel(PyObject *module, PyObject *Py_UNUSED(ignored))
 
 #endif /* defined(ANDROID_API_LEVEL) */
 
+PyDoc_STRVAR(sys_setinspectflag__doc__,
+"setinspectflag($module, flag, /)\n"
+"--\n"
+"\n"
+"Set True to inspect interactively after running script.");
+
+#define SYS_SETINSPECTFLAG_METHODDEF    \
+    {"setinspectflag", (PyCFunction)sys_setinspectflag, METH_O, sys_setinspectflag__doc__},
+
+static PyObject *
+sys_setinspectflag_impl(PyObject *module, int new_val);
+
+static PyObject *
+sys_setinspectflag(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    int new_val;
+
+    new_val = PyObject_IsTrue(arg);
+    if (new_val < 0) {
+        goto exit;
+    }
+    return_value = sys_setinspectflag_impl(module, new_val);
+
+exit:
+    return return_value;
+}
+
 #ifndef SYS_GETWINDOWSVERSION_METHODDEF
     #define SYS_GETWINDOWSVERSION_METHODDEF
 #endif /* !defined(SYS_GETWINDOWSVERSION_METHODDEF) */
@@ -1050,4 +1078,4 @@ sys_getandroidapilevel(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=109787af3401cd27 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=380cc462a417837c input=a9049054013a1b77]*/

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1636,6 +1636,31 @@ sys_getandroidapilevel_impl(PyObject *module)
 #endif   /* ANDROID_API_LEVEL */
 
 
+
+
+/*[clinic input]
+sys.setinspectflag
+
+    flag as new_val: bool
+    /
+
+Set True to inspect interactively after running script.
+
+[clinic start generated code]*/
+
+static PyObject *
+sys_setinspectflag_impl(PyObject *module, int new_val)
+/*[clinic end generated code: output=12e1c926420f9717 input=d21b6f13f637b3a1]*/
+{
+    PyInterpreterState *interp = _PyInterpreterState_Get();
+
+    _PyCoreConfig *config = &interp->core_config;
+    config->inspect = new_val;
+    Py_InspectFlag = new_val;
+    Py_RETURN_NONE;
+}
+
+
 static PyMethodDef sys_methods[] = {
     /* Might as well keep this in alphabetic order */
     {"breakpointhook",  (PyCFunction)(void(*)(void))sys_breakpointhook,
@@ -1690,6 +1715,7 @@ static PyMethodDef sys_methods[] = {
      METH_VARARGS | METH_KEYWORDS, set_asyncgen_hooks_doc},
     SYS_GET_ASYNCGEN_HOOKS_METHODDEF
     SYS_GETANDROIDAPILEVEL_METHODDEF
+    SYS_SETINSPECTFLAG_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 


### PR DESCRIPTION
I sometime use a hack to start interactive console after running script.

```py
import os

os.environ['PYTHONINSPECT'] = 'x'
print("Hello")
```

This hack works because `PYTHONINSPECT` is checked [here](https://github.com/python/cpython/blob/master/Modules/main.c#L738) when exiting Python.

However, if the script uses `sys.exit()` to exit from Python, interactive console doen't apper because unhandled `SystemExit` exception leads `exit(3)` call to kill process, without checking `PYTHONINSPECT`.

```py
import os, sys

os.environ['PYTHONINSPECT'] = 'x'
print("Hello")

sys.exit(1)  # Interactive console will not start
```

I think feature to allow updating `Py_InspectFlag` is useful, and this is a bugs to be fixed. However, setting environment variable to start console is not intuituve.

So instead of fixing bug, I would like to propose a small function to set `Py_InspectFlag` to start interactive console after running script.

```
sys.setinteractiveflag(bool)
```

Thoughts?



<!-- issue-number: [bpo-36164](https://bugs.python.org/issue36164) -->
https://bugs.python.org/issue36164
<!-- /issue-number -->
