### PR TITLE
bpo-36672: Fix a compiler warning in winreg.SetValue()

### DIFF
--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -1614,7 +1614,7 @@ winreg_SetValue_impl(PyObject *module, HKEY key, const Py_UNICODE *sub_key,
     }
 
     Py_BEGIN_ALLOW_THREADS
-    rc = RegSetValueW(key, sub_key, REG_SZ, value, value_length+1);
+    rc = RegSetValueW(key, sub_key, REG_SZ, value, (DWORD)(value_length + 1));
     Py_END_ALLOW_THREADS
     if (rc != ERROR_SUCCESS)
         return PyErr_SetFromWindowsErrWithFunction(rc, "RegSetValue");


### PR DESCRIPTION


<!-- issue-number: [bpo-36672](https://bugs.python.org/issue36672) -->
https://bugs.python.org/issue36672
<!-- /issue-number -->
