### PR TITLE
bpo-36345: Add a new example in the documentation of wsgiref

### DIFF
--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -781,3 +781,35 @@ This is a working "Hello World" WSGI application::
 
        # Serve until process is killed
        httpd.serve_forever()
+
+
+Example of a small wsgiref based web server::
+
+   # Takes a path to serve from and an optional port number (defaults to 8000),
+   # then tries to serve files.  Mime types are guessed from the file names, 404
+   # errors are raised if the file is not found.
+   import sys
+   import os
+   import mimetypes
+   from wsgiref import simple_server, util
+
+   def app(environ, respond):
+       fn = os.path.join(path, environ['PATH_INFO'][1:])
+       if '.' not in fn.split(os.path.sep)[-1]:
+           fn = os.path.join(fn, 'index.html')
+       type = mimetypes.guess_type(fn)[0]
+
+       if os.path.exists(fn):
+           respond('200 OK', [('Content-Type', type)])
+           return util.FileWrapper(open(fn, "rb"))
+       else:
+           respond('404 Not Found', [('Content-Type', 'text/plain')])
+           return [b'not found']
+
+    path = sys.argv[1]
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
+    with simple_server.make_server('', port, app) as httpd:
+        print("Serving {} on port {}, control-C to stop".format(path, port))
+
+        # Serve until process is killed
+        httpd.serve_forever()

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -783,7 +783,7 @@ This is a working "Hello World" WSGI application::
        httpd.serve_forever()
 
 
-Example of a small wsgiref based web server::
+Example of a small wsgiref-based web server::
 
    # Takes a path to serve from and an optional port number (defaults to 8000),
    # then tries to serve files.  Mime types are guessed from the file names, 404

--- a/Misc/NEWS.d/next/Documentation/2019-03-23-09-25-12.bpo-36345.L704Zv.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-03-23-09-25-12.bpo-36345.L704Zv.rst
@@ -1,0 +1,2 @@
+Using the code of the ``Tools/scripts/serve.py`` script as an example in the
+:mod:`wsgiref` documentation.  Contributed by Stéphane Wirtel.


### PR DESCRIPTION
It's the second PR where I convert the code of `Tools/scripts/serve.py` as an example in the documentation of `wsgiref`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36345](https://bugs.python.org/issue36345) -->
https://bugs.python.org/issue36345
<!-- /issue-number -->
