### PR TITLE
bpo-36763: Add _PyCoreConfig_InitPythonConfig()

### DIFF
--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -86,12 +86,18 @@ typedef struct {
 
        If it is equal to 1, LC_CTYPE locale is read to decide it it should be
        coerced or not (ex: PYTHONCOERCECLOCALE=1). Internally, it is set to 2
-       if the LC_CTYPE locale must be coerced. */
+       if the LC_CTYPE locale must be coerced.
+
+       It is set to 0 by default. Set it to -1 to let Python decides
+       if it should be enabled or not. */
     int coerce_c_locale;
 
     /* Emit a warning if the LC_CTYPE locale is coerced?
 
-       Disabled by default. Set to 1 by PYTHONCOERCECLOCALE=warn. */
+       Disabled by default. Set to 1 by PYTHONCOERCECLOCALE=warn.
+
+       Set it to -1 to get its value from the PYTHONCOERCECLOCALE environment
+       variable. */
     int coerce_c_locale_warn;
 
 #ifdef MS_WINDOWS
@@ -116,7 +122,10 @@ typedef struct {
        Set to 0 by "-X utf8=0" and PYTHONUTF8=0.
 
        If equals to -1, it is set to 1 if the LC_CTYPE locale is "C" or
-       "POSIX", otherwise inherit Py_UTF8Mode value. */
+       "POSIX", otherwise it is set to 0.
+
+       If equals to -2, inherit Py_UTF8Mode value value (which is equal to 0
+       by default). */
     int utf8_mode;
 
     int dev_mode;           /* Development mode. PYTHONDEVMODE, -X dev */
@@ -138,8 +147,13 @@ typedef struct {
         ._config_version = _Py_CONFIG_VERSION, \
         .isolated = -1, \
         .use_environment = -1, \
+        .utf8_mode = -2, \
         .dev_mode = -1, \
         .allocator = PYMEM_ALLOCATOR_NOT_SET}
+
+PyAPI_FUNC(void) _PyPreConfig_Init(_PyPreConfig *config);
+PyAPI_FUNC(void) _PyPreConfig_InitPythonConfig(_PyPreConfig *config);
+PyAPI_FUNC(void) _PyPreConfig_InitIsolateConfig(_PyPreConfig *config);
 
 
 /* --- _PyCoreConfig ---------------------------------------------- */
@@ -213,8 +227,8 @@ typedef struct {
 
     /* Command line arguments (sys.argv).
 
-       By default, Python command line arguments are parsed and then stripped
-       from argv. Set parse_argv to 0 to avoid that.
+       Set parse_argv to 1 to parse argv as Python command line arguments are
+       parsed and then strip Python arguments from argv.
 
        If argv is empty, an empty string is added to ensure that sys.argv
        always exists and is never empty. */
@@ -442,7 +456,7 @@ typedef struct {
         .faulthandler = -1, \
         .tracemalloc = -1, \
         .use_module_search_paths = 0, \
-        .parse_argv = 1, \
+        .parse_argv = 0, \
         .site_import = -1, \
         .bytes_warning = -1, \
         .inspect = -1, \
@@ -453,13 +467,17 @@ typedef struct {
         .verbose = -1, \
         .quiet = -1, \
         .user_site_directory = -1, \
-        .configure_c_stdio = 1, \
+        .configure_c_stdio = 0, \
         .buffered_stdio = -1, \
         ._install_importlib = 1, \
         .check_hash_pycs_mode = NULL, \
         .pathconfig_warnings = -1, \
         ._init_main = 1}
 /* Note: _PyCoreConfig_INIT sets other fields to 0/NULL */
+
+PyAPI_FUNC(void) _PyCoreConfig_Init(_PyCoreConfig *config);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPythonConfig(_PyCoreConfig *config);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitIsolateConfig(_PyCoreConfig *config);
 
 #ifdef __cplusplus
 }

--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -88,16 +88,16 @@ typedef struct {
        coerced or not (ex: PYTHONCOERCECLOCALE=1). Internally, it is set to 2
        if the LC_CTYPE locale must be coerced.
 
-       It is set to 0 by default. Set it to -1 to let Python decides
-       if it should be enabled or not. */
+       Disable by default (set to 0). Set it to -1 to let Python decides if it
+       should be enabled or not. */
     int coerce_c_locale;
 
     /* Emit a warning if the LC_CTYPE locale is coerced?
 
-       Disabled by default. Set to 1 by PYTHONCOERCECLOCALE=warn.
+       Set to 1 by PYTHONCOERCECLOCALE=warn.
 
-       Set it to -1 to get its value from the PYTHONCOERCECLOCALE environment
-       variable. */
+       Disable by default (set to 0). Set it to -1 to let Python decides if it
+       should be enabled or not. */
     int coerce_c_locale_warn;
 
 #ifdef MS_WINDOWS
@@ -227,8 +227,8 @@ typedef struct {
 
     /* Command line arguments (sys.argv).
 
-       Set parse_argv to 1 to parse argv as Python command line arguments are
-       parsed and then strip Python arguments from argv.
+       Set parse_argv to 1 to parse argv as Python command line arguments
+       and then strip Python arguments from argv.
 
        If argv is empty, an empty string is added to ensure that sys.argv
        always exists and is never empty. */

--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -94,7 +94,7 @@ PyAPI_FUNC(void) _PyPreConfig_InitIsolatedConfig(_PyPreConfig *config);
 PyAPI_FUNC(int) _PyPreConfig_Copy(_PyPreConfig *config,
     const _PyPreConfig *config2);
 PyAPI_FUNC(PyObject*) _PyPreConfig_AsDict(const _PyPreConfig *config);
-PyAPI_FUNC(void) _PyCoreConfig_GetCoreConfig(_PyPreConfig *config,
+PyAPI_FUNC(void) _PyPreConfig_GetCoreConfig(_PyPreConfig *config,
     const _PyCoreConfig *core_config);
 PyAPI_FUNC(_PyInitError) _PyPreConfig_Read(_PyPreConfig *config,
     const _PyArgv *args);

--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -88,6 +88,9 @@ PyAPI_FUNC(_PyInitError) _PyPreCmdline_Read(_PyPreCmdline *cmdline,
 
 /* --- _PyPreConfig ----------------------------------------------- */
 
+PyAPI_FUNC(void) _PyPreConfig_Init(_PyPreConfig *config);
+PyAPI_FUNC(void) _PyPreConfig_InitPythonConfig(_PyPreConfig *config);
+PyAPI_FUNC(void) _PyPreConfig_InitIsolatedConfig(_PyPreConfig *config);
 PyAPI_FUNC(int) _PyPreConfig_Copy(_PyPreConfig *config,
     const _PyPreConfig *config2);
 PyAPI_FUNC(PyObject*) _PyPreConfig_AsDict(const _PyPreConfig *config);
@@ -101,6 +104,8 @@ PyAPI_FUNC(_PyInitError) _PyPreConfig_Write(const _PyPreConfig *config);
 /* --- _PyCoreConfig ---------------------------------------------- */
 
 PyAPI_FUNC(void) _PyCoreConfig_Clear(_PyCoreConfig *);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPythonConfig(_PyCoreConfig *config);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitIsolatedConfig(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_Copy(
     _PyCoreConfig *config,
     const _PyCoreConfig *config2);

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -748,10 +748,19 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     def test_init_parse_argv(self):
         core_config = {
             'argv': ['-c', 'arg1', '-v', 'arg3'],
+            'program_name': './argv0',
             'parse_argv': 1,
             'run_command': 'pass\n',
+            'use_environment': 0,
         }
         self.check_config("init_parse_argv", core_config, {})
+
+    def test_init_dont_parse_argv(self):
+        core_config = {
+            'argv': ['./argv0', '-E', '-c', 'pass', 'arg1', '-v', 'arg3'],
+            'program_name': './argv0',
+        }
+        self.check_config("init_dont_parse_argv", core_config, {})
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -307,7 +307,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
         'pycache_prefix': None,
         'program_name': GET_DEFAULT_CONFIG,
-        'parse_argv': 1,
+        'parse_argv': 0,
         'argv': [""],
 
         'xoptions': [],
@@ -333,7 +333,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'verbose': 0,
         'quiet': 0,
         'user_site_directory': 1,
-        'configure_c_stdio': 1,
+        'configure_c_stdio': 0,
         'buffered_stdio': 1,
 
         'stdio_encoding': GET_DEFAULT_CONFIG,
@@ -588,6 +588,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'pycache_prefix': 'conf_pycache_prefix',
             'program_name': './conf_program_name',
             'argv': ['-c', 'arg2'],
+            'parse_argv': 1,
             'xoptions': ['core_xoption1=3', 'core_xoption2=', 'core_xoption3'],
             'warnoptions': ['error::ResourceWarning', 'default::BytesWarning'],
             'run_command': 'pass\n',
@@ -600,7 +601,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'write_bytecode': 0,
             'verbose': 1,
             'quiet': 1,
-            'configure_c_stdio': 0,
+            'configure_c_stdio': 1,
             'buffered_stdio': 0,
             'user_site_directory': 0,
             'faulthandler': 1,
@@ -661,14 +662,14 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         }
         self.check_config("init_dev_mode", config, preconfig)
 
-    def test_init_isolated(self):
+    def test_init_isolated_flag(self):
         preconfig = {}
         config = {
             'isolated': 1,
             'use_environment': 0,
             'user_site_directory': 0,
         }
-        self.check_config("init_isolated", config, preconfig)
+        self.check_config("init_isolated_flag", config, preconfig)
 
     def test_preinit_isolated1(self):
         # _PyPreConfig.isolated=1, _PyCoreConfig.isolated not set
@@ -690,6 +691,25 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         }
         self.check_config("preinit_isolated2", config, preconfig)
 
+    def test_init_isolated_config(self):
+        preconfig = {}
+        config = {
+            'isolated': 1,
+            'use_environment': 0,
+            'user_site_directory': 0,
+            'install_signal_handlers': 0,
+            'pathconfig_warnings': 0,
+        }
+        self.check_config("init_isolated_config", config, preconfig)
+
+    def test_init_python_config(self):
+        preconfig = {}
+        config = {
+            'configure_c_stdio': 1,
+            'parse_argv': 1,
+        }
+        self.check_config("init_python_config", config, preconfig)
+
     def test_init_read_set(self):
         preconfig = {}
         core_config = {
@@ -707,6 +727,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'argv': ['-c', 'arg2'],
             'program_name': './python3',
             'run_command': code + '\n',
+            'parse_argv': 1,
         }
         self.check_config("init_run_main", core_config, preconfig)
 
@@ -718,17 +739,19 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'argv': ['-c', 'arg2'],
             'program_name': './python3',
             'run_command': code + '\n',
+            'parse_argv': 1,
             '_init_main': 0,
         }
         self.check_config("init_main", core_config, preconfig,
                           stderr="Run Python code before _Py_InitializeMain")
 
-    def test_init_dont_parse_argv(self):
+    def test_init_parse_argv(self):
         core_config = {
-            'argv': ['-v', '-c', 'arg1', '-W', 'arg2'],
-            'parse_argv': 0,
+            'argv': ['-c', 'arg1', '-v', 'arg3'],
+            'parse_argv': 1,
+            'run_command': 'pass\n',
         }
-        self.check_config("init_dont_parse_argv", core_config, {})
+        self.check_config("init_parse_argv", core_config, {})
 
 
 if __name__ == "__main__":

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -52,12 +52,15 @@ pymain_init(const _PyArgv *args)
     fedisableexcept(FE_OVERFLOW);
 #endif
 
-    _PyPreConfig preconfig = _PyPreConfig_INIT;
-    /* Set to -1 to enable them depending on the LC_CTYPE locale and the
-       environment variables (PYTHONUTF8 and PYTHONCOERCECLOCALE)  */
-    preconfig.coerce_c_locale = -1;
-    preconfig.utf8_mode = -1;
+    _PyPreConfig preconfig;
+    _PyPreConfig_InitPythonConfig(&preconfig);
     err = _Py_PreInitializeFromPyArgv(&preconfig, args);
+    if (_Py_INIT_FAILED(err)) {
+        return err;
+    }
+
+    _PyCoreConfig config;
+    err = _PyCoreConfig_InitPythonConfig(&config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -65,10 +68,12 @@ pymain_init(const _PyArgv *args)
     /* pass NULL as the config: config is read from command line arguments,
        environment variables, configuration files */
     if (args->use_bytes_argv) {
-        return _Py_InitializeFromArgs(NULL, args->argc, args->bytes_argv);
+        return _Py_InitializeFromArgs(&config,
+                                      args->argc, args->bytes_argv);
     }
     else {
-        return _Py_InitializeFromWideArgs(NULL, args->argc, args->wchar_argv);
+        return _Py_InitializeFromWideArgs(&config,
+                                          args->argc, args->wchar_argv);
     }
 }
 

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -76,7 +76,8 @@ main(int argc, char *argv[])
     }
     text[text_size] = '\0';
 
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
     config.use_environment = 0;
     config.user_site_directory = 0;
     config.site_import = 0;

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -291,7 +291,9 @@ static int test_initialize_twice(void)
 static int test_initialize_pymain(void)
 {
     wchar_t *argv[] = {L"PYTHON", L"-c",
-                       L"import sys; print(f'Py_Main() after Py_Initialize: sys.argv={sys.argv}')",
+                       (L"import sys; "
+                        L"print(f'Py_Main() after Py_Initialize: "
+                        L"sys.argv={sys.argv}')"),
                        L"arg2"};
     _testembed_Py_Initialize();
 
@@ -376,7 +378,8 @@ static int test_init_from_config(void)
 {
     _PyInitError err;
 
-    _PyPreConfig preconfig = _PyPreConfig_INIT;
+    _PyPreConfig preconfig;
+    _PyPreConfig_Init(&preconfig);
 
     putenv("PYTHONMALLOC=malloc_debug");
     preconfig.allocator = PYMEM_ALLOCATOR_MALLOC;
@@ -391,7 +394,8 @@ static int test_init_from_config(void)
     }
 
     /* Test _Py_InitializeFromConfig() */
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
     config.install_signal_handlers = 0;
 
     /* FIXME: test use_environment */
@@ -400,7 +404,7 @@ static int test_init_from_config(void)
     config.use_hash_seed = 1;
     config.hash_seed = 123;
 
-    /* dev_mode=1 is tested in test_init_dev_mode() */
+    /* dev_mode=1 is tested in init_dev_mode() */
 
     putenv("PYTHONFAULTHANDLER=");
     config.faulthandler = 1;
@@ -432,6 +436,7 @@ static int test_init_from_config(void)
     };
     config.argv.length = Py_ARRAY_LENGTH(argv);
     config.argv.items = argv;
+    config.parse_argv = 1;
 
     static wchar_t* xoptions[3] = {
         L"core_xoption1=3",
@@ -481,7 +486,7 @@ static int test_init_from_config(void)
     Py_QuietFlag = 0;
     config.quiet = 1;
 
-    config.configure_c_stdio = 0;
+    config.configure_c_stdio = 1;
 
     putenv("PYTHONUNBUFFERED=");
     Py_UnbufferedStdioFlag = 0;
@@ -516,25 +521,27 @@ static int test_init_from_config(void)
 }
 
 
-static int test_init_dont_parse_argv(void)
+static int init_parse_argv(void)
 {
     _PyInitError err;
 
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
 
     static wchar_t* argv[] = {
-        L"-v",
+        L"-E",
         L"-c",
+        L"pass",
         L"arg1",
-        L"-W",
-        L"arg2",
+        L"-v",
+        L"arg3",
     };
 
     config.program_name = L"./_testembed";
 
     config.argv.length = Py_ARRAY_LENGTH(argv);
     config.argv.items = argv;
-    config.parse_argv = 0;
+    config.parse_argv = 1;
 
     err = _Py_InitializeFromConfig(&config);
     if (_Py_INIT_FAILED(err)) {
@@ -619,12 +626,13 @@ static int test_init_env_dev_mode_alloc(void)
 }
 
 
-static int test_init_isolated(void)
+static int init_isolated_flag(void)
 {
     _PyInitError err;
 
     /* Test _PyCoreConfig.isolated=1 */
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
 
     Py_IsolatedFlag = 0;
     config.isolated = 1;
@@ -648,7 +656,8 @@ static int test_preinit_isolated1(void)
 {
     _PyInitError err;
 
-    _PyPreConfig preconfig = _PyPreConfig_INIT;
+    _PyPreConfig preconfig;
+    _PyPreConfig_Init(&preconfig);
     preconfig.isolated = 1;
 
     err = _Py_PreInitialize(&preconfig);
@@ -656,7 +665,8 @@ static int test_preinit_isolated1(void)
         _Py_ExitInitError(err);
     }
 
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
     config.program_name = L"./_testembed";
 
     test_init_env_dev_mode_putenvs();
@@ -675,7 +685,8 @@ static int test_preinit_isolated2(void)
 {
     _PyInitError err;
 
-    _PyPreConfig preconfig = _PyPreConfig_INIT;
+    _PyPreConfig preconfig;
+    _PyPreConfig_Init(&preconfig);
     preconfig.isolated = 0;
 
     err = _Py_PreInitialize(&preconfig);
@@ -684,7 +695,8 @@ static int test_preinit_isolated2(void)
     }
 
     /* Test _PyCoreConfig.isolated=1 */
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
 
     Py_IsolatedFlag = 0;
     config.isolated = 1;
@@ -703,9 +715,72 @@ static int test_preinit_isolated2(void)
 }
 
 
-static int test_init_dev_mode(void)
+static int init_isolated_config(void)
 {
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyInitError err;
+
+    _PyPreConfig preconfig;
+    _PyPreConfig_InitIsolatedConfig(&preconfig);
+
+    err = _Py_PreInitialize(&preconfig);
+    if (_Py_INIT_FAILED(err)) {
+        _Py_ExitInitError(err);
+    }
+
+    _PyPreConfig *rt_preconfig = &_PyRuntime.preconfig;
+    assert(rt_preconfig->isolated == 1);
+    assert(rt_preconfig->use_environment == 0);
+
+    _PyCoreConfig config;
+    err = _PyCoreConfig_InitIsolatedConfig(&config);
+    if (_Py_INIT_FAILED(err)) {
+        _Py_ExitInitError(err);
+    }
+    config.program_name = L"./_testembed";
+
+    err = _Py_InitializeFromConfig(&config);
+    if (_Py_INIT_FAILED(err)) {
+        _Py_ExitInitError(err);
+    }
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+
+static int init_python_config(void)
+{
+    _PyInitError err;
+
+    _PyPreConfig preconfig;
+    _PyPreConfig_InitPythonConfig(&preconfig);
+
+    err = _Py_PreInitialize(&preconfig);
+    if (_Py_INIT_FAILED(err)) {
+        _Py_ExitInitError(err);
+    }
+
+    _PyCoreConfig config;
+    err = _PyCoreConfig_InitPythonConfig(&config);
+    if (_Py_INIT_FAILED(err)) {
+        _Py_ExitInitError(err);
+    }
+    config.program_name = L"./_testembed";
+
+    err = _Py_InitializeFromConfig(&config);
+    if (_Py_INIT_FAILED(err)) {
+        _Py_ExitInitError(err);
+    }
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+
+static int init_dev_mode(void)
+{
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
     putenv("PYTHONFAULTHANDLER=");
     putenv("PYTHONMALLOC=");
     config.dev_mode = 1;
@@ -723,7 +798,8 @@ static int test_init_dev_mode(void)
 static int test_init_read_set(void)
 {
     _PyInitError err;
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
 
     err = _PyCoreConfig_DecodeLocale(&config.program_name, "./init_read_set");
     if (_Py_INIT_FAILED(err)) {
@@ -772,13 +848,15 @@ static void configure_init_main(_PyCoreConfig *config)
 {
     config->argv.length = Py_ARRAY_LENGTH(init_main_argv);
     config->argv.items = init_main_argv;
+    config->parse_argv = 1;
     config->program_name = L"./python3";
 }
 
 
 static int test_init_run_main(void)
 {
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
     configure_init_main(&config);
 
     _PyInitError err = _Py_InitializeFromConfig(&config);
@@ -792,7 +870,8 @@ static int test_init_run_main(void)
 
 static int test_init_main(void)
 {
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
     configure_init_main(&config);
     config._init_main = 0;
 
@@ -821,7 +900,8 @@ static int test_init_main(void)
 
 static int test_run_main(void)
 {
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
 
     wchar_t *argv[] = {L"python3", L"-c",
                        (L"import sys; "
@@ -829,6 +909,7 @@ static int test_run_main(void)
                        L"arg2"};
     config.argv.length = Py_ARRAY_LENGTH(argv);
     config.argv.items = argv;
+    config.parse_argv = 1;
     config.program_name = L"./python3";
 
     _PyInitError err = _Py_InitializeFromConfig(&config);
@@ -869,12 +950,14 @@ static struct TestCase TestCases[] = {
     { "init_default_config", test_init_default_config },
     { "init_global_config", test_init_global_config },
     { "init_from_config", test_init_from_config },
-    { "init_dont_parse_argv", test_init_dont_parse_argv },
+    { "init_parse_argv", init_parse_argv },
     { "init_env", test_init_env },
     { "init_env_dev_mode", test_init_env_dev_mode },
     { "init_env_dev_mode_alloc", test_init_env_dev_mode_alloc },
-    { "init_dev_mode", test_init_dev_mode },
-    { "init_isolated", test_init_isolated },
+    { "init_dev_mode", init_dev_mode },
+    { "init_isolated_flag", init_isolated_flag },
+    { "init_isolated_config", init_isolated_config },
+    { "init_python_config", init_python_config },
     { "preinit_isolated1", test_preinit_isolated1 },
     { "preinit_isolated2", test_preinit_isolated2 },
     { "init_read_set", test_init_read_set },

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -521,7 +521,7 @@ static int test_init_from_config(void)
 }
 
 
-static int init_parse_argv(void)
+static int test_init_parse_argv(int parse_argv)
 {
     _PyInitError err;
 
@@ -529,6 +529,7 @@ static int init_parse_argv(void)
     _PyCoreConfig_Init(&config);
 
     static wchar_t* argv[] = {
+        L"./argv0",
         L"-E",
         L"-c",
         L"pass",
@@ -537,11 +538,9 @@ static int init_parse_argv(void)
         L"arg3",
     };
 
-    config.program_name = L"./_testembed";
-
     config.argv.length = Py_ARRAY_LENGTH(argv);
     config.argv.items = argv;
-    config.parse_argv = 1;
+    config.parse_argv = parse_argv;
 
     err = _Py_InitializeFromConfig(&config);
     if (_Py_INIT_FAILED(err)) {
@@ -550,6 +549,18 @@ static int init_parse_argv(void)
     dump_config();
     Py_Finalize();
     return 0;
+}
+
+
+static int init_parse_argv(void)
+{
+    return test_init_parse_argv(1);
+}
+
+
+static int init_dont_parse_argv(void)
+{
+    return test_init_parse_argv(0);
 }
 
 
@@ -951,6 +962,7 @@ static struct TestCase TestCases[] = {
     { "init_global_config", test_init_global_config },
     { "init_from_config", test_init_from_config },
     { "init_parse_argv", init_parse_argv },
+    { "init_dont_parse_argv", init_dont_parse_argv },
     { "init_env", test_init_env },
     { "init_env_dev_mode", test_init_env_dev_mode },
     { "init_env_dev_mode_alloc", test_init_env_dev_mode_alloc },

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -109,7 +109,7 @@ static const char usage_6[] =
 /* UTF-8 mode (PEP 540): if equals to 1, use the UTF-8 encoding, and change
    stdin and stdout error handler to "surrogateescape". It is equal to
    -1 by default: unknown, will be set by Py_Main() */
-int Py_UTF8Mode = -1;
+int Py_UTF8Mode = 0;
 int Py_DebugFlag = 0; /* Needed by parser.c */
 int Py_VerboseFlag = 0; /* Needed by import.c */
 int Py_QuietFlag = 0; /* Needed by sysmodule.c */
@@ -517,6 +517,61 @@ _PyCoreConfig_Clear(_PyCoreConfig *config)
     CLEAR(config->run_filename);
     CLEAR(config->check_hash_pycs_mode);
 #undef CLEAR
+}
+
+
+void
+_PyCoreConfig_Init(_PyCoreConfig *config)
+{
+    *config = _PyCoreConfig_INIT;
+}
+
+
+_PyInitError
+_PyCoreConfig_InitPythonConfig(_PyCoreConfig *config)
+{
+    _PyCoreConfig_Init(config);
+
+    config->configure_c_stdio = 1;
+    config->parse_argv = 1;
+
+    return _Py_INIT_OK();
+}
+
+
+_PyInitError
+_PyCoreConfig_InitIsolatedConfig(_PyCoreConfig *config)
+{
+    _PyCoreConfig_Init(config);
+
+    /* set to 1 */
+    config->isolated = 1;
+    config->site_import = 1;
+    config->write_bytecode = 1;
+    config->buffered_stdio = 1;
+
+    /* set to 0 */
+    config->use_environment = 0;
+    config->dev_mode = 0;
+    config->install_signal_handlers = 0;
+    config->use_hash_seed = 0;
+    config->faulthandler = 0;
+    config->tracemalloc = 0;
+    config->bytes_warning = 0;
+    config->inspect = 0;
+    config->interactive = 0;
+    config->optimization_level = 0;
+    config->parser_debug = 0;
+    config->verbose = 0;
+    config->quiet = 0;
+    config->user_site_directory = 0;
+    config->configure_c_stdio = 0;
+    config->pathconfig_warnings = 0;
+#ifdef MS_WINDOWS
+    config->legacy_windows_stdio = 0;
+#endif
+
+    return _Py_INIT_OK();
 }
 
 
@@ -2018,7 +2073,8 @@ core_read_precmdline(_PyCoreConfig *config, _PyPreCmdline *precmdline)
         return _Py_INIT_NO_MEMORY();
     }
 
-    _PyPreConfig preconfig = _PyPreConfig_INIT;
+    _PyPreConfig preconfig;
+    _PyPreConfig_Init(&preconfig);
     if (_PyPreConfig_Copy(&preconfig, &_PyRuntime.preconfig) < 0) {
         err = _Py_INIT_NO_MEMORY();
         return err;

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -39,7 +39,8 @@ Py_FrozenMain(int argc, char **argv)
         }
     }
 
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
     config.pathconfig_warnings = 0;   /* Suppress errors from getpath.c */
 
     if ((p = Py_GETENV("PYTHONINSPECT")) && *p != '\0')

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -392,7 +392,8 @@ pathconfig_global_init(void)
     }
 
     _PyInitError err;
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
 
     err = _PyCoreConfig_Read(&config);
     if (_Py_INIT_FAILED(err)) {

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -382,7 +382,7 @@ fail:
 
 
 void
-_PyCoreConfig_GetCoreConfig(_PyPreConfig *config,
+_PyPreConfig_GetCoreConfig(_PyPreConfig *config,
                             const _PyCoreConfig *core_config)
 {
 #define COPY_ATTR(ATTR) \

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -260,6 +260,42 @@ _PyPreCmdline_Read(_PyPreCmdline *cmdline,
 
 /* --- _PyPreConfig ----------------------------------------------- */
 
+void
+_PyPreConfig_Init(_PyPreConfig *config)
+{
+    *config = _PyPreConfig_INIT;
+}
+
+
+void
+_PyPreConfig_InitPythonConfig(_PyPreConfig *config)
+{
+    _PyPreConfig_Init(config);
+
+    /* Set to -1 to enable C locale coercion (PEP 538) and UTF-8 Mode (PEP 540)
+       depending on the LC_CTYPE locale, PYTHONUTF8 and PYTHONCOERCECLOCALE
+       environment variables. */
+    config->coerce_c_locale = -1;
+    config->coerce_c_locale_warn = -1;
+    config->utf8_mode = -1;
+}
+
+
+void
+_PyPreConfig_InitIsolatedConfig(_PyPreConfig *config)
+{
+    _PyPreConfig_Init(config);
+
+    config->isolated = 1;
+    config->use_environment = 0;
+#ifdef MS_WINDOWS
+    config->legacy_windows_fs_encoding = 0;
+#endif
+    config->utf8_mode = 0;
+    config->dev_mode = 0;
+}
+
+
 int
 _PyPreConfig_Copy(_PyPreConfig *config, const _PyPreConfig *config2)
 {
@@ -366,11 +402,11 @@ static void
 _PyPreConfig_GetGlobalConfig(_PyPreConfig *config)
 {
 #define COPY_FLAG(ATTR, VALUE) \
-    if (config->ATTR == -1) { \
+    if (config->ATTR < 0) { \
         config->ATTR = VALUE; \
     }
 #define COPY_NOT_FLAG(ATTR, VALUE) \
-    if (config->ATTR == -1) { \
+    if (config->ATTR < 0) { \
         config->ATTR = !(VALUE); \
     }
 
@@ -379,8 +415,8 @@ _PyPreConfig_GetGlobalConfig(_PyPreConfig *config)
 #ifdef MS_WINDOWS
     COPY_FLAG(legacy_windows_fs_encoding, Py_LegacyWindowsFSEncodingFlag);
 #endif
-    if (Py_UTF8Mode > 0) {
-        config->utf8_mode = 1;
+    if (config->utf8_mode == -2) {
+        config->utf8_mode = Py_UTF8Mode;
     }
 
 #undef COPY_FLAG
@@ -392,11 +428,11 @@ static void
 _PyPreConfig_SetGlobalConfig(const _PyPreConfig *config)
 {
 #define COPY_FLAG(ATTR, VAR) \
-    if (config->ATTR != -1) { \
+    if (config->ATTR >= 0) { \
         VAR = config->ATTR; \
     }
 #define COPY_NOT_FLAG(ATTR, VAR) \
-    if (config->ATTR != -1) { \
+    if (config->ATTR >= 0) { \
         VAR = !config->ATTR; \
     }
 
@@ -575,7 +611,9 @@ preconfig_init_coerce_c_locale(_PyPreConfig *config)
             }
         }
         else if (strcmp(env, "warn") == 0) {
-            config->coerce_c_locale_warn = 1;
+            if (config->coerce_c_locale_warn < 0) {
+                config->coerce_c_locale_warn = 1;
+            }
         }
         else {
             if (config->coerce_c_locale < 0) {
@@ -587,19 +625,19 @@ preconfig_init_coerce_c_locale(_PyPreConfig *config)
     /* Test if coerce_c_locale equals to -1 or equals to 1:
        PYTHONCOERCECLOCALE=1 doesn't imply that the C locale is always coerced.
        It is only coerced if if the LC_CTYPE locale is "C". */
-    if (config->coerce_c_locale == 0 || config->coerce_c_locale == 2) {
-        return;
+    if (config->coerce_c_locale < 0 || config->coerce_c_locale == 1) {
+        /* The C locale enables the C locale coercion (PEP 538) */
+        if (_Py_LegacyLocaleDetected()) {
+            config->coerce_c_locale = 2;
+        }
+        else {
+            config->coerce_c_locale = 0;
+        }
     }
 
-    /* The C locale enables the C locale coercion (PEP 538) */
-    if (_Py_LegacyLocaleDetected()) {
-        config->coerce_c_locale = 2;
+    if (config->coerce_c_locale_warn < 0) {
+        config->coerce_c_locale_warn = 0;
     }
-    else {
-        config->coerce_c_locale = 0;
-    }
-
-    assert(config->coerce_c_locale >= 0);
 }
 
 
@@ -659,6 +697,7 @@ preconfig_read(_PyPreConfig *config, _PyPreCmdline *cmdline)
     }
 
     assert(config->coerce_c_locale >= 0);
+    assert(config->coerce_c_locale_warn >= 0);
 #ifdef MS_WINDOWS
     assert(config->legacy_windows_fs_encoding >= 0);
 #endif
@@ -700,7 +739,8 @@ _PyPreConfig_Read(_PyPreConfig *config, const _PyArgv *args)
     }
 
     /* Save the config to be able to restore it if encodings change */
-    _PyPreConfig save_config = _PyPreConfig_INIT;
+    _PyPreConfig save_config;
+    _PyPreConfig_Init(&save_config);
     if (_PyPreConfig_Copy(&save_config, config) < 0) {
         return _Py_INIT_NO_MEMORY();
     }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -701,7 +701,8 @@ _Py_PreInitializeFromPyArgv(const _PyPreConfig *src_config, const _PyArgv *args)
         return _Py_INIT_OK();
     }
 
-    _PyPreConfig config = _PyPreConfig_INIT;
+    _PyPreConfig config;
+    _PyPreConfig_Init(&config);
 
     if (src_config) {
         if (_PyPreConfig_Copy(&config, src_config) < 0) {
@@ -752,7 +753,8 @@ _PyInitError
 _Py_PreInitializeFromCoreConfig(const _PyCoreConfig *coreconfig,
                                 const _PyArgv *args)
 {
-    _PyPreConfig config = _PyPreConfig_INIT;
+    _PyPreConfig config;
+    _PyPreConfig_Init(&config);
     if (coreconfig != NULL) {
         _PyCoreConfig_GetCoreConfig(&config, coreconfig);
     }
@@ -829,7 +831,8 @@ _Py_InitializeCore(_PyRuntimeState *runtime,
         return err;
     }
 
-    _PyCoreConfig local_config = _PyCoreConfig_INIT;
+    _PyCoreConfig local_config;
+    _PyCoreConfig_Init(&local_config);
     err = pyinit_coreconfig(runtime, &local_config, src_config, args, interp_p);
     _PyCoreConfig_Clear(&local_config);
     return err;
@@ -1051,7 +1054,8 @@ Py_InitializeEx(int install_sigs)
         return;
     }
 
-    _PyCoreConfig config = _PyCoreConfig_INIT;
+    _PyCoreConfig config;
+    _PyCoreConfig_Init(&config);
     config.install_signal_handlers = install_sigs;
 
     err = _Py_InitializeFromConfig(&config);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -756,11 +756,19 @@ _Py_PreInitializeFromCoreConfig(const _PyCoreConfig *coreconfig,
     _PyPreConfig config;
     _PyPreConfig_Init(&config);
     if (coreconfig != NULL) {
-        _PyCoreConfig_GetCoreConfig(&config, coreconfig);
+        _PyPreConfig_GetCoreConfig(&config, coreconfig);
     }
-    return _Py_PreInitializeFromPyArgv(&config, args);
-    /* No need to clear config:
-       _PyCoreConfig_GetCoreConfig() doesn't allocate memory */
+
+    if (args == NULL && coreconfig != NULL && coreconfig->parse_argv) {
+        _PyArgv config_args = {
+            .use_bytes_argv = 0,
+            .argc = coreconfig->argv.length,
+            .wchar_argv = coreconfig->argv.items};
+        return _Py_PreInitializeFromPyArgv(&config, &config_args);
+    }
+    else {
+        return _Py_PreInitializeFromPyArgv(&config, args);
+    }
 }
 
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -49,7 +49,7 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
 
     _PyGC_Initialize(&runtime->gc);
     _PyEval_Initialize(&runtime->ceval);
-    runtime->preconfig = _PyPreConfig_INIT;
+    _PyPreConfig_Init(&runtime->preconfig);
 
     runtime->gilstate.check_enabled = 1;
 
@@ -189,7 +189,7 @@ PyInterpreterState_New(void)
     memset(interp, 0, sizeof(*interp));
     interp->id_refcount = -1;
     interp->check_interval = 100;
-    interp->core_config = _PyCoreConfig_INIT;
+    _PyCoreConfig_Init(&interp->core_config);
     interp->eval_frame = _PyEval_EvalFrameDefault;
 #ifdef HAVE_DLOPEN
 #if HAVE_DECL_RTLD_NOW


### PR DESCRIPTION
Add new functions to get the Python interpreter behavior:

* _PyPreConfig_InitPythonConfig()
* _PyCoreConfig_InitPythonConfig()

Add new functions to get an isolated configuration:

* _PyPreConfig_InitIsolateConfig()
* _PyCoreConfig_InitIsolateConfig()

Set _PyCoreConfig.configure_c_stdio to 0 by default to behave as
Python 3.7:

* Py_Main() configures C standard streams
* Py_Initialize() leaves C standard streams unchanged

_PyCoreConfig_Read() no longer sets coerce_c_locale_warn to 1 if it's
equal to 0. coerce_c_locale_warn must now be set to -1 (ex: using
_PyCoreConfig_InitPythonConfig()) to enable C locale coercion
warning.

Add unit tests for _PyCoreConfig_InitPythonConfig()
and _PyCoreConfig_InitIsolateConfig().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
