### PR TITLE
bpo-30835: email: Fix AttributeError when parsing invalid CTE

### DIFF
--- a/Lib/email/feedparser.py
+++ b/Lib/email/feedparser.py
@@ -320,7 +320,7 @@ class FeedParser:
                 self._cur.set_payload(EMPTYSTRING.join(lines))
                 return
             # Make sure a valid content type was specified per RFC 2045:6.4.
-            if (self._cur.get('content-transfer-encoding', '8bit').lower()
+            if (str(self._cur.get('content-transfer-encoding', '8bit')).lower()
                     not in ('7bit', '8bit', 'binary')):
                 defect = errors.InvalidMultipartContentTransferEncodingDefect()
                 self.policy.handle_defect(self._cur, defect)

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -1469,6 +1469,15 @@ Blah blah blah
         g.flatten(msg)
         self.assertEqual(b.getvalue(), source + b'>From R\xc3\xb6lli\n')
 
+    def test_mutltipart_with_bad_bytes_in_cte(self):
+        # bpo30835
+        source = textwrap.dedent("""\
+            From: aperson@example.com
+            Content-Type: multipart/mixed; boundary="1"
+            Content-Transfer-Encoding: \xc8
+        """).encode('utf-8')
+        msg = email.message_from_bytes(source)
+
 
 # Test the basic MIMEAudio class
 class TestMIMEAudio(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2019-05-27-15-29-46.bpo-30835.3FoaWH.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-27-15-29-46.bpo-30835.3FoaWH.rst
@@ -1,0 +1,3 @@
+Fixed a bug in email parsing where a message with invalid bytes in
+content-transfer-encoding of a multipart message can cause an AttributeError.
+Patch by Andrew Donnellan.


### PR DESCRIPTION
This is basically https://github.com/python/cpython/pull/2544 along with a test and NEWS entry.

The bugfix + test was originally written by @adjlinux. I added the NEWS entry to get this merged since the orignial PR seems to be abandoned.

<!-- issue-number: [bpo-30835](https://bugs.python.org/issue30835) -->
https://bugs.python.org/issue30835
<!-- /issue-number -->
