### PR TITLE
WIP: bpo-36465: Remove Py_TRACE_REFS special build

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -710,11 +710,8 @@ extra checks are performed:
 
 There may be additional checks not mentioned here.
 
-Defining :c:macro:`Py_TRACE_REFS` enables reference tracing.  When defined, a
-circular doubly linked list of active objects is maintained by adding two extra
-fields to every :c:type:`PyObject`.  Total allocations are tracked as well.  Upon
-exit, all existing references are printed.  (In interactive mode this happens
-after every statement run by the interpreter.)  Implied by :c:macro:`Py_DEBUG`.
+Defining :c:macro:`Py_REF_DEBUG` enables reference tracing.  When defined,
+total allocations are tracked as well. Implied by :c:macro:`Py_DEBUG`.
 
 Please refer to :file:`Misc/SpecialBuilds.txt` in the Python source distribution
 for more detailed information.

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -493,23 +493,6 @@ metatype) initializes :c:member:`~PyTypeObject.tp_itemsize`, which means that it
 type objects) *must* have the :attr:`ob_size` field.
 
 
-.. c:member:: PyObject* PyObject._ob_next
-             PyObject* PyObject._ob_prev
-
-   These fields are only present when the macro ``Py_TRACE_REFS`` is defined.
-   Their initialization to *NULL* is taken care of by the ``PyObject_HEAD_INIT``
-   macro.  For statically allocated objects, these fields always remain *NULL*.
-   For dynamically allocated objects, these two fields are used to link the object
-   into a doubly-linked list of *all* live objects on the heap.  This could be used
-   for various debugging purposes; currently the only use is to print the objects
-   that are still alive at the end of a run when the environment variable
-   :envvar:`PYTHONDUMPREFS` is set.
-
-   **Inheritance:**
-
-   These fields are not inherited by subtypes.
-
-
 .. c:member:: Py_ssize_t PyObject.ob_refcnt
 
    This is the type object's reference count, initialized to ``1`` by the

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -927,8 +927,3 @@ if Python was configured with the ``--with-pydebug`` build option.
 
    If set, Python will print threading debug info.
 
-
-.. envvar:: PYTHONDUMPREFS
-
-   If set, Python will dump objects and reference counts still alive after
-   shutting down the interpreter.

