### PR TITLE
bpo-35983: improve and test old trashcan macros

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -341,6 +341,15 @@ class CAPITest(unittest.TestCase):
         for i in range(1000):
             L = MyList((L,))
 
+    def test_trashcan_compat(self):
+        # bpo-35983: Check that the trashcan works with the
+        # backwards-compatibility macros
+        # Py_TRASHCAN_SAFE_BEGIN/Py_TRASHCAN_SAFE_END
+        from _testcapi import SingleContainer
+        L = None
+        for i in range(2**20):
+            L = SingleContainer(L)
+
     def test_trashcan_python_class1(self):
         self.do_test_trashcan_python_class(list)
 

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4334,7 +4334,7 @@ order (MRO) for bases """
         o.whatever = Provoker(o)
         del o
 
-    def test_wrapper_segfault(self):
+    def test_wrapper_trashcan(self):
         # SF 927248: deeply nested wrappers could cause stack overflow
         f = lambda:None
         for i in range(1000000):

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5520,6 +5520,85 @@ static PyTypeObject MyList_Type = {
     MyList_new,                                 /* tp_new */
 };
 
+/* Test bpo-35983: trashcan backwards compatibility macros */
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *item;
+} SingleContainerObject;
+
+static PyObject *
+SingleContainer_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *obj;
+    if (!_PyArg_NoKeywords("SingleContainer", kwargs)) {
+        return NULL;
+    }
+    if (!PyArg_UnpackTuple(args, "SingleContainer", 1, 1, &obj)) {
+        return NULL;
+    }
+    SingleContainerObject *op = PyObject_GC_New(SingleContainerObject, type);
+    if (op) {
+        Py_INCREF(obj);
+        op->item = obj;
+    }
+    return (PyObject *)op;
+}
+
+void
+SingleContainer_dealloc(SingleContainerObject* op)
+{
+    /* Intentionally use the old
+     * Py_TRASHCAN_SAFE_BEGIN/Py_TRASHCAN_SAFE_END macros */
+    PyObject_GC_UnTrack(op);
+    Py_TRASHCAN_SAFE_BEGIN(op);
+    Py_DECREF(op->item);
+    PyObject_GC_Del(op);
+    Py_TRASHCAN_SAFE_END(op);
+}
+
+static PyTypeObject SingleContainer_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "SingleContainer",
+    sizeof(SingleContainerObject),
+    0,
+    (destructor)SingleContainer_dealloc,        /* tp_dealloc */
+    0,                                          /* tp_print */
+    0,                                          /* tp_getattr */
+    0,                                          /* tp_setattr */
+    0,                                          /* tp_reserved */
+    0,                                          /* tp_repr */
+    0,                                          /* tp_as_number */
+    0,                                          /* tp_as_sequence */
+    0,                                          /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    0,                                          /* tp_call */
+    0,                                          /* tp_str */
+    0,                                          /* tp_getattro */
+    0,                                          /* tp_setattro */
+    0,                                          /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+                         Py_TPFLAGS_HAVE_GC,    /* tp_flags */
+    0,                                          /* tp_doc */
+    0,                                          /* tp_traverse */
+    0,                                          /* tp_clear */
+    0,                                          /* tp_richcompare */
+    0,                                          /* tp_weaklistoffset */
+    0,                                          /* tp_iter */
+    0,                                          /* tp_iternext */
+    0,                                          /* tp_methods */
+    0,                                          /* tp_members */
+    0,                                          /* tp_getset */
+    0,                                          /* tp_base */
+    0,                                          /* tp_dict */
+    0,                                          /* tp_descr_get */
+    0,                                          /* tp_descr_set */
+    0,                                          /* tp_dictoffset */
+    0,                                          /* tp_init */
+    0,                                          /* tp_alloc */
+    SingleContainer_new                         /* tp_new */
+};
+
 
 /* Test PEP 560 */
 
@@ -5639,6 +5718,11 @@ PyInit__testcapi(void)
         return NULL;
     Py_INCREF(&MyList_Type);
     PyModule_AddObject(m, "MyList", (PyObject *)&MyList_Type);
+
+    if (PyType_Ready(&SingleContainer_Type) < 0)
+        return NULL;
+    Py_INCREF(&SingleContainer_Type);
+    PyModule_AddObject(m, "SingleContainer", (PyObject *)&SingleContainer_Type);
 
     if (PyType_Ready(&GenericAlias_Type) < 0)
         return NULL;


### PR DESCRIPTION
This is a follow-up to #11841. I made a separate PR since that one has been reviewed already.

I realized that the backwards-compatibility macros `Py_TRASHCAN_SAFE_BEGIN(op)` can be made safe by only using the trashcan if the class inherits directly from `object`. That case is safe and it's also a very common case (few builtin types have a non-trivial subtype).

<!-- issue-number: [bpo-35983](https://bugs.python.org/issue35983) -->
https://bugs.python.org/issue35983
<!-- /issue-number -->
