### PR TITLE
bpo-27639: Slices of UserLists are instances of UserList now.

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1072,7 +1072,7 @@ class UserList(_collections_abc.MutableSequence):
             if type(initlist) == type(self.data):
                 self.data[:] = initlist
             elif isinstance(initlist, UserList):
-                self.data[:] = initlist.data[:]
+                self.data[:] = initlist.data
             else:
                 self.data = list(initlist)
     def __repr__(self): return repr(self.data)
@@ -1085,8 +1085,16 @@ class UserList(_collections_abc.MutableSequence):
         return other.data if isinstance(other, UserList) else other
     def __contains__(self, item): return item in self.data
     def __len__(self): return len(self.data)
-    def __getitem__(self, i): return self.data[i]
-    def __setitem__(self, i, item): self.data[i] = item
+    def __getitem__(self, i):
+        if isinstance(i, slice):
+            return self.__class__(self.data[i])
+        else:
+            return self.data[i]
+    def __setitem__(self, i, item):
+        if isinstance(i, slice) and isinstance(item, UserList):
+            self.data[i] = item.data
+        else:
+            self.data[i] = item
     def __delitem__(self, i): del self.data[i]
     def __add__(self, other):
         if isinstance(other, UserList):

--- a/Lib/test/test_userlist.py
+++ b/Lib/test/test_userlist.py
@@ -17,6 +17,14 @@ class UserListTest(list_tests.CommonTest):
             for j in range(-3, 6):
                 self.assertEqual(u[i:j], l[i:j])
 
+    def test_slice_type(self):
+        l = [0, 1, 2, 3, 4]
+        u = self.type2test(l)
+        self.assertIsInstance(u[:], self.type2test)
+        self.assertEqual(u[:], l)
+        self.assertIsInstance(u[::-1], self.type2test)
+        self.assertEqual(u[::-1], l[::-1])
+
     def test_add_specials(self):
         u = UserList("spam")
         u2 = u + "eggs"

--- a/Misc/NEWS.d/next/Library/2017-12-22-21-35-25.bpo-27639.ely6aI.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-22-21-35-25.bpo-27639.ely6aI.rst
@@ -1,0 +1,2 @@
+Slices of :class:`collections.UserList` objects are now instances of ``UserList``
+or its subclasses.  Patch by Dmitry Kazakov.


### PR DESCRIPTION
Patch by Dmitry Kazakov.



<!-- issue-number: [bpo-27639](https://bugs.python.org/issue27639) -->
https://bugs.python.org/issue27639
<!-- /issue-number -->
