### PR TITLE
bpo-36983: Fix typing.__all__ and add test for exported names

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3605,6 +3605,30 @@ class AllTests(BaseTestCase):
         self.assertIn('SupportsBytes', a)
         self.assertIn('SupportsComplex', a)
 
+    def test_all_exported_names(self):
+        import typing
+
+        actual_all = set(typing.__all__)
+        computed_all = {
+            k for k, v in vars(typing).items()
+            # explicitly exported, not a thing with __module__
+            if k in actual_all or (
+                # avoid private names
+                not k.startswith('_') and
+                # avoid things in the io / re typing submodules
+                k not in typing.io.__all__ and
+                k not in typing.re.__all__ and
+                k not in {'io', 're'} and
+                # there's a few types and metaclasses that aren't exported
+                not k.endswith(('Meta', '_contra', '_co')) and
+                not k.upper() == k and
+                # but export all things that have __module__ == 'typing'
+                getattr(v, '__module__', None) == typing.__name__
+            )
+        }
+        self.assertSetEqual(computed_all, actual_all)
+
+
 
 if __name__ == '__main__':
     main()

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -35,6 +35,7 @@ __all__ = [
     'Callable',
     'ClassVar',
     'Final',
+    'ForwardRef',
     'Generic',
     'Literal',
     'Optional',
@@ -81,11 +82,13 @@ __all__ = [
     'SupportsRound',
 
     # Concrete collection types.
+    'ChainMap',
     'Counter',
     'Deque',
     'Dict',
     'DefaultDict',
     'List',
+    'OrderedDict',
     'Set',
     'FrozenSet',
     'NamedTuple',  # Not really a type.

--- a/Misc/NEWS.d/next/Library/2019-05-20-20-41-30.bpo-36983.hz-fLr.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-20-20-41-30.bpo-36983.hz-fLr.rst
@@ -1,0 +1,2 @@
+Add missing names to ``typing.__all__``: ``ChainMap``, ``ForwardRef``,
+``OrderedDict`` - by Anthony Sottile.


### PR DESCRIPTION


<!-- issue-number: [bpo-36983](https://bugs.python.org/issue36983) -->
https://bugs.python.org/issue36983
<!-- /issue-number -->
