### PR TITLE
bpo-36763: Use _PyCoreConfig_InitPythonConfig()

### DIFF
--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -115,27 +115,8 @@ typedef struct {
     PyMemAllocatorName allocator;
 } _PyPreConfig;
 
-#ifdef MS_WINDOWS
-#  define _PyPreConfig_WINDOWS_INIT \
-        .legacy_windows_fs_encoding = -1,
-#else
-#  define _PyPreConfig_WINDOWS_INIT
-#endif
-
-#define _PyPreConfig_INIT \
-    (_PyPreConfig){ \
-        _PyPreConfig_WINDOWS_INIT \
-        ._config_version = _Py_CONFIG_VERSION, \
-        .isolated = -1, \
-        .use_environment = -1, \
-        .configure_locale = 1, \
-        .utf8_mode = -2, \
-        .dev_mode = -1, \
-        .allocator = PYMEM_ALLOCATOR_NOT_SET}
-
-PyAPI_FUNC(void) _PyPreConfig_Init(_PyPreConfig *config);
 PyAPI_FUNC(void) _PyPreConfig_InitPythonConfig(_PyPreConfig *config);
-PyAPI_FUNC(void) _PyPreConfig_InitIsolateConfig(_PyPreConfig *config);
+PyAPI_FUNC(void) _PyPreConfig_InitIsolatedConfig(_PyPreConfig *config);
 
 
 /* --- _PyCoreConfig ---------------------------------------------- */
@@ -419,47 +400,23 @@ typedef struct {
 
 } _PyCoreConfig;
 
