### PR TITLE
bpo-37000: Optimized randbelow for powers of two

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -250,8 +250,12 @@ class Random(_random.Random):
     def _randbelow_with_getrandbits(self, n):
         "Return a random int in the range [0,n).  Raises ValueError if n==0."
 
+        if n == 0:
+            raise ValueError("Boundary cannot be zero")
+        if n == 1:
+            return 0
         getrandbits = self.getrandbits
-        k = n.bit_length()  # don't use (n-1) here because n can be 1
+        k = (n-1).bit_length()
         r = getrandbits(k)          # 0 <= r < 2**k
         while r >= n:
             r = getrandbits(k)

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -1408,3 +1408,13 @@ Modify ``PyObject_Init`` to correctly increase the refcount of heap-
 allocated Type objects. Also fix the refcounts of the heap-allocated types
 that were either doing this manually or not decreasing the type's refcount
 in tp_dealloc
+
+..
+
+.. bpo: 37000
+.. date: 2019-05-22-08-37-19
+.. nonce: glswRa
+.. section: Library
+
+Fixed a performance issue in ``random._randbelow_with_getrandint`` when
+the number supplied is a power of two.

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -1408,13 +1408,3 @@ Modify ``PyObject_Init`` to correctly increase the refcount of heap-
 allocated Type objects. Also fix the refcounts of the heap-allocated types
 that were either doing this manually or not decreasing the type's refcount
 in tp_dealloc
-
-..
-
-.. bpo: 37000
-.. date: 2019-05-22-08-37-19
-.. nonce: glswRa
-.. section: Library
-
-Fixed a performance issue in ``random._randbelow_with_getrandint`` when
-the number supplied is a power of two.

--- a/Misc/NEWS.d/next/Library/2019-05-22-06-48-25.bpo-37000.pXcb5I.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-22-06-48-25.bpo-37000.pXcb5I.rst
@@ -1,0 +1,1 @@
+Fixed a performance issue in ``random._randbelow_with_getrandint`` when the number supplied is a power of two.


### PR DESCRIPTION


<!-- issue-number: [bpo-37000](https://bugs.python.org/issue37000) -->
https://bugs.python.org/issue37000
<!-- /issue-number -->
