### PR TITLE
[2.7] bpo-35647: Fix path check in cookiejar

### DIFF
--- a/Lib/cookielib.py
+++ b/Lib/cookielib.py
@@ -984,7 +984,7 @@ class DefaultCookiePolicy(CookiePolicy):
             req_path = request_path(request)
             if ((cookie.version > 0 or
                  (cookie.version == 0 and self.strict_ns_set_path)) and
-                not req_path.startswith(cookie.path)):
+                not self.path_return_ok(cookie.path, request)):
                 _debug("   path attribute %s is not a prefix of request "
                        "path %s", cookie.path, req_path)
                 return False
@@ -1182,11 +1182,15 @@ class DefaultCookiePolicy(CookiePolicy):
     def path_return_ok(self, path, request):
         _debug("- checking cookie path=%s", path)
         req_path = request_path(request)
-        if not req_path.startswith(path):
-            _debug("  %s does not path-match %s", req_path, path)
-            return False
-        return True
+        pathlen = len(path)
+        if req_path == path:
+            return True
+        elif (req_path.startswith(path) and
+              (path.endswith("/") or req_path[pathlen:pathlen+1] == "/")):
+            return True
 
+        _debug("  %s does not path-match %s", req_path, path)
+        return False
 
 def vals_sorted_by_key(adict):
     keys = adict.keys()

--- a/Lib/test/test_cookielib.py
+++ b/Lib/test/test_cookielib.py
@@ -646,6 +646,35 @@ class CookieTests(TestCase):
         req = Request("http://www.example.com")
         self.assertEqual(request_path(req), "/")
 
+    def test_path_prefix_match(self):
+        from cookielib import CookieJar, DefaultCookiePolicy
+        from urllib2 import Request
+
+        pol = DefaultCookiePolicy()
+        strict_ns_path_pol = DefaultCookiePolicy(strict_ns_set_path=True)
+
+        c = CookieJar(pol)
+        base_url = "http://bar.com"
+        interact_netscape(c, base_url, 'spam=eggs; Path=/foo')
+        cookie = c._cookies['bar.com']['/foo']['spam']
+
+        for path, ok in [('/foo', True),
+                         ('/foo/', True),
+                         ('/foo/bar', True),
+                         ('/', False),
+                         ('/foobad/foo', False)]:
+            url = '{0}{1}'.format(base_url, path)
+            req = Request(url)
+            h = interact_netscape(c, url)
+            if ok:
+                self.assertIn('spam=eggs', h,
+                              "cookie not set for {0}".format(path))
+                self.assertTrue(strict_ns_path_pol.set_ok_path(cookie, req))
+            else:
+                self.assertNotIn('spam=eggs', h,
+                                 "cookie set for {0}".format(path))
+                self.assertFalse(strict_ns_path_pol.set_ok_path(cookie, req))
+
     def test_request_port(self):
         from urllib2 import Request
         from cookielib import request_port, DEFAULT_HTTP_PORT

--- a/Misc/NEWS.d/next/Security/2019-05-20-00-49-29.bpo-35647.oWmiGU.rst
+++ b/Misc/NEWS.d/next/Security/2019-05-20-00-49-29.bpo-35647.oWmiGU.rst
@@ -1,0 +1,3 @@
+Don't set cookie for a request when the request path is a prefix match of
+the cookie's path attribute but doesn't end with "/". Patch by Karthikeyan
+Singaravelan.


### PR DESCRIPTION
This is a manual backport of e260f092cd0d8975c777e73ca6fb549d59b5d452 since 2.7 has `http.cookiejar` in `cookielib`

<!-- issue-number: [bpo-35647](https://bugs.python.org/issue35647) -->
https://bugs.python.org/issue35647
<!-- /issue-number -->
