### PR TITLE
bpo-36373: Deprecate explicit loop parameter in all public asyncio APIs [task] [WIP]

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -334,6 +334,9 @@ Running Tasks Concurrently
    cancellation of one submitted Task/Future to cause other
    Tasks/Futures to be cancelled.
 
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
+
    .. _asyncio_example_gather:
 
    Example::
@@ -410,6 +413,9 @@ Shielding From Cancellation
            res = await shield(something())
        except CancelledError:
            res = None
+
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
 
 
 Timeouts
@@ -568,6 +574,9 @@ Waiting Primitives
    Raises :exc:`asyncio.TimeoutError` if the timeout occurs before
    all Futures are done.
 
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
+
    Example::
 
        for f in as_completed(aws):
@@ -693,6 +702,9 @@ Task Object
 
    .. versionchanged:: 3.8
       Added the ``name`` parameter.
+
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
 
    .. method:: cancel()
 

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -116,10 +116,9 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
         return _all_tasks_compat(loop)
 
     def __init__(self, coro, *, loop=None, name=None):
-        if loop:
-            warnings.warn("The loop argument is deprecated since Python 3.8, "
-                          "and scheduled for removal in Python 3.10.",
-                           DeprecationWarning, stacklevel=2)
+        warnings.warn("The loop argument is deprecated since Python 3.8, "
+                      "and scheduled for removal in Python 3.10.",
+                       DeprecationWarning, stacklevel=2)
         super().__init__(loop=loop)
         if self._source_traceback:
             del self._source_traceback[-1]
@@ -672,10 +671,9 @@ class _GatheringFuture(futures.Future):
     """
 
     def __init__(self, children, *, loop=None):
-        if loop:
-            warnings.warn("The loop argument is deprecated since Python 3.8, "
-                          "and scheduled for removal in Python 3.10.",
-                          DeprecationWarning, stacklevel=2)
+        warnings.warn("The loop argument is deprecated since Python 3.8, "
+                      "and scheduled for removal in Python 3.10.",
+                       DeprecationWarning, stacklevel=2)
         super().__init__(loop=loop)
         self._children = children
         self._cancel_requested = False

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -116,6 +116,10 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
         return _all_tasks_compat(loop)
 
     def __init__(self, coro, *, loop=None, name=None):
+        if loop:
+            warnings.warn("The loop argument is deprecated since Python 3.8, "
+                          "and scheduled for removal in Python 3.10.",
+                           DeprecationWarning, stacklevel=2)
         super().__init__(loop=loop)
         if self._source_traceback:
             del self._source_traceback[-1]
@@ -544,7 +548,12 @@ def as_completed(fs, *, loop=None, timeout=None):
     """
     if futures.isfuture(fs) or coroutines.iscoroutine(fs):
         raise TypeError(f"expect a list of futures, not {type(fs).__name__}")
-    loop = loop if loop is not None else events.get_event_loop()
+    if loop is None:
+        loop = events.get_event_loop()
+    else:
+        warnings.warn("The loop argument is deprecated since Python 3.8, "
+                      "and scheduled for removal in Python 3.10.",
+                      DeprecationWarning, stacklevel=2)
     todo = {ensure_future(f, loop=loop) for f in set(fs)}
     from .queues import Queue  # Import here to avoid circular import problem.
     done = Queue(loop=loop)
@@ -619,6 +628,10 @@ def ensure_future(coro_or_future, *, loop=None):
 
     If the argument is a Future, it is returned directly.
     """
+    if loop:
+        warnings.warn("The loop argument is deprecated since Python 3.8, "
+                      "and scheduled for removal in Python 3.10.",
+                      DeprecationWarning, stacklevel=2)
     if coroutines.iscoroutine(coro_or_future):
         if loop is None:
             loop = events.get_event_loop()
@@ -659,6 +672,10 @@ class _GatheringFuture(futures.Future):
     """
 
     def __init__(self, children, *, loop=None):
+        if loop:
+            warnings.warn("The loop argument is deprecated since Python 3.8, "
+                          "and scheduled for removal in Python 3.10.",
+                          DeprecationWarning, stacklevel=2)
         super().__init__(loop=loop)
         self._children = children
         self._cancel_requested = False
@@ -704,6 +721,10 @@ def gather(*coros_or_futures, loop=None, return_exceptions=False):
     if not coros_or_futures:
         if loop is None:
             loop = events.get_event_loop()
+        else:
+            warnings.warn("The loop argument is deprecated since Python 3.8, "
+                          "and scheduled for removal in Python 3.10.",
+                          DeprecationWarning, stacklevel=2)
         outer = loop.create_future()
         outer.set_result([])
         return outer
@@ -813,6 +834,10 @@ def shield(arg, *, loop=None):
         except CancelledError:
             res = None
     """
+    if loop:
+        warnings.warn("The loop argument is deprecated since Python 3.8, "
+                      "and scheduled for removal in Python 3.10.",
+                      DeprecationWarning, stacklevel=2)
     inner = ensure_future(arg, loop=loop)
     if inner.done():
         # Shortcut.


### PR DESCRIPTION
This PR deprecate explicit loop parameters in all public asyncio APIs

This issues is split to be easier to review.

First step: tasks.py

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36373](https://bugs.python.org/issue36373) -->
https://bugs.python.org/issue36373
<!-- /issue-number -->
