### PR TITLE
bpo-36763: _Py_RunMain() doesn't call Py_Exit() anymore

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -100,6 +100,8 @@ PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromCoreConfig(
     const _PyCoreConfig *coreconfig,
     const _PyArgv *args);
 
+PyAPI_FUNC(int) _Py_HandleSystemExit(int *exitcode_p);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C API/2019-05-17-19-23-24.bpo-36763.TswmDy.rst
+++ b/Misc/NEWS.d/next/C API/2019-05-17-19-23-24.bpo-36763.TswmDy.rst
@@ -1,0 +1,3 @@
+``Py_Main()`` now returns the exitcode rather than calling
+``Py_Exit(exitcode)`` when calling ``PyErr_Print()`` if the current
+exception type is ``SystemExit``.


### PR DESCRIPTION
Py_Main() and _Py_RunMain() now return the exitcode rather than
calling Py_Exit(exitcode) when calling PyErr_Print() if the current
exception type is SystemExit and -i command line is used
(core_config.inspect=1).

* Add _Py_HandleSystemExit()
* Add pymain_exit_err_print()
* Add pymain_exit_print()

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
