### PR TITLE
bpo-36512: future_factory argument for Thread/ProcessPoolExecutor

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -132,7 +132,7 @@ And::
    executor.submit(wait_on_future)
 
 
-.. class:: ThreadPoolExecutor(max_workers=None, thread_name_prefix='', initializer=None, initargs=())
+.. class:: ThreadPoolExecutor(max_workers=None, thread_name_prefix='', initializer=None, initargs=(), future_factory=None)
 
    An :class:`Executor` subclass that uses a pool of at most *max_workers*
    threads to execute calls asynchronously.
@@ -142,6 +142,10 @@ And::
    initializer.  Should *initializer* raise an exception, all currently
    pending jobs will raise a :exc:`~concurrent.futures.thread.BrokenThreadPool`,
    as well as any attempt to submit more jobs to the pool.
+
+   *future_factory* is an optional callable that is called to create a
+   :class:`Future` returned by :meth:`ThreadPoolExecutor.submit`.
+   If ``None`` :class:`Future` is used.
 
    .. versionchanged:: 3.5
       If *max_workers* is ``None`` or
@@ -158,6 +162,9 @@ And::
 
    .. versionchanged:: 3.7
       Added the *initializer* and *initargs* arguments.
+
+   .. versionchanged:: 3.8
+      Added *future_factory* argument.
 
 
 .. _threadpoolexecutor-example:
@@ -209,7 +216,7 @@ that :class:`ProcessPoolExecutor` will not work in the interactive interpreter.
 Calling :class:`Executor` or :class:`Future` methods from a callable submitted
 to a :class:`ProcessPoolExecutor` will result in deadlock.
 
-.. class:: ProcessPoolExecutor(max_workers=None, mp_context=None, initializer=None, initargs=())
+.. class:: ProcessPoolExecutor(max_workers=None, mp_context=None, initializer=None, initargs=(), future_factory=None)
 
    An :class:`Executor` subclass that executes calls asynchronously using a pool
    of at most *max_workers* processes.  If *max_workers* is ``None`` or not
@@ -226,6 +233,10 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
    pending jobs will raise a :exc:`~concurrent.futures.process.BrokenProcessPool`,
    as well any attempt to submit more jobs to the pool.
 
+   *future_factory* is an optional callable that is called to create a
+   :class:`Future` returned by :meth:`ThreadPoolExecutor.submit`.
+   If ``None`` :class:`Future` is used.
+
    .. versionchanged:: 3.3
       When one of the worker processes terminates abruptly, a
       :exc:`BrokenProcessPool` error is now raised.  Previously, behaviour
@@ -237,6 +248,9 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
       start_method for worker processes created by the pool.
 
       Added the *initializer* and *initargs* arguments.
+
+   .. versionchanged:: 3.8
+      Added *future_factory* argument.
 
 
 .. _processpoolexecutor-example:

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -277,6 +277,36 @@ create_executor_tests(InitializerMixin)
 create_executor_tests(FailingInitializerMixin)
 
 
+class DefaultFutureFactoryMixin(ExecutorMixin):
+    def test_default_future_factory(self):
+        future = self.executor.submit(mul, 1, 1)
+        future.result()
+
+        self.assertTrue(isinstance(future, Future))
+
+
+class FutureFactoryMixin(ExecutorMixin):
+    custom_future_class = type("CustomFuture", (Future,), {})
+    executor_kwargs = {"future_factory": custom_future_class}
+
+    def test_future_factory(self):
+        future = self.executor.submit(mul, 1, 1)
+        future.result()
+
+        self.assertTrue(isinstance(future, self.custom_future_class))
+
+
+class FutureFactoryCallableMixin(ExecutorMixin):
+    def test_future_factory_must_be_callable(self):
+        with self.assertRaises(TypeError):
+            self.executor_type(future_factory="not callable")
+
+
+create_executor_tests(DefaultFutureFactoryMixin)
+create_executor_tests(FutureFactoryMixin)
+create_executor_tests(FutureFactoryCallableMixin)
+
+
 class ExecutorShutdownTest:
     def test_run_after_shutdown(self):
         self.executor.shutdown()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1848,3 +1848,4 @@ Peter Åstrand
 Zheao Li
 Carsten Klein
 Diego Rojas
+Stefan Hoelzl

--- a/Misc/NEWS.d/next/Library/2019-04-02-22-08-30.bpo-36512.d74RT2s.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-02-22-08-30.bpo-36512.d74RT2s.rst
@@ -1,0 +1,3 @@
+*future_factory* argument for ``concurrent.futures.ThreadExecutorPool``
+and ``concurrent.futures.ProcessExecutorPool`` to controle the type of
+Future created by ``concurrent.futures.Executor.submit``


### PR DESCRIPTION
adding a future_factory argument to Thread/ProcessPoolExecutor to control which type of Future should be created by Executor.submit

<!-- issue-number: [bpo-36512](https://bugs.python.org/issue36512) -->
https://bugs.python.org/issue36512
<!-- /issue-number -->
