### PR TITLE
bpo-36282: Improved error message for too much positional arguments.

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -157,7 +157,7 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         self.assertRaisesRegex(TypeError, msg, {}.__contains__, 0, 1)
 
     def test_varargs3(self):
-        msg = r"^from_bytes\(\) takes at most 2 positional arguments \(3 given\)"
+        msg = r"^from_bytes\(\) takes exactly 2 positional arguments \(3 given\)"
         self.assertRaisesRegex(TypeError, msg, int.from_bytes, b'a', 'little', False)
 
     def test_varargs1min(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-13-22-47-28.bpo-36282.zs7RKP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-13-22-47-28.bpo-36282.zs7RKP.rst
@@ -1,0 +1,2 @@
+Improved error message for too much positional arguments in some builtin
+functions.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2137,7 +2137,7 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
                          "%.200s%s takes %s %d positional argument%s (%d given)",
                          (parser->fname == NULL) ? "function" : parser->fname,
                          (parser->fname == NULL) ? "" : "()",
-                         (parser->min != INT_MAX) ? "at most" : "exactly",
+                         (parser->min < parser->max) ? "at most" : "exactly",
                          parser->max,
                          parser->max == 1 ? "" : "s",
                          nargs);


### PR DESCRIPTION


<!-- issue-number: [bpo-36282](https://bugs.python.org/issue36282) -->
https://bugs.python.org/issue36282
<!-- /issue-number -->
