### PR TITLE
gh-80919: Add `array_hook` kwarg to json module functions/classes

### DIFF
--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -271,8 +271,8 @@ def detect_encoding(b):
     return 'utf-8'
 
 
-def load(fp, *, cls=None, object_hook=None, parse_float=None,
-        parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
+def load(fp, *, cls=None, object_hook=None, parse_float=None, parse_int=None, 
+        parse_constant=None, object_pairs_hook=None, array_hook=None, **kw):
     """Deserialize ``fp`` (a ``.read()``-supporting file-like object containing
     a JSON document) to a Python object.
 
@@ -287,17 +287,24 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
     This feature can be used to implement custom decoders.  If ``object_hook``
     is also defined, the ``object_pairs_hook`` takes priority.
 
+    ``array_hook`` is an optional function that will be called with the
+    result of any array literal decoded (a ``list``).  The return value of
+    ``array_hook`` will be used instead of the ``list``.  This can be used
+    to use another datatype for JSON Arrays (e.g. ``tuple``), or to provide
+    custom deserializations.
+
     To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
     kwarg; otherwise ``JSONDecoder`` is used.
     """
     return loads(fp.read(),
         cls=cls, object_hook=object_hook,
         parse_float=parse_float, parse_int=parse_int,
-        parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
+        parse_constant=parse_constant, object_pairs_hook=object_pairs_hook,
+        array_hook=array_hook, **kw)
 
 
-def loads(s, *, cls=None, object_hook=None, parse_float=None,
-        parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
+def loads(s, *, cls=None, object_hook=None, parse_float=None, parse_int=None, 
+        parse_constant=None, object_pairs_hook=None, array_hook=None, **kw):
     """Deserialize ``s`` (a ``str``, ``bytes`` or ``bytearray`` instance
     containing a JSON document) to a Python object.
 
@@ -311,6 +318,12 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
     return value of ``object_pairs_hook`` will be used instead of the ``dict``.
     This feature can be used to implement custom decoders.  If ``object_hook``
     is also defined, the ``object_pairs_hook`` takes priority.
+
+    ``array_hook`` is an optional function that will be called with the
+    result of any array literal decoded (a ``list``).  The return value of
+    ``array_hook`` will be used instead of the ``list``. This can be used
+    to use another datatype for JSON Arrays (e.g. ``tuple``), or to provide
+    custom deserializations.
 
     ``parse_float``, if specified, will be called with the string
     of every JSON float to be decoded. By default this is equivalent to
@@ -350,10 +363,11 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
             stacklevel=2
         )
         del kw['encoding']
-
+    # cached decoder
     if (cls is None and object_hook is None and
             parse_int is None and parse_float is None and
-            parse_constant is None and object_pairs_hook is None and not kw):
+            parse_constant is None and object_pairs_hook is None and
+            array_hook is None and not kw):
         return _default_decoder.decode(s)
     if cls is None:
         cls = JSONDecoder
@@ -361,6 +375,8 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
         kw['object_hook'] = object_hook
     if object_pairs_hook is not None:
         kw['object_pairs_hook'] = object_pairs_hook
+    if array_hook is not None:
+        kw['array_hook'] = array_hook
     if parse_float is not None:
         kw['parse_float'] = parse_float
     if parse_int is not None:

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -271,7 +271,7 @@ def detect_encoding(b):
     return 'utf-8'
 
 
-def load(fp, *, cls=None, object_hook=None, parse_float=None, parse_int=None, 
+def load(fp, *, cls=None, object_hook=None, parse_float=None, parse_int=None,
         parse_constant=None, object_pairs_hook=None, array_hook=None, **kw):
     """Deserialize ``fp`` (a ``.read()``-supporting file-like object containing
     a JSON document) to a Python object.
@@ -303,7 +303,7 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None, parse_int=None,
         array_hook=array_hook, **kw)
 
 
-def loads(s, *, cls=None, object_hook=None, parse_float=None, parse_int=None, 
+def loads(s, *, cls=None, object_hook=None, parse_float=None, parse_int=None,
         parse_constant=None, object_pairs_hook=None, array_hook=None, **kw):
     """Deserialize ``s`` (a ``str``, ``bytes`` or ``bytearray`` instance
     containing a JSON document) to a Python object.

--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -250,9 +250,9 @@ def JSONArray(s_and_end, scan_once, array_hook,
                     end = _w(s, end + 1).end()
         except IndexError:
             pass
-    
+
     if array_hook is not None:
-            values = array_hook(values)
+        values = array_hook(values)
     return values, end
 
 

--- a/Lib/json/scanner.py
+++ b/Lib/json/scanner.py
@@ -72,4 +72,3 @@ def py_make_scanner(context):
     return scan_once
 
 make_scanner = c_make_scanner or py_make_scanner
-# make_scanner = py_make_scanner

--- a/Lib/json/scanner.py
+++ b/Lib/json/scanner.py
@@ -23,6 +23,7 @@ def py_make_scanner(context):
     parse_constant = context.parse_constant
     object_hook = context.object_hook
     object_pairs_hook = context.object_pairs_hook
+    array_hook = context.array_hook
     memo = context.memo
 
     def _scan_once(string, idx):
@@ -37,7 +38,7 @@ def py_make_scanner(context):
             return parse_object((string, idx + 1), strict,
                 _scan_once, object_hook, object_pairs_hook, memo)
         elif nextchar == '[':
-            return parse_array((string, idx + 1), _scan_once)
+            return parse_array((string, idx + 1), _scan_once, array_hook)
         elif nextchar == 'n' and string[idx:idx + 4] == 'null':
             return None, idx + 4
         elif nextchar == 't' and string[idx:idx + 4] == 'true':
@@ -71,3 +72,4 @@ def py_make_scanner(context):
     return scan_once
 
 make_scanner = c_make_scanner or py_make_scanner
+# make_scanner = py_make_scanner

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -42,6 +42,22 @@ class TestDecode:
                                     object_pairs_hook=OrderedDict),
                          OrderedDict([('empty', OrderedDict())]))
 
+    def test_array_hook(self):
+        s = '[{"xkd": [1]}, {"kcw": 2, "art":3}, "hxm", 42, [1], [2, [1, []]]]'
+        lsts = [{"xkd":[1]},  {"kcw":2, "art":3}, "hxm", 42, [1],  [2, [1, []]]]
+        tups = ({"xkd":(1,)}, {"kcw":2, "art":3}, "hxm", 42, (1,), (2, (1, ())))
+        self.assertEqual(self.loads(s), lsts)
+        self.assertEqual(self.loads(s, array_hook=lambda x: x), lsts)
+        self.assertEqual(self.json.load(StringIO(s), array_hook=lambda x: x),
+                         lsts)
+        tups1 = self.loads(s, array_hook=tuple)
+        self.assertEqual(tups1, tups)
+        self.assertEqual(type(tups1), tuple)
+        # check that empty object literals work
+        self.assertEqual(self.loads('[]', array_hook=tuple), ())
+        self.assertEqual(self.loads('[[], {"a": []}, [[]]]', array_hook=tuple),
+                         ((), {"a": ()}, ((),)))
+
     def test_decoder_optimizations(self):
         # Several optimizations were made that skip over calls to
         # the whitespace regex, so this test is designed to try and


### PR DESCRIPTION
The json module allows a user to provide an `object_hook` function, which, if provided, is called to transform the dict that is created as a result of parsing a JSON Object.

It'd be nice if there was something analogous for JSON Arrays: an `array_hook` function to transform the list that is created as a result of parsing a JSON Array.

At the moment transforming JSON Arrays requires one of the following approaches (as far as I can see):

(1) Providing an object_hook function that will recursively transform any lists in the values of an Object/dict, including any nested lists, AND recursively transforming the final result in the event that the top level JSON object being parsed is an array (this array is never inside a JSON Object that goes through the `object_hook` transformation).
(2) Transforming the entire parsed result after parsing is finished by recursively transforming any lists in the final result, including recursively traversing nested lists AND nested dicts.

Providing an array_hook would cut out the need for either approach, as the recursive case from the recursive functions I mentioned could be used as the `array_hook` function directly (without the recursion).


## An example of usage:

Let's say we want JSON Arrays represented using tuples rather than lists, e.g. so that they are hashable straight out-of-the-(json)-box. Before this enhancement, this change requires one of the two methods I mentioned above. It is not so difficult to implement these recursive functions, but seems inelegant. After the change, `tuple` could be used as the `array_hook` directly:

```
>>> json.loads('{"foo": [[1, 2], "spam", [], ["eggs"]]}', array_hook=tuple)
{'foo': ((1, 2), 'spam', (), ('eggs',))}
```

It seems (in my opinion) this is more elegant than converting via an `object_hook` or traversing the whole structure after parsing.

## The patch:

I am submitting a patch that adds an `array_hook` kwarg to the `json` module's functions `load` and `loads`, and to the `json.decoder` module's `JSONDecoder`, `JSONArray` and `JSONObject` classes. I also hooked these together in the `json.scanner` module's `py_make_scanner` function.


It seems that `json.scanner` will prefer the `c_make_scanner` function defined in `Modules/_json.c` when it is available. I am not confident enough in my C skills or C x Python knowledge to dive into this module and make the analogous changes. But I assume they will be simple for someone who can read C x Python code, and that the changes will be analogous to those required to `Lib/json/scanner.py`. I need help to accomplish this part of the patch.


## Testing:

In the mean time, I added a test to `test_json.test_decode`. It's CURRENTLY FAILING because the implementation of the patch is incomplete (I believe this is only due to the missing part of the patch---the required changes to `Modules/_json.c` I identified above).

When I manually reset `json.scanner.make_scanner` to `json.scanner.py_make_scanner` and play around with the new `array_hook` functionality, it seems to work.



<!-- issue-number: [bpo-36738](https://bugs.python.org/issue36738) -->
https://bugs.python.org/issue36738
<!-- /issue-number -->

<!-- gh-issue-number: gh-80919 -->
* Issue: gh-80919
<!-- /gh-issue-number -->
