### PR TITLE
bpo-36769: Document that fnmatch.filter supports any kind of iterable

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -75,7 +75,7 @@ patterns.
 
 .. function:: filter(names, pattern)
 
-   Return the subset of the list of *names* that match *pattern*. It is the same as
+   Return a list of items in iterable *names* that match *pattern*. It is the same as
    ``[n for n in names if fnmatch(n, pattern)]``, but implemented more efficiently.
 
 

--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -75,7 +75,7 @@ patterns.
 
 .. function:: filter(names, pattern)
 
-   Return a list of items in iterable *names* that match *pattern*. It is the same as
+   Construct a list from those elements of the iterable *names* that match *pattern*. It is the same as
    ``[n for n in names if fnmatch(n, pattern)]``, but implemented more efficiently.
 
 

--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -46,7 +46,7 @@ def _compile_pattern(pat):
     return re.compile(res).match
 
 def filter(names, pat):
-    """Return the subset of the list NAMES that match PAT."""
+    """Return a list of items in iterable NAMES that match PAT."""
     result = []
     pat = os.path.normcase(pat)
     match = _compile_pattern(pat)

--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -46,7 +46,7 @@ def _compile_pattern(pat):
     return re.compile(res).match
 
 def filter(names, pat):
-    """Return a list of items in iterable NAMES that match PAT."""
+    """Construct a list from those elements of the iterable NAMES that match PAT."""
     result = []
     pat = os.path.normcase(pat)
     match = _compile_pattern(pat)


### PR DESCRIPTION


<!-- issue-number: [bpo-36769](https://bugs.python.org/issue36769) -->
https://bugs.python.org/issue36769
<!-- /issue-number -->
