### PR TITLE
bpo-36763: _PyInitError always use int for exitcode

### DIFF
--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -15,11 +15,7 @@ typedef struct {
     } _type;
     const char *_func;
     const char *err_msg;
-#ifdef MS_WINDOWS
-    unsigned int exitcode;
-#else
     int exitcode;
-#endif
 } _PyInitError;
 
 /* Almost all errors causing Python initialization to fail */

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -570,18 +570,17 @@ Py_GetProgramName(void)
    directory ("-m module" case) which will be prepended to sys.argv:
    sys.path[0].
 
-   Return 1 if the path is correctly resolved, but *path0_p can be NULL
-   if the Unicode object fail to be created.
+   Return 1 if the path is correctly resolved and written into *path0_p.
 
-   Return 0 if it fails to resolve the full path (and *path0_p will be NULL).
-   For example, return 0 if the current working directory has been removed
-   (bpo-36236) or if argv is empty.
+   Return 0 if it fails to resolve the full path. For example, return 0 if the
+   current working directory has been removed (bpo-36236) or if argv is empty.
+
+   Raise an exception and return -1 on error.
    */
 int
 _PyPathConfig_ComputeSysPath0(const _PyWstrList *argv, PyObject **path0_p)
 {
     assert(_PyWstrList_CheckConsistency(argv));
-    assert(*path0_p == NULL);
 
     if (argv->length == 0) {
         /* Leave sys.path unchanged if sys.argv is empty */
@@ -697,7 +696,12 @@ _PyPathConfig_ComputeSysPath0(const _PyWstrList *argv, PyObject **path0_p)
     }
 #endif /* All others */
 
-    *path0_p = PyUnicode_FromWideChar(path0, n);
+    PyObject *path0_obj = PyUnicode_FromWideChar(path0, n);
+    if (path0_obj == NULL) {
+        return -1;
+    }
+
+    *path0_p = path0_obj;
     return 1;
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2124,17 +2124,14 @@ Py_FatalError(const char *msg)
 void _Py_NO_RETURN
 _Py_ExitInitError(_PyInitError err)
 {
-    assert(_Py_INIT_FAILED(err));
     if (_Py_INIT_IS_EXIT(err)) {
-#ifdef MS_WINDOWS
-        ExitProcess(err.exitcode);
-#else
         exit(err.exitcode);
-#endif
+    }
+    else if (_Py_INIT_IS_ERROR(err)) {
+        fatal_error(err._func, err.err_msg, 1);
     }
     else {
-        assert(_Py_INIT_IS_ERROR(err));
-        fatal_error(err._func, err.err_msg, 1);
+        Py_FatalError("_Py_ExitInitError() must not be called on success");
     }
 }
 


### PR DESCRIPTION
We cannot use "unsigned int" for exitcode on Windows, since
Py_Main() and _Py_RunMain() always return an "int".

Changes:

* _PyPathConfig_ComputeSysPath0() now returns -1 if an exception is
  raised.
* pymain_run_python() no longer uses _PyInitError but display the
  exception and set exitcode to 1 in case of error.
* Fix _Py_RunMain(): return an exitcode rather than calling
  exit() on pymain_run_python() failure.
* _Py_ExitInitError() no longer uses ExitProcess() on Windows, use
  exit() on all platforms.
* _Py_ExitInitError() now fails with a fatal error if 'err' is not an
  error not an exit.

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
