### PR TITLE
bpo-36447: Fix refleak in sysmodule.c when calling SET_SYS_FROM_STRING_BORROW

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2635,6 +2635,7 @@ _PySys_InitMain(PyInterpreterState *interp)
         return -1;
     }
     SET_SYS_FROM_STRING_BORROW("_xoptions", xoptions);
+    Py_DECREF(xoptions);
 
 #undef COPY_LIST
 #undef SET_SYS_FROM_WSTR


### PR DESCRIPTION
`SET_SYS_FROM_STRING_BORROW` calls `PyDict_SetItemString` and that increases the refcount of the `xoptions` dict.

<!-- issue-number: [bpo-36447](https://bugs.python.org/issue36447) -->
https://bugs.python.org/issue36447
<!-- /issue-number -->
