### PR TITLE
bpo-36867: Make semaphore_tracker track other system resources.

### DIFF
--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -11,7 +11,7 @@ import warnings
 from . import connection
 from . import process
 from .context import reduction
-from . import semaphore_tracker
+from . import resource_tracker
 from . import spawn
 from . import util
 
@@ -69,7 +69,7 @@ class ForkServer(object):
             parent_r, child_w = os.pipe()
             child_r, parent_w = os.pipe()
             allfds = [child_r, child_w, self._forkserver_alive_fd,
-                      semaphore_tracker.getfd()]
+                      resource_tracker.getfd()]
             allfds += fds
             try:
                 reduction.sendfds(client, allfds)
@@ -90,7 +90,7 @@ class ForkServer(object):
         ensure_running() will do nothing.
         '''
         with self._lock:
-            semaphore_tracker.ensure_running()
+            resource_tracker.ensure_running()
             if self._forkserver_pid is not None:
                 # forkserver was launched before, is it still running?
                 pid, status = os.waitpid(self._forkserver_pid, os.WNOHANG)
@@ -290,7 +290,7 @@ def _serve_one(child_r, fds, unused_fds, handlers):
         os.close(fd)
 
     (_forkserver._forkserver_alive_fd,
-     semaphore_tracker._semaphore_tracker._fd,
+     resource_tracker._resource_tracker._fd,
      *_forkserver._inherited_fds) = fds
 
     # Run process object received over pipe

--- a/Lib/multiprocessing/popen_spawn_posix.py
+++ b/Lib/multiprocessing/popen_spawn_posix.py
@@ -36,8 +36,8 @@ class Popen(popen_fork.Popen):
         return fd
 
     def _launch(self, process_obj):
-        from . import semaphore_tracker
-        tracker_fd = semaphore_tracker.getfd()
+        from . import resource_tracker
+        tracker_fd = resource_tracker.getfd()
         self._fds.append(tracker_fd)
         prep_data = spawn.get_preparation_data(process_obj._name)
         fp = io.BytesIO()

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -33,7 +33,7 @@ _HAVE_SIGMASK = hasattr(signal, 'pthread_sigmask')
 _IGNORED_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 
 _CLEANUP_FUNCS = {
-    'folder': shutil.rmtree,
+    'noop': lambda: None,
     'semaphore': _multiprocessing.sem_unlink,
     'shared_memory': _posixshmem.shm_unlink
 }
@@ -119,7 +119,7 @@ class ResourceTracker(object):
         try:
             # We cannot use send here as it calls ensure_running, creating
             # a cycle.
-            os.write(self._fd, b'PROBE:0:folder\n')
+            os.write(self._fd, b'PROBE:0:noop\n')
         except OSError:
             return False
         else:

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -1,3 +1,6 @@
+###############################################################################
+# Server process to keep track of unlinked resources (like shared memory
+# segments, semaphores etc.) and clean them.
 #
 # On Unix we run a server process which keeps track of unlinked
 # resources. The server ignores SIGINT and SIGTERM and reads from a
@@ -5,11 +8,12 @@
 # end of the pipe, so we get EOF when all other processes have exited.
 # Then the server process unlinks any remaining resource names.
 #
-# This is important because the system only supports a limited number
-# of named resources, and they will not be automatically removed till
-# the next reboot.  Without this resource tracker process, "killall
-# python" would probably leave unlinked resources.
-#
+# This is important because there may be system limits for such resources: for
+# instance, the system only supports a limited number of named semaphores, and
+# shared-memory segments live in the RAM. If a python process leaks such a
+# resoucre, this resource will not be removed till the next reboot.  Without
+# this resource tracker process, "killall python" would probably leave unlinked
+# resources.
 
 import os
 import signal

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -22,6 +22,7 @@ import sys
 import threading
 import warnings
 import _multiprocessing
+import _posixshmem
 
 from . import spawn
 from . import util
@@ -33,7 +34,8 @@ _IGNORED_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 
 _CLEANUP_FUNCS = {
     'folder': shutil.rmtree,
-    'semaphore': _multiprocessing.sem_unlink
+    'semaphore': _multiprocessing.sem_unlink,
+    'shared_memory': _posixshmem.shm_unlink
 }
 
 

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -207,6 +207,6 @@ def main(fd):
                     try:
                         _CLEANUP_FUNCS[rtype](name)
                     except Exception as e:
-                        warnings.warn('resource_tracker: %s: %r' % (name, e))
+                        warnings.warn('resource_tracker: %r: %s' % (name, e))
                 finally:
                     pass

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -11,7 +11,7 @@
 # This is important because there may be system limits for such resources: for
 # instance, the system only supports a limited number of named semaphores, and
 # shared-memory segments live in the RAM. If a python process leaks such a
-# resoucre, this resource will not be removed till the next reboot.  Without
+# resource, this resource will not be removed till the next reboot.  Without
 # this resource tracker process, "killall python" would probably leave unlinked
 # resources.
 

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -16,7 +16,6 @@
 # resources.
 
 import os
-import shutil
 import signal
 import sys
 import threading
@@ -174,9 +173,9 @@ def main(fd):
                     cmd, name, rtype = line.strip().decode('ascii').split(':')
                     cleanup_func = _CLEANUP_FUNCS.get(rtype, None)
                     if cleanup_func is None:
-                        raise ValueError('Cannot register for automatic '
-                                         'cleanup: unknown resource type {}'
-                                         .format(name, rtype))
+                        raise ValueError(
+                            f'Cannot register {name} for automatic cleanup: '
+                            f'unknown resource type {rtype}')
 
                     if cmd == 'REGISTER':
                         cache[rtype].add(name)

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -197,7 +197,7 @@ def main(fd):
             if rtype_cache:
                 try:
                     warnings.warn('resource_tracker: There appear to be %d '
-                                  'leaked %ss to clean up at shutdown' %
+                                  'leaked %s objects to clean up at shutdown' %
                                   (len(rtype_cache), rtype))
                 except Exception:
                     pass

--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -117,8 +117,6 @@ class SharedMemory:
 
             from .resource_tracker import register
             register(self._name, "shared_memory")
-            util.Finalize(self, SharedMemory._cleanup,  (self._name,),
-                          exitpriority=0)
 
         else:
 
@@ -238,13 +236,9 @@ class SharedMemory:
         called once (and only once) across all processes which have access
         to the shared memory block."""
         if _USE_POSIX and self._name:
+            from .resource_tracker import unregister
             _posixshmem.shm_unlink(self._name)
-
-    @staticmethod
-    def _cleanup(name):
-        from .resource_tracker import unregister
-        _posixshmem.shm_unlink(name)
-        unregister(name, "shared_memory")
+            unregister(self._name, "shared_memory")
 
 
 _encoding = "utf8"

--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -15,8 +15,6 @@ import errno
 import struct
 import secrets
 
-from . import util
-
 if os.name == "nt":
     import _winapi
     _USE_POSIX = False

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -111,8 +111,8 @@ def spawn_main(pipe_handle, parent_pid=None, tracker_fd=None):
                 _winapi.CloseHandle(source_process)
         fd = msvcrt.open_osfhandle(new_handle, os.O_RDONLY)
     else:
-        from . import semaphore_tracker
-        semaphore_tracker._semaphore_tracker._fd = tracker_fd
+        from . import resource_tracker
+        resource_tracker._resource_tracker._fd = tracker_fd
         fd = pipe_handle
     exitcode = _main(fd)
     sys.exit(exitcode)

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -77,7 +77,7 @@ class SemLock(object):
             # disabled.  When the object is garbage collected or the
             # process shuts down we unlink the semaphore name
             from .resource_tracker import register
-            register(self._semlock.name)
+            register(self._semlock.name, "semaphore")
             util.Finalize(self, SemLock._cleanup, (self._semlock.name,),
                           exitpriority=0)
 
@@ -85,7 +85,7 @@ class SemLock(object):
     def _cleanup(name):
         from .resource_tracker import unregister
         sem_unlink(name)
-        unregister(name)
+        unregister(name, "semaphore")
 
     def _make_methods(self):
         self.acquire = self._semlock.acquire

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -76,14 +76,14 @@ class SemLock(object):
             # We only get here if we are on Unix with forking
             # disabled.  When the object is garbage collected or the
             # process shuts down we unlink the semaphore name
-            from .semaphore_tracker import register
+            from .resource_tracker import register
             register(self._semlock.name)
             util.Finalize(self, SemLock._cleanup, (self._semlock.name,),
                           exitpriority=0)
 
     @staticmethod
     def _cleanup(name):
-        from .semaphore_tracker import unregister
+        from .resource_tracker import unregister
         sem_unlink(name)
         unregister(name)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3879,129 +3879,31 @@ class _TestSharedMemory(BaseTestCase):
         deserialized_sl.shm.close()
         sl.shm.close()
 
-    @unittest.skipUnless(os.name == 'posix', 'posix shared memory')
     def test_posix_shared_memory_cleaned_after_process_termination(self):
         import subprocess
+        from multiprocessing import shared_memory
         cmd = '''if 1:
             import os, time, sys
             from multiprocessing import shared_memory
 
             # Create a shared_memory segment, and send the segment name
             sm = shared_memory.SharedMemory(create=True, size=10)
