### PR TITLE
bpo-36904: new function _PyStack_DictAsVector

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -457,6 +457,19 @@ class FastCallTests(unittest.TestCase):
                 result = _testcapi.pyobject_fastcallkeywords(func, args, kwnames)
                 self.check_result(result, expected)
 
+    def test_fastcall_clearing_dict(self):
+        # Test bpo-36907: the point of the test is just checking that this
+        # does not crash.
+        class IntWithDict:
+            __slots__ = ["kwargs"]
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+            def __index__(self):
+                self.kwargs.clear()
+                L = [2**i for i in range(10000)]
+                return 0
+        x = IntWithDict(dont_inherit=IntWithDict())
+        compile("pass", "", "exec", x, **x.kwargs)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Provide `_PyStack_DictAsVector` as safe and more efficient replacement for `_PyStack_UnpackDict`.

<!-- issue-number: [bpo-36904](https://bugs.python.org/issue36904) -->
https://bugs.python.org/issue36904
<!-- /issue-number -->
<!-- issue-number: [bpo-36907](https://bugs.python.org/issue36907) -->
https://bugs.python.org/issue36907
<!-- /issue-number -->
