### PR TITLE
bpo-36227: ElementTree.tostring() default_namespace argument

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -594,7 +594,8 @@ Functions
 
 
 .. function:: tostring(element, encoding="us-ascii", method="xml", *, \
-                       default_namespace=None, short_empty_elements=True)
+                       xml_declaration=None, default_namespace=None,
+                       short_empty_elements=True)
 
    Generates a string representation of an XML element, including all
    subelements.  *element* is an :class:`Element` instance.  *encoding* [1]_ is
@@ -613,6 +614,7 @@ Functions
 
 
 .. function:: tostringlist(element, encoding="us-ascii", method="xml", *, \
+                           xml_declaration=None, default_namespace=None,
                            short_empty_elements=True)
 
    Generates a string representation of an XML element, including all

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -594,18 +594,22 @@ Functions
 
 
 .. function:: tostring(element, encoding="us-ascii", method="xml", *, \
-                       short_empty_elements=True)
+                       default_namespace=None, short_empty_elements=True)
 
    Generates a string representation of an XML element, including all
    subelements.  *element* is an :class:`Element` instance.  *encoding* [1]_ is
    the output encoding (default is US-ASCII).  Use ``encoding="unicode"`` to
    generate a Unicode string (otherwise, a bytestring is generated).  *method*
    is either ``"xml"``, ``"html"`` or ``"text"`` (default is ``"xml"``).
-   *short_empty_elements* has the same meaning as in :meth:`ElementTree.write`.
-   Returns an (optionally) encoded string containing the XML data.
+   *default_namespace* and *short_empty_elements* has the same meaning as in
+   :meth:`ElementTree.write`. Returns an (optionally) encoded string containing
+   the XML data.
 
    .. versionadded:: 3.4
       The *short_empty_elements* parameter.
