### PR TITLE
bpo-36871: Ensure method signature is used when asserting mock calls to a method

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -739,9 +739,10 @@ class NonCallableMock(Base):
 
     def _get_call_signature_from_name(self, name):
         """
-        If there is no name like the case for call check against functions
-        with tuples then return the self's spec signature.
-        If the name is not empty then remove () and split by '.' to get
+        * If call objects are asserted against a method/function like obj.meth1
+        then there could be no name for the call object to lookup. Hence just
+        return the spec_signature of the method/function being asserted against.
+        * If the name is not empty then remove () and split by '.' to get
         list of names to iterate through the children until a potential
         match is found. A child mock is created only during attribute access
         so if we get a _SpecState then no attributes of the spec were accessed

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -743,7 +743,9 @@ class NonCallableMock(Base):
         with tuples then return the self's spec signature.
         If the name is not empty then remove () and split by '.' to get
         list of names to iterate through the children until a potential
-        match is found.
+        match is found. A child mock is created only during attribute access
+        so if we get a _SpecState then no attributes of the spec were accessed
+        and can be safely exited.
         """
         if not name:
             return self._spec_signature
@@ -754,13 +756,11 @@ class NonCallableMock(Base):
 
         for name in names:
             child = children.get(name)
-            if child is None:
+            if child is None or isinstance(child, _SpecState):
                 break
             else:
-                children = child._mock_children.get(name)
+                children = child._mock_children
                 sig = child._spec_signature
-                if children is None:
-                    break
 
         return sig
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -754,12 +754,12 @@ class NonCallableMock(Base):
 
         for name in names:
             child = children.get(name)
-            if not child:
+            if child is None:
                 break
             else:
                 children = child._mock_children.get(name)
                 sig = child._spec_signature
-                if not children:
+                if children is None:
                     break
 
         return sig

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1344,7 +1344,7 @@ class MockTest(unittest.TestCase):
 
             class Foo:
 
-                def __init__(self): pass
+                def __init__(self, a): pass
                 def meth1(self, a, b): pass
 
         mock_class = create_autospec(Something)
@@ -1354,17 +1354,20 @@ class MockTest(unittest.TestCase):
             m.assert_has_calls([call.meth(1, 2, 3, d=1)])
             m.assert_has_calls([call.meth(1, 2, 3, 1)])
 
-        mock_class = create_autospec(Something)
+        mock_class.reset_mock()
 
         for m in [mock_class, mock_class()]:
             self.assertRaises(AssertionError, m.assert_has_calls, [call.Foo()])
-            m.Foo().meth1(1, 2)
-            m.assert_has_calls([call.Foo(), call.Foo().meth1(1, 2)])
+            m.Foo(1).meth1(1, 2)
+            m.assert_has_calls([call.Foo(1), call.Foo(1).meth1(1, 2)])
+            m.Foo.assert_has_calls([call(1), call().meth1(1, 2)])
 
-        mock_class = create_autospec(Something)
+        mock_class.reset_mock()
+
         invalid_calls = [call.meth(1),
                          call.non_existent(1),
-                         call.Foo().non_existent(1)]
+                         call.Foo().non_existent(1),
+                         call.Foo().meth(1, 2, 3, 4)]
 
         for kall in invalid_calls:
             self.assertRaises(AssertionError,

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1336,6 +1336,38 @@ class MockTest(unittest.TestCase):
                         )
 
 
+    def test_assert_has_calls_nested_spec(self):
+        class Something:
+
+            def __init__(self, a): pass
+            def meth(self, a, b, c, d=None): pass
+
+            class Foo:
+
+                def meth1(self, a, b): pass
+
+        mock = create_autospec(Something)
+        mock.meth(1, 2, 3, d=1)
+
+        mock.assert_has_calls([call.meth(1, 2, 3, d=1)])
+        mock.assert_has_calls([call.meth(1, 2, 3, 1)])
+
+        mock = create_autospec(Something)
+        mock.Foo().meth1(1, 2)
+
+        mock.assert_has_calls([call.Foo(), call.Foo().meth1(1, 2)])
+
+        invalid_calls = [call.meth(1),
+                         call.non_existent(1),
+                         call.Foo().non_existent(1)]
+
+        for kall in invalid_calls:
+            self.assertRaises(AssertionError,
+                              mock.assert_has_calls,
+                              [kall]
+            )
+
+
     def test_assert_has_calls_with_function_spec(self):
         def f(a, b, c, d=None): pass
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1339,31 +1339,36 @@ class MockTest(unittest.TestCase):
     def test_assert_has_calls_nested_spec(self):
         class Something:
 
-            def __init__(self, a): pass
+            def __init__(self): pass
             def meth(self, a, b, c, d=None): pass
 
             class Foo:
 
+                def __init__(self): pass
                 def meth1(self, a, b): pass
 
-        mock = create_autospec(Something)
-        mock.meth(1, 2, 3, d=1)
+        mock_class = create_autospec(Something)
 
-        mock.assert_has_calls([call.meth(1, 2, 3, d=1)])
-        mock.assert_has_calls([call.meth(1, 2, 3, 1)])
+        for m in [mock_class, mock_class()]:
+            m.meth(1, 2, 3, d=1)
+            m.assert_has_calls([call.meth(1, 2, 3, d=1)])
+            m.assert_has_calls([call.meth(1, 2, 3, 1)])
 
-        mock = create_autospec(Something)
-        mock.Foo().meth1(1, 2)
+        mock_class = create_autospec(Something)
 
-        mock.assert_has_calls([call.Foo(), call.Foo().meth1(1, 2)])
+        for m in [mock_class, mock_class()]:
+            self.assertRaises(AssertionError, m.assert_has_calls, [call.Foo()])
+            m.Foo().meth1(1, 2)
+            m.assert_has_calls([call.Foo(), call.Foo().meth1(1, 2)])
 
+        mock_class = create_autospec(Something)
         invalid_calls = [call.meth(1),
                          call.non_existent(1),
                          call.Foo().non_existent(1)]
 
         for kall in invalid_calls:
             self.assertRaises(AssertionError,
-                              mock.assert_has_calls,
+                              mock_class.assert_has_calls,
                               [kall]
             )
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1368,6 +1368,14 @@ class MockTest(unittest.TestCase):
             )
 
 
+    def test_assert_has_calls_nested_without_spec(self):
+        m = MagicMock()
+        m().foo().bar().baz()
+        m.one().two().three()
+        calls = call.one().two().three().call_list()
+        m.assert_has_calls(calls)
+
+
     def test_assert_has_calls_with_function_spec(self):
         def f(a, b, c, d=None): pass
 

--- a/Misc/NEWS.d/next/Library/2019-05-12-12-58-37.bpo-36871.6xiEHZ.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-12-12-58-37.bpo-36871.6xiEHZ.rst
@@ -1,0 +1,3 @@
+Ensure method signature is used instead of constructor signature of a class
+while asserting mock object against method calls. Patch by Karthikeyan
+Singaravelan.


### PR DESCRIPTION


<!-- issue-number: [bpo-36871](https://bugs.python.org/issue36871) -->
https://bugs.python.org/issue36871
<!-- /issue-number -->
