### PR TITLE
[2.7] bpo-18368: Fix memory leaks in PyOS_StdioReadline() when realloc() fails

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-14-17-30-46.bpo-18368.WXaHAo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-14-17-30-46.bpo-18368.WXaHAo.rst
@@ -1,0 +1,1 @@
+PyOS_StdioReadline() no longer leaks memory when realloc() fails.


### PR DESCRIPTION
Backport from the python3 branch.

<!-- issue-number: [bpo-18368](https://bugs.python.org/issue18368) -->
https://bugs.python.org/issue18368
<!-- /issue-number -->
