### PR TITLE
Doc: Replace the deprecated highlightlang directive by highlight.

### DIFF
--- a/Doc/c-api/abstract.rst
+++ b/Doc/c-api/abstract.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _abstract:
 

--- a/Doc/c-api/allocation.rst
+++ b/Doc/c-api/allocation.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _allocating-objects:
 

--- a/Doc/c-api/apiabiversion.rst
+++ b/Doc/c-api/apiabiversion.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _apiabiversion:
 

--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _arg-parsing:
 

--- a/Doc/c-api/bool.rst
+++ b/Doc/c-api/bool.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _boolobjects:
 

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. index::
    single: buffer protocol

--- a/Doc/c-api/bytearray.rst
+++ b/Doc/c-api/bytearray.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _bytearrayobjects:
 

--- a/Doc/c-api/bytes.rst
+++ b/Doc/c-api/bytes.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _bytesobjects:
 

--- a/Doc/c-api/capsule.rst
+++ b/Doc/c-api/capsule.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _capsules:
 

--- a/Doc/c-api/cell.rst
+++ b/Doc/c-api/cell.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _cell-objects:
 

--- a/Doc/c-api/code.rst
+++ b/Doc/c-api/code.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _codeobjects:
 

--- a/Doc/c-api/complex.rst
+++ b/Doc/c-api/complex.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _complexobjects:
 

--- a/Doc/c-api/concrete.rst
+++ b/Doc/c-api/concrete.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _concrete:

--- a/Doc/c-api/contextvars.rst
+++ b/Doc/c-api/contextvars.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _contextvarsobjects:
 

--- a/Doc/c-api/conversion.rst
+++ b/Doc/c-api/conversion.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _string-conversion:
 

--- a/Doc/c-api/coro.rst
+++ b/Doc/c-api/coro.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _coro-objects:
 

--- a/Doc/c-api/datetime.rst
+++ b/Doc/c-api/datetime.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _datetimeobjects:
 

--- a/Doc/c-api/descriptor.rst
+++ b/Doc/c-api/descriptor.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _descriptor-objects:
 

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _dictobjects:
 

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _exceptionhandling:

--- a/Doc/c-api/file.rst
+++ b/Doc/c-api/file.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _fileobjects:
 

--- a/Doc/c-api/float.rst
+++ b/Doc/c-api/float.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _floatobjects:
 

--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _function-objects:
 

--- a/Doc/c-api/gcsupport.rst
+++ b/Doc/c-api/gcsupport.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _supporting-cycle-detection:
 

--- a/Doc/c-api/gen.rst
+++ b/Doc/c-api/gen.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _gen-objects:
 

--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _importing:
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _initialization:

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _api-intro:

--- a/Doc/c-api/iter.rst
+++ b/Doc/c-api/iter.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _iterator:
 

--- a/Doc/c-api/iterator.rst
+++ b/Doc/c-api/iterator.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _iterator-objects:
 

--- a/Doc/c-api/list.rst
+++ b/Doc/c-api/list.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _listobjects:
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _longobjects:
 

--- a/Doc/c-api/mapping.rst
+++ b/Doc/c-api/mapping.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _mapping:
 

--- a/Doc/c-api/marshal.rst
+++ b/Doc/c-api/marshal.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _marshalling-utils:
 

--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _memory:

--- a/Doc/c-api/memoryview.rst
+++ b/Doc/c-api/memoryview.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _memoryview-objects:
 

--- a/Doc/c-api/method.rst
+++ b/Doc/c-api/method.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _instancemethod-objects:
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _moduleobjects:
 

--- a/Doc/c-api/none.rst
+++ b/Doc/c-api/none.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _noneobject:
 

--- a/Doc/c-api/number.rst
+++ b/Doc/c-api/number.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _number:
 

--- a/Doc/c-api/objbuffer.rst
+++ b/Doc/c-api/objbuffer.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 Old Buffer Protocol
 -------------------

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _object:
 

