### PR TITLE
bpo-36356: Fix leak of locale string

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-03-18-23-49-15.bpo-36356.WNrwYI.rst
+++ b/Misc/NEWS.d/next/Build/2019-03-18-23-49-15.bpo-36356.WNrwYI.rst
@@ -1,0 +1,1 @@
+Fix leaks that led to build failure when configured with address sanitizer.

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -514,6 +514,7 @@ _PyPreConfig_Read(_PyPreConfig *config)
     err = preconfig_read(config, NULL);
 
     setlocale(LC_CTYPE, old_loc);
+    PyMem_RawFree(old_loc);
 
     return err;
 }


### PR DESCRIPTION
Additional leaks are present in the full test suite, but this allows for building of an address sanitized python binary

<!-- issue-number: [bpo-36356](https://bugs.python.org/issue36356) -->
https://bugs.python.org/issue36356
<!-- /issue-number -->
