### PR TITLE
[3.7] bpo-36965: replace include of  crtdbg.h with windows.h, backport 925af1d 3.7 (GH-13421)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-05-20-20-26-36.bpo-36965.KsfI-N.rst
+++ b/Misc/NEWS.d/next/Windows/2019-05-20-20-26-36.bpo-36965.KsfI-N.rst
@@ -1,0 +1,1 @@
+include of STATUS_CONTROL_C_EXIT without depending on MSC compiler

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -30,6 +30,7 @@
 #  define PYTHONHOMEHELP "<prefix>\\python{major}{minor}"
 #else
 #  define PYTHONHOMEHELP "<prefix>/lib/pythonX.X"
+#endif
 
 #define COPYRIGHT \
     "Type \"help\", \"copyright\", \"credits\" or \"license\" " \

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -18,8 +18,8 @@
 #  endif
 #endif
 
-#ifdef _MSC_VER
-#  include <crtdbg.h>
+#ifdef MS_WINDOWS
+#  include <windows.h>  /* STATUS_CONTROL_C_EXIT */
 #endif
 
 #ifdef __FreeBSD__
@@ -30,7 +30,6 @@
 #  define PYTHONHOMEHELP "<prefix>\\python{major}{minor}"
 #else
 #  define PYTHONHOMEHELP "<prefix>/lib/pythonX.X"
-#endif
 
 #define COPYRIGHT \
     "Type \"help\", \"copyright\", \"credits\" or \"license\" " \


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36965](https://bugs.python.org/issue36965) -->
https://bugs.python.org/issue36965
<!-- /issue-number -->
