### PR TITLE
bpo-34616: add flags to allow top-level-await 

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -257,6 +257,12 @@ are always available.  They are listed here in alphabetical order.
    can be found as the :attr:`~__future__._Feature.compiler_flag` attribute on
    the :class:`~__future__._Feature` instance in the :mod:`__future__` module.
 
+   The optional argument *flags* also control wether the compiled source is
+   allowed to contain top-level ``await``, ``async for`` and ``async with``.
+   When the bit ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` is set, the the return code
+   object has ``CO_COROUTINE`` set in ``co_code``, and can be interacitvely
+   executed via ``yield from eval(code_object)``.
+
    The argument *optimize* specifies the optimization level of the compiler; the
    default value of ``-1`` selects the optimization level of the interpreter as
    given by :option:`-O` options.  Explicit levels are ``0`` (no optimization;
@@ -289,6 +295,10 @@ are always available.  They are listed here in alphabetical order.
    .. versionchanged:: 3.5
       Previously, :exc:`TypeError` was raised when null bytes were encountered
       in *source*.
+
+   .. versionadded:: 3.8
+      *flags* can now be used to accept source that would contain a top-level
+      ``await``, ``async for`` or ``async with``.
 
 
 .. class:: complex([real[, imag]])

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -257,10 +257,10 @@ are always available.  They are listed here in alphabetical order.
    can be found as the :attr:`~__future__._Feature.compiler_flag` attribute on
    the :class:`~__future__._Feature` instance in the :mod:`__future__` module.
 
-   The optional argument *flags* also control wether the compiled source is
+   The optional argument *flags* also controls whether the compiled source is
    allowed to contain top-level ``await``, ``async for`` and ``async with``.
    When the bit ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` is set, the the return code
-   object has ``CO_COROUTINE`` set in ``co_code``, and can be interacitvely
+   object has ``CO_COROUTINE`` set in ``co_code``, and can be interactively
    executed via ``yield from eval(code_object)``.
 
    The argument *optimize* specifies the optimization level of the compiler; the

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -297,8 +297,8 @@ are always available.  They are listed here in alphabetical order.
       in *source*.
 
    .. versionadded:: 3.8
-      *flags* can now be used to accept source that would contain a top-level
-      ``await``, ``async for`` or ``async with``.
+      ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` can now be passed in flags to enable
+      support for top-level await, async for, and async with.
 
 
 .. class:: complex([real[, imag]])

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -259,7 +259,7 @@ are always available.  They are listed here in alphabetical order.
 
    The optional argument *flags* also controls whether the compiled source is
    allowed to contain top-level ``await``, ``async for`` and ``async with``.
-   When the bit ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` is set, the the return code
+   When the bit ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` is set, the return code
    object has ``CO_COROUTINE`` set in ``co_code``, and can be interactively
    executed via ``await eval(code_object)``.
 
@@ -298,7 +298,7 @@ are always available.  They are listed here in alphabetical order.
 
    .. versionadded:: 3.8
       ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` can now be passed in flags to enable
