### PR TITLE
bpo-36811: Fix a C compiler warning.

### DIFF
--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1171,7 +1171,7 @@ checkpath(PyObject* tag)
         char *p = PyBytes_AS_STRING(tag);
         const Py_ssize_t len = PyBytes_GET_SIZE(tag);
         if (len >= 3 && p[0] == '{' && (
-                p[1] == '}' || p[1] == '*' && p[2] == '}')) {
+                p[1] == '}' || (p[1] == '*' && p[2] == '}'))) {
             /* wildcard: '{}tag' or '{*}tag' */
             return 1;
         }


### PR DESCRIPTION


<!-- issue-number: [bpo-36811](https://bugs.python.org/issue36811) -->
https://bugs.python.org/issue36811
<!-- /issue-number -->
