### PR TITLE
bpo-36377: Specify that range() can not be compared

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -680,17 +680,17 @@ Comparing Sequences and Other Types
 ===================================
 
 Sequence objects can be compared to some objects with the same sequence type,
-for instance `range()` object is a `sequence` type, but they can not be compared.
-The comparison uses *lexicographical* ordering: first the first two items are
-compared, and if they differ this determines the outcome of the comparison; if
-they are equal, the next two items are compared, and so on, until either
-sequence is exhausted. If two items to be compared are themselves sequences of
-the same type, the lexicographical comparison is carried out recursively.  If
-all items of two sequences compare equal, the sequences are considered equal.
-If one sequence is an initial sub-sequence of the other, the shorter sequence is
-the smaller (lesser) one.  Lexicographical ordering for strings uses the Unicode
-code point number to order individual characters.  Some examples of comparisons
-between sequences of the same type::
+for instance ``range()`` object is a ``sequence`` type, but they can not be
+compared. The comparison uses *lexicographical* ordering: first the first two
+items are compared, and if they differ this determines the outcome of the
+comparison; if they are equal, the next two items are compared, and so on, until
+either sequence is exhausted. If two items to be compared are themselves
+sequences of the same type, the lexicographical comparison is carried out
+recursively.  If all items of two sequences compare equal, the sequences are
+considered equal. If one sequence is an initial sub-sequence of the other, the
+shorter sequence is the smaller (lesser) one.  Lexicographical ordering for
+strings uses the Unicode code point number to order individual characters.
+Some examples of comparisons between sequences of the same type::
 
    (1, 2, 3)              < (1, 2, 4)
    [1, 2, 3]              < [1, 2, 4]

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -678,7 +678,7 @@ intended.
 
 Comparing Sequences and Other Types
 ===================================
-Sequence objects tipically may be compared to other objects with the same sequence
+Sequence objects typically may be compared to other objects with the same sequence
 type. The comparison uses *lexicographical* ordering: first the first two
 items are compared, and if they differ this determines the outcome of the
 comparison; if they are equal, the next two items are compared, and so on, until

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -679,7 +679,8 @@ intended.
 Comparing Sequences and Other Types
 ===================================
 
-Sequence objects may be compared to other objects with the same sequence type.
+Sequence objects can be compared to some objects with the same sequence type,
+for instance `range()` object is a `sequence` type, but they can not be compared.
 The comparison uses *lexicographical* ordering: first the first two items are
 compared, and if they differ this determines the outcome of the comparison; if
 they are equal, the next two items are compared, and so on, until either

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -678,10 +678,8 @@ intended.
 
 Comparing Sequences and Other Types
 ===================================
-Sequence objects can be compared to other objects with the same sequence type,
-although there exist some exceptions to this rule like ``range()``, which is a
-``sequence`` type, but they can not be compared with other ``range()`` objects.
-The comparison uses *lexicographical* ordering: first the first two
+Sequence objects tipically may be compared to other objects with the same sequence
+type. The comparison uses *lexicographical* ordering: first the first two
 items are compared, and if they differ this determines the outcome of the
 comparison; if they are equal, the next two items are compared, and so on, until
 either sequence is exhausted. If two items to be compared are themselves

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -678,10 +678,10 @@ intended.
 
 Comparing Sequences and Other Types
 ===================================
-
-Sequence objects can be compared to some objects with the same sequence type,
-for instance ``range()`` object is a ``sequence`` type, but they can not be
-compared. The comparison uses *lexicographical* ordering: first the first two
+Sequence objects can be compared to other objects with the same sequence type,
+although there exist some exceptions to this rule like ``range()``, which is a
+``sequence`` type, but they can not be compared with other ``range()`` objects.
+The comparison uses *lexicographical* ordering: first the first two
 items are compared, and if they differ this determines the outcome of the
 comparison; if they are equal, the next two items are compared, and so on, until
 either sequence is exhausted. If two items to be compared are themselves


### PR DESCRIPTION
[bpo-36377](https://bugs.python.org/issue36377): Specify that range() object is a secuence type but they can not be compared.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36377](https://bugs.python.org/issue36377) -->
https://bugs.python.org/issue36377
<!-- /issue-number -->
