### PR TITLE
bpo-16079: fix duplicate test method name in test_gzip.

### DIFF
--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -746,7 +746,7 @@ class TestCommandLine(unittest.TestCase):
         self.assertEqual(out[:2], b"\x1f\x8b")
 
     @create_and_remove_directory(TEMPDIR)
-    def test_compress_infile_outfile(self):
+    def test_compress_infile_outfile_default(self):
         local_testgzip = os.path.join(TEMPDIR, 'testgzip')
         gzipname = local_testgzip + '.gz'
         self.assertFalse(os.path.exists(gzipname))


### PR DESCRIPTION
I'm doing this one as an example for others.

<!-- issue-number: [bpo-16079](https://bugs.python.org/issue16079) -->
https://bugs.python.org/issue16079
<!-- /issue-number -->
