### PR TITLE
bpo-36347: stop using RESTRICTED constants

### DIFF
--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -101,9 +101,9 @@ static PyMethodDef method_methods[] = {
 #define MO_OFF(x) offsetof(PyMethodObject, x)
 
 static PyMemberDef method_memberlist[] = {
-    {"__func__", T_OBJECT, MO_OFF(im_func), READONLY|RESTRICTED,
+    {"__func__", T_OBJECT, MO_OFF(im_func), READONLY,
      "the function (or other callable) implementing a method"},
-    {"__self__", T_OBJECT, MO_OFF(im_self), READONLY|RESTRICTED,
+    {"__self__", T_OBJECT, MO_OFF(im_self), READONLY,
      "the instance to which a method is bound"},
     {NULL}      /* Sentinel */
 };
@@ -405,7 +405,7 @@ PyInstanceMethod_Function(PyObject *im)
 #define IMO_OFF(x) offsetof(PyInstanceMethodObject, x)
 
 static PyMemberDef instancemethod_memberlist[] = {
-    {"__func__", T_OBJECT, IMO_OFF(func), READONLY|RESTRICTED,
+    {"__func__", T_OBJECT, IMO_OFF(func), READONLY,
      "the function (or other callable) implementing a method"},
     {NULL}      /* Sentinel */
 };

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -238,12 +238,10 @@ PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
 #define OFF(x) offsetof(PyFunctionObject, x)
 
 static PyMemberDef func_memberlist[] = {
-    {"__closure__",   T_OBJECT,     OFF(func_closure),
-     RESTRICTED|READONLY},
-    {"__doc__",       T_OBJECT,     OFF(func_doc), PY_WRITE_RESTRICTED},
-    {"__globals__",   T_OBJECT,     OFF(func_globals),
-     RESTRICTED|READONLY},
-    {"__module__",    T_OBJECT,     OFF(func_module), PY_WRITE_RESTRICTED},
+    {"__closure__",   T_OBJECT,     OFF(func_closure), READONLY},
+    {"__doc__",       T_OBJECT,     OFF(func_doc), 0},
+    {"__globals__",   T_OBJECT,     OFF(func_globals), READONLY},
+    {"__module__",    T_OBJECT,     OFF(func_module), 0},
     {NULL}  /* Sentinel */
 };
 

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -203,7 +203,7 @@ static PyGetSetDef meth_getsets [] = {
 #define OFF(x) offsetof(PyCFunctionObject, x)
 
 static PyMemberDef meth_members[] = {
-    {"__module__",    T_OBJECT,     OFF(m_module), PY_WRITE_RESTRICTED},
+    {"__module__",    T_OBJECT,     OFF(m_module), 0},
     {NULL}
 };
 


### PR DESCRIPTION
The constants `RESTRICTED` and `PY_WRITE_RESTRICTED` no longer have a meaning in Python 3. Therefore, CPython should not use them.

CC @matrixise 

<!-- issue-number: [bpo-36347](https://bugs.python.org/issue36347) -->
https://bugs.python.org/issue36347
<!-- /issue-number -->


Automerge-Triggered-By: @encukou