### PR TITLE
bpo-36683: rename duplicate function test_io_encoding to test_pyio_encoding

### DIFF
--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -195,7 +195,7 @@ class UTF8ModeTests(unittest.TestCase):
     def test_io_encoding(self):
         self.check_io_encoding('io')
 
-    def test_io_encoding(self):
+    def test_pyio_encoding(self):
         self.check_io_encoding('_pyio')
 
     def test_locale_getpreferredencoding(self):


### PR DESCRIPTION
rename duplicate function test_io_encoding to test_pyio_encoding

<!-- issue-number: [bpo-36683](https://bugs.python.org/issue36683) -->
https://bugs.python.org/issue36683
<!-- /issue-number -->
