### PR TITLE
bpo-37017: Make PyObject_CallMethodObjArgs use LOAD_METHOD optimization

### DIFF
--- a/Misc/NEWS.d/next/C API/2019-05-22-17-33-52.bpo-37107.8BVPR-.rst
+++ b/Misc/NEWS.d/next/C API/2019-05-22-17-33-52.bpo-37107.8BVPR-.rst
@@ -1,2 +1,4 @@
-Update PyObject_CallMethodObjArgs and _PyObject_CallMethodIdObjArgs to use
-_PyObject_GetMethod to avoid creating a bound method object in many cases.
+Update c:func:PyObject_CallMethodObjArgs and c:func:_PyObject_CallMethodIdObjArgs
+to use c:func:_PyObject_GetMethod to avoid creating a bound method object in many
+cases.
+Patch by Michael J. Sullivan.

--- a/Misc/NEWS.d/next/C API/2019-05-22-17-33-52.bpo-37107.8BVPR-.rst
+++ b/Misc/NEWS.d/next/C API/2019-05-22-17-33-52.bpo-37107.8BVPR-.rst
@@ -1,0 +1,2 @@
+Update PyObject_CallMethodObjArgs and _PyObject_CallMethodIdObjArgs to use
+_PyObject_GetMethod to avoid creating a bound method object in many cases.

