### PR TITLE
bpo-37031: Fix PyOS_AfterFork_Child()

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -448,11 +448,11 @@ PyOS_AfterFork_Child(void)
 {
     _PyRuntimeState *runtime = &_PyRuntime;
     _PyGILState_Reinit(runtime);
-    _PyInterpreterState_DeleteExceptMain(runtime);
     _PyEval_ReInitThreads(runtime);
     _PyImport_ReInitLock();
     _PySignal_AfterFork();
     _PyRuntimeState_ReInitThreads(runtime);
+    _PyInterpreterState_DeleteExceptMain(runtime);
 
     run_at_forkers(_PyInterpreterState_Get()->after_forkers_child, 0);
 }


### PR DESCRIPTION
PyOS_AfterFork_Child(): _PyInterpreterState_DeleteExceptMain() must
be called after _PyRuntimeState_ReInitThreads().

_PyRuntimeState_ReInitThreads() resets interpreters mutex after fork,
mutex used by _PyInterpreterState_DeleteExceptMain().

<!-- issue-number: [bpo-37031](https://bugs.python.org/issue37031) -->
https://bugs.python.org/issue37031
<!-- /issue-number -->
