### PR TITLE
Remove workaround for defaults in namedtuple now that we have the defaults parameter

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1017,14 +1017,6 @@ fields:
 .. versionchanged:: 3.5
    Property docstrings became writeable.
 
-Default values can be implemented by using :meth:`~somenamedtuple._replace` to
-customize a prototype instance:
-
-    >>> Account = namedtuple('Account', 'owner balance transaction_count')
-    >>> default_account = Account('<owner name>', 0.0, 0)
-    >>> johns_account = default_account._replace(owner='John')
-    >>> janes_account = default_account._replace(owner='Jane')
-
 
 .. seealso::
 

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1017,7 +1017,6 @@ fields:
 .. versionchanged:: 3.5
    Property docstrings became writeable.
 
-
 .. seealso::
 
     * See :class:`typing.NamedTuple` for a way to add type hints for named


### PR DESCRIPTION
The intention is to prevent the previous more verbose style now that a more fitting solution has been implemented.