### PR TITLE
[3.7] bpo-27987: align PyGC_Head to alignof(long double)

### DIFF
--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -255,7 +255,7 @@ typedef union _gc_head {
         union _gc_head *gc_prev;
         Py_ssize_t gc_refs;
     } gc;
-    double dummy;  /* force worst-case alignment */
+    long double dummy;  /* force worst-case alignment (16 byte for amd64) */
 } PyGC_Head;
 
 extern PyGC_Head *_PyGC_generation0;

--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -255,7 +255,11 @@ typedef union _gc_head {
         union _gc_head *gc_prev;
         Py_ssize_t gc_refs;
     } gc;
-    long double dummy;  /* force worst-case alignment (16 byte for amd64) */
+    long double dummy;  /* force worst-case alignment */
+    // malloc returns memory block aligned for any built-in types and
+    // long double is the largest standard C type.
+    // On amd64 linux, long double requires 16 byte alignment.
+    // See bpo-27987 for more discussion.
 } PyGC_Head;
 
 extern PyGC_Head *_PyGC_generation0;

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-15-18-28-43.bpo-27987.FaxuLy.rst
@@ -1,0 +1,2 @@
+``PyGC_Head`` structure is aligned to ``long double``.  This is needed to
+GC-ed objects are aligned properly.  Patch by Inada Naoki.


### PR DESCRIPTION


<!-- issue-number: [bpo-27987](https://bugs.python.org/issue27987) -->
https://bugs.python.org/issue27987
<!-- /issue-number -->
