### PR TITLE
bpo-36734: Fix compilation of faulthandler.c on HP-UX

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-04-26-17-14-20.bpo-36734.p2MaiN.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-26-17-14-20.bpo-36734.p2MaiN.rst
@@ -1,0 +1,2 @@
+Fix compilation of ``faulthandler.c`` on HP-UX. Initialize ``stack_t
+current_stack`` to zero using ``memset()``.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1370,7 +1370,8 @@ void _PyFaulthandler_Fini(void)
 #ifdef HAVE_SIGALTSTACK
     if (stack.ss_sp != NULL) {
         /* Fetch the current alt stack */
-        stack_t current_stack = {};
+        stack_t current_stack;
+        memset(&current_stack, 0, sizeof(current_stack));
         if (sigaltstack(NULL, &current_stack) == 0) {
             if (current_stack.ss_sp == stack.ss_sp) {
                 /* The current alt stack is the one that we installed.


### PR DESCRIPTION
Initialize "stack_t current_stack" to zero using memset().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36734](https://bugs.python.org/issue36734) -->
https://bugs.python.org/issue36734
<!-- /issue-number -->
