### PR TITLE
Reference zipimport source code from docs

### DIFF
--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -6,6 +6,8 @@
 
 .. moduleauthor:: Just van Rossum <just@letterror.com>
 
+**Source code:** :source:`Lib/zipimport.py`
+
 --------------
 
 This module adds the ability to import Python modules (:file:`\*.py`,


### PR DESCRIPTION
zipimport module is written in Python so reference the source code from docs.