### PR TITLE
bpo-30458: Disable https related urllib tests on a build without ssl

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -329,6 +329,7 @@ class urlopen_HttpTests(unittest.TestCase, FakeHTTPMixin, FakeFTPMixin):
         finally:
             self.unfakehttp()
 
+    @unittest.skipUnless(ssl, "ssl module required")
     def test_url_with_control_char_rejected(self):
         for char_no in list(range(0, 0x21)) + [0x7f]:
             char = chr(char_no)
@@ -354,6 +355,7 @@ class urlopen_HttpTests(unittest.TestCase, FakeHTTPMixin, FakeFTPMixin):
             finally:
                 self.unfakehttp()
 
+    @unittest.skipUnless(ssl, "ssl module required")
     def test_url_with_newline_header_injection_rejected(self):
         self.fakehttp(b"HTTP/1.1 200 OK\r\n\r\nHello.")
         host = "localhost:7777?a=1 HTTP/1.1\r\nX-injected: header\r\nTEST: 123"


### PR DESCRIPTION
These tests require an SSL enabled build. Skip these tests when python is built without SSL to fix test failures.

<!-- issue-number: [bpo-30458](https://bugs.python.org/issue30458) -->
https://bugs.python.org/issue30458
<!-- /issue-number -->
