### PR TITLE
bpo-36896: Clarify that some types constructors are unstable

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -98,6 +98,9 @@ the types that arise only incidentally during processing such as the
 Typical use of these names is for :func:`isinstance` or
 :func:`issubclass` checks.
 
+
+If you instantiate any of these types, note that signatures may vary between Python versions.
+
 Standard names are defined for the following types:
 
 .. data:: FunctionType

--- a/Misc/NEWS.d/next/Documentation/2019-05-31-10-46-36.bpo-36896.wkXTW9.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-05-31-10-46-36.bpo-36896.wkXTW9.rst
@@ -1,0 +1,2 @@
+Clarify that some types have unstable constructor signature between Python
+versions.


### PR DESCRIPTION
At least it will represent the current state, which seem to be a
consensus; but is not explicit.

Not sure this requires a News item; it would also be good to add this
info in the constructors docstrings.

<!-- issue-number: [bpo-36896](https://bugs.python.org/issue36896) -->
https://bugs.python.org/issue36896
<!-- /issue-number -->
