### PR TITLE
bpo-31904: Fix file not exist error string

### DIFF
--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -5,8 +5,9 @@ Glossary:
 """
 from unittest import TestCase, mock
 from unittest import mock
-import sys
 import errno
+import os
+import sys
 import tabnanny
 import tokenize
 import tempfile
@@ -234,12 +235,8 @@ class TestCheck(TestCase):
     def test_when_no_file(self):
         """A python file which does not exist actually in system."""
         path = 'no_file.py'
-        if sys.platform == "vxworks":
-            err = f"{path!r}: I/O Error: [Errno {errno.ENOENT}] " \
-                  f"no such file or directory: {path!r}\n"
-        else:
-            err = f"{path!r}: I/O Error: [Errno {errno.ENOENT}] " \
-                  f"No such file or directory: {path!r}\n"
+        err = (f"{path!r}: I/O Error: [Errno {errno.ENOENT}] "
+              f"{os.strerror(errno.ENOENT)}: {path!r}\n")
         self.verify_tabnanny_check(path, err=err)
 
     def test_errored_directory(self):

--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -5,6 +5,7 @@ Glossary:
 """
 from unittest import TestCase, mock
 from unittest import mock
+import sys
 import errno
 import tabnanny
 import tokenize
@@ -233,8 +234,12 @@ class TestCheck(TestCase):
     def test_when_no_file(self):
         """A python file which does not exist actually in system."""
         path = 'no_file.py'
-        err = f"{path!r}: I/O Error: [Errno {errno.ENOENT}] " \
-              f"No such file or directory: {path!r}\n"
+        if sys.platform == "vxworks":
+            err = f"{path!r}: I/O Error: [Errno {errno.ENOENT}] " \
+                  f"no such file or directory: {path!r}\n"
+        else:
+            err = f"{path!r}: I/O Error: [Errno {errno.ENOENT}] " \
+                  f"No such file or directory: {path!r}\n"
         self.verify_tabnanny_check(path, err=err)
 
     def test_errored_directory(self):

--- a/Misc/NEWS.d/next/Library/2019-04-01-16-06-36.bpo-31904.peaceF.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-01-16-06-36.bpo-31904.peaceF.rst
@@ -1,0 +1,1 @@
+Handle VxWorks error string of ENOENT

--- a/Misc/NEWS.d/next/Library/2019-04-01-16-06-36.bpo-31904.peaceF.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-01-16-06-36.bpo-31904.peaceF.rst
@@ -1,1 +1,0 @@
-Handle VxWorks error string of ENOENT

--- a/Misc/NEWS.d/next/Tests/2019-04-01-16-06-36.bpo-31904.peaceF.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-01-16-06-36.bpo-31904.peaceF.rst
@@ -1,0 +1,1 @@
+Fix test_tabnanny on VxWorks: adjust ENOENT error message.


### PR DESCRIPTION
The strerror return "no such file or directory" when error code is ENOENT on VxWorks, this is different from Linux, change test_tabnanny.py toVxWorks excpected string.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
