### PR TITLE
bpo-33110: Catches errors raised when running add_done_callback on already completed futures.

### DIFF
--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -404,7 +404,10 @@ class Future(object):
             if self._state not in [CANCELLED, CANCELLED_AND_NOTIFIED, FINISHED]:
                 self._done_callbacks.append(fn)
                 return
-        fn(self)
+        try:
+            fn(self)
+        except Exception:
+            LOGGER.exception('exception calling callback for %r', self)
 
     def result(self, timeout=None):
         """Return the result of the call that the future represents.

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -1092,7 +1092,6 @@ class FutureTests(BaseTestCase):
             f.set_result(5)
             f.add_done_callback(raising_fn)
 
-            # Verify the callback exception was caught
             self.assertIn('exception calling callback for', stderr.getvalue())
             self.assertIn('doh!', stderr.getvalue())
 

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -1080,6 +1080,23 @@ class FutureTests(BaseTestCase):
         f.add_done_callback(fn)
         self.assertTrue(was_cancelled)
 
+    def test_done_callback_raises_already_succeeded(self):
+        with test.support.captured_stderr() as stderr:
+            def raising_fn(callback_future):
+                raise Exception('doh!')
+
+            f = Future()
+
+            # Set the result first to simulate a future that runs instantly,
+            # effectively allowing the callback to be run immediately.
+            f.set_result(5)
+            f.add_done_callback(raising_fn)
+
+            # Verify the callback exception was caught
+            self.assertIn('exception calling callback for', stderr.getvalue())
+            self.assertIn('doh!', stderr.getvalue())
+
+
     def test_repr(self):
         self.assertRegex(repr(PENDING_FUTURE),
                          '<Future at 0x[0-9a-f]+ state=pending>')

--- a/Misc/NEWS.d/next/Library/2019-05-06-22-34-47.bpo-33110.rSJSCh.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-06-22-34-47.bpo-33110.rSJSCh.rst
@@ -1,0 +1,1 @@
+Adds error handling to concurrent.futures add_done_callback, so that callbacks triggered on futures added to already completed futures are handled in the same manner as callbacks attached to running futures are, when the future subsequently finishes.

--- a/Misc/NEWS.d/next/Library/2019-05-06-22-34-47.bpo-33110.rSJSCh.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-06-22-34-47.bpo-33110.rSJSCh.rst
@@ -1,1 +1,1 @@
-Adds error handling to concurrent.futures add_done_callback, so that callbacks triggered on futures added to already completed futures are handled in the same manner as callbacks attached to running futures are, when the future subsequently finishes.
+Handle exceptions raised by functions added by concurrent.futures add_done_callback correctly when the Future has already completed.


### PR DESCRIPTION
Wraps the callback call within the `add_done_callback` function within concurrent.futures, in order to behave in an identical manner to callbacks added to a running future are triggered once it has completed.

Prior to this change, adding a callback to a future which has already completed, which raises, will allow that exception to raise, where running that callback later (i.e. once a future completes), wraps the callback execution in a `try..except` statement.  This pull request matches that behavior for callbacks added to an already complete future.

I feel this brings the `add_done_callback` behavior inline with the documentation.  I have added a unit test alongside this change which demonstrates the behavior.

Please let me know if there's anything I need to tweak here etc.

<!-- issue-number: [bpo-33110](https://bugs.python.org/issue33110) -->
https://bugs.python.org/issue33110
<!-- /issue-number -->
