### PR TITLE
bpo-9194: Fix the bounds checking in winreg.c's fixupMultiSZ()

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-04-04-08-59-44.bpo-9194.DzakhD.rst
+++ b/Misc/NEWS.d/next/Windows/2019-04-04-08-59-44.bpo-9194.DzakhD.rst
@@ -1,1 +1,0 @@
-Fix the bounds checking in winreg.c's ``fixupMultiSZ()``.

--- a/Misc/NEWS.d/next/Windows/2019-04-04-08-59-44.bpo-9194.DzakhD.rst
+++ b/Misc/NEWS.d/next/Windows/2019-04-04-08-59-44.bpo-9194.DzakhD.rst
@@ -1,0 +1,1 @@
+Fix the bounds checking in winreg.c's ``fixupMultiSZ()``.

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -521,7 +521,7 @@ fixupMultiSZ(wchar_t **str, wchar_t *data, int len)
     Q = data + len;
     for (P = data, i = 0; P < Q && *P != '\0'; P++, i++) {
         str[i] = P;
-        for(; *P != '\0'; P++)
+        for (; P < Q && *P != '\0'; P++)
             ;
     }
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-9194](https://bugs.python.org/issue9194) -->
https://bugs.python.org/issue9194
<!-- /issue-number -->
