### PR TITLE
bpo-36301: Add _PyRuntimeState.preconfig

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -8,6 +8,7 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
 #endif
 
+#include "cpython/coreconfig.h"
 #include "pystate.h"
 #include "pythread.h"
 
@@ -176,6 +177,7 @@ typedef struct pyruntimestate {
     struct _ceval_runtime_state ceval;
     struct _gilstate_runtime_state gilstate;
 
+    _PyPreConfig preconfig;
     // XXX Consolidate globals found via the check-c-globals script.
 } _PyRuntimeState;
 

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -862,5 +862,14 @@ _PyPreConfig_Write(_PyPreConfig *config)
     /* Set LC_CTYPE to the user preferred locale */
     _Py_SetLocaleFromEnv(LC_CTYPE);
 
+    /* Write the new pre-configuration into _PyRuntime */
+    PyMemAllocatorEx old_alloc;
+    _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+    int res = _PyPreConfig_Copy(&_PyRuntime.preconfig, config);
+    PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+    if (res < 0) {
+        return _Py_INIT_NO_MEMORY();
+    }
+
     return _Py_INIT_OK();
 }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -41,6 +41,7 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
 
     _PyGC_Initialize(&runtime->gc);
     _PyEval_Initialize(&runtime->ceval);
+    runtime->preconfig = _PyPreConfig_INIT;
 
     runtime->gilstate.check_enabled = 1;
 
@@ -96,6 +97,8 @@ _PyRuntimeState_Fini(_PyRuntimeState *runtime)
         PyThread_free_lock(runtime->xidregistry.mutex);
         runtime->xidregistry.mutex = NULL;
     }
+
+    _PyPreConfig_Clear(&runtime->preconfig);
 
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 }


### PR DESCRIPTION
_PyPreConfig_Write() now writes the applied pre-configuration into
_PyRuntimeState.preconfig.

<!-- issue-number: [bpo-36301](https://bugs.python.org/issue36301) -->
https://bugs.python.org/issue36301
<!-- /issue-number -->
