### PR TITLE
bpo-36842: Pass positional only parameters to code_new audit hook

### DIFF
--- a/Doc/c-api/code.rst
+++ b/Doc/c-api/code.rst
@@ -43,7 +43,7 @@ bound into a function.
    .. versionchanged:: 3.8
       An extra parameter is required (*posonlyargcount*) to support :PEP:`570`.
 
-   .. audit-event:: code.__new__ "code filename name argcount kwonlyargcount nlocals stacksize flags"
+   .. audit-event:: code.__new__ "code filename name argcount posonlyargcount kwonlyargcount nlocals stacksize flags"
 
 .. c:function:: PyCodeObject* PyCode_NewEmpty(const char *filename, const char *funcname, int firstlineno)
 

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -391,9 +391,9 @@ code_new(PyTypeObject *type, PyObject *args, PyObject *kw)
                           &PyTuple_Type, &cellvars))
         return NULL;
 
-    if (PySys_Audit("code.__new__", "OOOiiiii",
-                    code, filename, name, argcount, kwonlyargcount,
-                    nlocals, stacksize, flags) < 0) {
+    if (PySys_Audit("code.__new__", "OOOiiiiii",
+                    code, filename, name, argcount, posonlyargcount,
+                    kwonlyargcount, nlocals, stacksize, flags) < 0) {
         goto cleanup;
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36842](https://bugs.python.org/issue36842) -->
https://bugs.python.org/issue36842
<!-- /issue-number -->
