### PR TITLE
bpo-33608: make arm macros match x86 macros

### DIFF
--- a/Include/internal/pycore_atomic.h
+++ b/Include/internal/pycore_atomic.h
@@ -407,13 +407,13 @@ typedef struct _Py_atomic_int {
 #define _Py_atomic_store_32bit(ATOMIC_VAL, NEW_VAL, ORDER) \
   switch (ORDER) { \
   case _Py_memory_order_acquire: \
-    _InterlockedExchange_acq((volatile long*)&((ATOMIC_VAL)->_value), (int)NEW_VAL); \
+    _InterlockedExchange_acq((volatile long*)(ATOMIC_VAL), (int)NEW_VAL); \
     break; \
   case _Py_memory_order_release: \
-    _InterlockedExchange_rel((volatile long*)&((ATOMIC_VAL)->_value), (int)NEW_VAL); \
+    _InterlockedExchange_rel((volatile long*)(ATOMIC_VAL), (int)NEW_VAL); \
     break; \
   default: \
-    _InterlockedExchange((volatile long*)&((ATOMIC_VAL)->_value), (int)NEW_VAL); \
+    _InterlockedExchange((volatile long*)(ATOMIC_VAL), (int)NEW_VAL); \
     break; \
   }
 


### PR DESCRIPTION
The ARM changes to _Py_atomic_store_32bit don't match the x86 changes and cause a build break.
Changing _Py_atomic_store_32bit for ARM to match x86 fixes the build issue.
@ericsnowcurrently @zooba

<!-- issue-number: [bpo-33608](https://bugs.python.org/issue33608) -->
https://bugs.python.org/issue33608
<!-- /issue-number -->
