### PR TITLE
bpo-34373: Fix time.mktime() on AIX

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-04-08-14-41-22.bpo-34373.lEAl_-.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-08-14-41-22.bpo-34373.lEAl_-.rst
@@ -1,0 +1,1 @@
+Fix :func:`time.mktime` error handling on AIX for year before 1970.


### PR DESCRIPTION
* Fix time.mktime() on AIX: fix code checking for mktime() failure
  for years before 1970.
* mktime(): rename variable 'buf' to 'tm'.
* _PyTime_localtime(): avoid abs() which is limited to int type,
  use "localtime" rather than "ctime" in the error message.
* _PyTime_localtime(): EINVAL constant is now always available.
* _PyTime_localtime(): initialize errno to 0 just in case if
  localtime_r() doesn't set errno on error.

<!-- issue-number: [bpo-34373](https://bugs.python.org/issue34373) -->
https://bugs.python.org/issue34373
<!-- /issue-number -->
