### PR TITLE
bpo-36464: fix parallel build race problem

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1456,7 +1456,7 @@ LIBPL=		@LIBPL@
 LIBPC=		$(LIBDIR)/pkgconfig
 
 libainstall:	@DEF_MAKE_RULE@ python-config
-	@for i in $(LIBDIR) $(LIBPL) $(LIBPC); \
+	@for i in $(LIBDIR) $(LIBPL) $(LIBPC) $(BINDIR); \
 	do \
 		if test ! -d $(DESTDIR)$$i; then \
 			echo "Creating directory $$i"; \

--- a/Misc/NEWS.d/next/Build/2019-06-03-03-28-07.bpo-36464._stf8p.rst
+++ b/Misc/NEWS.d/next/Build/2019-06-03-03-28-07.bpo-36464._stf8p.rst
@@ -1,0 +1,1 @@
+fix parallel build race problem during make install -j xx


### PR DESCRIPTION
This issue reproduces on python2 and python3

When using make -j with the 'install' target, it's possible for altbininstall
(which normally creates BINDIR) and libainstall (which doesn't, though it
installs python-config there) to race, resulting in a failure due to
attempting to install python-config into a nonexistent BINDIR. Ensure it also
exists in the libainstall target.

Signed-off-by: Changqing Li <changqing.li@windriver.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36464](https://bugs.python.org/issue36464) -->
https://bugs.python.org/issue36464
<!-- /issue-number -->
