### PR TITLE
bpo-36948: Fix NameError in urllib.request.URLopener.retrieve

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1464,11 +1464,15 @@ class URLopener_Tests(unittest.TestCase, FakeHTTPMixin):
                 "//c:|windows%/:=&?~#+!$,;'@()*[]|/path/")
 
     def test_urlopener_retrieve_file(self):
-        with tempfile.NamedTemporaryFile() as file_obj:
-            with self.assertWarns(DeprecationWarning):
-                url = f'file://localhost{file_obj.name}'
-                filename, _ = urllib.request.URLopener().retrieve(url)
-                self.assertEqual(filename, file_obj.name)
+        with self.assertWarns(DeprecationWarning):
+            try:
+                fd, tmp_file = tempfile.mkstemp()
+                fileurl = 'file:' + urllib.request.pathname2url(tmp_file)
+                filename, _ = urllib.request.URLopener().retrieve(fileurl)
+                self.assertEqual(filename, tmp_file)
+            finally:
+                os.close(fd)
+                os.unlink(tmp_file)
 
     def test_urlopener_retrieve_remote(self):
         with self.assertWarns(DeprecationWarning):

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1465,10 +1465,12 @@ class URLopener_Tests(unittest.TestCase, FakeHTTPMixin):
 
     @support.ignore_warnings(category=DeprecationWarning)
     def test_urlopener_retrieve_file(self):
-        with tempfile.NamedTemporaryFile() as fileobj:
-            fileurl = "file:" + urllib.request.pathname2url(fileobj.name)
-            filename, _ = urllib.request.URLopener().retrieve(fileurl)
-            self.assertEqual(filename, fileobj.name)
+        fd, tmpfile = tempfile.mkstemp()
+        self.addCleanup(os.close, fd)
+        self.addCleanup(os.unlink, tmpfile)
+        fileurl = "file:" + urllib.request.pathname2url(tmpfile)
+        filename, _ = urllib.request.URLopener().retrieve(fileurl)
+        self.assertEqual(filename, tmpfile)
 
     @support.ignore_warnings(category=DeprecationWarning)
     def test_urlopener_retrieve_remote(self):

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1467,7 +1467,7 @@ class URLopener_Tests(unittest.TestCase, FakeHTTPMixin):
     def test_urlopener_retrieve_file(self):
         with support.temp_dir() as tmpdir:
             fd, tmpfile = tempfile.mkstemp(dir=tmpdir)
-            self.addCleanup(os.close, fd)
+            os.close(fd)
             fileurl = "file:" + urllib.request.pathname2url(tmpfile)
             filename, _ = urllib.request.URLopener().retrieve(fileurl)
             self.assertEqual(filename, tmpfile)

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1466,7 +1466,7 @@ class URLopener_Tests(unittest.TestCase, FakeHTTPMixin):
     def test_urlopener_retrieve_file(self):
         with tempfile.NamedTemporaryFile() as file_obj:
             with self.assertWarns(DeprecationWarning):
-                url = f'file://{file_obj.name}'
+                url = f'file://localhost{file_obj.name}'
                 filename, _ = urllib.request.URLopener().retrieve(url)
                 self.assertEqual(filename, file_obj.name)
 

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1465,12 +1465,12 @@ class URLopener_Tests(unittest.TestCase, FakeHTTPMixin):
 
     @support.ignore_warnings(category=DeprecationWarning)
     def test_urlopener_retrieve_file(self):
-        fd, tmpfile = tempfile.mkstemp()
-        self.addCleanup(os.close, fd)
-        self.addCleanup(os.unlink, tmpfile)
-        fileurl = "file:" + urllib.request.pathname2url(tmpfile)
-        filename, _ = urllib.request.URLopener().retrieve(fileurl)
-        self.assertEqual(filename, tmpfile)
+        with support.temp_dir() as tmpdir:
+            fd, tmpfile = tempfile.mkstemp(dir=tmpdir)
+            self.addCleanup(os.close, fd)
+            fileurl = "file:" + urllib.request.pathname2url(tmpfile)
+            filename, _ = urllib.request.URLopener().retrieve(fileurl)
+            self.assertEqual(filename, tmpfile)
 
     @support.ignore_warnings(category=DeprecationWarning)
     def test_urlopener_retrieve_remote(self):

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1463,26 +1463,20 @@ class URLopener_Tests(unittest.TestCase, FakeHTTPMixin):
                 "spam://c:|windows%/:=&?~#+!$,;'@()*[]|/path/"),
                 "//c:|windows%/:=&?~#+!$,;'@()*[]|/path/")
 
