### PR TITLE
bpo-36353: fix -R option of build_ext for OSX

### DIFF
--- a/Lib/distutils/tests/test_unixccompiler.py
+++ b/Lib/distutils/tests/test_unixccompiler.py
@@ -29,7 +29,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
 
         # darwin
         sys.platform = 'darwin'
-        self.assertEqual(self.cc.rpath_foo(), '-L/foo')
+        self.assertEqual(self.cc.rpath_foo(), '-Wl,-rpath,/foo')
 
         # hp-ux
         sys.platform = 'hp-ux'

--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -233,8 +233,7 @@ class UnixCCompiler(CCompiler):
         # we use this hack.
         compiler = os.path.basename(sysconfig.get_config_var("CC"))
         if sys.platform[:6] == "darwin":
-            # MacOSX's linker doesn't understand the -R flag at all
-            return "-L" + dir
+            return "-Wl,-rpath," + dir
         elif sys.platform[:7] == "freebsd":
             return "-Wl,-rpath=" + dir
         elif sys.platform[:5] == "hp-ux":

--- a/Misc/NEWS.d/next/macOS/2019-03-19-15-37-57.bpo-36353.GRvcMe.rst
+++ b/Misc/NEWS.d/next/macOS/2019-03-19-15-37-57.bpo-36353.GRvcMe.rst
@@ -1,0 +1,1 @@
+Fix ``--rpath (-R)`` option of ``build_ext`` for clang on OSX. It now gets translated correctly to ``-Wl,-rpath,[argument of -R]`` instead of ``-L [argument of -R]``.


### PR DESCRIPTION
For users who would like a workaround for this bug, make the following modification to your `setup.py` (tested with Cython and setuptools, but should also work in other situations):

```python
from Cython.Distutils.build_ext import new_build_ext as build_ext
# alternative:
# from distutils.command import build_ext

class my_build_ext(build_ext):
    """Workaround for rpath bug in distutils for OSX."""

    def finalize_options(self):
        super().finalize_options()
        # Special treatment of rpath in case of OSX, to work around python
        # distutils bug 36353. This constructs proper rpath arguments for clang.
        # See https://bugs.python.org/issue36353
        if sys.platform[:6] == "darwin":
            for path in self.rpath:
                for ext in self.extensions:
                    ext.extra_link_args.append("-Wl,-rpath," + path)
            self.rpath[:] = []

setup(
    cmdclass={'build_ext': my_build_ext}
    # ...
)
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36353](https://bugs.python.org/issue36353) -->
https://bugs.python.org/issue36353
<!-- /issue-number -->
