### PR TITLE
bpo-36819: Fix out-of-bounds writes in encoders

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -531,6 +531,26 @@ class UTF32Test(ReadTest, unittest.TestCase):
         self.assertEqual('\U00010000' * 1024,
                          codecs.utf_32_decode(encoded_be)[0])
 
+    def test_bug36819(self):
+        class State():
+            num = []
+
+            def __init__(self):
+                self.num.append(None)
+
+            def check(self):
+                return len(self.num)
+
+        def err(exc):
+            state = State()
+            # The interpreter should segfault after a handful of attempts.
+            # 50 was chosen to try to ensure a segfault without a fix,
+            # but not OOM a machine with one.
+            return ("a", exc.end if state.check() == 50 else exc.start)
+
+        codecs.register_error("err", err)
+        codecs.utf_32_encode("\udc80", "err")
+
 
 class UTF32LETest(ReadTest, unittest.TestCase):
     encoding = "utf-32-le"
@@ -709,6 +729,26 @@ class UTF16Test(ReadTest, unittest.TestCase):
             reader = codecs.open(support.TESTFN, 'U', encoding=self.encoding)
         with reader:
             self.assertEqual(reader.read(), s1)
+
+    def test_bug36819(self):
+        class State():
+            num = []
+
+            def __init__(self):
+                self.num.append(None)
+
+            def check(self):
+                return len(self.num)
+
+        def err(exc):
+            state = State()
+            # The interpreter should segfault after a handful of attempts.
+            # 50 was chosen to try to ensure a segfault without a fix,
+            # but not OOM a machine with one.
+            return ("a", exc.end if state.check() == 50 else exc.start)
+
+        codecs.register_error("err", err)
+        codecs.utf_16_encode("\udc80", "err")
 
 class UTF16LETest(ReadTest, unittest.TestCase):
     encoding = "utf-16-le"

--- a/Misc/NEWS.d/next/Security/2019-05-06-20-58-09.bpo-36819.a58LPK.rst
+++ b/Misc/NEWS.d/next/Security/2019-05-06-20-58-09.bpo-36819.a58LPK.rst
@@ -1,0 +1,3 @@
+Fix utf-16 and utf-32 encoders to properly re-size their output buffers
+and prevent writing to un-allocated memory when dispatching to a general
+error handler. Patch by Andrei Talaba.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -5628,14 +5628,14 @@ _PyUnicode_EncodeUTF32(PyObject *str,
         }
 
         /* four bytes are reserved for each surrogate */
-        if (moreunits > 1) {
+        if (moreunits) {
             Py_ssize_t outpos = out - (uint32_t*) PyBytes_AS_STRING(v);
             if (moreunits >= (PY_SSIZE_T_MAX - PyBytes_GET_SIZE(v)) / 4) {
                 /* integer overflow */
                 PyErr_NoMemory();
                 goto error;
             }
-            if (_PyBytes_Resize(&v, PyBytes_GET_SIZE(v) + 4 * (moreunits - 1)) < 0)
+            if (_PyBytes_Resize(&v, PyBytes_GET_SIZE(v) + 4 * moreunits) < 0)
                 goto error;
             out = (uint32_t*) PyBytes_AS_STRING(v) + outpos;
         }
@@ -5980,14 +5980,14 @@ _PyUnicode_EncodeUTF16(PyObject *str,
         }
 
         /* two bytes are reserved for each surrogate */
-        if (moreunits > 1) {
+        if (moreunits) {
             Py_ssize_t outpos = out - (unsigned short*) PyBytes_AS_STRING(v);
             if (moreunits >= (PY_SSIZE_T_MAX - PyBytes_GET_SIZE(v)) / 2) {
                 /* integer overflow */
                 PyErr_NoMemory();
                 goto error;
             }
-            if (_PyBytes_Resize(&v, PyBytes_GET_SIZE(v) + 2 * (moreunits - 1)) < 0)
+            if (_PyBytes_Resize(&v, PyBytes_GET_SIZE(v) + 2 * moreunits) < 0)
                 goto error;
             out = (unsigned short*) PyBytes_AS_STRING(v) + outpos;
         }


### PR DESCRIPTION
The utf_16 and utf_32 encoders (found in _PyUnicode_EncodeUTF16 and
_PyUnicode_EncodeUTF32, respectively) don't properly re-size the output
buffer. This leads to out-of-bounds writes, and segfaults.

This change ensures that the encoder will re-allocate the buffer even
when the general error handler only writes one codepoint, and will
allocate enough extra memory to fit the full result.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36819](https://bugs.python.org/issue36819) -->
https://bugs.python.org/issue36819
<!-- /issue-number -->
