### PR TITLE
bpo-36567: use debian's manpage service for references

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -24,8 +24,7 @@ except ImportError:
     _tkinter = None
 '''
 
-# Manpage config
-manpages_url = os.getenv('MANPAGES_URL', 'https://manpages.debian.org/{path}')
+manpages_url = 'https://manpages.debian.org/{path}'
 
 # General substitutions.
 project = 'Python'

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -23,6 +23,10 @@ try:
 except ImportError:
     _tkinter = None
 '''
+
+# Manpage config
+manpages_url = os.getenv('MANPAGES_URL', 'https://manpages.debian.org/{path}')
+
 # General substitutions.
 project = 'Python'
 copyright = '2001-%s, Python Software Foundation' % time.strftime('%Y')

--- a/Misc/NEWS.d/next/Documentation/2019-05-15-14-31-40.bpo-36567.MNbyoI.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-05-15-14-31-40.bpo-36567.MNbyoI.rst
@@ -1,1 +1,0 @@
-Use debian's manpage service website for references.

--- a/Misc/NEWS.d/next/Documentation/2019-05-15-14-31-40.bpo-36567.MNbyoI.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-05-15-14-31-40.bpo-36567.MNbyoI.rst
@@ -1,0 +1,1 @@
+Use debian's manpage service website for references.


### PR DESCRIPTION
use `MANPAGES_URL` env variable for manpage references. If that variable not found, use debians manpage service.

<!-- issue-number: [bpo-36567](https://bugs.python.org/issue36567) -->
https://bugs.python.org/issue36567
<!-- /issue-number -->
