### PR TITLE
bpo-36475: Finalize PyEval_AcquireLock() and PyEval_AcquireThread() properly

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1095,6 +1095,7 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    :c:func:`PyEval_RestoreThread` is a higher-level function which is always
    available (even when threads have not been initialized).
 
+
 .. c:function:: void PyEval_ReleaseThread(PyThreadState *tstate)
 
    Reset the current thread state to *NULL* and release the global interpreter

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -863,7 +863,6 @@ code, or when embedding the Python interpreter:
       check if the interpreter is in process of being finalized before calling
       this function to avoid unwanted termination.
 
-
 .. c:function:: PyThreadState* PyThreadState_Get()
 
    Return the current thread state.  The global interpreter lock must be held.

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -863,6 +863,7 @@ code, or when embedding the Python interpreter:
       check if the interpreter is in process of being finalized before calling
       this function to avoid unwanted termination.
 
+
 .. c:function:: PyThreadState* PyThreadState_Get()
 
    Return the current thread state.  The global interpreter lock must be held.
@@ -1080,9 +1081,27 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    *tstate*, which should not be *NULL*.  The lock must have been created earlier.
    If this thread already has the lock, deadlock ensues.
 
+   .. note::
+      Calling this function from a thread when the runtime is finalizing
+      will terminate the thread, even if the thread was not created by Python.
+      You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
+      check if the interpreter is in process of being finalized before calling
+      this function to avoid unwanted termination.
+
+   .. versionchanged:: 3.8
+      Updated to be consistent with :c:func:`PyEval_RestoreThread`,
+      :c:func:`Py_END_ALLOW_THREADS`, and :c:func:`PyGILState_Ensure`,
+      and terminate the current thread if called while the interpreter is finalizing.
+
    :c:func:`PyEval_RestoreThread` is a higher-level function which is always
    available (even when threads have not been initialized).
 
+   .. note::
+      Calling this function from a thread when the runtime is finalizing
+      will terminate the thread, even if the thread was not created by Python.
+      You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
+      check if the interpreter is in process of being finalized before calling
+      this function to avoid unwanted termination.
 
 .. c:function:: void PyEval_ReleaseThread(PyThreadState *tstate)
 
@@ -1105,6 +1124,18 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
       This function does not update the current thread state.  Please use
       :c:func:`PyEval_RestoreThread` or :c:func:`PyEval_AcquireThread`
       instead.
+
+   .. note::
+      Calling this function from a thread when the runtime is finalizing
+      will terminate the thread, even if the thread was not created by Python.
+      You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
+      check if the interpreter is in process of being finalized before calling
+      this function to avoid unwanted termination.
+
+   .. versionchanged:: 3.8
+      Updated to be consistent with :c:func:`PyEval_RestoreThread`,
+      :c:func:`Py_END_ALLOW_THREADS`, and :c:func:`PyGILState_Ensure`,
+      and terminate the current thread if called while the interpreter is finalizing.
 
 
 .. c:function:: void PyEval_ReleaseLock()

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1096,13 +1096,6 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    :c:func:`PyEval_RestoreThread` is a higher-level function which is always
    available (even when threads have not been initialized).
 
-   .. note::
-      Calling this function from a thread when the runtime is finalizing
-      will terminate the thread, even if the thread was not created by Python.
-      You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
-      check if the interpreter is in process of being finalized before calling
-      this function to avoid unwanted termination.
-
 .. c:function:: void PyEval_ReleaseThread(PyThreadState *tstate)
 
    Reset the current thread state to *NULL* and release the global interpreter

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -725,7 +725,7 @@ Changes in Python behavior
   older Python versions include the version number, it is recommended to
   always use the ``sys.platform.startswith('aix')``.
   (Contributed by M. Felt in :issue:`36588`.)
-  
+
 * :c:func:`PyEval_AcquireLock` and :c:func:`PyEval_AcquireThread` now
   terminate the current thread if called while the interpreter is
   finalizing, making them consistent with :c:func:`PyEval_RestoreThread`,

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -725,6 +725,13 @@ Changes in Python behavior
   older Python versions include the version number, it is recommended to
   always use the ``sys.platform.startswith('aix')``.
   (Contributed by M. Felt in :issue:`36588`.)
+  
+* :c:func:`PyEval_AcquireLock` and :c:func:`PyEval_AcquireThread` now
+  terminate the current thread if called while the interpreter is
+  finalizing, making them consistent with :c:func:`PyEval_RestoreThread`,
+  :c:func:`Py_END_ALLOW_THREADS`, and :c:func:`PyGILState_Ensure`. If this
+  behaviour is not desired, guard the call by checking :c:func:`_Py_IsFinalizing`
+  or :c:func:`sys.is_finalizing`.
 
 Changes in the Python API
 -------------------------

--- a/Misc/NEWS.d/next/Core and Builtins/2019-04-02-20-02-22.bpo-36475.CjRps3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-02-20-02-22.bpo-36475.CjRps3.rst
@@ -1,0 +1,4 @@
+:c:func:`PyEval_AcquireLock` and :c:func:`PyEval_AcquireThread` now
+terminate the current thread if called while the interpreter is
+finalizing, making them consistent with :c:func:`PyEval_RestoreThread`,
+:c:func:`Py_END_ALLOW_THREADS`, and :c:func:`PyGILState_Ensure`.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -204,6 +204,17 @@ _PyEval_FiniThreads(void)
     }
 }
 
+static inline void
+exit_thread_if_finalizing(PyThreadState *tstate)
+{
+    /* _Py_Finalizing is protected by the GIL */
+    if (_Py_IsFinalizing() && !_Py_CURRENTLY_FINALIZING(tstate)) {
+        drop_gil(tstate);
+        PyThread_exit_thread();
+        Py_UNREACHABLE();
+    }
+}
+
 void
 PyEval_AcquireLock(void)
 {
@@ -5189,17 +5200,6 @@ format_awaitable_error(PyTypeObject *type, int prevopcode)
                          "that does not implement __await__: %.100s",
                          type->tp_name);
         }
-    }
-}
-
-static inline void
-exit_thread_if_finalizing(PyThreadState *tstate)
-{
-    /* _Py_Finalizing is protected by the GIL */
-    if (_Py_IsFinalizing() && !_Py_CURRENTLY_FINALIZING(tstate)) {
-        drop_gil(tstate);
-        PyThread_exit_thread();
-        Py_UNREACHABLE();
     }
 }
 


### PR DESCRIPTION
I have added changes to finalize finalize `PyEval_AcquireLock() `and `PyEval_AcquireThread() `properly.

<!-- issue-number: [bpo-36475](https://bugs.python.org/issue36475) -->
https://bugs.python.org/issue36475
<!-- /issue-number -->
