### PR TITLE
[2.7] bpo-36713: Rename duplicated method in test_unicode.

### DIFF
--- a/Lib/ctypes/test/test_unicode.py
+++ b/Lib/ctypes/test/test_unicode.py
@@ -93,7 +93,7 @@ class StringTestCase(UnicodeTestCase):
         func.argtypes = None
         func.restype = ctypes.c_int
 
-    def test_ascii_replace(self):
+    def test_ascii_strict(self):
         func = self.func
         ctypes.set_conversion_mode("ascii", "strict")
         self.assertEqual(func("abc"), "abc")

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -47,6 +47,7 @@ Juancarlo Añez
 Chris Angelico
 Jérémy Anger
 Jon Anglin
+Michele Angrisano
 Ankur Ankan
 Heidi Annexstad
 Ramchandra Apte

--- a/Misc/NEWS.d/next/Library/2019-05-23-15-57-36.bpo-36713.sjPhnf.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-23-15-57-36.bpo-36713.sjPhnf.rst
@@ -1,0 +1,1 @@
+Rename the :meth:`test_ascii_replace` to :meth:`test_ascii_strict`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

In the issue-36713 was requested to remove the duplicated method `test_ascii_replace` in the `test_unicode `module. After Ezio's review we have decided to rename it with `test_ascii_strict`.


<!-- issue-number: [bpo-36713](https://bugs.python.org/issue36713) -->
https://bugs.python.org/issue36713
<!-- /issue-number -->
