### PR TITLE
[3.7] bpo-35726: Prevented QueueHandler formatting from affecting other handlers (GH-11537)

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -27,6 +27,7 @@ import logging, socket, os, pickle, struct, time, re
 from stat import ST_DEV, ST_INO, ST_MTIME
 import queue
 import threading
+import copy
 
 #
 # Some constants...
@@ -1377,6 +1378,8 @@ class QueueHandler(logging.Handler):
         # exc_info and exc_text attributes, as they are no longer
         # needed and, if not None, will typically not be pickleable.
         msg = self.format(record)
+        # bpo-35726: make copy of record to avoid affecting other handlers in the chain.
+        record = copy.copy(record)
         record.message = msg
         record.msg = msg
         record.args = None

--- a/Misc/NEWS.d/next/Library/2019-01-13-01-33-00.bpo-35726.dasdas.rst
+++ b/Misc/NEWS.d/next/Library/2019-01-13-01-33-00.bpo-35726.dasdas.rst
@@ -1,0 +1,1 @@
+QueueHandler.prepare() now makes a copy of the record before modifying and enqueueing it, to avoid affecting other handlers in the chain.


### PR DESCRIPTION
QueueHandler.prepare() now makes a copy of the record before modifying and enqueueing it, to avoid affecting other handlers in the chain.
(cherry picked from commit da6424e96ada72c15c91bddb0a411acf7119e10a)

Co-authored-by: Manjusaka <lizheao940510@gmail.com>

<!-- issue-number: [bpo-35726](https://bugs.python.org/issue35726) -->
https://bugs.python.org/issue35726
<!-- /issue-number -->
