### PR TITLE
bpo-22640: Add silent mode to py_compile

### DIFF
--- a/Doc/library/py_compile.rst
+++ b/Doc/library/py_compile.rst
@@ -42,6 +42,13 @@ byte-code cache files in the directory containing the source code.
    is raised.  This function returns the path to byte-compiled file, i.e.
    whatever *cfile* value was used.
 
+   The *doraise* and *quiet* arguments determine how errors are handled while
+   compiling file. If *quiet* is 0 or 1, and *doraise* is false, the default
+   behaviour is enabled: an error string is written to ``sys.stderr``, and the
+   function returns ``None`` instead of a path. If *doraise* is true,
+   a :exc:`PyCompileError` is raised instead. However if *quiet* is 2,
+   no message is written, and *doraise* has no effect.
+
    If the path that *cfile* becomes (either explicitly specified or computed)
    is a symlink or non-regular file, :exc:`FileExistsError` will be raised.
    This is to act as a warning that import will turn those paths into regular
@@ -81,6 +88,10 @@ byte-code cache files in the directory containing the source code.
       The :envvar:`SOURCE_DATE_EPOCH` environment variable no longer
       overrides the value of the *invalidation_mode* argument, and determines
       its default value instead.
+
+   .. versionchanged:: 3.8
+      The *quiet* parameter was added to support silent mode. It returns full
+      output with false or 0, errors only with 1, and no output with 2.
 
 
 .. class:: PycInvalidationMode

--- a/Doc/library/py_compile.rst
+++ b/Doc/library/py_compile.rst
@@ -90,8 +90,7 @@ byte-code cache files in the directory containing the source code.
       its default value instead.
 
    .. versionchanged:: 3.8
-      The *quiet* parameter was added to support silent mode. It returns full
-      output with false or 0, errors only with 1, and no output with 2.
+      The *quiet* parameter was added.
 
 
 .. class:: PycInvalidationMode

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -231,6 +231,22 @@ New Modules
 Improved Modules
 ================
 
+* The :meth:`_asdict()` method for :func:`collections.namedtuple` now returns
+  a :class:`dict` instead of a :class:`collections.OrderedDict`.  This works because
+  regular dicts have guaranteed ordering in since Python 3.7.  If the extra
+  features of :class:`OrderedDict` are required, the suggested remediation is
+  to cast the result to the desired type: ``OrderedDict(nt._asdict())``.
+  (Contributed by Raymond Hettinger in :issue:`35864`.)
+
+* The :mod:`unicodedata` module has been upgraded to use the `Unicode 12.0.0
+  <http://blog.unicode.org/2019/03/announcing-unicode-standard-version-120.html>`_
+  release.
+
+* The :meth:`py_compile.compile` method now supports silent mode. (Contributed by
+  Joannah Nanjekye in :issue:`22640`.)
+
+
+=======
 
 asyncio
 -------

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -231,17 +231,6 @@ New Modules
 Improved Modules
 ================
 
-* The :meth:`_asdict()` method for :func:`collections.namedtuple` now returns
-  a :class:`dict` instead of a :class:`collections.OrderedDict`.  This works because
-  regular dicts have guaranteed ordering in since Python 3.7.  If the extra
-  features of :class:`OrderedDict` are required, the suggested remediation is
-  to cast the result to the desired type: ``OrderedDict(nt._asdict())``.
-  (Contributed by Raymond Hettinger in :issue:`35864`.)
-
-* The :mod:`unicodedata` module has been upgraded to use the `Unicode 12.0.0
-  <http://blog.unicode.org/2019/03/announcing-unicode-standard-version-120.html>`_
-  release.
-
 * The :meth:`py_compile.compile` method now supports silent mode. (Contributed by
   Joannah Nanjekye in :issue:`22640`.)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -231,9 +231,6 @@ New Modules
 Improved Modules
 ================
 
-* The :meth:`py_compile.compile` method now supports silent mode. (Contributed by
-  Joannah Nanjekye in :issue:`22640`.)
-
 
 =======
 
@@ -405,6 +402,13 @@ plistlib
 Added new :class:`plistlib.UID` and enabled support for reading and writing
 NSKeyedArchiver-encoded binary plists.
 (Contributed by Jon Janzen in :issue:`26707`.)
+
+
+py_compile
+----------
+
+* The :meth:`py_compile.compile` method now supports silent mode.
+  (Contributed by Joannah Nanjekye in :issue:`22640`.)
 
 
 socket

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -405,7 +405,7 @@ NSKeyedArchiver-encoded binary plists.
 py_compile
 ----------
 
-The :meth:`py_compile.compile` method now supports silent mode.
+The :func:`py_compile.compile` method now supports silent mode.
 (Contributed by Joannah Nanjekye in :issue:`22640`.)
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -405,7 +405,7 @@ NSKeyedArchiver-encoded binary plists.
 py_compile
 ----------
 
-:meth:`py_compile.compile` method now supports silent mode.
+The :meth:`py_compile.compile` method now supports silent mode.
 (Contributed by Joannah Nanjekye in :issue:`22640`.)
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -407,8 +407,8 @@ NSKeyedArchiver-encoded binary plists.
 py_compile
 ----------
 
-* The :meth:`py_compile.compile` method now supports silent mode.
-  (Contributed by Joannah Nanjekye in :issue:`22640`.)
+The :meth:`py_compile.compile` method now supports silent mode.
+(Contributed by Joannah Nanjekye in :issue:`22640`.)
 
 
 socket

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -405,7 +405,7 @@ NSKeyedArchiver-encoded binary plists.
 py_compile
 ----------
 
