### PR TITLE
bpo-36381: warn when no PY_SSIZE_T_CLEAN

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -701,9 +701,10 @@ Changes in the Python API
 Changes in the C API
 --------------------
 
-* Use of ``#`` variants of formats without ``PY_SSIZE_T_CLEAN`` defined
-  raises ``PendingDeprecationWarning`` now.  Read :ref:`arg-parsing` for
-  detail.
+* Use of ``#`` variants of formats in parsing or building value (e.g.
+  :c:func:`PyArg_ParseTuple`, :c:func:`Py_BuildValue`, :c:func:`PyObject_CallFunction`,
+  etc.) without ``PY_SSIZE_T_CLEAN`` defined raises ``DeprecationWarning`` now.
+  It will be removed in 3.10 or 4.0.  Read :ref:`arg-parsing` for detail.
   (Contributed by Inada Naoki in :issue:`36381`.)
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -698,6 +698,15 @@ Changes in the Python API
   set for regular user accounts.
 
 
+Changes in the C API
+--------------------
+
+* Use of ``#`` variants of formats without ``PY_SSIZE_T_CLEAN`` defined
+  raises ``PendingDeprecationWarning`` now.  Read :ref:`arg-parsing` for
+  detail.
+  (Contributed by Inada Naoki in :issue:`36381`.)
+
+
 CPython bytecode changes
 ------------------------
 

--- a/Misc/NEWS.d/next/C API/2019-03-20-22-02-40.bpo-36381.xlzDJ2.rst
+++ b/Misc/NEWS.d/next/C API/2019-03-20-22-02-40.bpo-36381.xlzDJ2.rst
@@ -1,0 +1,2 @@
+Raise PendingDeprecationWarning when '#' formats are used for building or
+parsing values without PY_SSIZE_T_CLEAN.

--- a/Misc/NEWS.d/next/C API/2019-03-20-22-02-40.bpo-36381.xlzDJ2.rst
+++ b/Misc/NEWS.d/next/C API/2019-03-20-22-02-40.bpo-36381.xlzDJ2.rst
@@ -1,2 +1,2 @@
-Raise PendingDeprecationWarning when '#' formats are used for building or
-parsing values without PY_SSIZE_T_CLEAN.
+Raise ``DeprecationWarning`` when '#' formats are used for building or
+parsing values without ``PY_SSIZE_T_CLEAN``.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -682,7 +682,7 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
 #define FETCH_SIZE      int *q=NULL;Py_ssize_t *q2=NULL;\
     if (flags & FLAG_SIZE_T) q2=va_arg(*p_va, Py_ssize_t*); \
     else { \
-        if (PyErr_WarnEx(PyExc_PendingDeprecationWarning, \
+        if (PyErr_WarnEx(PyExc_DeprecationWarning, \
                     "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) { \
             return NULL; \
         } \
@@ -2598,7 +2598,7 @@ skipitem(const char **p_format, va_list *p_va, int flags)
                     if (flags & FLAG_SIZE_T)
                         (void) va_arg(*p_va, Py_ssize_t *);
                     else {
-                        if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+                        if (PyErr_WarnEx(PyExc_DeprecationWarning,
                                     "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) {
                             return NULL;
                         }

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -681,7 +681,13 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
     /* For # codes */
 #define FETCH_SIZE      int *q=NULL;Py_ssize_t *q2=NULL;\
     if (flags & FLAG_SIZE_T) q2=va_arg(*p_va, Py_ssize_t*); \
-    else q=va_arg(*p_va, int*);
+    else { \
+        if (PyErr_WarnEx(PyExc_PendingDeprecationWarning, \
+                    "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) { \
+            return NULL; \
+        } \
+        q=va_arg(*p_va, int*); \
+    }
 #define STORE_SIZE(s)   \
     if (flags & FLAG_SIZE_T) \
         *q2=s; \
@@ -2591,8 +2597,13 @@ skipitem(const char **p_format, va_list *p_va, int flags)
                 if (p_va != NULL) {
                     if (flags & FLAG_SIZE_T)
                         (void) va_arg(*p_va, Py_ssize_t *);
-                    else
+                    else {
+                        if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+                                    "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) {
+                            return NULL;
+                        }
                         (void) va_arg(*p_va, int *);
+                    }
                 }
                 format++;
             } else if ((c == 's' || c == 'z' || c == 'y' || c == 'w')

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -342,8 +342,13 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
                 ++*p_format;
                 if (flags & FLAG_SIZE_T)
                     n = va_arg(*p_va, Py_ssize_t);
-                else
+                else {
+                    if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+                                "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) {
+                        return NULL;
+                    }
                     n = va_arg(*p_va, int);
+                }
             }
             else
                 n = -1;
@@ -390,8 +395,13 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
                 ++*p_format;
                 if (flags & FLAG_SIZE_T)
                     n = va_arg(*p_va, Py_ssize_t);
-                else
+                else {
+                    if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+                                "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) {
+                        return NULL;
+                    }
                     n = va_arg(*p_va, int);
+                }
             }
             else
                 n = -1;
@@ -423,8 +433,13 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
                 ++*p_format;
                 if (flags & FLAG_SIZE_T)
                     n = va_arg(*p_va, Py_ssize_t);
-                else
+                else {
+                    if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+                                "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) {
+                        return NULL;
+                    }
                     n = va_arg(*p_va, int);
+                }
             }
             else
                 n = -1;

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -343,7 +343,7 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
                 if (flags & FLAG_SIZE_T)
                     n = va_arg(*p_va, Py_ssize_t);
                 else {
-                    if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+                    if (PyErr_WarnEx(PyExc_DeprecationWarning,
                                 "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) {
                         return NULL;
                     }
@@ -396,7 +396,7 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
                 if (flags & FLAG_SIZE_T)
                     n = va_arg(*p_va, Py_ssize_t);
                 else {
-                    if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+                    if (PyErr_WarnEx(PyExc_DeprecationWarning,
                                 "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) {
                         return NULL;
                     }
@@ -434,7 +434,7 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
                 if (flags & FLAG_SIZE_T)
                     n = va_arg(*p_va, Py_ssize_t);
                 else {
-                    if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+                    if (PyErr_WarnEx(PyExc_DeprecationWarning,
                                 "PY_SSIZE_T_CLEAN will be required for '#' formats", 1)) {
                         return NULL;
                     }


### PR DESCRIPTION
We will remove int support from 3.10 or 4.0.


<!-- issue-number: [bpo-8677](https://bugs.python.org/issue8677) -->
https://bugs.python.org/issue8677
<!-- /issue-number -->
