### PR TITLE
bpo-36532: Example of formatter with new str.format style

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1934,8 +1934,6 @@ completely orthogonal to how an individual logging message is constructed.
 Example how to setup a formatter with the new str.format style::
 
     formatter = logging.Formatter("[{asctime:s}] [{name:25s}] {levelname:8s} | {message:s}", style='{')
-    # this now works:
-    logging.getLogger('MyLogger').info('test {:d}', 5)
 
 Logging calls (:meth:`~Logger.debug`, :meth:`~Logger.info` etc.) only take
 positional parameters for the actual logging message itself, with keyword

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1931,6 +1931,11 @@ the specification of ``{`` or ``$`` to support the formatting approaches
 supported by :meth:`str.format` and :class:`string.Template`. Note that this
 governs the formatting of logging messages for final output to logs, and is
 completely orthogonal to how an individual logging message is constructed.
+Example how to setup a formatter with the new str.format style::
+
+    formatter = logging.Formatter("[{asctime:s}] [{name:25s}] {levelname:8s} | {message:s}", style='{')
+    # this now works:
+    logging.getLogger('MyLogger').info('test {:d}', 5)
 
 Logging calls (:meth:`~Logger.debug`, :meth:`~Logger.info` etc.) only take
 positional parameters for the actual logging message itself, with keyword


### PR DESCRIPTION
Added example how to setup a formatter with the new str.format style because it was not totally clear


<!-- issue-number: [bpo-36532](https://bugs.python.org/issue36532) -->
https://bugs.python.org/issue36532
<!-- /issue-number -->
