### PR TITLE
bpo-36549: str.capitalize now titlecases the first character instead of uppercasing it

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1509,6 +1509,10 @@ expression support in the :mod:`re` module).
    Return a copy of the string with its first character capitalized and the
    rest lowercased.
 
+   .. versionchanged:: 3.8
+      The first character is now put into titlecase rather than uppercase.
+      This means that characters like digraphs will only have their first
+      letter capitalized, instead of the full character.
 
 .. method:: str.casefold()
 
@@ -2052,8 +2056,7 @@ expression support in the :mod:`re` module).
         >>> import re
         >>> def titlecase(s):
         ...     return re.sub(r"[A-Za-z]+('[A-Za-z]+)?",
-        ...                   lambda mo: mo.group(0)[0].upper() +
-        ...                              mo.group(0)[1:].lower(),
+        ...                   lambda mo: mo.group(0).capitalize(),
         ...                   s)
         ...
         >>> titlecase("they're bill's friends.")

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -977,7 +977,7 @@ class CommonTest(BaseTest):
     def test_capitalize_nonascii(self):
         # check that titlecased chars are lowered correctly
         # \u1ffc is the titlecased char
-        self.checkequal('\u03a9\u0399\u1ff3\u1ff3\u1ff3',
+        self.checkequal('\u1ffc\u1ff3\u1ff3\u1ff3',
                         '\u1ff3\u1ff3\u1ffc\u1ffc', 'capitalize')
         # check with cased non-letter chars
         self.checkequal('\u24c5\u24e8\u24e3\u24d7\u24de\u24dd',

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -811,7 +811,7 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertEqual('h\u0130'.capitalize(), 'H\u0069\u0307')
         exp = '\u0399\u0308\u0300\u0069\u0307'
         self.assertEqual('\u1fd2\u0130'.capitalize(), exp)
-        self.assertEqual('ﬁnnish'.capitalize(), 'FInnish')
+        self.assertEqual('ﬁnnish'.capitalize(), 'Finnish')
         self.assertEqual('A\u0345\u03a3'.capitalize(), 'A\u0345\u03c2')
 
     def test_title(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-04-11-12-41-31.bpo-36549.QSp8of.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-11-12-41-31.bpo-36549.QSp8of.rst
@@ -1,0 +1,2 @@
+Change str.capitalize to use titlecase for the first character instead of
+uppercase.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9675,7 +9675,7 @@ do_capitalize(int kind, void *data, Py_ssize_t length, Py_UCS4 *res, Py_UCS4 *ma
     Py_UCS4 c, mapped[3];
 
     c = PyUnicode_READ(kind, data, 0);
-    n_res = _PyUnicode_ToUpperFull(c, mapped);
+    n_res = _PyUnicode_ToTitleFull(c, mapped);
     for (j = 0; j < n_res; j++) {
         *maxchar = Py_MAX(*maxchar, mapped[j]);
         res[k++] = mapped[j];


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
this PR slightly tweaks the behaviour of `str.capitalize` so that it puts the first character into titlecase rather than uppercase. this only really changes the result for strings starting with digraphs or ligatures.

this my first contribution here so i hope everything is correct! :) i wasn't too sure exactly which part of the documentation needed to be changed so i just put what i assumed was right.

https://bugs.python.org/issue36549


<!-- issue-number: [bpo-36549](https://bugs.python.org/issue36549) -->
https://bugs.python.org/issue36549
<!-- /issue-number -->
