### PR TITLE
bpo-35906: Fix CRLF injection in urllib

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1059,6 +1059,16 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splithost("//example.net/file#"),
                          ('example.net', '/file#'))
 
+        # bpo-35906: disallow line breaks
+        self.assertEqual(splithost('//127.0.0.1:1234/?q=HTTP/1.1\r\nHeader: Value'),
+	                     (None, '//127.0.0.1:1234/?q=HTTP/1.1\r\nHeader: Value'))
+
+        self.assertEqual(splithost('//127.0.0.1:1234?q=HTTP/1.1\r\nHeader: Value'),
+	                     (None, '//127.0.0.1:1234?q=HTTP/1.1\r\nHeader: Value'))
+
+        self.assertEqual(splithost('//127.0.0.1:1234#q=HTTP/1.1\r\nHeader: Value'),
+	                     (None, '//127.0.0.1:1234#q=HTTP/1.1\r\nHeader: Value'))
+
     def test_splituser(self):
         splituser = urllib.parse._splituser
         self.assertEqual(splituser('User:Pass@www.python.org:080'),

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1061,13 +1061,13 @@ class Utility_Tests(unittest.TestCase):
 
         # bpo-35906: disallow line breaks
         self.assertEqual(splithost('//127.0.0.1:1234/?q=HTTP/1.1\r\nHeader: Value'),
-	                     (None, '//127.0.0.1:1234/?q=HTTP/1.1\r\nHeader: Value'))
+                         (None, '//127.0.0.1:1234/?q=HTTP/1.1\r\nHeader: Value'))
 
         self.assertEqual(splithost('//127.0.0.1:1234?q=HTTP/1.1\r\nHeader: Value'),
-	                     (None, '//127.0.0.1:1234?q=HTTP/1.1\r\nHeader: Value'))
+                         (None, '//127.0.0.1:1234?q=HTTP/1.1\r\nHeader: Value'))
 
         self.assertEqual(splithost('//127.0.0.1:1234#q=HTTP/1.1\r\nHeader: Value'),
-	                     (None, '//127.0.0.1:1234#q=HTTP/1.1\r\nHeader: Value'))
+                         (None, '//127.0.0.1:1234#q=HTTP/1.1\r\nHeader: Value'))
 
     def test_splituser(self):
         splituser = urllib.parse._splituser

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -1016,7 +1016,7 @@ def _splithost(url):
     """splithost('//host[:port]/path') --> 'host[:port]', '/path'."""
     global _hostprog
     if _hostprog is None:
-        _hostprog = re.compile('//([^/#?]*)(.*)', re.DOTALL)
+        _hostprog = re.compile('//([^/#?]*)(.*)$')
 
     match = _hostprog.match(url)
     if match:

--- a/Misc/NEWS.d/next/Library/2019-03-24-14-36-23.bpo-35906.TU53mt.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-24-14-36-23.bpo-35906.TU53mt.rst
@@ -1,0 +1,1 @@
+Fix CRLF injection in urllib as disallowing line breaks in parse


### PR DESCRIPTION
Disallowing line break in URL parser.
Although I reported security issue a few months ago, it has not been fixed.
Please patch this vulnerability.

<!-- issue-number: [bpo-35906](https://bugs.python.org/issue35906) -->
https://bugs.python.org/issue35906
<!-- /issue-number -->
