### PR TITLE
[3.7] bpo-36365: Fix compiler warning in structseq.c

### DIFF
--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -182,10 +182,16 @@ structseq_repr(PyStructSequence *obj)
     endofbuf= &buf[REPR_BUFFER_SIZE-5];
 
     /* "typename(", limited to  TYPE_MAXSIZE */
-    len = strlen(typ->tp_name) > TYPE_MAXSIZE ? TYPE_MAXSIZE :
-                            strlen(typ->tp_name);
-    strncpy(pbuf, typ->tp_name, len);
-    pbuf += len;
+    assert(TYPE_MAXSIZE < sizeof(buf));
+    len = strlen(typ->tp_name);
+    if (len <= TYPE_MAXSIZE) {
+        strcpy(pbuf, typ->tp_name);
+        pbuf += len;
+    }
+    else {
+        strncpy(pbuf, typ->tp_name, TYPE_MAXSIZE);
+        pbuf += TYPE_MAXSIZE;
+    }
     *pbuf++ = '(';
 
     for (i=0; i < VISIBLE_SIZE(obj); i++) {


### PR DESCRIPTION


<!-- issue-number: [bpo-36365](https://bugs.python.org/issue36365) -->
https://bugs.python.org/issue36365
<!-- /issue-number -->
