### PR TITLE
bpo-36188: Clean up 'unbound' method left-overs

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -578,12 +578,6 @@ Callable types
       to be bound.  The new method's :attr:`__func__` attribute is the original
       function object.
 
-      When a user-defined method object is created by retrieving another method
-      object from a class or instance, the behaviour is the same as for a
-      function object, except that the :attr:`__func__` attribute of the new
-      instance is not the original method object but its :attr:`__func__`
-      attribute.
-
       When an instance method object is created by retrieving a class method
       object from a class or instance, its :attr:`__self__` attribute is the
       class itself, and its :attr:`__func__` attribute is the function object

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-04-18-05-31.bpo-36188.EuUZNz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-04-18-05-31.bpo-36188.EuUZNz.rst
@@ -1,0 +1,2 @@
+Cleaned up left-over vestiges of Python 2 unbound method handling in method objects and documentation.
+Patch by Martijn Pieters

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -267,10 +267,7 @@ static Py_hash_t
 method_hash(PyMethodObject *a)
 {
     Py_hash_t x, y;
-    if (a->im_self == NULL)
-        x = _Py_HashPointer(Py_None);
-    else
-        x = _Py_HashPointer(a->im_self);
+    x = _Py_HashPointer(a->im_self);
     y = PyObject_Hash(a->im_func);
     if (y == -1)
         return -1;
@@ -294,11 +291,6 @@ method_call(PyObject *method, PyObject *args, PyObject *kwargs)
     PyObject *self, *func;
 
     self = PyMethod_GET_SELF(method);
-    if (self == NULL) {
-        PyErr_BadInternalCall();
-        return NULL;
-    }
-
     func = PyMethod_GET_FUNCTION(method);
 
     return _PyObject_Call_Prepend(func, self, args, kwargs);
@@ -307,15 +299,8 @@ method_call(PyObject *method, PyObject *args, PyObject *kwargs)
 static PyObject *
 method_descr_get(PyObject *meth, PyObject *obj, PyObject *cls)
 {
-    /* Don't rebind an already bound method of a class that's not a base
-       class of cls. */
-    if (PyMethod_GET_SELF(meth) != NULL) {
-        /* Already bound */
-        Py_INCREF(meth);
-        return meth;
-    }
-    /* Bind it to obj */
-    return PyMethod_New(PyMethod_GET_FUNCTION(meth), obj);
+    Py_INCREF(meth);
+    return meth;
 }
 
 PyTypeObject PyMethod_Type = {


### PR DESCRIPTION
Methods are always bound, and `__self__` can no longer be `NULL`
(`method_new()` and `PyMethod_New()` both explicitly check for this).

Moreover, once a bound method is bound, it *stays* bound and won't be re-bound
to something else, so the section in the datamodel that talks about accessing
methods in a different descriptor-binding context doesn't apply any more in
Python 3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36188](https://bugs.python.org/issue36188) -->
https://bugs.python.org/issue36188
<!-- /issue-number -->
