### PR TITLE
[2.7] bpo-35907: Complete test_urllib.test_local_file_open()

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1049,12 +1049,16 @@ class URLopener_Tests(unittest.TestCase):
             "//c:|windows%/:=&?~#+!$,;'@()*[]|/path/")
 
     def test_local_file_open(self):
+        # bpo-35907, CVE-2019-9948: urllib must reject local_file:// scheme
         class DummyURLopener(urllib.URLopener):
             def open_local_file(self, url):
                 return url
         for url in ('local_file://example', 'local-file://example'):
-            self.assertRaises(IOError, DummyURLopener().open, url)
             self.assertRaises(IOError, urllib.urlopen, url)
+            self.assertRaises(IOError, urllib.URLopener().open, url)
+            self.assertRaises(IOError, urllib.URLopener().retrieve, url)
+            self.assertRaises(IOError, DummyURLopener().open, url)
+            self.assertRaises(IOError, DummyURLopener().retrieve, url)
 
 # Just commented them out.
 # Can't really tell why keep failing in windows and sparc.

--- a/Misc/NEWS.d/next/Library/2019-02-13-17-21-10.bpo-35907.ckk2zg.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-13-17-21-10.bpo-35907.ckk2zg.rst
@@ -1,1 +1,3 @@
-CVE-2019-9948: Avoid file reading as disallowing the unnecessary URL scheme in urllib.urlopen
+CVE-2019-9948: Avoid file reading as disallowing the unnecessary URL scheme in
+:func:`urllib.urlopen`, :meth:`urllib.URLopener.open` and
+:meth:`urllib.URLopener.retrieve`.


### PR DESCRIPTION
Test also URLopener().open(), URLopener().retrieve(), and
DummyURLopener().retrieve().

<!-- issue-number: [bpo-35907](https://bugs.python.org/issue35907) -->
https://bugs.python.org/issue35907
<!-- /issue-number -->
