### PR TITLE
Revert adding @maxking to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@ Objects/dict*                 @methane
 Python/bootstrap_hash.c       @python/crypto-team
 
 # Email and related
-**/*mail*                     @python/email-team @maxking
+**/*mail*                     @python/email-team
 **/*smtp*                     @python/email-team
 **/*mime*                     @python/email-team
 **/*imap*                     @python/email-team


### PR DESCRIPTION
This reverts commit 71dc7c5fbd856df83202f39c1f41ccd07c6eceb7. Turns out you must have write access for CODEOWNERS to work.