### PR TITLE
bpo-36974: remove _PyObject_HasFastCall

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -55,10 +55,6 @@ PyAPI_FUNC(int) _PyStack_UnpackDict(
    40 bytes on the stack. */
 #define _PY_FASTCALL_SMALL_STACK 5
 
-/* Return 1 if callable supports FASTCALL calling convention for positional
-   arguments: see _PyObject_Vectorcall() and _PyObject_FastCallDict() */
-PyAPI_FUNC(int) _PyObject_HasFastCall(PyObject *callable);
-
 PyAPI_FUNC(PyObject *) _Py_CheckFunctionResult(PyObject *callable,
                                                PyObject *result,
                                                const char *where);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -107,7 +107,7 @@ partial_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         return NULL;
     }
 
-    pto->use_fastcall = _PyObject_HasFastCall(func);
+    pto->use_fastcall = (_PyVectorcall_Function(func) != NULL);
 
     return (PyObject *)pto;
 }
@@ -365,7 +365,7 @@ partial_setstate(partialobject *pto, PyObject *state)
         Py_INCREF(dict);
 
     Py_INCREF(fn);
-    pto->use_fastcall = _PyObject_HasFastCall(fn);
+    pto->use_fastcall = (_PyVectorcall_Function(fn) != NULL);
     Py_SETREF(pto->fn, fn);
     Py_SETREF(pto->args, fnargs);
     Py_SETREF(pto->kw, kw);

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -9,22 +9,6 @@ static PyObject *
 cfunction_call_varargs(PyObject *func, PyObject *args, PyObject *kwargs);
 
 
-int
-_PyObject_HasFastCall(PyObject *callable)
-{
-    if (PyFunction_Check(callable)) {
-        return 1;
-    }
-    else if (PyCFunction_Check(callable)) {
-        return !(PyCFunction_GET_FLAGS(callable) & METH_VARARGS);
-    }
-    else {
-        assert (PyCallable_Check(callable));
-        return 0;
-    }
-}
-
-
 static PyObject *
 null_error(void)
 {


### PR DESCRIPTION
**After implementing PEP 590** (#13185)

<!-- issue-number: [bpo-36974](https://bugs.python.org/issue36974) -->
https://bugs.python.org/issue36974
<!-- /issue-number -->
