### PR TITLE
bpo-36229: Avoid unnecessary copies for list, set, and bytearray ops.

### DIFF
--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -163,8 +163,8 @@ class ListTest(list_tests.CommonTest):
         iterable = [0] * 10
         iter_size = sys.getsizeof(iterable)
 
-        self.assertEqual(iter_size, sys.getsizeof(list([0] * 10)))
-        self.assertEqual(iter_size, sys.getsizeof(list(range(10))))
+        self.assertGreaterEqual(iter_size, sys.getsizeof(list([0] * 10)))
+        self.assertGreaterEqual(iter_size, sys.getsizeof(list(range(10))))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -222,6 +222,7 @@ Ian Bruntlett
 Floris Bruynooghe
 Matt Bryant
 Stan Bubrouski
+Brandt Bucher
 Colm Buckley
 Erik de Bueger
 Jan-Hein Bührman

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-07-22-03-19.bpo-36229.gn6GOI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-07-22-03-19.bpo-36229.gn6GOI.rst
@@ -1,0 +1,2 @@
+Improved performance for chained operations on built-in mutable collections.
+Patch by Brandt Bucher.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -297,18 +297,6 @@ bytearray_length(PyByteArrayObject *self)
     return Py_SIZE(self);
 }
 
-static PyObject *bytearray_iconcat(PyByteArrayObject *, PyObject *);
-
-static PyObject *
-bytearray_concat(PyByteArrayObject *self, PyObject *other)
-{
-    if (Py_REFCNT(self) == 1) {
-        return bytearray_iconcat(self, other);
-    }
-    
-    return PyByteArray_Concat((PyObject *)self, other);
-}
-
 static PyObject *
 bytearray_iconcat(PyByteArrayObject *self, PyObject *other)
 {
@@ -336,35 +324,13 @@ bytearray_iconcat(PyByteArrayObject *self, PyObject *other)
     return (PyObject *)self;
 }
 
-static PyObject *bytearray_irepeat(PyByteArrayObject *, Py_ssize_t);
-
 static PyObject *
-bytearray_repeat(PyByteArrayObject *self, Py_ssize_t count)
+bytearray_concat(PyByteArrayObject *self, PyObject *other)
 {
-    PyByteArrayObject *result;
-    Py_ssize_t mysize;
-    Py_ssize_t size;
-
-    if (count < 0)
-        count = 0;
-    mysize = Py_SIZE(self);
-    if (count > 0 && mysize > PY_SSIZE_T_MAX / count)
-        return PyErr_NoMemory();
     if (Py_REFCNT(self) == 1) {
-        return bytearray_irepeat(self, count);
+        return bytearray_iconcat(self, other);
     }
-    size = mysize * count;
-    result = (PyByteArrayObject *)PyByteArray_FromStringAndSize(NULL, size);
-    if (result != NULL && size != 0) {
-        if (mysize == 1)
-            memset(result->ob_bytes, self->ob_bytes[0], size);
-        else {
-            Py_ssize_t i;
-            for (i = 0; i < count; i++)
-                memcpy(result->ob_bytes + i*mysize, self->ob_bytes, mysize);
-        }
-    }
-    return (PyObject *)result;
+    return PyByteArray_Concat((PyObject *)self, other);
 }
 
 static PyObject *
@@ -394,6 +360,35 @@ bytearray_irepeat(PyByteArrayObject *self, Py_ssize_t count)
 
     Py_INCREF(self);
     return (PyObject *)self;
