### PR TITLE
bpo-33632: Avoid signed integer overflow in the _thread module

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-04-08-08-29-45.bpo-33632.y-fhEY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-08-08-29-45.bpo-33632.y-fhEY.rst
@@ -1,0 +1,1 @@
+Avoid signed integer overflow in the :mod:`_thread` module.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -45,11 +45,12 @@ static PyLockStatus
 acquire_timed(PyThread_type_lock lock, _PyTime_t timeout)
 {
     PyLockStatus r;
-    _PyTime_t endtime = 0;
+    _PyTime_t starttime = 0;
     _PyTime_t microseconds;
 
-    if (timeout > 0)
-        endtime = _PyTime_GetMonotonicClock() + timeout;
+    if (timeout > 0) {
+        starttime = _PyTime_GetMonotonicClock();
+    }
 
     do {
         microseconds = _PyTime_AsMicroseconds(timeout, _PyTime_ROUND_CEILING);
@@ -73,12 +74,14 @@ acquire_timed(PyThread_type_lock lock, _PyTime_t timeout)
             /* If we're using a timeout, recompute the timeout after processing
              * signals, since those can take time.  */
             if (timeout > 0) {
-                timeout = endtime - _PyTime_GetMonotonicClock();
+                _PyTime_t elapsed = _PyTime_GetMonotonicClock() - starttime;
 
-                /* Check for negative values, since those mean block forever.
-                 */
-                if (timeout < 0) {
+                if (timeout < elapsed) {
                     r = PY_LOCK_FAILURE;
+                }
+                else {
+                    timeout -= elapsed;
+                    starttime += elapsed;
                 }
             }
         }


### PR DESCRIPTION
Co-Authored-By: Martin Panter <vadmium+py@gmail.com>

<!-- issue-number: [bpo-33632](https://bugs.python.org/issue33632) -->
https://bugs.python.org/issue33632
<!-- /issue-number -->
