### PR TITLE
Revert "bpo-36084: Add native thread ID to threading.Thread objects (GH-11993)"

### DIFF
--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -85,18 +85,6 @@ This module defines the following constants and functions:
    may be recycled when a thread exits and another thread is created.
 
 
-.. function:: get_native_id()
-
-   Return the native integral Thread ID of the current thread assigned by the kernel.
-   This is a non-negative integer.
-   Its value may be used to uniquely identify this particular thread system-wide
-   (until the thread terminates, after which the value may be recycled by the OS).
-
-   .. availability:: Windows, FreeBSD, Linux, macOS.
-
-   .. versionadded:: 3.8
-
-
 .. function:: stack_size([size])
 
    Return the thread stack size used when creating new threads.  The optional

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -49,18 +49,6 @@ This module defines the following functions:
    .. versionadded:: 3.3
 
 
-.. function:: get_native_id()
-
-   Return the native integral Thread ID of the current thread assigned by the kernel.
-   This is a non-negative integer.
-   Its value may be used to uniquely identify this particular thread system-wide
-   (until the thread terminates, after which the value may be recycled by the OS).
-
-   .. availability:: Windows, FreeBSD, Linux, macOS.
-
-   .. versionadded:: 3.8
-
-
 .. function:: enumerate()
 
    Return a list of all :class:`Thread` objects currently alive.  The list
@@ -308,25 +296,6 @@ since it is impossible to detect the termination of alien threads.
       function.  Thread identifiers may be recycled when a thread exits and
       another thread is created.  The identifier is available even after the
       thread has exited.
-
-   .. attribute:: native_id
-
-      The native integral thread ID of this thread or ``0`` if the thread has not
-      been started.  This is a non-negative integer.  See the
-      :func:`get_native_id` function.
-      This represents the Thread ID (``TID``) as assigned to the
-      thread by the OS (kernel).  Its value may be used to uniquely identify
-      this particular thread system-wide.
-
-      .. note::
-
-         Similar to Process IDs, Thread IDs are only valid (guaranteed unique
-         system-wide) from the time the thread is created until the thread
-         has been terminated.
-
-      .. availability:: Windows, FreeBSD, Linux, macOS.
-
-      .. versionadded:: 3.8
 
    .. method:: is_alive()
 

--- a/Include/pythread.h
+++ b/Include/pythread.h
@@ -25,7 +25,6 @@ PyAPI_FUNC(void) PyThread_init_thread(void);
 PyAPI_FUNC(unsigned long) PyThread_start_new_thread(void (*)(void *), void *);
 PyAPI_FUNC(void) _Py_NO_RETURN PyThread_exit_thread(void);
 PyAPI_FUNC(unsigned long) PyThread_get_thread_ident(void);
-PyAPI_FUNC(unsigned long) PyThread_get_thread_native_id(void);
 
 PyAPI_FUNC(PyThread_type_lock) PyThread_allocate_lock(void);
 PyAPI_FUNC(void) PyThread_free_lock(PyThread_type_lock);

--- a/Lib/_dummy_thread.py
+++ b/Lib/_dummy_thread.py
@@ -71,10 +71,6 @@ def get_ident():
     """
     return 1
 
-def get_native_id():
-    """Dummy implementation of _thread.get_native_id()."""
-    return 0
-
 def allocate_lock():
     """Dummy implementation of _thread.allocate_lock()."""
     return LockType()

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -104,10 +104,6 @@ class ThreadTests(BaseTestCase):
             self.assertRegex(repr(t), r'^<TestThread\(.*, initial\)>$')
             t.start()
 
-        native_ids = set(t.native_id for t in threads) | {threading.get_native_id()}
-        self.assertNotIn(None, native_ids)
-        self.assertEqual(len(native_ids), NUMTASKS + 1)
-
         if verbose:
             print('waiting for all tasks to complete')
         for t in threads:

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -23,8 +23,8 @@ except ImportError:
 # with the multiprocessing module, which doesn't provide the old
 # Java inspired names.
 
-__all__ = ['get_ident', 'get_native_id', 'active_count', 'Condition',
-           'current_thread', 'enumerate', 'main_thread', 'TIMEOUT_MAX',
+__all__ = ['get_ident', 'active_count', 'Condition', 'current_thread',
+           'enumerate', 'main_thread', 'TIMEOUT_MAX',
            'Event', 'Lock', 'RLock', 'Semaphore', 'BoundedSemaphore', 'Thread',
            'Barrier', 'BrokenBarrierError', 'Timer', 'ThreadError',
            'setprofile', 'settrace', 'local', 'stack_size']
@@ -34,7 +34,6 @@ _start_new_thread = _thread.start_new_thread
 _allocate_lock = _thread.allocate_lock
 _set_sentinel = _thread._set_sentinel
 get_ident = _thread.get_ident
-get_native_id = _thread.get_native_id
 ThreadError = _thread.error
 try:
     _CRLock = _thread.RLock
@@ -791,7 +790,6 @@ class Thread:
         else:
             self._daemonic = current_thread().daemon
         self._ident = None
-        self._native_id = 0
         self._tstate_lock = None
         self._started = Event()
         self._is_stopped = False
@@ -893,9 +891,6 @@ class Thread:
     def _set_ident(self):
         self._ident = get_ident()
 
-    def _set_native_id(self):
-        self._native_id = get_native_id()
-
     def _set_tstate_lock(self):
         """
         Set a lock object which will be released by the interpreter when
