### PR TITLE
bpo-37085: Expose SocketCAN bcm_msg_head flags

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -375,7 +375,7 @@ Constants
    .. availability:: Linux >= 2.6.25.
 
    .. note::
-   The :data:`CAN_BCM_CAN_FD_FRAME` flag is only available on Linux >= 4.8.
+      The :data:`CAN_BCM_CAN_FD_FRAME` flag is only available on Linux >= 4.8.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -375,7 +375,7 @@ Constants
    .. availability:: Linux >= 2.6.25.
 
    .. note::
-    The :data:`CAN_BCM_CAN_FD_FRAME` flag is only available on Linux >= 4.8.
+   The :data:`CAN_BCM_CAN_FD_FRAME` flag is only available on Linux >= 4.8.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -374,6 +374,9 @@ Constants
 
    .. availability:: Linux >= 2.6.25.
 
+   .. note::
+    The :data:`CAN_BCM_CAN_FD_FRAME` flag is only available on Linux >= 4.8.
+
    .. versionadded:: 3.4
 
 .. data:: CAN_RAW_FD_FRAMES

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1872,6 +1872,25 @@ class BasicCANTest(unittest.TestCase):
         socket.CAN_BCM_RX_TIMEOUT   # cyclic message is absent
         socket.CAN_BCM_RX_CHANGED   # updated CAN frame (detected content change)
 
+        # flags
+        socket.CAN_BCM_SETTIMER
+        socket.CAN_BCM_STARTTIMER
+        socket.CAN_BCM_TX_COUNTEVT
+        socket.CAN_BCM_TX_ANNOUNCE
+        socket.CAN_BCM_TX_CP_CAN_ID
+        socket.CAN_BCM_RX_FILTER_ID
+        socket.CAN_BCM_RX_CHECK_DLC
+        socket.CAN_BCM_RX_NO_AUTOTIMER
+        socket.CAN_BCM_RX_ANNOUNCE_RESUME
+        socket.CAN_BCM_TX_RESET_MULTI_IDX
+        socket.CAN_BCM_RX_RTR_FRAME
+
+    @unittest.skipUnless(hasattr(socket, "CAN_BCM_CAN_FD_FRAME"),
+                         'socket.CAN_BCM_CAN_FD_FRAME required for this test')
+    def testBCMConstantsSupportsFD(self):
+        # This is only present on Linux kernel 4.8+
+        socket.CAN_BCM_CAN_FD_FRAME
+
     def testCreateSocket(self):
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
             pass

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1885,9 +1885,10 @@ class BasicCANTest(unittest.TestCase):
         socket.CAN_BCM_TX_RESET_MULTI_IDX
         socket.CAN_BCM_RX_RTR_FRAME
 
-    @unittest.skipUnless(hasattr(socket, "CAN_BCM_CAN_FD_FRAME"),
-                         'socket.CAN_BCM_CAN_FD_FRAME required for this test')
-    def testBCMConstantsSupportsFD(self):
+    @unittest.skipUnless(hasattr(socket, "CAN_BCM"),
+                         'socket.CAN_BCM required for this test.')
+    @support.requires_linux_version(4, 8)
+    def testBCMConstantsLinux48(self):
         # This is only present on Linux kernel 4.8+
         socket.CAN_BCM_CAN_FD_FRAME
 

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1885,13 +1885,6 @@ class BasicCANTest(unittest.TestCase):
         socket.CAN_BCM_TX_RESET_MULTI_IDX
         socket.CAN_BCM_RX_RTR_FRAME
 
-    @unittest.skipUnless(hasattr(socket, "CAN_BCM"),
-                         'socket.CAN_BCM required for this test.')
-    @support.requires_linux_version(4, 8)
-    def testBCMConstantsLinux48(self):
-        # This is only present on Linux kernel 4.8+
-        socket.CAN_BCM_CAN_FD_FRAME
-
     def testCreateSocket(self):
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
             pass

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -394,6 +394,7 @@ Alon Diamant
 Toby Dickenson
 Mark Dickinson
 Jack Diederich
+Karl Ding
 Daniel Diniz
 Humberto Diogenes
 Yves Dionne