--- a/Misc/NEWS.d/next/C API/2019-05-22-17-33-52.bpo-37107.8BVPR-.rst
+++ b/Misc/NEWS.d/next/C API/2019-05-22-17-33-52.bpo-37107.8BVPR-.rst
@@ -1,4 +1,4 @@
-Update c:func:PyObject_CallMethodObjArgs and c:func:_PyObject_CallMethodIdObjArgs
-to use c:func:_PyObject_GetMethod to avoid creating a bound method object in many
+Update :c:func:`PyObject_CallMethodObjArgs` and ``_PyObject_CallMethodIdObjArgs``
+to use ``_PyObject_GetMethod`` to avoid creating a bound method object in many
 cases.
 Patch by Michael J. Sullivan.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1159,7 +1159,7 @@ _PyObject_CallMethodId_SizeT(PyObject *obj, _Py_Identifier *name,
 /* --- Call with "..." arguments ---------------------------------- */
 
 static PyObject *
-object_vacall(PyObject *callable, va_list vargs)
+object_vacall(PyObject *base, PyObject *callable, va_list vargs)
 {
     PyObject *small_stack[_PY_FASTCALL_SMALL_STACK];
     PyObject **stack;
@@ -1174,7 +1174,7 @@ object_vacall(PyObject *callable, va_list vargs)
 
     /* Count the number of arguments */
     va_copy(countva, vargs);
-    nargs = 0;
+    nargs = base ? 1 : 0;
     while (1) {
         PyObject *arg = va_arg(countva, PyObject *);
         if (arg == NULL) {
@@ -1196,7 +1196,12 @@ object_vacall(PyObject *callable, va_list vargs)
         }
     }
 
-    for (i = 0; i < nargs; ++i) {
+    i = 0;
+    if (base) {
+        stack[i++] = base;
+    }
+
+    for (; i < nargs; ++i) {
         stack[i] = va_arg(vargs, PyObject *);
     }
 
@@ -1210,23 +1215,28 @@ object_vacall(PyObject *callable, va_list vargs)
 }
 
 
+/* Private API for the LOAD_METHOD opcode. */
+extern int _PyObject_GetMethod(PyObject *, PyObject *, PyObject **);
+
 PyObject *
-PyObject_CallMethodObjArgs(PyObject *callable, PyObject *name, ...)
+PyObject_CallMethodObjArgs(PyObject *obj, PyObject *name, ...)
 {
     va_list vargs;
-    PyObject *result;
+    PyObject *callable, *result;
+    int is_method;
 
-    if (callable == NULL || name == NULL) {
+    if (obj == NULL || name == NULL) {
         return null_error();
     }
 
-    callable = PyObject_GetAttr(callable, name);
+    is_method = _PyObject_GetMethod(obj, name, &callable);
     if (callable == NULL) {
         return NULL;
     }
+    obj = is_method ? obj : NULL;
 
     va_start(vargs, name);
-    result = object_vacall(callable, vargs);
+    result = object_vacall(obj, callable, vargs);
     va_end(vargs);
 
     Py_DECREF(callable);
@@ -1240,18 +1250,24 @@ _PyObject_CallMethodIdObjArgs(PyObject *obj,
 {
     va_list vargs;
     PyObject *callable, *result;
+    int is_method;
 
     if (obj == NULL || name == NULL) {
         return null_error();
     }
 
-    callable = _PyObject_GetAttrId(obj, name);
+    PyObject *oname = _PyUnicode_FromId(name); /* borrowed */
+    if (!oname)
+        return NULL;
+
+    is_method = _PyObject_GetMethod(obj, oname, &callable);
     if (callable == NULL) {
         return NULL;
     }
+    obj = is_method ? obj : NULL;
 
     va_start(vargs, name);
-    result = object_vacall(callable, vargs);
+    result = object_vacall(obj, callable, vargs);
     va_end(vargs);
 
     Py_DECREF(callable);
@@ -1266,7 +1282,7 @@ PyObject_CallFunctionObjArgs(PyObject *callable, ...)
     PyObject *result;
 
     va_start(vargs, callable);
-    result = object_vacall(callable, vargs);
+    result = object_vacall(NULL, callable, vargs);
     va_end(vargs);
 
     return result;

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1229,6 +1229,7 @@ PyObject_CallMethodObjArgs(PyObject *obj, PyObject *name, ...)
         return null_error();
     }
 
+    callable = NULL;
     is_method = _PyObject_GetMethod(obj, name, &callable);
     if (callable == NULL) {
         return NULL;
@@ -1260,6 +1261,7 @@ _PyObject_CallMethodIdObjArgs(PyObject *obj,
     if (!oname)
         return NULL;
 
+    callable = NULL;
     is_method = _PyObject_GetMethod(obj, oname, &callable);
     if (callable == NULL) {
         return NULL;

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1222,15 +1222,14 @@ PyObject *
 PyObject_CallMethodObjArgs(PyObject *obj, PyObject *name, ...)
 {
     va_list vargs;
-    PyObject *callable, *result;
-    int is_method;
+    PyObject *result;
 
     if (obj == NULL || name == NULL) {
         return null_error();
     }
 
-    callable = NULL;
-    is_method = _PyObject_GetMethod(obj, name, &callable);
+    PyObject *callable = NULL;
+    int is_method = _PyObject_GetMethod(obj, name, &callable);
     if (callable == NULL) {
         return NULL;
     }
@@ -1250,8 +1249,7 @@ _PyObject_CallMethodIdObjArgs(PyObject *obj,
                               struct _Py_Identifier *name, ...)
 {
     va_list vargs;
-    PyObject *callable, *result;
-    int is_method;
+    PyObject *result;
 
     if (obj == NULL || name == NULL) {
         return null_error();
@@ -1261,8 +1259,8 @@ _PyObject_CallMethodIdObjArgs(PyObject *obj,
     if (!oname)
         return NULL;
 
-    callable = NULL;
-    is_method = _PyObject_GetMethod(obj, oname, &callable);
+    PyObject *callable = NULL;
+    int is_method = _PyObject_GetMethod(obj, oname, &callable);
     if (callable == NULL) {
         return NULL;
     }

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1221,9 +1221,6 @@ extern int _PyObject_GetMethod(PyObject *, PyObject *, PyObject **);
 PyObject *
 PyObject_CallMethodObjArgs(PyObject *obj, PyObject *name, ...)
 {
-    va_list vargs;
-    PyObject *result;
-
     if (obj == NULL || name == NULL) {
         return null_error();
     }
@@ -1235,8 +1232,9 @@ PyObject_CallMethodObjArgs(PyObject *obj, PyObject *name, ...)
     }
     obj = is_method ? obj : NULL;
 
+    va_list vargs;
     va_start(vargs, name);
-    result = object_vacall(obj, callable, vargs);
+    PyObject *result = object_vacall(obj, callable, vargs);
     va_end(vargs);
 
     Py_DECREF(callable);
@@ -1248,16 +1246,14 @@ PyObject *
 _PyObject_CallMethodIdObjArgs(PyObject *obj,
                               struct _Py_Identifier *name, ...)
 {
-    va_list vargs;
-    PyObject *result;
-
     if (obj == NULL || name == NULL) {
         return null_error();
     }
 
     PyObject *oname = _PyUnicode_FromId(name); /* borrowed */
-    if (!oname)
+    if (!oname) {
         return NULL;
+    }
 
     PyObject *callable = NULL;
     int is_method = _PyObject_GetMethod(obj, oname, &callable);
@@ -1266,8 +1262,9 @@ _PyObject_CallMethodIdObjArgs(PyObject *obj,
     }
     obj = is_method ? obj : NULL;
 
+    va_list vargs;
     va_start(vargs, name);
-    result = object_vacall(obj, callable, vargs);
+    PyObject *result = object_vacall(obj, callable, vargs);
     va_end(vargs);
 
     Py_DECREF(callable);


### PR DESCRIPTION
Update PyObject_CallMethodObjArgs and _PyObject_CallMethodIdObjArgs
to use _PyObject_GetMethod to avoid creating a bound method object
in many cases.

On a microbenchmark of PyObject_CallMethodObjArgs calling a method on
an interpreted Python class, this optimization resulted in a 1.7x
speedup.

<!-- issue-number: [bpo-37017](https://bugs.python.org/issue37017) -->
https://bugs.python.org/issue37017
<!-- /issue-number -->
