### PR TITLE
[3.7] bpo-35564: add master_doc='contents' to conf.py

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -46,6 +46,8 @@ smartquotes_excludes = {
     'languages': ['ja', 'fr', 'zh_TW', 'zh_CN'], 'builders': ['man', 'text'],
 }
 
+# Avoid a warning with Sphinx >= 2.0
+master_doc = 'contents'
 
 # Options for HTML output
 # -----------------------

--- a/Misc/NEWS.d/next/Documentation/2018-12-22-22-52-05.bpo-35564.TuEU_D.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-12-22-22-52-05.bpo-35564.TuEU_D.rst
@@ -1,0 +1,1 @@
+Explicitly set master_doc variable in conf.py for compliance with Sphinx 2.0


### PR DESCRIPTION
This is to avoid a:
```
WARNING: Since v2.0, Sphinx uses "index" as master_doc by default. Please add "master_doc = 'contents'" to your conf.py.
```

(cherry picked from commit fc8284e22074af8154e9865c8391b955f13a308b)

Co-authored-by: Jean-François B <jfbu@free.fr>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35564](https://bugs.python.org/issue35564) -->
https://bugs.python.org/issue35564
<!-- /issue-number -->
