### PR TITLE
bpo-34271: Fix compatibility with 1.0.2 (GH-13728)

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -658,12 +658,12 @@ class SSLContext(_SSLContext):
         def inner(conn, direction, version, content_type, msg_type, data):
             try:
                 version = TLSVersion(version)
-            except TypeError:
+            except ValueError:
                 pass
 
             try:
                 content_type = _TLSContentType(content_type)
-            except TypeError:
+            except ValueError:
                 pass
 
             if content_type == _TLSContentType.HEADER:
@@ -674,7 +674,7 @@ class SSLContext(_SSLContext):
                 msg_enum = _TLSMessageType
             try:
                 msg_type = msg_enum(msg_type)
-            except TypeError:
+            except ValueError:
                 pass
 
             return callback(conn, direction, version,

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3703,7 +3703,7 @@ class ThreadedTests(unittest.TestCase):
         # client 1.0, server 1.2 (mismatch)
         server_context.minimum_version = ssl.TLSVersion.TLSv1_2
         server_context.maximum_version = ssl.TLSVersion.TLSv1_2
-        client_context.minimum_version = ssl.TLSVersion.TLSv1
+        client_context.maximum_version = ssl.TLSVersion.TLSv1
         client_context.maximum_version = ssl.TLSVersion.TLSv1
         with ThreadedEchoServer(context=server_context) as server:
             with client_context.wrap_socket(socket.socket(),
@@ -4529,50 +4529,16 @@ class TestSSLDebug(unittest.TestCase):
                                             server_hostname=hostname) as s:
                 s.connect((HOST, server.port))
 
-        self.assertEqual(msg, [
-            ("write", TLSVersion.TLSv1, _TLSContentType.HEADER,
-             _TLSMessageType.CERTIFICATE_STATUS),
-            ("write", TLSVersion.TLSv1_2, _TLSContentType.HANDSHAKE,
-             _TLSMessageType.CLIENT_HELLO),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.CERTIFICATE_STATUS),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HANDSHAKE,
-             _TLSMessageType.SERVER_HELLO),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.CERTIFICATE_STATUS),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HANDSHAKE,
-             _TLSMessageType.CERTIFICATE),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.CERTIFICATE_STATUS),
+        self.assertIn(
             ("read", TLSVersion.TLSv1_2, _TLSContentType.HANDSHAKE,
              _TLSMessageType.SERVER_KEY_EXCHANGE),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.CERTIFICATE_STATUS),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HANDSHAKE,
-             _TLSMessageType.SERVER_DONE),
-            ("write", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.CERTIFICATE_STATUS),
-            ("write", TLSVersion.TLSv1_2, _TLSContentType.HANDSHAKE,
-             _TLSMessageType.CLIENT_KEY_EXCHANGE),
-            ("write", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.FINISHED),
+            msg
+        )
+        self.assertIn(
             ("write", TLSVersion.TLSv1_2, _TLSContentType.CHANGE_CIPHER_SPEC,
              _TLSMessageType.CHANGE_CIPHER_SPEC),
-            ("write", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.CERTIFICATE_STATUS),
-            ("write", TLSVersion.TLSv1_2, _TLSContentType.HANDSHAKE,
-             _TLSMessageType.FINISHED),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.CERTIFICATE_STATUS),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HANDSHAKE,
-             _TLSMessageType.NEWSESSION_TICKET),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.FINISHED),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HEADER,
-             _TLSMessageType.CERTIFICATE_STATUS),
-            ("read", TLSVersion.TLSv1_2, _TLSContentType.HANDSHAKE,
-             _TLSMessageType.FINISHED),
-        ])
+            msg
+        )
 
 
 def test_main(verbose=False):

--- a/Modules/_ssl/debughelpers.c
+++ b/Modules/_ssl/debughelpers.c
@@ -1,5 +1,12 @@
 /* Debug helpers */
 
+#ifndef SSL3_MT_CHANGE_CIPHER_SPEC
+/* Dummy message type for handling CCS like a normal handshake message
+ * not defined in OpenSSL 1.0.2
+ */
+#define SSL3_MT_CHANGE_CIPHER_SPEC              0x0101
+#endif
+
 static void
 _PySSL_msg_callback(int write_p, int version, int content_type,
                     const void *buf, size_t len, SSL *ssl, void *arg)
@@ -41,11 +48,13 @@ _PySSL_msg_callback(int write_p, int version, int content_type,
       case SSL3_RT_HANDSHAKE:
         msg_type = (int)cbuf[0];
         break;
+#ifdef SSL3_RT_HEADER
       case SSL3_RT_HEADER:
         /* frame header encodes version in bytes 1..2 */
         version = cbuf[1] << 8 | cbuf[2];
         msg_type = (int)cbuf[0];
         break;
+#endif
 #ifdef SSL3_RT_INNER_CONTENT_TYPE
       case SSL3_RT_INNER_CONTENT_TYPE:
         msg_type = (int)cbuf[0];

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -51,10 +51,11 @@ OPENSSL_RECENT_VERSIONS = [
 ]
 
 LIBRESSL_OLD_VERSIONS = [
+    "2.9.2",
 ]
 
 LIBRESSL_RECENT_VERSIONS = [
-    "2.7.4",
+    "2.8.3",
 ]
 
 # store files in ../multissl


### PR DESCRIPTION
Fix various compatibility issues with LibreSSL and OpenSSL 1.0.2
introduced by [bpo-34271](https://bugs.python.org/issue34271).

Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: [bpo-34271](https://bugs.python.org/issue34271) -->
https://bugs.python.org/issue34271
<!-- /issue-number -->
