### PR TITLE
gh-80407: Fix multipart false positive header defects

### DIFF
--- a/Lib/email/feedparser.py
+++ b/Lib/email/feedparser.py
@@ -189,6 +189,7 @@ class FeedParser:
         assert not self._msgstack
         # Look for final set of defects
         if root.get_content_maintype() == 'multipart' \
+               and not self._headersonly \
                and not root.is_multipart():
             defect = errors.MultipartInvariantViolationDefect()
             self.policy.handle_defect(root, defect)

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -211,7 +211,7 @@ def parse_headers(fp, _class=HTTPMessage):
         if line in (b'\r\n', b'\n', b''):
             break
     hstring = b''.join(headers).decode('iso-8859-1')
-    return email.parser.Parser(_class=_class).parsestr(hstring)
+    return email.parser.Parser(_class=_class).parsestr(hstring, headersonly=True)
 
 
 class HTTPResponse(io.BufferedIOBase):

--- a/Lib/test/test_email/test_parser.py
+++ b/Lib/test/test_email/test_parser.py
@@ -5,6 +5,12 @@ from email.message import Message, EmailMessage
 from email.policy import default
 from test.test_email import TestEmailBase
 
+class TestFeedParser(TestEmailBase):
+    def test_multipart_message_with_headers_only(self):
+        import email.parser
+        header = 'Content-Type: multipart/related; boundary="==="\r\n\r\n'
+        msg = email.parser.Parser().parsestr(header, headersonly=True)
+        self.assertDefectsEqual(msg.defects, [])
 
 class TestCustomMessage(TestEmailBase):
 

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -359,6 +359,11 @@ class HeaderTests(TestCase):
         self.assertEqual(lines[1], "header: First: val")
         self.assertEqual(lines[2], "header: Second: val")
 
+    def test_parse_valid_multipart_header(self):
+        header = b'Content-Type: multipart/related; boundary="==="\r\n\r\n'
+        fp = io.BytesIO(header)
+        message = client.parse_headers(fp)
+        self.assertListEqual(message.defects, [])
 
 class TransferEncodingTest(TestCase):
     expected_body = b"It's just a flesh wound"

--- a/Misc/NEWS.d/next/Library/2019-09-05-12-13-11.bpo-36226.J5mcDO.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-05-12-13-11.bpo-36226.J5mcDO.rst
@@ -1,0 +1,2 @@
+Fixes false MultipartInvariantViolationDefects which were triggered when
+only headers of a multipart message were parsed.

--- a/Misc/NEWS.d/next/Library/2019-09-05-12-14-30.bpo-36226.KJV4rP.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-05-12-14-30.bpo-36226.KJV4rP.rst
@@ -1,0 +1,2 @@
+Fixes false StartBoundaryNotFoundDefects which were triggered by
+parse_headers not forwarding the headersonly to the email parser.


### PR DESCRIPTION
The current implementation of `multipart/related` in urllib triggers header defects even though the headers are valid:
`[StartBoundaryNotFoundDefect(), MultipartInvariantViolationDefect()]`

The example header is valid according to RFC 2387 (https://tools.ietf.org/html/rfc2387):
```
Content-Type: multipart/related; boundary="===" 

```

Both defects are triggered by the fact that httplib only passes on headers to the underlying email parser, while the email parser assumes to receive a full message. The simple fix is to tell the underlying email parser that we are only passing the header: https://github.com/python/cpython/commit/89285439c7f94a3e62cee3d15e343218903c2af8

The second issue is related, but independent: The underlying email parser checks if the parsed message is of type multipart by checking of the object "root" is of type list. As we only passed the header (and set `headersonly=True`), the check does makes no sense anymore at this point, creating a false positive: https://github.com/python/cpython/pull/12214/commits/a82e662ab3339072d7b86a8090989fba60ef9c37



This issue has been a while with python (backport to 3.7 easily possible) and can also be found in urllib3 (hence also requests, etc):
* https://stackoverflow.com/questions/49338811/does-requests-properly-support-multipart-responses
* https://github.com/urllib3/urllib3/issues/800

<!-- issue-number: [bpo-36226](https://bugs.python.org/issue36226) -->
https://bugs.python.org/issue36226
<!-- /issue-number -->

<!-- gh-issue-number: gh-80407 -->
* Issue: gh-80407
<!-- /gh-issue-number -->
