### PR TITLE
bpo-36618: Don't add -fmax-type-align=8 flag for clang

### DIFF
--- a/configure
+++ b/configure
@@ -6905,26 +6905,6 @@ then
     esac
 fi
 
-if test -n "${cc_is_clang}"
-then
-    # bpo-36618: Add -fmax-type-align=8 to CFLAGS when clang compiler is
-    # detected. The pymalloc memory allocator aligns memory on 8 bytes. On
-    # x86-64, clang expects alignment on 16 bytes by default and so uses MOVAPS
-    # instruction which can lead to segmentation fault. Instruct clang that
-    # Python is limited to alignemnt on 8 bytes to use MOVUPS instruction
-    # instead: slower but don't trigger a SIGSEGV if the memory is not aligned
-    # on 16 bytes.
-    #
-    # Sadly, the flag must be added to CFLAGS and not just CFLAGS_NODIST,
-    # since third party C extensions can have the same issue.
-    #
-    # Check if -fmax-type-align flag is supported (it's not supported by old
-    # clang versions):
-    if "$CC" -v --help 2>/dev/null |grep -- -fmax-type-align > /dev/null; then
-        CFLAGS="$CFLAGS -fmax-type-align=8"
-    fi
-fi
-
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1543,26 +1543,6 @@ then
     esac
 fi
 
-if test -n "${cc_is_clang}"
-then
-    # bpo-36618: Add -fmax-type-align=8 to CFLAGS when clang compiler is
-    # detected. The pymalloc memory allocator aligns memory on 8 bytes. On
-    # x86-64, clang expects alignment on 16 bytes by default and so uses MOVAPS
-    # instruction which can lead to segmentation fault. Instruct clang that
-    # Python is limited to alignemnt on 8 bytes to use MOVUPS instruction
-    # instead: slower but don't trigger a SIGSEGV if the memory is not aligned
-    # on 16 bytes.
-    #
-    # Sadly, the flag must be added to CFLAGS and not just CFLAGS_NODIST,
-    # since third party C extensions can have the same issue.
-    #
-    # Check if -fmax-type-align flag is supported (it's not supported by old
-    # clang versions):
-    if "$CC" -v --help 2>/dev/null |grep -- -fmax-type-align > /dev/null; then
-        CFLAGS="$CFLAGS -fmax-type-align=8"
-    fi
-fi
-
 AC_SUBST(BASECFLAGS)
 AC_SUBST(CFLAGS_NODIST)
 AC_SUBST(LDFLAGS_NODIST)


### PR DESCRIPTION
Python 3.8 now respects the x86-64 ABI: memory allocations are
aligned on 16 bytes. The clang flag was only used as a temporary
workaround.

<!-- issue-number: [bpo-36618](https://bugs.python.org/issue36618) -->
https://bugs.python.org/issue36618
<!-- /issue-number -->