+}
+
+static PyObject *
+bytearray_repeat(PyByteArrayObject *self, Py_ssize_t count)
+{
+    PyByteArrayObject *result;
+    Py_ssize_t mysize;
+    Py_ssize_t size;
+
+    if (count < 0)
+        count = 0;
+    mysize = Py_SIZE(self);
+    if (count > 0 && mysize > PY_SSIZE_T_MAX / count)
+        return PyErr_NoMemory();
+    if (Py_REFCNT(self) == 1) {
+        return bytearray_irepeat(self, count);
+    }
+    size = mysize * count;
+    result = (PyByteArrayObject *)PyByteArray_FromStringAndSize(NULL, size);
+    if (result != NULL && size != 0) {
+        if (mysize == 1)
+            memset(result->ob_bytes, self->ob_bytes[0], size);
+        else {
+            Py_ssize_t i;
+            for (i = 0; i < count; i++)
+                memcpy(result->ob_bytes + i*mysize, self->ob_bytes, mysize);
+        }
+    }
+    return (PyObject *)result;
 }
 
 static PyObject *

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -297,6 +297,18 @@ bytearray_length(PyByteArrayObject *self)
     return Py_SIZE(self);
 }
 
+static PyObject *bytearray_iconcat(PyByteArrayObject *, PyObject *);
+
+static PyObject *
+bytearray_concat(PyByteArrayObject *self, PyObject *other)
+{
+    if (Py_REFCNT(self) == 1) {
+        return bytearray_iconcat(self, other);
+    }
+    
+    return PyByteArray_Concat((PyObject *)self, other);
+}
+
 static PyObject *
 bytearray_iconcat(PyByteArrayObject *self, PyObject *other)
 {
@@ -324,6 +336,8 @@ bytearray_iconcat(PyByteArrayObject *self, PyObject *other)
     return (PyObject *)self;
 }
 