-            sm._buf[0] = 1
-            os.write({w}, sm._name.encode("ascii") + b"\\n")
+            sys.stdout.write(sm._name + '\\n')
+            sys.stdout.flush()
             time.sleep(100)
         '''
-        cmd2 = '''if 1:
-            from multiprocessing import shared_memory
-            import os, time, sys
-
-            # Send back the first byte of sm
-            sm = shared_memory.SharedMemory("{smm_name}", create=False)
-            os.write({w}, str(sm._buf[0]).encode("ascii") + b"\\n")
-            time.sleep(100)
-        '''
-        r, w = os.pipe()
-        p = subprocess.Popen([sys.executable, '-E', '-c', cmd.format(w=w)],
-                             pass_fds=[w],
-                             stderr=subprocess.PIPE)
-
-        f = open(r, 'rb')
-        name = f.readline().rstrip().decode('ascii')
-
-        p2 = subprocess.Popen([sys.executable, '-E', '-c',
-                               cmd2.format(smm_name=name, w=w)],
-                              pass_fds=[w], stderr=subprocess.PIPE)
-
-        # make sure that the shared memory segment is correctly seen among
-        # different processes
-        first_elem = int(f.readline().rstrip().decode('ascii'))
-        self.assertEqual(first_elem, 1)
-        f.close()
-        os.close(w)
+        p = subprocess.Popen([sys.executable, '-E', '-c', cmd],
+                             stdout=subprocess.PIPE)
+        name = p.stdout.readline().strip().decode()
 
         # killing abruptly processes holding reference to a shared memory
         # segment should not leak the given memory segment.
         p.terminate()
-        p2.terminate()
         p.wait()
-        p2.wait()
         time.sleep(1.0)  # wait for the OS to collect the segment
 
-        import _posixshmem
-        with self.assertRaises(OSError) as ctx:
-            _posixshmem.shm_unlink(name)
-
-    @unittest.skipUnless(sys.platform == 'win32', 'Windows shared memory')
-    def test_windows_shared_memory_cleaned_after_process_termination(self):
-        import subprocess
-        cmd = '''if 1:
-            import os, time, sys
-            import msvcrt, _winapi
-            from multiprocessing import shared_memory, reduction
-
-
-            # Create a shared_memory segment, and send the segment name
-            source_process = _winapi.OpenProcess(
-                _winapi.PROCESS_DUP_HANDLE, False, {parent_pid})
-            w = msvcrt.open_osfhandle(reduction.duplicate(
-                    {w}, source_process=source_process), 0)
-
-            sm = shared_memory.SharedMemory(create=True, size=10)
-            sm._buf[0] = 1
-            os.write(w, sm._name.encode("ascii") + b"\\n")
-            time.sleep(100)
-        '''
-        cmd2 = '''if 1:
-            import msvcrt, _winapi
-            import os, time, sys
-            from multiprocessing import shared_memory, reduction
-
-
-            source_process = _winapi.OpenProcess(
-                _winapi.PROCESS_DUP_HANDLE, False, {parent_pid})
-            w = msvcrt.open_osfhandle(reduction.duplicate(
-                    {w}, source_process=source_process), 0)
-
-            # Send back the first byte of sm
-            sm = shared_memory.SharedMemory("{smm_name}", create=False)
-            os.write(w, str(sm._buf[0]).encode("ascii") + b"\\n")
-            time.sleep(100)
-        '''
-        r, w = os.pipe()
-        import msvcrt
-        p = subprocess.Popen([sys.executable, '-E', '-c',
-                              cmd.format(w=msvcrt.get_osfhandle(w),
-                                         parent_pid=os.getpid())],
-                             stderr=subprocess.PIPE)
-
-        f = open(r, 'rb')
-        name = f.readline().rstrip().decode('ascii')
-
-        p2 = subprocess.Popen([sys.executable, '-E', '-c',
-                               cmd2.format(smm_name=name,
-                                           w=msvcrt.get_osfhandle(w),
-                                           parent_pid=os.getpid())],
-                              stderr=subprocess.PIPE)
-
-        # make sure that the shared memory segment is correctly seen among
-        # different processes
-        first_elem = int(f.readline().rstrip().decode('ascii'))
-        f.close()
-        os.close(w)
-        self.assertEqual(first_elem, 1)
-
-        # killing abruptly processes holding reference to a shared memory
-        # segment should not leak the given memory segment.
-        p.terminate()
-        p2.terminate()
-        p.wait()
-        p2.wait()
-        time.sleep(1.0)
         with self.assertRaises(FileNotFoundError):
-            from multiprocessing import shared_memory
             smm = shared_memory.SharedMemory(name, create=False)
-
 
 #
 #

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4855,6 +4855,9 @@ class TestResourceTracker(unittest.TestCase):
         '''
         for rtype in resource_tracker._CLEANUP_FUNCS:
             with self.subTest(rtype=rtype):
