### PR TITLE
bpo-37105: Add deprecated-remove information on stream doc

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -67,7 +67,7 @@ and work with streams:
 
       The *ssl_handshake_timeout* parameter.
 
-   .. deprecated-removed :: 3.8 3.10
+   .. deprecated-removed:: 3.8 3.10
 
       `open_connection()` is deprecated in favor of `connect()`.
 
@@ -104,7 +104,7 @@ and work with streams:
 
       The *ssl_handshake_timeout* and *start_serving* parameters.
 
-   .. deprecated-removed :: 3.8 3.10
+   .. deprecated-removed:: 3.8 3.10
 
       `start_server()` is deprecated if favor of `StreamServer()`
 
@@ -132,7 +132,7 @@ and work with streams:
 
       The *path* parameter can now be a :term:`path-like object`
 
-   .. deprecated-removed :: 3.8 3.10
+   .. deprecated-removed:: 3.8 3.10
 
       `open_unix_connection()` is deprecated if favor of `connect_unix()`.
 
@@ -158,7 +158,7 @@ and work with streams:
 
       The *path* parameter can now be a :term:`path-like object`.
 
-   .. deprecated-removed :: 3.8 3.10
+   .. deprecated-removed:: 3.8 3.10
 
       `start_unix_server()` is deprecated in favor of `UnixStreamServer()`.
 

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -68,7 +68,8 @@ and work with streams:
       The *ssl_handshake_timeout* parameter.
 
    .. deprecated-removed :: 3.8 3.10
-      ``open_connection()`` is deprecated in favor of ``connect()``.
+
+      `open_connection()` is deprecated in favor of `connect()`.
 
 .. coroutinefunction:: start_server(client_connected_cb, host=None, \
                           port=None, \*, loop=None, limit=None, \
@@ -104,7 +105,8 @@ and work with streams:
       The *ssl_handshake_timeout* and *start_serving* parameters.
 
    .. deprecated-removed :: 3.8 3.10
-      ``start_server()`` is deprecated if favor of ``StreamServer()``
+
+      `start_server()` is deprecated if favor of `StreamServer()`
 
 
 .. rubric:: Unix Sockets
@@ -131,7 +133,8 @@ and work with streams:
       The *path* parameter can now be a :term:`path-like object`
 
    .. deprecated-removed :: 3.8 3.10
-      ``open_unix_connection()`` is deprecated if favor of ``connect_unix()``.
+
+      `open_unix_connection()` is deprecated if favor of `connect_unix()`.
 
 
 .. coroutinefunction:: start_unix_server(client_connected_cb, path=None, \
@@ -156,7 +159,8 @@ and work with streams:
       The *path* parameter can now be a :term:`path-like object`.
 
    .. deprecated-removed :: 3.8 3.10
-      ``start_unix_server()`` is deprecated in favor of ``UnixStreamServer()``.
+
+      `start_unix_server()` is deprecated in favor of `UnixStreamServer()`.
 
 
 ---------

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -67,6 +67,9 @@ and work with streams:
 
       The *ssl_handshake_timeout* parameter.
 
+   .. deprecated-removed :: 3.8 3.10
+      ``open_connection()`` is deprecated in favor of ``connect()``.
+
 .. coroutinefunction:: start_server(client_connected_cb, host=None, \
                           port=None, \*, loop=None, limit=None, \
                           family=socket.AF_UNSPEC, \
@@ -100,6 +103,9 @@ and work with streams:
 
       The *ssl_handshake_timeout* and *start_serving* parameters.
 
+   .. deprecated-removed :: 3.8 3.10
+      ``start_server()`` is deprecated if favor of ``StreamServer()``
+
 
 .. rubric:: Unix Sockets
 
@@ -124,6 +130,9 @@ and work with streams:
 
       The *path* parameter can now be a :term:`path-like object`
 
+   .. deprecated-removed :: 3.8 3.10
+      ``open_unix_connection()`` is deprecated if favor of ``connect_unix()``.
+
 
 .. coroutinefunction:: start_unix_server(client_connected_cb, path=None, \
                           \*, loop=None, limit=None, sock=None, \
@@ -145,6 +154,9 @@ and work with streams:
    .. versionchanged:: 3.7
 
       The *path* parameter can now be a :term:`path-like object`.
+
+   .. deprecated-removed :: 3.8 3.10
+      ``start_unix_server()`` is deprecated in favor of ``UnixStreamServer()``.
 
 
 ---------


### PR DESCRIPTION
According to the code on streams.py the functions:
``open_connection()``, ``start_server()``, ``open_unix_connection()``,
``start_unix_server()`` are deprecated. I inform that on
documentation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37105](https://bugs.python.org/issue37105) -->
https://bugs.python.org/issue37105
<!-- /issue-number -->
