### PR TITLE
bpo-36560: regrtest: don't collect the GC twice

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -82,12 +82,14 @@ def dash_R(ns, the_module, test_name, test_func):
         print(("1234567890"*(repcount//10 + 1))[:repcount], file=sys.stderr,
               flush=True)
 
+    dash_R_cleanup(fs, ps, pic, zdc, abcs)
+
     for i in rep_range:
         test_func()
         dash_R_cleanup(fs, ps, pic, zdc, abcs)
 
-        # Collect cyclic trash and read memory statistics immediately after.
-        support.gc_collect()
+        # dash_R_cleanup() ends with collecting cyclic trash:
+        # read memory statistics immediately after.
         alloc_after = getallocatedblocks()
         rc_after = gettotalrefcount()
         fd_after = fd_count()


### PR DESCRIPTION
dash_R() function of libregrtest doesn't call support.gc_collect()
directly anymore: it's already called by dash_R_cleanup().

Call dash_R_cleanup() before starting the loop.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36560](https://bugs.python.org/issue36560) -->
https://bugs.python.org/issue36560
<!-- /issue-number -->
