### PR TITLE
bpo-31904: Add subprocess module support for VxWorks RTOS

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -394,6 +394,8 @@ functions.
 
       Popen(['/bin/sh', '-c', args[0], args[1], ...])
 
+   VxWorks does not support shell argument.
+
    On Windows with ``shell=True``, the :envvar:`COMSPEC` environment variable
    specifies the default shell.  The only time you need to specify
    ``shell=True`` on Windows is when the command you wish to execute is built
@@ -448,6 +450,8 @@ functions.
    If *preexec_fn* is set to a callable object, this object will be called in the
    child process just before the child is executed.
    (POSIX only)
+
+   VxWorks does not support preexec_fn argument.
 
    .. warning::
 
@@ -508,6 +512,8 @@ functions.
 
    If *start_new_session* is true the setsid() system call will be made in the
    child process prior to the execution of the subprocess.  (POSIX only)
+
+   VxWorks does not support start_new_session argument.
 
    .. versionchanged:: 3.2
       *start_new_session* was added.

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -741,10 +741,10 @@ class Popen(object):
                 if shell:
                     raise ValueError("shell is not supported on VxWorks")
                 if preexec_fn is not None:
-                    raise ValueError("Preexecution function is not supported"
-                                     "on VxWorks");
+                    raise ValueError("preexec_fn is not supported on VxWorks")
                 if start_new_session:
-                    raise ValueError("VxWorks does not support sessions");
+                    raise ValueError("start_new_session is not supported"
+                                      "on VxWorks")
             # POSIX
             if pass_fds and not close_fds:
                 warnings.warn("pass_fds overriding close_fds.", RuntimeWarning)
@@ -1599,8 +1599,9 @@ class Popen(object):
                             cwd, env_list,
                             p2cread, p2cwrite, c2pread, c2pwrite,
                             errread, errwrite,
-                            errpipe_read, errpipe_write,
-                            restore_signals, start_new_session, preexec_fn)
+                            errpipe_read, errpipe_write)
+                        if self.pid != -1:
+                            self._child_created = True
                     else:
                         self.pid = _posixsubprocess.fork_exec(
                             args, executable_list,
@@ -1610,9 +1611,7 @@ class Popen(object):
                             errread, errwrite,
                             errpipe_read, errpipe_write,
                             restore_signals, start_new_session, preexec_fn)
-                    self._child_created = True
-                    if _vxworks and self.pid == -1:
-                        self._child_created = False
+                        self._child_created = True
                 finally:
                     # be sure the FD is closed no matter what
                     os.close(errpipe_write)

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -49,7 +49,7 @@ if vxworks:
 
     no_shell = True
     no_preexec_fn = True
-elif not mswindows:
+else:
     import _posixsubprocess
     mock_modname = "subprocess._posixsubprocess.fork_exec"
     mock_submod  = subprocess._posixsubprocess

--- a/Misc/NEWS.d/next/Library/2019-03-04-14-57-25.bpo-31904.28djD8.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-04-14-57-25.bpo-31904.28djD8.rst
@@ -1,0 +1,1 @@
+Support subprocess module on VxWorks.

