### PR TITLE
[2.7] bpo-36234: test_os: check TypeError for invalid uid type

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -735,30 +735,36 @@ class PosixUidGidTests(unittest.TestCase):
     def test_setuid(self):
         if os.getuid() != 0:
             self.assertRaises(os.error, os.setuid, 0)
+        self.assertRaises(TypeError, os.setuid, 'not an int')
         self.assertRaises(OverflowError, os.setuid, 1<<32)
 
     @unittest.skipUnless(hasattr(os, 'setgid'), 'test needs os.setgid()')
     def test_setgid(self):
         if os.getuid() != 0:
             self.assertRaises(os.error, os.setgid, 0)
+        self.assertRaises(TypeError, os.setgid, 'not an int')
         self.assertRaises(OverflowError, os.setgid, 1<<32)
 
     @unittest.skipUnless(hasattr(os, 'seteuid'), 'test needs os.seteuid()')
     def test_seteuid(self):
         if os.getuid() != 0:
             self.assertRaises(os.error, os.seteuid, 0)
+        self.assertRaises(TypeError, os.seteuid, 'not an int')
         self.assertRaises(OverflowError, os.seteuid, 1<<32)
 
     @unittest.skipUnless(hasattr(os, 'setegid'), 'test needs os.setegid()')
     def test_setegid(self):
         if os.getuid() != 0:
             self.assertRaises(os.error, os.setegid, 0)
+        self.assertRaises(TypeError, os.setegid, 'not an int')
         self.assertRaises(OverflowError, os.setegid, 1<<32)
 
     @unittest.skipUnless(hasattr(os, 'setreuid'), 'test needs os.setreuid()')
     def test_setreuid(self):
         if os.getuid() != 0:
             self.assertRaises(os.error, os.setreuid, 0, 0)
+        self.assertRaises(TypeError, os.setreuid, 'not an int', 0)
+        self.assertRaises(TypeError, os.setreuid, 0, 'not an int')
         self.assertRaises(OverflowError, os.setreuid, 1<<32, 0)
         self.assertRaises(OverflowError, os.setreuid, 0, 1<<32)
 
@@ -774,6 +780,8 @@ class PosixUidGidTests(unittest.TestCase):
     def test_setregid(self):
         if os.getuid() != 0:
             self.assertRaises(os.error, os.setregid, 0, 0)
+        self.assertRaises(TypeError, os.setregid, 'not an int', 0)
+        self.assertRaises(TypeError, os.setregid, 0, 'not an int')
         self.assertRaises(OverflowError, os.setregid, 1<<32, 0)
         self.assertRaises(OverflowError, os.setregid, 0, 1<<32)
 

--- a/Misc/NEWS.d/next/Tests/2019-03-08-12-53-37.bpo-36234.NRVK6W.rst
+++ b/Misc/NEWS.d/next/Tests/2019-03-08-12-53-37.bpo-36234.NRVK6W.rst
@@ -1,0 +1,2 @@
+test_posix.PosixUidGidTests: add tests for invalid uid/gid type (str).
+Patch written by David Malcolm.


### PR DESCRIPTION
Patch written by David Malcolm.

Co-Authored-By: David Malcolm <dmalcolm@redhat.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36234](https://bugs.python.org/issue36234) -->
https://bugs.python.org/issue36234
<!-- /issue-number -->