-      support for top-level await, async for, and async with.
+      support for top-level ``await``, ``async for``, and ``async with``.
 
 
 .. class:: complex([real[, imag]])

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -261,7 +261,7 @@ are always available.  They are listed here in alphabetical order.
    allowed to contain top-level ``await``, ``async for`` and ``async with``.
    When the bit ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` is set, the the return code
    object has ``CO_COROUTINE`` set in ``co_code``, and can be interactively
-   executed via ``yield from eval(code_object)``.
+   executed via ``await eval(code_object)``.
 
    The argument *optimize* specifies the optimization level of the compiler; the
    default value of ``-1`` selects the optimization level of the interpreter as

--- a/Include/compile.h
+++ b/Include/compile.h
@@ -23,7 +23,7 @@ PyAPI_FUNC(PyCodeObject *) PyNode_Compile(struct _node *, const char *);
 #define PyCF_ONLY_AST 0x0400
 #define PyCF_IGNORE_COOKIE 0x0800
 #define PyCF_TYPE_COMMENTS 0x1000
-#define PyCF_AWAIT 0x2000
+#define PyCF_ALLOW_TOP_LEVEL_AWAIT 0x2000
 
 #ifndef Py_LIMITED_API
 typedef struct {

--- a/Include/compile.h
+++ b/Include/compile.h
@@ -23,6 +23,7 @@ PyAPI_FUNC(PyCodeObject *) PyNode_Compile(struct _node *, const char *);
 #define PyCF_ONLY_AST 0x0400
 #define PyCF_IGNORE_COOKIE 0x0800
 #define PyCF_TYPE_COMMENTS 0x1000
+#define PyCF_AWAIT 0x2000
 
 #ifndef Py_LIMITED_API
 typedef struct {

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -386,6 +386,10 @@ class BuiltinTest(unittest.TestCase):
                              msg='source={!r} mode={!r})'.format(source, mode))
 
     def test_compile_async_generator(self):
+        """
+        With the PyCF_ALLOW_TOP_LEVEL_AWAIT flag added in 3.8, we want to
+        make sure AsyncGenerators are still properly not marked with CO_COROUTINE
+        """
         co = compile(dedent("""async def ticker():
                 for i in range(10):
                     yield i

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -372,7 +372,7 @@ class BuiltinTest(unittest.TestCase):
                                   msg='source={!r} mode={!r})'.format(source, mode)):
                     compile(source, '?' , mode)
                 co = compile(source, '?', mode, flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
-                self.assertEqual(co.co_flags & CO_COROUTINE, CO_COROUTINE)
+                self.assertEqual(co.co_flags & CO_COROUTINE, CO_COROUTINE, msg='source={!r} mode={!r})'.format(source, mode))
 
     def test_compile_async_generator(self):
         co = compile(dedent("""async def ticker():

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -20,6 +20,7 @@ import warnings
 from contextlib import ExitStack
 from inspect import CO_COROUTINE
 from textwrap import dedent
+from types import AsyncGeneratorType
 from operator import neg
 from test.support import (
     EnvironmentVarGuard, TESTFN, check_warnings, swap_attr, unlink)
@@ -371,8 +372,10 @@ class BuiltinTest(unittest.TestCase):
                 with self.assertRaises(SyntaxError,
                                   msg='source={!r} mode={!r})'.format(source, mode)):
                     compile(source, '?' , mode)
+
                 co = compile(source, '?', mode, flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
-                self.assertEqual(co.co_flags & CO_COROUTINE, CO_COROUTINE, msg='source={!r} mode={!r})'.format(source, mode))
+                self.assertEqual(co.co_flags & CO_COROUTINE, CO_COROUTINE,
+                                 msg='source={!r} mode={!r})'.format(source, mode))
 
     def test_compile_async_generator(self):
         co = compile(dedent("""async def ticker():
@@ -381,9 +384,6 @@ class BuiltinTest(unittest.TestCase):
                     await asyncio.sleep(0)"""), '?', 'exec', flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
         glob = {}
         exec(co, glob)
-
-        from types import AsyncGeneratorType
-
         self.assertEqual(type(glob['ticker']()), AsyncGeneratorType)
 
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -377,9 +377,6 @@ class BuiltinTest(unittest.TestCase):
             for i in range(n):
                 yield i
 
-        async def async_exec(co, *args):
-            await eval(co, *args)
-
         modes = ('single', 'exec')
         code_samples = ['''a = await asyncio.sleep(0, result=1)''',
         '''async for i in arange(1):
@@ -410,7 +407,7 @@ class BuiltinTest(unittest.TestCase):
                 self.assertEqual(globals_['a'], 1)
 
                 globals_ = {'asyncio': asyncio, 'a':0, 'arange': arange}
-                asyncio.run(async_exec(co, globals_))
+                asyncio.run(eval(co, globals_))
                 self.assertEqual(globals_['a'], 1)
         except Exception:
             asyncio.set_event_loop_policy(policy)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -377,14 +377,13 @@ class BuiltinTest(unittest.TestCase):
                pass''']
         for mode, code_sample in product(modes,code_samples):
             source = dedent(code_sample)
-            msg = 'source={!r} mode={!r})'
-            with self.assertRaises(SyntaxError, msg=msg.format(source, mode)):
+            with self.assertRaises(SyntaxError, msg=f"{source=} {mode=}"):
                 compile(source, '?' , mode)
 
             co = compile(source, '?', mode, flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
 
             self.assertEqual(co.co_flags & CO_COROUTINE, CO_COROUTINE,
-                             msg=msg.format(source, mode))
+                             msg=f"{source=} {mode=}")
 
     def test_compile_async_generator(self):
         """

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -377,13 +377,14 @@ class BuiltinTest(unittest.TestCase):
                pass''']
         for mode, code_sample in product(modes,code_samples):
             source = dedent(code_sample)
-            with self.assertRaises(SyntaxError,
-                                   msg='source={!r} mode={!r})'.format(source, mode)):
+            msg = 'source={!r} mode={!r})'
+            with self.assertRaises(SyntaxError, msg=msg.format(source, mode)):
                 compile(source, '?' , mode)
 
             co = compile(source, '?', mode, flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+
             self.assertEqual(co.co_flags & CO_COROUTINE, CO_COROUTINE,
-                             msg='source={!r} mode={!r})'.format(source, mode))
+                             msg=msg.format(source, mode))
 
     def test_compile_async_generator(self):
         """

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -369,7 +369,8 @@ class BuiltinTest(unittest.TestCase):
 
         Make sure it compiles only with the PyCF_ALLOW_TOP_LEVEL_AWAIT flag set,
         and make sure the generated code object has the CO_COROUTINE flag set in
-        order to execute it with `yield from eval(.....)` instead of exec.
+        order to execute it with  `await eval(.....)` instead of exec, or via a
+        FunctionType.
         """
 
         # helper function just to check we can run top=level async-for
@@ -399,13 +400,13 @@ class BuiltinTest(unittest.TestCase):
                                  msg=f"{source=} {mode=}")
 
 
-                # test we can create and  advance a fucntion type
-
+                # test we can create and  advance a function type
                 globals_ = {'asyncio': asyncio, 'a':0, 'arange': arange}
                 async_f = FunctionType(co, globals_)
                 asyncio.run(async_f())
                 self.assertEqual(globals_['a'], 1)
 
+                # test we can await-eval,
                 globals_ = {'asyncio': asyncio, 'a':0, 'arange': arange}
                 asyncio.run(eval(co, globals_))
                 self.assertEqual(globals_['a'], 1)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -410,9 +410,8 @@ class BuiltinTest(unittest.TestCase):
                 globals_ = {'asyncio': asyncio, 'a':0, 'arange': arange}
                 asyncio.run(eval(co, globals_))
                 self.assertEqual(globals_['a'], 1)
-        except Exception:
+        finally:
             asyncio.set_event_loop_policy(policy)
-            raise
 
     def test_compile_async_generator(self):
         """

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -390,10 +390,12 @@ class BuiltinTest(unittest.TestCase):
         With the PyCF_ALLOW_TOP_LEVEL_AWAIT flag added in 3.8, we want to
         make sure AsyncGenerators are still properly not marked with CO_COROUTINE
         """
-        co = compile(dedent("""async def ticker():
+        code = dedent("""async def ticker():
                 for i in range(10):
                     yield i
-                    await asyncio.sleep(0)"""), '?', 'exec', flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+                    await asyncio.sleep(0)""")
+
+        co = compile(code, '?', 'exec', flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
         glob = {}
         exec(co, glob)
         self.assertEqual(type(glob['ticker']()), AsyncGeneratorType)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-07-17-12-37.bpo-34616.0Y0_9r.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-07-17-12-37.bpo-34616.0Y0_9r.rst
@@ -1,0 +1,1 @@
+The ``compile()`` builtin functions now support the ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` flag,  which allow to compile sources that  contains top-level ``await``, ``async with`` or ``async for``. This is useful to evaluate async-code from with an already async functions; for example in a custom REPL.

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1000,6 +1000,8 @@ class ASTModuleVisitor(PickleVisitor):
         self.emit("if (!m) return NULL;", 1)
         self.emit("d = PyModule_GetDict(m);", 1)
         self.emit('if (PyDict_SetItemString(d, "AST", (PyObject*)&AST_type) < 0) return NULL;', 1)
