### PR TITLE
bpo-28269: Replace strcasecmp with system function stricmp

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-05-05-05-23-34.bpo-28269.-MOHI7.rst
+++ b/Misc/NEWS.d/next/Windows/2019-05-05-05-23-34.bpo-28269.-MOHI7.rst
@@ -1,0 +1,1 @@
+Replace strcasecmp with system function stricmp

--- a/Misc/NEWS.d/next/Windows/2019-05-05-05-23-34.bpo-28269.-MOHI7.rst
+++ b/Misc/NEWS.d/next/Windows/2019-05-05-05-23-34.bpo-28269.-MOHI7.rst
@@ -1,1 +1,1 @@
-Replace strcasecmp with system function stricmp
+Replace use of :c:func:`strcasecmp` for the system function :c:func:`_stricmp`. Patch by Minmin Gong.

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -279,7 +279,7 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
             import_python = GetPythonImport(hDLL);
 
             if (import_python &&
-                stricmp(buffer,import_python)) {
+                _stricmp(buffer,import_python)) {
                 PyErr_Format(PyExc_ImportError,
                              "Module use of %.150s conflicts "
                              "with this version of Python.",

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -38,24 +38,6 @@ const char *_PyImport_DynLoadFiletab[] = {
     NULL
 };
 
-/* Case insensitive string compare, to avoid any dependencies on particular
-   C RTL implementations */
-
-static int strcasecmp (const char *string1, const char *string2)
-{
-    int first, second;
-
-    do {
-        first  = tolower(*string1);
-        second = tolower(*string2);
-        string1++;
-        string2++;
-    } while (first && first == second);
-
-    return (first - second);
-}
-
-
 /* Function to return the name of the "python" DLL that the supplied module
    directly imports.  Looks through the list of imported modules and
    returns the first entry that starts with "python" (case sensitive) and
@@ -297,7 +279,7 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
             import_python = GetPythonImport(hDLL);
 
             if (import_python &&
-                strcasecmp(buffer,import_python)) {
+                stricmp(buffer,import_python)) {
                 PyErr_Format(PyExc_ImportError,
                              "Module use of %.150s conflicts "
                              "with this version of Python.",


### PR DESCRIPTION
The idea is from a comment in the issue. Replace strcasecmp in Python/dynload_win.c to posix stricmp,
1. MinGW can compile this file,
2. Don't need to maintain strcasecmp,
3. No #ifdef/#endif. The code is converged between compilers.


<!-- issue-number: [bpo-28269](https://bugs.python.org/issue28269) -->
https://bugs.python.org/issue28269
<!-- /issue-number -->
