### PR TITLE
bpo-36679: rename duplicate test_class_getitem function

### DIFF
--- a/Lib/test/test_genericclass.py
+++ b/Lib/test/test_genericclass.py
@@ -158,7 +158,7 @@ class TestClassGetitem(unittest.TestCase):
         self.assertEqual(getitem_args[0], (C, (int, str)))
         self.assertEqual(getitem_args[1], {})
 
-    def test_class_getitem(self):
+    def test_class_getitem_format(self):
         class C:
             def __class_getitem__(cls, item):
                 return f'C[{item.__name__}]'


### PR DESCRIPTION
rename duplicate `test_class_getitem` to `test_class_getitem_format`, I'm not sure should I add news for it?


<!-- issue-number: [bpo-36679](https://bugs.python.org/issue36679) -->
https://bugs.python.org/issue36679
<!-- /issue-number -->
