### PR TITLE
bpo-36270: add link to traceback object reference in sys.exc_info docs

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -281,7 +281,7 @@ always available.
    ``(type, value, traceback)``.  Their meaning is: *type* gets the type of the
    exception being handled (a subclass of :exc:`BaseException`); *value* gets
    the exception instance (an instance of the exception type); *traceback* gets
-   a traceback object (see the Reference Manual) which encapsulates the call
+   a traceback object (see :ref:`Reference Manual <traceback-objects>`) which encapsulates the call
    stack at the point where the exception originally occurred.
 
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -281,7 +281,7 @@ always available.
    ``(type, value, traceback)``.  Their meaning is: *type* gets the type of the
    exception being handled (a subclass of :exc:`BaseException`); *value* gets
    the exception instance (an instance of the exception type); *traceback* gets
-   a traceback object (see :ref:`Reference Manual <traceback-objects>`) which encapsulates the call
+   a :ref:`traceback object <traceback-objects>` which encapsulates the call
    stack at the point where the exception originally occurred.
 
 

--- a/Misc/NEWS.d/next/Documentation/2019-05-06-17-35-13.bpo-36270.l57NHN.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-05-06-17-35-13.bpo-36270.l57NHN.rst
@@ -1,1 +1,0 @@
-Add a link pointing to the traceback object reference documentation in the sys.exc_info return value documentation block.

--- a/Misc/NEWS.d/next/Documentation/2019-05-06-17-35-13.bpo-36270.l57NHN.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-05-06-17-35-13.bpo-36270.l57NHN.rst
@@ -1,0 +1,1 @@
+Add a link pointing to the traceback object reference documentation in the sys.exc_info return value documentation block.


### PR DESCRIPTION
Add a link pointing to the traceback object reference documentation
in the sys.exc_info return value documentation block.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36270](https://bugs.python.org/issue36270) -->
https://bugs.python.org/issue36270
<!-- /issue-number -->
