### PR TITLE
[2.7] bpo-36742: Fixes handling of pre-normalization characters in urlsplit() (GH-13017)

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -641,6 +641,12 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertIn(u'\u2100', denorm_chars)
         self.assertIn(u'\uFF03', denorm_chars)
 
+        # bpo-36742: Verify port separators are ignored when they
+        # existed prior to decomposition
+        urllib.parse.urlsplit('http://\u30d5\u309a:80')
+        with self.assertRaises(ValueError):
+            urllib.parse.urlsplit('http://\u30d5\u309a\ufe1380')
+
         for scheme in [u"http", u"https", u"ftp"]:
             for c in denorm_chars:
                 url = u"{}://netloc{}false.netloc/path".format(scheme, c)

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -643,9 +643,9 @@ class UrlParseTestCase(unittest.TestCase):
 
         # bpo-36742: Verify port separators are ignored when they
         # existed prior to decomposition
-        urlparse.urlsplit('http://\u30d5\u309a:80')
+        urlparse.urlsplit(u'http://\u30d5\u309a:80')
         with self.assertRaises(ValueError):
-            urlparse.urlsplit('http://\u30d5\u309a\ufe1380')
+            urlparse.urlsplit(u'http://\u30d5\u309a\ufe1380')
 
         for scheme in [u"http", u"https", u"ftp"]:
             for c in denorm_chars:

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -643,9 +643,9 @@ class UrlParseTestCase(unittest.TestCase):
 
         # bpo-36742: Verify port separators are ignored when they
         # existed prior to decomposition
-        urllib.parse.urlsplit('http://\u30d5\u309a:80')
+        urlparse.urlsplit('http://\u30d5\u309a:80')
         with self.assertRaises(ValueError):
-            urllib.parse.urlsplit('http://\u30d5\u309a\ufe1380')
+            urlparse.urlsplit('http://\u30d5\u309a\ufe1380')
 
         for scheme in [u"http", u"https", u"ftp"]:
             for c in denorm_chars:

--- a/Lib/urlparse.py
+++ b/Lib/urlparse.py
@@ -171,13 +171,16 @@ def _checknetloc(netloc):
     # looking for characters like \u2100 that expand to 'a/c'
     # IDNA uses NFKC equivalence, so normalize for this check
     import unicodedata
-    netloc2 = unicodedata.normalize('NFKC', netloc)
-    if netloc == netloc2:
+    n = netloc.rpartition('@')[2] # ignore anything to the left of '@'
+    n = n.replace(':', '')        # ignore characters already included
+    n = n.replace('#', '')        # but not the surrounding text
+    n = n.replace('?', '')
+    netloc2 = unicodedata.normalize('NFKC', n)
+    if n == netloc2:
         return
-    _, _, netloc = netloc.rpartition('@') # anything to the left of '@' is okay
     for c in '/?#@:':
         if c in netloc2:
-            raise ValueError("netloc '" + netloc2 + "' contains invalid " +
+            raise ValueError("netloc '" + netloc + "' contains invalid " +
                              "characters under NFKC normalization")
 
 def urlsplit(url, scheme='', allow_fragments=True):

--- a/Misc/NEWS.d/next/Security/2019-04-29-15-34-59.bpo-36742.QCUY0i.rst
+++ b/Misc/NEWS.d/next/Security/2019-04-29-15-34-59.bpo-36742.QCUY0i.rst
@@ -1,0 +1,1 @@
+Fixes mishandling of pre-normalization characters in urlsplit().


### PR DESCRIPTION


<!-- issue-number: [bpo-36742](https://bugs.python.org/issue36742) -->
https://bugs.python.org/issue36742
<!-- /issue-number -->
