### PR TITLE
[WIP] bpo-36560: _abc now uses weakref.WeakSet type

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import warnings
+import weakref
 from inspect import isabstract
 from test import support
 try:
@@ -11,10 +12,7 @@ except ImportError:
     import weakref
 
     def _get_dump(cls):
-        # Reimplement _get_dump() for pure-Python implementation of
-        # the abc module (Lib/_py_abc.py)
-        registry_weakrefs = set(weakref.ref(obj) for obj in cls._abc_registry)
-        return (registry_weakrefs, cls._abc_cache,
+        return (cls._abc_registry, cls._abc_cache,
                 cls._abc_negative_cache, cls._abc_negative_cache_version)
 
 
@@ -47,7 +45,7 @@ def dash_R(the_module, test, indirect_test, huntrleaks):
         if not isabstract(abc):
             continue
         for obj in abc.__subclasses__() + [abc]:
-            abcs[obj] = _get_dump(obj)[0]
+            abcs[obj] = set(weakref.ref(obj) for obj in _get_dump(obj)[0])
 
     # bpo-31217: Integer pool to get a single integer object for the same
     # value. The pool is used to prevent false alarm when checking for memory


### PR DESCRIPTION
The C accelerator _abc now uses the weakref.WeakSet type rather than
the set type holding weak references.

Changes:

* _abc._get_dump() now returns lists rather than sets.
* subclasscheck_check_registry() now longer holds a second strong
  reference to 'rkey' to call PyObject_IsSubclass(): the 'registry'
  list already holds a strong reference.

<!-- issue-number: [bpo-36560](https://bugs.python.org/issue36560) -->
https://bugs.python.org/issue36560
<!-- /issue-number -->
