### PR TITLE
bpo-36371: Fix FancyGetopt.generate_help is now correctly working with None and empty strings as help_text

### DIFF
--- a/Lib/distutils/fancy_getopt.py
+++ b/Lib/distutils/fancy_getopt.py
@@ -8,9 +8,12 @@ additional features:
   * options set attributes of a passed-in object
 """
 
-import sys, string, re
+import sys
+import string
+import re
 import getopt
 from distutils.errors import *
+
 
 # Much like command_re in distutils.core, this is close to but not quite
 # the same as a Python NAME -- except, in the spirit of most GNU
@@ -25,6 +28,7 @@ neg_alias_re = re.compile("^(%s)=!(%s)$" % (longopt_pat, longopt_pat))
 # This is used to translate long options to legitimate Python identifiers
 # (for use as attributes of some object).
 longopt_xlate = str.maketrans('-', '_')
+
 
 class FancyGetopt:
     """Wrapper around the standard 'getopt()' module that provides some
@@ -351,7 +355,7 @@ class FancyGetopt:
                     lines.append("  --%-*s  %s" %
                                  (max_opt, opt_names, text[0]))
                 else:
-                    lines.append("  --%-*s" % opt_names)
+                    lines.append("  --%-*s" % (max_opt, opt_names))
 
             for l in text[1:]:
                 lines.append(big_indent + l)
@@ -372,13 +376,14 @@ def fancy_getopt(options, negative_opt, object, args):
 
 WS_TRANS = {ord(_wschar) : ' ' for _wschar in string.whitespace}
 
+
 def wrap_text(text, width):
     """wrap_text(text : string, width : int) -> [string]
 
     Split 'text' into multiple lines of no more than 'width' characters
     each, and return the list of strings that results.
     """
-    if text is None:
+    if not text:
         return []
     if len(text) <= width:
         return [text]

--- a/Lib/distutils/tests/test_fancy_getopt.py
+++ b/Lib/distutils/tests/test_fancy_getopt.py
@@ -1,0 +1,28 @@
+"""Tests for distutils.fancy_getopt."""
+import unittest
+from test.support import run_unittest
+from distutils.fancy_getopt import FancyGetopt
+
+
+class FancyGetoptTestCase(unittest.TestCase):
+
+    def _get_fancy_getopt_instance(self, option_table):
+        return FancyGetopt(option_table)
+
+    def test_generate_help_with_none_help_text(self):
+        instance = self._get_fancy_getopt_instance([('long', 'l', None)])
+        help_text = instance.generate_help()
+        self.assertEqual(help_text, ['Option summary:', '  --long (-l)'])
+
+    def test_generate_help_with_empty_help_text(self):
+        instance = self._get_fancy_getopt_instance([('long', 'l', '')])
+        help_text = instance.generate_help()
+        self.assertEqual(help_text, ['Option summary:', '  --long (-l)'])
+
+
+def test_suite():
+    return unittest.makeSuite(FancyGetoptTestCase)
+
+
+if __name__ == "__main__":
+    run_unittest(test_suite())


### PR DESCRIPTION
[issue-36371](https://bugs.python.org/issue36371): Fix error in string formating and now `FancyGetopt.generate_help` works correct without help_text and stop adding 2 redundant whitespaces to the end of string if help_text is empty string.

<!-- issue-number: [bpo-36371](https://bugs.python.org/issue36371) -->
https://bugs.python.org/issue36371
<!-- /issue-number -->
