### PR TITLE
bpo-37011: Make PDB reset the original trace function when leaving

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1089,7 +1089,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         argument (which is an arbitrary expression or statement to be
         executed in the current environment).
         """
-        sys.settrace(None)
+        self._resettrace()
         globals = self.curframe.f_globals
         locals = self.curframe_locals
         p = Pdb(self.completekey, self.stdin, self.stdout)
@@ -1101,7 +1101,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             exc_info = sys.exc_info()[:2]
             self.error(traceback.format_exception_only(*exc_info)[-1].strip())
         self.message("LEAVING RECURSIVE DEBUGGER")
-        sys.settrace(self.trace_dispatch)
+        self._settrace(self.trace_dispatch)
         self.lastcmd = p.lastcmd
 
     complete_debug = _complete_expression

--- a/Misc/NEWS.d/next/Library/2019-05-22-16-38-37.bpo-37011.tGBbTH.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-22-16-38-37.bpo-37011.tGBbTH.rst
@@ -1,0 +1,2 @@
+PDB now reset the previous tracing function when leaving. Patch contributed
+by Rémi Lapeyre.

--- a/Misc/NEWS.d/next/Library/2019-05-22-16-38-37.bpo-37011.tGBbTH.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-22-16-38-37.bpo-37011.tGBbTH.rst
@@ -1,2 +1,2 @@
-PDB now reset the previous tracing function when leaving. Patch contributed
+PDB now resets the previous tracing function when leaving. Patch contributed
 by Rémi Lapeyre.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37011](https://bugs.python.org/issue37011) -->
https://bugs.python.org/issue37011
<!-- /issue-number -->
