### PR TITLE
bpo-36459: Fix a possible double PyMem_FREE() due to tokenizer.c's tok_nextc()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-27-22-35-16.bpo-36459.UAvkKp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-27-22-35-16.bpo-36459.UAvkKp.rst
@@ -1,0 +1,1 @@
+Fix a possible double ``PyMem_FREE()`` due to tokenizer.c's ``tok_nextc()``.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -963,7 +963,6 @@ tok_nextc(struct tok_state *tok)
                 newbuf = (char *)PyMem_REALLOC(newbuf,
                                                newsize);
                 if (newbuf == NULL) {
-                    PyMem_FREE(tok->buf);
                     tok->done = E_NOMEM;
                     tok->cur = tok->inp;
                     return EOF;


### PR DESCRIPTION
Remove the PyMem_FREE() call added in cb90c89.  The buffer will be
freed when PyTokenizer_Free() is called on the tokenizer state.

<!-- issue-number: [bpo-36459](https://bugs.python.org/issue36459) -->
https://bugs.python.org/issue36459
<!-- /issue-number -->
