### PR TITLE
bpo-27805: Allow opening /dev/std{out,err} in append mode

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1542,7 +1542,11 @@ class FileIO(RawIOBase):
                 # For consistent behaviour, we explicitly seek to the
                 # end of file (otherwise, it might be done only on the
                 # first write()).
-                os.lseek(fd, 0, SEEK_END)
+                try:
+                    os.lseek(fd, 0, SEEK_END)
+                except OSError as exc:
+                    if exc.errno != errno.ESPIPE:
+                        raise
         except:
             if owned_fd is not None:
                 os.close(owned_fd)

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3660,6 +3660,12 @@ class TextIOWrapperTest(unittest.TestCase):
         t.write('x')
         t.tell()
 
+    def test_issue27805_open_append_dev_stdout(self):
+        p = '/dev/stdout'
+        if not os.path.exists(p):
+            self.skipTest(f"{p} does not exist")
+        self.open(p, 'a').close()
+
 
 class MemviewBytesIO(io.BytesIO):
     '''A BytesIO object whose read method returns memoryviews

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-11-15-46-36.bpo-27805.xBP-3h.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-11-15-46-36.bpo-27805.xBP-3h.rst
@@ -1,0 +1,1 @@
+Allow opening ``/dev/std{out,err}`` in append mode.


### PR DESCRIPTION
For example, `open('/dev/stdout', 'a')` will no longer raise an `OSError`.



<!-- issue-number: [bpo-27805](https://bugs.python.org/issue27805) -->
https://bugs.python.org/issue27805
<!-- /issue-number -->
