### PR TITLE
[WIP] bpo-17013: Implement WaitableMock to create Mock objects that can wait until called

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2495,6 +2495,7 @@ class WaitableMock(MagicMock):
 
     def __init__(self, *args, event_class=threading.Event, **kwargs):
         _safe_super(WaitableMock, self).__init__(*args, **kwargs)
+        self._event_class = event_class
         self._event = event_class()
         self._expected_calls = defaultdict(lambda: event_class())
 
@@ -2523,7 +2524,7 @@ class WaitableMock(MagicMock):
         `timeout` - time to wait for in seconds. Defaults to 1.
         """
         if args:
-            if args not in self.expected_calls:
+            if args not in self._expected_calls:
                 event = self._event_class()
                 self._expected_calls[args] = event
             else:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2497,7 +2497,7 @@ class WaitableMock(MagicMock):
         _safe_super(WaitableMock, self).__init__(*args, **kwargs)
         self._event_class = event_class
         self._event = event_class()
-        self._expected_calls = defaultdict(lambda: event_class())
+        self._expected_calls = defaultdict(event_class)
 
     def _mock_call(self, *args, **kwargs):
         ret_value = _safe_super(WaitableMock, self)._mock_call(*args, **kwargs)

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2519,20 +2519,16 @@ class WaitableMock(MagicMock):
 
     def wait_until_called_with(self, *args, timeout=1.0):
         """Wait until the mock object is called with given args.
-        If args is empty then it waits for the mock object to be called.
 
         `timeout` - time to wait for in seconds. Defaults to 1.
         """
-        if args:
-            if args not in self._expected_calls:
-                event = self._event_class()
-                self._expected_calls[args] = event
-            else:
-                event = self._expected_calls[args]
+        if args not in self._expected_calls:
+            event = self._event_class()
+            self._expected_calls[args] = event
         else:
-            event = self._event
+            event = self._expected_calls[args]
 
-        return event.is_set() or event.wait(timeout=timeout)
+        return event.wait(timeout=timeout)
 
 
 def seal(mock):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2495,7 +2495,6 @@ class WaitableMock(MagicMock):
 
     def __init__(self, *args, event_class=threading.Event, **kwargs):
         _safe_super(WaitableMock, self).__init__(*args, **kwargs)
-        self._event_class = event_class
         self._event = event_class()
         self._expected_calls = defaultdict(event_class)
 
@@ -2522,12 +2521,7 @@ class WaitableMock(MagicMock):
 
         `timeout` - time to wait for in seconds. Defaults to 1.
         """
-        if args not in self._expected_calls:
-            event = self._event_class()
-            self._expected_calls[args] = event
-        else:
-            event = self._expected_calls[args]
-
+        event = self._expected_calls[args]
         return event.wait(timeout=timeout)
 
 

--- a/Lib/unittest/test/testmock/testwaitablemock.py
+++ b/Lib/unittest/test/testmock/testwaitablemock.py
@@ -99,7 +99,6 @@ class TestWaitableMock(unittest.TestCase):
                 something.method_1.wait_until_called(timeout=0.1)
                 something.method_1.assert_not_called()
 
-                time.sleep(0.5)
                 something.method_1.wait_until_called()
                 something.method_1.assert_called_once()
 
@@ -125,6 +124,7 @@ class TestWaitableMock(unittest.TestCase):
 
                 something.method_1.wait_until_called(timeout=2.0)
                 something.method_1.assert_called_once_with(1)
+                self.assertEqual(something.method_1.mock_calls, [call(1)])
                 something.method_2.assert_has_calls(
                     [call(1), call(2)], any_order=True)
 

--- a/Lib/unittest/test/testmock/testwaitablemock.py
+++ b/Lib/unittest/test/testmock/testwaitablemock.py
@@ -123,11 +123,21 @@ class TestWaitableMock(unittest.TestCase):
                 something.method_1.wait_until_called_with(1, timeout=0.1)
                 something.method_1.assert_not_called()
 
-                time.sleep(0.5)
-
+                something.method_1.wait_until_called(timeout=2.0)
                 something.method_1.assert_called_once_with(1)
                 something.method_2.assert_has_calls(
                     [call(1), call(2)], any_order=True)
+
+
+    def test_wait_until_called_with_default_event(self):
+        waitable_mock = WaitableMock(event_class=threading.Event)
+
+        with patch(f'{__name__}.Something', waitable_mock):
+            something = Something()
+            something.method_1(1)
+
+            something.method_1.assert_called_once_with(1)
+            something.method_1.wait_until_called_with()
 
 
 if __name__ == "__main__":

