### PR TITLE
bpo-33524: Fix the folding of email header when max_line_length is 0 or None

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -68,6 +68,7 @@ XXX: provide complete list of token types.
 """
 
 import re
+import sys
 import urllib   # For urllib.parse.unquote
 from string import hexdigits
 from operator import itemgetter
@@ -2590,7 +2591,7 @@ def _refold_parse_tree(parse_tree, *, policy):
 
     """
     # max_line_length 0/None means no limit, ie: infinitely long.
-    maxlen = policy.max_line_length or float("+inf")
+    maxlen = policy.max_line_length or sys.maxsize
     encoding = 'utf-8' if policy.utf8 else 'us-ascii'
     lines = ['']
     last_ew = None

--- a/Lib/email/policy.py
+++ b/Lib/email/policy.py
@@ -3,6 +3,7 @@ code that adds all the email6 features.
 """
 
 import re
+import sys
 from email._policybase import Policy, Compat32, compat32, _extend_docstrings
 from email.utils import _has_surrogates
 from email.headerregistry import HeaderRegistry as HeaderRegistry
@@ -203,7 +204,7 @@ class EmailPolicy(Policy):
     def _fold(self, name, value, refold_binary=False):
         if hasattr(value, 'name'):
             return value.fold(policy=self)
-        maxlen = self.max_line_length if self.max_line_length else float('inf')
+        maxlen = self.max_line_length if self.max_line_length else sys.maxsize
         lines = value.splitlines()
         refold = (self.refold_source == 'all' or
                   self.refold_source == 'long' and

--- a/Lib/test/test_email/test_policy.py
+++ b/Lib/test/test_email/test_policy.py
@@ -1,4 +1,5 @@
 import io
+import sys
 import types
 import textwrap
 import unittest
@@ -133,6 +134,18 @@ class PolicyAPITests(unittest.TestCase):
         added = added + email.policy.default
         for attr, value in expected.items():
             self.assertEqual(getattr(added, attr), value)
+
+    def test_fold_zero_max_line_length(self):
+        expected = 'Subject: =?utf-8?q?=C3=A1?=\n'
+
+        msg = email.message.EmailMessage()
+        msg['Subject'] = 'á'
+
+        p1 = email.policy.default.clone(max_line_length=0)
+        p2 = email.policy.default.clone(max_line_length=None)
+
+        self.assertEqual(p1.fold('Subject', msg['Subject']), expected)
+        self.assertEqual(p2.fold('Subject', msg['Subject']), expected)
 
     def test_register_defect(self):
         class Dummy:

--- a/Misc/NEWS.d/next/Library/2019-05-17-11-44-21.bpo-33524.8y_xUU.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-17-11-44-21.bpo-33524.8y_xUU.rst
@@ -1,0 +1,3 @@
+Fix the folding of email header when the max_line_length is 0 or None and the
+header contains non-ascii characters.  Contributed by Licht Takeuchi
+(@Licht-T).


### PR DESCRIPTION
Updated version of #6966 with requested NEWS entry since that PR looks abandoned.

Original Patch by @Licht-T 

<!-- issue-number: [bpo-33524](https://bugs.python.org/issue33524) -->
https://bugs.python.org/issue33524
<!-- /issue-number -->
