### PR TITLE
bpo-34602: Avoid failures setting macOS stack resource limit

### DIFF
--- a/Misc/NEWS.d/next/macOS/2019-04-29-10-54-14.bpo-34602.Lrl2zU.rst
+++ b/Misc/NEWS.d/next/macOS/2019-04-29-10-54-14.bpo-34602.Lrl2zU.rst
@@ -1,0 +1,3 @@
+Avoid failures setting macOS stack resource limit with resource.setrlimit.
+This reverts an earlier fix for bpo-18075 which forced a non-default stack
+size when building the interpreter executable on macOS.

--- a/configure
+++ b/configure
@@ -9542,12 +9542,6 @@ then
 	# -u libsys_s pulls in all symbols in libsys
 	Darwin/*)
 		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
-
-		# Issue #18075: the default maximum stack size (8MBytes) is too
-		# small for the default recursion limit. Increase the stack size
-		# to ensure that tests don't crash
-		LINKFORSHARED="-Wl,-stack_size,1000000 $LINKFORSHARED"
-
 		if test "$enable_framework"
 		then
 			LINKFORSHARED="$LINKFORSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'

--- a/configure.ac
+++ b/configure.ac
@@ -2701,12 +2701,6 @@ then
 	# -u libsys_s pulls in all symbols in libsys
 	Darwin/*)
 		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
-
-		# Issue #18075: the default maximum stack size (8MBytes) is too
-		# small for the default recursion limit. Increase the stack size
-		# to ensure that tests don't crash
-		LINKFORSHARED="-Wl,-stack_size,1000000 $LINKFORSHARED"
-
 		if test "$enable_framework"
 		then
 			LINKFORSHARED="$LINKFORSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'


### PR DESCRIPTION
Under some conditions the earlier fix for [bpo-18075](https://bugs.python.org/issue18075), "Infinite recursion
tests triggering a segfault on Mac OS X", now causes failures on macOS
when attempting to change stack limit with resource.setrlimit
resource.RLIMIT_STACK, like regrtest does when running the test suite.
The reverted change had specified a non-default stack size when linking
the python executable on macOS.  As of macOS 10.14.4, the previous
code causes a hard failure when running tests, although similar
failures had been seen under some conditions under some earlier
systems.  For now, revert the original change and resume using
the default stack size when linking the interpreter.

<!-- issue-number: [bpo-34602](https://bugs.python.org/issue34602) -->
https://bugs.python.org/issue34602
<!-- /issue-number -->
