### PR TITLE
bpo-31904: Only UTF-8 encoding is supported on VxWorks

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -331,6 +331,8 @@ The :mod:`locale` module defines the following exception and functions:
       The function now always returns ``UTF-8`` on Android or if the UTF-8 mode
       is enabled.
 
+   On VxWorks, always return ``'UTF-8'``, the locale and the *do_setlocale*
+   argument are ignored.
 
 .. function:: normalize(localename)
 

--- a/Lib/test/test_c_locale_coercion.py
+++ b/Lib/test/test_c_locale_coercion.py
@@ -52,6 +52,10 @@ elif sys.platform == "cygwin":
     # TODO: Work out a robust dynamic test for this that doesn't rely on
     #       CPython's own locale handling machinery
     EXPECT_COERCION_IN_DEFAULT_LOCALE = False
+elif sys.platform == "vxworks":
+    # VxWorks defaults to using UTF-8 for all system interfaces
+    EXPECTED_C_LOCALE_STREAM_ENCODING = "utf-8"
+    EXPECTED_C_LOCALE_FS_ENCODING = "utf-8"
 
 # Note that the above expectations are still wrong in some cases, such as:
 # * Windows when PYTHONLEGACYWINDOWSFSENCODING is set

--- a/Misc/NEWS.d/next/Library/2019-05-20-10-20-02.bpo-31904.a845cm.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-20-10-20-02.bpo-31904.a845cm.rst
@@ -1,0 +1,1 @@
+Port test_c_locale_coercion to VxWorks: only UTF-8 encoding is supported on VxWorks


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

VxWorks uses UTF-8 as the system encoding. So the test case test_c_locale_coercion.py need to be updated to use UTF-8 on VxWorks.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