--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -147,7 +147,6 @@ typedef struct {
     int import_time;        /* PYTHONPROFILEIMPORTTIME, -X importtime */
     int show_ref_count;     /* -X showrefcount */
     int show_alloc_count;   /* -X showalloccount */
-    int dump_refs;          /* PYTHONDUMPREFS */
     int malloc_stats;       /* PYTHONMALLOCSTATS */
 
     /* Python filesystem encoding and error handler:

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -335,11 +335,7 @@ _PyObject_GenericSetAttrWithDict(PyObject *, PyObject *,
 static inline void _Py_Dealloc_inline(PyObject *op)
 {
     destructor dealloc = Py_TYPE(op)->tp_dealloc;
-#ifdef Py_TRACE_REFS
-    _Py_ForgetReference(op);
-#else
     _Py_INC_TPFREES(op);
-#endif
     (*dealloc)(op);
 }
 #define _Py_Dealloc(op) _Py_Dealloc_inline(op)

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -200,14 +200,6 @@ PyAPI_FUNC(int) PyModule_ExecDef(PyObject *module, PyModuleDef *def);
 #define PYTHON_ABI_VERSION 3
 #define PYTHON_ABI_STRING "3"
 
-#ifdef Py_TRACE_REFS
- /* When we are tracing reference counts, rename module creation functions so
-    modules compiled with incompatible settings will generate a
-    link-time error. */
- #define PyModule_Create2 PyModule_Create2TraceRefs
- #define PyModule_FromDefAndSpec2 PyModule_FromDefAndSpec2TraceRefs
-#endif
-
 PyAPI_FUNC(PyObject *) PyModule_Create2(struct PyModuleDef*,
                                      int apiver);
 #ifndef Py_LIMITED_API

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1637,9 +1637,6 @@ def python_is_optimized():
 
 _header = 'nP'
 _align = '0n'
-if hasattr(sys, "gettotalrefcount"):
-    _header = '2P' + _header
-    _align = '0P'
 _vheader = _header + 'n'
 
 def calcobjsize(fmt):

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -293,7 +293,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'import_time': 0,
         'show_ref_count': 0,
         'show_alloc_count': 0,
-        'dump_refs': 0,
         'malloc_stats': 0,
 
         'filesystem_encoding': GET_DEFAULT_CONFIG,

--- a/Misc/SpecialBuilds.txt
+++ b/Misc/SpecialBuilds.txt
@@ -36,47 +36,6 @@ sys.gettotalrefcount()
     Return current total of all refcounts.
 
 
-Py_TRACE_REFS
--------------
-
-Turn on heavy reference debugging.  This is major surgery.  Every PyObject grows
-two more pointers, to maintain a doubly-linked list of all live heap-allocated
-objects.  Most built-in type objects are not in this list, as they're statically
-allocated.  Starting in Python 2.3, if COUNT_ALLOCS (see below) is also defined,
-a static type object T does appear in this list if at least one object of type T
-has been created.
-
-Note that because the fundamental PyObject layout changes, Python modules
-compiled with Py_TRACE_REFS are incompatible with modules compiled without it.
-
-Py_TRACE_REFS implies Py_REF_DEBUG.
-
-Special gimmicks:
-
-sys.getobjects(max[, type])
-    Return list of the (no more than) max most-recently allocated objects, most
-    recently allocated first in the list, least-recently allocated last in the
-    list.  max=0 means no limit on list length.  If an optional type object is
-    passed, the list is also restricted to objects of that type.  The return
-    list itself, and some temp objects created just to call sys.getobjects(),
-    are excluded from the return list.  Note that the list returned is just
-    another object, though, so may appear in the return list the next time you
-    call getobjects(); note that every object in the list is kept alive too,
-    simply by virtue of being in the list.
-
-envvar PYTHONDUMPREFS
-    If this envvar exists, Py_FinalizeEx() arranges to print a list of all
-    still-live heap objects.  This is printed twice, in different formats,
-    before and after Py_FinalizeEx has cleaned up everything it can clean up.  The
-    first output block produces the repr() of each object so is more
-    informative; however, a lot of stuff destined to die is still alive then.
-    The second output block is much harder to work with (repr() can't be invoked
-    anymore -- the interpreter has been torn down too far), but doesn't list any
-    objects that will die.  The tool script combinerefs.py can be run over this
-    to combine the info from both output blocks.  The second output block, and
-    combinerefs.py, were new in Python 2.3b1.
-
-
 PYMALLOC_DEBUG
 --------------
 
@@ -156,7 +115,7 @@ Py_DEBUG
 
 This is what is generally meant by "a debug build" of Python.
 
-Py_DEBUG implies LLTRACE, Py_REF_DEBUG, Py_TRACE_REFS, and PYMALLOC_DEBUG (if
+Py_DEBUG implies LLTRACE, Py_REF_DEBUG, and PYMALLOC_DEBUG (if
 WITH_PYMALLOC is enabled).  In addition, C assert()s are enabled (via the C way:
 by not defining NDEBUG), and some routines do additional sanity checks inside
 "#ifdef Py_DEBUG" blocks.
@@ -191,10 +150,6 @@ objects can go away.  COUNT_ALLOCS can blow up in 2.2 and 2.2.1 because of this;
 this was fixed in 2.2.2.  Use of COUNT_ALLOCS makes all heap-allocated type
 objects immortal, except for those for which no object of that type is ever
 allocated.
-
-Starting with Python 2.3, If Py_TRACE_REFS is also defined, COUNT_ALLOCS
-arranges to ensure that the type object for each allocated object appears in the
-doubly-linked list of all objects maintained by Py_TRACE_REFS.
 
 Special gimmicks:
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3224,9 +3224,7 @@ slot_tp_del(PyObject *self)
     /* If Py_REF_DEBUG, _Py_NewReference bumped _Py_RefTotal, so
      * we need to undo that. */
     _Py_DEC_REFTOTAL;
-    /* If Py_TRACE_REFS, _Py_NewReference re-added self to the object
-     * chain, so no more to do there.
-     * If COUNT_ALLOCS, the original decref bumped tp_frees, and
+    /* If COUNT_ALLOCS, the original decref bumped tp_frees, and
      * _Py_NewReference bumped tp_allocs:  both of those need to be
      * undone.
      */

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3015,7 +3015,7 @@ _PyBytes_Resize(PyObject **pv, Py_ssize_t newsize)
     }
     /* XXX UNREF/NEWREF interface should be more symmetrical */
     _Py_DEC_REFTOTAL;
-    _Py_ForgetReference(v);
+    _Py_INC_TPFREES(op);
     *pv = (PyObject *)
         PyObject_REALLOC(v, PyBytesObject_SIZE + newsize);
     if (*pv == NULL) {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5721,7 +5721,7 @@ PyLong_Fini(void)
     PyLongObject *v = small_ints;
     for (i = 0; i < NSMALLNEGINTS + NSMALLPOSINTS; i++, v++) {
         _Py_DEC_REFTOTAL;
-        _Py_ForgetReference((PyObject*)v);
+        _Py_INC_TPFREES((PyObject*)v);
     }
 #endif
 }

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2549,8 +2549,5 @@ static PyTypeObject _PySetDummy_Type = {
     Py_TPFLAGS_DEFAULT, /*tp_flags */
 };
 
-static PyObject _dummy_struct = {
-  _PyObject_EXTRA_INIT
-  2, &_PySetDummy_Type
-};
+static PyObject _dummy_struct = {2, &_PySetDummy_Type};
 

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -88,10 +88,7 @@ PyTypeObject PyEllipsis_Type = {
     ellipsis_new,                       /* tp_new */
 };
 
-PyObject _Py_EllipsisObject = {
-    _PyObject_EXTRA_INIT
-    1, &PyEllipsis_Type
-};
+PyObject _Py_EllipsisObject = {1, &PyEllipsis_Type};
 
 
 /* Slice object implementation */

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -364,14 +364,6 @@ PyStructSequence_InitType2(PyTypeObject *type, PyStructSequence_Desc *desc)
     PyMemberDef *members;
     Py_ssize_t n_members, n_unnamed_members;
 
-#ifdef Py_TRACE_REFS
-    /* if the type object was chained, unchain it first
-       before overwriting its storage */
-    if (type->ob_base.ob_base._ob_next) {
-        _Py_ForgetReference((PyObject *)type);
-    }
-#endif
-
     /* PyTypeObject has already been initialized */
     if (Py_REFCNT(type) != 0) {
         PyErr_BadInternalCall();

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -101,10 +101,6 @@ PyTuple_New(Py_ssize_t size)
         _Py_fast_tuple_allocs++;
 #endif
         /* Inline PyObject_InitVar */
-#ifdef Py_TRACE_REFS
-        Py_SIZE(op) = size;
-        Py_TYPE(op) = &PyTuple_Type;
-#endif
         _Py_NewReference((PyObject *)op);
     }
     else
@@ -906,7 +902,7 @@ _PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
     _Py_DEC_REFTOTAL;
     if (_PyObject_GC_IS_TRACKED(v))
         _PyObject_GC_UNTRACK(v);
-    _Py_ForgetReference((PyObject *) v);
+    _Py_INC_TPFREES((PyObject *) v);
     /* DECREF items deleted by shrinkage */
     for (i = newsize; i < oldsize; i++) {
         Py_CLEAR(v->ob_item[i]);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5242,15 +5242,6 @@ PyType_Ready(PyTypeObject *type)
 
     type->tp_flags |= Py_TPFLAGS_READYING;
 
-#ifdef Py_TRACE_REFS
-    /* PyType_Ready is the closest thing we have to a choke point
-     * for type objects, so is the best place I can think of to try
-     * to get type objects into the doubly-linked list of all objects.
-     * Still, not all type objects go through PyType_Ready.
-     */
-    _Py_AddToAllObjects((PyObject *)type, 0);
-#endif
-
     if (type->tp_name == NULL) {
         PyErr_Format(PyExc_SystemError,
                      "Type does not define the tp_name field.");

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -954,7 +954,7 @@ resize_compact(PyObject *unicode, Py_ssize_t length)
         _PyUnicode_UTF8_LENGTH(unicode) = 0;
     }
     _Py_DEC_REFTOTAL;
-    _Py_ForgetReference(unicode);
+    _Py_INC_TPFREES(unicode);
 
     new_unicode = (PyObject *)PyObject_REALLOC(unicode, new_size);
     if (new_unicode == NULL) {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2808,22 +2808,10 @@ _PyBuiltin_Init(void)
         return NULL;
     dict = PyModule_GetDict(mod);
 
-#ifdef Py_TRACE_REFS
-    /* "builtins" exposes a number of statically allocated objects
-     * that, before this code was added in 2.3, never showed up in
-     * the list of "all objects" maintained by Py_TRACE_REFS.  As a
-     * result, programs leaking references to None and False (etc)
-     * couldn't be diagnosed by examining sys.getobjects(0).
-     */
-#define ADD_TO_ALL(OBJECT) _Py_AddToAllObjects((PyObject *)(OBJECT), 0)
-#else
-#define ADD_TO_ALL(OBJECT) (void)0
-#endif
-
 #define SETBUILTIN(NAME, OBJECT) \
-    if (PyDict_SetItemString(dict, NAME, (PyObject *)OBJECT) < 0)       \
+    if (PyDict_SetItemString(dict, NAME, (PyObject *)OBJECT) < 0) {     \
         return NULL;                                                    \
-    ADD_TO_ALL(OBJECT)
+    }
 
     SETBUILTIN("None",                  Py_None);
     SETBUILTIN("Ellipsis",              Py_Ellipsis);
@@ -2864,6 +2852,5 @@ _PyBuiltin_Init(void)
     Py_DECREF(debug);
 
     return mod;
-#undef ADD_TO_ALL
 #undef SETBUILTIN
 }

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -562,7 +562,6 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
     COPY_ATTR(import_time);
     COPY_ATTR(show_ref_count);
     COPY_ATTR(show_alloc_count);
-    COPY_ATTR(dump_refs);
     COPY_ATTR(malloc_stats);
 
     COPY_WSTR_ATTR(pycache_prefix);
@@ -672,7 +671,6 @@ _PyCoreConfig_AsDict(const _PyCoreConfig *config)
     SET_ITEM_INT(import_time);
     SET_ITEM_INT(show_ref_count);
     SET_ITEM_INT(show_alloc_count);
-    SET_ITEM_INT(dump_refs);
     SET_ITEM_INT(malloc_stats);
     SET_ITEM_STR(filesystem_encoding);
     SET_ITEM_STR(filesystem_errors);
@@ -1085,9 +1083,6 @@ config_read_env_vars(_PyCoreConfig *config)
                  "PYTHONLEGACYWINDOWSSTDIO");
 #endif
 
-    if (_PyCoreConfig_GetEnv(config, "PYTHONDUMPREFS")) {
-        config->dump_refs = 1;
-    }
     if (_PyCoreConfig_GetEnv(config, "PYTHONMALLOCSTATS")) {
         config->malloc_stats = 1;
     }

--- a/Python/pyarena.c
+++ b/Python/pyarena.c
@@ -167,10 +167,6 @@ PyArena_Free(PyArena *arena)
     */
 #endif
     block_free(arena->a_head);
-    /* This property normally holds, except when the code being compiled
-       is sys.getobjects(0), in which case there will be two references.
-    assert(arena->a_objects->ob_refcnt == 1);
-    */
 
     Py_DECREF(arena->a_objects);
     PyMem_Free(arena);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1165,9 +1165,6 @@ Py_FinalizeEx(void)
 #ifdef Py_REF_DEBUG
     int show_ref_count = interp->core_config.show_ref_count;
 #endif
-#ifdef Py_TRACE_REFS
-    int dump_refs = interp->core_config.dump_refs;
-#endif
 #ifdef WITH_PYMALLOC
     int malloc_stats = interp->core_config.malloc_stats;
 #endif
@@ -1260,17 +1257,6 @@ Py_FinalizeEx(void)
     }
 #endif
 
