### PR TITLE
Update the explanation for __init__.py to Python 3

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -416,21 +416,19 @@ your package (expressed in terms of a hierarchical filesystem):
                  reverse.py
                  ...
          filters/                  Subpackage for filters
-                 __init__.py
                  equalizer.py
                  vocoder.py
                  karaoke.py
                  ...
 
 When importing the package, Python searches through the directories on
-``sys.path`` looking for the package subdirectory.
+``sys.path`` looking for the package subdirectory. Any directory with
+a compatible name is a Python package.
 
-The :file:`__init__.py` files are required to make Python treat the directories
-as containing packages; this is done to prevent directories with a common name,
-such as ``string``, from unintentionally hiding valid modules that occur later
-on the module search path. In the simplest case, :file:`__init__.py` can just be
-an empty file, but it can also execute initialization code for the package or
-set the ``__all__`` variable, described later.
+The :file:`__init__.py` files exist to execute initialization code for
+the package or set the ``__all__`` variable, described later.
+Packages without :file:`__init__.py`, like :mod:`filters` in our example,
+are called :term:`namespace packages`.
 
 Users of the package can import individual modules from the package, for
 example::


### PR DESCRIPTION
Since Python 3.0 shipped with `__future__.absolute_import` enabled, the tutorial paragraph about `__init__.py` has been wrong.

The files are not anymore

> required to make Python treat the directories as containing packages

and will no longer

> prevent directories with a common name, such as string, from unintentionally hiding valid modules that occur later on the module search path

### TODO

Should I add a sentence mentioning that some 3rd party tools still expect `__init__.py` files and therefore don’t support namespace packages? (E.g. flask/werkzeug I think)

---

I don’t know if this needs a bpo number, please tell me.