### PR TITLE
bpo-36807: When saving a file in IDLE, call flush and fsync

### DIFF
--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -384,6 +384,8 @@ class IOBinding:
         try:
             with open(filename, "wb") as f:
                 f.write(chars)
+                f.flush()
+                os.fsync(f.fileno())
             return True
         except OSError as msg:
             tkMessageBox.showerror("I/O Error", str(msg),

--- a/Misc/NEWS.d/next/IDLE/2019-05-05-16-27-53.bpo-13102.AGNWYJ.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-05-05-16-27-53.bpo-13102.AGNWYJ.rst
@@ -1,0 +1,1 @@
+When saving a file, call os.flush() so bits are flushed to e.g. USB drive.


### PR DESCRIPTION
This came up during today's final PyCon keynote -- IDLE was called out
as one of the two editors *not* to use when live-coding on Adafruit's
Circuit Playground Express (https://www.adafruit.com/product/3333).

I *think* that the problem referred to is that IDLE doesn't guarantee
that the bits are actually flushed to disk -- they may linger in the
OS filesystem cache.  And I *think* this PR fixes the issue.

I've tested that this doesn't break things, but I don't have the right
cable around so I cannot test this with the hardware handed out to
PyCon attendees until Wednesday at the earliest.


<!-- issue-number: [bpo-36807](https://bugs.python.org/issue36807) -->
https://bugs.python.org/issue36807
<!-- /issue-number -->
