### PR TITLE
[3.7] bpo-33482: fix codecs.StreamRecoder.writelines (GH-6779)

### DIFF
--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -838,7 +838,7 @@ class StreamRecoder:
 
     def writelines(self, list):
 
-        data = ''.join(list)
+        data = b''.join(list)
         data, bytesdecoded = self.decode(data, self.errors)
         return self.writer.write(data)
 

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3298,5 +3298,26 @@ class Latin1Test(unittest.TestCase):
                 self.assertEqual(data.decode('latin1'), expected)
 
 
+class StreamRecoderTest(unittest.TestCase):
+    def test_writelines(self):
+        bio = io.BytesIO()
+        codec = codecs.lookup('ascii')
+        sr = codecs.StreamRecoder(bio, codec.encode, codec.decode,
+                                  encodings.ascii.StreamReader, encodings.ascii.StreamWriter)
+        sr.writelines([b'a', b'b'])
+        self.assertEqual(bio.getvalue(), b'ab')
+
+    def test_write(self):
+        bio = io.BytesIO()
+        codec = codecs.lookup('latin1')
+        # Recode from Latin-1 to utf-8.
+        sr = codecs.StreamRecoder(bio, codec.encode, codec.decode,
+                                  encodings.utf_8.StreamReader, encodings.utf_8.StreamWriter)
+
+        text = 'àñé'
+        sr.write(text.encode('latin1'))
+        self.assertEqual(bio.getvalue(), text.encode('utf-8'))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Documentation/2018-05-13-10-36-37.bpo-33482.jalAaQ.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-13-10-36-37.bpo-33482.jalAaQ.rst
@@ -1,0 +1,1 @@
+Make `codecs.StreamRecoder.writelines` take a list of bytes.


### PR DESCRIPTION
A very simple fix. I found this while writing typeshed stubs for StreamRecoder.

https://bugs.python.org/issue33482.
(cherry picked from commit b3be4072888a4ce054993c2801802721466ea02d)

Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-33482](https://bugs.python.org/issue33482) -->
https://bugs.python.org/issue33482
<!-- /issue-number -->
