### PR TITLE
bpo-36185: typo: Doc/c-api/objbuffer.rst

### DIFF
--- a/Doc/c-api/objbuffer.rst
+++ b/Doc/c-api/objbuffer.rst
@@ -42,7 +42,7 @@ an object, and :c:func:`PyBuffer_Release` when the buffer view can be released.
    Otherwise returns ``0``.  This function always succeeds.
 
    Note that this function tries to get and release a buffer, and exceptions
-   which occur while calling correspoding functions will get suppressed.
+   which occur while calling corresponding functions will get suppressed.
    To get error reporting use :c:func:`PyObject_GetBuffer()` instead.
 
 


### PR DESCRIPTION
[bpo-36185](https://bugs.python.org/issue36185): typo: Doc/c-api/objbuffer.rst

<!-- issue-number: [bpo-36185](https://bugs.python.org/issue36185) -->
https://bugs.python.org/issue36185
<!-- /issue-number -->
