### PR TITLE
bpo-36659: distutils UnixCCompiler removes stdlib from rpath

### DIFF
--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -82,6 +82,15 @@ class UnixCCompiler(CCompiler):
     if sys.platform == "cygwin":
         exe_extension = ".exe"
 
+    def _fix_lib_args(self, libraries, library_dirs, runtime_library_dirs):
+        """Remove standard library path from rpath"""
+        libraries, library_dirs, runtime_library_dirs = super()._fix_lib_args(
+            libraries, library_dirs, runtime_library_dirs)
+        libdir = sysconfig.get_config_var('LIBDIR')
+        if runtime_library_dirs and (libdir in runtime_library_dirs):
+            runtime_library_dirs.remove(libdir)
+        return libraries, library_dirs, runtime_library_dirs
+
     def preprocess(self, source, output_file=None, macros=None,
                    include_dirs=None, extra_preargs=None, extra_postargs=None):
         fixed_args = self._fix_compile_args(None, macros, include_dirs)

--- a/Misc/NEWS.d/next/Library/2019-04-18-17-08-26.bpo-36659.no6Dvs.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-18-17-08-26.bpo-36659.no6Dvs.rst
@@ -1,0 +1,2 @@
+distutils UnixCCompiler now removes the standard library from the run-time
+search path ("rpath").


### PR DESCRIPTION
distutils UnixCCompiler now removes the standard library from the
run-time search path ("rpath").

Initial patch written by David Malcolm.

Co-Authored-By: David Malcolm <dmalcolm@redhat.com>

<!-- issue-number: [bpo-36659](https://bugs.python.org/issue36659) -->
https://bugs.python.org/issue36659
<!-- /issue-number -->
