### PR TITLE
bpo-35900: Enable custom reduction callback registration in _pickle

### DIFF
--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -368,13 +368,13 @@ The :mod:`pickle` module exports two classes, :class:`Pickler` and
 
    .. method:: reducer_override(self, obj)
 
-      Special reducer that can be defined in ``Pickler`` subclasses. This
-      method has priority over any reducer in the ``dispatch_table``.  It
+      Special reducer that can be defined in :class:`Pickler` subclasses. This
+      method has priority over any reducer in the :attr:`dispatch_table`.  It
       should conform to the same interface as a :meth:`__reduce__` method, and
       can optionally return ``NotImplemented`` to fallback on
-      ``dispatch_table``-registered reducers to pickle ``obj``.
+      :attr:`dispatch_table`-registered reducers to pickle ``obj``.
 
-      For a detailed example on how to use ``reducer_override``, see:
+      For a detailed example on how to use :meth:`~Pickler.reducer_override`, see:
       :ref:`reducer_override`.
 
       .. versionadded:: 3.8
@@ -743,27 +743,28 @@ share the same dispatch table.  The equivalent code using the
 Subclassing the ``Pickler`` class
 ---------------------------------
 
-For most use-cases, it is recommended to simply use the ``dispatch_table`` of a
-``Pickler`` instance to customize its behavior, as explained above.
+For most use-cases, it is recommended to simply use the :attr:`~Pickler.dispatch_table` of a
+:class:`Pickler` instance to customize its behavior, as explained above.
 
-However, using the ``dispatch_table`` may not be flexible enough. In particular
+However, using the :attr:`~Pickler.dispatch_table` may not be flexible enough. In particular
 we may want to customize the pickling logic based on another criterion than the
 object's type, or we may want to customize the pickling of functions and
 classes.
 
-For those cases, it is possible to subclass from the ``Pickler`` class and
-implement a ``reducer_override`` method. This method can return an arbitrary
+For those cases, it is possible to subclass from the :class:`Pickler` class and
+implement a :meth:`~Pickler.reducer_override` method. This method can return an arbitrary
 reduction tuple (see :meth:`__reduce__`). It can alternatively return
 ``NotImplemented`` to fallback to the traditional behavior.
 
-If both the ``dispatch_table`` and ``reducer_override`` are defined, then
-the ``reducer_override`` method takes priority.
+If both the :attr:`~Pickler.dispatch_table` and :meth:`~Pickler.reducer_override` are defined, then
+the :meth:`~Pickler.reducer_override` method takes priority.
 
 .. Note::
    For performance reasons, the C implementation of pickle does not allow to
    override the pickling of the following objects: ``None``, ``True``,
-   ``False``, and instances of ``long``, ``float``, ``bytes``, ``str``,
-   ``dict``, ``set``, ``frozenset``, ``list`` and ``tuple``.
+   ``False``, and instances of :class:`int`, :class:`float`, :class:`bytes`,
+   :class:`str`, :class:`dict`, :class:`set`, :class:`frozenset`, :class:`list`
+   and :class:`tuple`.
 
 
 Here is a simple example::

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -375,7 +375,7 @@ The :mod:`pickle` module exports two classes, :class:`Pickler` and
       ``dispatch_table``-registered reducers to pickle ``obj``.
 
       For a detailed example on how to use ``reducer_override``, see:
-      `Subclassing the Pickler class`_
+      :ref:`reducer_override`
 
       .. versionadded:: 3.8
 
@@ -740,7 +740,7 @@ share the same dispatch table.  The equivalent code using the
 
 .. _reducer_override:
 
-Subclassing the Pickler class
+Subclassing the ``Pickler`` class
 ---------------------------------
 
 For most use-cases, it is recommended to simply use the ``dispatch_table`` of a

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -727,30 +727,30 @@ share the same dispatch table.  The equivalent code using the
 
 .. _reducer_override:
 
-Subclassing the Pickler class
------------------------------
+Subclassing the ``Pickler`` class
+---------------------------------
 
 For most use-cases, it is recommended to simply use the ``dispatch_table`` of a
 ``Pickler`` instance to customize its behavior, as explained above.
 
-However, using the ``dispatch_table`` may not be flexible enough. in particular
-if we want to customize the pickling logic based on another criterion than the
-object's type, or if we want to customize the pickling of functions and
+However, using the ``dispatch_table`` may not be flexible enough. In particular
+we may want to customize the pickling logic based on another criterion than the
+object's type, or we may want to customize the pickling of functions and
 classes.
 
 For those cases, it is possible to subclass from the ``Pickler`` class and
-implement a `reducer_override` method. This method can return an arbitrary
+implement a ``reducer_override`` method. This method can return an arbitrary
 reduction tuple (see :meth:`__reduce__`). It can alternatively return
 ``NotImplemented`` to fallback to the traditional behavior.
 
 If both the ``dispatch_table`` and ``reducer_override`` are defined, then
-``reducer_override`` method takes priority.
+the ``reducer_override`` method takes priority.
 
 .. Note::
    For performance reasons, the C implementation of pickle does not allow to
    override the pickling of the following objects: ``None``, ``True``,
    ``False``, and instances of ``long``, ``float``, ``bytes``, ``str``,
-   ``dict``, ``set``, ``frozenset``, ``list``, ``tuple``,
+   ``dict``, ``set``, ``frozenset``, ``list`` and ``tuple``.
 
 
 Here is a simple example::
@@ -766,7 +766,6 @@ Here is a simple example::
    class MyPickler(pickle.Pickler):
        def reducer_override(self, obj):
            """Custom reducer for MyClass."""
-
            if getattr(obj, "__name__", None) == "MyClass":
                return type, (obj.__name__, obj.__bases__,
                              {'my_attribute': obj.my_attribute})

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -356,6 +356,18 @@ The :mod:`pickle` module exports two classes, :class:`Pickler` and
 
       .. versionadded:: 3.3
 
