### PR TITLE
bpo-36508: python-config don't export LINKFORSHARED

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1464,14 +1464,13 @@ python-config: $(srcdir)/Misc/python-config.in Misc/python-config.sh
 	@ # Substitution happens here, as the completely-expanded BINDIR
 	@ # is not available in configure
 	sed -e "s,@EXENAME@,$(BINDIR)/python$(LDVERSION)$(EXE)," < $(srcdir)/Misc/python-config.in >python-config.py
+	@ # Replace makefile compat. variable references with shell script compat. ones; $(VAR) -> ${VAR}
+	LC_ALL=C sed -e 's,\$$(\([A-Za-z0-9_]*\)),\$$\{\1\},g' < Misc/python-config.sh >python-config
 	@ # On Darwin, always use the python version of the script, the shell
 	@ # version doesn't use the compiler customizations that are provided
 	@ # in python (_osx_support.py).
 	@if test `uname -s` = Darwin; then \
 		cp python-config.py python-config; \
-	else \
-		# Replace makefile compat. variable references with shell script compat. ones; $(VAR) -> ${VAR} \
-		LC_ALL=C sed -e 's,\$$(\([A-Za-z0-9_]*\)),\$$\{\1\},g' < Misc/python-config.sh >python-config; \
 	fi
 
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -104,6 +104,8 @@ PY_LDFLAGS_NODIST=$(CONFIGURE_LDFLAGS_NODIST) $(LDFLAGS_NODIST)
 NO_AS_NEEDED=	@NO_AS_NEEDED@
 SGI_ABI=	@SGI_ABI@
 CCSHARED=	@CCSHARED@
+# LINKFORSHARED are the flags passed to the $(CC) command that links
+# the python executable -- this is only needed for a few systems
 LINKFORSHARED=	@LINKFORSHARED@
 ARFLAGS=	@ARFLAGS@
 # Extra C flags added for building the interpreter object files.
@@ -1462,13 +1464,14 @@ python-config: $(srcdir)/Misc/python-config.in Misc/python-config.sh
 	@ # Substitution happens here, as the completely-expanded BINDIR
 	@ # is not available in configure
 	sed -e "s,@EXENAME@,$(BINDIR)/python$(LDVERSION)$(EXE)," < $(srcdir)/Misc/python-config.in >python-config.py
-	@ # Replace makefile compat. variable references with shell script compat. ones; $(VAR) -> ${VAR}
-	LC_ALL=C sed -e 's,\$$(\([A-Za-z0-9_]*\)),\$$\{\1\},g' < Misc/python-config.sh >python-config
 	@ # On Darwin, always use the python version of the script, the shell
 	@ # version doesn't use the compiler customizations that are provided
 	@ # in python (_osx_support.py).
 	@if test `uname -s` = Darwin; then \
 		cp python-config.py python-config; \
+	else \
+		# Replace makefile compat. variable references with shell script compat. ones; $(VAR) -> ${VAR} \
+		LC_ALL=C sed -e 's,\$$(\([A-Za-z0-9_]*\)),\$$\{\1\},g' < Misc/python-config.sh >python-config; \
 	fi
 
 

--- a/Misc/NEWS.d/next/Build/2019-04-02-17-01-23.bpo-36508.SN5Y6N.rst
+++ b/Misc/NEWS.d/next/Build/2019-04-02-17-01-23.bpo-36508.SN5Y6N.rst
@@ -1,0 +1,3 @@
+``python-config --ldflags`` no longer includes flags of the
+``LINKFORSHARED`` variable. The ``LINKFORSHARED`` variable must only be used
+to build executables.

--- a/Misc/python-config.in
+++ b/Misc/python-config.in
@@ -55,8 +55,6 @@ for opt in opt_flags:
         if opt == '--ldflags':
             if not getvar('Py_ENABLE_SHARED'):
                 libs.insert(0, '-L' + getvar('LIBPL'))
-            if not getvar('PYTHONFRAMEWORK'):
-                libs.extend(getvar('LINKFORSHARED').split())
         print(' '.join(libs))
 
     elif opt == '--extension-suffix':

--- a/Misc/python-config.sh.in
+++ b/Misc/python-config.sh.in
@@ -44,7 +44,6 @@ ABIFLAGS="@ABIFLAGS@"
 LIBS="-lpython${VERSION}${ABIFLAGS} @LIBS@ $SYSLIBS"
 BASECFLAGS="@BASECFLAGS@"
 LDLIBRARY="@LDLIBRARY@"
-LINKFORSHARED="@LINKFORSHARED@"
 OPT="@OPT@"
 PY_ENABLE_SHARED="@PY_ENABLE_SHARED@"
 LDVERSION="@LDVERSION@"
@@ -89,15 +88,11 @@ do
             echo "$LIBS"
         ;;
         --ldflags)
-            LINKFORSHAREDUSED=
-            if [ -z "$PYTHONFRAMEWORK" ] ; then
-                LINKFORSHAREDUSED=$LINKFORSHARED
-            fi
             LIBPLUSED=
             if [ "$PY_ENABLE_SHARED" = "0" ] ; then
                 LIBPLUSED="-L$LIBPL"
             fi
-            echo "$LIBPLUSED -L$libdir $LIBS $LINKFORSHAREDUSED"
+            echo "$LIBPLUSED -L$libdir $LIBS"
         ;;
         --extension-suffix)
             echo "$SO"


### PR DESCRIPTION
python-config --ldflags no longer includes flags of the LINKFORSHARED
variable. The LINKFORSHARED variable must only be used to build
executables.

<!-- issue-number: [bpo-36508](https://bugs.python.org/issue36508) -->
https://bugs.python.org/issue36508
<!-- /issue-number -->
