### PR TITLE
bpo-35952: Fix pythoninfo when the compiler is missing

### DIFF
--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -571,13 +571,23 @@ def collect_cc(info_add):
     except ImportError:
         args = CC.split()
     args.append('--version')
-    proc = subprocess.Popen(args,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT,
-                            universal_newlines=True)
-    stdout = proc.communicate()[0]
-    if proc.returncode:
-        # CC --version failed: ignore error
+    proc = None
+    try:
+        proc = subprocess.Popen(args,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                universal_newlines=True)
+    except (FileNotFoundError, PermissionError):
+        # Cannot run the compiler, for example when Python has been
+        # cross-compiled and installed on the target platform where the
+        # compiler is missing.
+        pass
+    else:
+        stdout = proc.communicate()[0]
+
+    # Failed to run the compiler or 'CC --version' failed.
+    if proc is None or proc.returncode:
+        info_add('CC.name', normalize_text(CC))
         return
 
     text = stdout.splitlines()[0]

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -571,23 +571,20 @@ def collect_cc(info_add):
     except ImportError:
         args = CC.split()
     args.append('--version')
-    proc = None
     try:
         proc = subprocess.Popen(args,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,
                                 universal_newlines=True)
-    except (FileNotFoundError, PermissionError):
+    except OSError:
         # Cannot run the compiler, for example when Python has been
         # cross-compiled and installed on the target platform where the
         # compiler is missing.
-        pass
-    else:
-        stdout = proc.communicate()[0]
+        return
 
-    # Failed to run the compiler or 'CC --version' failed.
-    if proc is None or proc.returncode:
-        info_add('CC.name', normalize_text(CC))
+    stdout = proc.communicate()[0]
+    if proc.returncode:
+        # CC --version failed: ignore error
         return
 
     text = stdout.splitlines()[0]

--- a/Misc/NEWS.d/next/Library/2019-04-29-11-47-06.bpo-35952.3uNuyo.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-29-11-47-06.bpo-35952.3uNuyo.rst
@@ -1,1 +1,1 @@
-pythoninfo prints the compiler name when failing to get its version.
+Fix pythoninfo when the compiler is missing.

--- a/Misc/NEWS.d/next/Library/2019-04-29-11-47-06.bpo-35952.3uNuyo.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-29-11-47-06.bpo-35952.3uNuyo.rst
@@ -1,0 +1,1 @@
+pythoninfo prints the compiler name when failing to get its version.


### PR DESCRIPTION
<!-- issue-number: [bpo-35952](https://bugs.python.org/issue35952) -->
https://bugs.python.org/issue35952
<!-- /issue-number -->
