### PR TITLE
bpo-35967: Baseline values for uname -p

### DIFF
--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -5,6 +5,7 @@ import sys
 import sysconfig
 import tempfile
 import unittest
+import collections
 from unittest import mock
 
 from test import support
@@ -188,6 +189,13 @@ class PlatformTest(unittest.TestCase):
         self.assertEqual(res[3], res.version)
         self.assertEqual(res[4], res.machine)
         self.assertEqual(res[5], res.processor)
+
+    def test_uname_processor(self):
+        expected = collections.defaultdict(
+            set,
+            Darwin={'i386'},
+        )[platform.system()]
+        self.assertIn(platform.uname().processor, expected)
 
     @unittest.skipUnless(sys.platform.startswith('win'), "windows only test")
     def test_uname_win32_ARCHITEW6432(self):

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -191,11 +191,20 @@ class PlatformTest(unittest.TestCase):
         self.assertEqual(res[5], res.processor)
 
     def test_uname_processor(self):
-        expected = collections.defaultdict(
-            set,
-            Darwin={'i386'},
-        )[platform.system()]
-        self.assertIn(platform.uname().processor, expected)
+        """
+        On some systems, the processor must match the output
+        of 'uname -p'.
+        """
+        if sys.platform in ['win32', 'OpenVMS']:
+            return
+
+        try:
+            output = subprocess.check_output(['uname', '-p'], text=True)
+        except subprocess.CalledProcessError:
+            return
+
+        expected = output.strip()
+        self.assertEqual(platform.uname().processor, expected)
 
     @unittest.skipUnless(sys.platform.startswith('win'), "windows only test")
     def test_uname_win32_ARCHITEW6432(self):

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -6,6 +6,7 @@ import sysconfig
 import tempfile
 import unittest
 import collections
+import contextlib
 from unittest import mock
 
 from test import support
@@ -196,13 +197,11 @@ class PlatformTest(unittest.TestCase):
         On some systems, the processor must match the output
         of 'uname -p'. See Issue 35967 for rationale.
         """
-        try:
-            output = subprocess.check_output(['uname', '-p'], text=True)
-        except subprocess.CalledProcessError:
-            return
-
-        expected = output.strip()
-        self.assertEqual(platform.uname().processor, expected)
+        with contextlib.suppress(subprocess.CalledProcessError):
+            self.assertEqual(
+                platform.uname().processor,
+                subprocess.check_output(['uname', '-p'], text=True).strip(),
+            )
 
     @unittest.skipUnless(sys.platform.startswith('win'), "windows only test")
     def test_uname_win32_ARCHITEW6432(self):

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -190,14 +190,12 @@ class PlatformTest(unittest.TestCase):
         self.assertEqual(res[4], res.machine)
         self.assertEqual(res[5], res.processor)
 
+    @unittest.skipIf(sys.platform in ['win32', 'OpenVMS'], "uname -p not used")
     def test_uname_processor(self):
         """
         On some systems, the processor must match the output
-        of 'uname -p'.
+        of 'uname -p'. See Issue 35967 for rationale.
         """
-        if sys.platform in ['win32', 'OpenVMS']:
-            return
-
         try:
             output = subprocess.check_output(['uname', '-p'], text=True)
         except subprocess.CalledProcessError:


### PR DESCRIPTION
As requested in the ticket, I'm working to define the expected values for uname -p.

<!-- issue-number: [bpo-35967](https://bugs.python.org/issue35967) -->
https://bugs.python.org/issue35967
<!-- /issue-number -->
