### PR TITLE
bpo-36907: fix refcount bug in _PyStack_UnpackDict()

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -8,6 +8,7 @@ except ImportError:
 import struct
 import collections
 import itertools
+import gc
 
 
 class FunctionCalls(unittest.TestCase):
@@ -466,6 +467,7 @@ class FastCallTests(unittest.TestCase):
                 self.kwargs = kwargs
             def __index__(self):
                 self.kwargs.clear()
+                gc.collect()
                 return 0
         x = IntWithDict(dont_inherit=IntWithDict())
         # We test the argument handling of "compile" here, the compilation

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -457,6 +457,21 @@ class FastCallTests(unittest.TestCase):
                 result = _testcapi.pyobject_fastcallkeywords(func, args, kwnames)
                 self.check_result(result, expected)
 
+    def test_fastcall_clearing_dict(self):
+        # Test bpo-36907: the point of the test is just checking that this
+        # does not crash.
+        class IntWithDict:
+            __slots__ = ["kwargs"]
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+            def __index__(self):
+                self.kwargs.clear()
+                return 0
+        x = IntWithDict(dont_inherit=IntWithDict())
+        # We test the argument handling of "compile" here, the compilation
+        # itself is not relevant. When we pass flags=x below, x.__index__() is
+        # called, which changes the keywords dict.
+        compile("pass", "", "exec", x, **x.kwargs)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-17-12-28-24.bpo-36907.rk7kgp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-17-12-28-24.bpo-36907.rk7kgp.rst
@@ -1,0 +1,2 @@
+Fix a crash when calling a C function with a keyword dict (``f(**kwargs)``)
+and changing the dict ``kwargs`` while that function is running.


### PR DESCRIPTION
A minimal patch fixing [bpo-36907](https://bugs.python.org/issue36907)

CC @encukou 

<!-- issue-number: [bpo-36907](https://bugs.python.org/issue36907) -->
https://bugs.python.org/issue36907
<!-- /issue-number -->
