### PR TITLE
bpo-36996: Handle async functions when mock.patch is used as a decorator

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1239,7 +1239,7 @@ class _patch(object):
 
 
     def decorate_callable(self, func):
-        # NB. Keep the method in sync with decorate_async_callable
+        # NB. Keep the method in sync with decorate_async_callable()
         if hasattr(func, 'patchings'):
             func.patchings.append(self)
             return func

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1256,7 +1256,7 @@ class _patch(object):
 
 
     def decorate_async_callable(self, func):
-        # NB. Keep the method in sync with decorate_callable
+        # NB. Keep the method in sync with decorate_callable()
         if hasattr(func, 'patchings'):
             func.patchings.append(self)
             return func

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -62,6 +62,14 @@ class AsyncPatchDecoratorTest(unittest.TestCase):
 
         test_async()
 
+    def test_async_def_patch(self):
+        @patch(f"{__name__}.async_func", AsyncMock())
+        async def test_async():
+            self.assertIsInstance(async_func, AsyncMock)
+
+        self.assertTrue(inspect.iscoroutinefunction(async_func))
+        asyncio.run(test_async())
+
 
 class AsyncPatchCMTest(unittest.TestCase):
     def test_is_async_function_cm(self):
@@ -86,6 +94,14 @@ class AsyncPatchCMTest(unittest.TestCase):
                 self.assertIsInstance(mock_method, AsyncMock)
 
         test_async()
+
+    def test_async_def_cm(self):
+        async def test_async():
+            with patch(f"{__name__}.async_func", AsyncMock()):
+                self.assertIsInstance(async_func, AsyncMock)
+            self.assertTrue(inspect.iscoroutinefunction(async_func))
+
+        asyncio.run(test_async())
 
 
 class AsyncMockTest(unittest.TestCase):

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -67,8 +67,8 @@ class AsyncPatchDecoratorTest(unittest.TestCase):
         async def test_async():
             self.assertIsInstance(async_func, AsyncMock)
 
-        self.assertTrue(inspect.iscoroutinefunction(async_func))
         asyncio.run(test_async())
+        self.assertTrue(inspect.iscoroutinefunction(async_func))
 
 
 class AsyncPatchCMTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2019-05-22-22-55-18.bpo-36996.XQx08d.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-22-22-55-18.bpo-36996.XQx08d.rst
@@ -1,0 +1,1 @@
+Handle :func:`unittest.mock.patch` used as a decorator on async functions.


### PR DESCRIPTION
Return a coroutine while patching async functions with a decorator. 

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>

<!-- issue-number: [bpo-36996](https://bugs.python.org/issue36996) -->
https://bugs.python.org/issue36996
<!-- /issue-number -->
