### PR TITLE
bpo-30485: Re-allow empty strings in ElementPath namespace mappings

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2466,9 +2466,6 @@ class ElementFindTest(unittest.TestCase):
         nsmap = {'xx': 'X', None: 'Y'}
         self.assertEqual(len(root.findall(".//xx:b", namespaces=nsmap)), 2)
         self.assertEqual(len(root.findall(".//b", namespaces=nsmap)), 1)
-        nsmap = {'xx': 'X', '': 'Y'}
-        with self.assertRaisesRegex(ValueError, 'namespace prefix'):
-            root.findall(".//xx:b", namespaces=nsmap)
 
     def test_bad_find(self):
         e = ET.XML(SAMPLE_XML)

--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -275,8 +275,6 @@ def iterfind(elem, path, namespaces=None):
 
     cache_key = (path,)
     if namespaces:
-        if '' in namespaces:
-            raise ValueError("empty namespace prefix must be passed as None, not the empty string")
         if None in namespaces:
             cache_key += (namespaces[None],) + tuple(sorted(
                 item for item in namespaces.items() if item[0] is not None))


### PR DESCRIPTION
They might actually be harmless and unused (and thus went undetected previously).

<!-- issue-number: [bpo-30485](https://bugs.python.org/issue30485) -->
https://bugs.python.org/issue30485
<!-- /issue-number -->
