### PR TITLE
bpo-36648: fix mmap issue for  VxWorks

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-18-14-25-36.bpo-31904.ds3d67.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-18-14-25-36.bpo-31904.ds3d67.rst
@@ -1,0 +1,1 @@
+Fix mmap fail for VxWorks

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1162,6 +1162,13 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
 #ifdef MAP_ANONYMOUS
         /* BSD way to map anonymous memory */
         flags |= MAP_ANONYMOUS;
+
+        /* VxWorks only support MAP_ANONYMOUS with MAP_PRIVATE flag */
+#ifdef __VXWORKS__
+        flags &= ~MAP_SHARED;
+        flags |= MAP_PRIVATE;
+#endif
+
 #else
         /* SVR4 method to map anonymous memory is to open /dev/zero */
         fd = devzero = _Py_open("/dev/zero", O_RDWR);

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1163,7 +1163,7 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
         /* BSD way to map anonymous memory */
         flags |= MAP_ANONYMOUS;
 
-        /* VxWorks only support MAP_ANONYMOUS with MAP_PRIVATE flag */
+        /* VxWorks only supports MAP_ANONYMOUS with MAP_PRIVATE flag */
 #ifdef __VXWORKS__
         flags &= ~MAP_SHARED;
         flags |= MAP_PRIVATE;


### PR DESCRIPTION
The mmap module set MAP_SHARED flag when map anonymous memory, however VxWorks only support MAP_PRIVATE when map anonymous memory, this commit clear MAP_SHARED and set MAP_PRIVATE, after doing this, all of anonymous memory related test run pass on VxWorks.



<!-- issue-number: [bpo-36648](https://bugs.python.org/issue36648) -->
https://bugs.python.org/issue36648
<!-- /issue-number -->
