### PR TITLE
[doc] Mention with and except clauses in globals()

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -944,7 +944,7 @@ Names listed in a :keyword:`global` statement must not be used in the same code
 block textually preceding that :keyword:`!global` statement.
 
 Names listed in a :keyword:`global` statement must not be defined as formal
-parameters or in a :keyword:`for` loop control target, :keyword:`class`
+parameters, or as targets in :keyword:`with` statements or :keyword:`except` clauses, or in a :keyword:`for` target list, :keyword:`class`
 definition, function definition, :keyword:`import` statement, or variable
 annotation.
 


### PR DESCRIPTION
Also changed "loop control target" to "target list", as that's the actual term used by for's grammar.

The long line is intentional. If the PR is approved I'll add the line breaks.