### PR TITLE
Revert "Correct some "-operator" mentions"

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -971,7 +971,7 @@ function:
     >>> getattr(p, 'x')
     11
 
-To convert a dictionary to a named tuple, use the ``**`` operator
+To convert a dictionary to a named tuple, use the double-star-operator
 (as described in :ref:`tut-unpacking-arguments`):
 
     >>> d = {'x': 11, 'y': 22}

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -560,7 +560,7 @@ The reverse situation occurs when the arguments are already in a list or tuple
 but need to be unpacked for a function call requiring separate positional
 arguments.  For instance, the built-in :func:`range` function expects separate
 *start* and *stop* arguments.  If they are not available separately, write the
-function call with the  ``*`` operator to unpack the arguments out of a list
+function call with the  ``*``\ -operator to unpack the arguments out of a list
 or tuple::
 
    >>> list(range(3, 6))            # normal call with separate arguments
@@ -573,7 +573,7 @@ or tuple::
    single: **; in function calls
 
 In the same fashion, dictionaries can deliver keyword arguments with the
-``**`` operator::
+``**``\ -operator::
 
    >>> def parrot(voltage, state='a stiff', action='voom'):
    ...     print("-- This parrot wouldn't", action, end=' ')


### PR DESCRIPTION
Reverts python/cpython#1034 which creates confusion with the '**' operator for __pow__