### PR TITLE
bpo-33608: Fix PyEval_InitThreads() warning

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -177,7 +177,7 @@ PyEval_InitThreads(void)
 
     _PyRuntime.ceval.pending.lock = PyThread_allocate_lock();
     if (_PyRuntime.ceval.pending.lock == NULL) {
-        return Py_FatalError("Can't initialize threads for pending calls");
+        Py_FatalError("Can't initialize threads for pending calls");
     }
 }
 


### PR DESCRIPTION
The function has no return value.

Fix the following warning on Windows:

    python\ceval.c(180): warning C4098: 'PyEval_InitThreads':
    'void' function returning a value

<!-- issue-number: [bpo-33608](https://bugs.python.org/issue33608) -->
https://bugs.python.org/issue33608
<!-- /issue-number -->
