### PR TITLE
bpo-14826: document that URLopener quotes fullurl.

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1435,6 +1435,7 @@ some point in the future.
       The *data* argument has the same meaning as the *data* argument of
       :func:`urlopen`.
 
+      This method always quotes *fullurl* using :func:`~urllib.parse.quote`.
 
    .. method:: open_unknown(fullurl, data=None)
 


### PR DESCRIPTION
clarify an existing API behavior in the docs.

<!-- issue-number: [bpo-14826](https://bugs.python.org/issue14826) -->
https://bugs.python.org/issue14826
<!-- /issue-number -->
