### PR TITLE
bpo-37045: PEP 591: Add final qualifiers to typing module

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -940,6 +940,30 @@ The module defines the following classes, functions and decorators:
 
    See :pep:`484` for details and comparison with other typing semantics.
 
+.. decorator:: final
+
+   A decorator to indicate to type checkers that the decorated method
+   cannot be overridden, and the decorated class cannot be subclassed.
+   For example::
+
+      class Base:
+          @final
+          def done(self) -> None:
+              ...
+      class Sub(Base):
+          def done(self) -> None:  # Error reported by type checker
+                ...
+
+      @final
+      class Leaf:
+          ...
+      class Other(Leaf):  # Error reported by type checker
+          ...
+
+    There is no runtime checking of these properties.
+
+   .. versionadded:: 3.8
+
 .. decorator:: no_type_check
 
    Decorator to indicate that annotations are not type hints.
@@ -1103,6 +1127,24 @@ The module defines the following classes, functions and decorators:
       Starship.stats = {}     # This is OK
 
    .. versionadded:: 3.5.3
+
+.. data:: Final
+
+   A special typing construct to indicate that a name cannot be
+   re-assigned or overridden in a subclass. For example::
+
+      MAX_SIZE: Final = 9000
+      MAX_SIZE += 1  # Error reported by type checker
+
+      class Connection:
+          TIMEOUT: Final[int] = 10
+
+      class FastConnector(Connection):
+          TIMEOUT = 1  # Error reported by type checker
+
+    There is no runtime checking of these properties.
+
+   .. versionadded:: 3.8
 
 .. data:: AnyStr
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -960,7 +960,7 @@ The module defines the following classes, functions and decorators:
       class Other(Leaf):  # Error reported by type checker
           ...
 
-    There is no runtime checking of these properties.
+   There is no runtime checking of these properties.
 
    .. versionadded:: 3.8
 
@@ -1142,7 +1142,7 @@ The module defines the following classes, functions and decorators:
       class FastConnector(Connection):
           TIMEOUT = 1  # Error reported by type checker
 
-    There is no runtime checking of these properties.
+   There is no runtime checking of these properties.
 
    .. versionadded:: 3.8
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1130,8 +1130,8 @@ The module defines the following classes, functions and decorators:
 
 .. data:: Final
 
-   A special typing construct to indicate that a name cannot be
-   re-assigned or overridden in a subclass. For example::
+   A special typing construct to indicate to type checkers that a name
+   cannot be re-assigned or overridden in a subclass. For example::
 
       MAX_SIZE: Final = 9000
       MAX_SIZE += 1  # Error reported by type checker

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -960,7 +960,8 @@ The module defines the following classes, functions and decorators:
       class Other(Leaf):  # Error reported by type checker
           ...
 
-   There is no runtime checking of these properties.
+   There is no runtime checking of these properties. See :pep:`591` for
+   more details.
 
    .. versionadded:: 3.8
 
@@ -1142,7 +1143,8 @@ The module defines the following classes, functions and decorators:
       class FastConnector(Connection):
           TIMEOUT = 1  # Error reported by type checker
 
-   There is no runtime checking of these properties.
+   There is no runtime checking of these properties. See :pep:`591` for
+   more details.
 
    .. versionadded:: 3.8
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -12,7 +12,7 @@ from typing import T, KT, VT  # Not in __all__.
 from typing import Union, Optional
 from typing import Tuple, List, MutableMapping
 from typing import Callable
-from typing import Generic, ClassVar
+from typing import Generic, ClassVar, Final, final
 from typing import cast
 from typing import get_type_hints
 from typing import no_type_check, no_type_check_decorator
@@ -1436,6 +1436,53 @@ class ClassVarTests(BaseTestCase):
             isinstance(1, ClassVar[int])
         with self.assertRaises(TypeError):
             issubclass(int, ClassVar)
