### PR TITLE
bpo-36260: Add pitfalls to zipfile module documentation

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -816,5 +816,34 @@ Command-line options
 
    Test whether the zipfile is valid or not.
 
+Decompression pitfalls
+----------------------
 
+The extraction in zipfile module might fail against some pitfalls listed below.
+
+From file itself
+  Decompression may fail due to incorrect password / CRC checksum / ZIP format or   
+  unsupported compression method / decryption.
+
+File System limitations
+  Exceeding limitations on different file systems can cause decompression failed. 
+  Such as allowable characters in the directory entries, length of the file name, 
+  length of the pathname, size of a single file, and number of files, etc.
+
+Resources limitations
+  The lack of memory or disk volume would lead to decompression
+  failed. For example, decompression bombs (aka `ZIP bomb`_) 
+  apply to zipfile library that can cause disk volume exhaustion.
+
+Interruption
+  Interruption during the decompression, such as pressing control-C or killing the 
+  decompression process may result in incomplete decompression of the archive.
+
+Default behaviors of extraction
+  Not knowing the default extraction behaviors 
+  can cause unexpected decompression results. 
+  For example, when extracting the same archive twice, 
+  it overwrites files without asking. 
+
+.. _ZIP bomb: https://en.wikipedia.org/wiki/Zip_bomb
 .. _PKZIP Application Note: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -822,28 +822,29 @@ Decompression pitfalls
 The extraction in zipfile module might fail against some pitfalls listed below.
 
 From file itself
-  Decompression may fail due to incorrect password / CRC checksum / ZIP format or   
+  Decompression may fail due to incorrect password / CRC checksum / ZIP format or
   unsupported compression method / decryption.
 
 File System limitations
-  Exceeding limitations on different file systems can cause decompression failed. 
-  Such as allowable characters in the directory entries, length of the file name, 
+  Exceeding limitations on different file systems can cause decompression failed.
+  Such as allowable characters in the directory entries, length of the file name,
   length of the pathname, size of a single file, and number of files, etc.
 
 Resources limitations
   The lack of memory or disk volume would lead to decompression
-  failed. For example, decompression bombs (aka `ZIP bomb`_) 
+  failed. For example, decompression bombs (aka `ZIP bomb`_)
   apply to zipfile library that can cause disk volume exhaustion.
 
 Interruption
-  Interruption during the decompression, such as pressing control-C or killing the 
+  Interruption during the decompression, such as pressing control-C or killing the
   decompression process may result in incomplete decompression of the archive.
 
 Default behaviors of extraction
-  Not knowing the default extraction behaviors 
-  can cause unexpected decompression results. 
-  For example, when extracting the same archive twice, 
-  it overwrites files without asking. 
+  Not knowing the default extraction behaviors
+  can cause unexpected decompression results.
+  For example, when extracting the same archive twice,
+  it overwrites files without asking.
+
 
 .. _ZIP bomb: https://en.wikipedia.org/wiki/Zip_bomb
 .. _PKZIP Application Note: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -819,31 +819,41 @@ Command-line options
 Decompression pitfalls
 ----------------------
 
-The extraction in zipfile module might fail against some pitfalls listed below.
+The extraction in zipfile module might fail due to some pitfalls listed below.
 
 From file itself
-  Decompression may fail due to incorrect password / CRC checksum / ZIP format or
-  unsupported compression method / decryption.
+~~~~~~~~~~~~~~~~
+
+Decompression may fail due to incorrect password / CRC checksum / ZIP format or
+unsupported compression method / decryption.
 
 File System limitations
-  Exceeding limitations on different file systems can cause decompression failed.
-  Such as allowable characters in the directory entries, length of the file name,
-  length of the pathname, size of a single file, and number of files, etc.
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Exceeding limitations on different file systems can cause decompression failed.
+Such as allowable characters in the directory entries, length of the file name,
+length of the pathname, size of a single file, and number of files, etc.
 
 Resources limitations
-  The lack of memory or disk volume would lead to decompression
-  failed. For example, decompression bombs (aka `ZIP bomb`_)
-  apply to zipfile library that can cause disk volume exhaustion.
+~~~~~~~~~~~~~~~~~~~~~
+
+The lack of memory or disk volume would lead to decompression
+failed. For example, decompression bombs (aka `ZIP bomb`_)
+apply to zipfile library that can cause disk volume exhaustion.
 
 Interruption
-  Interruption during the decompression, such as pressing control-C or killing the
-  decompression process may result in incomplete decompression of the archive.
+~~~~~~~~~~~~
+
+Interruption during the decompression, such as pressing control-C or killing the
+decompression process may result in incomplete decompression of the archive.
 
 Default behaviors of extraction
-  Not knowing the default extraction behaviors
-  can cause unexpected decompression results.
-  For example, when extracting the same archive twice,
-  it overwrites files without asking.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Not knowing the default extraction behaviors
+can cause unexpected decompression results.
+For example, when extracting the same archive twice,
+it overwrites files without asking.
 
 
 .. _ZIP bomb: https://en.wikipedia.org/wiki/Zip_bomb

--- a/Misc/NEWS.d/next/Documentation/2019-06-04-09-29-00.bpo-36260.WrGuc-.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-06-04-09-29-00.bpo-36260.WrGuc-.rst
@@ -1,0 +1,1 @@
+Add decompression pitfalls to zipfile module documentation.


### PR DESCRIPTION
We saw vulnerability warning description (including zip bomb) in Doc/library/xml.rst file.
This gave us the idea of documentation improvement. 

So, we moved a little bit forward :D

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36260](https://bugs.python.org/issue36260) -->
https://bugs.python.org/issue36260
<!-- /issue-number -->
