### PR TITLE
bpo-36926: implement methoddescr_call without _PyMethodDef_RawFastCallDict

### DIFF
--- a/Objects/call.c
+++ b/Objects/call.c
@@ -753,6 +753,7 @@ cfunction_call_varargs(PyObject *func, PyObject *args, PyObject *kwargs)
 {
     assert(!PyErr_Occurred());
     assert(kwargs == NULL || PyDict_Check(kwargs));
+    assert(PyCFunction_GET_FLAGS(func) & METH_VARARGS);
 
     PyCFunction meth = PyCFunction_GET_FUNCTION(func);
     PyObject *self = PyCFunction_GET_SELF(func);


### PR DESCRIPTION
`skip news` because this is an implementation detail.

CC @encukou @markshannon 

<!-- issue-number: [bpo-36926](https://bugs.python.org/issue36926) -->
https://bugs.python.org/issue36926
<!-- /issue-number -->
