### PR TITLE
bpo-36611: Fix test_sys.test_getallocatedblocks()

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -767,8 +767,13 @@ class SysModuleTest(unittest.TestCase):
         except ImportError:
             with_pymalloc = support.with_pymalloc()
         else:
-            alloc_name = _testcapi.pymem_getallocatorsname()
-            with_pymalloc = (alloc_name in ('pymalloc', 'pymalloc_debug'))
+            try:
+                alloc_name = _testcapi.pymem_getallocatorsname()
+            except RuntimeError as exc:
+                # "cannot get allocators name" (ex: tracemalloc is used)
+                with_pymalloc = True
+            else:
+                with_pymalloc = (alloc_name in ('pymalloc', 'pymalloc_debug'))
 
         # Some sanity checks
         a = sys.getallocatedblocks()

--- a/Misc/NEWS.d/next/Tests/2019-04-12-12-44-42.bpo-36611.UtorXL.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-12-12-44-42.bpo-36611.UtorXL.rst
@@ -1,0 +1,2 @@
+Fix ``test_sys.test_getallocatedblocks()`` when :mod:`tracemalloc` is
+enabled.


### PR DESCRIPTION
Fix test_sys.test_getallocatedblocks() when tracemalloc is used: if
the name of Python memory allocators cannot get read, consider that
pymalloc is disabled.

Fix the following test:

./python -X tracemalloc -m test test_sys -m test_getallocatedblocks

<!-- issue-number: [bpo-36611](https://bugs.python.org/issue36611) -->
https://bugs.python.org/issue36611
<!-- /issue-number -->
