### PR TITLE
MNT: set stacklevel in the getfullargspec deprecation warning to 2

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1112,7 +1112,7 @@ def getfullargspec(func):
     """
 
     warnings.warn("Use inspect.signature() instead of inspect.getfullargspec()",
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
     try:
         # Re: `skip_bound_arg=False`
         #


### PR DESCRIPTION
This is consistent with the rest of the `warnings.warn` usage in the
inspect.py module and aids identifying code that needs to be fixed.

This warning came in via d5d2b4546939b98244708e5bb0cfccd55b99d244

I think this falls under the "trivial enough it does not need an issue" as 
b5601586223f13f77a16ed64f16bea1ece063997 which did the same for the other warnings in inspect.py did not have an issue with it.
