### PR TITLE
bpo-36522: Print all values for headers with multiple values

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -320,8 +320,8 @@ class HTTPResponse(io.BufferedIOBase):
         self.headers = self.msg = parse_headers(self.fp)
 
         if self.debuglevel > 0:
-            for hdr in self.headers:
-                print("header:", hdr + ":", self.headers.get(hdr))
+            for hdr, val in self.headers.items():
+                print("header:", hdr + ":", val)
 
         # are we using the chunked-style of transfer encoding?
         tr_enc = self.headers.get("transfer-encoding")

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -348,7 +348,8 @@ class HeaderTests(TestCase):
         body = (
             b'HTTP/1.1 200 OK\r\n'
             b'First: val\r\n'
-            b'Second: val\r\n'
+            b'Second: val1\r\n'
+            b'Second: val2\r\n'
         )
         sock = FakeSocket(body)
         resp = client.HTTPResponse(sock, debuglevel=1)
@@ -357,7 +358,8 @@ class HeaderTests(TestCase):
         lines = output.getvalue().splitlines()
         self.assertEqual(lines[0], "reply: 'HTTP/1.1 200 OK\\r\\n'")
         self.assertEqual(lines[1], "header: First: val")
-        self.assertEqual(lines[2], "header: Second: val")
+        self.assertEqual(lines[2], "header: Second: val1")
+        self.assertEqual(lines[3], "header: Second: val2")
 
 
 class TransferEncodingTest(TestCase):

--- a/Misc/NEWS.d/next/Library/2019-04-03-20-46-47.bpo-36522.g5x3By.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-03-20-46-47.bpo-36522.g5x3By.rst
@@ -1,0 +1,1 @@
+If *debuglevel* is set to >0 in :mod:`http.client`, print all values for headers with multiple values for the same header name. Patch by Matt Houglum.


### PR DESCRIPTION
This is a follow-up to https://bugs.python.org/issue33365.  The fix for that issue (see https://github.com/python/cpython/pull/6611) added a statement to also print header values, but it does not account for the case where multiple values exist for the same header name (note that multiple header values for the same header name can be supplied in one comma-separated entry, or in multiple entries; see [this StackOverflow post](https://stackoverflow.com/questions/3096888/standard-for-adding-multiple-values-of-a-single-http-header-to-a-request-or-resp)). E.g. if my response contained these headers:

    x-goog-hash: crc32c=KAwGng==
    x-goog-hash: md5=eB5eJF1ptWaXm4bijSPyxw==

then the debug output would print whichever of those values is returned from `self.headers.get("x-goog-hash")` for both prints:

    header: x-goog-hash: crc32c=KAwGng==
    header: x-goog-hash: crc32c=KAwGng==

This PR changes the header iteration to use `self.headers.items()` instead, which will return the key and value pair to be printed, resulting in the correct debug output:

    header: x-goog-hash: crc32c=KAwGng==
    header: x-goog-hash: md5=eB5eJF1ptWaXm4bijSPyxw==

<!-- issue-number: [bpo-36522](https://bugs.python.org/issue36522) -->
https://bugs.python.org/issue36522
<!-- /issue-number -->
