### PR TITLE
bpo-36681: remove duplicate test_regression_29220 function

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -315,12 +315,6 @@ class BuiltinLevelsTest(BaseTest):
         self.assertEqual(logging.getLevelName('INFO'), logging.INFO)
         self.assertEqual(logging.getLevelName(logging.INFO), 'INFO')
 
-    def test_regression_29220(self):
-        """See issue #29220 for more information."""
-        logging.addLevelName(logging.INFO, '')
-        self.addCleanup(logging.addLevelName, logging.INFO, 'INFO')
-        self.assertEqual(logging.getLevelName(logging.INFO), '')
-
     def test_issue27935(self):
         fatal = logging.getLevelName('FATAL')
         self.assertEqual(fatal, logging.FATAL)


### PR DESCRIPTION
Remove duplicate `test_regression_29220` function

<!-- issue-number: [bpo-36681](https://bugs.python.org/issue36681) -->
https://bugs.python.org/issue36681
<!-- /issue-number -->
