### PR TITLE
bpo-32021: Support brotli .br encoding in mimetypes

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -393,6 +393,7 @@ def _default_mime_types():
         '.Z': 'compress',
         '.bz2': 'bzip2',
         '.xz': 'xz',
+        '.br': 'br',
         }
 
     # Before adding new types, make sure they are either registered with IANA,

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-11-13-30-40.bpo-32021.dpbtkP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-11-13-30-40.bpo-32021.dpbtkP.rst
@@ -1,0 +1,1 @@
+Include brotli .br encoding in mimetypes encodings_map


### PR DESCRIPTION
Currently python mimetypes does not support the [brotli](https://tools.ietf.org/html/rfc7932) file extension. Brotli has [decent browser support](https://caniuse.com/#feat=brotli) at this point.

My particular use case for this is that I would like the AWS S3 CLI to automatically set the Content-Type and Content-Encoding headers on brotli files uploaded to it - so for example a file script.js.br would have Content-Type: 'application/javascript' and Content-Encoding br. This [relies on mimetypes](https://github.com/aws/aws-cli/blob/develop/awscli/customizations/s3/utils.py#L288).



<!-- issue-number: [bpo-32021](https://bugs.python.org/issue32021) -->
https://bugs.python.org/issue32021
<!-- /issue-number -->
