### PR TITLE
 bpo-21131: don't use SIGSTKSZ for stack size in sigaltstack

### DIFF
--- a/Include/internal/pycore_thread.h
+++ b/Include/internal/pycore_thread.h
@@ -14,7 +14,7 @@ extern "C" {
 /*
  * Find the size of the stack the system uses by default.
  */
-PyAPI_FUNC(size_t) _PyThread_preferred_stacksize();
+PyAPI_FUNC(size_t) _PyThread_preferred_stacksize(void);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_thread.h
+++ b/Include/internal/pycore_thread.h
@@ -1,0 +1,22 @@
+#ifndef Py_INTERNAL_THREAD_H
+#define Py_INTERNAL_THREAD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#ifndef Py_BUILD_CORE
+#  error "this header requires Py_BUILD_CORE define"
+#endif
+
+/*
+ * Find the size of the stack the system uses by default.
+ */
+PyAPI_FUNC(size_t) _PyThread_preferred_stacksize();
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_THREAD_H */

--- a/Misc/NEWS.d/next/Core and Builtins/2019-05-31-09-34-39.bpo-21131.14CLBu.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-05-31-09-34-39.bpo-21131.14CLBu.rst
@@ -1,0 +1,3 @@
+Fix stack overflow in signal handlers managed by :mod:`faulthandler` -
+add new :c:func:`_PyThread_preferred_stack_size` and use this to find an
+appropriate stack size in preference to SIGSTKSZ.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 #include "pycore_initconfig.h"
 #include "pycore_traceback.h"
+#include "pycore_thread.h"
 #include "pythread.h"
 #include <signal.h>
 #include <object.h>
@@ -1325,7 +1326,7 @@ _PyFaulthandler_Init(int enable)
      * be able to allocate memory on the stack, even on a stack overflow. If it
      * fails, ignore the error. */
     stack.ss_flags = 0;
-    stack.ss_size = SIGSTKSZ;
+    stack.ss_size = _PyThread_preferred_stacksize();
     stack.ss_sp = PyMem_Malloc(stack.ss_size);
     if (stack.ss_sp != NULL) {
         err = sigaltstack(&stack, &old_stack);

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -496,3 +496,13 @@ PyThread_tss_get(Py_tss_t *key)
     SetLastError(error);
     return result;
 }
+
+size_t
+_PyThread_preferred_stacksize()
+{
+    /*
+     * Windows default stack size is 1MB, overridable by the linker in the
+     * executable
+     */
+    return 1024 * 1024;
+}

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -887,7 +887,7 @@ PyThread_tss_get(Py_tss_t *key)
  * need to know the actual amount of space to allocate.
  */
 size_t
-_PyThread_preferred_stacksize()
+_PyThread_preferred_stacksize(void)
 {
 #if defined(THREAD_STACK_SIZE) && (THREAD_STACK_SIZE == 0)
     /* If we have the stacksize thread attribute, we can use it to find the


### PR DESCRIPTION
Following up discussion on http://bugs.python.org/issue21131

vstinner suggested using the logic in `thread_pthread.h` to work out the "good" stack size for sigaltstack. I've integrated the logic in there, but it doesn't actually provide an accessible way of finding the default thread stack size - it just nominally requests pthread_create to create a stack of a "default" size by not poking at the stack size attribute.

So, instead, I've rejigged the macros in that file to provide PLATFORM_STACK_SIZE and PLATFORM_STACK_PREFERRED that are available regardless of the ability of pthreads to set the thread stack size attribute (i.e., regardless of the presence of _POSIX_THREAD_ATTR_STACK_SIZE) (and simplified some of the conditionals in the code using THREAD_STACK_SIZE in the process). The eventual sizes past to `pthread_attr_setstacksize` are unaffected.

This is then used as a fallback in the new function, `size_t _Pthread_preferred_stacksize()` , which will first attempt to use a default-constructed pthread_attr_t to work out at runtime what size stack the system prefers for new threads. This value is far more likely to be usable than the value defined in SIGSTKSZ.

If that call fails, or the thread size attribute is not available, we default to the maximum of PTHREAD_STACK_MIN, whatever we've defined for PLATFORM_STACK_SIZE for those platforms with an inadequate default stacksize, or finally the arbitrary 32k setting previously used as a floor.

All feedback gratefully appreciated.

<!-- issue-number: [bpo-21131](https://bugs.python.org/issue21131) -->
https://bugs.python.org/issue21131
<!-- /issue-number -->
