### PR TITLE
bpo-24048: Save the live exception during import.c's remove_module()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-04-29-03-27-22.bpo-24048.vXxUDQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-29-03-27-22.bpo-24048.vXxUDQ.rst
@@ -1,0 +1,1 @@
+Save the live exception during import.c's ``remove_module()``.

--- a/Python/import.c
+++ b/Python/import.c
@@ -837,14 +837,18 @@ PyImport_AddModule(const char *name)
 static void
 remove_module(PyObject *name)
 {
+    PyObject *type, *value, *traceback;
+    PyErr_Fetch(&type, &value, &traceback);
     PyObject *modules = PyImport_GetModuleDict();
+    if (!PyMapping_HasKey(modules, name)) {
+        goto out;
+    }
     if (PyMapping_DelItem(modules, name) < 0) {
-        if (!PyMapping_HasKey(modules, name)) {
-            return;
-        }
         Py_FatalError("import:  deleting existing key in "
                       "sys.modules failed");
     }
+out:
+    PyErr_Restore(type, value, traceback);
 }
 
 


### PR DESCRIPTION
Save the live exception during the course of remove_module().

<!-- issue-number: [bpo-24048](https://bugs.python.org/issue24048) -->
https://bugs.python.org/issue24048
<!-- /issue-number -->
