### PR TITLE
bpo-36375: PEP 499 implementation: "python -m foo" binds the main module as both __main__ and foo in sys.modules

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -974,13 +974,13 @@ qualify as a built-in module.  This is because the manner in which
 ``__main__`` is initialized depends on the flags and other options with
 which the interpreter is invoked.
 
-When Python is started with the :option:`-m` option, if the name
-provided resolves to a module (as distinct from a package) then the
-module is associated as both ``sys.modules['__main__']`` and also
-as ``sys.modules[``name``]``. This prevents a future import of the
-named module creating a distinct module instance which cauases
-subtle failures because references like ``__main__.foo`` are to
-distinct objects from references like name``.foo``.
+When Python is started with the :option:`-m` ``module_name`` option,
+if the name provided resolves to a module (as distinct from a package)
+then the module is associated as both ``sys.modules['__main__']``
+and also as ``sys.modules[module_name]``. This prevents a future import
+of the named module creating a distinct module instance which causes
+subtle failures because references like ``__main__.foo`` resolve to
+distinct objects from references like ``module_name.foo``.
 
 .. versionchanged:: 3.8
    The :option:`-m` formerly installed the module only as

--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -974,6 +974,19 @@ qualify as a built-in module.  This is because the manner in which
 ``__main__`` is initialized depends on the flags and other options with
 which the interpreter is invoked.
 
+When Python is started with the :option:`-m` option, if the name
+provided resolves to a module (as distinct from a package) then the
+module is associated as both ``sys.modules['__main__']`` and also
+as ``sys.modules[``name``]``. This prevents a future import of the
+named module creating a distinct module instance which cauases
+subtle failures because references like ``__main__.foo`` are to
+distinct objects from references like name``.foo``.
+
+.. versionchanged:: 3.8
+   The :option:`-m` formerly installed the module only as
+   ``sys.modules['__main__']`` without aliasing it as its module
+   name.
+
 .. _main_spec:
 
 __main__.__spec__
@@ -1001,11 +1014,11 @@ Note that ``__main__.__spec__`` is always ``None`` in the last case,
 instead. Use the :option:`-m` switch if valid module metadata is desired
 in :mod:`__main__`.
 
-Note also that even when ``__main__`` corresponds with an importable module
-and ``__main__.__spec__`` is set accordingly, they're still considered
-*distinct* modules. This is due to the fact that blocks guarded by
-``if __name__ == "__main__":`` checks only execute when the module is used
-to populate the ``__main__`` namespace, and not during normal import.
+Note also that when ``__main__`` corresponds with an importable
+module and ``__main__.__spec__`` is set accordingly, ``__name__``
+is still ``"__main__"`` so that blocks guarded by ``if __name__
+== "__main__":`` execute when the module is used to populate the
+``__main__`` namespace.
 
 
 Open issues

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -76,6 +76,7 @@ import bdb
 import dis
 import code
 import glob
+import types
 import pprint
 import signal
 import inspect
@@ -1533,8 +1534,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         import runpy
         mod_name, mod_spec, code = runpy._get_module_details(module_name)
         self.mainpyfile = self.canonic(code.co_filename)
-        import __main__
-        __main__.__dict__.clear()
+        __main__ = types.ModuleType(module_name, 'New __main__ module for pdb.')
         __main__.__dict__.update({
             "__name__": "__main__",
             "__file__": self.mainpyfile,
@@ -1543,6 +1543,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             "__spec__": mod_spec,
             "__builtins__": __builtins__,
         })
+        sys.modules['__main__'] = __main__
         self.run(code)
 
     def _runscript(self, filename):
@@ -1551,12 +1552,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         #
         # So we clear up the __main__ and set several special variables
         # (this gets rid of pdb's globals and cleans old variables on restarts).
-        import __main__
-        __main__.__dict__.clear()
+        __main__ = types.ModuleType("__main__", 'New __main__ module for pdb.')
         __main__.__dict__.update({"__name__"    : "__main__",
                                   "__file__"    : filename,
                                   "__builtins__": __builtins__,
                                  })
+        sys.modules['__main__'] = __main__
 
         # When bdb sets tracing, a number of call and line events happens
         # BEFORE debugger even reaches user's code (and the exact sequence of

--- a/Lib/runpy.py
+++ b/Lib/runpy.py
@@ -187,7 +187,28 @@ def _run_module_as_main(mod_name, alter_argv=True):
     except _Error as exc:
         msg = "%s: %s" % (sys.executable, exc)
         sys.exit(msg)
-    main_globals = sys.modules["__main__"].__dict__
+    main_module = sys.modules["__main__"]
+    main_module_name = mod_spec.name
+    if not main_module.is_package(main_module_name):
+        global_module = sys.modules.get(main_module_name)
+        if global_module is not main_module:
+            if global_module:
+                main_module_spec = getattr(main_module, '__spec__')
+                main_module_desc = repr(main_module_spec or main_module)
+                global_module_spec = getattr(global_module, '__spec__')
+                global_module_desc = repr(global_module_spec or global_module)
+                from warnings import warn
+                msg = "main module {main_module_name!r}:" \
+                    " a different module {global_module_desc}" \
+                    " is already present in sys.modules" \
+                    " and will be replaced by {main_module_desc}" \
+                    .format(
+                        main_module_name=main_module_name,
+                        main_module_desc=main_module_desc,
+                        global_module_desc=global_module_desc)
+                warn(RuntimeWarning(msg))
+            sys.modules[main_module_name] = main_module
+    main_globals = main_module.__dict__
     if alter_argv:
         sys.argv[0] = mod_spec.origin
     return _run_code(code, main_globals, None,

--- a/Lib/runpy.py
+++ b/Lib/runpy.py
@@ -189,7 +189,8 @@ def _run_module_as_main(mod_name, alter_argv=True):
         sys.exit(msg)
     main_module = sys.modules["__main__"]
     main_module_name = mod_spec.name
-    if not main_module.is_package(main_module_name):
+    main_module_pkg = getattr(main_module, '__package__', '') or ''
+    if main_module_pkg == '':
         global_module = sys.modules.get(main_module_name)
         if global_module is not main_module:
             if global_module:

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -376,6 +376,32 @@ class CmdLineTest(unittest.TestCase):
                    "be directly executed")
             self._check_import_error(["-m", "test_pkg"], msg, cwd=script_dir)
 
