### PR TITLE
[2.7] bpo-36212: Fix two possible reference leaks in the hotshot module.

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-14-14-40-22.bpo-36212.IEgRI8.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-14-14-40-22.bpo-36212.IEgRI8.rst
@@ -1,0 +1,1 @@
+Fix two possible reference leaks in the hotshot module.

--- a/Modules/_hotshot.c
+++ b/Modules/_hotshot.c
@@ -482,8 +482,11 @@ restart:
     }
     else if (!err) {
         result = PyTuple_New(4);
-        if (result == NULL)
+        if (result == NULL) {
+            Py_XDECREF(s1);
+            Py_XDECREF(s2);
             return NULL;
+        }
         PyTuple_SET_ITEM(result, 0, PyInt_FromLong(what));
         PyTuple_SET_ITEM(result, 2, PyInt_FromLong(fileno));
         if (s1 == NULL)


### PR DESCRIPTION


<!-- issue-number: [bpo-36212](https://bugs.python.org/issue36212) -->
https://bugs.python.org/issue36212
<!-- /issue-number -->
