### PR TITLE
bpo-34632: fix test_importlib with installed CPython

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1323,6 +1323,7 @@ LIBSUBDIRS=	tkinter tkinter/test tkinter/test/test_tkinter \
 		importlib/metadata \
 		test/test_importlib \
 		test/test_importlib/builtin \
+		test/test_importlib/data \
 		test/test_importlib/data01 \
 		test/test_importlib/data01/subdirectory \
 		test/test_importlib/data02 \


### PR DESCRIPTION
"Installed" builders on buildbot.python.org [1] run tests on an
installed CPython copy [2]. Running tests in this way requires all
testing data also installed.

This commit fixes the following error during running tests on an
installed copy:

> ModuleNotFoundError: No module named 'test.test_importlib.data'

[1] https://buildbot.python.org/all/#/builders?tags=%2Binstalled&tags=%2B3.x
[2] https://github.com/python/buildmaster-config/blob/master/master/custom/factories.py

<!-- issue-number: [bpo-34632](https://bugs.python.org/issue34632) -->
https://bugs.python.org/issue34632
<!-- /issue-number -->
