### PR TITLE
bpo-36389: _PyObject_IsFreed() now also detects uninitialized memory

### DIFF
--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -161,16 +161,20 @@ PyAPI_FUNC(int) _PyMem_SetDefaultAllocator(
 
    The heuristic relies on the debug hooks on Python memory allocators which
    fills newly allocated memory with CLEANBYTE (0xCB) and newly freed memory
-   with DEADBYTE (0xDB). */
+   with DEADBYTE (0xDB). Detect also "untouchable bytes" marked
+   with FORBIDDENBYTE (0xFB). */
 static inline int _PyMem_IsPtrFreed(void *ptr)
 {
     uintptr_t value = (uintptr_t)ptr;
 #if SIZEOF_VOID_P == 8
     return (value == (uintptr_t)0xCBCBCBCBCBCBCBCB
-            || value == (uintptr_t)0xDBDBDBDBDBDBDBDB);
+            || value == (uintptr_t)0xDBDBDBDBDBDBDBDB
+            || value == (uintptr_t)0xFBFBFBFBFBFBFBFB
+            );
 #elif SIZEOF_VOID_P == 4
     return (value == (uintptr_t)0xCBCBCBCB
-            || value == (uintptr_t)0xDBDBDBDB);
+            || value == (uintptr_t)0xDBDBDBDB
+            || value == (uintptr_t)0xFBFBFBFB);
 #else
 #  error "unknown pointer size"
 #endif

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -155,6 +155,27 @@ PyAPI_FUNC(int) _PyMem_SetDefaultAllocator(
     PyMemAllocatorDomain domain,
     PyMemAllocatorEx *old_alloc);
 
+/* Heuristic checking if a pointer value is newly allocated
+   (uninitialized) or newly freed. The pointer is not dereferenced, only the
+   pointer value is checked.
+
+   The heuristic relies on the debug hooks on Python memory allocators which
+   fills newly allocated memory with CLEANBYTE (0xCB) and newly freed memory
+   with DEADBYTE (0xDB). */
+static inline int _PyMem_IsPtrFreed(void *ptr)
+{
+    uintptr_t value = (uintptr_t)ptr;
+#if SIZEOF_VOID_P == 8
+    return (value == (uintptr_t)0xCBCBCBCBCBCBCBCB
+            || value == (uintptr_t)0xDBDBDBDBDBDBDBDB);
+#elif SIZEOF_VOID_P == 4
+    return (value == (uintptr_t)0xCBCBCBCB
+            || value == (uintptr_t)0xDBDBDBDB);
+#else
+#  error "unknown pointer size"
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -23,8 +23,6 @@ PyAPI_FUNC(int) _PyMem_SetupAllocators(const char *opt);
 
 /* Try to get the allocators name set by _PyMem_SetupAllocators(). */
 PyAPI_FUNC(const char*) _PyMem_GetAllocatorsName(void);
-
-PyAPI_FUNC(int) _PyMem_IsFreed(void *ptr, size_t size);
 #endif   /* !defined(Py_LIMITED_API) */
 
 

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -543,6 +543,9 @@ class PyMemDebugTests(unittest.TestCase):
     def test_pyobject_is_freed_uninitialized(self):
         self.check_pyobject_is_freed('pyobject_uninitialized')
 
+    def test_pyobject_is_freed_forbidden_bytes(self):
+        self.check_pyobject_is_freed('pyobject_forbidden_bytes')
+
     def test_pyobject_is_freed_free(self):
         self.check_pyobject_is_freed('pyobject_freed')
 

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -526,6 +526,25 @@ class PyMemDebugTests(unittest.TestCase):
         code = 'import _testcapi; _testcapi.pyobject_malloc_without_gil()'
         self.check_malloc_without_gil(code)
 
+    def check_pyobject_is_freed(self, func):
+        code = textwrap.dedent('''
+            import os, sys, _testcapi
+            obj = _testcapi.{func}()
+            if _testcapi.pyobject_is_freed(obj):
+                # Exit immediately to avoid crash on deallocation invalid obj
+                os._exit(0)
+            else:
+                sys.exit(2)
+        ''')
+        code = code.format(func=func)
+        assert_python_ok('-c', code, PYTHONMALLOC=self.PYTHONMALLOC)
+
+    def test_pyobject_is_freed_uninitialized(self):
+        self.check_pyobject_is_freed('pyobject_uninitialized')
+
+    def test_pyobject_is_freed_free(self):
+        self.check_pyobject_is_freed('pyobject_freed')
+
 
 class PyMemMallocDebugTests(PyMemDebugTests):
     PYTHONMALLOC = 'malloc_debug'

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4247,7 +4247,7 @@ pyobject_is_freed(PyObject *self, PyObject *op)
 static PyObject*
 pyobject_uninitialized(PyObject *self, PyObject *args)
 {
-    PyObject *op = (PyObject *)PyObject_Malloc(sizeof(PyObject *));
+    PyObject *op = (PyObject *)PyObject_Malloc(sizeof(PyObject));
     if (op == NULL) {
         return NULL;
     }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4251,9 +4251,25 @@ pyobject_uninitialized(PyObject *self, PyObject *args)
     if (op == NULL) {
         return NULL;
     }
-    /* Initialize reference count to avoid early crash in ceval or the GC */
+    /* Initialize reference count to avoid early crash in ceval or GC */
     Py_REFCNT(op) = 1;
     /* object fields like ob_type are uninitialized! */
+    return op;
+}
+
+
+static PyObject*
+pyobject_forbidden_bytes(PyObject *self, PyObject *args)
+{
+    /* Allocate an incomplete PyObject structure: truncate 'ob_type' field */
+    PyObject *op = (PyObject *)PyObject_Malloc(offsetof(PyObject, ob_type));
+    if (op == NULL) {
+        return NULL;
+    }
+    /* Initialize reference count to avoid early crash in ceval or GC */
+    Py_REFCNT(op) = 1;
+    /* ob_type field is after the memory block: part of "forbidden bytes"
+       when using debug hooks on memory allocatrs! */
     return op;
 }
 
@@ -4266,7 +4282,7 @@ pyobject_freed(PyObject *self, PyObject *args)
         return NULL;
     }
     Py_TYPE(op)->tp_dealloc(op);
