### PR TITLE
[3.7] bpo-34408: Prevent a null pointer dereference and resource leakage in `PyInterpreterState_New()` (GH-8767)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-14-22-35-19.bpo-34408.aomWYW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-14-22-35-19.bpo-34408.aomWYW.rst
@@ -1,0 +1,1 @@
+Prevent a null pointer dereference and resource leakage in ``PyInterpreterState_New()``.


### PR DESCRIPTION

* A pointer in `PyInterpreterState_New()` could have been `NULL` when being dereferenced.

* Memory was leaked in `PyInterpreterState_New()` when taking some error-handling code path.
(cherry picked from commit 95d630e)

Co-authored-by: Pablo Galindo <Pablogsal@gmail.com>