### PR TITLE
bpo-36869: Avoid warning of unused variables

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -459,6 +459,7 @@ static PyObject *empty_values[1] = { NULL };
 int
 _PyDict_CheckConsistency(PyObject *op, int check_content)
 {
+#ifndef NDEBUG
     _PyObject_ASSERT(op, PyDict_Check(op));
     PyDictObject *mp = (PyDictObject *)op;
 
@@ -481,23 +482,20 @@ _PyDict_CheckConsistency(PyObject *op, int check_content)
         PyDictKeyEntry *entries = DK_ENTRIES(keys);
         Py_ssize_t i;
 
-#ifndef NDEBUG
         for (i=0; i < keys->dk_size; i++) {
             Py_ssize_t ix = dictkeys_get_index(keys, i);
             _PyObject_ASSERT(op, DKIX_DUMMY <= ix && ix <= usable);
         }
-#endif
+
         for (i=0; i < usable; i++) {
             PyDictKeyEntry *entry = &entries[i];
             PyObject *key = entry->me_key;
 
             if (key != NULL) {
                 if (PyUnicode_CheckExact(key)) {
-#ifndef NDEBUG
                     Py_hash_t hash = ((PyASCIIObject *)key)->hash;
                     _PyObject_ASSERT(op, hash != -1);
                     _PyObject_ASSERT(op, entry->me_hash == hash);
-#endif
                 }
                 else {
                     /* test_dict fails if PyObject_Hash() is called again */
@@ -520,7 +518,7 @@ _PyDict_CheckConsistency(PyObject *op, int check_content)
             }
         }
     }
-
+#endif
     return 1;
 }
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -481,20 +481,23 @@ _PyDict_CheckConsistency(PyObject *op, int check_content)
         PyDictKeyEntry *entries = DK_ENTRIES(keys);
         Py_ssize_t i;
 
+#ifndef NDEBUG
         for (i=0; i < keys->dk_size; i++) {
             Py_ssize_t ix = dictkeys_get_index(keys, i);
             _PyObject_ASSERT(op, DKIX_DUMMY <= ix && ix <= usable);
         }
-
+#endif
         for (i=0; i < usable; i++) {
             PyDictKeyEntry *entry = &entries[i];
             PyObject *key = entry->me_key;
 
             if (key != NULL) {
                 if (PyUnicode_CheckExact(key)) {
+#ifndef NDEBUG
                     Py_hash_t hash = ((PyASCIIObject *)key)->hash;
                     _PyObject_ASSERT(op, hash != -1);
                     _PyObject_ASSERT(op, entry->me_hash == hash);
+#endif
                 }
                 else {
                     /* test_dict fails if PyObject_Hash() is called again */


### PR DESCRIPTION
When run ```./configure && make -j4``` there are two warnings on
Object/dictobject.c file about ix and hash variable are not used.

Zachary Ware make me note that when _PyObject_ASSERT is call and NDEBUG
is defined that expand to ((void)0).

So this PR add a #ifndef check to avoid the warnings.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36869](https://bugs.python.org/issue36869) -->
https://bugs.python.org/issue36869
<!-- /issue-number -->
