### PR TITLE
bpo-31904: Fix test_os failures for VxWorks RTOS

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1418,9 +1418,20 @@ class URandomFDTests(unittest.TestCase):
             import errno
             import os
             import resource
-
             soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-            resource.setrlimit(resource.RLIMIT_NOFILE, (1, hard_limit))
+            try:
+                resource.setrlimit(resource.RLIMIT_NOFILE, (1, hard_limit))
+            except (ValueError,OSError):
+                for i in range(1, hard_limit + 1):
+                    try:
+                        os.open(os.devnull, os.O_RDONLY)
+                    except OSError as e:
+                        if e.errno == errno.EMFILE:
+                           break
+                    else:
+                        continue
+            else:
+                pass
             try:
                 os.urandom(16)
             except OSError as e:
@@ -1516,7 +1527,8 @@ def _execvpe_mockup(defpath=None):
         os.execve = orig_execve
         os.defpath = orig_defpath
 
-
+@unittest.skipUnless(hasattr(os, 'execv'),
+                         "No os.execv or os.execve function to test.")
 class ExecTests(unittest.TestCase):
     @unittest.skipIf(USING_LINUXTHREADS,
                      "avoid triggering a linuxthreads bug: see issue #4970")

--- a/Misc/NEWS.d/next/Tests/2019-03-14-14-50-11.bpo-31904.iu3g9k.rst
+++ b/Misc/NEWS.d/next/Tests/2019-03-14-14-50-11.bpo-31904.iu3g9k.rst
@@ -1,0 +1,2 @@
+Improve the test_urandom_failure.
+Skip the ExecTests test cases in test_os.py for VxWorks.


### PR DESCRIPTION
This is the successive PR after #11968 and #12118. The resource.setrlimit() can't set NOFILE to 1 on VxWorks, we can only track the highest fd value in use, and only permit lowering NOFILE up to that value, so in testcase 'test_urandom_failure' I have to keep opening '/dev/null' until reporting errno EMFILE to make sure the fd table is full already and we can't open any more file.
And the VxWorks doesn't support execv like functions, so I skipped them.
More and full support on modules for VxWorks will continuously be added by the coming PRs.
VxWorks is a product developed and owned by Wind River. For VxWorks introduction or more details, go to https://www.windriver.com/products/vxworks/
Wind River will have a dedicated engineering team to contribute to the support as maintainers.
We already have a working buildbot worker internally, but has not bound to master. We will check the process for the buildbot, then add it.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
