### PR TITLE
bpo-36618: Don't add -fmax-type-align flag to old clang

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-04-12-19-49-10.bpo-36618.gcI9iq.rst
+++ b/Misc/NEWS.d/next/Build/2019-04-12-19-49-10.bpo-36618.gcI9iq.rst
@@ -4,5 +4,5 @@ alignment on 16 bytes by default and so uses MOVAPS instruction which can
 lead to segmentation fault. Instruct clang that Python is limited to
 alignemnt on 8 bytes to use MOVUPS instruction instead: slower but don't
 trigger a SIGSEGV if the memory is not aligned on 16 bytes. Sadly, the flag
-must be expected to ``CFLAGS`` and not just ``CFLAGS_NODIST``, since third
-party C extensions can have the same issue.
+must be added to ``CFLAGS`` and not just ``CFLAGS_NODIST``, since third party C
+extensions can have the same issue.

--- a/configure
+++ b/configure
@@ -6889,9 +6889,14 @@ then
     # instead: slower but don't trigger a SIGSEGV if the memory is not aligned
     # on 16 bytes.
     #
-    # Sadly, the flag must be expected to CFLAGS and not just CFLAGS_NODIST,
+    # Sadly, the flag must be added to CFLAGS and not just CFLAGS_NODIST,
     # since third party C extensions can have the same issue.
-    CFLAGS="$CFLAGS -fmax-type-align=8"
+    #
+    # Check if -fmax-type-align flag is supported (it's not supported by old
+    # clang versions):
+    if "$CC" -v --help 2>/dev/null |grep -- -fmax-type-align > /dev/null; then
+        CFLAGS="$CFLAGS -fmax-type-align=8"
+    fi
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1540,9 +1540,14 @@ then
     # instead: slower but don't trigger a SIGSEGV if the memory is not aligned
     # on 16 bytes.
     #
-    # Sadly, the flag must be expected to CFLAGS and not just CFLAGS_NODIST,
+    # Sadly, the flag must be added to CFLAGS and not just CFLAGS_NODIST,
     # since third party C extensions can have the same issue.
-    CFLAGS="$CFLAGS -fmax-type-align=8"
+    #
+    # Check if -fmax-type-align flag is supported (it's not supported by old
+    # clang versions):
+    if "$CC" -v --help 2>/dev/null |grep -- -fmax-type-align > /dev/null; then
+        CFLAGS="$CFLAGS -fmax-type-align=8"
+    fi
 fi
 
 AC_SUBST(BASECFLAGS)


### PR DESCRIPTION


<!-- issue-number: [bpo-36618](https://bugs.python.org/issue36618) -->
https://bugs.python.org/issue36618
<!-- /issue-number -->
