### PR TITLE
gh-66333: Allow to break into pdb with Ctrl-C for all the commands t…

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -158,6 +158,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             pass
         self.allow_kbdint = False
         self.nosigint = nosigint
+        self.sigint_triggered_cmd = None
 
         # Read $HOME/.pdbrc and ./.pdbrc
         self.rcLines = []
@@ -188,9 +189,29 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def sigint_handler(self, signum, frame):
         if self.allow_kbdint:
             raise KeyboardInterrupt
-        self.message("\nProgram interrupted. (Use 'cont' to resume).")
-        self.set_step()
-        self.set_trace(frame)
+        try:
+            self.message("\nReceived SIGINT signal\nResuming Pdb ... (please wait)")
+        except RuntimeError:
+            # 'print' is not safe in signal handlers, check issue24283
+            # if we encounter this issue, we just silently resume the execution
+            pass
+        if self.sigint_triggered_cmd == 'continue':
+            self.set_trace(frame)
+        else:
+            self.set_step()
+
+    def register_sigint_handler(self, triggered_cmd):
+        if self.nosigint:
+            return
+        self.sigint_triggered_cmd = triggered_cmd
+        try:
+            Pdb._previous_sigint_handler = \
+                signal.signal(signal.SIGINT, self.sigint_handler)
+        except ValueError:
+            # ValueError happens when any do_xxx() is invoked from
+            # a non-main thread in which case we just continue without
+            # SIGINT set.
+            pass
 
     def reset(self):
         bdb.Bdb.reset(self)
@@ -988,6 +1009,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 return
         else:
             lineno = None
+        self.register_sigint_handler(triggered_cmd='until')
         self.set_until(self.curframe, lineno)
         return 1
     do_unt = do_until
@@ -1007,6 +1029,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         Continue execution until the next line in the current function
         is reached or it returns.
         """
+        self.register_sigint_handler(triggered_cmd='next')
         self.set_next(self.curframe)
         return 1
     do_n = do_next
@@ -1032,6 +1055,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """r(eturn)
         Continue execution until the current function returns.
         """
+        self.register_sigint_handler(triggered_cmd='return')
         self.set_return(self.curframe)
         return 1
     do_r = do_return
@@ -1040,16 +1064,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """c(ont(inue))
         Continue execution, only stop when a breakpoint is encountered.
         """
-        if not self.nosigint:
-            try:
-                Pdb._previous_sigint_handler = \
-                    signal.signal(signal.SIGINT, self.sigint_handler)
-            except ValueError:
-                # ValueError happens when do_continue() is invoked from
-                # a non-main thread in which case we just continue without
-                # SIGINT set. Would printing a message here (once) make
-                # sense?
-                pass
+        self.register_sigint_handler(triggered_cmd='continue')
         self.set_continue()
         return 1
     do_c = do_cont = do_continue

--- a/Misc/NEWS.d/next/Library/2019-05-18-17-25-06.bpo-22135.BlsIEq.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-18-17-25-06.bpo-22135.BlsIEq.rst
@@ -1,0 +1,1 @@
+Now we can resume the `Pdb` execution by using `Ctrl+C` when we are running a long processing function. It works if the function is run by `continue`, `next`, `until` and `return` commands. Patch by Chun-Yu Tseng.


### PR DESCRIPTION
This PR comes from https://bugs.python.org/issue22135.
I mainly use registered `signal_handler` to handle Ctrl-C behavior and add a unit test.




<!-- issue-number: [bpo-22135](https://bugs.python.org/issue22135) -->
https://bugs.python.org/issue22135
<!-- /issue-number -->

<!-- gh-issue-number: gh-66333 -->
* Issue: gh-66333
<!-- /gh-issue-number -->
