### PR TITLE
bpo-36235: Fix distutils test_customize_compiler() on macOS

### DIFF
--- a/Lib/distutils/tests/test_sysconfig.py
+++ b/Lib/distutils/tests/test_sysconfig.py
@@ -92,6 +92,9 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
             'CCSHARED': '--sc-ccshared',
             'LDSHARED': 'sc_ldshared',
             'SHLIB_SUFFIX': 'sc_shutil_suffix',
+
+            # On macOS, disable _osx_support.customize_compiler()
+            'CUSTOMIZED_OSX_COMPILER': 'True',
         }
 
         comp = compiler()


### PR DESCRIPTION
Set CUSTOMIZED_OSX_COMPILER to True to disable
_osx_support.customize_compiler().

<!-- issue-number: [bpo-36235](https://bugs.python.org/issue36235) -->
https://bugs.python.org/issue36235
<!-- /issue-number -->
