### PR TITLE
bpo-36763: Cleanup precmdline in _PyCoreConfig_Read()

### DIFF
--- a/Include/internal/pycore_getopt.h
+++ b/Include/internal/pycore_getopt.h
@@ -17,6 +17,6 @@ typedef struct {
     int val;
 } _PyOS_LongOption;
 
-extern int _PyOS_GetOpt(Py_ssize_t argc, wchar_t **argv, int *longindex);
+extern int _PyOS_GetOpt(Py_ssize_t argc, wchar_t * const *argv, int *longindex);
 
 #endif /* !Py_INTERNAL_PYGETOPT_H */

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -1486,20 +1486,10 @@ config_init_fs_encoding(_PyCoreConfig *config, const _PyPreConfig *preconfig)
 
 
 static _PyInitError
-config_read(_PyCoreConfig *config, _PyPreCmdline *cmdline)
+config_read(_PyCoreConfig *config)
 {
     _PyInitError err;
     const _PyPreConfig *preconfig = &_PyRuntime.preconfig;
-
-    if (_PyPreCmdline_SetCoreConfig(cmdline, config) < 0) {
-        return _Py_INIT_NO_MEMORY();
-    }
-
-    if (config->isolated > 0) {
-        /* _PyPreCmdline_Read() sets use_environment to 0 if isolated is set,
-           _PyPreCmdline_SetCoreConfig() overrides config->use_environment. */
-        config->user_site_directory = 0;
-    }
 
     if (config->use_environment) {
         err = config_read_env_vars(config);
@@ -1584,6 +1574,19 @@ config_read(_PyCoreConfig *config, _PyPreCmdline *cmdline)
             return _Py_INIT_NO_MEMORY();
         }
     }
+
+    if (config->check_hash_pycs_mode == NULL) {
+        err = _PyCoreConfig_SetString(&config->check_hash_pycs_mode,
+                                      L"default");
+        if (_Py_INIT_FAILED(err)) {
+            return err;
+        }
+    }
+
+    if (config->configure_c_stdio < 0) {
+        config->configure_c_stdio = 1;
+    }
+
     return _Py_INIT_OK();
 }
 
@@ -1669,11 +1672,11 @@ config_usage(int error, const wchar_t* program)
 
 /* Parse the command line arguments */
 static _PyInitError
