### PR TITLE
bpo-36253: Remove use after free reference in ctypes test suite

### DIFF
--- a/Lib/ctypes/test/test_stringptr.py
+++ b/Lib/ctypes/test/test_stringptr.py
@@ -70,8 +70,11 @@ class StringPtrTestCase(unittest.TestCase):
         x = r[0], r[1], r[2], r[3], r[4]
         self.assertEqual(x, (b"c", b"d", b"e", b"f", b"\000"))
         del buf
-        # x1 will NOT be the same as x, usually:
-        x1 = r[0], r[1], r[2], r[3], r[4]
+        # Because r is a pointer to memory that is freed after deleting buf,
+        # the pointer is hanging and using it would reference freed memory.
+        # The value of x1 may not, and often will not, be the same as x if
+        # something else overwrites the released memory.
+        # x1 = r[0], r[1], r[2], r[3], r[4]
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/ctypes/test/test_stringptr.py
+++ b/Lib/ctypes/test/test_stringptr.py
@@ -72,9 +72,6 @@ class StringPtrTestCase(unittest.TestCase):
         del buf
         # Because r is a pointer to memory that is freed after deleting buf,
         # the pointer is hanging and using it would reference freed memory.
-        # The value of x1 may not, and often will not, be the same as x if
-        # something else overwrites the released memory.
-        # x1 = r[0], r[1], r[2], r[3], r[4]
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Tests/2019-03-18-03-05-50.bpo-36253.eS66E6.rst
+++ b/Misc/NEWS.d/next/Tests/2019-03-18-03-05-50.bpo-36253.eS66E6.rst
@@ -1,0 +1,1 @@
+Remove reference to freed memory in ctypes test suite

--- a/Misc/NEWS.d/next/Tests/2019-03-18-03-05-50.bpo-36253.eS66E6.rst
+++ b/Misc/NEWS.d/next/Tests/2019-03-18-03-05-50.bpo-36253.eS66E6.rst
@@ -1,1 +1,0 @@
-Remove reference to freed memory in ctypes test suite


### PR DESCRIPTION
Removes invalid reference to freed memory in ctypes test case.

Once buf is deleted and freed r becomes a dangling pointer, further use requires reading from freed memory.

Bug found using asan, full details and stack trace attached in the bug tracker.

<!-- issue-number: [bpo-36253](https://bugs.python.org/issue36253) -->
https://bugs.python.org/issue36253
<!-- /issue-number -->
