### PR TITLE
bpo-30535: Explicitly note that sys.meta_path is not empty

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -926,7 +926,8 @@ always available.
 
     A list of :term:`meta path finder` objects that have their
     :meth:`~importlib.abc.MetaPathFinder.find_spec` methods called to see if one
-    of the objects can find the module to be imported. The
+    of the objects can find the module to be imported. By default, it holds entries
+    to handle the standard kinds of modules (.py files, extension modules...). The
     :meth:`~importlib.abc.MetaPathFinder.find_spec` method is called with at
     least the absolute name of the module being imported. If the module to be
     imported is contained in a package, then the parent package's :attr:`__path__`


### PR DESCRIPTION
Explicitly note that sys.meta_path is not empty

<!-- issue-number: [bpo-30535](https://bugs.python.org/issue30535) -->
https://bugs.python.org/issue30535
<!-- /issue-number -->
