### PR TITLE
bpo-36479: Exit threads when interpreter is finalizing rather than runtime

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-05-16-19-58.bpo-36479.FPztBY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-05-16-19-58.bpo-36479.FPztBY.rst
@@ -1,0 +1,1 @@
+Exit threads when interpreter is finalizing rather than runtime.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -207,8 +207,11 @@ _PyEval_FiniThreads(void)
 static inline void
 exit_thread_if_finalizing(PyThreadState *tstate)
 {
+    /* Get interpreter pointer */
+    PyInterpreterState *interp = tstate->interp;
+
     /* _Py_Finalizing is protected by the GIL */
-    if (_Py_IsFinalizing() && !_Py_CURRENTLY_FINALIZING(tstate)) {
+    if (interp->finalizing && !_Py_CURRENTLY_FINALIZING(tstate)) {
         drop_gil(tstate);
         PyThread_exit_thread();
     }


### PR DESCRIPTION
I have added changes to exit threads when the interpreter is finalizing.

I have halted to update this until PR until [GH-12667](https://github.com/python/cpython/pull/12667) is merged.

<!-- issue-number: [bpo-36479](https://bugs.python.org/issue36479) -->
https://bugs.python.org/issue36479
<!-- /issue-number -->
