### PR TITLE
bpo-14546: Fix the argument handling in Tools/scripts/lll.py

### DIFF
--- a/Lib/test/test_tools/test_lll.py
+++ b/Lib/test/test_tools/test_lll.py
@@ -1,0 +1,45 @@
+"""Tests for the lll script in the Tools/script directory."""
+
+import os
+import sys
+import tempfile
+from test import support
+from test.test_tools import skip_if_missing, import_tool
+import unittest
+
+skip_if_missing()
+
+
+class lllTests(unittest.TestCase):
+
+    def setUp(self):
+        self.lll = import_tool('lll')
+        oldargv = sys.argv
+
+        def fixup():
+            sys.argv = oldargv
+        self.addCleanup(fixup)
+
+    def test_lll_multiple_dirs(self):
+        with tempfile.TemporaryDirectory() as dir1, \
+             tempfile.TemporaryDirectory() as dir2:
+            fn1 = os.path.join(dir1, 'foo1')
+            fn2 = os.path.join(dir2, 'foo2')
+            for fn, dir in (fn1, dir1), (fn2, dir2):
+                open(fn, 'w').close()
+                os.symlink(fn, os.path.join(dir, 'symlink'))
+
+            sys.argv = ['lll', dir1, dir2]
+            with support.captured_stdout() as output:
+                self.lll.main()
+            self.assertEqual(output.getvalue(),
+                f'{dir1}:\n'
+                f'symlink -> {fn1}\n'
+                '\n'
+                f'{dir2}:\n'
+                f'symlink -> {fn2}\n'
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/test/test_tools/test_lll.py
+++ b/Lib/test/test_tools/test_lll.py
@@ -1,7 +1,6 @@
 """Tests for the lll script in the Tools/script directory."""
 
 import os
-import sys
 import tempfile
 from test import support
 from test.test_tools import skip_if_missing, import_tool
@@ -14,11 +13,6 @@ class lllTests(unittest.TestCase):
 
     def setUp(self):
         self.lll = import_tool('lll')
-        oldargv = sys.argv
-
-        def fixup():
-            sys.argv = oldargv
-        self.addCleanup(fixup)
 
     def test_lll_multiple_dirs(self):
         with tempfile.TemporaryDirectory() as dir1, \
@@ -29,13 +23,12 @@ class lllTests(unittest.TestCase):
                 open(fn, 'w').close()
                 os.symlink(fn, os.path.join(dir, 'symlink'))
 
-            sys.argv = ['lll', dir1, dir2]
             with support.captured_stdout() as output:
-                self.lll.main()
+                self.lll.main([dir1, dir2])
             self.assertEqual(output.getvalue(),
                 f'{dir1}:\n'
                 f'symlink -> {fn1}\n'
-                '\n'
+                f'\n'
                 f'{dir2}:\n'
                 f'symlink -> {fn2}\n'
             )

--- a/Misc/NEWS.d/next/Tools-Demos/2019-04-30-14-30-29.bpo-14546.r38Y-6.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2019-04-30-14-30-29.bpo-14546.r38Y-6.rst
@@ -1,0 +1,1 @@
+Fix the argument handling in Tools/scripts/lll.py.

--- a/Tools/scripts/lll.py
+++ b/Tools/scripts/lll.py
@@ -13,8 +13,7 @@ def lll(dirname):
             full = os.path.join(dirname, name)
             if os.path.islink(full):
                 print(name, '->', os.readlink(full))
-def main():
-    args = sys.argv[1:]
+def main(args):
     if not args: args = [os.curdir]
     first = 1
     for arg in args:
@@ -25,4 +24,4 @@ def main():
         lll(arg)
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])

--- a/Tools/scripts/lll.py
+++ b/Tools/scripts/lll.py
@@ -22,7 +22,7 @@ def main():
             if not first: print()
             first = 0
             print(arg + ':')
-    lll(arg)
+        lll(arg)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The Tools/scripts/lll.py script was handling only the last argument.

The unit test follows the style of the other unit tests under
Lib/test/test_tools.

<!-- issue-number: [bpo-14546](https://bugs.python.org/issue14546) -->
https://bugs.python.org/issue14546
<!-- /issue-number -->
