### PR TITLE
[2.7] bpo-34652: Remove lchmod from the big func checking block. (GH-9247)

### DIFF
--- a/configure
+++ b/configure
@@ -10632,10 +10632,16 @@ done
 # links. Some libc implementations have a stub lchmod implementation that always
 # returns an error.
 if test "$MACHDEP" != linux; then
+  for ac_func in lchmod
+do :
   ac_fn_c_check_func "$LINENO" "lchmod" "ac_cv_func_lchmod"
 if test "x$ac_cv_func_lchmod" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LCHMOD 1
+_ACEOF
 
 fi
+done
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -3138,7 +3138,7 @@ AC_CHECK_FUNCS(alarm setitimer getitimer bind_textdomain_codeset chown \
 # links. Some libc implementations have a stub lchmod implementation that always
 # returns an error.
 if test "$MACHDEP" != linux; then
-  AC_CHECK_FUNC(lchmod)
+  AC_CHECK_FUNCS(lchmod)
 fi
 
 # For some functions, having a definition is not sufficient, since

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -439,6 +439,9 @@
 /* Define to 1 if you have the 'lchflags' function. */
 #undef HAVE_LCHFLAGS
 
+/* Define to 1 if you have the `lchmod' function. */
+#undef HAVE_LCHMOD
+
 /* Define to 1 if you have the `lchown' function. */
 #undef HAVE_LCHOWN
 


### PR DESCRIPTION
A fix for 69e96910153219b0b15a18323b917bd74336d229, which resulted in
lchmod being disabled on all platforms, not just Linux.

(cherry picked from commit ed709d5699716bf7237856dc20aba321e2dfff6d)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34652](https://bugs.python.org/issue34652) -->
https://bugs.python.org/issue34652
<!-- /issue-number -->
