### PR TITLE
bpo-36010: Add venv to the nuget distribution

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-03-16-10-24-58.bpo-36010.dttWfp.rst
+++ b/Misc/NEWS.d/next/Windows/2019-03-16-10-24-58.bpo-36010.dttWfp.rst
@@ -1,0 +1,1 @@
+Add the venv standard library module to the nuget distribution for Windows.

--- a/PC/layout/support/options.py
+++ b/PC/layout/support/options.py
@@ -53,7 +53,16 @@ PRESETS = {
     },
     "nuget": {
         "help": "nuget package",
-        "options": ["stable", "pip", "distutils", "venv", "dev", "props"],
+        "options": [
+            "dev",
+            "tools",
+            "pip",
+            "stable",
+            "distutils",
+            "venv",
+            "launchers",
+            "props"
+        ],
     },
     "default": {
         "help": "development kit package",

--- a/PC/layout/support/options.py
+++ b/PC/layout/support/options.py
@@ -60,7 +60,6 @@ PRESETS = {
             "stable",
             "distutils",
             "venv",
-            "launchers",
             "props"
         ],
     },

--- a/PC/layout/support/options.py
+++ b/PC/layout/support/options.py
@@ -53,7 +53,7 @@ PRESETS = {
     },
     "nuget": {
         "help": "nuget package",
-        "options": ["stable", "pip", "distutils", "dev", "props"],
+        "options": ["stable", "pip", "distutils", "venv", "dev", "props"],
     },
     "default": {
         "help": "development kit package",

--- a/Tools/nuget/make_pkg.proj
+++ b/Tools/nuget/make_pkg.proj
@@ -28,7 +28,7 @@
         <PythonArguments>$(PythonArguments) -b "$(BuildPath.TrimEnd(`\`))" -s "$(PySourcePath.TrimEnd(`\`))"</PythonArguments>
         <PythonArguments>$(PythonArguments) -t "$(IntermediateOutputPath)obj"</PythonArguments>
         <PythonArguments>$(PythonArguments) --copy "$(IntermediateOutputPath)pkg"</PythonArguments>
-        <PythonArguments>$(PythonArguments) --include-dev --include-tools --include-pip --include-stable --include-launcher --include-props</PythonArguments>
+        <PythonArguments>$(PythonArguments) --preset-nuget</PythonArguments>
         
         <PackageArguments Condition="$(Packages) != ''">"$(IntermediateOutputPath)pkg\pip.exe" -B -m pip install -U $(Packages)</PackageArguments>
         


### PR DESCRIPTION
Adds the venv standard library module to the nuget distribution.

<!-- issue-number: [bpo-36010](https://bugs.python.org/issue36010) -->
https://bugs.python.org/issue36010
<!-- /issue-number -->
