### PR TITLE
bpo-30202 : Update test.test_importlib.test_abc to test find_spec()

### DIFF
--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -362,13 +362,13 @@ class MetaPathFinderFindModuleTests:
         spec = self.util.spec_from_loader('blah', loader)
         finder = self.finder(spec)
         found = finder.find_spec('blah', 'blah', None)
+        self.assertEqual(found, spec)
 
     def test_no_spec(self):
         finder = self.finder(None)
         path = ['a', 'b', 'c']
         name = 'blah'
-        with self.assertWarns(DeprecationWarning):
-            found = finder.find_module(name, path)
+        found = finder.find_spec(name, path, None)
         self.assertIsNone(found)
         self.assertEqual(name, finder.called_for[0])
         self.assertEqual(path, finder.called_for[1])
@@ -377,9 +377,8 @@ class MetaPathFinderFindModuleTests:
         loader = object()
         spec = self.util.spec_from_loader('blah', loader)
         finder = self.finder(spec)
-        with self.assertWarns(DeprecationWarning):
-            found = finder.find_module('blah', None)
-        self.assertIs(found, spec.loader)
+        found = finder.find_spec('blah', None)
+        self.assertIs(found, spec)
 
 
 (Frozen_MPFFindModuleTests,

--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -357,6 +357,12 @@ class MetaPathFinderFindModuleTests:
 
         return MetaPathSpecFinder()
 
+    def test_find_spec(self):
+        loader = object()
+        spec = self.util.spec_from_loader('blah', loader)
+        finder = self.finder(spec)
+        found = finder.find_spec('blah', 'blah', None)
+
     def test_no_spec(self):
         finder = self.finder(None)
         path = ['a', 'b', 'c']

--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -357,18 +357,28 @@ class MetaPathFinderFindModuleTests:
 
         return MetaPathSpecFinder()
 
-    def test_find_spec(self):
+    def test_find_module(self):
+        finder = self.finder(None)
+        path = ['a', 'b', 'c']
+        name = 'blah'
+        with self.assertWarns(DeprecationWarning):
+            found = finder.find_module(name, path)
+        self.assertIsNone(found)
+
+    def test_find_spec_with_explicit_target(self):
         loader = object()
         spec = self.util.spec_from_loader('blah', loader)
         finder = self.finder(spec)
-        found = finder.find_spec('blah', 'blah', None)
+        with self.assertWarns(DeprecationWarning):
+            found = finder.find_spec('blah', 'blah', None)
         self.assertEqual(found, spec)
 
     def test_no_spec(self):
         finder = self.finder(None)
         path = ['a', 'b', 'c']
         name = 'blah'
-        found = finder.find_spec(name, path, None)
+        with self.assertWarns(DeprecationWarning):
+            found = finder.find_spec(name, path, None)
         self.assertIsNone(found)
         self.assertEqual(name, finder.called_for[0])
         self.assertEqual(path, finder.called_for[1])
@@ -377,7 +387,8 @@ class MetaPathFinderFindModuleTests:
         loader = object()
         spec = self.util.spec_from_loader('blah', loader)
         finder = self.finder(spec)
-        found = finder.find_spec('blah', None)
+        with self.assertWarns(DeprecationWarning):
+            found = finder.find_spec('blah', None)
         self.assertIs(found, spec)
 
 

--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -369,16 +369,14 @@ class MetaPathFinderFindModuleTests:
         loader = object()
         spec = self.util.spec_from_loader('blah', loader)
         finder = self.finder(spec)
-        with self.assertWarns(DeprecationWarning):
-            found = finder.find_spec('blah', 'blah', None)
+        found = finder.find_spec('blah', 'blah', None)
         self.assertEqual(found, spec)
 
     def test_no_spec(self):
         finder = self.finder(None)
         path = ['a', 'b', 'c']
         name = 'blah'
-        with self.assertWarns(DeprecationWarning):
-            found = finder.find_spec(name, path, None)
+        found = finder.find_spec(name, path, None)
         self.assertIsNone(found)
         self.assertEqual(name, finder.called_for[0])
         self.assertEqual(path, finder.called_for[1])
@@ -387,8 +385,7 @@ class MetaPathFinderFindModuleTests:
         loader = object()
         spec = self.util.spec_from_loader('blah', loader)
         finder = self.finder(spec)
-        with self.assertWarns(DeprecationWarning):
-            found = finder.find_spec('blah', None)
+        found = finder.find_spec('blah', None)
         self.assertIs(found, spec)
 
 

--- a/Misc/NEWS.d/next/Tests/2019-04-15-19-05-35.bpo-30202.Wt7INj.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-15-19-05-35.bpo-30202.Wt7INj.rst
@@ -1,0 +1,1 @@
+Update ``test.test_importlib.test_abc`` to test ``find_spec()``.


### PR DESCRIPTION
I have added a test for find_spec() in test.test_importlib.test_abc and also made some other tests use find_spec instead of find_module().

I may have not looked at all possible areas to use find_spec(), so please let me know in the reviews for this PR.

<!-- issue-number: [bpo-30202](https://bugs.python.org/issue30202) -->
https://bugs.python.org/issue30202
<!-- /issue-number -->
