### PR TITLE
bpo-33608: Factor out a private, per-interpreter _Py_AddPendingCall().

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -20,11 +20,13 @@ PyAPI_FUNC(void) _PyEval_SignalReceived(
 PyAPI_FUNC(int) _PyEval_AddPendingCall(
     PyThreadState *tstate,
     struct _ceval_runtime_state *,
+    struct _ceval_interpreter_state *,
     int (*func)(void *),
     void *arg);
-PyAPI_FUNC(void) _PyEval_FinishPendingCalls(_PyRuntimeState *);
+PyAPI_FUNC(void) _PyEval_FinishPendingCalls(PyInterpreterState *);
 PyAPI_FUNC(void) _PyEval_SignalAsyncExc(
-    struct _ceval_runtime_state *);
+    struct _ceval_runtime_state *,
+    struct _ceval_interpreter_state *);
 PyAPI_FUNC(void) _PyEval_ReInitThreads(
     _PyRuntimeState *runtime);
 

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -21,6 +21,7 @@ PyAPI_FUNC(int) _PyEval_AddPendingCall(
     PyThreadState *tstate,
     struct _ceval_runtime_state *,
     struct _ceval_interpreter_state *,
+    unsigned long thread_id,
     int (*func)(void *),
     void *arg);
 PyAPI_FUNC(void) _PyEval_FinishPendingCalls(PyInterpreterState *);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -12,7 +12,6 @@ extern "C" {
 #include "pycore_pystate.h"
 #include "pythread.h"
 
-PyAPI_FUNC(void) _Py_FinishPendingCalls(_PyRuntimeState *runtime);
 PyAPI_FUNC(void) _PyEval_Initialize(struct _ceval_runtime_state *);
 PyAPI_FUNC(void) _PyEval_FiniThreads(
     struct _ceval_runtime_state *);
@@ -23,6 +22,7 @@ PyAPI_FUNC(int) _PyEval_AddPendingCall(
     struct _ceval_runtime_state *,
     int (*func)(void *),
     void *arg);
+PyAPI_FUNC(void) _PyEval_FinishPendingCalls(_PyRuntimeState *);
 PyAPI_FUNC(void) _PyEval_SignalAsyncExc(
     struct _ceval_runtime_state *);
 PyAPI_FUNC(void) _PyEval_ReInitThreads(

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -15,16 +15,16 @@ extern "C" {
 PyAPI_FUNC(void) _Py_FinishPendingCalls(_PyRuntimeState *runtime);
 PyAPI_FUNC(void) _PyEval_Initialize(struct _ceval_runtime_state *);
 PyAPI_FUNC(void) _PyEval_FiniThreads(
-    struct _ceval_runtime_state *ceval);
+    struct _ceval_runtime_state *);
 PyAPI_FUNC(void) _PyEval_SignalReceived(
-    struct _ceval_runtime_state *ceval);
+    struct _ceval_runtime_state *);
 PyAPI_FUNC(int) _PyEval_AddPendingCall(
     PyThreadState *tstate,
-    struct _ceval_runtime_state *ceval,
+    struct _ceval_runtime_state *,
     int (*func)(void *),
     void *arg);
 PyAPI_FUNC(void) _PyEval_SignalAsyncExc(
-    struct _ceval_runtime_state *ceval);
+    struct _ceval_runtime_state *);
 PyAPI_FUNC(void) _PyEval_ReInitThreads(
     _PyRuntimeState *runtime);
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -25,7 +25,7 @@ struct pyruntimestate;
 
 /* ceval state */
 