@@ -908,7 +903,6 @@ class Thread:
         try:
             self._set_ident()
             self._set_tstate_lock()
-            self._set_native_id()
             self._started.set()
             with _active_limbo_lock:
                 _active[self._ident] = self
@@ -1083,17 +1077,6 @@ class Thread:
         assert self._initialized, "Thread.__init__() not called"
         return self._ident
 
-    @property
-    def native_id(self):
-        """Native integral thread ID of this thread or 0 if it has not been started.
-
-        This is a non-negative integer. See the get_native_id() function.
-        This represents the Thread ID as reported by the kernel.
-
-        """
-        assert self._initialized, "Thread.__init__() not called"
-        return self._native_id
-
     def is_alive(self):
         """Return whether the thread is alive.
 
@@ -1193,7 +1176,6 @@ class _MainThread(Thread):
         self._set_tstate_lock()
         self._started.set()
         self._set_ident()
-        self._set_native_id()
         with _active_limbo_lock:
             _active[self._ident] = self
 
@@ -1213,7 +1195,6 @@ class _DummyThread(Thread):
 
         self._started.set()
         self._set_ident()
-        self._set_native_id()
         with _active_limbo_lock:
             _active[self._ident] = self
 

--- a/Misc/NEWS.d/next/Core and Builtins/2019-02-22-23-03-20.bpo-36084.86Eh4X.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-02-22-23-03-20.bpo-36084.86Eh4X.rst
@@ -1,1 +1,0 @@
-Add native thread ID (TID) to threading.Thread objects

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1160,20 +1160,6 @@ be relied upon, and the number should be seen purely as a magic cookie.\n\
 A thread's identity may be reused for another thread after it exits.");
 
 static PyObject *
-thread_get_native_id(PyObject *self, PyObject *Py_UNUSED(ignored))
-{
-    unsigned long native_id = PyThread_get_thread_native_id();
-    return PyLong_FromUnsignedLong(native_id);
-}
-
-PyDoc_STRVAR(get_native_id_doc,
-"get_native_id() -> integer\n\
-\n\
-Return a non-negative integer identifying the thread as reported\n\
-by the OS (kernel). This may be used to uniquely identify a\n\
-particular thread within a system.");
-
-static PyObject *
 thread__count(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyInterpreterState *interp = _PyInterpreterState_Get();
@@ -1324,8 +1310,6 @@ static PyMethodDef thread_methods[] = {
      METH_NOARGS, interrupt_doc},
     {"get_ident",               thread_get_ident,
      METH_NOARGS, get_ident_doc},
-    {"get_native_id",           thread_get_native_id,
-     METH_NOARGS, get_native_id_doc},
     {"_count",                  thread__count,
      METH_NOARGS, _count_doc},
     {"stack_size",              (PyCFunction)thread_stack_size,

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -143,8 +143,6 @@ LeaveNonRecursiveMutex(PNRMUTEX mutex)
 
 unsigned long PyThread_get_thread_ident(void);
 
-unsigned long PyThread_get_thread_native_id(void);
-
 /*
  * Initialization of the C package, should not be needed.
  */
@@ -222,20 +220,6 @@ PyThread_start_new_thread(void (*func)(void *), void *arg)
  */
 unsigned long
 PyThread_get_thread_ident(void)
-{
-    if (!initialized)
-        PyThread_init_thread();
-
-    return GetCurrentThreadId();
-}
-
-/*
- * Return the native Thread ID (TID) of the calling thread.
- * The native ID of a thread is valid and guaranteed to be unique system-wide
- * from the time the thread is created until the thread has been terminated.
- */
-unsigned long
-PyThread_get_thread_native_id(void)
 {
     if (!initialized)
         PyThread_init_thread();

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -12,12 +12,6 @@
 #endif
 #include <signal.h>
 
-#if defined(__linux__)
-#include <sys/syscall.h>
-#elif defined(__FreeBSD__)
-#include <pthread_np.h>
-#endif
-
 /* The POSIX spec requires that use of pthread_attr_setstacksize
    be conditional on _POSIX_THREAD_ATTR_STACKSIZE being defined. */
 #ifdef _POSIX_THREAD_ATTR_STACKSIZE
@@ -306,27 +300,6 @@ PyThread_get_thread_ident(void)
         PyThread_init_thread();
     threadid = pthread_self();
     return (unsigned long) threadid;
-}
-
-unsigned long
-PyThread_get_thread_native_id(void)
-{
-    if (!initialized)
-        PyThread_init_thread();
-#ifdef __APPLE__
-    uint64_t native_id;
-    pthread_threadid_np(NULL, &native_id);
-#elif defined(__linux__)
-    pid_t native_id;
-    native_id = syscall(__NR_gettid);
-#elif defined(__FreeBSD__)
-    pid_t native_id;
-    native_id = pthread_getthreadid_np();
-#else
-    unsigned long native_id;
-    native_id = 0;
-#endif
-    return (unsigned long) native_id;
 }
 
 void _Py_NO_RETURN


### PR DESCRIPTION
This reverts commit 4959c33d2555b89b494c678d99be81a65ee864b0.

<!-- issue-number: [bpo-36084](https://bugs.python.org/issue36084) -->
https://bugs.python.org/issue36084
<!-- /issue-number -->
