### PR TITLE
[3.7] bpo-27639: Correct return type for UserList slicing operation

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1083,7 +1083,11 @@ class UserList(_collections_abc.MutableSequence):
         return other.data if isinstance(other, UserList) else other
     def __contains__(self, item): return item in self.data
     def __len__(self): return len(self.data)
-    def __getitem__(self, i): return self.data[i]
+    def __getitem__(self, i):
+        if isinstance(i, slice):
+            return self.__class__(self.data[i])
+        else:
+            return self.data[i]
     def __setitem__(self, i, item): self.data[i] = item
     def __delitem__(self, i): del self.data[i]
     def __add__(self, other):

--- a/Lib/test/test_userlist.py
+++ b/Lib/test/test_userlist.py
@@ -17,6 +17,12 @@ class UserListTest(list_tests.CommonTest):
             for j in range(-3, 6):
                 self.assertEqual(u[i:j], l[i:j])
 
+    def test_slice_type(self):
+        l = [0, 1, 2, 3, 4]
+        u = UserList(l)
+        self.assertIsInstance(u[:], u.__class__)
+        self.assertEqual(u[:],u)
+
     def test_add_specials(self):
         u = UserList("spam")
         u2 = u + "eggs"

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-07-15-49-17.bpo-27639.b1Ah87.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-07-15-49-17.bpo-27639.b1Ah87.rst
@@ -1,0 +1,2 @@
+Correct return type for UserList slicing operations. Patch by Michael Blahay,
+Erick Cervantes, and vaultah


### PR DESCRIPTION
Added logic to __getitem__ magic method for UserList to ensure that the return
type matches that of self.


<!-- issue-number: [bpo-27639](https://bugs.python.org/issue27639) -->
https://bugs.python.org/issue27639
<!-- /issue-number -->
