### PR TITLE
bpo-36763: Rework _PyInitError API

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -114,10 +114,10 @@ extern "C" {
 
 #define DECODE_LOCALE_ERR(NAME, LEN) \
     ((LEN) == (size_t)-2) \
-     ? _Py_INIT_USER_ERR("cannot decode " NAME) \
+     ? _Py_INIT_ERR("cannot decode " NAME) \
      : _Py_INIT_NO_MEMORY()
 
-#define PATHLEN_ERR() _Py_INIT_USER_ERR("path configuration: path too long")
+#define PATHLEN_ERR() _Py_INIT_ERR("path configuration: path too long")
 
 typedef struct {
     wchar_t *path_env;                 /* PATH environment variable */

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -570,7 +570,7 @@ exit_sigint(void)
 static void _Py_NO_RETURN
 pymain_exit_error(_PyInitError err)
 {
-    if (_Py_INIT_HAS_EXITCODE(err)) {
+    if (_Py_INIT_IS_EXIT(err)) {
         /* If it's an error rather than a regular exit, leave Python runtime
            alive: _Py_ExitInitError() uses the current exception and use
            sys.stdout in this case. */

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -578,8 +578,8 @@ _Py_HashRandomization_Init(const _PyCoreConfig *config)
            pyurandom() is non-blocking mode (blocking=0): see the PEP 524. */
         res = pyurandom(secret, secret_size, 0, 0);
         if (res < 0) {
-            return _Py_INIT_USER_ERR("failed to get random numbers "
-                                     "to initialize Python");
+            return _Py_INIT_ERR("failed to get random numbers "
+                                "to initialize Python");
         }
     }
     return _Py_INIT_OK();

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -475,7 +475,7 @@ Py_GetArgcArgv(int *argc, wchar_t ***argv)
 
 #define DECODE_LOCALE_ERR(NAME, LEN) \
     (((LEN) == -2) \
-     ? _Py_INIT_USER_ERR("cannot decode " NAME) \
+     ? _Py_INIT_ERR("cannot decode " NAME) \
      : _Py_INIT_NO_MEMORY())
 
 /* Free memory allocated in config, but don't clear all attributes */
@@ -1018,8 +1018,8 @@ config_init_hash_seed(_PyCoreConfig *config)
             || seed > 4294967295UL
             || (errno == ERANGE && seed == ULONG_MAX))
         {
-            return _Py_INIT_USER_ERR("PYTHONHASHSEED must be \"random\" "
-                                     "or an integer in range [0; 4294967295]");
+            return _Py_INIT_ERR("PYTHONHASHSEED must be \"random\" "
+                                "or an integer in range [0; 4294967295]");
         }
         /* Use a specific hash */
         config->use_hash_seed = 1;
@@ -1129,8 +1129,7 @@ config_init_tracemalloc(_PyCoreConfig *config)
             valid = 0;
         }
         if (!valid) {
-            return _Py_INIT_USER_ERR("PYTHONTRACEMALLOC: invalid number "
-                                     "of frames");
+            return _Py_INIT_ERR("PYTHONTRACEMALLOC: invalid number of frames");
         }
         config->tracemalloc = nframe;
     }
@@ -1146,8 +1145,8 @@ config_init_tracemalloc(_PyCoreConfig *config)
                 valid = 0;
             }
             if (!valid) {
-                return _Py_INIT_USER_ERR("-X tracemalloc=NFRAME: "
-                                         "invalid number of frames");
+                return _Py_INIT_ERR("-X tracemalloc=NFRAME: "
+                                    "invalid number of frames");
             }
         }
         else {
@@ -1267,8 +1266,8 @@ config_get_locale_encoding(char **locale_encoding)
 #else
     const char *encoding = nl_langinfo(CODESET);
     if (!encoding || encoding[0] == '\0') {
-        return _Py_INIT_USER_ERR("failed to get the locale encoding: "
-                                 "nl_langinfo(CODESET) failed");
+        return _Py_INIT_ERR("failed to get the locale encoding: "
+                            "nl_langinfo(CODESET) failed");
     }
 #endif
     *locale_encoding = _PyMem_RawStrdup(encoding);

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -18,9 +18,7 @@ Py_FrozenMain(int argc, char **argv)
 {
     _PyInitError err = _PyRuntime_Initialize();
     if (_Py_INIT_FAILED(err)) {
-        fprintf(stderr, "Fatal Python error: %s\n", err.msg);
-        fflush(stderr);
-        exit(1);
+        _Py_ExitInitError(err);
     }
 
     const char *p;

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -7,7 +7,7 @@
 
 #define DECODE_LOCALE_ERR(NAME, LEN) \
     (((LEN) == -2) \
-     ? _Py_INIT_USER_ERR("cannot decode " NAME) \
+     ? _Py_INIT_ERR("cannot decode " NAME) \
      : _Py_INIT_NO_MEMORY())
 
 
@@ -526,7 +526,7 @@ preconfig_init_utf8_mode(_PyPreConfig *config, const _PyPreCmdline *cmdline)
                 config->utf8_mode = 0;
             }
             else {
-                return _Py_INIT_USER_ERR("invalid -X utf8 option value");
+                return _Py_INIT_ERR("invalid -X utf8 option value");
             }
         }
         else {
@@ -544,8 +544,8 @@ preconfig_init_utf8_mode(_PyPreConfig *config, const _PyPreCmdline *cmdline)
             config->utf8_mode = 0;
         }
         else {
-            return _Py_INIT_USER_ERR("invalid PYTHONUTF8 environment "
-                                     "variable value");
+            return _Py_INIT_ERR("invalid PYTHONUTF8 environment "
+                                "variable value");
         }
         return _Py_INIT_OK();
     }
@@ -831,7 +831,7 @@ _PyPreConfig_SetAllocator(_PyPreConfig *config)
     PyMem_GetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     if (_PyMem_SetupAllocators(config->allocator) < 0) {
-        return _Py_INIT_USER_ERR("Unknown PYTHONMALLOC allocator");
+        return _Py_INIT_ERR("Unknown PYTHONMALLOC allocator");
     }
 
     /* Copy the pre-configuration with the new allocator */


### PR DESCRIPTION
* Remove _PyInitError.user_err field and _Py_INIT_USER_ERR() macro:
  use _Py_INIT_ERR() instead. _Py_ExitInitError() now longer calls
  abort() on error: exit with exit code 1 instead.
* Add _PyInitError._type private field
* exitcode field type is now unsigned int on Windows
* Rename prefix field to _func
* Rename msg field to err_msg

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
