### PR TITLE
bpo-9883: Remove names from the "unimplemented interfaces" list in the minidom docs that are actually implemented.

### DIFF
--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -238,21 +238,7 @@ The following interfaces have no implementation in :mod:`xml.dom.minidom`:
 
 * :class:`DOMTimeStamp`
 
-* :class:`DocumentType`
-
-* :class:`DOMImplementation`
-
-* :class:`CharacterData`
-
-* :class:`CDATASection`
-
-* :class:`Notation`
-
-* :class:`Entity`
-
 * :class:`EntityReference`
-
-* :class:`DocumentFragment`
 
 Most of these reflect information in the XML document that is not of general
 utility to most DOM users.


### PR DESCRIPTION


<!-- issue-number: [bpo-9883](https://bugs.python.org/issue9883) -->
https://bugs.python.org/issue9883
<!-- /issue-number -->
