### PR TITLE
[2.7] bpo-28552: Fix distutils.sysconfig for empty sys.executable (GH-12875)

### DIFF
--- a/Lib/distutils/command/build.py
+++ b/Lib/distutils/command/build.py
@@ -114,7 +114,7 @@ class build(Command):
             self.build_scripts = os.path.join(self.build_base,
                                               'scripts-' + sys.version[0:3])
 
-        if self.executable is None:
+        if self.executable is None and sys.executable:
             self.executable = os.path.normpath(sys.executable)
 
     def run(self):

--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -25,7 +25,12 @@ EXEC_PREFIX = os.path.normpath(sys.exec_prefix)
 # Path to the base directory of the project. On Windows the binary may
 # live in project/PCBuild9.  If we're dealing with an x64 Windows build,
 # it'll live in project/PCbuild/amd64.
-project_base = os.path.dirname(os.path.abspath(sys.executable))
+if sys.executable:
+    project_base = os.path.dirname(os.path.abspath(sys.executable))
+else:
+    # sys.executable can be empty if argv[0] has been changed and Python is
+    # unable to retrieve the real program name
+    project_base = os.getcwd()
 if os.name == "nt" and "pcbuild" in project_base[-8:].lower():
     project_base = os.path.abspath(os.path.join(project_base, os.path.pardir))
 # PC/VS7.1
@@ -79,7 +84,12 @@ def get_python_inc(plat_specific=0, prefix=None):
 
     if os.name == "posix":
         if python_build:
-            buildir = os.path.dirname(sys.executable)
+            if sys.executable:
+                buildir = os.path.dirname(sys.executable)
+            else:
+                # sys.executable can be empty if argv[0] has been changed
+                # and Python is unable to retrieve the real program name
+                buildir = os.getcwd()
             if plat_specific:
                 # python.h is located in the buildir
                 inc_dir = buildir

--- a/Misc/NEWS.d/next/Library/2019-04-18-16-10-29.bpo-28552.MW1TLt.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-18-16-10-29.bpo-28552.MW1TLt.rst
@@ -1,0 +1,4 @@
+Fix :mod:`distutils.sysconfig` if :data:`sys.executable` is ``None`` or an
+empty string: use :func:`os.getcwd` to initialize ``project_base``.  Fix
+also the distutils build command: don't use :data:`sys.executable` if it is
+``None`` or an empty string.


### PR DESCRIPTION
[bpo-28552](https://bugs.python.org/issue28552), [bpo-7774](https://bugs.python.org/issue7774): Fix distutils.sysconfig if sys.executable is
None or an empty string: use os.getcwd() to initialize project_base.

Fix also the distutils build command: don't use sys.executable if
it's evaluated as false (None or empty string).

<!-- issue-number: [bpo-28552](https://bugs.python.org/issue28552) -->
https://bugs.python.org/issue28552
<!-- /issue-number -->
