### PR TITLE
bpo-36298: Raise ModuleNotFoundError in pyclbr when a module can't be found

### DIFF
--- a/Lib/pyclbr.py
+++ b/Lib/pyclbr.py
@@ -162,15 +162,16 @@ def _readmodule(module, path, inpackage=None):
     spec = importlib.util._find_spec_from_path(fullmodule, search_path)
     _modules[fullmodule] = tree
     # Is module a package?
-    if spec.submodule_search_locations is not None:
+    if getattr(spec, 'submodule_search_locations', None) is not None:
         tree['__path__'] = spec.submodule_search_locations
     try:
         source = spec.loader.get_source(fullmodule)
-        if source is None:
-            return tree
     except (AttributeError, ImportError):
         # If module is not Python source, we cannot do anything.
         return tree
+    else:
+        if source is None:
+            return tree
 
     fname = spec.loader.get_filename(fullmodule)
     return _create_tree(fullmodule, path, fname, source, tree, inpackage)

--- a/Lib/pyclbr.py
+++ b/Lib/pyclbr.py
@@ -160,6 +160,8 @@ def _readmodule(module, path, inpackage=None):
     else:
         search_path = path + sys.path
     spec = importlib.util._find_spec_from_path(fullmodule, search_path)
+    if spec is None:
+        raise ModuleNotFoundError(f"no module named {fullmodule!r}", name=fullmodule)
     _modules[fullmodule] = tree
     # Is module a package?
     if getattr(spec, 'submodule_search_locations', None) is not None:

--- a/Lib/pyclbr.py
+++ b/Lib/pyclbr.py
@@ -164,7 +164,7 @@ def _readmodule(module, path, inpackage=None):
         raise ModuleNotFoundError(f"no module named {fullmodule!r}", name=fullmodule)
     _modules[fullmodule] = tree
     # Is module a package?
-    if getattr(spec, 'submodule_search_locations', None) is not None:
+    if spec.submodule_search_locations is not None:
         tree['__path__'] = spec.submodule_search_locations
     try:
         source = spec.loader.get_source(fullmodule)

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -10,6 +10,7 @@ from types import FunctionType, MethodType, BuiltinFunctionType
 import pyclbr
 from unittest import TestCase, main as unittest_main
 from test import support
+from test.test_importlib import util as test_importlib_util
 from functools import partial
 
 StaticMethodType = type(staticmethod(lambda: None))
@@ -235,10 +236,29 @@ class PyclbrTest(TestCase):
         cm('email.parser')
         cm('test.test_pyclbr')
 
-    def test_issue_14798(self):
+
+class ReadmoduleTests(TestCase):
+
+    def setUp(self):
+        self._modules = pyclbr._modules.copy()
+
+    def tearDown(self):
+        pyclbr._modules = self._modules
+
+
+    def test_dotted_name_not_a_package(self):
         # test ImportError is raised when the first part of a dotted name is
-        # not a package
+        # not a package.
+        #
+        # Issue #14798.
         self.assertRaises(ImportError, pyclbr.readmodule_ex, 'asyncore.foo')
+
+    def test_module_has_no_spec(self):
+        module_name = "justnone"
+        assert module_name not in pyclbr._modules
+        with test_importlib_util.uncache(module_name):
+            sys.modules[module_name] = None  # Lacks a __spec__.
+            self.assertFalse(pyclbr.readmodule_ex(module_name))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -254,11 +254,11 @@ class ReadmoduleTests(TestCase):
         self.assertRaises(ImportError, pyclbr.readmodule_ex, 'asyncore.foo')
 
     def test_module_has_no_spec(self):
-        module_name = "justnone"
+        module_name = "doesnotexist"
         assert module_name not in pyclbr._modules
         with test_importlib_util.uncache(module_name):
-            sys.modules[module_name] = None  # Lacks a __spec__.
-            self.assertFalse(pyclbr.readmodule_ex(module_name))
+            with self.assertRaises(ModuleNotFoundError):
+                pyclbr.readmodule_ex(module_name)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2019-03-15-13-54-07.bpo-36298.amEVK2.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-15-13-54-07.bpo-36298.amEVK2.rst
@@ -1,2 +1,2 @@
-Raise an ImportError in pyclbr when no module spec is found for a module.
+Raise ModuleNotFoundError in pyclbr when a module can't be found.
 Thanks to 'mental' for the bug report.

--- a/Misc/NEWS.d/next/Library/2019-03-15-13-54-07.bpo-36298.amEVK2.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-15-13-54-07.bpo-36298.amEVK2.rst
@@ -1,0 +1,2 @@
+Raise an ImportError in pyclbr when no module spec is found for a module.
+Thanks to 'mental' for the bug report.


### PR DESCRIPTION
Before, an `AttributeError` was raised due to trying to access an attribute that exists on specs but having received `None` instead for a non-existent module.

<!-- issue-number: [bpo-36298](https://bugs.python.org/issue36298) -->
https://bugs.python.org/issue36298
<!-- /issue-number -->
