### PR TITLE
bpo-36299: array('u') uses Py_UCS4 instead of Py_UNICODE 

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -22,7 +22,7 @@ defined:
 +-----------+--------------------+-------------------+-----------------------+-------+
 | ``'B'``   | unsigned char      | int               | 1                     |       |
 +-----------+--------------------+-------------------+-----------------------+-------+
-| ``'u'``   | Py_UNICODE         | Unicode character | 2                     | \(1)  |
+| ``'u'``   | Py_UCS4            | Unicode character | 4                     |       |
 +-----------+--------------------+-------------------+-----------------------+-------+
 | ``'h'``   | signed short       | int               | 2                     |       |
 +-----------+--------------------+-------------------+-----------------------+-------+
@@ -36,9 +36,9 @@ defined:
 +-----------+--------------------+-------------------+-----------------------+-------+
 | ``'L'``   | unsigned long      | int               | 4                     |       |
 +-----------+--------------------+-------------------+-----------------------+-------+
-| ``'q'``   | signed long long   | int               | 8                     | \(2)  |
+| ``'q'``   | signed long long   | int               | 8                     | \(1)  |
 +-----------+--------------------+-------------------+-----------------------+-------+
-| ``'Q'``   | unsigned long long | int               | 8                     | \(2)  |
+| ``'Q'``   | unsigned long long | int               | 8                     | \(1)  |
 +-----------+--------------------+-------------------+-----------------------+-------+
 | ``'f'``   | float              | float             | 4                     |       |
 +-----------+--------------------+-------------------+-----------------------+-------+
@@ -48,16 +48,6 @@ defined:
 Notes:
 
 (1)
-   The ``'u'`` type code corresponds to Python's obsolete unicode character
-   (:c:type:`Py_UNICODE` which is :c:type:`wchar_t`). Depending on the
-   platform, it can be 16 bits or 32 bits.
-
-   ``'u'`` will be removed together with the rest of the :c:type:`Py_UNICODE`
-   API.
-
-   .. deprecated-removed:: 3.3 4.0
-
-(2)
    The ``'q'`` and ``'Q'`` type codes are available only if
    the platform C compiler used to build Python supports C :c:type:`long long`,
    or, on Windows, :c:type:`__int64`.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -162,6 +162,13 @@ Improved Modules
   release.
 
 
+array
+-----
+
+``array('u')`` uses ``Py_UCS4`` instead of deprecated ``Py_UNICODE`` now.
+And it is not deprecated now.  (Contributed by Inada Naoki in :issue:`36299`.)
+
+
 asyncio
 -------
 

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1123,12 +1123,8 @@ class UnicodeTest(StringTest, unittest.TestCase):
 
     def test_issue17223(self):
         # this used to crash
-        if sizeof_wchar == 4:
-            # U+FFFFFFFF is an invalid code point in Unicode 6.0
-            invalid_str = b'\xff\xff\xff\xff'
-        else:
-            # PyUnicode_FromUnicode() cannot fail with 16-bit wchar_t
-            self.skipTest("specific to 32-bit wchar_t")
+        # U+FFFFFFFF is an invalid code point in Unicode 6.0
+        invalid_str = b'\xff\xff\xff\xff'
         a = array.array('u', invalid_str)
         self.assertRaises(ValueError, a.tounicode)
         self.assertRaises(ValueError, str, a)

--- a/Misc/NEWS.d/next/Library/2019-03-22-19-26-41.bpo-36299.fbhazC.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-22-19-26-41.bpo-36299.fbhazC.rst
@@ -1,0 +1,2 @@
+``array('u')`` uses ``Py_UCS4`` instead of deprecated ``Py_UNICODE`` now.
+Patch by Inada Naoki.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2592,7 +2592,7 @@ array_buffer_getbuf(arrayobject *self, Py_buffer *view, int flags)
     if ((flags & PyBUF_FORMAT) == PyBUF_FORMAT) {
         view->format = (char *)self->ob_descr->formats;
         if (self->ob_descr->typecode == 'u') {
-            view->format = "w";
+            view->format = "I";
         }
     }
 

--- a/Modules/clinic/arraymodule.c.h
+++ b/Modules/clinic/arraymodule.c.h
@@ -448,20 +448,23 @@ PyDoc_STRVAR(array_array_fromunicode__doc__,
     {"fromunicode", (PyCFunction)array_array_fromunicode, METH_O, array_array_fromunicode__doc__},
 
 static PyObject *
-array_array_fromunicode_impl(arrayobject *self, const Py_UNICODE *ustr,
-                             Py_ssize_clean_t ustr_length);
+array_array_fromunicode_impl(arrayobject *self, PyObject *ustr);
 
 static PyObject *
 array_array_fromunicode(arrayobject *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
-    const Py_UNICODE *ustr;
-    Py_ssize_clean_t ustr_length;
+    PyObject *ustr;
 
-    if (!PyArg_Parse(arg, "u#:fromunicode", &ustr, &ustr_length)) {
+    if (!PyUnicode_Check(arg)) {
+        _PyArg_BadArgument("fromunicode", 0, "str", arg);
         goto exit;
     }
-    return_value = array_array_fromunicode_impl(self, ustr, ustr_length);
+    if (PyUnicode_READY(arg) == -1) {
+        goto exit;
+    }
+    ustr = arg;
+    return_value = array_array_fromunicode_impl(self, ustr);
 
 exit:
     return return_value;
@@ -599,4 +602,4 @@ PyDoc_STRVAR(array_arrayiterator___setstate____doc__,
 
 #define ARRAY_ARRAYITERATOR___SETSTATE___METHODDEF    \
     {"__setstate__", (PyCFunction)array_arrayiterator___setstate__, METH_O, array_arrayiterator___setstate____doc__},
-/*[clinic end generated code: output=c9a40f11f1a866fb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=91ed246782171854 input=a9049054013a1b77]*/


### PR DESCRIPTION


<!-- issue-number: [bpo-36299](https://bugs.python.org/issue36299) -->
https://bugs.python.org/issue36299
<!-- /issue-number -->
