### PR TITLE
bpo-31904: Add _crypt module support for VxWorks RTOS

### DIFF
--- a/Doc/library/crypt.rst
+++ b/Doc/library/crypt.rst
@@ -30,6 +30,8 @@ the :manpage:`crypt(3)` routine in the running system.  Therefore, any
 extensions available on the current implementation will also  be available on
 this module.
 
+Note: VxWorks doesn't support this module.
+
 Hashing Methods
 ---------------
 

--- a/Misc/NEWS.d/next/Library/2019-03-14-15-21-01.bpo-31904.38fdkg.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-14-15-21-01.bpo-31904.38fdkg.rst
@@ -1,1 +1,1 @@
-Adapt _crypt module to VxWorks.
+Remove crypt module support for VxWorks.

--- a/Misc/NEWS.d/next/Library/2019-03-14-15-21-01.bpo-31904.38fdkg.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-14-15-21-01.bpo-31904.38fdkg.rst
@@ -1,0 +1,1 @@
+Adapt _crypt module to VxWorks.

--- a/Modules/_cryptmodule.c
+++ b/Modules/_cryptmodule.c
@@ -4,7 +4,9 @@
 #include "Python.h"
 
 #include <sys/types.h>
-
+#ifdef __VXWORKS__
+#include <openssl/des.h>
+#endif
 /* Module crypt */
 
 /*[clinic input]
@@ -40,7 +42,11 @@ crypt_crypt_impl(PyObject *module, const char *word, const char *salt)
     memset(&data, 0, sizeof(data));
     crypt_result = crypt_r(word, salt, &data);
 #else
+#ifdef __VXWORKS__
+    crypt_result = DES_crypt(word, salt);
+#else
     crypt_result = crypt(word, salt);
+#endif
 #endif
     return Py_BuildValue("s", crypt_result);
 }

--- a/Modules/_cryptmodule.c
+++ b/Modules/_cryptmodule.c
@@ -6,6 +6,7 @@
 #include <sys/types.h>
 #ifdef __VXWORKS__
 #include <openssl/des.h>
+#define crypt DES_crypt
 #endif
 /* Module crypt */
 
@@ -42,11 +43,7 @@ crypt_crypt_impl(PyObject *module, const char *word, const char *salt)
     memset(&data, 0, sizeof(data));
     crypt_result = crypt_r(word, salt, &data);
 #else
-#ifdef __VXWORKS__
-    crypt_result = DES_crypt(word, salt);
-#else
     crypt_result = crypt(word, salt);
-#endif
 #endif
     return Py_BuildValue("s", crypt_result);
 }

--- a/Modules/_cryptmodule.c
+++ b/Modules/_cryptmodule.c
@@ -4,10 +4,7 @@
 #include "Python.h"
 
 #include <sys/types.h>
-#ifdef __VXWORKS__
-#include <openssl/des.h>
-#define crypt DES_crypt
-#endif
+
 /* Module crypt */
 
 /*[clinic input]

--- a/setup.py
+++ b/setup.py
@@ -980,12 +980,7 @@ class PyBuildExt(build_ext):
         else:
             libs = []
 
-        if not VXWORKS:
-            self.add(Extension('_crypt', ['_cryptmodule.c'],
-                               libraries=libs))
-        elif self.compiler.find_library_file(self.lib_dirs, 'OPENSSL'):
-            libs = ['OPENSSL']
-            self.add(Extension('_crypt', ['_cryptmodule.c'],
+        self.add(Extension('_crypt', ['_cryptmodule.c'],
                                libraries=libs))
 
     def detect_socket(self):
@@ -1641,7 +1636,8 @@ class PyBuildExt(build_ext):
         if TEST_EXTENSIONS:
             self.detect_test_extensions()
         self.detect_readline_curses()
-        self.detect_crypt()
+        if not VXWORKS:
+            self.detect_crypt()
         self.detect_socket()
         self.detect_openssl_hashlib()
         self.detect_dbm_gdbm()


### PR DESCRIPTION
This is the successive PR after #11968. This PR adds _crypt module support for VxWorks RTOS.
VxWorks has no APIs crypt() and crypt_r() provided. Instead, DES_crypt() is defined in openssl/des.h to replace the crypt(). It has the same prototype as crypt(). This extension module _crypt will not be built if VxWorks users don't enable the OPENSSL features. See https://github.com/python/cpython/blob/f2f55e7f03d332fd43bc665a86d585a79c3b3ed4/setup.py#L976-L989
More and full support on modules for VxWorks will continuously be added by the coming PRs.
VxWorks is a product developed and owned by Wind River. For VxWorks introduction or more details, go to https://www.windriver.com/products/vxworks/
Wind River will have a dedicated engineering team to contribute to the support as maintainers.
We already have a working buildbot worker internally, but has not bound to master. We will check the process for the buildbot, then add it.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
