### PR TITLE
bpo-36368: Ignore SIGINT in SharedMemoryManager servers.

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -17,6 +17,7 @@ __all__ = [ 'BaseManager', 'SyncManager', 'BaseProxy', 'Token',
 
 import sys
 import threading
+import signal
 import array
 import queue
 import time
@@ -596,6 +597,9 @@ class BaseManager(object):
         '''
         Create a server, report its address and run it
         '''
+        # bpo-36368: protect server process from KeyboardInterrupt signals
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+
         if initializer is not None:
             initializer(*initargs)
 

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -598,10 +598,7 @@ class BaseManager(object):
         Create a server, report its address and run it
         '''
         # bpo-36368: protect server process from KeyboardInterrupt signals
-        if sys.platform != 'win32':
-            signal.signal(signal.SIGINT, signal.SIG_IGN)
-        else:
-            signal.signal(signal.CTRL_C_EVENT, signal.SIG_IGN)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
 
         if initializer is not None:
             initializer(*initargs)

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -598,7 +598,10 @@ class BaseManager(object):
         Create a server, report its address and run it
         '''
         # bpo-36368: protect server process from KeyboardInterrupt signals
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        if sys.platform != 'win32':
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+        else:
+            signal.signal(signal.CTRL_C_EVENT, signal.SIG_IGN)
 
         if initializer is not None:
             initializer(*initargs)

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3743,9 +3743,13 @@ class _TestSharedMemory(BaseTestCase):
         # make sure the manager works properly at the beginning
         sl = smm.ShareableList(range(10))
 
-        # the manager's server should ignore SIGINT (<-KeyboardInterrupt)
-        # signals, and maintain its connection with the current process
-        os.kill(smm._process.pid, signal.SIGINT)
+        # the manager's server should ignore KeyboardInterrupt signals, and
+        # maintain its connection with the current process
+        if sys.platform != 'win32':
+            os.kill(smm._process.pid, signal.SIGINT)
+        else:
+            os.kill(smm._process.pid, signal.CTRL_C_EVENT)
+
         sl2 = smm.ShareableList(range(10))
         smm.shutdown()
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3734,7 +3734,7 @@ class _TestSharedMemory(BaseTestCase):
 
         sms.close()
 
-    @unittest.skipIf(WIN32, "test not feasible in Windows")
+    @unittest.skipIf(os.name != "posix", "not feasible in non-posix platforms")
     def test_shared_memory_SharedMemoryServer_ignores_sigint(self):
         # bpo-36368: protect SharedMemoryManager server process from
         # KeyboardInterrupt signals.

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3742,12 +3742,12 @@ class _TestSharedMemory(BaseTestCase):
 
         # make sure the manager works properly at the beginning
         sl = smm.ShareableList(range(10))
-        sl.shm.unlink()
 
         # the manager's server should ignore SIGINT (<-KeyboardInterrupt)
         # signals, and maintain its connection with the current process
         os.kill(smm._process.pid, signal.SIGINT)
         sl2 = smm.ShareableList(range(10))
+        smm.shutdown()
 
     def test_shared_memory_SharedMemoryManager_basics(self):
         smm1 = multiprocessing.managers.SharedMemoryManager()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3734,6 +3734,7 @@ class _TestSharedMemory(BaseTestCase):
 
         sms.close()
 
+    @unittest.skipIf(WIN32, "test not feasible in Windows")
     def test_shared_memory_SharedMemoryServer_ignores_sigint(self):
         # bpo-36368: protect SharedMemoryManager server process from
         # KeyboardInterrupt signals.
@@ -3745,10 +3746,7 @@ class _TestSharedMemory(BaseTestCase):
 
         # the manager's server should ignore KeyboardInterrupt signals, and
         # maintain its connection with the current process
-        if sys.platform != 'win32':
-            os.kill(smm._process.pid, signal.SIGINT)
-        else:
-            os.kill(smm._process.pid, signal.CTRL_C_EVENT)
+        os.kill(smm._process.pid, signal.SIGINT)
 
         sl2 = smm.ShareableList(range(10))
         smm.shutdown()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3751,8 +3751,8 @@ class _TestSharedMemory(BaseTestCase):
 
         sl2 = smm.ShareableList(range(10))
 
-        # test that the custom signal handler registered in the Manager do not
-        # affect signal handling in the parent process.
+        # test that the custom signal handler registered in the Manager does
+        # not affect signal handling in the parent process.
         with self.assertRaises(KeyboardInterrupt):
                 os.kill(os.getpid(), signal.SIGINT)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3734,6 +3734,21 @@ class _TestSharedMemory(BaseTestCase):
 
         sms.close()
 
+    def test_shared_memory_SharedMemoryServer_ignores_sigint(self):
+        # bpo-36368: procect SharedMemoryManager server process from
+        # KeyboardInterrupt signals.
+        smm = multiprocessing.managers.SharedMemoryManager()
+        smm.start()
+
+        # make sure the manager works properly at the beginning
+        sl = smm.ShareableList(range(10))
+        sl.shm.unlink()
+
+        # the manager's server should ignore SIGINT (<-KeyboardInterrupt)
+        # signals, and maintain its connection with the current process
+        os.kill(smm._process.pid, signal.SIGINT)
+        sl2 = smm.ShareableList(range(10))
+
     def test_shared_memory_SharedMemoryManager_basics(self):
         smm1 = multiprocessing.managers.SharedMemoryManager()
         with self.assertRaises(ValueError):

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3754,7 +3754,7 @@ class _TestSharedMemory(BaseTestCase):
         # test that the custom signal handler registered in the Manager does
         # not affect signal handling in the parent process.
         with self.assertRaises(KeyboardInterrupt):
-                os.kill(os.getpid(), signal.SIGINT)
+            os.kill(os.getpid(), signal.SIGINT)
 
         smm.shutdown()
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3735,7 +3735,7 @@ class _TestSharedMemory(BaseTestCase):
         sms.close()
 
     def test_shared_memory_SharedMemoryServer_ignores_sigint(self):
-        # bpo-36368: procect SharedMemoryManager server process from
+        # bpo-36368: protect SharedMemoryManager server process from
         # KeyboardInterrupt signals.
         smm = multiprocessing.managers.SharedMemoryManager()
         smm.start()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3745,10 +3745,17 @@ class _TestSharedMemory(BaseTestCase):
         sl = smm.ShareableList(range(10))
 
         # the manager's server should ignore KeyboardInterrupt signals, and
-        # maintain its connection with the current process
+        # maintain its connection with the current process, and success when
+        # asked to deliver memory segments.
         os.kill(smm._process.pid, signal.SIGINT)
 
         sl2 = smm.ShareableList(range(10))
+
+        # test that the custom signal handler registered in the Manager do not
+        # affect signal handling in the parent process.
+        with self.assertRaises(KeyboardInterrupt):
+                os.kill(os.getpid(), signal.SIGINT)
+
         smm.shutdown()
 
     def test_shared_memory_SharedMemoryManager_basics(self):

--- a/Misc/NEWS.d/next/Library/2019-03-21-16-00-00.bpo-36368.zsRT1.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-21-16-00-00.bpo-36368.zsRT1.rst
@@ -1,0 +1,2 @@
+Fix a bug crashing SharedMemoryManager instances in interactive sessions after
+a ctrl-c (KeyboardInterrupt) was sent


### PR DESCRIPTION
When starting a `SharedMemoryManager` in an interactive session, any `KeyboardInterrupt` event will be transmitted to the (sub)process running the shared memory server, which causes the `Manager` to be unusable thereafter.

This PR catches `SIGINT` signals in server processes.


<!-- issue-number: [bpo-36338](https://bugs.python.org/issue36338) -->
https://bugs.python.org/issue36368
<!-- /issue-number -->
