### PR TITLE
bpo-36952: remove bufsize keyword (deprecated 3.6, removed 3.8)

### DIFF
--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -54,7 +54,7 @@ provided by this module.
 The following function is the primary interface of this module:
 
 
-.. function:: input(files=None, inplace=False, backup='', bufsize=0, mode='r', openhook=None)
+.. function:: input(files=None, inplace=False, backup='', mode='r', openhook=None)
 
    Create an instance of the :class:`FileInput` class.  The instance will be used
    as global state for the functions of this module, and is also returned to use
@@ -71,9 +71,6 @@ The following function is the primary interface of this module:
 
    .. versionchanged:: 3.2
       Can be used as a context manager.
-
-   .. deprecated-removed:: 3.6 3.8
-      The *bufsize* parameter.
 
 The following functions use the global state created by :func:`fileinput.input`;
 if there is no active state, :exc:`RuntimeError` is raised.
@@ -135,7 +132,7 @@ The class which implements the sequence behavior provided by the module is
 available for subclassing as well:
 
 
-.. class:: FileInput(files=None, inplace=False, backup='', bufsize=0, mode='r', openhook=None)
+.. class:: FileInput(files=None, inplace=False, backup='', mode='r', openhook=None)
 
    Class :class:`FileInput` is the implementation; its methods :meth:`filename`,
    :meth:`fileno`, :meth:`lineno`, :meth:`filelineno`, :meth:`isfirstline`,
@@ -165,9 +162,6 @@ available for subclassing as well:
 
    .. deprecated:: 3.4
       The ``'rU'`` and ``'U'`` modes.
-
-   .. deprecated-removed:: 3.6 3.8
-      The *bufsize* parameter.
 
    .. deprecated:: 3.8
       Support for :meth:`__getitem__` method is deprecated.

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -70,7 +70,7 @@ The following function is the primary interface of this module:
               process(line)
 
    .. versionchanged:: 3.8
-      The keyword parameter *mode* and *openhook* are now keyword-only.
+      The keyword parameters *mode* and *openhook* are now keyword-only.
 
    .. versionchanged:: 3.2
       Can be used as a context manager.

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -69,11 +69,12 @@ The following function is the primary interface of this module:
           for line in f:
               process(line)
 
+   .. versionchanged:: 3.2
+      Can be used as a context manager.
+
    .. versionchanged:: 3.8
       The keyword parameters *mode* and *openhook* are now keyword-only.
 
-   .. versionchanged:: 3.2
-      Can be used as a context manager.
 
 The following functions use the global state created by :func:`fileinput.input`;
 if there is no active state, :exc:`RuntimeError` is raised.
@@ -161,9 +162,6 @@ available for subclassing as well:
           process(input)
 
 
-   .. versionchanged:: 3.8
-      The keyword parameter *mode* and *openhook* are now keyword-only.
-
    .. versionchanged:: 3.2
       Can be used as a context manager.
 
@@ -172,6 +170,10 @@ available for subclassing as well:
 
    .. deprecated:: 3.8
       Support for :meth:`__getitem__` method is deprecated.
+
+   .. versionchanged:: 3.8
+      The keyword parameter *mode* and *openhook* are now keyword-only.
+
 
 
 **Optional in-place filtering:** if the keyword argument ``inplace=True`` is

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -71,7 +71,7 @@ The following function is the primary interface of this module:
 
    .. versionchanged:: 3.8
       The keyword parameter *mode* and *openhook* are now keyword-only.
-      
+
    .. versionchanged:: 3.2
       Can be used as a context manager.
 

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -54,7 +54,7 @@ provided by this module.
 The following function is the primary interface of this module:
 
 
-.. function:: input(files=None, inplace=False, backup='', mode='r', openhook=None)
+.. function:: input(files=None, inplace=False, backup='', *, mode='r', openhook=None)
 
    Create an instance of the :class:`FileInput` class.  The instance will be used
    as global state for the functions of this module, and is also returned to use
@@ -69,6 +69,9 @@ The following function is the primary interface of this module:
           for line in f:
               process(line)
 
+   .. versionchanged:: 3.8
+      The keyword parameter *mode* and *openhook* are now keyword-only.
+      
    .. versionchanged:: 3.2
       Can be used as a context manager.
 
