### PR TITLE
bpo-36165 Fix rst formatting for several links in ssl documentation

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -665,7 +665,7 @@ Constants
 
 .. data:: PROTOCOL_SSLv23
 
-   Alias for data:`PROTOCOL_TLS`.
+   Alias for :data:`PROTOCOL_TLS`.
 
    .. deprecated:: 3.6
 
@@ -1821,7 +1821,7 @@ to speed up repeated connections from the same clients.
 
 .. attribute:: SSLContext.sslsocket_class
 
-   The return type of :meth:`SSLContext.wrap_sockets`, defaults to
+   The return type of :meth:`SSLContext.wrap_socket`, defaults to
    :class:`SSLSocket`. The attribute can be overridden on instance of class
    in order to return a custom subclass of :class:`SSLSocket`.
 
@@ -1831,7 +1831,7 @@ to speed up repeated connections from the same clients.
                                 server_hostname=None, session=None)
 
    Wrap the BIO objects *incoming* and *outgoing* and return an instance of
-   attr:`SSLContext.sslobject_class` (default :class:`SSLObject`). The SSL
+   :attr:`SSLContext.sslobject_class` (default :class:`SSLObject`). The SSL
    routines will read input data from the incoming BIO and write data to the
    outgoing BIO.
 


### PR DESCRIPTION
* The formatting for ssl.PROTOCOL_SSLv23 and ssl.SSLContext.wrap_bio was
  missing a colon so they weren't properly formatted as links.

* Corrected link SSLContext.wrap_socket() to be singular instead of plural

Fixes https://bugs.python.org/issue36165

<!-- issue-number: [bpo-36165](https://bugs.python.org/issue36165) -->
https://bugs.python.org/issue36165
<!-- /issue-number -->
