### PR TITLE
bpo-36406: Handle namespace packages in doctest

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1060,8 +1060,7 @@ class DocTestFinder:
             filename = None
         else:
             # __file__ can be None for empty packages
-            filename = (getattr(module, '__file__', module.__name__) or
-                        module.__name__)
+            filename = getattr(module, '__file__', None) or module.__name__
             if filename[-4:] == ".pyc":
                 filename = filename[:-1]
         return self._parser.get_doctest(docstring, globs, name,

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1059,8 +1059,10 @@ class DocTestFinder:
         if module is None:
             filename = None
         else:
-            filename = getattr(module, '__file__', module.__name__)
-            if filename and filename[-4:] == ".pyc":
+            # __file__ can be None for empty packages
+            filename = (getattr(module, '__file__', module.__name__) or
+                        module.__name__)
+            if filename[-4:] == ".pyc":
                 filename = filename[:-1]
         return self._parser.get_doctest(docstring, globs, name,
                                         filename, lineno)

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1060,7 +1060,7 @@ class DocTestFinder:
             filename = None
         else:
             filename = getattr(module, '__file__', module.__name__)
-            if filename[-4:] == ".pyc":
+            if filename and filename[-4:] == ".pyc":
                 filename = filename[:-1]
         return self._parser.get_doctest(docstring, globs, name,
                                         filename, lineno)

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1059,7 +1059,7 @@ class DocTestFinder:
         if module is None:
             filename = None
         else:
-            # __file__ can be None for empty packages
+            # __file__ can be None for empty packages.
             filename = getattr(module, '__file__', None) or module.__name__
             if filename[-4:] == ".pyc":
                 filename = filename[:-1]

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1059,7 +1059,7 @@ class DocTestFinder:
         if module is None:
             filename = None
         else:
-            # __file__ can be None for empty packages.
+            # __file__ can be None for namespace packages.
             filename = getattr(module, '__file__', None) or module.__name__
             if filename[-4:] == ".pyc":
                 filename = filename[:-1]

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -698,8 +698,11 @@ class TestDocTestFinder(unittest.TestCase):
             finally:
                 support.forget(pkg_name)
                 sys.path.pop()
-            assert doctest.DocTestFinder().find(mod) == []
 
+            empty_doctest_finder = doctest.DocTestFinder(exclude_empty=False)
+
+            self.assertEqual(len(doctest.DocTestFinder().find(mod)), 0)
+            self.assertEqual(len(empty_doctest_finder.find(mod)), 1)
 
 def test_DocTestParser(): r"""
 Unit tests for the `DocTestParser` class.

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -699,10 +699,11 @@ class TestDocTestFinder(unittest.TestCase):
                 support.forget(pkg_name)
                 sys.path.pop()
 
-            empty_doctest_finder = doctest.DocTestFinder(exclude_empty=False)
+            include_empty_finder = doctest.DocTestFinder(exclude_empty=False)
+            exclude_empty_finder = doctest.DocTestFinder(exclude_empty=True)
 
-            self.assertEqual(len(doctest.DocTestFinder().find(mod)), 0)
-            self.assertEqual(len(empty_doctest_finder.find(mod)), 1)
+            self.assertEqual(len(include_empty_finder.find(mod)), 1)
+            self.assertEqual(len(exclude_empty_finder.find(mod)), 0)
 
 def test_DocTestParser(): r"""
 Unit tests for the `DocTestParser` class.

--- a/Misc/NEWS.d/next/Library/2019-03-24-12-12-27.bpo-36406.mCEkOl.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-24-12-12-27.bpo-36406.mCEkOl.rst
@@ -1,0 +1,1 @@
+Handle empty packages in :mod:`doctest`. Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Library/2019-03-24-12-12-27.bpo-36406.mCEkOl.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-24-12-12-27.bpo-36406.mCEkOl.rst
@@ -1,1 +1,1 @@
-Handle empty packages in :mod:`doctest`. Patch by Karthikeyan Singaravelan.
+Handle namespace packages in :mod:`doctest`. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
Handle namespace packages in doctest where `__file__` of empty package returns None

<!-- issue-number: [bpo-36406](https://bugs.python.org/issue36406) -->
https://bugs.python.org/issue36406
<!-- /issue-number -->
