### PR TITLE
[2.7] bpo-36289: Fix a possible reference leak in the io module.

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-14-15-42-48.bpo-36289.wYKS47.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-14-15-42-48.bpo-36289.wYKS47.rst
@@ -1,0 +1,1 @@
+Fix a possible reference leak in the io module.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1363,6 +1363,7 @@ _bufferedreader_read_all(buffered *self)
         res = buffered_flush_and_rewind_unlocked(self);
         if (res == NULL) {
             Py_DECREF(chunks);
+            Py_XDECREF(data);
             return NULL;
         }
         Py_CLEAR(res);


### PR DESCRIPTION


<!-- issue-number: [bpo-36289](https://bugs.python.org/issue36289) -->
https://bugs.python.org/issue36289
<!-- /issue-number -->
