### PR TITLE
bpo-36680: rename duplicate test_source_from_cache_path_like_arg function

### DIFF
--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -682,7 +682,7 @@ class PEP3147Tests:
 
     @unittest.skipIf(sys.implementation.cache_tag is None,
                      'requires sys.implementation.cache_tag not be None')
-    def test_source_from_cache_path_like_arg(self):
+    def test_cache_from_source_path_like_arg(self):
         path = pathlib.PurePath('foo', 'bar', 'baz', 'qux.py')
         expect = os.path.join('foo', 'bar', 'baz', '__pycache__',
                               'qux.{}.pyc'.format(self.tag))


### PR DESCRIPTION
Rename duplicate function `test_source_from_cache_path_like_arg` to `test_cache_from_source_path_like_arg`

<!-- issue-number: [bpo-36680](https://bugs.python.org/issue36680) -->
https://bugs.python.org/issue36680
<!-- /issue-number -->
