### PR TITLE
gh-80642: timeit - Additional changes for autorange

### DIFF
--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -58,29 +58,36 @@ Python Interface
 The module defines three convenience functions and a public class:
 
 
-.. function:: timeit(stmt='pass', setup='pass', timer=<default timer>, number=1000000, globals=None)
+.. function:: timeit(stmt='pass', setup='pass', timer=<default timer>, number=1000000, globals=None, max_time_taken=0.2)
 
    Create a :class:`Timer` instance with the given statement, *setup* code and
    *timer* function and run its :meth:`.timeit` method with *number* executions.
    The optional *globals* argument specifies a namespace in which to execute the
-   code.
+   code. If *number* is 0, :meth:`.autorange` method is executed, a convenience
+   function that calls :meth:`.timeit` repeatedly so that the total time >= *max_time_taken* second.
 
    .. versionchanged:: 3.5
       The optional *globals* parameter was added.
 
+   .. versionchanged:: 3.7
+      The optional *max_time_taken* parameter was added.
 
-.. function:: repeat(stmt='pass', setup='pass', timer=<default timer>, repeat=5, number=1000000, globals=None)
+
+.. function:: repeat(stmt='pass', setup='pass', timer=<default timer>, repeat=5, number=1000000, globals=None, max_time_taken=0.2)
 
    Create a :class:`Timer` instance with the given statement, *setup* code and
    *timer* function and run its :meth:`.repeat` method with the given *repeat*
    count and *number* executions.  The optional *globals* argument specifies a
-   namespace in which to execute the code.
+   namespace in which to execute the code. If *number* is 0, :meth:`.autorange`
+   method is executed, a convenience function that calls :meth:`.timeit` repeatedly
+   so that the total time >= *max_time_taken* second.
 
    .. versionchanged:: 3.5
       The optional *globals* parameter was added.
 
    .. versionchanged:: 3.7
       Default value of *repeat* changed from 3 to 5.
+      The optional *max_time_taken* parameter was added.
 
 .. function:: default_timer()
 
@@ -90,7 +97,7 @@ The module defines three convenience functions and a public class:
       :func:`time.perf_counter` is now the default timer.
 
 
-.. class:: Timer(stmt='pass', setup='pass', timer=<timer function>, globals=None)
+.. class:: Timer(stmt='pass', setup='pass', timer=<timer function>, globals=None, max_time_taken=0.2)
 
    Class for timing execution speed of small code snippets.
 
@@ -115,6 +122,9 @@ The module defines three convenience functions and a public class:
 
    .. versionchanged:: 3.5
       The optional *globals* parameter was added.
+
+   .. versionchanged:: 3.7
+      The optional *max_time_taken* parameter was added.
 
    .. method:: Timer.timeit(number=1000000)
 
@@ -142,10 +152,10 @@ The module defines three convenience functions and a public class:
       Automatically determine how many times to call :meth:`.timeit`.
 
       This is a convenience function that calls :meth:`.timeit` repeatedly
-      so that the total time >= 0.2 second, returning the eventual
+      so that the total time >= *Timer.max_time_taken* second, returning the eventual
       (number of loops, time taken for that number of loops). It calls
       :meth:`.timeit` with increasing numbers from the sequence 1, 2, 5,
-      10, 20, 50, ... until the time taken is at least 0.2 second.
+      10, 20, 50, ... until the time taken is at least *max_time_taken* second.
 
       If *callback* is given and is not ``None``, it will be called after
       each trial with two arguments: ``callback(number, time_taken)``.
@@ -202,7 +212,7 @@ Command-Line Interface
 
 When called as a program from the command line, the following form is used::
 
-   python -m timeit [-n N] [-r N] [-u U] [-s S] [-h] [statement ...]
+   python -m timeit [-n N] [-r N] [-u U] [-s S] [-m M] [-h] [statement ...]
 
 Where the following options are understood:
 
@@ -232,6 +242,12 @@ Where the following options are understood:
     specify a time unit for timer output; can select nsec, usec, msec, or sec
 
    .. versionadded:: 3.5
+
+.. cmdoption:: -m, --max_time_taken=M
+
+    calls :meth:`.timeit` repeatedly so that the total time >= *max_time_taken* second
+
+   .. versionadded:: 3.7
 
 .. cmdoption:: -v, --verbose
 

