### PR TITLE
bpo-36308: Fix _PyPathConfig_ComputeArgv0 warning

### DIFF
--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -567,7 +567,7 @@ _PyPathConfig_ComputeArgv0(const _PyWstrList *argv)
 {
     assert(_PyWstrList_CheckConsistency(argv));
 
-    wchar_t *argv0;
+    wchar_t *argv0 = NULL;
     wchar_t *p = NULL;
     Py_ssize_t n = 0;
     int have_script_arg = 0;


### PR DESCRIPTION
'argv0' may be used uninitialized in this function

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36308](https://bugs.python.org/issue36308) -->
https://bugs.python.org/issue36308
<!-- /issue-number -->
