### PR TITLE
bpo-27987: align PyGC_Head to alignof(long double) explicitly

### DIFF
--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -43,20 +43,23 @@ PyAPI_FUNC(Py_ssize_t) _PyGC_CollectIfEnabled(void);
      && (Py_TYPE(o)->tp_is_gc == NULL || Py_TYPE(o)->tp_is_gc(o)))
 
 /* GC information is stored BEFORE the object structure. */
-typedef struct {
-    // Pointer to next object in the list.
-    // 0 means the object is not tracked
-    uintptr_t _gc_next;
+typedef union {
+    struct {
+        // Pointer to next object in the list.
+        // 0 means the object is not tracked
+        uintptr_t next;
 
-    // Pointer to previous object in the list.
-    // Lowest two bits are used for flags documented later.
-    uintptr_t _gc_prev;
+        // Pointer to previous object in the list.
+        // Lowest two bits are used for flags documented later.
+        uintptr_t prev;
+    } _gc;
+    long double _dummy;  /* for worst alignment */
 } PyGC_Head;
 
 #define _Py_AS_GC(o) ((PyGC_Head *)(o)-1)
 
 /* True if the object is currently tracked by the GC. */
-#define _PyObject_GC_IS_TRACKED(o) (_Py_AS_GC(o)->_gc_next != 0)
+#define _PyObject_GC_IS_TRACKED(o) (_Py_AS_GC(o)->_gc.next != 0)
 
 /* True if the object may be tracked by the GC in the future, or already is.
    This can be useful to implement some optimizations. */
@@ -65,7 +68,7 @@ typedef struct {
         (!PyTuple_CheckExact(obj) || _PyObject_GC_IS_TRACKED(obj)))
 
 
-/* Bit flags for _gc_prev */
+/* Bit flags for _gc.prev */
 /* Bit 0 is set when tp_finalize is called */
 #define _PyGC_PREV_MASK_FINALIZED  (1)
 /* Bit 1 is set when the object is in generation which is GCed currently. */
@@ -74,23 +77,23 @@ typedef struct {
 #define _PyGC_PREV_SHIFT           (2)
 #define _PyGC_PREV_MASK            (((uintptr_t) -1) << _PyGC_PREV_SHIFT)
 
-// Lowest bit of _gc_next is used for flags only in GC.
+// Lowest bit of _gc.next is used for flags only in GC.
 // But it is always 0 for normal code.
-#define _PyGCHead_NEXT(g)        ((PyGC_Head*)(g)->_gc_next)
-#define _PyGCHead_SET_NEXT(g, p) ((g)->_gc_next = (uintptr_t)(p))
+#define _PyGCHead_NEXT(g)        ((PyGC_Head*)(g)->_gc.next)
+#define _PyGCHead_SET_NEXT(g, p) ((g)->_gc.next = (uintptr_t)(p))
 
-// Lowest two bits of _gc_prev is used for _PyGC_PREV_MASK_* flags.
-#define _PyGCHead_PREV(g) ((PyGC_Head*)((g)->_gc_prev & _PyGC_PREV_MASK))
+// Lowest two bits of _gc.prev is used for _PyGC_PREV_MASK_* flags.
+#define _PyGCHead_PREV(g) ((PyGC_Head*)((g)->_gc.prev & _PyGC_PREV_MASK))
 #define _PyGCHead_SET_PREV(g, p) do { \
     assert(((uintptr_t)p & ~_PyGC_PREV_MASK) == 0); \
-    (g)->_gc_prev = ((g)->_gc_prev & ~_PyGC_PREV_MASK) \
+    (g)->_gc.prev = ((g)->_gc.prev & ~_PyGC_PREV_MASK) \
         | ((uintptr_t)(p)); \
     } while (0)
 
 #define _PyGCHead_FINALIZED(g) \
-    (((g)->_gc_prev & _PyGC_PREV_MASK_FINALIZED) != 0)
+    (((g)->_gc.prev & _PyGC_PREV_MASK_FINALIZED) != 0)
 #define _PyGCHead_SET_FINALIZED(g) \
-    ((g)->_gc_prev |= _PyGC_PREV_MASK_FINALIZED)
+    ((g)->_gc.prev |= _PyGC_PREV_MASK_FINALIZED)
 
 #define _PyGC_FINALIZED(o) \
     _PyGCHead_FINALIZED(_Py_AS_GC(o))

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -19,7 +19,7 @@ PyAPI_FUNC(int) _PyDict_CheckConsistency(PyObject *mp, int check_content);
  * NB: While the object is tracked by the collector, it must be safe to call the
  * ob_traverse method.
  *
- * Internal note: _PyRuntime.gc.generation0->_gc_prev doesn't have any bit flags
+ * Internal note: _PyRuntime.gc.generation0->_gc.prev doesn't have any bit flags
  * because it's not object header.  So we don't use _PyGCHead_PREV() and
  * _PyGCHead_SET_PREV() for it to avoid unnecessary bitwise operations.
  *
@@ -34,15 +34,15 @@ static inline void _PyObject_GC_TRACK_impl(const char *filename, int lineno,
 
     PyGC_Head *gc = _Py_AS_GC(op);
     _PyObject_ASSERT_FROM(op,
-                          (gc->_gc_prev & _PyGC_PREV_MASK_COLLECTING) == 0,
+                          (gc->_gc.prev & _PyGC_PREV_MASK_COLLECTING) == 0,
                           "object is in generation which is garbage collected",
                           filename, lineno, "_PyObject_GC_TRACK");
 
-    PyGC_Head *last = (PyGC_Head*)(_PyRuntime.gc.generation0->_gc_prev);
+    PyGC_Head *last = (PyGC_Head*)(_PyRuntime.gc.generation0->_gc.prev);
     _PyGCHead_SET_NEXT(last, gc);
     _PyGCHead_SET_PREV(gc, last);
     _PyGCHead_SET_NEXT(gc, _PyRuntime.gc.generation0);
-    _PyRuntime.gc.generation0->_gc_prev = (uintptr_t)gc;
+    _PyRuntime.gc.generation0->_gc.prev = (uintptr_t)gc;
 }
 
 #define _PyObject_GC_TRACK(op) \
@@ -69,8 +69,8 @@ static inline void _PyObject_GC_UNTRACK_impl(const char *filename, int lineno,
     PyGC_Head *next = _PyGCHead_NEXT(gc);
     _PyGCHead_SET_NEXT(prev, next);
     _PyGCHead_SET_PREV(next, prev);
-    gc->_gc_next = 0;
-    gc->_gc_prev &= _PyGC_PREV_MASK_FINALIZED;
+    gc->_gc.next = 0;
+    gc->_gc.prev &= _PyGC_PREV_MASK_FINALIZED;
 }
 
 #define _PyObject_GC_UNTRACK(op) \


### PR DESCRIPTION
PyGC_Head consists two uintptr_t variables so it is aligned to 16 byte
on amd64 platform already.

This commit makes this alignment more explicit, although make code
bit ugly.

<!-- issue-number: [bpo-27987](https://bugs.python.org/issue27987) -->
https://bugs.python.org/issue27987
<!-- /issue-number -->
