### PR TITLE
bpo-36341: Fix tests calling bind() on AF_UNIX sockets

### DIFF
--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -73,7 +73,7 @@ class SelectorStartServerTests(BaseStartServer, unittest.TestCase):
     def new_loop(self):
         return asyncio.SelectorEventLoop()
 
-    @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), 'no Unix sockets')
+    @support.skip_unless_bind_unix_socket
     def test_start_unix_server_1(self):
         HELLO_MSG = b'1' * 1024 * 5 + b'\n'
         started = threading.Event()

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1777,8 +1777,13 @@ class GeneralModuleTests(unittest.TestCase):
             self.addCleanup(shutil.rmtree, tmpdir)
             s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.addCleanup(s.close)
-            s.bind(os.path.join(tmpdir, 'socket'))
-            self._test_socket_fileno(s, socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                s.bind(os.path.join(tmpdir, 'socket'))
+            except PermissionError:
+                pass
+            else:
+                self._test_socket_fileno(s, socket.AF_UNIX,
+                                         socket.SOCK_STREAM)
 
     def test_socket_fileno_rejects_float(self):
         with self.assertRaisesRegex(TypeError, "integer argument expected"):

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -2,7 +2,8 @@ import unittest
 import os
 import socket
 import sys
-from test.support import TESTFN, import_fresh_module
+from test.support import (TESTFN, import_fresh_module,
+                          skip_unless_bind_unix_socket)
 
 c_stat = import_fresh_module('stat', fresh=['_stat'])
 py_stat = import_fresh_module('stat', blocked=['_stat'])
@@ -192,7 +193,7 @@ class TestFilemode:
                 self.assertS_IS("BLK", st_mode)
                 break
 
-    @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), 'requires unix socket')
+    @skip_unless_bind_unix_socket
     def test_socket(self):
         with socket.socket(socket.AF_UNIX) as s:
             s.bind(TESTFN)

--- a/Misc/NEWS.d/next/Tests/2019-03-18-10-47-45.bpo-36341.UXlY0P.rst
+++ b/Misc/NEWS.d/next/Tests/2019-03-18-10-47-45.bpo-36341.UXlY0P.rst
@@ -1,0 +1,2 @@
+Fix tests that may fail with PermissionError upon calling bind() on AF_UNIX
+sockets.


### PR DESCRIPTION
Those tests may fail with PermissionError.


<!-- issue-number: [bpo-36341](https://bugs.python.org/issue36341) -->
https://bugs.python.org/issue36341
<!-- /issue-number -->
