### PR TITLE
bpo-37115: Support annotations in positional-only arguments

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -620,13 +620,21 @@ class GrammarTests(unittest.TestCase):
         self.assertEqual(f.__annotations__, {'return': list})
         def f(x: int): pass
         self.assertEqual(f.__annotations__, {'x': int})
+        def f(x: int, /): pass
+        self.assertEqual(f.__annotations__, {'x': int})
+        def f(x: int = 34, /): pass
+        self.assertEqual(f.__annotations__, {'x': int})
         def f(*x: str): pass
         self.assertEqual(f.__annotations__, {'x': str})
         def f(**x: float): pass
         self.assertEqual(f.__annotations__, {'x': float})
         def f(x, y: 1+2): pass
         self.assertEqual(f.__annotations__, {'y': 3})
+        def f(x, y: 1+2, /): pass
+        self.assertEqual(f.__annotations__, {'y': 3})
         def f(a, b: 1, c: 2, d): pass
+        self.assertEqual(f.__annotations__, {'b': 1, 'c': 2})
+        def f(a, b: 1, /, c: 2, d): pass
         self.assertEqual(f.__annotations__, {'b': 1, 'c': 2})
         def f(a, b: 1, c: 2, d, e: 3 = 4, f=5, *g: 6): pass
         self.assertEqual(f.__annotations__,
@@ -636,6 +644,11 @@ class GrammarTests(unittest.TestCase):
         self.assertEqual(f.__annotations__,
                          {'b': 1, 'c': 2, 'e': 3, 'g': 6, 'h': 7, 'j': 9,
                           'k': 11, 'return': 12})
+        def f(a, b: 1, c: 2, d, e: 3 = 4, f: int = 5, /, *g: 6, h: 7, i=8, j: 9 = 10,
+              **k: 11) -> 12: pass
+        self.assertEqual(f.__annotations__,
+                          {'b': 1, 'c': 2, 'e': 3, 'f': int, 'g': 6, 'h': 7, 'j': 9,
+                           'k': 11, 'return': 12})
         # Check for issue #20625 -- annotations mangling
         class Spam:
             def f(self, *, __kw: 1):

--- a/Lib/test/test_type_comments.py
+++ b/Lib/test/test_type_comments.py
@@ -99,8 +99,21 @@ def fa(
 ):
     pass
 
+def fa(
+    a = 1,  # type: A
+    /
+):
+    pass
+
 def fab(
     a,  # type: A
+    b,  # type: B
+):
+    pass
+
+def fab(
+    a,  # type: A
+    /,
     b,  # type: B
 ):
     pass
@@ -151,6 +164,13 @@ def fav(
 
 def fav(
     a,  # type: A
+    /,
+    *v,  # type: V
+):
+    pass
+
+def fav(
+    a,  # type: A
     *v  # type: V
 ):
     pass
@@ -163,12 +183,27 @@ def fak(
 
 def fak(
     a,  # type: A
+    /,
+    **k,  # type: K
+):
+    pass
+
+def fak(
+    a,  # type: A
     **k  # type: K
 ):
     pass
 
 def favk(
     a,  # type: A
+    *v,  # type: V
+    **k,  # type: K
+):
+    pass
+
+def favk(
+    a,  # type: A
+    /,
     *v,  # type: V
     **k,  # type: K
 ):
@@ -290,18 +325,21 @@ class TypeCommentTests(unittest.TestCase):
             for t in tree.body:
                 # The expected args are encoded in the function name
                 todo = set(t.name[1:])
-                self.assertEqual(len(t.args.args),
+                self.assertEqual(len(t.args.args) + len(t.args.posonlyargs),
                                  len(todo) - bool(t.args.vararg) - bool(t.args.kwarg))
                 self.assertTrue(t.name.startswith('f'), t.name)
-                for c in t.name[1:]:
+                for index, c in enumerate(t.name[1:]):
                     todo.remove(c)
                     if c == 'v':
                         arg = t.args.vararg
                     elif c == 'k':
                         arg = t.args.kwarg
                     else:
-                        assert 0 <= ord(c) - ord('a') < len(t.args.args)
-                        arg = t.args.args[ord(c) - ord('a')]
+                        assert 0 <= ord(c) - ord('a') < len(t.args.posonlyargs + t.args.args)
+                        if index < len(t.args.posonlyargs):
+                            arg = t.args.posonlyargs[ord(c) - ord('a')]
+                        else:
+                            arg = t.args.args[ord(c) - ord('a') - len(t.args.posonlyargs)]
                     self.assertEqual(arg.arg, c)  # That's the argument name
                     self.assertEqual(arg.type_comment, arg.arg.upper())
                 assert not todo

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1991,6 +1991,8 @@ compiler_visit_annotations(struct compiler *c, arguments_ty args,
 
     if (!compiler_visit_argannotations(c, args->args, names))
         goto error;
+    if (!compiler_visit_argannotations(c, args->posonlyargs, names))
+        goto error;
     if (args->vararg && args->vararg->annotation &&
         !compiler_visit_argannotation(c, args->vararg->arg,
                                      args->vararg->annotation, names))


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37115](https://bugs.python.org/issue37115) -->
https://bugs.python.org/issue37115
<!-- /issue-number -->