+
+   .. versionadded:: 3.8
+      The *default_namespace* parameter.
 
 
 .. function:: tostringlist(element, encoding="us-ascii", method="xml", *, \

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -601,15 +601,15 @@ Functions
    the output encoding (default is US-ASCII).  Use ``encoding="unicode"`` to
    generate a Unicode string (otherwise, a bytestring is generated).  *method*
    is either ``"xml"``, ``"html"`` or ``"text"`` (default is ``"xml"``).
-   *default_namespace* and *short_empty_elements* has the same meaning as in
-   :meth:`ElementTree.write`. Returns an (optionally) encoded string containing
-   the XML data.
+   *xml_declaration*, *default_namespace* and *short_empty_elements* has the same
+   meaning as in :meth:`ElementTree.write`. Returns an (optionally) encoded string
+   containing the XML data.
 
    .. versionadded:: 3.4
       The *short_empty_elements* parameter.
 
    .. versionadded:: 3.8
-      The *default_namespace* parameter.
+      The *xml_declaration* and *default_namespace* parameters.
 
 
 .. function:: tostringlist(element, encoding="us-ascii", method="xml", *, \
@@ -620,15 +620,18 @@ Functions
    the output encoding (default is US-ASCII).  Use ``encoding="unicode"`` to
    generate a Unicode string (otherwise, a bytestring is generated).  *method*
    is either ``"xml"``, ``"html"`` or ``"text"`` (default is ``"xml"``).
-   *short_empty_elements* has the same meaning as in :meth:`ElementTree.write`.
-   Returns a list of (optionally) encoded strings containing the XML data.
-   It does not guarantee any specific sequence, except that
-   ``b"".join(tostringlist(element)) == tostring(element)``.
+   *xml_declaration*, *default_namespace* and *short_empty_elements* has the same
+   meaning as in :meth:`ElementTree.write`. Returns a list of (optionally) encoded
+   strings containing the XML data. It does not guarantee any specific sequence,
+   except that ``b"".join(tostringlist(element)) == tostring(element)``.
 
    .. versionadded:: 3.2
 
    .. versionadded:: 3.4
       The *short_empty_elements* parameter.
+
+   .. versionadded:: 3.8
+      The *xml_declaration* and *default_namespace* parameters.
 
 
 .. function:: XML(text, parser=None)

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -767,6 +767,19 @@ class ElementTreeTest(unittest.TestCase):
             '<body xmlns="http://effbot.org/ns"><tag /></body>'
         )
 
+    def test_tostring_default_namespace_different_namespace(self):
+        elem = ET.XML('<body xmlns="http://effbot.org/ns"><tag/></body>')
+        self.assertEqual(
+            ET.tostring(elem, encoding='unicode', default_namespace='foobar'),
+            '<ns1:body xmlns="foobar" xmlns:ns1="http://effbot.org/ns"><ns1:tag /></ns1:body>'
+        )
+
+    def test_tostring_default_namespace_original_no_namespace(self):
+        elem = ET.XML('<body><tag/></body>')
+        EXPECTED_MSG = '^cannot use non-qualified names with default_namespace option$'
+        with self.assertRaisesRegex(ValueError, EXPECTED_MSG):
+            ET.tostring(elem, encoding='unicode', default_namespace='foobar')
+
     def test_tostring_xml_declaration(self):
         elem = ET.XML('<body><tag/></body>')
         self.assertEqual(

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -821,10 +821,16 @@ class ElementTreeTest(unittest.TestCase):
             '<body><tag /></body>'
         )
         self.assertEqual(
-            [str(bstr, encoding='us-ascii') for bstr in ET.tostringlist(elem, xml_declaration=True)],
-            ["<?xml version='1.0' encoding='us-ascii'?>\n<body><tag /></body>"]
+            b''.join(ET.tostringlist(elem, xml_declaration=True)),
+            b"<?xml version='1.0' encoding='us-ascii'?>\n<body><tag /></body>"
         )
+        import locale
+        preferredencoding = locale.getpreferredencoding()
         stringlist = ET.tostringlist(elem, encoding='unicode', xml_declaration=True)
+        self.assertEqual(
+            ''.join(stringlist),
+            f"<?xml version='1.0' encoding='{preferredencoding}'?>\n<body><tag /></body>"
+        )
         self.assertRegex(stringlist[0], r"^<\?xml version='1.0' encoding='.+'?>")
         self.assertEqual(['<body', '>', '<tag', ' />', '</body>'], stringlist[1:])
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -794,19 +794,19 @@ class ElementTreeTest(unittest.TestCase):
     def test_tostringlist_default_namespace(self):
         elem = ET.XML('<body xmlns="http://effbot.org/ns"><tag/></body>')
         self.assertEqual(
-            ET.tostringlist(elem, encoding='unicode')[0:2],
-            ['<ns0:body', ' xmlns:ns0="http://effbot.org/ns"']
+            ''.join(ET.tostringlist(elem, encoding='unicode')),
+            '<ns0:body xmlns:ns0="http://effbot.org/ns"><ns0:tag /></ns0:body>'
         )
         self.assertEqual(
-            ET.tostringlist(elem, encoding='unicode', default_namespace='http://effbot.org/ns')[0:2],
-            ['<body', ' xmlns="http://effbot.org/ns"']
+            ''.join(ET.tostringlist(elem, encoding='unicode', default_namespace='http://effbot.org/ns')),
+            '<body xmlns="http://effbot.org/ns"><tag /></body>'
         )
 
     def test_tostringlist_xml_declaration(self):
         elem = ET.XML('<body><tag/></body>')
         self.assertEqual(
-            ET.tostringlist(elem, encoding='unicode'),
-            ['<body', '>', '<tag', ' />', '</body>']
+            ''.join(ET.tostringlist(elem, encoding='unicode')),
+            '<body><tag /></body>'
         )
         self.assertEqual(
             [str(bstr, encoding='us-ascii') for bstr in ET.tostringlist(elem, xml_declaration=True)],

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -780,15 +780,27 @@ class ElementTreeTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, EXPECTED_MSG):
             ET.tostring(elem, encoding='unicode', default_namespace='foobar')
 
-    def test_tostring_xml_declaration(self):
+    def test_tostring_no_xml_declaration(self):
         elem = ET.XML('<body><tag/></body>')
         self.assertEqual(
             ET.tostring(elem, encoding='unicode'),
             '<body><tag /></body>'
         )
+
+    def test_tostring_xml_declaration(self):
+        elem = ET.XML('<body><tag/></body>')
         self.assertEqual(
-            str(ET.tostring(elem, encoding='utf8', xml_declaration=True), encoding='utf8'),
-            "<?xml version='1.0' encoding='utf8'?>\n<body><tag /></body>"
+            ET.tostring(elem, encoding='utf8', xml_declaration=True),
+            b"<?xml version='1.0' encoding='utf8'?>\n<body><tag /></body>"
+        )
+
+    def test_tostring_xml_declaration_unicode_encoding(self):
+        elem = ET.XML('<body><tag/></body>')
+        import locale
+        preferredencoding = locale.getpreferredencoding()
+        self.assertEqual(
+            f"<?xml version='1.0' encoding='{preferredencoding}'?>\n<body><tag /></body>",
+            ET.tostring(elem, encoding='unicode', xml_declaration=True)
         )
 
     def test_tostringlist_default_namespace(self):

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -796,9 +796,12 @@ class ElementTreeTest(unittest.TestCase):
             ['<body', '>', '<tag', ' />', '</body>']
         )
         self.assertEqual(
-            ET.tostringlist(elem, encoding='unicode', xml_declaration=True),
-            ["<?xml version='1.0' encoding='cp1252'?>\n", '<body', '>', '<tag', ' />', '</body>']
+            [str(bstr, encoding='us-ascii') for bstr in ET.tostringlist(elem, xml_declaration=True)],
+            ["<?xml version='1.0' encoding='us-ascii'?>\n<body><tag /></body>"]
         )