--- a/Misc/NEWS.d/next/Library/2019-06-18-16-29-31.bpo-37085.GeYaD6.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-18-16-29-31.bpo-37085.GeYaD6.rst
@@ -1,2 +1,2 @@
-Add support for the optional Linux SocketCAN Broadcast Manager
-constants used as flags to configure the BCM behaviour.
+Add the optional Linux SocketCAN Broadcast Manager constants, used as flags
+to configure the BCM behaviour, in the socket module.  Patch by Karl Ding.

--- a/Misc/NEWS.d/next/Library/2019-06-18-16-29-31.bpo-37085.GeYaD6.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-18-16-29-31.bpo-37085.GeYaD6.rst
@@ -1,1 +1,2 @@
-Added support for the Linux SocketCAN Broadcast Manager API constants.
+Add support for the optional Linux SocketCAN Broadcast Manager
+constants used as flags to configure the BCM behaviour.

--- a/Misc/NEWS.d/next/Library/2019-06-18-16-29-31.bpo-37085.GeYaD6.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-18-16-29-31.bpo-37085.GeYaD6.rst
@@ -1,0 +1,1 @@
+Added support for the Linux SocketCAN Broadcast Manager API constants.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7683,7 +7683,7 @@ PyInit__socket(void)
     PyModule_AddIntConstant(m, "CAN_BCM_RX_ANNOUNCE_RESUME", RX_ANNOUNCE_RESUME);
     PyModule_AddIntConstant(m, "CAN_BCM_TX_RESET_MULTI_IDX", TX_RESET_MULTI_IDX);
     PyModule_AddIntConstant(m, "CAN_BCM_RX_RTR_FRAME", RX_RTR_FRAME);
-#ifdef  CAN_FD_FRAME
+#ifdef CAN_FD_FRAME
     /* CAN_FD_FRAME was only introduced in the 4.8.x kernel series */
     PyModule_AddIntConstant(m, "CAN_BCM_CAN_FD_FRAME", CAN_FD_FRAME);
 #endif

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7656,6 +7656,8 @@ PyInit__socket(void)
 #endif
 #ifdef HAVE_LINUX_CAN_BCM_H
     PyModule_AddIntMacro(m, CAN_BCM);
+
+    /* BCM opcodes */
     PyModule_AddIntConstant(m, "CAN_BCM_TX_SETUP", TX_SETUP);
     PyModule_AddIntConstant(m, "CAN_BCM_TX_DELETE", TX_DELETE);
     PyModule_AddIntConstant(m, "CAN_BCM_TX_READ", TX_READ);
@@ -7668,40 +7670,21 @@ PyInit__socket(void)
     PyModule_AddIntConstant(m, "CAN_BCM_RX_STATUS", RX_STATUS);
     PyModule_AddIntConstant(m, "CAN_BCM_RX_TIMEOUT", RX_TIMEOUT);
     PyModule_AddIntConstant(m, "CAN_BCM_RX_CHANGED", RX_CHANGED);
-#ifdef  SETTIMER
+
+    /* BCM flags */
     PyModule_AddIntConstant(m, "CAN_BCM_SETTIMER", SETTIMER);
-#endif
-#ifdef  STARTTIMER
     PyModule_AddIntConstant(m, "CAN_BCM_STARTTIMER", STARTTIMER);
-#endif
-#ifdef  TX_COUNTEVT
     PyModule_AddIntConstant(m, "CAN_BCM_TX_COUNTEVT", TX_COUNTEVT);
-#endif
-#ifdef  TX_ANNOUNCE
     PyModule_AddIntConstant(m, "CAN_BCM_TX_ANNOUNCE", TX_ANNOUNCE);
-#endif
-#ifdef  TX_CP_CAN_ID
     PyModule_AddIntConstant(m, "CAN_BCM_TX_CP_CAN_ID", TX_CP_CAN_ID);
-#endif
-#ifdef  RX_FILTER_ID
     PyModule_AddIntConstant(m, "CAN_BCM_RX_FILTER_ID", RX_FILTER_ID);
-#endif
-#ifdef  RX_CHECK_DLC
     PyModule_AddIntConstant(m, "CAN_BCM_RX_CHECK_DLC", RX_CHECK_DLC);
-#endif
-#ifdef  RX_NO_AUTOTIMER
     PyModule_AddIntConstant(m, "CAN_BCM_RX_NO_AUTOTIMER", RX_NO_AUTOTIMER);
-#endif
-#ifdef  RX_ANNOUNCE_RESUME
     PyModule_AddIntConstant(m, "CAN_BCM_RX_ANNOUNCE_RESUME", RX_ANNOUNCE_RESUME);
