### PR TITLE
bpo-36356: pymain_free() calls _PyRuntime_Finalize()

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -184,6 +184,8 @@ PyAPI_FUNC(void) _PyRuntimeState_ReInitThreads(void);
    Return NULL on success, or return an error message on failure. */
 PyAPI_FUNC(_PyInitError) _PyRuntime_Initialize(void);
 
+PyAPI_FUNC(void) _PyRuntime_Finalize(void);
+
 #define _Py_CURRENTLY_FINALIZING(tstate) \
     (_PyRuntime.finalizing == tstate)
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -839,6 +839,7 @@ pymain_free(void)
     _PyPathConfig_ClearGlobal();
     _Py_ClearStandardStreamEncoding();
     _Py_ClearArgcArgv();
+    _PyRuntime_Finalize();
 }
 
 


### PR DESCRIPTION
Ensure that _PyRuntime_Finalize() is always call. This change fix a
few memory leaks when running "python3 -V".

<!-- issue-number: [bpo-36356](https://bugs.python.org/issue36356) -->
https://bugs.python.org/issue36356
<!-- /issue-number -->
