### PR TITLE
bpo-36807: Fix typo in NEWS item about IDLE (os.flush() should be os.fsync())

### DIFF
--- a/Misc/NEWS.d/next/IDLE/2019-05-05-16-27-53.bpo-13102.AGNWYJ.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-05-05-16-27-53.bpo-13102.AGNWYJ.rst
@@ -1,1 +1,1 @@
-When saving a file, call os.flush() so bits are flushed to e.g. USB drive.
+When saving a file, call os.fsync() so bits are flushed to e.g. USB drive.


### PR DESCRIPTION
Typo reported by Dan Halbert. Should be incorporated into the backports as well.

<!-- issue-number: [bpo-36807](https://bugs.python.org/issue36807) -->
https://bugs.python.org/issue36807
<!-- /issue-number -->
