### PR TITLE
bpo-36384: Remove check for leading zeroes in IPv4 addresses

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1165,12 +1165,6 @@ class _BaseV4:
             raise ValueError(msg % octet_str)
         # Convert to integer (we know digits are legal)
         octet_int = int(octet_str, 10)
-        # Any octets that look like they *might* be written in octal,
-        # and which don't look exactly the same in both octal and
-        # decimal are rejected as ambiguous
-        if octet_int > 7 and octet_str[0] == '0':
-            msg = "Ambiguous (octal/decimal) value in %r not permitted"
-            raise ValueError(msg % octet_str)
         if octet_int > 255:
             raise ValueError("Octet %d (> 255) not permitted" % octet_int)
         return octet_int

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -92,11 +92,14 @@ class CommonTestMixin:
                 y = pickle.loads(pickle.dumps(x, proto))
                 self.assertEqual(y, x)
 
+
 class CommonTestMixin_v4(CommonTestMixin):
 
     def test_leading_zeros(self):
         self.assertInstancesEqual("000.000.000.000", "0.0.0.0")
         self.assertInstancesEqual("192.168.000.001", "192.168.0.1")
+        self.assertInstancesEqual("016.016.016.016", "16.16.16.16")
+        self.assertInstancesEqual("001.000.008.016", "1.0.8.16")
 
     def test_int(self):
         self.assertInstancesEqual(0, "0.0.0.0")
@@ -228,15 +231,6 @@ class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
         assertBadOctet("1.2.3.4e0", "4e0")
         assertBadOctet("1.2.3.4::", "4::")
         assertBadOctet("1.a.2.3", "a")
-
-    def test_octal_decimal_ambiguity(self):
-        def assertBadOctet(addr, octet):
-            msg = "Ambiguous (octal/decimal) value in %r not permitted in %r"
-            with self.assertAddressError(re.escape(msg % (octet, addr))):
-                ipaddress.IPv4Address(addr)
-
-        assertBadOctet("016.016.016.016", "016")
-        assertBadOctet("001.000.008.016", "008")
 
     def test_octet_length(self):
         def assertBadOctet(addr, octet):

--- a/Misc/NEWS.d/next/Library/2019-03-27-02-09-22.bpo-36385.we2F45.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-27-02-09-22.bpo-36385.we2F45.rst
@@ -1,0 +1,1 @@
+Stop rejecting IPv4 octets for leading zeroes.

--- a/Misc/NEWS.d/next/Library/2019-03-27-02-09-22.bpo-36385.we2F45.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-27-02-09-22.bpo-36385.we2F45.rst
@@ -1,1 +1,1 @@
-Stop rejecting IPv4 octets for leading zeroes.
+Stop rejecting IPv4 octets for being ambiguously octal. Leading zeros are ignored, and no longer are assumed to specify octal octets. Octets are always decimal numbers. Octets must still be no more than three digits, including leading zeroes.


### PR DESCRIPTION
Stop rejecting IPv4 octets with leading zeroes as ambiguously octal.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36384](https://bugs.python.org/issue36384) -->
https://bugs.python.org/issue36384
<!-- /issue-number -->
