### PR TITLE
bpo-36239: Skip comments in gettext infos

### DIFF
--- a/Lib/gettext.py
+++ b/Lib/gettext.py
@@ -417,6 +417,7 @@ class GNUTranslations(NullTranslations):
                     item = b_item.decode().strip()
                     if not item:
                         continue
+                    # Skip over comment lines:
                     if item.startswith('#-#-#-#-#') and item.endswith('#-#-#-#-#'):
                         continue
                     k = v = None

--- a/Lib/gettext.py
+++ b/Lib/gettext.py
@@ -417,6 +417,8 @@ class GNUTranslations(NullTranslations):
                     item = b_item.decode().strip()
                     if not item:
                         continue
+                    if item.startswith('#-#-#-#-#') and item.endswith('#-#-#-#-#'):
+                        continue
                     k = v = None
                     if ':' in item:
                         k, v = item.split(':', 1)

--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -685,6 +685,12 @@ class GNUTranslationParsingTest(GettextBaseTest):
             t = gettext.GNUTranslations(fp)
 
     def test_ignore_comments_in_headers_issue36239(self):
+        """Checks that comments like:
+
+            #-#-#-#-#  messages.po (EdX Studio)  #-#-#-#-#
+
+        are ignored.
+        """
         with open(MOFILE, 'wb') as fp:
             fp.write(base64.decodebytes(GNU_MO_DATA_ISSUE_17898))
         with open(MOFILE, 'rb') as fp:

--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -684,6 +684,13 @@ class GNUTranslationParsingTest(GettextBaseTest):
             # If this runs cleanly, the bug is fixed.
             t = gettext.GNUTranslations(fp)
 
+    def test_ignore_comments_in_headers_issue36239(self):
+        with open(MOFILE, 'wb') as fp:
+            fp.write(base64.decodebytes(GNU_MO_DATA_ISSUE_17898))
+        with open(MOFILE, 'rb') as fp:
+            t = gettext.GNUTranslations(fp)
+            self.assertEqual(t.info()["plural-forms"], "nplurals=2; plural=(n != 1);")
+
 
 class UnicodeTranslationsTest(GettextBaseTest):
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2019-03-09-23-51-27.bpo-36239.BHJ3Ln.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-09-23-51-27.bpo-36239.BHJ3Ln.rst
@@ -1,0 +1,1 @@
+Parsing .mo files now ignores comments starting and ending with #-#-#-#-#.


### PR DESCRIPTION


<!-- issue-number: [bpo-36239](https://bugs.python.org/issue36239) -->
https://bugs.python.org/issue36239
<!-- /issue-number -->
