### PR TITLE
bpo-36279: Ensure os.wait3() rusage is initialized

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-13-03-56-36.bpo-36279.4CC01n.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-13-03-56-36.bpo-36279.4CC01n.rst
@@ -1,0 +1,2 @@
+The :func:`os.wait3` function could return uninitialized memory if the system
+call succeeded, but no child process exit status was reported.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7354,6 +7354,12 @@ wait_helper(pid_t pid, int status, struct rusage *ru)
     if (pid == -1)
         return posix_error();
 
+    /* If wait succeeded but no child was ready to report status, ru will not
+     * have been populated. Clear it to avoid returning uninitialized stack to
+     * the caller. */
+    if (pid == 0)
+        memset(ru, 0, sizeof(*ru));
+
     if (struct_rusage == NULL) {
         PyObject *m = PyImport_ImportModuleNoBlock("resource");
         if (m == NULL)


### PR DESCRIPTION


<!-- issue-number: [bpo-36279](https://bugs.python.org/issue36279) -->
https://bugs.python.org/issue36279
<!-- /issue-number -->
