### PR TITLE
bpo-36427: Document that PyEval_RestoreThread and PyGILState_Ensure can terminate the calling thread

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -855,6 +855,12 @@ code, or when embedding the Python interpreter:
    created, the current thread must not have acquired it, otherwise deadlock
    ensues.
 
+   .. warning::
+      Calling this function from a thread when the interpreter is finalizing
+      will terminate the thread, even if the thread was not created by Python.
+      You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
+      check if the interpreter is in process of being finalized before calling
+      this function to avoid unwanted termination.
 
 .. c:function:: PyThreadState* PyThreadState_Get()
 
@@ -902,6 +908,12 @@ with sub-interpreters:
    When the function returns, the current thread will hold the GIL and be able
    to call arbitrary Python code.  Failure is a fatal error.
 
+   .. warning::
+      Calling this function from a thread when the interpreter is finalizing
+      will terminate the thread, even if the thread was not created by Python.
+      You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
+      check if the interpreter is in process of being finalized before calling
+      this function to avoid unwanted termination.
 
 .. c:function:: void PyGILState_Release(PyGILState_STATE)
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -855,8 +855,8 @@ code, or when embedding the Python interpreter:
    created, the current thread must not have acquired it, otherwise deadlock
    ensues.
 
-   .. warning::
-      Calling this function from a thread when the interpreter is finalizing
+   .. note::
+      Calling this function from a thread when the runtime is finalizing
       will terminate the thread, even if the thread was not created by Python.
       You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
       check if the interpreter is in process of being finalized before calling
@@ -908,8 +908,8 @@ with sub-interpreters:
    When the function returns, the current thread will hold the GIL and be able
    to call arbitrary Python code.  Failure is a fatal error.
 
-   .. warning::
-      Calling this function from a thread when the interpreter is finalizing
+   .. note::
+      Calling this function from a thread when the runtime is finalizing
       will terminate the thread, even if the thread was not created by Python.
       You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
       check if the interpreter is in process of being finalized before calling


### PR DESCRIPTION


<!-- issue-number: [bpo-36427](https://bugs.python.org/issue36427) -->
https://bugs.python.org/issue36427
<!-- /issue-number -->
