### PR TITLE
bpo-31904: fix signalmodule issue in VxWorks

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-04-03-10-14-36.bpo-31904.xd3b78.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-03-10-14-36.bpo-31904.xd3b78.rst
@@ -1,0 +1,1 @@
+fix VxWorks signalmodule issue

--- a/Misc/NEWS.d/next/Library/2019-04-03-10-14-36.bpo-31904.xd3b78.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-03-10-14-36.bpo-31904.xd3b78.rst
@@ -1,1 +1,1 @@
-fix VxWorks signalmodule issue
+fix the data type issue in 'wakeup' in signalmodule

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -117,7 +117,11 @@ static volatile struct {
 #else
 #define INVALID_FD (-1)
 static volatile struct {
+#ifdef __VXWORKS__
+    int fd;
+#else
     sig_atomic_t fd;
+#endif
     int warn_on_full_buffer;
 } wakeup = {.fd = INVALID_FD, .warn_on_full_buffer = 1};
 #endif

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -117,11 +117,7 @@ static volatile struct {
 #else
 #define INVALID_FD (-1)
 static volatile struct {
-#ifdef __VXWORKS__
     int fd;
-#else
-    sig_atomic_t fd;
-#endif
     int warn_on_full_buffer;
 } wakeup = {.fd = INVALID_FD, .warn_on_full_buffer = 1};
 #endif


### PR DESCRIPTION
The type of sig_atomic_t is 'unsigned char' in VxWorks, so it can't be assigned to -1, so in the signalmodule.c. I set the data type of fd in struct 'wakeup' to 'int' for VxWorks.

More and full support on modules for VxWorks will continuously be added by the coming PRs.
VxWorks is a product developed and owned by Wind River. For VxWorks introduction or more details, go to https://www.windriver.com/products/vxworks/
Wind River will have a dedicated engineering team to contribute to the support as maintainers.
We already have a working buildbot worker internally, but has not bound to master. We will check the process for the buildbot, then add it.


<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
