### PR TITLE
bpo-36884: Fix DeprecationWarning in test_asyncio StreamReader instantiation

### DIFF
--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -94,7 +94,7 @@ class StreamReaderTests(BaseTest):
     def test_readline(self):
         DATA = b'line1\nline2\nline3'
 
-        stream = asyncio.StreamReader(loop=self.loop)
+        stream = asyncio.StreamReader(loop=self.loop, _asyncio_internal=True)
         stream.feed_data(DATA)
         stream.feed_eof()
 


### PR DESCRIPTION


<!-- issue-number: [bpo-36884](https://bugs.python.org/issue36884) -->
https://bugs.python.org/issue36884
<!-- /issue-number -->
