### PR TITLE
bpo-36513: Enable building cpython nuget package for arm32

### DIFF
--- a/Tools/nuget/build.bat
+++ b/Tools/nuget/build.bat
@@ -6,20 +6,24 @@ if "%Py_OutDir%"=="" set Py_OutDir=%PCBUILD%
 
 set BUILDX86=
 set BUILDX64=
+set BUILDARM32=
 set REBUILD=
 set OUTPUT=
 set PACKAGES=
+set PYTHON_EXE=
 
 :CheckOpts
 if "%~1" EQU "-h" goto Help
 if "%~1" EQU "-x86" (set BUILDX86=1) && shift && goto CheckOpts
 if "%~1" EQU "-x64" (set BUILDX64=1) && shift && goto CheckOpts
+if "%~1" EQU "-arm32" (set BUILDARM32=1) && shift && goto CheckOpts
 if "%~1" EQU "-r" (set REBUILD=-r) && shift && goto CheckOpts
 if "%~1" EQU "-o" (set OUTPUT="/p:OutputPath=%~2") && shift && shift && goto CheckOpts
 if "%~1" EQU "--out" (set OUTPUT="/p:OutputPath=%~2") && shift && shift && goto CheckOpts
 if "%~1" EQU "-p" (set PACKAGES=%PACKAGES% %~2) && shift && shift && goto CheckOpts
+if "%~1" EQU "--python-exe" (set PYTHON_EXE="/p:PythonExe=%~2") && shift && shift && goto CheckOpts
 
-if not defined BUILDX86 if not defined BUILDX64 (set BUILDX86=1) && (set BUILDX64=1)
+if not defined BUILDX86 if not defined BUILDX64 if not defined BUILDARM32 (set BUILDX86=1) && (set BUILDX64=1) && (set BUILDARM32=1)
 
 call "%D%..\msi\get_externals.bat"
 call "%PCBUILD%find_msbuild.bat" %MSBUILD%
@@ -32,7 +36,7 @@ if defined BUILDX86 (
     ) else if not exist "%Py_OutDir%win32\python.exe" call "%PCBUILD%build.bat" -e
     if errorlevel 1 goto :eof
 
-    %MSBUILD% "%D%make_pkg.proj" /p:Configuration=Release /p:Platform=x86 %OUTPUT% %PACKAGES%
+    %MSBUILD% "%D%make_pkg.proj" /p:Configuration=Release /p:Platform=x86 %OUTPUT% %PACKAGES% %PYTHON_EXE%
     if errorlevel 1 goto :eof
 )
 
@@ -41,7 +45,16 @@ if defined BUILDX64 (
     ) else if not exist "%Py_OutDir%amd64\python.exe" call "%PCBUILD%build.bat" -p x64 -e
     if errorlevel 1 goto :eof
 
-    %MSBUILD% "%D%make_pkg.proj" /p:Configuration=Release /p:Platform=x64 %OUTPUT% %PACKAGES%
+    %MSBUILD% "%D%make_pkg.proj" /p:Configuration=Release /p:Platform=x64 %OUTPUT% %PACKAGES% %PYTHON_EXE%
+    if errorlevel 1 goto :eof
+)
+
+if defined BUILDARM32 (
+    if defined REBUILD ( call "%PCBUILD%build.bat" -p ARM -e -r --no-tkinter
+    ) else if not exist "%Py_OutDir%arm32\python.exe" call "%PCBUILD%build.bat" -p ARM -e --no-tkinter
+    if errorlevel 1 goto :eof
+
+    %MSBUILD% "%D%make_pkg.proj" /p:Configuration=Release /p:Platform=ARM %OUTPUT% %PACKAGES% %PYTHON_EXE%
     if errorlevel 1 goto :eof
 )
 

--- a/Tools/nuget/make_pkg.proj
+++ b/Tools/nuget/make_pkg.proj
@@ -4,6 +4,7 @@
         <ProjectGuid>{10487945-15D1-4092-A214-338395C4116B}</ProjectGuid>
         <OutputName>python</OutputName>
         <OutputName Condition="$(Platform) == 'x86'">$(OutputName)x86</OutputName>
+        <OutputName Condition="$(Platform) == 'ARM'">$(OutputName)arm32</OutputName>
         <OutputName Condition="$(BuildForDaily) == 'true'">$(OutputName)daily</OutputName>
         <OutputSuffix></OutputSuffix>
         <SupportSigning>false</SupportSigning>

--- a/Tools/nuget/pythonarm32.nuspec
+++ b/Tools/nuget/pythonarm32.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>pythonarm32</id>
+    <title>Python (ARM32)</title>
+    <authors>Python Software Foundation</authors>
+    <version>0.0.0.0</version>
+    <licenseUrl>https://docs.python.org/3/license.html</licenseUrl>
+    <projectUrl>https://www.python.org/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Installs Python ARM32 for use in build scenarios.</description>
+    <iconUrl>https://www.python.org/static/favicon.ico</iconUrl>
+    <tags>python</tags>
+  </metadata>
+  <files>
+    <file src="**\*" exclude="python.props" target="tools" />
+    <file src="python.props" target="build\native" />
+  </files>
+</package>


### PR DESCRIPTION
Add support for building nuget packages Windows ARM32.

The nuget package contains the headers and libs required to cross-compile arm32 binary distribution packages for inclusion in wheels.

Since the arm32 nuget package is being built on x86/x64 build host $(PythonExe) needs to be overridden with a non-arm binary for the build steps.  The parameter --python-exe was added to enable the user to specify which python.exe to use.  The version of the specified python.exe should match exactly the version of the arm32 binaries being packaged.

@zooba @zware 

<!-- issue-number: [bpo-36513](https://bugs.python.org/issue36513) -->
https://bugs.python.org/issue36513
<!-- /issue-number -->
