### PR TITLE
bpo-35184: Fix XML_POOR_ENTROPY option that breaks makesetup parsing of pyexpat line in Setup.dist

### DIFF
--- a/Modules/Setup.dist
+++ b/Modules/Setup.dist
@@ -368,7 +368,7 @@ _symtable symtablemodule.c
 # Interface to the Expat XML parser
 # More information on Expat can be found at www.libexpat.org.
 #
-#pyexpat expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DXML_POOR_ENTROPY=1 -DUSE_PYEXPAT_CAPI
+#pyexpat expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DXML_POOR_ENTROPY -DUSE_PYEXPAT_CAPI
 
 # Hye-Shik Chang's CJKCodecs
 


### PR DESCRIPTION

When the line is uncommented, the equals character causes it to be incorrectly interpreted
as a macro definition by makesetup.  This results in an invalid Makefile output.

The expat code only requires XML_POOR_ENTROPY to be defined; the value is unnecessary.

<!-- issue-number: [bpo-35184](https://bugs.python.org/issue35184) -->
https://bugs.python.org/issue35184
<!-- /issue-number -->
