### PR TITLE
Have UserDict.__init__() implicitly check for updating w/ bool(kwargs) instead of len()

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1014,7 +1014,7 @@ class UserDict(_collections_abc.MutableMapping):
         self.data = {}
         if dict is not None:
             self.update(dict)
-        if len(kwargs):
+        if kwargs:
             self.update(kwargs)
     def __len__(self): return len(self.data)
     def __getitem__(self, key):


### PR DESCRIPTION
Semantically the same, but more idiomatic by checking against `kwargs` instead of `len(kwargs)`.