### PR TITLE
bpo-37126: Allow structseq objects to be tracked by the GC

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-01-20-03-13.bpo-37126.tP6lL4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-01-20-03-13.bpo-37126.tP6lL4.rst
@@ -1,0 +1,2 @@
+All structseq objects are now tracked by the garbage collector. Patch by
+Pablo Galindo.

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -72,26 +72,17 @@ structseq_traverse(PyStructSequence *obj, visitproc visit, void *arg)
     return 0;
 }
 
-static int
-structseq_clear(PyStructSequence *obj)
-{
-    Py_ssize_t i, size;
-
-    size = REAL_SIZE(obj);
-    for (i = 0; i < size; ++i) {
-        Py_CLEAR(obj->ob_item[i]);
-    }
-    return 0;
-}
-
 static void
 structseq_dealloc(PyStructSequence *obj)
 {
+    Py_ssize_t i, size;
     PyTypeObject *tp;
+
     tp = (PyTypeObject *) Py_TYPE(obj);
-
-    structseq_clear(obj);
-
+    size = REAL_SIZE(obj);
+    for (i = 0; i < size; ++i) {
+        Py_XDECREF(obj->ob_item[i]);
+    }
     PyObject_GC_Del(obj);
     if (PyType_GetFlags(tp) & Py_TPFLAGS_HEAPTYPE) {
         Py_DECREF(tp);
@@ -412,7 +403,6 @@ PyStructSequence_InitType2(PyTypeObject *type, PyStructSequence_Desc *desc)
     type->tp_new = structseq_new;
     type->tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC;
     type->tp_traverse = (traverseproc) structseq_traverse;
-    type->tp_clear = (inquiry)structseq_clear;
 
     n_members = count_members(desc, &n_unnamed_members);
     members = PyMem_NEW(PyMemberDef, n_members - n_unnamed_members + 1);
@@ -451,7 +441,7 @@ PyStructSequence_NewType(PyStructSequence_Desc *desc)
     PyMemberDef *members;
     PyObject *bases;
     PyTypeObject *type;
-    PyType_Slot slots[9];
+    PyType_Slot slots[8];
     PyType_Spec spec;
     Py_ssize_t n_members, n_unnamed_members;
 
@@ -472,8 +462,7 @@ PyStructSequence_NewType(PyStructSequence_Desc *desc)
     slots[4] = (PyType_Slot){Py_tp_new, structseq_new};
     slots[5] = (PyType_Slot){Py_tp_members, members};
     slots[6] = (PyType_Slot){Py_tp_traverse, (traverseproc)structseq_traverse};
-    slots[7] = (PyType_Slot){Py_tp_clear, (inquiry)structseq_clear};
-    slots[8] = (PyType_Slot){0, 0};
+    slots[7] = (PyType_Slot){0, 0};
 
     /* Initialize Spec */
     /* The name in this PyType_Spec is statically allocated so it is */


### PR DESCRIPTION
<!-- issue-number: [bpo-37126](https://bugs.python.org/issue37126) -->
https://bugs.python.org/issue37126
<!-- /issue-number -->

`structseq` objects can be involved in reference cycles but they are not tracked by the gc. One example of such case is:
https://bugs.python.org/issue37126

