### PR TITLE
bpo-28866: No type cache for types with specialized mro, invalidation is hard.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-08-16-36-51.bpo-28866.qCv_bj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-08-16-36-51.bpo-28866.qCv_bj.rst
@@ -1,0 +1,2 @@
+Avoid caching attributes of classes which type defines mro() to avoid a hard
+cache invalidation problem.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -78,6 +78,9 @@ slot_tp_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 static void
 clear_slotdefs(void);
 
+static PyObject *
+lookup_method(PyObject *self, _Py_Identifier *attrid, int *unbound);
+
 /*
  * finds the beginning of the docstring's introspection signature.
  * if present, returns a pointer pointing to the first '('.
@@ -300,9 +303,11 @@ type_mro_modified(PyTypeObject *type, PyObject *bases) {
         return;
 
     if (custom) {
+        _Py_IDENTIFIER(mro);
+        int unbound;
         PyObject *mro_meth = lookup_method((PyObject *)type, &PyId_mro,
                                            &unbound);
-        PyObject *type_mro_meth = lookup_method(&PyType_Type, &PyId_mro,
+        PyObject *type_mro_meth = lookup_method((PyObject *)&PyType_Type, &PyId_mro,
                                            &unbound);
         if (mro_meth == NULL || type_mro_meth == NULL ||
             mro_meth != type_mro_meth)

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1925,6 +1925,8 @@ mro_invoke(PyTypeObject *type)
                                            &unbound);
         if (mro_meth == NULL)
             return NULL;
+        type->tp_flags &= ~(Py_TPFLAGS_HAVE_VERSION_TAG|
+                            Py_TPFLAGS_VALID_VERSION_TAG);
         mro_result = call_unbound_noarg(unbound, mro_meth, (PyObject *)type);
         Py_DECREF(mro_meth);
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -79,7 +79,7 @@ static void
 clear_slotdefs(void);
 
 static PyObject *
-lookup_method(PyObject *self, _Py_Identifier *attrid, int *unbound);
+lookup_maybe_method(PyObject *self, _Py_Identifier *attrid, int *unbound);
 
 /*
  * finds the beginning of the docstring's introspection signature.
@@ -305,13 +305,19 @@ type_mro_modified(PyTypeObject *type, PyObject *bases) {
     if (custom) {
         _Py_IDENTIFIER(mro);
         int unbound;
-        PyObject *mro_meth = lookup_method((PyObject *)type, &PyId_mro,
-                                           &unbound);
-        PyObject *type_mro_meth = lookup_method((PyObject *)&PyType_Type, &PyId_mro,
-                                           &unbound);
+        PyObject *mro_meth = lookup_maybe_method(
+            (PyObject *)type, &PyId_mro, &unbound);
+        PyObject *type_mro_meth = lookup_maybe_method(
+            (PyObject *)&PyType_Type, &PyId_mro, &unbound);
         if (mro_meth == NULL || type_mro_meth == NULL ||
             mro_meth != type_mro_meth)
+        {
             clear = 1;
+        }
+        if (mro_meth != NULL)
+            Py_DECREF(mro_meth);
+        if (type_mro_meth != NULL)
+            Py_DECREF(type_mro_meth);
     }
     if (!clear) {
         n = PyTuple_GET_SIZE(bases);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -316,6 +316,8 @@ type_mro_modified(PyTypeObject *type, PyObject *bases) {
             goto clear;
         if (mro_meth != type_mro_meth)
             goto clear;
+        Py_XDECREF(mro_meth);
+        Py_XDECREF(type_mro_meth);
     }
     n = PyTuple_GET_SIZE(bases);
     for (i = 0; i < n; i++) {


### PR DESCRIPTION
This is an alternative implementation of https://github.com/python/cpython/pull/13117 based on @markshannon idea (https://bugs.python.org/issue28866#msg341581).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-28866](https://bugs.python.org/issue28866) -->
https://bugs.python.org/issue28866
<!-- /issue-number -->
