### PR TITLE
bpo-36868: Fix what's new for SSLContext.hostname_checks_common_name

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1307,7 +1307,7 @@ including failing the host name check now raises
 :exc:`~ssl.SSLCertVerificationError` and aborts the handshake with a proper
 TLS Alert message.  The new exception contains additional information.
 Host name validation can be customized with
-:attr:`SSLContext.host_flags <ssl.SSLContext.host_flags>`.
+:attr:`SSLContext.hostname_checks_common_name <ssl.SSLContext.hostname_checks_common_name>`.
 (Contributed by Christian Heimes in :issue:`31399`.)
 
 .. note::
@@ -1320,8 +1320,7 @@ The ``ssl`` module no longer sends IP addresses in SNI TLS extension.
 (Contributed by Christian Heimes in :issue:`32185`.)
 
 :func:`~ssl.match_hostname` no longer supports partial wildcards like
-``www*.example.org``. :attr:`SSLContext.host_flags <ssl.SSLContext.host_flags>`
-has partial wildcard matching disabled by default.
+``www*.example.org``.
 (Contributed by Mandeep Singh in :issue:`23033` and Christian Heimes in
 :issue:`31399`.)
 

--- a/Misc/NEWS.d/next/Documentation/2019-05-11-17-42-15.bpo-36868.yioL0R.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-05-11-17-42-15.bpo-36868.yioL0R.rst
@@ -1,0 +1,2 @@
+What's new now mentions SSLContext.hostname_checks_common_name instead of
+SSLContext.host_flags.


### PR DESCRIPTION
What's new now mentions SSLContext.hostname_checks_common_name instead of SSLContext.host_flags.

<!-- issue-number: [bpo-36868](https://bugs.python.org/issue36868) -->
https://bugs.python.org/issue36868
<!-- /issue-number -->
