### PR TITLE
bpo-37015: Ensure tasks created by _accept_connection2 due to AsyncMock are completed

### DIFF
--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -363,9 +363,12 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock.accept.return_value = (mock.Mock(), mock.Mock())
         backlog = 100
         # Mock the coroutine generation for a connection to prevent
-        # warnings related to un-awaited coroutines.
+        # warnings related to un-awaited coroutines. _accept_connection2
+        # is an async function that is patched with AsyncMock. Use MagicMock
+        # since the coroutine is not awaited.
         mock_obj = mock.patch.object
-        with mock_obj(self.loop, '_accept_connection2') as accept2_mock:
+        with mock_obj(self.loop, '_accept_connection2',
+                      new=mock.MagicMock()) as accept2_mock:
             accept2_mock.return_value = None
             with mock_obj(self.loop, 'create_task') as task_mock:
                 task_mock.return_value = None

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -370,8 +370,8 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         # task pending warnings.
         mock_obj = mock.patch.object
         with mock_obj(self.loop, '_accept_connection2') as accept2_mock:
-                self.loop._accept_connection(
-                    mock.Mock(), sock, backlog=backlog)
+            self.loop._accept_connection(
+                mock.Mock(), sock, backlog=backlog)
         self.loop.run_until_complete(asyncio.sleep(0))
         self.assertEqual(sock.accept.call_count, backlog)
 


### PR DESCRIPTION
From 3.8 async functions used with mock.patch return an `AsyncMock`. `_accept_connection2` is an async function where create_task is also mocked. Don't mock `create_task` so that tasks are created out of coroutine returned by `AsyncMock` and the tasks are completed.

<!-- issue-number: [bpo-37015](https://bugs.python.org/issue37015) -->
https://bugs.python.org/issue37015
<!-- /issue-number -->
