### PR TITLE
bpo-31904: Skip setting RLIMIT_FSIZE and RLIMIT_CPU test case for VxWorks

### DIFF
--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -76,6 +76,8 @@ this module for those platforms.
    ``setrlimit`` may also raise :exc:`error` if the underlying system call
    fails.
 
+   VxWorks only support setting RLIMIT_NOFILE and idtype must be P_PID.
+
 .. function:: prlimit(pid, resource[, limits])
 
    Combines :func:`setrlimit` and :func:`getrlimit` in one function and

--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -76,7 +76,7 @@ this module for those platforms.
    ``setrlimit`` may also raise :exc:`error` if the underlying system call
    fails.
 
-   VxWorks only support setting RLIMIT_NOFILE and idtype must be P_PID.
+   VxWorks only supports setting :data:`RLIMIT_NOFILE`.
 
 .. function:: prlimit(pid, resource[, limits])
 

--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -4,6 +4,13 @@ import unittest
 from test import support
 import time
 
+_support_rlimit_fsize_set=True
+_support_rlimit_cpu_set=True
+
+if sys.platform == "vxworks":
+    _support_rlimit_fsize_set=False
+    _support_rlimit_cpu_set=False
+
 resource = support.import_module('resource')
 
 # This test is checking a few specific problem spots with the resource module.
@@ -28,7 +35,8 @@ class ResourceTest(unittest.TestCase):
             # the number to a C long long and that the conversion doesn't raise
             # an error.
             self.assertEqual(resource.RLIM_INFINITY, max)
-            resource.setrlimit(resource.RLIMIT_FSIZE, (cur, max))
+            if _support_rlimit_fsize_set:
+                resource.setrlimit(resource.RLIMIT_FSIZE, (cur, max))
 
     def test_fsize_enforced(self):
         try:
@@ -124,7 +132,8 @@ class ResourceTest(unittest.TestCase):
                         return len(tuple(range(1000000)))
                     raise IndexError
 
-            resource.setrlimit(resource.RLIMIT_CPU, BadSequence())
+            if _support_rlimit_cpu_set:
+                resource.setrlimit(resource.RLIMIT_CPU, BadSequence())
 
     def test_pagesize(self):
         pagesize = resource.getpagesize()

--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -4,13 +4,6 @@ import unittest
 from test import support
 import time
 
-_support_rlimit_fsize_set=True
-_support_rlimit_cpu_set=True
-
-if sys.platform == "vxworks":
-    _support_rlimit_fsize_set=False
-    _support_rlimit_cpu_set=False
-
 resource = support.import_module('resource')
 
 # This test is checking a few specific problem spots with the resource module.
@@ -23,6 +16,8 @@ class ResourceTest(unittest.TestCase):
         self.assertRaises(TypeError, resource.setrlimit)
         self.assertRaises(TypeError, resource.setrlimit, 42, 42, 42)
 
+    @unittest.skipIf(sys.platform == "vxworks",
+                     "setting RLIMIT_FSIZE is not supported on VxWorks")
     def test_fsize_ismax(self):
         try:
             (cur, max) = resource.getrlimit(resource.RLIMIT_FSIZE)
@@ -35,8 +30,7 @@ class ResourceTest(unittest.TestCase):
             # the number to a C long long and that the conversion doesn't raise
             # an error.
             self.assertEqual(resource.RLIM_INFINITY, max)
-            if _support_rlimit_fsize_set:
-                resource.setrlimit(resource.RLIMIT_FSIZE, (cur, max))
+            resource.setrlimit(resource.RLIMIT_FSIZE, (cur, max))
 
     def test_fsize_enforced(self):
         try:
@@ -118,6 +112,8 @@ class ResourceTest(unittest.TestCase):
             pass
 
     # Issue 6083: Reference counting bug
+    @unittest.skipIf(sys.platform == "vxworks",
+                     "setting RLIMIT_CPU is not supported on VxWorks")
     def test_setrusage_refcount(self):
         try:
             limits = resource.getrlimit(resource.RLIMIT_CPU)
@@ -132,8 +128,7 @@ class ResourceTest(unittest.TestCase):
                         return len(tuple(range(1000000)))
                     raise IndexError
 
-            if _support_rlimit_cpu_set:
-                resource.setrlimit(resource.RLIMIT_CPU, BadSequence())
+            resource.setrlimit(resource.RLIMIT_CPU, BadSequence())
 
     def test_pagesize(self):
         pagesize = resource.getpagesize()

--- a/Misc/NEWS.d/next/Library/2019-04-08-09-24-36.bpo-31904.ab03ea.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-08-09-24-36.bpo-31904.ab03ea.rst
@@ -1,0 +1,1 @@
+Skip setting RLIMIT_FSIZE and RLIMIT_CPU test case for VxWorks

--- a/Misc/NEWS.d/next/Library/2019-04-08-09-24-36.bpo-31904.ab03ea.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-08-09-24-36.bpo-31904.ab03ea.rst
@@ -1,1 +1,0 @@
-Skip setting RLIMIT_FSIZE and RLIMIT_CPU test case for VxWorks

--- a/Misc/NEWS.d/next/Tests/2019-04-08-09-24-36.bpo-31904.ab03ea.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-08-09-24-36.bpo-31904.ab03ea.rst
@@ -1,0 +1,1 @@
+Port test_resource to VxWorks: skip tests cases setting RLIMIT_FSIZE and RLIMIT_CPU.


### PR DESCRIPTION
Skip setting RLIMIT_FSIZE and RLIMIT_CPU test case for VxWorks

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
