### PR TITLE
[2.7] bpo-36179: Fix ref leaks in _hashopenssl (GH-12158)

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-04-10-42-46.bpo-36179.jEyuI-.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-04-10-42-46.bpo-36179.jEyuI-.rst
@@ -1,0 +1,2 @@
+Fix two unlikely reference leaks in _hashopenssl. The leaks only occur in
+out-of-memory cases.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -133,18 +133,19 @@ newEVPobject(PyObject *name)
     if (retval == NULL)
         return NULL;
 
-    retval->ctx = EVP_MD_CTX_new();
-    if (retval->ctx == NULL) {
-        PyErr_NoMemory();
-        return NULL;
-    }
-
     /* save the name for .name to return */
     Py_INCREF(name);
     retval->name = name;
 #ifdef WITH_THREAD
     retval->lock = NULL;
 #endif
+
+    retval->ctx = EVP_MD_CTX_new();
+    if (retval->ctx == NULL) {
+        Py_DECREF(retval);
+        PyErr_NoMemory();
+        return NULL;
+    }
 
     return retval;
 }
@@ -205,6 +206,7 @@ EVP_copy(EVPobject *self, PyObject *unused)
         return NULL;
 
     if (!locked_EVP_MD_CTX_copy(newobj->ctx, self)) {
+        Py_DECREF(newobj);
         return _setException(PyExc_ValueError);
     }
     return (PyObject *)newobj;


### PR DESCRIPTION
Fix two unlikely reference leaks in _hashopenssl. The leaks only occur in
out-of-memory cases. Thanks to Charalampos Stratakis.

Signed-off-by: Christian Heimes <christian@python.org>

https://bugs.python.org/issue36179.
(cherry picked from commit b7bc283ab6a23ee98784400ebffe7fe410232a2e)

Co-authored-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-36179](https://bugs.python.org/issue36179) -->
https://bugs.python.org/issue36179
<!-- /issue-number -->
