### PR TITLE
bpo-21536: Fix What's New in Python 3.8 entry

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -138,7 +138,8 @@ environment variable, can be set using the new ``./configure --with-trace-refs``
 build option.
 (Contributed by Victor Stinner in :issue:`36465`.)
 
-On Unix, C extensions are no longer linked to libpython. It is now possible
+On Unix, C extensions are no longer linked to libpython except on Android.
+It is now possible
 for a statically linked Python to load a C extension built using a shared
 library Python.
 (Contributed by Victor Stinner in :issue:`21536`.)


### PR DESCRIPTION
Android still links to libpython.

<!-- issue-number: [bpo-21536](https://bugs.python.org/issue21536) -->
https://bugs.python.org/issue21536
<!-- /issue-number -->