+    @support.ignore_warnings(category=DeprecationWarning)
     def test_urlopener_retrieve_file(self):
-        with self.assertWarns(DeprecationWarning):
-            try:
-                fd, tmp_file = tempfile.mkstemp()
-                fileurl = 'file:' + urllib.request.pathname2url(tmp_file)
-                filename, _ = urllib.request.URLopener().retrieve(fileurl)
-                self.assertEqual(filename, tmp_file)
-            finally:
-                os.close(fd)
-                os.unlink(tmp_file)
+        with tempfile.NamedTemporaryFile() as fileobj:
+            fileurl = "file:" + urllib.request.pathname2url(fileobj.name)
+            filename, _ = urllib.request.URLopener().retrieve(fileurl)
+            self.assertEqual(filename, fileobj.name)
 
+    @support.ignore_warnings(category=DeprecationWarning)
     def test_urlopener_retrieve_remote(self):
-        with self.assertWarns(DeprecationWarning):
-            try:
-                self.fakehttp(b"HTTP/1.1 200 OK\r\n\r\nHello!")
-                url = "http://www.python.org/file.txt"
-                filename, _ = urllib.request.URLopener().retrieve(url)
-                self.assertEqual(os.path.splitext(filename)[1], '.txt')
-            finally:
-                self.unfakehttp()
+        url = "http://www.python.org/file.txt"
+        self.fakehttp(b"HTTP/1.1 200 OK\r\n\r\nHello!")
+        self.addCleanup(self.unfakehttp)
+        filename, _ = urllib.request.URLopener().retrieve(url)
+        self.assertEqual(os.path.splitext(filename)[1], ".txt")
 
 
 # Just commented them out.

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1445,7 +1445,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertIsInstance(urllib.request.thishost(), tuple)
 
 
-class URLopener_Tests(unittest.TestCase, FakeHTTPMixin):
+class URLopener_Tests(FakeHTTPMixin, unittest.TestCase):
     """Testcase to test the open method of URLopener class."""
 
     def test_quoted_open(self):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1783,7 +1783,7 @@ class URLopener:
                 fp = self.open_local_file(url1)
                 hdrs = fp.info()
                 fp.close()
-                return url2pathname(splithost(url1)[1]), hdrs
+                return url2pathname(_splithost(url1)[1]), hdrs
             except OSError as msg:
                 pass
         fp = self.open(url, data)
@@ -1792,10 +1792,10 @@ class URLopener:
             if filename:
                 tfp = open(filename, 'wb')
             else:
-                garbage, path = splittype(url)
-                garbage, path = splithost(path or "")
-                path, garbage = splitquery(path or "")
-                path, garbage = splitattr(path or "")
+                garbage, path = _splittype(url)
+                garbage, path = _splithost(path or "")
+                path, garbage = _splitquery(path or "")
+                path, garbage = _splitattr(path or "")
                 suffix = os.path.splitext(path)[1]
                 (fd, filename) = tempfile.mkstemp(suffix)
                 self.__tempfiles.append(filename)

--- a/Misc/NEWS.d/next/Library/2019-05-17-21-42-58.bpo-36948.vnUDvk.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-17-21-42-58.bpo-36948.vnUDvk.rst
@@ -1,0 +1,2 @@
+Fix :exc:`NameError` in :meth:`urllib.request.URLopener.retrieve`. Patch by
+Karthikeyan Singaravelan.


### PR DESCRIPTION
Fix NameError in urllib.request.URLopener.retrieve by using correct imports.

<!-- issue-number: [bpo-36948](https://bugs.python.org/issue36948) -->
https://bugs.python.org/issue36948
<!-- /issue-number -->
