### PR TITLE
bpo-36452: dictiter: track maximum iteration count

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -470,6 +470,15 @@ class DictTest(unittest.TestCase):
             for i in d:
                 d[i+1] = 1
 
+    def test_mutating_iteration_delete(self):
+        # change dict content during iteration
+        d = {}
+        d[0] = 0
+        with self.assertRaises(RuntimeError):
+            for i in d:
+                del d[0]
+                d[1] = 1
+
     def test_mutating_lookup(self):
         # changing dict during a lookup (issue #14417)
         class NastyKey:

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-27-23-53-00.bpo-36452.xhK2lT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-27-23-53-00.bpo-36452.xhK2lT.rst
@@ -1,0 +1,1 @@
+Changing `dict` keys during iteration will now be detected in certain corner cases where the number of keys isn't changed (but they keys themselves are), and a `RuntimeError` will be raised.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3543,6 +3543,12 @@ dictiter_iternextkey(dictiterobject *di)
             goto fail;
         key = entry_ptr->me_key;
     }
+    // We found an element (key), but did not expect it
+    if (di->len == 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "dictionary keys changed during iteration");
+        goto fail;
+    }
     di->di_pos = i+1;
     di->len--;
     Py_INCREF(key);


### PR DESCRIPTION
Using: Python 3.8 (git commit ID: d5a5a33f12b60129d57f9b423b77d2fcba506834), the following code snippet:
```
a = {0: 0}

for i in a:
    del a[i]
    a[i+1] = 0
    print(i)
```

Prints the following output:

```
0
1
2
3
4
```

The reason for this seems to be the way the internal key list is managed and the "next" value in this list is retrieved. The amount of items seems to be related to `USABLE_FRACTION(PyDict_MINSIZE)`.  

Since cases where the dictionary size changes are detected with a `RuntimeError`, I would expect the invariant "the number of iterations is the len() of the dict at the time the iterator is created" to be enforced. Whether to raise a StopIteration instead or raising a RuntimeError is up for debate.  

This pull request tries to detect this corner case and raise a `RuntimeError` instead (plus a unit test).

Note also that without the patch, the `__length_hint__()` of the iterator actually underflows:

```
a = {0: 0}
it = iter(a)
print('Length hint:', it.__length_hint__())
next(it)
print('Length hint:', it.__length_hint__())
del a[0]
a[1] = 0
next(it)
print('Length hint:', it.__length_hint__())
```

Which - on an AMD64 machine - prints:

```
Length hint: 1
Length hint: 0
Length hint: 18446744073709551615
```

<!-- issue-number: [bpo-36452](https://bugs.python.org/issue36452) -->
https://bugs.python.org/issue36452
<!-- /issue-number -->
