### PR TITLE
bpo-36320: Switch typing.NamedTuple from OrderedDict to regular dict

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -838,10 +838,9 @@ The module defines the following classes, functions and decorators:
 
    Fields with a default value must come after any fields without a default.
 
-   The resulting class has two extra attributes: ``_field_types``,
-   giving a dict mapping field names to types, and ``_field_defaults``, a dict
-   mapping field names to default values.  (The field names are in the
-   ``_fields`` attribute, which is part of the namedtuple API.)
+   The resulting class has an extra attribute ``__annotations__`` giving a
+   dict that maps the field names to the field types.  (The field names are in
+   the ``_fields`` attribute, which is part of the namedtuple API.)
 
    ``NamedTuple`` subclasses can also have docstrings and methods::
 
@@ -862,6 +861,15 @@ The module defines the following classes, functions and decorators:
 
    .. versionchanged:: 3.6.1
       Added support for default values, methods, and docstrings.
+
+   .. versionchanged:: 3.8
+      Deprecated the ``_field_types`` attribute in favor of the more
+      standard ``__annotations__`` which has the same information.
+
+   .. versionchanged:: 3.8
+      The ``_field_types`` and ``__annotations__`` attributes are
+      now regular dictionaries instead of instances of ``OrderedDict``.
+
 
 .. function:: NewType(typ)
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -864,7 +864,7 @@ The module defines the following classes, functions and decorators:
 
    .. versionchanged:: 3.8
       Deprecated the ``_field_types`` attribute in favor of the more
-      standard ``__annotations__`` which has the same information.
+      standard ``__annotations__`` attribute which has the same information.
 
    .. versionchanged:: 3.8
       The ``_field_types`` and ``__annotations__`` attributes are

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -840,7 +840,9 @@ The module defines the following classes, functions and decorators:
 
    The resulting class has an extra attribute ``__annotations__`` giving a
    dict that maps the field names to the field types.  (The field names are in
-   the ``_fields`` attribute, which is part of the namedtuple API.)
+   the ``_fields`` attribute and the default values are in the
+   ``_field_defaults`` attribute both of which are part of the namedtuple
+   API.)
 
    ``NamedTuple`` subclasses can also have docstrings and methods::
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -510,8 +510,8 @@ Deprecated
 
   (Contributed by Berker Peksag in :issue:`9372`.)
 
-* The :class:`typing.NamedTuple` has deprecated the ``_field_types`` attribute
-  in favor of the ``__annotations__`` attribute which had the same
+* The :class:`typing.NamedTuple` class has deprecated the ``_field_types``
+  attribute in favor of the ``__annotations__`` attribute which has the same
   information.  (Contributed by Raymond Hettinger in :issue:`36320`.)
 
 * :mod:`ast` classes ``Num``, ``Str``, ``Bytes``, ``NameConstant`` and

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -510,6 +510,10 @@ Deprecated
 
   (Contributed by Berker Peksag in :issue:`9372`.)
 
+* The :class:`typing.NamedTuple` has deprecated the ``_field_types`` attribute
+  in favor of the ``__annotations__`` attribute which had the same
+  information.  (Contributed by Raymond Hettinger in :issue:`36320`.)
+
 * :mod:`ast` classes ``Num``, ``Str``, ``Bytes``, ``NameConstant`` and
   ``Ellipsis`` are considered deprecated and will be removed in future Python
   versions. :class:`~ast.Constant` should be used instead.

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1325,8 +1325,8 @@ def _make_nmtuple(name, types):
     types = [(n, _type_check(t, msg)) for n, t in types]
     nm_tpl = collections.namedtuple(name, [n for n, t in types])
     # Prior to PEP 526, only _field_types attribute was assigned.
-    # Now, both __annotations__ and _field_types are used to maintain compatibility.
-    nm_tpl.__annotations__ = nm_tpl._field_types = collections.OrderedDict(types)
+    # Now __annotations__ are used and _field_types is deprecated (remove in 3.9)
+    nm_tpl.__annotations__ = nm_tpl._field_types = dict(types)
     try:
         nm_tpl.__module__ = sys._getframe(2).f_globals.get('__name__', '__main__')
     except (AttributeError, ValueError):
@@ -1361,7 +1361,7 @@ class NamedTupleMeta(type):
                                 "follow default field(s) {default_names}"
                                 .format(field_name=field_name,
                                         default_names=', '.join(defaults_dict.keys())))
-        nm_tpl.__new__.__annotations__ = collections.OrderedDict(types)
+        nm_tpl.__new__.__annotations__ = dict(types)
         nm_tpl.__new__.__defaults__ = tuple(defaults)
         nm_tpl._field_defaults = defaults_dict
         # update from user namespace without overriding special namedtuple attributes
@@ -1386,12 +1386,10 @@ class NamedTuple(metaclass=NamedTupleMeta):
 
         Employee = collections.namedtuple('Employee', ['name', 'id'])
 
-    The resulting class has extra __annotations__ and _field_types
-    attributes, giving an ordered dict mapping field names to types.
-    __annotations__ should be preferred, while _field_types
-    is kept to maintain pre PEP 526 compatibility. (The field names
-    are in the _fields attribute, which is part of the namedtuple
-    API.) Alternative equivalent keyword syntax is also accepted::
+    The resulting class has an extra __annotations__ attribute, giving a
+    dict that maps field names to types.  (The field names are also in
+    the _fields attribute, which is part of the namedtuple API.)
+    Alternative equivalent keyword syntax is also accepted::
 
         Employee = NamedTuple('Employee', name=str, id=int)
 

--- a/Misc/NEWS.d/next/Library/2019-03-18-01-08-14.bpo-36320.-06b9_.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-18-01-08-14.bpo-36320.-06b9_.rst
@@ -1,0 +1,3 @@
+The typing.NamedTuple() class has deprecated the _field_types attribute in
+favor of the __annotations__ attribute which carried the same information.
+Also, both attributes were converted from OrderedDict to a regular dict.


### PR DESCRIPTION
Also,  deprecate the *_field_types* attributes which duplicated the information in *\__annotations__*.

<!-- issue-number: [bpo-36320](https://bugs.python.org/issue36320) -->
https://bugs.python.org/issue36320
<!-- /issue-number -->
