### PR TITLE
bpo-36729: Delete unused text variable on tests

### DIFF
--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1283,7 +1283,6 @@ foo(...)
 """)
 
         X.attr.__name__ = 'foo'
-        text = pydoc.plain(pydoc.render_doc(X.attr))
         self.assertEqual(self._get_summary_lines(X.attr), """\
 foo
     Custom descriptor

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1250,7 +1250,6 @@ cm(x) method of builtins.type instance
         class X:
             attr = Descr()
 
-        text = pydoc.plain(pydoc.render_doc(X.attr))
         self.assertEqual(self._get_summary_lines(X.attr), """\
 <test.test_pydoc.TestDescriptions.test_custom_non_data_descriptor.<locals>.Descr object>""")
 
@@ -1276,11 +1275,9 @@ foo(...)
         class X:
             attr = Descr()
 
-        text = pydoc.plain(pydoc.render_doc(X.attr))
         self.assertEqual(self._get_summary_lines(X.attr), "")
 
         X.attr.__doc__ = 'Custom descriptor'
-        text = pydoc.plain(pydoc.render_doc(X.attr))
         self.assertEqual(self._get_summary_lines(X.attr), """\
     Custom descriptor
 """)


### PR DESCRIPTION
On ```test_custom_non_data_descriptor``` and
```test_custom_data_descriptor``` there was a text variable
not used. This PR remove it.

I think that is not necessary NEWS here.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36729](https://bugs.python.org/issue36729) -->
https://bugs.python.org/issue36729
<!-- /issue-number -->
