### PR TITLE
bpo-36301: Add _Py_GetEnv() function

### DIFF
--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -76,15 +76,17 @@ PyAPI_FUNC(int) _Py_str_to_int(
 PyAPI_FUNC(const wchar_t*) _Py_get_xoption(
     const _PyWstrList *xoptions,
     const wchar_t *name);
+PyAPI_FUNC(const char*) _Py_GetEnv(
+    int use_environment,
+    const char *name);
 
 PyAPI_FUNC(void) _PyPreConfig_Clear(_PyPreConfig *config);
 PyAPI_FUNC(int) _PyPreConfig_Copy(_PyPreConfig *config,
     const _PyPreConfig *config2);
 PyAPI_FUNC(void) _PyPreConfig_GetGlobalConfig(_PyPreConfig *config);
 PyAPI_FUNC(void) _PyPreConfig_SetGlobalConfig(const _PyPreConfig *config);
-PyAPI_FUNC(const char*) _PyPreConfig_GetEnv(const _PyPreConfig *config,
-    const char *name);
-PyAPI_FUNC(void) _Py_get_env_flag(_PyPreConfig *config,
+PyAPI_FUNC(void) _Py_get_env_flag(
+    int use_environment,
     int *flag,
     const char *name);
 PyAPI_FUNC(_PyInitError) _PyPreConfig_Read(_PyPreConfig *config,
@@ -107,14 +109,6 @@ PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetPathConfig(
     const _PyCoreConfig *config);
 PyAPI_FUNC(void) _PyCoreConfig_GetGlobalConfig(_PyCoreConfig *config);
 PyAPI_FUNC(void) _PyCoreConfig_SetGlobalConfig(const _PyCoreConfig *config);
-PyAPI_FUNC(const char*) _PyCoreConfig_GetEnv(
-    const _PyCoreConfig *config,
-    const char *name);
-PyAPI_FUNC(int) _PyCoreConfig_GetEnvDup(
-    const _PyCoreConfig *config,
-    wchar_t **dest,
-    wchar_t *wname,
-    char *name);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_ReadFromArgv(_PyCoreConfig *config,
     const _PyArgv *args);

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -655,7 +655,7 @@ pymain_run_file(_PyCoreConfig *config, PyCompilerFlags *cf)
 static void
 pymain_run_startup(_PyCoreConfig *config, PyCompilerFlags *cf)
 {
-    const char *startup = _PyCoreConfig_GetEnv(config, "PYTHONSTARTUP");
+    const char *startup = _Py_GetEnv(config->preconfig.use_environment, "PYTHONSTARTUP");
     if (startup == NULL) {
         return;
     }
@@ -735,7 +735,7 @@ pymain_repl(_PyCoreConfig *config, PyCompilerFlags *cf, int *exitcode)
 {
     /* Check this environment variable at the end, to give programs the
        opportunity to set it from Python. */
-    if (!Py_InspectFlag && _PyCoreConfig_GetEnv(config, "PYTHONINSPECT")) {
+    if (!Py_InspectFlag && _Py_GetEnv(config->preconfig.use_environment, "PYTHONINSPECT")) {
         Py_InspectFlag = 1;
         config->inspect = 1;
     }

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -610,14 +610,14 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
 }
 
 
-const char*
+static const char*
 _PyCoreConfig_GetEnv(const _PyCoreConfig *config, const char *name)
 {
-    return _PyPreConfig_GetEnv(&config->preconfig, name);
+    return _Py_GetEnv(config->preconfig.use_environment, name);
 }
 
 
-int
+static int
 _PyCoreConfig_GetEnvDup(const _PyCoreConfig *config,
                         wchar_t **dest,
                         wchar_t *wname, char *name)
@@ -924,34 +924,34 @@ config_wstr_to_int(const wchar_t *wstr, int *result)
 static _PyInitError
 config_read_env_vars(_PyCoreConfig *config)
 {
-    _PyPreConfig *preconfig = &config->preconfig;
+    int use_env = config->preconfig.use_environment;
 
     /* Get environment variables */
-    _Py_get_env_flag(preconfig, &config->parser_debug, "PYTHONDEBUG");
-    _Py_get_env_flag(preconfig, &config->verbose, "PYTHONVERBOSE");
-    _Py_get_env_flag(preconfig, &config->optimization_level, "PYTHONOPTIMIZE");
-    _Py_get_env_flag(preconfig, &config->inspect, "PYTHONINSPECT");
+    _Py_get_env_flag(use_env, &config->parser_debug, "PYTHONDEBUG");
+    _Py_get_env_flag(use_env, &config->verbose, "PYTHONVERBOSE");
+    _Py_get_env_flag(use_env, &config->optimization_level, "PYTHONOPTIMIZE");
+    _Py_get_env_flag(use_env, &config->inspect, "PYTHONINSPECT");
 
     int dont_write_bytecode = 0;
-    _Py_get_env_flag(preconfig, &dont_write_bytecode, "PYTHONDONTWRITEBYTECODE");
+    _Py_get_env_flag(use_env, &dont_write_bytecode, "PYTHONDONTWRITEBYTECODE");
     if (dont_write_bytecode) {
         config->write_bytecode = 0;
     }
 
     int no_user_site_directory = 0;
-    _Py_get_env_flag(preconfig, &no_user_site_directory, "PYTHONNOUSERSITE");
+    _Py_get_env_flag(use_env, &no_user_site_directory, "PYTHONNOUSERSITE");
     if (no_user_site_directory) {
         config->user_site_directory = 0;
     }
 
     int unbuffered_stdio = 0;
-    _Py_get_env_flag(preconfig, &unbuffered_stdio, "PYTHONUNBUFFERED");
+    _Py_get_env_flag(use_env, &unbuffered_stdio, "PYTHONUNBUFFERED");
     if (unbuffered_stdio) {
         config->buffered_stdio = 0;
     }
 
 #ifdef MS_WINDOWS
-    _Py_get_env_flag(preconfig, &config->legacy_windows_stdio,
+    _Py_get_env_flag(use_env, &config->legacy_windows_stdio,
                  "PYTHONLEGACYWINDOWSSTDIO");
 #endif
 

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -270,11 +270,11 @@ _PyPreConfig_SetGlobalConfig(const _PyPreConfig *config)
 
 
 const char*
-_PyPreConfig_GetEnv(const _PyPreConfig *config, const char *name)
+_Py_GetEnv(int use_environment, const char *name)
 {
-    assert(config->use_environment >= 0);
+    assert(use_environment >= 0);
 
-    if (!config->use_environment) {
+    if (!use_environment) {
         return NULL;
     }
 
@@ -285,6 +285,13 @@ _PyPreConfig_GetEnv(const _PyPreConfig *config, const char *name)
     else {
         return NULL;
     }
+}
+
+
+static const char*
+_PyPreConfig_GetEnv(const _PyPreConfig *config, const char *name)
+{
+    return _Py_GetEnv(config->use_environment, name);
 }
 
 
@@ -307,9 +314,9 @@ _Py_str_to_int(const char *str, int *result)
 
 
 void
-_Py_get_env_flag(_PyPreConfig *config, int *flag, const char *name)
+_Py_get_env_flag(int use_environment, int *flag, const char *name)
 {
-    const char *var = _PyPreConfig_GetEnv(config, name);
+    const char *var = _Py_GetEnv(use_environment, name);
     if (!var) {
         return;
     }
@@ -434,8 +441,9 @@ preconfig_read(_PyPreConfig *config, _PyPreCmdline *cmdline)
     /* legacy_windows_fs_encoding, utf8_mode, coerce_c_locale */
     if (config->use_environment) {
 #ifdef MS_WINDOWS
-        _Py_get_env_flag(config, &config->legacy_windows_fs_encoding,
-                "PYTHONLEGACYWINDOWSFSENCODING");
+        _Py_get_env_flag(config->use_environment,
+                         &config->legacy_windows_fs_encoding,
+                         "PYTHONLEGACYWINDOWSFSENCODING");
 #endif
 
         const char *env = _PyPreConfig_GetEnv(config, "PYTHONCOERCECLOCALE");


### PR DESCRIPTION
* Make _PyPreConfig_GetEnv(), _PyCoreConfig_GetEnv() and
  _PyCoreConfig_GetEnvDup() private
* _Py_get_env_flag() first parameter becomes "int use_environment"

<!-- issue-number: [bpo-36301](https://bugs.python.org/issue36301) -->
https://bugs.python.org/issue36301
<!-- /issue-number -->
