### PR TITLE
bpo-37004: Documented asymmetry of string arguments in difflib.SequenceMatcher for ratio method

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -547,7 +547,7 @@ The :class:`SequenceMatcher` class has this constructor:
 
          Caution: The result of a :meth:`ratio` call may depend on the order of
          the arguments. For instance::
-            
+
             >>> SequenceMatcher(None, 'tide', 'diet').ratio()
             0.25
             >>> SequenceMatcher(None, 'diet', 'tide').ratio()

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -545,13 +545,13 @@ The :class:`SequenceMatcher` class has this constructor:
 
       .. note::
 
-         Caution: The result of a :meth:`ratio` call is *NOT* symmetric with 
-         respect to the order of the arguments. For instance::
+         Caution: The result of a :meth:`ratio` call may depend on the order of
+         the arguments. For instance::
             
-            >>> SequenceMatcher(None, 'brady', 'byrd').ratio()
-            0.6666666666666666
-            >>> SequenceMatcher(None, 'byrd', 'brady').ratio()
-            0.4444444444444444
+            >>> SequenceMatcher(None, 'tide', 'diet').ratio()
+            0.25
+            >>> SequenceMatcher(None, 'diet', 'tide').ratio()
+            0.5
 
 
    .. method:: quick_ratio()

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -543,6 +543,16 @@ The :class:`SequenceMatcher` class has this constructor:
       to try :meth:`quick_ratio` or :meth:`real_quick_ratio` first to get an
       upper bound.
 
+      .. note::
+
+         Caution: The result of a :meth:`ratio` call is *NOT* symmetric with 
+         respect to the order of the arguments. For instance::
+            
+            >>> SequenceMatcher(None, 'brady', 'byrd').ratio()
+            0.6666666666666666
+            >>> SequenceMatcher(None, 'byrd', 'brady').ratio()
+            0.4444444444444444
+
 
    .. method:: quick_ratio()
 

--- a/Misc/NEWS.d/next/Documentation/2019-05-22-04-30-07.bpo-37004.BRgxrt.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-05-22-04-30-07.bpo-37004.BRgxrt.rst
@@ -1,0 +1,1 @@
+In the documentation for difflib, a note was added explicitly warning that the results of SequenceMatcher's ratio method may depend on the order of the input strings.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37004](https://bugs.python.org/issue37004) -->
https://bugs.python.org/issue37004
<!-- /issue-number -->


Automerge-Triggered-By: @tim-one