### PR TITLE
bpo-13120: fix typo with test_issue13120() method name

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1267,8 +1267,8 @@ class PdbTestCase(unittest.TestCase):
             'Fail to step into the caller after a return')
 
     def test_issue13120(self):
-        # invoking "continue" on a non-main thread triggered an exception
-        # inside signal.signal
+        # Invoking "continue" on a non-main thread triggered an exception
+        # inside signal.signal.
 
         with open(support.TESTFN, 'wb') as f:
             f.write(textwrap.dedent("""

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1266,7 +1266,7 @@ class PdbTestCase(unittest.TestCase):
             any('main.py(5)foo()->None' in l for l in stdout.splitlines()),
             'Fail to step into the caller after a return')
 
-    def test_issue13210(self):
+    def test_issue13120(self):
         # invoking "continue" on a non-main thread triggered an exception
         # inside signal.signal
 


### PR DESCRIPTION
Incorrect issue number '13210' added in 539ee5da6f.

<!-- issue-number: [bpo-13120](https://bugs.python.org/issue13120) -->
https://bugs.python.org/issue13120
<!-- /issue-number -->
