### PR TITLE
bpo-36274: Encode request lines with surrogate escapes

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1095,8 +1095,9 @@ class HTTPConnection:
                              f"(found at least {match.group()!r})")
         request = '%s %s %s' % (method, url, self._http_vsn_str)
 
-        # Non-ASCII characters should have been eliminated earlier
-        self._output(request.encode('ascii'))
+        # Encode with surrogate escapes, to allow non-ascii bytes without
+        # making it too easy to write an out-of-spec client
+        self._output(request.encode('ascii', errors='surrogateescape'))
 
         if self._http_vsn == 11:
             # Issue some standard headers for better HTTP/1.1 compliance

--- a/Misc/NEWS.d/next/Library/2019-07-08-09-20-10.bpo-36274.8XicsH.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-08-09-20-10.bpo-36274.8XicsH.rst
@@ -1,0 +1,3 @@
+``http.client`` can now make requests with non-ASCII request-targets using
+surrogate escape sequences. Callers are still encouraged to URL-quote the
+request-target instead so as to comply with the RFC.


### PR DESCRIPTION
While this is out of spec according to RFC 7230 (which limits
expected octets to some subset of ASCII), it is often useful to
be able to mimic an out-of-spec client when testing a server or
application.

Don't use Latin-1 (though that would be in keeping with how we
handle headers and bodies) to encourage callers to write
RFC-complient clients. Rather, use surrogate escape sequences
('\udc80' - '\udcff') to increase friction while still
allowing out-of-spec requests to be expressable.

This is the second fix proposed in the bug report; the first was submitted as #12314 so reviewers can decide between fixes.

https://bugs.python.org/issue36274

<!-- issue-number: [bpo-36274](https://bugs.python.org/issue36274) -->
https://bugs.python.org/issue36274
<!-- /issue-number -->
