### PR TITLE
bpo-12639: msilib.Directory.start_component() fails if *keyfile* is not None

### DIFF
--- a/Lib/msilib/__init__.py
+++ b/Lib/msilib/__init__.py
@@ -273,7 +273,7 @@ class Directory:
         if AMD64:
             flags |= 256
         if keyfile:
-            keyid = self.cab.gen_id(self.absolute, keyfile)
+            keyid = self.cab.gen_id(keyfile)
             self.keyfiles[keyfile] = keyid
         else:
             keyid = None

--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -83,6 +83,15 @@ class MsiDatabaseTestCase(unittest.TestCase):
         db.Close()
         self.addCleanup(unlink, db_path)
 
+    def test_directory_start_component_keyfile(self):
+        db, db_path = init_database()
+        self.addCleanup(db.Close)
+        feature = msilib.Feature(db, 0, 'Feature', 'A feature', 'Python')
+        cab = msilib.CAB('CAB')
+        dir = msilib.Directory(db, cab, None, TESTFN, 'TARGETDIR',
+                               'SourceDir', 0)
+        dir.start_component(None, feature, None, 'keyfile')
+
 
 class Test_make_id(unittest.TestCase):
     #http://msdn.microsoft.com/en-us/library/aa369212(v=vs.85).aspx

--- a/Misc/NEWS.d/next/Library/2019-05-30-16-16-47.bpo-12639.TQFOR4.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-30-16-16-47.bpo-12639.TQFOR4.rst
@@ -1,0 +1,2 @@
+:meth:`msilib.Directory.start_component()` no longer fails if *keyfile* is
+not ``None``.


### PR DESCRIPTION
msilib.Directory.start_component() was passing an extra argument to
CAB.gen_id().


<!-- issue-number: [bpo-12639](https://bugs.python.org/issue12639) -->
https://bugs.python.org/issue12639
<!-- /issue-number -->