-#endif
-#ifdef  TX_RESET_MULTI_IDX
     PyModule_AddIntConstant(m, "CAN_BCM_TX_RESET_MULTI_IDX", TX_RESET_MULTI_IDX);
-#endif
-#ifdef  RX_RTR_FRAME
     PyModule_AddIntConstant(m, "CAN_BCM_RX_RTR_FRAME", RX_RTR_FRAME);
-#endif
 #ifdef  CAN_FD_FRAME
+    /* CAN_FD_FRAME was only introduced in the 4.8.x kernel series */
     PyModule_AddIntConstant(m, "CAN_BCM_CAN_FD_FRAME", CAN_FD_FRAME);
 #endif
 #endif

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7668,6 +7668,42 @@ PyInit__socket(void)
     PyModule_AddIntConstant(m, "CAN_BCM_RX_STATUS", RX_STATUS);
     PyModule_AddIntConstant(m, "CAN_BCM_RX_TIMEOUT", RX_TIMEOUT);
     PyModule_AddIntConstant(m, "CAN_BCM_RX_CHANGED", RX_CHANGED);
+#ifdef  SETTIMER
+    PyModule_AddIntConstant(m, "CAN_BCM_SETTIMER", SETTIMER);
+#endif
+#ifdef  STARTTIMER
+    PyModule_AddIntConstant(m, "CAN_BCM_STARTTIMER", STARTTIMER);
+#endif
+#ifdef  TX_COUNTEVT
+    PyModule_AddIntConstant(m, "CAN_BCM_TX_COUNTEVT", TX_COUNTEVT);
+#endif
+#ifdef  TX_ANNOUNCE
+    PyModule_AddIntConstant(m, "CAN_BCM_TX_ANNOUNCE", TX_ANNOUNCE);
+#endif
+#ifdef  TX_CP_CAN_ID
+    PyModule_AddIntConstant(m, "CAN_BCM_TX_CP_CAN_ID", TX_CP_CAN_ID);
+#endif
+#ifdef  RX_FILTER_ID
+    PyModule_AddIntConstant(m, "CAN_BCM_RX_FILTER_ID", RX_FILTER_ID);
+#endif
+#ifdef  RX_CHECK_DLC
+    PyModule_AddIntConstant(m, "CAN_BCM_RX_CHECK_DLC", RX_CHECK_DLC);
+#endif
+#ifdef  RX_NO_AUTOTIMER
+    PyModule_AddIntConstant(m, "CAN_BCM_RX_NO_AUTOTIMER", RX_NO_AUTOTIMER);
+#endif
+#ifdef  RX_ANNOUNCE_RESUME
+    PyModule_AddIntConstant(m, "CAN_BCM_RX_ANNOUNCE_RESUME", RX_ANNOUNCE_RESUME);
+#endif
+#ifdef  TX_RESET_MULTI_IDX
+    PyModule_AddIntConstant(m, "CAN_BCM_TX_RESET_MULTI_IDX", TX_RESET_MULTI_IDX);
+#endif
+#ifdef  RX_RTR_FRAME
+    PyModule_AddIntConstant(m, "CAN_BCM_RX_RTR_FRAME", RX_RTR_FRAME);
+#endif
+#ifdef  CAN_FD_FRAME
+    PyModule_AddIntConstant(m, "CAN_BCM_CAN_FD_FRAME", CAN_FD_FRAME);
+#endif
 #endif
 #ifdef SOL_RDS
     PyModule_AddIntMacro(m, SOL_RDS);


### PR DESCRIPTION
Expose the CAN_BCM SocketCAN constants used in the bcm_msg_head struct
flags (provided by <linux/can/bcm.h>) under the socket library.

This adds the following constants with a CAN_BCM prefix:

  * SETTIMER
  * STARTTIMER
  * TX_COUNTEVT
  * TX_ANNOUNCE
  * TX_CP_CAN_ID
  * RX_FILTER_ID
  * RX_CHECK_DLC
  * RX_NO_AUTOTIMER
  * RX_ANNOUNCE_RESUME
  * TX_RESET_MULTI_IDX
  * RX_RTR_FRAME
  * CAN_FD_FRAME

<!-- issue-number: [bpo-37085](https://bugs.python.org/issue37085) -->
https://bugs.python.org/issue37085
<!-- /issue-number -->
