### PR TITLE
bpo-36745: Fix a possible reference leak in PyObject_SetAttr()

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1044,8 +1044,10 @@ PyObject_SetAttr(PyObject *v, PyObject *name, PyObject *value)
     }
     if (tp->tp_setattr != NULL) {
         const char *name_str = PyUnicode_AsUTF8(name);
-        if (name_str == NULL)
+        if (name_str == NULL) {
+            Py_DECREF(name);
             return -1;
+        }
         err = (*tp->tp_setattr)(v, (char *)name_str, value);
         Py_DECREF(name);
         return err;


### PR DESCRIPTION


<!-- issue-number: [bpo-36745](https://bugs.python.org/issue36745) -->
https://bugs.python.org/issue36745
<!-- /issue-number -->
