### PR TITLE
bpo-35279: reduce default max_workers of ThreadPoolExecutor

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -161,12 +161,12 @@ And::
 
    .. versionchanged:: 3.8
       Default value of *max_workers* is changed to ``min(32, os.cpu_count() + 4)``.
-      This default value preserves at least 5 worker for I/O bound task.  It utilize
-      at most 32 CPU cores for CPU bound task which release GIL.  And it avoid using
-      very large resource implicitly on many core machines.
+      This default value preserves at least 5 workers for I/O bound tasks.
+      It utilizes at most 32 CPU cores for CPU bound tasks which release the GIL.
+      And it avoids using very large resources implicitly on many-core machines.
 
-      ThreadPoolExecutor now reuses idle worker threads before starting *max_workers*
-      worker threads too.
+      ThreadPoolExecutor now reuses idle worker threads before starting
+      *max_workers* worker threads too.
 
 
 .. _threadpoolexecutor-example:

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -159,6 +159,15 @@ And::
    .. versionchanged:: 3.7
       Added the *initializer* and *initargs* arguments.
 
+   .. versionchanged:: 3.8
+      Default value of *max_workers* is changed to ``min(32, os.cpu_count() + 4)``.
+      This default value preserves at least 5 worker for I/O bound task.  It utilize
+      at most 32 CPU cores for CPU bound task which release GIL.  And it avoid using
+      very large resource implicitly on many core machines.
+
+      ThreadPoolExecutor now reuses idle worker threads before starting *max_workers*
+      worker threads too.
+
 
 .. _threadpoolexecutor-example:
 

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -755,8 +755,8 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
 
     def test_default_workers(self):
         executor = self.executor_type()
-        self.assertEqual(executor._max_workers,
-                         (os.cpu_count() or 1) * 5)
+        expected = min(32, (os.cpu_count() or 1) + 4)
+        self.assertEqual(executor._max_workers, expected)
 
     def test_saturation(self):
         executor = self.executor_type(4)

--- a/Misc/NEWS.d/next/Library/2019-05-28-19-14-29.bpo-35279.PX7yl9.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-28-19-14-29.bpo-35279.PX7yl9.rst
@@ -1,0 +1,3 @@
+Change default *max_workers* of ``ThreadPoolExecutor`` from ``cpu_count() *
+5`` to ``min(32, cpu_count() + 4))``.  Previous value was unreasonably
+large on many cores machines.


### PR DESCRIPTION


<!-- issue-number: [bpo-35279](https://bugs.python.org/issue35279) -->
https://bugs.python.org/issue35279
<!-- /issue-number -->
