### PR TITLE
bpo-36775: Add _PyUnicode_InitEncodings()

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -16,10 +16,11 @@ PyAPI_DATA(int) _Py_UnhandledKeyboardInterrupt;
 
 PyAPI_FUNC(int) _Py_UnixMain(int argc, char **argv);
 
-PyAPI_FUNC(int) _Py_SetFileSystemEncoding(
+extern int _Py_SetFileSystemEncoding(
     const char *encoding,
     const char *errors);
-PyAPI_FUNC(void) _Py_ClearFileSystemEncoding(void);
+extern void _Py_ClearFileSystemEncoding(void);
+extern _PyInitError _PyUnicode_InitEncodings(PyInterpreterState *interp);
 
 PyAPI_FUNC(void) _Py_ClearStandardStreamEncoding(void);
 


### PR DESCRIPTION
Move get_codec_name() and initfsencoding() from pylifecycle.c to
unicodeobject.c.

Rename also "init" functions in pylifecycle.c.

<!-- issue-number: bpo-36775 -->
https://bugs.python.org/issue36775
<!-- /issue-number -->
