### PR TITLE
Fix typos in docs and docstrings

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -708,7 +708,7 @@ iterations of the loop.
 
    Cleans up the value stack and the block stack.  If *preserve_tos* is not
    ``0`` TOS first is popped from the stack and pushed on the stack after
-   perfoming other stack operations:
+   performing other stack operations:
 
    * If TOS is ``NULL`` or an integer (pushed by :opcode:`BEGIN_FINALLY`
      or :opcode:`CALL_FINALLY`) it is popped from the stack.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -815,7 +815,7 @@ Customizing default Python versions
 In some cases, a version qualifier can be included in a command to dictate
 which version of Python will be used by the command. A version qualifier
 starts with a major version number and can optionally be followed by a period
-('.') and a minor version specifier. Furthermore it is possible to specifiy
+('.') and a minor version specifier. Furthermore it is possible to specify
 if a 32 or 64 bit implementation shall be requested by adding "-32" or "-64".
 
 For example, a shebang line of ``#!python`` has no version qualifier, while

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1286,7 +1286,7 @@ Changes in the C API
   (Contributed by Zackery Spytz in :issue:`33407`.)
 
 * The interpreter does not pretend to support binary compatibility of
-  extension types accross feature releases, anymore.  A :c:type:`PyTypeObject`
+  extension types across feature releases, anymore.  A :c:type:`PyTypeObject`
   exported by a third-party extension module is supposed to have all the
   slots expected in the current Python version, including
   :c:member:`~PyTypeObject.tp_finalize` (:const:`Py_TPFLAGS_HAVE_FINALIZE`

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -193,7 +193,7 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                 # prevents subprocess execution if the watcher
                 # is not ready to handle it.
                 raise RuntimeError("asyncio.get_child_watcher() is not activated, "
-                                   "subproccess support is not installed.")
+                                   "subprocess support is not installed.")
             waiter = self.create_future()
             transp = _UnixSubprocessTransport(self, protocol, args, shell,
                                               stdin, stdout, stderr, bufsize,

--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -384,7 +384,7 @@ class Bdb:
         return None
 
     def _prune_breaks(self, filename, lineno):
-        """Prune breakpoints for filname:lineno.
+        """Prune breakpoints for filename:lineno.
 
         A list of breakpoints is maintained in the Bdb instance and in
         the Breakpoint class.  If a breakpoint in the Bdb instance no

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -545,7 +545,7 @@ class CCompiler:
         'extra_preargs' and 'extra_postargs' are implementation- dependent.
         On platforms that have the notion of a command-line (e.g. Unix,
         DOS/Windows), they are most likely lists of strings: extra
-        command-line arguments to prepand/append to the compiler command
+        command-line arguments to prepend/append to the compiler command
         line.  On other platforms, consult the implementation class
         documentation.  In any event, they are intended as an escape hatch
         for those occasions when the abstract compiler framework doesn't

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2385,7 +2385,7 @@ def parse_mime_parameters(value):
     the formal RFC grammar, but it is more convenient for us for the set of
     parameters to be treated as its own TokenList.
 
-    This is 'parse' routine because it consumes the reminaing value, but it
+    This is 'parse' routine because it consumes the remaining value, but it
     would never be called to parse a full header.  Instead it is called to
     parse everything after the non-parameter value of a specific MIME header.
 

--- a/Lib/encodings/__init__.py
+++ b/Lib/encodings/__init__.py
@@ -12,7 +12,7 @@
     * getregentry() -> codecs.CodecInfo object
     The getregentry() API must return a CodecInfo object with encoder, decoder,
     incrementalencoder, incrementaldecoder, streamwriter and streamreader
-    atttributes which adhere to the Python Codec Interface Standard.
+    attributes which adhere to the Python Codec Interface Standard.
 
     In addition, a module may optionally also define the following
     APIs which are then used by the package's codec search function:

--- a/Lib/lib2to3/fixes/fix_metaclass.py
+++ b/Lib/lib2to3/fixes/fix_metaclass.py
@@ -1,6 +1,6 @@
 """Fixer for __metaclass__ = X -> (metaclass=X) methods.
 
-   The various forms of classef (inherits nothing, inherits once, inherints
+   The various forms of classef (inherits nothing, inherits once, inherits
    many) don't parse the same in the CST so we look at ALL classes for
    a __metaclass__ and if we find one normalize the inherits to all be
    an arglist.

--- a/Lib/pstats.py
+++ b/Lib/pstats.py
@@ -632,12 +632,12 @@ if __name__ == '__main__':
             print("", file=self.stream)
             return 1
         def help_EOF(self):
-            print("Leave the profile brower.", file=self.stream)
+            print("Leave the profile browser.", file=self.stream)
 
         def do_quit(self, line):
             return 1
         def help_quit(self):
-            print("Leave the profile brower.", file=self.stream)
+            print("Leave the profile browser.", file=self.stream)
 
         def do_read(self, line):
             if line:

--- a/Lib/pyclbr.py
+++ b/Lib/pyclbr.py
@@ -50,7 +50,7 @@ _modules = {}  # Initialize cache of modules we've seen.
 
 
 class _Object:
-    "Informaton about Python class or function."
+    "Information about Python class or function."
     def __init__(self, module, name, file, lineno, parent):
         self.module = module
         self.name = name

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -862,7 +862,7 @@ class SSLObject:
     @property
     def server_hostname(self):
         """The currently set server hostname (for SNI), or ``None`` if no
-        server hostame is set."""
+        server hostname is set."""
         return self._sslobj.server_hostname
 
     def read(self, len=1024, buffer=None):

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -833,7 +833,7 @@ class TurtleScreenBase(object):
         Arguments: title is the title of the dialog window,
         prompt is a text mostly describing what numerical information to input.
         default: default value
-        minval: minimum value for imput
+        minval: minimum value for input
         maxval: maximum value for input
 
         The number input must be in the range minval .. maxval if these are

--- a/Lib/turtledemo/paint.py
+++ b/Lib/turtledemo/paint.py
@@ -7,7 +7,7 @@ A simple  event-driven paint program
 
 - left mouse button moves turtle
 - middle mouse button changes color
-- right mouse button toogles betweem pen up
+- right mouse button toggles between pen up
 (no line drawn when the turtle moves) and
 pen down (line is drawn). If pen up follows
 at least two pen-down moves, the polygon that

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -2163,7 +2163,7 @@ class Path:
     >>> (b / 'missing.txt').exists()
     False
 
-    Coersion to string:
+    Coercion to string:
 
     >>> str(c)
     'abcde.zip/b/c.txt'


### PR DESCRIPTION
I have limited typos to user facing output and avoided typos in source code comments to reduce diff.

perfoming -> performing
specifiy -> specify
accross -> across
filname -> filename
prepand -> prepend
reminaing -> remaining
atttributes -> attributes
inherints -> inherits
brower -> browser
Informaton -> Information
hostame -> hostname
imput -> input
toogles betweem -> toggles between
Coersion -> Coercion