### PR TITLE
[WIP] bpo-36263: Fix hashlib.scrypt()

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-11-16-52-09.bpo-36263.IzB4p5.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-11-16-52-09.bpo-36263.IzB4p5.rst
@@ -1,0 +1,1 @@
+Fix :func:`hashlib.scrypt`: pass the salt when validating arguments.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -771,7 +771,11 @@ _hashlib_scrypt_impl(PyObject *module, Py_buffer *password, Py_buffer *salt,
     }
 
     /* let OpenSSL validate the rest */
-    retval = EVP_PBE_scrypt(NULL, 0, NULL, 0, n, r, p, maxmem, NULL, 0);
+    retval = EVP_PBE_scrypt(
+        NULL, 0,
+        (const unsigned char *)salt->buf, (size_t)salt->len,
+        n, r, p, maxmem,
+        NULL, 0);
     if (!retval) {
         /* sorry, can't do much better */
         PyErr_SetString(PyExc_ValueError,


### PR DESCRIPTION
Fix hashlib.scrypt(): pass the salt when validating arguments.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36263](https://bugs.python.org/issue36263) -->
https://bugs.python.org/issue36263
<!-- /issue-number -->
