### PR TITLE
bpo-36764: Types module now has a ABCData type

### DIFF
--- a/Lib/types.py
+++ b/Lib/types.py
@@ -50,6 +50,11 @@ ClassMethodDescriptorType = type(dict.__dict__['fromkeys'])
 
 ModuleType = type(sys)
 
+from abc import ABC
+class _D(ABC):
+    pass
+ABCData = type(_D._abc_impl)
+
 try:
     raise TypeError
 except TypeError:

--- a/Misc/NEWS.d/next/Library/2019-05-01-08-04-47.bpo-36764.Im4BRF.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-01-08-04-47.bpo-36764.Im4BRF.rst
@@ -1,0 +1,1 @@
+Add ABCData type to types module. Contributed by Batuhan Taskaya.


### PR DESCRIPTION
The _abc_data type used in abstract base classes. It can obtained by
creating an ABC then getting its _abc_impl attribute.

<!-- issue-number: [bpo-36764](https://bugs.python.org/issue36764) -->
https://bugs.python.org/issue36764
<!-- /issue-number -->
