### PR TITLE
bpo-36170: posix_spawn doesn't exist on 3.7

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3465,7 +3465,7 @@ written in Python, such as a mail server's external command delivery program.
    :c:data:`POSIX_SPAWN_SETSCHEDPARAM` and :c:data:`POSIX_SPAWN_SETSCHEDULER`
    flags.
 
-   .. versionadded:: 3.7
+   .. versionadded:: 3.8
 
    .. availability:: Unix.
 


### PR DESCRIPTION
The 3.8 docs claim that `os.posix_spawn` was introduced in 3.7, but it wasn't; it will be introduced in 3.8.

<!-- issue-number: [bpo-36170](https://bugs.python.org/issue36170) -->
https://bugs.python.org/issue36170
<!-- /issue-number -->
