### PR TITLE
bpo-34616: Document top level async in whatsnew/3.8.

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -244,28 +244,7 @@ The :func:`compile` built-in has been improved to accept the
 ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` flag. With this new flag passed,
 :func:`compile` will allow top-level ``await``, ``async for`` and ``async with``
 constructs that are usually considered invalid syntax. Asynchronous code object
-marked with the ``CO_COROUTINE`` flag may then be returned. They
-can be used in conjunction with ``await eval(...)`` (instead of ``exec``) to – for
-example – run async snippets in doctest, or build an async-repl.
-
-Example of a bare-bones async REPL ::
-
-    import asyncio
-    from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT as ALLOW_AWAIT
-    from inspect import CO_COROUTINE
-
-    async def async_exec(co):
-        if co.co_flags & CO_COROUTINE:
-            await eval(co)
-        else:
-            exec(co)
-
-    async def repl():
-        while True:
-            text = input('>>> ')
-            await async_exec(compile(text, '', 'single', flags=ALLOW_AWAIT))
-
-    asyncio.run(repl())
+marked with the ``CO_COROUTINE`` flag may then be returned.
 
 (Contributed by Matthias Bussonnier in :issue:`34616`)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -244,9 +244,9 @@ The :func:`compile` built-in has been improved to accept the
 ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` flag. With this new flag passed,
 :func:`compile` will allow top-level ``await``, ``async for`` and ``async with``
 constructs that are usually considered invalid syntax. Asynchronous code object
-marked with the ``CO_COROUTINE`` flag may then be returned. Those code-objects
-can be used in conjunction with ``await eval(...)`` (instead of ``exec``) to for
-example run async snippets in doctest, or build an async-repl.
+marked with the ``CO_COROUTINE`` flag may then be returned. They
+can be used in conjunction with ``await eval(...)`` (instead of ``exec``) to – for
+example – run async snippets in doctest, or build an async-repl.
 
 Example of a bare-bones async REPL ::
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -237,6 +237,37 @@ asyncio
 
 On Windows, the default event loop is now :class:`~asyncio.ProactorEventLoop`.
 
+builtins
+--------
+
+The :func:`compile` built-in has been improved to accept the
+``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` flag. With this new flag passed,
+:func:`compile` will allow top-level ``await``, ``async for`` and ``async with``
+constructs that are usually considered invalid syntax. Asynchronous code object
+marked with the ``CO_COROUTINE`` flag may then be returned. Those code-objects
+can be used in conjunction with ``await eval(...)`` (instead of ``exec``) to for
+example run async snippets in doctest, or build an async-repl.
+
+Example of a bare-bones async REPL ::
+
+    import asyncio
+    from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT as ALLOW_AWAIT
+    from inspect import CO_COROUTINE
+
+    async def async_exec(co):
+        if co.co_flags & CO_COROUTINE:
+            await eval(co)
+        else:
+            exec(co)
+
+    async def repl():
+        while True:
+            text = input('>>> ')
+            await async_exec(compile(text, '', 'single', flags=ALLOW_AWAIT))
+
+    asyncio.run(repl())
+
+(Contributed by Matthias Bussonnier in :issue:`34616`)
 
 collections
 -----------


### PR DESCRIPTION


<!-- issue-number: [bpo-34616](https://bugs.python.org/issue34616) -->
https://bugs.python.org/issue34616
<!-- /issue-number -->
