### PR TITLE
bpo-36531: Only count number of members once in PyType_FromSpec

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2897,6 +2897,7 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
     nmembers = 0;
     for (slot = spec->slots; slot->slot; slot++) {
         if (slot->slot == Py_tp_members) {
+            nmembers = 0;
             for (memb = slot->pfunc; memb->name != NULL; memb++) {
                 nmembers++;
             }


### PR DESCRIPTION
If a user accidentally defined more than one Py_tp_members in the spec, PyType_FromSpec will ignore all but the last use case. However, the number of members count will cause the type to allocate more memory than needed. This leads to weird behavior and crashes.

This is a simple one line solution to make the type initialization safer.



<!-- issue-number: [bpo-36531](https://bugs.python.org/issue36531) -->
https://bugs.python.org/issue36531
<!-- /issue-number -->
