### PR TITLE
bpo-36264: Don't honor POSIX `HOME` in `os.path.expanduser` on windows

### DIFF
--- a/Lib/distutils/tests/test_config.py
+++ b/Lib/distutils/tests/test_config.py
@@ -60,6 +60,7 @@ class BasePyPIRCCommandTestCase(support.TempdirManager,
         super(BasePyPIRCCommandTestCase, self).setUp()
         self.tmp_dir = self.mkdtemp()
         os.environ['HOME'] = self.tmp_dir
+        os.environ['USERPROFILE'] = self.tmp_dir
         self.rc = os.path.join(self.tmp_dir, '.pypirc')
         self.dist = Distribution()
 

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -463,7 +463,7 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
             # win32-style
             if sys.platform == 'win32':
                 # home drive should be found
-                os.environ['HOME'] = temp_dir
+                os.environ['USERPROFILE'] = temp_dir
                 files = dist.find_config_files()
                 self.assertIn(user_filename, files,
                               '%r not found in %r' % (user_filename, files))

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -299,9 +299,7 @@ def expanduser(path):
     while i < n and path[i] not in _get_bothseps(path):
         i += 1
 
-    if 'HOME' in os.environ:
-        userhome = os.environ['HOME']
-    elif 'USERPROFILE' in os.environ:
+    if 'USERPROFILE' in os.environ:
         userhome = os.environ['USERPROFILE']
     elif not 'HOMEPATH' in os.environ:
         return path

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -154,6 +154,7 @@ class NetrcTestCase(unittest.TestCase):
             called.append(s)
             with support.EnvironmentVarGuard() as environ:
                 environ.set('HOME', fake_home)
+                environ.set('USERPROFILE', fake_home)
                 result = orig_expanduser(s)
                 return result
 

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -262,20 +262,21 @@ class TestNtpath(unittest.TestCase):
             env['USERPROFILE'] = 'C:\\eric\\idle'
             tester('ntpath.expanduser("~test")', 'C:\\eric\\test')
             tester('ntpath.expanduser("~")', 'C:\\eric\\idle')
-
-            env.clear()
-            env['HOME'] = 'C:\\idle\\eric'
-            tester('ntpath.expanduser("~test")', 'C:\\idle\\test')
-            tester('ntpath.expanduser("~")', 'C:\\idle\\eric')
-
             tester('ntpath.expanduser("~test\\foo\\bar")',
-                   'C:\\idle\\test\\foo\\bar')
+                   'C:\\eric\\test\\foo\\bar')
             tester('ntpath.expanduser("~test/foo/bar")',
-                   'C:\\idle\\test/foo/bar')
+                   'C:\\eric\\test/foo/bar')
             tester('ntpath.expanduser("~\\foo\\bar")',
-                   'C:\\idle\\eric\\foo\\bar')
+                   'C:\\eric\\idle\\foo\\bar')
             tester('ntpath.expanduser("~/foo/bar")',
-                   'C:\\idle\\eric/foo/bar')
+                   'C:\\eric\\idle/foo/bar')
+
+            # bpo-36264: ignore `HOME` when set on windows
+            env.clear()
+            env['HOME'] = 'F:\\'
+            env['USERPROFILE'] = 'C:\\eric\\idle'
+            tester('ntpath.expanduser("~test")', 'C:\\eric\\test')
+            tester('ntpath.expanduser("~")', 'C:\\eric\\idle')
 
     @unittest.skipUnless(nt, "abspath requires 'nt' module")
     def test_abspath(self):

--- a/Misc/NEWS.d/next/Windows/2019-03-11-09-33-47.bpo-36264.rTzWce.rst
+++ b/Misc/NEWS.d/next/Windows/2019-03-11-09-33-47.bpo-36264.rTzWce.rst
@@ -1,0 +1,2 @@
+Don't honor POSIX ``HOME`` in ``os.path.expanduser`` on windows.  Patch by
+Anthony Sottile.


### PR DESCRIPTION


<!-- issue-number: [bpo-36264](https://bugs.python.org/issue36264) -->
https://bugs.python.org/issue36264
<!-- /issue-number -->
