### PR TITLE
bpo-31904: fix test_utf8_mode fail issue on VxWorks

### DIFF
--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -12,7 +12,7 @@ from test.support.script_helper import assert_python_ok, assert_python_failure
 
 MS_WINDOWS = (sys.platform == 'win32')
 POSIX_LOCALES = ('C', 'POSIX')
-_vxworks = (sys.platform == "vxworks")
+VXWORKS = (sys.platform == "vxworks")
 
 class UTF8ModeTests(unittest.TestCase):
     DEFAULT_ENV = {
@@ -225,7 +225,7 @@ class UTF8ModeTests(unittest.TestCase):
             with self.subTest(LC_ALL=loc):
                 check('utf8', [arg_utf8], LC_ALL=loc)
 
-        if sys.platform == 'darwin' or support.is_android or _vxworks:
+        if sys.platform == 'darwin' or support.is_android or VXWORKS:
             c_arg = arg_utf8
         elif sys.platform.startswith("aix"):
             c_arg = arg.decode('iso-8859-1')

--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -12,7 +12,7 @@ from test.support.script_helper import assert_python_ok, assert_python_failure
 
 MS_WINDOWS = (sys.platform == 'win32')
 POSIX_LOCALES = ('C', 'POSIX')
-
+_vxworks = (sys.platform == "vxworks")
 
 class UTF8ModeTests(unittest.TestCase):
     DEFAULT_ENV = {
@@ -225,7 +225,7 @@ class UTF8ModeTests(unittest.TestCase):
             with self.subTest(LC_ALL=loc):
                 check('utf8', [arg_utf8], LC_ALL=loc)
 
-        if sys.platform == 'darwin' or support.is_android:
+        if sys.platform == 'darwin' or support.is_android or _vxworks:
             c_arg = arg_utf8
         elif sys.platform.startswith("aix"):
             c_arg = arg.decode('iso-8859-1')

--- a/Misc/NEWS.d/next/Tests/2019-03-19-17-39-25.bpo-31904.QxhhRx.rst
+++ b/Misc/NEWS.d/next/Tests/2019-03-19-17-39-25.bpo-31904.QxhhRx.rst
@@ -1,0 +1,2 @@
+VxWorks uses UTF-8 as the system encoding. So the test case test_utf8_mode.py
+need to be updated to use UTF-8 on VxWorks.

--- a/Misc/NEWS.d/next/Tests/2019-03-19-17-39-25.bpo-31904.QxhhRx.rst
+++ b/Misc/NEWS.d/next/Tests/2019-03-19-17-39-25.bpo-31904.QxhhRx.rst
@@ -1,2 +1,1 @@
-VxWorks uses UTF-8 as the system encoding. So the test case test_utf8_mode.py
-need to be updated to use UTF-8 on VxWorks.
+Fix test_utf8_mode on VxWorks: Python always use UTF-8 on VxWorks.


### PR DESCRIPTION
VxWorks uses UTF-8 as the system encoding. So the test case test_utf8_mode.py need to be updated to use UTF-8 on VxWorks.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
