### PR TITLE
[3.6] bpo-34745: Fix asyncio sslproto memory issues (GH-12386)

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -478,7 +478,11 @@ class SSLProtocol(protocols.Protocol):
             self._loop.call_soon(self._app_protocol.connection_lost, exc)
         self._transport = None
         self._app_transport = None
+        if getattr(self, '_handshake_timeout_handle', None):
+            self._handshake_timeout_handle.cancel()
         self._wakeup_waiter(exc)
+        self._app_protocol = None
+        self._sslpipe = None
 
     def pause_writing(self):
         """Called when the low-level transport's buffer goes over

--- a/Misc/NEWS.d/next/Library/2019-03-17-16-43-29.bpo-34745.nOfm7_.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-17-16-43-29.bpo-34745.nOfm7_.rst
@@ -1,0 +1,1 @@
+Fix :mod:`asyncio` ssl memory issues caused by circular references


### PR DESCRIPTION
* Fix handshake timeout leak in asyncio/sslproto, refs MagicStack/uvloopGH-222
* Break circular ref _SSLPipe <-> SSLProtocol
* [bpo-34745](https://bugs.python.org/issue34745): Fix asyncio ssl memory leak
* Break circular ref SSLProtocol <-> UserProtocol
* Add NEWS entry
* Dropped unit test whose base test is missing in 3.6 ***<-- Please kindly suggest***

(cherry picked from commit f683f46)

https://bugs.python.org/issue34745

<!-- issue-number: [bpo-34745](https://bugs.python.org/issue34745) -->
https://bugs.python.org/issue34745
<!-- /issue-number -->
