### PR TITLE
bpo-24638: Improve the error message in asyncio.ensure_future()

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -627,7 +627,8 @@ def ensure_future(coro_or_future, *, loop=None):
         return task
     elif futures.isfuture(coro_or_future):
         if loop is not None and loop is not futures._get_loop(coro_or_future):
-            raise ValueError('loop argument must agree with Future')
+            raise ValueError('The future belongs to a different loop than '
+                             'the one specified as the loop argument')
         return coro_or_future
     elif inspect.isawaitable(coro_or_future):
         return ensure_future(_wrap_awaitable(coro_or_future), loop=loop)

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -236,6 +236,15 @@ class BaseTaskTests:
         with self.assertRaises(TypeError):
             asyncio.ensure_future('ok')
 
+    def test_ensure_future_error_msg(self):
+        loop = asyncio.new_event_loop()
+        f = self.new_future(self.loop)
+        with self.assertRaisesRegex(ValueError, 'The future belongs to a '
+                                    'different loop than the one specified as '
+                                    'the loop argument'):
+            asyncio.ensure_future(f, loop=loop)
+        loop.close()
+
     def test_get_stack(self):
         T = None
 


### PR DESCRIPTION


<!-- issue-number: [bpo-24638](https://bugs.python.org/issue24638) -->
https://bugs.python.org/issue24638
<!-- /issue-number -->
