### PR TITLE
bpo-35907, CVE-2019-9948: urllib rejects local_file:// scheme

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1481,6 +1481,19 @@ class URLopener_Tests(FakeHTTPMixin, unittest.TestCase):
         filename, _ = urllib.request.URLopener().retrieve(url)
         self.assertEqual(os.path.splitext(filename)[1], ".txt")
 
+    @support.ignore_warnings(category=DeprecationWarning)
+    def test_local_file_open(self):
+        # bpo-35907, CVE-2019-9948: urllib must reject local_file:// scheme
+        class DummyURLopener(urllib.request.URLopener):
+            def open_local_file(self, url):
+                return url
+        for url in ('local_file://example', 'local-file://example'):
+            self.assertRaises(OSError, urllib.request.urlopen, url)
+            self.assertRaises(OSError, urllib.request.URLopener().open, url)
+            self.assertRaises(OSError, urllib.request.URLopener().retrieve, url)
+            self.assertRaises(OSError, DummyURLopener().open, url)
+            self.assertRaises(OSError, DummyURLopener().retrieve, url)
+
 
 # Just commented them out.
 # Can't really tell why keep failing in windows and sparc.

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1745,7 +1745,7 @@ class URLopener:
         name = 'open_' + urltype
         self.type = urltype
         name = name.replace('-', '_')
-        if not hasattr(self, name):
+        if not hasattr(self, name) or name == 'open_local_file':
             if proxy:
                 return self.open_unknown_proxy(proxy, fullurl, data)
             else:

--- a/Misc/NEWS.d/next/Security/2019-05-21-23-20-18.bpo-35907.NC_zNK.rst
+++ b/Misc/NEWS.d/next/Security/2019-05-21-23-20-18.bpo-35907.NC_zNK.rst
@@ -1,0 +1,2 @@
+CVE-2019-9948: Avoid file reading as disallowing the unnecessary URL scheme in
+``URLopener().open()`` ``URLopener().retrieve()`` of :mod:`urllib.request`.


### PR DESCRIPTION
CVE-2019-9948: Avoid file reading as disallowing the unnecessary URL
scheme in URLopener().open() of urllib.request.

Co-Authored-By: SH <push0ebp@gmail.com>

<!-- issue-number: [bpo-35907](https://bugs.python.org/issue35907) -->
https://bugs.python.org/issue35907
<!-- /issue-number -->
