### PR TITLE
bpo-17576: Strict __int__ and __index__ return types; operator.index always uses __index__

### DIFF
--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -586,9 +586,7 @@ class TestCopy(unittest.TestCase):
         y = copy.deepcopy(x)
         self.assertIsNot(y, x)
         self.assertEqual(y, x)
-        self.assertIsNot(y.stop, x.stop)
         self.assertEqual(y.stop, x.stop)
-        self.assertIsInstance(y.stop, I)
 
     # _reconstruct()
 

--- a/Lib/test/test_getargs2.py
+++ b/Lib/test/test_getargs2.py
@@ -158,15 +158,15 @@ class Unsigned_TestCase(unittest.TestCase):
         self.assertEqual(99, getargs_b(Index()))
         self.assertEqual(0, getargs_b(IndexIntSubclass()))
         self.assertRaises(TypeError, getargs_b, BadIndex())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_b(BadIndex2()))
+        with self.assertRaises(TypeError):
+            getargs_b(BadIndex2())
         self.assertEqual(0, getargs_b(BadIndex3()))
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(99, getargs_b(Int()))
         self.assertEqual(0, getargs_b(IntSubclass()))
         self.assertRaises(TypeError, getargs_b, BadInt())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_b(BadInt2()))
+        with self.assertRaises(TypeError):
+            getargs_b(BadInt2())
         self.assertEqual(0, getargs_b(BadInt3()))
 
         self.assertRaises(OverflowError, getargs_b, -1)
@@ -184,15 +184,15 @@ class Unsigned_TestCase(unittest.TestCase):
         self.assertEqual(99, getargs_B(Index()))
         self.assertEqual(0, getargs_B(IndexIntSubclass()))
         self.assertRaises(TypeError, getargs_B, BadIndex())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_B(BadIndex2()))
+        with self.assertRaises(TypeError):
+            getargs_B(BadIndex2())
         self.assertEqual(0, getargs_B(BadIndex3()))
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(99, getargs_B(Int()))
         self.assertEqual(0, getargs_B(IntSubclass()))
         self.assertRaises(TypeError, getargs_B, BadInt())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_B(BadInt2()))
+        with self.assertRaises(TypeError):
+            getargs_B(BadInt2())
         self.assertEqual(0, getargs_B(BadInt3()))
 
         self.assertEqual(UCHAR_MAX, getargs_B(-1))
@@ -210,15 +210,15 @@ class Unsigned_TestCase(unittest.TestCase):
         self.assertEqual(99, getargs_H(Index()))
         self.assertEqual(0, getargs_H(IndexIntSubclass()))
         self.assertRaises(TypeError, getargs_H, BadIndex())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_H(BadIndex2()))
+        with self.assertRaises(TypeError):
+            getargs_H(BadIndex2())
         self.assertEqual(0, getargs_H(BadIndex3()))
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(99, getargs_H(Int()))
         self.assertEqual(0, getargs_H(IntSubclass()))
         self.assertRaises(TypeError, getargs_H, BadInt())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_H(BadInt2()))
+        with self.assertRaises(TypeError):
+            getargs_H(BadInt2())
         self.assertEqual(0, getargs_H(BadInt3()))
 
         self.assertEqual(USHRT_MAX, getargs_H(-1))
@@ -237,15 +237,15 @@ class Unsigned_TestCase(unittest.TestCase):
         self.assertEqual(99, getargs_I(Index()))
         self.assertEqual(0, getargs_I(IndexIntSubclass()))
         self.assertRaises(TypeError, getargs_I, BadIndex())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_I(BadIndex2()))
+        with self.assertRaises(TypeError):
+            getargs_I(BadIndex2())
         self.assertEqual(0, getargs_I(BadIndex3()))
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(99, getargs_I(Int()))
         self.assertEqual(0, getargs_I(IntSubclass()))
         self.assertRaises(TypeError, getargs_I, BadInt())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_I(BadInt2()))
+        with self.assertRaises(TypeError):
+            getargs_I(BadInt2())
         self.assertEqual(0, getargs_I(BadInt3()))
 
         self.assertEqual(UINT_MAX, getargs_I(-1))
@@ -290,15 +290,15 @@ class Signed_TestCase(unittest.TestCase):
         self.assertEqual(99, getargs_h(Index()))
         self.assertEqual(0, getargs_h(IndexIntSubclass()))
         self.assertRaises(TypeError, getargs_h, BadIndex())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_h(BadIndex2()))
+        with self.assertRaises(TypeError):
+            getargs_h(BadIndex2())
         self.assertEqual(0, getargs_h(BadIndex3()))
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(99, getargs_h(Int()))
         self.assertEqual(0, getargs_h(IntSubclass()))
         self.assertRaises(TypeError, getargs_h, BadInt())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_h(BadInt2()))
