### PR TITLE
bpo-37075: Fix string concatenation in assert_has_awaits error message

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1945,7 +1945,7 @@ The full list of supported magic methods is:
 * Container methods: ``__getitem__``, ``__setitem__``, ``__delitem__``,
   ``__contains__``, ``__len__``, ``__iter__``, ``__reversed__``
   and ``__missing__``
-* Context manager: ``__enter__``, ``__exit__``, ``__aenter`` and ``__aexit__``
+* Context manager: ``__enter__``, ``__exit__``, ``__aenter__`` and ``__aexit__``
 * Unary numeric methods: ``__neg__``, ``__pos__`` and ``__invert__``
 * The numeric methods (including right hand and in-place variants):
   ``__add__``, ``__sub__``, ``__mul__``, ``__matmul__``, ``__div__``, ``__truediv__``,

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2027,6 +2027,7 @@ Methods and their defaults:
 * ``__len__``: 0
 * ``__iter__``: iter([])
 * ``__exit__``: False
+* ``__aexit__``: False
 * ``__complex__``: 1j
 * ``__float__``: 1.0
 * ``__bool__``: True

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -790,12 +790,12 @@ class NonCallableMock(Base):
         return _format_call_signature(name, args, kwargs)
 
 
-    def _format_mock_failure_message(self, args, kwargs):
-        message = 'expected call not found.\nExpected: %s\nActual: %s'
+    def _format_mock_failure_message(self, args, kwargs, action='call'):
+        message = 'expected %s not found.\nExpected: %s\nActual: %s'
         expected_string = self._format_mock_call_signature(args, kwargs)
         call_args = self.call_args
         actual_string = self._format_mock_call_signature(*call_args)
-        return message % (expected_string, actual_string)
+        return message % (action, expected_string, actual_string)
 
 
     def _call_matcher(self, _call):
@@ -2108,7 +2108,7 @@ class AsyncMockMixin(Base):
             raise AssertionError(f'Expected await: {expected}\nNot awaited')
 
         def _error_message():
-            msg = self._format_mock_failure_message(args, kwargs)
+            msg = self._format_mock_failure_message(args, kwargs, action='await')
             return msg
 
         expected = self._call_matcher((args, kwargs))
@@ -2162,7 +2162,7 @@ class AsyncMockMixin(Base):
         if not any_order:
             if expected not in all_awaits:
                 raise AssertionError(
-                    f'Awaits not found.\nExpected: {_CallList(calls)}\n',
+                    f'Awaits not found.\nExpected: {_CallList(calls)}\n'
                     f'Actual: {self.await_args_list}'
                 ) from cause
             return

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -526,7 +526,8 @@ class AsyncMockAssert(unittest.TestCase):
 
     def test_assert_awaited_with(self):
         asyncio.run(self._runnable_test())
-        with self.assertRaises(AssertionError):
+        msg = 'expected await not found'
+        with self.assertRaisesRegex(AssertionError, msg):
             self.mock.assert_awaited_with('foo')
 
         asyncio.run(self._runnable_test('foo'))
@@ -564,8 +565,9 @@ class AsyncMockAssert(unittest.TestCase):
     def test_assert_has_awaits_no_order(self):
         calls = [call('NormalFoo'), call('baz')]
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(AssertionError) as cm:
             self.mock.assert_has_awaits(calls)
+        self.assertEqual(len(cm.exception.args), 1)
 
         asyncio.run(self._runnable_test('foo'))
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
* Fix the implicit string concatenation in `assert_has_awaits` error message.
* Use "await" instead of "call" in `assert_awaited_with` error message.


<!-- issue-number: [bpo-37075](https://bugs.python.org/issue37075) -->
https://bugs.python.org/issue37075
<!-- /issue-number -->
