### PR TITLE
bpo-37098: Skip memfd_create test before Linux 3.17 (GH-13677)

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3123,6 +3123,7 @@ class TermsizeTests(unittest.TestCase):
 
 
 @unittest.skipUnless(hasattr(os, 'memfd_create'), 'requires os.memfd_create')
+@support.requires_linux_version(3, 17)
 class MemfdCreateTests(unittest.TestCase):
     def test_memfd_create(self):
         fd = os.memfd_create("Hi", os.MFD_CLOEXEC)

--- a/Misc/NEWS.d/next/Tests/2019-05-30-10-57-39.bpo-37098.SfXt1M.rst
+++ b/Misc/NEWS.d/next/Tests/2019-05-30-10-57-39.bpo-37098.SfXt1M.rst
@@ -1,0 +1,1 @@
+Fix test_memfd_create on older Linux Kernels.


### PR DESCRIPTION


<!-- issue-number: [bpo-37098](https://bugs.python.org/issue37098) -->
https://bugs.python.org/issue37098
<!-- /issue-number -->
