### PR TITLE
bpo-36778: Update cp65001 codec documentation

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1106,10 +1106,6 @@ particular, the following variants typically exist:
 +-----------------+--------------------------------+--------------------------------+
 | cp1258          | windows-1258                   | Vietnamese                     |
 +-----------------+--------------------------------+--------------------------------+
-| cp65001         |                                | Alias to ``utf_8`` encoding    |
-|                 |                                |                                |
-|                 |                                | .. versionadded:: 3.3          |
-+-----------------+--------------------------------+--------------------------------+
 | euc_jp          | eucjp, ujis, u-jis             | Japanese                       |
 +-----------------+--------------------------------+--------------------------------+
 | euc_jis_2004    | jisx0213, eucjis2004           | Japanese                       |
@@ -1234,7 +1230,7 @@ particular, the following variants typically exist:
 +-----------------+--------------------------------+--------------------------------+
 | utf_7           | U7, unicode-1-1-utf-7          | all languages                  |
 +-----------------+--------------------------------+--------------------------------+
-| utf_8           | U8, UTF, utf8                  | all languages                  |
+| utf_8           | U8, UTF, utf8, cp65001         | all languages                  |
 +-----------------+--------------------------------+--------------------------------+
 | utf_8_sig       |                                | all languages                  |
 +-----------------+--------------------------------+--------------------------------+
@@ -1244,6 +1240,9 @@ particular, the following variants typically exist:
    (``U+D800``--``U+DFFF``) to be encoded.
    The utf-32\* decoders no longer decode
    byte sequences that correspond to surrogate code points.
+
+.. versionchanged:: 3.8
+   ``cp65001`` is now an alias to ``utf_8``.
 
 
 Python Specific Encodings


### PR DESCRIPTION
Remove cp65001 from the table of codecs, list it as an alias of utf_8
and add a versionchanged markup.

<!-- issue-number: [bpo-36778](https://bugs.python.org/issue36778) -->
https://bugs.python.org/issue36778
<!-- /issue-number -->
