### PR TITLE
bpo-36793: Remove unneeded __str__ definitions.

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -802,6 +802,13 @@ Changes in Python behavior
   raised when getting the attribute from the type dictionary are no longer
   ignored.  (Contributed by Serhiy Storchaka in :issue:`35459`.)
 
+* Removed ``__str__`` implementations from builtin types :class:`bool`,
+  :class:`int`, :class:`float`, :class:`complex` and few classes from
+  the standard library.  They now inherit ``__str__()`` from :class:`object`.
+  As result, defining the ``__repr__()`` method in the subclass of these
+  classes will affect they string representation.
+  (Contributed by Serhiy Storchaka in :issue:`36793`.)
+
 * On AIX, :attr:`sys.platform` doesn't contain the major version anymore.
   It is always ``'aix'``, instead of ``'aix3'`` .. ``'aix7'``.  Since
   older Python versions include the version number, it is recommended to

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -5631,8 +5631,6 @@ class _WorkRep(object):
     def __repr__(self):
         return "(%r, %r, %r)" % (self.sign, self.int, self.exp)
 
-    __str__ = __repr__
-
 
 
 def _normalize(op1, op2, prec = 0):

--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -262,8 +262,6 @@ class dispatcher:
                 status.append(repr(self.addr))
         return '<%s at %#x>' % (' '.join(status), id(self))
 
-    __str__ = __repr__
-
     def add_channel(self, map=None):
         #self.log_info('adding channel %s' % self)
         if map is None:

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -2300,7 +2300,7 @@ class DocTestCase(unittest.TestCase):
         name = self._dt_test.name.split('.')
         return "%s (%s)" % (name[-1], '.'.join(name[:-1]))
 
-    __str__ = __repr__
+    __str__ = object.__str__
 
     def shortDescription(self):
         return "Doctest: " + self._dt_test.name
@@ -2399,7 +2399,6 @@ class DocFileCase(DocTestCase):
 
     def __repr__(self):
         return self._dt_test.filename
-    __str__ = __repr__
 
     def format_failure(self, err):
         return ('Failed doctest test for %s\n  File "%s", line 0\n\n%s'

--- a/Lib/email/charset.py
+++ b/Lib/email/charset.py
@@ -241,10 +241,8 @@ class Charset:
         self.output_codec = CODEC_MAP.get(self.output_charset,
                                           self.output_charset)
 
-    def __str__(self):
+    def __repr__(self):
         return self.input_charset.lower()
-
-    __repr__ = __str__
 
     def __eq__(self, other):
         return str(self) == str(other).lower()

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1419,8 +1419,7 @@ class IncompleteRead(HTTPException):
             e = ''
         return '%s(%i bytes read%s)' % (self.__class__.__name__,
                                         len(self.partial), e)
-    def __str__(self):
-        return repr(self)
+    __str__ = object.__str__
 
 class ImproperConnectionState(HTTPException):
     pass

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -268,7 +268,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
         list=list,
         str=str,
         tuple=tuple,
-        _intstr=int.__str__,
+        _intstr=int.__repr__,
     ):
 
     if _indent is not None and not isinstance(_indent, str):
@@ -307,7 +307,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             elif value is False:
                 yield buf + 'false'
             elif isinstance(value, int):
-                # Subclasses of int/float may override __str__, but we still
+                # Subclasses of int/float may override _repr__, but we still
                 # want to encode them as integers/floats in JSON. One example
                 # within the standard library is IntEnum.
                 yield buf + _intstr(value)

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -307,7 +307,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             elif value is False:
                 yield buf + 'false'
             elif isinstance(value, int):
-                # Subclasses of int/float may override _repr__, but we still
+                # Subclasses of int/float may override __repr__, but we still
                 # want to encode them as integers/floats in JSON. One example
                 # within the standard library is IntEnum.
                 yield buf + _intstr(value)

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -364,11 +364,9 @@ class LogRecord(object):
         else:
             self.process = None
 
-    def __str__(self):
+    def __repr__(self):
         return '<LogRecord: %s, %s, %s, %s, "%s">'%(self.name, self.levelno,
             self.pathname, self.lineno, self.msg)
