### PR TITLE
bpo-36235: make test_customize_compiler more robust

### DIFF
--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -81,6 +81,7 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         os.environ['CC'] = 'my_cc'
         os.environ['ARFLAGS'] = '--myarflags'
         os.environ['CFLAGS'] = '--mycflags'
+        os.environ.pop('CPPFLAGS', None)
 
         # make sure AR gets caught
         class compiler:


### PR DESCRIPTION
This test was failing if $CPPFLAGS is set when building python.

<!-- issue-number: [bpo-36235](https://bugs.python.org/issue36235) -->
https://bugs.python.org/issue36235
<!-- /issue-number -->
