### PR TITLE
bpo-8677: use PY_SSIZE_T_CLEAN in sqlite

### DIFF
--- a/Modules/_sqlite/cache.h
+++ b/Modules/_sqlite/cache.h
@@ -23,6 +23,7 @@
 
 #ifndef PYSQLITE_CACHE_H
 #define PYSQLITE_CACHE_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 /* The LRU cache is implemented as a combination of a doubly-linked with a

--- a/Modules/_sqlite/connection.h
+++ b/Modules/_sqlite/connection.h
@@ -23,6 +23,7 @@
 
 #ifndef PYSQLITE_CONNECTION_H
 #define PYSQLITE_CONNECTION_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pythread.h"
 #include "structmember.h"

--- a/Modules/_sqlite/cursor.h
+++ b/Modules/_sqlite/cursor.h
@@ -23,6 +23,7 @@
 
 #ifndef PYSQLITE_CURSOR_H
 #define PYSQLITE_CURSOR_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 #include "statement.h"

--- a/Modules/_sqlite/microprotocols.h
+++ b/Modules/_sqlite/microprotocols.h
@@ -26,6 +26,7 @@
 #ifndef PSYCOPG_MICROPROTOCOLS_H
 #define PSYCOPG_MICROPROTOCOLS_H 1
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 /** the names of the three mandatory methods **/

--- a/Modules/_sqlite/module.h
+++ b/Modules/_sqlite/module.h
@@ -23,6 +23,7 @@
 
 #ifndef PYSQLITE_MODULE_H
 #define PYSQLITE_MODULE_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 #define PYSQLITE_VERSION "2.6.0"

--- a/Modules/_sqlite/prepare_protocol.h
+++ b/Modules/_sqlite/prepare_protocol.h
@@ -23,6 +23,7 @@
 
 #ifndef PYSQLITE_PREPARE_PROTOCOL_H
 #define PYSQLITE_PREPARE_PROTOCOL_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 typedef struct

--- a/Modules/_sqlite/row.h
+++ b/Modules/_sqlite/row.h
@@ -23,6 +23,7 @@
 
 #ifndef PYSQLITE_ROW_H
 #define PYSQLITE_ROW_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 typedef struct _Row

--- a/Modules/_sqlite/statement.h
+++ b/Modules/_sqlite/statement.h
@@ -23,6 +23,7 @@
 
 #ifndef PYSQLITE_STATEMENT_H
 #define PYSQLITE_STATEMENT_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 #include "connection.h"

--- a/Modules/_sqlite/util.h
+++ b/Modules/_sqlite/util.h
@@ -23,6 +23,7 @@
 
 #ifndef PYSQLITE_UTIL_H
 #define PYSQLITE_UTIL_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pythread.h"
 #include "sqlite3.h"


### PR DESCRIPTION
Modules/_sqlite/cursor.c uses "y#" format.

<!-- issue-number: [bpo-8677](https://bugs.python.org/issue8677) -->
https://bugs.python.org/issue8677
<!-- /issue-number -->
