### PR TITLE
[3.7] Fix compiler warning in call_readline() (GH-10820)

### DIFF
--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1239,7 +1239,7 @@ static char *
 call_readline(FILE *sys_stdin, FILE *sys_stdout, const char *prompt)
 {
     size_t n;
-    char *p, *q;
+    char *p;
     int signal;
 
 #ifdef SAVE_LOCALE
@@ -1296,10 +1296,10 @@ call_readline(FILE *sys_stdin, FILE *sys_stdout, const char *prompt)
     }
     /* Copy the malloc'ed buffer into a PyMem_Malloc'ed one and
        release the original. */
-    q = p;
+    char *q = p;
     p = PyMem_RawMalloc(n+2);
     if (p != NULL) {
-        strncpy(p, q, n);
+        memcpy(p, q, n);
         p[n] = '\n';
         p[n+1] = '\0';
     }


### PR DESCRIPTION
Replace strncpy() with memcpy() in call_readline() to fix the
following warning, the NUL byte is written manually just after:

Modules/readline.c: In function ‘call_readline’:
Modules/readline.c:1303:9: warning: ‘strncpy’ output truncated before
terminating nul copying as many bytes from a string as its length
[-Wstringop-truncation]
         strncpy(p, q, n);
         ^~~~~~~~~~~~~~~~
Modules/readline.c:1279:9: note: length computed here
     n = strlen(p);
         ^~~~~~~~~

(cherry picked from commit 1600f60414e620c4298c15dac803427d8f0a977c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
