### PR TITLE
bpo-32424: Improve test coverage for xml.etree.ElementTree

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1984,9 +1984,9 @@ class BasicElementTest(ElementTestCase, unittest.TestCase):
         e1 = ET.Element('e1')
         e2 = ET.Element('e2')
         e3 = ET.Element('e3')
-        e1.append(e2)
-        e2.append(e2)
         e3.append(e1)
+        e2.append(e3)
+        e1.append(e2)
         wref = weakref.ref(e1)
         del e1, e2, e3
         gc_collect()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -647,6 +647,7 @@ Christian Heimes
 Thomas Heller
 Malte Helmert
 Lance Finn Helsten
+Gordon P. Hemsley
 Jonathan Hendry
 Nathan Henrie
 Michael Henry

--- a/Misc/NEWS.d/next/Tests/2019-04-21-17-53-50.bpo-32424.Q4rBmn.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-21-17-53-50.bpo-32424.Q4rBmn.rst
@@ -1,0 +1,2 @@
+Fix typo in test_cyclic_gc() test for xml.etree.ElementTree. Patch by Gordon
+P. Hemsley.

--- a/Misc/NEWS.d/next/Tests/2019-04-21-17-55-18.bpo-32424.yDy49h.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-21-17-55-18.bpo-32424.yDy49h.rst
@@ -1,0 +1,1 @@
+Improve test coverage for xml.etree.ElementTree. Patch by Gordon P. Hemsley.


### PR DESCRIPTION
(Spun off from #5046.)

Add unit tests to improve coverage for xml.etree.ElementTree.

According to my testing, these should all pass in both the C and Python implementations of ElementTree.

<!-- issue-number: [bpo-32424](https://bugs.python.org/issue32424) -->
https://bugs.python.org/issue32424
<!-- /issue-number -->
