### PR TITLE
bpo-36638: fix WindowsLoadTracker exception on small windows SKUs

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -632,7 +632,7 @@ class Regrtest:
             except FileNotFoundError as error:
                 # Windows IoT Core and Windows Nano Server do not provide
                 # typeperf.exe for x64, x86 or ARM
-                print('Failed to create WindowsLoadTracker: {}'.format(str(error)))
+                print('Failed to create WindowsLoadTracker: {}'.format(error))
 
         self.run_tests()
         self.display_result()

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -630,7 +630,7 @@ class Regrtest:
                 load_tracker = WindowsLoadTracker()
                 self.getloadavg = load_tracker.getloadavg
             except FileNotFoundError as error:
-                # typeperf.exe is not present on small editions 
+                # typeperf.exe is not present on small editions
                 # of windows like Windows IoT Core or nanoserver
                 print ('Failed to create WindowsLoadTracker: {}'.format(str(error)))
 

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -624,15 +624,15 @@ class Regrtest:
                 return os.getloadavg()[0]
             self.getloadavg = getloadavg_1m
         elif sys.platform == 'win32' and (self.ns.worker_args is None):
-            # Windows IoT Core and nanoserver do not provide
-            # typeperf.exe for x64, x86 or ARM
-            if os.path.isfile('c:/windows/system32/typeperf.exe'):
-                from test.libregrtest.win_utils import WindowsLoadTracker
+            from test.libregrtest.win_utils import WindowsLoadTracker
 
+            try:
                 load_tracker = WindowsLoadTracker()
                 self.getloadavg = load_tracker.getloadavg
-            else:
-                print('Not using WinLoadTracker: typeperf.exe not found')
+            except FileNotFoundError as error:
+                # Windows IoT Core and Windows Nano Server do not provide
+                # typeperf.exe for x64, x86 or ARM
+                print ('Failed to create WindowsLoadTracker: {}'.format(str(error)))
 
         self.run_tests()
         self.display_result()

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -632,7 +632,7 @@ class Regrtest:
             except FileNotFoundError as error:
                 # Windows IoT Core and Windows Nano Server do not provide
                 # typeperf.exe for x64, x86 or ARM
-                print ('Failed to create WindowsLoadTracker: {}'.format(str(error)))
+                print('Failed to create WindowsLoadTracker: {}'.format(str(error)))
 
         self.run_tests()
         self.display_result()

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -624,15 +624,15 @@ class Regrtest:
                 return os.getloadavg()[0]
             self.getloadavg = getloadavg_1m
         elif sys.platform == 'win32' and (self.ns.worker_args is None):
-            from test.libregrtest.win_utils import WindowsLoadTracker
+            # Windows IoT Core and nanoserver do not provide
+            # typeperf.exe for x64, x86 or ARM
+            if os.path.isfile('c:/windows/system32/typeperf.exe'):
+                from test.libregrtest.win_utils import WindowsLoadTracker
 
-            try:
                 load_tracker = WindowsLoadTracker()
                 self.getloadavg = load_tracker.getloadavg
-            except FileNotFoundError as error:
-                # typeperf.exe is not present on small editions
-                # of windows like Windows IoT Core or nanoserver
-                print ('Failed to create WindowsLoadTracker: {}'.format(str(error)))
+            else:
+                print('Not using WinLoadTracker: typeperf.exe not found')
 
         self.run_tests()
         self.display_result()

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -626,8 +626,13 @@ class Regrtest:
         elif sys.platform == 'win32' and (self.ns.worker_args is None):
             from test.libregrtest.win_utils import WindowsLoadTracker
 
-            load_tracker = WindowsLoadTracker()
-            self.getloadavg = load_tracker.getloadavg
+            try:
+                load_tracker = WindowsLoadTracker()
+                self.getloadavg = load_tracker.getloadavg
+            except FileNotFoundError as error:
+                # typeperf.exe is not present on small editions 
+                # of windows like Windows IoT Core or nanoserver
+                print ('Failed to create WindowsLoadTracker: {}'.format(str(error)))
 
         self.run_tests()
         self.display_result()


### PR DESCRIPTION
typeperf.exe is not present on small editions 
of windows like Windows IoT Core or nanoserver
This causes WindowsLoadTracker to throw an exception during test initialization.

@ammaraskar @zooba

<!-- issue-number: [bpo-36638](https://bugs.python.org/issue36638) -->
https://bugs.python.org/issue36638
<!-- /issue-number -->
