### PR TITLE
bpo-36274: Encode request lines as Latin-1

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1095,8 +1095,8 @@ class HTTPConnection:
                              f"(found at least {match.group()!r})")
         request = '%s %s %s' % (method, url, self._http_vsn_str)
 
-        # Non-ASCII characters should have been eliminated earlier
-        self._output(request.encode('ascii'))
+        # Encode as latin-1, like we do headers and data
+        self._output(request.encode('latin-1'))
 
         if self._http_vsn == 11:
             # Issue some standard headers for better HTTP/1.1 compliance

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -275,6 +275,37 @@ class HeaderTests(TestCase):
         conn.request('GET', '/foo')
         self.assertTrue(sock.data.startswith(expected))
 
+    def test_request_path_handling(self):
+        happy_cases = (
+            ('/', b'/'),
+            ('', b'/'),
+            ('/\xe4\xbd\xa0\xe5\xa5\xbd',
+             b'/\xe4\xbd\xa0\xe5\xa5\xbd'),
+        )
+        for caller_path, expected_path in happy_cases:
+            with self.subTest((caller_path, expected_path)):
+                conn = client.HTTPConnection('server.fqdn')
+                sock = FakeSocket('')
+                conn.sock = sock
+                conn.request('GET', caller_path)
+                expected = (b'GET ' + expected_path + b' HTTP/1.1\r\n'
+                            b'Host: server.fqdn\r\n'
+                            b'Accept-Encoding: identity\r\n\r\n')
+                self.assertEqual(sock.data, expected)
+
+        error_cases = (
+            '/\u4f60\u597d',
+            '/\udce4\udcbd\udca0\udce5\udca5\udcbd',
+        )
+        for caller_path in error_cases:
+            with self.subTest(caller_path):
+                conn = client.HTTPConnection('server.fqdn')
+                sock = FakeSocket('')
+                conn.sock = sock
+                with self.assertRaises(UnicodeEncodeError):
+                    conn.request('GET', caller_path)
+                self.assertEqual(sock.data, b'')
+
     def test_malformed_headers_coped_with(self):
         # Issue 19996
         body = "HTTP/1.1 200 OK\r\nFirst: val\r\n: nval\r\nSecond: val\r\n\r\n"
@@ -720,8 +751,7 @@ class BasicTest(TestCase):
             sock = FakeSocket(body)
             conn.sock = sock
             conn.request('GET', '/foo', body)
-            self.assertTrue(sock.data.startswith(expected), '%r != %r' %
-                    (sock.data[:len(expected)], expected))
+            self.assertEqual(sock.data[:len(expected)], expected)
 
     def test_send(self):
         expected = b'this is a test this is only a test'

--- a/Misc/NEWS.d/next/Library/2019-07-08-09-20-10.bpo-36274.8XicsH.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-08-09-20-10.bpo-36274.8XicsH.rst
@@ -1,0 +1,2 @@
+``http.client`` now accepts ISO-8859-1 request-targets. Callers are still
+encouraged to URL-quote the request-target so as to comply with the RFC.


### PR DESCRIPTION
While this is out of spec according to RFC 7230 (which limits expected octets to some subset of ASCII), it is often useful to be able to mimic an out-of-spec client when testing a server or application.

Use Latin-1 in keeping with how we handle headers and bodies. This is the first fix proposed in the bug report; the second will also be submitted so reviewers can decide between fixes.

https://bugs.python.org/issue36274

<!-- issue-number: [bpo-36274](https://bugs.python.org/issue36274) -->
https://bugs.python.org/issue36274
<!-- /issue-number -->
