### PR TITLE
[3.7] bpo-35907, CVE-2019-9948: urllib rejects local_file:// scheme (GH-13474)

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -16,6 +16,7 @@ except ImportError:
     ssl = None
 import sys
 import tempfile
+import warnings
 from nturl2path import url2pathname, pathname2url
 
 from base64 import b64encode
@@ -1462,6 +1463,23 @@ class URLopener_Tests(unittest.TestCase):
             self.assertEqual(DummyURLopener().open(
                 "spam://c:|windows%/:=&?~#+!$,;'@()*[]|/path/"),
                 "//c:|windows%/:=&?~#+!$,;'@()*[]|/path/")
+
+    def test_local_file_open(self):
+        # bpo-35907, CVE-2019-9948: urllib must reject local_file:// scheme
+        class DummyURLopener(urllib.request.URLopener):
+            def open_local_file(self, url):
+                return url
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("ignore", DeprecationWarning)
+
+            for url in ('local_file://example', 'local-file://example'):
+                self.assertRaises(OSError, urllib.request.urlopen, url)
+                self.assertRaises(OSError, urllib.request.URLopener().open, url)
+                self.assertRaises(OSError, urllib.request.URLopener().retrieve, url)
+                self.assertRaises(OSError, DummyURLopener().open, url)
+                self.assertRaises(OSError, DummyURLopener().retrieve, url)
+
 
 # Just commented them out.
 # Can't really tell why keep failing in windows and sparc.

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1746,7 +1746,7 @@ class URLopener:
         name = 'open_' + urltype
         self.type = urltype
         name = name.replace('-', '_')
-        if not hasattr(self, name):
+        if not hasattr(self, name) or name == 'open_local_file':
             if proxy:
                 return self.open_unknown_proxy(proxy, fullurl, data)
             else:

--- a/Misc/NEWS.d/next/Security/2019-05-21-23-20-18.bpo-35907.NC_zNK.rst
+++ b/Misc/NEWS.d/next/Security/2019-05-21-23-20-18.bpo-35907.NC_zNK.rst
@@ -1,0 +1,2 @@
+CVE-2019-9948: Avoid file reading as disallowing the unnecessary URL scheme in
+``URLopener().open()`` and ``URLopener().retrieve()`` of :mod:`urllib.request`.


### PR DESCRIPTION
CVE-2019-9948: Avoid file reading as disallowing the unnecessary URL
scheme in URLopener().open() and URLopener().retrieve()
of urllib.request.

Co-Authored-By: SH <push0ebp@gmail.com>
(cherry picked from commit 0c2b6a3943aa7b022e8eb4bfd9bffcddebf9a587)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35907](https://bugs.python.org/issue35907) -->
https://bugs.python.org/issue35907
<!-- /issue-number -->
