### PR TITLE
gh-81211: hide undocumented commands in cmd module

### DIFF
--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -217,6 +217,11 @@ Instances of :class:`Cmd` subclasses have some public instance variables:
    :mod:`readline`, on systems that support it, the interpreter will automatically
    support :program:`Emacs`\ -like line editing  and command-history keystrokes.)
 
+.. attribute:: Cmd.hide_undoc
+
+    A flag, defaulting to false. If true, :meth:`do_help` and :meth:`completenames`
+    won't include undocumented commands (that is, there are do_*() methods without
+    corresponding help_*() methods).
 
 .. _cmd-example:
 

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -223,6 +223,8 @@ Instances of :class:`Cmd` subclasses have some public instance variables:
     won't include undocumented commands (that is, there are do_*() methods without
     corresponding help_*() methods).
 
+    .. versionadded:: 3.8
+
 .. _cmd-example:
 
 Cmd Example

--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -72,6 +72,7 @@ class Cmd:
     undoc_header = "Undocumented commands:"
     nohelp = "*** No help on %s"
     use_rawinput = 1
+    hide_undoc = 0
 
     def __init__(self, completekey='tab', stdin=None, stdout=None):
         """Instantiate a line-oriented interpreter framework.
@@ -245,8 +246,16 @@ class Cmd:
         return []
 
     def completenames(self, text, *ignored):
+        """ Method returns all commands.
+
+        If hide_undoc is True, only the commands with "help_" are returned.
+        """
         dotext = 'do_'+text
-        return [a[3:] for a in self.get_names() if a.startswith(dotext)]
+        names = self.get_names()
+        commands = [a[3:] for a in names if a.startswith(dotext)]
+        if self.hide_undoc:
+            commands = [a for a in commands if 'help_' + a in names]
+        return commands
 
     def complete(self, text, state):
         """Return the next possible completion for 'text'.
@@ -333,7 +342,8 @@ class Cmd:
             self.stdout.write("%s\n"%str(self.doc_leader))
             self.print_topics(self.doc_header,   cmds_doc,   15,80)
             self.print_topics(self.misc_header,  list(help.keys()),15,80)
-            self.print_topics(self.undoc_header, cmds_undoc, 15,80)
+            if not self.hide_undoc:
+                self.print_topics(self.undoc_header, cmds_undoc, 15,80)
 
     def print_topics(self, header, cmds, cmdlen, maxcol):
         if cmds:

--- a/Lib/test/test_cmd.py
+++ b/Lib/test/test_cmd.py
@@ -60,6 +60,10 @@ class samplecmdclass(cmd.Cmd):
     []
     >>> mycmd.completenames("help")
     ['help']
+    >>> mycmd.hide_undoc = True
+    >>> mycmd.completenames("s")
+    []
+    >>> mycmd.hide_undoc = False
 
     Test for the function complete_help():
     >>> mycmd.complete_help("a")

--- a/Misc/NEWS.d/next/Library/2019-05-24-07-40-56.bpo-37030.xs7uwm.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-24-07-40-56.bpo-37030.xs7uwm.rst
@@ -1,0 +1,1 @@
+cmd.py: Hide undocumented commands in help and completenames

--- a/Misc/NEWS.d/next/Library/2019-05-24-07-40-56.bpo-37030.xs7uwm.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-24-07-40-56.bpo-37030.xs7uwm.rst
@@ -1,1 +1,1 @@
-cmd.py: Hide undocumented commands in help and completenames
+cmd.py: Hide undocumented commands in help and completenames by Aldwin Pollefeyt


### PR DESCRIPTION
A flag, defaulting to false. If true, :meth:`do_help` and :meth:`completenames`
won't include undocumented commands (that is, there are do_*() methods without
corresponding help_*() methods).


<!-- issue-number: [bpo-37030](https://bugs.python.org/issue37030) -->
https://bugs.python.org/issue37030
<!-- /issue-number -->

<!-- gh-issue-number: gh-81211 -->
* Issue: gh-81211
<!-- /gh-issue-number -->
