### PR TITLE
bpo-36867: Create the resource_tracker before launching SharedMemoryManagers

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -21,6 +21,7 @@ import signal
 import array
 import queue
 import time
+import os
 from os import getpid
 
 from traceback import format_exc
@@ -1349,6 +1350,14 @@ if HAS_SHMEM:
         _Server = SharedMemoryServer
 
         def __init__(self, *args, **kwargs):
+            if os.name == "posix":
+                # bpo-36867: Ensure the resource_tracker is running before
+                # launching the manager process, so that concurrent
+                # shared_memory manipulation both in the manager and in the
+                # current process does not create two resource_tracker
+                # processes.
+                from . import resource_tracker
+                resource_tracker.ensure_running()
             BaseManager.__init__(self, *args, **kwargs)
             util.debug(f"{self.__class__.__name__} created by pid {getpid()}")
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -17,6 +17,7 @@ import array
 import socket
 import random
 import logging
+import subprocess
 import struct
 import operator
 import pickle
@@ -3769,7 +3770,6 @@ class _TestSharedMemory(BaseTestCase):
     def test_shared_memory_SharedMemoryManager_reuses_resource_tracker(self):
         # bpo-36867: test that a SharedMemoryManager uses the
         # same resource_tracker process as its parent.
-        import subprocess
         cmd = '''if 1:
             from multiprocessing.managers import SharedMemoryManager
 
@@ -3779,16 +3779,13 @@ class _TestSharedMemory(BaseTestCase):
             sl = smm.ShareableList(range(10))
             smm.shutdown()
         '''
-        p = subprocess.Popen([sys.executable, '-E', '-c', cmd],
-                             stderr=subprocess.PIPE)
-        p.wait()
+        rc, out, err = test.support.script_helper.assert_python_ok('-c', cmd)
 
         # Before bpo-36867 was fixed, a SharedMemoryManager not using the same
         # resource_tracker process as its parent would make the parent's
         # tracker complain about sl being leaked even though smm.shutdown()
         # properly released sl.
-        stderr = p.stderr.read().strip().decode()
-        self.assertNotRegex(stderr, "resource_tracker")
+        self.assertFalse(err)
 
     def test_shared_memory_SharedMemoryManager_basics(self):
         smm1 = multiprocessing.managers.SharedMemoryManager()
@@ -3929,8 +3926,6 @@ class _TestSharedMemory(BaseTestCase):
         sl.shm.close()
 
     def test_shared_memory_cleaned_after_process_termination(self):
-        import subprocess
-        from multiprocessing import shared_memory
         cmd = '''if 1:
             import os, time, sys
             from multiprocessing import shared_memory
@@ -3941,18 +3936,24 @@ class _TestSharedMemory(BaseTestCase):
             sys.stdout.flush()
             time.sleep(100)
         '''
-        p = subprocess.Popen([sys.executable, '-E', '-c', cmd],
-                             stdout=subprocess.PIPE)
-        name = p.stdout.readline().strip().decode()
+        with subprocess.Popen([sys.executable, '-E', '-c', cmd],
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE) as p:
+            name = p.stdout.readline().strip().decode()
 
-        # killing abruptly processes holding reference to a shared memory
-        # segment should not leak the given memory segment.
-        p.terminate()
-        p.wait()
-        time.sleep(1.0)  # wait for the OS to collect the segment
+            # killing abruptly processes holding reference to a shared memory
+            # segment should not leak the given memory segment.
+            p.terminate()
+            p.wait()
+            time.sleep(1.0)  # wait for the OS to collect the segment
 
-        with self.assertRaises(FileNotFoundError):
-            smm = shared_memory.SharedMemory(name, create=False)
+            # The shared memory file was deleted.
+            with self.assertRaises(FileNotFoundError):
+                smm = shared_memory.SharedMemory(name, create=False)
+            # A warning was emitted by the subprocess' own resource_tracker.
+            err = p.stderr.read().decode()
+            self.assertIn("resource_tracker: There appear to be 1 leaked "
+                          "shared_memory objects to clean up at shutdown", err)
 
 #
 #
@@ -4585,7 +4586,7 @@ class TestFlags(unittest.TestCase):
         print(json.dumps(flags))
 
     def test_flags(self):
-        import json, subprocess
+        import json
         # start child process using unusual flags
         prog = ('from test._test_multiprocessing import TestFlags; ' +
                 'TestFlags.run_in_child()')
@@ -4891,7 +4892,6 @@ class TestResourceTracker(unittest.TestCase):
         #
         # Check that killing process does not leak named semaphores
         #
