### PR TITLE
bpo-36829: Add test.support.catch_unraisable_exception()

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3042,15 +3042,13 @@ class catch_unraisable_exception:
 
     Usage:
 
-        try:
-            with support.catch_unraisable_exception() as cm:
-                ...
-
-            # check the expected unraisable exception
+        with support.catch_unraisable_exception() as cm:
             ...
-        finally:
-            # Explicitly break reference cycle
-            cm = None
+
+            # check the expected unraisable exception: use cm.unraisable
+            ...
+
+        # cm.unraisable is None here (to break a reference cycle)
 
     The finally block is required: cm.unraisable contains a traceback object
     which indirectly references the 'cm' variable, it's a reference cycle.
@@ -3069,4 +3067,6 @@ class catch_unraisable_exception:
         return self
 
     def __exit__(self, *exc_info):
+        # Clear the unraisable exception to explicitly break a reference cycle
+        self.unraisable = None
         sys.unraisablehook = self._old_hook

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3034,3 +3034,39 @@ def collision_stats(nbins, nballs):
         collisions = k - occupied
         var = dn*(dn-1)*((dn-2)/dn)**k + meanempty * (1 - meanempty)
         return float(collisions), float(var.sqrt())
+
+
+class catch_unraisable_exception:
+    """
+    Context manager catching unraisable exception using sys.unraisablehook.
+
+    Usage:
+
+        try:
+            with support.catch_unraisable_exception() as cm:
+                ...
+
+            # check the expected unraisable exception
+            ...
+        finally:
+            # Explicitly break reference cycle
+            cm = None
+
+    The finally block is required: cm.unraisable contains a traceback object
+    which indirectly references the 'cm' variable, it's a reference cycle.
+    """
+
+    def __init__(self):
+        self.unraisable = None
+        self._old_hook = None
+
+    def _hook(self, unraisable):
+        self.unraisable = unraisable
+
+    def __enter__(self):
+        self._old_hook = sys.unraisablehook
+        sys.unraisablehook = self._hook
+        return self
+
+    def __exit__(self, *exc_info):
+        sys.unraisablehook = self._old_hook

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3049,9 +3049,6 @@ class catch_unraisable_exception:
             ...
 
         # cm.unraisable is None here (to break a reference cycle)
