### PR TITLE
[2.7] bpo-10417: Fix unicode description in unittest.TestCase

### DIFF
--- a/Lib/unittest/runner.py
+++ b/Lib/unittest/runner.py
@@ -50,7 +50,12 @@ class TextTestResult(result.TestResult):
     def startTest(self, test):
         super(TextTestResult, self).startTest(test)
         if self.showAll:
-            self.stream.write(self.getDescription(test))
+            default_encoding = sys.getdefaultencoding()
+            encoding = getattr(self.stream, 'encoding', default_encoding)
+            description = self.getDescription(test)
+            description = description.encode(encoding, "backslashreplace") \
+                                     .decode(encoding)
+            self.stream.write(description)
             self.stream.write(" ... ")
             self.stream.flush()
 

--- a/Lib/unittest/runner.py
+++ b/Lib/unittest/runner.py
@@ -51,7 +51,8 @@ class TextTestResult(result.TestResult):
         super(TextTestResult, self).startTest(test)
         if self.showAll:
             default_encoding = sys.getdefaultencoding()
-            encoding = getattr(self.stream, 'encoding', default_encoding)
+            encoding = (getattr(self.stream, 'encoding', None) or
+                        default_encoding)
             description = self.getDescription(test)
             description = description.encode(encoding, "backslashreplace") \
                                      .decode(encoding)

--- a/Lib/unittest/test/test_result.py
+++ b/Lib/unittest/test/test_result.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sys
 import textwrap
 from StringIO import StringIO
@@ -293,6 +294,22 @@ class Test_TestResult(unittest.TestCase):
         def test(result):
             self.assertTrue(result.failfast)
         runner.run(test)
+
+    def testUnicodeDescription(self):
+        import cStringIO
+
+        old_encoding = sys.getdefaultencoding()
+        with test_support.CleanImport('sys'):
+            import sys as temp_sys
+            temp_sys.setdefaultencoding("ascii")
+            try:
+                stream = cStringIO.StringIO()
+                runner = unittest.TextTestRunner(stream=stream, verbosity=2)
+                desc = u"""täst - docstring with unicode character"""
+                test = unittest.FunctionTestCase(lambda: None, description=desc)
+                runner.run(test)
+            finally:
+                temp_sys.setdefaultencoding(old_encoding)
 
 
 classDict = dict(unittest.TestResult.__dict__)

--- a/Misc/NEWS.d/next/Library/2019-04-14-22-58-52.bpo-10417.LCYlev.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-14-22-58-52.bpo-10417.LCYlev.rst
@@ -1,0 +1,2 @@
+Fix unicode description in :class:`unittest.TestCase` for verbose mode.
+Based on patch by Victor Stinner.


### PR DESCRIPTION
Fix non-ascii description in `unittest.TestCase` for verbose mode by encoding them before writing to stream. 

Based on patch by Victor Stinner at https://bugs.python.org/msg121294

<!-- issue-number: [bpo-10417](https://bugs.python.org/issue10417) -->
https://bugs.python.org/issue10417
<!-- /issue-number -->
