### PR TITLE
bpo-36301: Cleanup preconfig code

### DIFF
--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -73,7 +73,12 @@ typedef struct {
        set to !Py_IgnoreEnvironmentFlag. */
     int use_environment;
 
-    int coerce_c_locale;    /* PYTHONCOERCECLOCALE, -1 means unknown */
+    /* PYTHONCOERCECLOCALE, -1 means unknown.
+
+       If it is equal to 1, LC_CTYPE locale is read to decide it it should be
+       coerced or not (ex: PYTHONCOERCECLOCALE=1). Internally, it is set to 2
+       if the LC_CTYPE locale must be coerced. */
+    int coerce_c_locale;
     int coerce_c_locale_warn; /* PYTHONCOERCECLOCALE=warn */
 
 #ifdef MS_WINDOWS

--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -25,12 +25,12 @@ typedef struct {
 /* Note: _PyPreCmdline_INIT sets other fields to 0/NULL */
 
 PyAPI_FUNC(void) _PyPreCmdline_Clear(_PyPreCmdline *cmdline);
-PyAPI_FUNC(_PyInitError) _PyPreCmdline_Init(_PyPreCmdline *cmdline,
+PyAPI_FUNC(_PyInitError) _PyPreCmdline_SetArgv(_PyPreCmdline *cmdline,
     const _PyArgv *args);
-PyAPI_FUNC(_PyInitError) _PyPreCmdline_Read(_PyPreCmdline *cmdline);
 PyAPI_FUNC(void) _PyPreCmdline_SetPreConfig(
     const _PyPreCmdline *cmdline,
     _PyPreConfig *config);
+PyAPI_FUNC(_PyInitError) _PyPreCmdline_Read(_PyPreCmdline *cmdline);
 
 
 /* --- _PyWstrList ------------------------------------------------ */
@@ -76,7 +76,8 @@ PyAPI_FUNC(const char*) _PyPreConfig_GetEnv(const _PyPreConfig *config,
 PyAPI_FUNC(void) _Py_get_env_flag(_PyPreConfig *config,
     int *flag,
     const char *name);
-PyAPI_FUNC(_PyInitError) _PyPreConfig_Read(_PyPreConfig *config);
+PyAPI_FUNC(_PyInitError) _PyPreConfig_Read(_PyPreConfig *config,
+    const _PyArgv *args);
 PyAPI_FUNC(int) _PyPreConfig_AsDict(const _PyPreConfig *config,
     PyObject *dict);
 PyAPI_FUNC(_PyInitError) _PyPreConfig_ReadFromArgv(_PyPreConfig *config,
@@ -103,12 +104,10 @@ PyAPI_FUNC(int) _PyCoreConfig_GetEnvDup(
     wchar_t **dest,
     wchar_t *wname,
     char *name);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config,
-    const _PyPreConfig *preconfig);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_ReadFromArgv(_PyCoreConfig *config,
-    const _PyArgv *args,
-    const _PyPreConfig *preconfig);
-PyAPI_FUNC(void) _PyCoreConfig_Write(const _PyCoreConfig *config);
+    const _PyArgv *args);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_Write(const _PyCoreConfig *config);
 
 #ifdef __cplusplus
 }

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -1501,7 +1501,12 @@ _PyCoreConfig_Write(const _PyCoreConfig *config)
     _PyCoreConfig_SetGlobalConfig(config);
     config_init_stdio(config);
 
-    if (_PyPreConfig_Copy(&_PyRuntime.preconfig, &config->preconfig) < 0) {
+    /* Write the new pre-configuration into _PyRuntime */
+    PyMemAllocatorEx old_alloc;
+    _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+    int res = _PyPreConfig_Copy(&_PyRuntime.preconfig, &config->preconfig);
+    PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+    if (res < 0) {
         return _Py_INIT_NO_MEMORY();
     }
 

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -1330,46 +1330,6 @@ config_init_fs_encoding(_PyCoreConfig *config)
 }
 
 
-static _PyInitError
-_PyCoreConfig_ReadPreConfig(_PyCoreConfig *config)
-{
-    _PyInitError err;
-    _PyPreConfig local_preconfig = _PyPreConfig_INIT;
-    _PyPreConfig_GetGlobalConfig(&local_preconfig);
-
-    if (_PyPreConfig_Copy(&local_preconfig, &config->preconfig) < 0) {
-        err = _Py_INIT_NO_MEMORY();
-        goto done;
-    }
-
-    err = _PyPreConfig_Read(&local_preconfig);
-    if (_Py_INIT_FAILED(err)) {
-        goto done;
-    }
-
-    if (_PyPreConfig_Copy(&config->preconfig, &local_preconfig) < 0) {
-        err = _Py_INIT_NO_MEMORY();
-        goto done;
-    }
-    err = _Py_INIT_OK();
-
-done:
-    _PyPreConfig_Clear(&local_preconfig);
-    return err;
-}
-
-
-static _PyInitError
-_PyCoreConfig_GetPreConfig(_PyCoreConfig *config)
-{
-    /* Read config written by _PyPreConfig_Write() */
-    if (_PyPreConfig_Copy(&config->preconfig, &_PyRuntime.preconfig) < 0) {
-        return _Py_INIT_NO_MEMORY();
-    }
-    return _Py_INIT_OK();
-}
-
-
 /* Read the configuration into _PyCoreConfig from:
 
    * Environment variables
@@ -1377,7 +1337,7 @@ _PyCoreConfig_GetPreConfig(_PyCoreConfig *config)
 
    See _PyCoreConfig_ReadFromArgv() to parse also command line arguments. */
 _PyInitError
-_PyCoreConfig_Read(_PyCoreConfig *config, const _PyPreConfig *preconfig)
+_PyCoreConfig_Read(_PyCoreConfig *config)
 {
     _PyInitError err;
 
@@ -1386,24 +1346,11 @@ _PyCoreConfig_Read(_PyCoreConfig *config, const _PyPreConfig *preconfig)
         return err;
     }
 
-    err = _PyCoreConfig_GetPreConfig(config);
-    if (_Py_INIT_FAILED(err)) {
-        return err;
+    if (_PyPreConfig_Copy(&config->preconfig, &_PyRuntime.preconfig) < 0) {
+        return _Py_INIT_NO_MEMORY();
     }
 
     _PyCoreConfig_GetGlobalConfig(config);
-
-    if (preconfig != NULL) {
-        if (_PyPreConfig_Copy(&config->preconfig, preconfig) < 0) {
-            return _Py_INIT_NO_MEMORY();
-        }
-    }
-    else {
-        err = _PyCoreConfig_ReadPreConfig(config);
-        if (_Py_INIT_FAILED(err)) {
-            return err;
-        }
-    }
 
     assert(config->preconfig.use_environment >= 0);
 
@@ -1548,11 +1495,17 @@ config_init_stdio(const _PyCoreConfig *config)
 
    - set Py_xxx global configuration variables
    - initialize C standard streams (stdin, stdout, stderr) */
-void
+_PyInitError
 _PyCoreConfig_Write(const _PyCoreConfig *config)
 {
     _PyCoreConfig_SetGlobalConfig(config);
     config_init_stdio(config);
+
+    if (_PyPreConfig_Copy(&_PyRuntime.preconfig, &config->preconfig) < 0) {
+        return _Py_INIT_NO_MEMORY();
+    }
+
+    return _Py_INIT_OK();
 }
 
 
@@ -2047,8 +2000,7 @@ config_usage(int error, const wchar_t* program)
 
 /* Parse command line options and environment variables. */
 static _PyInitError
-config_from_cmdline(_PyCoreConfig *config, _PyCmdline *cmdline,
-                    const _PyPreConfig *preconfig)
+config_from_cmdline(_PyCoreConfig *config, _PyCmdline *cmdline)
 {
     int need_usage = 0;
     _PyInitError err;
@@ -2067,7 +2019,7 @@ config_from_cmdline(_PyCoreConfig *config, _PyCmdline *cmdline,
         return err;
     }
 
-    _PyPreCmdline_SetPreConfig(&cmdline->precmdline, &config->preconfig);
+    _PyPreCmdline_SetPreConfig(&cmdline->precmdline, &_PyRuntime.preconfig);
     if (_PyWstrList_Extend(&config->xoptions, &cmdline->precmdline.xoptions) < 0) {
         return _Py_INIT_NO_MEMORY();
     }
@@ -2098,7 +2050,7 @@ config_from_cmdline(_PyCoreConfig *config, _PyCmdline *cmdline,
         return err;
     }
 
-    err = _PyCoreConfig_Read(config, preconfig);
+    err = _PyCoreConfig_Read(config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -2129,8 +2081,7 @@ config_from_cmdline(_PyCoreConfig *config, _PyCmdline *cmdline,
    * Environment variables
    * Py_xxx global configuration variables */
 _PyInitError
-_PyCoreConfig_ReadFromArgv(_PyCoreConfig *config, const _PyArgv *args,
-                           const _PyPreConfig *preconfig)
+_PyCoreConfig_ReadFromArgv(_PyCoreConfig *config, const _PyArgv *args)
 {
     _PyInitError err;
 
@@ -2141,12 +2092,12 @@ _PyCoreConfig_ReadFromArgv(_PyCoreConfig *config, const _PyArgv *args,
 
     _PyCmdline cmdline = {.precmdline = _PyPreCmdline_INIT};
 
-    err = _PyPreCmdline_Init(&cmdline.precmdline, args);
+    err = _PyPreCmdline_SetArgv(&cmdline.precmdline, args);
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }
 
-    err = config_from_cmdline(config, &cmdline, preconfig);
+    err = config_from_cmdline(config, &cmdline);
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -394,7 +394,7 @@ pathconfig_global_init(void)
     _PyInitError err;
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    err = _PyCoreConfig_Read(&config, NULL);
+    err = _PyCoreConfig_Read(&config);
     if (_Py_INIT_FAILED(err)) {
         goto error;
     }


### PR DESCRIPTION
Prepare code to move some _PyPreConfig parameters into _PyPreCmdline.
Changes:

* _PyCoreConfig_ReadFromArgv(): remove preconfig parameter,
  use _PyRuntime.preconfig.
* Add _PyPreCmdline_GetPreConfig(). _PyPreConfig_Read() now calls it.
* Rename _PyPreCmdline_Init() to _PyPreCmdline_SetArgv()
* Factorize _Py_PreInitializeFromPreConfig() code: add
  pyinit_preinit().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36301](https://bugs.python.org/issue36301) -->
https://bugs.python.org/issue36301
<!-- /issue-number -->