+        self.emit('if (PyModule_AddIntMacro(m, PyCF_ALLOW_TOP_LEVEL_AWAIT) < 0)', 1)
+        self.emit("return NULL;", 2)
         self.emit('if (PyModule_AddIntMacro(m, PyCF_ONLY_AST) < 0)', 1)
         self.emit("return NULL;", 2)
         self.emit('if (PyModule_AddIntMacro(m, PyCF_TYPE_COMMENTS) < 0)', 1)

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -8776,6 +8776,8 @@ PyInit__ast(void)
     if (!m) return NULL;
     d = PyModule_GetDict(m);
     if (PyDict_SetItemString(d, "AST", (PyObject*)&AST_type) < 0) return NULL;
+    if (PyModule_AddIntMacro(m, PyCF_ALLOW_TOP_LEVEL_AWAIT) < 0)
+        return NULL;
     if (PyModule_AddIntMacro(m, PyCF_ONLY_AST) < 0)
         return NULL;
     if (PyModule_AddIntMacro(m, PyCF_TYPE_COMMENTS) < 0)

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5720,7 +5720,9 @@ compute_code_flags(struct compiler *c)
     /* (Only) inherit compilerflags in PyCF_MASK */
     flags |= (c->c_flags->cf_flags & PyCF_MASK);
 
-    if ((c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT) && ste->ste_coroutine && !ste->ste_generator) {
+    if ((c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT) &&
+         ste->ste_coroutine &&
+         !ste->ste_generator) {
         flags |= CO_COROUTINE;
     }
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2609,9 +2609,12 @@ static int
 compiler_async_for(struct compiler *c, stmt_ty s)
 {
     basicblock *start, *except, *end;
-    if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION) {
+    if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT){
+        c->u->u_ste->ste_coroutine = 1;
+    } else if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION) {
         return compiler_error(c, "'async for' outside async function");
     }