--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -69,7 +69,7 @@ The module defines three convenience functions and a public class:
    .. versionchanged:: 3.5
       The optional *globals* parameter was added.
 
-   .. versionchanged:: 3.7
+   .. versionchanged:: 3.8
       The optional *max_time_taken* parameter was added.
 
 
@@ -123,7 +123,7 @@ The module defines three convenience functions and a public class:
    .. versionchanged:: 3.5
       The optional *globals* parameter was added.
 
-   .. versionchanged:: 3.7
+   .. versionchanged:: 3.8
       The optional *max_time_taken* parameter was added.
 
    .. method:: Timer.timeit(number=1000000)
@@ -247,7 +247,7 @@ Where the following options are understood:
 
     calls :meth:`.timeit` repeatedly so that the total time >= *max_time_taken* second
 
-   .. versionadded:: 3.7
+   .. versionadded:: 3.8
 
 .. cmdoption:: -v, --verbose
 

--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -214,7 +214,7 @@ Command-Line Interface
 
 When called as a program from the command line, the following form is used::
 
-   python -m timeit [-n N] [-r N] [-u U] [-s S] [-m M] [-h] [statement ...]
+   python -m timeit [-n N] [-r N] [-u U] [-s S] [-h] [statement ...]
 
 Where the following options are understood:
 

--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -58,36 +58,38 @@ Python Interface
 The module defines three convenience functions and a public class:
 
 
-.. function:: timeit(stmt='pass', setup='pass', timer=<default timer>, number=1000000, globals=None, max_time_taken=0.2)
+.. function:: timeit(stmt='pass', setup='pass', timer=<default timer>, number=1000000, globals=None, target_time=0.2)
 
    Create a :class:`Timer` instance with the given statement, *setup* code and
    *timer* function and run its :meth:`.timeit` method with *number* executions.
    The optional *globals* argument specifies a namespace in which to execute the
    code. If *number* is 0, :meth:`.autorange` method is executed, a convenience
-   function that calls :meth:`.timeit` repeatedly so that the total time >= *max_time_taken* second.
+   function that calls :meth:`.timeit` repeatedly so that the total time >= *target_time* second.
 
    .. versionchanged:: 3.5
       The optional *globals* parameter was added.
 
    .. versionchanged:: 3.8
-      The optional *max_time_taken* parameter was added.
+      The optional *target_time* parameter was added.
 
 
-.. function:: repeat(stmt='pass', setup='pass', timer=<default timer>, repeat=5, number=1000000, globals=None, max_time_taken=0.2)
+.. function:: repeat(stmt='pass', setup='pass', timer=<default timer>, repeat=5, number=1000000, globals=None, target_time=0.2)
 
    Create a :class:`Timer` instance with the given statement, *setup* code and
    *timer* function and run its :meth:`.repeat` method with the given *repeat*
    count and *number* executions.  The optional *globals* argument specifies a
    namespace in which to execute the code. If *number* is 0, :meth:`.autorange`
    method is executed, a convenience function that calls :meth:`.timeit` repeatedly
-   so that the total time >= *max_time_taken* second.
+   so that the total time >= *target_time* second.
 
    .. versionchanged:: 3.5
       The optional *globals* parameter was added.
 
    .. versionchanged:: 3.7
       Default value of *repeat* changed from 3 to 5.
-      The optional *max_time_taken* parameter was added.
+
+   .. versionchanged:: 3.8
+      The optional *target_time* parameter was added.
 
 .. function:: default_timer()
 
@@ -97,7 +99,7 @@ The module defines three convenience functions and a public class:
       :func:`time.perf_counter` is now the default timer.
 
 
-.. class:: Timer(stmt='pass', setup='pass', timer=<timer function>, globals=None, max_time_taken=0.2)
+.. class:: Timer(stmt='pass', setup='pass', timer=<timer function>, globals=None, target_time=0.2)
 
    Class for timing execution speed of small code snippets.
 
@@ -124,7 +126,7 @@ The module defines three convenience functions and a public class:
       The optional *globals* parameter was added.
 
    .. versionchanged:: 3.8
