### PR TITLE
bpo-36763: Add _PyPreConfig._config_init

### DIFF
--- a/Include/cpython/coreconfig.h
+++ b/Include/cpython/coreconfig.h
@@ -40,9 +40,18 @@ typedef struct {
 
 #define _Py_CONFIG_VERSION 1
 
+typedef enum {
+    /* Py_Initialize() API: backward compatibility with Python 3.6 and 3.7 */
+    _PyConfig_INIT_COMPAT = 1,
+    _PyConfig_INIT_PYTHON = 2,
+    _PyConfig_INIT_ISOLATED = 3
+} _PyConfigInitEnum;
+
+
 typedef struct {
     int _config_version;  /* Internal configuration version,
                              used for ABI compatibility */
+    int _config_init;     /* _PyConfigInitEnum value */
 
     /* Parse _Py_PreInitializeFromArgs() arguments?
        See _PyCoreConfig.parse_argv */
@@ -107,10 +116,7 @@ typedef struct {
        Set to 0 by "-X utf8=0" and PYTHONUTF8=0.
 
        If equals to -1, it is set to 1 if the LC_CTYPE locale is "C" or
-       "POSIX", otherwise it is set to 0.
-
-       If equals to -2, inherit Py_UTF8Mode value value (which is equal to 0
-       by default). */
+       "POSIX", otherwise it is set to 0. Inherit Py_UTF8Mode value value. */
     int utf8_mode;
 
     int dev_mode;           /* Development mode. PYTHONDEVMODE, -X dev */
@@ -126,16 +132,10 @@ PyAPI_FUNC(void) _PyPreConfig_InitIsolatedConfig(_PyPreConfig *config);
 
 /* --- _PyCoreConfig ---------------------------------------------- */
 
-typedef enum {
-    _PyCoreConfig_INIT = 0,
-    _PyCoreConfig_INIT_PYTHON = 1,
-    _PyCoreConfig_INIT_ISOLATED = 2
-} _PyCoreConfigInitEnum;
-
 typedef struct {
     int _config_version;  /* Internal configuration version,
                              used for ABI compatibility */
-    int _config_init;     /* _PyCoreConfigInitEnum value */
+    int _config_init;     /* _PyConfigInitEnum value */
 
     int isolated;         /* Isolated mode? see _PyPreConfig.isolated */
     int use_environment;  /* Use environment variables? see _PyPreConfig.use_environment */

--- a/Include/internal/pycore_coreconfig.h
+++ b/Include/internal/pycore_coreconfig.h
@@ -120,7 +120,7 @@ PyAPI_FUNC(_PyInitError) _PyPreCmdline_Read(_PyPreCmdline *cmdline,
 
 /* --- _PyPreConfig ----------------------------------------------- */
 
-PyAPI_FUNC(void) _PyPreConfig_Init(_PyPreConfig *config);
+PyAPI_FUNC(void) _PyPreConfig_InitCompatConfig(_PyPreConfig *config);
 PyAPI_FUNC(void) _PyPreConfig_InitFromCoreConfig(
     _PyPreConfig *config,
     const _PyCoreConfig *coreconfig);
@@ -139,7 +139,7 @@ PyAPI_FUNC(_PyInitError) _PyPreConfig_Write(const _PyPreConfig *config);
 
 /* --- _PyCoreConfig ---------------------------------------------- */
 
-PyAPI_FUNC(void) _PyCoreConfig_Init(_PyCoreConfig *config);
+PyAPI_FUNC(void) _PyCoreConfig_InitCompatConfig(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_Copy(
     _PyCoreConfig *config,
     const _PyCoreConfig *config2);

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -76,18 +76,30 @@ main(int argc, char *argv[])
     }
     text[text_size] = '\0';
 
+    _PyInitError err;
     _PyCoreConfig config;
-    _PyCoreConfig_InitIsolatedConfig(&config);
+
+    err = _PyCoreConfig_InitIsolatedConfig(&config);
+    if (_PyInitError_Failed(err)) {
+        _PyCoreConfig_Clear(&config);
+        _Py_ExitInitError(err);
+    }
 
     config.site_import = 0;
-    config.program_name = L"./_freeze_importlib";
+
+    err = _PyCoreConfig_SetString(&config, &config.program_name,
+                                  L"./_freeze_importlib");
+    if (_PyInitError_Failed(err)) {
+        _PyCoreConfig_Clear(&config);
+        _Py_ExitInitError(err);
+    }
+
     /* Don't install importlib, since it could execute outdated bytecode. */
     config._install_importlib = 0;
     config._init_main = 0;
 
-    _PyInitError err = _Py_InitializeFromConfig(&config);
-    /* No need to call _PyCoreConfig_Clear() since we didn't allocate any
-       memory: program_name is a constant string. */
+    err = _Py_InitializeFromConfig(&config);
+    _PyCoreConfig_Clear(&config);
     if (_PyInitError_Failed(err)) {
         _Py_ExitInitError(err);
     }

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -40,7 +40,11 @@ Py_FrozenMain(int argc, char **argv)
     }
 
     _PyCoreConfig config;
-    _PyCoreConfig_InitPythonConfig(&config);
+    err = _PyCoreConfig_InitPythonConfig(&config);
+    if (_PyInitError_Failed(err)) {
+        _PyCoreConfig_Clear(&config);
+        _Py_ExitInitError(err);
+    }
     config.pathconfig_warnings = 0;   /* Suppress errors from getpath.c */
 
     if ((p = Py_GETENV("PYTHONINSPECT")) && *p != '\0')
@@ -82,8 +86,7 @@ Py_FrozenMain(int argc, char **argv)
         Py_SetProgramName(argv_copy[0]);
 
     err = _Py_InitializeFromConfig(&config);
-    /* No need to call _PyCoreConfig_Clear() since we didn't allocate any
-       memory: program_name is a constant string. */
+    _PyCoreConfig_Clear(&config);
     if (_PyInitError_Failed(err)) {
         _Py_ExitInitError(err);
     }

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -383,7 +383,7 @@ pathconfig_global_init(void)
 
     _PyInitError err;
     _PyCoreConfig config;
-    _PyCoreConfig_Init(&config);
+    _PyCoreConfig_InitCompatConfig(&config);
 
     err = _PyCoreConfig_Read(&config);
     if (_Py_INIT_FAILED(err)) {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -867,7 +867,7 @@ _Py_InitializeCore(_PyRuntimeState *runtime,
     }
 
     _PyCoreConfig local_config;
-    _PyCoreConfig_Init(&local_config);
+    _PyCoreConfig_InitCompatConfig(&local_config);
     err = pyinit_coreconfig(runtime, &local_config, src_config, args, interp_p);
     _PyCoreConfig_Clear(&local_config);
     return err;
@@ -1096,7 +1096,7 @@ Py_InitializeEx(int install_sigs)
     }
 
     _PyCoreConfig config;
-    _PyCoreConfig_Init(&config);
+    _PyCoreConfig_InitCompatConfig(&config);
     config.install_signal_handlers = install_sigs;
 
     err = _Py_InitializeFromConfig(&config);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -49,7 +49,7 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
 
     _PyGC_Initialize(&runtime->gc);
     _PyEval_Initialize(&runtime->ceval);
-    _PyPreConfig_Init(&runtime->preconfig);
+    _PyPreConfig_InitPythonConfig(&runtime->preconfig);
 
     runtime->gilstate.check_enabled = 1;
 
@@ -189,7 +189,13 @@ PyInterpreterState_New(void)
     memset(interp, 0, sizeof(*interp));
     interp->id_refcount = -1;
     interp->check_interval = 100;
-    _PyCoreConfig_Init(&interp->core_config);
+
+    _PyInitError err = _PyCoreConfig_InitPythonConfig(&interp->core_config);
+    if (_Py_INIT_FAILED(err)) {
+        PyMem_RawFree(interp);
+        return NULL;
+    }
+
     interp->eval_frame = _PyEval_EvalFrameDefault;
 #ifdef HAVE_DLOPEN
 #if HAVE_DECL_RTLD_NOW


### PR DESCRIPTION
* _PyPreConfig_GetGlobalConfig() and  _PyCoreConfig_GetGlobalConfig()
  now do nothing if the configuration was not initialized with
  _PyPreConfig_Init() and _PyCoreConfig_Init()
* Remove utf8_mode=-2 special case: use utf8_mode=-1 instead.
* Fix _PyPreConfig_InitPythonConfig():

  * isolated = 0 instead of -1
  * use_environment = 1 instead of -1

* Rename _PyConfig_INIT to  _PyConfig_INIT_COMPAT
* Rename _PyPreConfig_Init() to _PyPreConfig_InitCompatConfig()
* Rename _PyCoreConfig_Init() to _PyCoreConfig_InitCompatConfig()
* PyInterpreterState_New() now uses _PyCoreConfig_InitPythonConfig()
  as default configuration, but it's very quickly overriden anyway.

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
