### PR TITLE
bpo-36407: Fix writing indentations of CDATA section (xml.dom.minidom)

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -1631,5 +1631,21 @@ class MinidomTest(unittest.TestCase):
                          '<?xml version="1.0" ?>\n'
                          '<curriculum status="public" company="example"/>\n')
 
+    def testCDATAWriting(self):
+        doc = Document()
+        root = doc.createElement('root')
+        doc.appendChild(root)
+        node = doc.createElement('node')
+        root.appendChild(node)
+        data = doc.createCDATASection('</data>')
+        node.appendChild(data)
+
+        doc1 = parseString(doc.toxml())
+        val1 = doc1.getElementsByTagName('node')[0].firstChild.nodeValue
+        doc2 = parseString(doc.toprettyxml())
+        val2 = doc2.getElementsByTagName('node')[0].firstChild.nodeValue
+
+        self.confirm(val1 == val2)
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -1631,21 +1631,21 @@ class MinidomTest(unittest.TestCase):
                          '<?xml version="1.0" ?>\n'
                          '<curriculum status="public" company="example"/>\n')
 
-    def testCDATAWriting(self):
-        doc = Document()
-        root = doc.createElement('root')
-        doc.appendChild(root)
-        node = doc.createElement('node')
-        root.appendChild(node)
-        data = doc.createCDATASection('</data>')
-        node.appendChild(data)
+    def test_toprettyxml_with_cdata(self):
+        xml_str = '<?xml version="1.0" ?><root><node><![CDATA[</data>]]></node></root>'
+        doc = parseString(xml_str)
+        self.assertEqual(doc.toprettyxml(),
+                         '<?xml version="1.0" ?>\n'
+                         '<root>\n'
+                         '\t<node><![CDATA[</data>]]></node>\n'
+                         '</root>\n')
 
-        doc1 = parseString(doc.toxml())
-        val1 = doc1.getElementsByTagName('node')[0].firstChild.nodeValue
-        doc2 = parseString(doc.toprettyxml())
-        val2 = doc2.getElementsByTagName('node')[0].firstChild.nodeValue
-
-        self.confirm(val1 == val2)
+    def test_cdata_parsing(self):
+        xml_str = '<?xml version="1.0" ?><root><node><![CDATA[</data>]]></node></root>'
+        dom1 = parseString(xml_str)
+        self.checkWholeText(dom1.getElementsByTagName('node')[0].firstChild, '</data>')
+        dom2 = parseString(dom1.toprettyxml())
+        self.checkWholeText(dom2.getElementsByTagName('node')[0].firstChild, '</data>')
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -862,7 +862,8 @@ class Element(Node):
         if self.childNodes:
             writer.write(">")
             if (len(self.childNodes) == 1 and
-                self.childNodes[0].nodeType == Node.TEXT_NODE):
+                self.childNodes[0].nodeType in (
+                        Node.TEXT_NODE, Node.CDATA_SECTION_NODE)):
                 self.childNodes[0].writexml(writer, '', '', '')
             else:
                 writer.write(newl)

--- a/Misc/NEWS.d/next/Library/2019-03-23-17-16-15.bpo-36407.LG3aC4.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-23-17-16-15.bpo-36407.LG3aC4.rst
@@ -1,0 +1,1 @@
+Fixed wrong indentation writing for CDATA section in xml.dom.minidom

--- a/Misc/NEWS.d/next/Library/2019-03-23-17-16-15.bpo-36407.LG3aC4.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-23-17-16-15.bpo-36407.LG3aC4.rst
@@ -1,1 +1,2 @@
-Fixed wrong indentation writing for CDATA section in xml.dom.minidom
+Fixed wrong indentation writing for CDATA section in xml.dom.minidom.
+Patch by Vladimir Surjaninov.


### PR DESCRIPTION
[bpo-36407](https://bugs.python.org/issue36407): This little change fixes indentations when we are writing xml with CDATA section. Also a result document now can be parsed correctly as if we would write it without indentations.

<!-- issue-number: [bpo-36407](https://bugs.python.org/issue36407) -->
https://bugs.python.org/issue36407
<!-- /issue-number -->
