### PR TITLE
bpo-26835: Add file sealing constants to fcntl (GH-13694)

### DIFF
--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -28,6 +28,10 @@ descriptor.
    Operations in this module used to raise an :exc:`IOError` where they now
    raise an :exc:`OSError`.
 
+.. versionchanged:: 3.8
+   The fcntl module now contains ``F_ADD_SEALS``, ``F_GET_SEALS``, and
+   ``F_SEAL_*`` constants for sealing of :func:`os.memfd_create` file
+   descriptors.
 
 The module defines the following functions:
 

--- a/Misc/NEWS.d/next/Library/2019-05-31-11-33-11.bpo-26835.xGbUX0.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-31-11-33-11.bpo-26835.xGbUX0.rst
@@ -1,0 +1,1 @@
+The fcntl module now contains file sealing constants for sealing of memfds.

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -620,7 +620,15 @@ all_ins(PyObject* m)
     if (PyModule_AddIntMacro(m, I_PLINK)) return -1;
     if (PyModule_AddIntMacro(m, I_PUNLINK)) return -1;
 #endif
-
+#ifdef F_ADD_SEALS
+    /* Linux: file sealing for memfd_create() */
+    if (PyModule_AddIntMacro(m, F_ADD_SEALS)) return -1;
+    if (PyModule_AddIntMacro(m, F_GET_SEALS)) return -1;
+    if (PyModule_AddIntMacro(m, F_SEAL_SEAL)) return -1;
+    if (PyModule_AddIntMacro(m, F_SEAL_SHRINK)) return -1;
+    if (PyModule_AddIntMacro(m, F_SEAL_GROW)) return -1;
+    if (PyModule_AddIntMacro(m, F_SEAL_WRITE)) return -1;
+#endif
     return 0;
 }
 


### PR DESCRIPTION
Co-authored-by: nanjekyejoannah <nanjekyejoannah@gmail.com>

<!-- issue-number: [bpo-26835](https://bugs.python.org/issue26835) -->
https://bugs.python.org/issue26835
<!-- /issue-number -->
