### PR TITLE
[3.7] bpo-9566: Fix compiler warnings on Windows

### DIFF
--- a/Include/pydtrace.h
+++ b/Include/pydtrace.h
@@ -29,7 +29,7 @@ static inline void PyDTrace_LINE(const char *arg0, const char *arg1, int arg2) {
 static inline void PyDTrace_FUNCTION_ENTRY(const char *arg0, const char *arg1, int arg2)  {}
 static inline void PyDTrace_FUNCTION_RETURN(const char *arg0, const char *arg1, int arg2) {}
 static inline void PyDTrace_GC_START(int arg0) {}
-static inline void PyDTrace_GC_DONE(int arg0) {}
+static inline void PyDTrace_GC_DONE(Py_ssize_t arg0) {}
 static inline void PyDTrace_INSTANCE_NEW_START(int arg0) {}
 static inline void PyDTrace_INSTANCE_NEW_DONE(int arg0) {}
 static inline void PyDTrace_INSTANCE_DELETE_START(int arg0) {}

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4282,7 +4282,7 @@ fstring_fix_node_location(const node *parent, node *n, char *expr_str)
                     break;
                 start--;
             }
-            cols += substr - start;
+            cols += (int)(substr - start);
             /* Fix lineno in mulitline strings. */
             while ((substr = strchr(substr + 1, '\n')))
                 lines--;


### PR DESCRIPTION
Backport changes from master:

* [bpo-9566](https://bugs.python.org/issue9566): Fix compiler warnings in gcmodule.c (GH-11010)
* [bpo-30465](https://bugs.python.org/issue30465): Fix C downcast warning on Windows in ast.c (GH-6593)
* [bpo-9566](https://bugs.python.org/issue9566): Fix compiler warnings in peephole.c (GH-10652)
* [bpo-27645](https://bugs.python.org/issue27645), sqlite: Fix integer overflow on sleep (GH-6594)


<!-- issue-number: [bpo-9566](https://bugs.python.org/issue9566) -->
https://bugs.python.org/issue9566
<!-- /issue-number -->
