### PR TITLE
bpo-37104: docs: Add docs about the `Logger.disabled` attribute

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -352,6 +352,15 @@ is the module's name in the Python package namespace.
    .. versionchanged:: 3.7
       Loggers can now be pickled and unpickled.
 
+   .. attribute:: Logger.disabled
+
+      If this attribute evaluates to ``True``, this logger will not output any
+      of the events logged through this logger directly. Note that this
+      disables logging on this specific Logger object, not in any of its
+      children.
+
+      The constructor sets this attribute to ``False``.
+
 .. _levels:
 
 Logging Levels


### PR DESCRIPTION
Add documentation about the attribute that allows disabling logging for the specific logger.

I can add a news-entry but I really think it is not worth it for this change.

Should this be backported to previous versions? The disabled attribute has been in Logger since the beginning.

<!-- issue-number: [bpo-37104](https://bugs.python.org/issue37104) -->
https://bugs.python.org/issue37104
<!-- /issue-number -->
