### PR TITLE
Don't use the LHS/RHS acronym in Simple statements

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -169,12 +169,12 @@ Assignment of an object to a single target is recursively defined as follows.
   .. _attr-target-note:
 
   Note: If the object is a class instance and the attribute reference occurs on
-  both sides of the assignment operator, the RHS expression, ``a.x`` can access
+  both sides of the assignment operator, the right-hand side expression, ``a.x`` can access
   either an instance attribute or (if no instance attribute exists) a class
-  attribute.  The LHS target ``a.x`` is always set as an instance attribute,
+  attribute.  The left-hand side target ``a.x`` is always set as an instance attribute,
   creating it if necessary.  Thus, the two occurrences of ``a.x`` do not
-  necessarily refer to the same attribute: if the RHS expression refers to a
-  class attribute, the LHS creates a new instance attribute as the target of the
+  necessarily refer to the same attribute: if the right-hand side expression refers to a
+  class attribute, the left-hand side creates a new instance attribute as the target of the
   assignment::
 
      class Cls:


### PR DESCRIPTION
Prefer the full wording instead, as it is more meaningful for someone not familiar with the terms.

Also, LFS/RHS is not used anywhere else in the documentation, while left/right-hand side mentions are common.