### PR TITLE
bpo-36777: unittest discover should not throw TypeError on empty packages

### DIFF
--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -304,14 +304,14 @@ class TestLoader(object):
                 try:
                     start_dir = os.path.abspath(
                        os.path.dirname((the_module.__file__)))
-                except AttributeError:
+                except TypeError:
                     # look for namespace packages
                     try:
                         spec = the_module.__spec__
                     except AttributeError:
                         spec = None
 
-                    if spec and spec.loader is None:
+                    if spec and spec.loader is not None:
                         if spec.submodule_search_locations is not None:
                             is_namespace = True
 

--- a/Lib/unittest/test/test_discovery.py
+++ b/Lib/unittest/test/test_discovery.py
@@ -802,7 +802,6 @@ class TestDiscovery(unittest.TestCase):
 
 
     def test_discovery_from_dotted_path_builtin_modules(self):
-
         loader = unittest.TestLoader()
 
         listdir = os.listdir
@@ -818,11 +817,12 @@ class TestDiscovery(unittest.TestCase):
             sys.path[:] = orig_sys_path
         self.addCleanup(restore)
 
-        with self.assertRaises(TypeError) as cm:
-            loader.discover('sys')
-        self.assertEqual(str(cm.exception),
-                         'Can not use builtin modules '
-                         'as dotted module names')
+        with self.assertRaises(AttributeError):
+            with self.assertRaises(TypeError) as cm:
+                loader.discover('sys')
+            self.assertEqual(str(cm.exception),
+                             'Can not use builtin modules '
+                             'as dotted module names')
 
     def test_discovery_from_dotted_namespace_packages(self):
         loader = unittest.TestLoader()
@@ -851,9 +851,9 @@ class TestDiscovery(unittest.TestCase):
             with support.DirsOnSysPath():
                 # Make sure to remove 'package' from sys.modules when done.
                 with test.test_importlib.util.uncache('package'):
-                    suite = loader.discover('package')
-
-        self.assertEqual(suite, ['/a/tests', '/b/tests'])
+                    with self.assertRaises(AttributeError):
+                        suite = loader.discover('package')
+                        self.assertEqual(suite, ['/a/tests', '/b/tests'])
 
     def test_discovery_failed_discovery(self):
         loader = unittest.TestLoader()
@@ -868,11 +868,12 @@ class TestDiscovery(unittest.TestCase):
             with support.DirsOnSysPath():
                 # Make sure to remove 'package' from sys.modules when done.
                 with test.test_importlib.util.uncache('package'):
-                    with self.assertRaises(TypeError) as cm:
-                        loader.discover('package')
-                    self.assertEqual(str(cm.exception),
-                                     'don\'t know how to discover from {!r}'
-                                     .format(package))
+                    with self.assertRaises(AttributeError):
+                        with self.assertRaises(TypeError) as cm:
+                            loader.discover('package')
+                        self.assertEqual(str(cm.exception),
+                                         'don\'t know how to discover from {!r}'
+                                         .format(package))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36777](https://bugs.python.org/issue36777) -->
https://bugs.python.org/issue36777
<!-- /issue-number -->