+    def test_module_self_import(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script',
+                    "import sys; import script\n"
+                    "if sys.modules['__main__'] is not sys.modules['script']:\n"
+                    "    raise AssertionError(\"sys.modules['__main__'] is not sys.modules['script']\")"
+                    )
+            rc, out, err = assert_python_ok('-m', 'script',
+                                            __isolated=False,
+                                            __cleanenv=True,
+                                            PYTHONPATH=script_dir)
+
+    def test_package_self_import(self):
+        with support.temp_dir() as script_dir:
+            pkg_dir = os.path.join(script_dir, 'test_pkg')
+            make_pkg(pkg_dir)
+            script_name = _make_test_script(pkg_dir, '__main__',
+                    "import sys; import test_pkg\n"
+                    "if sys.modules['__main__'] is sys.modules['test_pkg']:\n"
+                    "    raise AssertionError(\"sys.modules['__main__'] is sys.modules['test_pkg']\")"
+                    )
+            rc, out, err = assert_python_ok('-m', 'test_pkg',
+                                            __isolated=False,
+                                            __cleanenv=True,
+                                            PYTHONPATH=script_dir)
+
     def test_issue8202(self):
         # Make sure package __init__ modules see "-m" in sys.argv0 while
         # searching for the module to execute

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
@@ -1,0 +1,8 @@
+PEP 499 implemented: the "python -m module_name" command line option now binds the imported module
+to both ``sys.modules['__main__'`` and additionally to ``sys.modules['module_name']``.
+This prevents subtle bug that arise when a later import of the module by name within the code
+formerly produced a distinct instance of the module,
+which led to hard to debug issues where the object resolved by ``__main__.obj_name``
+was distinct from the object resolved by ``module_name.obj_name``.
+This led to subtle breakage of code which relied on objtect identity tests,
+particularly ``isinstance`` tests and ``try/except`` clauses.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
@@ -1,8 +1,8 @@
 PEP 499 implemented: the "python -m module_name" command line option now binds the imported module
-to both ``sys.modules['__main__'`` and additionally to ``sys.modules['module_name']``.
+to both ``sys.modules['__main__]'`` and additionally to ``sys.modules['module_name']``.
 This prevents subtle bug that arise when a later import of the module by name within the code
 formerly produced a distinct instance of the module,
 which led to hard to debug issues where the object resolved by ``__main__.obj_name``
 was distinct from the object resolved by ``module_name.obj_name``.
 This led to subtle breakage of code which relied on objtect identity tests,
-particularly ``isinstance`` tests and ``try/except`` clauses.
+particularly ``isinstance()`` tests and ``try/except`` clauses.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-20-00-38-35.bpo-36375.d178R0.rst
@@ -1,8 +1,8 @@
 PEP 499 implemented: the "python -m module_name" command line option now binds the imported module
 to both ``sys.modules['__main__]'`` and additionally to ``sys.modules['module_name']``.
-This prevents subtle bug that arise when a later import of the module by name within the code
+This prevents a subtle bug that arise when a later import of the module by name within the code
 formerly produced a distinct instance of the module,
 which led to hard to debug issues where the object resolved by ``__main__.obj_name``
 was distinct from the object resolved by ``module_name.obj_name``.
-This led to subtle breakage of code which relied on objtect identity tests,
+This led to subtle breakage of code which relied on object identity tests,
 particularly ``isinstance()`` tests and ``try/except`` clauses.

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -166,6 +166,11 @@ Searches
 for the named module and runs the corresponding
 .I .py
 file as a script.
+This also imports the
+.I .py
+file
+as
+.IR module-name .
 .TP
 .B \-O
 Remove assert statements and any code conditional on the value of


### PR DESCRIPTION
This contains documentation updates, `runpy.py` implementation, two unit tests and a fix for `Lib/pdb.py` to accomodate new aliasing of `__main__ `as the module's canonical name.

A run of "make test" on my El Capitan Mac here now shows the following failures:

    test_c_locale_coercion test_smtpnet test_ssl test_urllib
    test_urllib2 test_urllib2net test_xmlrpc

Of these:

  test_c_locale_coercion appears to be due to differences between my OS release and presumably more modern Darwin releases: various "utf-8" vs "ascii" mismatches in the output.

  text_xmlrpc seems to run forever, here

  the other tests fail for network based reasons.

WRT to a run against the master branch, the failure set is the same.

I cannot reproduce the hashlib based failures seen by Travis on my earlier PR. It will be interesting to see what Travis says now.

<!-- issue-number: [bpo-36375](https://bugs.python.org/issue36375) -->
https://bugs.python.org/issue36375
<!-- /issue-number -->
