### PR TITLE
bpo-2180: Treat line continuation at EOF as a `SyntaxError`

### DIFF
--- a/Lib/test/test_eof.py
+++ b/Lib/test/test_eof.py
@@ -24,5 +24,11 @@ class EOFTestCase(unittest.TestCase):
         else:
             raise support.TestFailed
 
+    def test_line_continuation_EOF(self):
+        expect = 'unexpected EOF while parsing (<string>, line 1)'
+        with self.assertRaises(SyntaxError) as excinfo:
+            exec('x = 5\\')
+        self.assertEqual(str(excinfo.exception), expect)
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_eof.py
+++ b/Lib/test/test_eof.py
@@ -1,7 +1,10 @@
 """test script for a few new invalid token catches"""
 
-import unittest
+import subprocess
+import sys
+import tempfile
 from test import support
+import unittest
 
 class EOFTestCase(unittest.TestCase):
     def test_EOFC(self):
@@ -25,10 +28,32 @@ class EOFTestCase(unittest.TestCase):
             raise support.TestFailed
 
     def test_line_continuation_EOF(self):
+        """A contination at the end of input must be an error; bpo2180."""
         expect = 'unexpected EOF while parsing (<string>, line 1)'
         with self.assertRaises(SyntaxError) as excinfo:
             exec('x = 5\\')
         self.assertEqual(str(excinfo.exception), expect)
+        with self.assertRaises(SyntaxError) as excinfo:
+            exec('\\')
+        self.assertEqual(str(excinfo.exception), expect)
+
+    @unittest.skipIf(not sys.executable, "sys.executable required")
+    def test_line_continuation_EOF_from_file_bpo2180(self):
+        """Ensure tok_nextc() does not add too many ending newlines."""
+        with tempfile.NamedTemporaryFile() as temp_f:
+            temp_f.write(b'\\')
+            temp_f.flush()
+            proc = subprocess.run([sys.executable, temp_f.name],
+                                  capture_output=True)
+            self.assertIn(b'unexpected EOF while parsing', proc.stderr)
+            self.assertGreater(proc.returncode, 0)
+            temp_f.seek(0)
+            temp_f.write(b'y = 6\\')
+            temp_f.flush()
+            proc = subprocess.run([sys.executable, temp_f.name],
+                                  capture_output=True)
+            self.assertIn(b'unexpected EOF while parsing', proc.stderr)
+            self.assertGreater(proc.returncode, 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-17-18-34-30.bpo-2180.aBqHeW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-17-18-34-30.bpo-2180.aBqHeW.rst
@@ -1,0 +1,1 @@
+Treat line continuation at EOF as a ``SyntaxError`` by Anthony Sottile.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -983,7 +983,8 @@ tok_nextc(struct tok_state *tok)
                         return EOF;
                     /* Last line does not end in \n,
                        fake one */
-                    strcpy(tok->inp, "\n");
+                    if (tok->inp[-1] != '\n')
+                        strcpy(tok->inp, "\n");
                 }
                 tok->inp = strchr(tok->inp, '\0');
                 done = tok->inp[-1] == '\n';
@@ -1673,6 +1674,14 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
             tok->done = E_LINECONT;
             tok->cur = tok->inp;
             return ERRORTOKEN;
+        }
+        c = tok_nextc(tok);
+        if (c == EOF) {
+            tok->done = E_EOF;
+            tok->cur = tok->inp;
+            return ERRORTOKEN;
+        } else {
+            tok_backup(tok, c);
         }
         tok->cont_line = 1;
         goto again; /* Read next line */


### PR DESCRIPTION
This makes the parser consistent with the tokenize module (already the case
in `pypy`).

sample
------

```python
x = 5\
```

before
------

```console
$ python3 t.py
$ python3 -mtokenize t.py
t.py:2:0: error: EOF in multi-line statement
```

after
-----

```console
$ ./python t.py
  File "t.py", line 3
    x = 5\

         ^
SyntaxError: unexpected EOF while parsing
$ ./python -m tokenize t.py
t.py:2:0: error: EOF in multi-line statement
```


<!-- issue-number: [bpo-2180](https://bugs.python.org/issue2180) -->
https://bugs.python.org/issue2180
<!-- /issue-number -->
