### PR TITLE
bpo-36891: Enhancement in site.py

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -604,24 +604,22 @@ if not sys.flags.no_site:
     main()
 
 def custsite_info(sname, usepath) :
-  if usepath :
-     print("%s ON: %s" % (sname , usepath) )
-  else :
-     print("%s OFF" % (sname) )
+    if usepath :
+        print("%s ON: %s" % (sname , usepath) )
+    else :
+        print("%s OFF" % (sname) )
 
 
 def envpath_info(vname) :
-  env = os.environ.copy()
-  strpath = env[vname]
-  if strpath == "" :
-     return
-
-  print("env[%s] = [" % vname)
-  for vdir in strpath.split(';') :
-    if vdir :
-      print("  %s" % (vdir))
-
-  print("]")
+    env = os.environ.copy()
+    strpath = env[vname]
+    if strpath == "" :
+       return
+    print("env[%s] = [" % vname)
+    for vdir in strpath.split(';') :
+        if vdir :
+            print("  %s" % (vdir))
+    print("]")
 
 
 def _script():

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -133,20 +133,20 @@ def removeduppaths_ex(atpath, mustexist):
         if dircase not in known_paths:
             doadd = True
             if mustexist :
-               doadd = os.path.exists(dir)
+                doadd = os.path.exists(dir)
             if doadd:
-               L.append(dir)
-               known_paths.add(dircase)
+                L.append(dir)
+                known_paths.add(dircase)
 
     atpath[:] = L
     return known_paths
 # end removeduppath_ex()
 
 
-# compatibility for those, who use it outside site.py, works as before, may be deprecated 
+# compatibility for those, who use it outside site.py, works as before, may be deprecated
 def removeduppaths():
     """ Remove duplicate entries from sys.path along with making them absolute"""
-    return removeduppaths_ex(sys.path , False) # False: keep nonexistent in path      
+    return removeduppaths_ex(sys.path , False) # False: keep nonexistent in path
 
 
 def _init_pathinfo():
@@ -540,12 +540,12 @@ def exec_imp_module(modName) :
             # There is 'collection_mods' list there and subsequent AssertFailed()
             # is trying to ensure listed modules not loaded yet.
             # Attempt to use 'import importlib' cause listed module 'types' loaded.
-            # Same problem  it just try 'from importlib import import_module', 
-            # even without any other changes this file 
+            # Same problem  it just try 'from importlib import import_module',
+            # even without any other changes this file
             retmod = __import__( modName )
             usename = retmod.__file__
         except ImportError as exc:
-            if exc.name == modName : 
+            if exc.name == modName :
                 pass   # continue: no module found - no problem
             else:      # module found, but error in running
                 raise
@@ -614,7 +614,7 @@ def envpath_info(vname) :
     env = os.environ.copy()
     strpath = env[vname]
     if strpath == "" :
-       return
+        return
     print("env[%s] = [" % vname)
     for vdir in strpath.split(';') :
         if vdir :

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -625,11 +625,11 @@ def envpath_info(vname) :
 def useful_info() :
     global use_sitevendor, use_sitecustomize, use_usercustomize
 
-    print("sys.version:", sys.version ) 
-    print("sys._git:", sys._git ) 
-    print("sys.prefix:", sys.prefix) 
-    print("sys.base_prefix:", sys.base_prefix) 
-    print("sys.executable:", sys.executable) 
+    print("sys.version:", sys.version )
+    print("sys._git:", sys._git )
+    print("sys.prefix:", sys.prefix)
+    print("sys.base_prefix:", sys.base_prefix)
+    print("sys.executable:", sys.executable)
     print("sys.path = [")
     for dir in sys.path:
         print("  %s" % (dir))
@@ -657,7 +657,7 @@ def useful_info() :
     else :
         print("sys._xoptions is empty")
 
-    print("sys.warnoptions:", sys.warnoptions ) 
+    print("sys.warnoptions:", sys.warnoptions )
 # end useful_info
 
 

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -622,6 +622,45 @@ def envpath_info(vname) :
     print("]")
 
 