+        stringlist = ET.tostringlist(elem, encoding='unicode', xml_declaration=True)
+        self.assertRegex(stringlist[0], r"^<\?xml version='1.0' encoding='.+'?>")
+        self.assertEqual(['<body', '>', '<tag', ' />', '</body>'], stringlist[1:])
 
     def test_encoding(self):
         def check(encoding, body=''):

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -767,6 +767,17 @@ class ElementTreeTest(unittest.TestCase):
             '<body xmlns="http://effbot.org/ns"><tag /></body>'
         )
 
+    def test_tostring_xml_declaration(self):
+        elem = ET.XML('<body><tag/></body>')
+        self.assertEqual(
+            ET.tostring(elem, encoding='unicode'),
+            '<body><tag /></body>'
+        )
+        self.assertEqual(
+            str(ET.tostring(elem, encoding='utf8', xml_declaration=True), encoding='utf8'),
+            "<?xml version='1.0' encoding='utf8'?>\n<body><tag /></body>"
+        )
+
     def test_encoding(self):
         def check(encoding, body=''):
             xml = ("<?xml version='1.0' encoding='%s'?><xml>%s</xml>" %

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -778,6 +778,28 @@ class ElementTreeTest(unittest.TestCase):
             "<?xml version='1.0' encoding='utf8'?>\n<body><tag /></body>"
         )
 
