### PR TITLE
bpo-35900: Add a state_setter arg to save_reduce

### DIFF
--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -629,7 +629,7 @@ or both.
      value``.  This is primarily used for dictionary subclasses, but may be used
      by other classes as long as they implement :meth:`__setitem__`.
 
-   * Optionally, an callable with a ``(obj, state)`` signature. This
+   * Optionally, a callable with a ``(obj, state)`` signature. This
      callable allows the user to programatically control the state-updating
      behavior of a specific object, instead of using ``obj``'s static
      :meth:`__setstate__` method. If not ``None``, this callable will have

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -598,7 +598,7 @@ or both.
    module; the pickle module searches the module namespace to determine the
    object's module.  This behaviour is typically useful for singletons.
 
-   When a tuple is returned, it must be between two and five items long.
+   When a tuple is returned, it must be between two and six items long.
    Optional items can either be omitted, or ``None`` can be provided as their
    value.  The semantics of each item are in order:
 
@@ -636,7 +636,7 @@ or both.
      priority over ``obj``'s :meth:`__setstate__`.
 
      .. versionadded:: 3.8
-        The ``state_setter`` option was added.
+        The optional sixth tuple item, ``(obj, state)``, was added.
 
 
 .. method:: object.__reduce_ex__(protocol)

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -635,6 +635,9 @@ or both.
      :meth:`__setstate__` method. If not ``None``, this callable will have
      priority over ``obj``'s :meth:`__setstate__`.
 
+     .. versionadded:: 3.8
+        The ``state_setter`` option was added.
+
 
 .. method:: object.__reduce_ex__(protocol)
 

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -630,9 +630,10 @@ or both.
      by other classes as long as they implement :meth:`__setitem__`.
 
    * Optionally, an callable with a ``(obj, state)`` signature. This
-     callable allows the user to control the state-updating part of classes
-     the user did not create. If not ``None``, this callable will have priority
-     over any :meth:`__setitem__` method.
+     callable allows the user to programatically control the state-updating
+     behavior of a specific object, instead of using ``obj``'s static
+     :meth:`__setstate__` method. If not ``None``, this callable will have
+     priority over ``obj``'s :meth:`__setstate__`.
 
 
 .. method:: object.__reduce_ex__(protocol)

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -629,7 +629,7 @@ or both.
      value``.  This is primarily used for dictionary subclasses, but may be used
      by other classes as long as they implement :meth:`__setitem__`.
 
-   * Optionally, an callable with a ``(obj, state, slotstate)`` signature. This
+   * Optionally, an callable with a ``(obj, state)`` signature. This
      callable allows the user to control the state-updating part of classes
      the user did not create. If not ``None``, this callable will have priority
      over any :meth:`__setitem__` method.

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -629,6 +629,11 @@ or both.
      value``.  This is primarily used for dictionary subclasses, but may be used
      by other classes as long as they implement :meth:`__setitem__`.
 
+   * Optionally, an callable with a ``(obj, state, slotstate)`` signature. This
+     callable allows the user to control the state-updating part of classes
+     the user did not create. If not ``None``, this callable will have priority
+     over any :meth:`__setitem__` method.
+
 
 .. method:: object.__reduce_ex__(protocol)
 

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -660,16 +660,19 @@ class _Pickler:
                 write(BUILD)
             else:
                 # If a state_setter is specified, call it instead of load_build
-                # to update obj's with its previous state.  The first 4
-                # save/write instructions push state_setter and its tuple of
-                # expected arguments (obj, state) onto the stack. The REDUCE
-                # opcode triggers the state_setter(obj, state) function call.
-                # Finally, because state-updating routines only do in-place
-                # modification, the whole operation has to be
-                # stack-transparent.  Thus, we finally pop the call's output
-                # from the stack.
-                save(state_setter), save(obj), save(state), write(TUPLE2)
+                # to update obj's with its previous state.
+                # First, push state_setter and its tuple of expected arguments
+                # (obj, state) onto the stack.
+                save(state_setter)
+                save(obj)
+                save(state)
+                write(TUPLE2)
+                # Trigger a state_setter(obj, state) function call.
                 write(REDUCE)
+                # The purpose of state_setter is to carry-out an
+                # inplace modification of obj. We do not care about what the
+                # method might return, so its output is eventually removed from
+                # the stack.
                 write(POP)
 
     # Methods below this point are dispatched through the dispatch table

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -664,7 +664,7 @@ class _Pickler:
                 # First, push state_setter and its tuple of expected arguments
                 # (obj, state) onto the stack.
                 save(state_setter)
-                save(obj)
+                save(obj)  # simple BINGET opcode as obj is already memoized.
                 save(state)
                 write(TUPLE2)
                 # Trigger a state_setter(obj, state) function call.

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -1567,8 +1567,11 @@ class _Unpickler:
 
         elif isinstance(state, tuple) and len(state) == 3:
             setstate, state, slostate = state
