### PR TITLE
bpo-36972: Add SupportsIndex

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -532,6 +532,8 @@ The module defines the following classes, functions and decorators:
 .. class:: SupportsIndex
 
     An ABC with one abstract method ``__index__``.
+    
+    .. versionadded:: 3.8
 
 .. class:: SupportsAbs
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -529,6 +529,10 @@ The module defines the following classes, functions and decorators:
 
     An ABC with one abstract method ``__bytes__``.
 
+.. class:: SupportsIndex
+
+    An ABC with one abstract method ``__index__``.
+
 .. class:: SupportsAbs
 
     An ABC with one abstract method ``__abs__`` that is covariant

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -532,7 +532,7 @@ The module defines the following classes, functions and decorators:
 .. class:: SupportsIndex
 
     An ABC with one abstract method ``__index__``.
-    
+
     .. versionadded:: 3.8
 
 .. class:: SupportsAbs

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -568,6 +568,10 @@ class ProtocolTests(BaseTestCase):
         self.assertIsSubclass(list, typing.Reversible)
         self.assertNotIsSubclass(int, typing.Reversible)
 
+    def test_supports_index(self):
+        self.assertIsSubclass(int, typing.SupportsIndex)
+        self.assertNotIsSubclass(str, typing.SupportsIndex)
+
     def test_protocol_instance_type_error(self):
         with self.assertRaises(TypeError):
             isinstance(0, typing.SupportsAbs)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -74,6 +74,7 @@ __all__ = [
     'SupportsBytes',
     'SupportsComplex',
     'SupportsFloat',
+    'SupportsIndex',
     'SupportsInt',
     'SupportsRound',
 
@@ -1301,6 +1302,14 @@ class SupportsBytes(_Protocol):
 
     @abstractmethod
     def __bytes__(self) -> bytes:
+        pass
+
+
+class SupportsIndex(_Protocol):
+    __slots__ = ()
+
+    @abstractmethod
+    def __index__(self) -> int:
         pass
 
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -354,6 +354,7 @@ Tom Culliton
 Raúl Cumplido
 Antonio Cuni
 Brian Curtin
+Paul Dagnelie
 Lisandro Dalcin
 Darren Dale
 Andrew Dalke

--- a/Misc/NEWS.d/next/Library/2019-05-20-17-08-26.bpo-36972.3l3SGc.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-20-17-08-26.bpo-36972.3l3SGc.rst
@@ -1,1 +1,1 @@
-Add SupportsIndex protocol to allow type checking to detect classes that can have `hex()` `oct()` and `bin()` called on them.
+Add SupportsIndex protocol to the typing module to allow type checking to detect classes that can be passed to `hex()`, `oct()` and `bin()`.

--- a/Misc/NEWS.d/next/Library/2019-05-20-17-08-26.bpo-36972.3l3SGc.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-20-17-08-26.bpo-36972.3l3SGc.rst
@@ -1,0 +1,1 @@
+Add SupportsIndex protocol to allow type checking to detect classes that can have `hex()` `oct()` and `bin()` called on them.


### PR DESCRIPTION
In order to support typing checks calling `hex()` `oct()` and `bin()` on user-defined classes, a SupportIndex protocol is required. The ability to check these at runtime would be good to add for completeness sake. This is pretty much just a copy of SupportsInt with the names tweaked.  Passed tests on my laptop.

<!-- issue-number: [bpo-36972](https://bugs.python.org/issue36972) -->
https://bugs.python.org/issue36972
<!-- /issue-number -->
