### PR TITLE
bpo-36552: Change OverflowError to a ValueError for range objects > PY_SIZE_MAX

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-04-08-04-45-02.bpo-36552.X5p6-M.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-08-04-45-02.bpo-36552.X5p6-M.rst
@@ -1,0 +1,1 @@
+Calculating the length of range objects whose length is larger than PY_SIZE_MAX will now raise a ValueError instead of an OverflowError.

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -212,7 +212,13 @@ compute_range_length(PyObject *start, PyObject *stop, PyObject *step)
 static Py_ssize_t
 range_length(rangeobject *r)
 {
-    return PyLong_AsSsize_t(r->length);
+    Py_ssize_t size = PyLong_AsSsize_t(r->length);
+    if (size < 0 && PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_OverflowError)) {
+        PyErr_Clear();
+        PyErr_Format(PyExc_ValueError, "Range object too large to calculate length (Overflow Error)");
+        return -1;
+    }
+    return size;
 }
 
 static PyObject *


### PR DESCRIPTION
When calculating length of range() objects that have an r->length > PY_SIZE_MAX, the underlying PyLong_AsSsize_t() function will raise an OverflowError:

```
>>> a = list(range(2**256))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: Python int too large to convert to C ssize_t
>>> a = range(2**256)
>>> len(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: Python int too large to convert to C ssize_t
```

This is expected behaviour, but to the average user, who won't know what ssize_t is, or what this has to do with Python int, the user message is confusing and OverflowError is the symptom but not the cause. The cause is that the length sent to range was in a value too large to calculate. 

This patch changes OverflowError to ValueError to hint to the user that the value sent to the range object constructor is too large.

```
>>> a = list(range(2**256))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Range object too large to calculate length (Overflow Error)
>>> a = range(2**256)
>>> len(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Range object too large to calculate length (Overflow Error)
```

<!-- issue-number: [bpo-36552](https://bugs.python.org/issue36552) -->
https://bugs.python.org/issue36552
<!-- /issue-number -->
