### PR TITLE
bpo-37094: Add example for TestCase.skipTest in unittest doc

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -539,7 +539,7 @@ This is the output of running the example above in verbose mode::
 
    test_format (__main__.MyTestCase) ... skipped 'not supported in this library version'
    test_nothing (__main__.MyTestCase) ... skipped 'demonstrating skipping'
-   test_skip_me (tmp.MyTestCase) ... skipped 'skip'
+   test_skip_me (__main__.MyTestCase) ... skipped 'skip'
    test_windows_support (__main__.MyTestCase) ... skipped 'requires Windows'
 
    ----------------------------------------------------------------------

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -510,7 +510,8 @@ that is broken and will fail, but shouldn't be counted as a failure on a
 :class:`TestResult`.
 
 Skipping a test is simply a matter of using the :func:`skip` :term:`decorator`
-or one of its conditional variants.
+or one of its conditional variants. And :meth:`TestCase.skipTest` could be used to
+skip a test.
 
 Basic skipping looks like this::
 
@@ -530,6 +531,9 @@ Basic skipping looks like this::
        def test_windows_support(self):
            # windows specific testing code
            pass
+
+       def test_skip_me(self):
+           self.skipTest("skip")
 
 This is the output of running the example above in verbose mode::
 
@@ -568,7 +572,7 @@ the test unless the passed object has a certain attribute::
            return lambda func: func
        return unittest.skip("{!r} doesn't have {!r}".format(obj, attr))
 
-The following decorators implement test skipping and expected failures:
+The following decorators and exception implement test skipping and expected failures:
 
 .. decorator:: skip(reason)
 

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -512,7 +512,6 @@ that is broken and will fail, but shouldn't be counted as a failure on a
 Skipping a test is simply a matter of using the :func:`skip` :term:`decorator`
 or one of its conditional variants, calling :meth:`TestCase.skipTest` within a
 :meth:`~TestCase.setUp` or test method, or raising :exc:`SkipTest` directly.
-skip a test.
 
 Basic skipping looks like this::
 
@@ -533,7 +532,7 @@ Basic skipping looks like this::
            # windows specific testing code
            pass
 
-       def test_skip_me(self):
+       def test_maybe_skipped(self):
            if not external_resource_available():
                self.skipTest("external resource not available")
            # test code that depends on the external resource
@@ -543,7 +542,7 @@ This is the output of running the example above in verbose mode::
 
    test_format (__main__.MyTestCase) ... skipped 'not supported in this library version'
    test_nothing (__main__.MyTestCase) ... skipped 'demonstrating skipping'
-   test_skip_me (__main__.MyTestCase) ... skipped 'skip'
+   test_maybe_skipped (__main__.MyTestCase) ... skipped 'external resource not available'
    test_windows_support (__main__.MyTestCase) ... skipped 'requires Windows'
 
    ----------------------------------------------------------------------

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -539,12 +539,13 @@ This is the output of running the example above in verbose mode::
 
    test_format (__main__.MyTestCase) ... skipped 'not supported in this library version'
    test_nothing (__main__.MyTestCase) ... skipped 'demonstrating skipping'
+   test_skip_me (tmp.MyTestCase) ... skipped 'skip'
    test_windows_support (__main__.MyTestCase) ... skipped 'requires Windows'
 
    ----------------------------------------------------------------------
-   Ran 3 tests in 0.005s
+   Ran 4 tests in 0.005s
 
-   OK (skipped=3)
+   OK (skipped=4)
 
 Classes can be skipped just like methods::
 

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -510,7 +510,8 @@ that is broken and will fail, but shouldn't be counted as a failure on a
 :class:`TestResult`.
 
 Skipping a test is simply a matter of using the :func:`skip` :term:`decorator`
-or one of its conditional variants. And :meth:`TestCase.skipTest` could be used to
+or one of its conditional variants, calling :meth:`TestCase.skipTest` within a
+:meth:`~TestCase.setUp` or test method, or raising :exc:`SkipTest` directly.
 skip a test.
 
 Basic skipping looks like this::
@@ -533,7 +534,10 @@ Basic skipping looks like this::
            pass
 
        def test_skip_me(self):
-           self.skipTest("skip")
+           if not external_resource_available():
+               self.skipTest("external resource not available")
+           # test code that depends on the external resource
+           pass
 
 This is the output of running the example above in verbose mode::
 


### PR DESCRIPTION
Also includes other minor test skipping doc improvements.

<!-- issue-number: [bpo-37094](https://bugs.python.org/issue37094) -->
https://bugs.python.org/issue37094
<!-- /issue-number -->