### PR TITLE
bpo-36559: random: import hashlib on demand

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -42,7 +42,6 @@ from math import log as _log, exp as _exp, pi as _pi, e as _e, ceil as _ceil
 from math import sqrt as _sqrt, acos as _acos, cos as _cos, sin as _sin
 from os import urandom as _urandom
 from _collections_abc import Set as _Set, Sequence as _Sequence
-from hashlib import sha512 as _sha512
 from itertools import accumulate as _accumulate, repeat as _repeat
 from bisect import bisect as _bisect
 import os as _os
@@ -137,9 +136,11 @@ class Random(_random.Random):
             a = -2 if x == -1 else x
 
         if version == 2 and isinstance(a, (str, bytes, bytearray)):
+            from hashlib import sha512
+
             if isinstance(a, str):
                 a = a.encode()
-            a += _sha512(a).digest()
+            a += sha512(a).digest()
             a = int.from_bytes(a, 'big')
 
         super().seed(a)

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -136,11 +136,11 @@ class Random(_random.Random):
             a = -2 if x == -1 else x
 
         if version == 2 and isinstance(a, (str, bytes, bytearray)):
-            from hashlib import sha512
+            import hashlib
 
             if isinstance(a, str):
                 a = a.encode()
-            a += sha512(a).digest()
+            a += hashlib.sha512(a).digest()
             a = int.from_bytes(a, 'big')
 
         super().seed(a)

--- a/Misc/NEWS.d/next/Library/2019-04-08-15-12-41.bpo-36559.4WbW6P.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-08-15-12-41.bpo-36559.4WbW6P.rst
@@ -1,0 +1,3 @@
+"import random" no longer imports the :mod:`hashlib` module by default. The
+:mod:`hashlib` module is now imported on demand, to hash a string seed in
+:meth:`random.Random.seed`.


### PR DESCRIPTION
"import random" no longer imports the hashlib module by default.
hashlib is now imported on demand, to hash a string seed in
Random.seed().

<!-- issue-number: [bpo-36559](https://bugs.python.org/issue36559) -->
https://bugs.python.org/issue36559
<!-- /issue-number -->
