### PR TITLE
bpo-37070: Cleanup fstring debug handling

### DIFF
--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -284,7 +284,7 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         eq("(x:=10)")
         eq("f'{(x:=10):=10}'")
 
-    def test_fstring_annotations(self):
+    def test_fstring_debug_annotations(self):
         # f-strings with '=' don't round trip very well, so set the expected
         # result explicitely.
         self.assertAnnotationEqual("f'{x=!r}'", expected="f'x={x!r}'")

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -284,6 +284,7 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         eq("(x:=10)")
         eq("f'{(x:=10):=10}'")
 
+    def test_fstring_annotations(self):
         # f-strings with '=' don't round trip very well, so set the expected
         # result explicitely.
         self.assertAnnotationEqual("f'{x=!r}'", expected="f'x={x!r}'")

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -5010,8 +5010,8 @@ fstring_parse(const char **str, const char *end, int raw, int recurse_lvl,
 
    *expression is set to the expression.  For an '=' "debug" expression,
    *expr_text is set to the debug text (the original text of the expression,
-   *including the '=' and any whitespace around it, as a string object).  If
-   *not a debug expression, *expr_text set to NULL. */
+   including the '=' and any whitespace around it, as a string object).  If
+   not a debug expression, *expr_text set to NULL. */
 static int
 fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
                   PyObject **expr_text, expr_ty *expression,
@@ -5038,6 +5038,8 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
        expressions. */
     Py_ssize_t nested_depth = 0;
     char parenstack[MAXLEVEL];
+
+    *expr_text = NULL;
 
     /* Can only nest one level deep. */
     if (recurse_lvl >= 2) {
@@ -5214,8 +5216,6 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
         if (!*expr_text) {
             goto error;
         }
-    } else {
-        *expr_text = NULL;
     }
 
     /* Check for a conversion char, if present. */
@@ -5281,6 +5281,7 @@ unexpected_end_of_string:
     /* Falls through to error. */
 
 error:
+    Py_XDECREF(*expr_text);
     return -1;
 
 }
@@ -5591,6 +5592,28 @@ FstringParser_ConcatAndDel(FstringParser *state, PyObject *str)
     return 0;
 }
 
+/* Move *literal into the parser state object, thus transfering ownership.
+   Set *literal to NULL. If there's already a literal in the state object,
+   concatenate to it. */
+static int
+FstringParser_ConcatLiteral(FstringParser *state, PyObject **literal)
+{
+    if (!*literal) {
+        /* Do nothing. Just leave last_str alone (and possibly NULL). */
+    } else if (!state->last_str) {
+        /* Note that the literal can be zero length, if the input string is
+           "\\\n" or "\\\r", among others. */
+        state->last_str = *literal;
+    } else {
+        /* We have a literal, concatenate it. */
+        assert(PyUnicode_GET_LENGTH(*literal) != 0);
+        if (FstringParser_ConcatAndDel(state, *literal) < 0)
+            return -1;
+    }
+    *literal = NULL;  /* We've transfered ownership to the "state" object. */
+    return 0;
+}
+
 /* Parse an f-string. The f-string is in *str to end, with no
    'f' or quotes. */
 static int
@@ -5603,7 +5626,8 @@ FstringParser_ConcatFstring(FstringParser *state, const char **str,
 
     /* Parse the f-string. */
     while (1) {
-        PyObject *literal[2] = {NULL, NULL};
+        PyObject *literal = NULL;
+        PyObject *expr_text = NULL;
         expr_ty expression = NULL;
 
         /* If there's a zero length literal in front of the
@@ -5611,34 +5635,25 @@ FstringParser_ConcatFstring(FstringParser *state, const char **str,
            the f-string, expression will be NULL (unless result == 1,
            see below). */
         int result = fstring_find_literal_and_expr(str, end, raw, recurse_lvl,
-                                                   &literal[0], &literal[1],
+                                                   &literal, &expr_text,
                                                    &expression, c, n);
         if (result < 0)
             return -1;
 
-        /* Add the literals, if any. */
-        for (int i = 0; i < 2; i++) {
-            if (!literal[i]) {
-                /* Do nothing. Just leave last_str alone (and possibly
-                   NULL). */
-            } else if (!state->last_str) {
-                /*  Note that the literal can be zero length, if the
-                    input string is "\\\n" or "\\\r", among others. */
-                state->last_str = literal[i];
-                literal[i] = NULL;
-            } else {
-                /* We have a literal, concatenate it. */
-                assert(PyUnicode_GET_LENGTH(literal[i]) != 0);
-                if (FstringParser_ConcatAndDel(state, literal[i]) < 0)
-                    return -1;
-                literal[i] = NULL;
-            }
+        /* Add the literal, if any. */
+        if (FstringParser_ConcatLiteral(state, &literal) < 0) {
+            Py_XDECREF(expr_text);
+            return -1;
+        }
+        /* Add the expr_text, if any. */
+        if (FstringParser_ConcatLiteral(state, &expr_text) < 0) {
+            return -1;
         }
 
         /* We've dealt with the literals now. They can't be leaked on further
            errors. */
-        assert(literal[0] == NULL);
-        assert(literal[1] == NULL);
+        assert(literal == NULL);
+        assert(expr_text == NULL);
 
         /* See if we should just loop around to get the next literal
            and expression, while ignoring the expression this


### PR DESCRIPTION
Fix potential memory leaks.
Fix some comments.
Make literal/expr_text handling clearer.
Move string annotation testing to a separate function.

<!-- issue-number: [bpo-37070](https://bugs.python.org/issue37070) -->
https://bugs.python.org/issue37070
<!-- /issue-number -->