-            setstate(inst, state, slotstate)
-            return
+            if slotstate is None:
+                setstate(inst, (state, slotstate))
+            else:
+                setstate(inst, state)
+
         if state:
             inst_dict = inst.__dict__
             intern = sys.intern

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2994,6 +2994,19 @@ class AAA(object):
 class BBB(object):
     pass
 
+
+def setstate_bbb(obj, state, slotstate):
+    """Custom state setter for BBB objects
+
+    Such callable may be created by other persons than the ones who created the
+    BBB class. If passed as the state_setter item of a custom reducer, this
+    allows for custom state setting behavior of BBB objects. One can think of
+    it as the analogous of list_setitems or dict_setitems but for foreign
+    classes/functions.
+    """
+    obj.a = 'foo'
+
+
 class AbstractDispatchTableTests(unittest.TestCase):
 
     def test_default_dispatch_table(self):
@@ -3080,6 +3093,19 @@ class AbstractDispatchTableTests(unittest.TestCase):
         self.assertIsInstance(custom_load_dump(b), BBB)
         self.assertEqual(default_load_dump(a), REDUCE_A)
         self.assertIsInstance(default_load_dump(b), BBB)
+
+        # End-to-end testing of save_reduce with the state_setter keyword
+        # argument. This is a dispatch_table test as state_setter is useful to
+        # register custom state-setting behavior for classes that were not
+        # created by the user.
+        def reduce_bbb(obj):
+            return BBB, (), obj.__dict__, None, None, setstate_bbb
+
+        dispatch_table[BBB] = reduce_bbb
+
+        b = BBB()
+
+        self.assertEqual(custom_load_dump(b).a, 'foo')
 
 
 if __name__ == "__main__":

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3115,8 +3115,6 @@ class AbstractDispatchTableTests(unittest.TestCase):
 
         dispatch_table[BBB] = reduce_bbb
 
-        b = BBB()
-
         # The custom reducer reduce_bbb includes a state setter, that should
         # have priority over BBB.__setstate__
         self.assertEqual(custom_load_dump(b).a, "custom state_setter")

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3095,9 +3095,10 @@ class AbstractDispatchTableTests(unittest.TestCase):
         self.assertIsInstance(default_load_dump(b), BBB)
 
         # End-to-end testing of save_reduce with the state_setter keyword
-        # argument. This is a dispatch_table test as state_setter is useful to
-        # register custom state-setting behavior for classes that were not
-        # created by the user.
+        # argument. This is a dispatch_table test as the primary goal of
+        # state_setter is to tweak objects reduction behavior.
+        # In particular, state_setter is useful when the default __setstate__
+        # behavior is not flexible enough.
         def reduce_bbb(obj):
             return BBB, (), obj.__dict__, None, None, setstate_bbb
 

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3005,7 +3005,6 @@ def setstate_bbb(obj, state):
     classes/functions.
     """
     obj.a = 'foo'
-    return obj
 
 class AbstractDispatchTableTests(unittest.TestCase):
 

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3005,7 +3005,7 @@ def setstate_bbb(obj, state):
     classes/functions.
     """
     obj.a = 'foo'
-
+    return obj
 
 class AbstractDispatchTableTests(unittest.TestCase):
 

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3006,6 +3006,7 @@ def setstate_bbb(obj, state):
     """
     obj.a = 'foo'
 
+
 class AbstractDispatchTableTests(unittest.TestCase):
 
     def test_default_dispatch_table(self):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2995,7 +2995,7 @@ class BBB(object):
     pass
 
 
-def setstate_bbb(obj, state, slotstate):
+def setstate_bbb(obj, state):
     """Custom state setter for BBB objects
 
     Such callable may be created by other persons than the ones who created the

--- a/Misc/NEWS.d/next/Library/2019-03-27-15-09-00.bpo-35900.fh56UU.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-27-15-09-00.bpo-35900.fh56UU.rst
@@ -1,0 +1,2 @@
+allow the user to speficy custom functions to set the state of an object in
+save_reduce via the new state_setter keyword argument.

--- a/Misc/NEWS.d/next/Library/2019-03-27-15-09-00.bpo-35900.fh56UU.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-27-15-09-00.bpo-35900.fh56UU.rst
@@ -1,2 +1,3 @@
-Allow the user to specify custom functions to set the state of an object in
-save_reduce via the new state_setter keyword argument.
+Allow reduction methods to return a 6-item tuple where the 6th item specifies a
+custom state-setting method that's called instead of the regular
+``__setstate__`` method.

