### PR TITLE
[2.7] bpo-36150: Fix possible assertion failures due to _ctypes.c's PyCData_reduce(). (GH-12106)

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2795,16 +2795,18 @@ static PyObject *
 PyCData_reduce(PyObject *_self, PyObject *args)
 {
     CDataObject *self = (CDataObject *)_self;
+    PyObject *dict;
 
     if (PyObject_stgdict(_self)->flags & (TYPEFLAG_ISPOINTER|TYPEFLAG_HASPOINTER)) {
         PyErr_SetString(PyExc_ValueError,
                         "ctypes objects containing pointers cannot be pickled");
         return NULL;
     }
-    return Py_BuildValue("O(O(NN))",
-                         _unpickle,
-                         Py_TYPE(_self),
-                         PyObject_GetAttrString(_self, "__dict__"),
+    dict = PyObject_GetAttrString(_self, "__dict__");
+    if (dict == NULL) {
+        return NULL;
+    }
+    return Py_BuildValue("O(O(NN))", _unpickle, Py_TYPE(_self), dict,
                          PyString_FromStringAndSize(self->b_ptr, self->b_size));
 }
 


### PR DESCRIPTION

(cherry picked from commit 5f2c50810a67982b0c80f6d3258fee3647f67005)


<!-- issue-number: [bpo-36150](https://bugs.python.org/issue36150) -->
https://bugs.python.org/issue36150
<!-- /issue-number -->
