### PR TITLE
bpo-36684: Split out gcc and test coverage builds for better results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,9 @@ matrix:
     - os: linux
       language: c
       compiler: clang
-      env: TESTING=cpython
-      addons:
-        apt:
-          packages:
-            - xvfb
-    - os: linux
-      language: c
-      compiler: gcc
+      # gcc also works, but to keep the # of concurrent builds down, we use one C
+      # compiler here and the other to run the coverage build. Clang is preferred
+      # in this instance for its better error messages.
       env: TESTING=cpython
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,14 @@ matrix:
     - os: linux
       language: c
       compiler: clang
-      # gcc also works, but to keep the # of concurrent builds down, we use one C
-      # compiler here and the other to run the coverage build. Clang is preferred
-      # in this instance for its better error messages.
+      env: TESTING=cpython
+      addons:
+        apt:
+          packages:
+            - xvfb
+    - os: linux
+      language: c
+      compiler: gcc
       env: TESTING=cpython
       addons:
         apt:
@@ -86,22 +91,36 @@ matrix:
       addons:
         apt:
           packages:
-            - lcov
             - xvfb
       before_script:
         - ./configure
-        - make coverage -s -j4
+        - make -j4
         # Need a venv that can parse covered code.
         - ./python -m venv venv
         - ./venv/bin/python -m pip install -U coverage
         - ./venv/bin/python -m test.pythoninfo
       script:
         # Skip tests that re-run the entire test suite.
-        - xvfb-run ./venv/bin/python -m coverage run --pylib -m test --fail-env-changed -uall,-cpu -x test_multiprocessing_fork -x test_multiprocessing_forkserver -x test_multiprocessing_spawn -x test_concurrent_futures
+        - xvfb-run ./venv/bin/python -m coverage run --branch --pylib -m test --fail-env-changed -uall,-cpu -x test_multiprocessing_fork -x test_multiprocessing_forkserver -x test_multiprocessing_spawn -x test_concurrent_futures || true
       after_script:  # Probably should be after_success once test suite updated to run under coverage.py.
         # Make the `coverage` command available to Codecov w/ a version of Python that can parse all source files.
         - source ./venv/bin/activate
-        - make coverage-lcov
+        - bash <(curl -s https://codecov.io/bash)
+    - os: linux
+      language: c
+      compiler: gcc
+      env: OPTIONAL=true
+      addons:
+        apt:
+          packages:
+            - lcov
+            - xvfb
+      before_script:
+        - ./configure
+      script:
+        - xvfb-run make -j4 coverage-report
+      after_script:  # Probably should be after_success once test suite updated to run under coverage.py.
+        - make pythoninfo
         - bash <(curl -s https://codecov.io/bash)
 
 


### PR DESCRIPTION
The optional test coverage builds shouldn't be relied upon to certify
that gcc builds don't fail.

The combined Python and C coverage test runs now exceed Travis's
50-minute time limit. Splitting them into separate runs gives more
leeway.

Also, adding branch coverage to Python testing and ensure that
coverage is reported even if tests fail. (The primary builds are
for tracking test failures.)

<!-- issue-number: [bpo-36684](https://bugs.python.org/issue36684) -->
https://bugs.python.org/issue36684
<!-- /issue-number -->
