### PR TITLE
bpo-36829: Add a -X option to abort in PyErr_WriteUnraisable()

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -81,6 +81,10 @@ Printing and clearing
    in which the unraisable exception occurred. If possible,
    the repr of *obj* will be printed in the warning message.
 
+   .. versionchanged:: 3.8
+      The :option:`-X` ``abortunraisable`` command-line option causes this
+      function to abort the current process.
+
 
 Raising exceptions
 ==================

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -446,6 +446,9 @@ Miscellaneous options
    * ``-X pycache_prefix=PATH`` enables writing ``.pyc`` files to a parallel
      tree rooted at the given directory instead of to the code tree. See also
      :envvar:`PYTHONPYCACHEPREFIX`.
+   * ``-X abortunraisable`` causes the :c:func:`PyErr_WriteUnraisable`
+     function to abort the current process.  This is useful for debugging
+     purposes.
 
    It also allows passing arbitrary values and retrieving them through the
    :data:`sys._xoptions` dictionary.
@@ -466,8 +469,9 @@ Miscellaneous options
       The ``-X importtime``, ``-X dev`` and ``-X utf8`` options.
 
    .. versionadded:: 3.8
-      The ``-X pycache_prefix`` option. The ``-X dev`` option now logs
-      ``close()`` exceptions in :class:`io.IOBase` destructor.
+      The ``-X pycache_prefix`` and ``-X abortunraisable`` options. The
+      ``-X dev`` option now logs ``close()`` exceptions in the
+      :class:`io.IOBase` destructor.
 
 
 Options you shouldn't use

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -206,6 +206,9 @@ Other Language Changes
   and Windows use this to properly terminate scripts in interactive sessions.
   (Contributed by Google via Gregory P. Smith in :issue:`1054041`.)
 
+* The new :option:`-X` ``abortunraisable`` option causes the
+  :c:func:`PyErr_WriteUnraisable` C API function to abort the current process.
+  (Contributed by Zackery Spytz in :issue:`36829`.)
 
 New Modules
 ===========

--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -171,6 +171,7 @@ typedef struct {
     int import_time;        /* PYTHONPROFILEIMPORTTIME, -X importtime */
     int show_ref_count;     /* -X showrefcount */
     int show_alloc_count;   /* -X showalloccount */
+    int abort_unraisable;   /* -X abortunraisable */
     int dump_refs;          /* PYTHONDUMPREFS */
     int malloc_stats;       /* PYTHONMALLOCSTATS */
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -301,7 +301,7 @@ def _args_from_interpreter_flags():
     if dev_mode:
         args.extend(('-X', 'dev'))
     for opt in ('faulthandler', 'tracemalloc', 'importtime',
-                'showalloccount', 'showrefcount', 'utf8'):
+                'showalloccount', 'showrefcount', 'utf8', 'abortunraisable'):
         if opt in xoptions:
             value = xoptions[opt]
             if value is True:

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -303,6 +303,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'import_time': 0,
         'show_ref_count': 0,
         'show_alloc_count': 0,
+        'abort_unraisable': 0,
         'dump_refs': 0,
         'malloc_stats': 0,
 
@@ -554,6 +555,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'import_time': 1,
             'show_ref_count': 1,
             'show_alloc_count': 1,
+            'abort_unraisable': 1,
             'malloc_stats': 1,
 
             'stdio_encoding': 'iso8859-1',

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -495,6 +495,7 @@ class TestSupport(unittest.TestCase):
             ['-X', 'importtime'],
             ['-X', 'showalloccount'],
             ['-X', 'showrefcount'],
+            ['-X', 'abortunraisable'],
             ['-X', 'tracemalloc'],
             ['-X', 'tracemalloc=3'],
         ):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-07-14-16-10.bpo-36829.e35gtA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-07-14-16-10.bpo-36829.e35gtA.rst
@@ -1,0 +1,2 @@
+Add a -X command-line option to abort the current process if
+:c:func:`PyErr_WriteUnraisable` is called.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -405,6 +405,7 @@ static int test_init_from_config(void)
 
     config.show_ref_count = 1;
     config.show_alloc_count = 1;
+    config.abort_unraisable = 1;
     /* FIXME: test dump_refs: bpo-34223 */
 
     putenv("PYTHONMALLOCSTATS=0");

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -619,6 +619,7 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
     COPY_ATTR(import_time);
     COPY_ATTR(show_ref_count);
     COPY_ATTR(show_alloc_count);
+    COPY_ATTR(abort_unraisable);
     COPY_ATTR(dump_refs);
     COPY_ATTR(malloc_stats);
 
@@ -721,6 +722,7 @@ _PyCoreConfig_AsDict(const _PyCoreConfig *config)
     SET_ITEM_INT(import_time);
     SET_ITEM_INT(show_ref_count);
     SET_ITEM_INT(show_alloc_count);
+    SET_ITEM_INT(abort_unraisable);
     SET_ITEM_INT(dump_refs);
     SET_ITEM_INT(malloc_stats);
     SET_ITEM_WSTR(filesystem_encoding);
@@ -1506,6 +1508,9 @@ config_read(_PyCoreConfig *config, _PyPreCmdline *cmdline)
     }
     if (config_get_xoption(config, L"showalloccount")) {
         config->show_alloc_count = 1;
+    }
+    if (config_get_xoption(config, L"abortunraisable")) {
+        config->abort_unraisable = 1;
     }
 
     err = config_read_complex_options(config);

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1028,6 +1028,10 @@ done:
     Py_XDECREF(t);
     Py_XDECREF(v);
     Py_XDECREF(tb);
+    PyInterpreterState *interp = _PyInterpreterState_Get();
+    if (interp->core_config.abort_unraisable) {
+        Py_FatalError("Unraisable exception");
+    }
     PyErr_Clear(); /* Just in case */
 }
 


### PR DESCRIPTION
Add a -X command-line option to abort the current process
if PyErr_WriteUnraisable() is called.


<!-- issue-number: [bpo-36829](https://bugs.python.org/issue36829) -->
https://bugs.python.org/issue36829
<!-- /issue-number -->
