### PR TITLE
bpo-36722: Debug build loads libraries built in release mode

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-04-25-21-02-40.bpo-36722.8NApVM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-25-21-02-40.bpo-36722.8NApVM.rst
@@ -1,0 +1,2 @@
+In debug build, import now also looks for C extensions compiled in release
+mode and for C extensions compiled in the stable ABI.

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -38,9 +38,10 @@ const char *_PyImport_DynLoadFiletab[] = {
     ".dll",
 #else  /* !__CYGWIN__ */
     "." SOABI ".so",
-#ifndef Py_DEBUG
+#ifdef ALT_SOABI
+    "." ALT_SOABI ".so",
+#endif
     ".abi" PYTHON_ABI_STRING ".so",
-#endif /* ! Py_DEBUG */
     ".so",
 #endif  /* __CYGWIN__ */
     NULL,

--- a/configure
+++ b/configure
@@ -632,6 +632,7 @@ THREADHEADERS
 LIBPL
 PY_ENABLE_SHARED
 EXT_SUFFIX
+ALT_SOABI
 SOABI
 LIBC
 LIBM
@@ -15126,6 +15127,17 @@ $as_echo_n "checking SOABI... " >&6; }
 SOABI='cpython-'`echo $VERSION | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SOABI" >&5
 $as_echo "$SOABI" >&6; }
+
+if test "$Py_DEBUG" = 'true'; then
+  # Similar to SOABI but remove "d" flag from ABIFLAGS
+
+  ALT_SOABI='cpython-'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+
+cat >>confdefs.h <<_ACEOF
+#define ALT_SOABI "${ALT_SOABI}"
+_ACEOF
+
+fi
 
 
 case $ac_sys_system in

--- a/configure.ac
+++ b/configure.ac
@@ -4627,6 +4627,14 @@ AC_MSG_CHECKING(SOABI)
 SOABI='cpython-'`echo $VERSION | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
 AC_MSG_RESULT($SOABI)
 
+if test "$Py_DEBUG" = 'true'; then
+  # Similar to SOABI but remove "d" flag from ABIFLAGS
+  AC_SUBST(ALT_SOABI)
+  ALT_SOABI='cpython-'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+  AC_DEFINE_UNQUOTED(ALT_SOABI, "${ALT_SOABI}",
+            [Alternative SOABI used in debug build to load C extensions built in release mode])
+fi
+
 AC_SUBST(EXT_SUFFIX)
 case $ac_sys_system in
     Linux*|GNU*|Darwin|VxWorks)

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -12,6 +12,10 @@
    support for AIX C++ shared extension modules. */
 #undef AIX_GENUINE_CPLUSPLUS
 
+/* Alternative SOABI used in debug build to load C extensions built in release
+   mode */
+#undef ALT_SOABI
+
 /* The Android API level. */
 #undef ANDROID_API_LEVEL
 


### PR DESCRIPTION
In debug build, import now also looks for C extensions compiled in
release mode and for C extensions compiled in the stable ABI.

<!-- issue-number: [bpo-36722](https://bugs.python.org/issue36722) -->
https://bugs.python.org/issue36722
<!-- /issue-number -->
