### PR TITLE
Declare globals FMT_XML and FMT_BINARY

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -67,6 +67,7 @@ from xml.parsers.expat import ParserCreate
 
 PlistFormat = enum.Enum('PlistFormat', 'FMT_XML FMT_BINARY', module=__name__)
 globals().update(PlistFormat.__members__)
+global FMT_XML, FMT_BINARY  # explicitly declare globals to aid humans and linters
 
 
 #


### PR DESCRIPTION
> `PlistFormat = enum.Enum('PlistFormat', 'FMT_XML FMT_BINARY', module=__name__)`
> `globals().update(PlistFormat.__members__)`
> `global FMT_XML, FMT_BINARY  # explicitly declare globals to aid humans and linters`

The first two lines create two global variables in a nonstandard way.
The third line makes explicit what the first two lines have accomplished.

[flake8](http://flake8.pycqa.org) testing of https://github.com/python/cpython on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./Lib/plistlib.py:48:1: F822 undefined name 'FMT_BINARY' in __all__
__all__ = [
^
./Lib/plistlib.py:48:1: F822 undefined name 'FMT_XML' in __all__
__all__ = [
^
./Lib/plistlib.py:112:29: F821 undefined name 'FMT_XML'
        dump(value, fp, fmt=FMT_XML, sort_keys=True, skipkeys=False)
                            ^
./Lib/plistlib.py:135:24: F821 undefined name 'FMT_XML'
    dump(value, f, fmt=FMT_XML, sort_keys=True, skipkeys=False)
                       ^
./Lib/plistlib.py:917:5: F821 undefined name 'FMT_XML'
    FMT_XML: dict(
    ^
./Lib/plistlib.py:922:5: F821 undefined name 'FMT_BINARY'
    FMT_BINARY: dict(
    ^
./Lib/plistlib.py:961:28: F821 undefined name 'FMT_XML'
def dump(value, fp, *, fmt=FMT_XML, sort_keys=True, skipkeys=False):
                           ^
./Lib/plistlib.py:972:25: F821 undefined name 'FMT_XML'
def dumps(value, *, fmt=FMT_XML, skipkeys=False, sort_keys=True):
                        ^
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