+   .. method:: reducer_override(self, obj)
+
+      Special reducer that can be defined in :class:`Pickler` subclasses. This
+      method has priority over any reducer in the :attr:`dispatch_table`.  It
+      should conform to the same interface as a :meth:`__reduce__` method, and
+      can optionally return ``NotImplemented`` to fallback on
+      :attr:`dispatch_table`-registered reducers to pickle ``obj``.
+
+      For a detailed example, see :ref:`reducer_override`.
+
+      .. versionadded:: 3.8
+
    .. attribute:: fast
 
       Deprecated. Enable fast mode if set to a true value.  The fast mode
@@ -365,19 +377,6 @@ The :mod:`pickle` module exports two classes, :class:`Pickler` and
       recurse infinitely.
 
       Use :func:`pickletools.optimize` if you need more compact pickles.
-
-   .. method:: reducer_override(self, obj)
-
-      Special reducer that can be defined in :class:`Pickler` subclasses. This
-      method has priority over any reducer in the :attr:`dispatch_table`.  It
-      should conform to the same interface as a :meth:`__reduce__` method, and
-      can optionally return ``NotImplemented`` to fallback on
-      :attr:`dispatch_table`-registered reducers to pickle ``obj``.
-
-      For a detailed example on how to use :meth:`~Pickler.reducer_override`,
-      see: :ref:`reducer_override`.
-
-      .. versionadded:: 3.8
 
 
 .. class:: Unpickler(file, \*, fix_imports=True, encoding="ASCII", errors="strict")
@@ -738,71 +737,6 @@ share the same dispatch table.  The equivalent code using the
    f = io.BytesIO()
    p = pickle.Pickler(f)
 
-.. _reducer_override:
-
-Subclassing the ``Pickler`` class
----------------------------------
-
-For most use-cases, it is recommended to simply use the
-:attr:`~Pickler.dispatch_table` of a :class:`Pickler` instance to customize its
-behavior, as explained above.
-
-However, using the :attr:`~Pickler.dispatch_table` may not be flexible enough.
-In particular we may want to customize the pickling logic based on another
-criterion than the object's type, or we may want to customize the pickling of
-functions and classes.
-
-For those cases, it is possible to subclass from the :class:`Pickler` class and
-implement a :meth:`~Pickler.reducer_override` method. This method can return an
-arbitrary reduction tuple (see :meth:`__reduce__`). It can alternatively return
-``NotImplemented`` to fallback to the traditional behavior.
-
-If both the :attr:`~Pickler.dispatch_table` and
-:meth:`~Pickler.reducer_override` are defined, then the
-:meth:`~Pickler.reducer_override` method takes priority.
-
-.. Note::
-   For performance reasons, the C implementation of pickle does not allow to
-   override the pickling of the following objects: ``None``, ``True``,
-   ``False``, and instances of :class:`int`, :class:`float`, :class:`bytes`,
-   :class:`str`, :class:`dict`, :class:`set`, :class:`frozenset`, :class:`list`
-   and :class:`tuple`.
-
-
-Here is a simple example::
-
-   import io
-   import pickle
-
-
-   class MyClass:
-       my_attribute = 1
-
-
-   class MyPickler(pickle.Pickler):
-       def reducer_override(self, obj):
-           """Custom reducer for MyClass."""
-           if getattr(obj, "__name__", None) == "MyClass":
-               return type, (obj.__name__, obj.__bases__,
-                             {'my_attribute': obj.my_attribute})
-           else:
-               # For any other object, fallback to the usual pickling routines
-               # (builtin or dispatch_table)
-               return NotImplemented
-
-
-   f = io.BytesIO()
-   p = MyPickler(f)
-   p.dump(MyClass)
-
-   del MyClass
-
-   my_depickled_class = pickle.loads(f.getvalue())
-
-   assert my_depickled_class.__name__ == "MyClass"
-   assert my_depickled_class.my_attribute == 1
-
-
 .. _pickle-state:
 
 Handling Stateful Objects
@@ -868,6 +802,65 @@ A sample usage might be something like this::
    >>> new_reader = pickle.loads(pickle.dumps(reader))
    >>> new_reader.readline()
    '3: Goodbye!'
+
+.. _reducer_override:
+
+Custom Reduction for Types, Functions, and Other Objects
+--------------------------------------------------------
+
+.. versionadded:: 3.8
+
+Sometimes, :attr:`~Pickler.dispatch_table` may not be flexible enough.
+In particular we may want to customize pickling based on another criterion
+than the object's type, or we may want to customize the pickling of
+functions and classes.
+
+For those cases, it is possible to subclass from the :class:`Pickler` class and
+implement a :meth:`~Pickler.reducer_override` method. This method can return an
+arbitrary reduction tuple (see :meth:`__reduce__`). It can alternatively return
+``NotImplemented`` to fallback to the traditional behavior.
+
+If both the :attr:`~Pickler.dispatch_table` and
+:meth:`~Pickler.reducer_override` are defined, then
+:meth:`~Pickler.reducer_override` method takes priority.
+
+.. Note::
+   For performance reasons, :meth:`~Pickler.reducer_override` may not be
+   called for the following objects: ``None``, ``True``, ``False``, and
+   exact instances of :class:`int`, :class:`float`, :class:`bytes`,
+   :class:`str`, :class:`dict`, :class:`set`, :class:`frozenset`, :class:`list`
+   and :class:`tuple`.
+
+Here is a simple example where we allow pickling and reconstructing
+a given class::
+
+   import io
+   import pickle
+
+   class MyClass:
+       my_attribute = 1
+
+   class MyPickler(pickle.Pickler):
+       def reducer_override(self, obj):
+           """Custom reducer for MyClass."""
+           if getattr(obj, "__name__", None) == "MyClass":
+               return type, (obj.__name__, obj.__bases__,
+                             {'my_attribute': obj.my_attribute})
+           else:
+               # For any other object, fallback to usual reduction
+               return NotImplemented
+
+   f = io.BytesIO()
+   p = MyPickler(f)
+   p.dump(MyClass)
+
+   del MyClass
+
+   unpickled_class = pickle.loads(f.getvalue())
+
+   assert isinstance(unpickled_class, type)
+   assert unpickled_class.__name__ == "MyClass"
+   assert unpickled_class.my_attribute == 1
 
 
 .. _pickle-restrict:

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -375,7 +375,7 @@ The :mod:`pickle` module exports two classes, :class:`Pickler` and
       ``dispatch_table``-registered reducers to pickle ``obj``.
 
       For a detailed example on how to use ``reducer_override``, see:
