### PR TITLE
bpo-36974: Make tp_call=PyVectorcall_Call work for inherited types

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5853,7 +5853,7 @@ MethodDescriptor_vectorcall(PyObject *callable, PyObject *const *args,
 static PyObject *
 MethodDescriptor_new(PyTypeObject* type, PyObject* args, PyObject *kw)
 {
-    MethodDescriptorObject *op = PyObject_New(MethodDescriptorObject, type);
+    MethodDescriptorObject *op = type->tp_alloc(type, 0);
     op->vectorcall = MethodDescriptor_vectorcall;
     return (PyObject *)op;
 }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5145,20 +5145,22 @@ inherit_slots(PyTypeObject *type, PyTypeObject *base)
     }
     COPYSLOT(tp_repr);
     /* tp_hash see tp_richcompare */
-    /* Inherit tp_vectorcall_offset only if tp_call is not overridden */
-    if (!type->tp_call) {
-        COPYSLOT(tp_vectorcall_offset);
-    }
-    /* Inherit_Py_TPFLAGS_HAVE_VECTORCALL for non-heap types
-     * if tp_call is not overridden */
-    if (!type->tp_call &&
-        (base->tp_flags & _Py_TPFLAGS_HAVE_VECTORCALL) &&
-        !(type->tp_flags & _Py_TPFLAGS_HAVE_VECTORCALL) &&
-        !(type->tp_flags & Py_TPFLAGS_HEAPTYPE))
     {
-        type->tp_flags |= _Py_TPFLAGS_HAVE_VECTORCALL;
+        /* Inherit tp_vectorcall_offset only if tp_call is not overridden */
+        if (!type->tp_call) {
+            COPYSLOT(tp_vectorcall_offset);
+        }
+        /* Inherit_Py_TPFLAGS_HAVE_VECTORCALL for non-heap types
+        * if tp_call is not overridden */
+        if (!type->tp_call &&
+            (base->tp_flags & _Py_TPFLAGS_HAVE_VECTORCALL) &&
+            !(type->tp_flags & _Py_TPFLAGS_HAVE_VECTORCALL) &&
+            !(type->tp_flags & Py_TPFLAGS_HEAPTYPE))
+        {
+            type->tp_flags |= _Py_TPFLAGS_HAVE_VECTORCALL;
+        }
+        COPYSLOT(tp_call);
     }
-    COPYSLOT(tp_call);
     COPYSLOT(tp_str);
     {
         /* Copy comparison-related slots only when

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5145,18 +5145,20 @@ inherit_slots(PyTypeObject *type, PyTypeObject *base)
     }
     COPYSLOT(tp_repr);
     /* tp_hash see tp_richcompare */
-    COPYSLOT(tp_call);
-    /* Inherit tp_vectorcall_offset and _Py_TPFLAGS_HAVE_VECTORCALL if tp_call
-     * was inherited, but only for extension types */
-    if ((base->tp_flags & _Py_TPFLAGS_HAVE_VECTORCALL) &&
+    /* Inherit tp_vectorcall_offset only if tp_call is not overridden */
+    if (!type->tp_call) {
+        COPYSLOT(tp_vectorcall_offset);
+    }
+    /* Inherit_Py_TPFLAGS_HAVE_VECTORCALL for non-heap types
+     * if tp_call is not overridden */
+    if (!type->tp_call &&
+        (base->tp_flags & _Py_TPFLAGS_HAVE_VECTORCALL) &&
         !(type->tp_flags & _Py_TPFLAGS_HAVE_VECTORCALL) &&
-        !(type->tp_flags & Py_TPFLAGS_HEAPTYPE) &&
-        base->tp_call &&
-        type->tp_call == base->tp_call)
+        !(type->tp_flags & Py_TPFLAGS_HEAPTYPE))
     {
-        type->tp_vectorcall_offset = base->tp_vectorcall_offset;
         type->tp_flags |= _Py_TPFLAGS_HAVE_VECTORCALL;
     }
+    COPYSLOT(tp_call);
     COPYSLOT(tp_str);
     {
         /* Copy comparison-related slots only when


### PR DESCRIPTION
When inheriting a heap subclass from a vectorcall class that sets `.tp_call=PyVectorcall_Call` (as recommended), the subclass does not inherit `_Py_TPFLAGS_HAVE_VECTORCALL`, and thus `PyVectorcall_Call` does not work for it.

This attempts to solve the issue by:
* always inheriting `tp_vectorcall_offset` unless `tp_call` is overridden in the subclass
* inheriting _Py_TPFLAGS_HAVE_VECTORCALL for static types, unless `tp_call` is overridden
* making `PyVectorcall_Call` ignore `_Py_TPFLAGS_HAVE_VECTORCALL`

This means it'll be ever more important to only call `PyVectorcall_Call` on classes that support vectorcall. In `PyVectorcall_Call`'s intended role as `tp_call` filler, that's not a problem.

cc @jdemeyer (not Mark, as he seemed to want to stay out of subclassing – but he's nosy on the issue)


<!-- issue-number: [bpo-36974](https://bugs.python.org/issue36974) -->
https://bugs.python.org/issue36974
<!-- /issue-number -->
