### PR TITLE
bpo-36301: Fix Py_Main() memory leaks

### DIFF
--- a/Modules/main.c
+++ b/Modules/main.c
@@ -888,13 +888,13 @@ pymain_main(_PyArgv *args)
     PyInterpreterState *interp;
     err = pymain_init(args, &interp);
     if (_Py_INIT_FAILED(err)) {
-        _Py_ExitInitError(err);
+        goto exit_init_error;
     }
 
     int exitcode = 0;
     err = pymain_run_python(interp, &exitcode);
     if (_Py_INIT_FAILED(err)) {
-        _Py_ExitInitError(err);
+        goto exit_init_error;
     }
 
     if (Py_FinalizeEx() < 0) {
@@ -910,6 +910,10 @@ pymain_main(_PyArgv *args)
     }
 
     return exitcode;
+
+exit_init_error:
+    pymain_free();
+    _Py_ExitInitError(err);
 }
 
 

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -149,7 +149,12 @@ done:
 void
 _PyPathConfig_ClearGlobal(void)
 {
+    PyMemAllocatorEx old_alloc;
+    _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
     _PyPathConfig_Clear(&_Py_path_config);
+
+    PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 }
 
 

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -758,6 +758,7 @@ _PyPreConfig_ReadFromArgv(_PyPreConfig *config, const _PyArgv *args)
 done:
     if (init_ctype_locale != NULL) {
         setlocale(LC_CTYPE, init_ctype_locale);
+        PyMem_RawFree(init_ctype_locale);
     }
     _PyPreConfig_Clear(&save_config);
     Py_UTF8Mode = init_utf8_mode ;


### PR DESCRIPTION
[bpo-36301](https://bugs.python.org/issue36301), [bpo-36333](https://bugs.python.org/issue36333):

* Fix memory allocator used by _PyPathConfig_ClearGlobal():
  force the default allocator.
* _PyPreConfig_ReadFromArgv(): free init_ctype_locale memory.
* pymain_main(): call pymain_free() on init error

Co-Authored-By: Stéphane Wirtel <stephane@wirtel.be>

<!-- issue-number: [bpo-36301](https://bugs.python.org/issue36301) -->
https://bugs.python.org/issue36301
<!-- /issue-number -->
