### PR TITLE
bpo-36454: Fix test_time.test_monotonic()

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -470,8 +470,9 @@ class TimeTestCase(unittest.TestCase):
         t2 = time.monotonic()
         dt = t2 - t1
         self.assertGreater(t2, t1)
-        # Issue #20101: On some Windows machines, dt may be slightly low
-        self.assertTrue(0.45 <= dt <= 1.0, dt)
+        # bpo-20101: tolerate a difference of 50 ms because of bad timer
+        # resolution on Windows
+        self.assertTrue(0.450 <= dt)
 
         # monotonic() is a monotonic but non adjustable clock
         info = time.get_clock_info('monotonic')

--- a/Misc/NEWS.d/next/Tests/2019-04-23-17-48-11.bpo-36454.0q4lQz.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-23-17-48-11.bpo-36454.0q4lQz.rst
@@ -1,0 +1,2 @@
+Fix test_time.test_monotonic() on slow buildbots: only test the minimum
+time, not the maximum time.

--- a/Misc/NEWS.d/next/Tests/2019-04-23-17-48-11.bpo-36454.0q4lQz.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-23-17-48-11.bpo-36454.0q4lQz.rst
@@ -1,2 +1,3 @@
-Fix test_time.test_monotonic() on slow buildbots: only test the minimum
-time, not the maximum time.
+Change test_time.test_monotonic() to test only the lower bound of elapsed time
+after a sleep command rather than the upper bound. This prevents unnecessary
+test failures on slow buildbots. Patch by Victor Stinner.


### PR DESCRIPTION
Fix test_time.test_monotonic() on slow buildbots: only test the
minimum time, not the maximum time.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36454](https://bugs.python.org/issue36454) -->
https://bugs.python.org/issue36454
<!-- /issue-number -->
