### PR TITLE
bpo-36859: Use sqlite3_stmt_readonly API when possible to determine if statement is DML.K

### DIFF
--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -444,11 +444,63 @@ class UnhashableCallbacksTestCase(unittest.TestCase):
             self.con.execute('SELECT %s()' % aggr_name)
 
 
+class DMLStatementDetectionTestCase(unittest.TestCase):
+    """
+    https://bugs.python.org/issue36859
+
+    Use sqlite3_stmt_readonly to determine if the statement is DML or not.
+    """
+    @unittest.skipIf(sqlite.sqlite_version_info < (3, 8, 3),
+                     'needs sqlite 3.8.3 or newer')
+    def test_dml_detection_cte(self):
+        conn = sqlite.connect(':memory:')
+        conn.execute('create table kv ("key" text, "val" integer)')
+        self.assertFalse(conn.in_transaction)
+        conn.execute('insert into kv (key, val) values (?, ?), (?, ?)',
+                     ('k1', 1, 'k2', 2))
+        self.assertTrue(conn.in_transaction)
+
+        conn.commit()
+        self.assertFalse(conn.in_transaction)
+
+        rc = conn.execute('update kv set val=val + ?', (10,))
+        self.assertEqual(rc.rowcount, 2)
+        self.assertTrue(conn.in_transaction)
+        conn.commit()
+        self.assertFalse(conn.in_transaction)
+
+        rc = conn.execute('with c(k, v) as (select key, val + ? from kv) '
+                          'update kv set val=(select v from c where k=kv.key)',
+                          (100,))
+        self.assertEqual(rc.rowcount, 2)
+        self.assertTrue(conn.in_transaction)
+
+        curs = conn.execute('select key, val from kv order by key')
+        self.assertEqual(curs.fetchall(), [('k1', 111), ('k2', 112)])
+
+    def test_dml_detection_sql_comment(self):
+        conn = sqlite.connect(':memory:')
+        conn.execute('create table kv ("key" text, "val" integer)')
+        conn.execute('insert into kv (key, val) values (?, ?), (?, ?)',
+                     ('k1', 1, 'k2', 2))
+        conn.commit()
+
+        self.assertFalse(conn.in_transaction)
+        rc = conn.execute('-- a comment\nupdate kv set val=val + ?', (10,))
+        self.assertEqual(rc.rowcount, 2)
+        self.assertTrue(conn.in_transaction)
+
+        curs = conn.execute('select key, val from kv order by key')
+        self.assertEqual(curs.fetchall(), [('k1', 11), ('k2', 12)])
+        conn.rollback()
+
+
 def suite():
     regression_suite = unittest.makeSuite(RegressionTests, "Check")
     return unittest.TestSuite((
         regression_suite,
         unittest.makeSuite(UnhashableCallbacksTestCase),
+        unittest.makeSuite(DMLStatementDetectionTestCase),
     ))
 
 def test():

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -510,6 +510,11 @@ class DMLStatementDetectionTestCase(unittest.TestCase):
         conn.execute('ROLLBACK')
         self.assertFalse(conn.in_transaction)
 
+    def test_dml_detection_vacuum(self):
+        conn = sqlite.connect(':memory:')
+        conn.execute('vacuum')
+        self.assertFalse(conn.in_transaction)
+
 
 def suite():
     regression_suite = unittest.makeSuite(RegressionTests, "Check")

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -478,6 +478,8 @@ class DMLStatementDetectionTestCase(unittest.TestCase):
         curs = conn.execute('select key, val from kv order by key')
         self.assertEqual(curs.fetchall(), [('k1', 111), ('k2', 112)])
 
+    @unittest.skipIf(sqlite.sqlite_version_info < (3, 7, 11),
+                     'needs sqlite 3.7.11 or newer')
     def test_dml_detection_sql_comment(self):
         conn = sqlite.connect(':memory:')
         conn.execute('create table kv ("key" text, "val" integer)')

--- a/Misc/NEWS.d/next/Library/2019-05-09-09-54-00.bpo-36859.CuCkEd.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-09-09-54-00.bpo-36859.CuCkEd.rst
@@ -1,3 +1,2 @@
-Use `sqlite3_stmt_readonly()` internally to determine if a SQL statement is
-data-modifying. Requires sqlite3 3.7.11 or newer. Patch contributed by Charles
-Leifer.
+Use ``sqlite3_stmt_readonly()`` internally to determine if a SQL statement is
+data-modifying. Requires sqlite3 3.7.11 or newer. Patch by Charles Leifer.

--- a/Misc/NEWS.d/next/Library/2019-05-09-09-54-00.bpo-36859.CuCkEd.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-09-09-54-00.bpo-36859.CuCkEd.rst
@@ -1,0 +1,1 @@
+Use `sqlite3_stmt_readonly` internally to determine if a SQL statement is data-modifying.

