### PR TITLE
bpo-36245: Fix more empty environment variable checks

### DIFF
--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -2,8 +2,8 @@
 setlocal
 rem Simple script to fetch source for external libraries
 
-if "%PCBUILD%"=="" (set PCBUILD=%~dp0)
-if "%EXTERNALS_DIR%"=="" (set EXTERNALS_DIR=%PCBUILD%\..\externals)
+if NOT DEFINED PCBUILD (set PCBUILD=%~dp0)
+if NOT DEFINED EXTERNALS_DIR (set EXTERNALS_DIR=%PCBUILD%\..\externals)
 
 set DO_FETCH=true
 set DO_CLEAN=false


### PR DESCRIPTION


<!-- issue-number: [bpo-36245](https://bugs.python.org/issue36245) -->
https://bugs.python.org/issue36245
<!-- /issue-number -->
