### PR TITLE
[2.7] bpo-9194: Fix the bounds checking in winreg.c's fixupMultiSZ() (GH-12687)

### DIFF
--- a/PC/_winreg.c
+++ b/PC/_winreg.c
@@ -727,7 +727,7 @@ fixupMultiSZ(char **str, char *data, int len)
     Q = data + len;
     for (P = data, i = 0; P < Q && *P != '\0'; P++, i++) {
         str[i] = P;
-        for(; *P != '\0'; P++)
+        for (; P < Q && *P != '\0'; P++)
             ;
     }
 }


### PR DESCRIPTION

(cherry picked from commit 56ed86490cb8221c874d432461d77702437f63e5)


<!-- issue-number: [bpo-9194](https://bugs.python.org/issue9194) -->
https://bugs.python.org/issue9194
<!-- /issue-number -->
