### PR TITLE
Pass _asyncio_internal=True into stream tests on windows

### DIFF
--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -100,9 +100,11 @@ class ProactorTests(test_utils.TestCase):
 
         clients = []
         for i in range(5):
-            stream_reader = asyncio.StreamReader(loop=self.loop)
+            stream_reader = asyncio.StreamReader(loop=self.loop,
+                                                 _asyncio_internal=True)
             protocol = asyncio.StreamReaderProtocol(stream_reader,
-                                                    loop=self.loop)
+                                                    loop=self.loop,
+                                                    _asyncio_internal=True)
             trans, proto = await self.loop.create_pipe_connection(
                 lambda: protocol, ADDRESS)
             self.assertIsInstance(trans, asyncio.Transport)


### PR DESCRIPTION
To suppress DeprecationWarning in tests