### PR TITLE
bpo-36965: include windows.h to be able to use STATUS_CONTROL_C_EXIT

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-05-20-20-26-36.bpo-36965.KsfI-N.rst
+++ b/Misc/NEWS.d/next/Windows/2019-05-20-20-26-36.bpo-36965.KsfI-N.rst
@@ -1,0 +1,1 @@
+include of STATUS_CONTROL_C_EXIT without depending on MSC compiler

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -18,8 +18,9 @@
 #if defined(HAVE_GETPID) && defined(HAVE_UNISTD_H)
 #  include <unistd.h>   /* getpid() */
 #endif
-#ifdef _MSC_VER
-#  include <crtdbg.h>   /* STATUS_CONTROL_C_EXIT */
+#ifdef MS_WINDOWS
+#  include <ntdef.h>      /* NTSTATUS */
+#  include <ntstatus.h>   /* STATUS_CONTROL_C_EXIT */
 #endif
 /* End of includes for exit_sigint() */
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -19,8 +19,7 @@
 #  include <unistd.h>   /* getpid() */
 #endif
 #ifdef MS_WINDOWS
-#  include <winternl.h>      /* NTSTATUS */
-#  include <ntstatus.h>   /* STATUS_CONTROL_C_EXIT */
+#  include <windows.h>  /* STATUS_CONTROL_C_EXIT */
 #endif
 /* End of includes for exit_sigint() */
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -19,7 +19,7 @@
 #  include <unistd.h>   /* getpid() */
 #endif
 #ifdef MS_WINDOWS
-#  include <ntdef.h>      /* NTSTATUS */
+#  include <winternl.h>      /* NTSTATUS */
 #  include <ntstatus.h>   /* STATUS_CONTROL_C_EXIT */
 #endif
 /* End of includes for exit_sigint() */


### PR DESCRIPTION
According to the Microsoft documentation at

https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/using-ntstatus-values

system-supplied status codes are defined in ntstatus.h. and the NTSTATUS type is defined in ntdef.h

this PR includes both ntstatus.h and ntdef.h to be able to use STATUS_CONTROL_C_EXIT when compiling for windows.

<!-- issue-number: [bpo-36965](https://bugs.python.org/issue36965) -->
https://bugs.python.org/issue36965
<!-- /issue-number -->
