### PR TITLE
bpo-36345: Doc: make serve uses http.server instead of Tools/scripts/server.py 

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -174,7 +174,7 @@ check:
 	$(PYTHON) tools/rstlint.py -i tools -i $(VENVDIR) -i README.rst
 
 serve:
-	$(PYTHON) ../Tools/scripts/serve.py build/html
+	$(PYTHON) -m http.server -d build/html
 
 # Targets for daily automated doc build
 # By default, Sphinx only rebuilds pages where the page content has changed.

--- a/Doc/make.bat
+++ b/Doc/make.bat
@@ -172,7 +172,7 @@ cmd /S /C "%PYTHON% tools\rstlint.py -i tools"
 goto end
 
 :serve
-cmd /S /C "%PYTHON% ..\Tools\scripts\serve.py "%BUILDDIR%\html""
+cmd /S /C "%PYTHON% -m http.server -d "%BUILDDIR%\html""
 goto end
 
 :end

--- a/Misc/NEWS.d/next/Documentation/2019-03-18-15-11-24.bpo-36345.aRmIHE.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-03-18-15-11-24.bpo-36345.aRmIHE.rst
@@ -1,0 +1,2 @@
+make serve uses :mod:`http.server` with ``-d`` parameter instead of
+``Tools/scripts/server.py``. Contributed by Stéphane Wirtel


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36345](https://bugs.python.org/issue36345) -->
https://bugs.python.org/issue36345
<!-- /issue-number -->
