### PR TITLE
bpo-36645: Fix ambiguous formatting in re.sub() documentation.

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -908,6 +908,7 @@ form.
       Unknown escapes in *repl* consisting of ``'\'`` and an ASCII letter
       now are errors.
 
+   .. versionchanged:: 3.7
       Empty matches for the pattern are replaced when adjacent to a previous
       non-empty match.
 


### PR DESCRIPTION
This PR also needs to be backported to 3.7.

<!-- issue-number: [bpo-36645](https://bugs.python.org/issue36645) -->
https://bugs.python.org/issue36645
<!-- /issue-number -->
