### PR TITLE
bpo-18748: _pyio.IOBase emits unraisable exception

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -303,7 +303,7 @@ for :func:`property`, :func:`classmethod`, and :func:`staticmethod`::
 io
 --
 
-In development mode (:opt:`-X` ``env``) and in debug build, the
+In development mode (:option:`-X` ``env``) and in debug build, the
 :class:`io.IOBase` finalizer now logs the exception if the ``close()`` method
 fails. The exception is ignored silently by default in release build.
 (Contributed by Victor Stinner in :issue:`18748`.)

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -300,6 +300,15 @@ for :func:`property`, :func:`classmethod`, and :func:`staticmethod`::
           self.bit_rate = round(bit_rate / 1000.0, 1)
           self.duration = ceil(duration)
 
+io
+--
+
+In development mode (:opt:`-X` ``env``) and in debug build, the
+:class:`io.IOBase` finalizer now logs the exception if the ``close()`` method
+fails. The exception is ignored silently by default in release build.
+(Contributed by Victor Stinner in :issue:`18748`.)
+
+
 gc
 --
 

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -67,9 +67,9 @@ MEMORY_SANITIZER = (
     '--with-memory-sanitizer' in _config_args
 )
 
-# Does io.IOBase logs unhandled exceptions on calling close()?
-# They are silenced by default in release build.
-DESTRUCTOR_LOG_ERRORS = (hasattr(sys, "gettotalrefcount") or sys.flags.dev_mode)
+# Does io.IOBase finalizer log the exception if the close() method fails?
+# The exception is ignored silently by default in release build.
+IOBASE_EMITS_UNRAISABLE = (hasattr(sys, "gettotalrefcount") or sys.flags.dev_mode)
 
 
 def _default_chunk_size():
@@ -1098,23 +1098,19 @@ class CommonBufferedTests:
         # Test that the exception state is not modified by a destructor,
         # even if close() fails.
         rawio = self.CloseFailureIO()
-        def f():
-            self.tp(rawio).xyzzy
-        with support.captured_output("stderr") as s:
-            self.assertRaises(AttributeError, f)
-        s = s.getvalue().strip()
-        if s:
-            # The destructor *may* have printed an unraisable error, check it
-            lines = s.splitlines()
-            if DESTRUCTOR_LOG_ERRORS:
-                self.assertEqual(len(lines), 5)
-                self.assertTrue(lines[0].startswith("Exception ignored in: "), lines)
-                self.assertEqual(lines[1], "Traceback (most recent call last):", lines)
-                self.assertEqual(lines[4], 'OSError:', lines)
+        try:
+            with support.catch_unraisable_exception() as cm:
+                with self.assertRaises(AttributeError):
+                    self.tp(rawio).xyzzy
+
+            if IOBASE_EMITS_UNRAISABLE:
+                self.assertIsNotNone(cm.unraisable)
+                self.assertEqual(cm.unraisable.exc_type, OSError)
             else:
-                self.assertEqual(len(lines), 1)
-                self.assertTrue(lines[-1].startswith("Exception OSError: "), lines)
-                self.assertTrue(lines[-1].endswith(" ignored"), lines)
+                self.assertIsNone(cm.unraisable)
+        finally:
+            # Explicitly break reference cycle
+            cm = None
 
     def test_repr(self):
         raw = self.MockRawIO()
@@ -2859,23 +2855,19 @@ class TextIOWrapperTest(unittest.TestCase):
         # Test that the exception state is not modified by a destructor,
         # even if close() fails.
         rawio = self.CloseFailureIO()
-        def f():
-            self.TextIOWrapper(rawio).xyzzy
-        with support.captured_output("stderr") as s:
-            self.assertRaises(AttributeError, f)
-        s = s.getvalue().strip()
-        if s:
-            # The destructor *may* have printed an unraisable error, check it
-            lines = s.splitlines()
-            if DESTRUCTOR_LOG_ERRORS:
-                self.assertEqual(len(lines), 5)
-                self.assertTrue(lines[0].startswith("Exception ignored in: "), lines)
-                self.assertEqual(lines[1], "Traceback (most recent call last):", lines)
-                self.assertEqual(lines[4], 'OSError:', lines)
+        try:
+            with support.catch_unraisable_exception() as cm:
+                with self.assertRaises(AttributeError):
+                    self.TextIOWrapper(rawio).xyzzy
+
+            if IOBASE_EMITS_UNRAISABLE:
+                self.assertIsNotNone(cm.unraisable)
+                self.assertEqual(cm.unraisable.exc_type, OSError)
             else:
-                self.assertEqual(len(lines), 1)
-                self.assertTrue(lines[-1].startswith("Exception OSError: "), lines)
-                self.assertTrue(lines[-1].endswith(" ignored"), lines)
+                self.assertIsNone(cm.unraisable)
+        finally:
+            # Explicitly break reference cycle
+            cm = None
 
     # Systematic tests of the text I/O API
 

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1103,11 +1103,10 @@ class CommonBufferedTests:
                 with self.assertRaises(AttributeError):
                     self.tp(rawio).xyzzy
 
-            if IOBASE_EMITS_UNRAISABLE:
-                self.assertIsNotNone(cm.unraisable)
-                self.assertEqual(cm.unraisable.exc_type, OSError)
-            else:
+            if not IOBASE_EMITS_UNRAISABLE:
                 self.assertIsNone(cm.unraisable)
+            elif cm.unraisable is not None:
+                self.assertEqual(cm.unraisable.exc_type, OSError)
         finally:
             # Explicitly break reference cycle
             cm = None
@@ -2860,11 +2859,10 @@ class TextIOWrapperTest(unittest.TestCase):
                 with self.assertRaises(AttributeError):
                     self.TextIOWrapper(rawio).xyzzy
 
-            if IOBASE_EMITS_UNRAISABLE:
-                self.assertIsNotNone(cm.unraisable)
-                self.assertEqual(cm.unraisable.exc_type, OSError)
-            else:
+            if not IOBASE_EMITS_UNRAISABLE:
                 self.assertIsNone(cm.unraisable)
+            elif cm.unraisable is not None:
+                self.assertEqual(cm.unraisable.exc_type, OSError)
         finally:
             # Explicitly break reference cycle
             cm = None


### PR DESCRIPTION
In development (-X dev) mode and in a debug build, IOBase finalizer
of the _pyio module now logs the exception if the close() method
fails. The exception is ignored silently by default in release build.

test_io: test_error_through_destructor() now uses
support.catch_unraisable_exception() rather than capturing stderr.

<!-- issue-number: [bpo-18748](https://bugs.python.org/issue18748) -->
https://bugs.python.org/issue18748
<!-- /issue-number -->
