### PR TITLE
[3.7] bpo-36356: pymain_free() calls _PyRuntime_Finalize()

### DIFF
--- a/Include/internal/pystate.h
+++ b/Include/internal/pystate.h
@@ -118,6 +118,9 @@ PyAPI_FUNC(void) _PyRuntimeState_Fini(_PyRuntimeState *);
    Return NULL on success, or return an error message on failure. */
 PyAPI_FUNC(_PyInitError) _PyRuntime_Initialize(void);
 
+PyAPI_FUNC(void) _PyRuntime_Finalize(void);
+
+
 #define _Py_CURRENTLY_FINALIZING(tstate) \
     (_PyRuntime.finalizing == tstate)
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -660,6 +660,8 @@ pymain_free_raw(_PyMain *pymain)
     orig_argc = 0;
     orig_argv = NULL;
 
+    _PyRuntime_Finalize();
+
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 }
 


### PR DESCRIPTION
Ensure that _PyRuntime_Finalize() is always call. This change fix a
few memory leaks when running "python3 -V".

<!-- issue-number: [bpo-36356](https://bugs.python.org/issue36356) -->
https://bugs.python.org/issue36356
<!-- /issue-number -->
