### PR TITLE
[2.7] bpo-36019: Use pythontest.net instead of example.com in network tests (GH-11941)

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -246,6 +246,11 @@ The :mod:`test.support` module defines the following constants:
    Set to a name that is safe to use as the name of a temporary file.  Any
    temporary file that is created should be closed and unlinked (removed).
 
+
+.. data:: TEST_HTTP_URL
+
+    Define the URL of a dedicated HTTP server for the network tests.
+
 The :mod:`test.support` module defines the following functions:
 
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -720,6 +720,10 @@ else:
 # module name.
 TESTFN = "{}_{}_tmp".format(TESTFN, os.getpid())
 
+# Define the URL of a dedicated HTTP server for the network tests.
+# The URL must use clear-text HTTP: no redirection to encrypted HTTPS.
+TEST_HTTP_URL = "http://www.pythontest.net"
+
 # Save the initial cwd
 SAVEDCWD = os.getcwd()
 

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -517,7 +517,7 @@ FF
 
         try:
             self.assertRaises(urllib.ContentTooShortError, urllib.urlretrieve,
-                    'http://example.com', reporthook=_reporthook)
+                    test_support.TEST_HTTP_URL, reporthook=_reporthook)
         finally:
             self.unfakehttp()
 
@@ -532,7 +532,7 @@ Content-Type: text/html; charset=iso-8859-1
 FF
 ''')
         try:
-            self.assertRaises(urllib.ContentTooShortError, urllib.urlretrieve, 'http://example.com/')
+            self.assertRaises(urllib.ContentTooShortError, urllib.urlretrieve, test_support.TEST_HTTP_URL)
         finally:
             self.unfakehttp()
 

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -517,7 +517,7 @@ FF
 
         try:
             self.assertRaises(urllib.ContentTooShortError, urllib.urlretrieve,
-                    test_support.TEST_HTTP_URL, reporthook=_reporthook)
+                    'http://example.com', reporthook=_reporthook)
         finally:
             self.unfakehttp()
 
@@ -532,7 +532,7 @@ Content-Type: text/html; charset=iso-8859-1
 FF
 ''')
         try:
-            self.assertRaises(urllib.ContentTooShortError, urllib.urlretrieve, test_support.TEST_HTTP_URL)
+            self.assertRaises(urllib.ContentTooShortError, urllib.urlretrieve, 'http://example.com/')
         finally:
             self.unfakehttp()
 

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -85,7 +85,7 @@ class CloseSocketTest(unittest.TestCase):
         # underlying socket
 
         # delve deep into response to fetch socket._socketobject
-        response = _urlopen_with_retry("http://www.example.com/")
+        response = _urlopen_with_retry(test_support.TEST_HTTP_URL)
         abused_fileobject = response.fp
         self.assertIs(abused_fileobject.__class__, socket._fileobject)
         httpresponse = abused_fileobject._sock
@@ -169,7 +169,7 @@ class OtherNetworkTests(unittest.TestCase):
                     "http://www.pythontest.net/index.html#frag")
 
     def test_fileno(self):
-        req = urllib2.Request("http://www.example.com")
+        req = urllib2.Request(test_support.TEST_HTTP_URL)
         opener = urllib2.build_opener()
         res = opener.open(req)
         try:
@@ -180,7 +180,7 @@ class OtherNetworkTests(unittest.TestCase):
             res.close()
 
     def test_custom_headers(self):
-        url = "http://www.example.com"
+        url = test_support.TEST_HTTP_URL
         with test_support.transient_internet(url):
             opener = urllib2.build_opener()
             request = urllib2.Request(url)
@@ -258,14 +258,14 @@ class OtherNetworkTests(unittest.TestCase):
 class TimeoutTest(unittest.TestCase):
     def test_http_basic(self):
         self.assertIsNone(socket.getdefaulttimeout())
-        url = "http://www.example.com"
+        url = test_support.TEST_HTTP_URL
         with test_support.transient_internet(url, timeout=None):
             u = _urlopen_with_retry(url)
             self.assertIsNone(u.fp._sock.fp._sock.gettimeout())
 
     def test_http_default_timeout(self):
         self.assertIsNone(socket.getdefaulttimeout())
-        url = "http://www.example.com"
+        url = test_support.TEST_HTTP_URL
         with test_support.transient_internet(url):
             socket.setdefaulttimeout(60)
             try:
@@ -276,7 +276,7 @@ class TimeoutTest(unittest.TestCase):
 
     def test_http_no_timeout(self):
         self.assertIsNone(socket.getdefaulttimeout())
-        url = "http://www.example.com"
+        url = test_support.TEST_HTTP_URL
         with test_support.transient_internet(url):
             socket.setdefaulttimeout(60)
             try:
@@ -286,7 +286,7 @@ class TimeoutTest(unittest.TestCase):
             self.assertIsNone(u.fp._sock.fp._sock.gettimeout())
 
     def test_http_timeout(self):
