### PR TITLE
bpo-36356: pymain_exit_error() only call pymain_free() for exit

### DIFF
--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -33,8 +33,10 @@ typedef struct {
 #define _Py_INIT_NO_MEMORY() _Py_INIT_USER_ERR("memory allocation failed")
 #define _Py_INIT_EXIT(EXITCODE) \
     (_PyInitError){.prefix = NULL, .msg = NULL, .user_err = 0, .exitcode = (EXITCODE)}
+#define _Py_INIT_HAS_EXITCODE(err) \
+    (err.exitcode != -1)
 #define _Py_INIT_FAILED(err) \
-    (err.msg != NULL || err.exitcode != -1)
+    (err.msg != NULL || _Py_INIT_HAS_EXITCODE(err))
 
 /* --- _PyWstrList ------------------------------------------------ */
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -570,7 +570,12 @@ exit_sigint(void)
 static void _Py_NO_RETURN
 pymain_exit_error(_PyInitError err)
 {
-    pymain_free();
+    if (_Py_INIT_HAS_EXITCODE(err)) {
+        /* If it's an error rather than a regular exit, leave Python runtime
+           alive: _Py_ExitInitError() uses the current exception and use
+           sys.stdout in this case. */
+        pymain_free();
+    }
     _Py_ExitInitError(err);
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2172,7 +2172,7 @@ Py_FatalError(const char *msg)
 void _Py_NO_RETURN
 _Py_ExitInitError(_PyInitError err)
 {
-    if (err.exitcode >= 0) {
+    if (_Py_INIT_HAS_EXITCODE(err)) {
         exit(err.exitcode);
     }
     else {


### PR DESCRIPTION
Add _Py_INIT_HAS_EXITCODE() macro.

<!-- issue-number: [bpo-36356](https://bugs.python.org/issue36356) -->
https://bugs.python.org/issue36356
<!-- /issue-number -->
