### PR TITLE
bpo-36398: Fix a possible crash in structseq_repr()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-21-22-19-38.bpo-36398.B_jXGe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-21-22-19-38.bpo-36398.B_jXGe.rst
@@ -1,0 +1,1 @@
+Fix a possible crash in ``structseq_repr()``.

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -176,7 +176,7 @@ structseq_repr(PyStructSequence *obj)
                                                strlen(typ->tp_name),
                                                NULL);
     if (type_name == NULL) {
-        goto error;
+        return NULL;
     }
 
     _PyUnicodeWriter_Init(&writer);


### PR DESCRIPTION
If the first PyUnicode_DecodeUTF8() call fails in structseq_repr(),
_PyUnicodeWriter_Dealloc() will be called on an uninitialized
_PyUnicodeWriter.

<!-- issue-number: [bpo-36398](https://bugs.python.org/issue36398) -->
https://bugs.python.org/issue36398
<!-- /issue-number -->
