### PR TITLE
bpo-36441: Fixes creating a venv when debug binaries are installed.

### DIFF
--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -195,6 +195,9 @@ class EnvBuilder:
                     src = os.path.join(os.path.dirname(src), basename + ext)
                 else:
                     src = srcfn
+                if not os.path.exists(src):
+                    logger.warning('Unable to copy %r', src)
+                    return
 
             shutil.copyfile(src, dst)
 

--- a/Misc/NEWS.d/next/Windows/2019-03-26-11-46-15.bpo-36441.lYjGF1.rst
+++ b/Misc/NEWS.d/next/Windows/2019-03-26-11-46-15.bpo-36441.lYjGF1.rst
@@ -1,0 +1,1 @@
+Fixes creating a venv when debug binaries are installed.

--- a/Tools/msi/lib/lib_files.wxs
+++ b/Tools/msi/lib/lib_files.wxs
@@ -69,6 +69,15 @@
     </Fragment>
     
     <Fragment>
+        <!-- The auto-generated directory is not available when building debug binaries -->
+        <DirectoryRef Id="Lib">
+            <Directory Id="Lib_venv__d" Name="venv">
+                <Directory Id="Lib_venv_scripts__d" Name="scripts">
+                    <Directory Id="Lib_venv_scripts_nt__d" Name="nt" />
+                </Directory>
+            </Directory>
+        </DirectoryRef>
+
         <ComponentGroup Id="lib_extensions_d">
             <?foreach ext in $(var.exts)?>
             
@@ -86,6 +95,12 @@
             </Component>
             <Component Id="sqlite3_d.pdb" Directory="DLLs" Guid="*">
                 <File Name="sqlite3_d.pdb" KeyPath="yes" />
+            </Component>
+            <Component Id="venvlauncher_d.exe" Directory="Lib_venv_scripts_nt__d" Guid="*">
+                <File Name="python_d.exe" Source="venvlauncher_d.exe" KeyPath="yes" />
+            </Component>
+            <Component Id="venvwlauncher_d.exe" Directory="Lib_venv_scripts_nt__d" Guid="*">
+                <File Name="pythonw_d.exe" Source="venvwlauncher_d.exe" KeyPath="yes" />
             </Component>
         </ComponentGroup>
     </Fragment>


### PR DESCRIPTION


<!-- issue-number: [bpo-36441](https://bugs.python.org/issue36441) -->
https://bugs.python.org/issue36441
<!-- /issue-number -->
