### PR TITLE
bpo-36302: Sort list of sources

### DIFF
--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -490,7 +490,8 @@ class build_ext(Command):
                   "in 'ext_modules' option (extension '%s'), "
                   "'sources' must be present and must be "
                   "a list of source filenames" % ext.name)
-        sources = list(sources)
+        # sort to make the resulting .so file build reproducible
+        sources = sorted(sources)
 
         ext_path = self.get_ext_fullpath(ext.name)
         depends = sources + ext.depends

--- a/Misc/NEWS.d/next/Library/2019-03-21-19-23-46.bpo-36302.Yc591g.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-21-19-23-46.bpo-36302.Yc591g.rst
@@ -1,0 +1,2 @@
+distutils sorts source file lists so that Extension .so files
+build more reproducibly by default


### PR DESCRIPTION
When building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output .so files.
Thus without the patch, builds (in disposable VMs) would usually differ.

Without this patch, all callers have to be patched individually
https://github.com/dugsong/libdnet/pull/42
https://github.com/sass/libsass-python/pull/212
https://github.com/tahoe-lafs/pycryptopp/pull/41
https://github.com/yt-project/yt/pull/2206
https://github.com/pyproj4/pyproj/pull/142
https://github.com/pytries/datrie/pull/49
but that is an infinite effort.

See https://reproducible-builds.org/ for why this matters.

<!-- issue-number: [bpo-36302](https://bugs.python.org/issue36302) -->
https://bugs.python.org/issue36302
<!-- /issue-number -->
