### PR TITLE
bpo-36763: Fix Py_SetStandardStreamEncoding()

### DIFF
--- a/Misc/NEWS.d/next/C API/2019-05-01-00-42-08.bpo-36763.vghb86.rst
+++ b/Misc/NEWS.d/next/C API/2019-05-01-00-42-08.bpo-36763.vghb86.rst
@@ -1,0 +1,2 @@
+Fix memory leak in :c:func:`Py_SetStandardStreamEncoding`: release memory if
+the function is called twice.

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -375,6 +375,7 @@ Py_SetStandardStreamEncoding(const char *encoding, const char *errors)
      * Py_Initialize hasn't been called yet.
      */
     if (encoding) {
+        PyMem_RawFree(_Py_StandardStreamEncoding);
         _Py_StandardStreamEncoding = _PyMem_RawStrdup(encoding);
         if (!_Py_StandardStreamEncoding) {
             res = -2;
@@ -382,11 +383,11 @@ Py_SetStandardStreamEncoding(const char *encoding, const char *errors)
         }
     }
     if (errors) {
+        PyMem_RawFree(_Py_StandardStreamErrors);
         _Py_StandardStreamErrors = _PyMem_RawStrdup(errors);
         if (!_Py_StandardStreamErrors) {
-            if (_Py_StandardStreamEncoding) {
-                PyMem_RawFree(_Py_StandardStreamEncoding);
-            }
+            PyMem_RawFree(_Py_StandardStreamEncoding);
+            _Py_StandardStreamEncoding = NULL;
             res = -3;
             goto done;
         }


### PR DESCRIPTION
Fix memory leak in Py_SetStandardStreamEncoding(): release memory
if the function is called twice.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
