### PR TITLE
gh-81135: Skip test_recursive_repr test when running test_xml_etree under coverage trace

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2320,6 +2320,7 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
         e.extend([ET.Element('bar')])
         self.assertRaises(ValueError, e.remove, X('baz'))
 
+    @unittest.skipIf(sys.gettrace(), "Skips under coverage.")
     def test_recursive_repr(self):
         # Issue #25455
         e = ET.Element('foo')


### PR DESCRIPTION
The test_recursive_repr test modifies the tracing environment, causing the
remainder of the tests to lose coverage information.

<!-- issue-number: [bpo-36954](https://bugs.python.org/issue36954) -->
https://bugs.python.org/issue36954
<!-- /issue-number -->

<!-- gh-issue-number: gh-81135 -->
* Issue: gh-81135
<!-- /gh-issue-number -->