--- a/Misc/NEWS.d/next/Library/2019-03-27-15-09-00.bpo-35900.fh56UU.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-27-15-09-00.bpo-35900.fh56UU.rst
@@ -1,2 +1,2 @@
-allow the user to speficy custom functions to set the state of an object in
+Allow the user to specify custom functions to set the state of an object in
 save_reduce via the new state_setter keyword argument.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3718,7 +3718,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
 
     if (state_setter == Py_None)
         state_setter = NULL;
-    else if (!PyFunction_Check(state_setter)) {
+    else if (!PyCallable_Check(state_setter)) {
         PyErr_Format(st->PicklingError, "sixth element of the tuple "
                      "returned by __reduce__ must be a function, not %s",
                      Py_TYPE(state_setter)->tp_name);

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6267,27 +6267,6 @@ load_build(UnpicklerObject *self)
         Py_INCREF(slotstate);
         Py_DECREF(tmp);
     }
-    /* state can embed a callable state setter */
-    else if (PyTuple_Check(state) && PyTuple_GET_SIZE(state) == 3) {
-        PyObject *state_slotstate;
-
-        setstate = PyTuple_GET_ITEM(state, 0);
-        state_slotstate = PyTuple_GetSlice(state, 1, 3);
-
-        Py_INCREF(setstate);
-
-        /* call the setstate function */
-        if (PyObject_CallFunctionObjArgs(setstate, inst, state_slotstate,
-                                         NULL) == NULL){
-            Py_DECREF(state_slotstate);
-            Py_DECREF(setstate);
-            return -1;
-        }
-
-        Py_DECREF(state_slotstate);
-        Py_DECREF(setstate);
-        return 0;
-    }
     else
         slotstate = NULL;
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6238,7 +6238,7 @@ load_additems(UnpicklerObject *self)
 static int
 load_build(UnpicklerObject *self)
 {
-    PyObject *state, *inst, *slotstate;
+    PyObject *state, *inst, *slotstate, *statearg;
     PyObject *setstate;
     int status = 0;
     _Py_IDENTIFIER(__setstate__);
@@ -6297,13 +6297,22 @@ load_build(UnpicklerObject *self)
         Py_INCREF(slotstate);
         Py_DECREF(tmp);
         /* call the setstate function */
-        if (PyObject_CallFunctionObjArgs(setstate, inst, state,
-                                         slotstate, NULL) == NULL){
+        if (slotstate != Py_None) {
+            statearg = Py_BuildValue("(OO)", state, slotstate);
+        }
+        else {
+            statearg = state;
+            Py_INCREF(state);
+        }
+
+        if (PyObject_CallFunctionObjArgs(setstate, inst, statearg,
+                                         NULL) == NULL){
             return -1;
         }
 
         Py_DECREF(setstate);
         Py_DECREF(state);
+        Py_DECREF(statearg);
         Py_DECREF(slotstate);
         return 0;
     }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3675,7 +3675,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
     size = PyTuple_Size(args);
     if (size < 2 || size > 6) {
         PyErr_SetString(st->PicklingError, "tuple returned by "
-                        "__reduce__ must contain 2 through 5 elements");
+                        "__reduce__ must contain 2 through 6 elements");
         return -1;
     }
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3952,12 +3952,12 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
         else {
             const char tupletwo_op = TUPLE2;
             const char pop_op = POP;
-            if (_Pickler_Write(self, &pop_op, 1) < 0 ||
-                save(self, state_setter, 0) < 0 ||
+            if (save(self, state_setter, 0) < 0 ||
                 save(self, obj, 0) < 0 ||
                 save(self, state, 0) < 0 ||
                 _Pickler_Write(self, &tupletwo_op, 1) < 0 ||
-                _Pickler_Write(self, &reduce_op, 1) < 0)
+                _Pickler_Write(self, &reduce_op, 1) < 0 ||
+                _Pickler_Write(self, &pop_op, 1) < 0)
                 return -1;
         }
     }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3952,8 +3952,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
         else {
             const char tupletwo_op = TUPLE2;
             const char pop_op = POP;
-            if (
-                _Pickler_Write(self, &pop_op, 1) < 0 ||
+            if (_Pickler_Write(self, &pop_op, 1) < 0 ||
                 save(self, state_setter, 0) < 0 ||
                 save(self, obj, 0) < 0 ||
                 save(self, state, 0) < 0 ||

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3950,40 +3950,17 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
                 return -1;
         }
         else {
-            PyObject *statetup = NULL;
-
-            /* If a state_setter is specified, and state is a dict, we could be
-             * tempted to save a (state_setter, state) as state, but this would
-             * collide with load_build's (state, slotstate) special handling.
-             * Therefore, create a new format for state saving: (state_setter,
-             * state, slotstate)
-             */
-            if PyDict_Check(state)
-                statetup = Py_BuildValue("(OOO)", state_setter, state,
-                                         Py_None);
-            else if PyTuple_Check(state) {
-                if (PyTuple_GET_SIZE(state) == 2) {
-                    statetup = Py_BuildValue("(OOO)", state_setter,
-                                             PyTuple_GetItem(state, 0),
-                                             PyTuple_GetItem(state, 1));
-                }
-            }
-
-            if (statetup == NULL) {
-                PyErr_SetString(st->PicklingError,
-                                "state must be either a dict or a tuple of"
-                                " length 2");
+            const char tupletwo_op = TUPLE2;
+            const char pop_op = POP;
+            if (
+                _Pickler_Write(self, &pop_op, 1) < 0 ||
+                save(self, state_setter, 0) < 0 ||
+                save(self, obj, 0) < 0 ||
+                save(self, state, 0) < 0 ||
+                _Pickler_Write(self, &tupletwo_op, 1) < 0 ||
+                _Pickler_Write(self, &reduce_op, 1) < 0)
                 return -1;
-            }
-
-            if (save(self, statetup, 0) < 0 ||
-                _Pickler_Write(self, &build_op, 1) < 0) {
-                Py_DECREF(statetup);
-                return -1;
-            }
-            Py_DECREF(statetup);
         }
-
     }
     return 0;
 }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3952,7 +3952,6 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
         else {
             PyObject *statetup = NULL;
 
-
             /* If a state_setter is specified, and state is a dict, we could be
              * tempted to save a (state_setter, state) as state, but this would
              * collide with load_build's (state, slotstate) special handling.
@@ -3963,7 +3962,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
                 statetup = Py_BuildValue("(OOO)", state_setter, state,
                                          Py_None);
             else if PyTuple_Check(state) {
-                if (PyTuple_GET_SIZE(state) == 2){
+                if (PyTuple_GET_SIZE(state) == 2) {
                     statetup = Py_BuildValue("(OOO)", state_setter,
                                              PyTuple_GetItem(state, 0),
                                              PyTuple_GetItem(state, 1));

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3977,7 +3977,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
             }
 
             if (save(self, statetup, 0) < 0 ||
-                _Pickler_Write(self, &build_op, 1) < 0){
+                _Pickler_Write(self, &build_op, 1) < 0) {
                 Py_DECREF(statetup);
                 return -1;
             }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3720,7 +3720,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
         state_setter = NULL;
     else if (!PyFunction_Check(state_setter)) {
         PyErr_Format(st->PicklingError, "sixth element of the tuple "
-                     "returned by __reduce__ must be an function, not %s",
+                     "returned by __reduce__ must be a function, not %s",
                      Py_TYPE(state_setter)->tp_name);
         return -1;
     }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6283,7 +6283,7 @@ load_build(UnpicklerObject *self)
         Py_INCREF(slotstate);
         Py_DECREF(tmp);
     }
-    /* proto 5 addition: state can embed a callable state setter */
+    /* state can embed a callable state setter */
     else if (PyTuple_Check(state) && PyTuple_GET_SIZE(state) == 3) {
         PyObject *state_slotstate;
 


### PR DESCRIPTION
Second PR of [bpo-35900](https://bugs.python.org/issue35900).

# What

The aim of this PR is to allow users to specify custom state setting methods for types they have no control on. This is done via adding a `state_setter` keyword argument in `Pickler.save_reduce`, expected to be a callable. This callable will be called at unpickling time with the following signature `state_setter(obj, state, slotstate)`.

# Why

A practical use case is the one of [cloudpickle](https://github.com/cloudpipe/cloudpickle) that provides extended serialization procedures, especially for functions and classes. In `cloudpickle`, functions and classes are reconstructed from scratch at unpickling time. As for other built-in types reconstructed from scratch (list, dicts...), circular-references are handled by initalizing a skeleton-object, and then updating it in a state-setting phase. This state-setting phase currently only relies on potential `__getstate__` methods, or fallbacks to a default procedure, and this is simply not enough to properly reconstruct functions and classes, hence this proposal.

See cloudpipe/cloudpickle#253 for more details.

- [x] implementaion 
- [x] unit-tests

# Notes

## dependencies

This PR comes alongside #12499 . Without it, leveraging #12499 changes won't work for `functions` and `classes`.

## cross-protocol/version usage
An interrogation that remains is whether using this new API with a protocol < 5 should raise an error at pickling time. If not, `unpickling` will not succeed if the pickle string is loaded using a `python < 3.8`.  This may be surprising for users as one can assume that the point of using low protocols is to ensure retro-compatibility with older python versions. On the other side, this API will probably be of interested for advanced user only, that would understand why using a new API with an old protocol. As of today, this is still an open question.


<!-- issue-number: [bpo-35900](https://bugs.python.org/issue35900) -->
https://bugs.python.org/issue35900
<!-- /issue-number -->
