### PR TITLE
It is not consistent - Old-style octal: now disallowed.

### DIFF
--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1518,10 +1518,13 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
                             return syntaxerror(tok, "invalid decimal literal");
                         }
                     }
-                    if (c != '0') {
+                    if (isdigit(c)) {
+                        c = tok_nextc(tok);
+                        nonzero = 1;
+                    }
+                    else {
                         break;
                     }
-                    c = tok_nextc(tok);
                 }
                 if (isdigit(c)) {
                     nonzero = 1;


### PR DESCRIPTION
Right:
**>>>** 01
   File "<stdin>", line 1
SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers
**>>>**

Error: The results are not consistent
**>>>** 00
0
**>>>**

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
