### PR TITLE
BPO-17561: set create_server backlog default to None

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -595,7 +595,7 @@ The following functions all create :ref:`socket objects <socket-objects>`.
    .. versionchanged:: 3.2
       *source_address* was added.
 
-.. function:: create_server(address, *, family=AF_INET, backlog=0, reuse_port=False, dualstack_ipv6=False)
+.. function:: create_server(address, *, family=AF_INET, backlog=None, reuse_port=False, dualstack_ipv6=False)
 
    Convenience function which creates a TCP socket bound to *address* (a 2-tuple
    ``(host, port)``) and return the socket object.

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -745,7 +745,7 @@ def has_dualstack_ipv6():
         return False
 
 
-def create_server(address, *, family=AF_INET, backlog=0, reuse_port=False,
+def create_server(address, *, family=AF_INET, backlog=None, reuse_port=False,
                   dualstack_ipv6=False):
     """Convenience function which creates a SOCK_STREAM type socket
     bound to *address* (a 2-tuple (host, port)) and return the socket
@@ -804,7 +804,10 @@ def create_server(address, *, family=AF_INET, backlog=0, reuse_port=False,
             msg = '%s (while attempting to bind on address %r)' % \
                 (err.strerror, address)
             raise error(err.errno, msg) from None
-        sock.listen(backlog)
+        if backlog is None:
+            sock.listen()
+        else:
+            sock.listen(backlog)
         return sock
     except error:
         sock.close()

--- a/Misc/NEWS.d/next/Library/2019-04-09-04-08-46.bpo-17561.hOhVnh.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-09-04-08-46.bpo-17561.hOhVnh.rst
@@ -1,0 +1,1 @@
+Set backlog=None as the default for socket.create_server.


### PR DESCRIPTION
This fixes BB failures experienced in https://github.com/python/cpython/pull/11784#issuecomment-481036369 and references BPO-17561. 

It turns out doing `socket.listen(0)` does not equal to "choose a reasonable default". It literally means "set backlog to 0". As such set `backlog=None` as the default for `socket.create_server`. With this in place the C extension will choose `min(SOMAXCONN, 128)` as the default backlog.
