### PR TITLE
bpo-36613: call remove_done_callback if exception

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -495,10 +495,11 @@ async def _wait(fs, timeout, return_when, loop):
     finally:
         if timeout_handle is not None:
             timeout_handle.cancel()
+        for f in fs:
+            f.remove_done_callback(_on_completion)
 
     done, pending = set(), set()
     for f in fs:
-        f.remove_done_callback(_on_completion)
         if f.done():
             done.add(f)
         else:

--- a/Misc/NEWS.d/next/Library/2019-04-12-13-52-15.bpo-36613.hqT1qn.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-12-13-52-15.bpo-36613.hqT1qn.rst
@@ -1,0 +1,1 @@
+Fix :mod:`asyncio` wait() not removing callback if exception


### PR DESCRIPTION
Call remove_done_callback() in finally block.

<!-- issue-number: [bpo-36613](https://bugs.python.org/issue36613) -->
https://bugs.python.org/issue36613
<!-- /issue-number -->