-    /* Reset reference count to avoid early crash in ceval or the GC */
+    /* Reset reference count to avoid early crash in ceval or GC */
     Py_REFCNT(op) = 1;
     /* object memory is freed! */
     return op;
@@ -4946,6 +4962,7 @@ static PyMethodDef TestMethods[] = {
     {"pymem_getallocatorsname", test_pymem_getallocatorsname, METH_NOARGS},
     {"pyobject_is_freed", (PyCFunction)(void(*)(void))pyobject_is_freed, METH_O},
     {"pyobject_uninitialized", pyobject_uninitialized, METH_NOARGS},
+    {"pyobject_forbidden_bytes", pyobject_forbidden_bytes, METH_NOARGS},
     {"pyobject_freed", pyobject_freed, METH_NOARGS},
     {"pyobject_malloc_without_gil", pyobject_malloc_without_gil, METH_NOARGS},
     {"tracemalloc_track", tracemalloc_track, METH_VARARGS},

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1914,7 +1914,7 @@ _Py_GetAllocatedBlocks(void)
 
 /* Special bytes broadcast into debug memory blocks at appropriate times.
  * Strings of these are unlikely to be valid addresses, floats, ints or
- * 7-bit ASCII.
+ * 7-bit ASCII. If modified, _PyMem_IsPtrFreed() should be updated as well.
  */
 #undef CLEANBYTE
 #undef DEADBYTE
@@ -2056,22 +2056,6 @@ _PyMem_DebugRawCalloc(void *ctx, size_t nelem, size_t elsize)
     assert(elsize == 0 || nelem <= (size_t)PY_SSIZE_T_MAX / elsize);
     nbytes = nelem * elsize;
     return _PyMem_DebugRawAlloc(1, ctx, nbytes);
-}
-
-
-/* Heuristic checking if the memory has been freed. Rely on the debug hooks on
-   Python memory allocators which fills the memory with DEADBYTE (0xDB) when
-   memory is deallocated. */
-int
-_PyMem_IsFreed(void *ptr, size_t size)
-{
-    unsigned char *bytes = ptr;
-    for (size_t i=0; i < size; i++) {
-        if (bytes[i] != DEADBYTE) {
-            return 0;
-        }
-    }
-    return 1;
 }
 
 


### PR DESCRIPTION
Replace _PyMem_IsFreed() function with _PyMem_IsPtrFreed() inline
function. The function is now way more efficient, it became a simple
comparison on integers, rather than a short loop.

<!-- issue-number: [bpo-36389](https://bugs.python.org/issue36389) -->
https://bugs.python.org/issue36389
<!-- /issue-number -->
