### PR TITLE
bpo-36565: Fix libregrtest for Python without builtin _abc

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -8,9 +8,13 @@ from test import support
 try:
     from _abc import _get_dump
 except ImportError:
+    import weakref
+
     def _get_dump(cls):
-        # For legacy Python version
-        return (cls._abc_registry, cls._abc_cache,
+        # Reimplement _get_dump() for pure-Python implementation of
+        # the abc module (Lib/_py_abc.py)
+        registry_weakrefs = set(weakref.ref(obj) for obj in cls._abc_registry)
+        return (registry_weakrefs, cls._abc_cache,
                 cls._abc_negative_cache, cls._abc_negative_cache_version)
 
 

--- a/Misc/NEWS.d/next/Tests/2019-04-08-19-01-21.bpo-36565.2bxgtU.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-08-19-01-21.bpo-36565.2bxgtU.rst
@@ -1,0 +1,2 @@
+Fix reference hunting (``python3 -m test -R 3:3``) when Python has no
+built-in abc module.


### PR DESCRIPTION
Fix reference hunting (``python3 -m test -R 3:3``) when Python has no
built-in abc module: fix _get_dump() reimplementation of libregrtest.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36565](https://bugs.python.org/issue36565) -->
https://bugs.python.org/issue36565
<!-- /issue-number -->
