### PR TITLE
[2.7] bpo-26423: Fix possible overflow in wrap_lenfunc() (GH-13606)

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -403,6 +403,10 @@ class OperatorsTest(unittest.TestCase):
         a.setstate(100)
         self.assertEqual(a.getstate(), 100)
 
+    def test_wrap_lenfunc_bad_cast(self):
+        self.assertEqual(xrange(sys.maxsize).__len__(), sys.maxsize)
+
+
 class ClassPropertiesAndMethods(unittest.TestCase):
 
     def assertHasAttr(self, obj, name):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-27-18-00-19.bpo-26423.RgUOE8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-27-18-00-19.bpo-26423.RgUOE8.rst
@@ -1,0 +1,2 @@
+Fix possible overflow in ``wrap_lenfunc()`` when
+``sizeof(long) < sizeof(Py_ssize_t)`` (e.g., 64-bit Windows).

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4398,7 +4398,7 @@ wrap_lenfunc(PyObject *self, PyObject *args, void *wrapped)
     res = (*func)(self);
     if (res == -1 && PyErr_Occurred())
         return NULL;
-    return PyInt_FromLong((long)res);
+    return PyInt_FromSsize_t(res);
 }
 
 static PyObject *


### PR DESCRIPTION
Fix possible overflow in wrap_lenfunc() when
sizeof(long) < sizeof(Py_ssize_t) (e.g., 64-bit Windows).

(cherry picked from commit 05f16416d99dc9fc76fef11e56f16593e7a5955e)

<!-- issue-number: [bpo-26423](https://bugs.python.org/issue26423) -->
https://bugs.python.org/issue26423
<!-- /issue-number -->
