### PR TITLE
bpo-36838: Suggest 'make venv' when missing Doc/ tools.

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -48,11 +48,19 @@ build:
 	@if [ -f  ../Misc/NEWS ] ; then \
 		echo "Using existing Misc/NEWS file"; \
 		cp ../Misc/NEWS build/NEWS; \
-	elif [ -d ../Misc/NEWS.d ]; then \
-		echo "Building NEWS from Misc/NEWS.d with blurb"; \
-		$(BLURB) merge -f build/NEWS; \
+	elif $(BLURB) help >/dev/null 2>&1 && $(SPHINXBUILD) --version >/dev/null 2>&1; then \
+		if [ -d ../Misc/NEWS.d ]; then \
+			echo "Building NEWS from Misc/NEWS.d with blurb"; \
+			$(BLURB) merge -f build/NEWS; \
+		else \
+			echo "Neither Misc/NEWS.d nor Misc/NEWS found; cannot build docs"; \
+			exit 1; \
+		fi \
 	else \
-		echo "Neither Misc/NEWS.d nor Misc/NEWS found; cannot build docs"; \
+		echo ""; \
+		echo "Missing the required blurb or sphinx-build tools."; \
+		echo "Please run 'make venv' to install local copies."; \
+		echo ""; \
 		exit 1; \
 	fi
 	$(SPHINXBUILD) $(ALLSPHINXOPTS)


### PR DESCRIPTION
```
Doc/$ make html
mkdir -p build

Missing the required blurb or sphinx-build tools.
Please run 'make venv' to install local copies.
```

<!-- issue-number: [bpo-36838](https://bugs.python.org/issue36838) -->
https://bugs.python.org/issue36838
<!-- /issue-number -->
