### PR TITLE
bpo-36771: Add a `direntries` argument to `os.walk`

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2808,7 +2808,7 @@ features:
       Accepts a :term:`path-like object`.
 
 
-.. function:: walk(top, topdown=True, onerror=None, followlinks=False)
+.. function:: walk(top, topdown=True, onerror=None, followlinks=False, direntries=False)
 
    .. index::
       single: directory; walking
@@ -2864,6 +2864,10 @@ features:
       If you pass a relative pathname, don't change the current working directory
       between resumptions of :func:`walk`.  :func:`walk` never changes the current
       directory, and assumes that its caller doesn't either.
+
+   By default, the ``dirnames`` and ``filenames`` parts of the return tuple are
+   strings, but if the optional argument *direntries* is True, these will be lists
+   of :class:`os.DirEntry` objects instead.
 
    This example displays the number of bytes taken by non-directory files in each
    directory under the starting directory, except that it doesn't look under any

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1853,3 +1853,4 @@ Peter Åstrand
 Zheao Li
 Carsten Klein
 Diego Rojas
+Christopher J. Kucera

--- a/Misc/NEWS.d/next/Library/2019-05-01-11-02-50.bpo-36771.mPBwlG.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-01-11-02-50.bpo-36771.mPBwlG.rst
@@ -1,0 +1,1 @@
+Add an optional `direntries` argument to `os.walk`.


### PR DESCRIPTION
This will allow users to make use of the os.DirEntry objects
already used by os.walk.  I'm not sure what should be done
with os.fwalk, though, nor what should be done in the unit
tests, so this commit is surely insufficient on its own.

https://bugs.python.org/issue36771

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36771](https://bugs.python.org/issue36771) -->
https://bugs.python.org/issue36771
<!-- /issue-number -->
