### PR TITLE
bpo-36746: Create test for fcntl.lockf()

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-04-28-18-36-54.bpo-36746.aqYNtS.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-28-18-36-54.bpo-36746.aqYNtS.rst
@@ -1,1 +1,0 @@
-A test for `fcntl.lockf()` is now implemented.

--- a/Misc/NEWS.d/next/Tests/2019-04-28-18-36-54.bpo-36746.aqYNtS.rst
+++ b/Misc/NEWS.d/next/Tests/2019-04-28-18-36-54.bpo-36746.aqYNtS.rst
@@ -1,0 +1,1 @@
+A test for `fcntl.lockf()` is now implemented.


### PR DESCRIPTION
I have created a test for` fcntl.lockf()`.

<!-- issue-number: [bpo-36746](https://bugs.python.org/issue36746) -->
https://bugs.python.org/issue36746
<!-- /issue-number -->
