### PR TITLE
bpo-32573: Handle the case when sys.argv is not set

### DIFF
--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -169,10 +169,15 @@ def get_preparation_data(name):
     else:
         sys_path[i] = process.ORIGINAL_DIR
 
+    try:
+        sys_argv = sys.argv
+    except AttributeError:
+        sys_argv = []
+
     d.update(
         name=name,
         sys_path=sys_path,
-        sys_argv=sys.argv,
+        sys_argv=sys_argv,
         orig_dir=process.ORIGINAL_DIR,
         dir=os.getcwd(),
         start_method=get_start_method(),


### PR DESCRIPTION
I encountered a situation where `sys.argv` wasn't set when using Python as an embedded interpreter. The proposed update will avoid an AttributeError in that case. If `sys.argv` is set, it should not change behavior.

There's discussions related to correct behavior in this case: 
https://bugs.python.org/issue32573

Is this proposed update to spawn.py the correct fix, or should the embedded case be handled differently, somehow?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32573](https://bugs.python.org/issue32573) -->
https://bugs.python.org/issue32573
<!-- /issue-number -->
