### PR TITLE
Fix documentation

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2277,7 +2277,11 @@ with the :class:`Pool` class.
    .. method:: successful()
 
       Return whether the call completed without raising an exception.  Will
-      raise :exc:`ValueError` if the result is not ready.
+      raise :exc:`AssertionError` if the result is not ready.
+      
+      .. versionchanged:: 3.7
+         If the result is not ready, :exc:`ValueError` is raised instead of
+         :exc:`AssertionError`.
 
 The following example demonstrates the use of a pool::
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2278,7 +2278,7 @@ with the :class:`Pool` class.
 
       Return whether the call completed without raising an exception.  Will
       raise :exc:`AssertionError` if the result is not ready.
-      
+
       .. versionchanged:: 3.7
          If the result is not ready, :exc:`ValueError` is raised instead of
          :exc:`AssertionError`.

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2277,7 +2277,7 @@ with the :class:`Pool` class.
    .. method:: successful()
 
       Return whether the call completed without raising an exception.  Will
-      raise :exc:`AssertionError` if the result is not ready.
+      raise :exc:`ValueError` if the result is not ready.
 
 The following example demonstrates the use of a pool::
 


### PR DESCRIPTION
Based on the source code https://github.com/python/cpython/blob/4a686504eb2bbf69adf78077458508a7ba131667/Lib/multiprocessing/pool.py#L755 AsyncResult.successful() raises a ValueError, not an AssertionError.
