### PR TITLE
bpo-31341: cleanup IRIX-specific macros sgi and __sgi

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -12,10 +12,6 @@
 #include "pyconfig.h"
 #include "pymacconfig.h"
 
-#if defined(__sgi) && !defined(_SGI_MP_SOURCE)
-#  define _SGI_MP_SOURCE
-#endif
-
 // stdlib.h, stdio.h, errno.h and string.h headers are not used by Python
 // headers, but kept for backward compatibility. They are excluded from the
 // limited C API of Python 3.11.

--- a/Misc/NEWS.d/next/Build/2019-03-27-22-51-32.bpo-31341.vVaJ0N.rst
+++ b/Misc/NEWS.d/next/Build/2019-03-27-22-51-32.bpo-31341.vVaJ0N.rst
@@ -1,0 +1,1 @@
+Cleanup IRIX-specific macros sgi and __sgi.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -117,7 +117,7 @@ static const char PyCursesVersion[] = "2.2";
 #define CURSES_MODULE
 #include "py_curses.h"
 
-#if defined(HAVE_TERM_H) || defined(__sgi)
+#ifdef HAVE_TERM_H
 /* For termname, longname, putp, tigetflag, tigetnum, tigetstr, tparm
    which are not declared in SysV curses and for setupterm. */
 #include <term.h>
@@ -130,7 +130,7 @@ static const char PyCursesVersion[] = "2.2";
 #include <langinfo.h>
 #endif
 
-#if !defined(HAVE_NCURSES_H) && (defined(sgi) || defined(__sun) || defined(SCO5))
+#if !defined(HAVE_NCURSES_H) && (defined(__sun) || defined(SCO5))
 #define STRICT_SYSV_CURSES       /* Don't use ncurses extensions */
 typedef chtype attr_t;           /* No attr_t type is available */
 #endif

--- a/Modules/nismodule.c
+++ b/Modules/nismodule.c
@@ -19,11 +19,6 @@
 #include <rpcsvc/yp_prot.h>
 #include <rpcsvc/ypclnt.h>
 
-#ifdef __sgi
-/* This is missing from rpcsvc/ypclnt.h */
-extern int yp_get_default_domain(char **);
-#endif
-
 PyDoc_STRVAR(get_default_domain__doc__,
 "get_default_domain() -> str\n\
 Corresponds to the C library yp_get_default_domain() call, returning\n\

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -351,16 +351,6 @@ module os
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=94a0f0f978acae17]*/
 
-#ifndef _MSC_VER
-
-#if defined(__sgi)&&_COMPILER_VERSION>=700
-/* declare ctermid_r if compiling with MIPSPro 7.x in ANSI C mode
-   (default) */
-extern char        *ctermid_r(char *);
-#endif
-
-#endif /* !_MSC_VER */
-
 #if defined(__VXWORKS__)
 #  include <vxCpuLib.h>
 #  include <rtpLib.h>

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -42,11 +42,6 @@
 #include <sys/poll.h>
 #endif
 
-#ifdef __sgi
-/* This is missing from unistd.h */
-extern void bzero(void *, int);
-#endif
-
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -181,7 +181,7 @@ shutdown(how) -- shut down traffic in one or both directions\n\
 #ifdef HAVE_GETHOSTBYNAME_R
 # if defined(_AIX) && !defined(_LINUX_SOURCE_COMPAT)
 #  define HAVE_GETHOSTBYNAME_R_3_ARG
-# elif defined(__sun) || defined(__sgi)
+# elif defined(__sun)
 #  define HAVE_GETHOSTBYNAME_R_5_ARG
 # elif defined(__linux__)
 /* Rely on the configure script */
@@ -198,30 +198,6 @@ shutdown(how) -- shut down traffic in one or both directions\n\
 
 #if defined(__APPLE__) || defined(__CYGWIN__) || defined(__NetBSD__)
 #  include <sys/ioctl.h>
-#endif
-
-
-#if defined(__sgi) && _COMPILER_VERSION>700 && !_SGIAPI
-/* make sure that the reentrant (gethostbyaddr_r etc)
-   functions are declared correctly if compiling with
-   MIPSPro 7.x in ANSI C mode (default) */
-
-/* XXX Using _SGIAPI is the wrong thing,
-   but I don't know what the right thing is. */
-#undef _SGIAPI /* to avoid warning */
-#define _SGIAPI 1
-
-#undef _XOPEN_SOURCE
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <netinet/in.h>
-#ifdef _SS_ALIGNSIZE
-#define HAVE_GETADDRINFO 1
-#define HAVE_GETNAMEINFO 1
-#endif
-
-#define HAVE_INET_PTON
-#include <netdb.h>
 #endif
 
 /* Solaris fails to define this variable at all. */
@@ -382,12 +358,7 @@ remove_unusable_flags(PyObject *m)
 #endif
 
 /* include Python's addrinfo.h unless it causes trouble */
-#if defined(__sgi) && _COMPILER_VERSION>700 && defined(_SS_ALIGNSIZE)
-  /* Do not include addinfo.h on some newer IRIX versions.
-   * _SS_ALIGNSIZE is defined in sys/socket.h by 6.5.21,
-   * for example, but not by 6.5.10.
-   */
-#elif defined(_MSC_VER) && _MSC_VER>1201
+#if defined(_MSC_VER) && _MSC_VER>1201
   /* Do not include addrinfo.h for MSVC7 or greater. 'addrinfo' and
    * EAI_* constants are defined in (the already included) ws2tcpip.h.
    */

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -2,12 +2,6 @@
 
 #include "Python.h"
 
-/* Apparently, on SGI, termios.h won't define CTRL if _XOPEN_SOURCE
-   is defined, so we define it here. */
-#if defined(__sgi)
-#define CTRL(c) ((c)&037)
-#endif
-
 #if defined(__sun)
 /* We could do better. Check issue-32660 */
 #include <sys/filio.h>

--- a/Python/mystrtoul.c
+++ b/Python/mystrtoul.c
@@ -1,10 +1,6 @@
 #include "Python.h"
 #include "pycore_long.h"          // _PyLong_DigitValue
 
-#if defined(__sgi) && !defined(_SGI_MP_SOURCE)
-#define _SGI_MP_SOURCE
-#endif
-
 /* strtol and strtoul, renamed to avoid conflicts */
 
 


### PR DESCRIPTION
To make work on curses-related modules simpler https://bugs.python.org/issue28190

<!-- issue-number: [bpo-31341](https://bugs.python.org/issue31341) -->
https://bugs.python.org/issue31341
<!-- /issue-number -->
