### PR TITLE
bpo-36722: Style and grammar edits for ABI entry

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -101,20 +101,21 @@ subdirectories).
 Debug build uses the same ABI as release build
 -----------------------------------------------
 
-Python now uses the same ABI when built in release and in debug mode. On Unix,
-when Python is build in debug mode, it is now possible to load C extensions
-built in release mode and C extensions built using the stable ABI.
+Python now uses the same ABI whether it built in release or debug mode. On
+Unix, when Python is built in debug mode, it is now possible to load C
+extensions built in release mode and C extensions built using the stable ABI.
 
-Release build and debug build are now ABI compatible: the ``Py_DEBUG`` define
-no longer implies the ``Py_TRACE_REFS`` define which introduces the only ABI
-incompatibility. A new ``./configure --with-trace-refs`` build option is now
-required to get ``Py_TRACE_REFS`` define which adds :func:`sys.getobjects`
-function and :envvar:`PYTHONDUMPREFS` environment variable.
+Release builds and debug builds are now ABI compatible: defining the
+``Py_DEBUG`` macro no longer implies the ``Py_TRACE_REFS`` macro, which
+introduces the only ABI incompatibility. The ``Py_TRACE_REFS`` macro, which
+adds the :func:`sys.getobjects` function and the :envvar:`PYTHONDUMPREFS`
+environment variable, can be set using the new ``./configure --with-trace-refs``
+build option.
 (Contributed by Victor Stinner in :issue:`36465`.)
 
-On Unix, C extensions are no longer linked to libpython. It is now possible to
-load a C extension built using a shared library Python
-with a statically linked Python.
+On Unix, C extensions are no longer linked to libpython. It is now possible
+for a statically linked Python to load a C extension built using a shared
+library Python.
 (Contributed by Victor Stinner in :issue:`21536`.)
 
 On Unix, when Python is built in debug mode, import now also looks for C

--- a/Misc/NEWS.d/next/Build/2019-04-09-18-19-43.bpo-36465.-w6vx6.rst
+++ b/Misc/NEWS.d/next/Build/2019-04-09-18-19-43.bpo-36465.-w6vx6.rst
@@ -1,5 +1,6 @@
-Release build and debug build are now ABI compatible: the ``Py_DEBUG`` define
-no longer implies ``Py_TRACE_REFS`` define which introduces the only ABI
-incompatibility. A new ``./configure --with-trace-refs`` build option is now
-required to get ``Py_TRACE_REFS`` define which adds :func:`sys.getobjects`
-function and ``PYTHONDUMPREFS`` environment variable.
+Release builds and debug builds are now ABI compatible: defining the
+``Py_DEBUG`` macro no longer implies the ``Py_TRACE_REFS`` macro, which
+introduces the only ABI incompatibility. The ``Py_TRACE_REFS`` macro, which
+adds the :func:`sys.getobjects` function and the :envvar:`PYTHONDUMPREFS`
+environment variable, can be set using the new ``./configure --with-trace-refs``
+build option.

--- a/Misc/NEWS.d/next/Build/2019-04-25-01-51-52.bpo-21536.ACQkiC.rst
+++ b/Misc/NEWS.d/next/Build/2019-04-25-01-51-52.bpo-21536.ACQkiC.rst
@@ -1,12 +1,12 @@
 On Unix, C extensions are no longer linked to libpython.
 
-It is now possible to load a C extension built using a shared library Python
-with a statically linked Python.
+It is now possible for a statically linked Python to load a C extension built
+using a shared library Python.
 
 When Python is embedded, ``libpython`` must not be loaded with ``RTLD_LOCAL``,
 but ``RTLD_GLOBAL`` instead. Previously, using ``RTLD_LOCAL``, it was already
-not possible to load C extensions which were not linked to ``libpython``, like
-C extensions of the standard library built by the ``*shared*`` section of
+not possible to load C extensions which were not linked to ``libpython``, such
+as C extensions of the standard library built by the ``*shared*`` section of
 ``Modules/Setup``.
 
 distutils, python-config and python-config.py have been modified.

--- a/Misc/SpecialBuilds.txt
+++ b/Misc/SpecialBuilds.txt
@@ -1,5 +1,5 @@
 This file describes some special Python build types enabled via compile-time
-preprocessor defines.
+preprocessor directives.
 
 IMPORTANT: if you want to build a debug-enabled Python, it is recommended that
 you use ``./configure --with-pydebug``, rather than the options listed here.


### PR DESCRIPTION
@vstinner expedited the merge for this ABI entry to make sure it's in before the alpha4 release. This is a cleanup PR with my copy edits.

The one thing I wasn't sure about is that I changed the word "define" to "macro" in a few places, referring to preprocessor directives like `Py_TRACE_REFS`. Macro sounds more right to me than "define", though I did always think there was a qualitative difference between expansion macros and macros you define for `#ifdef` guards. Anyway, `man gcc` says "`[-Dmacro[=defn]...] [-Umacro]`, so I think "macro" is correct.

CC: @elprans

<!-- issue-number: [bpo-36722](https://bugs.python.org/issue36722) -->
https://bugs.python.org/issue36722
<!-- /issue-number -->
