### PR TITLE
Fix audit event typo : urllib.request -> urllib.Request

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -95,10 +95,10 @@ The :mod:`urllib.request` module defines the following functions:
    parameter to ``urllib.urlopen``, can be obtained by using
    :class:`ProxyHandler` objects.
 
-   .. audit-event:: urllib.request "fullurl data headers method"
+   .. audit-event:: urllib.Request "fullurl data headers method"
 
       The default opener raises an :func:`auditing event <sys.audit>`
-      ``urllib.request`` with arguments ``fullurl``, ``data``, ``headers``,
+      ``urllib.Request`` with arguments ``fullurl``, ``data``, ``headers``,
       ``method`` taken from the request object.
 
    .. versionchanged:: 3.2


### PR DESCRIPTION
As per the PEP and the [audit event raised](https://github.com/python/cpython/blob/13d4e6a4a090031f8214e058ed3c8fd47767e05f/Lib/urllib/request.py#L524) in urllib.request this should be `urllib.Request`

cc: @zooba 