### PR TITLE
[3.6] bpo-36520: Email header folded incorrectly (GH-13608)

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2662,6 +2662,7 @@ def _refold_parse_tree(parse_tree, *, policy):
             newline = _steal_trailing_WSP_if_exists(lines)
             if newline or part.startswith_fws():
                 lines.append(newline + tstr)
+                last_ew = None
                 continue
         if not hasattr(part, 'encode'):
             # It's not a terminal, try folding the subparts.

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -784,6 +784,80 @@ class TestEmailMessage(TestEmailMessageBase, TestEmailBase):
         m['Subject'] = 'unicöde'
         self.assertEqual(str(m), 'Subject: unicöde\n\n')
 
+    def test_folding_with_utf8_encoding_1(self):
+        # issue #36520
+        m = EmailMessage()
+        m['Subject'] = 'Hello Wörld! Hello Wörld! '\
+                       'Hello Wörld! Hello Wörld!Hello Wörld!'
+        self.assertEqual(bytes(m), \
+                         b'Subject: Hello =?utf-8?q?W=C3=B6rld!_Hello_W'\
+                         b'=C3=B6rld!_Hello_W=C3=B6rld!?=\n'\
+                         b' Hello =?utf-8?q?W=C3=B6rld!Hello_W=C3=B6rld!?=\n\n')
+
+
+    def test_folding_with_utf8_encoding_2(self):
+        # issue #36520
+        m = EmailMessage()
+        m['Subject'] = 'Hello Wörld! Hello Wörld! '\
+                       'Hello Wörlds123! Hello Wörld!Hello Wörld!'
+        self.assertEqual(bytes(m), \
+                         b'Subject: Hello =?utf-8?q?W=C3=B6rld!_Hello_W'\
+                         b'=C3=B6rld!_Hello_W=C3=B6rlds123!?=\n'\
+                         b' Hello =?utf-8?q?W=C3=B6rld!Hello_W=C3=B6rld!?=\n\n')
+
+    def test_folding_with_utf8_encoding_3(self):
+        # issue #36520
+        m = EmailMessage()
+        m['Subject'] = 'Hello-Wörld!-Hello-Wörld!-Hello-Wörlds123! '\
+                       'Hello Wörld!Hello Wörld!'
+        self.assertEqual(bytes(m), \
+                         b'Subject: =?utf-8?q?Hello-W=C3=B6rld!-Hello-W'\
+                         b'=C3=B6rld!-Hello-W=C3=B6rlds123!?=\n'\
+                         b' Hello =?utf-8?q?W=C3=B6rld!Hello_W=C3=B6rld!?=\n\n')
+
+    def test_folding_with_utf8_encoding_4(self):
+        # issue #36520
+        m = EmailMessage()
+        m['Subject'] = 'Hello-Wörld!-Hello-Wörld!-Hello-Wörlds123!-Hello'\
+                       ' Wörld!Hello Wörld!'
+        self.assertEqual(bytes(m), \
+                         b'Subject: =?utf-8?q?Hello-W=C3=B6rld!-Hello-W'\
+                         b'=C3=B6rld!-Hello-W=C3=B6rlds123!?=\n'\
+                         b' =?utf-8?q?-Hello_W=C3=B6rld!Hello_W=C3=B6rld!?=\n\n')
+
+    def test_folding_with_utf8_encoding_5(self):
+        # issue #36520
+        m = EmailMessage()
+        m['Subject'] = '123456789 123456789 123456789 123456789 123456789'\
+                       ' 123456789 123456789 Hello Wörld!'
+        self.assertEqual(bytes(m), \
+                         b'Subject: 123456789 123456789 123456789 123456789'\
+                         b' 123456789 123456789 123456789\n'\
+                         b' Hello =?utf-8?q?W=C3=B6rld!?=\n\n')
+
+    def test_folding_with_utf8_encoding_6(self):
+        # issue #36520
+        m = EmailMessage()
+        m['Subject'] = '123456789 123456789 123456789 123456789 Hello Wörld!'\
+                       ' 123456789 123456789 123456789 123456789 123456789'\
+                       ' 123456789'
+        self.assertEqual(bytes(m), \
+                         b'Subject: 123456789 123456789 123456789 123456789'\
+                         b' Hello =?utf-8?q?W=C3=B6rld!?=\n 123456789 '\
+                         b'123456789 123456789 123456789 123456789 '\
+                         b'123456789\n\n')
+
+    def test_folding_with_utf8_encoding_7(self):
+        # issue #36520
+        m = EmailMessage()
+        m['Subject'] = '123456789 123456789 Hello Wörld! Hello Wörld! '\
+                       '123456789-123456789 123456789 Hello Wörld! 123456789'\
+                       ' 123456789'
+        self.assertEqual(bytes(m), \
+                         b'Subject: 123456789 123456789 Hello =?utf-8?q?'\
+                         b'W=C3=B6rld!_Hello_W=C3=B6rld!?=\n'\
+                         b' 123456789-123456789 123456789 Hello '\
+                         b'=?utf-8?q?W=C3=B6rld!?= 123456789\n 123456789\n\n')
 
 class TestMIMEPart(TestEmailMessageBase, TestEmailBase):
     # Doing the full test run here may seem a bit redundant, since the two

--- a/Misc/NEWS.d/next/Library/2019-05-28-02-37-00.bpo-36520.W4tday.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-28-02-37-00.bpo-36520.W4tday.rst
@@ -1,0 +1,1 @@
+Lengthy email headers with UTF-8 characters are now properly encoded when they are folded.


### PR DESCRIPTION
Folding long email headers that contain multiple UTF-8 words in the first line results in corruption when UTF-8 words are found in subsequent lines. The fix is to reset the variable tracking the encoded word location in the line when a new line is started.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36520](https://bugs.python.org/issue36520) -->
https://bugs.python.org/issue36520
<!-- /issue-number -->