-#ifdef Py_TRACE_REFS
-    /* Display all objects still alive -- this can invoke arbitrary
-     * __repr__ overrides, so requires a mostly-intact interpreter.
-     * Alas, a lot of stuff may still be alive now that will be cleaned
-     * up later.
-     */
-    if (dump_refs) {
-        _Py_PrintReferences(stderr);
-    }
-#endif /* Py_TRACE_REFS */
-
     /* Clear interpreter state and all thread states. */
     PyInterpreterState_Clear(interp);
 
@@ -1321,15 +1307,6 @@ Py_FinalizeEx(void)
 
     PyInterpreterState_Delete(interp);
 
-#ifdef Py_TRACE_REFS
-    /* Display addresses (& refcnts) of all objects still alive.
-     * An address can be used to find the repr of the object, printed
-     * above by _Py_PrintReferences.
-     */
-    if (dump_refs) {
-        _Py_PrintReferenceAddresses(stderr);
-    }
-#endif /* Py_TRACE_REFS */
 #ifdef WITH_PYMALLOC
     if (malloc_stats) {
         _PyObject_DebugMallocStats(stderr);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1581,11 +1581,6 @@ sys__debugmallocstats_impl(PyObject *module)
     Py_RETURN_NONE;
 }
 
-#ifdef Py_TRACE_REFS
-/* Defined in objects.c because it uses static globals if that file */
-extern PyObject *_Py_GetObjects(PyObject *, PyObject *);
-#endif
-
 #ifdef DYNAMIC_EXECUTION_PROFILE
 /* Defined in ceval.c because it uses static globals if that file */
 extern PyObject *_Py_GetDXProfile(PyObject *,  PyObject *);
