### PR TITLE
Fix RuntimeWarning in unittest.mock asyncio example

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -862,7 +862,7 @@ object::
     >>> mock = AsyncMock()
     >>> asyncio.iscoroutinefunction(mock)
     True
-    >>> inspect.isawaitable(mock())
+    >>> inspect.isawaitable(mock())  # doctest: +SKIP
     True
 
   The result of ``mock()`` is an async function which will have the outcome
@@ -888,7 +888,7 @@ object::
     >>> mock = MagicMock(async_func)
     >>> mock
     <MagicMock spec='function' id='...'>
-    >>> mock()
+    >>> mock()  # doctest: +SKIP
     <coroutine object AsyncMockMixin._mock_call at ...>
 
   .. method:: assert_awaited()

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -862,7 +862,11 @@ object::
     >>> mock = AsyncMock()
     >>> asyncio.iscoroutinefunction(mock)
     True
-    >>> inspect.isawaitable(mock())
+    >>> async_func = mock()
+    >>> async def main():
+    ...     await async_func
+    >>> asyncio.run(main())
+    >>> inspect.isawaitable(async_func)
     True
 
   The result of ``mock()`` is an async function which will have the outcome

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -862,11 +862,7 @@ object::
     >>> mock = AsyncMock()
     >>> asyncio.iscoroutinefunction(mock)
     True
-    >>> async_func = mock()
-    >>> async def main():
-    ...     await async_func
-    >>> asyncio.run(main())
-    >>> inspect.isawaitable(async_func)
+    >>> inspect.isawaitable(mock())
     True
 
   The result of ``mock()`` is an async function which will have the outcome

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -892,6 +892,8 @@ object::
     >>> mock = MagicMock(async_func)
     >>> mock
     <MagicMock spec='function' id='...'>
+    >>> mock()
+    <coroutine object AsyncMockMixin._mock_call at ...>
 
   .. method:: assert_awaited()
 

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -892,8 +892,6 @@ object::
     >>> mock = MagicMock(async_func)
     >>> mock
     <MagicMock spec='function' id='...'>
-    >>> mock()
-    <coroutine object AsyncMockMixin._mock_call at ...>
 
   .. method:: assert_awaited()
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2204,7 +2204,7 @@ class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock):
     :class:`.Mock` object: the wrapped object may have methods
     defined as async function functions.
 
-    Based on Martin Richard's asyntest project.
+    Based on Martin Richard's asynctest project.
     """
 
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2204,7 +2204,7 @@ class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock):
     :class:`.Mock` object: the wrapped object may have methods
     defined as async function functions.
 
-    Based on Martin Richard's asynctest project.
+    Based on Martin Richard's asyntest project.
     """
 
 


### PR DESCRIPTION
* This PR fixes the `RuntimeWarning` in `inspect.isawaitable(mock())` where `mock()` was not awaited.
* Fix typo in asynctest project.