### PR TITLE
bpo-36974: rename _FastCallKeywords -> _Vectorcall

### DIFF
--- a/Include/descrobject.h
+++ b/Include/descrobject.h
@@ -92,7 +92,7 @@ PyAPI_FUNC(PyObject *) PyDescr_NewGetSet(PyTypeObject *,
                                                struct PyGetSetDef *);
 #ifndef Py_LIMITED_API
 
-PyAPI_FUNC(PyObject *) _PyMethodDescr_FastCallKeywords(
+PyAPI_FUNC(PyObject *) _PyMethodDescr_Vectorcall(
         PyObject *descrobj, PyObject *const *args, size_t nargsf, PyObject *kwnames);
 PyAPI_FUNC(PyObject *) PyDescr_NewWrapper(PyTypeObject *,
                                                 struct wrapperbase *, void *);

--- a/Include/funcobject.h
+++ b/Include/funcobject.h
@@ -66,7 +66,7 @@ PyAPI_FUNC(PyObject *) _PyFunction_FastCallDict(
     Py_ssize_t nargs,
     PyObject *kwargs);
 
-PyAPI_FUNC(PyObject *) _PyFunction_FastCallKeywords(
+PyAPI_FUNC(PyObject *) _PyFunction_Vectorcall(
     PyObject *func,
     PyObject *const *stack,
     size_t nargsf,

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -47,7 +47,7 @@ PyAPI_FUNC(PyObject *) _PyCFunction_FastCallDict(PyObject *func,
     Py_ssize_t nargs,
     PyObject *kwargs);
 
-PyAPI_FUNC(PyObject *) _PyCFunction_FastCallKeywords(PyObject *func,
+PyAPI_FUNC(PyObject *) _PyCFunction_Vectorcall(PyObject *func,
     PyObject *const *stack,
     size_t nargsf,
     PyObject *kwnames);

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -374,8 +374,8 @@ _PyFunction_FastCallDict(PyObject *func, PyObject *const *args, Py_ssize_t nargs
 
 
 PyObject *
-_PyFunction_FastCallKeywords(PyObject *func, PyObject* const* stack,
-                             size_t nargsf, PyObject *kwnames)
+_PyFunction_Vectorcall(PyObject *func, PyObject* const* stack,
+                       size_t nargsf, PyObject *kwnames)
 {
     PyCodeObject *co = (PyCodeObject *)PyFunction_GET_CODE(func);
     PyObject *globals = PyFunction_GET_GLOBALS(func);
@@ -714,9 +714,9 @@ exit:
 
 
 PyObject *
-_PyCFunction_FastCallKeywords(PyObject *func,
-                              PyObject *const *args, size_t nargsf,
-                              PyObject *kwnames)
+_PyCFunction_Vectorcall(PyObject *func,
+                        PyObject *const *args, size_t nargsf,
+                        PyObject *kwnames)
 {
     PyObject *result;
 

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -264,9 +264,9 @@ methoddescr_call(PyMethodDescrObject *descr, PyObject *args, PyObject *kwargs)
 
 // same to methoddescr_call(), but use FASTCALL convention.
 PyObject *
-_PyMethodDescr_FastCallKeywords(PyObject *descrobj,
-                                PyObject *const *args, size_t nargsf,
-                                PyObject *kwnames)
+_PyMethodDescr_Vectorcall(PyObject *descrobj,
+                          PyObject *const *args, size_t nargsf,
+                          PyObject *kwnames)
 {
     assert(Py_TYPE(descrobj) == &PyMethodDescr_Type);
     PyMethodDescrObject *descr = (PyMethodDescrObject *)descrobj;
@@ -756,7 +756,7 @@ PyDescr_NewMethod(PyTypeObject *type, PyMethodDef *method)
                                              type, method->ml_name);
     if (descr != NULL) {
         descr->d_method = method;
-        descr->vectorcall = &_PyMethodDescr_FastCallKeywords;
+        descr->vectorcall = _PyMethodDescr_Vectorcall;
     }
     return (PyObject *)descr;
 }

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -36,7 +36,7 @@ PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname
     op->func_defaults = NULL; /* No default arguments */
     op->func_kwdefaults = NULL; /* No keyword only defaults */
     op->func_closure = NULL;
-    op->vectorcall = _PyFunction_FastCallKeywords;
+    op->vectorcall = _PyFunction_Vectorcall;
 
     consts = ((PyCodeObject *)code)->co_consts;
     if (PyTuple_Size(consts) >= 1) {

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -52,7 +52,7 @@ PyCFunction_NewEx(PyMethodDef *ml, PyObject *self, PyObject *module)
         op->vectorcall = NULL;
     }
     else {
-        op->vectorcall = &_PyCFunction_FastCallKeywords;
+        op->vectorcall = _PyCFunction_Vectorcall;
     }
     _PyObject_GC_TRACK(op);
     return (PyObject *)op;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4815,7 +4815,7 @@ trace_call_function(PyThreadState *tstate,
 {
     PyObject *x;
     if (PyCFunction_Check(func)) {
-        C_TRACE(x, _PyCFunction_FastCallKeywords(func, args, nargs, kwnames));
+        C_TRACE(x, _PyCFunction_Vectorcall(func, args, nargs, kwnames));
         return x;
     }
     else if (Py_TYPE(func) == &PyMethodDescr_Type && nargs > 0) {
@@ -4831,9 +4831,9 @@ trace_call_function(PyThreadState *tstate,
         if (func == NULL) {
             return NULL;
         }
-        C_TRACE(x, _PyCFunction_FastCallKeywords(func,
-                                                 args+1, nargs-1,
-                                                 kwnames));
+        C_TRACE(x, _PyCFunction_Vectorcall(func,
+                                           args+1, nargs-1,
+                                           kwnames));
         Py_DECREF(func);
         return x;
     }

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1564,7 +1564,7 @@ class Frame(object):
             return False
 
         if caller in ('_PyCFunction_FastCallDict',
-                      '_PyCFunction_FastCallKeywords',
+                      '_PyCFunction_Vectorcall',
                       'cfunction_call_varargs'):
             arg_name = 'func'
             # Within that frame:


### PR DESCRIPTION
Ensure name consistency by using `XXX_Vectorcall` for all vectorcall wrappers.

Depends on #13185 

CC @encukou @markshannon 

<!-- issue-number: [bpo-36974](https://bugs.python.org/issue36974) -->
https://bugs.python.org/issue36974
<!-- /issue-number -->
