### PR TITLE
bpo-36366: Return None on stopping unstarted patch object

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1398,7 +1398,7 @@ class _patch(object):
     def __exit__(self, *exc_info):
         """Undo the patch."""
         if not _is_started(self):
-            raise RuntimeError('stop called on unstarted patcher')
+            return
 
         if self.is_local and self.temp_original is not DEFAULT:
             setattr(self.target, self.attribute, self.temp_original)

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -772,13 +772,13 @@ class PatchTest(unittest.TestCase):
 
 
     def test_stop_without_start(self):
-        # bpo-36366: calling stop without start will return None
+        # bpo-36366: calling stop without start will return None.
         patcher = patch(foo_name, 'bar', 3)
         self.assertIsNone(patcher.stop())
 
 
-    def test_stop_double_stop(self):
-        # bpo-36366: calling stop on an already stopped patch will return None
+    def test_stop_idempotent(self):
+        # bpo-36366: calling stop on an already stopped patch will return None.
         patcher = patch(foo_name, 'bar', 3)
 
         patcher.start()

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -772,10 +772,18 @@ class PatchTest(unittest.TestCase):
 
 
     def test_stop_without_start(self):
+        # bpo-36366: calling stop without start will return None
+        patcher = patch(foo_name, 'bar', 3)
+        self.assertIsNone(patcher.stop())
+
+
+    def test_stop_double_stop(self):
+        # bpo-36366: calling stop on an already stopped patch will return None
         patcher = patch(foo_name, 'bar', 3)
 
-        # calling stop without start used to produce a very obscure error
-        self.assertRaises(RuntimeError, patcher.stop)
+        patcher.start()
+        patcher.stop()
+        self.assertIsNone(patcher.stop())
 
 
     def test_patchobject_start_stop(self):

--- a/Misc/NEWS.d/next/Library/2019-03-20-15-13-18.bpo-36366.n0eav_.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-20-15-13-18.bpo-36366.n0eav_.rst
@@ -1,3 +1,4 @@
-Calling ``stop`` on an unstarted or stopped :func:`unittest.mock.patch`
-object will not raise :exc:`RuntimeError` and returns `None`. Patch by
-Karthikeyan Singaravelan.
+Calling ``stop()`` on an unstarted or stopped :func:`unittest.mock.patch`
+object will now return `None` instead of raising :exc:`RuntimeError`,
+making the method idempotent.
+Patch byKarthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Library/2019-03-20-15-13-18.bpo-36366.n0eav_.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-20-15-13-18.bpo-36366.n0eav_.rst
@@ -1,0 +1,3 @@
+Calling ``stop`` on an unstarted or stopped :func:`unittest.mock.patch`
+object will not raise :exc:`RuntimeError` and returns `None`. Patch by
+Karthikeyan Singaravelan.


### PR DESCRIPTION
Return None after calling unittest.mock.patch.object.stop() regardless of whether the object was started. This makes the method idempotent.

<!-- issue-number: [bpo-36366](https://bugs.python.org/issue36366) -->
https://bugs.python.org/issue36366
<!-- /issue-number -->
