### PR TITLE
bpo-37134: Add PEP570 notation to the documentation

### DIFF
--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -70,7 +70,7 @@ The module defines the following exception and functions:
    size required by the format, as reflected by :func:`calcsize`.
 
 
-.. function:: unpack_from(format, buffer, offset=0)
+.. function:: unpack_from(format, /, buffer, offset=0)
 
    Unpack from *buffer* starting at position *offset*, according to the format
    string *format*.  The result is a tuple even if it contains exactly one

--- a/Doc/library/zlib.rst
+++ b/Doc/library/zlib.rst
@@ -47,7 +47,7 @@ The available exception and functions in this module are:
       platforms, use ``adler32(data) & 0xffffffff``.
 
 
-.. function:: compress(data, level=-1)
+.. function:: compress(data, /, level=-1)
 
    Compresses the bytes in *data*, returning a bytes object containing compressed data.
    *level* is an integer from ``0`` to ``9`` or ``-1`` controlling the level of compression;
@@ -132,7 +132,7 @@ The available exception and functions in this module are:
       platforms, use ``crc32(data) & 0xffffffff``.
 
 
-.. function:: decompress(data, wbits=MAX_WBITS, bufsize=DEF_BUF_SIZE)
+.. function:: decompress(data, /, wbits=MAX_WBITS, bufsize=DEF_BUF_SIZE)
 
    Decompresses the bytes in *data*, returning a bytes object containing the
    uncompressed data.  The *wbits* parameter depends on


### PR DESCRIPTION


<!-- issue-number: [bpo-37134](https://bugs.python.org/issue37134) -->
https://bugs.python.org/issue37134
<!-- /issue-number -->
