### PR TITLE
bpo-36817: Do not decrement reference for expr_text on fstring = parsing failure

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1148,6 +1148,8 @@ non-important content
         self.assertEqual(f'{C()=:x}', 'C()=FORMAT-x')
         self.assertEqual(f'{C()=!r:*^20}', 'C()=********REPR********')
 
+        self.assertRaises(SyntaxError, eval, "f'{C=]'")
+
     def test_walrus(self):
         x = 20
         # This isn't an assignment expression, it's 'x', with a format

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -5283,7 +5283,6 @@ unexpected_end_of_string:
     /* Falls through to error. */
 
 error:
-    Py_XDECREF(expr_text);
     return -1;
 
 }


### PR DESCRIPTION
<!-- issue-number: [bpo-36817](https://bugs.python.org/issue36817) -->
https://bugs.python.org/issue36817
<!-- /issue-number -->

Add an extra check to detect the failure.
