### PR TITLE
docs(Lib/distutils/util.py): strtobool docstring mention case-insensitivity

### DIFF
--- a/Doc/distutils/apiref.rst
+++ b/Doc/distutils/apiref.rst
@@ -1196,9 +1196,9 @@ other utility module.
 
    Convert a string representation of truth to true (1) or false (0).
 
-   True values are ``y``, ``yes``, ``t``, ``true``, ``on``  and ``1``; false values
-   are ``n``, ``no``, ``f``, ``false``,  ``off`` and ``0``.  Raises
-   :exc:`ValueError` if *val*  is anything else.
+   True values are ``y``, ``yes``, ``t``, ``true``, ``on``, and ``1``; false values
+   are ``n``, ``no``, ``f``, ``false``, ``off``, and ``0``. Letters are treated
+   case-insensitively.  Raises :exc:`ValueError` if *val*  is anything else.
 
 
 .. function:: byte_compile(py_files[, optimize=0, force=0, prefix=None, base_dir=None, verbose=1, dry_run=0, direct=None])

--- a/Lib/distutils/tests/test_util.py
+++ b/Lib/distutils/tests/test_util.py
@@ -269,14 +269,18 @@ class UtilTestCase(support.EnvironGuard, unittest.TestCase):
                          ['one', 'two', 'three', 'four'])
 
     def test_strtobool(self):
-        yes = ('y', 'Y', 'yes', 'True', 't', 'true', 'True', 'On', 'on', '1')
-        no = ('n', 'no', 'f', 'false', 'off', '0', 'Off', 'No', 'N')
+        yes = ('y', 'yes', 't', 'true', 'on', '1')
+        no = ('n', 'no', 'f', 'false', 'off', '0')
 
         for y in yes:
-            self.assertTrue(strtobool(y))
+            # Test if the alphabets are treated case-insensitively
+            self.assertTrue(strtobool(y.lower()))
+            self.assertTrue(strtobool(y.upper()))
 
         for n in no:
-            self.assertFalse(strtobool(n))
+            # Test if the alphabets are treated case-insensitively
+            self.assertFalse(strtobool(n.lower()))
+            self.assertFalse(strtobool(n.upper()))
 
     def test_rfc822_escape(self):
         header = 'I am a\npoor\nlonesome\nheader\n'

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -295,8 +295,8 @@ def strtobool (val):
     """Convert a string representation of truth to true (1) or false (0).
 
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
-    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
-    'val' is anything else.
+    are 'n', 'no', 'f', 'false', 'off', and '0'. Alphabets are treated
+    case-insensitively. Raises ValueError if 'val' is anything else.
     """
     val = val.lower()
     if val in ('y', 'yes', 't', 'true', 'on', '1'):

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -295,7 +295,7 @@ def strtobool (val):
     """Convert a string representation of truth to true (1) or false (0).
 
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
-    are 'n', 'no', 'f', 'false', 'off', and '0'. Alphabets are treated
+    are 'n', 'no', 'f', 'false', 'off', and '0'. Letters are treated
     case-insensitively. Raises ValueError if 'val' is anything else.
     """
     val = val.lower()


### PR DESCRIPTION
Minor docstring improvement, no bpo or issue needed.

The docstring for function `strtobool` didn't mention that the true values and false values are treated case-insensitively. E.g. `strtobool` treats `True` and `TRUE` are treated same as `true`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
