### PR TITLE
bpo-36865: allow 'rt' mode in FileInput

### DIFF
--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -27,8 +27,8 @@ replaced by ``sys.stdin`` and the optional arguments *mode* and *openhook*
 are ignored.  To specify an alternative list of filenames, pass it as the
 first argument to :func:`.input`.  A single file name is also allowed.
 
-All files are opened in text mode by default, but you can override this by
-specifying the *mode* parameter in the call to :func:`.input` or
+All files are opened in their default read mode by default, but you can override
+this by specifying the *mode* parameter in the call to :func:`.input` or
 :class:`FileInput`.  If an I/O error occurs during opening or reading a file,
 :exc:`OSError` is raised.
 

--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -28,10 +28,10 @@ numbers are zero; nextfile() has no effect.  After all lines have been
 read, filename() and the line number functions return the values
 pertaining to the last line read; nextfile() has no effect.
 
-All files are opened in text mode by default, you can override this by
-setting the mode parameter to input() or FileInput.__init__().
-If an I/O error occurs during opening or reading a file, the OSError
-exception is raised.
+All files are opened in their default read mode by default.
+You can override this by setting the mode parameter to input() or
+FileInput.__init__(). If an I/O error occurs during opening or reading
+a file, the OSError exception is raised.
 
 If sys.stdin is used more than once, the second and further use will
 return no lines, except perhaps for interactive use, or if it has been
@@ -184,6 +184,9 @@ class FileInput:
     sequential order; random access and readline() cannot be mixed.
     """
 
+    allowed_modes = ('r', 'rt', 'rU', 'U', 'rb')
+    allowed_modes_text = "'r', 'rt', 'rU', 'U', or 'rb'"
+
     def __init__(self, files=None, inplace=False, backup="", *,
                  mode="r", openhook=None):
         if isinstance(files, str):
@@ -209,9 +212,8 @@ class FileInput:
         self._isstdin = False
         self._backupfilename = None
         # restrict mode argument to reading modes
-        if mode not in ('r', 'rU', 'U', 'rb'):
-            raise ValueError("FileInput opening mode must be one of "
-                             "'r', 'rU', 'U' and 'rb'")
+        if mode not in FileInput.allowed_modes:
+            raise ValueError("FileInput opening mode must be one of " + FileInput.allowed_modes_text)
         if 'U' in mode:
             import warnings
             warnings.warn("'U' mode is deprecated",

--- a/Misc/NEWS.d/next/Library/2019-05-09-13-18-09.bpo-36865.sCr099.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-09-13-18-09.bpo-36865.sCr099.rst
@@ -1,0 +1,2 @@
+Allow FileInput to take 'rt' mode, which is supported by all its current
+delegates


### PR DESCRIPTION
The FileInput class (https://github.com/python/cpython/blob/master/Lib/fileinput.py) delegates to the open function, gzip, or bz2. Each of these delegates supports the 'rt' mode flag, so FileInput can probably support it as well.

This might clear up some confusion as in https://bugs.python.org/issue5758, which, in accordance with the FileInput docs, assumes all files opened with the 'r' flag will be opened in text mode. For gzip and bz2 this is not the case, they will be opened in binary 'rb' mode.

This pull request adds the 'rt' mode to the allowed modes, expands the unit test for FileInput to test opening with all allowed modes, and makes the documentation in FileInput about the behavior of the 'r' flag more accurate.


<!-- issue-number: [bpo-36865](https://bugs.python.org/issue36865) -->
https://bugs.python.org/issue36865
<!-- /issue-number -->
