### PR TITLE
[2.7] bpo-26423: Fix test_descr.test_wrap_lenfunc_bad_cast() on 32-bit Windows

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -404,7 +404,11 @@ class OperatorsTest(unittest.TestCase):
         self.assertEqual(a.getstate(), 100)
 
     def test_wrap_lenfunc_bad_cast(self):
-        self.assertEqual(xrange(sys.maxsize).__len__(), sys.maxsize)
+        try:
+            large_range = xrange(sys.maxsize)
+        except OverflowError as exc:
+            self.skipTest("xrange(sys.maxsize) failed with: %s" % exc)
+        self.assertEqual(large_range.__len__(), sys.maxsize)
 
 
 class ClassPropertiesAndMethods(unittest.TestCase):


### PR DESCRIPTION
Skip the test if xrange(sys.maxsize) raises an OverflowError.

<!-- issue-number: [bpo-26423](https://bugs.python.org/issue26423) -->
https://bugs.python.org/issue26423
<!-- /issue-number -->