-      :ref:`reducer_override`
+      :ref:`reducer_override`.
 
       .. versionadded:: 3.8
 

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -725,6 +725,69 @@ share the same dispatch table.  The equivalent code using the
    f = io.BytesIO()
    p = pickle.Pickler(f)
 
+.. _reducer_override:
+
+Subclassing the Pickler class
+-----------------------------
+
+For most use-cases, it is recommended to simply use the ``dispatch_table`` of a
+``Pickler`` instance to customize its behavior, as explained above.
+
+However, using the ``dispatch_table`` may not be flexible enough. in particular
+if we want to customize the pickling logic based on another criterion than the
+object's type, or if we want to customize the pickling of functions and
+classes.
+
+For those cases, it is possible to subclass from the ``Pickler`` class and
+implement a `reducer_override` method. This method can return an arbitrary
+reduction tuple (see :meth:`__reduce__`). It can alternatively return
+``NotImplemented`` to fallback to the traditional behavior.
+
+If both the ``dispatch_table`` and ``reducer_override`` are defined, then
+``reducer_override`` method takes priority.
+
+.. Note::
+   For performance reasons, the C implementation of pickle does not allow to
+   override the pickling of the following objects: ``None``, ``True``,
+   ``False``, and instances of ``long``, ``float``, ``bytes``, ``str``,
+   ``dict``, ``set``, ``frozenset``, ``list``, ``tuple``,
+
+
+Here is a simple example::
+
+   import io
+   import pickle
+
+
+   class MyClass:
+       my_attribute = 1
+
+
+   class MyPickler(pickle.Pickler):
+       def reducer_override(self, obj):
+           """Custom reducer for MyClass."""
+
+           if getattr(obj, "__name__", None) == "MyClass":
+               return type, (obj.__name__, obj.__bases__,
+                             {'my_attribute': obj.my_attribute})
+           else:
+               # For any other object, fallback to the usual pickling routines
+               # (builtin or dispatch_table)
+               return NotImplemented
+
+
+   f = io.BytesIO()
+   p = MyPickler(f)
+   p.dump(MyClass)
+
+   del MyClass
+
+   my_depickled_class = pickle.loads(f.getvalue())
+
+   assert my_depickled_class.__name__ == "MyClass"
+   assert my_depickled_class.my_attribute == 1
+
+
 .. _pickle-state:
 
 Handling Stateful Objects

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -368,13 +368,14 @@ The :mod:`pickle` module exports two classes, :class:`Pickler` and
 
    .. method:: reducer_override(self, obj)
 
-      Special reducer that can be defined in ``Pickler`` subclasses. This method has
-      priority over any reducer in the ``dispatch_table``.
-      It should conform to the same interface as a :meth:`__reduce__` method,
-      and can optionally return ``NotImplemented`` to fallback on
+      Special reducer that can be defined in ``Pickler`` subclasses. This
+      method has priority over any reducer in the ``dispatch_table``.  It
+      should conform to the same interface as a :meth:`__reduce__` method, and
+      can optionally return ``NotImplemented`` to fallback on
       ``dispatch_table``-registered reducers to pickle ``obj``.
 
-      For a detailed example on how to use ``reducer_override``, see: `Subclassing the Pickler class`_
+      For a detailed example on how to use ``reducer_override``, see:
+      `Subclassing the Pickler class`_
 
       .. versionadded:: 3.8
 

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -374,8 +374,8 @@ The :mod:`pickle` module exports two classes, :class:`Pickler` and
       can optionally return ``NotImplemented`` to fallback on
       :attr:`dispatch_table`-registered reducers to pickle ``obj``.
 
-      For a detailed example on how to use :meth:`~Pickler.reducer_override`, see:
-      :ref:`reducer_override`.
+      For a detailed example on how to use :meth:`~Pickler.reducer_override`,
+      see: :ref:`reducer_override`.
 
       .. versionadded:: 3.8
 
@@ -743,21 +743,23 @@ share the same dispatch table.  The equivalent code using the
 Subclassing the ``Pickler`` class
 ---------------------------------
 
-For most use-cases, it is recommended to simply use the :attr:`~Pickler.dispatch_table` of a
-:class:`Pickler` instance to customize its behavior, as explained above.
+For most use-cases, it is recommended to simply use the
+:attr:`~Pickler.dispatch_table` of a :class:`Pickler` instance to customize its
+behavior, as explained above.
 
-However, using the :attr:`~Pickler.dispatch_table` may not be flexible enough. In particular
-we may want to customize the pickling logic based on another criterion than the
-object's type, or we may want to customize the pickling of functions and
-classes.
+However, using the :attr:`~Pickler.dispatch_table` may not be flexible enough.
+In particular we may want to customize the pickling logic based on another
+criterion than the object's type, or we may want to customize the pickling of
+functions and classes.
 
 For those cases, it is possible to subclass from the :class:`Pickler` class and
-implement a :meth:`~Pickler.reducer_override` method. This method can return an arbitrary
-reduction tuple (see :meth:`__reduce__`). It can alternatively return
+implement a :meth:`~Pickler.reducer_override` method. This method can return an
+arbitrary reduction tuple (see :meth:`__reduce__`). It can alternatively return
 ``NotImplemented`` to fallback to the traditional behavior.
 
-If both the :attr:`~Pickler.dispatch_table` and :meth:`~Pickler.reducer_override` are defined, then
-the :meth:`~Pickler.reducer_override` method takes priority.
+If both the :attr:`~Pickler.dispatch_table` and
+:meth:`~Pickler.reducer_override` are defined, then the
+:meth:`~Pickler.reducer_override` method takes priority.
 
 .. Note::
    For performance reasons, the C implementation of pickle does not allow to

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -366,6 +366,18 @@ The :mod:`pickle` module exports two classes, :class:`Pickler` and
 
       Use :func:`pickletools.optimize` if you need more compact pickles.
 