+        with self.assertRaises(TypeError):
+            getargs_h(BadInt2())
         self.assertEqual(0, getargs_h(BadInt3()))
 
         self.assertRaises(OverflowError, getargs_h, SHRT_MIN-1)
@@ -316,15 +316,15 @@ class Signed_TestCase(unittest.TestCase):
         self.assertEqual(99, getargs_i(Index()))
         self.assertEqual(0, getargs_i(IndexIntSubclass()))
         self.assertRaises(TypeError, getargs_i, BadIndex())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_i(BadIndex2()))
+        with self.assertRaises(TypeError):
+            getargs_i(BadIndex2())
         self.assertEqual(0, getargs_i(BadIndex3()))
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(99, getargs_i(Int()))
         self.assertEqual(0, getargs_i(IntSubclass()))
         self.assertRaises(TypeError, getargs_i, BadInt())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_i(BadInt2()))
+        with self.assertRaises(TypeError):
+            getargs_i(BadInt2())
         self.assertEqual(0, getargs_i(BadInt3()))
 
         self.assertRaises(OverflowError, getargs_i, INT_MIN-1)
@@ -342,15 +342,15 @@ class Signed_TestCase(unittest.TestCase):
         self.assertEqual(99, getargs_l(Index()))
         self.assertEqual(0, getargs_l(IndexIntSubclass()))
         self.assertRaises(TypeError, getargs_l, BadIndex())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_l(BadIndex2()))
+        with self.assertRaises(TypeError):
+            getargs_l(BadIndex2())
         self.assertEqual(0, getargs_l(BadIndex3()))
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(99, getargs_l(Int()))
         self.assertEqual(0, getargs_l(IntSubclass()))
         self.assertRaises(TypeError, getargs_l, BadInt())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_l(BadInt2()))
+        with self.assertRaises(TypeError):
+            getargs_l(BadInt2())
         self.assertEqual(0, getargs_l(BadInt3()))
 
         self.assertRaises(OverflowError, getargs_l, LONG_MIN-1)
@@ -367,11 +367,12 @@ class Signed_TestCase(unittest.TestCase):
         # (PY_SSIZE_T_MIN ... PY_SSIZE_T_MAX)
         self.assertRaises(TypeError, getargs_n, 3.14)
         self.assertEqual(99, getargs_n(Index()))
-        self.assertEqual(0, getargs_n(IndexIntSubclass()))
+        self.assertEqual(getargs_n(IndexIntSubclass()), 99)
         self.assertRaises(TypeError, getargs_n, BadIndex())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_n(BadIndex2()))
-        self.assertEqual(0, getargs_n(BadIndex3()))
+        with self.assertRaises(TypeError):
+            getargs_n(BadIndex2())
+        with self.assertRaises(TypeError):
+            getargs_n(BadIndex3())
         self.assertRaises(TypeError, getargs_n, Int())
         self.assertEqual(0, getargs_n(IntSubclass()))
         self.assertRaises(TypeError, getargs_n, BadInt())
@@ -397,15 +398,14 @@ class LongLong_TestCase(unittest.TestCase):
         self.assertEqual(99, getargs_L(Index()))
         self.assertEqual(0, getargs_L(IndexIntSubclass()))
         self.assertRaises(TypeError, getargs_L, BadIndex())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_L(BadIndex2()))
+        with self.assertRaises(TypeError):
+            getargs_L(BadIndex2())
         self.assertEqual(0, getargs_L(BadIndex3()))
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(99, getargs_L(Int()))
+        self.assertEqual(99, getargs_L(Int()))
         self.assertEqual(0, getargs_L(IntSubclass()))
         self.assertRaises(TypeError, getargs_L, BadInt())
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(1, getargs_L(BadInt2()))
+        with self.assertRaises(TypeError):
+            getargs_L(BadInt2())
         self.assertEqual(0, getargs_L(BadInt3()))
 
         self.assertRaises(OverflowError, getargs_L, LLONG_MIN-1)

--- a/Lib/test/test_index.py
+++ b/Lib/test/test_index.py
@@ -66,10 +66,10 @@ class BaseTestCase(unittest.TestCase):
         direct_index = my_int.__index__()
         operator_index = operator.index(my_int)
         self.assertEqual(direct_index, 8)
-        self.assertEqual(operator_index, 7)
+        self.assertEqual(operator_index, 8)
         # Both results should be of exact type int.
         self.assertIs(type(direct_index), int)
-        #self.assertIs(type(operator_index), int)
+        self.assertIs(type(operator_index), int)
 
     def test_index_returns_int_subclass(self):
         class BadInt:
@@ -81,13 +81,12 @@ class BaseTestCase(unittest.TestCase):
                 return True
 
         bad_int = BadInt()
-        with self.assertWarns(DeprecationWarning):
-            n = operator.index(bad_int)
-        self.assertEqual(n, 1)
+        with self.assertRaises(TypeError):
+            operator.index(bad_int)
 
         bad_int = BadInt2()
