### PR TITLE
Fix grammar in assertCountEqual docstring

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1206,9 +1206,11 @@ class TestCase(object):
 
 
     def assertCountEqual(self, first, second, msg=None):
-        """An unordered sequence comparison asserting that the same elements,
-        regardless of order.  If the same element occurs more than once,
+        """An unordered sequence comparison asserting that the same elements
+        are present, regardless of order. If the same element occurs more than once,
         it verifies that the elements occur the same number of times.
+
+        Equivalent to:
 
             self.assertEqual(Counter(list(first)),
                              Counter(list(second)))


### PR DESCRIPTION
Fixes a sentence in a docstring that's missing a verb; also adds text to indicate what the lines of code mean.  (I initially wondered if it was intended to be an example usage.)

I noticed this error in Python 3.5, but we probably don't need to backport it any further than 3.7.