### PR TITLE
Doc: Add an optional obsolete header.

### DIFF
--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -116,14 +116,8 @@ see the make targets above).
 Deprecation header
 ==================
 
-You can define the ``outdated_message`` and ``outdated_link_text``
-variables in ``html_context`` to show a red banner on each page
-redirecting to the "latest" version.
-
-The ``outdated_message`` comes first, the ``outdated_link_text`` comes
-afterwards as a link, like this::
-
-    {{ outdated_message }}<a href="to new version">{{ outdated_link_text }}</a>.
+You can define the ``outdated`` variable in ``html_context`` to show a
+red banner on each page redirecting to the "latest" version.
 
 The link points to the same page on ``/3/``, sadly for the moment the
 language is lost during the process.

--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -113,6 +113,21 @@ Then, from the ``Doc`` directory, run ::
 where ``<builder>`` is one of html, text, latex, or htmlhelp (for explanations
 see the make targets above).
 
+Deprecation header
+==================
+
+You can define the ``outdated_message`` and ``outdated_link_text``
+variables in ``html_context`` to show a red banner on each page
+redirecting to the "latest" version.
+
+The ``outdated_message`` comes first, the ``outdated_link_text`` comes
+afterwards as a link, like this::
+
+    {{ outdated_message }}<a href="to new version">{{ outdated_link_text }}</a>.
+
+The link points to the same page on ``/3/``, sadly for the moment the
+language is lost during the process.
+
 
 Contributing
 ============

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -1,10 +1,13 @@
 {% extends "!layout.html" %}
 
 {% block header %}
-{%- if outdated_message is defined and outdated_link_text is defined %}
+{%- if outdated %}
 <div id="outdated-warning" style="padding: .5em; text-align: center; background-color: #FFBABA; color: #6A0E0E;">
-    {{ outdated_message }}
-    <a href="/3/{{ pagename }}{{ file_suffix }}">{{ outdated_link_text }}</a>.
+    {% trans %}This document is for an old version of Python that is no longer supported.
+    You should upgrade, and read the {% endtrans %}
+    <a href="/3/{{ pagename }}{{ file_suffix }}">
+        {% trans %} Python documentation for the last stable release {% endtrans %}
+    </a>.
 </div>
 {%- endif %}
 {% endblock %}

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -1,5 +1,14 @@
 {% extends "!layout.html" %}
 
+{% block header %}
+{%- if outdated_message is defined and outdated_link_text is defined %}
+<div id="outdated-warning" style="padding: .5em; text-align: center; background-color: #FFBABA; color: #6A0E0E;">
+    {{ outdated_message }}
+    <a href="/3/{{ pagename }}{{ file_suffix }}">{{ outdated_link_text }}</a>.
+</div>
+{%- endif %}
+{% endblock %}
+
 {% block rootrellink %}
 {{ super() }}
     <li>

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -5,9 +5,7 @@
 <div id="outdated-warning" style="padding: .5em; text-align: center; background-color: #FFBABA; color: #6A0E0E;">
     {% trans %}This document is for an old version of Python that is no longer supported.
     You should upgrade, and read the {% endtrans %}
-    <a href="/3/{{ pagename }}{{ file_suffix }}">
-        {% trans %} Python documentation for the last stable release {% endtrans %}
-    </a>.
+    <a href="/3/{{ pagename }}{{ file_suffix }}">{% trans %} Python documentation for the last stable release {% endtrans %}</a>.
 </div>
 {%- endif %}
 {% endblock %}


### PR DESCRIPTION
This is to be backported to old versions of documentation, and when activated can look like this:

![](https://screenshotscdn.firefoxusercontent.com/images/e6e0ad65-a264-4a9f-bca5-ae9a4d0bfb77.png)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
