### PR TITLE
bpo-36597: fix weakref example code

### DIFF
--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -489,14 +489,14 @@ Unless you set the :attr:`~finalize.atexit` attribute to
 :const:`False`, a finalizer will be called when the program exits if it
 is still alive.  For instance
 
-    .. doctest::
-       :options: +SKIP
+.. doctest::
+   :options: +SKIP
 
-       >>> obj = Object()
-       >>> weakref.finalize(obj, print, "obj dead or exiting")
-       <finalize object at ...; for 'Object' at ...>
-       >>> exit()
-       obj dead or exiting
+   >>> obj = Object()
+   >>> weakref.finalize(obj, print, "obj dead or exiting")
+   <finalize object at ...; for 'Object' at ...>
+   >>> exit()
+   obj dead or exiting
 
 
 Comparing finalizers with :meth:`__del__` methods

--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -489,11 +489,14 @@ Unless you set the :attr:`~finalize.atexit` attribute to
 :const:`False`, a finalizer will be called when the program exits if it
 is still alive.  For instance
 
-    >>> obj = Object()
-    >>> weakref.finalize(obj, print, "obj dead or exiting")  #doctest:+ELLIPSIS
-    <finalize object at ...; for 'Object' at ...>
-    >>> del obj
-    obj dead or exiting
+    .. doctest::
+       :options: +SKIP
+
+       >>> obj = Object()
+       >>> weakref.finalize(obj, print, "obj dead or exiting")
+       <finalize object at ...; for 'Object' at ...>
+       >>> exit()
+       obj dead or exiting
 
 
 Comparing finalizers with :meth:`__del__` methods


### PR DESCRIPTION
Commit 57b1a2862 fixed doctest, but example code is not
match with document.

Just skip the doctest.

<!-- issue-number: [bpo-36597](https://bugs.python.org/issue36597) -->
https://bugs.python.org/issue36597
<!-- /issue-number -->
