### PR TITLE
bpo-36389: Add gc.enable_object_debugger()

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -263,6 +263,39 @@ values but should not rebind them):
    .. versionadded:: 3.3
 
 
+The :mod:`gc` module provides an "object debugger" which checks frequently if
+all Python objects tracked by the garbage collector look valid:
+
+* check that the reference counter is greater than or equal to 1;
+* check that the pointer to the type is not NULL;
+* if debug hooks on memory allocators (:c:func:`PyMem_SetupDebugHooks`) are
+  enabled (:envvar:`PYTHONMALLOC` environment variable set to ``"debug"`` or
+  :option:`-X` ``dev`` command line option), detect freed memory.
+
+This debugger aims to debug bugs in C extensions.
+
+.. function:: enable_object_debugger(threshold)
+
+   Enable the object debugger.
+
+   Check that all Python objects tracked by the garbage collector look valid
+   every *threshold* memory allocation or deallocation made by the garbage
+   collector.
+
+   Low *threshold* can have a significant negative impact on Python
+   performance, but should detect earlier Python objects which look invalid.
+
+   *threshold* must be greater than or equal to 1.
+
+   .. versionadded:: 3.8
+
+.. function:: disable_object_debugger()
+
+   Disable the object debugger.
+
+   .. versionadded:: 3.8
+
+
 The following constants are provided for use with :func:`set_debug`:
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -206,6 +206,11 @@ gc
 indicating a generation to get objects from. Contributed in
 :issue:`36016` by Pablo Galindo.
 
