### PR TITLE
bpo-36851: Clean the frame stack if the execution ends with a return and the stack is not empty

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -130,6 +130,7 @@ import sys
 import threading
 import unittest
 import weakref
+import opcode
 try:
     import ctypes
 except ImportError:
@@ -378,6 +379,43 @@ if check_impl_detail(cpython=True) and ctypes is not None:
             tt.start()
             tt.join()
             self.assertEqual(LAST_FREED, 500)
+
+        @cpython_only
+        def test_clean_stack_on_return(self):
+
+            def f(x):
+                return x
+
+            code = f.__code__
+            ct = type(f.__code__)
+
+            # Insert an extra LOAD_FAST, this duplicates the value of
+            # 'x' in the stack, leaking it if the frame is not properly
+            # cleaned up upon exit.
+
+            bytecode = list(code.co_code)
+            bytecode.insert(-2, opcode.opmap['LOAD_FAST'])
+            bytecode.insert(-2, 0)
+
+            c = ct(code.co_argcount, code.co_posonlyargcount,
+                   code.co_kwonlyargcount, code.co_nlocals, code.co_stacksize+1,
+                   code.co_flags, bytes(bytecode),
+                   code.co_consts, code.co_names, code.co_varnames,
+                   code.co_filename, code.co_name, code.co_firstlineno,
+                   code.co_lnotab, code.co_freevars, code.co_cellvars)
+            new_function = type(f)(c, f.__globals__, 'nf', f.__defaults__, f.__closure__)
+
+            class Var:
+                pass
+            the_object = Var()
+            var = weakref.ref(the_object)
+
+            new_function(the_object)
+
+            # Check if the_object is leaked
+            del the_object
+            assert var() is None
+
 
 def test_main(verbose=None):
     from test import test_code

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-08-11-42-06.bpo-36851.J7DiCW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-08-11-42-06.bpo-36851.J7DiCW.rst
@@ -1,0 +1,2 @@
+The ``FrameType`` stack is now correctly cleaned up if the execution ends
+with a return and the stack is not empty.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1755,7 +1755,7 @@ main_loop:
         case TARGET(RETURN_VALUE): {
             retval = POP();
             assert(f->f_iblock == 0);
-            goto return_or_yield;
+            goto exit_returning;
         }
 
         case TARGET(GET_AITER): {
@@ -1924,7 +1924,7 @@ main_loop:
             /* and repeat... */
             assert(f->f_lasti >= (int)sizeof(_Py_CODEUNIT));
             f->f_lasti -= sizeof(_Py_CODEUNIT);
-            goto return_or_yield;
+            goto exit_yielding;
         }
 
         case TARGET(YIELD_VALUE): {
@@ -1941,7 +1941,7 @@ main_loop:
             }
 
             f->f_stacktop = stack_pointer;
-            goto return_or_yield;
+            goto exit_yielding;
         }
 
         case TARGET(POP_EXCEPT): {
@@ -3579,16 +3579,18 @@ exception_unwind:
         break;
     } /* main loop */
 
+    assert(retval == NULL);
+    assert(PyErr_Occurred());
+
+exit_returning:
+
     /* Pop remaining stack entries. */
     while (!EMPTY()) {
         PyObject *o = POP();
         Py_XDECREF(o);
     }
 
-    assert(retval == NULL);
-    assert(PyErr_Occurred());
-
-return_or_yield:
+exit_yielding:
     if (tstate->use_tracing) {
         if (tstate->c_tracefunc) {
             if (call_trace_protected(tstate->c_tracefunc, tstate->c_traceobj,


### PR DESCRIPTION
<!-- issue-number: [bpo-36851](https://bugs.python.org/issue36851) -->
https://bugs.python.org/issue36851
<!-- /issue-number -->


When evaluating a frame object, it is possible to exit the execution with some variables in the stack. The frame deallocator (frame_dealloc) only cleans the stack if f_stacktop is not NULL, but this only happens for generators and when trace functions are set. The eval loop does this cleanup already if an exception is being raised, but not if a RETURN_VALUE is set.

In the PyconUS sprints, @DinoV  and I have been working on this and we have decided that the cleanest approach is shared the same goto label with the path for exception handling, effectively cleaning up