### PR TITLE
bpo-36157:Document PyInterpreterState_Main()

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1382,6 +1382,11 @@ These functions are only intended to be used by advanced debugging tools.
    Return the interpreter state object at the head of the list of all such objects.
 
 
+.. c:function:: PyInterpreterState* PyInterpreterState_Main()
+
+   Return the main interpreter state object.
+
+
 .. c:function:: PyInterpreterState* PyInterpreterState_Next(PyInterpreterState *interp)
 
    Return the next interpreter state object after *interp* from the list of all

--- a/Misc/NEWS.d/next/Documentation/2019-03-08-15-39-47.bpo-36157.nF1pP1.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-03-08-15-39-47.bpo-36157.nF1pP1.rst
@@ -1,0 +1,1 @@
+Added Documention for  PyInterpreterState_Main().


### PR DESCRIPTION
I have added documentation for `PyInterpreterState_Main()`.
 I chose to place it under Advanced Debugger Support together with similar functions like `PyInterpreterState_Head()`, `PyInterpreterState_Next(`), and `PyInterpreterState_ThreadHead()` .

<!-- issue-number: [bpo-36157](https://bugs.python.org/issue36157) -->
https://bugs.python.org/issue36157
<!-- /issue-number -->
