### PR TITLE
bpo-36918: Don't close the object which is again closed by destructor

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -79,6 +79,8 @@ def fakehttp(fakedata):
 
         def close(self):
             self.io_refs -= 1
+            if self.io_refs == 0:
+                io.BytesIO.close(self)
 
     class FakeHTTPConnection(http.client.HTTPConnection):
 

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -402,6 +402,8 @@ Connection: close
 Content-Type: text/html; charset=iso-8859-1
 ''')
         try:
+            # Silence destructor error
+            http.client.HTTPConnection.close = lambda self: None
             self.assertRaises(OSError, urlopen, "http://python.org/")
         finally:
             self.unfakehttp()
@@ -416,6 +418,8 @@ Connection: close
 Content-Type: text/html; charset=iso-8859-1
 ''')
         try:
+            # Silence destructor error
+            http.client.HTTPConnection.close = lambda self: None
             msg = "Redirection to url 'file:"
             with self.assertRaisesRegex(urllib.error.HTTPError, msg):
                 urlopen("http://python.org/")
@@ -431,6 +435,8 @@ Location: file://guidocomputer.athome.com:/python/license
 Connection: close
 ''')
             try:
+                # Silence destructor error
+                http.client.HTTPConnection.close = lambda self: None
                 self.assertRaises(urllib.error.HTTPError, urlopen,
                     "http://something")
             finally:

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -79,8 +79,6 @@ def fakehttp(fakedata):
 
         def close(self):
             self.io_refs -= 1
-            if self.io_refs == 0:
-                io.BytesIO.close(self)
 
     class FakeHTTPConnection(http.client.HTTPConnection):
 


### PR DESCRIPTION
At the end of test `BytesIO` destructor is called that calls flush and close. Closing the object when the internal counter in FakeSocket gets to zero causes flush to be called on closed object in destructor. Mock the close function and let destructor do the work instead.

<!-- issue-number: [bpo-36918](https://bugs.python.org/issue36918) -->
https://bugs.python.org/issue36918
<!-- /issue-number -->