-struct _pending_calls {
+struct _ceval_pending_calls {
     int finishing;
     PyThread_type_lock lock;
     /* Request for running pending calls. */
@@ -65,7 +65,7 @@ struct _ceval_runtime_state {
 };
 
 struct _ceval_interpreter_state {
-    struct _pending_calls pending;
+    struct _ceval_pending_calls pending;
 };
 
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "sysmodule.h"
 
 #include "pycore_gil.h"   /* _gil_runtime_state  */
+//#include "pycore_atomic.h"
 #include "pycore_pathconfig.h"
 #include "pycore_pymem.h"
 #include "pycore_warnings.h"
@@ -53,14 +54,20 @@ struct _ceval_runtime_state {
     int tracing_possible;
     /* This single variable consolidates all requests to break out of
        the fast path in the eval loop. */
+    // XXX This can move to _ceval_interpreter_state once all parts
+    // from COMPUTE_EVAL_BREAKER have moved under PyInterpreterState.
     _Py_atomic_int eval_breaker;
     /* Request for dropping the GIL */
     _Py_atomic_int gil_drop_request;
-    struct _pending_calls pending;
     /* Request for checking signals. */
     _Py_atomic_int signals_pending;
     struct _gil_runtime_state gil;
 };
+
+struct _ceval_interpreter_state {
+    struct _pending_calls pending;
+};
+
 
 /* interpreter state */
 
@@ -88,6 +95,8 @@ struct _is {
 
     /* Used in Python/sysmodule.c. */
     int check_interval;
+
+    struct _ceval_interpreter_state ceval;
 
     /* Used in Modules/_threadmodule.c. */
     long num_threads;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -15,7 +15,6 @@ extern "C" {
 #include "sysmodule.h"
 
 #include "pycore_gil.h"   /* _gil_runtime_state  */
-//#include "pycore_atomic.h"
 #include "pycore_pathconfig.h"
 #include "pycore_pymem.h"
 #include "pycore_warnings.h"

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -97,8 +97,6 @@ struct _is {
     /* Used in Python/sysmodule.c. */
     int check_interval;
 
-    struct _ceval_interpreter_state ceval;
-
     /* Used in Modules/_threadmodule.c. */
     long num_threads;
     /* Support for runtime thread stack size tuning.
@@ -146,6 +144,7 @@ struct _is {
 
     uint64_t tstate_next_unique_id;
 
+    struct _ceval_interpreter_state ceval;
     struct _warnings_runtime_state warnings;
 
     PyObject *audit_hooks;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -37,6 +37,7 @@ struct _pending_calls {
     int async_exc;
 #define NPENDINGCALLS 32
     struct {
+        unsigned long thread_id;
         int (*func)(void *);
         void *arg;
     } calls[NPENDINGCALLS];

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -431,7 +431,7 @@ class TestPendingCalls(unittest.TestCase):
     def test_pendingcalls_threaded(self):
 
         #do every callback on a separate thread
-        n = 32 #total callbacks
+        n = 32 #total callbacks (see NPENDINGCALLS in pycore_ceval.h)
         threads = []
         class foo(object):pass
         context = foo()

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-15-12-13-46.bpo-33608.avmvVP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-15-12-13-46.bpo-33608.avmvVP.rst
@@ -1,0 +1,5 @@
+We added a new internal _Py_AddPendingCall() that operates relative to the
+provided interpreter.  This allows us to use the existing implementation to
+ask another interpreter to do work that cannot be done in the current
+interpreter, like decref an object the other interpreter owns.  The existing
+Py_AddPendingCall() only operates relative to the main interpreter.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2677,6 +2677,7 @@ pending_threadfunc(PyObject *self, PyObject *arg)
     Py_INCREF(callable);
 
     Py_BEGIN_ALLOW_THREADS
+    /* XXX Use the internal _Py_AddPendingCall(). */
     r = Py_AddPendingCall(&_pending_callback, callable);
     Py_END_ALLOW_THREADS
 

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -299,7 +299,9 @@ trip_signal(int sig_num)
                 {
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
-                    _PyEval_AddPendingCall(tstate, &runtime->ceval,
+                    _PyEval_AddPendingCall(tstate,
+                                           &runtime->ceval,
+                                           &tstate->interp->ceval,
                                            report_wakeup_send_error,
                                            (void *)(intptr_t) last_error);
                 }
@@ -318,7 +320,9 @@ trip_signal(int sig_num)
                 {
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
-                    _PyEval_AddPendingCall(tstate, &runtime->ceval,
+                    _PyEval_AddPendingCall(tstate,
+                                           &runtime->ceval,
+                                           &tstate->interp->ceval,
                                            report_wakeup_write_error,
                                            (void *)(intptr_t)errno);
                 }

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -21,6 +21,7 @@
 #include <process.h>
 #endif
 #endif
+#include "internal/pycore_pystate.h"
 
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -260,6 +260,7 @@ trip_signal(int sig_num)
     /* Notify ceval.c */
     _PyRuntimeState *runtime = &_PyRuntime;
     PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);
+    PyInterpreterState *interp = runtime->interpreters.main;
     _PyEval_SignalReceived(&runtime->ceval);
 
     /* And then write to the wakeup fd *after* setting all the globals and
@@ -302,7 +303,7 @@ trip_signal(int sig_num)
                        still use it for this exceptional case. */
                     _PyEval_AddPendingCall(tstate,
                                            &runtime->ceval,
-                                           &tstate->interp->ceval,
+                                           &interp->ceval,
                                            runtime->main_thread,
                                            report_wakeup_send_error,
                                            (void *)(intptr_t) last_error);
@@ -324,7 +325,7 @@ trip_signal(int sig_num)
                        still use it for this exceptional case. */
                     _PyEval_AddPendingCall(tstate,
                                            &runtime->ceval,
-                                           &tstate->interp->ceval,
+                                           &interp->ceval,
                                            runtime->main_thread,
                                            report_wakeup_write_error,
                                            (void *)(intptr_t)errno);

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -303,6 +303,7 @@ trip_signal(int sig_num)
                     _PyEval_AddPendingCall(tstate,
                                            &runtime->ceval,
                                            &tstate->interp->ceval,
+                                           runtime->main_thread,
                                            report_wakeup_send_error,
                                            (void *)(intptr_t) last_error);
                 }
@@ -324,6 +325,7 @@ trip_signal(int sig_num)
                     _PyEval_AddPendingCall(tstate,
                                            &runtime->ceval,
                                            &tstate->interp->ceval,
+                                           runtime->main_thread,
                                            report_wakeup_write_error,
                                            (void *)(intptr_t)errno);
                 }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -101,15 +101,13 @@ static long dxp[256];
 #endif
 #endif
 
-#define GIL_REQUEST _Py_atomic_load_relaxed(&(ceval_r)->gil_drop_request)
-
 /* This can set eval_breaker to 0 even though gil_drop_request became
    1.  We believe this is all right because the eval loop will release
    the GIL eventually anyway. */
 #define COMPUTE_EVAL_BREAKER(ceval_r) \
     _Py_atomic_store_relaxed( \
         &(ceval_r)->eval_breaker, \
-        GIL_REQUEST | \
+        _Py_atomic_load_relaxed(&(ceval_r)->gil_drop_request) | \
         _Py_atomic_load_relaxed(&(ceval_r)->signals_pending) | \
         _Py_atomic_load_relaxed(&(ceval_r)->pending.calls_to_do) | \
         (ceval_r)->pending.async_exc)

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -535,7 +535,7 @@ make_pending_calls(PyInterpreterState *interp)
                                    &runtime->ceval, &interp->ceval,
                                    thread_id,
                                    func, arg);
-            return 0;
+            goto error;
         }
 
         /* having released the lock, perform the callback */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -444,10 +444,11 @@ _PyEval_AddPendingCall(PyThreadState *tstate,
         return -1;
     }
     int result = _push_pending_call(pending, func, arg);
-    PyThread_release_lock(pending->lock);
 
     /* signal loop */
     SIGNAL_PENDING_CALLS(ceval_r, ceval_i);
+    PyThread_release_lock(pending->lock);
+
     return result;
 }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -540,7 +540,7 @@ error:
 }
 
 void
