### PR TITLE
bpo-36829: PyErr_WriteUnraisable() normalizes exception

### DIFF
--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -86,6 +86,10 @@ PyAPI_FUNC(void) _Py_DumpHexadecimal(
     unsigned long value,
     Py_ssize_t width);
 
+PyAPI_FUNC(PyObject*) _PyTraceBack_FromFrame(
+    PyObject *tb_next,
+    struct _frame *frame);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -882,7 +882,6 @@ class UnraisableHookTest(unittest.TestCase):
         import _testcapi
         import types
         try:
-            # raise the exception to get a traceback in the except block
             _testcapi.write_unraisable_exc(exc, obj)
             return types.SimpleNamespace(exc_type=type(exc),
                                          exc_value=exc,

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -883,18 +883,14 @@ class UnraisableHookTest(unittest.TestCase):
         import types
         try:
             # raise the exception to get a traceback in the except block
-            try:
-                raise exc
-            except Exception as exc2:
-                _testcapi.write_unraisable_exc(exc2, obj)
-                return types.SimpleNamespace(exc_type=type(exc2),
-                                             exc_value=exc2,
-                                             exc_traceback=exc2.__traceback__,
-                                             object=obj)
+            _testcapi.write_unraisable_exc(exc, obj)
+            return types.SimpleNamespace(exc_type=type(exc),
+                                         exc_value=exc,
+                                         exc_traceback=exc.__traceback__,
+                                         object=obj)
         finally:
             # Explicitly break any reference cycle
             exc = None
-            exc2 = None
 
     def test_original_unraisablehook(self):
         obj = "an object"

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-22-23-01-29.bpo-36829.MfOcUg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-22-23-01-29.bpo-36829.MfOcUg.rst
@@ -1,0 +1,4 @@
+:c:func:`PyErr_WriteUnraisable` now creates a traceback object if there is
+no current traceback. Moreover, call :c:func:`PyErr_NormalizeException` and
+:c:func:`PyException_SetTraceback` to normalize the exception value. Ignore any
+error.

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -227,13 +227,26 @@ PyTypeObject PyTraceBack_Type = {
     tb_new,                                     /* tp_new */
 };
 
+
+PyObject*
+_PyTraceBack_FromFrame(PyObject *tb_next, PyFrameObject *frame)
+{
+    if (tb_next != NULL && !PyTraceBack_Check(tb_next)) {
+        PyErr_BadInternalCall();
+        return NULL;
+    }
+
+    return tb_create_raw((PyTracebackObject *)tb_next, frame, frame->f_lasti,
+                         PyFrame_GetLineNumber(frame));
+}
+
+
 int
 PyTraceBack_Here(PyFrameObject *frame)
 {
     PyObject *exc, *val, *tb, *newtb;
     PyErr_Fetch(&exc, &val, &tb);
-    newtb = tb_create_raw((PyTracebackObject *)tb, frame, frame->f_lasti,
-                          PyFrame_GetLineNumber(frame));
+    newtb = _PyTraceBack_FromFrame(tb, frame);
     if (newtb == NULL) {
         _PyErr_ChainExceptions(exc, val, tb);
         return -1;

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -231,10 +231,8 @@ PyTypeObject PyTraceBack_Type = {
 PyObject*
 _PyTraceBack_FromFrame(PyObject *tb_next, PyFrameObject *frame)
 {
-    if (tb_next != NULL && !PyTraceBack_Check(tb_next)) {
-        PyErr_BadInternalCall();
-        return NULL;
-    }
+    assert(tb_next == NULL || PyTraceBack_Check(tb_next));
+    assert(frame != NULL);
 
     return tb_create_raw((PyTracebackObject *)tb_next, frame, frame->f_lasti,
                          PyFrame_GetLineNumber(frame));


### PR DESCRIPTION
PyErr_WriteUnraisable() now creates a traceback object if there is no
current traceback. Moreover, call PyErr_NormalizeException() and
PyException_SetTraceback() to normalize the exception value.

<!-- issue-number: [bpo-36829](https://bugs.python.org/issue36829) -->
https://bugs.python.org/issue36829
<!-- /issue-number -->