+   .. method:: reducer_override(self, obj)
+
+      Special reducer that can be defined in ``Pickler`` subclasses. This method has
+      priority over any reducer in the ``dispatch_table``.
+      It should conform to the same interface as a :meth:`__reduce__` method,
+      and can optionally return ``NotImplemented`` to fallback on
+      ``dispatch_table``-registered reducers to pickle ``obj``.
+
+      For a detailed example on how to use ``reducer_override``, see: `Subclassing the Pickler class`_
+
+      .. versionadded:: 3.8
+
 
 .. class:: Unpickler(file, \*, fix_imports=True, encoding="ASCII", errors="strict")
 
@@ -727,7 +739,7 @@ share the same dispatch table.  The equivalent code using the
 
 .. _reducer_override:
 
-Subclassing the ``Pickler`` class
+Subclassing the Pickler class
 ---------------------------------
 
 For most use-cases, it is recommended to simply use the ``dispatch_table`` of a

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -497,6 +497,12 @@ class _Pickler:
             self.write(self.get(x[0]))
             return
 
+        reducer_override = getattr(self, "reducer_override", None)
+        if reducer_override is not None:
+            rv = reducer_override(obj)
+            if rv is not NotImplemented:
+                return self.save_reduce(obj=obj, *rv)
+
         # Check the type dispatch table
         t = type(obj)
         f = self.dispatch.get(t)

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -497,40 +497,43 @@ class _Pickler:
             self.write(self.get(x[0]))
             return
 
-        reducer_override = getattr(self, "reducer_override", None)
-        if reducer_override is not None:
-            rv = reducer_override(obj)
-            if rv is not NotImplemented:
-                return self.save_reduce(obj=obj, *rv)
-
-        # Check the type dispatch table
-        t = type(obj)
-        f = self.dispatch.get(t)
-        if f is not None:
-            f(self, obj) # Call unbound method with explicit self
-            return
-
-        # Check private dispatch table if any, or else copyreg.dispatch_table
-        reduce = getattr(self, 'dispatch_table', dispatch_table).get(t)
+        rv = NotImplemented
+        reduce = getattr(self, "reducer_override", None)
         if reduce is not None:
             rv = reduce(obj)
-        else:
-            # Check for a class with a custom metaclass; treat as regular class
-            if issubclass(t, type):
-                self.save_global(obj)
+
+        if rv is NotImplemented:
+
+            # Check the type dispatch table
+            t = type(obj)
+            f = self.dispatch.get(t)
+            if f is not None:
+                f(self, obj)  # Call unbound method with explicit self
                 return
 
-            # Check for a __reduce_ex__ method, fall back to __reduce__
-            reduce = getattr(obj, "__reduce_ex__", None)
+            # Check private dispatch table if any, or else
+            # copyreg.dispatch_table
+            reduce = getattr(self, 'dispatch_table', dispatch_table).get(t)
             if reduce is not None:
-                rv = reduce(self.proto)
+                rv = reduce(obj)
             else:
-                reduce = getattr(obj, "__reduce__", None)
+                # Check for a class with a custom metaclass; treat as regular
+                # class
+                if issubclass(t, type):
+                    self.save_global(obj)
+                    return
+
+                # Check for a __reduce_ex__ method, fall back to __reduce__
+                reduce = getattr(obj, "__reduce_ex__", None)
                 if reduce is not None:
-                    rv = reduce()
+                    rv = reduce(self.proto)
                 else:
-                    raise PicklingError("Can't pickle %r object: %r" %
-                                        (t.__name__, obj))
+                    reduce = getattr(obj, "__reduce__", None)
+                    if reduce is not None:
+                        rv = reduce()
+                    else:
+                        raise PicklingError("Can't pickle %r object: %r" %
+                                            (t.__name__, obj))
 
         # Check for string returned by reduce(), meaning "save as global"
         if isinstance(rv, str):

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -503,7 +503,6 @@ class _Pickler:
             rv = reduce(obj)
 
         if rv is NotImplemented:
-
             # Check the type dispatch table
             t = type(obj)
             f = self.dispatch.get(t)

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3030,11 +3030,6 @@ class AbstractHookTests(unittest.TestCase):
             if obj_name == 'MyClass':
                 return str, ('some str',)
 
-            elif obj_name == 'log':
-                # letting the pickler falling back to buitlin save_global to
-                # pickle functions named 'log' by attribute.
-                return NotImplemented
-
             elif obj_name == 'g':
                 # in this case, the callback returns an invalid result (not a
                 # 2-5 tuple), the pickler should raise a proper error.
@@ -3068,6 +3063,10 @@ class AbstractHookTests(unittest.TestCase):
 
                 self.assertEqual(new_f, 5)
                 self.assertEqual(some_str, 'some str')
+                # math.log does not have its usual reducer overriden, so the
+                # custom reduction callback should silently direct the pickler
+                # to the default pickling by attribute, by returning
+                # NotImplemented
                 self.assertIs(math_log, math.log)
 
                 with self.assertRaises(pickle.PicklingError):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3028,8 +3028,8 @@ class AbstractCustomPicklerClass:
             return str, ('some str',)
 
         elif obj_name == 'g':
-            # in this case, the callback returns an invalid result (not
-            # a 2-5 tuple), the pickler should raise a proper error.
+            # in this case, the callback returns an invalid result (not a 2-5
+            # tuple or a string), the pickler should raise a proper error.
             return False
         elif obj_name == 'h':
             # Simulate a case when the reducer fails. The error should
@@ -3071,7 +3071,7 @@ class AbstractHookTests(unittest.TestCase):
                 # NotImplemented
                 self.assertIs(math_log, math.log)
 