--- a/Misc/NEWS.d/next/Library/2019-05-09-09-54-00.bpo-36859.CuCkEd.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-09-09-54-00.bpo-36859.CuCkEd.rst
@@ -1,1 +1,3 @@
-Use `sqlite3_stmt_readonly` internally to determine if a SQL statement is data-modifying.
+Use `sqlite3_stmt_readonly()` internally to determine if a SQL statement is
+data-modifying. Requires sqlite3 3.7.11 or newer. Patch contributed by Charles
+Leifer.

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -73,7 +73,11 @@ static int pysqlite_statement_is_dml(sqlite3_stmt *statement, const char *sql)
 
             is_dml = (PyOS_strnicmp(p, "begin", 5) &&
                       PyOS_strnicmp(p, "create", 6) &&
-                      PyOS_strnicmp(p, "drop", 4));
+                      PyOS_strnicmp(p, "drop", 4) &&
+                      PyOS_strnicmp(p, "alter", 5) &&
+                      PyOS_strnicmp(p, "analyze", 7) &&
+                      PyOS_strnicmp(p, "reindex", 7) &&
+                      PyOS_strnicmp(p, "vacuum", 6));
             break;
         }
     }

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -28,7 +28,7 @@
 #include "prepare_protocol.h"
 #include "util.h"
 
-#if SQLITE_VERSION_NUMBER >= 3007011
+#if SQLITE_VERSION_NUMBER >= 3007004
 #define HAVE_SQLITE3_STMT_READONLY
 #endif
 

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -52,17 +52,16 @@ typedef enum {
     TYPE_UNKNOWN
 } parameter_type;
 
-int pysqlite_statement_is_dml(sqlite3_stmt *st, const char *sql)
+static int pysqlite_statement_is_dml(sqlite3_stmt *statement, const char *sql)
 {
     const char* p;
     int is_dml = 0;
 
 #ifdef HAVE_SQLITE3_STMT_READONLY
-    is_dml = !sqlite3_stmt_readonly(st);
+    is_dml = !sqlite3_stmt_readonly(statement);
     if (is_dml) {
         /* Retain backwards-compatibility, as sqlite3_stmt_readonly will return
-         * false for BEGIN [IMMEDIATE|EXCLUSIVE] or DDL statements.
-         */
+         * false for BEGIN [IMMEDIATE|EXCLUSIVE] or DDL statements. */
         for (p = sql; *p != 0; p++) {
             switch (*p) {
                 case ' ':
@@ -81,8 +80,7 @@ int pysqlite_statement_is_dml(sqlite3_stmt *st, const char *sql)
 #else
     /* Determine if the statement is a DML statement. SELECT is the only
      * exception. This is a fallback for older versions of SQLite which do not
-     * support the sqlite3_stmt_readonly() API.
-     */
+     * support the sqlite3_stmt_readonly() API. */
     for (p = sql; *p != 0; p++) {
         switch (*p) {
             case ' ':

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -58,7 +58,7 @@ int pysqlite_statement_is_dml(sqlite3_stmt *st, const char *sql)
     int is_dml = 0;
 
 #ifdef HAVE_SQLITE3_STMT_READONLY
-    is_dml = ! sqlite3_stmt_readonly(st);
+    is_dml = !sqlite3_stmt_readonly(st);
     if (is_dml) {
         /* Retain backwards-compatibility, as sqlite3_stmt_readonly will return
          * false for BEGIN [IMMEDIATE|EXCLUSIVE] or DDL statements.
@@ -79,7 +79,10 @@ int pysqlite_statement_is_dml(sqlite3_stmt *st, const char *sql)
         }
     }
 #else
-    /* Original implementation. */
+    /* Determine if the statement is a DML statement. SELECT is the only
+     * exception. This is a fallback for older versions of SQLite which do not
+     * support the sqlite3_stmt_readonly() API.
+     */
     for (p = sql; *p != 0; p++) {
         switch (*p) {
             case ' ':


### PR DESCRIPTION
Implements fix for https://bugs.python.org/issue36859

The stdlib sqlite3 module attempts to detect if a statement is data-modifying, which it currently does by stripping whitespace and looking at the start of the SQL string. There are numerous issues with this approach:

* If the sql string starts with a comment it is marked as not DML, even though it may be.
* Common table expressions can be used with INSERT/UPDATE/DELETE queries and will not be caught using the current logic.
* Possibly other stuff?

In sqlite 3.7.11, the `sqlite3_stmt_readonly` API was added which implements this logic correctly.

pysqlite has weeeird quirks with how it handles DDL (create/drop), which the above api correctly identifies as writing to the db, but for our purposes should not be considered DML. Same for `begin exclusive` and `begin immediate` transaction controls.

So this patch:

* for old sqlite (prior to 3.7.11) the current behavior is retained, else
* use sqlite3_stmt_readonly instead and then be sure that we don't mark create/drop/begin as being data-modifying.
* adds tests.
* is backwards-compatible but more robust

[Sqlite docs for sqlite3_stmt_readonly](https://www.sqlite.org/capi3ref.html#sqlite3_stmt_readonly).

<!-- issue-number: [bpo-36859](https://bugs.python.org/issue36859) -->
https://bugs.python.org/issue36859
<!-- /issue-number -->
