### PR TITLE
bpo-36763: _PyCoreConfig_SetPyArgv() preinitializes Python

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -8,7 +8,8 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_pystate.h"   /* _PyRuntimeState */
+#include "pycore_coreconfig.h"   /* _PyArgv */
+#include "pycore_pystate.h"      /* _PyRuntimeState */
 
 /* True if the main interpreter thread exited due to an unhandled
  * KeyboardInterrupt exception, suggesting the user pressed ^C. */
@@ -90,8 +91,12 @@ extern void _PyGILState_Fini(_PyRuntimeState *runtime);
 
 PyAPI_FUNC(void) _PyGC_DumpShutdownStats(_PyRuntimeState *runtime);
 
+PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromPyArgv(
+    const _PyPreConfig *src_config,
+    const _PyArgv *args);
 PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromCoreConfig(
-    const _PyCoreConfig *coreconfig);
+    const _PyCoreConfig *coreconfig,
+    const _PyArgv *args);
 
 #ifdef __cplusplus
 }

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -57,14 +57,7 @@ pymain_init(const _PyArgv *args)
        environment variables (PYTHONUTF8 and PYTHONCOERCECLOCALE)  */
     preconfig.coerce_c_locale = -1;
     preconfig.utf8_mode = -1;
-    if (args->use_bytes_argv) {
-        err = _Py_PreInitializeFromArgs(&preconfig,
-                                        args->argc, args->bytes_argv);
-    }
-    else {
-        err = _Py_PreInitializeFromWideArgs(&preconfig,
-                                            args->argc, args->wchar_argv);
-    }
+    err = _Py_PreInitializeFromPyArgv(&preconfig, args);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }


### PR DESCRIPTION
_PyCoreConfig_SetPyArgv() now pre-initializes Python if needed to
ensure that the locale encoding is properly configured.

* Add _Py_PreInitializeFromPyArgv() internal function.
* Add 'args' parameter to _Py_PreInitializeFromCoreConfig()

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