-
-    The finally block is required: cm.unraisable contains a traceback object
-    which indirectly references the 'cm' variable, it's a reference cycle.
     """
 
     def __init__(self):

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2342,12 +2342,24 @@ class OriginTrackingTest(unittest.TestCase):
         orig_wuc = warnings._warn_unawaited_coroutine
         try:
             warnings._warn_unawaited_coroutine = lambda coro: 1/0
-            with support.captured_stderr() as stream:
-                corofn()
-                support.gc_collect()
-            self.assertIn("Exception ignored in", stream.getvalue())
-            self.assertIn("ZeroDivisionError", stream.getvalue())
-            self.assertIn("was never awaited", stream.getvalue())
+            try:
+                # Note: catch_unraisable_exception() resurect the coroutine
+                with support.catch_unraisable_exception() as cm, \
+                     support.captured_stderr() as stream:
+                    # only store repr() to avoid keeping the coroutine alive
+                    coro = corofn()
+                    coro_repr = repr(coro)
+
+                    # clear reference to the coroutine without awaiting for it
+                    del coro
+                    support.gc_collect()
+
+                self.assertEqual(repr(cm.unraisable.object), coro_repr)
+                self.assertEqual(cm.unraisable.exc_type, ZeroDivisionError)
+                self.assertIn("was never awaited", stream.getvalue())
+            finally:
+                # Explicitly break reference cycle
+                cm = None
 
             del warnings._warn_unawaited_coroutine
             with support.captured_stderr() as stream:

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2342,24 +2342,19 @@ class OriginTrackingTest(unittest.TestCase):
         orig_wuc = warnings._warn_unawaited_coroutine
         try:
             warnings._warn_unawaited_coroutine = lambda coro: 1/0
-            try:
-                # Note: catch_unraisable_exception() resurect the coroutine
-                with support.catch_unraisable_exception() as cm, \
-                     support.captured_stderr() as stream:
-                    # only store repr() to avoid keeping the coroutine alive
-                    coro = corofn()
-                    coro_repr = repr(coro)
+            with support.catch_unraisable_exception() as cm, \
+                 support.captured_stderr() as stream:
+                # only store repr() to avoid keeping the coroutine alive
+                coro = corofn()
+                coro_repr = repr(coro)
 
-                    # clear reference to the coroutine without awaiting for it
-                    del coro
-                    support.gc_collect()
+                # clear reference to the coroutine without awaiting for it
+                del coro
+                support.gc_collect()
 
                 self.assertEqual(repr(cm.unraisable.object), coro_repr)
                 self.assertEqual(cm.unraisable.exc_type, ZeroDivisionError)
                 self.assertIn("was never awaited", stream.getvalue())
-            finally:
-                # Explicitly break reference cycle
-                cm = None
 
             del warnings._warn_unawaited_coroutine
             with support.captured_stderr() as stream:

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1193,15 +1193,12 @@ class ExceptionTests(unittest.TestCase):
         for test_class in (BrokenDel, BrokenExceptionDel):
             with self.subTest(test_class):
                 obj = test_class()
-                try:
-                    with support.catch_unraisable_exception() as cm:
-                        del obj
+                with support.catch_unraisable_exception() as cm:
+                    del obj
 
-                    self.assertEqual(cm.unraisable.object, test_class.__del__)
+                    self.assertEqual(cm.unraisable.object,
+                                     test_class.__del__)
                     self.assertIsNotNone(cm.unraisable.exc_traceback)
-                finally:
-                    # Explicitly break reference cycle
-                    cm = None
 
     def test_unhandled(self):
         # Check for sensible reporting of unhandled exceptions

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1184,21 +1184,12 @@ class ExceptionTests(unittest.TestCase):
                 # The following line is included in the traceback report:
                 raise exc
 
-        class BrokenExceptionDel:
-            def __del__(self):
-                exc = BrokenStrException()
-                # The following line is included in the traceback report:
-                raise exc
+        obj = BrokenDel()
+        with support.catch_unraisable_exception() as cm:
+            del obj
 
-        for test_class in (BrokenDel, BrokenExceptionDel):
-            with self.subTest(test_class):
-                obj = test_class()
-                with support.catch_unraisable_exception() as cm:
-                    del obj
-
-                    self.assertEqual(cm.unraisable.object,
-                                     test_class.__del__)
-                    self.assertIsNotNone(cm.unraisable.exc_traceback)
+            self.assertEqual(cm.unraisable.object, BrokenDel.__del__)
+            self.assertIsNotNone(cm.unraisable.exc_traceback)
 
     def test_unhandled(self):
         # Check for sensible reporting of unhandled exceptions

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -2167,7 +2167,7 @@ to test.
 ...     l = Leaker()
 ...     del l
 ...
-...     Leaker.__del__ == cm.unraisable.object
+...     cm.unraisable.object == Leaker.__del__
 ...     cm.unraisable.exc_type == RuntimeError
 ...     str(cm.unraisable.exc_value) == "del failed"
 ...     cm.unraisable.exc_traceback is not None

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -2163,18 +2163,14 @@ to test.
 ...             raise RuntimeError(message)
 ...         invoke("del failed")
 ...
->>> try:
-...     with support.catch_unraisable_exception() as cm:
-...         l = Leaker()
-...         del l
+>>> with support.catch_unraisable_exception() as cm:
+...     l = Leaker()
+...     del l
 ...
 ...     Leaker.__del__ == cm.unraisable.object
 ...     cm.unraisable.exc_type == RuntimeError
 ...     str(cm.unraisable.exc_value) == "del failed"
 ...     cm.unraisable.exc_traceback is not None
-... finally:
-...     # Explicitly break reference cycle
-...     cm = None
 True
 True
 True

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -909,6 +909,47 @@ class UnraisableHookTest(unittest.TestCase):
         self.assertIn('Traceback (most recent call last):\n', err)
         self.assertIn('ValueError: 42\n', err)
 
+    def test_original_unraisablehook_err(self):
+        # bpo-22836: PyErr_WriteUnraisable() should give sensible reports
+        class BrokenDel:
+            def __del__(self):
+                exc = ValueError("del is broken")
+                # The following line is included in the traceback report:
+                raise exc
+
+        class BrokenStrException(Exception):
+            def __str__(self):
+                raise Exception("str() is broken")
+
+        class BrokenExceptionDel:
+            def __del__(self):
+                exc = BrokenStrException()
+                # The following line is included in the traceback report:
+                raise exc
+
+        for test_class in (BrokenDel, BrokenExceptionDel):
+            with self.subTest(test_class):
+                obj = test_class()
+                with test.support.captured_stderr() as stderr, \
+                     test.support.swap_attr(sys, 'unraisablehook',
+                                            sys.__unraisablehook__):
+                    # Trigger obj.__del__()
+                    del obj
+
+                report = stderr.getvalue()
+                self.assertIn("Exception ignored", report)
+                self.assertIn(test_class.__del__.__qualname__, report)
+                self.assertIn("test_sys.py", report)
+                self.assertIn("raise exc", report)
+                if test_class is BrokenExceptionDel:
+                    self.assertIn("BrokenStrException", report)
+                    self.assertIn("<exception str() failed>", report)
+                else:
+                    self.assertIn("ValueError", report)
+                    self.assertIn("del is broken", report)
+                self.assertTrue(report.endswith("\n"))
+
+
     def test_original_unraisablehook_wrong_type(self):
         exc = ValueError(42)
         with test.support.swap_attr(sys, 'unraisablehook',

--- a/Misc/NEWS.d/next/Tests/2019-05-22-12-57-15.bpo-36829.e9mRWC.rst
+++ b/Misc/NEWS.d/next/Tests/2019-05-22-12-57-15.bpo-36829.e9mRWC.rst
@@ -1,0 +1,2 @@
+Add :func:`test.support.catch_unraisable_exception`: context manager
+catching unraisable exception using :func:`sys.unraisablehook`.


### PR DESCRIPTION
* Copy test_exceptions.test_unraisable() to
  test_sys.UnraisableHookTest().
* test_exceptions.test_unraisable() uses catch_unraisable_exception();
  simplify the test. test_sys now checks the exact output.
* Use catch_unraisable_exception() in test_coroutines,
  test_exceptions, test_generators.

<!-- issue-number: [bpo-36829](https://bugs.python.org/issue36829) -->
https://bugs.python.org/issue36829
<!-- /issue-number -->