+                if rtype == "noop":
+                    # Artefact resource type used by the resource_tracker
+                    continue
                 r, w = os.pipe()
                 p = subprocess.Popen([sys.executable,
                                      '-E', '-c', cmd.format(w=w, rtype=rtype)],

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4828,13 +4828,7 @@ class TestResourceTracker(unittest.TestCase):
 
 
             def create_and_register_resource(rtype):
-                if rtype == "folder":
-                    folder_name = tempfile.mkdtemp()
-                    # tempfile.mkdtemp() does not register the created folder
-                    # automatically.
-                    resource_tracker.register(folder_name, rtype)
-                    return None, folder_name
-                elif rtype == "semaphore":
+                if rtype == "semaphore":
                     lock = mp.Lock()
                     return lock, lock._semlock.name
                 elif rtype == "shared_memory":

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -41,7 +41,6 @@ import multiprocessing.pool
 import multiprocessing.queues
 
 from multiprocessing import util
-from multiprocessing import resource_tracker
 
 try:
     from multiprocessing import reduction
@@ -89,8 +88,11 @@ def join_process(process):
     support.join_thread(process, timeout=TIMEOUT)
 
 
-def _resource_unlink(name, rtype):
-    resource_tracker._CLEANUP_FUNCS[rtype](name)
+if os.name == "posix":
+    from multiprocessing import resource_tracker
+
+    def _resource_unlink(name, rtype):
+        resource_tracker._CLEANUP_FUNCS[rtype](name)
 
 
 #

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4835,8 +4835,6 @@ class TestResourceTracker(unittest.TestCase):
                     resource_tracker.register(folder_name, rtype)
                     return None, folder_name
                 elif rtype == "semaphore":
-                    # create a Lock using the low-level _multiprocessing to
-                    # separate resource creation from tracking registration.
                     lock = mp.Lock()
                     return lock, lock._semlock.name
                 elif rtype == "shared_memory":

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4819,6 +4819,7 @@ class TestResourceTracker(unittest.TestCase):
             import time, os, tempfile
             import multiprocessing as mp
             from multiprocessing import resource_tracker
+            from multiprocessing.shared_memory import SharedMemory
 
             mp.set_start_method("spawn")
             rand = tempfile._RandomNameSequence()
@@ -4836,6 +4837,9 @@ class TestResourceTracker(unittest.TestCase):
                     # separate resource creation from tracking registration.
                     lock = mp.Lock()
                     return lock, lock._semlock.name
+                elif rtype == "shared_memory":
+                    sm = SharedMemory(create=True, size=10)
+                    return sm, sm._name
                 else:
                     raise ValueError(
                         "Resource type {{}} not understood".format(rtype))

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3879,7 +3879,7 @@ class _TestSharedMemory(BaseTestCase):
         deserialized_sl.shm.close()
         sl.shm.close()
 
-    def test_posix_shared_memory_cleaned_after_process_termination(self):
+    def test_shared_memory_cleaned_after_process_termination(self):
         import subprocess
         from multiprocessing import shared_memory
         cmd = '''if 1:

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4875,8 +4875,8 @@ class TestResourceTracker(unittest.TestCase):
                     ctx.exception.errno, (errno.ENOENT, errno.EINVAL))
                 err = p.stderr.read().decode('utf-8')
                 p.stderr.close()
-                expected = (
-                    'resource_tracker: There appear to be 2 leaked {}s'.format(
+                expected = ('resource_tracker: There appear to be 2 leaked {} '
+                            'objects'.format(
                             rtype))
                 self.assertRegex(err, expected)
                 self.assertRegex(err, r'resource_tracker: %r: \[Errno' % name1)

--- a/Misc/NEWS.d/next/Library/2019-05-09-18-12-55.bpo-36867.FuwVTi.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-09-18-12-55.bpo-36867.FuwVTi.rst
@@ -1,0 +1,1 @@
+The multiprocessing.resource_tracker replaces the multiprocessing.semaphore_tracker module. Other than semaphores, resource_tracker also tracks shared_memory segments.

--- a/PCbuild/lib.pyproj
+++ b/PCbuild/lib.pyproj
@@ -678,7 +678,7 @@
     <Compile Include="multiprocessing\queues.py" />
     <Compile Include="multiprocessing\reduction.py" />
     <Compile Include="multiprocessing\resource_sharer.py" />
-    <Compile Include="multiprocessing\semaphore_tracker.py" />
+    <Compile Include="multiprocessing\resource_tracker.py" />
     <Compile Include="multiprocessing\sharedctypes.py" />
     <Compile Include="multiprocessing\spawn.py" />
     <Compile Include="multiprocessing\synchronize.py" />


### PR DESCRIPTION
## Primary Purpose
This PR proposes to extend the `semaphore_tracker` range of action to other system resources.  
Currently in `python3.8`, if a process that created a  `shared_memory` object gets violently terminated (with `kill` for example), the memory segment will not be properly released until the next machine reboot. This will be problematic for long-running clusters used by many different users.

The primary reason of this PR is thus to extend the `semaphore_tracker` to track also  `shared_memory` segments. The `semaphore_tracker` module gets consequently renamed  `resource_tracker`.

## Extension to a potentially public API
Additionally, the design of the `resource_tracker` is more generic, and possibly suggests a new **public API** to enable the tracking other named-resources. For now, the private `_CLEANUP_FUNCS` dict references all the types that can possibly be tracked. 

To start tracking a new type, the `resource_tracker` only needs to know which cleanup routine to apply to each leaked instance of this type after the python session ends.  The public API would thus consist of a function like `resource_tracker.register_resource_type(resource_type, cleanup_func)`, where: 
* resource_type is a `string`
* `cleanup_func` must be a callable taking a single string as an argument. 

Under the hood, `register_resource_type` would populate the `CLEANUP_FUNCS` with the new (`type, cleanup_func`) record.

## Operating System Availability
To ease the review process of this PR.  the resource_tracker is now POSIX only. I however have a functional windows implementation that I will provide upon demand :)

pinging @pitrou  @ogrisel  @tomMoral 

@pablogsal this may interest you as well :)

<!-- issue-number: [bpo-36867](https://bugs.python.org/issue36867) -->
https://bugs.python.org/issue36867
<!-- /issue-number -->
