### PR TITLE
DOC: Space beaking whole definition.

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -225,7 +225,7 @@ Glossary
       statement by defining :meth:`__enter__` and :meth:`__exit__` methods.
       See :pep:`343`.
 
-    context variable
+   context variable
       A variable which can have different values depending on its context.
       This is similar to Thread-Local Storage in which each execution
       thread may have a different value for a variable. However, with context


### PR DESCRIPTION
![](https://screenshotscdn.firefoxusercontent.com/images/d985b517-9d1e-4078-bd66-2da5833c6582.png)

This should fix the definition of Context Variable ("ntext variable" in the above screenshot)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