-        n = operator.index(bad_int)
-        self.assertEqual(n, 0)
+        with self.assertRaises(TypeError):
+            operator.index(bad_int)
 
 
 class SeqTestCase:

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -488,10 +488,8 @@ class IntTestCases(unittest.TestCase):
                 return True
 
         bad_int = BadIndex()
-        with self.assertWarns(DeprecationWarning):
+        with self.assertRaises(TypeError):
             n = int(bad_int)
-        self.assertEqual(n, 1)
-        self.assertIs(type(n), int)
 
         bad_int = BadIndex2()
         n = int(bad_int)
@@ -499,28 +497,22 @@ class IntTestCases(unittest.TestCase):
         self.assertIs(type(n), int)
 
         bad_int = BadInt()
-        with self.assertWarns(DeprecationWarning):
-            n = int(bad_int)
-        self.assertEqual(n, 1)
-        self.assertIs(type(n), int)
+        with self.assertRaises(TypeError):
+            int(bad_int)
 
         bad_int = BadInt2()
-        with self.assertWarns(DeprecationWarning):
-            n = int(bad_int)
-        self.assertEqual(n, 1)
-        self.assertIs(type(n), int)
+        with self.assertRaises(TypeError):
+            int(bad_int)
 
         bad_int = TruncReturnsBadIndex()
-        with self.assertWarns(DeprecationWarning):
+        with self.assertRaises(TypeError):
             n = int(bad_int)
-        self.assertEqual(n, 1)
-        self.assertIs(type(n), int)
+            import pdb; pdb.set_trace()
+            print("bob")
 
         bad_int = TruncReturnsBadInt()
-        with self.assertWarns(DeprecationWarning):
-            n = int(bad_int)
-        self.assertEqual(n, 1)
-        self.assertIs(type(n), int)
+        with self.assertRaises(TypeError):
+            int(bad_int)
 
         good_int = TruncReturnsIntSubclass()
         n = int(good_int)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-02-11-52-03.bpo-17576.l-SSM4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-02-11-52-03.bpo-17576.l-SSM4.rst
@@ -1,0 +1,2 @@
+Remove long-deprecated allowance for ``__int__`` and ``__index__`` methods
+to return subclasses of ``int``.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -163,25 +163,16 @@ _PyLong_FromNbInt(PyObject *integral)
     /* Convert using the nb_int slot, which should return something
        of exact type int. */
     result = nb->nb_int(integral);
-    if (!result || PyLong_CheckExact(result))
+    if (!result || PyLong_CheckExact(result)) {
         return result;
-    if (!PyLong_Check(result)) {
+    }
+    else {
         PyErr_Format(PyExc_TypeError,
                      "__int__ returned non-int (type %.200s)",
                      result->ob_type->tp_name);
         Py_DECREF(result);
         return NULL;
     }
-    /* Issue #17576: warn if 'result' not of exact type int. */
-    if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
-            "__int__ returned non-int (type %.200s).  "
-            "The ability to return an instance of a strict subclass of int "
-            "is deprecated, and may be removed in a future version of Python.",
-            result->ob_type->tp_name)) {
-        Py_DECREF(result);
-        return NULL;
-    }
-    return result;
 }
 
 /* Convert the given object to a PyLongObject using the nb_index or
@@ -216,26 +207,16 @@ _PyLong_FromNbIndexOrNbInt(PyObject *integral)
     /* Convert using the nb_index slot, which should return something
        of exact type int. */
         result = nb->nb_index(integral);
-        if (!result || PyLong_CheckExact(result))
+        if (!result || PyLong_CheckExact(result)) {
             return result;
-        if (!PyLong_Check(result)) {
+        }
+        else {
             PyErr_Format(PyExc_TypeError,
                          "__index__ returned non-int (type %.200s)",
                          result->ob_type->tp_name);
             Py_DECREF(result);
             return NULL;
         }
-        /* Issue #17576: warn if 'result' not of exact type int. */
-        if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
-                "__index__ returned non-int (type %.200s).  "
-                "The ability to return an instance of a strict subclass of int "
-                "is deprecated, and may be removed in a future version of Python.",
-                result->ob_type->tp_name))
-        {
-            Py_DECREF(result);
-            return NULL;
-        }
-        return result;
     }
 
     result = _PyLong_FromNbInt(integral);


### PR DESCRIPTION
This PR:

- turns the `DeprecationWarning`s introduced by @serhiy-storchaka in Python 3.4 for non-integer return values from `__int__` and `__index__` into `TypeError`s
- makes `operator.index` and `PyNumber_Index` always give the same return value as `__index__`. This fixes the inconsistency reported by @warsaw in [bpo-17576](https://bugs.python.org/issue17576).

Still working on doc updates and what's-new entries, but making the PR now so that others can review.

<!-- issue-number: [bpo-17576](https://bugs.python.org/issue17576) -->
https://bugs.python.org/issue17576
<!-- /issue-number -->
