### PR TITLE
bpo-36285: Array module int overflow

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1401,16 +1401,17 @@ class LargeArrayTest(unittest.TestCase):
     typecode = 'b'
 
     def example(self, size):
+        # We assess a base memuse of <=2.125 for constructing this array
         base = array.array(self.typecode, [0, 1, 2, 3, 4, 5, 6, 7]) * (size // 8)
         base += array.array(self.typecode, [99]*(size % 8) + [8, 9, 10, 11])
         return base
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_example_data(self, size):
         example = self.example(size)
         self.assertEqual(len(example), size+4)
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_access(self, size):
         example = self.example(size)
         self.assertEqual(example[0], 0)
@@ -1420,7 +1421,7 @@ class LargeArrayTest(unittest.TestCase):
         self.assertEqual(example[size+3], 11)
         self.assertEqual(example[-1], 11)
 
-    @support.bigmemtest(_2G, memuse=2)
+    @support.bigmemtest(_2G, memuse=2.125+1)
     def test_slice(self, size):
         example = self.example(size)
         self.assertEqual(list(example[:4]), [0, 1, 2, 3])
@@ -1438,40 +1439,40 @@ class LargeArrayTest(unittest.TestCase):
         else:
             self.assertEqual(list(part[-2:]), [8, 10])
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_count(self, size):
         example = self.example(size)
         self.assertEqual(example.count(0), size//8)
         self.assertEqual(example.count(11), 1)
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_append(self, size):
         example = self.example(size)
         example.append(12)
         self.assertEqual(example[-1], 12)
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_extend(self, size):
         example = self.example(size)
         example.extend(iter([12, 13, 14, 15]))
         self.assertEqual(len(example), size+8)
         self.assertEqual(list(example[-8:]), [8, 9, 10, 11, 12, 13, 14, 15])
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_frombytes(self, size):
         example = self.example(size)
         example.frombytes(b'abcd')
         self.assertEqual(len(example), size+8)
         self.assertEqual(list(example[-8:]), [8, 9, 10, 11] + list(b'abcd'))
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_fromlist(self, size):
         example = self.example(size)
         example.fromlist([12, 13, 14, 15])
         self.assertEqual(len(example), size+8)
         self.assertEqual(list(example[-8:]), [8, 9, 10, 11, 12, 13, 14, 15])
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_index(self, size):
         example = self.example(size)
         self.assertEqual(example.index(0), 0)
@@ -1479,7 +1480,7 @@ class LargeArrayTest(unittest.TestCase):
         self.assertEqual(example.index(7), 7)
         self.assertEqual(example.index(11), size+3)
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_insert(self, size):
         example = self.example(size)
         example.insert(0, 12)
@@ -1490,7 +1491,7 @@ class LargeArrayTest(unittest.TestCase):
         self.assertEqual(example[10], 13)
         self.assertEqual(example[size+1], 14)
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_pop(self, size):
         example = self.example(size)
         self.assertEqual(example.pop(0), 0)
@@ -1503,7 +1504,7 @@ class LargeArrayTest(unittest.TestCase):
         self.assertEqual(example.pop(), 11)
         self.assertEqual(len(example), size)
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_remove(self, size):
         example = self.example(size)
         example.remove(0)
@@ -1514,7 +1515,7 @@ class LargeArrayTest(unittest.TestCase):
         self.assertEqual(example[size], 9)
         self.assertEqual(example[size+1], 11)
 
-    @support.bigmemtest(_2G, memuse=1)
+    @support.bigmemtest(_2G, memuse=2.125)
     def test_reverse(self, size):
         example = self.example(size)
         example.reverse()
@@ -1528,7 +1529,7 @@ class LargeArrayTest(unittest.TestCase):
         self.assertEqual(list(example[-4:]), [8, 9, 10, 11])
 
     # list takes about 9 bytes per element
-    @support.bigmemtest(_2G, memuse=1+9)
+    @support.bigmemtest(_2G, memuse=2.125+9)
     def test_tolist(self, size):
         example = self.example(size)
         ls = example.tolist()

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1399,17 +1399,14 @@ class DoubleTest(FPTest, unittest.TestCase):
 
 class LargeListTest(unittest.TestCase):
     typecode = 'b'
-    values1 = [0, 1, 2, 3, 4, 5, 6, 7]
-    values2 = [8, 9, 10, 11]
-    example_multiplier = 0x10000000
 
     def example(self, size):
         base = array.array(self.typecode, [0, 1, 2, 3, 4, 5, 6, 7]) * (size // 8)
-        base += array.array(self.typecode, [100]*(size % 8) + self.values2)
+        base += array.array(self.typecode, [99]*(size % 8) + [8, 9, 10, 11])
         return base
 
     @support.bigmemtest(_2G, memuse=1)
-    def test_build_example(self, size):
+    def test_example_data(self, size):
         example = self.example(size)
         self.assertEqual(len(example), size+4)
 

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1423,10 +1423,8 @@ class LargeListTest(unittest.TestCase):
     @support.bigmemtest(_2G, memuse=1)
     def test_count(self, size):
         example = self.example(size)
-        for value in [0, 1, 6, 7]:
-            self.assertEqual(example.count(value), size//8) # TODO
-        for value in [8, 11]:
-            self.assertEqual(example.count(value), 1)
+        self.assertEqual(example.count(0), size//8)
+        self.assertEqual(example.count(11), 1)
 
     @support.bigmemtest(_2G, memuse=1)
     def test_append(self, size):
@@ -1461,7 +1459,6 @@ class LargeListTest(unittest.TestCase):
         self.assertEqual(example.index(0), 0)
         self.assertEqual(example.index(1), 1)
         self.assertEqual(example.index(7), 7)
-        self.assertEqual(example.index(8), size)
         self.assertEqual(example.index(11), size+3)
 
     @support.bigmemtest(_2G, memuse=1)

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1420,6 +1420,24 @@ class LargeArrayTest(unittest.TestCase):
         self.assertEqual(example[size+3], 11)
         self.assertEqual(example[-1], 11)
 
+    @support.bigmemtest(_2G, memuse=2)
+    def test_slice(self, size):
+        example = self.example(size)
+        self.assertEqual(list(example[:4]), [0, 1, 2, 3])
+        self.assertEqual(list(example[-4:]), [8, 9, 10, 11])
+        part = example[1:-1]
+        self.assertEqual(len(part), size+2)
+        self.assertEqual(part[0], 1)
+        self.assertEqual(part[-1], 10)
+        del part
+        part = example[::2]
+        self.assertEqual(len(part), (size+5)//2)
+        self.assertEqual(list(part[:4]), [0, 2, 4, 6])
+        if size % 2:
+            self.assertEqual(list(part[-2:]), [9, 11])
+        else:
+            self.assertEqual(list(part[-2:]), [8, 10])
+
     @support.bigmemtest(_2G, memuse=1)
     def test_count(self, size):
         example = self.example(size)

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1509,6 +1509,7 @@ class LargeArrayTest(unittest.TestCase):
         self.assertEqual(list(example[:4]), [0, 1, 2, 3])
         self.assertEqual(list(example[-4:]), [8, 9, 10, 11])
 
+    # list takes about 9 bytes per element
     @support.bigmemtest(_2G, memuse=1+9)
     def test_tolist(self, size):
         example = self.example(size)

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -4,6 +4,7 @@
 
 import unittest
 from test import support
+from test.support import _2G
 import weakref
 import pickle
 import operator
@@ -1402,106 +1403,121 @@ class LargeListTest(unittest.TestCase):
     values2 = [8, 9, 10, 11]
     example_multiplier = 0x10000000
 
-    def example(self):
-        return array.array(self.typecode, self.values1) * self.example_multiplier + array.array(self.typecode, self.values2)
+    def example(self, size):
+        base = array.array(self.typecode, [0, 1, 2, 3, 4, 5, 6, 7]) * (size // 8)
+        base += array.array(self.typecode, [100]*(size % 8) + self.values2)
+        return base
 
-    def test_build_example(self):
-        example = self.example()
-        self.assertEqual(len(example), 0x80000004)
+    @support.bigmemtest(_2G, memuse=1)
+    def test_build_example(self, size):
+        example = self.example(size)
+        self.assertEqual(len(example), size+4)
 
-    def test_access(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_access(self, size):
+        example = self.example(size)
         self.assertEqual(example[0], 0)
-        self.assertEqual(example[-0x80000004], 0)
-        self.assertEqual(example[0x80000000], 8)
+        self.assertEqual(example[-(size+4)], 0)
+        self.assertEqual(example[size], 8)
         self.assertEqual(example[-4], 8)
-        self.assertEqual(example[0x80000003], 11)
+        self.assertEqual(example[size+3], 11)
         self.assertEqual(example[-1], 11)
 
-    def test_count(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_count(self, size):
+        example = self.example(size)
         for value in [0, 1, 6, 7]:
-            self.assertEqual(example.count(value), 0x10000000)
+            self.assertEqual(example.count(value), size//8) # TODO
         for value in [8, 11]:
             self.assertEqual(example.count(value), 1)
 
-    def test_append(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_append(self, size):
+        example = self.example(size)
         example.append(12)
         self.assertEqual(example[-1], 12)
 
-    def test_extend(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_extend(self, size):
+        example = self.example(size)
         example.extend(iter([12, 13, 14, 15]))
-        self.assertEqual(len(example), 0x80000008)
+        self.assertEqual(len(example), size+8)
         self.assertEqual(list(example[-8:]), [8, 9, 10, 11, 12, 13, 14, 15])
 
-    def test_frombytes(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_frombytes(self, size):
+        example = self.example(size)
         example.frombytes(b'abcd')
-        self.assertEqual(len(example), 0x80000008)
+        self.assertEqual(len(example), size+8)
         self.assertEqual(list(example[-8:]), [8, 9, 10, 11] + list(b'abcd'))
 
-    def test_fromlist(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_fromlist(self, size):
+        example = self.example(size)
         example.fromlist([12, 13, 14, 15])
-        self.assertEqual(len(example), 0x80000008)
+        self.assertEqual(len(example), size+8)
         self.assertEqual(list(example[-8:]), [8, 9, 10, 11, 12, 13, 14, 15])
 
-    def test_index(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_index(self, size):
+        example = self.example(size)
         self.assertEqual(example.index(0), 0)
         self.assertEqual(example.index(1), 1)
         self.assertEqual(example.index(7), 7)
-        self.assertEqual(example.index(8), 0x80000000)
-        self.assertEqual(example.index(11), 0x80000003)
+        self.assertEqual(example.index(8), size)
+        self.assertEqual(example.index(11), size+3)
 
-    def test_insert(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_insert(self, size):
+        example = self.example(size)
         example.insert(0, 12)
         example.insert(10, 13)
-        example.insert(0x80000001, 14)
-        self.assertEqual(len(example), 0x80000007)
+        example.insert(size+1, 14)
+        self.assertEqual(len(example), size+7)
         self.assertEqual(example[0], 12)
         self.assertEqual(example[10], 13)
-        self.assertEqual(example[0x80000001], 14)
+        self.assertEqual(example[size+1], 14)
 
-    def test_pop(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_pop(self, size):
+        example = self.example(size)
         self.assertEqual(example.pop(0), 0)
         self.assertEqual(example[0], 1)
-        self.assertEqual(example.pop(0x80000001), 10)
-        self.assertEqual(example[0x80000001], 11)
+        self.assertEqual(example.pop(size+1), 10)
+        self.assertEqual(example[size+1], 11)
         self.assertEqual(example.pop(1), 2)
         self.assertEqual(example[1], 3)
-        self.assertEqual(len(example), 0x80000001)
+        self.assertEqual(len(example), size+1)
         self.assertEqual(example.pop(), 11)
-        self.assertEqual(len(example), 0x80000000)
+        self.assertEqual(len(example), size)
 
-    def test_remove(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_remove(self, size):
+        example = self.example(size)
         example.remove(0)
-        self.assertEqual(len(example), 0x80000003)
+        self.assertEqual(len(example), size+3)
         self.assertEqual(example[0], 1)
         example.remove(10)
-        self.assertEqual(len(example), 0x80000002)
-        self.assertEqual(example[0x80000000], 9)
-        self.assertEqual(example[0x80000001], 11)
+        self.assertEqual(len(example), size+2)
+        self.assertEqual(example[size], 9)
+        self.assertEqual(example[size+1], 11)
 
-    def test_reverse(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1)
+    def test_reverse(self, size):
+        example = self.example(size)
         example.reverse()
-        self.assertEqual(len(example), 0x80000004)
+        self.assertEqual(len(example), size+4)
         self.assertEqual(example[0], 11)
-        self.assertEqual(example[4], 7)
+        self.assertEqual(example[3], 8)
         self.assertEqual(example[-1], 0)
         example.reverse()
-        self.assertEqual(len(example), 0x80000004)
+        self.assertEqual(len(example), size+4)
         self.assertEqual(list(example[:4]), [0, 1, 2, 3])
         self.assertEqual(list(example[-4:]), [8, 9, 10, 11])
 
-    def test_tolist(self):
-        example = self.example()
+    @support.bigmemtest(_2G, memuse=1+9)
+    def test_tolist(self, size):
+        example = self.example(size)
         ls = example.tolist()
         self.assertEqual(len(ls), len(example))
         self.assertEqual(ls[:8], list(example[:8]))

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1397,7 +1397,7 @@ class DoubleTest(FPTest, unittest.TestCase):
             self.fail("Array of size > maxsize created - MemoryError expected")
 
 
-class LargeListTest(unittest.TestCase):
+class LargeArrayTest(unittest.TestCase):
     typecode = 'b'
 
     def example(self, size):

--- a/Misc/NEWS.d/next/Library/2019-03-14-01-09-59.bpo-36285.G-usj8.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-14-01-09-59.bpo-36285.G-usj8.rst
@@ -1,0 +1,1 @@
+Fix integer overflows in the array module. Patch by Stephan Hohe.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1174,7 +1174,7 @@ static PyObject *
 array_array_remove(arrayobject *self, PyObject *v)
 /*[clinic end generated code: output=bef06be9fdf9dceb input=0b1e5aed25590027]*/
 {
-    int i;
+    Py_ssize_t i;
 
     for (i = 0; i < Py_SIZE(self); i++) {
         PyObject *selfi;
@@ -2029,7 +2029,7 @@ array__array_reconstructor_impl(PyObject *module, PyTypeObject *arraytype,
     switch (mformat_code) {
     case IEEE_754_FLOAT_LE:
     case IEEE_754_FLOAT_BE: {
-        int i;
+        Py_ssize_t i;
         int le = (mformat_code == IEEE_754_FLOAT_LE) ? 1 : 0;
         Py_ssize_t itemcount = Py_SIZE(items) / 4;
         const unsigned char *memstr =
@@ -2051,7 +2051,7 @@ array__array_reconstructor_impl(PyObject *module, PyTypeObject *arraytype,
     }
     case IEEE_754_DOUBLE_LE:
     case IEEE_754_DOUBLE_BE: {
-        int i;
+        Py_ssize_t i;
         int le = (mformat_code == IEEE_754_DOUBLE_LE) ? 1 : 0;
         Py_ssize_t itemcount = Py_SIZE(items) / 8;
         const unsigned char *memstr =
@@ -2106,7 +2106,7 @@ array__array_reconstructor_impl(PyObject *module, PyTypeObject *arraytype,
     case UNSIGNED_INT64_BE:
     case SIGNED_INT64_LE:
     case SIGNED_INT64_BE: {
-        int i;
+        Py_ssize_t i;
         const struct mformatdescr mf_descr =
             mformat_descriptors[mformat_code];
         Py_ssize_t itemcount = Py_SIZE(items) / mf_descr.size;


### PR DESCRIPTION
Several loops use `int` variables instead of `Py_ssize_t`. The one in `array.remove()` definitely can lead to a crash, for the others I haven't verified if it actually crashes. But using `Py_ssize_t` instead of `int` is more correct in any case.

I also added a bunch of tests for arrays >=2G. 

<!-- issue-number: [bpo-36285](https://bugs.python.org/issue36285) -->
https://bugs.python.org/issue36285
<!-- /issue-number -->
