### PR TITLE
[3.7] bpo-33725: multiprocessing uses spawn by default on macOS (GH-13603)

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -102,7 +102,7 @@ to start a process.  These *start methods* are
     will not be inherited.  Starting a process using this method is
     rather slow compared to using *fork* or *forkserver*.
 
-    Available on Unix and Windows.  The default on Windows.
+    Available on Unix and Windows.  The default on Windows and macOS.
 
   *fork*
     The parent process uses :func:`os.fork` to fork the Python
@@ -123,6 +123,11 @@ to start a process.  These *start methods* are
 
     Available on Unix platforms which support passing file descriptors
     over Unix pipes.
+
+.. versionchanged:: 3.7.4
+
+   On macOS, *spawn* start method is now the default: *fork* start method is no
+   longer reliable on macOS, see :issue:`33725`.
 
 .. versionchanged:: 3.4
    *spawn* added on all unix platforms, and *forkserver* added for

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -310,7 +310,12 @@ if sys.platform != 'win32':
         'spawn': SpawnContext(),
         'forkserver': ForkServerContext(),
     }
-    _default_context = DefaultContext(_concrete_contexts['fork'])
+    if sys.platform == 'darwin':
+        # bpo-33725: running arbitrary code after fork() is no longer reliable
+        # on macOS since macOS 10.14 (Mojave). Use spawn by default instead.
+        _default_context = DefaultContext(_concrete_contexts['spawn'])
+    else:
+        _default_context = DefaultContext(_concrete_contexts['fork'])
 
 else:
 

--- a/Misc/NEWS.d/next/Library/2019-05-28-01-17-42.bpo-33725.fFZoDG.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-28-01-17-42.bpo-33725.fFZoDG.rst
@@ -1,0 +1,2 @@
+On macOS, the :mod:`multiprocessing` module now uses *spawn* start method by
+default.


### PR DESCRIPTION
On macOS, the multiprocessing module now uses the "spawn" start
method by default.

(cherry picked from commit 17a5588740b3d126d546ad1a13bdac4e028e6d50)

<!-- issue-number: [bpo-33725](https://bugs.python.org/issue33725) -->
https://bugs.python.org/issue33725
<!-- /issue-number -->
