### PR TITLE
bpo-30485: Change the prefix for defining the default namespace in ElementPath from None to ''

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -764,7 +764,7 @@ Element Objects
       Finds the first subelement matching *match*.  *match* may be a tag name
       or a :ref:`path <elementtree-xpath>`.  Returns an element instance
       or ``None``.  *namespaces* is an optional mapping from namespace prefix
-      to full name.  Pass ``None`` as prefix to move all unprefixed tag names
+      to full name.  Pass ``''`` as prefix to move all unprefixed tag names
       in the expression into the given namespace.
 
 
@@ -773,7 +773,7 @@ Element Objects
       Finds all matching subelements, by tag name or
       :ref:`path <elementtree-xpath>`.  Returns a list containing all matching
       elements in document order.  *namespaces* is an optional mapping from
-      namespace prefix to full name.  Pass ``None`` as prefix to move all
+      namespace prefix to full name.  Pass ``''`` as prefix to move all
       unprefixed tag names in the expression into the given namespace.
 
 
@@ -784,7 +784,7 @@ Element Objects
       of the first matching element, or *default* if no element was found.
       Note that if the matching element has no text content an empty string
       is returned. *namespaces* is an optional mapping from namespace prefix
-      to full name.  Pass ``None`` as prefix to move all unprefixed tag names
+      to full name.  Pass ``''`` as prefix to move all unprefixed tag names
       in the expression into the given namespace.
 
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2463,7 +2463,7 @@ class ElementFindTest(unittest.TestCase):
         nsmap = {'xx': 'Y'}
         self.assertEqual(len(root.findall(".//xx:b", namespaces=nsmap)), 1)
         self.assertEqual(len(root.findall(".//b", namespaces=nsmap)), 2)
-        nsmap = {'xx': 'X', None: 'Y'}
+        nsmap = {'xx': 'X', '': 'Y'}
         self.assertEqual(len(root.findall(".//xx:b", namespaces=nsmap)), 2)
         self.assertEqual(len(root.findall(".//b", namespaces=nsmap)), 1)
 

--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -71,7 +71,7 @@ xpath_tokenizer_re = re.compile(
     )
 
 def xpath_tokenizer(pattern, namespaces=None):
-    default_namespace = namespaces.get(None) if namespaces else None
+    default_namespace = namespaces.get('') if namespaces else None
     for token in xpath_tokenizer_re.findall(pattern):
         tag = token[1]
         if tag and tag[0] != "{":
@@ -275,11 +275,7 @@ def iterfind(elem, path, namespaces=None):
 
     cache_key = (path,)
     if namespaces:
-        if None in namespaces:
-            cache_key += (namespaces[None],) + tuple(sorted(
-                item for item in namespaces.items() if item[0] is not None))
-        else:
-            cache_key += tuple(sorted(namespaces.items()))
+        cache_key += tuple(sorted(namespaces.items()))
 
     try:
         selector = _cache[cache_key]

--- a/Misc/NEWS.d/next/Library/2019-04-13-23-42-33.bpo-30485.JHhjJS.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-13-23-42-33.bpo-30485.JHhjJS.rst
@@ -1,3 +1,3 @@
 Path expressions in xml.etree.ElementTree can now avoid explicit namespace
 prefixes for tags (or the "{namespace}tag" notation) by passing a default
-namespace with a 'None' prefix.
+namespace with an empty string prefix.


### PR DESCRIPTION
There is existing code that uses that and it's more convenient to have an all-string-keys dict (e.g. when sorting items etc.).


<!-- issue-number: [bpo-30485](https://bugs.python.org/issue30485) -->
https://bugs.python.org/issue30485
<!-- /issue-number -->
