### PR TITLE
bpo-36935: Remove usage of the deprecated PyErr_SetFromWindowsErrWithUnicodeFilename()

### DIFF
--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -502,7 +502,7 @@ _winapi_CreateFileMapping_impl(PyObject *module, HANDLE file_handle,
     Py_END_ALLOW_THREADS
 
     if (handle == NULL) {
-        PyErr_SetFromWindowsErrWithUnicodeFilename(0, name);
+        PyErr_SetFromWindowsErr(0);
         handle = INVALID_HANDLE_VALUE;
     }
 
@@ -1379,7 +1379,7 @@ _winapi_OpenFileMapping_impl(PyObject *module, DWORD desired_access,
     Py_END_ALLOW_THREADS
 
     if (handle == NULL) {
-        PyErr_SetFromWindowsErrWithUnicodeFilename(0, name);
+        PyErr_SetFromWindowsErr(0);
         handle = INVALID_HANDLE_VALUE;
     }
 

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -502,7 +502,9 @@ _winapi_CreateFileMapping_impl(PyObject *module, HANDLE file_handle,
     Py_END_ALLOW_THREADS
 
     if (handle == NULL) {
-        PyErr_SetFromWindowsErr(0);
+        PyObject *temp = PyUnicode_FromWideChar(name, -1);
+        PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, 0, temp);
+        Py_XDECREF(temp);
         handle = INVALID_HANDLE_VALUE;
     }
 
@@ -1379,7 +1381,9 @@ _winapi_OpenFileMapping_impl(PyObject *module, DWORD desired_access,
     Py_END_ALLOW_THREADS
 
     if (handle == NULL) {
-        PyErr_SetFromWindowsErr(0);
+        PyObject *temp = PyUnicode_FromWideChar(name, -1);
+        PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, 0, temp);
+        Py_XDECREF(temp);
         handle = INVALID_HANDLE_VALUE;
     }
 


### PR DESCRIPTION
In e895de3e7f3cc2f7213b87621cfe9812ea4343f0, the
deprecated function PyErr_SetFromWindowsErrWithUnicodeFilename() was
added in two functions in Modules/_winapi.c. This function was
deprecated in 3.3.

<!-- issue-number: [bpo-36935](https://bugs.python.org/issue36935) -->
https://bugs.python.org/issue36935
<!-- /issue-number -->
