### PR TITLE
bpo-34160: Update news entry for XML order attributes

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -614,6 +614,10 @@ Changes in the Python API
   specialized methods like :meth:`~tkinter.ttk.Treeview.selection_set` for
   changing the selection.  (Contributed by Serhiy Storchaka in :issue:`31508`.)
 
+* The :meth: `writexml`, :meth: `toxml` and :meth: `toprettyxml` methods
+  now preserves the attribute order specified by the user.
+  (Contributed by Diego Rojas and Raymond Hettinger in :issue: `34160`.)
+
 * A :mod:`dbm.dumb` database opened with flags ``'r'`` is now read-only.
   :func:`dbm.dumb.open` with flags ``'r'`` and ``'w'`` no longer creates
   a database if it does not exist.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -614,9 +614,9 @@ Changes in the Python API
   specialized methods like :meth:`~tkinter.ttk.Treeview.selection_set` for
   changing the selection.  (Contributed by Serhiy Storchaka in :issue:`31508`.)
 
-* The :meth: `writexml`, :meth: `toxml` and :meth: `toprettyxml` methods
+* The :meth:`writexml`, :meth:`toxml` and :meth:`toprettyxml` methods
   now preserves the attribute order specified by the user.
-  (Contributed by Diego Rojas and Raymond Hettinger in :issue: `34160`.)
+  (Contributed by Diego Rojas and Raymond Hettinger in :issue:`34160`.)
 
 * A :mod:`dbm.dumb` database opened with flags ``'r'`` is now read-only.
   :func:`dbm.dumb.open` with flags ``'r'`` and ``'w'`` no longer creates

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -614,8 +614,9 @@ Changes in the Python API
   specialized methods like :meth:`~tkinter.ttk.Treeview.selection_set` for
   changing the selection.  (Contributed by Serhiy Storchaka in :issue:`31508`.)
 
-* The :meth:`writexml`, :meth:`toxml` and :meth:`toprettyxml` methods
-  now preserves the attribute order specified by the user.
+* The :meth:`writexml`, :meth:`toxml` and :meth:`toprettyxml` methods of the
+  :mod:`xml.dom.minidom` module, and :mod:`xml.etree` now preserve the attribute
+  order specified by the user.
   (Contributed by Diego Rojas and Raymond Hettinger in :issue:`34160`.)
 
 * A :mod:`dbm.dumb` database opened with flags ``'r'`` is now read-only.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1847,3 +1847,4 @@ Doug Zongker
 Peter Åstrand
 Zheao Li
 Carsten Klein
+Diego Rojas


### PR DESCRIPTION
Update news entry for change of Python API which preserves the XML order attributes.

<!-- issue-number: [bpo-34160](https://bugs.python.org/issue34160) -->
https://bugs.python.org/issue34160
<!-- /issue-number -->
