### PR TITLE
Document that logging registers shutdown as an exit handler

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1215,7 +1215,7 @@ functions.
    closing all handlers. This should be called at application exit and no
    further use of the logging system should be made after this call.
 
-   When then logging module is imported, it registers this function as an exit
+   When the logging module is imported, it registers this function as an exit
    handler (see :mod:`atexit`), so normally there's no need to do that
    manually.
 

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1215,6 +1215,10 @@ functions.
    closing all handlers. This should be called at application exit and no
    further use of the logging system should be made after this call.
 
+   When then logging module is imported, it registers this function as an exit
+   handler (see :mod:`atexit`), so normally there's no need to do that
+   manually.
+
 
 .. function:: setLoggerClass(klass)
 


### PR DESCRIPTION
Before reading the code from the module I had added the atexit.register(logging.shutdown) line to my own code, unnecessarily. I think it could be documented.