### PR TITLE
bpo-36433: fix confusing error messages in classmethoddescr_call

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1601,8 +1601,11 @@ order (MRO) for bases """
             spam_cm()
         with self.assertRaises(TypeError):
             spam_cm(spam.spamlist())
-        with self.assertRaises(TypeError):
+        with self.assertRaises(TypeError) as cm:
             spam_cm(list)
+        self.assertEqual(cm.exception.args[0],
+                         "descriptor 'classmeth' requires a subtype of "
+                         "'spamlist' but received 'list'")
 
     def test_staticmethods(self):
         # Testing static methods...

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1601,21 +1601,21 @@ order (MRO) for bases """
         with self.assertRaises(TypeError) as cm:
             spam_cm()
         self.assertEqual(
-            cm.exception.args[0],
+            str(cm.exception),
             "descriptor 'classmeth' of 'xxsubtype.spamlist' "
             "object needs an argument")
 
         with self.assertRaises(TypeError) as cm:
             spam_cm(spam.spamlist())
         self.assertEqual(
-            cm.exception.args[0],
-            "descriptor 'classmeth' requires a subtype of 'xxsubtype.spamlist' "
+            str(cm.exception),
+            "descriptor 'classmeth' requires a type "
             "but received a 'xxsubtype.spamlist' instance")
 
         with self.assertRaises(TypeError) as cm:
             spam_cm(list)
         self.assertEqual(
-            cm.exception.args[0],
+            str(cm.exception),
             "descriptor 'classmeth' requires a subtype of 'xxsubtype.spamlist' "
             "but received 'list'")
 

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1597,15 +1597,27 @@ order (MRO) for bases """
         self.assertEqual(x2, SubSpam)
         self.assertEqual(a2, a1)
         self.assertEqual(d2, d1)
-        with self.assertRaises(TypeError):
+
+        with self.assertRaises(TypeError) as cm:
             spam_cm()
-        with self.assertRaises(TypeError):
+        self.assertEqual(
+            cm.exception.args[0],
+            "descriptor 'classmeth' of 'xxsubtype.spamlist' "
+            "object needs an argument")
+
+        with self.assertRaises(TypeError) as cm:
             spam_cm(spam.spamlist())
+        self.assertEqual(
+            cm.exception.args[0],
+            "descriptor 'classmeth' requires a subtype of 'xxsubtype.spamlist' "
+            "but received a 'xxsubtype.spamlist' instance")
+
         with self.assertRaises(TypeError) as cm:
             spam_cm(list)
-        self.assertEqual(cm.exception.args[0],
-                         "descriptor 'classmeth' requires a subtype of "
-                         "'spamlist' but received 'list'")
+        self.assertEqual(
+            cm.exception.args[0],
+            "descriptor 'classmeth' requires a subtype of 'xxsubtype.spamlist' "
+            "but received 'list'")
 
     def test_staticmethods(self):
         # Testing static methods...

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-26-17-23-02.bpo-36433.-8XzZf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-26-17-23-02.bpo-36433.-8XzZf.rst
@@ -1,0 +1,1 @@
+Fixed TypeError message in classmethoddescr_call.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -314,8 +314,8 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
     self = PyTuple_GET_ITEM(args, 0);
     if (!PyType_Check(self)) {
         PyErr_Format(PyExc_TypeError,
-                     "descriptor '%V' requires a type "
-                     "but received a '%.100s'",
+                     "descriptor '%V' requires a subtype of '%.100s' "
+                     "but received a '%.100s' instance",
                      descr_name((PyDescrObject *)descr), "?",
                      PyDescr_TYPE(descr)->tp_name,
                      self->ob_type->tp_name);
@@ -323,8 +323,7 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
     }
     if (!PyType_IsSubtype((PyTypeObject *)self, PyDescr_TYPE(descr))) {
         PyErr_Format(PyExc_TypeError,
-                     "descriptor '%V' "
-                     "requires a subtype of '%.100s' "
+                     "descriptor '%V' requires a subtype of '%.100s' "
                      "but received '%.100s'",
                      descr_name((PyDescrObject *)descr), "?",
                      PyDescr_TYPE(descr)->tp_name,

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -314,10 +314,9 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
     self = PyTuple_GET_ITEM(args, 0);
     if (!PyType_Check(self)) {
         PyErr_Format(PyExc_TypeError,
-                     "descriptor '%V' requires a subtype of '%.100s' "
+                     "descriptor '%V' requires a type "
                      "but received a '%.100s' instance",
                      descr_name((PyDescrObject *)descr), "?",
-                     PyDescr_TYPE(descr)->tp_name,
                      self->ob_type->tp_name);
         return NULL;
     }

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -325,10 +325,10 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
         PyErr_Format(PyExc_TypeError,
                      "descriptor '%V' "
                      "requires a subtype of '%.100s' "
-                     "but received '%.100s",
+                     "but received '%.100s'",
                      descr_name((PyDescrObject *)descr), "?",
                      PyDescr_TYPE(descr)->tp_name,
-                     self->ob_type->tp_name);
+                     ((PyTypeObject*)self)->tp_name);
         return NULL;
     }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-36433](https://bugs.python.org/issue36433) -->
https://bugs.python.org/issue36433
<!-- /issue-number -->
