### PR TITLE
[3.7] bpo-32573: sys.argv always exists and is non-empty

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -287,7 +287,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'coerce_c_locale_warn': 0,
 
         'program_name': './_testembed',
-        'argv': [],
+        'argv': [''],
         'program': None,
 
         'xoptions': [],

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-24-18-23-15.bpo-32573.LSe-jY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-24-18-23-15.bpo-32573.LSe-jY.rst
@@ -1,0 +1,2 @@
+Ensure that :data:`sys.argv` always exists and is non-empty. When Python is
+embedded in an application and ``argv`` is not set, use ``['']``.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -2373,6 +2373,17 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         }
     }
 
+    /* ensure that sys.argv is always set and non-empty */
+    if (config->argc < 0) {
+        config->argc = 0;
+    }
+    if (config->argc == 0) {
+        err = wstrlist_append(&config->argc, &config->argv, L"");
+        if (_Py_INIT_FAILED(err)) {
+            return err;
+        }
+    }
+
     /* default values */
     if (config->dev_mode) {
         if (config->faulthandler < 0) {
@@ -2401,10 +2412,6 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
     if (config->utf8_mode < 0) {
         config->utf8_mode = 0;
     }
-    if (config->argc < 0) {
-        config->argc = 0;
-    }
-
     return _Py_INIT_OK();
 }
 


### PR DESCRIPTION
Ensure that sys.argv always exists and is non-empty.

When Python is embedded in an application and ``argv`` is not set,
use [''].

<!-- issue-number: [bpo-32573](https://bugs.python.org/issue32573) -->
https://bugs.python.org/issue32573
<!-- /issue-number -->
