### PR TITLE
Fix docstring of the ssl module

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -18,9 +18,9 @@ Functions:
                           seconds past the Epoch (the time values
                           returned from time.time())
 
-  fetch_server_certificate (HOST, PORT) -- fetch the certificate provided
-                          by the server running on HOST at port PORT.  No
-                          validation of the certificate is performed.
+  get_server_certificate -- (HOST, PORT) -- fetch the certificate provided
+                            by the server running on HOST at port PORT.  No
+                            validation of the certificate is performed.
 
 Integer constants:
 


### PR DESCRIPTION
`get_server_certificate` is the function it is referring to; there is no `fetch_server_certificate`