### PR TITLE
bpo-36751: Undeprecate getfullargspec

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -948,11 +948,6 @@ Classes and functions
    APIs. This function is retained primarily for use in code that needs to
    maintain compatibility with the Python 2 ``inspect`` module API.
 
-   .. deprecated:: 3.8
-      Use :func:`signature` and
-      :ref:`Signature Object <inspect-signature-object>`, which provide a
-      better introspecting API for callables.
-
    .. versionchanged:: 3.4
       This function is now based on :func:`signature`, but still ignores
       ``__wrapped__`` attributes and includes the already bound first

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -767,10 +767,6 @@ Deprecated
   <positional-only_parameter>`.
   (Contributed by Serhiy Storchaka in :issue:`36492`.)
 
-* The function :func:`~inspect.getfullargspec` in the :mod:`inspect`
-  module is deprecated in favor of the :func:`inspect.signature`
-  API.  (Contributed by Pablo Galindo in :issue:`36751`.)
-
 
 API and Feature Removals
 ========================

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1103,16 +1103,10 @@ def getfullargspec(func):
     'kwonlydefaults' is a dictionary mapping names from kwonlyargs to defaults.
     'annotations' is a dictionary mapping parameter names to annotations.
 
-    .. deprecated:: 3.8
-        Use inspect.signature() instead of inspect.getfullargspec().
-
     Notable differences from inspect.signature():
       - the "self" parameter is always reported, even for bound methods
       - wrapper chains defined by __wrapped__ *not* unwrapped automatically
     """
-
-    warnings.warn("Use inspect.signature() instead of inspect.getfullargspec()",
-                  DeprecationWarning, stacklevel=2)
     try:
         # Re: `skip_bound_arg=False`
         #

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -750,25 +750,22 @@ class TestClassesAndFunctions(unittest.TestCase):
 
     def assertArgSpecEquals(self, routine, args_e, varargs_e=None,
                             varkw_e=None, defaults_e=None, formatted=None):
-        with self.assertWarns(DeprecationWarning):
-            args, varargs, varkw, defaults = inspect.getargspec(routine)
+        args, varargs, varkw, defaults = inspect.getargspec(routine)
         self.assertEqual(args, args_e)
         self.assertEqual(varargs, varargs_e)
         self.assertEqual(varkw, varkw_e)
         self.assertEqual(defaults, defaults_e)
         if formatted is not None:
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults),
-                                 formatted)
+            self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults),
+                             formatted)
 
     def assertFullArgSpecEquals(self, routine, args_e, varargs_e=None,
                                     varkw_e=None, defaults_e=None,
                                     posonlyargs_e=[], kwonlyargs_e=[],
                                     kwonlydefaults_e=None,
                                     ann_e={}, formatted=None):
-        with self.assertWarns(DeprecationWarning):
-            args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, ann = \
-                inspect.getfullargspec(routine)
+        args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, ann = \
+            inspect.getfullargspec(routine)
         self.assertEqual(args, args_e)
         self.assertEqual(varargs, varargs_e)
         self.assertEqual(varkw, varkw_e)
@@ -777,9 +774,8 @@ class TestClassesAndFunctions(unittest.TestCase):
         self.assertEqual(kwonlydefaults, kwonlydefaults_e)
         self.assertEqual(ann, ann_e)
         if formatted is not None:
-            with self.assertWarns(DeprecationWarning):
-                self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults,
-                                                       kwonlyargs, kwonlydefaults, ann),
+            self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults,
+                                                   kwonlyargs, kwonlydefaults, ann),
                              formatted)
 
     def test_getargspec(self):
@@ -879,13 +875,11 @@ class TestClassesAndFunctions(unittest.TestCase):
 
     def test_getfullargspec_signature_annos(self):
         def test(a:'spam') -> 'ham': pass
-        with self.assertWarns(DeprecationWarning):
-            spec = inspect.getfullargspec(test)
+        spec = inspect.getfullargspec(test)
         self.assertEqual(test.__annotations__, spec.annotations)
 
         def test(): pass
-        with self.assertWarns(DeprecationWarning):
-            spec = inspect.getfullargspec(test)
+        spec = inspect.getfullargspec(test)
         self.assertEqual(test.__annotations__, spec.annotations)
 
     @unittest.skipIf(MISSING_C_DOCSTRINGS,
@@ -910,8 +904,7 @@ class TestClassesAndFunctions(unittest.TestCase):
     def test_getfullargspec_builtin_func(self):
         import _testcapi
         builtin = _testcapi.docstring_with_signature_with_defaults
-        with self.assertWarns(DeprecationWarning):
-            spec = inspect.getfullargspec(builtin)
+        spec = inspect.getfullargspec(builtin)
         self.assertEqual(spec.defaults[0], 'avocado')
 
     @cpython_only
@@ -920,20 +913,17 @@ class TestClassesAndFunctions(unittest.TestCase):
     def test_getfullargspec_builtin_func_no_signature(self):
         import _testcapi
         builtin = _testcapi.docstring_no_signature
-        with self.assertWarns(DeprecationWarning):
-            with self.assertRaises(TypeError):
-                inspect.getfullargspec(builtin)
+        with self.assertRaises(TypeError):
+            inspect.getfullargspec(builtin)
 
     def test_getfullargspec_definition_order_preserved_on_kwonly(self):
         for fn in signatures_with_lexicographic_keyword_only_parameters():
-            with self.assertWarns(DeprecationWarning):
-                signature = inspect.getfullargspec(fn)
+            signature = inspect.getfullargspec(fn)
             l = list(signature.kwonlyargs)
             sorted_l = sorted(l)
             self.assertTrue(l)
             self.assertEqual(l, sorted_l)
-        with self.assertWarns(DeprecationWarning):
-            signature = inspect.getfullargspec(unsorted_keyword_only_parameters_fn)
+        signature = inspect.getfullargspec(unsorted_keyword_only_parameters_fn)
         l = list(signature.kwonlyargs)
         self.assertEqual(l, unsorted_keyword_only_parameters)
 
@@ -1390,9 +1380,8 @@ class TestGetcallargsFunctions(unittest.TestCase):
     def assertEqualCallArgs(self, func, call_params_string, locs=None):
         locs = dict(locs or {}, func=func)
         r1 = eval('func(%s)' % call_params_string, None, locs)
-        with self.assertWarns(DeprecationWarning):
-            r2 = eval('inspect.getcallargs(func, %s)' % call_params_string, None,
-                      locs)
+        r2 = eval('inspect.getcallargs(func, %s)' % call_params_string, None,
+                  locs)
         self.assertEqual(r1, r2)
 
     def assertEqualException(self, func, call_param_string, locs=None):
@@ -1404,9 +1393,8 @@ class TestGetcallargsFunctions(unittest.TestCase):
         else:
             self.fail('Exception not raised')
         try:
-            with self.assertWarns(DeprecationWarning):
-                eval('inspect.getcallargs(func, %s)' % call_param_string, None,
-                     locs)
+            eval('inspect.getcallargs(func, %s)' % call_param_string, None,
+                 locs)
         except Exception as e:
             ex2 = e
         else:
@@ -1564,16 +1552,14 @@ class TestGetcallargsFunctions(unittest.TestCase):
         def f5(*, a): pass
         with self.assertRaisesRegex(TypeError,
                                     'missing 1 required keyword-only'):
-            with self.assertWarns(DeprecationWarning):
-                inspect.getcallargs(f5)
+            inspect.getcallargs(f5)
 
 
         # issue20817:
         def f6(a, b, c):
             pass
         with self.assertRaisesRegex(TypeError, "'a', 'b' and 'c'"):
-            with self.assertWarns(DeprecationWarning):
-                inspect.getcallargs(f6)
+            inspect.getcallargs(f6)
 
         # bpo-33197
         with self.assertRaisesRegex(ValueError,

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -33,17 +33,6 @@ directory if the :envvar:`PATH` environment variable is not set.
 
 ..
 
-.. bpo: 36751
-.. date: 2019-04-29-23-30-21
-.. nonce: 3NCRbm
-.. section: Core and Builtins
-
-The :func:`~inspect.getfullargspec` function in the :mod:`inspect` module is
-deprecated in favor of the :func:`inspect.signature` API. Contributed by
-Pablo Galindo.
-
-..
-
 .. bpo: 36722
 .. date: 2019-04-25-21-02-40
 .. nonce: 8NApVM


### PR DESCRIPTION
<!-- issue-number: [bpo-36751](https://bugs.python.org/issue36751) -->
https://bugs.python.org/issue36751
<!-- /issue-number -->
