### PR TITLE
bpo-36876: Use a consistent variable name for kwlist.

### DIFF
--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -51,7 +51,7 @@ bisect_right(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t lo = 0;
     Py_ssize_t hi = -1;
     Py_ssize_t index;
-    static char *keywords[] = {"a", "x", "lo", "hi", NULL};
+    static char *kwlist[] = {"a", "x", "lo", "hi", NULL};
 
     if (kw == NULL && PyTuple_GET_SIZE(args) == 2) {
         list = PyTuple_GET_ITEM(args, 0);
@@ -59,7 +59,7 @@ bisect_right(PyObject *self, PyObject *args, PyObject *kw)
     }
     else {
         if (!PyArg_ParseTupleAndKeywords(args, kw, "OO|nn:bisect_right",
-                                         keywords, &list, &item, &lo, &hi))
+                                         kwlist, &list, &item, &lo, &hi))
             return NULL;
     }
     index = internal_bisect_right(list, item, lo, hi);
@@ -87,7 +87,7 @@ insort_right(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t lo = 0;
     Py_ssize_t hi = -1;
     Py_ssize_t index;
-    static char *keywords[] = {"a", "x", "lo", "hi", NULL};
+    static char *kwlist[] = {"a", "x", "lo", "hi", NULL};
 
     if (kw == NULL && PyTuple_GET_SIZE(args) == 2) {
         list = PyTuple_GET_ITEM(args, 0);
@@ -95,7 +95,7 @@ insort_right(PyObject *self, PyObject *args, PyObject *kw)
     }
     else {
         if (!PyArg_ParseTupleAndKeywords(args, kw, "OO|nn:insort_right",
-                                         keywords, &list, &item, &lo, &hi))
+                                         kwlist, &list, &item, &lo, &hi))
             return NULL;
     }
     index = internal_bisect_right(list, item, lo, hi);
@@ -168,7 +168,7 @@ bisect_left(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t lo = 0;
     Py_ssize_t hi = -1;
     Py_ssize_t index;
-    static char *keywords[] = {"a", "x", "lo", "hi", NULL};
+    static char *kwlist[] = {"a", "x", "lo", "hi", NULL};
 
     if (kw == NULL && PyTuple_GET_SIZE(args) == 2) {
         list = PyTuple_GET_ITEM(args, 0);
@@ -176,7 +176,7 @@ bisect_left(PyObject *self, PyObject *args, PyObject *kw)
     }
     else {
         if (!PyArg_ParseTupleAndKeywords(args, kw, "OO|nn:bisect_left",
-                                         keywords, &list, &item, &lo, &hi))
+                                         kwlist, &list, &item, &lo, &hi))
             return NULL;
     }
     index = internal_bisect_left(list, item, lo, hi);
@@ -204,14 +204,14 @@ insort_left(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t lo = 0;
     Py_ssize_t hi = -1;
     Py_ssize_t index;
-    static char *keywords[] = {"a", "x", "lo", "hi", NULL};
+    static char *kwlist[] = {"a", "x", "lo", "hi", NULL};
 
     if (kw == NULL && PyTuple_GET_SIZE(args) == 2) {
         list = PyTuple_GET_ITEM(args, 0);
         item = PyTuple_GET_ITEM(args, 1);
     } else {
         if (!PyArg_ParseTupleAndKeywords(args, kw, "OO|nn:insort_left",
-                                         keywords, &list, &item, &lo, &hi))
+                                         kwlist, &list, &item, &lo, &hi))
             return NULL;
     }
     index = internal_bisect_left(list, item, lo, hi);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2432,13 +2432,13 @@ delta_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     PyObject *y = NULL;         /* temp sum of microseconds */
     double leftover_us = 0.0;
 
