### PR TITLE
[2.7] bpo-36216: Only print test messages when verbose (GH-12291)

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -644,7 +644,8 @@ class UrlParseTestCase(unittest.TestCase):
         for scheme in [u"http", u"https", u"ftp"]:
             for c in denorm_chars:
                 url = u"{}://netloc{}false.netloc/path".format(scheme, c)
-                print "Checking %r" % url
+                if test_support.verbose:
+                    print "Checking %r" % url
                 with self.assertRaises(ValueError):
                     urlparse.urlsplit(url)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-36216](https://bugs.python.org/issue36216) -->
https://bugs.python.org/issue36216
<!-- /issue-number -->
