### PR TITLE
bpo-28552: Fix distutils.sysconfig for empty sys.executable

### DIFF
--- a/Lib/distutils/command/build.py
+++ b/Lib/distutils/command/build.py
@@ -116,7 +116,7 @@ class build(Command):
             self.build_scripts = os.path.join(self.build_base,
                                               'scripts-%d.%d' % sys.version_info[:2])
 
-        if self.executable is None:
+        if self.executable is None and sys.executable:
             self.executable = os.path.normpath(sys.executable)
 
         if isinstance(self.parallel, str):

--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -28,7 +28,12 @@ BASE_EXEC_PREFIX = os.path.normpath(sys.base_exec_prefix)
 if "_PYTHON_PROJECT_BASE" in os.environ:
     project_base = os.path.abspath(os.environ["_PYTHON_PROJECT_BASE"])
 else:
-    project_base = os.path.dirname(os.path.abspath(sys.executable))
+    if sys.executable:
+        project_base = os.path.dirname(os.path.abspath(sys.executable))
+    else:
+        # sys.executable can be empty if argv[0] has been changed and Python is
+        # unable to retrieve the real program name
+        project_base = os.getcwd()
 
 
 # python_build: (Boolean) if true, we're either building Python or

--- a/Misc/NEWS.d/next/Library/2019-04-18-16-10-29.bpo-28552.MW1TLt.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-18-16-10-29.bpo-28552.MW1TLt.rst
@@ -1,4 +1,4 @@
 Fix :mod:`distutils.sysconfig` if :data:`sys.executable` is ``None`` or an
 empty string: use :func:`os.getcwd` to initialize ``project_base``.  Fix
 also the distutils build command: don't use :data:`sys.executable` if it is
-None or an empty string.
+``None`` or an empty string.

--- a/Misc/NEWS.d/next/Library/2019-04-18-16-10-29.bpo-28552.MW1TLt.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-18-16-10-29.bpo-28552.MW1TLt.rst
@@ -1,0 +1,4 @@
+Fix :mod:`distutils.sysconfig` if :data:`sys.executable` is ``None`` or an
+empty string: use :func:`os.getcwd` to initialize ``project_base``.  Fix
+also the distutils build command: don't use :data:`sys.executable` if it is
+None or an empty string.


### PR DESCRIPTION
[bpo-28552](https://bugs.python.org/issue28552), [bpo-7774](https://bugs.python.org/issue7774): Fix distutils.sysconfig if sys.executable is
None or an empty string: use os.getcwd() to initialize project_base.

Fix also the distutils build command: don't use sys.executable if
it's evaluated as false (None or empty string).

<!-- issue-number: [bpo-28552](https://bugs.python.org/issue28552) -->
https://bugs.python.org/issue28552
<!-- /issue-number -->
