### PR TITLE
bpo-36367: Free buffer if realloc fails in tokenize.c

### DIFF
--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -649,9 +649,14 @@ translate_newlines(const char *s, int exec_input, struct tok_state *tok) {
     }
     *current = '\0';
     final_length = current - buf + 1;
-    if (final_length < needed_length && final_length)
+    if (final_length < needed_length && final_length) {
         /* should never fail */
-        buf = PyMem_REALLOC(buf, final_length);
+        char* result = PyMem_REALLOC(buf, final_length);
+        if (result == NULL) {
+            PyMem_FREE(buf);
+        }
+        buf = result;
+    }
     return buf;
 }
 
@@ -958,6 +963,7 @@ tok_nextc(struct tok_state *tok)
                 newbuf = (char *)PyMem_REALLOC(newbuf,
                                                newsize);
                 if (newbuf == NULL) {
+                    PyMem_FREE(tok->buf);
                     tok->done = E_NOMEM;
                     tok->cur = tok->inp;
                     return EOF;


### PR DESCRIPTION


<!-- issue-number: [bpo-36367](https://bugs.python.org/issue36367) -->
https://bugs.python.org/issue36367
<!-- /issue-number -->