+static PyObject *bytearray_irepeat(PyByteArrayObject *, Py_ssize_t);
+
 static PyObject *
 bytearray_repeat(PyByteArrayObject *self, Py_ssize_t count)
 {
@@ -336,6 +350,9 @@ bytearray_repeat(PyByteArrayObject *self, Py_ssize_t count)
     mysize = Py_SIZE(self);
     if (count > 0 && mysize > PY_SSIZE_T_MAX / count)
         return PyErr_NoMemory();
+    if (Py_REFCNT(self) == 1) {
+        return bytearray_irepeat(self, count);
+    }
     size = mysize * count;
     result = (PyByteArrayObject *)PyByteArray_FromStringAndSize(NULL, size);
     if (result != NULL && size != 0) {
@@ -2113,7 +2130,7 @@ bytearray_sizeof_impl(PyByteArrayObject *self)
 
 static PySequenceMethods bytearray_as_sequence = {
     (lenfunc)bytearray_length,              /* sq_length */
-    (binaryfunc)PyByteArray_Concat,         /* sq_concat */
+    (binaryfunc)bytearray_concat,           /* sq_concat */
     (ssizeargfunc)bytearray_repeat,         /* sq_repeat */
     (ssizeargfunc)bytearray_getitem,        /* sq_item */
     0,                                      /* sq_slice */

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -515,6 +515,8 @@ PyList_GetSlice(PyObject *a, Py_ssize_t ilow, Py_ssize_t ihigh)
     return list_slice((PyListObject *)a, ilow, ihigh);
 }
 
+static PyObject *list_inplace_concat(PyListObject *, PyObject *);
+
 static PyObject *
 list_concat(PyListObject *a, PyObject *bb)
 {
@@ -531,6 +533,9 @@ list_concat(PyListObject *a, PyObject *bb)
 #define b ((PyListObject *)bb)
     if (Py_SIZE(a) > PY_SSIZE_T_MAX - Py_SIZE(b))
         return PyErr_NoMemory();
+    if (Py_REFCNT(a) == 1) {
+        return list_inplace_concat(a, bb);
+    }
     size = Py_SIZE(a) + Py_SIZE(b);
     np = (PyListObject *) list_new_prealloc(size);
     if (np == NULL) {
@@ -555,6 +560,8 @@ list_concat(PyListObject *a, PyObject *bb)
 #undef b
 }
 
+static PyObject *list_inplace_repeat(PyListObject *, Py_ssize_t);
+
 static PyObject *
 list_repeat(PyListObject *a, Py_ssize_t n)
 {
@@ -570,6 +577,9 @@ list_repeat(PyListObject *a, Py_ssize_t n)
     size = Py_SIZE(a) * n;
     if (size == 0)
         return PyList_New(0);
+    if (Py_REFCNT(a) == 1) {
+        return list_inplace_repeat(a, n);
+    }
     np = (PyListObject *) list_new_prealloc(size);
     if (np == NULL)
         return NULL;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1202,6 +1202,8 @@ PyDoc_STRVAR(union_doc,
 \n\
 (i.e. all elements that are in either set.)");
 
+static PyObject *set_ior(PySetObject *, PyObject *);
+
 static PyObject *
 set_or(PySetObject *so, PyObject *other)
 {
@@ -1210,6 +1212,9 @@ set_or(PySetObject *so, PyObject *other)
     if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
         Py_RETURN_NOTIMPLEMENTED;
 
+    if (PySet_Check(so) && Py_REFCNT(so) == 1) {
+        return set_ior(so, other);
+    }
     result = (PySetObject *)set_copy(so, NULL);
     if (result == NULL)
         return NULL;
@@ -1366,11 +1371,16 @@ set_intersection_update_multi(PySetObject *so, PyObject *args)
 PyDoc_STRVAR(intersection_update_doc,
 "Update a set with the intersection of itself and another.");
 
+static PyObject *set_iand(PySetObject *, PyObject *);
+
 static PyObject *
 set_and(PySetObject *so, PyObject *other)
 {
     if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
         Py_RETURN_NOTIMPLEMENTED;
+    if (PySet_Check(so) && Py_REFCNT(so) == 1) {
+        return set_iand(so, other);
+    }
     return set_intersection(so, other);
 }
 
@@ -1624,11 +1634,17 @@ PyDoc_STRVAR(difference_doc,
 "Return the difference of two or more sets as a new set.\n\
 \n\
 (i.e. all elements that are in this set but not the others.)");
+
+static PyObject *set_isub(PySetObject *, PyObject *);
+
 static PyObject *
 set_sub(PySetObject *so, PyObject *other)
 {
     if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
         Py_RETURN_NOTIMPLEMENTED;
+    if (PySet_Check(so) && Py_REFCNT(so) == 1) {
+        return set_isub(so, other);
+    }
     return set_difference(so, other);
 }
 
@@ -1730,11 +1746,16 @@ PyDoc_STRVAR(symmetric_difference_doc,
 \n\
 (i.e. all elements that are in exactly one of the sets.)");
 
+static PyObject *set_ixor(PySetObject *, PyObject *);
+
 static PyObject *
 set_xor(PySetObject *so, PyObject *other)
 {
     if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
         Py_RETURN_NOTIMPLEMENTED;
+    if (PySet_Check(so) && Py_REFCNT(so) == 1) {
+        return set_ixor(so, other);
+    }
     return set_symmetric_difference(so, other);
 }
 

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1202,7 +1202,17 @@ PyDoc_STRVAR(union_doc,
 \n\
 (i.e. all elements that are in either set.)");
 
-static PyObject *set_ior(PySetObject *, PyObject *);
+static PyObject *
+set_ior(PySetObject *so, PyObject *other)
+{
+    if (!PyAnySet_Check(other))
+        Py_RETURN_NOTIMPLEMENTED;
+
+    if (set_update_internal(so, other))
+        return NULL;
+    Py_INCREF(so);
+    return (PyObject *)so;
+}
 
 static PyObject *
 set_or(PySetObject *so, PyObject *other)
@@ -1211,7 +1221,6 @@ set_or(PySetObject *so, PyObject *other)
 
     if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
         Py_RETURN_NOTIMPLEMENTED;
-
     if (PySet_Check(so) && Py_REFCNT(so) == 1) {
         return set_ior(so, other);
     }
@@ -1225,18 +1234,6 @@ set_or(PySetObject *so, PyObject *other)
         return NULL;
     }
     return (PyObject *)result;
-}
-
-static PyObject *
-set_ior(PySetObject *so, PyObject *other)
-{
-    if (!PyAnySet_Check(other))
-        Py_RETURN_NOTIMPLEMENTED;
-
-    if (set_update_internal(so, other))
-        return NULL;
-    Py_INCREF(so);
-    return (PyObject *)so;
 }
 
 static PyObject *
@@ -1371,19 +1368,6 @@ set_intersection_update_multi(PySetObject *so, PyObject *args)
 PyDoc_STRVAR(intersection_update_doc,
 "Update a set with the intersection of itself and another.");
 
-static PyObject *set_iand(PySetObject *, PyObject *);
-
-static PyObject *
-set_and(PySetObject *so, PyObject *other)
-{
-    if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
-        Py_RETURN_NOTIMPLEMENTED;
-    if (PySet_Check(so) && Py_REFCNT(so) == 1) {
-        return set_iand(so, other);
-    }
-    return set_intersection(so, other);
-}
-
 static PyObject *
 set_iand(PySetObject *so, PyObject *other)
 {
@@ -1397,6 +1381,17 @@ set_iand(PySetObject *so, PyObject *other)
     Py_DECREF(result);
     Py_INCREF(so);
     return (PyObject *)so;
+}
+
+static PyObject *
+set_and(PySetObject *so, PyObject *other)
+{
+    if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
+        Py_RETURN_NOTIMPLEMENTED;
+    if (PySet_Check(so) && Py_REFCNT(so) == 1) {
+        return set_iand(so, other);
+    }
+    return set_intersection(so, other);
 }
 
 static PyObject *
@@ -1635,7 +1630,16 @@ PyDoc_STRVAR(difference_doc,
 \n\
 (i.e. all elements that are in this set but not the others.)");
 
-static PyObject *set_isub(PySetObject *, PyObject *);
+static PyObject *
+set_isub(PySetObject *so, PyObject *other)
+{
+    if (!PyAnySet_Check(other))
+        Py_RETURN_NOTIMPLEMENTED;
+    if (set_difference_update_internal(so, other))
+        return NULL;
+    Py_INCREF(so);
+    return (PyObject *)so;
+}
 
 static PyObject *
 set_sub(PySetObject *so, PyObject *other)
@@ -1646,17 +1650,6 @@ set_sub(PySetObject *so, PyObject *other)
         return set_isub(so, other);
     }
     return set_difference(so, other);
-}
-
-static PyObject *
-set_isub(PySetObject *so, PyObject *other)
-{
-    if (!PyAnySet_Check(other))
-        Py_RETURN_NOTIMPLEMENTED;
-    if (set_difference_update_internal(so, other))
-        return NULL;
-    Py_INCREF(so);
-    return (PyObject *)so;
 }
 
 static PyObject *
@@ -1746,19 +1739,6 @@ PyDoc_STRVAR(symmetric_difference_doc,
 \n\
 (i.e. all elements that are in exactly one of the sets.)");
 
-static PyObject *set_ixor(PySetObject *, PyObject *);
-
-static PyObject *
-set_xor(PySetObject *so, PyObject *other)
-{
-    if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
-        Py_RETURN_NOTIMPLEMENTED;
-    if (PySet_Check(so) && Py_REFCNT(so) == 1) {
-        return set_ixor(so, other);
-    }
-    return set_symmetric_difference(so, other);
-}
-
 static PyObject *
 set_ixor(PySetObject *so, PyObject *other)
 {
@@ -1772,6 +1752,17 @@ set_ixor(PySetObject *so, PyObject *other)
     Py_DECREF(result);
     Py_INCREF(so);
     return (PyObject *)so;
+}
+
+static PyObject *
+set_xor(PySetObject *so, PyObject *other)
+{
+    if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
+        Py_RETURN_NOTIMPLEMENTED;
+    if (PySet_Check(so) && Py_REFCNT(so) == 1) {
+        return set_ixor(so, other);
+    }
+    return set_symmetric_difference(so, other);
 }
 
 static PyObject *


### PR DESCRIPTION
The relevant changes are all in the first commit, which has a cleaner diff. The second commit reorganized the affected functions to avoid separate declarations... which sort of mangled it. The additions are actually quite small (about 30 lines of code, total).

<!-- issue-number: [bpo-36229](https://bugs.python.org/issue36229) -->
https://bugs.python.org/issue36229
<!-- /issue-number -->
