### PR TITLE
bpo-36256: Fix bug in parsermodule when parsing if statements

### DIFF
--- a/Lib/test/test_parser.py
+++ b/Lib/test/test_parser.py
@@ -319,6 +319,10 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
         self.check_suite("try: pass\nexcept: pass\nelse: pass\n"
                          "finally: pass\n")
 
+    def test_if_stmt(self):
+        self.check_suite("if True:\n  pass\nelse:\n  pass\n")
+        self.check_suite("if True:\n  pass\nelif True:\n  pass\nelse:\n  pass\n")
+
     def test_position(self):
         # An absolutely minimal test of position information.  Better
         # tests would be a big project.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-21-00-24-18.bpo-12477.OZHa0t.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-21-00-24-18.bpo-12477.OZHa0t.rst
@@ -1,0 +1,2 @@
+Fix bug in parsermodule when parsing a state in a DFA that has two or more
+arcs with labels of the same type. Patch by Pablo Galindo.

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -703,7 +703,7 @@ validate_node(node *tree)
                 PyErr_Format(parser_error, "Expected node type %d, got %d.",
                              next_type, ch_type);
             }
-            else if (expected_str) {
+            else if (expected_str != NULL) {
                 PyErr_Format(parser_error, "Illegal terminal: expected '%s'.",
                              expected_str);
             }

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -676,7 +676,7 @@ validate_node(node *tree)
             short a_label = dfa_state->s_arc[arc].a_lbl;
             assert(a_label < _PyParser_Grammar.g_ll.ll_nlabels);
 
-            char* label_str = _PyParser_Grammar.g_ll.ll_label[a_label].lb_str;
+            const char *label_str = _PyParser_Grammar.g_ll.ll_label[a_label].lb_str;
             if ((_PyParser_Grammar.g_ll.ll_label[a_label].lb_type == ch_type)
                 && ( (ch->n_str == NULL ) || (label_str == NULL)
                      || (strcmp(ch->n_str, label_str) == 0))

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -678,7 +678,7 @@ validate_node(node *tree)
 
             const char *label_str = _PyParser_Grammar.g_ll.ll_label[a_label].lb_str;
             if ((_PyParser_Grammar.g_ll.ll_label[a_label].lb_type == ch_type)
-                && ( (ch->n_str == NULL ) || (label_str == NULL)
+                && ((ch->n_str == NULL) || (label_str == NULL)
                      || (strcmp(ch->n_str, label_str) == 0))
                ) {
                 /* The child is acceptable; if non-terminal, validate it recursively. */

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -675,7 +675,11 @@ validate_node(node *tree)
         for (arc = 0; arc < dfa_state->s_narcs; ++arc) {
             short a_label = dfa_state->s_arc[arc].a_lbl;
             assert(a_label < _PyParser_Grammar.g_ll.ll_nlabels);
-            if (_PyParser_Grammar.g_ll.ll_label[a_label].lb_type == ch_type) {
+            char* label_str = _PyParser_Grammar.g_ll.ll_label[a_label].lb_str;
+            if ((_PyParser_Grammar.g_ll.ll_label[a_label].lb_type == ch_type)
+                && ( (ch->n_str == NULL ) || (label_str == NULL)
+                     || (strcmp(ch->n_str, label_str) == 0))
+               ) {
                 /* The child is acceptable; if non-terminal, validate it recursively. */
                 if (ISNONTERMINAL(ch_type) && !validate_node(ch))
                     return 0;

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -697,7 +697,7 @@ validate_node(node *tree)
                 goto illegal_num_children;
 
             int next_type = _PyParser_Grammar.g_ll.ll_label[a_label].lb_type;
-            const char* expected_str = _PyParser_Grammar.g_ll.ll_label[a_label].lb_str;
+            const char *expected_str = _PyParser_Grammar.g_ll.ll_label[a_label].lb_str;
 
             if (ISNONTERMINAL(next_type)) {
                 PyErr_Format(parser_error, "Expected node type %d, got %d.",

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -675,6 +675,7 @@ validate_node(node *tree)
         for (arc = 0; arc < dfa_state->s_narcs; ++arc) {
             short a_label = dfa_state->s_arc[arc].a_lbl;
             assert(a_label < _PyParser_Grammar.g_ll.ll_nlabels);
+
             char* label_str = _PyParser_Grammar.g_ll.ll_label[a_label].lb_str;
             if ((_PyParser_Grammar.g_ll.ll_label[a_label].lb_type == ch_type)
                 && ( (ch->n_str == NULL ) || (label_str == NULL)
@@ -692,17 +693,24 @@ validate_node(node *tree)
         /* What would this state have accepted? */
         {
             short a_label = dfa_state->s_arc->a_lbl;
-            int next_type;
             if (!a_label) /* Wouldn't accept any more children */
                 goto illegal_num_children;
 
-            next_type = _PyParser_Grammar.g_ll.ll_label[a_label].lb_type;
-            if (ISNONTERMINAL(next_type))
+            int next_type = _PyParser_Grammar.g_ll.ll_label[a_label].lb_type;
+            const char* expected_str = _PyParser_Grammar.g_ll.ll_label[a_label].lb_str;
+
+            if (ISNONTERMINAL(next_type)) {
                 PyErr_Format(parser_error, "Expected node type %d, got %d.",
                              next_type, ch_type);
-            else
+            }
+            else if (expected_str) {
+                PyErr_Format(parser_error, "Illegal terminal: expected '%s'.",
+                             expected_str);
+            }
+            else {
                 PyErr_Format(parser_error, "Illegal terminal: expected %s.",
                              _PyParser_TokenNames[next_type]);
+            }
             return 0;
         }
 


### PR DESCRIPTION
This one was tricky! :)

In the parser module, when validating nodes before starting the parsing with to create a ST in "parser_newstobject" there is a problem that appears when two arcs in the same DFA state has transitions with labels with the same type. For example, the DFA for if_stmt has a state with
two labels with the same type: "elif" and "else" (type NAME). The algorithm tries one by one the arcs until the label that starts the arc transition has a label with the same type of the current child label we are
triying to accept. In this case, the arc for "elif" comes before the arc for "else"and passes this test (because the current child label is "else" and has the same type as "elif"). This lead to expecting a namedexpr_test (305) instead of a colon (11). The solution is to compare also the string representation (in case there is one) of the labels to see if the transition that we have is the correct one.


<!-- issue-number: [bpo-36256](https://bugs.python.org/issue36256) -->
https://bugs.python.org/issue36256
<!-- /issue-number -->