+
+
+class FinalTests(BaseTestCase):
+
+    def test_basics(self):
+        Final[int]  # OK
+        with self.assertRaises(TypeError):
+            Final[1]
+        with self.assertRaises(TypeError):
+            Final[int, str]
+        with self.assertRaises(TypeError):
+            Final[int][str]
+        with self.assertRaises(TypeError):
+            Optional[Final[int]]
+
+    def test_repr(self):
+        self.assertEqual(repr(Final), 'typing.Final')
+        cv = Final[int]
+        self.assertEqual(repr(cv), 'typing.Final[int]')
+        cv = Final[Employee]
+        self.assertEqual(repr(cv), 'typing.Final[%s.Employee]' % __name__)
+
+    def test_cannot_subclass(self):
+        with self.assertRaises(TypeError):
+            class C(type(Final)):
+                pass
+        with self.assertRaises(TypeError):
+            class C(type(Final[int])):
+                pass
+
+    def test_cannot_init(self):
+        with self.assertRaises(TypeError):
+            Final()
+        with self.assertRaises(TypeError):
+            type(Final)()
+        with self.assertRaises(TypeError):
+            type(Final[Optional[int]])()
+
+    def test_no_isinstance(self):
+        with self.assertRaises(TypeError):
+            isinstance(1, Final[int])
+        with self.assertRaises(TypeError):
+            issubclass(int, Final)
+
+    def test_final_unmodified(self):
+        def func(x): ...
+        self.assertIs(func, final(func))
 
 
 class CastTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -401,17 +401,22 @@ ClassVar = _SpecialForm('ClassVar', doc=
     """)
 
 Final = _SpecialForm('Final', doc=
-"""A special typing construct to indicate that a name
-cannot be re-assigned or overridden in a subclass.
-For example:
-    MAX_SIZE: Final = 9000
-    MAX_SIZE += 1  # Error reported by type checker
-    class Connection:
-        TIMEOUT: Final[int] = 10
-    class FastConnector(Connection):
-        TIMEOUT = 1  # Error reported by type checker
-There is no runtime checking of these properties.
-""")
+    """Special typing construct to indicate final names.
+
+    A final name cannot be re-assigned or overridden in a subclass.
+    For example:
+
+      MAX_SIZE: Final = 9000
+      MAX_SIZE += 1  # Error reported by type checker
+
+      class Connection:
+          TIMEOUT: Final[int] = 10
+
+      class FastConnector(Connection):
+          TIMEOUT = 1  # Error reported by type checker
+
+    There is no runtime checking of these properties.
+    """)
 
 Union = _SpecialForm('Union', doc=
     """Union type; Union[X, Y] means either X or Y.
@@ -1101,21 +1106,26 @@ def overload(func):
 
 
 def final(f):
-    """This decorator can be used to indicate to type checkers that
-    the decorated method cannot be overridden, and decorated class
-    cannot be subclassed. For example:
-        class Base:
-            @final
-            def done(self) -> None:
+    """A decorator to indicate final methods and final classes.
+
+    Use this decorator to indicate to type checkers that the decorated
+    method cannot be overridden, and decorated class cannot be subclassed.
+    For example:
+
+      class Base:
+          @final
+          def done(self) -> None:
+              ...
+      class Sub(Base):
+          def done(self) -> None:  # Error reported by type checker
                 ...
-        class Sub(Base):
-            def done(self) -> None:  # Error reported by type checker
-                ...
-        @final
-        class Leaf:
-            ...
-        class Other(Leaf):  # Error reported by type checker
-            ...
+
+      @final
+      class Leaf:
+          ...
+      class Other(Leaf):  # Error reported by type checker
+          ...
+
     There is no runtime checking of these properties.
     """
     return f

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -401,7 +401,7 @@ ClassVar = _SpecialForm('ClassVar', doc=
     """)
 
 Final = _SpecialForm('Final', doc=
-    """Special typing construct to indicate final names.
+    """Special typing construct to indicate final names to type checkers.
 
     A final name cannot be re-assigned or overridden in a subclass.
     For example:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -35,6 +35,7 @@ __all__ = [
     'Any',
     'Callable',
     'ClassVar',
+    'Final',
     'Generic',
     'Optional',
     'Tuple',
@@ -92,6 +93,7 @@ __all__ = [
     # One-off things.
     'AnyStr',
     'cast',
+    'final',
     'get_type_hints',
     'NewType',
     'no_type_check',
@@ -121,7 +123,7 @@ def _type_check(arg, msg, is_argument=True):
     """
     invalid_generic_forms = (Generic, _Protocol)
     if is_argument:
-        invalid_generic_forms = invalid_generic_forms + (ClassVar, )
+        invalid_generic_forms = invalid_generic_forms + (ClassVar, Final)
 
     if arg is None:
         return type(None)
@@ -336,8 +338,8 @@ class _SpecialForm(_Final, _Immutable, _root=True):
 
     @_tp_cache
     def __getitem__(self, parameters):
-        if self._name == 'ClassVar':
-            item = _type_check(parameters, 'ClassVar accepts only single type.')
+        if self._name in ('ClassVar', 'Final'):
+            item = _type_check(parameters, f'{self._name} accepts only single type.')
             return _GenericAlias(self, (item,))
         if self._name == 'Union':
             if parameters == ():
@@ -397,6 +399,19 @@ ClassVar = _SpecialForm('ClassVar', doc=
     Note that ClassVar is not a class itself, and should not
     be used with isinstance() or issubclass().
     """)
+
+Final = _SpecialForm('Final', doc=
+"""A special typing construct to indicate that a name
+cannot be re-assigned or overridden in a subclass.
+For example:
+    MAX_SIZE: Final = 9000
+    MAX_SIZE += 1  # Error reported by type checker
+    class Connection:
+        TIMEOUT: Final[int] = 10
+    class FastConnector(Connection):
+        TIMEOUT = 1  # Error reported by type checker
+There is no runtime checking of these properties.
+""")
 
 Union = _SpecialForm('Union', doc=
     """Union type; Union[X, Y] means either X or Y.
@@ -1083,6 +1098,27 @@ def overload(func):
           # implementation goes here
     """
     return _overload_dummy
+
+
+def final(f):
+    """This decorator can be used to indicate to type checkers that
+    the decorated method cannot be overridden, and decorated class
+    cannot be subclassed. For example:
+        class Base:
+            @final
+            def done(self) -> None:
+                ...
+        class Sub(Base):
+            def done(self) -> None:  # Error reported by type checker
+                ...
+        @final
+        class Leaf:
+            ...
+        class Other(Leaf):  # Error reported by type checker
+            ...
+    There is no runtime checking of these properties.
+    """
+    return f
 
 
 class _ProtocolMeta(type):

--- a/Misc/NEWS.d/next/Library/2019-05-25-18-36-50.bpo-37045.suHdVJ.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-25-18-36-50.bpo-37045.suHdVJ.rst
@@ -1,0 +1,1 @@
+PEP 591: Add ``Final`` qualifier and ``@final`` decorator to the ``typing`` module.


### PR DESCRIPTION
cc @msullivan 

The implementation is straightforward, it just mimics `ClassVar` (since the latter is also a name/access qualifier, not really a type). Also it is essentially copied from `typing_extensions`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37045](https://bugs.python.org/issue37045) -->
https://bugs.python.org/issue37045
<!-- /issue-number -->
