### PR TITLE
bpo-36763: Add _PyCoreConfig_SetArgv

### DIFF
--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -108,10 +108,20 @@ PyAPI_FUNC(int) _PyCoreConfig_Copy(
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPathConfig(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetPathConfig(
     const _PyCoreConfig *config);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config,
-    const _PyArgv *args);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config);
 PyAPI_FUNC(void) _PyCoreConfig_Write(const _PyCoreConfig *config,
     _PyRuntimeState *runtime);
+
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetPyArgv(
+    _PyCoreConfig *config,
+    const _PyArgv *args);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetArgv(
+    _PyCoreConfig *config,
+    int argc,
+    char **argv);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetWideArgv(_PyCoreConfig *config,
+    int argc,
+    wchar_t **argv);
 
 
 /* --- Function used for testing ---------------------------------- */

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -602,8 +602,7 @@ def collect_gdbm(info_add):
 
 
 def collect_get_config(info_add):
-    # Dump global configuration variables, _PyCoreConfig
-    # and _PyMainInterpreterConfig
+    # Get global configuration variables, _PyPreConfig and _PyCoreConfig
     try:
         from _testinternalcapi import get_configs
     except ImportError:

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -2002,8 +2002,7 @@ config_init_argv(_PyCoreConfig *config, const _PyPreCmdline *cmdline)
 
 
 static _PyInitError
-core_read_precmdline(_PyCoreConfig *config, const _PyArgv *args,
-                     _PyPreCmdline *precmdline)
+core_read_precmdline(_PyCoreConfig *config, _PyPreCmdline *precmdline)
 {
     _PyInitError err;
 
@@ -2071,22 +2070,46 @@ done:
 }
 
 
+_PyInitError
+_PyCoreConfig_SetPyArgv(_PyCoreConfig *config, const _PyArgv *args)
+{
+    return _PyArgv_AsWstrList(args, &config->argv);
+}
+
+
+_PyInitError
+_PyCoreConfig_SetArgv(_PyCoreConfig *config, int argc, char **argv)
+{
+    _PyArgv args = {
+        .argc = argc,
+        .use_bytes_argv = 1,
+        .bytes_argv = argv,
+        .wchar_argv = NULL};
+    return _PyCoreConfig_SetPyArgv(config, &args);
+}
+
+
+_PyInitError
+_PyCoreConfig_SetWideArgv(_PyCoreConfig *config, int argc, wchar_t **argv)
+{
+    _PyArgv args = {
+        .argc = argc,
+        .use_bytes_argv = 0,
+        .bytes_argv = NULL,
+        .wchar_argv = argv};
+    return _PyCoreConfig_SetPyArgv(config, &args);
+}
+
+
 /* Read the configuration into _PyCoreConfig from:
 
    * Command line arguments
    * Environment variables
    * Py_xxx global configuration variables */
 _PyInitError
-_PyCoreConfig_Read(_PyCoreConfig *config, const _PyArgv *args)
+_PyCoreConfig_Read(_PyCoreConfig *config)
 {
     _PyInitError err;
-
-    if (args) {
-        err = _PyArgv_AsWstrList(args, &config->argv);
-        if (_Py_INIT_FAILED(err)) {
-            return err;
-        }
-    }
 
     err = _Py_PreInitializeFromCoreConfig(config);
     if (_Py_INIT_FAILED(err)) {
@@ -2096,7 +2119,7 @@ _PyCoreConfig_Read(_PyCoreConfig *config, const _PyArgv *args)
     _PyCoreConfig_GetGlobalConfig(config);
 
     _PyPreCmdline precmdline = _PyPreCmdline_INIT;
-    err = core_read_precmdline(config, args, &precmdline);
+    err = core_read_precmdline(config, &precmdline);
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -394,7 +394,7 @@ pathconfig_global_init(void)
     _PyInitError err;
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    err = _PyCoreConfig_Read(&config, NULL);
+    err = _PyCoreConfig_Read(&config);
     if (_Py_INIT_FAILED(err)) {
         goto error;
     }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -801,13 +801,22 @@ pyinit_coreconfig(_PyRuntimeState *runtime,
                   const _PyArgv *args,
                   PyInterpreterState **interp_p)
 {
+    _PyInitError err;
+
     if (src_config) {
         if (_PyCoreConfig_Copy(config, src_config) < 0) {
             return _Py_INIT_NO_MEMORY();
         }
     }
 
-    _PyInitError err = _PyCoreConfig_Read(config, args);
+    if (args) {
+        err = _PyCoreConfig_SetPyArgv(config, args);
+        if (_Py_INIT_FAILED(err)) {
+            return err;
+        }
+    }
+
+    err = _PyCoreConfig_Read(config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }


### PR DESCRIPTION
Changes:

* Add 2 new config methods:

  * _PyCoreConfig_SetArgv()
  * _PyCoreConfig_SetWideArgv()

* Add also an internal _PyCoreConfig_SetPyArgv() method.
* Remove 'args' parameter from _PyCoreConfig_Read().

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
