### PR TITLE
bpo-36559: random module: optimize sha512 import

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -42,10 +42,17 @@ from math import log as _log, exp as _exp, pi as _pi, e as _e, ceil as _ceil
 from math import sqrt as _sqrt, acos as _acos, cos as _cos, sin as _sin
 from os import urandom as _urandom
 from _collections_abc import Set as _Set, Sequence as _Sequence
-from hashlib import sha512 as _sha512
 from itertools import accumulate as _accumulate, repeat as _repeat
 from bisect import bisect as _bisect
 import os as _os
+
+try:
+    # hashlib is pretty heavy to load, try lean internal module first
+    from _sha512 import sha512 as _sha512
+except ImportError:
+    # fallback to official implementation
+    from hashlib import sha512 as _sha512
+
 
 __all__ = ["Random","seed","random","uniform","randint","choice","sample",
            "randrange","shuffle","normalvariate","lognormvariate",

--- a/Misc/NEWS.d/next/Library/2019-04-09-12-02-35.bpo-36559.LbDRrw.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-09-12-02-35.bpo-36559.LbDRrw.rst
@@ -1,0 +1,2 @@
+The random module now prefers the lean internal _sha512 module over hashlib
+for seed(version=2) to optimize import time.


### PR DESCRIPTION
The random module now prefers the lean internal _sha512 module over hashlib
for seed(version=2) to optimize import time.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36559](https://bugs.python.org/issue36559) -->
https://bugs.python.org/issue36559
<!-- /issue-number -->
