### PR TITLE
bpo-36085: Add installer check for KB2533625

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -754,7 +754,9 @@ Changes in the Python API
   used, and modifications to these will no longer have any effect on normal DLL
   resolution. If your application relies on these mechanisms, you should check
   for :func:`~os.add_dll_directory` and if it exists, use it to add your DLLs
-  directory while loading your library.
+  directory while loading your library. Note that Windows 7 users will need to
+  ensure that Windows Update KB2533625 has been installed (this is also verified
+  by the installer).
   (See :issue:`36085`.)
 
 

--- a/Tools/msi/build.bat
+++ b/Tools/msi/build.bat
@@ -6,7 +6,7 @@ set PCBUILD=%D%..\..\PCbuild\
 set BUILDX86=
 set BUILDX64=
 set BUILDDOC=
-set BUILDTEST=--test-marker
+set BUILDTEST=
 set BUILDPACK=
 set REBUILD=
 
@@ -16,6 +16,7 @@ if "%~1" EQU "-x86" (set BUILDX86=1) && shift && goto CheckOpts
 if "%~1" EQU "-x64" (set BUILDX64=1) && shift && goto CheckOpts
 if "%~1" EQU "--doc" (set BUILDDOC=1) && shift && goto CheckOpts
 if "%~1" EQU "--no-test-marker" (set BUILDTEST=) && shift && goto CheckOpts
+if "%~1" EQU "--test-marker" (set BUILDTEST=--test-marker) && shift && goto CheckOpts
 if "%~1" EQU "--pack" (set BUILDPACK=1) && shift && goto CheckOpts
 if "%~1" EQU "-r" (set REBUILD=-r) && shift && goto CheckOpts
 
@@ -69,11 +70,12 @@ if defined BUILDX64 (
 exit /B 0
 
 :Help
-echo build.bat [-x86] [-x64] [--doc] [-h] [--no-test-marker] [--pack] [-r]
+echo build.bat [-x86] [-x64] [--doc] [-h] [--test-marker] [--pack] [-r]
 echo.
 echo    -x86                Build x86 installers
 echo    -x64                Build x64 installers
 echo    --doc               Build CHM documentation
-echo    --no-test-marker    Build without test markers
+echo    --test-marker       Build with test markers
+echo    --no-test-marker    Build without test markers (default)
 echo    --pack              Embed core MSIs into installer
 echo    -r                  Rebuild rather than incremental build

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -2989,9 +2989,20 @@ private:
         LOC_STRING *pLocString = nullptr;
         
         if (IsWindowsServer()) {
-            if (IsWindowsVersionOrGreater(6, 1, 1)) {
-                BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Target OS is Windows Server 2008 R2 or later");
+            if (IsWindowsVersionOrGreater(6, 2, 0)) {
+                BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Target OS is Windows Server 2012 or later");
                 return;
+            } else if (IsWindowsVersionOrGreater(6, 1, 1)) {
+                HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
+                if (hKernel32 && !GetProcAddress(hKernel32, "AddDllDirectory")) {
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows Server 2008 R2 without KB2533625");
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "KB2533625 update is required to continue.");
+                    /* The "MissingSP1" error also specifies updates are required */
+                    LocGetString(_wixLoc, L"#(loc.FailureWS2K8R2MissingSP1)", &pLocString);
+                } else {
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Target OS is Windows Server 2008 R2 or later");
+                    return;
+                }
             } else if (IsWindowsVersionOrGreater(6, 1, 0)) {
                 BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows Server 2008 R2");
                 BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Service Pack 1 is required to continue installation");
@@ -3009,7 +3020,10 @@ private:
                 LocGetString(_wixLoc, L"#(loc.FailureWS2K3OrEarlier)", &pLocString);
             }
         } else {
-            if (IsWindows7SP1OrGreater()) {
+            if (IsWindows8OrGreater()) {
+                BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Target OS is Windows 8 or later");
+                return;
+            } else if (IsWindows7SP1OrGreater()) {
                 HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
                 if (hKernel32 && !GetProcAddress(hKernel32, "AddDllDirectory")) {
                     BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows 7 SP1 without KB2533625");

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -3010,8 +3010,16 @@ private:
             }
         } else {
             if (IsWindows7SP1OrGreater()) {
-                BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Target OS is Windows 7 SP1 or later");
-                return;
+                HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
+                if (hKernel32 && !GetProcAddress(hKernel32, "AddDllDirectory")) {
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows 7 SP1 without KB2533625");
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "KB2533625 update is required to continue.");
+                    /* The "MissingSP1" error also specifies updates are required */
+                    LocGetString(_wixLoc, L"#(loc.FailureWin7MissingSP1)", &pLocString);
+                } else {
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Target OS is Windows 7 SP1 or later");
+                    return;
+                }
             } else if (IsWindows7OrGreater()) {
                 BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows 7 RTM");
                 BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Service Pack 1 is required to continue installation");

--- a/Tools/msi/lib/lib_files.wxs
+++ b/Tools/msi/lib/lib_files.wxs
@@ -62,9 +62,6 @@
             <Component Id="libssl.pdb" Directory="DLLs" Guid="*">
                 <File Name="libssl$(var.ssltag).pdb" KeyPath="yes" />
             </Component>
-            <Component Id="libffi.pdb" Directory="DLLs" Guid="*">
-                <File Name="libffi-7.pdb" KeyPath="yes" />
-            </Component>
             <Component Id="venvlauncher.pdb" Directory="Lib_venv_scripts_nt__pdbs" Guid="*">
                 <File Name="python.pdb" Source="venvlauncher.pdb" KeyPath="yes" />
             </Component>


### PR DESCRIPTION
[bpo-36085](https://bugs.python.org/issue36085): Add installer check for KB2533625
Change default build option for Tools/msi/build.bat
Remove invalid reference to missing pdb file

<!-- issue-number: [bpo-36085](https://bugs.python.org/issue36085) -->
https://bugs.python.org/issue36085
<!-- /issue-number -->
