### PR TITLE
Remove outdated time.monotonic reference

### DIFF
--- a/Doc/library/sched.rst
+++ b/Doc/library/sched.rst
@@ -20,8 +20,7 @@ scheduler:
    The :class:`scheduler` class defines a generic interface to scheduling events.
    It needs two functions to actually deal with the "outside world" --- *timefunc*
    should be callable without arguments, and return  a number (the "time", in any
-   units whatsoever). If time.monotonic is not available, the *timefunc* default
-   is time.time instead. The *delayfunc* function should be callable with one
+   units whatsoever).  The *delayfunc* function should be callable with one
    argument, compatible with the output of *timefunc*, and should delay that many
    time units. *delayfunc* will also be called with the argument ``0`` after each
    event is run to allow other threads an opportunity to run in multi-threaded


### PR DESCRIPTION
Per ae58649, ``time.monotonic`` is always available, making the old note outdated.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