--- a/Doc/c-api/objimpl.rst
+++ b/Doc/c-api/objimpl.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _newtypes:
 

--- a/Doc/c-api/refcounting.rst
+++ b/Doc/c-api/refcounting.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _countingrefs:

--- a/Doc/c-api/reflection.rst
+++ b/Doc/c-api/reflection.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _reflection:
 

--- a/Doc/c-api/sequence.rst
+++ b/Doc/c-api/sequence.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _sequence:
 

--- a/Doc/c-api/set.rst
+++ b/Doc/c-api/set.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _setobjects:
 

--- a/Doc/c-api/slice.rst
+++ b/Doc/c-api/slice.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _slice-objects:
 

--- a/Doc/c-api/stable.rst
+++ b/Doc/c-api/stable.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _stable:
 

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _common-structs:
 

--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _os:
 

--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _tupleobjects:
 

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _typeobjects:
 

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _type-structs:
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _unicodeobjects:
 

--- a/Doc/c-api/utilities.rst
+++ b/Doc/c-api/utilities.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _utilities:
 

--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _veryhigh:

--- a/Doc/c-api/weakref.rst
+++ b/Doc/c-api/weakref.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _weakrefobjects:
 

--- a/Doc/extending/building.rst
+++ b/Doc/extending/building.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _building:
 
@@ -20,7 +20,7 @@ The initialization function has the signature:
 It returns either a fully-initialized module, or a :c:type:`PyModuleDef`
 instance. See :ref:`initializing-modules` for details.
 
-.. highlightlang:: python
+.. highlight:: python
 
 For modules with ASCII-only names, the function must be named
 ``PyInit_<modulename>``, with ``<modulename>`` replaced by the name of the
@@ -43,7 +43,7 @@ function corresponding to the filename is found.
 See the *"Multiple modules in one library"* section in :pep:`489` for details.
 
 
-.. highlightlang:: c
+.. highlight:: c
 
 Building C and C++ Extensions with distutils
 ============================================

--- a/Doc/extending/embedding.rst
+++ b/Doc/extending/embedding.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _embedding:

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _extending-intro:

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _new-types-topics:
 

--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _defining-new-types:
 

--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 
 .. _building-on-windows:

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -1,6 +1,6 @@
 :tocdepth: 2
 
-.. highlightlang:: none
+.. highlight:: none
 
 .. _windows-faq:
 

--- a/Doc/howto/clinic.rst
+++ b/Doc/howto/clinic.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 **********************
 Argument Clinic How-To

--- a/Doc/howto/cporting.rst
+++ b/Doc/howto/cporting.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: c
+.. highlight:: c
 
 .. _cporting-howto:
 

--- a/Doc/install/index.rst
+++ b/Doc/install/index.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: none
+.. highlight:: none
 
 .. _install-index:
 

--- a/Doc/installing/index.rst
+++ b/Doc/installing/index.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: none
+.. highlight:: none
 
 .. _installing-index:
 

--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -8,7 +8,7 @@
 
 --------------
 
-.. highlightlang:: none
+.. highlight:: none
 
 **This module is automatically imported during initialization.** The automatic
 import can be suppressed using the interpreter's :option:`-S` option.

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: none
+.. highlight:: none
 
 .. _history-and-license:
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: sh
+.. highlight:: sh
 
 .. ATTENTION: You probably should update Misc/python.man, too, if you modify
    this file.

--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: sh
+.. highlight:: sh
 
 .. _using-on-unix:
 

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1,4 +1,4 @@
-.. highlightlang:: none
+.. highlight:: none
 
 .. _using-on-windows:
 


### PR DESCRIPTION
highlightlang is deprecated since April 2018 in Sphinx and will be removed in Sphinx 4.0
See https://github.com/sphinx-doc/sphinx/pull/4845

@JulienPalard for the `skip news` I am not sure because we will stop to use `.. highlightlang ::` and it's not a feature/bugfix of Python. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
