### PR TITLE
bpo-20844: open script file with "rb" mode

### DIFF
--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -110,7 +110,7 @@ the same library that the Python runtime is using.
    closed before PyRun_SimpleFileExFlags returns.
 
    .. note::
-      On Windows, `FILE *fp` should be opened as binary mode (e.g. `fopen(filename, "rb")`.
+      On Windows, *fp* should be opened as binary mode (e.g. ``fopen(filename, "rb")``.
       Otherwise, Python may not handle script file with LF line ending correctly.
 
 

--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -109,6 +109,10 @@ the same library that the Python runtime is using.
    (:func:`sys.getfilesystemencoding`).  If *closeit* is true, the file is
    closed before PyRun_SimpleFileExFlags returns.
 
+   .. note::
+      On Windows, `FILE *fp` should be opened as binary mode (e.g. `fopen(filename, "rb")`.
+      Otherwise, Python may not handle script file with LF line ending correctly.
+
 
 .. c:function:: int PyRun_InteractiveOne(FILE *fp, const char *filename)
 

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -409,6 +409,23 @@ class CmdLineTest(unittest.TestCase):
                                       script_name, script_name, script_dir, '',
                                       importlib.machinery.SourceFileLoader)
 
+    def test_issue20884(self):
+        # On Windows, script with encoding cookie and LF line ending
+        # will be failed.
+        with support.temp_dir() as script_dir:
+            script_name = os.path.join(script_dir, "issue20884.py")
+            with open(script_name, "w", newline='\n') as f:
+                f.write("#coding: iso-8859-1\n")
+                f.write('"""\n')
+                for _ in range(30):
+                    f.write('x'*80 + '\n')
+                f.write('"""\n')
+
+            with support.change_cwd(path=script_dir):
+                rc, out, err = assert_python_ok(script_name)
+            self.assertEqual(b"", out)
+            self.assertEqual(b"", err)
+
     @contextlib.contextmanager
     def setup_test_pkg(self, *args):
         with support.temp_dir() as script_dir, \

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-29-18-47-50.bpo-20844.ge-7SM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-29-18-47-50.bpo-20844.ge-7SM.rst
@@ -1,0 +1,2 @@
+Fix running script with encoding cookie and LF line ending
+may fail on Windows.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -283,7 +283,7 @@ static int
 pymain_run_file(_PyCoreConfig *config, PyCompilerFlags *cf)
 {
     const wchar_t *filename = config->run_filename;
-    FILE *fp = _Py_wfopen(filename, L"r");
+    FILE *fp = _Py_wfopen(filename, L"rb");
     if (fp == NULL) {
         char *cfilename_buffer;
         const char *cfilename;


### PR DESCRIPTION
On Unix, this doesn't have any effect.
On Windows, "r" mode will cause error on `ftell`.

<!-- issue-number: [bpo-20844](https://bugs.python.org/issue20844) -->
https://bugs.python.org/issue20844
<!-- /issue-number -->
