### PR TITLE
[3.7] bpo-36235: Fix CFLAGS in distutils customize_compiler() (GH-12236)

### DIFF
--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -183,8 +183,8 @@ def customize_compiler(compiler):
                 _osx_support.customize_compiler(_config_vars)
                 _config_vars['CUSTOMIZED_OSX_COMPILER'] = 'True'
 
-        (cc, cxx, opt, cflags, ccshared, ldshared, shlib_suffix, ar, ar_flags) = \
-            get_config_vars('CC', 'CXX', 'OPT', 'CFLAGS',
+        (cc, cxx, cflags, ccshared, ldshared, shlib_suffix, ar, ar_flags) = \
+            get_config_vars('CC', 'CXX', 'CFLAGS',
                             'CCSHARED', 'LDSHARED', 'SHLIB_SUFFIX', 'AR', 'ARFLAGS')
 
         if 'CC' in os.environ:
@@ -207,7 +207,7 @@ def customize_compiler(compiler):
         if 'LDFLAGS' in os.environ:
             ldshared = ldshared + ' ' + os.environ['LDFLAGS']
         if 'CFLAGS' in os.environ:
-            cflags = opt + ' ' + os.environ['CFLAGS']
+            cflags = cflags + ' ' + os.environ['CFLAGS']
             ldshared = ldshared + ' ' + os.environ['CFLAGS']
         if 'CPPFLAGS' in os.environ:
             cpp = cpp + ' ' + os.environ['CPPFLAGS']

--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -9,7 +9,7 @@ import unittest
 from distutils import sysconfig
 from distutils.ccompiler import get_default_compiler
 from distutils.tests import support
-from test.support import TESTFN, run_unittest, check_warnings
+from test.support import TESTFN, run_unittest, check_warnings, swap_item
 
 class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
     def setUp(self):
@@ -78,7 +78,9 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
                          'not testing if default compiler is not unix')
     def test_customize_compiler(self):
         os.environ['AR'] = 'my_ar'
-        os.environ['ARFLAGS'] = '-arflags'
+        os.environ['CC'] = 'my_cc'
+        os.environ['ARFLAGS'] = '--myarflags'
+        os.environ['CFLAGS'] = '--mycflags'
 
         # make sure AR gets caught
         class compiler:
@@ -87,9 +89,14 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
             def set_executables(self, **kw):
                 self.exes = kw
 
+        # Make sure that sysconfig._config_vars is initialized
+        sysconfig.get_config_vars()
+
         comp = compiler()
-        sysconfig.customize_compiler(comp)
-        self.assertEqual(comp.exes['archiver'], 'my_ar -arflags')
+        with swap_item(sysconfig._config_vars, 'CFLAGS', '--sysconfig-cflags'):
+            sysconfig.customize_compiler(comp)
+        self.assertEqual(comp.exes['archiver'], 'my_ar --myarflags')
+        self.assertEqual(comp.exes['compiler'], 'my_cc --sysconfig-cflags --mycflags')
 
     def test_parse_makefile_base(self):
         self.makefile = TESTFN

--- a/Misc/NEWS.d/next/Library/2019-03-08-13-32-21.bpo-36235._M72wU.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-08-13-32-21.bpo-36235._M72wU.rst
@@ -1,0 +1,4 @@
+Fix ``CFLAGS`` in ``customize_compiler()`` of ``distutils.sysconfig``: when
+the ``CFLAGS`` environment variable is defined, don't override ``CFLAGS``
+variable with the ``OPT`` variable anymore. Initial patch written by David
+Malcolm.


### PR DESCRIPTION
Fix CFLAGS in customize_compiler() of distutils.sysconfig: when the
CFLAGS environment variable is defined, don't override CFLAGS variable with
the OPT variable anymore.

Initial patch written by David Malcolm.

Co-Authored-By: David Malcolm <dmalcolm@redhat.com>
(cherry picked from commit 86082c22d23285995a32aabb491527c9f5629556)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36235](https://bugs.python.org/issue36235) -->
https://bugs.python.org/issue36235
<!-- /issue-number -->
