### PR TITLE
Fix so that test.test_distutils can be executed by unittest and not j…

### DIFF
--- a/Lib/test/test_distutils.py
+++ b/Lib/test/test_distutils.py
@@ -10,8 +10,14 @@ import test.support
 
 
 def test_main():
+    # used by regrtest
     test.support.run_unittest(distutils.tests.test_suite())
     test.support.reap_children()
+
+
+def load_tests(*_):
+    # used by unittest
+    return distutils.tests.test_suite()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…ust regrtest

Our developer instructions list unittest with test discovery as the
method to execute individual tests so we should make that work.  This is
similar to add7cbfb0527aaa15879f5ea9aaf2c8b322f0868 but for testing
distutils rather than testing unittest.  For instance, this change will
enable the following to work:

./python -m unittest -v distutils.tests.test_file_util

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
