### PR TITLE
bpo-36495: Fix two out-of-bounds array reads

### DIFF
--- a/Misc/NEWS.d/next/Security/2019-03-31-15-06-35.bpo-36495.ahXWSI.rst
+++ b/Misc/NEWS.d/next/Security/2019-03-31-15-06-35.bpo-36495.ahXWSI.rst
@@ -1,1 +1,0 @@
-Fix two out-of-bound reads in the code that constructs abstract syntax trees.  Patch by Brad Larsen.

--- a/Misc/NEWS.d/next/Security/2019-03-31-15-06-35.bpo-36495.ahXWSI.rst
+++ b/Misc/NEWS.d/next/Security/2019-03-31-15-06-35.bpo-36495.ahXWSI.rst
@@ -1,0 +1,1 @@
+Fix two out-of-bound reads in the code that constructs abstract syntax trees.  Patch by Brad Larsen.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -1400,7 +1400,7 @@ handle_keywordonly_args(struct compiling *c, const node *n, int start,
                     goto error;
                 asdl_seq_SET(kwonlyargs, j++, arg);
                 i += 1; /* the name */
-                if (TYPE(CHILD(n, i)) == COMMA)
+                if (i < NCH(n) && TYPE(CHILD(n, i)) == COMMA)
                     i += 1; /* the comma, if present */
                 break;
             case TYPE_COMMENT:
@@ -1599,7 +1599,7 @@ ast_for_arguments(struct compiling *c, const node *n)
                 if (!kwarg)
                     return NULL;
                 i += 2; /* the double star and the name */
-                if (TYPE(CHILD(n, i)) == COMMA)
+                if (i < NCH(n) && TYPE(CHILD(n, i)) == COMMA)
                     i += 1; /* the comma, if present */
                 break;
             case TYPE_COMMENT:


### PR DESCRIPTION
https://bugs.python.org/issue36495

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36495](https://bugs.python.org/issue36495) -->
https://bugs.python.org/issue36495
<!-- /issue-number -->
