### PR TITLE
[2.7] closes bpo-36755: Suppress noisy error output in test HTTPS server.

### DIFF
--- a/Lib/test/ssl_servers.py
+++ b/Lib/test/ssl_servers.py
@@ -42,6 +42,11 @@ class HTTPSServer(_HTTPServer):
             raise
         return sslconn, addr
 
+    def handle_error(self, request, client_address):
+        "Suppose noisy error output by default."
+        if support.verbose:
+            _HTTPServer.handle_error(self, request, client_address)
+
 class RootedHTTPRequestHandler(SimpleHTTPRequestHandler):
     # need to override translate_path to get a known root,
     # instead of using os.curdir, since the test could be


### PR DESCRIPTION
TLS 1.3 has a more efficient handshake protocol. The client can reject the server's credentials and close the connection before the server has even finished writing out all of its initial data. Depending on whether the server finishes writing the rest of its handshake before the it sees the connection is reset, the server will read an empty line or see a ECONNRESET OSError. Nothing is really wrong here with the server or client, so just suppress the error output in the OSError case to fix the test.

This fix isn't required in Python 3 because clients that reject the server's certificate will shut down the TLS layer before closing the TCP connection.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36755](https://bugs.python.org/issue36755) -->
https://bugs.python.org/issue36755
<!-- /issue-number -->
