### PR TITLE
bpo-36845: validate integer network prefix when constructing IP networks

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1108,6 +1108,8 @@ class _BaseV4:
         if arg not in cls._netmask_cache:
             if isinstance(arg, int):
                 prefixlen = arg
+                if not (0 <= prefixlen <= cls._max_prefixlen):
+                    cls._report_invalid_netmask(prefixlen)
             else:
                 try:
                     # Check for a netmask in prefix length form
@@ -1538,6 +1540,8 @@ class _BaseV6:
         if arg not in cls._netmask_cache:
             if isinstance(arg, int):
                 prefixlen = arg
+                if not (0 <= prefixlen <= cls._max_prefixlen):
+                    cls._report_invalid_netmask(prefixlen)
             else:
                 prefixlen = cls._prefix_from_prefix_string(arg)
             netmask = IPv6Address(cls._ip_int_from_prefix(prefixlen))

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -466,6 +466,14 @@ class NetmaskTestMixin_v4(CommonTestMixin_v4):
         assertBadNetmask("1.1.1.1", "pudding")
         assertBadNetmask("1.1.1.1", "::")
 
+    def test_netmask_in_tuple_errors(self):
+        def assertBadNetmask(addr, netmask):
+            msg = "%r is not a valid netmask" % netmask
+            with self.assertNetmaskError(re.escape(msg)):
+                self.factory((addr, netmask))
+        assertBadNetmask("1.1.1.1", -1)
+        assertBadNetmask("1.1.1.1", 33)
+
     def test_pickle(self):
         self.pickle_test('192.0.2.0/27')
         self.pickle_test('192.0.2.0/31')  # IPV4LENGTH - 1
@@ -587,6 +595,14 @@ class NetmaskTestMixin_v6(CommonTestMixin_v6):
         assertBadNetmask("::1", "1.2.3.4")
         assertBadNetmask("::1", "pudding")
         assertBadNetmask("::", "::")
+
+    def test_netmask_in_tuple_errors(self):
+        def assertBadNetmask(addr, netmask):
+            msg = "%r is not a valid netmask" % netmask
+            with self.assertNetmaskError(re.escape(msg)):
+                self.factory((addr, netmask))
+        assertBadNetmask("::1", -1)
+        assertBadNetmask("::1", 129)
 
     def test_pickle(self):
         self.pickle_test('2001:db8::1000/124')

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1107,6 +1107,7 @@ Bastien Montagne
 Skip Montanaro
 Peter Moody
 Alan D. Moore
+Nicolai Moore
 Paul Moore
 Ross Moore
 Ben Morgan

--- a/Misc/NEWS.d/next/Library/2019-05-14-07-57-02.bpo-36845._GtFFf.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-14-07-57-02.bpo-36845._GtFFf.rst
@@ -1,2 +1,2 @@
-Added validation of integer prefixes to the constuction of IP networks and
+Added validation of integer prefixes to the construction of IP networks and
 interfaces in the ipaddress module.

--- a/Misc/NEWS.d/next/Library/2019-05-14-07-57-02.bpo-36845._GtFFf.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-14-07-57-02.bpo-36845._GtFFf.rst
@@ -1,0 +1,2 @@
+Added validation of integer prefixes to the constuction of IP networks and
+interfaces in the ipaddress module.


### PR DESCRIPTION


<!-- issue-number: [bpo-36845](https://bugs.python.org/issue36845) -->
https://bugs.python.org/issue36845
<!-- /issue-number -->
