### PR TITLE
bpo-36018: Make "seed" into a keyword only argument for NormalDist.samples()

### DIFF
--- a/Doc/library/statistics.rst
+++ b/Doc/library/statistics.rst
@@ -607,7 +607,7 @@ of applications in statistics.
        :exc:`StatisticsError` because it takes at least one point to estimate
        a central value and at least two points to estimate dispersion.
 
-    .. method:: NormalDist.samples(n, seed=None)
+    .. method:: NormalDist.samples(n, *, seed=None)
 
        Generates *n* random samples for a given mean and standard deviation.
        Returns a :class:`list` of :class:`float` values.

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -796,7 +796,7 @@ class NormalDist:
         xbar = fmean(data)
         return cls(xbar, stdev(data, xbar))
 
-    def samples(self, n, seed=None):
+    def samples(self, n, *, seed=None):
         'Generate *n* samples for a given mean and standard deviation.'
         gauss = random.gauss if seed is None else random.Random(seed).gauss
         mu, sigma = self.mu, self.sigma


### PR DESCRIPTION
Future-proof the API.

<!-- issue-number: [bpo-36018](https://bugs.python.org/issue36018) -->
https://bugs.python.org/issue36018
<!-- /issue-number -->
