### PR TITLE
[2.7] bpo-36504: Fix signed integer overflow in _ctypes.c's PyCArrayType_new(). (GH-12660)

### DIFF
--- a/Lib/ctypes/test/test_arrays.py
+++ b/Lib/ctypes/test/test_arrays.py
@@ -134,6 +134,12 @@ class ArrayTestCase(unittest.TestCase):
         t2 = my_int * 1
         self.assertIs(t1, t2)
 
+    def test_bpo36504_signed_int_overflow(self):
+        # The overflow check in PyCArrayType_new() could cause signed integer
+        # overflow.
+        with self.assertRaises(OverflowError):
+            c_char * sys.maxsize * 2
+
     @unittest.skipUnless(sys.maxsize > 2**32, 'requires 64bit platform')
     @precisionbigmemtest(size=_2G, memuse=1, dry_run=False)
     def test_large_array(self, size):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-04-02-04-10-32.bpo-36504.k_V8Bm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-02-04-10-32.bpo-36504.k_V8Bm.rst
@@ -1,0 +1,1 @@
+Fix signed integer overflow in _ctypes.c's ``PyCArrayType_new()``.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1534,7 +1534,7 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     }
 
     itemsize = itemdict->size;
-    if (length * itemsize < 0) {
+    if (length > PY_SSIZE_T_MAX / itemsize) {
         PyErr_SetString(PyExc_OverflowError,
                         "array too large");
         Py_DECREF(stgdict);


### PR DESCRIPTION
(cherry picked from commit 487b73ab39c80157474821ef9083f51e0846bd62)

<!-- issue-number: [bpo-36504](https://bugs.python.org/issue36504) -->
https://bugs.python.org/issue36504
<!-- /issue-number -->
