### PR TITLE
bpo-36829: sys.excepthook and sys.unraisablehook flush

### DIFF
--- a/Python/errors.c
+++ b/Python/errors.c
@@ -26,6 +26,7 @@ extern "C" {
 
 _Py_IDENTIFIER(builtins);
 _Py_IDENTIFIER(stderr);
+_Py_IDENTIFIER(flush);
 
 
 /* Forward declarations */
@@ -1254,6 +1255,14 @@ write_unraisable_exc_file(PyThreadState *tstate, PyObject *exc_type,
     if (PyFile_WriteString("\n", file) < 0) {
         return -1;
     }
+
+    /* Explicitly call file.flush() */
+    PyObject *res = _PyObject_CallMethodId(file, &PyId_flush, NULL);
+    if (!res) {
+        return -1;
+    }
+    Py_DECREF(res);
+
     return 0;
 }
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -978,6 +978,16 @@ _PyErr_Display(PyObject *file, PyObject *exception, PyObject *value, PyObject *t
     }
     print_exception_recursive(file, value, seen);
     Py_XDECREF(seen);
+
+    /* Call file.flush() */
+    PyObject *res = _PyObject_CallMethodId(file, &PyId_flush, NULL);
+    if (!res) {
+        /* Silently ignore file.flush() error */
+        PyErr_Clear();
+    }
+    else {
+        Py_DECREF(res);
+    }
 }
 
 void


### PR DESCRIPTION
sys.excepthook() and sys.unraisablehook() now explicitly flush the
file (usually sys.stderr).

If file.flush() fails, sys.excepthook() silently ignores the error,
whereas sys.unraisablehook() logs the new exception.

<!-- issue-number: [bpo-36829](https://bugs.python.org/issue36829) -->
https://bugs.python.org/issue36829
<!-- /issue-number -->
