### PR TITLE
[2.7] bpo-35925: Skip SSL tests that fail due to weak external certs or old TLS (GH-13124)

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-05-06-18-29-54.bpo-35925.gwQPuC.rst
+++ b/Misc/NEWS.d/next/Tests/2019-05-06-18-29-54.bpo-35925.gwQPuC.rst
@@ -1,0 +1,1 @@
+Skip specific nntplib and ssl networking tests when they would otherwise fail due to a modern OS or distro with a default OpenSSL policy of rejecting connections to servers with weak certificates or disabling TLS below TLSv1.2.


### PR DESCRIPTION
Modern Linux distros such as Debian Buster have default OpenSSL system
configurations that reject connections to servers with weak certificates
and the use of TLS versions less than TLSv1.2 by default. This causes our
test suite run with external networking resources enabled to skip these tests
when they encounter such a failure or configuration.

(cherry picked from commit 2cc0223)

Changes to test_ssl.py required as 2.7 has legacy protocol tests.

The test_httplib.py change is omitted from this backport as
self-signed.pythontest.net's certificate was updated and the
test_nntplib.py change is not applicable on 2.7.

Authored-by: Gregory P. Smith greg@krypto.org

<!-- issue-number: [bpo-35925](https://bugs.python.org/issue35925) -->
https://bugs.python.org/issue35925
<!-- /issue-number -->
