### PR TITLE
bpo-13611: Include C14N 2.0 test data in installation

### DIFF
--- a/Lib/test/xmltestdata/c14n-20/README
+++ b/Lib/test/xmltestdata/c14n-20/README
@@ -1,0 +1,14 @@
+C14N 2.0 test files
+===================
+
+This directory contains files from the draft note document listing
+test cases for the W3C C14N 2.0 specification:
+https://www.w3.org/TR/xml-c14n2-testcases/
+
+Direct source:
+https://www.w3.org/TR/xml-c14n2-testcases/files/
+
+Copied and distributed under these terms:
+
+Copyright © 2013 W3C® (MIT, ERCIM, Keio, Beihang),
+http://www.w3.org/Consortium/Legal/2015/doc-license

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1296,7 +1296,8 @@ LIBSUBDIRS=	tkinter tkinter/test tkinter/test/test_tkinter \
 		tkinter/test/test_ttk site-packages test \
 		test/audiodata \
 		test/capath test/data \
-		test/cjkencodings test/decimaltestdata test/xmltestdata \
+		test/cjkencodings test/decimaltestdata \
+		test/xmltestdata test/xmltestdata/c14n-20 \
 		test/dtracedata \
 		test/eintrdata \
 		test/imghdrdata \


### PR DESCRIPTION


<!-- issue-number: [bpo-13611](https://bugs.python.org/issue13611) -->
https://bugs.python.org/issue13611
<!-- /issue-number -->
