### PR TITLE
bpo-36763: Make _PyCoreConfig.check_hash_pycs_mode public

### DIFF
--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -363,7 +363,7 @@ typedef struct {
        Needed by freeze_importlib. */
     int _install_importlib;
 
-    /* Value of the --check-hash-based-pycs configure option. Valid values:
+    /* Value of the --check-hash-based-pycs command line option:
 
        - "default" means the 'check_source' flag in hash-based pycs
          determines invalidation
@@ -372,11 +372,10 @@ typedef struct {
        - "never" causes the interpreter to always assume hash-based pycs are
          valid
 
-       Set by the --check-hash-based-pycs command line option.
        The default value is "default".
 
        See PEP 552 "Deterministic pycs" for more details. */
-    const char *_check_hash_pycs_mode;
+    wchar_t *check_hash_pycs_mode;
 
     /* If greater than 0, suppress _PyPathConfig_Calculate() warnings.
 
@@ -418,7 +417,7 @@ typedef struct {
         .user_site_directory = -1, \
         .buffered_stdio = -1, \
         ._install_importlib = 1, \
-        ._check_hash_pycs_mode = "default", \
+        .check_hash_pycs_mode = NULL, \
         ._frozen = -1, \
         ._init_main = 1}
 /* Note: _PyCoreConfig_INIT sets other fields to 0/NULL */

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -346,7 +346,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'run_filename': None,
 
         '_install_importlib': 1,
-        '_check_hash_pycs_mode': 'default',
+        'check_hash_pycs_mode': 'default',
         '_frozen': 0,
         '_init_main': 1,
     }
@@ -577,7 +577,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'user_site_directory': 0,
             'faulthandler': 1,
 
-            '_check_hash_pycs_mode': 'always',
+            'check_hash_pycs_mode': 'always',
             '_frozen': 1,
         }
         self.check_config("init_from_config", config, preconfig)

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -495,7 +495,7 @@ static int test_init_from_config(void)
     Py_NoUserSiteDirectory = 0;
     config.user_site_directory = 0;
 
-    config._check_hash_pycs_mode = "always";
+    config.check_hash_pycs_mode = L"always";
 
     Py_FrozenFlag = 0;
     config._frozen = 1;

--- a/Python/import.c
+++ b/Python/import.c
@@ -2305,7 +2305,7 @@ PyInit__imp(void)
     if (d == NULL)
         goto failure;
     _PyCoreConfig *config = &_PyInterpreterState_Get()->core_config;
-    PyObject *pyc_mode = PyUnicode_FromString(config->_check_hash_pycs_mode);
+    PyObject *pyc_mode = PyUnicode_FromWideChar(config->check_hash_pycs_mode, -1);
     if (pyc_mode == NULL) {
         goto failure;
     }


### PR DESCRIPTION
_PyCoreConfig: Rename _check_hash_pycs_mode field to
check_hash_pycs_mode (make it public) and change its type from "const
char*" to "wchar_t*".

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
