### PR TITLE
bpo-35246: fix support for path-like args in asyncio subprocess

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1605,11 +1605,6 @@ class BaseEventLoop(events.AbstractEventLoop):
             raise ValueError("errors must be None")
 
         popen_args = (program,) + args
-        for arg in popen_args:
-            if not isinstance(arg, (str, bytes)):
-                raise TypeError(
-                    f"program arguments must be a bytes or text string, "
-                    f"not {type(arg).__name__}")
         protocol = protocol_factory()
         debug_log = None
         if self._debug:

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -7,6 +7,7 @@ from unittest import mock
 import asyncio
 from asyncio import base_subprocess
 from asyncio import subprocess
+import pathlib
 from test.test_asyncio import utils as test_utils
 from test import support
 
@@ -624,15 +625,14 @@ class SubprocessMixin:
 
     def test_create_subprocess_exec_with_path(self):
         async def execute():
-            from pathlib import Path
             p = await subprocess.create_subprocess_exec(
-                Path(sys.executable), '-c', 'pass')
+                pathlib.Path(sys.executable), '-c', 'pass')
             await p.wait()
             p = await subprocess.create_subprocess_exec(
-                sys.executable, '-c', 'pass', Path('.'))
+                sys.executable, '-c', 'pass', pathlib.Path('.'))
             await p.wait()
 
-        self.loop.run_until_complete(execute())
+        self.assertIsNone(self.loop.run_until_complete(execute()))
 
 if sys.platform != 'win32':
     # Unix

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -7,7 +7,6 @@ from unittest import mock
 import asyncio
 from asyncio import base_subprocess
 from asyncio import subprocess
-import pathlib
 from test.test_asyncio import utils as test_utils
 from test import support
 
@@ -626,10 +625,10 @@ class SubprocessMixin:
     def test_create_subprocess_exec_with_path(self):
         async def execute():
             p = await subprocess.create_subprocess_exec(
-                pathlib.Path(sys.executable), '-c', 'pass')
+                support.FakePath(sys.executable), '-c', 'pass')
             await p.wait()
             p = await subprocess.create_subprocess_exec(
-                sys.executable, '-c', 'pass', pathlib.Path('.'))
+                sys.executable, '-c', 'pass', support.FakePath('.'))
             await p.wait()
 
         self.assertIsNone(self.loop.run_until_complete(execute()))

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -622,6 +622,18 @@ class SubprocessMixin:
         self.loop.run_until_complete(execute())
 
 
+    def test_create_subprocess_exec_with_path(self):
+        async def execute():
+            from pathlib import Path
+            p = await subprocess.create_subprocess_exec(
+                Path(sys.executable), '-c', 'pass')
+            await p.wait()
+            p = await subprocess.create_subprocess_exec(
+                sys.executable, '-c', 'pass', Path('.'))
+            await p.wait()
+
+        self.loop.run_until_complete(execute())
+
 if sys.platform != 'win32':
     # Unix
     class SubprocessWatcherMixin(SubprocessMixin):

--- a/Misc/NEWS.d/next/Library/2019-05-28-23-17-35.bpo-35246.oXT21d.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-28-23-17-35.bpo-35246.oXT21d.rst
@@ -1,0 +1,1 @@
+Make :func:`asyncio.create_subprocess_exec` accept path-like arguments.


### PR DESCRIPTION
Drop isinstance checks from create_subprocess_exec function and let
subprocess module do them.

https://bugs.python.org/issue35246

<!-- issue-number: [bpo-35246](https://bugs.python.org/issue35246) -->
https://bugs.python.org/issue35246
<!-- /issue-number -->
