### PR TITLE
bpo-36127: Fix compiler warning in _PyArg_UnpackKeywords().

### DIFF
--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2422,7 +2422,7 @@ _PyArg_UnpackKeywords(PyObject *const *args, Py_ssize_t nargs,
     }
 
     /* copy keyword args using kwtuple to drive process */
-    for (i = Py_MAX(nargs, posonly); i < maxargs; i++) {
+    for (i = Py_MAX((int)nargs, posonly); i < maxargs; i++) {
         if (nkwargs) {
             keyword = PyTuple_GET_ITEM(kwtuple, i - posonly);
             if (kwargs != NULL) {


### PR DESCRIPTION
Since `nargs <= maxpos`, `nargs` can be casted to `int` without lost.

<!-- issue-number: [bpo-36127](https://bugs.python.org/issue36127) -->
https://bugs.python.org/issue36127
<!-- /issue-number -->
