### PR TITLE
bpo-36487: Make C-API docs  clear about what the main interpreter is

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1116,12 +1116,11 @@ same process and perhaps even in the same thread. Sub-interpreters allow
 you to do that.
 
 The "main" interpreter is the first one created when the runtime initializes.
-The :c:func:`PyInterpreterState_Main` funtion returns a pointer to this main
-interpreter's state. It is usually the only Python interpreter in a process.
-The main interpreter also has other responsibilities like signal and public
-calls handling in the main thread, is responsible for execution during runtime
-initialization, and it is usually the active interpreter during runtime
-finalization.
+It is usually the only Python interpreter in a process.  Unlike sub-interpreters,
+the main interpreter has unique process-global responsibilities like signal
+handling.  It is also responsible for execution during runtime initialization and
+is usually the active interpreter during runtime finalization.  The
+:c:func:`PyInterpreterState_Main` funtion returns a pointer to its state.
 
 You can switch between sub-interpreters using the :c:func:`PyThreadState_Swap`
 function. You can create and destroy them using the following functions:

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1115,7 +1115,7 @@ are cases where you need to create several independent interpreters in the
 same process and perhaps even in the same thread.
 
 Before sub-interpreters, there is a main interpreter which is the first one
-created by the CPython runtime during startup when the ``python`` command is
+created by the CPython runtime on startup when the ``python`` command is
 run. The :c:func:`PyInterpreterState_Main` funtion returns a pointer to this
 main interpreter's state.
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1112,10 +1112,16 @@ Sub-interpreter support
 
 While in most uses, you will only embed a single Python interpreter, there
 are cases where you need to create several independent interpreters in the
-same process and perhaps even in the same thread.  Sub-interpreters allow
-you to do that.  You can switch between sub-interpreters using the
-:c:func:`PyThreadState_Swap` function.  You can create and destroy them
-using the following functions:
+same process and perhaps even in the same thread.
+
+Before sub-interpreters, there is a main interpreter which is the first one
+created by the CPython runtime during startup when the ``python`` command is
+run. The :c:func:`PyInterpreterState_Main` funtion returns a pointer to this
+main interpreter's state.
+
+Sub-interpreters allow you to do that.  You can switch between
+sub-interpreters using the :c:func:`PyThreadState_Swap` function.
+You can create and destroy them using the following functions:
 
 
 .. c:function:: PyThreadState* Py_NewInterpreter()

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1112,16 +1112,19 @@ Sub-interpreter support
 
 While in most uses, you will only embed a single Python interpreter, there
 are cases where you need to create several independent interpreters in the
-same process and perhaps even in the same thread.
+same process and perhaps even in the same thread. Sub-interpreters allow
+you to do that.
 
-Before sub-interpreters, there is a main interpreter which is the first one
-created by the CPython runtime on startup when the ``python`` command is
-run. The :c:func:`PyInterpreterState_Main` funtion returns a pointer to this
-main interpreter's state.
+The main interpreter is the first one created when runtime initializes.
+The :c:func:`PyInterpreterState_Main` funtion returns a pointer to this main
+interpreter's state. It is usually the only Python interpreter in a process.
+The main interpreter also has other responsibilities like signal and public
+calls  handling in the main thread, can be taken over by a suninterpreter
+in the main thread, responsible for execution during runtime initialization
+and it is usually the active interpreter during runtime finalization.
 
-Sub-interpreters allow you to do that.  You can switch between
-sub-interpreters using the :c:func:`PyThreadState_Swap` function.
-You can create and destroy them using the following functions:
+You can switch between sub-interpreters using the :c:func:`PyThreadState_Swap`
+function. You can create and destroy them using the following functions:
 
 
 .. c:function:: PyThreadState* Py_NewInterpreter()

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1116,7 +1116,7 @@ same process and perhaps even in the same thread. Sub-interpreters allow
 you to do that.
 
 The "main" interpreter is the first one created when the runtime initializes.
-The :c:func:`PyInterpreterState_Main` funtion returns a pointer to this main
+The :c:func:`PyInterpreterState_Main` function returns a pointer to this main
 interpreter's state. It is usually the only Python interpreter in a process.
 The main interpreter also has other responsibilities like signal and public
 calls  handling in the main thread, can be taken over by a suninterpreter

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1115,7 +1115,7 @@ are cases where you need to create several independent interpreters in the
 same process and perhaps even in the same thread. Sub-interpreters allow
 you to do that.
 
-The main interpreter is the first one created when runtime initializes.
+The "main" interpreter is the first one created when the runtime initializes.
 The :c:func:`PyInterpreterState_Main` funtion returns a pointer to this main
 interpreter's state. It is usually the only Python interpreter in a process.
 The main interpreter also has other responsibilities like signal and public

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1116,12 +1116,12 @@ same process and perhaps even in the same thread. Sub-interpreters allow
 you to do that.
 
 The "main" interpreter is the first one created when the runtime initializes.
-The :c:func:`PyInterpreterState_Main` function returns a pointer to this main
+The :c:func:`PyInterpreterState_Main` funtion returns a pointer to this main
 interpreter's state. It is usually the only Python interpreter in a process.
 The main interpreter also has other responsibilities like signal and public
-calls  handling in the main thread, can be taken over by a suninterpreter
-in the main thread, responsible for execution during runtime initialization
-and it is usually the active interpreter during runtime finalization.
+calls handling in the main thread, is responsible for execution during runtime
+initialization, and it is usually the active interpreter during runtime
+finalization.
 
 You can switch between sub-interpreters using the :c:func:`PyThreadState_Swap`
 function. You can create and destroy them using the following functions:

--- a/Misc/NEWS.d/next/Documentation/2019-04-02-19-23-00.bpo-36487.Jg6-MG.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-04-02-19-23-00.bpo-36487.Jg6-MG.rst
@@ -1,0 +1,1 @@
+Make C-API docs  clear about what the "main" interpreter is.

--- a/Misc/NEWS.d/next/Documentation/2019-04-02-19-23-00.bpo-36487.Jg6-MG.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-04-02-19-23-00.bpo-36487.Jg6-MG.rst
@@ -1,1 +1,1 @@
-Make C-API docs  clear about what the "main" interpreter is.
+Make C-API docs clear about what the "main" interpreter is.


### PR DESCRIPTION
I have added documentation to clarify on what the main interpreter is.

<!-- issue-number: [bpo-36487](https://bugs.python.org/issue36487) -->
https://bugs.python.org/issue36487
<!-- /issue-number -->
