### PR TITLE
bpo-36778: Avoid functools in encodings.cp65001

### DIFF
--- a/Lib/encodings/cp65001.py
+++ b/Lib/encodings/cp65001.py
@@ -3,15 +3,14 @@ Code page 65001: Windows UTF-8 (CP_UTF8).
 """
 
 import codecs
-import functools
 
 if not hasattr(codecs, 'code_page_encode'):
     raise LookupError("cp65001 encoding is only available on Windows")
 
 ### Codec APIs
 
-encode = functools.partial(codecs.code_page_encode, 65001)
-_decode = functools.partial(codecs.code_page_decode, 65001)
+encode = lambda *args, **kw: codecs.code_page_encode(65001, *args, **kw)
+_decode = lambda *args, **kw: codecs.code_page_decode(65001, *args, **kw)
 
 def decode(input, errors='strict'):
     return codecs.code_page_decode(65001, input, errors, True)
@@ -21,13 +20,13 @@ class IncrementalEncoder(codecs.IncrementalEncoder):
         return encode(input, self.errors)[0]
 
 class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
-    _buffer_decode = _decode
+    _buffer_decode = staticmethod(_decode)
 
 class StreamWriter(codecs.StreamWriter):
-    encode = encode
+    encode = staticmethod(encode)
 
 class StreamReader(codecs.StreamReader):
-    decode = _decode
+    decode = staticmethod(_decode)
 
 ### encodings module API
 

--- a/Misc/NEWS.d/next/Library/2019-05-10-00-31-43.bpo-36778.Vgf2Cg.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-10-00-31-43.bpo-36778.Vgf2Cg.rst
@@ -1,0 +1,2 @@
+encodings.cp65001 (code page 65001, CP_UTF8) implementation now avoids
+functools.partial() to reduce the number of imports at startup.


### PR DESCRIPTION
Replace functools.partial() with lambda to reduce the number of
imports at startup. Avoid the following imports at startup:

- _collections
- _functools
- _heapq
- _operator
- collections
- functools
- heapq
- itertools
- keyword
- operator
- reprlib

<!-- issue-number: [bpo-36778](https://bugs.python.org/issue36778) -->
https://bugs.python.org/issue36778
<!-- /issue-number -->
