### PR TITLE
bpo-36707: Remove "m" flag from SOABI

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-04-24-02-29-15.bpo-36707.8ZNB67.rst
+++ b/Misc/NEWS.d/next/Build/2019-04-24-02-29-15.bpo-36707.8ZNB67.rst
@@ -1,0 +1,3 @@
+``./configure --with-pymalloc`` no longer adds the ``m`` flag to SOABI
+(sys.implementation.cache_tag). Enabling or disabling pymalloc has no impact
+on the ABI.

--- a/configure
+++ b/configure
@@ -11238,7 +11238,6 @@ then
 
 $as_echo "#define WITH_PYMALLOC 1" >>confdefs.h
 
-    ABIFLAGS="${ABIFLAGS}m"
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_pymalloc" >&5
 $as_echo "$with_pymalloc" >&6; }
@@ -15086,12 +15085,13 @@ $as_echo "#define AC_APPLE_UNIVERSAL_BUILD 1" >>confdefs.h
 # * The Python implementation (always 'cpython-' for us)
 # * The major and minor version numbers
 # * --with-pydebug (adds a 'd')
-# * --with-pymalloc (adds a 'm')
-# * --with-wide-unicode (adds a 'u')
 #
 # Thus for example, Python 3.2 built with wide unicode, pydebug, and pymalloc,
 # would get a shared library ABI version tag of 'cpython-32dmu' and shared
 # libraries would be named 'foo.cpython-32dmu.so'.
+#
+# In Python 3.2 and older, --with-wide-unicode added a 'u' flag.
+# In Python 3.7 and older, --with-pymalloc added a 'm' flag.
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking ABIFLAGS" >&5
 $as_echo_n "checking ABIFLAGS... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -3400,7 +3400,6 @@ if test "$with_pymalloc" != "no"
 then
     AC_DEFINE(WITH_PYMALLOC, 1,
      [Define if you want to compile in Python-specific mallocs])
-    ABIFLAGS="${ABIFLAGS}m"
 fi
 AC_MSG_RESULT($with_pymalloc)
 
@@ -4601,12 +4600,13 @@ AC_C_BIGENDIAN
 # * The Python implementation (always 'cpython-' for us)
 # * The major and minor version numbers
 # * --with-pydebug (adds a 'd')
-# * --with-pymalloc (adds a 'm')
-# * --with-wide-unicode (adds a 'u')
 #
 # Thus for example, Python 3.2 built with wide unicode, pydebug, and pymalloc,
 # would get a shared library ABI version tag of 'cpython-32dmu' and shared
 # libraries would be named 'foo.cpython-32dmu.so'.
+#
+# In Python 3.2 and older, --with-wide-unicode added a 'u' flag.
+# In Python 3.7 and older, --with-pymalloc added a 'm' flag.
 AC_SUBST(SOABI)
 AC_MSG_CHECKING(ABIFLAGS)
 AC_MSG_RESULT($ABIFLAGS)


### PR DESCRIPTION
./configure --with-pymalloc no longer add "m" flag to SOABI:
enabling or disabling pymalloc has no impact on the ABI.

<!-- issue-number: [bpo-36707](https://bugs.python.org/issue36707) -->
https://bugs.python.org/issue36707
<!-- /issue-number -->
