### PR TITLE
bpo-36900: Fix compilation on HP-UX

### DIFF
--- a/Python/dynload_hpux.c
+++ b/Python/dynload_hpux.c
@@ -6,6 +6,7 @@
 
 #include "Python.h"
 #include "importdl.h"
+#include "pycore_pystate.h"
 
 #if defined(__hp9000s300)
 #define FUNCNAME_PATTERN "_%.20s_%.200s"


### PR DESCRIPTION
dynload_hpux.c: add #include "pycore_pystate.h" for
_PyInterpreterState_GET_UNSAFE().

<!-- issue-number: [bpo-36900](https://bugs.python.org/issue36900) -->
https://bugs.python.org/issue36900
<!-- /issue-number -->
