### PR TITLE
bpo-37108: Support super with methods that use positional-only arguments

### DIFF
--- a/Lib/test/test_positional_only_arg.py
+++ b/Lib/test/test_positional_only_arg.py
@@ -398,6 +398,20 @@ class PositionalOnlyTestCase(unittest.TestCase):
         gen = f()
         self.assertEqual(next(gen), (1, 2))
 
+    def test_super(self):
+
+        sentinel = object()
+
+        class A:
+            def method(self):
+                return sentinel
+
+        class C(A):
+            def method(self, /):
+                return super().method()
+
+        self.assertEqual(C().method(), sentinel)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7764,7 +7764,7 @@ super_init(PyObject *self, PyObject *args, PyObject *kwds)
                             "super(): no code object");
             return -1;
         }
-        if (co->co_argcount == 0) {
+        if (co->co_posonlyargcount + co->co_argcount == 0) {
             PyErr_SetString(PyExc_RuntimeError,
                             "super(): no arguments");
             return -1;


### PR DESCRIPTION


<!-- issue-number: [bpo-37108](https://bugs.python.org/issue37108) -->
https://bugs.python.org/issue37108
<!-- /issue-number -->
