### PR TITLE
bpo-36430: Fix a possible reference leak in itertools.count()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-25-23-37-26.bpo-36430.sd9xxQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-25-23-37-26.bpo-36430.sd9xxQ.rst
@@ -1,0 +1,1 @@
+Fix a possible reference leak in :func:`itertools.count`.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -4089,6 +4089,7 @@ itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
     lz = (countobject *)type->tp_alloc(type, 0);
     if (lz == NULL) {
         Py_XDECREF(long_cnt);
+        Py_DECREF(long_step);
         return NULL;
     }
     lz->cnt = cnt;


### PR DESCRIPTION


<!-- issue-number: [bpo-36430](https://bugs.python.org/issue36430) -->
https://bugs.python.org/issue36430
<!-- /issue-number -->