+
 
     start = compiler_new_block(c);
     except = compiler_new_block(c);
@@ -4564,10 +4567,10 @@ compiler_async_with(struct compiler *c, stmt_ty s, int pos)
     withitem_ty item = asdl_seq_GET(s->v.AsyncWith.items, pos);
 
     assert(s->kind == AsyncWith_kind);
-    if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION) {
-        if (!(c->c_flags->cf_flags & 0x2000)) {
-            return compiler_error(c, "'async with' outside async function");
-        }
+    if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT){
+        c->u->u_ste->ste_coroutine = 1;
+    } else if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION){
+        return compiler_error(c, "'async with' outside async function");
     }
 
     block = compiler_new_block(c);
@@ -4775,18 +4778,17 @@ compiler_visit_expr1(struct compiler *c, expr_ty e)
         ADDOP(c, YIELD_FROM);
         break;
     case Await_kind:
-        if (c->u->u_ste->ste_type != FunctionBlock) {
-            if (!(c->c_flags->cf_flags & 0x2000)) {
+        if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT){
+            c->u->u_ste->ste_coroutine = 1;
+        } else {
+            if (c->u->u_ste->ste_type != FunctionBlock){
                 return compiler_error(c, "'await' outside function");
             }
 
-            c->u->u_ste->ste_coroutine = 1;
-        }
-
-        if (!(c->c_flags->cf_flags & 0x2000)) {
-            if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION &&
-                    c->u->u_scope_type != COMPILER_SCOPE_COMPREHENSION)
+            if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION && 
+                    c->u->u_scope_type != COMPILER_SCOPE_COMPREHENSION){
                 return compiler_error(c, "'await' outside async function");
+            }
         }
 
         VISIT(c, expr, e->v.Await.value);
@@ -5721,7 +5723,7 @@ compute_code_flags(struct compiler *c)
     /* (Only) inherit compilerflags in PyCF_MASK */
     flags |= (c->c_flags->cf_flags & PyCF_MASK);
 
-    if ((c->c_flags->cf_flags & 0x2000) && c->u->u_ste->ste_coroutine) {
+    if ((c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT) && ste->ste_coroutine && !ste->ste_generator) {
         flags |= CO_COROUTINE;
     }
 

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4567,8 +4567,9 @@ compiler_async_with(struct compiler *c, stmt_ty s, int pos)
     withitem_ty item = asdl_seq_GET(s->v.AsyncWith.items, pos);
 
     assert(s->kind == AsyncWith_kind);
-    if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION &&
-        !(c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT)){
+    if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT){
+        c->u->u_ste->ste_coroutine = 1;
+    } else if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION){
         return compiler_error(c, "'async with' outside async function");
     }
 
@@ -4777,7 +4778,7 @@ compiler_visit_expr1(struct compiler *c, expr_ty e)
         ADDOP(c, YIELD_FROM);
         break;
     case Await_kind:
-        if (! (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT)){
+        if (!(c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT)){
             if (c->u->u_ste->ste_type != FunctionBlock){
                 return compiler_error(c, "'await' outside function");
             }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4567,9 +4567,8 @@ compiler_async_with(struct compiler *c, stmt_ty s, int pos)
     withitem_ty item = asdl_seq_GET(s->v.AsyncWith.items, pos);
 
     assert(s->kind == AsyncWith_kind);
-    if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT){
-        c->u->u_ste->ste_coroutine = 1;
-    } else if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION){
+    if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION &&
+        !(c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT)){
         return compiler_error(c, "'async with' outside async function");
     }
 
@@ -4778,9 +4777,7 @@ compiler_visit_expr1(struct compiler *c, expr_ty e)
         ADDOP(c, YIELD_FROM);
         break;
     case Await_kind:
-        if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT){
-            c->u->u_ste->ste_coroutine = 1;
-        } else {
+        if (! (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT)){
             if (c->u->u_ste->ste_type != FunctionBlock){
                 return compiler_error(c, "'await' outside function");
             }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2615,7 +2615,6 @@ compiler_async_for(struct compiler *c, stmt_ty s)
         return compiler_error(c, "'async for' outside async function");
     }
 
-
     start = compiler_new_block(c);
     except = compiler_new_block(c);
     end = compiler_new_block(c);


### PR DESCRIPTION
Based on a work with @1st1 during PyCon 2019; and can be seen used in https://github.com/ipython/ipython/pull/11713 (which would dramatically reduce thee complexity and shave an extra few hundreds lines of IPython if we were supporting 3.8+ only).

<!-- issue-number: [bpo-34616](https://bugs.python.org/issue34616) -->
https://bugs.python.org/issue34616
<!-- /issue-number -->