-_Py_FinishPendingCalls(_PyRuntimeState *runtime)
+_PyEval_FinishPendingCalls(_PyRuntimeState *runtime)
 {
     assert(PyGILState_Check());
 

--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -189,7 +189,11 @@ take_gil(struct _ceval_runtime_state *ceval_r,
     if (tstate == NULL) {
         Py_FatalError("take_gil: NULL tstate");
     }
-    struct _ceval_interpreter_state *ceval_i = &tstate->interp->ceval;
+    PyInterpreterState *interp = tstate->interp;
+    if (interp == NULL) {
+        Py_FatalError("take_gil: NULL interp");
+    }
+    struct _ceval_interpreter_state *ceval_i = &interp->ceval;
 
     struct _gil_runtime_state *gil = &ceval_r->gil;
     int err = errno;

--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -141,9 +141,9 @@ static void recreate_gil(struct _gil_runtime_state *gil)
 }
 
 static void
-drop_gil(struct _ceval_runtime_state *ceval, PyThreadState *tstate)
+drop_gil(struct _ceval_runtime_state *ceval_r, PyThreadState *tstate)
 {
-    struct _gil_runtime_state *gil = &ceval->gil;
+    struct _gil_runtime_state *gil = &ceval_r->gil;
     if (!_Py_atomic_load_relaxed(&gil->locked)) {
         Py_FatalError("drop_gil: GIL is not locked");
     }
@@ -163,12 +163,12 @@ drop_gil(struct _ceval_runtime_state *ceval, PyThreadState *tstate)
     MUTEX_UNLOCK(gil->mutex);
 
 #ifdef FORCE_SWITCHING
-    if (_Py_atomic_load_relaxed(&ceval->gil_drop_request) && tstate != NULL) {
+    if (_Py_atomic_load_relaxed(&ceval_r->gil_drop_request) && tstate != NULL) {
         MUTEX_LOCK(gil->switch_mutex);
         /* Not switched yet => wait */
         if (((PyThreadState*)_Py_atomic_load_relaxed(&gil->last_holder)) == tstate)
         {
-            RESET_GIL_DROP_REQUEST(ceval);
+            RESET_GIL_DROP_REQUEST(ceval_r);
             /* NOTE: if COND_WAIT does not atomically start waiting when
                releasing the mutex, another thread can run through, take
                the GIL and drop it again, and reset the condition
@@ -181,13 +181,13 @@ drop_gil(struct _ceval_runtime_state *ceval, PyThreadState *tstate)
 }
 
 static void
-take_gil(struct _ceval_runtime_state *ceval, PyThreadState *tstate)
+take_gil(struct _ceval_runtime_state *ceval_r, PyThreadState *tstate)
 {
     if (tstate == NULL) {
         Py_FatalError("take_gil: NULL tstate");
     }
 
-    struct _gil_runtime_state *gil = &ceval->gil;
+    struct _gil_runtime_state *gil = &ceval_r->gil;
     int err = errno;
     MUTEX_LOCK(gil->mutex);
 
@@ -210,7 +210,7 @@ take_gil(struct _ceval_runtime_state *ceval, PyThreadState *tstate)
             _Py_atomic_load_relaxed(&gil->locked) &&
             gil->switch_number == saved_switchnum)
         {
-            SET_GIL_DROP_REQUEST(ceval);
+            SET_GIL_DROP_REQUEST(ceval_r);
         }
     }
 _ready:
@@ -232,11 +232,11 @@ _ready:
     COND_SIGNAL(gil->switch_cond);
     MUTEX_UNLOCK(gil->switch_mutex);
 #endif
-    if (_Py_atomic_load_relaxed(&ceval->gil_drop_request)) {
-        RESET_GIL_DROP_REQUEST(ceval);
+    if (_Py_atomic_load_relaxed(&ceval_r->gil_drop_request)) {
+        RESET_GIL_DROP_REQUEST(ceval_r);
     }
     if (tstate->async_exc != NULL) {
-        _PyEval_SignalAsyncExc(ceval);
+        _PyEval_SignalAsyncExc(ceval_r);
     }
 
     MUTEX_UNLOCK(gil->mutex);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1147,15 +1147,15 @@ Py_FinalizeEx(void)
         return status;
     }
 
+    /* Get current thread state and interpreter pointer */
+    PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);
+    PyInterpreterState *interp = tstate->interp;
+
     // Wrap up existing "threading"-module-created, non-daemon threads.
     wait_for_thread_shutdown();
 
     // Make any remaining pending calls.
-    _PyEval_FinishPendingCalls(runtime);
-
-    /* Get current thread state and interpreter pointer */
-    PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);
-    PyInterpreterState *interp = tstate->interp;
+    _PyEval_FinishPendingCalls(interp);
 
     /* The interpreter is still entirely intact at this point, and the
      * exit funcs may be relying on that.  In particular, if some thread
@@ -1579,6 +1579,9 @@ Py_EndInterpreter(PyThreadState *tstate)
 
     // Wrap up existing "threading"-module-created, non-daemon threads.
     wait_for_thread_shutdown();
+
+    // Make any remaining pending calls.
+    _PyEval_FinishPendingCalls(interp);
 
     call_py_exitfuncs(interp);
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1155,7 +1155,8 @@ Py_FinalizeEx(void)
     wait_for_thread_shutdown();
 
     // Make any remaining pending calls.
-    _PyEval_FinishPendingCalls(interp);
+    // XXX For the moment we are going to ignore any lingering pending calls.
+    //_PyEval_FinishPendingCalls(interp);
 
     /* The interpreter is still entirely intact at this point, and the
      * exit funcs may be relying on that.  In particular, if some thread

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1155,7 +1155,22 @@ Py_FinalizeEx(void)
     wait_for_thread_shutdown();
 
     // Make any remaining pending calls.
-    // XXX For the moment we are going to ignore any lingering pending calls.
+    /* XXX For the moment we are going to ignore lingering pending calls.
+     * We've seen sporadic on some of the buildbots during finalization
+     * with the changes for per-interpreter pending calls (see bpo-33608),
+     * meaning the previous _PyEval_FinishPendincCalls() call here is
+     * a trigger, if not responsible.
+     *
+     * Ignoring pending calls at this point in the runtime lifecycle
+     * is okay (for now) for the following reasons:
+     *
+     *  * pending calls are still not a widely-used feature
+     *  * this only affects runtime finalization, where the process is
+     *    likely to end soon anyway (except for some embdding cases)
+     *
+     * See bpo-37127 about resolving the problem.  Ultimately the call
+     * here should be re-enabled.
+     */
     //_PyEval_FinishPendingCalls(interp);
 
     /* The interpreter is still entirely intact at this point, and the

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1151,7 +1151,7 @@ Py_FinalizeEx(void)
     wait_for_thread_shutdown();
 
     // Make any remaining pending calls.
-    _Py_FinishPendingCalls(runtime);
+    _PyEval_FinishPendingCalls(runtime);
 
     /* Get current thread state and interpreter pointer */
     PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1510,6 +1510,7 @@ _PyCrossInterpreterData_Release(_PyCrossInterpreterData *data)
 
     // "Release" the data and/or the object.
     struct _gilstate_runtime_state *gilstate = &_PyRuntime.gilstate;
+    // XXX Use _Py_AddPendingCall().
     _call_in_interpreter(gilstate, interp, _release_xidata, data);
 }
 


### PR DESCRIPTION
This is effectively an un-revert of #11617 and #12024 (reverted in #12159). Portions of those were merged in other PRs (with lower risk) and this represents the remainder. Note that I found 3 different bugs in the original PRs and have fixed them here.

I also tried again (with some tweaks) in #12360, which I ended up reverting in #12806.  For this attempt I am dropping the code that calls any remaining pending calls during runtime finalization.  We'll see if the FreeBSD buildbot still hates me. :)

<!-- issue-number: [bpo-33608](https://bugs.python.org/issue33608) -->
https://bugs.python.org/issue33608
<!-- /issue-number -->
