### PR TITLE
bpo-36763: Add _PyCoreConfig.configure_c_stdio

### DIFF
--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -312,6 +312,14 @@ typedef struct {
       !Py_NoUserSiteDirectory. */
     int user_site_directory;
 
+    /* If non-zero, configure C standard steams (stdio, stdout,
+       stderr):
+
+       - Set O_BINARY mode on Windows.
+       - If buffered_stdio is equal to zero, make streams unbuffered.
+         Otherwise, enable streams buffering if interactive is non-zero. */
+    int configure_c_stdio;
+
     /* If equal to 0, enable unbuffered mode: force the stdout and stderr
        streams to be unbuffered.
 
@@ -439,6 +447,7 @@ typedef struct {
         .verbose = -1, \
         .quiet = -1, \
         .user_site_directory = -1, \
+        .configure_c_stdio = 1, \
         .buffered_stdio = -1, \
         ._install_importlib = 1, \
         .check_hash_pycs_mode = NULL, \

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -331,6 +331,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'verbose': 0,
         'quiet': 0,
         'user_site_directory': 1,
+        'configure_c_stdio': 1,
         'buffered_stdio': 1,
 
         'stdio_encoding': GET_DEFAULT_CONFIG,
@@ -558,6 +559,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'filesystem_encoding': 'utf-8',
             'filesystem_errors': self.UTF8_MODE_ERRORS,
             'user_site_directory': 0,
+            'pathconfig_warnings': 0,
         }
         self.check_config("init_global_config", config, preconfig)
 
@@ -597,11 +599,13 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'write_bytecode': 0,
             'verbose': 1,
             'quiet': 1,
+            'configure_c_stdio': 0,
             'buffered_stdio': 0,
             'user_site_directory': 0,
             'faulthandler': 1,
 
             'check_hash_pycs_mode': 'always',
+            'pathconfig_warnings': 0,
         }
         self.check_config("init_from_config", config, preconfig)
 

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -360,6 +360,8 @@ static int test_init_global_config(void)
     putenv("PYTHONUNBUFFERED=");
     Py_UnbufferedStdioFlag = 1;
 
+    Py_FrozenFlag = 1;
+
     /* FIXME: test Py_LegacyWindowsFSEncodingFlag */
     /* FIXME: test Py_LegacyWindowsStdioFlag */
 
@@ -481,6 +483,8 @@ static int test_init_from_config(void)
     Py_QuietFlag = 0;
     config.quiet = 1;
 
+    config.configure_c_stdio = 0;
+
     putenv("PYTHONUNBUFFERED=");
     Py_UnbufferedStdioFlag = 0;
     config.buffered_stdio = 0;
@@ -500,6 +504,9 @@ static int test_init_from_config(void)
     config.user_site_directory = 0;
 
     config.check_hash_pycs_mode = L"always";
+
+    Py_FrozenFlag = 0;
+    config.pathconfig_warnings = 0;
 
     err = _Py_InitializeFromConfig(&config);
     if (_Py_INIT_FAILED(err)) {


### PR DESCRIPTION
Add tests for configure_c_stdio and pathconfig_warnings parameters.

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
