### PR TITLE
bpo-36791: Safer detection of integer overflow in sum().

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2375,9 +2375,11 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
             }
             if (PyLong_CheckExact(item)) {
                 long b = PyLong_AsLongAndOverflow(item, &overflow);
-                long x = i_result + b;
-                if (overflow == 0 && ((x^i_result) >= 0 || (x^b) >= 0)) {
-                    i_result = x;
+                if (overflow == 0 &&
+                    (i_result >= 0 ? (b <= LONG_MAX - i_result)
+                                   : (b >= LONG_MIN - i_result)))
+                {
+                    i_result += b;
                     Py_DECREF(item);
                     continue;
                 }


### PR DESCRIPTION


<!-- issue-number: [bpo-36791](https://bugs.python.org/issue36791) -->
https://bugs.python.org/issue36791
<!-- /issue-number -->