--- a/Lib/unittest/test/testmock/testwaitablemock.py
+++ b/Lib/unittest/test/testmock/testwaitablemock.py
@@ -1,0 +1,134 @@
+import threading
+import time
+import unittest
+
+from test.support import start_threads
+from unittest.mock import patch, WaitableMock, call
+
+
+class Something:
+
+    def method_1(self):
+        pass
+
+    def method_2(self):
+        pass
+
+
+class TestWaitableMock(unittest.TestCase):
+
+
+    def _call_after_delay(self, func, *args, delay):
+        time.sleep(delay)
+        func(*args)
+
+
+    def test_instance_check(self):
+        waitable_mock = WaitableMock(event_class=threading.Event)
+
+        with patch(f'{__name__}.Something', waitable_mock):
+            something = Something()
+
+            self.assertIsInstance(something.method_1, WaitableMock)
+            self.assertIsInstance(
+                something.method_1().method_2(), WaitableMock)
+
+
+    def test_side_effect(self):
+        waitable_mock = WaitableMock(event_class=threading.Event)
+
+        with patch(f'{__name__}.Something', waitable_mock):
+            something = Something()
+            something.method_1.side_effect = [1]
+
+            self.assertEqual(something.method_1(), 1)
+
+
+    def test_spec(self):
+        waitable_mock = WaitableMock(
+            event_class=threading.Event, spec=Something)
+
+        with patch(f'{__name__}.Something', waitable_mock) as m:
+            something = m()
+
+            self.assertIsInstance(something.method_1, WaitableMock)
+            self.assertIsInstance(
+                something.method_1().method_2(), WaitableMock)
+
+            with self.assertRaises(AttributeError):
+                m.test
+
+
+    def test_wait_until_called(self):
+        waitable_mock = WaitableMock(event_class=threading.Event)
+
+        with patch(f'{__name__}.Something', waitable_mock):
+            something = Something()
+            thread = threading.Thread(target=self._call_after_delay,
+                                      args=(something.method_1, ),
+                                      kwargs={'delay': 0.5})
+
+            with start_threads([thread]):
+                something.method_1.wait_until_called()
+                something.method_1.assert_called_once()
+
+
+    def test_wait_until_called_magic_method(self):
+        waitable_mock = WaitableMock(event_class=threading.Event)
+
+        with patch(f'{__name__}.Something', waitable_mock):
+            something = Something()
+            thread = threading.Thread(target=self._call_after_delay,
+                                      args=(something.method_1.__str__, ),
+                                      kwargs={'delay': 0.5})
+
+            with start_threads([thread]):
+                something.method_1.__str__.wait_until_called()
+                something.method_1.__str__.assert_called_once()
+
+
+    def test_wait_until_called_timeout(self):
+        waitable_mock = WaitableMock(event_class=threading.Event)
+
+        with patch(f'{__name__}.Something', waitable_mock):
+            something = Something()
+            thread = threading.Thread(target=self._call_after_delay, args=(something.method_1, ),
+                                      kwargs={'delay': 0.5})
+
+            with start_threads([thread]):
+                something.method_1.wait_until_called(timeout=0.1)
+                something.method_1.assert_not_called()
+
+                time.sleep(0.5)
+                something.method_1.wait_until_called()
+                something.method_1.assert_called_once()
+
+
+    def test_wait_until_called_with(self):
+        waitable_mock = WaitableMock(event_class=threading.Event)
+
+        with patch(f'{__name__}.Something', waitable_mock):
+            something = Something()
+            thread_1 = threading.Thread(target=self._call_after_delay,
+                                        args=(something.method_1, 1),
+                                        kwargs={'delay': 0.5})
+            thread_2 = threading.Thread(target=self._call_after_delay,
+                                        args=(something.method_2, 1),
+                                        kwargs={'delay': 0.1})
+            thread_3 = threading.Thread(target=self._call_after_delay,
+                                        args=(something.method_2, 2),
+                                        kwargs={'delay': 0.1})
+
+            with start_threads([thread_1, thread_2, thread_3]):
+                something.method_1.wait_until_called_with(1, timeout=0.1)
+                something.method_1.assert_not_called()
+
+                time.sleep(0.5)
+
+                something.method_1.assert_called_once_with(1)
+                something.method_2.assert_has_calls(
+                    [call(1), call(2)], any_order=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Misc/NEWS.d/next/Library/2019-04-13-20-56-09.bpo-17013.R_sgfy.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-13-20-56-09.bpo-17013.R_sgfy.rst
@@ -1,0 +1,3 @@
+Add `WaitableMock` to :mod:`unittest.mock` that can be used to create Mock
+objects that can wait until they are called. Patch by Karthikeyan
+Singaravelan.


### PR DESCRIPTION
This is an initial implementation with preliminary docs and tests to see if it's worthy enough of addition.

Some notes : 

* Currently, it doesn't support waiting for calls with keyword arguments.
* It seems the calls to event object are also recorded in `mock_calls` . I think these should be filtered out or maybe I am doing something wrong.
* There is per call event object and per mock object event to track if mock was called with given arguments and to store just mock is called or not. Is there a better way to store this?

cc : @mariocj89 

<!-- issue-number: [bpo-17013](https://bugs.python.org/issue17013) -->
https://bugs.python.org/issue17013
<!-- /issue-number -->
