### PR TITLE
bpo-37046: PEP 586: Add Literal to typing module

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1078,6 +1078,22 @@ The module defines the following classes, functions and decorators:
    ``Callable[..., Any]``, and in turn to
    :class:`collections.abc.Callable`.
 
+.. data:: Literal
+
+   A type that can be used to indicate to type checkers that the
+   corresponding value has a value literally equivalent to the
+   provided parameter.  For example::
+
+      var: Literal[4] = 4
+
+   The type checker understands that var is literally equal to the
+   value 4 and no other value.
+
+   ``Literal[...]`` cannot be subclassed. There is no runtime checking
+   verifying that the parameter is actually a value instead of a type.
+
+   .. versionadded:: 3.8
+
 .. data:: ClassVar
 
    Special type construct to mark class variables.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1081,16 +1081,22 @@ The module defines the following classes, functions and decorators:
 .. data:: Literal
 
    A type that can be used to indicate to type checkers that the
-   corresponding value has a value literally equivalent to the
-   provided parameter.  For example::
+   corresponding variable or function parameter has a value equivalent to
+   the provided literal (or one of several literals). For example::
 
-      var: Literal[4] = 4
+      def validate_simple(data: Any) -> Literal[True]:  # always returns True
+          ...
 
-   The type checker understands that var is literally equal to the
-   value 4 and no other value.
+      MODE = Literal['r', 'rb', 'w', 'wb']
+      def open_helper(file: str, mode: MODE) -> str:
+          ...
 
-   ``Literal[...]`` cannot be subclassed. There is no runtime checking
-   verifying that the parameter is actually a value instead of a type.
+      open_helper('/some/path', 'r')  # Passes type check
+      open_helper('/other/path', 'typo')  # Error in type checker
+
+   ``Literal[...]`` cannot be subclassed. At runtime, an arbitrary value
+   is allowed as type argument to ``Literal[...]``, but type checkers may
+   impose restrictions. See :pep:`586` for more details about literal types.
 
    .. versionadded:: 3.8
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9,7 +9,7 @@ from copy import copy, deepcopy
 from typing import Any, NoReturn
 from typing import TypeVar, AnyStr
 from typing import T, KT, VT  # Not in __all__.
-from typing import Union, Optional
+from typing import Union, Optional, Literal
 from typing import Tuple, List, MutableMapping
 from typing import Callable
 from typing import Generic, ClassVar
@@ -487,6 +487,66 @@ class CallableTests(BaseTestCase):
     def test_ellipsis_in_generic(self):
         # Shouldn't crash; see https://github.com/python/typing/issues/259
         typing.List[Callable[..., str]]
+
+
+class LiteralTests(BaseTestCase):
+    def test_basics(self):
+        # All of these are allowed.
+        Literal[1]
+        Literal[1, 2, 3]
+        Literal["x", "y", "z"]
+        Literal[None]
+
+    def test_illegal_parameters_do_not_raise_runtime_errors(self):
+        # Type checkers should reject these types, but we do not
+        # raise errors at runtime to maintain maximium flexibility.
+        Literal[int]
+        Literal[Literal[1, 2], Literal[4, 5]]
+        Literal[3j + 2, ..., ()]
+        Literal[b"foo", u"bar"]
+        Literal[{"foo": 3, "bar": 4}]
+        Literal[T]
+
+    def test_literals_inside_other_types(self):
+        List[Literal[1, 2, 3]]
+        List[Literal[("foo", "bar", "baz")]]
+
+    def test_repr(self):
+        self.assertEqual(repr(Literal[1]), "typing.Literal[1]")
+        self.assertEqual(repr(Literal[1, True, "foo"]), "typing.Literal[1, True, 'foo']")
+        self.assertEqual(repr(Literal[int]), "typing.Literal[int]")
+        self.assertEqual(repr(Literal), "typing.Literal")
+        self.assertEqual(repr(Literal[None]), "typing.Literal[None]")
+
+    def test_cannot_init(self):
+        with self.assertRaises(TypeError):
+            Literal()
+        with self.assertRaises(TypeError):
+            Literal[1]()
+        with self.assertRaises(TypeError):
+            type(Literal)()
+        with self.assertRaises(TypeError):
+            type(Literal[1])()
+
+    def test_no_isinstance_or_issubclass(self):
+        with self.assertRaises(TypeError):
+            isinstance(1, Literal[1])
+        with self.assertRaises(TypeError):
+            isinstance(int, Literal[1])
+        with self.assertRaises(TypeError):
+            issubclass(1, Literal[1])
+        with self.assertRaises(TypeError):
+            issubclass(int, Literal[1])
+
+    def test_no_subclassing(self):
+        with self.assertRaises(TypeError):
+            class Foo(Literal[1]): pass
+        with self.assertRaises(TypeError):
+            class Bar(Literal): pass
+
+    def test_no_multiple_subscripts(self):
+        with self.assertRaises(TypeError):
+            Literal[1][1]
 
 
 XK = TypeVar('XK', str, bytes)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -496,14 +496,16 @@ class LiteralTests(BaseTestCase):
         Literal[1, 2, 3]
         Literal["x", "y", "z"]
         Literal[None]
