### PR TITLE
bpo-36993: Improve error detection of extra field in ZipFile

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1739,6 +1739,20 @@ class OtherTests(unittest.TestCase):
                 fp.seek(0, os.SEEK_SET)
                 self.assertEqual(fp.tell(), 0)
 
+    def test_malformatted_zip64_extra_field(self):
+        zipdata = (
+            b'PK\x03\x04\xfb\x03PK\x01\x02\x1e\xfb\x13\x00\x00\x00\xd3'
+            b'\x00\x978\xa2NwS\x17\x88\xfa\x00\x00\x00\xff\xff\xff\xff'
+            b'\x12\x00\x18\x00\x00\x00\x00\x00\x01\x00\x00\x00\xb4\x81'
+            b'\x00\x00\x00\x00zipfile_extract/\x00\x00'
+            # Start of the extra field.
+            b'\x01\x00\x00\x00//(///\xff\x00\x00\x00//////\xe8\x03\x00 '
+            b'PK\x05\x06\x00\x00\x00\x00\x01\x00\x01\x00X\x00\x00\x00F'
+            b'\x01\x00\xee\xff\x01'
+        )
+        with self.assertRaises(zipfile.BadZipFile):
+            zipfile.ZipFile(io.BytesIO(zipdata))
+
     def tearDown(self):
         unlink(TESTFN)
         unlink(TESTFN2)

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -463,6 +463,7 @@ class ZipInfo (object):
             tp, ln = unpack('<HH', extra[:4])
             if ln+4 > len(extra):
                 raise BadZipFile("Corrupt extra field %04x (size=%d)" % (tp, ln))
+            # Zip64 extended information extra field
             if tp == 0x0001:
                 if ln >= 24:
                     counts = unpack('<QQQ', extra[4:28])
@@ -470,8 +471,6 @@ class ZipInfo (object):
                     counts = unpack('<QQ', extra[4:20])
                 elif ln == 8:
                     counts = unpack('<Q', extra[4:12])
-                elif ln == 0:
-                    counts = ()
                 else:
                     raise BadZipFile("Corrupt extra field %04x (size=%d)" % (tp, ln))
 

--- a/Misc/NEWS.d/next/Library/2019-06-01-19-10-57.bpo-36993.9nIngf.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-01-19-10-57.bpo-36993.9nIngf.rst
@@ -1,0 +1,2 @@
+Improve error detection of malformed extra field in
+:class:`zipfile.ZipFile`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36993](https://bugs.python.org/issue36993) -->
https://bugs.python.org/issue36993
<!-- /issue-number -->
