### PR TITLE
bpo-36763: _Py_InitializeFromArgs() argc becomes Py_ssize_t

### DIFF
--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -18,11 +18,11 @@ PyAPI_FUNC(_PyInitError) _Py_PreInitialize(
     const _PyPreConfig *src_config);
 PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromArgs(
     const _PyPreConfig *src_config,
-    int argc,
+    Py_ssize_t argc,
     char **argv);
 PyAPI_FUNC(_PyInitError) _Py_PreInitializeFromWideArgs(
     const _PyPreConfig *src_config,
-    int argc,
+    Py_ssize_t argc,
     wchar_t **argv);
 
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
@@ -34,11 +34,11 @@ PyAPI_FUNC(_PyInitError) _Py_InitializeFromConfig(
     const _PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _Py_InitializeFromArgs(
     const _PyCoreConfig *config,
-    int argc,
+    Py_ssize_t argc,
     char **argv);
 PyAPI_FUNC(_PyInitError) _Py_InitializeFromWideArgs(
     const _PyCoreConfig *config,
-    int argc,
+    Py_ssize_t argc,
     wchar_t **argv);
 PyAPI_FUNC(_PyInitError) _Py_InitializeMain(void);
 

--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -61,7 +61,7 @@ PyAPI_FUNC(int) _PyWstrList_Extend(_PyWstrList *list,
 /* --- _PyArgv ---------------------------------------------------- */
 
 typedef struct {
-    int argc;
+    Py_ssize_t argc;
     int use_bytes_argv;
     char **bytes_argv;
     wchar_t **wchar_argv;
@@ -123,7 +123,7 @@ PyAPI_FUNC(_PyInitError) _PyPreCmdline_Read(_PyPreCmdline *cmdline,
 PyAPI_FUNC(void) _PyPreConfig_Init(_PyPreConfig *config);
 PyAPI_FUNC(void) _PyPreConfig_InitPythonConfig(_PyPreConfig *config);
 PyAPI_FUNC(void) _PyPreConfig_InitIsolatedConfig(_PyPreConfig *config);
-PyAPI_FUNC(int) _PyPreConfig_Copy(_PyPreConfig *config,
+PyAPI_FUNC(void) _PyPreConfig_Copy(_PyPreConfig *config,
     const _PyPreConfig *config2);
 PyAPI_FUNC(PyObject*) _PyPreConfig_AsDict(const _PyPreConfig *config);
 PyAPI_FUNC(void) _PyPreConfig_GetCoreConfig(_PyPreConfig *config,
@@ -158,10 +158,10 @@ PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetPyArgv(
     const _PyArgv *args);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetArgv(
     _PyCoreConfig *config,
-    int argc,
+    Py_ssize_t argc,
     char **argv);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetWideArgv(_PyCoreConfig *config,
-    int argc,
+    Py_ssize_t argc,
     wchar_t **argv);
 
 

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -1746,7 +1746,7 @@ config_usage(int error, const wchar_t* program)
 /* Parse the command line arguments */
 static _PyInitError
 config_parse_cmdline(_PyCoreConfig *config, _PyWstrList *warnoptions,
-                     int *opt_index)
+                     Py_ssize_t *opt_index)
 {
     _PyInitError err;
     const _PyWstrList *argv = &config->argv;
@@ -2044,7 +2044,7 @@ config_init_warnoptions(_PyCoreConfig *config,
 
 
 static _PyInitError
-config_update_argv(_PyCoreConfig *config, int opt_index)
+config_update_argv(_PyCoreConfig *config, Py_ssize_t opt_index)
 {
     const _PyWstrList *cmdline_argv = &config->argv;
     _PyWstrList config_argv = _PyWstrList_INIT;
@@ -2105,10 +2105,7 @@ core_read_precmdline(_PyCoreConfig *config, _PyPreCmdline *precmdline)
 
     _PyPreConfig preconfig;
     _PyPreConfig_Init(&preconfig);
-    if (_PyPreConfig_Copy(&preconfig, &_PyRuntime.preconfig) < 0) {
-        err = _Py_INIT_NO_MEMORY();
-        return err;
-    }
+    _PyPreConfig_Copy(&preconfig, &_PyRuntime.preconfig);
 
     _PyPreConfig_GetCoreConfig(&preconfig, config);
 
@@ -2145,7 +2142,7 @@ config_read_cmdline(_PyCoreConfig *config)
     }
 
     if (config->parse_argv) {
-        int opt_index;
+        Py_ssize_t opt_index;
         err = config_parse_cmdline(config, &cmdline_warnoptions, &opt_index);
         if (_Py_INIT_FAILED(err)) {
             goto done;
@@ -2207,7 +2204,7 @@ _PyCoreConfig_SetPyArgv(_PyCoreConfig *config, const _PyArgv *args)
 /* Set config.argv: decode argv using Py_DecodeLocale(). Pre-initialize Python
    if needed to ensure that encodings are properly configured. */
 _PyInitError
-_PyCoreConfig_SetArgv(_PyCoreConfig *config, int argc, char **argv)
+_PyCoreConfig_SetArgv(_PyCoreConfig *config, Py_ssize_t argc, char **argv)
 {
     _PyArgv args = {
         .argc = argc,
@@ -2219,7 +2216,7 @@ _PyCoreConfig_SetArgv(_PyCoreConfig *config, int argc, char **argv)
 
 
 _PyInitError
-_PyCoreConfig_SetWideArgv(_PyCoreConfig *config, int argc, wchar_t **argv)
+_PyCoreConfig_SetWideArgv(_PyCoreConfig *config, Py_ssize_t argc, wchar_t **argv)
 {
     _PyArgv args = {
         .argc = argc,

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -705,10 +705,7 @@ _Py_PreInitializeFromPyArgv(const _PyPreConfig *src_config, const _PyArgv *args)
     _PyPreConfig_Init(&config);
 
     if (src_config) {
-        if (_PyPreConfig_Copy(&config, src_config) < 0) {
-            err = _Py_INIT_NO_MEMORY();
-            return err;
-        }
+        _PyPreConfig_Copy(&config, src_config);
     }
 
     err = _PyPreConfig_Read(&config, args);
@@ -727,7 +724,7 @@ _Py_PreInitializeFromPyArgv(const _PyPreConfig *src_config, const _PyArgv *args)
 
 
 _PyInitError
-_Py_PreInitializeFromArgs(const _PyPreConfig *src_config, int argc, char **argv)
+_Py_PreInitializeFromArgs(const _PyPreConfig *src_config, Py_ssize_t argc, char **argv)
 {
     _PyArgv args = {.use_bytes_argv = 1, .argc = argc, .bytes_argv = argv};
     return _Py_PreInitializeFromPyArgv(src_config, &args);
@@ -735,7 +732,7 @@ _Py_PreInitializeFromArgs(const _PyPreConfig *src_config, int argc, char **argv)
 
 
 _PyInitError
-_Py_PreInitializeFromWideArgs(const _PyPreConfig *src_config, int argc, wchar_t **argv)
+_Py_PreInitializeFromWideArgs(const _PyPreConfig *src_config, Py_ssize_t argc, wchar_t **argv)
 {
     _PyArgv args = {.use_bytes_argv = 0, .argc = argc, .wchar_argv = argv};
     return _Py_PreInitializeFromPyArgv(src_config, &args);
@@ -1024,7 +1021,7 @@ init_python(const _PyCoreConfig *config, const _PyArgv *args)
 
 
 _PyInitError
-_Py_InitializeFromArgs(const _PyCoreConfig *config, int argc, char **argv)
+_Py_InitializeFromArgs(const _PyCoreConfig *config, Py_ssize_t argc, char **argv)
 {
     _PyArgv args = {.use_bytes_argv = 1, .argc = argc, .bytes_argv = argv};
     return init_python(config, &args);
@@ -1032,7 +1029,7 @@ _Py_InitializeFromArgs(const _PyCoreConfig *config, int argc, char **argv)
 
 
 _PyInitError
-_Py_InitializeFromWideArgs(const _PyCoreConfig *config, int argc, wchar_t **argv)
+_Py_InitializeFromWideArgs(const _PyCoreConfig *config, Py_ssize_t argc, wchar_t **argv)
 {
     _PyArgv args = {.use_bytes_argv = 0, .argc = argc, .wchar_argv = argv};
     return init_python(config, &args);


### PR DESCRIPTION
* The type of initlization function 'argc' parameters becomes
  Py_ssize_t, instead of int.
* Change _PyPreConfig_Copy() return type to void, instead of int.
  The function cannot fail anymore.
* Fix compilation warnings on Windows.

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
