### PR TITLE
bpo-36301: Cleanup preconfig.c and coreconfig.c

### DIFF
--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -21,8 +21,8 @@ PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromConfig(
     const _PyCoreConfig *coreconfig);
 
 PyAPI_FUNC(_PyInitError) _Py_InitializeCore(
-    PyInterpreterState **interp,
-    const _PyCoreConfig *);
+    const _PyCoreConfig *config,
+    PyInterpreterState **interp);
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
 
 

--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -14,8 +14,8 @@ extern "C" {
 typedef struct {
     _PyWstrList argv;
     _PyWstrList xoptions;     /* "-X value" option */
-    int use_environment;      /* -E option */
     int isolated;             /* -I option */
+    int use_environment;      /* -E option */
     int dev_mode;             /* -X dev and PYTHONDEVMODE */
 } _PyPreCmdline;
 
@@ -27,23 +27,14 @@ typedef struct {
 /* Note: _PyPreCmdline_INIT sets other fields to 0/NULL */
 
 PyAPI_FUNC(void) _PyPreCmdline_Clear(_PyPreCmdline *cmdline);
-PyAPI_FUNC(int) _PyPreCmdline_Copy(_PyPreCmdline *cmdline,
-    const _PyPreCmdline *cmdline2);
 PyAPI_FUNC(_PyInitError) _PyPreCmdline_SetArgv(_PyPreCmdline *cmdline,
     const _PyArgv *args);
-PyAPI_FUNC(void) _PyPreCmdline_GetPreConfig(
-    _PyPreCmdline *cmdline,
-    const _PyPreConfig *config);
-PyAPI_FUNC(void) _PyPreCmdline_SetPreConfig(
-    const _PyPreCmdline *cmdline,
-    _PyPreConfig *config);
-PyAPI_FUNC(void) _PyPreCmdline_GetCoreConfig(
-    _PyPreCmdline *cmdline,
-    const _PyCoreConfig *config);
-PyAPI_FUNC(void) _PyPreCmdline_SetCoreConfig(
+PyAPI_FUNC(int) _PyPreCmdline_SetCoreConfig(
     const _PyPreCmdline *cmdline,
     _PyCoreConfig *config);
-PyAPI_FUNC(_PyInitError) _PyPreCmdline_Read(_PyPreCmdline *cmdline);
+PyAPI_FUNC(_PyInitError) _PyPreCmdline_Read(_PyPreCmdline *cmdline,
+    const _PyPreConfig *preconfig,
+    const _PyCoreConfig *coreconfig);
 
 
 /* --- _PyWstrList ------------------------------------------------ */
@@ -57,6 +48,8 @@ PyAPI_FUNC(int) _PyWstrList_Copy(_PyWstrList *list,
 PyAPI_FUNC(int) _PyWstrList_Append(_PyWstrList *list,
     const wchar_t *item);
 PyAPI_FUNC(PyObject*) _PyWstrList_AsList(const _PyWstrList *list);
+PyAPI_FUNC(int) _PyWstrList_Extend(_PyWstrList *list,
+    const _PyWstrList *list2);
 
 
 /* --- _PyArgv ---------------------------------------------------- */
@@ -70,7 +63,7 @@ PyAPI_FUNC(_PyInitError) _PyArgv_AsWstrList(const _PyArgv *args,
 PyAPI_FUNC(void) _Py_ClearArgcArgv(void);
 
 
-/* --- _PyPreConfig ----------------------------------------------- */
+/* --- Helper functions ------------------------------------------- */
 
 PyAPI_FUNC(int) _Py_str_to_int(
     const char *str,
@@ -81,22 +74,20 @@ PyAPI_FUNC(const wchar_t*) _Py_get_xoption(
 PyAPI_FUNC(const char*) _Py_GetEnv(
     int use_environment,
     const char *name);
-
-PyAPI_FUNC(void) _PyPreConfig_Clear(_PyPreConfig *config);
-PyAPI_FUNC(int) _PyPreConfig_Copy(_PyPreConfig *config,
-    const _PyPreConfig *config2);
-PyAPI_FUNC(void) _PyPreConfig_GetGlobalConfig(_PyPreConfig *config);
-PyAPI_FUNC(void) _PyPreConfig_SetGlobalConfig(const _PyPreConfig *config);
 PyAPI_FUNC(void) _Py_get_env_flag(
     int use_environment,
     int *flag,
     const char *name);
+
+/* --- _PyPreConfig ----------------------------------------------- */
+
+PyAPI_FUNC(void) _PyPreConfig_Clear(_PyPreConfig *config);
+PyAPI_FUNC(int) _PyPreConfig_Copy(_PyPreConfig *config,
+    const _PyPreConfig *config2);
+PyAPI_FUNC(PyObject*) _PyPreConfig_AsDict(const _PyPreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyPreConfig_Read(_PyPreConfig *config,
     const _PyArgv *args,
     const _PyCoreConfig *coreconfig);
-PyAPI_FUNC(PyObject*) _PyPreConfig_AsDict(const _PyPreConfig *config);
-PyAPI_FUNC(_PyInitError) _PyPreConfig_ReadFromArgv(_PyPreConfig *config,
-    const _PyArgv *args);
 PyAPI_FUNC(_PyInitError) _PyPreConfig_Write(_PyPreConfig *config);
 
 
@@ -109,10 +100,7 @@ PyAPI_FUNC(int) _PyCoreConfig_Copy(
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPathConfig(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetPathConfig(
     const _PyCoreConfig *config);
-PyAPI_FUNC(void) _PyCoreConfig_GetGlobalConfig(_PyCoreConfig *config);
-PyAPI_FUNC(void) _PyCoreConfig_SetGlobalConfig(const _PyCoreConfig *config);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_ReadFromArgv(_PyCoreConfig *config,
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config,
     const _PyArgv *args);
 PyAPI_FUNC(void) _PyCoreConfig_Write(const _PyCoreConfig *config);
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -302,7 +302,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'pycache_prefix': None,
         'program_name': './_testembed',
         'argv': [""],
-        'program': None,
+        'program': '',
 
         'xoptions': [],
         'warnoptions': [],
@@ -537,6 +537,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'program_name': './globalvar',
             'site_import': 0,
             'bytes_warning': 1,
+            'warnoptions': ['default::BytesWarning'],
             'inspect': 1,
             'interactive': 1,
             'optimization_level': 2,
@@ -579,7 +580,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'argv': ['-c', 'pass'],
             'program': 'conf_program',
             'xoptions': ['core_xoption1=3', 'core_xoption2=', 'core_xoption3'],
-            'warnoptions': ['default', 'error::ResourceWarning'],
+            'warnoptions': ['error::ResourceWarning', 'default::BytesWarning'],
 
             'site_import': 0,
             'bytes_warning': 1,
@@ -629,14 +630,16 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         preconfig = dict(self.INIT_ENV_PRECONFIG,
                       allocator='debug')
         config = dict(self.INIT_ENV_CONFIG,
-                      dev_mode=1)
+                      dev_mode=1,
+                      warnoptions=['default'])
         self.check_config("init_env_dev_mode", config, preconfig)
 
     def test_init_env_dev_mode_alloc(self):
         preconfig = dict(self.INIT_ENV_PRECONFIG,
                          allocator='malloc')
         config = dict(self.INIT_ENV_CONFIG,
-                      dev_mode=1)
+                      dev_mode=1,
+                      warnoptions=['default'])
         self.check_config("init_env_dev_mode_alloc", config, preconfig)
 
     def test_init_dev_mode(self):
@@ -646,14 +649,12 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         config = {
             'faulthandler': 1,
             'dev_mode': 1,
+            'warnoptions': ['default'],
         }
         self.check_config("init_dev_mode", config, preconfig)
 
     def test_init_isolated(self):
-        preconfig = {
-            'isolated': 0,
-            'use_environment': 1,
-        }
+        preconfig = {}
         config = {
             'isolated': 1,
             'use_environment': 0,

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -289,7 +289,7 @@ pymain_init_preconfig(const _PyArgv *args)
 
     _PyPreConfig config = _PyPreConfig_INIT;
 
-    err = _PyPreConfig_ReadFromArgv(&config, args);
+    err = _PyPreConfig_Read(&config, args, NULL);
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }
@@ -306,12 +306,12 @@ static _PyInitError
 pymain_init_coreconfig(_PyCoreConfig *config, const _PyArgv *args,
                        PyInterpreterState **interp_p)
 {
-    _PyInitError err = _PyCoreConfig_ReadFromArgv(config, args);
+    _PyInitError err = _PyCoreConfig_Read(config, args);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
 
-    return _Py_InitializeCore(interp_p, config);
+    return _Py_InitializeCore(config, interp_p);
 }
 
 
@@ -359,22 +359,18 @@ pymain_init(const _PyArgv *args, PyInterpreterState **interp_p)
     }
 
     _PyCoreConfig config = _PyCoreConfig_INIT;
-
     err = pymain_init_coreconfig(&config, args, interp_p);
+    _PyCoreConfig_Clear(&config);
     if (_Py_INIT_FAILED(err)) {
-        goto done;
+        return err;
     }
 
     err = pymain_init_python_main(*interp_p);
     if (_Py_INIT_FAILED(err)) {
-        goto done;
+        return err;
     }
 
-    err = _Py_INIT_OK();
-
-done:
-    _PyCoreConfig_Clear(&config);
-    return err;
+    return _Py_INIT_OK();
 }
 
 

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -466,8 +466,7 @@ static int test_init_from_config(void)
     config.xoptions.length = Py_ARRAY_LENGTH(xoptions);
     config.xoptions.items = xoptions;
 
-    static wchar_t* warnoptions[2] = {
-        L"default",
+    static wchar_t* warnoptions[1] = {
         L"error::ResourceWarning",
     };
     config.warnoptions.length = Py_ARRAY_LENGTH(warnoptions);

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -394,7 +394,7 @@ pathconfig_global_init(void)
     _PyInitError err;
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    err = _PyCoreConfig_Read(&config);
+    err = _PyCoreConfig_Read(&config, NULL);
     if (_Py_INIT_FAILED(err)) {
         goto error;
     }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -482,7 +482,7 @@ _Py_Initialize_ReconfigureCore(PyInterpreterState **interp_p,
     }
     *interp_p = interp;
 
-    _PyCoreConfig_SetGlobalConfig(core_config);
+    _PyCoreConfig_Write(core_config);
 
     if (_PyCoreConfig_Copy(&interp->core_config, core_config) < 0) {
         return _Py_INIT_ERR("failed to copy core config");
@@ -506,7 +506,7 @@ pycore_init_runtime(const _PyCoreConfig *core_config)
         return _Py_INIT_ERR("main interpreter already initialized");
     }
 
-    _PyCoreConfig_SetGlobalConfig(core_config);
+    _PyCoreConfig_Write(core_config);
 
     _PyInitError err = _PyRuntime_Initialize();
     if (_Py_INIT_FAILED(err)) {
@@ -801,7 +801,7 @@ pyinit_coreconfig(_PyCoreConfig *config, const _PyCoreConfig *src_config,
         return _Py_INIT_ERR("failed to copy core config");
     }
 
-    _PyInitError err = _PyCoreConfig_Read(config);
+    _PyInitError err = _PyCoreConfig_Read(config, NULL);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -833,14 +833,12 @@ pyinit_coreconfig(_PyCoreConfig *config, const _PyCoreConfig *src_config,
  * safe to call without calling Py_Initialize first)
  */
 _PyInitError
-_Py_InitializeCore(PyInterpreterState **interp_p,
-                   const _PyCoreConfig *src_config)
+_Py_InitializeCore(const _PyCoreConfig *src_config,
+                   PyInterpreterState **interp_p)
 {
-    _PyInitError err;
-
     assert(src_config != NULL);
 
-    err = _Py_PreInitializeFromConfig(src_config);
+    _PyInitError err = _Py_PreInitializeFromConfig(src_config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -987,7 +985,7 @@ _Py_InitializeFromConfig(const _PyCoreConfig *config)
 {
     PyInterpreterState *interp = NULL;
     _PyInitError err;
-    err = _Py_InitializeCore(&interp, config);
+    err = _Py_InitializeCore(config, &interp);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }


### PR DESCRIPTION
* _PyCoreConfig_Write() now updates _PyRuntime.preconfig
* Remove _PyPreCmdline_Copy()
* _PyPreCmdline_Read() now accepts _PyPreConfig and _PyCoreConfig
  optional configurations.
* Rename _PyPreConfig_ReadFromArgv() to _PyPreConfig_Read(). Simplify
  the code.
* Calling _PyCoreConfig_Read() no longer adds the warning options
  twice: don't add a warning option if it's already in the list.
* Rename _PyCoreConfig_ReadFromArgv() to _PyCoreConfig_Read().
* Rename config_from_cmdline() to _PyCoreConfig_ReadFromArgv().
* Add more assertions on _PyCoreConfig in _PyCoreConfig_Read().
* Move some functions.
* Make some config functions private.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36301](https://bugs.python.org/issue36301) -->
https://bugs.python.org/issue36301
<!-- /issue-number -->
