### PR TITLE
bpo-36421: Fix a possible double decref in _ctypes.c's PyCArrayType_new()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-24-21-33-22.bpo-36421.gJ2Pv9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-24-21-33-22.bpo-36421.gJ2Pv9.rst
@@ -1,0 +1,1 @@
+Fix a possible double decref in _ctypes.c's ``PyCArrayType_new()``.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1522,6 +1522,7 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     stgdict->align = itemalign;
     stgdict->length = length;
     stgdict->proto = type_attr;
+    type_attr = NULL;
 
     stgdict->paramfunc = &PyCArrayType_paramfunc;
 


### PR DESCRIPTION
Set type_attr to NULL after the assignment to stgdict->proto (like
what is done with stgdict after the Py_SETREF() call) so that it is
not decrefed twice on error.


<!-- issue-number: [bpo-36421](https://bugs.python.org/issue36421) -->
https://bugs.python.org/issue36421
<!-- /issue-number -->
