### PR TITLE
bpo-14841: shutil.get_terminal_size: use stdin/stderr also

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1267,9 +1267,8 @@ def get_terminal_size(fallback=(80, 24)):
     # only query if necessary
     if columns <= 0 or lines <= 0:
         for check in [sys.__stdin__, sys.__stderr__, sys.__stdout__]:
-            fd = check.fileno()
             try:
-                size = os.get_terminal_size(fd)
+                size = os.get_terminal_size(check.fileno())
             except (AttributeError, ValueError, OSError):
                 # fd is None, closed, detached, or not a terminal, or
                 # os.get_terminal_size() is unsupported

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1266,17 +1266,21 @@ def get_terminal_size(fallback=(80, 24)):
 
     # only query if necessary
     if columns <= 0 or lines <= 0:
-        for check in [sys.__stdin__, sys.__stderr__, sys.__stdout__]:
-            try:
-                size = os.get_terminal_size(check.fileno())
-            except (AttributeError, ValueError, OSError):
-                # fd is None, closed, detached, or not a terminal, or
-                # os.get_terminal_size() is unsupported
-                continue
-            else:
-                break
-        else:
+        try:
+            os_get_terminal_size = os.get_terminal_size
+        except AttributeError:
             size = os.terminal_size(fallback)
+        else:
+            for check in [sys.__stdin__, sys.__stderr__, sys.__stdout__]:
+                try:
+                    size = os_get_terminal_size(check.fileno())
+                except (AttributeError, ValueError, OSError):
+                    # fd is None, closed, detached, or not a terminal.
+                    continue
+                else:
+                    break
+            else:
+                size = os.terminal_size(fallback)
         if columns <= 0:
             columns = size.columns
         if lines <= 0:

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2320,24 +2320,39 @@ class TermsizeTests(unittest.TestCase):
             del env['LINES']
             del env['COLUMNS']
             actual = shutil.get_terminal_size()
+            self.assertEqual(expected, actual)
 
-        self.assertEqual(expected, actual)
+            # Falls back to stdout.
+            with support.swap_attr(sys, '__stdin__', None), \
+                    support.swap_attr(sys, '__stderr__', None):
+                actual = shutil.get_terminal_size()
+                self.assertEqual(expected, actual)
+
+            # Falls back to stderr.
+            with support.swap_attr(sys, '__stdin__', None), \
+                    support.swap_attr(sys, '__stdout__', None):
+                actual = shutil.get_terminal_size()
+                self.assertEqual(expected, actual)
 
     def test_fallback(self):
         with support.EnvironmentVarGuard() as env:
             del env['LINES']
             del env['COLUMNS']
 
-            # sys.__stdout__ has no fileno()
-            with support.swap_attr(sys, '__stdout__', None):
+            # stdin/stderr/stdout have no fileno().
+            with support.swap_attr(sys, '__stdin__', None), \
+                    support.swap_attr(sys, '__stderr__', None), \
+                    support.swap_attr(sys, '__stdout__', None):
                 size = shutil.get_terminal_size(fallback=(10, 20))
             self.assertEqual(size.columns, 10)
             self.assertEqual(size.lines, 20)
 
-            # sys.__stdout__ is not a terminal on Unix
-            # or fileno() not in (0, 1, 2) on Windows
+            # stdin/stderr/stdout are not a terminal on Unix,
+            # or fileno() not in (0, 1, 2) on Windows.
             with open(os.devnull, 'w') as f, \
-                 support.swap_attr(sys, '__stdout__', f):
+                    support.swap_attr(sys, '__stdin__', f), \
+                    support.swap_attr(sys, '__stderr__', f), \
+                    support.swap_attr(sys, '__stdout__', f):
                 size = shutil.get_terminal_size(fallback=(30, 40))
             self.assertEqual(size.columns, 30)
             self.assertEqual(size.lines, 40)


### PR DESCRIPTION
stdout might be a pipe, e.g. `less`, and then stdin or stderr should be
used to query the terminal for its size.

This patch prefers stdin, since that is most likely connected to a
terminal.

<!-- issue-number: [bpo-14841](https://bugs.python.org/issue14841) -->
https://bugs.python.org/issue14841
<!-- /issue-number -->
