### PR TITLE
Update interactive.rst

### DIFF
--- a/Doc/tutorial/interactive.rst
+++ b/Doc/tutorial/interactive.rst
@@ -51,4 +51,4 @@ bpython_.
 
 .. _GNU Readline: https://tiswww.case.edu/php/chet/readline/rltop.html
 .. _IPython: https://ipython.org/
-.. _bpython: https://www.bpython-interpreter.org/
+.. _bpython: https://bpython-interpreter.org/


### PR DESCRIPTION
Updated [bpython link](https://bpython-interpreter.org) by removing www subdomain since the [old link](https://www.bpython-interpreter.org) has certificate problems. 

# bpython link update in the Python Tutorial.

```
Changed the link of bpython interpreter in the tutorial
```