### PR TITLE
[3.6] bpo-36247: zipfile - extract truncates (existing) file when bad password provided (zip encryption weakness)

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1767,6 +1767,15 @@ class DecryptionTests(unittest.TestCase):
         self.assertRaises(TypeError, self.zip.open, "test.txt", pwd="python")
         self.assertRaises(TypeError, self.zip.extract, "test.txt", pwd="python")
 
+    @requires_zlib
+    def test_wrong_password_collision(self):
+        member = "test.txt"
+        extracted = self.zip.extract(member, pwd=b"python")
+        size = os.stat(extracted).st_size
+        self.assertRaises(zipfile.BadZipFile, self.zip.extract, member, pwd=b"xxx")
+        self.assertEqual(os.stat(extracted).st_size, size)
+
+
 class AbstractTestsWithRandomBinaryFiles:
     @classmethod
     def setUpClass(cls):

--- a/Misc/NEWS.d/next/Library/2019-03-09-00-21-31.bpo-36247.Jnslls.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-09-00-21-31.bpo-36247.Jnslls.rst
@@ -1,0 +1,1 @@
+Issue discovered when working on https://stackoverflow.com/questions/54532010/zipfile-badzipfile-bad-crc-32-when-extracting-a-password-protected-zip-zip/55063500#55063500


### PR DESCRIPTION
As also specified in the issue, the details are on [[SO]: zipfile.BadZipFile: Bad CRC-32 when extracting a password protected .zip & .zip goes corrupt on extract (@CristiFati's answer)](https://stackoverflow.com/questions/54532010/zipfile-badzipfile-bad-crc-32-when-extracting-a-password-protected-zip-zip/55063500#55063500).

It's about *Python **3.6***, but it applies to any (actual) version.

This *PR*, attempts to fix the problem, and also provides a new test (for this specific scenario).
There's a great chance the problem affects a wider variety of scenarios, but tried to limit the fix as possible to this one (to avoid introducing regressions - maybe some other code relies on this behavior, although I doubt it).

Regarding the *"xxx"* password, I did some tests and this was the 1st one that  reproduced it. I tried with generated one char passwords, but I didn't run into the problem. Anyway, it's a coincidence (and I guess, not so important).

Notes:

- There will be a performance decrease (when extracting password protected files), due to additional operations (especially renames - who work with disks). But since files should be on the same *FS* (partition), there should be only metadata changes
- A regression would be: when the file to be extracted fits on the disk (size-wise), **but not together** with the existing one. In this case extraction will fail (previously it would have succeeded), but the good thing is that the old one will still be preserver. User deleting the previous file would fix  the problem

<!-- issue-number: [bpo-36247](https://bugs.python.org/issue36247) -->
https://bugs.python.org/issue36247
<!-- /issue-number -->
