### PR TITLE
bpo-36778: fix test_startup_imports if default codepage is UTF-8

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1619,9 +1619,28 @@ init_timezone(PyObject *m)
     And I'm lazy and hate C so nyer.
      */
 #ifdef HAVE_DECL_TZNAME
+#ifdef MS_WINDOWS
+#	include <locale.h>
+	// https://bugs.python.org/issue36778
+	// workaround bug in UCRT
+	// strptime fails if the current locale is a Unicode locale
+	int cp = GetACP();
+	char* save_locale = NULL;
+	if (cp == CP_UTF8 || cp == CP_UTF7)
+	{
+		save_locale = setlocale(LC_CTYPE, NULL);
+		setlocale(LC_CTYPE, "C");
+	}
+#endif
     PyObject *otz0, *otz1;
     tzset();
     PyModule_AddIntConstant(m, "timezone", _Py_timezone);
+#ifdef MS_WINDOWS
+	if (cp == CP_UTF8 || cp == CP_UTF7)
+	{
+		setlocale(LC_CTYPE, save_locale);
+	}
+#endif
 #ifdef HAVE_ALTZONE
     PyModule_AddIntConstant(m, "altzone", altzone);
 #else


### PR DESCRIPTION
Windows desktop skus have a default ANSI codepage (returned by GetACP()) of 1252 (Western European).  Windows IoT Core and Windows Nano Server have a default codepage of 65001 (UTF-8). 

This causes test_site.StartupImportTests.test_startup_imports to fail on Windows IoT Core and Windows Nano Server because cp65001.py is loaded instead of the frozen cp1252.py at startup.

I tried changing the default codepage to 65001 on my dev machine and rebuilding Python and it had no effect that I could tell on the generated frozen importlibs.

The simplest solutions would be for the test_startup_imports test to be skipped or changed to pass when the locale.getpreferredencoding() returns 'cp65001'

@zooba @zware

<!-- issue-number: [bpo-36778](https://bugs.python.org/issue36778) -->
https://bugs.python.org/issue36778
<!-- /issue-number -->
