### PR TITLE
bpo-36919: make test_source_encoding.test_issue2301 implementation-independent

### DIFF
--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -31,7 +31,7 @@ class MiscSourceEncodingTest(unittest.TestCase):
         try:
             compile(b"# coding: cp932\nprint '\x94\x4e'", "dummy", "exec")
         except SyntaxError as v:
-            self.assertEqual(v.text, "print '\u5e74'\n")
+            self.assertEqual(v.text.rstrip('\n'), "print '\u5e74'")
         else:
             self.fail()
 

--- a/Misc/NEWS.d/next/Tests/2019-05-28-15-41-34.bpo-36919.-vGt_m.rst
+++ b/Misc/NEWS.d/next/Tests/2019-05-28-15-41-34.bpo-36919.-vGt_m.rst
@@ -1,0 +1,2 @@
+Make ``test_source_encoding.test_issue2301`` implementation independent. The
+test will work now for both CPython and IronPython.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36919](https://bugs.python.org/issue36919) -->
https://bugs.python.org/issue36919
<!-- /issue-number -->
