### PR TITLE
bpo-36401: Have help() show readonly properties separately

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -203,6 +203,8 @@ def classify_class_attrs(object):
     for (name, kind, cls, value) in inspect.classify_class_attrs(object):
         if inspect.isdatadescriptor(value):
             kind = 'data descriptor'
+            if isinstance(value, property) and value.fset is None:
+                kind = 'readonly property'
         results.append((name, kind, cls, value))
     return results
 
@@ -884,6 +886,8 @@ class HTMLDoc(Doc):
                           lambda t: t[1] == 'class method')
             attrs = spill('Static methods %s' % tag, attrs,
                           lambda t: t[1] == 'static method')
+            attrs = spilldescriptors("Readonly properties %s:\n" % tag, attrs,
+                                     lambda t: t[1] == 'readonly property')
             attrs = spilldescriptors('Data descriptors %s' % tag, attrs,
                                      lambda t: t[1] == 'data descriptor')
             attrs = spilldata('Data and other attributes %s' % tag, attrs,
@@ -1341,6 +1345,8 @@ location listed above.
                           lambda t: t[1] == 'class method')
             attrs = spill("Static methods %s:\n" % tag, attrs,
                           lambda t: t[1] == 'static method')
+            attrs = spilldescriptors("Readonly properties %s:\n" % tag, attrs,
+                                     lambda t: t[1] == 'readonly property')
             attrs = spilldescriptors("Data descriptors %s:\n" % tag, attrs,
                                      lambda t: t[1] == 'data descriptor')
             attrs = spilldata("Data and other attributes %s:\n" % tag, attrs,

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2825,7 +2825,7 @@ class Color(enum.Enum)
  |      The value of the Enum member.
  |\x20\x20
  |  ----------------------------------------------------------------------
- |  Data descriptors inherited from enum.EnumMeta:
+ |  Readonly properties inherited from enum.EnumMeta:
  |\x20\x20
  |  __members__
  |      Returns a mapping of member name->value.

--- a/Misc/NEWS.d/next/Library/2019-03-23-10-25-07.bpo-36401.hYpVBS.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-23-10-25-07.bpo-36401.hYpVBS.rst
@@ -1,0 +1,2 @@
+The class documentation created by pydoc now has a separate section for
+readonly properties.


### PR DESCRIPTION


<!-- issue-number: [bpo-36401](https://bugs.python.org/issue36401) -->
https://bugs.python.org/issue36401
<!-- /issue-number -->
