### PR TITLE
bpo-36853: Fix suspicious.py to actually print the unused rules

### DIFF
--- a/Doc/tools/extensions/suspicious.py
+++ b/Doc/tools/extensions/suspicious.py
@@ -153,14 +153,15 @@ class CheckSuspiciousMarkupBuilder(Builder):
         self.any_issue = True
         self.write_log_entry(lineno, issue, text)
         if py3:
-            self.logger.warn('[%s:%d] "%s" found in "%-.120s"' %
-                             (self.docname, lineno, issue, text))
+            self.logger.warning('[%s:%d] "%s" found in "%-.120s"' %
+                                (self.docname, lineno, issue, text))
         else:
-            self.logger.warn('[%s:%d] "%s" found in "%-.120s"' % (
-                self.docname.encode(sys.getdefaultencoding(),'replace'),
-                lineno,
-                issue.encode(sys.getdefaultencoding(),'replace'),
-                text.strip().encode(sys.getdefaultencoding(),'replace')))
+            self.logger.warning(
+                '[%s:%d] "%s" found in "%-.120s"' % (
+                    self.docname.encode(sys.getdefaultencoding(),'replace'),
+                    lineno,
+                    issue.encode(sys.getdefaultencoding(),'replace'),
+                    text.strip().encode(sys.getdefaultencoding(),'replace')))
         self.app.statuscode = 1
 
     def write_log_entry(self, lineno, issue, text):

--- a/Doc/tools/extensions/suspicious.py
+++ b/Doc/tools/extensions/suspicious.py
@@ -115,10 +115,12 @@ class CheckSuspiciousMarkupBuilder(Builder):
     def finish(self):
         unused_rules = [rule for rule in self.rules if not rule.used]
         if unused_rules:
-            self.logger.warn('Found %s/%s unused rules:' %
-                             (len(unused_rules), len(self.rules)))
-            for rule in unused_rules:
-                self.logger.info(repr(rule))
+            self.logger.warning(
+                'Found %s/%s unused rules: %s' % (
+                    len(unused_rules), len(self.rules),
+                    ''.join(repr(rule) for rule in unused_rules),
+                )
+            )
         return
 
     def check_issue(self, line, lineno, issue):


### PR DESCRIPTION
There were two issues here:
- `self.warn` isn't a thing in modern sphinx
- `logger.warning` terminates immediately and then doesn't print the info lines below it

<!-- issue-number: [bpo-36853](https://bugs.python.org/issue36853) -->
https://bugs.python.org/issue36853
<!-- /issue-number -->
