### PR TITLE
bpo-36832: Add support for .parent and .joinpath in zipfile.Path

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -2481,6 +2481,14 @@ class TestPath(unittest.TestCase):
             assert a.read_text() == "content of a"
             assert a.read_bytes() == b"content of a"
 
+    def test_joinpath(self):
+        for zipfile_abcde in self.zipfile_abcde():
+            root = zipfile.Path(zipfile_abcde)
+            a = root.joinpath("a")
+            assert a.is_file()
+            e = root.joinpath("b").joinpath("d").joinpath("e.txt")
+            assert e.read_text() == "content of e"
+
     def test_traverse_truediv(self):
         for zipfile_abcde in self.zipfile_abcde():
             root = zipfile.Path(zipfile_abcde)
@@ -2501,6 +2509,12 @@ class TestPath(unittest.TestCase):
         for zipfile_abcde in self.zipfile_abcde():
             root = zipfile.Path(zipfile_abcde)
             root / pathlib.Path("a")
+
+    def test_parent(self):
+        for zipfile_abcde in self.zipfile_abcde():
+            root = zipfile.Path(zipfile_abcde)
+            assert (root / 'a').parent.at == ''
+            assert (root / 'a' / 'b').parent.at == 'a/'
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -2218,11 +2218,13 @@ class Path:
     def __repr__(self):
         return self.__repr.format(self=self)
 
-    def __truediv__(self, add):
+    def joinpath(self, add):
         next = posixpath.join(self.at, add)
         next_dir = posixpath.join(self.at, add, "")
         names = self._names()
         return self._next(next_dir if next not in names and next_dir in names else next)
+
+    __truediv__ = joinpath
 
     @staticmethod
     def _add_implied_dirs(names):
@@ -2231,6 +2233,13 @@ class Path:
             for name in map(posixpath.dirname, names)
             if name and name + "/" not in names
         ]
+
+    @property
+    def parent(self):
+        parent_at = posixpath.dirname(self.at)
+        if parent_at:
+            parent_at += '/'
+        return self._next(parent_at)
 
     def _names(self):
         return self._add_implied_dirs(self.root.namelist())


### PR DESCRIPTION
This PR extends the work in GH-13153 to add more pathlib compatibility and facilitates a simpler implementation of path finders/distributions [slated for importlib_metadata 0.11](https://gitlab.com/python-devs/importlib_metadata/merge_requests/60).

This functionality was released for backport in `zipp 0.5`.

<!-- issue-number: [bpo-36832](https://bugs.python.org/issue36832) -->
https://bugs.python.org/issue36832
<!-- /issue-number -->
