### PR TITLE
bpo-36895: remove time.clock() as per removal notice.

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -155,7 +155,7 @@ Functions
 
    .. availability:: Windows, Unix. Not available on VxWorks.
 
-   .. deprecated:: 3.3
+   .. deprecated-removed:: 3.3 3.8
       The behaviour of this function depends on the platform: use
       :func:`perf_counter` or :func:`process_time` instead, depending on your
       requirements, to have a well defined behaviour.

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -88,17 +88,6 @@ class TimeTestCase(unittest.TestCase):
             check_ns(time.clock_gettime(time.CLOCK_REALTIME),
                      time.clock_gettime_ns(time.CLOCK_REALTIME))
 
-    @unittest.skipUnless(hasattr(time, 'clock'),
-                         'need time.clock()')
-    def test_clock(self):
-        with self.assertWarns(DeprecationWarning):
-            time.clock()
-
-        with self.assertWarns(DeprecationWarning):
-            info = time.get_clock_info('clock')
-        self.assertTrue(info.monotonic)
-        self.assertFalse(info.adjustable)
-
     @unittest.skipUnless(hasattr(time, 'clock_gettime'),
                          'need time.clock_gettime()')
     def test_clock_realtime(self):
@@ -553,15 +542,9 @@ class TimeTestCase(unittest.TestCase):
 
     def test_get_clock_info(self):
         clocks = ['monotonic', 'perf_counter', 'process_time', 'time']
-        if hasattr(time, 'clock'):
-            clocks.append('clock')
 
         for name in clocks:
-            if name == 'clock':
-                with self.assertWarns(DeprecationWarning):
-                    info = time.get_clock_info('clock')
-            else:
-                info = time.get_clock_info(name)
+            info = time.get_clock_info(name)
 
             #self.assertIsInstance(info, dict)
             self.assertIsInstance(info.implementation, str)

--- a/Misc/NEWS.d/next/Library/2019-05-12-14-49-13.bpo-36895.ZZuuY7.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-12-14-49-13.bpo-36895.ZZuuY7.rst
@@ -1,0 +1,2 @@
+The function ``time.clock()`` was deprecated in 3.3 in favor of
+``time.perf_counter()`` and marked for removal in 3.8, it has removed.


### PR DESCRIPTION
`time.clock()` was deprecated in 3.3, and marked for removal removal in
3.8; this thus remove it from the time module.

Alternative is to bump the removal warning to 3.9

https://bugs.python.org/issue36895


<!-- issue-number: [bpo-36895](https://bugs.python.org/issue36895) -->
https://bugs.python.org/issue36895
<!-- /issue-number -->
