### PR TITLE
bpo-34861: better cProfile CLI defaults: sort by time, restrict to top 20

### DIFF
--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -12,7 +12,7 @@ import profile as _pyprofile
 # ____________________________________________________________
 # Simple interface
 
-def run(statement, filename=None, sort=-1):
+def run(statement, filename=None, sort=-1, numresults=None):
     return _pyprofile._Utils(Profile).run(statement, filename, sort,
             numresults)
 

--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -13,11 +13,13 @@ import profile as _pyprofile
 # Simple interface
 
 def run(statement, filename=None, sort=-1):
-    return _pyprofile._Utils(Profile).run(statement, filename, sort)
+    return _pyprofile._Utils(Profile).run(statement, filename, sort,
+            numresults)
 
-def runctx(statement, globals, locals, filename=None, sort=-1):
+def runctx(statement, globals, locals, filename=None, sort=-1,
+        numresults=None):
     return _pyprofile._Utils(Profile).runctx(statement, globals, locals,
-                                             filename, sort)
+                                             filename, sort, numresults)
 
 run.__doc__ = _pyprofile.run.__doc__
 runctx.__doc__ = _pyprofile.runctx.__doc__
@@ -37,9 +39,10 @@ class Profile(_lsprof.Profiler):
     # Most of the functionality is in the base class.
     # This subclass only adds convenient and backward-compatible methods.
 
-    def print_stats(self, sort=-1):
+    def print_stats(self, sort=-1, numresults=None):
         import pstats
-        pstats.Stats(self).strip_dirs().sort_stats(sort).print_stats()
+        pstats.Stats(self).strip_dirs().sort_stats(sort).print_stats(
+                numresults)
 
     def dump_stats(self, file):
         import marshal
@@ -155,8 +158,10 @@ def main():
         help="Save stats to <outfile>", default=None)
     parser.add_option('-s', '--sort', dest="sort",
         help="Sort order when printing to stdout, based on pstats.Stats class",
-        default=-1,
+        default='time',
         choices=sorted(pstats.Stats.sort_arg_dict_default))
+    parser.add_option('-n', '--numresults', dest="numresults", type="int",
+        help="Number of results to show", default=20)
     parser.add_option('-m', dest="module", action="store_true",
         help="Profile a library module", default=False)
 
@@ -185,7 +190,8 @@ def main():
                 '__package__': None,
                 '__cached__': None,
             }
-        runctx(code, globs, None, options.outfile, options.sort)
+        runctx(code, globs, None, options.outfile, options.sort,
+                options.numresults)
     else:
         parser.print_usage()
     return parser

--- a/Lib/profile.py
+++ b/Lib/profile.py
@@ -88,7 +88,7 @@ def run(statement, filename=None, sort=-1, numresults=None):
     standard name string (file/line/function-name) that is presented in
     each line.
     """
-    return _Utils(Profile).run(statement, filename, sort)
+    return _Utils(Profile).run(statement, filename, sort, numresults)
 
 def runctx(statement, globals, locals, filename=None, sort=-1,
         numresults=None):

--- a/Lib/pstats.py
+++ b/Lib/pstats.py
@@ -492,7 +492,10 @@ class TupleComp:
 
 def func_strip_path(func_name):
     filename, line, name = func_name
-    return os.path.basename(filename), line, name
+    path, base_name = os.path.split(filename)
+    if base_name.startswith('__'):
+        base_name = os.path.join(os.path.basename(path), base_name)
+    return base_name, line, name
 
 def func_get_function_name(func):
     return func[2]
@@ -509,7 +512,7 @@ def func_std_string(func_name): # match what old profile produced
         return "%s:%d(%s)" % func_name
 
 #**************************************************************************
-# The following functions combine statists for pairs functions.
+# The following functions combine statistics for pairs functions.
 # The bulk of the processing involves correctly handling "call" lists,
 # such as callers and callees.
 #**************************************************************************

--- a/Misc/NEWS.d/next/Library/2019-05-04-19-31-42.bpo-34861.4Clo6Y.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-04-19-31-42.bpo-34861.4Clo6Y.rst
@@ -1,0 +1,1 @@
+Better cProfile CLI defaults. Add option -n to restrict to top n lines (defaults to 20 for CLI); set default of -s to sort by time (instead of unsorted).


### PR DESCRIPTION
adds option -n to restrict to top n lines (defaults to 20 for CLI)
set default of -s to sort by time (instead of unsorted)
makes "python3 -m cProfile foo.py" directly usable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34861](https://bugs.python.org/issue34861) -->
https://bugs.python.org/issue34861
<!-- /issue-number -->
