### PR TITLE
bpo-35941: Fix performance regression in new code

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -835,8 +835,8 @@ class BasicSocketTests(unittest.TestCase):
                 cert, enc, trust = element
                 self.assertIsInstance(cert, bytes)
                 self.assertIn(enc, {"x509_asn", "pkcs_7_asn"})
-                self.assertIsInstance(trust, (set, bool))
-                if isinstance(trust, set):
+                self.assertIsInstance(trust, (frozenset, set, bool))
+                if isinstance(trust, (frozenset, set)):
                     trust_oids.update(trust)
 
         serverAuth = "1.3.6.1.5.5.7.3.1"


### PR DESCRIPTION
Accumulate certificates in a set instead of doing a costly list contain
operation. A Windows cert store can easily contain over hundred
certificates. The old code would result in way over 5,000 comparison
operations.

Signed-off-by: Christian Heimes <christian@python.org>

Untested, uncompiled C code. Let's see what the Windows build bot has to say.

<!-- issue-number: [bpo-35941](https://bugs.python.org/issue35941) -->
https://bugs.python.org/issue35941
<!-- /issue-number -->
