### PR TITLE
[2.7] bpo-14353: Fix detection of bind_textdomain_codeset in libintl

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-05-12-10-52-37.bpo-14353.LK1qWM.rst
+++ b/Misc/NEWS.d/next/Build/2019-05-12-10-52-37.bpo-14353.LK1qWM.rst
@@ -1,0 +1,2 @@
+Fix detection of the bind_textdomain_codeset function for building gettext
+support into the locale module.

--- a/configure
+++ b/configure
@@ -9051,6 +9051,64 @@ $as_echo "#define WITH_LIBINTL 1" >>confdefs.h
 
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing bind_textdomain_codeset" >&5
+$as_echo_n "checking for library containing bind_textdomain_codeset... " >&6; }
+if ${ac_cv_search_bind_textdomain_codeset+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char bind_textdomain_codeset ();
+int
+main ()
+{
+return bind_textdomain_codeset ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' intl; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_bind_textdomain_codeset=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_bind_textdomain_codeset+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_bind_textdomain_codeset+:} false; then :
+
+else
+  ac_cv_search_bind_textdomain_codeset=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_bind_textdomain_codeset" >&5
+$as_echo "$ac_cv_search_bind_textdomain_codeset" >&6; }
+ac_res=$ac_cv_search_bind_textdomain_codeset
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+$as_echo "#define HAVE_BIND_TEXTDOMAIN_CODESET 1" >>confdefs.h
+
+fi
+
 
 # checks for system dependent C++ extensions support
 case "$ac_sys_system" in
@@ -10588,7 +10646,7 @@ fi
 $as_echo "MACHDEP_OBJS" >&6; }
 
 # checks for library functions
-for ac_func in alarm setitimer getitimer bind_textdomain_codeset chown \
+for ac_func in alarm setitimer getitimer chown \
  clock confstr ctermid execv fchmod fchown fork fpathconf ftime ftruncate \
  gai_strerror getgroups getlogin getloadavg getpeername getpgid getpid \
  getentropy \

--- a/configure.ac
+++ b/configure.ac
@@ -2440,6 +2440,9 @@ fi
 AC_CHECK_LIB(intl, textdomain,
 	AC_DEFINE(WITH_LIBINTL, 1,
 	[Define to 1 if libintl is needed for locale functions.]))
+AC_SEARCH_LIBS(bind_textdomain_codeset, intl,
+	AC_DEFINE(HAVE_BIND_TEXTDOMAIN_CODESET, 1,
+	[Define to 1 if bind_textdomain_codeset is available.]))
 
 # checks for system dependent C++ extensions support
 case "$ac_sys_system" in
@@ -3117,7 +3120,7 @@ fi
 AC_MSG_RESULT(MACHDEP_OBJS)
 
 # checks for library functions
-AC_CHECK_FUNCS(alarm setitimer getitimer bind_textdomain_codeset chown \
+AC_CHECK_FUNCS(alarm setitimer getitimer chown \
  clock confstr ctermid execv fchmod fchown fork fpathconf ftime ftruncate \
  gai_strerror getgroups getlogin getloadavg getpeername getpgid getpid \
  getentropy \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -73,7 +73,7 @@
 /* Define if GCC supports __attribute__((format(PyArg_ParseTuple, 2, 3))) */
 #undef HAVE_ATTRIBUTE_FORMAT_PARSETUPLE
 
-/* Define to 1 if you have the `bind_textdomain_codeset' function. */
+/* Define to 1 if bind_textdomain_codeset is available. */
 #undef HAVE_BIND_TEXTDOMAIN_CODESET
 
 /* Define to 1 if you have the <bluetooth/bluetooth.h> header file. */


### PR DESCRIPTION
In Python-2.7, we were only searching for bind_textdomain_codeset in
libc.  We should have also checked for it in libintl.  This change from
Mel Flynn https://bugs.python.org/file24918/python27-configure.in.patch
fixes that.

This problem does not exist in the Python-3.x tree so this is not a backport but a fresh pull request against the 2.7 branch.

Fixes: https://bugs.python.org/issue14353

<!-- issue-number: [bpo-14353](https://bugs.python.org/issue14353) -->
https://bugs.python.org/issue14353
<!-- /issue-number -->