-                with self.assertRaises(Exception):
+                with self.assertRaises(pickle.PicklingError):
                     p.dump(g)
 
                 with self.assertRaisesRegex(

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3020,7 +3020,7 @@ class AbstractHookTests(unittest.TestCase):
         # test the CPickler ability to register custom, user-defined reduction
         # callbacks to pickle functions and classes.
 
-        def custom_reduction_callback(pickler, obj):
+        def custom_reduction_callback(obj):
             obj_name = obj.__name__
 
             if obj_name == 'f':

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3017,28 +3017,9 @@ def setstate_bbb(obj, state):
 
 class AbstractHookTests(unittest.TestCase):
     def test_pickler_hook(self):
-        # test the CPickler ability to register custom, user-defined reduction
-        # callbacks to pickle functions and classes.
-
-        def custom_reduction_callback(obj):
-            obj_name = obj.__name__
-
-            if obj_name == 'f':
-                # asking the pickler to save f as 5
-                return int, (5, )
-
-            if obj_name == 'MyClass':
-                return str, ('some str',)
-
-            elif obj_name == 'g':
-                # in this case, the callback returns an invalid result (not a
-                # 2-5 tuple), the pickler should raise a proper error.
-                return False
-            elif obj_name == 'h':
-                # Simulate a case when the reducer fails. The error should be
-                # propagated to the original ``dump`` call.
-                raise ValueError('The reducer just failed')
-            return NotImplemented
+        # test the ability of a custom, user-defined CPickler subclass to
+        # override the default reducing routines of any type using the method
+        # reducer_override
 
         def f():
             pass
@@ -3056,7 +3037,6 @@ class AbstractHookTests(unittest.TestCase):
             with self.subTest(proto=proto):
                 bio = io.BytesIO()
                 p = self.pickler_class(bio, proto)
-                p.reducer_override = custom_reduction_callback
 
                 p.dump([f, MyClass, math.log])
                 new_f, some_str, math_log = pickle.loads(bio.getvalue())

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3015,6 +3015,28 @@ def setstate_bbb(obj, state):
 
 
 
+class AbstractCustomPicklerClass:
+    """Pickler implementing a reducing hook using reducer_override."""
+    def reducer_override(self, obj):
+        obj_name = getattr(obj, "__name__", None)
+
+        if obj_name == 'f':
+            # asking the pickler to save f as 5
+            return int, (5, )
+
+        if obj_name == 'MyClass':
+            return str, ('some str',)
+
+        elif obj_name == 'g':
+            # in this case, the callback returns an invalid result (not
+            # a 2-5 tuple), the pickler should raise a proper error.
+            return False
+        elif obj_name == 'h':
+            # Simulate a case when the reducer fails. The error should
+            # be propagated to the original ``dump`` call.
+            raise ValueError('The reducer just failed')
+        return NotImplemented
+
 class AbstractHookTests(unittest.TestCase):
     def test_pickler_hook(self):
         # test the ability of a custom, user-defined CPickler subclass to
@@ -3049,7 +3071,7 @@ class AbstractHookTests(unittest.TestCase):
                 # NotImplemented
                 self.assertIs(math_log, math.log)
 
-                with self.assertRaises(pickle.PicklingError):
+                with self.assertRaises(Exception):
                     p.dump(g)
 
                 with self.assertRaisesRegex(

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3061,7 +3061,7 @@ class AbstractHookTests(unittest.TestCase):
             with self.subTest(proto=proto):
                 bio = io.BytesIO()
                 p = self.pickler_class(bio, proto)
-                p.global_hook = custom_reduction_callback
+                p.reducer_override = custom_reduction_callback
 
                 p.dump([f, MyClass, math.log])
                 new_f, some_str, math_log = pickle.loads(bio.getvalue())

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3031,10 +3031,12 @@ class AbstractCustomPicklerClass:
             # in this case, the callback returns an invalid result (not a 2-5
             # tuple or a string), the pickler should raise a proper error.
             return False
+
         elif obj_name == 'h':
             # Simulate a case when the reducer fails. The error should
             # be propagated to the original ``dump`` call.
             raise ValueError('The reducer just failed')
+
         return NotImplemented
 
 class AbstractHookTests(unittest.TestCase):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3033,7 +3033,7 @@ class AbstractHookTests(unittest.TestCase):
             elif obj_name == 'log':
                 # letting the pickler falling back to buitlin save_global to
                 # pickle functions named 'log' by attribute.
-                return NotImplementedError
+                return NotImplemented
 
             elif obj_name == 'g':
                 # in this case, the callback returns an invalid result (not a
@@ -3043,7 +3043,7 @@ class AbstractHookTests(unittest.TestCase):
                 # Simulate a case when the reducer fails. The error should be
                 # propagated to the original ``dump`` call.
                 raise ValueError('The reducer just failed')
-            return NotImplementedError
+            return NotImplemented
 
         def f():
             pass

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -258,7 +258,7 @@ if has_c_implementation:
         check_sizeof = support.check_sizeof
 
         def test_pickler(self):
-            basesize = support.calcobjsize('6P2n3i2n3iP')
+            basesize = support.calcobjsize('6P2n3i2n3i2P')
             p = _pickle.Pickler(io.BytesIO())
             self.assertEqual(object.__sizeof__(p), basesize)
             MT_size = struct.calcsize('3nP0n')

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -11,6 +11,7 @@ import weakref
 import unittest
 from test import support
 
+from test.pickletester import AbstractHookTests
 from test.pickletester import AbstractUnpickleTests
 from test.pickletester import AbstractPickleTests
 from test.pickletester import AbstractPickleModuleTests
@@ -252,6 +253,9 @@ if has_c_implementation:
         pickler_class = pickle.Pickler
         def get_dispatch_table(self):
             return collections.ChainMap({}, pickle.dispatch_table)
+
+    class CPicklerHookTests(AbstractHookTests):
+        pickler_class = _pickle.Pickler
 
     @support.cpython_only
     class SizeofTests(unittest.TestCase):
@@ -506,6 +510,7 @@ def test_main():
                       PyPicklerUnpicklerObjectTests,
                       CPicklerUnpicklerObjectTests,
                       CDispatchTableTests, CChainDispatchTableTests,
+                      CPicklerHookTests,
                       InMemoryPickleTests, SizeofTests])
     support.run_unittest(*tests)
     support.run_doctest(pickle)

--- a/Misc/NEWS.d/next/Library/2019-03-22-22-40-00.bpo-35900.oiee0o.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-22-22-40-00.bpo-35900.oiee0o.rst
@@ -1,2 +1,2 @@
 enable custom reduction callback registration for functions and classes in
-_pickle.c
+_pickle.c, using the new Pickler's attribute ``reducer_override``

