### PR TITLE
bpo-36900: import.c uses PyInterpreterState.core_config

### DIFF
--- a/Include/import.h
+++ b/Include/import.h
@@ -8,8 +8,6 @@ extern "C" {
 #endif
 
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(_PyInitError) _PyImportZip_Init(void);
-
 PyMODINIT_FUNC PyInit__imp(void);
 #endif /* !Py_LIMITED_API */
 PyAPI_FUNC(long) PyImport_GetMagicNumber(void);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -54,6 +54,8 @@ extern int _PyFloat_Init(void);
 extern _PyInitError _Py_HashRandomization_Init(const _PyCoreConfig *);
 
 extern _PyInitError _PyTypes_Init(void);
+extern _PyInitError _PyImportZip_Init(PyInterpreterState *interp);
+
 
 /* Various internal finalizers */
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -205,7 +205,7 @@ init_importlib_external(PyInterpreterState *interp)
         return _Py_INIT_ERR("external importer setup failed");
     }
     Py_DECREF(value);
-    return _PyImportZip_Init();
+    return _PyImportZip_Init(interp);
 }
 
 /* Helper functions to better handle the legacy C locale


### PR DESCRIPTION
Move _PyImportZip_Init() to the internal C API and add an 'interp'
parameter.

<!-- issue-number: [bpo-36900](https://bugs.python.org/issue36900) -->
https://bugs.python.org/issue36900
<!-- /issue-number -->
