### PR TITLE
bpo-36318: Adding support for setting the "disabled" attribute of loggers from logging.config.dictConfig

### DIFF
--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -794,6 +794,9 @@ class DictConfigurator(BaseConfigurator):
         propagate = config.get('propagate', None)
         if propagate is not None:
             logger.propagate = propagate
+        disabled = config.get('disabled', None)
+        if disabled is not None:
+            logger.disabled = disabled
 
     def configure_root(self, config, incremental=False):
         """Configure a root logger from a dictionary."""


### PR DESCRIPTION


<!-- issue-number: [bpo-36318](https://bugs.python.org/issue36318) -->
https://bugs.python.org/issue36318
<!-- /issue-number -->
