### PR TITLE
bpo-12202: Properly check MsiSummaryInfoGetProperty() calls in msilib

### DIFF
--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -85,12 +85,21 @@ class MsiDatabaseTestCase(unittest.TestCase):
 
     def test_directory_start_component_keyfile(self):
         db, db_path = init_database()
+        self.addCleanup(unlink, db_path)
         self.addCleanup(db.Close)
         feature = msilib.Feature(db, 0, 'Feature', 'A feature', 'Python')
         cab = msilib.CAB('CAB')
         dir = msilib.Directory(db, cab, None, TESTFN, 'TARGETDIR',
                                'SourceDir', 0)
         dir.start_component(None, feature, None, 'keyfile')
+
+    def test_getproperty_uninitialized_var(self):
+        db, db_path = init_database()
+        self.addCleanup(unlink, db_path)
+        self.addCleanup(db.Close)
+        si = db.GetSummaryInformation(0)
+        with self.assertRaises(msilib.MSIError):
+            si.GetProperty(-1)
 
 
 class Test_make_id(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2019-05-31-15-53-34.bpo-12202.nobzc9.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-31-15-53-34.bpo-12202.nobzc9.rst
@@ -1,0 +1,1 @@
+Fix the error handling in :meth:`msilib.SummaryInformation.GetProperty()`.

--- a/Misc/NEWS.d/next/Library/2019-05-31-15-53-34.bpo-12202.nobzc9.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-31-15-53-34.bpo-12202.nobzc9.rst
@@ -1,1 +1,2 @@
-Fix the error handling in :meth:`msilib.SummaryInformation.GetProperty()`.
+Fix the error handling in :meth:`msilib.SummaryInformation.GetProperty`. Patch
+by Zackery Spytz.

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -571,6 +571,9 @@ summary_getproperty(msiobj* si, PyObject *args)
         status = MsiSummaryInfoGetProperty(si->h, field, &type, &ival,
             &fval, sval, &ssize);
     }
+    if (status != ERROR_SUCCESS) {
+        return msierror(status);
+    }
 
     switch(type) {
         case VT_I2:


### PR DESCRIPTION


<!-- issue-number: [bpo-12202](https://bugs.python.org/issue12202) -->
https://bugs.python.org/issue12202
<!-- /issue-number -->
