### PR TITLE
bpo-36509: Add iot layout for windows iot containers

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-04-02-10-11-18.bpo-36509.DdaM67.rst
+++ b/Misc/NEWS.d/next/Windows/2019-04-02-10-11-18.bpo-36509.DdaM67.rst
@@ -1,0 +1,4 @@
+Added preset-iot layout for Windows IoT ARM containers. This layout doesn't
+contain UI components like tkinter or IDLE. It also doesn't contain files to
+support on-target builds since Windows ARM32 builds must be cross-compiled
+when using MSVC.

--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -66,6 +66,18 @@ DATA_DIRS = FileNameSet("data")
 TOOLS_DIRS = FileNameSet("scripts", "i18n", "pynche", "demo", "parser")
 TOOLS_FILES = FileSuffixSet(".py", ".pyw", ".txt")
 
+def copy_if_modified(src, dest):
+    try:
+        dest_stat = os.stat(dest)
+    except FileNotFoundError:
+        do_copy = True
+    else:
+        src_stat = os.stat(src)
+        do_copy = (src_stat.st_mtime != dest_stat.st_mtime or
+                   src_stat.st_size != dest_stat.st_size)
+
+    if do_copy:
+        shutil.copy2(src, dest)
 
 def get_lib_layout(ns):
     def _c(f):
@@ -426,7 +438,7 @@ def copy_files(files, ns):
                     need_compile.append((dest, ns.copy / dest))
                 else:
                     (ns.temp / "Lib" / dest).parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(src, ns.temp / "Lib" / dest)
+                    copy_if_modified(src, ns.temp / "Lib" / dest)
                     need_compile.append((dest, ns.temp / "Lib" / dest))
 
             if src not in EXCLUDE_FROM_CATALOG:
@@ -436,7 +448,7 @@ def copy_files(files, ns):
                 log_debug("Copy {} -> {}", src, ns.copy / dest)
                 (ns.copy / dest).parent.mkdir(parents=True, exist_ok=True)
                 try:
-                    shutil.copy2(src, ns.copy / dest)
+                    copy_if_modified(src, ns.copy / dest)
                 except shutil.SameFileError:
                     pass
 

--- a/PC/layout/support/options.py
+++ b/PC/layout/support/options.py
@@ -55,6 +55,10 @@ PRESETS = {
         "help": "nuget package",
         "options": ["stable", "pip", "distutils", "dev", "props"],
     },
+    "iot": {
+        "help": "Windows IoT Core",
+        "options": ["stable", "pip"],
+    },
     "default": {
         "help": "development kit package",
         "options": [


### PR DESCRIPTION
The layout should not contain tcl/tk, tkinter, distutils since ARM is cross-compiled and these features will not be useful on target ARM devices.

<!-- issue-number: [bpo-36509](https://bugs.python.org/issue36509) -->
https://bugs.python.org/issue36509
<!-- /issue-number -->
