### PR TITLE
bpo-36650: Fix handling of empty keyword args in C version of lru_cache.

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1271,6 +1271,19 @@ class TestLRU:
         self.assertEqual(f(20), '.20.')
         self.assertEqual(f.cache_info().currsize, 10)
 
+    def test_lru_bug_36650(self):
+        # C version of lru_cache was treating a call with an empty **kwargs
+        # dictionary as being distinct from a call with no keywords at all.
+        # This did not result in an incorrect answer, but it did trigger
+        # an unexpected cache miss which broke a doctest for a method cache.
+        @self.module.lru_cache()
+        def f(x):
+            pass
+
+        f(0)
+        f(0, **{})
+        self.assertEqual(f.cache_info().hits, 1)
+
     def test_lru_hash_only_once(self):
         # To protect against weird reentrancy bugs and to improve
         # efficiency when faced with slow __hash__ methods, the

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1275,7 +1275,8 @@ class TestLRU:
         # C version of lru_cache was treating a call with an empty **kwargs
         # dictionary as being distinct from a call with no keywords at all.
         # This did not result in an incorrect answer, but it did trigger
-        # an unexpected cache miss which broke a doctest for a method cache.
+        # an unexpected cache miss.
+
         @self.module.lru_cache()
         def f(x):
             pass

--- a/Misc/NEWS.d/next/Library/2019-04-19-15-29-55.bpo-36650._EVdrz.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-19-15-29-55.bpo-36650._EVdrz.rst
@@ -1,0 +1,4 @@
+The C version of functools.lru_cache() was treating calls with an empty
+*kwargs dictionary as being distinct from calls with no keywords at all.
+This did not result in an incorrect answer, but it did trigger an unexpected
+cache miss.

--- a/Misc/NEWS.d/next/Library/2019-04-19-15-29-55.bpo-36650._EVdrz.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-19-15-29-55.bpo-36650._EVdrz.rst
@@ -1,4 +1,4 @@
 The C version of functools.lru_cache() was treating calls with an empty
-*kwargs dictionary as being distinct from calls with no keywords at all.
+``**kwargs`` dictionary as being distinct from calls with no keywords at all.
 This did not result in an incorrect answer, but it did trigger an unexpected
 cache miss.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -750,8 +750,9 @@ lru_cache_make_key(PyObject *args, PyObject *kwds, int typed)
     PyObject *key, *keyword, *value;
     Py_ssize_t key_size, pos, key_pos, kwds_size;
 
-    /* short path, key will match args anyway, which is a tuple */
     kwds_size = kwds ? PyDict_GET_SIZE(kwds) : 0;
+
+    /* short path, key will match args anyway, which is a tuple */
     if (!typed && !kwds_size) {
         if (PyTuple_GET_SIZE(args) == 1) {
             key = PyTuple_GET_ITEM(args, 0);
@@ -765,7 +766,6 @@ lru_cache_make_key(PyObject *args, PyObject *kwds, int typed)
         Py_INCREF(args);
         return args;
     }
-    assert(kwds_size >= 0);
 
     key_size = PyTuple_GET_SIZE(args);
     if (kwds_size)

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -751,7 +751,7 @@ lru_cache_make_key(PyObject *args, PyObject *kwds, int typed)
     Py_ssize_t key_size, pos, key_pos, kwds_size;
 
     /* short path, key will match args anyway, which is a tuple */
-    if (!typed && !kwds) {
+    if (!typed && (!kwds || PyDict_GET_SIZE(kwds) == 0)) {
         if (PyTuple_GET_SIZE(args) == 1) {
             key = PyTuple_GET_ITEM(args, 0);
             if (PyUnicode_CheckExact(key) || PyLong_CheckExact(key)) {

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -751,7 +751,8 @@ lru_cache_make_key(PyObject *args, PyObject *kwds, int typed)
     Py_ssize_t key_size, pos, key_pos, kwds_size;
 
     /* short path, key will match args anyway, which is a tuple */
-    if (!typed && (!kwds || PyDict_GET_SIZE(kwds) == 0)) {
+    kwds_size = kwds ? PyDict_GET_SIZE(kwds) : 0;
+    if (!typed && !kwds_size) {
         if (PyTuple_GET_SIZE(args) == 1) {
             key = PyTuple_GET_ITEM(args, 0);
             if (PyUnicode_CheckExact(key) || PyLong_CheckExact(key)) {
@@ -764,8 +765,6 @@ lru_cache_make_key(PyObject *args, PyObject *kwds, int typed)
         Py_INCREF(args);
         return args;
     }
-
-    kwds_size = kwds ? PyDict_GET_SIZE(kwds) : 0;
     assert(kwds_size >= 0);
 
     key_size = PyTuple_GET_SIZE(args);


### PR DESCRIPTION


<!-- issue-number: [bpo-36650](https://bugs.python.org/issue36650) -->
https://bugs.python.org/issue36650
<!-- /issue-number -->