@@ -132,7 +135,7 @@ The class which implements the sequence behavior provided by the module is
 available for subclassing as well:
 
 
-.. class:: FileInput(files=None, inplace=False, backup='', mode='r', openhook=None)
+.. class:: FileInput(files=None, inplace=False, backup='', *, mode='r', openhook=None)
 
    Class :class:`FileInput` is the implementation; its methods :meth:`filename`,
    :meth:`fileno`, :meth:`lineno`, :meth:`filelineno`, :meth:`isfirstline`,
@@ -156,6 +159,10 @@ available for subclassing as well:
 
       with FileInput(files=('spam.txt', 'eggs.txt')) as input:
           process(input)
+
+
+   .. versionchanged:: 3.8
+      The keyword parameter *mode* and *openhook* are now keyword-only.
 
    .. versionchanged:: 3.2
       Can be used as a context manager.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -821,6 +821,10 @@ The following features and APIs have been removed from Python 3.8:
   exposed to the user.
   (Contributed by Aviv Palivoda in :issue:`30262`.)
 
+* The ``bufsize`` keyword argument of :func:`fileinput.input` and
+  :func:`fileinput.FileInput` which was ignored and deprecated since Python 3.6
+  has been removed. :issue:`36952`
+
 
 Porting to Python 3.8
 =====================

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -823,7 +823,7 @@ The following features and APIs have been removed from Python 3.8:
 
 * The ``bufsize`` keyword argument of :func:`fileinput.input` and
   :func:`fileinput.FileInput` which was ignored and deprecated since Python 3.6
-  has been removed. :issue:`36952`
+  has been removed. :issue:`36952` (Contributed by Matthias Bussonnier)
 
 
 Porting to Python 3.8