+def useful_info() :
+    global use_sitevendor, use_sitecustomize, use_usercustomize
+
+    print("sys.version:", sys.version ) 
+    print("sys._git:", sys._git ) 
+    print("sys.prefix:", sys.prefix) 
+    print("sys.base_prefix:", sys.base_prefix) 
+    print("sys.executable:", sys.executable) 
+    print("sys.path = [")
+    for dir in sys.path:
+        print("  %s" % (dir))
+    print("]")
+    envpath_info('PATH')
+
+    user_base = getuserbase()
+    user_site = getusersitepackages()
+    print("USER_BASE: %r (%s)" % (user_base,
+        "exists" if os.path.isdir(user_base) else "doesn't exist"))
+    print("USER_SITE: %r (%s)" % (user_site,
+        "exists" if os.path.isdir(user_site) else "doesn't exist"))
+    print("ENABLE_USER_SITE: %r" %  ENABLE_USER_SITE)
+
+    custsite_info("sitevendor" ,   use_sitevendor)
+    custsite_info("sitecustomize", use_sitecustomize)
+    custsite_info("usercustomize", use_usercustomize)
+
+    lng = len(sys._xoptions)
+    if (lng > 0) :
+        print("sys._xoptions = {") # name-value dictionary
+        for nm, val in sys._xoptions.items() :
+            print("  %s=%s" % (nm, val))
+        print("}")
+    else :
+        print("sys._xoptions is empty")
+
+    print("sys.warnoptions:", sys.warnoptions ) 
+# end useful_info
+
+
 def _script():
     help = """\
     %s [--user-base] [--user-site]
@@ -638,28 +677,9 @@ def _script():
      >2 - unknown error
     """
 
-    global use_sitevendor, use_sitecustomize, use_usercustomize
     args = sys.argv[1:]
     if not args:
-        print("sys.path = [")
-        for dir in sys.path:
-            print("  %s" % (dir))
-        print("]")
-
-        envpath_info('PATH')
-
-        user_base = getuserbase()
-        user_site = getusersitepackages()
-        print("USER_BASE: %r (%s)" % (user_base,
-            "exists" if os.path.isdir(user_base) else "doesn't exist"))
-        print("USER_SITE: %r (%s)" % (user_site,
-            "exists" if os.path.isdir(user_site) else "doesn't exist"))
-
-        print("ENABLE_USER_SITE: %r" %  ENABLE_USER_SITE)
-        custsite_info("sitevendor" ,   use_sitevendor)
-        custsite_info("sitecustomize", use_sitecustomize)
-        custsite_info("usercustomize", use_usercustomize)
-
+        useful_info()
         sys.exit(0)
 
     buffer = []
@@ -685,3 +705,5 @@ def _script():
 
 if __name__ == '__main__':
     _script()
+
+# eof site.py

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-13-16-06-49.bpo-36891.LLxZ61.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-13-16-06-49.bpo-36891.LLxZ61.rst
@@ -1,0 +1,1 @@
+Allow "sitevendor" Python startup-plugin in addition to already existed "sitecustomize" and "usercustomize".


### PR DESCRIPTION
Following Anaconda problem is addressed here: "python.exe -m conda update --all" gives error somewhere in SSL communication code. Real problem is that no proper PATH to folder with some DLLs and Anaconda does not provide it without calling to Home\Scripts\activate.bat. It would be better when Anaconda provides it automatically and end-user (like me) just start python.exe using full path to python.exe without any changes in system PATH and other environment variables.  

Proposed modification in site.py allows "sitevendor" customization plugin in addition to "sitecustomize" and "usercustomuze". More info displayed when "python.exe -m site" typed from command line.

I propose Anaconda to be shipped with proper startup/init code in PythonHome\sitevendor.py instead of using PythonHome\Scripts\activate.bat.  Old sitecustomize and usercustomize plugins continue to work as before (if already used by end-user).
New "sitevendor.py" can be placed near python.exe and contain something sitevendor.txt file attached. I am going to discuss adding this "sitevendor.py" with Anaconda developers, but Lib\site.py changes going to be taken from your CPython\Lib\site.py  (as I assume) 


[sitevendor.txt](https://github.com/python/cpython/files/3169197/sitevendor.txt)


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36891](https://bugs.python.org/issue36891) -->
https://bugs.python.org/issue36891
<!-- /issue-number -->
