### PR TITLE
bpo-36728: Remove PyEval_ReInitThreads() from C API

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -990,6 +990,11 @@ Changes in the Python API
 Changes in the C API
 --------------------
 
+* The :c:func:`PyEval_ReInitThreads` function has been removed from the C API.
+  It should not be called explicitly: use :c:func:`PyOS_AfterFork_Child`
+  instead.
+  (Contributed by Victor Stinner in :issue:`36728`.)
+
 * On Unix, C extensions are no longer linked to libpython except on
   Android. When Python is embedded, ``libpython`` must not be loaded with
   ``RTLD_LOCAL``, but ``RTLD_GLOBAL`` instead. Previously, using

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -195,7 +195,6 @@ PyAPI_FUNC(void) PyEval_AcquireLock(void) Py_DEPRECATED(3.2);
 PyAPI_FUNC(void) PyEval_ReleaseLock(void) /* Py_DEPRECATED(3.2) */;
 PyAPI_FUNC(void) PyEval_AcquireThread(PyThreadState *tstate);
 PyAPI_FUNC(void) PyEval_ReleaseThread(PyThreadState *tstate);
-PyAPI_FUNC(void) PyEval_ReInitThreads(void);
 
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(void) _PyEval_SetSwitchInterval(unsigned long microseconds);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -24,6 +24,8 @@ PyAPI_FUNC(int) _PyEval_AddPendingCall(
     void *arg);
 PyAPI_FUNC(void) _PyEval_SignalAsyncExc(
     struct _ceval_runtime_state *ceval);
+PyAPI_FUNC(void) _PyEval_ReInitThreads(
+    _PyRuntimeState *runtime);
 
 #ifdef __cplusplus
 }

--- a/Misc/NEWS.d/next/C API/2019-05-11-03-56-23.bpo-36728.FR-dMP.rst
+++ b/Misc/NEWS.d/next/C API/2019-05-11-03-56-23.bpo-36728.FR-dMP.rst
@@ -1,0 +1,2 @@
+The :c:func:`PyEval_ReInitThreads` function has been removed from the C API.
+It should not be called explicitly: use :c:func:`PyOS_AfterFork_Child` instead.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -25,15 +25,25 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "pycore_ceval.h"   /* _PyEval_ReInitThreads() */
+#ifdef MS_WINDOWS
+   /* include <windows.h> early to avoid conflict with pycore_condvar.h:
+
+        #define WIN32_LEAN_AND_MEAN
+        #include <windows.h>
+
+      FSCTL_GET_REPARSE_POINT is not exported with WIN32_LEAN_AND_MEAN. */
+#  include <windows.h>
+#endif
+
+#include "pycore_ceval.h"     /* _PyEval_ReInitThreads() */
+#include "pycore_pystate.h"   /* _PyRuntime */
 #include "pythread.h"
 #include "structmember.h"
 #ifndef MS_WINDOWS
-#include "posixmodule.h"
+#  include "posixmodule.h"
 #else
-#include "winreparse.h"
+#  include "winreparse.h"
 #endif
-#include "pycore_pystate.h"
 
 /* On android API level 21, 'AT_EACCESS' is not declared although
  * HAVE_FACCESSAT is defined. */

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -25,6 +25,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
+#include "pycore_ceval.h"   /* _PyEval_ReInitThreads() */
 #include "pythread.h"
 #include "structmember.h"
 #ifndef MS_WINDOWS
@@ -424,7 +425,7 @@ PyOS_AfterFork_Child(void)
     _PyRuntimeState *runtime = &_PyRuntime;
     _PyGILState_Reinit(runtime);
     _PyInterpreterState_DeleteExceptMain(runtime);
-    PyEval_ReInitThreads();
+    _PyEval_ReInitThreads(runtime);
     _PyImport_ReInitLock();
     _PySignal_AfterFork();
     _PyRuntimeState_ReInitThreads(runtime);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -289,9 +289,8 @@ PyEval_ReleaseThread(PyThreadState *tstate)
  */
 
 void
-PyEval_ReInitThreads(void)
+_PyEval_ReInitThreads(_PyRuntimeState *runtime)
 {
-    _PyRuntimeState *runtime = &_PyRuntime;
     struct _ceval_runtime_state *ceval = &runtime->ceval;
     if (!gil_created(&ceval->gil)) {
         return;


### PR DESCRIPTION
Remove the PyEval_ReInitThreads() function from the Python C API.
This function was exposed by mistake and should not be called
explicitly anyway.

Rename PyEval_ReInitThreads() to _PyEval_ReInitThreads() and add a
'runtime' parameter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36728](https://bugs.python.org/issue36728) -->
https://bugs.python.org/issue36728
<!-- /issue-number -->
