### PR TITLE
gh-68451: Fix unittest to discover tests named with non-ascii characters

### DIFF
--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -29,6 +29,12 @@ class _FailedTest(case.TestCase):
         return testFailure
 
 
+def _is_valid_module_filename(module_filename):
+    root, ext = os.path.splitext(module_filename)
+    if not (ext == '.py' and root.isidentifier()):
+        return False
+    return True
+
 def _make_failed_import_test(name, suiteClass):
     message = 'Failed to import test module: %s\n%s' % (
         name, traceback.format_exc())
@@ -366,8 +372,7 @@ class TestLoader(object):
         """
         basename = os.path.basename(full_path)
         if os.path.isfile(full_path):
-            root, ext = os.path.splitext(basename)
-            if not (ext == '.py' and root.isidentifier()):
+            if not _is_valid_module_filename(basename):
                 # valid Python identifiers only
                 return None, False
             if not self._match_path(basename, full_path, pattern):

--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -371,9 +371,15 @@ class TestLoader(object):
         """
         basename = os.path.basename(full_path)
         if os.path.isfile(full_path):
-            if not VALID_MODULE_NAME.match(basename):
-                # valid Python identifiers only
-                return None, False
+            root, ext = os.path.splitext(basename)
+            try:
+                if not (ext == '.py' and root.isidentifier()):
+                    # valid Python identifiers only
+                    return None, False
+            except AttributeError:
+                if not VALID_MODULE_NAME.match(basename):
+                    # valid Python identifiers only
+                    return None, False
             if not self._match_path(basename, full_path, pattern):
                 return None, False
             # if the test file matches, load it

--- a/Misc/NEWS.d/next/Library/2019-05-06-20-58-23.bpo-24263.BTKuFc.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-06-20-58-23.bpo-24263.BTKuFc.rst
@@ -1,0 +1,2 @@
+Fix unittest test discovery to find tests in files and directories with
+non-ascii characters in their filename


### PR DESCRIPTION
This is a continuation of https://github.com/python/cpython/pull/1338 from @louisom which is itself based on a patch in the bpo issue tracker from```sih4sing5hong5```.

In addition to rebasing louisom's work to current master, I've done some work to address comments on the earlier code:

* I've added some comments to explain both the test data and why the AttributeError catching is present (it is to enable backporting to the externally maintained unittest package) which is something that @serhiy-storchaka was wondering about in an earlier review: https://bugs.python.org/review/24263/diff/15147/Lib/unittest/loader.py#newcode425

* @rbtcollins reviewed the earlier attempt and said:
> it looks for isidentifier on $thing.py, but not on just $thing (which we need to do to handle packages, vs modules).

I've addressed that by adding a test using isidentifier() in the isdirectory section of the conditional: https://github.com/python/cpython/pull/13149/files#diff-c1c31e722f730423a5e6dcc3eb6eef67R471

and adding directory names which are not valid identifiers (but have ```__init__.py``` inside of them) to the test cases.


<!-- issue-number: [bpo-24263](https://bugs.python.org/issue24263) -->
https://bugs.python.org/issue24263
<!-- /issue-number -->

<!-- gh-issue-number: gh-68451 -->
* Issue: gh-68451
<!-- /gh-issue-number -->
