### PR TITLE
bpo-31171: add `-lpthread' to build multiprocessing for linux platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1597,6 +1597,8 @@ class PyBuildExt(build_ext):
                                ['cjkcodecs/_codecs_%s.c' % loc]))
 
     def detect_multiprocessing(self):
+        multiprocessing_lib = []
+
         # Richard Oudkerk's multiprocessing module
         if MS_WINDOWS:
             multiprocessing_srcs = ['_multiprocessing/multiprocessing.c',
@@ -1619,7 +1621,11 @@ class PyBuildExt(build_ext):
                                    libraries=libs,
                                    include_dirs=["Modules/_multiprocessing"]))
 
+            if HOST_PLATFORM.startswith('linux'):
+                multiprocessing_lib = ['pthread']
+
         self.add(Extension('_multiprocessing', multiprocessing_srcs,
+                           libraries=multiprocessing_lib,
                            include_dirs=["Modules/_multiprocessing"]))
 
     def detect_uuid(self):


### PR DESCRIPTION
While cross compiling on Linux, AC_RUN_IFELSE to check `-pthread' is always
false, add `-lpthread' to linker, it fixed multiprocessing.BoundedSemaphore
of 32-bit python did not work.

Whether corss compiling or not, whether supports `-pthread' or not, the fix
does not have side effect on Linux platform.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-31171](https://bugs.python.org/issue31171) -->
https://bugs.python.org/issue31171
<!-- /issue-number -->
