### PR TITLE
bpo-36674: Stops skipped tests from running in debug mode.

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -745,7 +745,11 @@ class TestCase(object):
     def debug(self):
         """Run the test without collecting errors in a TestResult"""
         self.setUp()
-        getattr(self, self._testMethodName)()
+        testMethod = getattr(self, self._testMethodName)
+        if (not getattr(self.__class__, "__unittest_skip__", False) and
+            not getattr(testMethod, "__unittest_skip__", False)):
+            # If the class or method was not skipped run it
+            testMethod()
         self.tearDown()
         while self._cleanups:
             function, args, kwargs = self._cleanups.pop(-1)

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -1777,6 +1777,31 @@ test case
             self.assertEqual(len(result.skipped), 1)
             self.assertEqual(result.testsRun, 1)
 
+    def testSkippingDebugMode(self):
+        def _skip(self=None):
+            raise unittest.SkipTest('some reason')
+        def nothing(self):
+            pass
+
+        class Test1(unittest.TestCase):
+            test_something = _skip
+
+        class Test2(unittest.TestCase):
+            setUp = _skip
+            test_something = nothing
+
+        class Test3(unittest.TestCase):
+            test_something = nothing
+            tearDown = _skip
+
+        class Test4(unittest.TestCase):
+            def test_something(self):
+                self.addCleanup(_skip)
+
+        for klass in (Test1, Test2, Test3, Test4):
+            with self.assertRaises(unittest.SkipTest):
+                klass('test_something').debug()
+
     def testSystemExit(self):
         def _raise(self=None):
             raise SystemExit

--- a/Misc/NEWS.d/next/Library/2019-05-08-10-34-49.bpo-36674.gp97J9.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-08-10-34-49.bpo-36674.gp97J9.rst
@@ -1,0 +1,2 @@
+Stops skipped tests from running with TestCase.debug(), following the
+functionality of TestCase.run().


### PR DESCRIPTION
TestCase.run() will skip tests that have skip/skipIf/skipWhatever applied to them, this PR applies the same skipped functionality when tests are run using TestCase.debug().

https://bugs.python.org/issue36674

<!-- issue-number: [bpo-36674](https://bugs.python.org/issue36674) -->
https://bugs.python.org/issue36674
<!-- /issue-number -->
