### PR TITLE
[3.7] bpo-36895: document time.clock() has been removed in 3.8

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -153,7 +153,7 @@ Functions
    :c:func:`QueryPerformanceCounter`. The resolution is typically better than one
    microsecond.
 
-   .. deprecated:: 3.3
+   .. deprecated-removed:: 3.3 3.8
       The behaviour of this function depends on the platform: use
       :func:`perf_counter` or :func:`process_time` instead, depending on your
       requirements, to have a well defined behaviour.


### PR DESCRIPTION

-- 

Not quite sure about the pull-request title, this is not a backport so there is no gh-XXXX

<!-- issue-number: [bpo-13286](https://bugs.python.org/issue13286) -->
https://bugs.python.org/issue36895
<!-- /issue-number -->
