### PR TITLE
bpo-21536: Revert Makefile change on python-config

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1460,7 +1460,9 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
 		$(PYTHON_FOR_BUILD) -m lib2to3.pgen2.driver $(DESTDIR)$(LIBDEST)/lib2to3/PatternGrammar.txt
 
-python-config: $(srcdir)/Misc/python-config.in $(srcdir)/Misc/python-config.sh
+# bpo-21536: Misc/python-config.sh is generated in the build directory
+# from $(srcdir)Misc/python-config.sh.in.
+python-config: $(srcdir)/Misc/python-config.in Misc/python-config.sh
 	@ # Substitution happens here, as the completely-expanded BINDIR
 	@ # is not available in configure
 	sed -e "s,@EXENAME@,$(BINDIR)/python$(LDVERSION)$(EXE)," < $(srcdir)/Misc/python-config.in >python-config.py


### PR DESCRIPTION
Misc/python-config.sh lives in the build directory, not in the source
directory.

<!-- issue-number: [bpo-21536](https://bugs.python.org/issue21536) -->
https://bugs.python.org/issue21536
<!-- /issue-number -->
