### PR TITLE
Fix wrong indentation of a paragraph in documentation

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -966,8 +966,8 @@ The module defines the following classes, functions and decorators:
 
       def fetch_response() -> Response: ...
 
-    Note that returning instances of private classes is not recommended.
-    It is usually preferable to make such classes public.
+   Note that returning instances of private classes is not recommended.
+   It is usually preferable to make such classes public.
 
 .. data:: Any
 


### PR DESCRIPTION
This paragraph doesn't seem to be a part of code, but merged into previous code block.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title


It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
