### PR TITLE
[2.7] bpo-27987: pymalloc: align by 16bytes on 64bit platform (GH-12850)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-04-16-11-52-21.bpo-27987.n2_DcQ.rst
@@ -1,0 +1,3 @@
+pymalloc returns memory blocks aligned by 16 bytes, instead of 8 bytes, on
+64-bit platforms to conform x86-64 ABI. Recent compilers assume this alignment
+more often. Patch by Inada Naoki.

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -154,8 +154,14 @@ static int running_on_valgrind = -1;
  *
  * You shouldn't change this unless you know what you are doing.
  */
+
+#if SIZEOF_VOID_P > 4
+#define ALIGNMENT              16               /* must be 2^N */
+#define ALIGNMENT_SHIFT         4
+#else
 #define ALIGNMENT               8               /* must be 2^N */
 #define ALIGNMENT_SHIFT         3
+#endif
 #define ALIGNMENT_MASK          (ALIGNMENT - 1)
 
 /* Return the number of bytes in size class I, as a uint. */


### PR DESCRIPTION
(cherry picked from commit f0be4bbb9b3cee876249c23f2ae6f38f43fa7495)

<!-- issue-number: [bpo-27987](https://bugs.python.org/issue27987) -->
https://bugs.python.org/issue27987
<!-- /issue-number -->
