### PR TITLE
bpo-36895: Undocument removed time.clock

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -136,30 +136,6 @@ Functions
       Unlike the C function of the same name, :func:`asctime` does not add a
       trailing newline.
 
-
-.. function:: clock()
-
-   .. index::
-      single: CPU time
-      single: processor time
-      single: benchmarking
-
-   On Unix, return the current processor time as a floating point number expressed
-   in seconds.  The precision, and in fact the very definition of the meaning of
-   "processor time", depends on that of the C function of the same name.
-
-   On Windows, this function returns wall-clock seconds elapsed since the first
-   call to this function, as a floating point number, based on the Win32 function
-   :c:func:`QueryPerformanceCounter`. The resolution is typically better than one
-   microsecond.
-
-   .. availability:: Windows, Unix. Not available on VxWorks.
-
-   .. deprecated-removed:: 3.3 3.8
-      The behaviour of this function depends on the platform: use
-      :func:`perf_counter` or :func:`process_time` instead, depending on your
-      requirements, to have a well defined behaviour.
-
 .. function:: pthread_getcpuclockid(thread_id)
 
    Return the *clk_id* of the thread-specific CPU-time clock for the specified *thread_id*.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -790,7 +790,7 @@ The following features and APIs have been removed from Python 3.8:
 
 * The function :func:`time.clock` has been removed, it was deprecated since Python
   3.3: use :func:`time.perf_counter` or :func:`time.process_time` instead, depending
-  on your requirements, to have a well defined behaviour.
+  on your requirements, to have a well defined behavior.
 
 * The ``pyvenv`` script has been removed in favor of ``python3.8 -m venv``
   to help eliminate confusion as to what Python interpreter the ``pyvenv``

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -788,6 +788,9 @@ The following features and APIs have been removed from Python 3.8:
 * The function :func:`platform.popen` has been removed, it was deprecated since
   Python 3.3: use :func:`os.popen` instead.
 
+* The function :func:`time.clock` has been removed, it was deprecated since Python
+  3.3: use :func:`time.perf_counter` or :func:`time.process_time` instead.
+
 * The ``pyvenv`` script has been removed in favor of ``python3.8 -m venv``
   to help eliminate confusion as to what Python interpreter the ``pyvenv``
   script is tied to. (Contributed by Brett Cannon in :issue:`25427`.)

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -789,7 +789,8 @@ The following features and APIs have been removed from Python 3.8:
   Python 3.3: use :func:`os.popen` instead.
 
 * The function :func:`time.clock` has been removed, it was deprecated since Python
-  3.3: use :func:`time.perf_counter` or :func:`time.process_time` instead.
+  3.3: use :func:`time.perf_counter` or :func:`time.process_time` instead, depending
+  on your requirements, to have a well defined behaviour.
 
 * The ``pyvenv`` script has been removed in favor of ``python3.8 -m venv``
   to help eliminate confusion as to what Python interpreter the ``pyvenv``


### PR DESCRIPTION
`time.clock` has been removed; undocument it and add its removal in the
what's new.

<!-- issue-number: [bpo-36895](https://bugs.python.org/issue36895) -->
https://bugs.python.org/issue36895
<!-- /issue-number -->
