### PR TITLE
bpo-36209: Fix Typo on hashlib

### DIFF
--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -775,7 +775,7 @@ _hashlib_scrypt_impl(PyObject *module, Py_buffer *password, Py_buffer *salt,
     if (!retval) {
         /* sorry, can't do much better */
         PyErr_SetString(PyExc_ValueError,
-                        "Invalid paramemter combination for n, r, p, maxmem.");
+                        "Invalid parameter combination for n, r, p, maxmem.");
         return NULL;
    }
 


### PR DESCRIPTION
[bpo-36209](https://bugs.python.org/issue36209): Typo in hashlib error message

<!-- issue-number: [bpo-36209](https://bugs.python.org/issue36209) -->
https://bugs.python.org/issue36209
<!-- /issue-number -->
