### PR TITLE
bpo-37072: Fix crash in PyAST_FromNodeObject() when flags is NULL

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-28-18-18-55.bpo-37072.1Hewl3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-28-18-18-55.bpo-37072.1Hewl3.rst
@@ -1,0 +1,1 @@
+Fix crash in PyAST_FromNodeObject() when flags is NULL.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -786,7 +786,7 @@ PyAST_FromNodeObject(const node *n, PyCompilerFlags *flags,
     /* borrowed reference */
     c.c_filename = filename;
     c.c_normalize = NULL;
-    c.c_feature_version = flags->cf_feature_version;
+    c.c_feature_version = flags ? flags->cf_feature_version : PY_MINOR_VERSION;
 
     if (TYPE(n) == encoding_decl)
         n = CHILD(n, 0);


### PR DESCRIPTION
I'm confident that this fixes the reported crash. flags=NULL is treated as using the latest minor version.

<!-- issue-number: [bpo-37072](https://bugs.python.org/issue37072) -->
https://bugs.python.org/issue37072
<!-- /issue-number -->