--- a/Misc/NEWS.d/next/Library/2019-03-22-22-40-00.bpo-35900.oiee0o.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-22-22-40-00.bpo-35900.oiee0o.rst
@@ -1,0 +1,2 @@
+enable custom reduction callback registration for functions and classes in
+_pickle.c

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4081,6 +4081,7 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
                 goto error;
             goto done;
         }
+        Py_DECREF(reduce_value);
     }
 
     if (type == &PyType_Type) {

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4068,8 +4068,8 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
      *  */
     if (self->reducer_override != NULL){
         PyObject *reduce_value = NULL;
-        reduce_value = PyObject_CallFunctionObjArgs(self->reducer_override, self, obj,
-                                                    NULL);
+        reduce_value = PyObject_CallFunctionObjArgs(self->reducer_override,
+                                                    obj, NULL);
         if (reduce_value == NULL){
             goto error;
         }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -616,7 +616,7 @@ typedef struct PicklerObject {
     PyObject *pers_func_self;   /* borrowed reference to self if pers_func
                                    is an unbound method, NULL otherwise */
     PyObject *dispatch_table;   /* private dispatch_table, can be NULL */
-    PyObject *reducer_override;      /* hook for invoking user-defined callbacks
+    PyObject *_reducer_override;/* hook for invoking user-defined callbacks
                                    instead of save_global when pickling
                                    functions and classes*/
 
@@ -1113,7 +1113,7 @@ _Pickler_New(void)
     self->fast_memo = NULL;
     self->max_output_len = WRITE_BUF_SIZE;
     self->output_len = 0;
-    self->reducer_override = NULL;
+    self->_reducer_override = NULL;
 
     self->memo = PyMemoTable_New();
     self->output_buffer = PyBytes_FromStringAndSize(NULL,
@@ -4066,9 +4066,9 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
      *  conditions are not exclusive anymore. If reducer_override returns
      *  NotImplementedError, then we must fallback to save_type or save_global
      *  */
-    if (self->reducer_override != NULL){
+    if (self->_reducer_override != NULL) {
         PyObject *reduce_value = NULL;
-        reduce_value = PyObject_CallFunctionObjArgs(self->reducer_override,
+        reduce_value = PyObject_CallFunctionObjArgs(self->_reducer_override,
                                                     obj, NULL);
         if (reduce_value == NULL){
             goto error;
@@ -4206,7 +4206,19 @@ static int
 dump(PicklerObject *self, PyObject *obj)
 {
     const char stop_op = STOP;
+    PyObject *tmp;
+    _Py_IDENTIFIER(reducer_override);
 
+    if (_PyObject_LookupAttrId((PyObject *)self, &PyId_reducer_override,
+                               &tmp) < 0) {
+        return -1;
+    }
+    /*  The private _reducer_override attribute of the pickler acts as a cache
+     *  of a potential reducer_override method. This cache is updated at each
+     *  Pickler.dump call*/
+    if (tmp != NULL) {
+        Py_XSETREF(self->_reducer_override, tmp);
+    }
     if (self->proto >= 2) {
         char header[2];
 
@@ -4726,7 +4738,6 @@ static PyMemberDef Pickler_members[] = {
     {"bin", T_INT, offsetof(PicklerObject, bin)},
     {"fast", T_INT, offsetof(PicklerObject, fast)},
     {"dispatch_table", T_OBJECT_EX, offsetof(PicklerObject, dispatch_table)},
-    {"reducer_override", T_OBJECT_EX, offsetof(PicklerObject, reducer_override)},
     {NULL}
 };
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4064,7 +4064,7 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
     }
     /*  The switch-on-type statement ends here because the next three
      *  conditions are not exclusive anymore. If reducer_override returns
-     *  NotImplementedError, then we must fallback to save_type or save_global
+     *  NotImplemented, then we must fallback to save_type or save_global
      *  */
     if (self->_reducer_override != NULL) {
         PyObject *reduce_value = NULL;

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -616,7 +616,7 @@ typedef struct PicklerObject {
     PyObject *pers_func_self;   /* borrowed reference to self if pers_func
                                    is an unbound method, NULL otherwise */
     PyObject *dispatch_table;   /* private dispatch_table, can be NULL */
-    PyObject *_reducer_override;/* hook for invoking user-defined callbacks
+    PyObject *reducer_override; /* hook for invoking user-defined callbacks
                                    instead of save_global when pickling
                                    functions and classes*/
 
@@ -1113,7 +1113,7 @@ _Pickler_New(void)
     self->fast_memo = NULL;
     self->max_output_len = WRITE_BUF_SIZE;
     self->output_len = 0;
-    self->_reducer_override = NULL;
+    self->reducer_override = NULL;
 
     self->memo = PyMemoTable_New();
     self->output_buffer = PyBytes_FromStringAndSize(NULL,
@@ -4062,111 +4062,116 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
         status = save_tuple(self, obj);
         goto done;
     }
-    /*  The switch-on-type statement ends here because the next three
-     *  conditions are not exclusive anymore. If reducer_override returns
-     *  NotImplemented, then we must fallback to save_type or save_global
-     *  */
-    reduce_value = Py_NotImplemented;
-    Py_INCREF(reduce_value);
-    if (self->_reducer_override != NULL) {
-        reduce_value = PyObject_CallFunctionObjArgs(self->_reducer_override,
+
+    /* Now, check reducer_override.  If it returns NotImplemented,
+     * fallback to save_type or save_global, and then perhaps to the
+     * regular reduction mechanism.
+     */
+    if (self->reducer_override != NULL) {
+        reduce_value = PyObject_CallFunctionObjArgs(self->reducer_override,
                                                     obj, NULL);
+        if (reduce_value == NULL) {
+            goto error;
+        }
+        if (reduce_value != Py_NotImplemented) {
+            goto reduce;
+        }
+        Py_DECREF(reduce_value);
+        reduce_value = NULL;
     }
 
-    if (reduce_value == Py_NotImplemented) {
-        if (type == &PyType_Type) {
-            status = save_type(self, obj);
-            goto done;
-        }
-        else if (type == &PyFunction_Type) {
-            status = save_global(self, obj, NULL);
-            goto done;
-        }
+    if (type == &PyType_Type) {
+        status = save_type(self, obj);
+        goto done;
+    }
+    else if (type == &PyFunction_Type) {
+        status = save_global(self, obj, NULL);
+        goto done;
+    }
 
-        /* XXX: This part needs some unit tests. */
+    /* XXX: This part needs some unit tests. */
 
-        /* Get a reduction callable, and call it.  This may come from
-         * self.dispatch_table, copyreg.dispatch_table, the object's
-         * __reduce_ex__ method, or the object's __reduce__ method.
-         */
-        if (self->dispatch_table == NULL) {
-            PickleState *st = _Pickle_GetGlobalState();
-            reduce_func = PyDict_GetItemWithError(st->dispatch_table,
-                                                  (PyObject *)type);
-            if (reduce_func == NULL) {
-                if (PyErr_Occurred()) {
-                    goto error;
-                }
-            } else {
-                /* PyDict_GetItemWithError() returns a borrowed reference.
-                   Increase the reference count to be consistent with
-                   PyObject_GetItem and _PyObject_GetAttrId used below. */
-                Py_INCREF(reduce_func);
-            }
-        } else {
-            reduce_func = PyObject_GetItem(self->dispatch_table,
-                                           (PyObject *)type);
-            if (reduce_func == NULL) {
-                if (PyErr_ExceptionMatches(PyExc_KeyError))
-                    PyErr_Clear();
-                else
-                    goto error;
-            }
-        }
-        if (reduce_func != NULL) {
-            Py_INCREF(obj);
-            reduce_value = _Pickle_FastCall(reduce_func, obj);
-        }
-        else if (PyType_IsSubtype(type, &PyType_Type)) {
-            status = save_global(self, obj, NULL);
-            goto done;
-        }
-        else {
-            _Py_IDENTIFIER(__reduce__);
-            _Py_IDENTIFIER(__reduce_ex__);
-
-
-            /* XXX: If the __reduce__ method is defined, __reduce_ex__ is
-               automatically defined as __reduce__. While this is convenient,
-               this make it impossible to know which method was actually
-               called. Of course, this is not a big deal. But still, it would
-               be nice to let the user know which method was called when
-               something go wrong. Incidentally, this means if __reduce_ex__ is
-               not defined, we don't actually have to check for a __reduce__
-               method. */
-
-            /* Check for a __reduce_ex__ method. */
-            if (_PyObject_LookupAttrId(obj, &PyId___reduce_ex__,
-                                       &reduce_func) < 0) {
+    /* Get a reduction callable, and call it.  This may come from
+     * self.dispatch_table, copyreg.dispatch_table, the object's
+     * __reduce_ex__ method, or the object's __reduce__ method.
+     */
+    if (self->dispatch_table == NULL) {
+        PickleState *st = _Pickle_GetGlobalState();
+        reduce_func = PyDict_GetItemWithError(st->dispatch_table,
+                                              (PyObject *)type);
+        if (reduce_func == NULL) {
+            if (PyErr_Occurred()) {
                 goto error;
             }
+        } else {
+            /* PyDict_GetItemWithError() returns a borrowed reference.
+               Increase the reference count to be consistent with
+               PyObject_GetItem and _PyObject_GetAttrId used below. */
+            Py_INCREF(reduce_func);
+        }
+    } else {
+        reduce_func = PyObject_GetItem(self->dispatch_table,
+                                       (PyObject *)type);
+        if (reduce_func == NULL) {
+            if (PyErr_ExceptionMatches(PyExc_KeyError))
+                PyErr_Clear();
+            else
+                goto error;
+        }
+    }
+    if (reduce_func != NULL) {
+        Py_INCREF(obj);
+        reduce_value = _Pickle_FastCall(reduce_func, obj);
+    }
+    else if (PyType_IsSubtype(type, &PyType_Type)) {
+        status = save_global(self, obj, NULL);
+        goto done;
+    }
+    else {
+        _Py_IDENTIFIER(__reduce__);
+        _Py_IDENTIFIER(__reduce_ex__);
+
+
+        /* XXX: If the __reduce__ method is defined, __reduce_ex__ is
+           automatically defined as __reduce__. While this is convenient, this
+           make it impossible to know which method was actually called. Of
+           course, this is not a big deal. But still, it would be nice to let
+           the user know which method was called when something go
+           wrong. Incidentally, this means if __reduce_ex__ is not defined, we
+           don't actually have to check for a __reduce__ method. */
+
+        /* Check for a __reduce_ex__ method. */
+        if (_PyObject_LookupAttrId(obj, &PyId___reduce_ex__, &reduce_func) < 0) {
+            goto error;
+        }
+        if (reduce_func != NULL) {
+            PyObject *proto;
+            proto = PyLong_FromLong(self->proto);
+            if (proto != NULL) {
+                reduce_value = _Pickle_FastCall(reduce_func, proto);
+            }
+        }
+        else {
+            PickleState *st = _Pickle_GetGlobalState();
+
+            /* Check for a __reduce__ method. */
+            reduce_func = _PyObject_GetAttrId(obj, &PyId___reduce__);
             if (reduce_func != NULL) {
-                PyObject *proto;
-                proto = PyLong_FromLong(self->proto);
-                if (proto != NULL) {
-                    reduce_value = _Pickle_FastCall(reduce_func, proto);
-                }
+                reduce_value = _PyObject_CallNoArg(reduce_func);
             }
             else {
-                PickleState *st = _Pickle_GetGlobalState();
-
-                /* Check for a __reduce__ method. */
-                reduce_func = _PyObject_GetAttrId(obj, &PyId___reduce__);
-                if (reduce_func != NULL) {
-                    reduce_value = _PyObject_CallNoArg(reduce_func);
-                }
-                else {
-                    PyErr_Format(st->PicklingError,
-                                 "can't pickle '%.200s' object: %R",
-                                 type->tp_name, obj);
-                    goto error;
-                }
+                PyErr_Format(st->PicklingError,
+                             "can't pickle '%.200s' object: %R",
+                             type->tp_name, obj);
+                goto error;
             }
         }
     }
+
     if (reduce_value == NULL)
         goto error;
 
+  reduce:
     if (PyUnicode_Check(reduce_value)) {
         status = save_global(self, obj, reduce_value);
         goto done;
@@ -4205,12 +4210,14 @@ dump(PicklerObject *self, PyObject *obj)
                                &tmp) < 0) {
         return -1;
     }
-    /*  The private _reducer_override attribute of the pickler acts as a cache
-     *  of a potential reducer_override method. This cache is updated at each
-     *  Pickler.dump call*/
+    /* Cache the reducer_override method, if it exists. */
     if (tmp != NULL) {
-        Py_XSETREF(self->_reducer_override, tmp);
+        Py_XSETREF(self->reducer_override, tmp);
     }
+    else {
+        Py_CLEAR(self->reducer_override);
+    }
+
     if (self->proto >= 2) {
         char header[2];
 
@@ -4334,6 +4341,7 @@ Pickler_dealloc(PicklerObject *self)
     Py_XDECREF(self->pers_func);
     Py_XDECREF(self->dispatch_table);
     Py_XDECREF(self->fast_memo);
+    Py_XDECREF(self->reducer_override);
 
     PyMemoTable_Del(self->memo);
 
@@ -4347,6 +4355,7 @@ Pickler_traverse(PicklerObject *self, visitproc visit, void *arg)
     Py_VISIT(self->pers_func);
     Py_VISIT(self->dispatch_table);
     Py_VISIT(self->fast_memo);
+    Py_VISIT(self->reducer_override);
     return 0;
 }
 
@@ -4358,6 +4367,7 @@ Pickler_clear(PicklerObject *self)
     Py_CLEAR(self->pers_func);
     Py_CLEAR(self->dispatch_table);
     Py_CLEAR(self->fast_memo);
+    Py_CLEAR(self->reducer_override);
 
     if (self->memo != NULL) {
         PyMemoTable *memo = self->memo;

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -616,7 +616,7 @@ typedef struct PicklerObject {
     PyObject *pers_func_self;   /* borrowed reference to self if pers_func
                                    is an unbound method, NULL otherwise */
     PyObject *dispatch_table;   /* private dispatch_table, can be NULL */
-    PyObject *global_hook;      /* hook for invoking user-defined callbacks
+    PyObject *reducer_override;      /* hook for invoking user-defined callbacks
                                    instead of save_global when pickling
                                    functions and classes*/
 
@@ -1113,7 +1113,7 @@ _Pickler_New(void)
     self->fast_memo = NULL;
     self->max_output_len = WRITE_BUF_SIZE;
     self->output_len = 0;
-    self->global_hook = NULL;
+    self->reducer_override = NULL;
 
     self->memo = PyMemoTable_New();
     self->output_buffer = PyBytes_FromStringAndSize(NULL,
@@ -4063,12 +4063,12 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
         goto done;
     }
     /*  The switch-on-type statement ends here because the next three
-     *  conditions are not exclusive anymore. If global_hook returns
+     *  conditions are not exclusive anymore. If reducer_override returns
      *  NotImplementedError, then we must fallback to save_type or save_global
      *  */
-    if (self->global_hook != NULL){
+    if (self->reducer_override != NULL){
         PyObject *reduce_value = NULL;
-        reduce_value = PyObject_CallFunctionObjArgs(self->global_hook, self, obj,
+        reduce_value = PyObject_CallFunctionObjArgs(self->reducer_override, self, obj,
                                                     NULL);
         if (reduce_value == NULL){
             goto error;
@@ -4725,7 +4725,7 @@ static PyMemberDef Pickler_members[] = {
     {"bin", T_INT, offsetof(PicklerObject, bin)},
     {"fast", T_INT, offsetof(PicklerObject, fast)},
     {"dispatch_table", T_OBJECT_EX, offsetof(PicklerObject, dispatch_table)},
-    {"global_hook", T_OBJECT_EX, offsetof(PicklerObject, global_hook)},
+    {"reducer_override", T_OBJECT_EX, offsetof(PicklerObject, reducer_override)},
     {NULL}
 };
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -2224,7 +2224,7 @@ save_bytes(PicklerObject *self, PyObject *obj)
            Python 2 *and* the appropriate 'bytes' object when unpickled
            using Python 3. Again this is a hack and we don't need to do this
            with newer protocols. */
-        PyObject *reduce_value = NULL;
+        PyObject *reduce_value;
         int status;
 
         if (PyBytes_GET_SIZE(obj) == 0) {
@@ -4070,15 +4070,16 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
         PyObject *reduce_value = NULL;
         reduce_value = PyObject_CallFunctionObjArgs(self->_reducer_override,
                                                     obj, NULL);
-        if (reduce_value == NULL){
+        if (reduce_value == NULL) {
             goto error;
         }
 
         if (reduce_value != Py_NotImplemented) {
             status = save_reduce(self, reduce_value, obj);
             Py_DECREF(reduce_value);
-            if (status < 0)
+            if (status < 0) {
                 goto error;
+            }
             goto done;
         }
         Py_DECREF(reduce_value);

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4074,7 +4074,7 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
             goto error;
         }
 
-        if (reduce_value != PyExc_NotImplementedError){
+        if (reduce_value != Py_NotImplemented){
             status = save_reduce(self, reduce_value, obj);
             Py_DECREF(reduce_value);
             if (status < 0)

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4074,7 +4074,7 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
             goto error;
         }
 
-        if (reduce_value != Py_NotImplemented){
+        if (reduce_value != Py_NotImplemented) {
             status = save_reduce(self, reduce_value, obj);
             Py_DECREF(reduce_value);
             if (status < 0)


### PR DESCRIPTION
The C implementation of the `Pickler` class does not allow to register custom pickling behavior for classes and functions.
This PR enables it by adding a hook that will call a user-defined callable for those types. If no callable is registered, then the `pickler` simply fallbacks the `save_global` method, as before.

See also: 
cloudpipe/cloudpickle#253
<!-- issue-number: [bpo-35900](https://bugs.python.org/issue35900) -->
https://bugs.python.org/issue35900
<!-- /issue-number -->
