### PR TITLE
[2.7] bpo-30458: Disallow control chars in http URLs. (GH-12755) (GH-13154)

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -9,10 +9,6 @@ import os
 import sys
 import mimetools
 import tempfile
-try:
-    import ssl
-except ImportError:
-    ssl = None
 
 from test import test_support
 from base64 import b64encode
@@ -261,7 +257,6 @@ class urlopen_HttpTests(unittest.TestCase, FakeHTTPMixin):
         finally:
             self.unfakehttp()
 
-    @unittest.skipUnless(ssl, "ssl module required")
     def test_url_with_control_char_rejected(self):
         for char_no in range(0, 0x21) + range(0x7f, 0x100):
             char = chr(char_no)
@@ -274,7 +269,6 @@ class urlopen_HttpTests(unittest.TestCase, FakeHTTPMixin):
             finally:
                 self.unfakehttp()
 
-    @unittest.skipUnless(ssl, "ssl module required")
     def test_url_with_newline_header_injection_rejected(self):
         self.fakehttp(b"HTTP/1.1 200 OK\r\n\r\nHello.")
         host = "localhost:7777?a=1 HTTP/1.1\r\nX-injected: header\r\nTEST: 123"

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1,5 +1,5 @@
 import unittest
-from test import support
+from test import test_support
 from test import test_urllib
 
 import os
@@ -686,7 +686,7 @@ class HandlerTests(unittest.TestCase):
         h = urllib2.FileHandler()
         o = h.parent = MockOpener()
 
-        TESTFN = support.TESTFN
+        TESTFN = test_support.TESTFN
         urlpath = sanepathname2url(os.path.abspath(TESTFN))
         towrite = "hello, world\n"
         urls = [
@@ -1157,7 +1157,7 @@ class HandlerTests(unittest.TestCase):
         opener.add_handler(auth_handler)
         opener.add_handler(http_handler)
         msg = "Basic Auth Realm was unquoted"
-        with support.check_warnings((msg, UserWarning)):
+        with test_support.check_warnings((msg, UserWarning)):
             self._test_basic_auth(opener, auth_handler, "Authorization",
                                   realm, http_handler, password_manager,
                                   "http://acme.example.com/protected",
@@ -1350,7 +1350,7 @@ class MiscTests(unittest.TestCase, FakeHTTPMixin):
         host = "localhost:7777?a=1 HTTP/1.1\r\nX-injected: header\r\nTEST: 123"
         schemeless_url = "//" + host + ":8080/test/?test=a"
         try:
-            # We explicitly test urllib.request.urlopen() instead of the top
+            # We explicitly test urllib2.urlopen() instead of the top
             # level 'def urlopen()' function defined in this... (quite ugly)
             # test suite.  They use different url opening codepaths.  Plain
             # urlopen uses FancyURLOpener which goes via a codepath that
@@ -1461,14 +1461,14 @@ class RequestTests(unittest.TestCase):
 
 def test_main(verbose=None):
     from test import test_urllib2
-    support.run_doctest(test_urllib2, verbose)
-    support.run_doctest(urllib2, verbose)
+    test_support.run_doctest(test_urllib2, verbose)
+    test_support.run_doctest(urllib2, verbose)
     tests = (TrivialTests,
              OpenerDirectorTests,
              HandlerTests,
              MiscTests,
              RequestTests)
-    support.run_unittest(*tests)
+    test_support.run_unittest(*tests)
 
 if __name__ == "__main__":
     test_main(verbose=True)

--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -659,7 +659,13 @@ class SimpleServerTestCase(BaseServerTestCase):
     def test_partial_post(self):
         # Check that a partial POST doesn't make the server loop: issue #14001.
         conn = httplib.HTTPConnection(ADDR, PORT)
-        conn.request('POST', '/RPC2 HTTP/1.0\r\nContent-Length: 100\r\n\r\nbye')
+        conn.send('POST /RPC2 HTTP/1.0\r\n'
+                  'Content-Length: 100\r\n\r\n'
+                  'bye HTTP/1.1\r\n'
+                  'Host: %s:%s\r\n'
+                  'Accept-Encoding: identity\r\n'
+                  'Content-Length: 0\r\n\r\n'
+                  % (ADDR, PORT))
         conn.close()
 
 class SimpleServerEncodingTestCase(BaseServerTestCase):

--- a/Misc/NEWS.d/next/Security/2019-04-10-08-53-30.bpo-30458.51E-DA.rst
+++ b/Misc/NEWS.d/next/Security/2019-04-10-08-53-30.bpo-30458.51E-DA.rst
@@ -1,0 +1,1 @@
+Address CVE-2019-9740 by disallowing URL paths with embedded whitespace or control characters through into the underlying http client request.  Such potentially malicious header injection URLs now cause an httplib.InvalidURL exception to be raised.


### PR DESCRIPTION
Disallow control chars in http URLs in urllib2.urlopen.  This
addresses a potential security problem for applications that do not
sanity check their URLs where http request headers could be injected.

Disable https related urllib tests on a build without ssl (GH-13032)
These tests require an SSL enabled build. Skip these tests when
python is built without SSL to fix test failures.

Use httplib.InvalidURL instead of ValueError as the new error case's
exception. (GH-13044)

Backport Co-Authored-By: Miro Hrončok <miro@hroncok.cz>

(cherry picked from commit 7e200e0763f5b71c199aaf98bd5588f291585619)

Notes on backport to Python 2.7:

* test_urllib tests urllib.urlopen() which quotes the URL and so is
  not vulerable to HTTP Header Injection.
* Add tests to test_urllib2 on urllib2.urlopen().
* Reject non-ASCII characters: range 0x80-0xff.

<!-- issue-number: [bpo-30458](https://bugs.python.org/issue30458) -->
https://bugs.python.org/issue30458
<!-- /issue-number -->
