### PR TITLE
bpo-36593: Fix isinstance check for Mock objects with spec executed under tracing

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -739,7 +739,7 @@ class NonCallableMock(Base):
 
         obj = self._mock_children.get(name, _missing)
         if name in self.__dict__:
-            super().__delattr__(name)
+            _safe_super(NonCallableMock, self).__delattr__(name)
         elif obj is _deleted:
             raise AttributeError(name)
         if obj is not _missing:

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1858,13 +1858,11 @@ class MockTest(unittest.TestCase):
 
         old_patch = unittest.mock.patch
 
-        def _cleanup(old_patch):
-            unittest.mock.patch = old_patch
-
         # Directly using __setattr__ on unittest.mock causes current imported
-        # reference to be updated. Use a function so that during cleanup the
+        # reference to be updated. Use a lambda so that during cleanup the
         # re-imported new reference is updated.
-        self.addCleanup(_cleanup, old_patch)
+        self.addCleanup(lambda patch: setattr(unittest.mock, 'patch', patch),
+                        old_patch)
 
         with patch.dict('sys.modules'):
             del sys.modules['unittest.mock']

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1857,6 +1857,15 @@ class MockTest(unittest.TestCase):
         # causes the objects patched to go out of sync
 
         old_patch = unittest.mock.patch
+
+        def _cleanup(old_patch):
+            unittest.mock.patch = old_patch
+
+        # Directly using __setattr__ on unittest.mock causes current imported
+        # reference to be updated. Use a function so that during cleanup the
+        # re-imported new reference is updated.
+        self.addCleanup(_cleanup, old_patch)
+
         with patch.dict('sys.modules'):
             del sys.modules['unittest.mock']
 
@@ -1877,8 +1886,6 @@ class MockTest(unittest.TestCase):
             for mock in mocks:
                 obj = mock(spec=Something)
                 self.assertIsInstance(obj, Something)
-
-        unittest.mock.patch = old_patch
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2019-04-11-22-11-24.bpo-36598.hfzDUl.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-11-22-11-24.bpo-36598.hfzDUl.rst
@@ -1,0 +1,2 @@
+Fix ``isinstance`` check for Mock objects with spec when the code is
+executed under tracing. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
This issue occurs only when the mock module import and code are executed under tracing. In order to test this I have tried patching `sys.modules` to remove `unittest.mock` in order to trigger an import under tracing. Though `unittest.mock` is deleted reference to `unittest.mock.patch` is held by two tests (test_patch_dict_test_prefix and test_patch_test_prefix) that change the `TEST_PREFIX`. Hence somehow there is a difference in the `unittest.mock.patch` object referred under these tests and inside mock module causing reference to unchanged `TEST_PREFIX` and hence test case failures. So I have kept a reference to old patch object and restored it in the end of this test to make sure everything is in sync. 

<!-- issue-number: [bpo-36593](https://bugs.python.org/issue36593) -->
https://bugs.python.org/issue36593
<!-- /issue-number -->
