### PR TITLE
bpo-36690: Fix typing error in demo rpython.py

### DIFF
--- a/Tools/demo/rpython.py
+++ b/Tools/demo/rpython.py
@@ -19,7 +19,7 @@ def main():
     port = PORT
     i = host.find(':')
     if i >= 0:
-        port = int(port[i+1:])
+        port = int(host[i+1:])
         host = host[:i]
     command = ' '.join(sys.argv[2:])
     with socket(AF_INET, SOCK_STREAM) as s:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
[bpo-36690](https://bugs.python.org/issue36690): Fix typing error in demo rpython.py
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Fixed typing error in File `Tools/demo/rpython.py` at Line 22 where `port[i+1:]` should be `host[i+1:]`


<!-- issue-number: [bpo-36690](https://bugs.python.org/issue36690) -->
https://bugs.python.org/issue36690
<!-- /issue-number -->
