### PR TITLE
bpo-36948: Fix test_urlopener_retrieve_file on Windows

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1470,7 +1470,8 @@ class URLopener_Tests(FakeHTTPMixin, unittest.TestCase):
             os.close(fd)
             fileurl = "file:" + urllib.request.pathname2url(tmpfile)
             filename, _ = urllib.request.URLopener().retrieve(fileurl)
-            self.assertEqual(filename, tmpfile)
+            # Some buildbots have TEMP folder that uses a lowercase drive letter.
+            self.assertEqual(os.path.normcase(filename), os.path.normcase(tmpfile))
 
     @support.ignore_warnings(category=DeprecationWarning)
     def test_urlopener_retrieve_remote(self):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36948](https://bugs.python.org/issue36948) -->
https://bugs.python.org/issue36948
<!-- /issue-number -->