-The :func:`py_compile.compile` now supports silent mode.
+:func:`py_compile.compile` now supports silent mode.
 (Contributed by Joannah Nanjekye in :issue:`22640`.)
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -232,8 +232,6 @@ Improved Modules
 ================
 
 
-=======
-
 asyncio
 -------
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -405,7 +405,7 @@ NSKeyedArchiver-encoded binary plists.
 py_compile
 ----------
 
-The :func:`py_compile.compile` method now supports silent mode.
+The :func:`py_compile.compile` now supports silent mode.
 (Contributed by Joannah Nanjekye in :issue:`22640`.)
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -407,7 +407,7 @@ NSKeyedArchiver-encoded binary plists.
 py_compile
 ----------
 
-The :meth:`py_compile.compile` method now supports silent mode.
+:meth:`py_compile.compile` method now supports silent mode.
 (Contributed by Joannah Nanjekye in :issue:`22640`.)
 
 

--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -77,7 +77,7 @@ def _get_default_invalidation_mode():
 
 
 def compile(file, cfile=None, dfile=None, doraise=False, optimize=-1,
-            invalidation_mode=None):
+            invalidation_mode=None, quiet=0):
     """Byte-compile one Python source file to Python bytecode.
 
     :param file: The source file name.
@@ -95,6 +95,8 @@ def compile(file, cfile=None, dfile=None, doraise=False, optimize=-1,
         are -1, 0, 1 and 2.  A value of -1 means to use the optimization
         level of the current interpreter, as given by -O command line options.
     :param invalidation_mode:
+    :param quiet: Return full output with False or 0, errors only with 1,
+        and no output with 2.
 
     :return: Path to the resulting byte compiled file.
 
@@ -143,11 +145,12 @@ def compile(file, cfile=None, dfile=None, doraise=False, optimize=-1,
                                      _optimize=optimize)
     except Exception as err:
         py_exc = PyCompileError(err.__class__, err, dfile or file)
-        if doraise:
-            raise py_exc
-        else:
-            sys.stderr.write(py_exc.msg + '\n')
-            return
+        if quiet < 2:
+            if doraise:
+                raise py_exc
+            else:
+                sys.stderr.write(py_exc.msg + '\n')
+        return
     try:
         dirname = os.path.dirname(cfile)
         if dirname:
@@ -194,10 +197,12 @@ def main(args=None):
                 compile(filename, doraise=True)
             except PyCompileError as error:
                 rv = 1
-                sys.stderr.write("%s\n" % error.msg)
+                if quiet < 2:
+                    sys.stderr.write("%s\n" % error.msg)
             except OSError as error:
                 rv = 1
-                sys.stderr.write("%s\n" % error)
+                if quiet < 2:
+                    sys.stderr.write("%s\n" % error)
     else:
         for filename in args:
             try:
@@ -205,7 +210,8 @@ def main(args=None):
             except PyCompileError as error:
                 # return value to indicate at least one failure
                 rv = 1
-                sys.stderr.write("%s\n" % error.msg)
+                if quiet < 2:
+                    sys.stderr.write("%s\n" % error.msg)
     return rv
 
 if __name__ == "__main__":

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -192,6 +192,14 @@ class PyCompileTestsBase:
                 fp.read(), 'test', {})
         self.assertEqual(flags, 0b1)
 
+    def test_quiet(self):
+        bad_coding = os.path.join(os.path.dirname(__file__), 'bad_coding2.py')
+        with support.captured_stderr():
+            self.assertIsNone(py_compile.compile(bad_coding, doraise=False, quiet=2))
+            self.assertIsNone(py_compile.compile(bad_coding, doraise=True, quiet=2))
+            with self.assertRaises(py_compile.PyCompileError):
+                py_compile.compile(bad_coding, doraise=True, quiet=1)
+
 
 class PyCompileTestsWithSourceEpoch(PyCompileTestsBase,
                                     unittest.TestCase,

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -194,9 +194,10 @@ class PyCompileTestsBase:
 
     def test_quiet(self):
         bad_coding = os.path.join(os.path.dirname(__file__), 'bad_coding2.py')
-        with support.captured_stderr():
+        with support.captured_stderr() as stderr:
             self.assertIsNone(py_compile.compile(bad_coding, doraise=False, quiet=2))
             self.assertIsNone(py_compile.compile(bad_coding, doraise=True, quiet=2))
+            self.assertEqual(stderr.getvalue(), '')
             with self.assertRaises(py_compile.PyCompileError):
                 py_compile.compile(bad_coding, doraise=True, quiet=1)
 

--- a/Misc/NEWS.d/next/Library/2019-04-26-22-13-26.bpo-22640.p3rheW.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-26-22-13-26.bpo-22640.p3rheW.rst
@@ -1,0 +1,1 @@
+`py_compile` now supports silent mode.

--- a/Misc/NEWS.d/next/Library/2019-04-26-22-13-26.bpo-22640.p3rheW.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-26-22-13-26.bpo-22640.p3rheW.rst
@@ -1,1 +1,2 @@
-`py_compile` now supports silent mode.
+:func:`py_compile.compile` now supports silent mode.  
+Patch by Joannah Nanjekye


### PR DESCRIPTION
I have added silent mode to py_compile.

<!-- issue-number: [bpo-22640](https://bugs.python.org/issue22640) -->
https://bugs.python.org/issue22640
<!-- /issue-number -->
