### PR TITLE
[2.7] bpo-35605: Fix documentation build for sphinx<1.6

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -57,7 +57,7 @@ templates_path = ['tools/templates']
 
 # Custom sidebar templates, filenames relative to this file.
 html_sidebars = {
-    'index': 'indexsidebar.html',
+    'index': ['indexsidebar.html'],
 }
 
 # Additional templates that should be rendered to pages.

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -15,7 +15,6 @@ SOURCE_URI = 'https://github.com/python/cpython/tree/2.7/%s'
 from docutils import nodes, utils
 from docutils.parsers.rst import Directive
 
-from sphinx.util import status_iterator
 from sphinx.util.nodes import split_explicit_title
 from sphinx.writers.html import HTMLTranslator
 from sphinx.writers.latex import LaTeXTranslator
@@ -173,6 +172,11 @@ class PydocTopicsBuilder(Builder):
         return ''  # no URIs
 
     def write(self, *ignored):
+        try:  # sphinx>=1.6
+            from sphinx.util import status_iterator
+        except ImportError:  # sphinx<1.6
+            status_iterator = self.status_iterator
+
         writer = TextWriter(self)
         for label in status_iterator(pydoc_topic_labels,
                                      'building topics... ',

--- a/Misc/NEWS.d/next/Documentation/2018-12-30-09-56-13.bpo-35605.gAWt32.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-12-30-09-56-13.bpo-35605.gAWt32.rst
@@ -1,0 +1,1 @@
+Fix documentation build for sphinx<1.6.  Patch by Anthony Sottile.


### PR DESCRIPTION
This one allow Python 2.7 to be build using Sphinx 1.2 as the conf.py says and to be built using Sphinx 2.0.0 (html_sidebars no longer accepting a string, but it accepts a list since Sphinx 1.0)

<!-- issue-number: [bpo-35605](https://bugs.python.org/issue35605) -->
https://bugs.python.org/issue35605
<!-- /issue-number -->
