### PR TITLE
bpo-36928: link threading.settrace to sys.settrace

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1204,8 +1204,8 @@ always available.
 
    Set the system's trace function, which allows you to implement a Python
    source code debugger in Python.  The function is thread-specific; for a
-   debugger to support multiple threads, it must be registered using
-   :func:`settrace` for each thread being debugged.
+   debugger to support multiple threads, it must register a trace function using
+   :func:`settrace` for each thread being debugged or use :func:`threading.settrace`.
 
    Trace functions should have three arguments: *frame*, *event*, and
    *arg*. *frame* is the current stack frame.  *event* is a string: ``'call'``,


### PR DESCRIPTION
# link threading.settrace to sys.settrace

linking the documentation of threading.settrace to sys.settrace.

sys.settrace mentions multi-threading but there is not link to threading.settrace which also can be used to set a trace function for threads.

<!-- issue-number: [bpo-36928](https://bugs.python.org/issue36928) -->
https://bugs.python.org/issue36928
<!-- /issue-number -->
