### PR TITLE
[2.7] bpo-36337: Use ssize_t and size_t for socket.send()/sendall()

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-03-18-10-08-30.bpo-36337.QhJnXy.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-18-10-08-30.bpo-36337.QhJnXy.rst
@@ -1,3 +1,3 @@
-Use ssize_t and size_t instead of int for the send() function (see
-http://man7.org/linux/man-pages/man2/send.2.html (Linux) and
-https://nixdoc.net/man-pages/FreeBSD/man2/send.2.html (FreeBSD)).
+Fix buffer overflow in :meth:`~socket.socket.send` and
+:meth:`~socket.socket.sendall` methods of :func:`socket.socket` for data larger
+than 2 GiB.

--- a/Misc/NEWS.d/next/Library/2019-03-18-10-08-30.bpo-36337.QhJnXy.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-18-10-08-30.bpo-36337.QhJnXy.rst
@@ -1,0 +1,3 @@
+Use ssize_t and size_t instead of int for the send() function (see
+http://man7.org/linux/man-pages/man2/send.2.html (Linux) and
+https://nixdoc.net/man-pages/FreeBSD/man2/send.2.html (FreeBSD)).

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2818,8 +2818,9 @@ sock_send(PySocketSockObject *s, PyObject *args)
 #ifdef __VMS
         n = sendsegmented(s->sock_fd, buf, len, flags);
 #elif defined(MS_WINDOWS)
-        if (len > INT_MAX)
+        if (len > INT_MAX) {
             len = INT_MAX;
+        }
         n = send(s->sock_fd, buf, (int)len, flags);
 #else
         n = send(s->sock_fd, buf, len, flags);
@@ -2876,8 +2877,9 @@ sock_sendall(PySocketSockObject *s, PyObject *args)
 #ifdef __VMS
             n = sendsegmented(s->sock_fd, buf, len, flags);
 #elif defined(MS_WINDOWS)
-            if (len > INT_MAX)
+            if (len > INT_MAX) {
                 len = INT_MAX;
+            }
             n = send(s->sock_fd, buf, (int)len, flags);
 #else
             n = send(s->sock_fd, buf, len, flags);

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -625,11 +625,11 @@ set_gaierror(int error)
 
 #ifdef __VMS
 /* Function to send in segments */
-static int
-sendsegmented(int sock_fd, char *buf, int len, int flags)
+static Py_ssize_t
+sendsegmented(int sock_fd, char *buf, Py_ssize_t len, int flags)
 {
     int n = 0;
-    int remaining = len;
+    Py_ssize_t remaining = len;
 
     while (remaining > 0) {
         unsigned int segment;
@@ -2819,7 +2819,7 @@ sock_send(PySocketSockObject *s, PyObject *args)
         if (len > INT_MAX) {
             len = INT_MAX;
         }
-        n = sendsegmented(s->sock_fd, buf, (int)len, flags);
+        n = sendsegmented(s->sock_fd, buf, len, flags);
 #elif defined(MS_WINDOWS)
         if (len > INT_MAX) {
             len = INT_MAX;
@@ -2881,7 +2881,7 @@ sock_sendall(PySocketSockObject *s, PyObject *args)
             if (len > INT_MAX) {
                 len = INT_MAX;
             }
-            n = sendsegmented(s->sock_fd, buf, (int)len, flags);
+            n = sendsegmented(s->sock_fd, buf, len, flags);
 #elif defined(MS_WINDOWS)
             if (len > INT_MAX) {
                 len = INT_MAX;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2817,7 +2817,7 @@ sock_send(PySocketSockObject *s, PyObject *args)
     if (!timeout) {
 #ifdef __VMS
         n = sendsegmented(s->sock_fd, buf, len, flags);
-#elif MS_WINDOWS
+#elif defined(MS_WINDOWS)
         if (len > INT_MAX)
             len = INT_MAX;
         n = send(s->sock_fd, buf, (int)len, flags);
@@ -2875,7 +2875,7 @@ sock_sendall(PySocketSockObject *s, PyObject *args)
         if (!timeout) {
 #ifdef __VMS
             n = sendsegmented(s->sock_fd, buf, len, flags);
-#elif MS_WINDOWS
+#elif defined(MS_WINDOWS)
             if (len > INT_MAX)
                 len = INT_MAX;
             n = send(s->sock_fd, buf, (int)len, flags);

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2816,7 +2816,7 @@ sock_send(PySocketSockObject *s, PyObject *args)
     timeout = internal_select_ex(s, 1, interval);
     if (!timeout) {
 #ifdef __VMS
-        n = sendsegmented(s->sock_fd, buf, len, flags);
+        n = sendsegmented(s->sock_fd, buf, (int)len, flags);
 #elif defined(MS_WINDOWS)
         if (len > INT_MAX) {
             len = INT_MAX;
@@ -2875,7 +2875,7 @@ sock_sendall(PySocketSockObject *s, PyObject *args)
         n = -1;
         if (!timeout) {
 #ifdef __VMS
-            n = sendsegmented(s->sock_fd, buf, len, flags);
+            n = sendsegmented(s->sock_fd, buf, (int)len, flags);
 #elif defined(MS_WINDOWS)
             if (len > INT_MAX) {
                 len = INT_MAX;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2816,6 +2816,9 @@ sock_send(PySocketSockObject *s, PyObject *args)
     timeout = internal_select_ex(s, 1, interval);
     if (!timeout) {
 #ifdef __VMS
+        if (len > INT_MAX) {
+            len = INT_MAX;
+        }
         n = sendsegmented(s->sock_fd, buf, (int)len, flags);
 #elif defined(MS_WINDOWS)
         if (len > INT_MAX) {
@@ -2875,6 +2878,9 @@ sock_sendall(PySocketSockObject *s, PyObject *args)
         n = -1;
         if (!timeout) {
 #ifdef __VMS
+            if (len > INT_MAX) {
+                len = INT_MAX;
+            }
             n = sendsegmented(s->sock_fd, buf, (int)len, flags);
 #elif defined(MS_WINDOWS)
             if (len > INT_MAX) {

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2837,7 +2837,7 @@ sock_send(PySocketSockObject *s, PyObject *args)
     PyBuffer_Release(&pbuf);
     if (n < 0)
         return s->errorhandler();
-    return PyInt_FromLong((long)n);
+    return PyLong_FromSsize_t(n);
 }
 
 PyDoc_STRVAR(send_doc,

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2797,7 +2797,9 @@ static PyObject *
 sock_send(PySocketSockObject *s, PyObject *args)
 {
     char *buf;
-    int len, n = -1, flags = 0, timeout;
+    int flags = 0, timeout;
+    ssize_t n = -1;
+    size_t len;
     Py_buffer pbuf;
 
     if (!PyArg_ParseTuple(args, "s*|i:send", &pbuf, &flags))
@@ -2847,7 +2849,9 @@ static PyObject *
 sock_sendall(PySocketSockObject *s, PyObject *args)
 {
     char *buf;
-    int len, n = -1, flags = 0, timeout, saved_errno;
+    int flags = 0, timeout, saved_errno;
+    ssize_t len;
+    size_t n = -1;
     Py_buffer pbuf;
 
     if (!PyArg_ParseTuple(args, "s*|i:sendall", &pbuf, &flags))

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -634,7 +634,7 @@ sendsegmented(int sock_fd, char *buf, Py_ssize_t len, int flags)
     while (remaining > 0) {
         unsigned int segment;
 
-        segment = (remaining >= SEGMENT_SIZE ? SEGMENT_SIZE : remaining);
+        segment = ((size_t)remaining >= SEGMENT_SIZE ? SEGMENT_SIZE : (unsigned int) remaining);
         n = send(sock_fd, buf, segment, flags);
         if (n < 0) {
             return n;
@@ -2816,9 +2816,6 @@ sock_send(PySocketSockObject *s, PyObject *args)
     timeout = internal_select_ex(s, 1, interval);
     if (!timeout) {
 #ifdef __VMS
-        if (len > INT_MAX) {
-            len = INT_MAX;
-        }
         n = sendsegmented(s->sock_fd, buf, len, flags);
 #elif defined(MS_WINDOWS)
         if (len > INT_MAX) {
@@ -2878,9 +2875,6 @@ sock_sendall(PySocketSockObject *s, PyObject *args)
         n = -1;
         if (!timeout) {
 #ifdef __VMS
-            if (len > INT_MAX) {
-                len = INT_MAX;
-            }
             n = sendsegmented(s->sock_fd, buf, len, flags);
 #elif defined(MS_WINDOWS)
             if (len > INT_MAX) {

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2837,7 +2837,7 @@ sock_send(PySocketSockObject *s, PyObject *args)
     PyBuffer_Release(&pbuf);
     if (n < 0)
         return s->errorhandler();
-    return PyLong_FromSsize_t(n);
+    return PyInt_FromSsize_t(n);
 }
 
 PyDoc_STRVAR(send_doc,


### PR DESCRIPTION
This PR is not yet completed (missing tests), I have "backported" a patch from 3.x.

<!-- issue-number: [bpo-36337](https://bugs.python.org/issue36337) -->
https://bugs.python.org/issue36337
<!-- /issue-number -->
