### PR TITLE
bpo-36710: Add runtime parameter to _PyThreadState_Init()

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -155,8 +155,6 @@ PyAPI_FUNC(PyInterpreterState *) _PyInterpreterState_Get(void);
 PyAPI_FUNC(int) _PyState_AddModule(PyObject*, struct PyModuleDef*);
 PyAPI_FUNC(void) _PyState_ClearModules(void);
 PyAPI_FUNC(PyThreadState *) _PyThreadState_Prealloc(PyInterpreterState *);
-PyAPI_FUNC(void) _PyThreadState_Init(PyThreadState *);
-PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyGILState_Reinit(void);
 
 /* Similar to PyThreadState_Get(), but don't issue a fatal error

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -231,6 +231,11 @@ PyAPI_FUNC(void) _PyRuntime_Finalize(void);
 
 /* Other */
 
+PyAPI_FUNC(void) _PyThreadState_Init(
+    _PyRuntimeState *runtime,
+    PyThreadState *tstate);
+PyAPI_FUNC(void) _PyThreadState_DeleteExcept(PyThreadState *tstate);
+
 PyAPI_FUNC(_PyInitError) _PyInterpreterState_Enable(_PyRuntimeState *);
 PyAPI_FUNC(void) _PyInterpreterState_DeleteExceptMain(void);
 

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -994,7 +994,7 @@ t_bootstrap(void *boot_raw)
 
     tstate = boot->tstate;
     tstate->thread_id = PyThread_get_thread_ident();
-    _PyThreadState_Init(tstate);
+    _PyThreadState_Init(&_PyRuntime, tstate);
     PyEval_AcquireThread(tstate);
     tstate->interp->num_threads++;
     res = PyObject_Call(boot->func, boot->args, boot->keyw);


### PR DESCRIPTION
* Add 'runtime' parameter to _PyThreadState_Init() and make the
  function internal.
* Make _PyThreadState_DeleteExcept() internal
* Add 'gilstate' parameter to _PyGILState_NoteThreadState()

<!-- issue-number: [bpo-36710](https://bugs.python.org/issue36710) -->
https://bugs.python.org/issue36710
<!-- /issue-number -->
