### PR TITLE
bpo-27737: Allow whitespace only headers encoding

### DIFF
--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -431,7 +431,7 @@ class _ValueFormatter:
         if end_of_line != (' ', ''):
             self._current_line.push(*end_of_line)
         if len(self._current_line) > 0:
-            if self._current_line.is_onlyws():
+            if self._current_line.is_onlyws() and self._lines:
                 self._lines[-1] += str(self._current_line)
             else:
                 self._lines.append(str(self._current_line))

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -4964,6 +4964,9 @@ A very long line that must get split to something other than at the
         msg['SomeHeader'] = '   value with leading ws'
         self.assertEqual(str(msg), "SomeHeader:    value with leading ws\n\n")
 
+    def test_whitespace_header(self):
+        self.assertEqual(Header(' ').encode(), ' ')
+
 
 
 # Test RFC 2231 header parameters (en/de)coding

--- a/Misc/NEWS.d/next/Library/2019-05-22-02-25-31.bpo-27737.7bgKpa.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-22-02-25-31.bpo-27737.7bgKpa.rst
@@ -1,0 +1,2 @@
+Allow whitespace only header encoding in ``email.header`` - by Batuhan
+Taskaya


### PR DESCRIPTION
Allow whitespace only headers encoding

<!-- issue-number: [bpo-27737](https://bugs.python.org/issue27737) -->
https://bugs.python.org/issue27737
<!-- /issue-number -->
