### PR TITLE
Revert "closes bpo-36139: release GIL around munmap(). (GH-12073)"

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-06-13-07-29.bpo-36139.6kedum.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-06-13-07-29.bpo-36139.6kedum.rst
@@ -1,1 +1,0 @@
-Release GIL when closing :class:`~mmap.mmap` objects.


### PR DESCRIPTION
This reverts commit bb9593af0ac835b93c2834d44b72fa34e30efed0.

<!-- issue-number: [bpo-36139](https://bugs.python.org/issue36139) -->
https://bugs.python.org/issue36139
<!-- /issue-number -->
