### PR TITLE
bpo-36900: Replace global conf vars with config

### DIFF
--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -376,7 +376,8 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
     {
         PyObject *RawIO_class = (PyObject *)&PyFileIO_Type;
 #ifdef MS_WINDOWS
-        if (!Py_LegacyWindowsStdioFlag && _PyIO_get_console_type(path_or_fd) != '\0') {
+        _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->core_config;
+        if (!config->legacy_windows_stdio && _PyIO_get_console_type(path_or_fd) != '\0') {
             RawIO_class = (PyObject *)&PyWindowsConsoleIO_Type;
             encoding = "utf-8";
         }

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -9,6 +9,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_pystate.h"   /* _PyInterpreterState_GET_UNSAFE() */
 #include "structmember.h"
 #include "_iomodule.h"
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -403,8 +403,8 @@ static int
 pymain_run_stdin(_PyCoreConfig *config, PyCompilerFlags *cf)
 {
     if (stdin_is_interactive(config)) {
-        Py_InspectFlag = 0; /* do exit on SystemExit */
         config->inspect = 0;
+        Py_InspectFlag = 0; /* do exit on SystemExit */
         pymain_run_startup(config, cf);
         pymain_run_interactive_hook();
     }
@@ -425,17 +425,17 @@ pymain_repl(_PyCoreConfig *config, PyCompilerFlags *cf, int *exitcode)
 {
     /* Check this environment variable at the end, to give programs the
        opportunity to set it from Python. */
-    if (!Py_InspectFlag && _Py_GetEnv(config->use_environment, "PYTHONINSPECT")) {
-        Py_InspectFlag = 1;
+    if (!config->inspect && _Py_GetEnv(config->use_environment, "PYTHONINSPECT")) {
         config->inspect = 1;
+        Py_InspectFlag = 1;
     }
 
-    if (!(Py_InspectFlag && stdin_is_interactive(config) && RUN_CODE(config))) {
+    if (!(config->inspect && stdin_is_interactive(config) && RUN_CODE(config))) {
         return;
     }
 
-    Py_InspectFlag = 0;
     config->inspect = 0;
+    Py_InspectFlag = 0;
     pymain_run_interactive_hook();
 
     int res = PyRun_AnyFileFlags(stdin, "<stdin>", cf);

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -998,7 +998,8 @@ bytearray_repr(PyByteArrayObject *self)
 static PyObject *
 bytearray_str(PyObject *op)
 {
-    if (Py_BytesWarningFlag) {
+    _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->core_config;
+    if (config->bytes_warning) {
         if (PyErr_WarnEx(PyExc_BytesWarning,
                          "str() on a bytearray instance", 1)) {
                 return NULL;
@@ -1023,7 +1024,8 @@ bytearray_richcompare(PyObject *self, PyObject *other, int op)
     if (rc < 0)
         return NULL;
     if (rc) {
-        if (Py_BytesWarningFlag && (op == Py_EQ || op == Py_NE)) {
+        _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->core_config;
+        if (config->bytes_warning && (op == Py_EQ || op == Py_NE)) {
             if (PyErr_WarnEx(PyExc_BytesWarning,
                             "Comparison between bytearray and string", 1))
                 return NULL;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1421,7 +1421,8 @@ bytes_repr(PyObject *op)
 static PyObject *
 bytes_str(PyObject *op)
 {
-    if (Py_BytesWarningFlag) {
+    _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->core_config;
+    if (config->bytes_warning) {
         if (PyErr_WarnEx(PyExc_BytesWarning,
                          "str() on a bytes instance", 1)) {
             return NULL;
@@ -1578,7 +1579,8 @@ bytes_richcompare(PyBytesObject *a, PyBytesObject *b, int op)
 
     /* Make sure both arguments are strings. */
     if (!(PyBytes_Check(a) && PyBytes_Check(b))) {
-        if (Py_BytesWarningFlag && (op == Py_EQ || op == Py_NE)) {
+        _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->core_config;
+        if (config->bytes_warning && (op == Py_EQ || op == Py_NE)) {
             rc = PyObject_IsInstance((PyObject*)a,
                                      (PyObject*)&PyUnicode_Type);
             if (!rc)

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -590,13 +590,15 @@ _PyModule_ClearDict(PyObject *d)
     Py_ssize_t pos;
     PyObject *key, *value;
 
+    int verbose = _PyInterpreterState_GET_UNSAFE()->core_config.verbose;
+
     /* First, clear only names starting with a single underscore */
     pos = 0;
     while (PyDict_Next(d, &pos, &key, &value)) {
         if (value != Py_None && PyUnicode_Check(key)) {
             if (PyUnicode_READ_CHAR(key, 0) == '_' &&
                 PyUnicode_READ_CHAR(key, 1) != '_') {
-                if (Py_VerboseFlag > 1) {
+                if (verbose > 1) {
                     const char *s = PyUnicode_AsUTF8(key);
                     if (s != NULL)
                         PySys_WriteStderr("#   clear[1] %s\n", s);
@@ -617,7 +619,7 @@ _PyModule_ClearDict(PyObject *d)
             if (PyUnicode_READ_CHAR(key, 0) != '_' ||
                 !_PyUnicode_EqualToASCIIString(key, "__builtins__"))
             {
-                if (Py_VerboseFlag > 1) {
+                if (verbose > 1) {
                     const char *s = PyUnicode_AsUTF8(key);
                     if (s != NULL)
                         PySys_WriteStderr("#   clear[2] %s\n", s);
@@ -675,8 +677,10 @@ module___init___impl(PyModuleObject *self, PyObject *name, PyObject *doc)
 static void
 module_dealloc(PyModuleObject *m)
 {
+    int verbose = _PyInterpreterState_GET_UNSAFE()->core_config.verbose;
+
     PyObject_GC_UnTrack(m);
-    if (Py_VerboseFlag && m->md_name) {
+    if (verbose && m->md_name) {
         PySys_FormatStderr("# destroy %S\n", m->md_name);
     }
     if (m->md_weaklist != NULL)

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -24,6 +24,7 @@
 #include "Python.h"
 
 #include "Python-ast.h"
+#include "pycore_pystate.h"   /* _PyInterpreterState_GET_UNSAFE() */
 #include "ast.h"
 #include "code.h"
 #include "symtable.h"
@@ -310,6 +311,7 @@ PyAST_CompileObject(mod_ty mod, PyObject *filename, PyCompilerFlags *flags,
     PyCodeObject *co = NULL;
     PyCompilerFlags local_flags;
     int merged;
+    _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->core_config;
 
     if (!__doc__) {
         __doc__ = PyUnicode_InternFromString("__doc__");
@@ -338,7 +340,7 @@ PyAST_CompileObject(mod_ty mod, PyObject *filename, PyCompilerFlags *flags,
     c.c_future->ff_features = merged;
     flags->cf_flags = merged;
     c.c_flags = flags;
-    c.c_optimize = (optimize == -1) ? Py_OptimizeFlag : optimize;
+    c.c_optimize = (optimize == -1) ? config->optimization_level : optimize;
     c.c_nestlevel = 0;
 
     if (!_PyAST_Optimize(mod, arena, c.c_optimize)) {

--- a/Python/dynload_hpux.c
+++ b/Python/dynload_hpux.c
@@ -19,48 +19,47 @@ dl_funcptr _PyImport_FindSharedFuncptr(const char *prefix,
                                        const char *shortname,
                                        const char *pathname, FILE *fp)
 {
-    dl_funcptr p;
-    shl_t lib;
-    int flags;
-    char funcname[258];
-
-    flags = BIND_FIRST | BIND_DEFERRED;
-    if (Py_VerboseFlag) {
+    int flags = BIND_FIRST | BIND_DEFERRED;
+    int verbose = _PyInterpreterState_GET_UNSAFE()->core_config.verbose;
+    if (verbose) {
         flags = BIND_FIRST | BIND_IMMEDIATE |
             BIND_NONFATAL | BIND_VERBOSE;
         printf("shl_load %s\n",pathname);
     }
-    lib = shl_load(pathname, flags, 0);
+
+    shl_t lib = shl_load(pathname, flags, 0);
     /* XXX Chuck Blake once wrote that 0 should be BIND_NOSTART? */
     if (lib == NULL) {
-        char buf[256];
-        PyObject *pathname_ob = NULL;
-        PyObject *buf_ob = NULL;
-        PyObject *shortname_ob = NULL;
-
-        if (Py_VerboseFlag)
+        if (verbose) {
             perror(pathname);
+        }
+        char buf[256];
         PyOS_snprintf(buf, sizeof(buf), "Failed to load %.200s",
                       pathname);
-        buf_ob = PyUnicode_FromString(buf);
-        shortname_ob = PyUnicode_FromString(shortname);
-        pathname_ob = PyUnicode_FromString(pathname);
+        PyObject *buf_ob = PyUnicode_FromString(buf);
+        PyObject *shortname_ob = PyUnicode_FromString(shortname);
+        PyObject *pathname_ob = PyUnicode_FromString(pathname);
         PyErr_SetImportError(buf_ob, shortname_ob, pathname_ob);
         Py_DECREF(buf_ob);
         Py_DECREF(shortname_ob);
         Py_DECREF(pathname_ob);
         return NULL;
     }
+
+    char funcname[258];
     PyOS_snprintf(funcname, sizeof(funcname), FUNCNAME_PATTERN,
                   prefix, shortname);
-    if (Py_VerboseFlag)
+    if (verbose) {
         printf("shl_findsym %s\n", funcname);
+    }
+
+    dl_funcptr p;
     if (shl_findsym(&lib, funcname, TYPE_UNDEFINED, (void *) &p) == -1) {
         shl_unload(lib);
         p = NULL;
     }
-    if (p == NULL && Py_VerboseFlag)
+    if (p == NULL && verbose) {
         perror(funcname);
-
+    }
     return p;
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -150,12 +150,13 @@ init_importlib(PyInterpreterState *interp, PyObject *sysmod)
     PyObject *importlib;
     PyObject *impmod;
     PyObject *value;
+    int verbose = interp->core_config.verbose;
 
     /* Import _importlib through its frozen version, _frozen_importlib. */
     if (PyImport_ImportFrozenModule("_frozen_importlib") <= 0) {
         return _Py_INIT_ERR("can't import _frozen_importlib");
     }
-    else if (Py_VerboseFlag) {
+    else if (verbose) {
         PySys_FormatStderr("import _frozen_importlib # frozen\n");
     }
     importlib = PyImport_AddModule("_frozen_importlib");
@@ -175,7 +176,7 @@ init_importlib(PyInterpreterState *interp, PyObject *sysmod)
     if (impmod == NULL) {
         return _Py_INIT_ERR("can't import _imp");
     }
-    else if (Py_VerboseFlag) {
+    else if (verbose) {
         PySys_FormatStderr("import _imp # builtin\n");
     }
     if (_PyImport_SetModuleString("_imp", impmod) < 0) {

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -591,10 +591,12 @@ handle_system_exit(void)
     PyObject *exception, *value, *tb;
     int exitcode = 0;
 
-    if (Py_InspectFlag)
+    int inspect = _PyInterpreterState_GET_UNSAFE()->core_config.inspect;
+    if (inspect) {
         /* Don't exit if -i flag was given. This flag is set to 0
          * when entering interactive mode for inspecting. */
         return;
+    }
 
     PyErr_Fetch(&exception, &value, &tb);
     fflush(stdout);


### PR DESCRIPTION
Replace global configuration variables with core_config read from the
current interpreter.

Cleanup dynload_hpux.c.

<!-- issue-number: [bpo-36900](https://bugs.python.org/issue36900) -->
https://bugs.python.org/issue36900
<!-- /issue-number -->
