### PR TITLE
In compileall documentation, use `option` word for command line interface.

### DIFF
--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -105,7 +105,7 @@ compile Python sources.
    byte-code file ending in ``.pyc``, never ``.pyo``.
 
 .. versionchanged:: 3.7
-   Added the ``--invalidation-mode`` parameter.
+   Added the ``--invalidation-mode`` option.
 
 
 There is no command-line option to control the optimization level used by the


### PR DESCRIPTION
For command line option, `option` is better than `parameter`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
