### PR TITLE
bpo-36774: Add !d to f-strings to make debugging easier.

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -148,6 +148,20 @@ extensions compiled in release mode and for C extensions compiled with the
 stable ABI.
 (Contributed by Victor Stinner in :issue:`36722`.)
 
+f-strings now support !d for quick and dirty  debugging
+-------------------------------------------------------
+
+Add ``!d`` conversion specifier to f-strings. ``f'{expr!d}'`` expands
+to the text of the expression, an equal sign, then the repr of the
+evaluated expression.  So::
+
+  x = 3
+  print(f'{x*9 + 15!d}')
+
+Would print ``x*9 + 15=42``.
+
+(Contributed by Eric V. Smith in  :issue:`36774`.)
+
 
 Other Language Changes
 ======================

--- a/Include/Python-ast.h
+++ b/Include/Python-ast.h
@@ -330,7 +330,7 @@ struct _expr {
             expr_ty value;
             int conversion;
             expr_ty format_spec;
-            string expr_source;
+            string expr_text;
         } FormattedValue;
 
         struct {
@@ -640,7 +640,7 @@ expr_ty _Py_Call(expr_ty func, asdl_seq * args, asdl_seq * keywords, int
                  PyArena *arena);
 #define FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7, a8) _Py_FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7, a8)
 expr_ty _Py_FormattedValue(expr_ty value, int conversion, expr_ty format_spec,
-                           string expr_source, int lineno, int col_offset, int
+                           string expr_text, int lineno, int col_offset, int
                            end_lineno, int end_col_offset, PyArena *arena);
 #define JoinedStr(a0, a1, a2, a3, a4, a5) _Py_JoinedStr(a0, a1, a2, a3, a4, a5)
 expr_ty _Py_JoinedStr(asdl_seq * values, int lineno, int col_offset, int

--- a/Include/Python-ast.h
+++ b/Include/Python-ast.h
@@ -330,6 +330,7 @@ struct _expr {
             expr_ty value;
             int conversion;
             expr_ty format_spec;
+            string expr_source;
         } FormattedValue;
 
         struct {
@@ -637,10 +638,10 @@ expr_ty _Py_Compare(expr_ty left, asdl_int_seq * ops, asdl_seq * comparators,
 expr_ty _Py_Call(expr_ty func, asdl_seq * args, asdl_seq * keywords, int
                  lineno, int col_offset, int end_lineno, int end_col_offset,
                  PyArena *arena);
-#define FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7) _Py_FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7)
+#define FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7, a8) _Py_FormattedValue(a0, a1, a2, a3, a4, a5, a6, a7, a8)
 expr_ty _Py_FormattedValue(expr_ty value, int conversion, expr_ty format_spec,
-                           int lineno, int col_offset, int end_lineno, int
-                           end_col_offset, PyArena *arena);
+                           string expr_source, int lineno, int col_offset, int
+                           end_lineno, int end_col_offset, PyArena *arena);
 #define JoinedStr(a0, a1, a2, a3, a4, a5) _Py_JoinedStr(a0, a1, a2, a3, a4, a5)
 expr_ty _Py_JoinedStr(asdl_seq * values, int lineno, int col_offset, int
                       end_lineno, int end_col_offset, PyArena *arena);

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -225,13 +225,14 @@ PyAPI_FUNC(void) _PyEval_SignalAsyncExc(void);
 #endif
 
 /* Masks and values used by FORMAT_VALUE opcode. */
-#define FVC_MASK      0x3
+#define FVC_MASK      0x7
 #define FVC_NONE      0x0
 #define FVC_STR       0x1
 #define FVC_REPR      0x2
 #define FVC_ASCII     0x3
-#define FVS_MASK      0x4
-#define FVS_HAVE_SPEC 0x4
+#define FVC_DEBUG     0x4
+#define FVS_MASK      0x8
+#define FVS_HAVE_SPEC 0x8
 
 #ifdef __cplusplus
 }

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -225,14 +225,13 @@ PyAPI_FUNC(void) _PyEval_SignalAsyncExc(void);
 #endif
 
 /* Masks and values used by FORMAT_VALUE opcode. */
-#define FVC_MASK      0x7
+#define FVC_MASK      0x3
 #define FVC_NONE      0x0
 #define FVC_STR       0x1
 #define FVC_REPR      0x2
 #define FVC_ASCII     0x3
-#define FVC_DEBUG     0x4
-#define FVS_MASK      0x8
-#define FVS_HAVE_SPEC 0x8
+#define FVS_MASK      0x4
+#define FVS_HAVE_SPEC 0x4
 
 #ifdef __cplusplus
 }

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1049,6 +1049,14 @@ non-important content
         self.assertEqual(eval('f"\\\n"'), '')
         self.assertEqual(eval('f"\\\r"'), '')
 
+    def test_debug_conversion(self):
+        x = 'A string'
+        self.assertEqual(f'{x!d}', 'x=' + repr(x))
+        self.assertEqual(f'{x !d}', 'x =' + repr(x))
+
+        x = 9
+        self.assertEqual(f'{3*x+15!d}', '3*x+15=42')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1057,6 +1057,12 @@ non-important content
         x = 9
         self.assertEqual(f'{3*x+15!d}', '3*x+15=42')
 
+        # There is code in ast.c that deals with non-ascii expression values.  So,
+        # use a unicode identifier to trigger that.
+        tenπ = 31.4
+        self.assertEqual(f'{tenπ!d:.2f}', 'tenπ=31.40')
+
+
     def test_debug_conversion_calls_format(self):
         # Test that !d calls format on the expression's value, if a
         # format spec is also provided.

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1057,6 +1057,10 @@ non-important content
         x = 9
         self.assertEqual(f'{3*x+15!d}', '3*x+15=42')
 
+        # Don't allow any format spec.
+        with self.assertRaisesRegex(SyntaxError, 'cannot specify a format spec with !d'):
+            eval("f'{0!d:0}'")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1074,6 +1074,13 @@ non-important content
         # Also test with non-identifiers.
         self.assertEqual(f'{"Σ"!d}', '"Σ"=\'Σ\'')
 
+        # Make sure nested still works.
+        self.assertEqual(f'{f"{3.1415!d:.1f}":*^20}', '*****3.1415=3.1*****')
+
+        # Make sure text before and after !d works correctly.
+        pi = 'π'
+        self.assertEqual(f'alpha α {pi!d} ω omega', "alpha α pi='π' ω omega")
+
     def test_debug_conversion_calls_format(self):
         # Test that !d calls format on the expression's value, if a
         # format spec is also provided.

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1,3 +1,12 @@
+# -*- coding: utf-8 -*-
+# There are tests here with unicode string literals and
+# identifiers. There's a code in ast.c that was added because of a
+# failure with a non-ascii-only expression.  So, I have tests for
+# that.  There are workarounds that would let me run tests for that
+# code without unicode identifiers and strings, but just using them
+# directly seems like the easiest and therefore safest thing to do.
+# Unicode identifiers in tests is allowed by PEP 3131.
+
 import ast
 import types
 import decimal
@@ -1062,6 +1071,8 @@ non-important content
         tenπ = 31.4
         self.assertEqual(f'{tenπ!d:.2f}', 'tenπ=31.40')
 
+        # Also test with non-identifiers.
+        self.assertEqual(f'{"Σ"!d}', '"Σ"=\'Σ\'')
 
     def test_debug_conversion_calls_format(self):
         # Test that !d calls format on the expression's value, if a

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1081,6 +1081,11 @@ non-important content
         pi = 'π'
         self.assertEqual(f'alpha α {pi!d} ω omega', "alpha α pi='π' ω omega")
 
+        # Check multi-lines.
+        self.assertEqual(f'''{
+3
+!d}''', '\n3\n=3')
+
     def test_debug_conversion_calls_format(self):
         # Test that !d calls format on the expression's value, if a
         # format spec is also provided.

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1081,7 +1081,7 @@ non-important content
         pi = 'π'
         self.assertEqual(f'alpha α {pi!d} ω omega', "alpha α pi='π' ω omega")
 
-        # Check multi-lines.
+        # Check multi-line expressions.
         self.assertEqual(f'''{
 3
 !d}''', '\n3\n=3')

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1057,9 +1057,22 @@ non-important content
         x = 9
         self.assertEqual(f'{3*x+15!d}', '3*x+15=42')
 
-        # Don't allow any format spec.
-        with self.assertRaisesRegex(SyntaxError, 'cannot specify a format spec with !d'):
-            eval("f'{0!d:0}'")
+    def test_debug_conversion_calls_format(self):
+        # Test that !d calls format on the expression's value, if a
+        # format spec is also provided.
+
+        class C:
+            def __repr__(self):
+                return 'my repr'
+
+            def __format__(self, spec):
+                return f'F{spec}'
+
+        # __format__ is called if a format spec is provided.
+        self.assertEqual(f'{C()!d:abc}', 'C()=Fabc')
+
+        # But __repr__ is called if one isn't.
+        self.assertEqual(f'{C()!d}', 'C()=my repr')
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
@@ -1,4 +1,4 @@
 Add a ``!x`` conversion specifier to f-strings. This is similar to
 ``!s`` and ``!r``. It produces the text of the expression, followed by
-an equal sign, followed by the value of the expression. So
+an equal sign, followed by the repr of the value of the expression. So
 ``f'{3*9+15!d}'`` would be equal to the string ``'3*9+15=42'``.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
@@ -1,4 +1,4 @@
 Add a !x conversion specifier to f-strings. This is similar to !s and !r. It
 produces the text of the expression, followed by an equal sign, followed by
 the value of the expression. So ``f'{3*9+15!d}'`` would be equal to the
-string ``3*9+15=42``.
+string ``'3*9+15=42'``.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
@@ -1,4 +1,4 @@
-Add a !x conversion specifier to f-strings. This is similar to !s and !r. It
-produces the text of the expression, followed by an equal sign, followed by
-the value of the expression. So ``f'{3*9+15!d}'`` would be equal to the
-string ``'3*9+15=42'``.
+Add a ``!x`` conversion specifier to f-strings. This is similar to
+``!s`` and ``!r``. It produces the text of the expression, followed by
+an equal sign, followed by the value of the expression. So
+``f'{3*9+15!d}'`` would be equal to the string ``'3*9+15=42'``.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
@@ -1,0 +1,4 @@
+Add a !x conversion specifier to f-strings. This is similar to !s and !r. It
+produces the text of the expression, followed by an equal sign, followed by
+the value of the expression. So ``f'{3*9+15!d}'`` would be equal to the
+string ``3*9+15=42``.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-02-11-48-08.bpo-36774.ZqbJ1J.rst
@@ -1,4 +1,4 @@
-Add a ``!x`` conversion specifier to f-strings. This is similar to
+Add a ``!d`` conversion specifier to f-strings. This is similar to
 ``!s`` and ``!r``. It produces the text of the expression, followed by
 an equal sign, followed by the repr of the value of the expression. So
 ``f'{3*9+15!d}'`` would be equal to the string ``'3*9+15=42'``.

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -76,7 +76,7 @@ module Python
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
          | Call(expr func, expr* args, keyword* keywords)
-         | FormattedValue(expr value, int? conversion, expr? format_spec)
+         | FormattedValue(expr value, int? conversion, expr? format_spec, string? expr_source)
          | JoinedStr(expr* values)
          | Constant(constant value, string? kind)
 

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -76,7 +76,7 @@ module Python
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
          | Call(expr func, expr* args, keyword* keywords)
-         | FormattedValue(expr value, int? conversion, expr? format_spec, string? expr_source)
+         | FormattedValue(expr value, int? conversion, expr? format_spec, string? expr_text)
          | JoinedStr(expr* values)
          | Constant(constant value, string? kind)
 

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -314,10 +314,12 @@ static char *Call_fields[]={
 static PyTypeObject *FormattedValue_type;
 _Py_IDENTIFIER(conversion);
 _Py_IDENTIFIER(format_spec);
+_Py_IDENTIFIER(expr_source);
 static char *FormattedValue_fields[]={
     "value",
     "conversion",
     "format_spec",
+    "expr_source",
 };
 static PyTypeObject *JoinedStr_type;
 static char *JoinedStr_fields[]={
@@ -950,7 +952,7 @@ static int init_types(void)
     Call_type = make_type("Call", expr_type, Call_fields, 3);
     if (!Call_type) return 0;
     FormattedValue_type = make_type("FormattedValue", expr_type,
-                                    FormattedValue_fields, 3);
+                                    FormattedValue_fields, 4);
     if (!FormattedValue_type) return 0;
     JoinedStr_type = make_type("JoinedStr", expr_type, JoinedStr_fields, 1);
     if (!JoinedStr_type) return 0;
@@ -2249,9 +2251,9 @@ Call(expr_ty func, asdl_seq * args, asdl_seq * keywords, int lineno, int
 }
 
 expr_ty
-FormattedValue(expr_ty value, int conversion, expr_ty format_spec, int lineno,
-               int col_offset, int end_lineno, int end_col_offset, PyArena
-               *arena)
+FormattedValue(expr_ty value, int conversion, expr_ty format_spec, string
+               expr_source, int lineno, int col_offset, int end_lineno, int
+               end_col_offset, PyArena *arena)
 {
     expr_ty p;
     if (!value) {
@@ -2266,6 +2268,7 @@ FormattedValue(expr_ty value, int conversion, expr_ty format_spec, int lineno,
     p->v.FormattedValue.value = value;
     p->v.FormattedValue.conversion = conversion;
     p->v.FormattedValue.format_spec = format_spec;
+    p->v.FormattedValue.expr_source = expr_source;
     p->lineno = lineno;
     p->col_offset = col_offset;
     p->end_lineno = end_lineno;
@@ -3494,6 +3497,11 @@ ast2obj_expr(void* _o)
         value = ast2obj_expr(o->v.FormattedValue.format_spec);
         if (!value) goto failed;
         if (_PyObject_SetAttrId(result, &PyId_format_spec, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        value = ast2obj_string(o->v.FormattedValue.expr_source);
+        if (!value) goto failed;
+        if (_PyObject_SetAttrId(result, &PyId_expr_source, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
@@ -7148,6 +7156,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty value;
         int conversion;
         expr_ty format_spec;
+        string expr_source;
 
         if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
             return 1;
@@ -7188,8 +7197,22 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = FormattedValue(value, conversion, format_spec, lineno,
-                              col_offset, end_lineno, end_col_offset, arena);
+        if (_PyObject_LookupAttrId(obj, &PyId_expr_source, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            expr_source = NULL;
+        }
+        else {
+            int res;
+            res = obj2ast_string(tmp, &expr_source, arena);
+            if (res != 0) goto failed;
+            Py_CLEAR(tmp);
+        }
+        *out = FormattedValue(value, conversion, format_spec, expr_source,
+                              lineno, col_offset, end_lineno, end_col_offset,
+                              arena);
         if (*out == NULL) goto failed;
         return 0;
     }

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -314,12 +314,12 @@ static char *Call_fields[]={
 static PyTypeObject *FormattedValue_type;
 _Py_IDENTIFIER(conversion);
 _Py_IDENTIFIER(format_spec);
-_Py_IDENTIFIER(expr_source);
+_Py_IDENTIFIER(expr_text);
 static char *FormattedValue_fields[]={
     "value",
     "conversion",
     "format_spec",
-    "expr_source",
+    "expr_text",
 };
 static PyTypeObject *JoinedStr_type;
 static char *JoinedStr_fields[]={
@@ -2252,7 +2252,7 @@ Call(expr_ty func, asdl_seq * args, asdl_seq * keywords, int lineno, int
 
 expr_ty
 FormattedValue(expr_ty value, int conversion, expr_ty format_spec, string
-               expr_source, int lineno, int col_offset, int end_lineno, int
+               expr_text, int lineno, int col_offset, int end_lineno, int
                end_col_offset, PyArena *arena)
 {
     expr_ty p;
@@ -2268,7 +2268,7 @@ FormattedValue(expr_ty value, int conversion, expr_ty format_spec, string
     p->v.FormattedValue.value = value;
     p->v.FormattedValue.conversion = conversion;
     p->v.FormattedValue.format_spec = format_spec;
-    p->v.FormattedValue.expr_source = expr_source;
+    p->v.FormattedValue.expr_text = expr_text;
     p->lineno = lineno;
     p->col_offset = col_offset;
     p->end_lineno = end_lineno;
@@ -3499,9 +3499,9 @@ ast2obj_expr(void* _o)
         if (_PyObject_SetAttrId(result, &PyId_format_spec, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(o->v.FormattedValue.expr_source);
+        value = ast2obj_string(o->v.FormattedValue.expr_text);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_expr_source, value) == -1)
+        if (_PyObject_SetAttrId(result, &PyId_expr_text, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
@@ -7156,7 +7156,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty value;
         int conversion;
         expr_ty format_spec;
-        string expr_source;
+        string expr_text;
 
         if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
             return 1;
@@ -7197,20 +7197,20 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_expr_source, &tmp) < 0) {
+        if (_PyObject_LookupAttrId(obj, &PyId_expr_text, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
             Py_CLEAR(tmp);
-            expr_source = NULL;
+            expr_text = NULL;
         }
         else {
             int res;
-            res = obj2ast_string(tmp, &expr_source, arena);
+            res = obj2ast_string(tmp, &expr_text, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = FormattedValue(value, conversion, format_spec, expr_source,
+        *out = FormattedValue(value, conversion, format_spec, expr_text,
                               lineno, col_offset, end_lineno, end_col_offset,
                               arena);
         if (*out == NULL) goto failed;

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -5184,15 +5184,15 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
 
         /* Validate the conversion. */
         if (!(conversion == 's' || conversion == 'r'
-              || conversion == 'a' || conversion == 'x')) {
+              || conversion == 'a' || conversion == 'd')) {
             ast_error(c, n,
                       "f-string: invalid conversion character: "
-                      "expected 's', 'r', 'a', or 'x'");
+                      "expected 's', 'r', 'a', or 'd'");
             return -1;
         }
 
         /* If !x, then save the source to the expression. */
-        if (conversion == 'x') {
+        if (conversion == 'd') {
             expr_source = PyUnicode_FromStringAndSize(expr_start,
                                                       expr_end-expr_start);
         }

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4999,7 +4999,7 @@ fstring_parse(const char **str, const char *end, int raw, int recurse_lvl,
 /* Parse the f-string at *str, ending at end.  We know *str starts an
    expression (so it must be a '{'). Returns the FormattedValue node, which
    includes the expression, conversion character, format_spec expression, and
-   optionally the text of the expression (if !x is used).
+   optionally the text of the expression (if !d is used).
 
    Note that I don't do a perfect job here: I don't make sure that a
    closing brace doesn't match an opening paren, for example. It
@@ -5191,7 +5191,7 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
             return -1;
         }
 
-        /* If !x, then save the source to the expression. */
+        /* If !d, then save the source to the expression. */
         if (conversion == 'd') {
             expr_text = PyUnicode_FromStringAndSize(expr_start,
                                                     expr_end-expr_start);

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -5222,13 +5222,6 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
     assert(**str == '}');
     *str += 1;
 
-    /* Can't have !d and a format spec. */
-    if (conversion == 'd' && format_spec != NULL) {
-        PyErr_SetString(PyExc_ValueError,
-                        "cannot specify a format spec with !d");
-        goto error;
-    }
-
     /* And now create the FormattedValue node that represents this
        entire expression with the conversion and format spec. */
     *expression = FormattedValue(simple_expression, conversion,

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -5017,7 +5017,7 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
     expr_ty simple_expression;
     expr_ty format_spec = NULL; /* Optional format specifier. */
     int conversion = -1; /* The conversion char. -1 if not specified. */
-    PyObject *expr_source = NULL; /* The text of the expression. */
+    PyObject *expr_text = NULL; /* The text of the expression, used for !d. */
 
     /* 0 if we're not in a string, else the quote char we're trying to
        match (single or double quote). */
@@ -5193,8 +5193,8 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
 
         /* If !x, then save the source to the expression. */
         if (conversion == 'd') {
-            expr_source = PyUnicode_FromStringAndSize(expr_start,
-                                                      expr_end-expr_start);
+            expr_text = PyUnicode_FromStringAndSize(expr_start,
+                                                    expr_end-expr_start);
         }
     }
 
@@ -5223,7 +5223,7 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
     /* And now create the FormattedValue node that represents this
        entire expression with the conversion and format spec. */
     *expression = FormattedValue(simple_expression, conversion,
-                                 format_spec, expr_source, LINENO(n),
+                                 format_spec, expr_text, LINENO(n),
                                  n->n_col_offset, n->n_end_lineno,
                                  n->n_end_col_offset, c->c_arena);
     if (!*expression)

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3440,8 +3440,6 @@ main_loop:
             case FVC_STR:   conv_fn = PyObject_Str;   break;
             case FVC_REPR:  conv_fn = PyObject_Repr;  break;
             case FVC_ASCII: conv_fn = PyObject_ASCII; break;
-            /* !x is a special case, handled later. */
-            case FVC_DEBUG: conv_fn = NULL;           break;
 
             default:
                 PyErr_Format(PyExc_SystemError,
@@ -3461,10 +3459,6 @@ main_loop:
                     goto error;
                 }
                 value = result;
-            } else if (which_conversion == FVC_DEBUG) {
-                /* If we're using !x, do the formatting, replace value with
-                   the result. */
-                printf("debug\n");
             }
 
             /* If value is a unicode object, and there's no fmt_spec,

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3436,13 +3436,18 @@ main_loop:
 
             /* See if any conversion is specified. */
             switch (which_conversion) {
+            case FVC_NONE:  conv_fn = NULL;           break;
             case FVC_STR:   conv_fn = PyObject_Str;   break;
             case FVC_REPR:  conv_fn = PyObject_Repr;  break;
             case FVC_ASCII: conv_fn = PyObject_ASCII; break;
+            /* !x is a special case, handled later. */
+            case FVC_DEBUG: conv_fn = NULL;           break;
 
-            /* Must be 0 (meaning no conversion), since only four
-               values are allowed by (oparg & FVC_MASK). */
-            default:        conv_fn = NULL;           break;
+            default:
+                PyErr_Format(PyExc_SystemError,
+                             "unexpected conversion flag %d",
+                             which_conversion);
+                goto error;
             }
 
             /* If there's a conversion function, call it and replace
@@ -3456,6 +3461,10 @@ main_loop:
                     goto error;
                 }
                 value = result;
+            } else if (which_conversion == FVC_DEBUG) {
+                /* If we're using !x, do the formatting, replace value with
+                   the result. */
+                printf("debug\n");
             }
 
             /* If value is a unicode object, and there's no fmt_spec,

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3969,16 +3969,19 @@ compiler_formatted_value(struct compiler *c, expr_ty e)
     if (e->v.FormattedValue.conversion == 'd') {
         /* Special handling here to generate basically:
            format(<text of the expr> + '=' + repr(value), format_spec) */
-        assert(e->v.FormattedValue.expr_source != NULL);
+        assert(e->v.FormattedValue.expr_text != NULL);
 
         /* The text of the expression. */
-        ADDOP_LOAD_CONST(c, e->v.FormattedValue.expr_source);
+        ADDOP_LOAD_CONST(c, e->v.FormattedValue.expr_text);
         /* The equal sign. */
         ADDOP_LOAD_CONST(c, equal_str);
         /* Evaluate the expression to be formatted. */
         VISIT(c, expr, e->v.FormattedValue.value);
-        /* Call repr on it. */
-        /* 3 for the text, the "=", and the value. */
+        /* Call repr on it, by using FORMAT_VALUE with FVC_REPR. */
+        ADDOP_I(c, FORMAT_VALUE, FVC_REPR);
+
+        /* Now combine the 3 strings on top of the stack: the text of the
+           expression, the "=", and the repr'd value. */
         ADDOP_I(c, BUILD_STRING, 3);
     } else {
         /* Just evaluate the expression to be formatted. */

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3966,7 +3966,7 @@ compiler_formatted_value(struct compiler *c, expr_ty e)
             return 0;
     }
 
-    if (e->v.FormattedValue.conversion == 'x') {
+    if (e->v.FormattedValue.conversion == 'd') {
         /* Special handling here to generate basically:
            format(<text of the expr> + '=' + repr(value), format_spec) */
         assert(e->v.FormattedValue.expr_source != NULL);
@@ -3989,7 +3989,7 @@ compiler_formatted_value(struct compiler *c, expr_ty e)
     case 's': oparg = FVC_STR;   break;
     case 'r': oparg = FVC_REPR;  break;
     case 'a': oparg = FVC_ASCII; break;
-    case 'x': oparg = FVC_NONE;  break; /* Already handled above. */
+    case 'd': oparg = FVC_NONE;  break; /* Already handled above. */
     case -1:  oparg = FVC_NONE;  break;
     default:
         PyErr_SetString(PyExc_SystemError,

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -211,8 +211,8 @@ static int compiler_async_comprehension_generator(
                                       expr_ty elt, expr_ty val, int type);
 
 static PyCodeObject *assemble(struct compiler *, int addNone);
-static PyObject *__doc__, *__annotations__;
-static PyObject *equal_str;
+static PyObject *__doc__, *__annotations__, *equal_str;
+
 #define CAPSULE_NAME "compile.c compiler unit"
 
 PyObject *

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3946,16 +3946,15 @@ compiler_formatted_value(struct compiler *c, expr_ty e)
     /* Our oparg encodes 2 pieces of information: the conversion
        character, and whether or not a format_spec was provided.
 
-       Convert the conversion char to 3 bits:
-       None: 0000  0x0  FVC_NONE
-       !s  : 0001  0x1  FVC_STR
-       !r  : 0010  0x2  FVC_REPR
-       !a  : 0011  0x3  FVC_ASCII
-       !x  : 0100  0x4  FVC_DEBUG
+       Convert the conversion char to 2 bit:
+       None: 000  0x0  FVC_NONE
+       !s  : 001  0x1  FVC_STR
+       !r  : 010  0x2  FVC_REPR
+       !a  : 011  0x3  FVC_ASCII
 
        next bit is whether or not we have a format spec:
-       yes : 1000  0x8
-       no  : 0000  0x0
+       yes : 100  0x4
+       no  : 000  0x0
     */
 
     int oparg;


### PR DESCRIPTION
!d will expand to the text of the expression, an equal sign, and the repr of the value of the expression.

<!-- issue-number: [bpo-36774](https://bugs.python.org/issue36774) -->
https://bugs.python.org/issue36774
<!-- /issue-number -->
