### PR TITLE
bpo-36425: Add Simplified Chinese to the language switcher

### DIFF
--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -22,6 +22,7 @@
       'fr': 'French',
       'ja': 'Japanese',
       'ko': 'Korean',
+      'zh-cn': 'Simplified Chinese',
   };
 
   function build_version_select(current_version, current_release) {

--- a/Misc/NEWS.d/next/Documentation/2019-03-27-22-46-00.bpo-36425.kG9gx1.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-03-27-22-46-00.bpo-36425.kG9gx1.rst
@@ -1,0 +1,2 @@
+New documentation translation: `Simplified Chinese
+<https://docs.python.org/zh-cn/>`_.


### PR DESCRIPTION
[bpo-36425](https://bugs.python.org/issue36425): Add Simplified Chinese to the language switcher

<!-- issue-number: [bpo-36425](https://bugs.python.org/issue36425) -->
https://bugs.python.org/issue36425
<!-- /issue-number -->
