### PR TITLE
bpo-36969: Make PDB args command display positional only arguments

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1132,7 +1132,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         co = self.curframe.f_code
         dict = self.curframe_locals
-        n = co.co_argcount + co.co_kwonlyargcount
+        n = co.co_argcount + co.co_posonlyargcount + co.co_kwonlyargcount
         if co.co_flags & inspect.CO_VARARGS: n = n+1
         if co.co_flags & inspect.CO_VARKEYWORDS: n = n+1
         for i in range(n):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -80,10 +80,14 @@ def test_pdb_basic_commands():
     >>> def test_function3(arg=None, *, kwonly=None):
     ...     pass
 
+    >>> def test_function4(a, b, c, /):
+    ...     pass
+
     >>> def test_function():
     ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     ...     ret = test_function_2('baz')
     ...     test_function3(kwonly=True)
+    ...     test_function4(1, 2, 3)
     ...     print(ret)
 
     >>> with PdbTestInput([  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
@@ -104,10 +108,14 @@ def test_pdb_basic_commands():
     ...     'next',       # step to test_function3()
     ...     'step',       # stepping into test_function3()
     ...     'args',       # display function args
+    ...     'return',     # return out of function
+    ...     'next',       # step to test_function4()
+    ...     'step',       # stepping to test_function4()
+    ...     'args',       # display function args
     ...     'continue',
     ... ]):
     ...    test_function()
-    > <doctest test.test_pdb.test_pdb_basic_commands[2]>(3)test_function()
+    > <doctest test.test_pdb.test_pdb_basic_commands[3]>(3)test_function()
     -> ret = test_function_2('baz')
     (Pdb) step
     --Call--
@@ -130,14 +138,14 @@ def test_pdb_basic_commands():
     [EOF]
     (Pdb) bt
     ...
-      <doctest test.test_pdb.test_pdb_basic_commands[3]>(21)<module>()
+      <doctest test.test_pdb.test_pdb_basic_commands[4]>(25)<module>()
     -> test_function()
-      <doctest test.test_pdb.test_pdb_basic_commands[2]>(3)test_function()
+      <doctest test.test_pdb.test_pdb_basic_commands[3]>(3)test_function()
     -> ret = test_function_2('baz')
     > <doctest test.test_pdb.test_pdb_basic_commands[0]>(1)test_function_2()
     -> def test_function_2(foo, bar='default'):
     (Pdb) up
-    > <doctest test.test_pdb.test_pdb_basic_commands[2]>(3)test_function()
+    > <doctest test.test_pdb.test_pdb_basic_commands[3]>(3)test_function()
     -> ret = test_function_2('baz')
     (Pdb) down
     > <doctest test.test_pdb.test_pdb_basic_commands[0]>(1)test_function_2()
@@ -176,7 +184,7 @@ def test_pdb_basic_commands():
     (Pdb) retval
     'BAZ'
     (Pdb) next
-    > <doctest test.test_pdb.test_pdb_basic_commands[2]>(4)test_function()
+    > <doctest test.test_pdb.test_pdb_basic_commands[3]>(4)test_function()
     -> test_function3(kwonly=True)
     (Pdb) step
     --Call--
@@ -185,6 +193,21 @@ def test_pdb_basic_commands():
     (Pdb) args
     arg = None
     kwonly = True
+    (Pdb) return
+    --Return--
+    > <doctest test.test_pdb.test_pdb_basic_commands[1]>(2)test_function3()->None
+    -> pass
+    (Pdb) next
+    > <doctest test.test_pdb.test_pdb_basic_commands[3]>(5)test_function()
+    -> test_function4(1, 2, 3)
+    (Pdb) step
+    --Call--
+    > <doctest test.test_pdb.test_pdb_basic_commands[2]>(1)test_function4()
+    -> def test_function4(a, b, c, /):
+    (Pdb) args
+    a = 1
+    b = 2
+    c = 3
     (Pdb) continue
     BAZ
     """

--- a/Misc/NEWS.d/next/Library/2019-05-21-12-31-21.bpo-36969.u7cxu7.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-21-12-31-21.bpo-36969.u7cxu7.rst
@@ -1,0 +1,2 @@
+PDB command `args` now  display positional only arguments. Patch contributed
+by Rémi Lapeyre.


### PR DESCRIPTION
CC @pablogsal 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36969](https://bugs.python.org/issue36969) -->
https://bugs.python.org/issue36969
<!-- /issue-number -->
