### PR TITLE
[3.7] Fix typo in docs for socket.CAN_RAW_FD_FRAMES (GH-13635)

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -373,7 +373,7 @@ Constants
 
    Enables CAN FD support in a CAN_RAW socket. This is disabled by default.
    This allows your application to send both CAN and CAN FD frames; however,
-   you one must accept both CAN and CAN FD frames when reading from the socket.
+   you must accept both CAN and CAN FD frames when reading from the socket.
 
    This constant is documented in the Linux documentation.
 


### PR DESCRIPTION
There is an extra "one" in the text description for the constant
socket.CAN_RAW_FD_FRAMES
(cherry picked from commit 1b05aa219041eb1c9dbcb4ec6c1fa5b20f060bf5)