### PR TITLE
bpo-35978: Correctly skips venv tests in venvs

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -24,10 +24,12 @@ try:
 except ImportError:
     ctypes = None
 
+# Platforms that set sys._base_executable can create venvs from within
+# another venv, so no need to skip tests that require venv.create().
 requireVenvCreate = unittest.skipUnless(
-    sys.platform.startswith('win')
+    hasattr(sys, '_base_executable')
     or sys.prefix == sys.base_prefix,
-    'Test requires venv.create')
+    'cannot run venv.create from within a venv on this platform')
 
 def check_output(cmd, encoding=None):
     p = subprocess.Popen(cmd,

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -24,8 +24,10 @@ try:
 except ImportError:
     ctypes = None
 
-skipInVenv = unittest.skipIf(sys.prefix != sys.base_prefix,
-                             'Test not appropriate in a venv')
+requireVenvCreate = unittest.skipUnless(
+    sys.platform.startswith('win')
+    or sys.prefix == sys.base_prefix,
+    'Test requires venv.create')
 
 def check_output(cmd, encoding=None):
     p = subprocess.Popen(cmd,
@@ -118,7 +120,7 @@ class BasicTest(BaseTest):
         context = builder.ensure_directories(self.env_dir)
         self.assertEqual(context.prompt, '(My prompt) ')
 
-    @skipInVenv
+    @requireVenvCreate
     def test_prefixes(self):
         """
         Test that the prefix values are as expected.
@@ -254,7 +256,7 @@ class BasicTest(BaseTest):
     # run the test, the pyvenv.cfg in the venv created in the test will
     # point to the venv being used to run the test, and we lose the link
     # to the source build - so Python can't initialise properly.
-    @skipInVenv
+    @requireVenvCreate
     def test_executable(self):
         """
         Test that the sys.executable value is as expected.
@@ -298,6 +300,7 @@ class BasicTest(BaseTest):
         )
         self.assertEqual(out.strip(), '0')
 
+    @requireVenvCreate
     def test_multiprocessing(self):
         """
         Test that the multiprocessing is able to spawn.
@@ -311,7 +314,7 @@ class BasicTest(BaseTest):
             'print(Pool(1).apply_async("Python".lower).get(3))'])
         self.assertEqual(out.strip(), "python".encode())
 
-@skipInVenv
+@requireVenvCreate
 class EnsurePipTest(BaseTest):
     """Test venv module installation of pip."""
     def assert_pip_not_installed(self):

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -176,18 +176,23 @@ class EnvBuilder:
                 # On Windows, we rewrite symlinks to our base python.exe into
                 # copies of venvlauncher.exe
                 basename, ext = os.path.splitext(os.path.basename(src))
-                if basename.endswith('_d'):
-                    ext = '_d' + ext
-                    basename = basename[:-2]
-                if sysconfig.is_python_build(True):
+                srcfn = os.path.join(os.path.dirname(__file__),
+                                     "scripts",
+                                     "nt",
+                                     basename + ext)
+                # Builds or venv's from builds need to remap source file
+                # locations, as we do not put them into Lib/venv/scripts
+                if sysconfig.is_python_build(True) or not os.path.isfile(srcfn):
+                    if basename.endswith('_d'):
+                        ext = '_d' + ext
+                        basename = basename[:-2]
                     if basename == 'python':
                         basename = 'venvlauncher'
                     elif basename == 'pythonw':
                         basename = 'venvwlauncher'
-                    scripts = os.path.dirname(src)
+                    src = os.path.join(os.path.dirname(src), basename + ext)
                 else:
-                    scripts = os.path.join(os.path.dirname(__file__), "scripts", "nt")
-                src = os.path.join(scripts, basename + ext)
+                    src = srcfn
 
             shutil.copyfile(src, dst)
 


### PR DESCRIPTION
As well as changing the skip decorator, I also slightly reordered the handling of running venv out of a build directory on Windows to minimize the work in the normal (non-build dir) case, and to also handle the venv-from-venv-from-build-directory case (where sysconfig doesn't correctly detect it).

<!-- issue-number: [bpo-35978](https://bugs.python.org/issue35978) -->
https://bugs.python.org/issue35978
<!-- /issue-number -->