-    static char *keywords[] = {
+    static char *kwlist[] = {
         "days", "seconds", "microseconds", "milliseconds",
         "minutes", "hours", "weeks", NULL
     };
 
     if (PyArg_ParseTupleAndKeywords(args, kw, "|OOOOOOO:__new__",
-                                    keywords,
+                                    kwlist,
                                     &day, &second, &us,
                                     &ms, &minute, &hour, &week) == 0)
         goto Done;
@@ -3007,13 +3007,13 @@ invalid_string_error:
 static PyObject *
 date_fromisocalendar(PyObject *cls, PyObject *args, PyObject *kw)
 {
-    static char *keywords[] = {
+    static char *kwlist[] = {
         "year", "week", "day", NULL
     };
 
     int year, week, day;
     if (PyArg_ParseTupleAndKeywords(args, kw, "iii:fromisocalendar",
-                keywords,
+                kwlist,
                 &year, &week, &day) == 0) {
         if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
             PyErr_Format(PyExc_ValueError,
@@ -3183,9 +3183,9 @@ date_strftime(PyDateTime_Date *self, PyObject *args, PyObject *kw)
     PyObject *tuple;
     PyObject *format;
     _Py_IDENTIFIER(timetuple);
-    static char *keywords[] = {"format", NULL};
+    static char *kwlist[] = {"format", NULL};
 
-    if (! PyArg_ParseTupleAndKeywords(args, kw, "U:strftime", keywords,
+    if (! PyArg_ParseTupleAndKeywords(args, kw, "U:strftime", kwlist,
                                       &format))
         return NULL;
 
@@ -4184,7 +4184,7 @@ time_isoformat(PyDateTime_Time *self, PyObject *args, PyObject *kw)
 {
     char buf[100];
     char *timespec = NULL;
-    static char *keywords[] = {"timespec", NULL};
+    static char *kwlist[] = {"timespec", NULL};
     PyObject *result;
     int us = TIME_GET_MICROSECOND(self);
     static char *specs[][2] = {
@@ -4196,7 +4196,7 @@ time_isoformat(PyDateTime_Time *self, PyObject *args, PyObject *kw)
     };
     size_t given_spec;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "|s:isoformat", keywords, &timespec))
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "|s:isoformat", kwlist, &timespec))
         return NULL;
 
     if (timespec == NULL || strcmp(timespec, "auto") == 0) {
@@ -4250,9 +4250,9 @@ time_strftime(PyDateTime_Time *self, PyObject *args, PyObject *kw)
     PyObject *result;
     PyObject *tuple;
     PyObject *format;
-    static char *keywords[] = {"format", NULL};
+    static char *kwlist[] = {"format", NULL};
 
-    if (! PyArg_ParseTupleAndKeywords(args, kw, "U:strftime", keywords,
+    if (! PyArg_ParseTupleAndKeywords(args, kw, "U:strftime", kwlist,
                                       &format))
         return NULL;
 
@@ -4984,10 +4984,10 @@ datetime_fromtimestamp(PyObject *cls, PyObject *args, PyObject *kw)
     PyObject *self;
     PyObject *timestamp;
     PyObject *tzinfo = Py_None;
-    static char *keywords[] = {"timestamp", "tz", NULL};
+    static char *kwlist[] = {"timestamp", "tz", NULL};
 
     if (! PyArg_ParseTupleAndKeywords(args, kw, "O|O:fromtimestamp",
-                                      keywords, &timestamp, &tzinfo))
+                                      kwlist, &timestamp, &tzinfo))
         return NULL;
     if (check_tzinfo_subclass(tzinfo) < 0)
         return NULL;
@@ -5041,13 +5041,13 @@ datetime_strptime(PyObject *cls, PyObject *args)
 static PyObject *
 datetime_combine(PyObject *cls, PyObject *args, PyObject *kw)
 {
-    static char *keywords[] = {"date", "time", "tzinfo", NULL};
+    static char *kwlist[] = {"date", "time", "tzinfo", NULL};
     PyObject *date;
     PyObject *time;
     PyObject *tzinfo = NULL;
     PyObject *result = NULL;
 
-    if (PyArg_ParseTupleAndKeywords(args, kw, "O!O!|O:combine", keywords,
+    if (PyArg_ParseTupleAndKeywords(args, kw, "O!O!|O:combine", kwlist,
                                     &PyDateTime_DateType, &date,
                                     &PyDateTime_TimeType, &time, &tzinfo)) {
         if (tzinfo == NULL) {
@@ -5415,7 +5415,7 @@ datetime_isoformat(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
 {
     int sep = 'T';
     char *timespec = NULL;
-    static char *keywords[] = {"sep", "timespec", NULL};
+    static char *kwlist[] = {"sep", "timespec", NULL};
     char buffer[100];
     PyObject *result = NULL;
     int us = DATE_GET_MICROSECOND(self);
@@ -5428,7 +5428,7 @@ datetime_isoformat(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
     };
     size_t given_spec;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "|Cs:isoformat", keywords, &sep, &timespec))
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "|Cs:isoformat", kwlist, &sep, &timespec))
         return NULL;
 
     if (timespec == NULL || strcmp(timespec, "auto") == 0) {
@@ -5871,9 +5871,9 @@ datetime_astimezone(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
     PyObject *temp;
     PyObject *self_tzinfo;
     PyObject *tzinfo = Py_None;
-    static char *keywords[] = {"tz", NULL};
+    static char *kwlist[] = {"tz", NULL};
 
-    if (! PyArg_ParseTupleAndKeywords(args, kw, "|O:astimezone", keywords,
+    if (! PyArg_ParseTupleAndKeywords(args, kw, "|O:astimezone", kwlist,
                                       &tzinfo))
         return NULL;
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -510,9 +510,9 @@ keyobject_call(keyobject *ko, PyObject *args, PyObject *kwds)
 {
     PyObject *object;
     keyobject *result;
-    static char *kwargs[] = {"obj", NULL};
+    static char *kwlist[] = {"obj", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:K", kwargs, &object))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:K", kwlist, &object))
         return NULL;
     result = PyObject_New(keyobject, &keyobject_type);
     if (!result)
@@ -566,10 +566,10 @@ static PyObject *
 functools_cmp_to_key(PyObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *cmp;
-    static char *kwargs[] = {"mycmp", NULL};
+    static char *kwlist[] = {"mycmp", NULL};
     keyobject *object;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:cmp_to_key", kwargs, &cmp))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:cmp_to_key", kwlist, &cmp))
         return NULL;
     object = PyObject_New(keyobject, &keyobject_type);
     if (!object)
@@ -1096,10 +1096,10 @@ lru_cache_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     lru_cache_object *obj;
     Py_ssize_t maxsize;
     PyObject *(*wrapper)(lru_cache_object *, PyObject *, PyObject *);
-    static char *keywords[] = {"user_function", "maxsize", "typed",
+    static char *kwlist[] = {"user_function", "maxsize", "typed",
                                "cache_info_type", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "OOpO:lru_cache", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "OOpO:lru_cache", kwlist,
                                      &func, &maxsize_O, &typed,
                                      &cache_info_type)) {
         return NULL;

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -189,8 +189,8 @@ INT_TYPE_CONVERTER_FUNC(lzma_match_finder, lzma_mf_converter)
 static void *
 parse_filter_spec_lzma(PyObject *spec)
 {
-    static char *optnames[] = {"id", "preset", "dict_size", "lc", "lp",
-                               "pb", "mode", "nice_len", "mf", "depth", NULL};
+    static char *kwlist[] = {"id", "preset", "dict_size", "lc", "lp",
+                             "pb", "mode", "nice_len", "mf", "depth", NULL};
     PyObject *id;
     PyObject *preset_obj;
     uint32_t preset = LZMA_PRESET_DEFAULT;
@@ -224,7 +224,7 @@ parse_filter_spec_lzma(PyObject *spec)
     }
 
     if (!PyArg_ParseTupleAndKeywords(empty_tuple, spec,
-                                     "|OOO&O&O&O&O&O&O&O&", optnames,
+                                     "|OOO&O&O&O&O&O&O&O&", kwlist,
                                      &id, &preset_obj,
                                      uint32_converter, &options->dict_size,
                                      uint32_converter, &options->lc,
@@ -245,12 +245,12 @@ parse_filter_spec_lzma(PyObject *spec)
 static void *
 parse_filter_spec_delta(PyObject *spec)
 {
-    static char *optnames[] = {"id", "dist", NULL};
+    static char *kwlist[] = {"id", "dist", NULL};
     PyObject *id;
     uint32_t dist = 1;
     lzma_options_delta *options;
 
-    if (!PyArg_ParseTupleAndKeywords(empty_tuple, spec, "|OO&", optnames,
+    if (!PyArg_ParseTupleAndKeywords(empty_tuple, spec, "|OO&", kwlist,
                                      &id, uint32_converter, &dist)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid filter specifier for delta filter");
@@ -269,12 +269,12 @@ parse_filter_spec_delta(PyObject *spec)
 static void *
 parse_filter_spec_bcj(PyObject *spec)
 {
-    static char *optnames[] = {"id", "start_offset", NULL};
+    static char *kwlist[] = {"id", "start_offset", NULL};
     PyObject *id;
     uint32_t start_offset = 0;
     lzma_options_bcj *options;
 
-    if (!PyArg_ParseTupleAndKeywords(empty_tuple, spec, "|OO&", optnames,
+    if (!PyArg_ParseTupleAndKeywords(empty_tuple, spec, "|OO&", kwlist,
                                      &id, uint32_converter, &start_offset)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid filter specifier for BCJ filter");
@@ -704,7 +704,7 @@ For one-shot compression, use the compress() function instead.
 static int
 Compressor_init(Compressor *self, PyObject *args, PyObject *kwargs)
 {
-    static char *arg_names[] = {"format", "check", "preset", "filters", NULL};
+    static char *kwlist[] = {"format", "check", "preset", "filters", NULL};
     int format = FORMAT_XZ;
     int check = -1;
     uint32_t preset = LZMA_PRESET_DEFAULT;
@@ -712,7 +712,7 @@ Compressor_init(Compressor *self, PyObject *args, PyObject *kwargs)
     PyObject *filterspecs = Py_None;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                                     "|iiOO:LZMACompressor", arg_names,
+                                     "|iiOO:LZMACompressor", kwlist,
                                      &format, &check, &preset_obj,
                                      &filterspecs))
         return -1;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1493,9 +1493,9 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
     int sleep_ms = 250;
     sqlite3 *bck_conn;
     sqlite3_backup *bck_handle;
-    static char *keywords[] = {"target", "pages", "progress", "name", "sleep", NULL};
+    static char *kwlist[] = {"target", "pages", "progress", "name", "sleep", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|$iOsO:backup", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|$iOsO:backup", kwlist,
                                      &pysqlite_ConnectionType, &target,
                                      &pages, &progress, &name, &sleep_obj)) {
         return NULL;

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1025,11 +1025,11 @@ getargs_tuple(PyObject *self, PyObject *args)
 static PyObject *
 getargs_keywords(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    static char *keywords[] = {"arg1","arg2","arg3","arg4","arg5", NULL};
+    static char *kwlist[] = {"arg1","arg2","arg3","arg4","arg5", NULL};
     static const char fmt[] = "(ii)i|(i(ii))(iii)i";
     int int_args[10]={-1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, fmt, keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, fmt, kwlist,
         &int_args[0], &int_args[1], &int_args[2], &int_args[3], &int_args[4],
         &int_args[5], &int_args[6], &int_args[7], &int_args[8], &int_args[9]))
         return NULL;
@@ -1042,12 +1042,12 @@ getargs_keywords(PyObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *
 getargs_keyword_only(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    static char *keywords[] = {"required", "optional", "keyword_only", NULL};
+    static char *kwlist[] = {"required", "optional", "keyword_only", NULL};
     int required = -1;
     int optional = -1;
     int keyword_only = -1;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "i|i$i", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "i|i$i", kwlist,
                                      &required, &optional, &keyword_only))
         return NULL;
     return Py_BuildValue("iii", required, optional, keyword_only);
@@ -1057,12 +1057,12 @@ getargs_keyword_only(PyObject *self, PyObject *args, PyObject *kwargs)
 static PyObject *
 getargs_positional_only_and_keywords(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-    static char *keywords[] = {"", "", "keyword", NULL};
+    static char *kwlist[] = {"", "", "keyword", NULL};
     int required = -1;
     int optional = -1;
     int keyword = -1;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "i|ii", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "i|ii", kwlist,
                                      &required, &optional, &keyword))
         return NULL;
     return Py_BuildValue("iii", required, optional, keyword);
@@ -5104,7 +5104,7 @@ static struct PyMemberDef test_members[] = {
 static PyObject *
 test_structmembers_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
-    static char *keywords[] = {
+    static char *kwlist[] = {
         "T_BOOL", "T_BYTE", "T_UBYTE", "T_SHORT", "T_USHORT",
         "T_INT", "T_UINT", "T_LONG", "T_ULONG", "T_PYSSIZET",
         "T_FLOAT", "T_DOUBLE", "T_STRING_INPLACE",
@@ -5118,7 +5118,7 @@ test_structmembers_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     if (ob == NULL)
         return NULL;
     memset(&ob->structmembers, 0, sizeof(all_structmembers));
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, fmt, keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, fmt, kwlist,
                                      &ob->structmembers.bool_member,
                                      &ob->structmembers.byte_member,
                                      &ob->structmembers.ubyte_member,

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -4245,9 +4245,9 @@ repeat_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     repeatobject *ro;
     PyObject *element;
     Py_ssize_t cnt = -1, n_kwds = 0;
-    static char *kwargs[] = {"object", "times", NULL};
+    static char *kwlist[] = {"object", "times", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|n:repeat", kwargs,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|n:repeat", kwlist,
                                      &element, &cnt))
         return NULL;
 

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1055,11 +1055,11 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
     int fd, flags = MAP_SHARED, prot = PROT_WRITE | PROT_READ;
     int devzero = -1;
     int access = (int)ACCESS_DEFAULT;
-    static char *keywords[] = {"fileno", "length",
-                               "flags", "prot",
-                               "access", "offset", NULL};
+    static char *kwlist[] = {"fileno", "length",
+                             "flags", "prot",
+                             "access", "offset", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "in|iii" _Py_PARSE_OFF_T, keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "in|iii" _Py_PARSE_OFF_T, kwlist,
                                      &fd, &map_size, &flags, &prot,
                                      &access, &offset))
         return NULL;
@@ -1221,11 +1221,11 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
     HANDLE fh = 0;
     int access = (access_mode)ACCESS_DEFAULT;
     DWORD flProtect, dwDesiredAccess;
-    static char *keywords[] = { "fileno", "length",
-                                "tagname",
-                                "access", "offset", NULL };
+    static char *kwlist[] = { "fileno", "length",
+                              "tagname",
+                              "access", "offset", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "in|ziL", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "in|ziL", kwlist,
                                      &fileno, &map_size,
                                      &tagname, &access, &offset)) {
         return NULL;

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -382,15 +382,15 @@ parser_st2tuple(PyST_Object *self, PyObject *args, PyObject *kw)
     PyObject *res = 0;
     int ok;
 
-    static char *keywords[] = {"st", "line_info", "col_info", NULL};
+    static char *kwlist[] = {"st", "line_info", "col_info", NULL};
 
     if (self == NULL || PyModule_Check(self)) {
-        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!|pp:st2tuple", keywords,
+        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!|pp:st2tuple", kwlist,
                                          &PyST_Type, &self, &line_info,
                                          &col_info);
     }
     else
-        ok = PyArg_ParseTupleAndKeywords(args, kw, "|pp:totuple", &keywords[1],
+        ok = PyArg_ParseTupleAndKeywords(args, kw, "|pp:totuple", &kwlist[1],
                                          &line_info, &col_info);
     if (ok != 0) {
         /*
@@ -418,14 +418,14 @@ parser_st2list(PyST_Object *self, PyObject *args, PyObject *kw)
     PyObject *res = 0;
     int ok;
 
-    static char *keywords[] = {"st", "line_info", "col_info", NULL};
+    static char *kwlist[] = {"st", "line_info", "col_info", NULL};
 
     if (self == NULL || PyModule_Check(self))
-        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!|pp:st2list", keywords,
+        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!|pp:st2list", kwlist,
                                          &PyST_Type, &self, &line_info,
                                          &col_info);
     else
-        ok = PyArg_ParseTupleAndKeywords(args, kw, "|pp:tolist", &keywords[1],
+        ok = PyArg_ParseTupleAndKeywords(args, kw, "|pp:tolist", &kwlist[1],
                                          &line_info, &col_info);
     if (ok) {
         /*
@@ -454,14 +454,14 @@ parser_compilest(PyST_Object *self, PyObject *args, PyObject *kw)
     PyObject*     filename = NULL;
     int ok;
 
-    static char *keywords[] = {"st", "filename", NULL};
+    static char *kwlist[] = {"st", "filename", NULL};
 
     if (self == NULL || PyModule_Check(self))
-        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!|O&:compilest", keywords,
+        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!|O&:compilest", kwlist,
                                          &PyST_Type, &self,
                                          PyUnicode_FSDecoder, &filename);
     else
-        ok = PyArg_ParseTupleAndKeywords(args, kw, "|O&:compile", &keywords[1],
+        ok = PyArg_ParseTupleAndKeywords(args, kw, "|O&:compile", &kwlist[1],
                                          PyUnicode_FSDecoder, &filename);
     if (!ok)
         goto error;
@@ -504,13 +504,13 @@ parser_isexpr(PyST_Object *self, PyObject *args, PyObject *kw)
     PyObject* res = 0;
     int ok;
 
-    static char *keywords[] = {"st", NULL};
+    static char *kwlist[] = {"st", NULL};
 
     if (self == NULL || PyModule_Check(self))
-        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!:isexpr", keywords,
+        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!:isexpr", kwlist,
                                          &PyST_Type, &self);
     else
-        ok = PyArg_ParseTupleAndKeywords(args, kw, ":isexpr", &keywords[1]);
+        ok = PyArg_ParseTupleAndKeywords(args, kw, ":isexpr", &kwlist[1]);
 
     if (ok) {
         /* Check to see if the ST represents an expression or not. */
@@ -527,13 +527,13 @@ parser_issuite(PyST_Object *self, PyObject *args, PyObject *kw)
     PyObject* res = 0;
     int ok;
 
-    static char *keywords[] = {"st", NULL};
+    static char *kwlist[] = {"st", NULL};
 
     if (self == NULL || PyModule_Check(self))
-        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!:issuite", keywords,
+        ok = PyArg_ParseTupleAndKeywords(args, kw, "O!:issuite", kwlist,
                                          &PyST_Type, &self);
     else
-        ok = PyArg_ParseTupleAndKeywords(args, kw, ":issuite", &keywords[1]);
+        ok = PyArg_ParseTupleAndKeywords(args, kw, ":issuite", &kwlist[1]);
 
     if (ok) {
         /* Check to see if the ST represents an expression or not. */
@@ -570,9 +570,9 @@ parser_do_parse(PyObject *args, PyObject *kw, const char *argspec, int type)
     int flags        = 0;
     perrdetail err;
 
-    static char *keywords[] = {"source", NULL};
+    static char *kwlist[] = {"source", NULL};
 
-    if (PyArg_ParseTupleAndKeywords(args, kw, argspec, keywords, &string)) {
+    if (PyArg_ParseTupleAndKeywords(args, kw, argspec, kwlist, &string)) {
         node* n = PyParser_ParseStringFlagsFilenameEx(string, NULL,
                                                        &_PyParser_Grammar,
                                                       (type == PyST_EXPR)
@@ -755,9 +755,9 @@ parser_tuple2st(PyST_Object *self, PyObject *args, PyObject *kw)
     PyObject *tuple;
     node *tree;
 
-    static char *keywords[] = {"sequence", NULL};
+    static char *kwlist[] = {"sequence", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "O:sequence2st", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kw, "O:sequence2st", kwlist,
                                      &tuple))
         return (0);
     if (!PySequence_Check(tuple)) {

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8845,19 +8845,19 @@ posix_sendfile(PyObject *self, PyObject *args, PyObject *kwdict)
     struct sf_hdtr sf;
     int flags = 0;
     /* Beware that "in" clashes with Python's own "in" operator keyword */
-    static char *keywords[] = {"out", "in",
-                                "offset", "count",
-                                "headers", "trailers", "flags", NULL};
+    static char *kwlist[] = {"out", "in",
+                             "offset", "count",
+                             "headers", "trailers", "flags", NULL};
 
     sf.headers = NULL;
     sf.trailers = NULL;
 
 #ifdef __APPLE__
     if (!PyArg_ParseTupleAndKeywords(args, kwdict, "iiO&O&|OOi:sendfile",
-        keywords, &out, &in, Py_off_t_converter, &offset, Py_off_t_converter, &sbytes,
+        kwlist, &out, &in, Py_off_t_converter, &offset, Py_off_t_converter, &sbytes,
 #else
     if (!PyArg_ParseTupleAndKeywords(args, kwdict, "iiO&n|OOi:sendfile",
-        keywords, &out, &in, Py_off_t_converter, &offset, &len,
+        kwlist, &out, &in, Py_off_t_converter, &offset, &len,
 #endif
                 &headers, &trailers, &flags))
             return NULL;
@@ -8961,10 +8961,10 @@ done:
 #else
     Py_ssize_t count;
     PyObject *offobj;
-    static char *keywords[] = {"out", "in",
-                                "offset", "count", NULL};
+    static char *kwlist[] = {"out", "in",
+                             "offset", "count", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwdict, "iiOn:sendfile",
-            keywords, &out, &in, &offobj, &count))
+            kwlist, &out, &in, &offobj, &count))
         return NULL;
 #ifdef __linux__
     if (offobj == Py_None) {

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -4569,7 +4569,7 @@ sock_sendmsg_afalg(PySocketSockObject *self, PyObject *args, PyObject *kwds)
     struct sock_sendmsg ctx;
     Py_ssize_t controllen;
     void *controlbuf = NULL;
-    static char *keywords[] = {"msg", "op", "iv", "assoclen", "flags", 0};
+    static char *kwlist[] = {"msg", "op", "iv", "assoclen", "flags", 0};
 
     if (self->sock_family != AF_ALG) {
         PyErr_SetString(PyExc_OSError,
@@ -4578,7 +4578,7 @@ sock_sendmsg_afalg(PySocketSockObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                                     "|O$O!y*O!i:sendmsg_afalg", keywords,
+                                     "|O$O!y*O!i:sendmsg_afalg", kwlist,
                                      &data_arg,
                                      &PyLong_Type, &opobj, &iv,
                                      &PyLong_Type, &assoclenobj, &flags)) {
@@ -5016,7 +5016,7 @@ sock_initobj(PyObject *self, PyObject *args, PyObject *kwds)
     PyObject *fdobj = NULL;
     SOCKET_T fd = INVALID_SOCKET;
     int family = -1, type = -1, proto = -1;
-    static char *keywords[] = {"family", "type", "proto", "fileno", 0};
+    static char *kwlist[] = {"family", "type", "proto", "fileno", 0};
 #ifndef MS_WINDOWS
 #ifdef SOCK_CLOEXEC
     int *atomic_flag_works = &sock_cloexec_works;
@@ -5026,7 +5026,7 @@ sock_initobj(PyObject *self, PyObject *args, PyObject *kwds)
 #endif
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                                     "|iiiO:socket", keywords,
+                                     "|iiiO:socket", kwlist,
                                      &family, &type, &proto, &fdobj))
         return -1;
 
@@ -6330,8 +6330,8 @@ socket_inet_ntop(PyObject *self, PyObject *args)
 static PyObject *
 socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
 {
-    static char* kwnames[] = {"host", "port", "family", "type", "proto",
-                              "flags", 0};
+    static char* kwlist[] = {"host", "port", "family", "type", "proto",
+                             "flags", 0};
     struct addrinfo hints, *res;
     struct addrinfo *res0 = NULL;
     PyObject *hobj = NULL;
@@ -6346,7 +6346,7 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
     socktype = protocol = flags = 0;
     family = AF_UNSPEC;
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|iiii:getaddrinfo",
-                          kwnames, &hobj, &pobj, &family, &socktype,
+                          kwlist, &hobj, &pobj, &family, &socktype,
                           &protocol, &flags)) {
         return NULL;
     }

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -115,11 +115,11 @@ syslog_openlog(PyObject * self, PyObject * args, PyObject *kwds)
     long logopt = 0;
     long facility = LOG_USER;
     PyObject *new_S_ident_o = NULL;
-    static char *keywords[] = {"ident", "logoption", "facility", 0};
+    static char *kwlist[] = {"ident", "logoption", "facility", 0};
     const char *ident = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                          "|Ull:openlog", keywords, &new_S_ident_o, &logopt, &facility))
+                          "|Ull:openlog", kwlist, &new_S_ident_o, &logopt, &facility))
         return NULL;
 
     if (new_S_ident_o) {

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1024,9 +1024,9 @@ get_source_line(PyObject *module_globals, int lineno)
 static PyObject *
 warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    static char *kwd_list[] = {"message", "category", "filename", "lineno",
-                                "module", "registry", "module_globals",
-                                "source", 0};
+    static char *kwlist[] = {"message", "category", "filename", "lineno",
+                             "module", "registry", "module_globals",
+                             "source", 0};
     PyObject *message;
     PyObject *category;
     PyObject *filename;
@@ -1039,7 +1039,7 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
     PyObject *returned;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOUi|OOOO:warn_explicit",
-                kwd_list, &message, &category, &filename, &lineno, &module,
+                kwlist, &message, &category, &filename, &lineno, &module,
                 &registry, &module_globals, &sourceobj))
         return NULL;
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1851,8 +1851,8 @@ builtin_pow_impl(PyObject *module, PyObject *x, PyObject *y, PyObject *z)
 static PyObject *
 builtin_print(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
-    static const char * const _keywords[] = {"sep", "end", "file", "flush", 0};
-    static struct _PyArg_Parser _parser = {"|OOOO:print", _keywords, 0};
+    static const char * const kwlist[] = {"sep", "end", "file", "flush", 0};
+    static struct _PyArg_Parser _parser = {"|OOOO:print", kwlist, 0};
     PyObject *sep = NULL, *end = NULL, *file = NULL, *flush = NULL;
     int i, err;
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -909,12 +909,12 @@ static PyStructSequence_Desc asyncgen_hooks_desc = {
 static PyObject *
 sys_set_asyncgen_hooks(PyObject *self, PyObject *args, PyObject *kw)
 {
-    static char *keywords[] = {"firstiter", "finalizer", NULL};
+    static char *kwlist[] = {"firstiter", "finalizer", NULL};
     PyObject *firstiter = NULL;
     PyObject *finalizer = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, kw, "|OO", keywords,
+            args, kw, "|OO", kwlist,
             &firstiter, &finalizer)) {
         return NULL;
     }


### PR DESCRIPTION
Having a consistent variable name helps simplify efforts to identify C globals that need to be moved.  (A consistent name is easier to ignore.)

<!-- issue-number: [bpo-36876](https://bugs.python.org/issue36876) -->
https://bugs.python.org/issue36876
<!-- /issue-number -->