@@ -1659,9 +1654,6 @@ static PyMethodDef sys_methods[] = {
 #endif
     SYS_GETFILESYSTEMENCODING_METHODDEF
     SYS_GETFILESYSTEMENCODEERRORS_METHODDEF
-#ifdef Py_TRACE_REFS
-    {"getobjects",      _Py_GetObjects, METH_VARARGS},
-#endif
     SYS_GETTOTALREFCOUNT_METHODDEF
     SYS_GETREFCOUNT_METHODDEF
     SYS_GETRECURSIONLIMIT_METHODDEF


### PR DESCRIPTION
Remove _ob_prev and _ob_next fields of PyObject when Python is
compiled in debug mode to make debug ABI closer to the release ABI.

Remove:

* sys.getobjects()
* PYTHONDUMPREFS environment variable
* _PyCoreConfig.dump_refs
* PyObject._ob_prev and PyObject._ob_next fields
* _PyObject_HEAD_EXTRA and _PyObject_EXTRA_INIT macros
* _Py_AddToAllObjects()
* _Py_PrintReferenceAddresses()
* _Py_PrintReferences()
* _Py_ForgetReference(op) is replaced with _Py_INC_TPFREES(op

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36465](https://bugs.python.org/issue36465) -->
https://bugs.python.org/issue36465
<!-- /issue-number -->
