### PR TITLE
bpo-36444: Rework _Py_InitializeFromConfig() API

### DIFF
--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -5,16 +5,6 @@
 extern "C" {
 #endif
 
-/* --- _PyArgv ---------------------------------------------------- */
-
-typedef struct {
-    int argc;
-    int use_bytes_argv;
-    char **bytes_argv;
-    wchar_t **wchar_argv;
-} _PyArgv;
-
-
 /* --- _PyInitError ----------------------------------------------- */
 
 typedef struct {

--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -14,23 +14,33 @@ PyAPI_FUNC(int) Py_SetStandardStreamEncoding(const char *encoding,
 
 /* PEP 432 Multi-phase initialization API (Private while provisional!) */
 
-PyAPI_FUNC(_PyInitError) _Py_PreInitialize(void);
-PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromPreConfig(
-    const _PyPreConfig *preconfig);
-PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromConfig(
-    const _PyCoreConfig *coreconfig);
+PyAPI_FUNC(_PyInitError) _Py_PreInitialize(
+    const _PyPreConfig *src_config);
+PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromArgs(
+    const _PyPreConfig *src_config,
+    int argc,
+    char **argv);
+PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromWideArgs(
+    const _PyPreConfig *src_config,
+    int argc,
+    wchar_t **argv);
 
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
 
 
-PyAPI_FUNC(_PyInitError) _Py_InitializeMainInterpreter(
-    PyInterpreterState *interp);
-
 /* Initialization and finalization */
 
 PyAPI_FUNC(_PyInitError) _Py_InitializeFromConfig(
+    const _PyCoreConfig *config);
+PyAPI_FUNC(_PyInitError) _Py_InitializeFromArgs(
     const _PyCoreConfig *config,
-    PyInterpreterState **interp_p);
+    int argc,
+    char **argv);
+PyAPI_FUNC(_PyInitError) _Py_InitializeFromWideArgs(
+    const _PyCoreConfig *config,
+    int argc,
+    wchar_t **argv);
+
 PyAPI_FUNC(void) _Py_NO_RETURN _Py_ExitInitError(_PyInitError err);
 
 /* Py_PyAtExit is for the atexit module, Py_AtExit is for low-level

--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -9,6 +9,54 @@ extern "C" {
 #endif
 
 
+/* --- _PyWstrList ------------------------------------------------ */
+
+#ifndef NDEBUG
+PyAPI_FUNC(int) _PyWstrList_CheckConsistency(const _PyWstrList *list);
+#endif
+PyAPI_FUNC(void) _PyWstrList_Clear(_PyWstrList *list);
+PyAPI_FUNC(int) _PyWstrList_Copy(_PyWstrList *list,
+    const _PyWstrList *list2);
+PyAPI_FUNC(int) _PyWstrList_Append(_PyWstrList *list,
+    const wchar_t *item);
+PyAPI_FUNC(PyObject*) _PyWstrList_AsList(const _PyWstrList *list);
+PyAPI_FUNC(int) _PyWstrList_Extend(_PyWstrList *list,
+    const _PyWstrList *list2);
+
+
+/* --- _PyArgv ---------------------------------------------------- */
+
+typedef struct {
+    int argc;
+    int use_bytes_argv;
+    char **bytes_argv;
+    wchar_t **wchar_argv;
+} _PyArgv;
+
+PyAPI_FUNC(_PyInitError) _PyArgv_AsWstrList(const _PyArgv *args,
+    _PyWstrList *list);
+
+
+/* --- Helper functions ------------------------------------------- */
+
+PyAPI_FUNC(int) _Py_str_to_int(
+    const char *str,
+    int *result);
+PyAPI_FUNC(const wchar_t*) _Py_get_xoption(
+    const _PyWstrList *xoptions,
+    const wchar_t *name);
+PyAPI_FUNC(const char*) _Py_GetEnv(
+    int use_environment,
+    const char *name);
+PyAPI_FUNC(void) _Py_get_env_flag(
+    int use_environment,
+    int *flag,
+    const char *name);
+
+/* Py_GetArgcArgv() helper */
+PyAPI_FUNC(void) _Py_ClearArgcArgv(void);
+
+
 /* --- _PyPreCmdline ------------------------------------------------- */
 
 typedef struct {
@@ -33,51 +81,8 @@ PyAPI_FUNC(int) _PyPreCmdline_SetCoreConfig(
     const _PyPreCmdline *cmdline,
     _PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyPreCmdline_Read(_PyPreCmdline *cmdline,
-    const _PyPreConfig *preconfig,
-    const _PyCoreConfig *coreconfig);
+    const _PyPreConfig *preconfig);
 
-
-/* --- _PyWstrList ------------------------------------------------ */
-
-#ifndef NDEBUG
-PyAPI_FUNC(int) _PyWstrList_CheckConsistency(const _PyWstrList *list);
-#endif
-PyAPI_FUNC(void) _PyWstrList_Clear(_PyWstrList *list);
-PyAPI_FUNC(int) _PyWstrList_Copy(_PyWstrList *list,
-    const _PyWstrList *list2);
-PyAPI_FUNC(int) _PyWstrList_Append(_PyWstrList *list,
-    const wchar_t *item);
-PyAPI_FUNC(PyObject*) _PyWstrList_AsList(const _PyWstrList *list);
-PyAPI_FUNC(int) _PyWstrList_Extend(_PyWstrList *list,
-    const _PyWstrList *list2);
-
-
-/* --- _PyArgv ---------------------------------------------------- */
-
-PyAPI_FUNC(_PyInitError) _PyArgv_AsWstrList(const _PyArgv *args,
-    _PyWstrList *list);
-
-
-/* --- Py_GetArgcArgv() helpers ----------------------------------- */
-
-PyAPI_FUNC(void) _Py_ClearArgcArgv(void);
-
-
-/* --- Helper functions ------------------------------------------- */
-
-PyAPI_FUNC(int) _Py_str_to_int(
-    const char *str,
-    int *result);
-PyAPI_FUNC(const wchar_t*) _Py_get_xoption(
-    const _PyWstrList *xoptions,
-    const wchar_t *name);
-PyAPI_FUNC(const char*) _Py_GetEnv(
-    int use_environment,
-    const char *name);
-PyAPI_FUNC(void) _Py_get_env_flag(
-    int use_environment,
-    int *flag,
-    const char *name);
 
 /* --- _PyPreConfig ----------------------------------------------- */
 
@@ -85,9 +90,10 @@ PyAPI_FUNC(void) _PyPreConfig_Clear(_PyPreConfig *config);
 PyAPI_FUNC(int) _PyPreConfig_Copy(_PyPreConfig *config,
     const _PyPreConfig *config2);
 PyAPI_FUNC(PyObject*) _PyPreConfig_AsDict(const _PyPreConfig *config);
+PyAPI_FUNC(void) _PyCoreConfig_GetCoreConfig(_PyPreConfig *config,
+    const _PyCoreConfig *core_config);
 PyAPI_FUNC(_PyInitError) _PyPreConfig_Read(_PyPreConfig *config,
-    const _PyArgv *args,
-    const _PyCoreConfig *coreconfig);
+    const _PyArgv *args);
 PyAPI_FUNC(_PyInitError) _PyPreConfig_Write(_PyPreConfig *config);
 
 

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -77,8 +77,8 @@ extern void _PyGILState_Fini(void);
 
 PyAPI_FUNC(void) _PyGC_DumpShutdownStats(void);
 
-PyAPI_FUNC(_PyInitError) _Py_PreInitializeInPlace(
-    _PyPreConfig *config);
+PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromCoreConfig(
+    const _PyCoreConfig *coreconfig);
 
 #ifdef __cplusplus
 }

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -86,7 +86,7 @@ main(int argc, char *argv[])
     config._frozen = 1;
     config._init_main = 0;
 
-    _PyInitError err = _Py_InitializeFromConfig(&config, NULL);
+    _PyInitError err = _Py_InitializeFromConfig(&config);
     /* No need to call _PyCoreConfig_Clear() since we didn't allocate any
        memory: program_name is a constant string. */
     if (_Py_INIT_FAILED(err)) {

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -408,7 +408,7 @@ static int test_init_from_config(void)
     Py_UTF8Mode = 0;
     preconfig.utf8_mode = 1;
 
-    err = _Py_PreInitializeFromPreConfig(&preconfig);
+    err = _Py_PreInitialize(&preconfig);
     if (_Py_INIT_FAILED(err)) {
         _Py_ExitInitError(err);
     }
@@ -529,7 +529,7 @@ static int test_init_from_config(void)
     Py_FrozenFlag = 0;
     config._frozen = 1;
 
-    err = _Py_InitializeFromConfig(&config, NULL);
+    err = _Py_InitializeFromConfig(&config);
     /* Don't call _PyCoreConfig_Clear() since all strings are static */
     if (_Py_INIT_FAILED(err)) {
         _Py_ExitInitError(err);
@@ -623,7 +623,7 @@ static int test_init_isolated(void)
     preconfig.coerce_c_locale = 0;
     preconfig.utf8_mode = 0;
 
-    err = _Py_PreInitializeFromPreConfig(&preconfig);
+    err = _Py_PreInitialize(&preconfig);
     if (_Py_INIT_FAILED(err)) {
         _Py_ExitInitError(err);
     }
@@ -638,7 +638,7 @@ static int test_init_isolated(void)
     config.program_name = L"./_testembed";
 
     test_init_env_dev_mode_putenvs();
-    err = _Py_InitializeFromConfig(&config, NULL);
+    err = _Py_InitializeFromConfig(&config);
     if (_Py_INIT_FAILED(err)) {
         _Py_ExitInitError(err);
     }
@@ -660,7 +660,7 @@ static int test_preinit_isolated1(void)
     preconfig.utf8_mode = 0;
     preconfig.isolated = 1;
 
-    err = _Py_PreInitializeFromPreConfig(&preconfig);
+    err = _Py_PreInitialize(&preconfig);
     if (_Py_INIT_FAILED(err)) {
         _Py_ExitInitError(err);
     }
@@ -669,7 +669,7 @@ static int test_preinit_isolated1(void)
     config.program_name = L"./_testembed";
 
     test_init_env_dev_mode_putenvs();
-    err = _Py_InitializeFromConfig(&config, NULL);
+    err = _Py_InitializeFromConfig(&config);
     if (_Py_INIT_FAILED(err)) {
         _Py_ExitInitError(err);
     }
@@ -691,7 +691,7 @@ static int test_preinit_isolated2(void)
     preconfig.utf8_mode = 0;
     preconfig.isolated = 0;
 
-    err = _Py_PreInitializeFromPreConfig(&preconfig);
+    err = _Py_PreInitialize(&preconfig);
     if (_Py_INIT_FAILED(err)) {
         _Py_ExitInitError(err);
     }
@@ -706,7 +706,7 @@ static int test_preinit_isolated2(void)
     config.program_name = L"./_testembed";
 
     test_init_env_dev_mode_putenvs();
-    err = _Py_InitializeFromConfig(&config, NULL);
+    err = _Py_InitializeFromConfig(&config);
     if (_Py_INIT_FAILED(err)) {
         _Py_ExitInitError(err);
     }
@@ -723,7 +723,7 @@ static int test_init_dev_mode(void)
     putenv("PYTHONMALLOC=");
     config.dev_mode = 1;
     config.program_name = L"./_testembed";
-    _PyInitError err = _Py_InitializeFromConfig(&config, NULL);
+    _PyInitError err = _Py_InitializeFromConfig(&config);
     if (_Py_INIT_FAILED(err)) {
         _Py_ExitInitError(err);
     }

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -82,7 +82,7 @@ Py_FrozenMain(int argc, char **argv)
     if (argc >= 1)
         Py_SetProgramName(argv_copy[0]);
 
-    err = _Py_InitializeFromConfig(&config, NULL);
+    err = _Py_InitializeFromConfig(&config);
     /* No need to call _PyCoreConfig_Clear() since we didn't allocate any
        memory: program_name is a constant string. */
     if (_Py_INIT_FAILED(err)) {


### PR DESCRIPTION
* _Py_PreInitialize() gets optional 'preconfig' and 'args'
  parameters. Remove _Py_PreInitializeFromPreConfig().
* Add "_PyArgv args" parameter to _Py_InitializeFromConfig().
* Remove coreconfig parameter of _PyPreCmdline_Read()
* Make _Py_InitializeMainInterpreter() private
* Rename _Py_PreInitializeFromConfig() to
  _Py_PreInitializeFromCoreConfig() and make it internal.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36444](https://bugs.python.org/issue36444) -->
https://bugs.python.org/issue36444
<!-- /issue-number -->
