### PR TITLE
[3.7] bpo-36829: Enhance PyErr_WriteUnraisable()

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -81,6 +81,8 @@ Printing and clearing
    in which the unraisable exception occurred. If possible,
    the repr of *obj* will be printed in the warning message.
 
+   An exception must be set when calling this function.
+
 
 Raising exceptions
 ==================

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-22-11-44-41.bpo-36829.ZmpHR9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-22-11-44-41.bpo-36829.ZmpHR9.rst
@@ -1,0 +1,4 @@
+:c:func:`PyErr_WriteUnraisable` now displays the exception even if
+displaying the traceback failed. Moreover, hold a strong reference to
+:data:`sys.stderr` while using it. Document that an exception must be set when
+calling :c:func:`PyErr_WriteUnraisable`.


### PR DESCRIPTION
PyErr_WriteUnraisable() now displays the exception even if displaying
the traceback failed. Moreover, hold a reference to sys.stderr while
using it.

Document that an exception must be set when calling
PyErr_WriteUnraisable(), but don't add an assertion to check it at
runtime.

Cleanup: use longer names for variables and create
write_unraisable_exc_file() subfunction.

<!-- issue-number: [bpo-36829](https://bugs.python.org/issue36829) -->
https://bugs.python.org/issue36829
<!-- /issue-number -->
