### PR TITLE
bpo-35947: Fix a compiler warning in _ctypes.c's StructUnionType_paramfunc()

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -406,7 +406,7 @@ StructUnionType_paramfunc(CDataObject *self)
     CDataObject *copied_self;
     StgDictObject *stgdict;
 
-    if (self->b_size > sizeof(void*)) {
+    if ((size_t)self->b_size > sizeof(void*)) {
         void *new_ptr = PyMem_Malloc(self->b_size);
         if (new_ptr == NULL)
             return NULL;


### PR DESCRIPTION
With GCC 8.2.0, I see the following:
```
/home/lubuntu2/cpython/Modules/_ctypes/_ctypes.c: In function ‘StructUnionType_paramfunc’:
/home/lubuntu2/cpython/Modules/_ctypes/_ctypes.c:409:22: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘long unsigned int’ [-Wsign-compare]
     if (self->b_size > sizeof(void*)) {
                      ^
```
This is due to 32119e10b792ad7ee4e5f951a2d89ddbaf111cc5.

<!-- issue-number: [bpo-35947](https://bugs.python.org/issue35947) -->
https://bugs.python.org/issue35947
<!-- /issue-number -->
