### PR TITLE
bpo-36969: Make PDB args command display keyword only arguments

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1132,9 +1132,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         co = self.curframe.f_code
         dict = self.curframe_locals
-        n = co.co_argcount
-        if co.co_flags & 4: n = n+1
-        if co.co_flags & 8: n = n+1
+        n = co.co_argcount + co.co_kwonlyargcount
+        if co.co_flags & inspect.CO_VARARGS: n = n+1
+        if co.co_flags & inspect.CO_VARKEYWORDS: n = n+1
         for i in range(n):
             name = co.co_varnames[i]
             if name in dict:

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -77,9 +77,13 @@ def test_pdb_basic_commands():
     ...     print('...')
     ...     return foo.upper()
 
+    >>> def test_function3(arg=None, *, kwonly=None):
+    ...     pass
+
     >>> def test_function():
     ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     ...     ret = test_function_2('baz')
+    ...     test_function3(kwonly=True)
     ...     print(ret)
 
     >>> with PdbTestInput([  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
@@ -97,10 +101,13 @@ def test_pdb_basic_commands():
     ...     'jump 8',     # jump over second for loop
     ...     'return',     # return out of function
     ...     'retval',     # display return value
+    ...     'next',       # step to test_function3()
+    ...     'step',       # stepping into test_function3()
+    ...     'args',       # display function args
     ...     'continue',
     ... ]):
     ...    test_function()
-    > <doctest test.test_pdb.test_pdb_basic_commands[1]>(3)test_function()
+    > <doctest test.test_pdb.test_pdb_basic_commands[2]>(3)test_function()
     -> ret = test_function_2('baz')
     (Pdb) step
     --Call--
@@ -123,14 +130,14 @@ def test_pdb_basic_commands():
     [EOF]
     (Pdb) bt
     ...
-      <doctest test.test_pdb.test_pdb_basic_commands[2]>(18)<module>()
+      <doctest test.test_pdb.test_pdb_basic_commands[3]>(21)<module>()
     -> test_function()
-      <doctest test.test_pdb.test_pdb_basic_commands[1]>(3)test_function()
+      <doctest test.test_pdb.test_pdb_basic_commands[2]>(3)test_function()
     -> ret = test_function_2('baz')
     > <doctest test.test_pdb.test_pdb_basic_commands[0]>(1)test_function_2()
     -> def test_function_2(foo, bar='default'):
     (Pdb) up
-    > <doctest test.test_pdb.test_pdb_basic_commands[1]>(3)test_function()
+    > <doctest test.test_pdb.test_pdb_basic_commands[2]>(3)test_function()
     -> ret = test_function_2('baz')
     (Pdb) down
     > <doctest test.test_pdb.test_pdb_basic_commands[0]>(1)test_function_2()
@@ -168,6 +175,16 @@ def test_pdb_basic_commands():
     -> return foo.upper()
     (Pdb) retval
     'BAZ'
+    (Pdb) next
+    > <doctest test.test_pdb.test_pdb_basic_commands[2]>(4)test_function()
+    -> test_function3(kwonly=True)
+    (Pdb) step
+    --Call--
+    > <doctest test.test_pdb.test_pdb_basic_commands[1]>(1)test_function3()
+    -> def test_function3(arg=None, *, kwonly=None):
+    (Pdb) args
+    arg = None
+    kwonly = True
     (Pdb) continue
     BAZ
     """

--- a/Misc/NEWS.d/next/Library/2019-05-20-23-31-20.bpo-36969.JkZORP.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-20-23-31-20.bpo-36969.JkZORP.rst
@@ -1,0 +1,2 @@
+PDB command `args` now  display keyword only arguments. Patch contributed by
+Rémi Lapeyre.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36969](https://bugs.python.org/issue36969) -->
https://bugs.python.org/issue36969
<!-- /issue-number -->
