### PR TITLE
Fix compiler warnings in the pystrehex module

### DIFF
--- a/Python/pystrhex.c
+++ b/Python/pystrhex.c
@@ -11,11 +11,11 @@ static PyObject *_Py_strhex_impl(const char* argbuf, const Py_ssize_t arglen,
     PyObject *retval;
     Py_UCS1* retbuf;
     Py_ssize_t i, j, resultlen = 0;
-    Py_UCS1 sep_char;
+    Py_UCS1 sep_char = 0;
     unsigned int abs_bytes_per_sep;
 
     if (sep) {
-        Py_ssize_t seplen = PyObject_Length(sep);
+        Py_ssize_t seplen = PyObject_Length((PyObject*)sep);
         if (seplen < 0) {
             return NULL;
         }


### PR DESCRIPTION
```C
Python/pystrhex.c: In function ‘_Py_strhex_impl’:
Python/pystrhex.c:18:45: warning: passing argument 1 of ‘PyObject_Size’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
         Py_ssize_t seplen = PyObject_Length(sep);
                                             ^~~
In file included from ./Include/Python.h:147,
                 from Python/pystrhex.c:3:
./Include/abstract.h:271:48: note: expected ‘PyObject *’ {aka ‘struct _object *’} but argument is of type ‘const PyObject *’ {aka ‘const struct _object *’}
 PyAPI_FUNC(Py_ssize_t) PyObject_Size(PyObject *o);
                                      ~~~~~~~~~~^
Python/pystrhex.c:90:29: warning: ‘sep_char’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                 retbuf[j++] = sep_char;
                 ~~~~~~~~~~~~^~~~~~~~~~
 CC='gcc -pthread' LDSHARED='gcc -pthread -shared    ' OPT='-g -Og -Wall'       _TCLTK_INCLUDES='' _TCLTK_LIBS=''       ./python -E ./setup.py -q build

```