### PR TITLE
bpo-36236: Handle removed cwd at Python init

### DIFF
--- a/Include/internal/pycore_pathconfig.h
+++ b/Include/internal/pycore_pathconfig.h
@@ -44,7 +44,9 @@ PyAPI_FUNC(_PyInitError) _PyPathConfig_SetGlobal(
 PyAPI_FUNC(_PyInitError) _PyPathConfig_Calculate_impl(
     _PyPathConfig *config,
     const _PyCoreConfig *core_config);
-PyAPI_FUNC(PyObject*) _PyPathConfig_ComputeArgv0(const _PyWstrList *argv);
+PyAPI_FUNC(int) _PyPathConfig_ComputeSysPath0(
+    const _PyWstrList *argv,
+    PyObject **path0);
 PyAPI_FUNC(int) _Py_FindEnvConfigValue(
     FILE *env_file,
     const wchar_t *key,

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-19-03-08-26.bpo-36236.5qN9qK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-19-03-08-26.bpo-36236.5qN9qK.rst
@@ -1,0 +1,2 @@
+At Python initialization, the current directory is no longer prepended to
+:data:`sys.path` if it has been removed.


### PR DESCRIPTION
At Python initialization, the current directory is no longer
prepended to sys.path if it has been removed.

Rename _PyPathConfig_ComputeArgv0() to
_PyPathConfig_ComputeSysPath0() to avoid confusion between argv[0]
and sys.path[0].

<!-- issue-number: [bpo-36236](https://bugs.python.org/issue36236) -->
https://bugs.python.org/issue36236
<!-- /issue-number -->