+    def test_tostringlist_default_namespace(self):
+        elem = ET.XML('<body xmlns="http://effbot.org/ns"><tag/></body>')
+        self.assertEqual(
+            ET.tostringlist(elem, encoding='unicode')[0:2],
+            ['<ns0:body', ' xmlns:ns0="http://effbot.org/ns"']
+        )
+        self.assertEqual(
+            ET.tostringlist(elem, encoding='unicode', default_namespace='http://effbot.org/ns')[0:2],
+            ['<body', ' xmlns="http://effbot.org/ns"']
+        )
+
+    def test_tostringlist_xml_declaration(self):
+        elem = ET.XML('<body><tag/></body>')
+        self.assertEqual(
+            ET.tostringlist(elem, encoding='unicode'),
+            ['<body', '>', '<tag', ' />', '</body>']
+        )
+        self.assertEqual(
+            ET.tostringlist(elem, encoding='unicode', xml_declaration=True),
+            ["<?xml version='1.0' encoding='cp1252'?>\n", '<body', '>', '<tag', ' />', '</body>']
+        )
+
     def test_encoding(self):
         def check(encoding, body=''):
             xml = ("<?xml version='1.0' encoding='%s'?><xml>%s</xml>" %

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -756,6 +756,17 @@ class ElementTreeTest(unittest.TestCase):
         elem = ET.fromstring("<html><body>text</body></html>")
         self.assertEqual(ET.tostring(elem), b'<html><body>text</body></html>')
 
+    def test_tostring_default_namespace(self):
+        elem = ET.XML('<body xmlns="http://effbot.org/ns"><tag/></body>')
+        self.assertEqual(
+            ET.tostring(elem, encoding='unicode'),
+            '<ns0:body xmlns:ns0="http://effbot.org/ns"><ns0:tag /></ns0:body>'
+        )
+        self.assertEqual(
+            ET.tostring(elem, encoding='unicode', default_namespace='http://effbot.org/ns'),
+            '<body xmlns="http://effbot.org/ns"><tag /></body>'
+        )
+
     def test_encoding(self):
         def check(encoding, body=''):
             xml = ("<?xml version='1.0' encoding='%s'?><xml>%s</xml>" %

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1132,8 +1132,10 @@ def tostring(element, encoding=None, method=None, *,
 
     """
     stream = io.StringIO() if encoding == 'unicode' else io.BytesIO()
-    ElementTree(element).write(stream, encoding, xml_declaration=xml_declaration,
-                               default_namespace=default_namespace, method=method,
+    ElementTree(element).write(stream, encoding,
+                               xml_declaration=xml_declaration,
+                               default_namespace=default_namespace,
+                               method=method,
                                short_empty_elements=short_empty_elements)
     return stream.getvalue()
 
@@ -1159,8 +1161,10 @@ def tostringlist(element, encoding=None, method=None, *,
                  short_empty_elements=True):
     lst = []
     stream = _ListDataStream(lst)
-    ElementTree(element).write(stream, encoding, xml_declaration=xml_declaration,
-                               default_namespace=default_namespace, method=method,
+    ElementTree(element).write(stream, encoding,
+                               xml_declaration=xml_declaration,
+                               default_namespace=default_namespace,
+                               method=method,
                                short_empty_elements=short_empty_elements)
     return lst
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1116,7 +1116,8 @@ def _escape_attrib_html(text):
 # --------------------------------------------------------------------
 
 def tostring(element, encoding=None, method=None, *,
-             default_namespace=None, short_empty_elements=True):
+             xml_declaration=None, default_namespace=None,
+             short_empty_elements=True):
     """Generate string representation of XML element.
 
     All subelements are included.  If encoding is "unicode", a string
@@ -1131,8 +1132,8 @@ def tostring(element, encoding=None, method=None, *,
 
     """
     stream = io.StringIO() if encoding == 'unicode' else io.BytesIO()
-    ElementTree(element).write(stream, encoding, default_namespace=default_namespace,
-                               method=method,
+    ElementTree(element).write(stream, encoding, xml_declaration=xml_declaration,
+                               default_namespace=default_namespace, method=method,
                                short_empty_elements=short_empty_elements)
     return stream.getvalue()
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1116,7 +1116,7 @@ def _escape_attrib_html(text):
 # --------------------------------------------------------------------
 
 def tostring(element, encoding=None, method=None, *,
-             short_empty_elements=True):
+             default_namespace=None, short_empty_elements=True):
     """Generate string representation of XML element.
 
     All subelements are included.  If encoding is "unicode", a string
@@ -1124,13 +1124,15 @@ def tostring(element, encoding=None, method=None, *,
 
     *element* is an Element instance, *encoding* is an optional output
     encoding defaulting to US-ASCII, *method* is an optional output which can
-    be one of "xml" (default), "html", "text" or "c14n".
+    be one of "xml" (default), "html", "text" or "c14n", *default_namespace*
+    sets the default XML namespace (for "xmlns").
 
     Returns an (optionally) encoded string containing the XML data.
 
     """
     stream = io.StringIO() if encoding == 'unicode' else io.BytesIO()
-    ElementTree(element).write(stream, encoding, method=method,
+    ElementTree(element).write(stream, encoding, default_namespace=default_namespace,
+                               method=method,
                                short_empty_elements=short_empty_elements)
     return stream.getvalue()
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1155,10 +1155,12 @@ class _ListDataStream(io.BufferedIOBase):
         return len(self.lst)
 
 def tostringlist(element, encoding=None, method=None, *,
+                 xml_declaration=None, default_namespace=None,
                  short_empty_elements=True):
     lst = []
     stream = _ListDataStream(lst)
-    ElementTree(element).write(stream, encoding, method=method,
+    ElementTree(element).write(stream, encoding, xml_declaration=xml_declaration,
+                               default_namespace=default_namespace, method=method,
                                short_empty_elements=short_empty_elements)
     return lst
 

--- a/Misc/NEWS.d/next/Library/2019-03-07-20-02-18.bpo-36227.i2Z1XR.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-07-20-02-18.bpo-36227.i2Z1XR.rst
@@ -1,2 +1,2 @@
-Added new keyword arguments `default_namespace` and `xml_declaration` to functions
+Added support for keyword arguments `default_namespace` and `xml_declaration` in functions
 ElementTree.tostring() and ElementTree.tostringlist().

--- a/Misc/NEWS.d/next/Library/2019-03-07-20-02-18.bpo-36227.i2Z1XR.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-07-20-02-18.bpo-36227.i2Z1XR.rst
@@ -1,0 +1,1 @@
+New keyword argument `default_namespace` to function ElementTree.tostring()

--- a/Misc/NEWS.d/next/Library/2019-03-07-20-02-18.bpo-36227.i2Z1XR.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-07-20-02-18.bpo-36227.i2Z1XR.rst
@@ -1,1 +1,2 @@
-New keyword argument `default_namespace` to function ElementTree.tostring()
+Added new keyword arguments `default_namespace` and `xml_declaration` to functions
+ElementTree.tostring() and ElementTree.tostringlist().


### PR DESCRIPTION


<!-- issue-number: [bpo-36227](https://bugs.python.org/issue36227) -->
https://bugs.python.org/issue36227
<!-- /issue-number -->
