### PR TITLE
bpo-36375: PEP499: implementation and documentation and test updates

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -933,6 +933,19 @@ qualify as a built-in module.  This is because the manner in which
 ``__main__`` is initialized depends on the flags and other options with
 which the interpreter is invoked.
 
+When Python is started with the :option:`-m` option, if the name
+provided resolves to a module (as distinct from a package) then the
+module is associated as both ``sys.modules['__main__']`` and also
+as ``sys.modules[``name``]``. This prevents a future import of the
+named module creating a distinct module instance which cauases
+subtle failures because references like ``__main__.foo`` are to
+distinct objects from references like name``.foo``.
+
+.. versionchanged:: 3.8
+   The :option:`-m` formerly installed the module only as
+   ``sys.modules['__main__']`` without aliasing it as its module
+   name.
+
 .. _main_spec:
 
 __main__.__spec__
@@ -960,11 +973,11 @@ Note that ``__main__.__spec__`` is always ``None`` in the last case,
 instead. Use the :option:`-m` switch if valid module metadata is desired
 in :mod:`__main__`.
 
-Note also that even when ``__main__`` corresponds with an importable module
-and ``__main__.__spec__`` is set accordingly, they're still considered
-*distinct* modules. This is due to the fact that blocks guarded by
-``if __name__ == "__main__":`` checks only execute when the module is used
-to populate the ``__main__`` namespace, and not during normal import.
+Note also that when ``__main__`` corresponds with an importable
+module and ``__main__.__spec__`` is set accordingly, ``__name__``
+is still ``"__main__"`` so that blocks guarded by ``if __name__
+== "__main__":`` execute when the module is used to populate the
+``__main__`` namespace.
 
 
 Open issues

--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -933,13 +933,13 @@ qualify as a built-in module.  This is because the manner in which
 ``__main__`` is initialized depends on the flags and other options with
 which the interpreter is invoked.
 
-When Python is started with the :option:`-m` option, if the name
-provided resolves to a module (as distinct from a package) then the
-module is associated as both ``sys.modules['__main__']`` and also
-as ``sys.modules[``name``]``. This prevents a future import of the
-named module creating a distinct module instance which cauases
-subtle failures because references like ``__main__.foo`` are to
-distinct objects from references like name``.foo``.
+When Python is started with the :option:`-m` ``module_name`` option,
+if the name provided resolves to a module (as distinct from a package)
+then the module is associated as both ``sys.modules['__main__']``
+and also as ``sys.modules[module_name]``. This prevents a future import
+of the named module creating a distinct module instance which causes
+subtle failures because references like ``__main__.foo`` resolve to
+distinct objects from references like ``module_name.foo``.
 
 .. versionchanged:: 3.8
    The :option:`-m` formerly installed the module only as

--- a/Lib/runpy.py
+++ b/Lib/runpy.py
@@ -188,7 +188,8 @@ def _run_module_as_main(mod_name, alter_argv=True):
         sys.exit(msg)
     main_module = sys.modules["__main__"]
     main_module_name = mod_spec.name
-    if not main_module.is_package(main_module_name):
+    main_module_pkg = getattr(main_module, '__package__', '') or ''
+    if main_module_pkg == '':
         global_module = sys.modules.get(main_module_name)
         if global_module is not main_module:
             if global_module:

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
@@ -1,0 +1,8 @@
+PEP 499 implemented: the "python -m module_name" command line option now binds the imported module
+to both ``sys.modules['__main__'`` and additionally to ``sys.modules['module_name']``.
+This prevents subtle bug that arise when a later import of the module by name within the code
+formerly produced a distinct instance of the module,
+which led to hard to debug issues where the object resolved by ``__main__.obj_name``
+was distinct from the object resolved by ``module_name.obj_name``.
+This led to subtle breakage of code which relied on objtect identity tests,
+particularly ``isinstance`` tests and ``try/except`` clauses.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
@@ -1,8 +1,8 @@
 PEP 499 implemented: the "python -m module_name" command line option now binds the imported module
-to both ``sys.modules['__main__'`` and additionally to ``sys.modules['module_name']``.
+to both ``sys.modules['__main__]'`` and additionally to ``sys.modules['module_name']``.
 This prevents subtle bug that arise when a later import of the module by name within the code
 formerly produced a distinct instance of the module,
 which led to hard to debug issues where the object resolved by ``__main__.obj_name``
 was distinct from the object resolved by ``module_name.obj_name``.
 This led to subtle breakage of code which relied on objtect identity tests,
-particularly ``isinstance`` tests and ``try/except`` clauses.
+particularly ``isinstance()`` tests and ``try/except`` clauses.

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -166,6 +166,11 @@ Searches
 for the named module and runs the corresponding
 .I .py
 file as a script.
+This also imports the
+.I .py
+file
+as
+.IR module-name .
 .TP
 .B \-O
 Remove assert statements and any code conditional on the value of


### PR DESCRIPTION
(Superseded, see https://github.com/python/cpython/pull/12490 instead)

This PR provides an implementation of the -m option semantics change from PEP 499. It also provides some documentation updates  and 2 unit tests.

<!-- issue-number: [bpo-36375](https://bugs.python.org/issue36375) -->
https://bugs.python.org/issue36375
<!-- /issue-number -->
