### PR TITLE
bpo-35838: document optionxform must be idempotent

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -721,6 +721,12 @@ be overridden by subclasses or by attribute assignment.
      >>> list(custom['Section2'].keys())
      ['AnotherKey']
 
+  .. note::
+     The optionxform function transforms option names to a canonical form.
+     This should be an idempotent function: if the name is already in
+     canonical form, it should be returned unchanged.
+
+
 .. attribute:: ConfigParser.SECTCRE
 
   A compiled regular expression used to parse section headers.  The default


### PR DESCRIPTION


<!-- issue-number: [bpo-35838](https://bugs.python.org/issue35838) -->
https://bugs.python.org/issue35838
<!-- /issue-number -->