-config_parse_cmdline(_PyCoreConfig *config, _PyPreCmdline *precmdline,
-                     _PyWstrList *warnoptions, int *opt_index)
+config_parse_cmdline(_PyCoreConfig *config, _PyWstrList *warnoptions,
+                     int *opt_index)
 {
     _PyInitError err;
-    const _PyWstrList *argv = &precmdline->argv;
+    const _PyWstrList *argv = &config->argv;
     int print_version = 0;
 
     _PyOS_ResetGetOpt();
@@ -1890,9 +1893,9 @@ config_init_env_warnoptions(const _PyCoreConfig *config, _PyWstrList *warnoption
 
 
 static _PyInitError
-config_init_program(_PyCoreConfig *config, const _PyPreCmdline *cmdline)
+config_init_program(_PyCoreConfig *config)
 {
-    const _PyWstrList *argv = &cmdline->argv;
+    const _PyWstrList *argv = &config->argv;
     wchar_t *program;
     if (argv->length >= 1) {
         program = argv->items[0];
@@ -1987,10 +1990,9 @@ config_init_warnoptions(_PyCoreConfig *config,
 
 
 static _PyInitError
-config_update_argv(_PyCoreConfig *config, const _PyPreCmdline *cmdline,
-                   int opt_index)
+config_update_argv(_PyCoreConfig *config, int opt_index)
 {
-    const _PyWstrList *cmdline_argv = &cmdline->argv;
+    const _PyWstrList *cmdline_argv = &config->argv;
     _PyWstrList config_argv = _PyWstrList_INIT;
 
     /* Copy argv to be able to modify it (to force -c/-m) */
@@ -2054,6 +2056,13 @@ core_read_precmdline(_PyCoreConfig *config, _PyPreCmdline *precmdline)
     _PyCoreConfig_GetCoreConfig(&preconfig, config);
 
     err = _PyPreCmdline_Read(precmdline, &preconfig);
+    if (_Py_INIT_FAILED(err)) {
+        goto done;
+    }
+
+    if (_PyPreCmdline_SetCoreConfig(precmdline, config) < 0) {
+        err = _Py_INIT_NO_MEMORY();
+    }
 
 done:
     _PyPreConfig_Clear(&preconfig);
@@ -2062,7 +2071,7 @@ done:
 
 
 static _PyInitError
-config_read_cmdline(_PyCoreConfig *config, _PyPreCmdline *precmdline)
+config_read_cmdline(_PyCoreConfig *config)
 {
     _PyInitError err;
     _PyWstrList cmdline_warnoptions = _PyWstrList_INIT;
@@ -2071,27 +2080,25 @@ config_read_cmdline(_PyCoreConfig *config, _PyPreCmdline *precmdline)
     if (config->parse_argv < 0) {
         config->parse_argv = 1;
     }
-    if (config->configure_c_stdio < 0) {
-        config->configure_c_stdio = 1;
+
+    if (config->program == NULL) {
+        err = config_init_program(config);
+        if (_Py_INIT_FAILED(err)) {
+            goto done;
+        }
     }
 
     if (config->parse_argv) {
         int opt_index;
-        err = config_parse_cmdline(config, precmdline, &cmdline_warnoptions,
-                                   &opt_index);
+        err = config_parse_cmdline(config, &cmdline_warnoptions, &opt_index);
         if (_Py_INIT_FAILED(err)) {
             goto done;
         }
 
-        err = config_update_argv(config, precmdline, opt_index);
+        err = config_update_argv(config, opt_index);
         if (_Py_INIT_FAILED(err)) {
             goto done;
         }
-    }
-
-    err = config_read(config, precmdline);
-    if (_Py_INIT_FAILED(err)) {
-        goto done;
     }
 
     if (config->use_environment) {
@@ -2105,13 +2112,6 @@ config_read_cmdline(_PyCoreConfig *config, _PyPreCmdline *precmdline)
                                   &cmdline_warnoptions, &env_warnoptions);
     if (_Py_INIT_FAILED(err)) {
         goto done;
-    }
-
-    if (config->check_hash_pycs_mode == NULL) {
-        err = _PyCoreConfig_SetString(&config->check_hash_pycs_mode, L"default");
-        if (_Py_INIT_FAILED(err)) {
-            goto done;
-        }
     }
 
     err = _Py_INIT_OK();
@@ -2199,14 +2199,18 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         goto done;
     }
 
-    if (config->program == NULL) {
-        err = config_init_program(config, &precmdline);
-        if (_Py_INIT_FAILED(err)) {
-            goto done;
-        }
+    assert(config->isolated >= 0);
+    if (config->isolated) {
+        config->use_environment = 0;
+        config->user_site_directory = 0;
     }
 
-    err = config_read_cmdline(config, &precmdline);
+    err = config_read_cmdline(config);
+    if (_Py_INIT_FAILED(err)) {
+        goto done;
+    }
+
+    err = config_read(config);
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -2062,7 +2062,10 @@ core_read_precmdline(_PyCoreConfig *config, _PyPreCmdline *precmdline)
 
     if (_PyPreCmdline_SetCoreConfig(precmdline, config) < 0) {
         err = _Py_INIT_NO_MEMORY();
+        goto done;
     }
+
+    err = _Py_INIT_OK();
 
 done:
     _PyPreConfig_Clear(&preconfig);

--- a/Python/getopt.c
+++ b/Python/getopt.c
@@ -41,7 +41,7 @@ int _PyOS_opterr = 1;                 /* generate error messages */
 Py_ssize_t _PyOS_optind = 1;          /* index into argv array   */
 const wchar_t *_PyOS_optarg = NULL;   /* optional argument       */
 
-static wchar_t *opt_ptr = L"";
+static const wchar_t *opt_ptr = L"";
 
 /* Python command line short and long options */
 
@@ -61,7 +61,7 @@ void _PyOS_ResetGetOpt(void)
     opt_ptr = L"";
 }
 
-int _PyOS_GetOpt(Py_ssize_t argc, wchar_t **argv, int *longindex)
+int _PyOS_GetOpt(Py_ssize_t argc, wchar_t * const *argv, int *longindex)
 {
     wchar_t *ptr;
     wchar_t option;

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -174,7 +174,7 @@ _PyPreCmdline_SetCoreConfig(const _PyPreCmdline *cmdline, _PyCoreConfig *config)
 static _PyInitError
 precmdline_parse_cmdline(_PyPreCmdline *cmdline)
 {
-    _PyWstrList *argv = &cmdline->argv;
+    const _PyWstrList *argv = &cmdline->argv;
 
     _PyOS_ResetGetOpt();
     /* Don't log parsing errors into stderr here: _PyCoreConfig_Read()


### PR DESCRIPTION
precmdline is only needed in _PyCoreConfig_Read(), not in
config_read_cmdline().

* _PyOS_GetOpt() now takes a list of constant strings
* precmdline_parse_cmdline(): mark argv as constant

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
