### PR TITLE
[3.7] bpo-37012 Fix a possible crash due to PyType_FromSpecWithBases() (GH-10304)

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2938,6 +2938,7 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
             size_t len = strlen(old_doc)+1;
             char *tp_doc = PyObject_MALLOC(len);
             if (tp_doc == NULL) {
+                type->tp_doc = NULL;
                 PyErr_NoMemory();
                 goto fail;
             }


### PR DESCRIPTION
If the PyObject_MALLOC() call failed in PyType_FromSpecWithBases(),
PyObject_Free() would be called on a static string in type_dealloc().
(cherry picked from commit 0613c1e481440aa8f54ba7f6056924c175fbcc13)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>


<!-- issue-number: [bpo-37012](https://bugs.python.org/issue37012) -->
https://bugs.python.org/issue37012
<!-- /issue-number -->