+New "object debugger" which checks frequently if all Python objects tracked by
+the garbage collector look valid: :func:`gc.enable_object_debugger` and
+:func:`gc.disable_object_debugger`. This debugger aims to debug bugs in C
+extensions. Contributed in :issue:`36389` by Victor Stinner.
+
 
 gzip
 ----

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -76,6 +76,8 @@ static inline void _PyObject_GC_UNTRACK_impl(const char *filename, int lineno,
 #define _PyObject_GC_UNTRACK(op) \
     _PyObject_GC_UNTRACK_impl(__FILE__, __LINE__, _PyObject_CAST(op))
 
+PyAPI_FUNC(void) _PyGC_DisableObjectDebugger(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -113,8 +113,11 @@ struct gc_generation_stats {
 
 struct _gc_object_debugger {
     int enabled;
-    int threshold;
-    int count;
+    struct gc_obj_dbg_gen {
+        int threshold; /* collection threshold */
+        int count; /* count of allocations or collections of younger
+                      generations */
+    } generations[NUM_GENERATIONS];
 };
 
 struct _gc_runtime_state {

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -111,6 +111,12 @@ struct gc_generation_stats {
     Py_ssize_t uncollectable;
 };
 
+struct _gc_object_debugger {
+    int enabled;
+    int threshold;
+    int count;
+};
+
 struct _gc_runtime_state {
     /* List of objects that still need to be cleaned up, singly linked
      * via their gc headers' gc_prev pointers.  */
@@ -143,6 +149,8 @@ struct _gc_runtime_state {
        collections, and are awaiting to undergo a full collection for
        the first time. */
     Py_ssize_t long_lived_pending;
+
+    struct _gc_object_debugger object_debugger;
 };
 
 PyAPI_FUNC(void) _PyGC_Initialize(struct _gc_runtime_state *);

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -822,6 +822,20 @@ class GCTests(unittest.TestCase):
         self.assertRaises(TypeError, gc.get_objects, "1")
         self.assertRaises(TypeError, gc.get_objects, 1.234)
 
+    @cpython_only
+    def test_object_debugger(self):
+        # Call the object debugger around 2 times
+        # (the test only needs that it's called at least once)
+        gc.enable_object_debugger(10)
+        objs = [{} for _ in range(20)]
+        gc.disable_object_debugger()
+
+    @cpython_only
+    def test_object_debugger_invalid_threshold(self):
+        self.assertRaises(ValueError, gc.enable_object_debugger, -1)
+        self.assertRaises(ValueError, gc.enable_object_debugger, 0)
+        self.assertRaises(OverflowError, gc.enable_object_debugger, 2 ** 100)
+
 
 class GCCallbackTests(unittest.TestCase):
     def setUp(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-21-12-09-05.bpo-36389.EkpMZP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-21-12-09-05.bpo-36389.EkpMZP.rst
@@ -1,0 +1,4 @@
+New "object debugger" which checks frequently if all Python objects tracked
+by the garbage collector are consistent: :func:`gc.enable_object_debugger`
+and :func:`gc.disable_object_debugger`. Contributed in :issue:`36389` by Victor
+Stinner.

--- a/Modules/clinic/gcmodule.c.h
+++ b/Modules/clinic/gcmodule.c.h
@@ -373,4 +373,71 @@ gc_get_freeze_count(PyObject *module, PyObject *Py_UNUSED(ignored))
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e40d384b1f0d513c input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(gc_py_enable_object_debugger__doc__,
+"enable_object_debugger($module, /, threshold)\n"
+"--\n"
+"\n"
+"Enable the object debugger.\n"
+"\n"
+"Check all Python objects tracked by the garbage collector every \'threshold\'\n"
+"memory allocation or deallocation made by the garbage collector.");
+
+#define GC_PY_ENABLE_OBJECT_DEBUGGER_METHODDEF    \
+    {"enable_object_debugger", (PyCFunction)(void(*)(void))gc_py_enable_object_debugger, METH_FASTCALL|METH_KEYWORDS, gc_py_enable_object_debugger__doc__},
+
+static PyObject *
+gc_py_enable_object_debugger_impl(PyObject *module, int threshold);
+
+static PyObject *
+gc_py_enable_object_debugger(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"threshold", NULL};
+    static _PyArg_Parser _parser = {NULL, _keywords, "enable_object_debugger", 0};
+    PyObject *argsbuf[1];
+    int threshold;
+    PyObject *_return_value;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    if (PyFloat_Check(args[0])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    threshold = _PyLong_AsInt(args[0]);
+    if (threshold == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    _return_value = gc_py_enable_object_debugger_impl(module, threshold);
+    if (_return_value != Py_None) {
+        goto exit;
+    }
+    return_value = Py_None;
+    Py_INCREF(Py_None);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(gc_py_disable_object_debugger__doc__,
+"disable_object_debugger($module, /)\n"
+"--\n"
+"\n"
+"Disable the object debugger.");
+
+#define GC_PY_DISABLE_OBJECT_DEBUGGER_METHODDEF    \
+    {"disable_object_debugger", (PyCFunction)gc_py_disable_object_debugger, METH_NOARGS, gc_py_disable_object_debugger__doc__},
+
+static PyObject *
+gc_py_disable_object_debugger_impl(PyObject *module);
+
+static PyObject *
+gc_py_disable_object_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return gc_py_disable_object_debugger_impl(module);
+}
+/*[clinic end generated code: output=341ba16a8fbc2b45 input=a9049054013a1b77]*/

--- a/Modules/clinic/gcmodule.c.h
+++ b/Modules/clinic/gcmodule.c.h
@@ -375,7 +375,8 @@ exit:
 }
 
 PyDoc_STRVAR(gc_py_enable_object_debugger__doc__,
-"enable_object_debugger($module, /, threshold)\n"
+"enable_object_debugger($module, /, threshold0, threshold1=-1,\n"
+"                       threshold2=-1)\n"
 "--\n"
 "\n"
 "Enable the object debugger.\n"
@@ -387,19 +388,23 @@ PyDoc_STRVAR(gc_py_enable_object_debugger__doc__,
     {"enable_object_debugger", (PyCFunction)(void(*)(void))gc_py_enable_object_debugger, METH_FASTCALL|METH_KEYWORDS, gc_py_enable_object_debugger__doc__},
 
 static PyObject *
-gc_py_enable_object_debugger_impl(PyObject *module, int threshold);
+gc_py_enable_object_debugger_impl(PyObject *module, int threshold0,
+                                  int threshold1, int threshold2);
 
 static PyObject *
 gc_py_enable_object_debugger(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"threshold", NULL};
+    static const char * const _keywords[] = {"threshold0", "threshold1", "threshold2", NULL};
     static _PyArg_Parser _parser = {NULL, _keywords, "enable_object_debugger", 0};
-    PyObject *argsbuf[1];
-    int threshold;
+    PyObject *argsbuf[3];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
+    int threshold0;
+    int threshold1 = -1;
+    int threshold2 = -1;
     PyObject *_return_value;
 
-    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 3, 0, argsbuf);
     if (!args) {
         goto exit;
     }
@@ -408,11 +413,38 @@ gc_py_enable_object_debugger(PyObject *module, PyObject *const *args, Py_ssize_t
                         "integer argument expected, got float" );
         goto exit;
     }
-    threshold = _PyLong_AsInt(args[0]);
-    if (threshold == -1 && PyErr_Occurred()) {
+    threshold0 = _PyLong_AsInt(args[0]);
+    if (threshold0 == -1 && PyErr_Occurred()) {
         goto exit;
     }
-    _return_value = gc_py_enable_object_debugger_impl(module, threshold);
+    if (!noptargs) {
+        goto skip_optional_pos;
+    }
+    if (args[1]) {
+        if (PyFloat_Check(args[1])) {
+            PyErr_SetString(PyExc_TypeError,
+                            "integer argument expected, got float" );
+            goto exit;
+        }
+        threshold1 = _PyLong_AsInt(args[1]);
+        if (threshold1 == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
+    }
+    if (PyFloat_Check(args[2])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    threshold2 = _PyLong_AsInt(args[2]);
+    if (threshold2 == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+skip_optional_pos:
+    _return_value = gc_py_enable_object_debugger_impl(module, threshold0, threshold1, threshold2);
     if (_return_value != Py_None) {
         goto exit;
     }
@@ -440,4 +472,4 @@ gc_py_disable_object_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return gc_py_disable_object_debugger_impl(module);
 }
-/*[clinic end generated code: output=341ba16a8fbc2b45 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=408f1549d404380c input=a9049054013a1b77]*/

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -6,6 +6,7 @@
 #undef Yield   /* undefine macro conflicting with <winbase.h> */
 #include "pycore_coreconfig.h"
 #include "pycore_context.h"
+#include "pycore_object.h"   /* _PyGC_DisableObjectDebugger() */
 #include "pycore_fileutils.h"
 #include "pycore_hamt.h"
 #include "pycore_pathconfig.h"
@@ -2062,6 +2063,9 @@ fatal_error(const char *prefix, const char *msg, int status)
         goto exit;
     }
     reentrant = 1;
+
+    /* Prevent reentrant call if called by the GC object debugger */
+    _PyGC_DisableObjectDebugger();
 
     fprintf(stderr, "Fatal Python error: ");
     if (prefix) {


### PR DESCRIPTION
New "object debugger" which checks frequently if all Python object tracked
by the garbage collector are consistent: gc.enable_object_debugger()
and gc.disable_object_debugger().

* Add new _PyObject_CheckConsistency() function
* _PyUnicode_CheckConsistency() and _PyDict_CheckConsistency() are
  now exposed in the internal API. _PyDict_CheckConsistency()
  parameter type becomes PyObject*.
* Add more checks to _PyType_CheckConsistency().

<!-- issue-number: [bpo-36389](https://bugs.python.org/issue36389) -->
https://bugs.python.org/issue36389
<!-- /issue-number -->
