### PR TITLE
gh-77046: Pass the _O_NOINHERIT flag to _open_osfhandle() calls

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-01-23-55-50.bpo-32865.Ha11I1.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-01-23-55-50.bpo-32865.Ha11I1.rst
@@ -1,0 +1,2 @@
+On Windows, do not use inheritable file descriptors to wrap handles in
+:func:`os.pipe`.

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -478,9 +478,11 @@ _io__WindowsConsoleIO_fileno_impl(winconsoleio *self)
     if (self->fd < 0 && self->handle != INVALID_HANDLE_VALUE) {
         _Py_BEGIN_SUPPRESS_IPH
         if (self->writable)
-            self->fd = _open_osfhandle((intptr_t)self->handle, _O_WRONLY | _O_BINARY);
+            self->fd = _open_osfhandle((intptr_t)self->handle,
+                                       _O_WRONLY | _O_BINARY | _O_NOINHERIT);
         else
-            self->fd = _open_osfhandle((intptr_t)self->handle, _O_RDONLY | _O_BINARY);
+            self->fd = _open_osfhandle((intptr_t)self->handle,
+                                       _O_RDONLY | _O_BINARY | _O_NOINHERIT);
         _Py_END_SUPPRESS_IPH
     }
     if (self->fd < 0)

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9200,8 +9200,8 @@ os_pipe_impl(PyObject *module)
     _Py_BEGIN_SUPPRESS_IPH
     ok = CreatePipe(&read, &write, &attr, 0);
     if (ok) {
-        fds[0] = _open_osfhandle((intptr_t)read, _O_RDONLY);
-        fds[1] = _open_osfhandle((intptr_t)write, _O_WRONLY);
+        fds[0] = _open_osfhandle((intptr_t)read, _O_RDONLY | _O_NOINHERIT);
+        fds[1] = _open_osfhandle((intptr_t)write, _O_WRONLY | _O_NOINHERIT);
         if (fds[0] == -1 || fds[1] == -1) {
             CloseHandle(read);
             CloseHandle(write);


### PR DESCRIPTION
On Windows, do not use inheritable file descriptors to wrap handles
in os.pipe().

<!-- issue-number: [bpo-32865](https://bugs.python.org/issue32865) -->
https://github.com/python/cpython/issues/77046
<!-- /issue-number -->


<!-- gh-issue-number: gh-77046 -->
* Issue: gh-77046
<!-- /gh-issue-number -->
