### PR TITLE
bpo-30668: add missing word in license.rst

### DIFF
--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -561,7 +561,7 @@ SipHash24
 ---------
 
 The file :file:`Python/pyhash.c` contains Marek Majkowski' implementation of
-Dan Bernstein's SipHash24 algorithm. The module contains the following note::
+Dan Bernstein's SipHash24 algorithm. It contains the following note::
 
   <MIT License>
   Copyright (c) 2013  Marek Majkowski <marek@popcount.org>

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -561,7 +561,7 @@ SipHash24
 ---------
 
 The file :file:`Python/pyhash.c` contains Marek Majkowski' implementation of
-Dan Bernstein's SipHash24 algorithm. The contains the following note::
+Dan Bernstein's SipHash24 algorithm. The module contains the following note::
 
   <MIT License>
   Copyright (c) 2013  Marek Majkowski <marek@popcount.org>


### PR DESCRIPTION


<!-- issue-number: [bpo-30668](https://bugs.python.org/issue30668) -->
https://bugs.python.org/issue30668
<!-- /issue-number -->
