### PR TITLE
bpo-36742: Fixes handling of pre-normalization characters in urlsplit()

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1011,6 +1011,12 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertIn('\u2100', denorm_chars)
         self.assertIn('\uFF03', denorm_chars)
 
+        # bpo-36742: Verify port separators are ignored when they
+        # existed prior to decomposition
+        urllib.parse.urlsplit('http://\u30d5\u309a:80')
+        with self.assertRaises(ValueError):
+            urllib.parse.urlsplit('http://\u30d5\u309a\ufe1380')
+
         for scheme in ["http", "https", "ftp"]:
             for c in denorm_chars:
                 url = "{}://netloc{}false.netloc/path".format(scheme, c)

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -402,13 +402,16 @@ def _checknetloc(netloc):
     # looking for characters like \u2100 that expand to 'a/c'
     # IDNA uses NFKC equivalence, so normalize for this check
     import unicodedata
-    netloc2 = unicodedata.normalize('NFKC', netloc)
-    if netloc == netloc2:
+    n = netloc.rpartition('@')[2] # ignore anything to the left of '@'
+    n = n.replace(':', '')        # ignore characters already included
+    n = n.replace('#', '')        # but not the surrounding text
+    n = n.replace('?', '')        # 
+    netloc2 = unicodedata.normalize('NFKC', n)
+    if n == netloc2:
         return
-    _, _, netloc = netloc.rpartition('@') # anything to the left of '@' is okay
     for c in '/?#@:':
         if c in netloc2:
-            raise ValueError("netloc '" + netloc2 + "' contains invalid " +
+            raise ValueError("netloc '" + netloc + "' contains invalid " +
                              "characters under NFKC normalization")
 
 def urlsplit(url, scheme='', allow_fragments=True):

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -405,7 +405,7 @@ def _checknetloc(netloc):
     n = netloc.rpartition('@')[2] # ignore anything to the left of '@'
     n = n.replace(':', '')        # ignore characters already included
     n = n.replace('#', '')        # but not the surrounding text
-    n = n.replace('?', '')        # 
+    n = n.replace('?', '')
     netloc2 = unicodedata.normalize('NFKC', n)
     if n == netloc2:
         return

--- a/Misc/NEWS.d/next/Security/2019-04-29-15-34-59.bpo-36742.QCUY0i.rst
+++ b/Misc/NEWS.d/next/Security/2019-04-29-15-34-59.bpo-36742.QCUY0i.rst
@@ -1,0 +1,1 @@
+Fixes mishandling of pre-normalization characters in urlsplit().


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36742](https://bugs.python.org/issue36742) -->
https://bugs.python.org/issue36742
<!-- /issue-number -->