-      The optional *max_time_taken* parameter was added.
+      The optional *target_time* parameter was added.
 
    .. method:: Timer.timeit(number=1000000)
 
@@ -147,15 +149,15 @@ The module defines three convenience functions and a public class:
             timeit.Timer('for i in range(10): oct(i)', 'gc.enable()').timeit()
 
 
-   .. method:: Timer.autorange(callback=None)
+   .. method:: Timer.autorange(callback=None, target_time=None)
 
       Automatically determine how many times to call :meth:`.timeit`.
 
       This is a convenience function that calls :meth:`.timeit` repeatedly
-      so that the total time >= *Timer.max_time_taken* second, returning the eventual
+      so that the total time >= *Timer.target_time* seconds, returning the eventual
       (number of loops, time taken for that number of loops). It calls
       :meth:`.timeit` with increasing numbers from the sequence 1, 2, 5,
-      10, 20, 50, ... until the time taken is at least *max_time_taken* second.
+      10, 20, 50, ... until the time taken is at least *target_time* seconds.
 
       If *callback* is given and is not ``None``, it will be called after
       each trial with two arguments: ``callback(number, time_taken)``.
@@ -243,9 +245,9 @@ Where the following options are understood:
 
    .. versionadded:: 3.5
 
-.. cmdoption:: -m, --max_time_taken=M
+.. cmdoption:: -t, --target_time=T
 
-    calls :meth:`.timeit` repeatedly so that the total time >= *max_time_taken* second
+    calls :meth:`.timeit` repeatedly so that the total time >= *target_time* seconds
 
    .. versionadded:: 3.8
 

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -107,8 +107,8 @@ class TestTimeit(unittest.TestCase):
             kwargs['number'] = number
         delta_time = t.timeit(**kwargs)
         self.assertEqual(self.fake_timer.setup_calls, 1)
-        self.assertEqual(self.fake_timer.count, number)
-        self.assertEqual(delta_time, number)
+        self.assertEqual(self.fake_timer.count, number or 1)
+        self.assertEqual(delta_time, number or (1, 1.0))
 
     # Takes too long to run in debug build.
     #def test_timeit_default_iters(self):
@@ -139,7 +139,11 @@ class TestTimeit(unittest.TestCase):
     def test_timeit_function_zero_iters(self):
         delta_time = timeit.timeit(self.fake_stmt, self.fake_setup, number=0,
                 timer=FakeTimer())
-        self.assertEqual(delta_time, 0)
+        self.assertEqual(delta_time, (1, 1.0))
+
+    def test_timeit_function_max_time_taken(self):
+        delta_time = timeit.timeit(self.fake_stmt, self.fake_setup, number=0,
+                timer=FakeTimer(), max_time_taken=1)
 
     def test_timeit_globals_args(self):
         global _global_timer
@@ -152,9 +156,9 @@ class TestTimeit(unittest.TestCase):
         timeit.timeit(stmt='local_timer.inc()', timer=local_timer,
                       globals=locals(), number=3)
 
-    def repeat(self, stmt, setup, repeat=None, number=None):
+    def repeat(self, stmt, setup, repeat=None, number=None, max_time_taken=0.5):
         self.fake_timer = FakeTimer()
-        t = timeit.Timer(stmt=stmt, setup=setup, timer=self.fake_timer)
+        t = timeit.Timer(stmt=stmt, setup=setup, timer=self.fake_timer, max_time_taken=max_time_taken)
         kwargs = {}
         if repeat is None:
             repeat = DEFAULT_REPEAT
@@ -166,8 +170,8 @@ class TestTimeit(unittest.TestCase):
             kwargs['number'] = number
         delta_times = t.repeat(**kwargs)
         self.assertEqual(self.fake_timer.setup_calls, repeat)
-        self.assertEqual(self.fake_timer.count, repeat * number)
-        self.assertEqual(delta_times, repeat * [float(number)])
+        self.assertEqual(self.fake_timer.count, (repeat * number) if number else repeat)
+        self.assertEqual(delta_times, repeat * [float(number) or (1, 1.0)])
 
     # Takes too long to run in debug build.
     #def test_repeat_default(self):
@@ -185,6 +189,10 @@ class TestTimeit(unittest.TestCase):
     def test_repeat_callable_stmt(self):
         self.repeat(self.fake_callable_stmt, self.fake_setup,
                 repeat=3, number=5)
