### PR TITLE
bpo-21536: Follow-up to #13549

### DIFF
--- a/configure
+++ b/configure
@@ -15131,10 +15131,10 @@ $as_echo "$LDVERSION" >&6; }
 
 # On Android and Cygwin the shared libraries must be linked with libpython.
 
-if test -z "$ANDROID_API_LEVEL" -o "$MACHDEP" != "cygwin"; then
-  LIBPYTHON=''
-else
+if test -n "$ANDROID_API_LEVEL" -o "$MACHDEP" = "cygwin"; then
   LIBPYTHON="-lpython${VERSION}${ABIFLAGS}"
+else
+  LIBPYTHON=''
 fi
 
 

--- a/configure
+++ b/configure
@@ -3292,6 +3292,8 @@ then
 	'')	MACHDEP="unknown";;
     esac
 fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: \"$MACHDEP\"" >&5
+$as_echo "\"$MACHDEP\"" >&6; }
 
 
 if test "$cross_compiling" = yes; then

--- a/configure.ac
+++ b/configure.ac
@@ -411,6 +411,7 @@ then
 	'')	MACHDEP="unknown";;
     esac
 fi
+AC_MSG_RESULT("$MACHDEP")
 
 AC_SUBST(_PYTHON_HOST_PLATFORM)
 if test "$cross_compiling" = yes; then

--- a/configure.ac
+++ b/configure.ac
@@ -4622,10 +4622,10 @@ AC_MSG_RESULT($LDVERSION)
 
 # On Android and Cygwin the shared libraries must be linked with libpython.
 AC_SUBST(LIBPYTHON)
-if test -z "$ANDROID_API_LEVEL" -o "$MACHDEP" != "cygwin"; then
-  LIBPYTHON=''
-else
+if test -n "$ANDROID_API_LEVEL" -o "$MACHDEP" = "cygwin"; then
   LIBPYTHON="-lpython${VERSION}${ABIFLAGS}"
+else
+  LIBPYTHON=''
 fi
 
 dnl define LIBPL after ABIFLAGS and LDVERSION is defined.


### PR DESCRIPTION
This test in #13549 was not correct.  I rewrote it a bit more clearly.  This is necessary for `python-config` to work properly on Cygwin.

I also added a small fix to a (trivial) bug I noticed in `configure`.  @vstinner 

<!-- issue-number: [bpo-21536](https://bugs.python.org/issue21536) -->
https://bugs.python.org/issue21536
<!-- /issue-number -->
