### PR TITLE
remove unnecessary tp_dealloc

### DIFF
--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1077,14 +1077,6 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
     return NULL;
 }
 
-/* =-= */
-
-static void
-bytes_dealloc(PyObject *op)
-{
-    Py_TYPE(op)->tp_free(op);
-}
-
 /* Unescape a backslash-escaped string. If unicode is non-zero,
    the string is a u-literal. If recode_encoding is non-zero,
    the string is UTF-8 encoded and should be re-encoded in the
@@ -2875,7 +2867,7 @@ PyTypeObject PyBytes_Type = {
     "bytes",
     PyBytesObject_SIZE,
     sizeof(char),
-    bytes_dealloc,                      /* tp_dealloc */
+    0,                                          /* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -343,12 +343,6 @@ PyComplex_AsCComplex(PyObject *op)
     }
 }
 
-static void
-complex_dealloc(PyObject *op)
-{
-    op->ob_type->tp_free(op);
-}
-
 static PyObject *
 complex_repr(PyComplexObject *v)
 {
@@ -1118,7 +1112,7 @@ PyTypeObject PyComplex_Type = {
     "complex",
     sizeof(PyComplexObject),
     0,
-    complex_dealloc,                            /* tp_dealloc */
+    0,                                          /* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3053,12 +3053,6 @@ PyLong_AsDouble(PyObject *v)
 
 /* Methods */
 
-static void
-long_dealloc(PyObject *v)
-{
-    Py_TYPE(v)->tp_free(v);
-}
-
 static int
 long_compare(PyLongObject *a, PyLongObject *b)
 {
@@ -5628,7 +5622,7 @@ PyTypeObject PyLong_Type = {
     "int",                                      /* tp_name */
     offsetof(PyLongObject, ob_digit),           /* tp_basicsize */
     sizeof(digit),                              /* tp_itemsize */
-    long_dealloc,                               /* tp_dealloc */
+    0,                                          /* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8099,19 +8099,13 @@ static PyMethodDef encoding_map_methods[] = {
     { 0 }
 };
 
-static void
-encoding_map_dealloc(PyObject* o)
-{
-    PyObject_FREE(o);
-}
-
 static PyTypeObject EncodingMapType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "EncodingMap",          /*tp_name*/
     sizeof(struct encoding_map),   /*tp_basicsize*/
     0,                      /*tp_itemsize*/
     /* methods */
-    encoding_map_dealloc,   /*tp_dealloc*/
+    0,                      /*tp_dealloc*/
     0,                      /*tp_print*/
     0,                      /*tp_getattr*/
     0,                      /*tp_setattr*/


### PR DESCRIPTION
object_dealloc does `Py_TYPE(o)->tp_free(o)`.
No customize, no override.