### PR TITLE
bpo-36719: regrtest closes explicitly WindowsLoadTracker

### DIFF
--- a/Lib/test/libregrtest/win_utils.py
+++ b/Lib/test/libregrtest/win_utils.py
@@ -60,9 +60,15 @@ class WindowsLoadTracker():
         # Close our copy of the write end of the pipe
         os.close(command_stdout)
 
-    def __del__(self):
+    def close(self):
+        if self.p is None:
+            return
         self.p.kill()
         self.p.wait()
+        self.p = None
+
+    def __del__(self):
+        self.close()
 
     def read_output(self):
         import _winapi


### PR DESCRIPTION
Regrtest.finalize() now closes explicitly the WindowsLoadTracker
instance.

<!-- issue-number: [bpo-36719](https://bugs.python.org/issue36719) -->
https://bugs.python.org/issue36719
<!-- /issue-number -->
