### PR TITLE
Fixed issue with asyncore.dispatcher added when asyncore.loop() in progress

### DIFF
--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -229,8 +229,8 @@ class dispatcher:
             # Set to nonblocking just to make sure for cases where we
             # get a socket from a blocking source.
             sock.setblocking(0)
-            self.set_socket(sock, map)
             self.connected = True
+            self.set_socket(sock, map)
             # The constructor no longer requires that the socket
             # passed be connected.
             try:
@@ -288,7 +288,8 @@ class dispatcher:
     def set_socket(self, sock, map=None):
         self.socket = sock
         self._fileno = sock.fileno()
-        self.add_channel(map)
+        if self.connected:
+            self.add_channel(map)
 
     def set_reuse_addr(self):
         # try to re-use a server port if possible
@@ -331,6 +332,7 @@ class dispatcher:
         self.connected = False
         self.connecting = True
         err = self.socket.connect_ex(address)
+        self.add_channel()
         if err in (EINPROGRESS, EALREADY, EWOULDBLOCK) \
         or err == EINVAL and os.name == 'nt':
             self.addr = address


### PR DESCRIPTION
Fixed issue with asyncore.dispatcher added when asyncore.loop() in progress (inside thread, for example). So, adding a new socket to socket_map before connecting causes it to be readable and this leads to socket close.

Got this in next example code:
```
def infinite_loop():
    while 1:
        asyncore.loop()

t = threading.Thread(target=infinite_loop)
t.start()
client = some_asyncore_dispatcher("http://someserver.com/")
client.connect()

```

