### PR TITLE
bpo-36894: Fix regression in test_multiprocessing_spawn (no tests run on Windows)

### DIFF
--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -20,8 +20,6 @@ import signal
 import sys
 import threading
 import warnings
-import _multiprocessing
-import _posixshmem
 
 from . import spawn
 from . import util
@@ -33,9 +31,16 @@ _IGNORED_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 
 _CLEANUP_FUNCS = {
     'noop': lambda: None,
-    'semaphore': _multiprocessing.sem_unlink,
-    'shared_memory': _posixshmem.shm_unlink
 }
+
+if os.name == 'posix':
+    import _multiprocessing
+    import _posixshmem
+
+    _CLEANUP_FUNCS.update({
+        'semaphore': _multiprocessing.sem_unlink,
+        'shared_memory': _posixshmem.shm_unlink,
+    })
 
 
 class ResourceTracker(object):


### PR DESCRIPTION
This regression was introduced in [bpo-36867](https://bugs.python.org/issue36867).

<!-- issue-number: [bpo-36894](https://bugs.python.org/issue36894) -->
https://bugs.python.org/issue36894
<!-- /issue-number -->
