### PR TITLE
bpo-37003: handle f-debug in ast-unparse,

### DIFF
--- a/Lib/test/test_tools/test_unparse.py
+++ b/Lib/test/test_tools/test_unparse.py
@@ -139,6 +139,9 @@ class UnparseTestCase(ASTTestCase):
         self.check_roundtrip(r"""f'{f"{0}"*3}'""")
         self.check_roundtrip(r"""f'{f"{y}"*3}'""")
 
+    def test_fstrings_debug(self):
+        self.check_roundtrip(r"""f'{f.a.b()=}'""")
+
     def test_del_statement(self):
         self.check_roundtrip("del x, y, z")
 

--- a/Lib/test/test_tools/test_unparse.py
+++ b/Lib/test/test_tools/test_unparse.py
@@ -141,6 +141,11 @@ class UnparseTestCase(ASTTestCase):
 
     def test_fstrings_debug(self):
         self.check_roundtrip(r"""f'{f.a.b()=}'""")
+        self.check_roundtrip(r"""f'{f.a.b()=!s:20}'""")
+        self.check_roundtrip(r"""f'{f.a.b()=!r}'""")
+        self.check_roundtrip(r"""f'{f.a.b() = !r}'""")
+        self.check_roundtrip(r"""f'*{n=:+<30}*'""")
+        self.check_roundtrip(r"""f'{x=:.2f}'""")
 
     def test_del_statement(self):
         self.check_roundtrip("del x, y, z")

--- a/Tools/parser/unparse.py
+++ b/Tools/parser/unparse.py
@@ -369,14 +369,14 @@ class Unparser:
             if expr.startswith("{"):
                 write(" ")  # Separate pair of opening brackets as "{ {"
             write(expr)
-            if t.conversion != -1:
-                conversion = chr(t.conversion)
-                assert conversion in "sra"
-                write(f"!{conversion}")
-            if t.format_spec:
-                write(":")
-                meth = getattr(self, "_fstring_" + type(t.format_spec).__name__)
-                meth(t.format_spec, write)
+        if t.conversion != -1:
+            conversion = chr(t.conversion)
+            assert conversion in "sra"
+            write(f"!{conversion}")
+        if t.format_spec:
+            write(":")
+            meth = getattr(self, "_fstring_" + type(t.format_spec).__name__)
+            meth(t.format_spec, write)
         write("}")
 
     def _Name(self, t):

--- a/Tools/parser/unparse.py
+++ b/Tools/parser/unparse.py
@@ -360,20 +360,23 @@ class Unparser:
 
     def _fstring_FormattedValue(self, t, write):
         write("{")
-        expr = io.StringIO()
-        Unparser(t.value, expr)
-        expr = expr.getvalue().rstrip("\n")
-        if expr.startswith("{"):
-            write(" ")  # Separate pair of opening brackets as "{ {"
-        write(expr)
-        if t.conversion != -1:
-            conversion = chr(t.conversion)
-            assert conversion in "sra"
-            write(f"!{conversion}")
-        if t.format_spec:
-            write(":")
-            meth = getattr(self, "_fstring_" + type(t.format_spec).__name__)
-            meth(t.format_spec, write)
+        if t.expr_text:
+            write(t.expr_text)
+        else:
+            expr = io.StringIO()
+            Unparser(t.value, expr)
+            expr = expr.getvalue().rstrip("\n")
+            if expr.startswith("{"):
+                write(" ")  # Separate pair of opening brackets as "{ {"
+            write(expr)
+            if t.conversion != -1:
+                conversion = chr(t.conversion)
+                assert conversion in "sra"
+                write(f"!{conversion}")
+            if t.format_spec:
+                write(":")
+                meth = getattr(self, "_fstring_" + type(t.format_spec).__name__)
+                meth(t.format_spec, write)
         write("}")
 
     def _Name(self, t):


### PR DESCRIPTION
Ast-unparse was mistaking f'{x=}' for f"{x!r}"


<!-- issue-number: [bpo-37003](https://bugs.python.org/issue37003) -->
https://bugs.python.org/issue37003
<!-- /issue-number -->