-        url = "http://www.example.com"
+        url = test_support.TEST_HTTP_URL
         with test_support.transient_internet(url):
             u = _urlopen_with_retry(url, timeout=120)
             self.assertEqual(u.fp._sock.fp._sock.gettimeout(), 120)

--- a/Lib/test/test_urllibnet.py
+++ b/Lib/test/test_urllibnet.py
@@ -1,4 +1,5 @@
 import unittest
+from test import support
 from test import test_support
 
 import socket
@@ -43,7 +44,7 @@ class URLTimeoutTest(unittest.TestCase):
         socket.setdefaulttimeout(None)
 
     def testURLread(self):
-        f = _open_with_retry(urllib.urlopen, "http://www.example.com/")
+        f = _open_with_retry(urllib.urlopen, support.TEST_HTTP_URL)
         x = f.read()
 
 class urlopenNetworkTests(unittest.TestCase):
@@ -66,7 +67,7 @@ class urlopenNetworkTests(unittest.TestCase):
 
     def test_basic(self):
         # Simple test expected to pass.
-        open_url = self.urlopen("http://www.example.com/")
+        open_url = self.urlopen(support.TEST_HTTP_URL)
         for attr in ("read", "readline", "readlines", "fileno", "close",
                      "info", "geturl"):
             self.assertTrue(hasattr(open_url, attr), "object returned from "
@@ -78,7 +79,7 @@ class urlopenNetworkTests(unittest.TestCase):
 
     def test_readlines(self):
         # Test both readline and readlines.
-        open_url = self.urlopen("http://www.example.com/")
+        open_url = self.urlopen(support.TEST_HTTP_URL)
         try:
             self.assertIsInstance(open_url.readline(), basestring,
                                   "readline did not return a string")
@@ -89,7 +90,7 @@ class urlopenNetworkTests(unittest.TestCase):
 
     def test_info(self):
         # Test 'info'.
-        open_url = self.urlopen("http://www.example.com/")
+        open_url = self.urlopen(support.TEST_HTTP_URL)
         try:
             info_obj = open_url.info()
         finally:
@@ -101,13 +102,12 @@ class urlopenNetworkTests(unittest.TestCase):
 
     def test_geturl(self):
         # Make sure same URL as opened is returned by geturl.
-        URL = "http://www.example.com/"
-        open_url = self.urlopen(URL)
+        open_url = self.urlopen(support.TEST_HTTP_URL)
         try:
             gotten_url = open_url.geturl()
         finally:
             open_url.close()
-        self.assertEqual(gotten_url, URL)
+        self.assertEqual(gotten_url, support.TEST_HTTP_URL)
 
     def test_getcode(self):
         # test getcode() with the fancy opener to get 404 error codes
@@ -123,12 +123,13 @@ class urlopenNetworkTests(unittest.TestCase):
     @unittest.skipUnless(hasattr(os, 'fdopen'), 'os.fdopen not available')
     def test_fileno(self):
         # Make sure fd returned by fileno is valid.
-        open_url = self.urlopen("http://www.example.com/")
+        open_url = self.urlopen(support.TEST_HTTP_URL)
         fd = open_url.fileno()
         FILE = os.fdopen(fd)
         try:
-            self.assertTrue(FILE.read(), "reading from file created using fd "
-                                      "returned by fileno failed")
+            self.assertTrue(FILE.read(),
+                            "reading from file created using fd "
+                            "returned by fileno failed")
         finally:
             FILE.close()
 
@@ -161,7 +162,7 @@ class urlretrieveNetworkTests(unittest.TestCase):
 
     def test_basic(self):
         # Test basic functionality.
-        file_location,info = self.urlretrieve("http://www.example.com/")
+        file_location,info = self.urlretrieve(support.TEST_HTTP_URL)
         self.assertTrue(os.path.exists(file_location), "file location returned by"
                         " urlretrieve is not a valid path")
         FILE = file(file_location)
@@ -174,7 +175,7 @@ class urlretrieveNetworkTests(unittest.TestCase):
 
     def test_specified_path(self):
         # Make sure that specifying the location of the file to write to works.
-        file_location,info = self.urlretrieve("http://www.example.com/",
+        file_location,info = self.urlretrieve(support.TEST_HTTP_URL,
                                               test_support.TESTFN)
         self.assertEqual(file_location, test_support.TESTFN)
         self.assertTrue(os.path.exists(file_location))
@@ -187,7 +188,7 @@ class urlretrieveNetworkTests(unittest.TestCase):
 
     def test_header(self):
         # Make sure header returned as 2nd value from urlretrieve is good.
-        file_location, header = self.urlretrieve("http://www.example.com/")
+        file_location, header = self.urlretrieve(support.TEST_HTTP_URL)
         os.unlink(file_location)
         self.assertIsInstance(header, mimetools.Message,
                               "header is not an instance of mimetools.Message")

--- a/Lib/test/test_urllibnet.py
+++ b/Lib/test/test_urllibnet.py
@@ -1,5 +1,4 @@
 import unittest
-from test import support
 from test import test_support
 
 import socket
@@ -44,7 +43,7 @@ class URLTimeoutTest(unittest.TestCase):
         socket.setdefaulttimeout(None)
 
     def testURLread(self):
-        f = _open_with_retry(urllib.urlopen, support.TEST_HTTP_URL)
+        f = _open_with_retry(urllib.urlopen, test_support.TEST_HTTP_URL)
         x = f.read()
 
 class urlopenNetworkTests(unittest.TestCase):
@@ -67,7 +66,7 @@ class urlopenNetworkTests(unittest.TestCase):
 
     def test_basic(self):
         # Simple test expected to pass.
-        open_url = self.urlopen(support.TEST_HTTP_URL)
+        open_url = self.urlopen(test_support.TEST_HTTP_URL)
         for attr in ("read", "readline", "readlines", "fileno", "close",
                      "info", "geturl"):
             self.assertTrue(hasattr(open_url, attr), "object returned from "
@@ -79,7 +78,7 @@ class urlopenNetworkTests(unittest.TestCase):
 
     def test_readlines(self):
         # Test both readline and readlines.
-        open_url = self.urlopen(support.TEST_HTTP_URL)
+        open_url = self.urlopen(test_support.TEST_HTTP_URL)
         try:
             self.assertIsInstance(open_url.readline(), basestring,
                                   "readline did not return a string")
@@ -90,7 +89,7 @@ class urlopenNetworkTests(unittest.TestCase):
 
     def test_info(self):
         # Test 'info'.
-        open_url = self.urlopen(support.TEST_HTTP_URL)
+        open_url = self.urlopen(test_support.TEST_HTTP_URL)
         try:
             info_obj = open_url.info()
         finally:
@@ -102,12 +101,12 @@ class urlopenNetworkTests(unittest.TestCase):
 
     def test_geturl(self):
         # Make sure same URL as opened is returned by geturl.
-        open_url = self.urlopen(support.TEST_HTTP_URL)
+        open_url = self.urlopen(test_support.TEST_HTTP_URL)
         try:
             gotten_url = open_url.geturl()
         finally:
             open_url.close()
-        self.assertEqual(gotten_url, support.TEST_HTTP_URL)
+        self.assertEqual(gotten_url, test_support.TEST_HTTP_URL)
 
     def test_getcode(self):
         # test getcode() with the fancy opener to get 404 error codes
@@ -123,7 +122,7 @@ class urlopenNetworkTests(unittest.TestCase):
     @unittest.skipUnless(hasattr(os, 'fdopen'), 'os.fdopen not available')
     def test_fileno(self):
         # Make sure fd returned by fileno is valid.
-        open_url = self.urlopen(support.TEST_HTTP_URL)
+        open_url = self.urlopen(test_support.TEST_HTTP_URL)
         fd = open_url.fileno()
         FILE = os.fdopen(fd)
         try:
@@ -162,7 +161,7 @@ class urlretrieveNetworkTests(unittest.TestCase):
 
     def test_basic(self):
         # Test basic functionality.
-        file_location,info = self.urlretrieve(support.TEST_HTTP_URL)
+        file_location,info = self.urlretrieve(test_support.TEST_HTTP_URL)
         self.assertTrue(os.path.exists(file_location), "file location returned by"
                         " urlretrieve is not a valid path")
         FILE = file(file_location)
@@ -175,7 +174,7 @@ class urlretrieveNetworkTests(unittest.TestCase):
 
     def test_specified_path(self):
         # Make sure that specifying the location of the file to write to works.
-        file_location,info = self.urlretrieve(support.TEST_HTTP_URL,
+        file_location,info = self.urlretrieve(test_support.TEST_HTTP_URL,
                                               test_support.TESTFN)
         self.assertEqual(file_location, test_support.TESTFN)
         self.assertTrue(os.path.exists(file_location))
@@ -188,13 +187,13 @@ class urlretrieveNetworkTests(unittest.TestCase):
 
     def test_header(self):
         # Make sure header returned as 2nd value from urlretrieve is good.
-        file_location, header = self.urlretrieve(support.TEST_HTTP_URL)
+        file_location, header = self.urlretrieve(test_support.TEST_HTTP_URL)
         os.unlink(file_location)
         self.assertIsInstance(header, mimetools.Message,
                               "header is not an instance of mimetools.Message")
 
     def test_data_header(self):
-        logo = "http://www.example.com/"
+        logo = test_support.TEST_HTTP_URL
         file_location, fileheaders = self.urlretrieve(logo)
         os.unlink(file_location)
         datevalue = fileheaders.getheader('Date')

--- a/Misc/NEWS.d/next/Tests/2019-03-05-13-27-36.bpo-36019.ebUjCm.rst
+++ b/Misc/NEWS.d/next/Tests/2019-03-05-13-27-36.bpo-36019.ebUjCm.rst
@@ -1,0 +1,2 @@
+Add test.support.TEST_HTTP_URL and replace references of
+http://www.example.com by this new constant. Contributed by Stéphane Wirtel.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36019](https://bugs.python.org/issue36019) -->
https://bugs.python.org/issue36019
<!-- /issue-number -->
