### PR TITLE
[3.7] bpo-36236: Handle removed cwd at Python init

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -139,7 +139,9 @@ PyAPI_FUNC(wchar_t *) Py_GetExecPrefix(void);
 PyAPI_FUNC(wchar_t *) Py_GetPath(void);
 #ifdef Py_BUILD_CORE
 PyAPI_FUNC(_PyInitError) _PyPathConfig_Init(const _PyCoreConfig *core_config);
-PyAPI_FUNC(PyObject*) _PyPathConfig_ComputeArgv0(int argc, wchar_t **argv);
+PyAPI_FUNC(int) _PyPathConfig_ComputeArgv0(
+    int argc, wchar_t **argv,
+    PyObject **argv0_p);
 PyAPI_FUNC(int) _Py_FindEnvConfigValue(
     FILE *env_file,
     const wchar_t *key,

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-19-23-55-00.bpo-36236.5qN9qK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-19-23-55-00.bpo-36236.5qN9qK.rst
@@ -1,0 +1,2 @@
+At Python initialization, the current directory is no longer prepended to
+:data:`sys.path` if it has been removed.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2615,7 +2615,10 @@ PySys_SetArgvEx(int argc, wchar_t **argv, int updatepath)
     if (updatepath) {
         /* If argv[0] is not '-c' nor '-m', prepend argv[0] to sys.path.
            If argv[0] is a symlink, use the real path. */
-        PyObject *argv0 = _PyPathConfig_ComputeArgv0(argc, argv);
+        PyObject *argv0 = NULL;
+        if (!_PyPathConfig_ComputeArgv0(argc, argv, &argv0)) {
+            return;
+        }
         if (argv0 == NULL) {
             Py_FatalError("can't compute path0 from argv");
         }


### PR DESCRIPTION
At Python initialization, the current directory is no longer
prepended to sys.path if it has been removed.

<!-- issue-number: [bpo-36236](https://bugs.python.org/issue36236) -->
https://bugs.python.org/issue36236
<!-- /issue-number -->
