### PR TITLE
Fix typo in docs for socket.CAN_RAW_FD_FRAMES

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -380,7 +380,7 @@ Constants
 
    Enables CAN FD support in a CAN_RAW socket. This is disabled by default.
    This allows your application to send both CAN and CAN FD frames; however,
-   you one must accept both CAN and CAN FD frames when reading from the socket.
+   you must accept both CAN and CAN FD frames when reading from the socket.
 
    This constant is documented in the Linux documentation.
 


### PR DESCRIPTION
There is an extra "one" in the text description for the constant
socket.CAN_RAW_FD_FRAMES

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
