### PR TITLE
bpo-36412: Fix a possible crash in dictobject.c's new_dict()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-23-19-51-09.bpo-36412.C7acGn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-23-19-51-09.bpo-36412.C7acGn.rst
@@ -1,0 +1,1 @@
+Fix a possible crash when creating a new dictionary.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -604,7 +604,9 @@ new_dict(PyDictKeysObject *keys, PyObject **values)
         mp = PyObject_GC_New(PyDictObject, &PyDict_Type);
         if (mp == NULL) {
             dictkeys_decref(keys);
-            free_values(values);
+            if (values != empty_values) {
+                free_values(values);
+            }
             return NULL;
         }
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-36412](https://bugs.python.org/issue36412) -->
https://bugs.python.org/issue36412
<!-- /issue-number -->
