### PR TITLE
subinterpreters: FIX a memory leak

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -20,6 +20,7 @@ extern int _Py_SetFileSystemEncoding(
     const char *errors);
 extern void _Py_ClearFileSystemEncoding(void);
 extern PyStatus _PyUnicode_InitEncodings(PyThreadState *tstate);
+extern void _PyUnicode_FiniEncodings(PyThreadState *tstate);
 #ifdef MS_WINDOWS
 extern int _PyUnicode_EnableLegacyWindowsFSEncoding(void);
 #endif

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15923,7 +15923,8 @@ _PyUnicode_EnableLegacyWindowsFSEncoding(void)
 #endif
 
 void
-_PyUnicode_FiniEncodings(PyThreadState *tstate) {
+_PyUnicode_FiniEncodings(PyThreadState *tstate)
+{
     PyInterpreterState *interp = tstate->interp;
 
     PyMem_RawFree(interp->fs_codec.encoding);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15922,6 +15922,15 @@ _PyUnicode_EnableLegacyWindowsFSEncoding(void)
 }
 #endif
 
+void
+_PyUnicode_FiniEncodings(PyThreadState *tstate) {
+    PyInterpreterState *interp = tstate->interp;
+
+    PyMem_RawFree(interp->fs_codec.encoding);
+    interp->fs_codec.encoding = NULL;
+    PyMem_RawFree(interp->fs_codec.errors);
+    interp->fs_codec.errors = NULL;
+}
 
 void
 _PyUnicode_Fini(void)
@@ -15947,13 +15956,9 @@ _PyUnicode_Fini(void)
     _PyUnicode_ClearStaticStrings();
     (void)PyUnicode_ClearFreeList();
 
-    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
-    PyMem_RawFree(interp->fs_codec.encoding);
-    interp->fs_codec.encoding = NULL;
-    PyMem_RawFree(interp->fs_codec.errors);
-    interp->fs_codec.errors = NULL;
+    PyThreadState *tstate = _PyThreadState_GET();
+    _PyUnicode_FiniEncodings(tstate);
 }
-
 
 /* A _string module, to export formatter_parser and formatter_field_name_split
    to the string.Formatter class implemented in Python. */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1597,6 +1597,7 @@ Py_EndInterpreter(PyThreadState *tstate)
     }
 
     _PyImport_Cleanup(tstate);
+    _PyUnicode_FiniEncodings(tstate);
     PyInterpreterState_Clear(interp);
     PyThreadState_Swap(NULL);
     PyInterpreterState_Delete(interp);


### PR DESCRIPTION
Was playing with:

    $ ./configure --with-assertions --with-lto --with-pydebug --with-address-sanitizer --disable-ipv6
    $ make -j4 profile-opt CFLAGS='-D __INSURE__'

(triple-checking while trying to close https://bugs.python.org/issue31200)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