-#ifdef MS_WINDOWS
-#  define _PyCoreConfig_WINDOWS_INIT \
-        .legacy_windows_stdio = -1,
-#else
-#  define _PyCoreConfig_WINDOWS_INIT
-#endif
-
-#define _PyCoreConfig_INIT \
-    (_PyCoreConfig){ \
-        _PyCoreConfig_WINDOWS_INIT \
-        ._config_version = _Py_CONFIG_VERSION, \
-        .isolated = -1, \
-        .use_environment = -1, \
-        .dev_mode = -1, \
-        .install_signal_handlers = 1, \
-        .use_hash_seed = -1, \
-        .faulthandler = -1, \
-        .tracemalloc = -1, \
-        .use_module_search_paths = 0, \
-        .parse_argv = 0, \
-        .site_import = -1, \
-        .bytes_warning = -1, \
-        .inspect = -1, \
-        .interactive = -1, \
-        .optimization_level = -1, \
-        .parser_debug= -1, \
-        .write_bytecode = -1, \
-        .verbose = -1, \
-        .quiet = -1, \
-        .user_site_directory = -1, \
-        .configure_c_stdio = 0, \
-        .buffered_stdio = -1, \
-        ._install_importlib = 1, \
-        .check_hash_pycs_mode = NULL, \
-        .pathconfig_warnings = -1, \
-        ._init_main = 1}
-/* Note: _PyCoreConfig_INIT sets other fields to 0/NULL */
-
-PyAPI_FUNC(void) _PyCoreConfig_Init(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPythonConfig(_PyCoreConfig *config);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitIsolateConfig(_PyCoreConfig *config);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitIsolatedConfig(_PyCoreConfig *config);
+PyAPI_FUNC(void) _PyCoreConfig_Clear(_PyCoreConfig *);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetString(
+    wchar_t **config_str,
+    const wchar_t *str);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_DecodeLocale(
+    wchar_t **config_str,
+    const char *str);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetArgv(
+    _PyCoreConfig *config,
+    Py_ssize_t argc,
+    char **argv);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetWideArgv(_PyCoreConfig *config,
+    Py_ssize_t argc,
+    wchar_t **argv);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -121,8 +121,6 @@ PyAPI_FUNC(_PyInitError) _PyPreCmdline_Read(_PyPreCmdline *cmdline,
 /* --- _PyPreConfig ----------------------------------------------- */
 
 PyAPI_FUNC(void) _PyPreConfig_Init(_PyPreConfig *config);
-PyAPI_FUNC(void) _PyPreConfig_InitPythonConfig(_PyPreConfig *config);
-PyAPI_FUNC(void) _PyPreConfig_InitIsolatedConfig(_PyPreConfig *config);
 PyAPI_FUNC(void) _PyPreConfig_Copy(_PyPreConfig *config,
     const _PyPreConfig *config2);
 PyAPI_FUNC(PyObject*) _PyPreConfig_AsDict(const _PyPreConfig *config);
@@ -135,34 +133,18 @@ PyAPI_FUNC(_PyInitError) _PyPreConfig_Write(const _PyPreConfig *config);
 
 /* --- _PyCoreConfig ---------------------------------------------- */
 
-PyAPI_FUNC(void) _PyCoreConfig_Clear(_PyCoreConfig *);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPythonConfig(_PyCoreConfig *config);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitIsolatedConfig(_PyCoreConfig *config);
+PyAPI_FUNC(void) _PyCoreConfig_Init(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_Copy(
     _PyCoreConfig *config,
     const _PyCoreConfig *config2);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetString(
-    wchar_t **config_str,
-    const wchar_t *str);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_DecodeLocale(
-    wchar_t **config_str,
-    const char *str);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPathConfig(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetPathConfig(
     const _PyCoreConfig *config);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config);
 PyAPI_FUNC(void) _PyCoreConfig_Write(const _PyCoreConfig *config,
     _PyRuntimeState *runtime);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetPyArgv(
     _PyCoreConfig *config,
     const _PyArgv *args);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetArgv(
-    _PyCoreConfig *config,
-    Py_ssize_t argc,
-    char **argv);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetWideArgv(_PyCoreConfig *config,
-    Py_ssize_t argc,
-    wchar_t **argv);
 
 
 /* --- Function used for testing ---------------------------------- */

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -77,14 +77,12 @@ main(int argc, char *argv[])
     text[text_size] = '\0';
 
     _PyCoreConfig config;
-    _PyCoreConfig_Init(&config);
-    config.use_environment = 0;
-    config.user_site_directory = 0;
+    _PyCoreConfig_InitIsolatedConfig(&config);
+
     config.site_import = 0;
     config.program_name = L"./_freeze_importlib";
     /* Don't install importlib, since it could execute outdated bytecode. */
     config._install_importlib = 0;
-    config.pathconfig_warnings = 0;
     config._init_main = 0;
 
     _PyInitError err = _Py_InitializeFromConfig(&config);

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -551,14 +551,69 @@ _PyCoreConfig_Clear(_PyCoreConfig *config)
 void
 _PyCoreConfig_Init(_PyCoreConfig *config)
 {
-    *config = _PyCoreConfig_INIT;
+    memset(config, 0, sizeof(*config));
+
+    config->_config_version = _Py_CONFIG_VERSION;
+    config->isolated = -1;
+    config->use_environment = -1;
+    config->dev_mode = -1;
+    config->install_signal_handlers = 1;
+    config->use_hash_seed = -1;
+    config->faulthandler = -1;
+    config->tracemalloc = -1;
+    config->use_module_search_paths = 0;
+    config->parse_argv = 0;
+    config->site_import = -1;
+    config->bytes_warning = -1;
+    config->inspect = -1;
+    config->interactive = -1;
+    config->optimization_level = -1;
+    config->parser_debug= -1;
+    config->write_bytecode = -1;
+    config->verbose = -1;
+    config->quiet = -1;
+    config->user_site_directory = -1;
+    config->configure_c_stdio = 0;
+    config->buffered_stdio = -1;
+    config->_install_importlib = 1;
+    config->check_hash_pycs_mode = NULL;
+    config->pathconfig_warnings = -1;
+    config->_init_main = 1;
+#ifdef MS_WINDOWS
+    config->legacy_windows_stdio = -1;
+#endif
+}
+
+
+static void
+_PyCoreConfig_InitDefaults(_PyCoreConfig *config)
+{
+    _PyCoreConfig_Init(config);
+
+    config->isolated = 0;
+    config->use_environment = 1;
+    config->site_import = 1;
+    config->bytes_warning = 0;
+    config->inspect = 0;
+    config->interactive = 0;
+    config->optimization_level = 0;
+    config->parser_debug= 0;
+    config->write_bytecode = 1;
+    config->verbose = 0;
+    config->quiet = 0;
+    config->user_site_directory = 1;
+    config->buffered_stdio = 1;
+    config->pathconfig_warnings = 1;
+#ifdef MS_WINDOWS
+    config->legacy_windows_stdio = 0;
+#endif
 }
 
 
 _PyInitError
 _PyCoreConfig_InitPythonConfig(_PyCoreConfig *config)
 {
-    _PyCoreConfig_Init(config);
+    _PyCoreConfig_InitDefaults(config);
 
     config->configure_c_stdio = 1;
     config->parse_argv = 1;
@@ -570,30 +625,16 @@ _PyCoreConfig_InitPythonConfig(_PyCoreConfig *config)
 _PyInitError
 _PyCoreConfig_InitIsolatedConfig(_PyCoreConfig *config)
 {
-    _PyCoreConfig_Init(config);
+    _PyCoreConfig_InitDefaults(config);
 
-    /* set to 1 */
     config->isolated = 1;
-    config->site_import = 1;
-    config->write_bytecode = 1;
-    config->buffered_stdio = 1;
-
-    /* set to 0 */
     config->use_environment = 0;
+    config->user_site_directory = 0;
     config->dev_mode = 0;
     config->install_signal_handlers = 0;
     config->use_hash_seed = 0;
     config->faulthandler = 0;
     config->tracemalloc = 0;
-    config->bytes_warning = 0;
-    config->inspect = 0;
-    config->interactive = 0;
-    config->optimization_level = 0;
-    config->parser_debug = 0;
-    config->verbose = 0;
-    config->quiet = 0;
-    config->user_site_directory = 0;
-    config->configure_c_stdio = 0;
     config->pathconfig_warnings = 0;
 #ifdef MS_WINDOWS
     config->legacy_windows_stdio = 0;

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -40,7 +40,7 @@ Py_FrozenMain(int argc, char **argv)
     }
 
     _PyCoreConfig config;
-    _PyCoreConfig_Init(&config);
+    _PyCoreConfig_InitPythonConfig(&config);
     config.pathconfig_warnings = 0;   /* Suppress errors from getpath.c */
 
     if ((p = Py_GETENV("PYTHONINSPECT")) && *p != '\0')

--- a/Python/preconfig.c
+++ b/Python/preconfig.c
@@ -241,8 +241,9 @@ _PyPreCmdline_Read(_PyPreCmdline *cmdline,
     }
 
     /* dev_mode */
-    if ((cmdline && _Py_get_xoption(&cmdline->xoptions, L"dev"))
-        || _Py_GetEnv(cmdline->use_environment, "PYTHONDEVMODE"))
+    if ((cmdline->dev_mode < 0)
+        && (_Py_get_xoption(&cmdline->xoptions, L"dev")
+            || _Py_GetEnv(cmdline->use_environment, "PYTHONDEVMODE")))
     {
         cmdline->dev_mode = 1;
     }
@@ -260,10 +261,22 @@ _PyPreCmdline_Read(_PyPreCmdline *cmdline,
 
 /* --- _PyPreConfig ----------------------------------------------- */
 
+
 void
 _PyPreConfig_Init(_PyPreConfig *config)
 {
-    *config = _PyPreConfig_INIT;
+    memset(config, 0, sizeof(*config));
+
+    config->_config_version = _Py_CONFIG_VERSION;
+    config->isolated = -1;
+    config->use_environment = -1;
+    config->configure_locale = 1;
+    config->utf8_mode = -2;
+    config->dev_mode = -1;
+    config->allocator = PYMEM_ALLOCATOR_NOT_SET;
+#ifdef MS_WINDOWS
+    config->legacy_windows_fs_encoding = -1;
+#endif
 }
 
 
@@ -289,11 +302,11 @@ _PyPreConfig_InitIsolatedConfig(_PyPreConfig *config)
     config->configure_locale = 0;
     config->isolated = 1;
     config->use_environment = 0;
+    config->utf8_mode = 0;
+    config->dev_mode = 0;
 #ifdef MS_WINDOWS
     config->legacy_windows_fs_encoding = 0;
 #endif
-    config->utf8_mode = 0;
-    config->dev_mode = 0;
 }
 
 


### PR DESCRIPTION
_PyPreConfig_InitPythonConfig() and _PyCoreConfig_InitPythonConfig()
no longer inherit their values from global configuration variables.

Changes:

* _PyPreCmdline_Read() now ignores -X dev and PYTHONDEVMODE
  if dev_mode is already set.
* Inline _PyPreConfig_INIT macro into _PyPreConfig_Init() function.
* Inline _PyCoreConfig_INIT macro into _PyCoreConfig_Init() function.
* Replace _PyCoreConfig_Init() with _PyCoreConfig_InitPythonConfig()
  in most tests of _testembed.c.
* Replace _PyCoreConfig_Init() with _PyCoreConfig_InitIsolatedConfig()
  in _freeze_importlib.c.
* Move some initialization functions from the internal
  to the private API.

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
