### PR TITLE
asyncio: PendingDeprecationWarning -> DeprecationWarning

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -97,7 +97,7 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
         """
         warnings.warn("Task.current_task() is deprecated, "
                       "use asyncio.current_task() instead",
-                      PendingDeprecationWarning,
+                      DeprecationWarning,
                       stacklevel=2)
         if loop is None:
             loop = events.get_event_loop()
@@ -111,7 +111,7 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
         """
         warnings.warn("Task.all_tasks() is deprecated, "
                       "use asyncio.all_tasks() instead",
-                      PendingDeprecationWarning,
+                      DeprecationWarning,
                       stacklevel=2)
         return _all_tasks_compat(loop)
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1634,26 +1634,26 @@ class BaseTaskTests:
     def test_current_task_deprecated(self):
         Task = self.__class__.Task
 
-        with self.assertWarns(PendingDeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             self.assertIsNone(Task.current_task(loop=self.loop))
 
         async def coro(loop):
-            with self.assertWarns(PendingDeprecationWarning):
+            with self.assertWarns(DeprecationWarning):
                 self.assertIs(Task.current_task(loop=loop), task)
 
             # See http://bugs.python.org/issue29271 for details:
             asyncio.set_event_loop(loop)
             try:
-                with self.assertWarns(PendingDeprecationWarning):
+                with self.assertWarns(DeprecationWarning):
                     self.assertIs(Task.current_task(None), task)
-                with self.assertWarns(PendingDeprecationWarning):
+                with self.assertWarns(DeprecationWarning):
                     self.assertIs(Task.current_task(), task)
             finally:
                 asyncio.set_event_loop(None)
 
         task = self.new_task(self.loop, coro(self.loop))
         self.loop.run_until_complete(task)
-        with self.assertWarns(PendingDeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             self.assertIsNone(Task.current_task(loop=self.loop))
 
     def test_current_task(self):
@@ -1982,7 +1982,7 @@ class BaseTaskTests:
         Task = self.__class__.Task
 
         async def coro():
-            with self.assertWarns(PendingDeprecationWarning):
+            with self.assertWarns(DeprecationWarning):
                 assert Task.all_tasks(self.loop) == {t}
 
         t = self.new_task(self.loop, coro())
@@ -2012,9 +2012,9 @@ class BaseTaskTests:
         # See http://bugs.python.org/issue29271 for details:
         asyncio.set_event_loop(self.loop)
         try:
-            with self.assertWarns(PendingDeprecationWarning):
+            with self.assertWarns(DeprecationWarning):
                 self.assertEqual(Task.all_tasks(), {task})
-            with self.assertWarns(PendingDeprecationWarning):
+            with self.assertWarns(DeprecationWarning):
                 self.assertEqual(Task.all_tasks(None), {task})
         finally:
             asyncio.set_event_loop(None)
@@ -2692,7 +2692,7 @@ class BaseTaskIntrospectionTests:
         self.assertEqual(asyncio.all_tasks(loop), set())
         self._register_task(task)
         self.assertEqual(asyncio.all_tasks(loop), set())
-        with self.assertWarns(PendingDeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             self.assertEqual(asyncio.Task.all_tasks(loop), {task})
         self._unregister_task(task)
 

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2088,7 +2088,7 @@ _asyncio_Task_current_task_impl(PyTypeObject *type, PyObject *loop)
     PyObject *ret;
     PyObject *current_task_func;
 
-    if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
                      "Task.current_task() is deprecated, " \
                      "use asyncio.current_task() instead",
                      1) < 0) {
@@ -2136,7 +2136,7 @@ _asyncio_Task_all_tasks_impl(PyTypeObject *type, PyObject *loop)
     PyObject *res;
     PyObject *all_tasks_func;
 
-    if (PyErr_WarnEx(PyExc_PendingDeprecationWarning,
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
                      "Task.all_tasks() is deprecated, " \
                      "use asyncio.all_tasks() instead",
                      1) < 0) {


### PR DESCRIPTION
`Task.current_task()` and `Task.all_tasks()` will be removed in 3.9.