### PR TITLE
[3.7] bpo-36822: Fix minor grammatical error in glossary.rst (GH-13145).

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -13,10 +13,10 @@ Glossary
       examples which can be executed interactively in the interpreter.
 
    ``...``
-      The default Python prompt of the interactive shell when entering code for
-      an indented code block, when within a pair of matching left and right
-      delimiters (parentheses, square brackets, curly braces or triple quotes),
-      or after specifying a decorator.
+      The default Python prompt of the interactive shell when entering the
+      code for an indented code block, when within a pair of matching left and
+      right delimiters (parentheses, square brackets, curly braces or triple
+      quotes), or after specifying a decorator.
 
    2to3
       A tool that tries to convert Python 2.x code to Python 3.x code by


### PR DESCRIPTION
(cherry picked from commit 90fb04c1e23c0fddd438bd0f73e7c018cacef4bc)

Co-authored-by: Sanyam Khurana <8039608+CuriousLearner@users.noreply.github.com>

Refers to https://github.com/python/cpython/pull/13145

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36822](https://bugs.python.org/issue36822) -->
https://bugs.python.org/issue36822
<!-- /issue-number -->
