### PR TITLE
bpo-36332: Allow compile() to handle AST objects with assignment expressions

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -135,6 +135,8 @@ exec_tests = [
     "@deco1\n@deco2()\nclass C: pass",
     # Decorator with generator argument
     "@deco(a for a in b)\ndef f(): pass",
+    # Simple assignment expression
+    "if a:=1:\n  True"
 ]
 
 # These are compiled through "single"
@@ -275,6 +277,13 @@ class AST_Tests(unittest.TestCase):
                     self._assertTrueorder(ast_tree, (0, 0))
                 with self.subTest(action="compiling", input=i, kind=kind):
                     compile(ast_tree, "?", kind)
+
+    def test_ast_validation(self):
+        # compile() is the only function that calls PyAST_Validate
+        snippets_to_validate = exec_tests + single_tests + eval_tests
+        for snippet in snippets_to_validate:
+            tree = ast.parse(snippet)
+            compile(tree, '<string>', 'exec')
 
     def test_slice(self):
         slc = ast.parse("x[::]").body[0].value.slice
@@ -1677,6 +1686,7 @@ exec_results = [
 ('Module', [('AsyncFunctionDef', (3, 0), 'f', ('arguments', [], None, [], [], None, []), [('Pass', (3, 15))], [('Name', (1, 1), 'deco1', ('Load',)), ('Call', (2, 0), ('Name', (2, 1), 'deco2', ('Load',)), [], [])], None, None)], []),
 ('Module', [('ClassDef', (3, 0), 'C', [], [], [('Pass', (3, 9))], [('Name', (1, 1), 'deco1', ('Load',)), ('Call', (2, 0), ('Name', (2, 1), 'deco2', ('Load',)), [], [])])], []),
 ('Module', [('FunctionDef', (2, 0), 'f', ('arguments', [], None, [], [], None, []), [('Pass', (2, 9))], [('Call', (1, 1), ('Name', (1, 1), 'deco', ('Load',)), [('GeneratorExp', (1, 5), ('Name', (1, 6), 'a', ('Load',)), [('comprehension', ('Name', (1, 12), 'a', ('Store',)), ('Name', (1, 17), 'b', ('Load',)), [], 0)])], [])], None, None)], []),
+('Module', [('If', (1, 0), ('NamedExpr', (1, 3), ('Name', (1, 3), 'a', ('Store',)), ('Constant', (1, 6), 1, None)), [('Expr', (2, 2), ('Constant', (2, 2), True, None))], [])], []),
 ]
 single_results = [
 ('Interactive', [('Expr', (1, 0), ('BinOp', (1, 0), ('Constant', (1, 0), 1, None), ('Add',), ('Constant', (1, 2), 2, None)))]),

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -136,7 +136,8 @@ exec_tests = [
     # Decorator with generator argument
     "@deco(a for a in b)\ndef f(): pass",
     # Simple assignment expression
-    "if a:=1:\n  True"
+    "(a := 1)",
+
 ]
 
 # These are compiled through "single"
@@ -1686,7 +1687,7 @@ exec_results = [
 ('Module', [('AsyncFunctionDef', (3, 0), 'f', ('arguments', [], None, [], [], None, []), [('Pass', (3, 15))], [('Name', (1, 1), 'deco1', ('Load',)), ('Call', (2, 0), ('Name', (2, 1), 'deco2', ('Load',)), [], [])], None, None)], []),
 ('Module', [('ClassDef', (3, 0), 'C', [], [], [('Pass', (3, 9))], [('Name', (1, 1), 'deco1', ('Load',)), ('Call', (2, 0), ('Name', (2, 1), 'deco2', ('Load',)), [], [])])], []),
 ('Module', [('FunctionDef', (2, 0), 'f', ('arguments', [], None, [], [], None, []), [('Pass', (2, 9))], [('Call', (1, 1), ('Name', (1, 1), 'deco', ('Load',)), [('GeneratorExp', (1, 5), ('Name', (1, 6), 'a', ('Load',)), [('comprehension', ('Name', (1, 12), 'a', ('Store',)), ('Name', (1, 17), 'b', ('Load',)), [], 0)])], [])], None, None)], []),
-('Module', [('If', (1, 0), ('NamedExpr', (1, 3), ('Name', (1, 3), 'a', ('Store',)), ('Constant', (1, 6), 1, None)), [('Expr', (2, 2), ('Constant', (2, 2), True, None))], [])], []),
+('Module', [('Expr', (1, 0), ('NamedExpr', (1, 1), ('Name', (1, 1), 'a', ('Store',)), ('Constant', (1, 6), 1, None)))], []),
 ]
 single_results = [
 ('Interactive', [('Expr', (1, 0), ('BinOp', (1, 0), ('Constant', (1, 0), 1, None), ('Add',), ('Constant', (1, 2), 2, None)))]),

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-18-09-27-54.bpo-36332.yEC-Vz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-18-09-27-54.bpo-36332.yEC-Vz.rst
@@ -1,0 +1,2 @@
+The builtin :func:`compile` can now handle AST objects that contain
+assignment expressions. Patch by Pablo Galindo.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -316,13 +316,14 @@ validate_expr(expr_ty exp, expr_context_ty ctx)
         return validate_exprs(exp->v.List.elts, ctx, 0);
     case Tuple_kind:
         return validate_exprs(exp->v.Tuple.elts, ctx, 0);
+    case NamedExpr_kind:
+        return validate_expr(exp->v.NamedExpr.value, Load);
     /* This last case doesn't have any checking. */
     case Name_kind:
         return 1;
-    default:
-        PyErr_SetString(PyExc_SystemError, "unexpected expression");
-        return 0;
     }
+    PyErr_SetString(PyExc_SystemError, "unexpected expression");
+    return 0;
 }
 
 static int


### PR DESCRIPTION


<!-- issue-number: [bpo-36332](https://bugs.python.org/issue36332) -->
https://bugs.python.org/issue36332
<!-- /issue-number -->
