### PR TITLE
bpo-26185: Fix repr() on empty ZipInfo object

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1657,6 +1657,33 @@ class OtherTests(unittest.TestCase):
         self.assertRaises(ValueError,
                           zipfile.ZipInfo, 'seventies', (1979, 1, 1, 0, 0, 0))
 
+    def test_create_empty_zipinfo_repr(self):
+        """Before bpo-26185, repr() on empty ZipInfo object was failing."""
+        zi = zipfile.ZipInfo(filename="empty")
+        self.assertEqual(repr(zi), "<ZipInfo filename='empty' file_size=0>")
+
+    def test_create_empty_zipinfo_default_attributes(self):
+        """Ensure all required attributes are set."""
+        zi = zipfile.ZipInfo()
+        self.assertEqual(zi.orig_filename, "NoName")
+        self.assertEqual(zi.filename, "NoName")
+        self.assertEqual(zi.date_time, (1980, 1, 1, 0, 0, 0))
+        self.assertEqual(zi.compress_type, zipfile.ZIP_STORED)
+        self.assertEqual(zi.comment, b"")
+        self.assertEqual(zi.extra, b"")
+        self.assertIn(zi.create_system, (0, 3))
+        self.assertEqual(zi.create_version, zipfile.DEFAULT_VERSION)
+        self.assertEqual(zi.extract_version, zipfile.DEFAULT_VERSION)
+        self.assertEqual(zi.reserved, 0)
+        self.assertEqual(zi.flag_bits, 0)
+        self.assertEqual(zi.volume, 0)
+        self.assertEqual(zi.internal_attr, 0)
+        self.assertEqual(zi.external_attr, 0)
+
+        # Before bpo-26185, both were missing
+        self.assertEqual(zi.file_size, 0)
+        self.assertEqual(zi.compress_size, 0)
+
     def test_zipfile_with_short_extra_field(self):
         """If an extra field in the header is less than 4 bytes, skip it."""
         zipdata = (

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1564,8 +1564,7 @@ class ZipFile:
                              "Close the first handle before opening another.")
 
         # Sizes and CRC are overwritten with correct data after processing the file
-        if not hasattr(zinfo, 'file_size'):
-            zinfo.file_size = 0
+        zinfo.file_size = 0
         zinfo.compress_size = 0
         zinfo.CRC = 0
 

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1563,8 +1563,7 @@ class ZipFile:
                              "another write handle open on it. "
                              "Close the first handle before opening another.")
 
-        # Sizes and CRC are overwritten with correct data after processing the file
-        zinfo.file_size = 0
+        # Size and CRC are overwritten with correct data after processing the file
         zinfo.compress_size = 0
         zinfo.CRC = 0
 

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -375,11 +375,11 @@ class ZipInfo (object):
         self.volume = 0                 # Volume number of file header
         self.internal_attr = 0          # Internal attributes
         self.external_attr = 0          # External file attributes
+        self.compress_size = 0          # Size of the compressed file
+        self.file_size = 0              # Size of the uncompressed file
         # Other attributes are set by class ZipFile:
         # header_offset         Byte offset to the file header
         # CRC                   CRC-32 of the uncompressed file
-        # compress_size         Size of the compressed file
-        # file_size             Size of the uncompressed file
 
     def __repr__(self):
         result = ['<%s filename=%r' % (self.__class__.__name__, self.filename)]

--- a/Misc/NEWS.d/next/Library/2019-05-20-14-17-29.bpo-26185.pQW4mI.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-20-14-17-29.bpo-26185.pQW4mI.rst
@@ -1,0 +1,2 @@
+Fix :func:`repr` on empty :class:`ZipInfo` object. Patch by Mickaël
+Schoentgen.


### PR DESCRIPTION
It was failing on `AttributeError` due to inexistant but required attributes `file_size` and `compress_size`.
They are now initialized to `0` in `ZipInfo.__init__()`.

Note that this is a second patch: Matthew Zipay wrote a first one back in 2016 (see it on BPO).
I wanted propose something else less "magic". I do not mind closing this one if it is not the good patch to apply :)

<!-- issue-number: [bpo-26185](https://bugs.python.org/issue26185) -->
https://bugs.python.org/issue26185
<!-- /issue-number -->
