### PR TITLE
doc: recursive glob ** follows symlinks to directories

### DIFF
--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -49,8 +49,9 @@ For example, ``'[?]'`` matches the character ``'?'``.
       single: **; in glob-style wildcards
 
    If *recursive* is true, the pattern "``**``" will match any files and zero or
-   more directories and subdirectories.  If the pattern is followed by an
-   ``os.sep``, only directories and subdirectories match.
+   more directories, subdirectories and symbolic links to directories. If the
+   pattern is followed by an ``os.sep`` or ``os.altsep`` then files will not
+   match.
 
    .. note::
       Using the "``**``" pattern in large directory trees may consume

--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -50,7 +50,7 @@ For example, ``'[?]'`` matches the character ``'?'``.
 
    If *recursive* is true, the pattern "``**``" will match any files and zero or
    more directories, subdirectories and symbolic links to directories. If the
-   pattern is followed by an ``os.sep`` or ``os.altsep`` then files will not
+   pattern is followed by an :data:`os.sep` or :data:`os.altsep` then files will not
    match.
 
    .. note::


### PR DESCRIPTION
The existing note does already warn that "Using the ** pattern in large
directory trees may consume an inordinate amount of time", however
following symbolic links to directories brings that to entirely new
levels; learned the hard way.

I initially assumed this was a bug, tentatively fixed with a simple:
```diff
-   if not dironly or entry.is_dir():
+   if not dironly or entry.is_dir(follow_symlinks=False):
```
... in `glob.py#_iterdir(dirname, dironly)`:

Later I found https://bugs.python.org/issue13968 in the git log and saw
this is working as intended with even a symlink loop test.