-
-    __repr__ = __str__
 
     def getMessage(self):
         """

--- a/Lib/sre_constants.py
+++ b/Lib/sre_constants.py
@@ -59,10 +59,8 @@ class _NamedIntConstant(int):
         self.name = name
         return self
 
-    def __str__(self):
+    def __repr__(self):
         return self.name
-
-    __repr__ = __str__
 
 MAXREPEAT = _NamedIntConstant(MAXREPEAT, 'MAXREPEAT')
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -203,7 +203,6 @@ if _mswindows:
             return "%s(%d)" % (self.__class__.__name__, int(self))
 
         __del__ = Close
-        __str__ = __repr__
 else:
     # When select or poll has indicated that the file is writable,
     # we can write up to _PIPE_BUF bytes without risk of blocking.

--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -186,8 +186,7 @@ INTERNAL_ERROR        = -32603
 
 class Error(Exception):
     """Base class for client errors."""
-    def __str__(self):
-        return repr(self)
+    __str__ = object.__str__
 
 ##
 # Indicates an HTTP-level protocol error.  This is raised by the HTTP
@@ -869,8 +868,6 @@ class MultiCall:
     def __repr__(self):
         return "<%s at %#x>" % (self.__class__.__name__, id(self))
 
-    __str__ = __repr__
-
     def __getattr__(self, name):
         return _MultiCallMethod(self.__call_list, name)
 
@@ -1467,8 +1464,6 @@ class ServerProxy:
             "<%s for %s%s>" %
             (self.__class__.__name__, self.__host, self.__handler)
             )
-
-    __str__ = __repr__
 
     def __getattr__(self, name):
         # magic method dispatcher

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-04-16-15-33.bpo-36793.Izog4Z.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-04-16-15-33.bpo-36793.Izog4Z.rst
@@ -1,0 +1,3 @@
+Removed ``__str__`` implementations from builtin types :class:`bool`,
+:class:`int`, :class:`float`, :class:`complex` and few classes from the
+standard library. They now inherit ``__str__()`` from :class:`object`.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -5390,7 +5390,7 @@ static PyTypeObject PyDecContext_Type =
     0,                                         /* tp_as_mapping */
     (hashfunc) 0,                              /* tp_hash */
     0,                                         /* tp_call */
-    (reprfunc) context_repr,                   /* tp_str */
+    0,                                         /* tp_str */
     (getattrofunc) context_getattr,            /* tp_getattro */
     (setattrofunc) context_setattr,            /* tp_setattro */
     (PyBufferProcs *) 0,                       /* tp_as_buffer */

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1482,7 +1482,7 @@ encoder_listencode_obj(PyEncoderObject *s, _PyAccu *acc,
         return _steal_accumulate(acc, encoded);
     }
     else if (PyLong_Check(obj)) {
-        PyObject *encoded = PyLong_Type.tp_str(obj);
+        PyObject *encoded = PyLong_Type.tp_repr(obj);
         if (encoded == NULL)
             return -1;
         return _steal_accumulate(acc, encoded);
@@ -1646,7 +1646,7 @@ encoder_listencode_dict(PyEncoderObject *s, _PyAccu *acc,
                 goto bail;
         }
         else if (PyLong_Check(key)) {
-            kstr = PyLong_Type.tp_str(key);
+            kstr = PyLong_Type.tp_repr(key);
             if (kstr == NULL) {
                 goto bail;
             }

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -147,7 +147,7 @@ PyTypeObject PyBool_Type = {
     0,                                          /* tp_as_mapping */
     0,                                          /* tp_hash */
     0,                                          /* tp_call */
-    bool_repr,                                  /* tp_str */
+    0,                                          /* tp_str */
     0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -1129,7 +1129,7 @@ PyTypeObject PyComplex_Type = {
     0,                                          /* tp_as_mapping */
     (hashfunc)complex_hash,                     /* tp_hash */
     0,                                          /* tp_call */
-    (reprfunc)complex_repr,                     /* tp_str */
+    0,                                          /* tp_str */
     PyObject_GenericGetAttr,                    /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1923,7 +1923,7 @@ PyTypeObject PyFloat_Type = {
     0,                                          /* tp_as_mapping */
     (hashfunc)float_hash,                       /* tp_hash */
     0,                                          /* tp_call */
-    (reprfunc)float_repr,                       /* tp_str */
+    0,                                          /* tp_str */
     PyObject_GenericGetAttr,                    /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5592,7 +5592,7 @@ PyTypeObject PyLong_Type = {
     0,                                          /* tp_as_mapping */
     (hashfunc)long_hash,                        /* tp_hash */
     0,                                          /* tp_call */
-    long_to_decimal_string,                     /* tp_str */
+    0,                                          /* tp_str */
     PyObject_GenericGetAttr,                    /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */


### PR DESCRIPTION
Classes that define `__str__` the same as `__repr__` can
just inherit it from object.


<!-- issue-number: [bpo-36793](https://bugs.python.org/issue36793) -->
https://bugs.python.org/issue36793
<!-- /issue-number -->
