### PR TITLE
bpo-37054, _pyio: Fix BytesIO and TextIOWrapper __del__()

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -873,6 +873,10 @@ class BytesIO(BufferedIOBase):
 
     """Buffered I/O implementation using an in-memory bytes buffer."""
 
+    # Initialize _buffer as soon as possible since it's used by __del__()
+    # which calls close()
+    _buffer = None
+
     def __init__(self, initial_bytes=None):
         buf = bytearray()
         if initial_bytes is not None:
@@ -900,7 +904,8 @@ class BytesIO(BufferedIOBase):
         return memoryview(self._buffer)
 
     def close(self):
-        self._buffer.clear()
+        if self._buffer is not None:
+            self._buffer.clear()
         super().close()
 
     def read(self, size=-1):
@@ -1969,6 +1974,10 @@ class TextIOWrapper(TextIOBase):
     """
 
     _CHUNK_SIZE = 2048
+
+    # Initialize _buffer as soon as possible since it's used by __del__()
+    # which calls close()
+    _buffer = None
 
     # The write_through argument has no effect here since this
     # implementation always writes through.  The argument is present only

--- a/Misc/NEWS.d/next/Library/2019-05-28-01-06-44.bpo-37054.sLULGQ.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-28-01-06-44.bpo-37054.sLULGQ.rst
@@ -1,0 +1,3 @@
+Fix destructor :class:`_pyio.BytesIO` and :class:`_pyio.TextIOWrapper`:
+initialize their ``_buffer`` attribute as soon as possible (in the class
+body), because it's used by ``__del__()`` which calls ``close()``.


### PR DESCRIPTION
Fix destructor _pyio.BytesIO and _pyio.TextIOWrapper: initialize
their _buffer attribute as soon as possible (in the class body),
because it's used by __del__() which calls close().

<!-- issue-number: [bpo-37054](https://bugs.python.org/issue37054) -->
https://bugs.python.org/issue37054
<!-- /issue-number -->
