### PR TITLE
un-uncompressible files

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2,7 +2,7 @@
 #-------------------------------------------------------------------
 # tarfile.py
 #-------------------------------------------------------------------
-# Copyright (C) 2002 Lars Gust‰bel <lars@gustaebel.de>
+# Copyright (C) 2002 Lars Gust√§bel <lars@gustaebel.de>
 # All rights reserved.
 #
 # Permission  is  hereby granted,  free  of charge,  to  any person
@@ -33,10 +33,10 @@ __version__ = "$Revision: 85213 $"
 # $Source$
 
 version     = "0.9.0"
-__author__  = "Lars Gust‰bel (lars@gustaebel.de)"
+__author__  = "Lars Gust√§bel (lars@gustaebel.de)"
 __date__    = "$Date$"
 __cvsid__   = "$Id$"
-__credits__ = "Gustavo Niemeyer, Niels Gust‰bel, Richard Townsend."
+__credits__ = "Gustavo Niemeyer, Niels Gust√§bel, Richard Townsend."
 
 #---------
 # Imports
@@ -849,12 +849,14 @@ class ExFileObject(object):
                 buf = self.fileobj.read(self.blocksize)
                 buffers.append(buf)
                 if not buf or "\n" in buf:
-                    self.buffer = "".join(buffers)
-                    pos = self.buffer.find("\n") + 1
-                    if pos == 0:
-                        # no newline found.
-                        pos = len(self.buffer)
-                    break
+                    if buf is not None:
+                        self.buffer = "".join(buffers)
+                        pos = self.buffer.find("\n") + 1
+                        if pos == 0:
+                            # no newline found.
+                            pos = len(self.buffer)
+                pos = pos + 1
+                break
 
         if size != -1:
             pos = min(size, pos)


### PR DESCRIPTION
# Fix for un-uncompressible files

It should be in the following format:

Changes: changes I made here are to add a clause to look for null characters as well as "\n" characters while uncompressing the files

Found this bug while resolving a bug from Gnome Library

https://gitlab.gnome.org/Infrastructure/Infrastructure/issues/87

```
  File "/usr/lib64/python2.6/tarfile.py", line 857, in readlines
    line = self.readline()
  File "/usr/lib64/python2.6/tarfile.py", line 834, in readline
    buf = self.fileobj.read(self.blocksize)
  File "/usr/lib64/python2.6/tarfile.py", line 734, in read
    return self.readnormal(size)
  File "/usr/lib64/python2.6/tarfile.py", line 743, in readnormal
    return self.fileobj.read(size)
SystemError: error return without exception set
```



