### PR TITLE
bpo-36770: add feature for shutil.make_archive

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-05-20-17-01-31.bpo-36770.SanQsw.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-20-17-01-31.bpo-36770.SanQsw.rst
@@ -1,0 +1,1 @@
+Add support for different ZIP compression methods in :func:`shutil.make_archive`


### PR DESCRIPTION
https://bugs.python.org/issue36770

Add support for different ZIP compression method.

if you just want to use different zip compression method, no need to rewrite entire _make_zipfile function.

e.g.
```python
>>> shutil.make_archive('archive', 'zip_lzma', '/path/to/whatever')
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36770](https://bugs.python.org/issue36770) -->
https://bugs.python.org/issue36770
<!-- /issue-number -->
