### PR TITLE
bpo-36962: Use dataclass for pkgutil.ModuleInfo

### DIFF
--- a/Doc/library/pkgutil.rst
+++ b/Doc/library/pkgutil.rst
@@ -13,7 +13,7 @@ support.
 
 .. class:: ModuleInfo(module_finder, name, ispkg)
 
-    A namedtuple that holds a brief summary of a module's info.
+    A dataclass that holds a brief summary of a module's info.
 
     .. versionadded:: 3.6
 

--- a/Lib/pkgutil.py
+++ b/Lib/pkgutil.py
@@ -1,6 +1,6 @@
 """Utilities to support packages."""
-
-from collections import namedtuple
+from __future__ import annotations
+from dataclasses import dataclass, field, astuple
 from functools import singledispatch as simplegeneric
 import importlib
 import importlib.util
@@ -19,9 +19,32 @@ __all__ = [
 ]
 
 
-ModuleInfo = namedtuple('ModuleInfo', 'module_finder name ispkg')
-ModuleInfo.__doc__ = 'A namedtuple with minimal info about a module.'
+@dataclass(frozen=True, order=True)
+class ModuleInfo:
+    """A dataclass with minimal info about a module."""
+    module_finder: FileFinder = field(compare = False)
+    name: str
+    ispkg: bool
 
+    def __contains__(self, item):
+        warnings.warn("Sequence access is deprecated, use attribute access instead",
+                      DeprecationWarning)
+        return item in astuple(self)
+
+    def __len__(self):
+        warnings.warn("Sequence access is deprecated, use attribute access instead",
+                      DeprecationWarning)
+        return len(astuple(self))
+
+    def __iter__(self):
+        warnings.warn("Sequence access is deprecated, use attribute access instead",
+                      DeprecationWarning)
+        return iter(astuple(self))
+
+    def __getitem__(self, item):
+        warnings.warn("Sequence access is deprecated, use attribute access instead",
+                      DeprecationWarning)
+        return astuple(self)[item]
 
 def _get_spec(finder, name):
     """Return the finder-specific module spec."""

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -133,7 +133,7 @@ class PkgutilTests(unittest.TestCase):
             'test_walkpackages_filesys.sub',
             'test_walkpackages_filesys.sub.mod',
         ]
-        actual= [e[1] for e in pkgutil.walk_packages([self.dirname])]
+        actual= [e.name for e in pkgutil.walk_packages([self.dirname])]
         self.assertEqual(actual, expected)
 
         for pkg in expected:
@@ -167,7 +167,7 @@ class PkgutilTests(unittest.TestCase):
             'test_walkpackages_zipfile.sub',
             'test_walkpackages_zipfile.sub.mod',
         ]
-        actual= [e[1] for e in pkgutil.walk_packages([zip_file])]
+        actual= [e.name for e in pkgutil.walk_packages([zip_file])]
         self.assertEqual(actual, expected)
         del sys.path[0]
 
@@ -228,6 +228,20 @@ class PkgutilPEP302Tests(unittest.TestCase):
         self.assertEqual(pkgutil.get_data('foo', 'dummy'), "Hello, world!")
         self.assertEqual(foo.loads, 1)
         del sys.modules['foo']
+
+    def test_module_info(self):
+        dummy = pkgutil.ModuleInfo(None, 'dummy', False)
+        with check_warnings() as w:
+            self.assertEqual(dummy[1], 'dummy')
+            self.assertTrue('dummy' in dummy)
+            self.assertEqual(len(dummy), 3)
+            _, name, __ = dummy
+            self.assertEqual(name, 'dummy')
+            self.assertEqual(len(w.warnings), 4)
+
+        self.assertEqual(dummy.name, 'dummy')
+        dummy2 = pkgutil.ModuleInfo(None, 'dummiest', False)
+        self.assertTrue(dummy > dummy2)
 
 
 # These tests, especially the setup and cleanup, are hideous. They

--- a/Misc/NEWS.d/next/Library/2019-05-19-06-19-19.bpo-36962.Yzh0BG.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-19-06-19-19.bpo-36962.Yzh0BG.rst
@@ -1,0 +1,2 @@
+pkgutil.ModuleInfo now a dataclass with rich compare methods instead of a
+namedtuple


### PR DESCRIPTION
Use dataclass for pkgutil.ModuleInfo instead of namedtuple. 

<!-- issue-number: [bpo-36962](https://bugs.python.org/issue36962) -->
https://bugs.python.org/issue36962
<!-- /issue-number -->
