### PR TITLE
bpo-36251: Fix format strings used in match_repr() and stdprinter_repr()

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-09-18-01-24.bpo-36251.zOp9l0.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-09-18-01-24.bpo-36251.zOp9l0.rst
@@ -1,0 +1,2 @@
+Fix format strings used for StdPrinter and MatchObject reprs. Patch by
+Stephan Hohe.

--- a/Misc/NEWS.d/next/Library/2019-03-09-18-01-24.bpo-36251.zOp9l0.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-09-18-01-24.bpo-36251.zOp9l0.rst
@@ -1,2 +1,2 @@
-Fix format strings used for StdPrinter and MatchObject reprs. Patch by
+Fix format strings used for stderrprinter and re.Match reprs. Patch by
 Stephan Hohe.

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -2306,7 +2306,7 @@ match_repr(MatchObject *self)
     if (group0 == NULL)
         return NULL;
     result = PyUnicode_FromFormat(
-            "<%s object; span=(%d, %d), match=%.50R>",
+            "<%s object; span=(%zd, %zd), match=%.50R>",
             Py_TYPE(self)->tp_name,
             self->mark[0], self->mark[1], group0);
     Py_DECREF(group0);

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -411,7 +411,7 @@ stdprinter_fileno(PyStdPrinter_Object *self, PyObject *Py_UNUSED(ignored))
 static PyObject *
 stdprinter_repr(PyStdPrinter_Object *self)
 {
-    return PyUnicode_FromFormat("<stdprinter(fd=%d) object at 0x%x>",
+    return PyUnicode_FromFormat("<stdprinter(fd=%d) object at %p>",
                                 self->fd, self);
 }
 


### PR DESCRIPTION
In `match_repr()`, the `mark`s are `Py_ssize_t`, not `int`.

In `stdprinter_repr()`, the argument is a pointer and the correct format specifier for that is `%p` (this includes the 0x prefix).

For reference: The [docs for PyUnicode_FromFormat][format]

 [format]: https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromFormat

<!-- issue-number: [bpo-36251](https://bugs.python.org/issue36251) -->
https://bugs.python.org/issue36251
<!-- /issue-number -->
