### PR TITLE
bpo-36678: rename and remove duplicate functions

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -697,7 +697,7 @@ class TestCase(unittest.TestCase):
             y: int
         self.assertNotEqual(Point(1, 3), C(1, 3))
 
-    def test_not_tuple(self):
+    def test_not_other_dataclass(self):
         # Test that some of the problems with namedtuple don't happen
         #  here.
         @dataclass
@@ -1403,7 +1403,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(asdict(gd), {'id': 0, 'users': {'first': {'name': 'Alice', 'id': 1},
                                                          'second': {'name': 'Bob', 'id': 2}}})
 
-    def test_helper_asdict_builtin_containers(self):
+    def test_helper_asdict_builtin_object_containers(self):
         @dataclass
         class Child:
             d: object
@@ -1576,7 +1576,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(astuple(gt), (0, (('Alice', 1), ('Bob', 2))))
         self.assertEqual(astuple(gd), (0, {'first': ('Alice', 1), 'second': ('Bob', 2)}))
 
-    def test_helper_astuple_builtin_containers(self):
+    def test_helper_astuple_builtin_object_containers(self):
         @dataclass
         class Child:
             d: object
@@ -3241,18 +3241,6 @@ class TestReplace(unittest.TestCase):
                                   ".<locals>.C(f=TestReplace.test_recursive_repr_indirection_two"
                                   ".<locals>.D(f=TestReplace.test_recursive_repr_indirection_two"
                                   ".<locals>.E(f=...)))")
-
-    def test_recursive_repr_two_attrs(self):
-        @dataclass
-        class C:
-            f: "C"
-            g: "C"
-
-        c = C(None, None)
-        c.f = c
-        c.g = c
-        self.assertEqual(repr(c), "TestReplace.test_recursive_repr_two_attrs"
-                                  ".<locals>.C(f=..., g=...)")
 
     def test_recursive_repr_misc_attrs(self):
         @dataclass


### PR DESCRIPTION
rename and remove duplicate functions

<!-- issue-number: [bpo-36678](https://bugs.python.org/issue36678) -->
https://bugs.python.org/issue36678
<!-- /issue-number -->
