### PR TITLE
bpo-37028: Implement asyncio REPL (activated via 'python -m asyncio')

### DIFF
--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -1,0 +1,47 @@
+import ast
+import asyncio
+import code
+import inspect
+import sys
+import types
+
+
+class AsyncIOInteractiveConsole(code.InteractiveConsole):
+
+    def __init__(self, locals=None):
+        super().__init__(locals)
+        self.compile.compiler.flags |= ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def runcode(self, code):
+        try:
+            func = types.FunctionType(code, self.locals)
+            coro = func()
+            if inspect.isawaitable(coro):
+                return self.loop.run_until_complete(coro)
+        except SystemExit:
+            raise
+        except BaseException:
+            self.showtraceback()
+
+
+if __name__ == '__main__':
+    console = AsyncIOInteractiveConsole(locals())
+
+    try:
+        import readline  # NoQA
+    except ImportError:
+        pass
+
+    banner = (
+        f'asyncio REPL\n\n'
+        f'Python {sys.version} on {sys.platform}\n'
+        f'Type "help", "copyright", "credits" or "license" '
+        f'for more information.\n'
+    )
+
+    console.interact(
+        banner=banner,
+        exitmsg='exiting asyncio REPL...')

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -70,11 +70,11 @@ class REPLThread(threading.Thread):
     def run(self):
         try:
             banner = (
-                f'asyncio REPL {sys.version} on {sys.platform}\n\n'
+                f'asyncio REPL {sys.version} on {sys.platform}\n'
                 f'Use "await" directly instead of "asyncio.run()".\n'
                 f'Type "help", "copyright", "credits" or "license" '
-                f'for more information.\n\n'
-                f'{getattr(sys, "ps1", ">>> ")}import asyncio\n'
+                f'for more information.\n'
+                f'{getattr(sys, "ps1", ">>> ")}import asyncio'
             )
 
             console.interact(
@@ -110,6 +110,7 @@ if __name__ == '__main__':
         pass
 
     repl_thread = REPLThread()
+    repl_thread.daemon = True
     repl_thread.start()
 
     while True:

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -71,7 +71,7 @@ class REPLThread(threading.Thread):
         try:
             banner = (
                 f'asyncio REPL {sys.version} on {sys.platform}\n\n'
-                f'Use "await" directly instead of asyncio.run().\n'
+                f'Use "await" directly instead of "asyncio.run()".\n'
                 f'Type "help", "copyright", "credits" or "license" '
                 f'for more information.\n\n'
                 f'{getattr(sys, "ps1", ">>> ")}import asyncio\n'

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -1,47 +1,100 @@
 import ast
 import asyncio
 import code
+import concurrent.futures
 import inspect
 import sys
+import threading
 import types
+
+from . import futures
 
 
 class AsyncIOInteractiveConsole(code.InteractiveConsole):
 
-    def __init__(self, locals=None):
+    def __init__(self, locals, loop):
         super().__init__(locals)
         self.compile.compiler.flags |= ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
 
-        self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self.loop)
+        self.loop = loop
 
     def runcode(self, code):
-        try:
+        future = concurrent.futures.Future()
+
+        def callback():
+            global repl_future
+
             func = types.FunctionType(code, self.locals)
-            coro = func()
-            if inspect.isawaitable(coro):
-                return self.loop.run_until_complete(coro)
+            try:
+                coro = func()
+            except BaseException as ex:
+                future.set_exception(ex)
+                return
+
+            if not inspect.iscoroutine(coro):
+                future.set_result(coro)
+                return
+
+            try:
+                repl_future = self.loop.create_task(coro)
+                futures._chain_future(repl_future, future)
+            except BaseException as exc:
+                future.set_exception(exc)
+
+        loop.call_soon_threadsafe(callback)
+
+        try:
+            return future.result()
         except SystemExit:
             raise
         except BaseException:
             self.showtraceback()
 
 
+class REPLThread(threading.Thread):
+
+    def run(self):
+        try:
+            banner = (
+                f'asyncio REPL {sys.version} on {sys.platform}\n'
+                f'Type "help", "copyright", "credits" or "license" '
+                f'for more information.\n\n'
+                f'{getattr(sys, "ps1", ">>> ")}import asyncio\n'
+            )
+
+            console.interact(
+                banner=banner,
+                exitmsg='exiting asyncio REPL...')
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+
+
 if __name__ == '__main__':
-    console = AsyncIOInteractiveConsole(locals())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    repl_locals = {'asyncio': asyncio}
+    for key in {'__name__', '__package__',
+                '__loader__', '__spec__',
+                '__builtins__', '__file__'}:
+        repl_locals[key] = locals()[key]
+
+    console = AsyncIOInteractiveConsole(repl_locals, loop)
+    repl_future = None
 
     try:
         import readline  # NoQA
     except ImportError:
         pass
 
-    banner = (
-        f'asyncio REPL\n\n'
-        f'Python {sys.version} on {sys.platform}\n'
-        f'Type "help", "copyright", "credits" or "license" '
-        f'for more information.\n'
-    )
+    REPLThread().start()
 
-    console.interact(
-        banner=banner,
-        exitmsg='exiting asyncio REPL...')
+    while True:
+        try:
+            loop.run_forever()
+        except KeyboardInterrupt:
+            if repl_future and not repl_future.done():
+                repl_future.cancel()
+            continue
+        else:
+            break

--- a/Misc/NEWS.d/next/Library/2019-05-23-18-57-34.bpo-37028.Vse6Pj.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-23-18-57-34.bpo-37028.Vse6Pj.rst
@@ -1,0 +1,1 @@
+Implement asyncio REPL


### PR DESCRIPTION
This makes it easy to play with asyncio APIs with simply
using async/await in the REPL.

@asvetlov would you mind playing with this?  Pull the branch, make sure to rebuild Python, and then `./python -m asyncio`.  I quite like this and I think it would be a valuable addition to asyncio 3.8.

<!-- issue-number: [bpo-37028](https://bugs.python.org/issue37028) -->
https://bugs.python.org/issue37028
<!-- /issue-number -->
