### PR TITLE
replace 'sequencial argument' by 'positional' in doc

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -250,7 +250,7 @@ since it is impossible to detect the termination of alien threads.
 
       You may override this method in a subclass.  The standard :meth:`run`
       method invokes the callable object passed to the object's constructor as
-      the *target* argument, if any, with sequential and keyword arguments taken
+      the *target* argument, if any, with positional and keyword arguments taken
       from the *args* and *kwargs* arguments, respectively.
 
    .. method:: join(timeout=None)


### PR DESCRIPTION
in `library/threading.rst` doc, the term *sequential argument* is used. I haven't seen that term anywhere else in documentation, and the glossary only uses *positional argument*.