--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -80,8 +80,7 @@ __all__ = ["input", "close", "nextfile", "filename", "lineno", "filelineno",
 
 _state = None
 
-def input(files=None, inplace=False, backup="", bufsize=0,
-          mode="r", openhook=None):
+def input(files=None, inplace=False, backup="", mode="r", openhook=None):
     """Return an instance of the FileInput class, which can be iterated.
 
     The parameters are passed to the constructor of the FileInput class.
@@ -91,7 +90,7 @@ def input(files=None, inplace=False, backup="", bufsize=0,
     global _state
     if _state and _state._file:
         raise RuntimeError("input() already active")
-    _state = FileInput(files, inplace, backup, bufsize, mode, openhook)
+    _state = FileInput(files, inplace, backup, mode, openhook)
     return _state
 
 def close():
@@ -173,7 +172,7 @@ def isstdin():
     return _state.isstdin()
 
 class FileInput:
-    """FileInput([files[, inplace[, backup[, bufsize, [, mode[, openhook]]]]]])
+    """FileInput([files[, inplace[, backup[, mode[, openhook]]]]])
 
     Class FileInput is the implementation of the module; its methods
     filename(), lineno(), fileline(), isfirstline(), isstdin(), fileno(),
@@ -185,7 +184,7 @@ class FileInput:
     sequential order; random access and readline() cannot be mixed.
     """
 
-    def __init__(self, files=None, inplace=False, backup="", bufsize=0,
+    def __init__(self, files=None, inplace=False, backup="",
                  mode="r", openhook=None):
         if isinstance(files, str):
             files = (files,)
@@ -201,10 +200,6 @@ class FileInput:
         self._files = files
         self._inplace = inplace
         self._backup = backup
-        if bufsize:
-            import warnings
-            warnings.warn('bufsize is deprecated and ignored',
-                          DeprecationWarning, stacklevel=2)
         self._savestdout = None
         self._output = None
         self._filename = None

--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -80,7 +80,7 @@ __all__ = ["input", "close", "nextfile", "filename", "lineno", "filelineno",
 
 _state = None
 
-def input(files=None, inplace=False, backup="", mode="r", openhook=None):
+def input(files=None, inplace=False, backup="", *, mode="r", openhook=None):
     """Return an instance of the FileInput class, which can be iterated.
 
     The parameters are passed to the constructor of the FileInput class.
@@ -90,7 +90,7 @@ def input(files=None, inplace=False, backup="", mode="r", openhook=None):
     global _state
     if _state and _state._file:
         raise RuntimeError("input() already active")
-    _state = FileInput(files, inplace, backup, mode, openhook)
+    _state = FileInput(files, inplace, backup, mode=mode, openhook=openhook)
     return _state
 
 def close():
@@ -172,7 +172,7 @@ def isstdin():
     return _state.isstdin()
 
 class FileInput:
-    """FileInput([files[, inplace[, backup[, mode[, openhook]]]]])
+    """FileInput([files[, inplace[, backup]]], *, mode=None, openhook=None)
 
     Class FileInput is the implementation of the module; its methods
     filename(), lineno(), fileline(), isfirstline(), isstdin(), fileno(),
@@ -184,7 +184,7 @@ class FileInput:
     sequential order; random access and readline() cannot be mixed.
     """
 
-    def __init__(self, files=None, inplace=False, backup="",
+    def __init__(self, files=None, inplace=False, backup="", *,
                  mode="r", openhook=None):
         if isinstance(files, str):
             files = (files,)

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -83,24 +83,20 @@ class LineReader:
 class BufferSizesTests(BaseTests, unittest.TestCase):
     def test_buffer_sizes(self):
         # First, run the tests with default and teeny buffer size.
-        for round, bs in (0, 0), (1, 30):
+        for round in (0, 1):
             t1 = self.writeTmp(''.join("Line %s of file 1\n" % (i+1) for i in range(15)))
             t2 = self.writeTmp(''.join("Line %s of file 2\n" % (i+1) for i in range(10)))
             t3 = self.writeTmp(''.join("Line %s of file 3\n" % (i+1) for i in range(5)))
             t4 = self.writeTmp(''.join("Line %s of file 4\n" % (i+1) for i in range(1)))
-            if bs:
-                with self.assertWarns(DeprecationWarning):
-                    self.buffer_size_test(t1, t2, t3, t4, bs, round)
-            else:
-                self.buffer_size_test(t1, t2, t3, t4, bs, round)
+            self.buffer_size_test(t1, t2, t3, t4, round)
 
-    def buffer_size_test(self, t1, t2, t3, t4, bs=0, round=0):
+    def buffer_size_test(self, t1, t2, t3, t4, round=0):
         pat = re.compile(r'LINE (\d+) OF FILE (\d+)')
 
         start = 1 + round*6
         if verbose:
-            print('%s. Simple iteration (bs=%s)' % (start+0, bs))
-        fi = FileInput(files=(t1, t2, t3, t4), bufsize=bs)
+            print('%s. Simple iteration' % (start+0))
+        fi = FileInput(files=(t1, t2, t3, t4))
         lines = list(fi)
         fi.close()
         self.assertEqual(len(lines), 31)
@@ -110,8 +106,8 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
         self.assertEqual(fi.filename(), t4)
 
         if verbose:
-            print('%s. Status variables (bs=%s)' % (start+1, bs))
-        fi = FileInput(files=(t1, t2, t3, t4), bufsize=bs)
+            print('%s. Status variables' % (start+1))
+        fi = FileInput(files=(t1, t2, t3, t4))
         s = "x"
         while s and s != 'Line 6 of file 2\n':
             s = fi.readline()
@@ -122,15 +118,15 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
         self.assertFalse(fi.isstdin())
 
         if verbose:
-            print('%s. Nextfile (bs=%s)' % (start+2, bs))
+            print('%s. Nextfile' % (start+2))
         fi.nextfile()
         self.assertEqual(fi.readline(), 'Line 1 of file 3\n')
         self.assertEqual(fi.lineno(), 22)
         fi.close()
 
         if verbose:
-            print('%s. Stdin (bs=%s)' % (start+3, bs))
-        fi = FileInput(files=(t1, t2, t3, t4, '-'), bufsize=bs)
+            print('%s. Stdin' % (start+3))
+        fi = FileInput(files=(t1, t2, t3, t4, '-'))
         savestdin = sys.stdin
         try:
             sys.stdin = StringIO("Line 1 of stdin\nLine 2 of stdin\n")
@@ -143,8 +139,8 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
             sys.stdin = savestdin
 
         if verbose:
-            print('%s. Boundary conditions (bs=%s)' % (start+4, bs))
-        fi = FileInput(files=(t1, t2, t3, t4), bufsize=bs)
+            print('%s. Boundary conditions' % (start+4))
+        fi = FileInput(files=(t1, t2, t3, t4))
         self.assertEqual(fi.lineno(), 0)
         self.assertEqual(fi.filename(), None)
         fi.nextfile()
@@ -152,10 +148,10 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
         self.assertEqual(fi.filename(), None)
 
         if verbose:
-            print('%s. Inplace (bs=%s)' % (start+5, bs))
+            print('%s. Inplace' % (start+5))
         savestdout = sys.stdout
         try:
-            fi = FileInput(files=(t1, t2, t3, t4), inplace=1, bufsize=bs)
+            fi = FileInput(files=(t1, t2, t3, t4), inplace=1)
             for line in fi:
                 line = line[:-1].upper()
                 print(line)
@@ -163,7 +159,7 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
         finally:
             sys.stdout = savestdout
 
-        fi = FileInput(files=(t1, t2, t3, t4), bufsize=bs)
+        fi = FileInput(files=(t1, t2, t3, t4))
         for line in fi:
             self.assertEqual(line[-1], '\n')
             m = pat.match(line[:-1])
@@ -533,12 +529,11 @@ class FileInputTests(BaseTests, unittest.TestCase):
 class MockFileInput:
     """A class that mocks out fileinput.FileInput for use during unit tests"""
 
-    def __init__(self, files=None, inplace=False, backup="", bufsize=0,
+    def __init__(self, files=None, inplace=False, backup="",
                  mode="r", openhook=None):
         self.files = files
         self.inplace = inplace
         self.backup = backup
-        self.bufsize = bufsize
         self.mode = mode
         self.openhook = openhook
         self._file = None
@@ -641,13 +636,11 @@ class Test_fileinput_input(BaseFileInputGlobalMethodsTest):
         files = object()
         inplace = object()
         backup = object()
-        bufsize = object()
         mode = object()
         openhook = object()
 
         # call fileinput.input() with different values for each argument
         result = fileinput.input(files=files, inplace=inplace, backup=backup,
-                                 bufsize=bufsize,
             mode=mode, openhook=openhook)
 
         # ensure fileinput._state was set to the returned object
@@ -658,7 +651,6 @@ class Test_fileinput_input(BaseFileInputGlobalMethodsTest):
         self.assertIs(files, result.files, "files")
         self.assertIs(inplace, result.inplace, "inplace")
         self.assertIs(backup, result.backup, "backup")
-        self.assertIs(bufsize, result.bufsize, "bufsize")
         self.assertIs(mode, result.mode, "mode")
         self.assertIs(openhook, result.openhook, "openhook")
 

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -90,9 +90,8 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
 
         pat = re.compile(r'LINE (\d+) OF FILE (\d+)')
 
-        start = 1
         if verbose:
-            print('%s. Simple iteration' % (start+0))
+            print('1. Simple iteration')
         fi = FileInput(files=(t1, t2, t3, t4))
         lines = list(fi)
         fi.close()
@@ -103,7 +102,7 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
         self.assertEqual(fi.filename(), t4)
 
         if verbose:
-            print('%s. Status variables' % (start+1))
+            print('2. Status variables')
         fi = FileInput(files=(t1, t2, t3, t4))
         s = "x"
         while s and s != 'Line 6 of file 2\n':
@@ -115,14 +114,14 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
         self.assertFalse(fi.isstdin())
 
         if verbose:
-            print('%s. Nextfile' % (start+2))
+            print('3. Nextfile')
         fi.nextfile()
         self.assertEqual(fi.readline(), 'Line 1 of file 3\n')
         self.assertEqual(fi.lineno(), 22)
         fi.close()
 
         if verbose:
-            print('%s. Stdin' % (start+3))
+            print('4. Stdin')
         fi = FileInput(files=(t1, t2, t3, t4, '-'))
         savestdin = sys.stdin
         try:
@@ -136,7 +135,7 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
             sys.stdin = savestdin
 
         if verbose:
-            print('%s. Boundary conditions' % (start+4))
+            print('5. Boundary conditions')
         fi = FileInput(files=(t1, t2, t3, t4))
         self.assertEqual(fi.lineno(), 0)
         self.assertEqual(fi.filename(), None)
@@ -145,7 +144,7 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
         self.assertEqual(fi.filename(), None)
 
         if verbose:
-            print('%s. Inplace' % (start+5))
+            print('6. Inplace')
         savestdout = sys.stdout
         try:
             fi = FileInput(files=(t1, t2, t3, t4), inplace=1)

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -82,18 +82,15 @@ class LineReader:
 
 class BufferSizesTests(BaseTests, unittest.TestCase):
     def test_buffer_sizes(self):
-        # First, run the tests with default and teeny buffer size.
-        for round in (0, 1):
-            t1 = self.writeTmp(''.join("Line %s of file 1\n" % (i+1) for i in range(15)))
-            t2 = self.writeTmp(''.join("Line %s of file 2\n" % (i+1) for i in range(10)))
-            t3 = self.writeTmp(''.join("Line %s of file 3\n" % (i+1) for i in range(5)))
-            t4 = self.writeTmp(''.join("Line %s of file 4\n" % (i+1) for i in range(1)))
-            self.buffer_size_test(t1, t2, t3, t4, round)
+        
+        t1 = self.writeTmp(''.join("Line %s of file 1\n" % (i+1) for i in range(15)))
+        t2 = self.writeTmp(''.join("Line %s of file 2\n" % (i+1) for i in range(10)))
+        t3 = self.writeTmp(''.join("Line %s of file 3\n" % (i+1) for i in range(5)))
+        t4 = self.writeTmp(''.join("Line %s of file 4\n" % (i+1) for i in range(1)))
 
-    def buffer_size_test(self, t1, t2, t3, t4, round=0):
         pat = re.compile(r'LINE (\d+) OF FILE (\d+)')
 
-        start = 1 + round*6
+        start = 1
         if verbose:
             print('%s. Simple iteration' % (start+0))
         fi = FileInput(files=(t1, t2, t3, t4))
@@ -116,7 +113,7 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
         self.assertEqual(fi.filelineno(), 6)
         self.assertFalse(fi.isfirstline())
         self.assertFalse(fi.isstdin())
-
+ 
         if verbose:
             print('%s. Nextfile' % (start+2))
         fi.nextfile()
@@ -529,7 +526,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
 class MockFileInput:
     """A class that mocks out fileinput.FileInput for use during unit tests"""
 
-    def __init__(self, files=None, inplace=False, backup="",
+    def __init__(self, files=None, inplace=False, backup="", *,
                  mode="r", openhook=None):
         self.files = files
         self.inplace = inplace

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -82,7 +82,7 @@ class LineReader:
 
 class BufferSizesTests(BaseTests, unittest.TestCase):
     def test_buffer_sizes(self):
-        
+
         t1 = self.writeTmp(''.join("Line %s of file 1\n" % (i+1) for i in range(15)))
         t2 = self.writeTmp(''.join("Line %s of file 2\n" % (i+1) for i in range(10)))
         t3 = self.writeTmp(''.join("Line %s of file 3\n" % (i+1) for i in range(5)))
@@ -113,7 +113,7 @@ class BufferSizesTests(BaseTests, unittest.TestCase):
         self.assertEqual(fi.filelineno(), 6)
         self.assertFalse(fi.isfirstline())
         self.assertFalse(fi.isstdin())
- 
+
         if verbose:
             print('%s. Nextfile' % (start+2))
         fi.nextfile()

--- a/Misc/NEWS.d/next/Library/2019-05-20-11-01-28.bpo-36952.MgZi7-.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-20-11-01-28.bpo-36952.MgZi7-.rst
@@ -1,0 +1,4 @@
+:func:`fileinput.input` and :class:`fileinput.FileInput` **bufsize**
+argument has been removed (was deprecated and ignored since Python 3.6),
+and as a result the **mode** and **openhook** arguments have been made
+keyword-only.


### PR DESCRIPTION
This keyword is marked as deprecated since 3.6 and for removal in 3.8.
It already had no effects.


<!-- issue-number: [bpo-36952](https://bugs.python.org/issue36952) -->
https://bugs.python.org/issue36952
<!-- /issue-number -->
