### PR TITLE
bpo-33608: Simplify DISPATCH by hoisting eval_breaker ahead of time.

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -602,6 +602,7 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
     PyObject **fastlocals, **freevars;
     PyObject *retval = NULL;            /* Return value */
     PyThreadState *tstate = _PyThreadState_GET();
+    _Py_atomic_int *eval_breaker = &_PyRuntime.ceval.eval_breaker;
     PyCodeObject *co;
 
     /* when tracing we set things up so that
@@ -687,7 +688,7 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
 
 #define DISPATCH() \
     { \
-        if (!_Py_atomic_load_relaxed(&_PyRuntime.ceval.eval_breaker)) { \
+        if (!_Py_atomic_load_relaxed(eval_breaker)) { \
                     FAST_DISPATCH(); \
         } \
         continue; \
@@ -989,7 +990,7 @@ main_loop:
            async I/O handler); see Py_AddPendingCall() and
            Py_MakePendingCalls() above. */
 
-        if (_Py_atomic_load_relaxed(&_PyRuntime.ceval.eval_breaker)) {
+        if (_Py_atomic_load_relaxed(eval_breaker)) {
             opcode = _Py_OPCODE(*next_instr);
             if (opcode == SETUP_FINALLY ||
                 opcode == SETUP_WITH ||


### PR DESCRIPTION
This is basically un-reverting gh-12062.

<!-- issue-number: [bpo-33608](https://bugs.python.org/issue33608) -->
https://bugs.python.org/issue33608
<!-- /issue-number -->