+        Literal[True]
+        Literal[1, "2", False]
+        Literal[Literal[1, 2], Literal[4, 5]]
+        Literal[b"foo", u"bar"]
 
     def test_illegal_parameters_do_not_raise_runtime_errors(self):
         # Type checkers should reject these types, but we do not
         # raise errors at runtime to maintain maximium flexibility.
         Literal[int]
-        Literal[Literal[1, 2], Literal[4, 5]]
         Literal[3j + 2, ..., ()]
-        Literal[b"foo", u"bar"]
         Literal[{"foo": 3, "bar": 4}]
         Literal[T]
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -439,17 +439,23 @@ Optional = _SpecialForm('Optional', doc=
 Literal = _SpecialForm('Literal', doc=
     """Special typing form to define literal types (a.k.a. value types).
 
-    This type constructor can be used to indicate to type checkers that
-    the corresponding variable has a value literally equivalent to the
-    provided parameter. For example:
+    This form can be used to indicate to type checkers that the corresponding
+    variable or function parameter has a value equivalent to the provided
+    literal (or one of several literals):
 
-      var: Literal[4] = 4
+      def validate_simple(data: Any) -> Literal[True]:  # always returns True
+          ...
 
-    The type checker understands that 'var' is literally equal to the
-    value 4 and no other value.
+      MODE = Literal['r', 'rb', 'w', 'wb']
+      def open_helper(file: str, mode: MODE) -> str:
+          ...
 
-    Literal[...] cannot be subclassed. There is no runtime checking
-    verifying that the parameter is actually a value instead of a type.
+      open_helper('/some/path', 'r')  # Passes type check
+      open_helper('/other/path', 'typo')  # Error in type checker
+
+   Literal[...] cannot be subclassed. At runtime, an arbitrary value
+   is allowed as type argument to Literal[...], but type checkers may
+   impose restrictions.
     """)
 
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -353,6 +353,10 @@ class _SpecialForm(_Final, _Immutable, _root=True):
         if self._name == 'Optional':
             arg = _type_check(parameters, "Optional[t] requires a single type.")
             return Union[arg, type(None)]
+        if self._name == 'Literal':
+            # There is no '_type_check' call because arguments to Literal[...] are
+            # values, not types.
+            return _GenericAlias(self, parameters)
         raise TypeError(f"{self} is not subscriptable")
 
 
@@ -429,6 +433,22 @@ Optional = _SpecialForm('Optional', doc=
     """Optional type.
 
     Optional[X] is equivalent to Union[X, None].
+    """)
+
+Literal = _SpecialForm('Literal', doc=
+    """Special typing form to define literal types (a.k.a. value types).
+
+    This type constructor can be used to indicate to type checkers that
+    the corresponding variable has a value literally equivalent to the
+    provided parameter. For example:
+
+      var: Literal[4] = 4
+
+    The type checker understands that 'var' is literally equal to the
+    value 4 and no other value.
+
+    Literal[...] cannot be subclassed. There is no runtime checking
+    verifying that the parameter is actually a value instead of a type.
     """)
 
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -36,6 +36,7 @@ __all__ = [
     'Callable',
     'ClassVar',
     'Generic',
+    'Literal',
     'Optional',
     'Tuple',
     'Type',

--- a/Misc/NEWS.d/next/Library/2019-05-25-19-12-53.bpo-37046.iuhQQj.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-25-19-12-53.bpo-37046.iuhQQj.rst
@@ -1,0 +1,1 @@
+PEP 586: Add ``Literal`` to the ``typing`` module.


### PR DESCRIPTION
cc @Michael0x2a @JukkaL

The implementation is straightforward and essentially is just copied from `typing_extensions`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37046](https://bugs.python.org/issue37046) -->
https://bugs.python.org/issue37046
<!-- /issue-number -->
