### PR TITLE
bpo-36936: CALL_FUNCTION_KW keyword names must be non-empty

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1136,7 +1136,8 @@ All of the following opcodes use their arguments.
 
    Calls a callable object with positional (if any) and keyword arguments.
    *argc* indicates the total number of positional and keyword arguments.
-   The top element on the stack contains a tuple of keyword argument names.
+   There must be at least one keyword argument. The top element on the stack
+   contains a non-empty tuple of keyword argument names.
    Below that are keyword arguments in the order corresponding to the tuple.
    Below that are positional arguments, with the right-most parameter on
    top.  Below the arguments is a callable object to call.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3357,7 +3357,9 @@ main_loop:
             PyObject **sp, *res, *names;
 
             names = POP();
-            assert(PyTuple_CheckExact(names) && PyTuple_GET_SIZE(names) <= oparg);
+            assert(PyTuple_CheckExact(names));
+            assert(PyTuple_GET_SIZE(names) > 0);
+            assert(PyTuple_GET_SIZE(names) <= oparg);
             sp = stack_pointer;
             res = call_function(tstate, &sp, oparg, names);
             stack_pointer = sp;


### PR DESCRIPTION
`skip news` because this is just documenting existing behavior

<!-- issue-number: [bpo-36936](https://bugs.python.org/issue36936) -->
https://bugs.python.org/issue36936
<!-- /issue-number -->
