### PR TITLE
bpo-23378: Add an extend action to argparse

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -797,6 +797,15 @@ how the command-line arguments should be handled. The supplied actions are:
     >>> parser.parse_args(['--version'])
     PROG 2.0
 
+* ``'extend'`` - This stores a list, and extends each argument value to the
+  list.
+  Example usage::
+
+    >>> parser = argparse.ArgumentParser()
+    >>> parser.add_argument("--foo", action="extend", nargs="+", type=str)
+    >>> parser.parse_args("--foo f1 --foo f2 f3 f4".split())
+    Namespace(foo=['f1', 'f2', 'f3', 'f4'])
+
 You may also specify an arbitrary action by passing an Action subclass or
 other object that implements the same interface.  The recommended way to do
 this is to extend :class:`Action`, overriding the ``__call__`` method

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -803,7 +803,7 @@ how the command-line arguments should be handled. The supplied actions are:
 
     >>> parser = argparse.ArgumentParser()
     >>> parser.add_argument("--foo", action="extend", nargs="+", type=str)
-    >>> parser.parse_args("--foo f1 --foo f2 f3 f4".split())
+    >>> parser.parse_args(["--foo", "f1", "--foo", "f2", "f3", "f4"])
     Namespace(foo=['f1', 'f2', 'f3', 'f4'])
 
 You may also specify an arbitrary action by passing an Action subclass or

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1154,6 +1154,12 @@ class _SubParsersAction(Action):
             vars(namespace).setdefault(_UNRECOGNIZED_ARGS_ATTR, [])
             getattr(namespace, _UNRECOGNIZED_ARGS_ATTR).extend(arg_strings)
 
+class _ExtendAction(_AppendAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest, None)
+        items = _copy_items(items)
+        items.extend(values)
+        setattr(namespace, self.dest, items)
 
 # ==============
 # Type classes
@@ -1262,6 +1268,7 @@ class _ActionsContainer(object):
         self.register('action', 'help', _HelpAction)
         self.register('action', 'version', _VersionAction)
         self.register('action', 'parsers', _SubParsersAction)
+        self.register('action', 'extend', _ExtendAction)
 
         # raise an exception if the conflict handler is invalid
         self._get_handler()

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1786,6 +1786,15 @@ class TestActionRegistration(TestCase):
         self.assertEqual(parser.parse_args(['42']), NS(badger='foo[42]'))
 
 
+class TestActionExtend(ParserTestCase):
+    argument_signatures = [
+        Sig('--foo', action="extend", nargs="+", type=str),
+    ]
+    failures = ()
+    successes = [
+        ('--foo f1 --foo f2 f3 f4', NS(foo=['f1', 'f2', 'f3', 'f4'])),
+    ]
+
 # ================
 # Subparsers tests
 # ================

--- a/Misc/NEWS.d/next/Library/2019-05-14-05-38-22.bpo-23378.R25teI.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-14-05-38-22.bpo-23378.R25teI.rst
@@ -1,0 +1,1 @@
+Add an extend action to argparser.


### PR DESCRIPTION
Add an extend action to argparse

<!-- issue-number: [bpo-23378](https://bugs.python.org/issue23378) -->
https://bugs.python.org/issue23378
<!-- /issue-number -->
