### PR TITLE
bpo-36710: Fix compiler warning on PyThreadState_Delete()

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -826,7 +826,7 @@ _PyThreadState_Delete(_PyRuntimeState *runtime, PyThreadState *tstate)
 void
 PyThreadState_Delete(PyThreadState *tstate)
 {
-    return _PyThreadState_Delete(&_PyRuntime, tstate);
+    _PyThreadState_Delete(&_PyRuntime, tstate);
 }
 
 


### PR DESCRIPTION
_PyThreadState_Delete() has no return value.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36710](https://bugs.python.org/issue36710) -->
https://bugs.python.org/issue36710
<!-- /issue-number -->