--- a/Modules/_vxwapi.c
+++ b/Modules/_vxwapi.c
@@ -117,8 +117,7 @@ rtp_spawn_impl(
            int c2pread, int c2pwrite,
            int errread, int errwrite,
            int errpipe_read, int errpipe_write,
-           int close_fds, int restore_signals,
-           PyObject *py_fds_to_keep)
+           int close_fds, PyObject *py_fds_to_keep)
 {
     int priority = 0;
     unsigned int uStackSize = 0;
@@ -243,7 +242,6 @@ rtp_spawn_impl(
 
     reached_preexec = 1;
 
-    /* close FDs after executing preexec_fn, which might open FDs */
     if (close_fds) {
         _close_open_fds(3, py_fds_to_keep);
     }
@@ -387,9 +385,6 @@ _vxwapi.rtp_spawn
     errwrite: int
     errpipe_read: int
     errpipe_write: int
-    restore_signals: int
-    call_setsid: int
-    preexec_fn: object
     /
 
 Spawn a real time process in the vxWorks OS
@@ -401,10 +396,9 @@ _vxwapi_rtp_spawn_impl(PyObject *module, PyObject *process_args,
                        PyObject *py_fds_to_keep, PyObject *cwd_obj,
                        PyObject *env_list, int p2cread, int p2cwrite,
                        int c2pread, int c2pwrite, int errread, int errwrite,
-                       int errpipe_read, int errpipe_write,
-                       int restore_signals, int call_setsid,
-                       PyObject *preexec_fn)
-/*[clinic end generated code: output=5f98889b783df975 input=30419f3fea045213]*/
+                       int errpipe_read, int errpipe_write)
+/*[clinic end generated code: output=e398e7eafdf8ce1e input=76a69d261378fad9]*/
+
 {
     PyObject *converted_args = NULL, *fast_args = NULL;
     char *const *argv = NULL, *const *envp = NULL;
@@ -423,16 +417,6 @@ _vxwapi_rtp_spawn_impl(PyObject *module, PyObject *process_args,
 
     if (_sanity_check_python_fd_sequence(py_fds_to_keep)) {
         PyErr_SetString(PyExc_ValueError, "bad value(s) in fds_to_keep");
-        return NULL;
-    }
-
-    if (preexec_fn != Py_None) {
-        PyErr_SetString(PyExc_RuntimeError, "Preexecution function is not supported on VxWorks");
-        return NULL;
-    }
-
-    if (call_setsid != 0) {
-        PyErr_SetString(PyExc_RuntimeError, "VxWorks does not support sessions");
         return NULL;
     }
 
@@ -483,7 +467,7 @@ _vxwapi_rtp_spawn_impl(PyObject *module, PyObject *process_args,
                         executable_list, argv, envp, cwd_obj,
                         p2cread, p2cwrite, c2pread, c2pwrite,
                         errread, errwrite, errpipe_read, errpipe_write,
-                        close_fds, restore_signals, py_fds_to_keep);
+                        close_fds, py_fds_to_keep);
 
     _restore_fds (saved_fd);
 

--- a/Modules/_vxwapi.c
+++ b/Modules/_vxwapi.c
@@ -1,0 +1,520 @@
+/*
+ * VxWorks Compatibility Wrapper
+ *
+ * Python interface to VxWorks methods
+ *
+ * Author: wenyan.xin@windriver.com
+ *
+ ************************************************/
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <Python.h>
+#include <rtpLib.h>
+#include <pathLib.h>
+#include <taskLibCommon.h>
+
+#include "clinic/_vxwapi.c.h"
+
+/*[clinic input]
+module _vxwapi
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=6efcf3b26a262ef1]*/
+
+/* Returns 1 if there is a problem with fd_sequence, 0 otherwise. */
+static int
+_sanity_check_python_fd_sequence(PyObject *fd_sequence)
+{
+    Py_ssize_t seq_idx;
+    long prev_fd = -1;
+    for (seq_idx = 0; seq_idx < PyTuple_GET_SIZE(fd_sequence); ++seq_idx) {
+        PyObject* py_fd = PyTuple_GET_ITEM(fd_sequence, seq_idx);
+        long iter_fd;
+        if (!PyLong_Check(py_fd)) {
+            return 1;
+        }
+        iter_fd = PyLong_AsLong(py_fd);
+        if (iter_fd < 0 || iter_fd <= prev_fd || iter_fd > INT_MAX) {
+            /* Negative, overflow, unsorted, too big for a fd. */
+            return 1;
+        }
+        prev_fd = iter_fd;
+    }
+    return 0;
+}
+
+/* Is fd found in the sorted Python Sequence? */
+static int
+_is_fd_in_sorted_fd_sequence(int fd, PyObject *fd_sequence)
+{
+    /* Binary search. */
+    Py_ssize_t search_min = 0;
+    Py_ssize_t search_max = PyTuple_GET_SIZE(fd_sequence) - 1;
+    if (search_max < 0)
+        return 0;
+    do {
+        long middle = (search_min + search_max) / 2;
+        long middle_fd = PyLong_AsLong(PyTuple_GET_ITEM(fd_sequence, middle));
+        if (fd == middle_fd)
+            return 1;
+        if (fd > middle_fd)
+            search_min = middle + 1;
+        else
+            search_max = middle - 1;
+    } while (search_min <= search_max);
+    return 0;
+}
+
+
+static void _close_open_fds(long start_fd, PyObject* py_fds_to_keep)
+{
+    int fd;
+    int ret;
+
+    for (fd = start_fd; fd < FD_SETSIZE; ++fd) {
+        ret = fcntl (fd, F_GETFD);
+        if (ret < 0)
+            continue;
+
+        if (_is_fd_in_sorted_fd_sequence(fd, py_fds_to_keep))
+            continue;
+
+        _Py_set_inheritable_async_safe(fd, 0, NULL);
+    }
+}
+
+
+static int
+make_inheritable(PyObject *py_fds_to_keep, int errpipe_write)
+{
+    Py_ssize_t i, len;
+
+    len = PyTuple_GET_SIZE(py_fds_to_keep);
+    for (i = 0; i < len; ++i) {
+        PyObject* fdobj = PyTuple_GET_ITEM(py_fds_to_keep, i);
+        long fd = PyLong_AsLong(fdobj);
+        assert(!PyErr_Occurred());
+        assert(0 <= fd && fd <= INT_MAX);
+        if (fd == errpipe_write) {
+            /* errpipe_write is part of py_fds_to_keep. It must be closed at
+               exec(), but kept open in the child process until exec() is
+               called. */
+            continue;
+        }
+        if (_Py_set_inheritable_async_safe((int)fd, 1, NULL) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+static PyObject *
+rtp_spawn_impl(
+           PyObject *executable_list,
+           char *const argvp[],
+           char *const envpp[],
+           PyObject *cwd_obj,
+           int p2cread, int p2cwrite,
+           int c2pread, int c2pwrite,
+           int errread, int errwrite,
+           int errpipe_read, int errpipe_write,
+           int close_fds, int restore_signals,
+           PyObject *py_fds_to_keep)
+{
+    int priority = 0;
+    unsigned int uStackSize = 0;
+    int options = 0;
+    int taskOptions = VX_FP_TASK;
+    char  pwdbuf[PATH_MAX]={0};
+    const char *cwd = NULL;
+    PyObject *cwd_obj2;
+    char *const *exec_array;
+
+    int p2cread_bk  = -1;
+    int c2pwrite_bk = -1;
+    int errwrite_bk = -1;
+
+    if (make_inheritable(py_fds_to_keep, errpipe_write) < 0)
+        goto error;
+
+    /* When duping fds, if there arises a situation where one of the fds is
+       either 0, 1 or 2, it is possible that it is overwritten (#12607). */
+    if (c2pwrite == 0) {
+        c2pwrite = dup(c2pwrite);
+        if (_Py_set_inheritable_async_safe(c2pwrite, 0, NULL) < 0) {
+            goto error;
+        }
+        c2pwrite_bk = c2pwrite;
+    }
+
+    if (c2pwrite_bk == -1 && p2cread == 1) {
+        p2cread = dup(p2cread);
+        if (_Py_set_inheritable_async_safe(p2cread, 0, NULL) < 0) {
+            goto error;
+        }
+        p2cread_bk = p2cread;
+    }
+
+    while (errwrite == 0 || errwrite == 1) {
+        errwrite = dup(errwrite);
+        if (_Py_set_inheritable_async_safe(errwrite, 0, NULL) < 0) {
+            goto error;
+        }
+        errwrite_bk = errwrite;
+    }
+
+    exec_array = _PySequence_BytesToCharpArray(executable_list);
+    if (!exec_array)
+        goto error;
+
+    if (cwd_obj != Py_None) {
+        if (PyUnicode_FSConverter(cwd_obj, &cwd_obj2) == 0)
+            goto error;
+        cwd = PyBytes_AsString(cwd_obj2);
+    } else {
+        cwd = NULL;
+        cwd_obj2 = NULL;
+    }
+
+    int pid = RTP_ID_ERROR;
+    int stdin_bk = -1, stdout_bk = -1, stderr_bk = -1;
+    int saved_errno, reached_preexec = 0;
+    const char* err_msg = "";
+    char hex_errno[sizeof(saved_errno)*2+1];
+
+    if (-1 != p2cwrite &&
+        _Py_set_inheritable_async_safe(p2cwrite, 0, NULL) < 0)
+        goto error;
+
+    if (-1 != c2pread &&
+        _Py_set_inheritable_async_safe(c2pread, 0, NULL) < 0)
+        goto error;
+
+    if (-1 != errread &&
+        _Py_set_inheritable_async_safe(errread, 0, NULL) < 0)
+        goto error;
+
+    if (-1 != errpipe_read &&
+        _Py_set_inheritable_async_safe(errpipe_read, 0, NULL) < 0)
+        goto error;
+
+    if (-1 != errpipe_write &&
+        _Py_set_inheritable_async_safe(errpipe_write, 0, NULL) < 0)
+        goto error;
+
+    if (p2cread == 0) {
+        if (_Py_set_inheritable_async_safe(p2cread, 1, NULL) < 0)
+            goto error;
+    }
+    else if (p2cread != -1) {
+        stdin_bk = dup(0);
+        if (dup2(p2cread, 0) == -1)  /* stdin */
+            goto error;
+    }
+
+    if (c2pwrite == 1) {
+        if (_Py_set_inheritable_async_safe(c2pwrite, 1, NULL) < 0)
+            goto error;
+    }
+    else if (c2pwrite != -1) {
+        stdout_bk = dup(1);
+        if (dup2(c2pwrite, 1) == -1)  /* stdout */
+            goto error;
+    }
+
+    if (errwrite == 2) {
+        if (_Py_set_inheritable_async_safe(errwrite, 1, NULL) < 0)
+            goto error;
+    }
+    else if (errwrite != -1) {
+        stderr_bk = dup(2);
+        if (dup2(errwrite, 2) == -1) /* stderr */
+            goto error;
+    }
+
+    char *cwd_bk = getcwd(pwdbuf, sizeof(pwdbuf));
+    if (cwd) {
+        if (chdir(cwd) == -1) {
+            if (ENODEV == errno) {
+                errno = ENOENT;
+            }
+            goto error;
+        }
+    }
+
+    reached_preexec = 1;
+
+    /* close FDs after executing preexec_fn, which might open FDs */
+    if (close_fds) {
+        _close_open_fds(3, py_fds_to_keep);
+    }
+
+    (void)taskPriorityGet (taskIdSelf(), &priority);
+    (void)taskStackSizeGet (taskIdSelf(), &uStackSize);
+
+    saved_errno = 0;
+    for (int i = 0; exec_array[i] != NULL; ++i) {
+        const char *executable = exec_array[i];
+        pid = rtpSpawn (executable, (const char **)argvp,
+             (const char**)envpp, priority, uStackSize, options, taskOptions);
+
+        if (RTP_ID_ERROR == pid && saved_errno == 0) {
+            if (ENODEV == errno) {
+                errno = ENOENT;
+            }
+            saved_errno = errno;
+        }
+    }
+
+    if (p2cread_bk != -1 )
+        close(p2cread_bk);
+
+    if (c2pwrite_bk != -1 )
+        close(c2pwrite_bk);
+
+    if (errwrite_bk != -1 )
+        close(errwrite_bk);
+
+    if (exec_array)
+        _Py_FreeCharPArray(exec_array);
+
+    if (stdin_bk >= 0) {
+        if (dup2(stdin_bk, 0) == -1)
+            goto error;
+        close(stdin_bk);
+    }
+    if (stdout_bk >= 0) {
+        if (dup2(stdout_bk, 1) == -1)
+            goto error;
+        close(stdout_bk);
+    }
+    if (stderr_bk >= 0) {
+        if (dup2(stderr_bk,2) == -1)
+            goto error;
+        close(stderr_bk);
+    }
+
+    if (cwd && cwd_bk)
+        chdir(cwd_bk);
+
+    if (RTP_ID_ERROR != pid) {
+        return Py_BuildValue("i", pid);
+    }
+
+    /* Report the first exec error, not the last. */
+    if (saved_errno)
+        errno = saved_errno;
+
+error:
+    saved_errno = errno;
+    /* Report the posix error to our parent process. */
+    /* We ignore all write() return values as the total size of our writes is
+       less than PIPEBUF and we cannot do anything about an error anyways.
+       Use _Py_write_noraise() to retry write() if it is interrupted by a
+       signal (fails with EINTR). */
+    if (saved_errno) {
+        char *cur;
+        _Py_write_noraise(errpipe_write, "OSError:", 8);
+        cur = hex_errno + sizeof(hex_errno);
+        while (saved_errno != 0 && cur != hex_errno) {
+            *--cur = Py_hexdigits[saved_errno % 16];
+            saved_errno /= 16;
+        }
+        _Py_write_noraise(errpipe_write, cur, hex_errno + sizeof(hex_errno) - cur);
+        _Py_write_noraise(errpipe_write, ":", 1);
+        if (!reached_preexec) {
+            /* Indicate to the parent that the error happened before rtpSpawn(). */
+            _Py_write_noraise(errpipe_write, "noexec", 6);
+        }
+        /* We can't call strerror(saved_errno).  It is not async signal safe.
+         * The parent process will look the error message up. */
+    } else {
+        _Py_write_noraise(errpipe_write, "SubprocessError:0:", 18);
+        _Py_write_noraise(errpipe_write, err_msg, strlen(err_msg));
+    }
+
+    return Py_BuildValue("i", pid);
+}
+
+
+static void _save_fds(int saved_fd[])
+{
+    int fd;
+    int flags;
+
+    if (!saved_fd) return;
+
+    for (fd = 0; fd < FD_SETSIZE; ++fd) {
+        flags = fcntl (fd, F_GETFD);
+        if (flags < 0)
+            continue;
+
+        saved_fd[fd] = !(flags & FD_CLOEXEC);
+    }
+}
+
+static void _restore_fds(int saved_fd[])
+{
+    int fd;
+    int flags;
+
+    if (!saved_fd) return;
+
+    for (fd = 0; fd < FD_SETSIZE; ++fd) {
+        flags = fcntl (fd, F_GETFD);
+        if (flags < 0)
+            continue;
+
+        if (-1 != saved_fd[fd]) {
+            _Py_set_inheritable_async_safe(fd, saved_fd[fd], NULL);
+        }
+    }
+}
+
+/*[clinic input]
+_vxwapi.rtp_spawn
+
+    process_args: object
+    executable_list: object
+    close_fds: int
+    py_fds_to_keep: object(subclass_of='&PyTuple_Type')
+    cwd_obj: object
+    env_list: object
+    p2cread: int
+    p2cwrite: int
+    c2pread: int
+    c2pwrite: int
+    errread: int
+    errwrite: int
+    errpipe_read: int
+    errpipe_write: int
+    restore_signals: int
+    call_setsid: int
+    preexec_fn: object
+    /
+
+Spawn a real time process in the vxWorks OS
+[clinic start generated code]*/
+
+static PyObject *
+_vxwapi_rtp_spawn_impl(PyObject *module, PyObject *process_args,
+                       PyObject *executable_list, int close_fds,
+                       PyObject *py_fds_to_keep, PyObject *cwd_obj,
+                       PyObject *env_list, int p2cread, int p2cwrite,
+                       int c2pread, int c2pwrite, int errread, int errwrite,
+                       int errpipe_read, int errpipe_write,
+                       int restore_signals, int call_setsid,
+                       PyObject *preexec_fn)
+/*[clinic end generated code: output=5f98889b783df975 input=30419f3fea045213]*/
+{
+    PyObject *converted_args = NULL, *fast_args = NULL;
+    char *const *argv = NULL, *const *envp = NULL;
+    int saved_fd[FD_SETSIZE] = {-1};
+
+    PyObject *return_value = NULL;
+    if (_PyInterpreterState_Get() != PyInterpreterState_Main()) {
+        PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
+        return NULL;
+    }
+
+    if (close_fds && errpipe_write < 3) {  /* precondition */
+        PyErr_SetString(PyExc_ValueError, "errpipe_write must be >= 3");
+        return NULL;
+    }
+
+    if (_sanity_check_python_fd_sequence(py_fds_to_keep)) {
+        PyErr_SetString(PyExc_ValueError, "bad value(s) in fds_to_keep");
+        return NULL;
+    }
+
+    if (preexec_fn != Py_None) {
+        PyErr_SetString(PyExc_RuntimeError, "Preexecution function is not supported on VxWorks");
+        return NULL;
+    }
+
+    if (call_setsid != 0) {
+        PyErr_SetString(PyExc_RuntimeError, "VxWorks does not support sessions");
+        return NULL;
+    }
+
+    /* Convert args and env into appropriate arguments */
+    /* These conversions are done in the parent process to avoid allocating
+       or freeing memory in the child process. */
+    if (process_args != Py_None) {
+        Py_ssize_t num_args;
+        Py_ssize_t arg_num;
+        /* Equivalent to:  */
+        /*  tuple(PyUnicode_FSConverter(arg) for arg in process_args)  */
+        fast_args = PySequence_Fast(process_args, "argv must be a tuple");
+        if (fast_args == NULL)
+            goto cleanup;
+        num_args = PySequence_Fast_GET_SIZE(fast_args);
+        converted_args = PyTuple_New(num_args);
+        if (converted_args == NULL)
+            goto cleanup;
+        for (arg_num = 0; arg_num < num_args; ++arg_num) {
+            PyObject *borrowed_arg, *converted_arg;
+            if (PySequence_Fast_GET_SIZE(fast_args) != num_args) {
+                   PyErr_SetString(PyExc_RuntimeError,
+                   "args changed during iteration");
+                goto cleanup;
+            }
+            borrowed_arg = PySequence_Fast_GET_ITEM(fast_args, arg_num);
+            if (PyUnicode_FSConverter(borrowed_arg, &converted_arg) == 0)
+                goto cleanup;
+            PyTuple_SET_ITEM(converted_args, arg_num, converted_arg);
+        }
+
+        argv = _PySequence_BytesToCharpArray(converted_args);
+        Py_CLEAR(converted_args);
+        Py_CLEAR(fast_args);
+        if (!argv)
+            goto cleanup;
+    }
+
+    if (env_list != Py_None) {
+        envp = _PySequence_BytesToCharpArray(env_list);
+        if (!envp)
+            goto cleanup;
+    }
+
+    _save_fds(saved_fd);
+
+    return_value = rtp_spawn_impl(
+                        executable_list, argv, envp, cwd_obj,
+                        p2cread, p2cwrite, c2pread, c2pwrite,
+                        errread, errwrite, errpipe_read, errpipe_write,
+                        close_fds, restore_signals, py_fds_to_keep);
+
+    _restore_fds (saved_fd);
+
+cleanup:
+    if (envp)
+        _Py_FreeCharPArray(envp);
+    if (argv)
+        _Py_FreeCharPArray(argv);
+    Py_XDECREF(converted_args);
+    Py_XDECREF(fast_args);
+    return return_value;
+}
+
+
+
+static PyMethodDef _vxwapiMethods[] = {
+    _VXWAPI_RTP_SPAWN_METHODDEF
+    { NULL, NULL }
+};
+
+static struct PyModuleDef _vxwapimodule = {
+    PyModuleDef_HEAD_INIT,
+    "_vxwapi",
+    NULL,
+    -1,
+    _vxwapiMethods
+};
+
+PyMODINIT_FUNC
+PyInit__vxwapi(void)
+{
+    return PyModule_Create(&_vxwapimodule);
+}
+

--- a/Modules/clinic/_vxwapi.c.h
+++ b/Modules/clinic/_vxwapi.c.h
@@ -6,7 +6,7 @@ PyDoc_STRVAR(_vxwapi_rtp_spawn__doc__,
 "rtp_spawn($module, process_args, executable_list, close_fds,\n"
 "          py_fds_to_keep, cwd_obj, env_list, p2cread, p2cwrite,\n"
 "          c2pread, c2pwrite, errread, errwrite, errpipe_read,\n"
-"          errpipe_write, restore_signals, call_setsid, preexec_fn, /)\n"
+"          errpipe_write, /)\n"
 "--\n"
 "\n"
 "Spawn a real time process in the vxWorks OS");
@@ -20,9 +20,7 @@ _vxwapi_rtp_spawn_impl(PyObject *module, PyObject *process_args,
                        PyObject *py_fds_to_keep, PyObject *cwd_obj,
                        PyObject *env_list, int p2cread, int p2cwrite,
                        int c2pread, int c2pwrite, int errread, int errwrite,
-                       int errpipe_read, int errpipe_write,
-                       int restore_signals, int call_setsid,
-                       PyObject *preexec_fn);
+                       int errpipe_read, int errpipe_write);
 
 static PyObject *
 _vxwapi_rtp_spawn(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
@@ -42,11 +40,8 @@ _vxwapi_rtp_spawn(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     int errwrite;
     int errpipe_read;
     int errpipe_write;
-    int restore_signals;
-    int call_setsid;
-    PyObject *preexec_fn;
 
-    if (!_PyArg_CheckPositional("rtp_spawn", nargs, 17, 17)) {
+    if (!_PyArg_CheckPositional("rtp_spawn", nargs, 14, 14)) {
         goto exit;
     }
     process_args = args[0];
@@ -139,28 +134,9 @@ _vxwapi_rtp_spawn(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (errpipe_write == -1 && PyErr_Occurred()) {
         goto exit;
     }
-    if (PyFloat_Check(args[14])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
-    restore_signals = _PyLong_AsInt(args[14]);
-    if (restore_signals == -1 && PyErr_Occurred()) {
-        goto exit;
-    }
-    if (PyFloat_Check(args[15])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
-    call_setsid = _PyLong_AsInt(args[15]);
-    if (call_setsid == -1 && PyErr_Occurred()) {
-        goto exit;
-    }
-    preexec_fn = args[16];
-    return_value = _vxwapi_rtp_spawn_impl(module, process_args, executable_list, close_fds, py_fds_to_keep, cwd_obj, env_list, p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite, errpipe_read, errpipe_write, restore_signals, call_setsid, preexec_fn);
+    return_value = _vxwapi_rtp_spawn_impl(module, process_args, executable_list, close_fds, py_fds_to_keep, cwd_obj, env_list, p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite, errpipe_read, errpipe_write);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=216bc865460f7764 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=44ceb0e8de454bd6 input=a9049054013a1b77]*/

--- a/Modules/clinic/_vxwapi.c.h
+++ b/Modules/clinic/_vxwapi.c.h
@@ -1,0 +1,166 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(_vxwapi_rtp_spawn__doc__,
+"rtp_spawn($module, process_args, executable_list, close_fds,\n"
+"          py_fds_to_keep, cwd_obj, env_list, p2cread, p2cwrite,\n"
+"          c2pread, c2pwrite, errread, errwrite, errpipe_read,\n"
+"          errpipe_write, restore_signals, call_setsid, preexec_fn, /)\n"
+"--\n"
+"\n"
+"Spawn a real time process in the vxWorks OS");
+
+#define _VXWAPI_RTP_SPAWN_METHODDEF    \
+    {"rtp_spawn", (PyCFunction)(void(*)(void))_vxwapi_rtp_spawn, METH_FASTCALL, _vxwapi_rtp_spawn__doc__},
+
+static PyObject *
+_vxwapi_rtp_spawn_impl(PyObject *module, PyObject *process_args,
+                       PyObject *executable_list, int close_fds,
+                       PyObject *py_fds_to_keep, PyObject *cwd_obj,
+                       PyObject *env_list, int p2cread, int p2cwrite,
+                       int c2pread, int c2pwrite, int errread, int errwrite,
+                       int errpipe_read, int errpipe_write,
+                       int restore_signals, int call_setsid,
+                       PyObject *preexec_fn);
+
+static PyObject *
+_vxwapi_rtp_spawn(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *process_args;
+    PyObject *executable_list;
+    int close_fds;
+    PyObject *py_fds_to_keep;
+    PyObject *cwd_obj;
+    PyObject *env_list;
+    int p2cread;
+    int p2cwrite;
+    int c2pread;
+    int c2pwrite;
+    int errread;
+    int errwrite;
+    int errpipe_read;
+    int errpipe_write;
+    int restore_signals;
+    int call_setsid;
+    PyObject *preexec_fn;
+
+    if (!_PyArg_CheckPositional("rtp_spawn", nargs, 17, 17)) {
+        goto exit;
+    }
+    process_args = args[0];
+    executable_list = args[1];
+    if (PyFloat_Check(args[2])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    close_fds = _PyLong_AsInt(args[2]);
+    if (close_fds == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (!PyTuple_Check(args[3])) {
+        _PyArg_BadArgument("rtp_spawn", 4, "tuple", args[3]);
+        goto exit;
+    }
+    py_fds_to_keep = args[3];
+    cwd_obj = args[4];
+    env_list = args[5];
+    if (PyFloat_Check(args[6])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    p2cread = _PyLong_AsInt(args[6]);
+    if (p2cread == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[7])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    p2cwrite = _PyLong_AsInt(args[7]);
+    if (p2cwrite == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[8])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    c2pread = _PyLong_AsInt(args[8]);
+    if (c2pread == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[9])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    c2pwrite = _PyLong_AsInt(args[9]);
+    if (c2pwrite == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[10])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    errread = _PyLong_AsInt(args[10]);
+    if (errread == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[11])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    errwrite = _PyLong_AsInt(args[11]);
+    if (errwrite == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[12])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    errpipe_read = _PyLong_AsInt(args[12]);
+    if (errpipe_read == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[13])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    errpipe_write = _PyLong_AsInt(args[13]);
+    if (errpipe_write == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[14])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    restore_signals = _PyLong_AsInt(args[14]);
+    if (restore_signals == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[15])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    call_setsid = _PyLong_AsInt(args[15]);
+    if (call_setsid == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    preexec_fn = args[16];
+    return_value = _vxwapi_rtp_spawn_impl(module, process_args, executable_list, close_fds, py_fds_to_keep, cwd_obj, env_list, p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite, errpipe_read, errpipe_write, restore_signals, call_setsid, preexec_fn);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=216bc865460f7764 input=a9049054013a1b77]*/

--- a/setup.py
+++ b/setup.py
@@ -807,7 +807,10 @@ class PyBuildExt(build_ext):
         self.add(Extension('_csv', ['_csv.c']))
 
         # POSIX subprocess module helper.
-        self.add(Extension('_posixsubprocess', ['_posixsubprocess.c']))
+        if VXWORKS:
+            self.add(Extension('_vxwapi', ['_vxwapi.c']))
+        else:
+            self.add(Extension('_posixsubprocess', ['_posixsubprocess.c']))
 
     def detect_test_extensions(self):
         # Python C API test module


### PR DESCRIPTION
This is the successive PR after #11968. This PR enables subprocess module support for VxWorks RTOS. VxWorks doesn't support fork()/exec(). Instead, we use rtpSpawn() to spawn new processes. So a new extension module named _vxwapi is added to offer the method rtp_spawn, which will be used in subprocess module to create new processes. 
More and full support on modules for VxWorks will continuously be added by the coming PRs.
VxWorks is a product developed and owned by Wind River. For VxWorks introduction or more details, go to https://www.windriver.com/products/vxworks/
Wind River will have a dedicated engineering team to contribute to the support as maintainers.
We already have a working buildbot worker internally, but has not bound to master. We will check the process for the buildbot, then add it.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
