### PR TITLE
bpo-36839: Support the buffer protocol in code objects

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -77,13 +77,18 @@ def dis(x=None, *, file=None, depth=None):
                 print(file=file)
     elif hasattr(x, 'co_code'): # Code object
         _disassemble_recursive(x, file=file, depth=depth)
-    elif isinstance(x, (bytes, bytearray)): # Raw bytecode
+    elif isinstance(x, (bytes, bytearray, memoryview)): # Raw bytecode
         _disassemble_bytes(x, file=file)
     elif isinstance(x, str):    # Source code
         _disassemble_str(x, file=file, depth=depth)
     else:
-        raise TypeError("don't know how to disassemble %s objects" %
-                        type(x).__name__)
+        try:
+            x = memoryview(x)
+        except TypeError:
+            raise TypeError("don't know how to disassemble %s objects" %
+                            type(x).__name__)
+        _disassemble_bytes(x, file=file)
+
 
 def distb(tb=None, *, file=None):
     """Disassemble a traceback (default: last traceback)."""

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -84,7 +84,7 @@ def dis(x=None, *, file=None, depth=None):
     else:
         try:
             x = memoryview(x)
-        except TypeError:
+        except Exception:
             raise TypeError("don't know how to disassemble %s objects" %
                             type(x).__name__)
         _disassemble_bytes(x, file=file)

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -462,13 +462,13 @@ class DisTests(unittest.TestCase):
         except ImportError:
             return
         from tempfile import NamedTemporaryFile
-        with NamedTemporaryFile('wb', suffix='.code') as f:
-            f.write(_f.__code__.co_code)
-            f.flush()
-            map = mmap.mmap(f.fileno(),
-                            length=0, access=mmap.ACCESS_READ)
+        with NamedTemporaryFile('wb', suffix='.code') as tmp_code:
+            tmp_code.write(_f.__code__.co_code)
+            tmp_code.flush()
+            with mmap.mmap(tmp_code.fileno(),
+                            length=0, access=mmap.ACCESS_READ) as map:
 
-            self.do_disassembly_test(map, dis_f_co_code)
+                self.do_disassembly_test(map, dis_f_co_code)
 
     def test_bug_708901(self):
         self.do_disassembly_test(bug708901, dis_bug708901)

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -453,6 +453,23 @@ class DisTests(unittest.TestCase):
     def test_dis(self):
         self.do_disassembly_test(_f, dis_f)
 
+    def test_dis_memoryview(self):
+        self.do_disassembly_test(memoryview(_f.__code__.co_code), dis_f_co_code)
+
+    def test_dis_mmap(self):
+        try:
+            import mmap
+        except ImportError:
+            return
+        from tempfile import NamedTemporaryFile
+        with NamedTemporaryFile('wb', suffix='.code') as f:
+            f.write(_f.__code__.co_code)
+            f.flush()
+            map = mmap.mmap(f.fileno(),
+                            length=0, access=mmap.ACCESS_READ)
+
+            self.do_disassembly_test(map, dis_f_co_code)
+
     def test_bug_708901(self):
         self.do_disassembly_test(bug708901, dis_bug708901)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-24-00-39-50.bpo-36839.C2qHv0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-24-00-39-50.bpo-36839.C2qHv0.rst
@@ -1,0 +1,1 @@
+Code objects can now be constructed with read-only buffers.  This enables sophisticated byte code sharing scenarios where the byte code can be shared across multiple processes in read-only memory, reducing the overhead of memory usage in fork-and-exec web servers.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -96,19 +96,23 @@ intern_string_constants(PyObject *tuple)
 
 static int
 code_check_buffer(PyObject *code) {
-    Py_buffer codebuffer = {};
+    Py_buffer codebuffer = {NULL, NULL};
     if (!PyBytes_Check(code)) {
-        if (PyObject_GetBuffer(code, &codebuffer, PyBUF_SIMPLE))
+        if (PyObject_GetBuffer(code, &codebuffer, PyBUF_SIMPLE)) {
             return 0;
+        }
 
-        int contiguous = PyBuffer_IsContiguous(&codebuffer, 'C');
+        int ok = codebuffer.readonly &&
+                 codebuffer.ndim == 1 &&
+                 codebuffer.strides == NULL;
 
         PyBuffer_Release(&codebuffer);
 
-        return contiguous;
+        return ok;
     }
     return 1;
 }
+
 
 PyCodeObject *
 PyCode_New(int argcount, int posonlyargcount, int kwonlyargcount,

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -336,7 +336,7 @@ _PyGen_yf(PyGenObject *gen)
     if (f && f->f_stacktop) {
         PyObject *bytecode = f->f_code->co_code;
         unsigned char *code;
-        Py_buffer view = {};
+        Py_buffer view = {NULL, NULL};
 
         if (PyBytes_Check(bytecode)) {
             code = (unsigned char *)PyBytes_AS_STRING(bytecode);
@@ -355,11 +355,13 @@ _PyGen_yf(PyGenObject *gen)
         }
 
         char opcode = code[f->f_lasti + sizeof(_Py_CODEUNIT)];
-        if (view.obj != NULL)
+        if (view.obj != NULL) {
             PyBuffer_Release(&view);
+        }
 
         if (opcode != YIELD_FROM)
             return NULL;
+
         yf = f->f_stacktop[-1];
         Py_INCREF(yf);
     }


### PR DESCRIPTION
[bpo-36839](https://bugs.python.org/issue36839): Support the buffer protocol in code objects

Adds support for code objects to be backed by any objects which implement the buffer protocol.  This relatively small core interpreter change makes it possible to build importer/loaders which can store their code objects in memory mapped files.  When used in an environment with fork/exec'd processes this can allow the memory to be successfully shared between all of the processes.





<!-- issue-number: [bpo-36839](https://bugs.python.org/issue36839) -->
https://bugs.python.org/issue36839
<!-- /issue-number -->
