### PR TITLE
bpo-36826: Handle := in ast_unparse.c

### DIFF
--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -275,6 +275,8 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         eq('f((x for x in a), 2)')
         eq('(((a)))', 'a')
         eq('(((a, b)))', '(a, b)')
+        eq("(x:=10)")
+        eq("f'{(x:=10):=10}'")
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-15-14-01-09.bpo-36826.GLrO3W.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-15-14-01-09.bpo-36826.GLrO3W.rst
@@ -1,0 +1,1 @@
+Add NamedExpression kind support to ast_unparse.c

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -810,6 +810,17 @@ append_ast_await(_PyUnicodeWriter *writer, expr_ty e, int level)
 }
 
 static int
+append_named_expr(_PyUnicodeWriter *writer, expr_ty e, int level)
+{
+    APPEND_STR_IF(level > PR_TUPLE, "(");
+    APPEND_EXPR(e->v.NamedExpr.target, PR_ATOM);
+    APPEND_STR(":=");
+    APPEND_EXPR(e->v.NamedExpr.value, PR_ATOM);
+    APPEND_STR_IF(level > PR_TUPLE, ")");
+    return 0;
+}
+
+static int
 append_ast_expr(_PyUnicodeWriter *writer, expr_ty e, int level)
 {
     switch (e->kind) {
@@ -867,6 +878,8 @@ append_ast_expr(_PyUnicodeWriter *writer, expr_ty e, int level)
         return append_ast_list(writer, e);
     case Tuple_kind:
         return append_ast_tuple(writer, e, level);
+    case NamedExpr_kind:
+        return append_named_expr(writer, e, level);
     default:
         PyErr_SetString(PyExc_SystemError,
                         "unknown expression kind");


### PR DESCRIPTION
Handle := in ast_unparse.c

<!-- issue-number: [bpo-36826](https://bugs.python.org/issue36826) -->
https://bugs.python.org/issue36826
<!-- /issue-number -->
