### PR TITLE
bpo-36629: Add support.get_socket_conn_refused_errs()

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1477,6 +1477,22 @@ socket_peer_reset = TransientResource(OSError, errno=errno.ECONNRESET)
 ioerror_peer_reset = TransientResource(OSError, errno=errno.ECONNRESET)
 
 
+def get_socket_conn_refused_errs():
+    """
+    Get the different socket error numbers ('errno') which can be received
+    when a connection is refused.
+    """
+    errors = [errno.ECONNREFUSED]
+    if hasattr(errno, 'ENETUNREACH'):
+        # On Solaris, ENETUNREACH is returned sometimes instead of ECONNREFUSED
+        errors.append(errno.ENETUNREACH)
+    if hasattr(errno, 'EADDRNOTAVAIL'):
+        # bpo-31910: socket.create_connection() fails randomly
+        # with EADDRNOTAVAIL on Travis CI
+        errors.append(errno.EADDRNOTAVAIL)
+    return errors
+
+
 @contextlib.contextmanager
 def transient_internet(resource_name, *, timeout=30.0, errnos=()):
     """Return a context manager that raises ResourceDenied when various issues

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -81,14 +81,8 @@ class TestImaplib(unittest.TestCase):
             except socket.error:
                 pass
 
-        expected_errnos = [
-            # This is the exception that should be raised.
-            errno.ECONNREFUSED,
-        ]
-        if hasattr(errno, 'EADDRNOTAVAIL'):
-            # socket.create_connection() fails randomly with
-            # EADDRNOTAVAIL on Travis CI.
-            expected_errnos.append(errno.EADDRNOTAVAIL)
+        # This is the exception that should be raised.
+        expected_errnos = support.get_socket_conn_refused_errs()
         with self.assertRaises(OSError) as cm:
             imaplib.IMAP4()
         self.assertIn(cm.exception.errno, expected_errnos)

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4804,14 +4804,7 @@ class NetworkConnectionNoServer(unittest.TestCase):
         # On Solaris, ENETUNREACH is returned in this circumstance instead
         # of ECONNREFUSED.  So, if that errno exists, add it to our list of
         # expected errnos.
-        expected_errnos = [ errno.ECONNREFUSED, ]
-        if hasattr(errno, 'ENETUNREACH'):
-            expected_errnos.append(errno.ENETUNREACH)
-        if hasattr(errno, 'EADDRNOTAVAIL'):
-            # bpo-31910: socket.create_connection() fails randomly
-            # with EADDRNOTAVAIL on Travis CI
-            expected_errnos.append(errno.EADDRNOTAVAIL)
-
+        expected_errnos = support.get_socket_conn_refused_errs()
         self.assertIn(cm.exception.errno, expected_errnos)
 
     def test_create_connection_timeout(self):

--- a/Misc/NEWS.d/next/Tests/2019-04-15-11-57-39.bpo-36629.ySnaL3.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-15-11-57-39.bpo-36629.ySnaL3.rst
@@ -1,0 +1,2 @@
+Fix ``test_imap4_host_default_value()`` of ``test_imaplib``: catch also
+:data:`errno.ENETUNREACH` error.


### PR DESCRIPTION
Fix test_imap4_host_default_value() of test_imaplib: catch also
errno.ENETUNREACH error.

<!-- issue-number: [bpo-36629](https://bugs.python.org/issue36629) -->
https://bugs.python.org/issue36629
<!-- /issue-number -->
