### PR TITLE
bpo-36749: AIX dynamic linker requires to link to libpython

### DIFF
--- a/Doc/distutils/apiref.rst
+++ b/Doc/distutils/apiref.rst
@@ -280,7 +280,7 @@ the full reference.
    .. versionchanged:: 3.8
 
       On Unix, C extensions are no longer linked to libpython except on
-      Android.
+      Android and AIX.
 
 
 .. class:: Distribution

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -884,7 +884,7 @@ Changes in the C API
 --------------------
 
 * On Unix, C extensions are no longer linked to libpython except on
-  Android. When Python is embedded, ``libpython`` must not be loaded with
+  Android and AIX. When Python is embedded, ``libpython`` must not be loaded with
   ``RTLD_LOCAL``, but ``RTLD_GLOBAL`` instead. Previously, using
   ``RTLD_LOCAL``, it was already not possible to load C extensions which were
   not linked to ``libpython``, like C extensions of the standard library built

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -714,20 +714,30 @@ class build_ext(Command):
                 # don't extend ext.libraries, it may be shared with other
                 # extensions, it is a reference to the original list
                 return ext.libraries + [pythonlib]
-        # On Android only the main executable and LD_PRELOADs are considered
-        # to be RTLD_GLOBAL, all the dependencies of the main executable
-        # remain RTLD_LOCAL and so the shared libraries must be linked with
-        # libpython when python is built with a shared python library (issue
-        # bpo-21536).
         else:
             from distutils.sysconfig import get_config_var
+            # bpo-21536: On Unix, C extensions are not linked to libpython.
+            link_libpython = False
             if get_config_var('Py_ENABLE_SHARED'):
                 # Either a native build on an Android device or the
                 # cross-compilation of Python.
                 if (hasattr(sys, 'getandroidapilevel') or
                         ('_PYTHON_HOST_PLATFORM' in os.environ and
                          get_config_var('ANDROID_API_LEVEL') != 0)):
-                    ldversion = get_config_var('LDVERSION')
-                    return ext.libraries + ['python' + ldversion]
+                    # bpo-21536: On Android only the main executable and
+                    # LD_PRELOADs are considered to be RTLD_GLOBAL, all the
+                    # dependencies of the main executable remain RTLD_LOCAL and
+                    # so the shared libraries must be linked with libpython
+                    # when python is built with a shared python library.
+                    link_libpython = True
+                elif sys.platform == 'aix':
+                    # bpo-36749: AIX dynamic linker requires that C extensions
+                    # are linked to libpython
+                    link_libpython = True
+
+            if link_libpython:
+                ldversion = get_config_var('LDVERSION')
+                libpython = 'python' + ldversion
+                return ext.libraries + [libpython]
 
         return ext.libraries

--- a/Misc/NEWS.d/next/Build/2019-04-25-01-51-52.bpo-21536.ACQkiC.rst
+++ b/Misc/NEWS.d/next/Build/2019-04-25-01-51-52.bpo-21536.ACQkiC.rst
@@ -1,4 +1,5 @@
-On Unix, C extensions are no longer linked to libpython except on Android.
+On Unix, C extensions are no longer linked to libpython except on Android
+and AIX.
 
 It is now possible for a statically linked Python to load a C extension built
 using a shared library Python.

--- a/configure
+++ b/configure
@@ -15155,12 +15155,22 @@ LDVERSION='$(VERSION)$(ABIFLAGS)'
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LDVERSION" >&5
 $as_echo "$LDVERSION" >&6; }
 
-# On Android the shared libraries must be linked with libpython.
 
-if test -z "$ANDROID_API_LEVEL"; then
-  LIBPYTHON=''
+link_libpython=
+if test -n "$ANDROID_API_LEVEL"; then
+  # On Android the shared libraries must be linked with libpython.
+  link_libpython = 1
 else
-  LIBPYTHON="-lpython${VERSION}${ABIFLAGS}"
+  case $ac_sys_system/$ac_sys_release in
+  AIX*)
+    # bpo-36749: AIX dynamic linker requires that C extensions
+    # are linked to libpython
+    link_libpython = 1
+    ;;
+  esac
+fi
+if test -n "$link_libpython"; then
+  LIBPYTHON="-lpython${LDVERSION}"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4648,12 +4648,22 @@ AC_MSG_CHECKING(LDVERSION)
 LDVERSION='$(VERSION)$(ABIFLAGS)'
 AC_MSG_RESULT($LDVERSION)
 
-# On Android the shared libraries must be linked with libpython.
 AC_SUBST(LIBPYTHON)
-if test -z "$ANDROID_API_LEVEL"; then
-  LIBPYTHON=''
+link_libpython=
+if test -n "$ANDROID_API_LEVEL"; then
+  # On Android the shared libraries must be linked with libpython.
+  link_libpython = 1
 else
-  LIBPYTHON="-lpython${VERSION}${ABIFLAGS}"
+  case $ac_sys_system/$ac_sys_release in
+  AIX*)
+    # bpo-36749: AIX dynamic linker requires that C extensions
+    # are linked to libpython
+    link_libpython = 1
+    ;;
+  esac
+fi
+if test -n "$link_libpython"; then
+  LIBPYTHON="-lpython${LDVERSION}"
 fi
 
 dnl define LIBPL after ABIFLAGS and LDVERSION is defined.


### PR DESCRIPTION
On AIX, the dynamic linker requires that C extensions are linked to
libpython.

<!-- issue-number: [bpo-36749](https://bugs.python.org/issue36749) -->
https://bugs.python.org/issue36749
<!-- /issue-number -->
