### PR TITLE
bpo-36625: Remove obsolete comments from docstrings in fractions module

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -512,16 +512,16 @@ class Fraction(numbers.Rational):
             return a._numerator // a._denominator
 
     def __floor__(a):
-        """Will be math.floor(a) in 3.0."""
+        """math.floor(a)"""
         return a.numerator // a.denominator
 
     def __ceil__(a):
-        """Will be math.ceil(a) in 3.0."""
+        """math.ceil(a)"""
         # The negations cleverly convince floordiv to return the ceiling.
         return -(-a.numerator // a.denominator)
 
     def __round__(self, ndigits=None):
-        """Will be round(self, ndigits) in 3.0.
+        """round(self, ndigits)
 
         Rounds half toward even.
         """

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1098,6 +1098,7 @@ Tim Mitchell
 Zubin Mithra
 Florian Mladitsch
 Doug Moen
+Jakub Molinski
 Juliette Monsel
 The Dragon De Monsyne
 Bastien Montagne

--- a/Misc/NEWS.d/next/Documentation/2019-04-15-12-02-45.bpo-36625.x3LMCF.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-04-15-12-02-45.bpo-36625.x3LMCF.rst
@@ -1,0 +1,1 @@
+Remove obsolete comments from docstrings in fractions.Fraction


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Updated 3 docstrings in `fractions.Fraction` containing comments referring to python 3.0.

New docstrings are consistent with other docstrings in the fractions module.

<!-- issue-number: [bpo-36625](https://bugs.python.org/issue36625) -->
https://bugs.python.org/issue36625
<!-- /issue-number -->