-        import subprocess
         cmd = '''if 1:
             import time, os, tempfile
             import multiprocessing as mp

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3788,8 +3788,7 @@ class _TestSharedMemory(BaseTestCase):
         # tracker complain about sl being leaked even though smm.shutdown()
         # properly released sl.
         stderr = p.stderr.read().strip().decode()
-        resource_tracker_msg_pattern = "resource_tracker"
-        self.assertNotRegex(stderr, resource_tracker_msg_pattern)
+        self.assertNotRegex(stderr, "resource_tracker")
 
     def test_shared_memory_SharedMemoryManager_basics(self):
         smm1 = multiprocessing.managers.SharedMemoryManager()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3950,10 +3950,15 @@ class _TestSharedMemory(BaseTestCase):
             # The shared memory file was deleted.
             with self.assertRaises(FileNotFoundError):
                 smm = shared_memory.SharedMemory(name, create=False)
-            # A warning was emitted by the subprocess' own resource_tracker.
-            err = p.stderr.read().decode()
-            self.assertIn("resource_tracker: There appear to be 1 leaked "
-                          "shared_memory objects to clean up at shutdown", err)
+
+            if os.name == 'posix':
+                # A warning was emitted by the subprocess' own
+                # resource_tracker (on Windows, shared memory segments
+                # are released automatically by the OS).
+                err = p.stderr.read().decode()
+                self.assertIn(
+                    "resource_tracker: There appear to be 1 leaked "
+                    "shared_memory objects to clean up at shutdown", err)
 
 #
 #

--- a/Misc/NEWS.d/next/Library/2019-05-13-13-02-43.bpo-36867.Qh-6mX.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-13-13-02-43.bpo-36867.Qh-6mX.rst
@@ -1,0 +1,1 @@
+Fix a bug making a SharedMemoryManager instance and its parent process use two separate resource_tracker processes.


### PR DESCRIPTION
TLDR; The `resource_tracker` needs to be created before `SharedMemoryManager` processes are launched (which is not the case for managers created using `fork`)

Take this example below:

```python
from multiprocessing.managers import SharedMemoryManager
from multiprocessing import resource_tracker


smm = SharedMemoryManager()
smm.start()
sl = smm.ShareableList(range(10))
smm.shutdown()
```

This simple and legitimate python scripts results in a very noisy output:
```python
/home/pierreglaser/repos/cpython/Lib/multiprocessing/resource_tracker.py:198: UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
/home/pierreglaser/repos/cpython/Lib/multiprocessing/resource_tracker.py:211: UserWarning: resource_tracker: '/psm_3bfa242d': [Errno 2] No such file or directory: '/psm_3bfa242d'
  warnings.warn('resource_tracker: %r: %s' % (name, e))
```

Here is why it happens:
1. `smm.start()` launches a new `manager` process. At this point in the main process, no `resource_tracker` is created if the `manager` is launched using `fork`.
2. `sl = smm.ShareableList(range(10))`  does two things:
   * First, it creates a new shared_memory object **from the parent process**. At creation, a `resource_tracker.register` call is done -> `resource_tracker.ensure_running` is done -> a new `resource_tracker` process is created. In addition, this `resource_tracker` now tracks `sl`. However, since the manager process was created before, it does not know that a new `resource_tracker` process was just created in the parent process..
   * Once `sl` is created, the `SharedMemoryManager` asks its `SharedMemoryTracker` ( which lives in the manager process) to track it.

3. `smm.shutdown` shuts down the manager. It thus asks the `SharedMemoryTracker` to destroy `sl`, which it tracks. To do so, 
    * it first opens it (using a `SharedMemory(name)`) call, which itself triggers a `resource_tracker.register` call -> `resource_tracker.ensure_running` call in the **manager process**, where no resource_tracker exists yet! Thus, another `ResourceTracker` instance /process is created and starts tracking `sl`
    * immediatly after, it `unlinks` `sl`. This sends an `unregister` call to the newly created `resource_tracker`.


When the script ends however, nothing has been done to tell the original `resource_tracker` created in the parent process that `sl` was properly unlinked. The `resource_tracker` thus thinks a leak happened, and tells the user (first line of my output)). However, there was no leak, as `sl` was properly unlinked by the manager. Therefore, the cleanup attempt of the `resource_tracker` fails, resulting the second error.


The solution to this problem is simply to create the right before the `manager` process is created.



<!-- issue-number: [bpo-36867](https://bugs.python.org/issue36867) -->
https://bugs.python.org/issue36867
<!-- /issue-number -->