+
+    def test_repeat_callable_max_time_taken(self):
+        self.repeat(self.fake_callable_stmt, self.fake_setup,
+                repeat=3, number=5, max_time_taken=1)
 
     def test_repeat_callable_setup(self):
         self.repeat(self.fake_stmt, self.fake_callable_setup,
@@ -208,7 +216,7 @@ class TestTimeit(unittest.TestCase):
     def test_repeat_function_zero_iters(self):
         delta_times = timeit.repeat(self.fake_stmt, self.fake_setup, number=0,
                 timer=FakeTimer())
-        self.assertEqual(delta_times, DEFAULT_REPEAT * [0.0])
+        self.assertEqual(delta_times, DEFAULT_REPEAT * [(1, 1.0)])
 
     def assert_exc_string(self, exc_string, expected_exc_name):
         exc_lines = exc_string.splitlines()

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -143,7 +143,8 @@ class TestTimeit(unittest.TestCase):
 
     def test_timeit_function_max_time_taken(self):
         delta_time = timeit.timeit(self.fake_stmt, self.fake_setup, number=0,
-                timer=FakeTimer(), max_time_taken=1)
+                timer=FakeTimer(), target_time=1)
+        self.assertEqual(delta_time, (1, 1.0))
 
     def test_timeit_globals_args(self):
         global _global_timer
@@ -156,9 +157,9 @@ class TestTimeit(unittest.TestCase):
         timeit.timeit(stmt='local_timer.inc()', timer=local_timer,
                       globals=locals(), number=3)
 
-    def repeat(self, stmt, setup, repeat=None, number=None, max_time_taken=0.5):
+    def repeat(self, stmt, setup, repeat=None, number=None, target_time=0.5):
         self.fake_timer = FakeTimer()
-        t = timeit.Timer(stmt=stmt, setup=setup, timer=self.fake_timer, max_time_taken=max_time_taken)
+        t = timeit.Timer(stmt=stmt, setup=setup, timer=self.fake_timer, target_time=target_time)
         kwargs = {}
         if repeat is None:
             repeat = DEFAULT_REPEAT
@@ -192,7 +193,7 @@ class TestTimeit(unittest.TestCase):
 
     def test_repeat_callable_max_time_taken(self):
         self.repeat(self.fake_callable_stmt, self.fake_setup,
-                repeat=3, number=5, max_time_taken=1)
+                repeat=3, number=5, target_time=1)
 
     def test_repeat_callable_setup(self):
         self.repeat(self.fake_stmt, self.fake_callable_setup,

--- a/Misc/NEWS.d/next/Library/2019-04-25-21-11-37.bpo-36461.TO5YyP.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-25-21-11-37.bpo-36461.TO5YyP.rst
@@ -1,0 +1,4 @@
+In timeit module:
+- added a new parameter *max_time_taken* to ``timeit.timeit()`` and ``timeit.replace()`` methods and ``timeit.Timer()`` class;
+- had `timeit` and `repeat` methods (and functions) fall back 
+  on `autorange` if the number is set to 0 or None.

--- a/Misc/NEWS.d/next/Library/2019-04-25-21-11-37.bpo-36461.TO5YyP.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-25-21-11-37.bpo-36461.TO5YyP.rst
@@ -1,4 +1,4 @@
 In timeit module:
-- added a new parameter *max_time_taken* to ``timeit.timeit()`` and ``timeit.replace()`` methods and ``timeit.Timer()`` class;
+- added a new parameter *target_time* to ``timeit.timeit()`` and ``timeit.replace()`` methods and ``timeit.Timer()`` class;
 - had `timeit` and `repeat` methods (and functions) fall back 
   on `autorange` if the number is set to 0 or None.


### PR DESCRIPTION
- make the 0.2s time configurable;
- have `timeit` and `repeat` methods (and functions) fall back 
  on `autorange` if the number is set to 0 or None.



<!-- issue-number: [bpo-36461](https://bugs.python.org/issue36461) -->
https://bugs.python.org/issue36461
<!-- /issue-number -->


<!-- gh-issue-number: gh-80642 -->
* Issue: gh-80642
<!-- /gh-issue-number -->
