### PR TITLE
bpo-36142: Add _PyMem_GetDebugAllocatorsName()

### DIFF
--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -155,6 +155,8 @@ PyAPI_FUNC(int) _PyMem_SetDefaultAllocator(
     PyMemAllocatorDomain domain,
     PyMemAllocatorEx *old_alloc);
 
+PyAPI_FUNC(const char*) _PyMem_GetDebugAllocatorsName(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -336,6 +336,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'legacy_windows_fs_encoding': 0,
             'legacy_windows_stdio': 0,
         })
+    DEBUG_ALLOCATOR = 'pymalloc_debug' if support.with_pymalloc() else 'malloc_debug'
 
     # main config
     COPY_MAIN_CONFIG = (
@@ -588,7 +589,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def test_init_env_dev_mode(self):
         config = dict(self.INIT_ENV_CONFIG,
-                      allocator='debug',
+                      allocator=self.DEBUG_ALLOCATOR,
                       dev_mode=1)
         self.check_config("init_env_dev_mode", config)
 
@@ -596,7 +597,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         config = {
             'dev_mode': 1,
             'faulthandler': 1,
-            'allocator': 'debug',
+            'allocator': self.DEBUG_ALLOCATOR,
         }
         self.check_config("init_dev_mode", config)
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -221,6 +221,20 @@ static PyMemAllocatorEx _PyObject = PYOBJ_ALLOC;
 #endif
 
 
+/* Get the effective name of "debug" memory allocators,
+   as if _PyMem_GetAllocatorsName() is called after
+   _PyMem_SetupAllocators("debug"). */
+const char*
+_PyMem_GetDebugAllocatorsName(void)
+{
+#ifdef WITH_PYMALLOC
+    return "pymalloc_debug";
+#else
+    return "malloc_debug";
+#endif
+}
+
+
 static int
 pymem_set_default_allocator(PyMemAllocatorDomain domain, int debug,
                             PyMemAllocatorEx *old_alloc)

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -139,6 +139,9 @@ static int test_forced_io_encoding(void)
 
 static int test_pre_initialization_api(void)
 {
+    /* the test doesn't support custom memory allocators */
+    putenv("PYTHONMALLOC=");
+
     /* Leading "./" ensures getpath.c can still find the standard library */
     _Py_EMBED_PREINIT_CHECK("Checking Py_DecodeLocale\n");
     wchar_t *program = Py_DecodeLocale("./spam", NULL);
@@ -235,6 +238,9 @@ static void bpo20891_thread(void *lockp)
 
 static int test_bpo20891(void)
 {
+    /* the test doesn't support custom memory allocators */
+    putenv("PYTHONMALLOC=");
+
     /* bpo-20891: Calling PyGILState_Ensure in a non-Python thread before
        calling PyEval_InitThreads() must not crash. PyGILState_Ensure() must
        call PyEval_InitThreads() for us in this case. */

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -453,7 +453,8 @@ preconfig_read(_PyPreConfig *config, const _PyPreCmdline *cmdline)
 
     /* allocator */
     if (config->dev_mode && config->allocator == NULL) {
-        config->allocator = _PyMem_RawStrdup("debug");
+        const char *allocator = _PyMem_GetDebugAllocatorsName();
+        config->allocator = _PyMem_RawStrdup(allocator);
         if (config->allocator == NULL) {
             return _Py_INIT_NO_MEMORY();
         }


### PR DESCRIPTION
The development mode now uses the effective name of the debug memory
allocator ("pymalloc_debug" or "malloc_debug"). So the name doesn't
change after setting the memory allocator.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36142](https://bugs.python.org/issue36142) -->
https://bugs.python.org/issue36142
<!-- /issue-number -->
