### PR TITLE
bpo-36301: _PyCoreConfig_Read() ensures that argv is non-empty

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -292,7 +292,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
         'pycache_prefix': None,
         'program_name': './_testembed',
-        'argv': [],
+        'argv': [""],
         'program': None,
 
         'xoptions': [],

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -1464,6 +1464,13 @@ _PyCoreConfig_Read(_PyCoreConfig *config, const _PyPreConfig *preconfig)
         return err;
     }
 
+    if (config->argv.length < 1) {
+        /* Ensure at least one (empty) argument is seen */
+        if (_PyWstrList_Append(&config->argv, L"") < 0) {
+            return _Py_INIT_NO_MEMORY();
+        }
+    }
+
     assert(config->preconfig.use_environment >= 0);
     assert(config->filesystem_encoding != NULL);
     assert(config->filesystem_errors != NULL);


### PR DESCRIPTION
If argv is empty, add an empty string.

<!-- issue-number: [bpo-36301](https://bugs.python.org/issue36301) -->
https://bugs.python.org/issue36301
<!-- /issue-number -->
