### PR TITLE
[2.7] bpo-36235: Fix distutils test_customize_compiler() on macOS

### DIFF
--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -73,6 +73,9 @@ class SysconfigTestCase(support.EnvironGuard,
         comp = compiler()
         old_vars = dict(sysconfig._config_vars)
         try:
+            # On macOS, disable _osx_support.customize_compiler()
+            sysconfig._config_vars['CUSTOMIZED_OSX_COMPILER'] = 'True'
+
             for key, value in sysconfig_vars.items():
                 sysconfig._config_vars[key] = value
             sysconfig.customize_compiler(comp)


### PR DESCRIPTION
Set CUSTOMIZED_OSX_COMPILER to True to disable
_osx_support.customize_compiler().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36235](https://bugs.python.org/issue36235) -->
https://bugs.python.org/issue36235
<!-- /issue-number -->
