### PR TITLE
bpo-36364: fix SharedMemoryManager examples

### DIFF
--- a/Doc/library/multiprocessing.shared_memory.rst
+++ b/Doc/library/multiprocessing.shared_memory.rst
@@ -218,8 +218,8 @@ The following example demonstrates the basic mechanisms of a
 .. doctest::
    :options: +SKIP
 
-   >>> from multiprocessing import shared_memory
-   >>> smm = shared_memory.SharedMemoryManager()
+   >>> from multiprocessing.managers import SharedMemoryManager
+   >>> smm = SharedMemoryManager()
    >>> smm.start()  # Start the process that manages the shared memory blocks
    >>> sl = smm.ShareableList(range(4))
    >>> sl
@@ -238,7 +238,7 @@ needed:
 .. doctest::
    :options: +SKIP
 
-   >>> with shared_memory.SharedMemoryManager() as smm:
+   >>> with SharedMemoryManager() as smm:
    ...     sl = smm.ShareableList(range(2000))
    ...     # Divide the work among two processes, storing partial results in sl
    ...     p1 = Process(target=do_work, args=(sl, 0, 1000))

--- a/Doc/library/multiprocessing.shared_memory.rst
+++ b/Doc/library/multiprocessing.shared_memory.rst
@@ -176,6 +176,7 @@ same ``numpy.ndarray`` from two distinct Python shells:
 
 
 .. class:: SharedMemoryManager([address[, authkey]])
+   :module: multiprocessing.managers
 
    A subclass of :class:`~multiprocessing.managers.BaseManager` which can be
    used for the management of shared memory blocks across processes.


### PR DESCRIPTION
Examples of the `multiprocessing.shared_memory` module try to import `SharedMemoryManager` from `multiprocessing.shared_memory` whereas this class is defined in `multiprocessing.managers`.