### PR TITLE
bpo-36544: setup.py reports missing _hashlib

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-04-09-18-34-51.bpo-36544.AN1BPM.rst
+++ b/Misc/NEWS.d/next/Build/2019-04-09-18-34-51.bpo-36544.AN1BPM.rst
@@ -1,0 +1,2 @@
+``setup.py`` now reports when the ``_hashlib`` module is missing because
+OpenSSL is not available.

--- a/setup.py
+++ b/setup.py
@@ -2151,16 +2151,17 @@ class PyBuildExt(build_ext):
         openssl_includes = split_var('OPENSSL_INCLUDES', '-I')
         openssl_libdirs = split_var('OPENSSL_LDFLAGS', '-L')
         openssl_libs = split_var('OPENSSL_LIBS', '-l')
-        if not openssl_libs:
-            # libssl and libcrypto not found
-            return None, None
 
         # Find OpenSSL includes
         ssl_incs = find_file(
             'openssl/ssl.h', self.inc_dirs, openssl_includes
         )
-        if ssl_incs is None:
-            return None, None
+
+        if not openssl_libs or ssl_incs is None:
+            # libssl and libcrypto not found
+            self.missing.append('_ssl')
+            self.missing.append('_hashlib')
+            return
 
         # OpenSSL 1.0.2 uses Kerberos for KRB5 ciphers
         krb5_h = find_file(


### PR DESCRIPTION
setup.py now reports when the _hashlib module is missing because
OpenSSL is not available.

<!-- issue-number: [bpo-36544](https://bugs.python.org/issue36544) -->
https://bugs.python.org/issue36544
<!-- /issue-number -->
