### PR TITLE
bpo-36856: Handle possible overflow in faulthandler_stack_overflow

### DIFF
--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1121,13 +1121,26 @@ faulthandler_stack_overflow(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     size_t depth, size;
     uintptr_t sp = (uintptr_t)&depth;
-    uintptr_t stop;
+    uintptr_t stop, lower_limit, upper_limit;
 
     faulthandler_suppress_crash_report();
     depth = 0;
-    stop = stack_overflow(sp - STACK_OVERFLOW_MAX_SIZE,
-                          sp + STACK_OVERFLOW_MAX_SIZE,
-                          &depth);
+
+    if (STACK_OVERFLOW_MAX_SIZE <= sp) {
+        lower_limit = sp - STACK_OVERFLOW_MAX_SIZE;
+    }
+    else {
+        lower_limit = 0;
+    }
+
+    if (UINTPTR_MAX - STACK_OVERFLOW_MAX_SIZE >= sp) {
+        upper_limit = sp + STACK_OVERFLOW_MAX_SIZE;
+    }
+    else {
+        upper_limit = UINTPTR_MAX;
+    }
+
+    stop = stack_overflow(lower_limit, upper_limit, &depth);
     if (sp < stop)
         size = stop - sp;
     else


### PR DESCRIPTION
With KPTI the stack pointer may be very close to `UINTPTR_MAX` so we have to check the possible overflow of `sp + STACK_OVERFLOW_MAX_SIZE`. As a precaution, also check if `sp - STACK_OVERFLOW_MAX_SIZE` underflows.

https://bugs.python.org/issue36856

<!-- issue-number: [bpo-36856](https://bugs.python.org/issue36856) -->
https://bugs.python.org/issue36856
<!-- /issue-number -->
