### PR TITLE
Fix markup and minor grammar improvements in Code_of_conduct.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,11 +2,11 @@
 
 Please note that all interactions on
 [Python Software Foundation](https://www.python.org/psf-landing/)-supported
-infrastructure is [covered](https://www.python.org/psf/records/board/minutes/2014-01-06/#management-of-the-psfs-web-properties>)
+infrastructure is [covered](https://www.python.org/psf/records/board/minutes/2014-01-06/#management-of-the-psfs-web-properties)
 by the [PSF Code of Conduct](https://www.python.org/psf/codeofconduct/),
-which includes all infrastructure used in the development of Python itself
+which includes all the infrastructure used in the development of Python itself
 (e.g. mailing lists, issue trackers, GitHub, etc.).
 
-In general this means everyone is expected to be open, considerate, and
-respectful of others no matter what their position is within the project.
+In general, this means that everyone is expected to be **open**, **considerate**, and
+**respectful** of others no matter what their position is within the project.
 


### PR DESCRIPTION
The old link had a > in the url which prevented the browser from jumping down to the correct section on that page.

That PSF page itself has an error: There's a duplicate "the" in that paragraph that needs to be removed: "...and conform to **the the** Python Community Code of Conduct."

While I was editing this file, I also fixed some grammar and bolded the 3 important keywords so that they catch the viewer's eyes. I can revert these changes if they are unwanted.

Thanks.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
