### PR TITLE
bpo-36511: Windows arm32 buildbot changes (remove extra space)

### DIFF
--- a/Tools/buildbot/test.bat
+++ b/Tools/buildbot/test.bat
@@ -41,7 +41,7 @@ scp -r "%PYTHON_SOURCE%Include" "%SSH_SERVER%:%REMOTE_PYTHON_DIR%Include"
 scp -r "%PYTHON_SOURCE%Lib" "%SSH_SERVER%:%REMOTE_PYTHON_DIR%Lib"
 
 set rt_args=%rt_opts% %dashU% -rwW --slowest --timeout=1200 --fail-env-changed %regrtest_args% %TEMP_ARGS%
-ssh %SSH_SERVER% "set TEMP=%REMOTE_PYTHON_DIR%temp & %REMOTE_PYTHON_DIR%PCbuild\rt.bat" %rt_args%
+ssh %SSH_SERVER% "set TEMP=%REMOTE_PYTHON_DIR%temp& %REMOTE_PYTHON_DIR%PCbuild\rt.bat" %rt_args%
 exit /b 0
 
 :Arm32SshHelp


### PR DESCRIPTION
@zooba
I just realized that this whitespace fix didn't get pushed.

<!-- issue-number: [bpo-36511](https://bugs.python.org/issue36511) -->
https://bugs.python.org/issue36511
<!-- /issue-number -->
