### PR TITLE
bpo-36307: Upgrade Travis CI to Xenial and rm obsolete sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: c
-dist: trusty
-sudo: false
+dist: xenial
 group: beta
 
 # To cache doc-building dependencies and C compiler output.


### PR DESCRIPTION
Currently, the .travis.yml config file still has a ``sudo: false`` key, which previously triggered the Container-based environment on Travis. However, that was [removed in December 2018](https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments), and so the key is now obsolete. Furthermore, the builds are still running in the Trusty (Ubuntu 14.04) environment, which will be at the end of its [5-year development lifecycle in April 2019 ](https://blog.ubuntu.com/2019/02/05/ubuntu-14-04-trusty-tahr) (next month). Therefore, ``sudo: false`` should be removed, and the presumably, if possible, the distribution should be upgraded to the modern ``dist: xenial`` (Ubuntu 16.04).

<!-- issue-number: [bpo-36307](https://bugs.python.org/issue36307) -->
https://bugs.python.org/issue36307
<!-- /issue-number -->
