### PR TITLE
Fix typos in docs and comments in idlelib

### DIFF
--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -12,7 +12,7 @@ database keys are tuples (config-type, section, item).  As implemented,
 there are  separate dicts for default and user values.  Each has
 config-type keys 'main', 'extensions', 'highlight', and 'keys'.  The
 value for each key is a ConfigParser instance that maps section and item
-to values.  For 'main' and 'extenstons', user values override
+to values.  For 'main' and 'extensions', user values override
 default values.  For 'highlight' and 'keys', user sections augment the
 default sections (and must, therefore, have distinct names).
 

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -199,7 +199,7 @@ class ConfigDialog(Toplevel):
     def help(self):
         """Create textview for config dialog help.
 
-        Attrbutes accessed:
+        Attributes accessed:
             note
 
         Methods:

--- a/Lib/idlelib/delegator.py
+++ b/Lib/idlelib/delegator.py
@@ -14,7 +14,7 @@ class Delegator:
 
     def resetcache(self):
         "Removes added attributes while leaving original attributes."
-        # Function is really about resetting delagator dict
+        # Function is really about resetting delegator dict
         # to original state.  Cache is just a means
         for key in self.__cache:
             try:

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -315,7 +315,7 @@ class EditorWindow(object):
                   self.CodeContext(self).toggle_code_context_event)
 
     def _filename_to_unicode(self, filename):
-        """Return filename as BMP unicode so diplayable in Tk."""
+        """Return filename as BMP unicode so displayable in Tk."""
         # Decode bytes to unicode.
         if isinstance(filename, bytes):
             try:

--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -12,7 +12,7 @@ or function) whose .__name__ attribute is also X (the usual situation).
 The first parameter of X must be 'parent'.  When called, the parent
 argument will be the root window.  X must create a child Toplevel
 window (or subclass thereof).  The Toplevel may be a test widget or
-dialog, in which case the callable is the corresonding class.  Or the
+dialog, in which case the callable is the corresponding class.  Or the
 Toplevel may contain the widget to be tested or set up a context in
 which a test widget is invoked.  In this latter case, the callable is a
 wrapper function that sets up the Toplevel and other objects.  Wrapper

--- a/Lib/idlelib/idle_test/mock_tk.py
+++ b/Lib/idlelib/idle_test/mock_tk.py
@@ -37,7 +37,7 @@ class Mbox_func:
     """Generic mock for messagebox functions, which all have the same signature.
 
     Instead of displaying a message box, the mock's call method saves the
-    arguments as instance attributes, which test functions can then examime.
+    arguments as instance attributes, which test functions can then examine.
     The test can set the result returned to ask function
     """
     def __init__(self, result=None):

--- a/Lib/idlelib/idle_test/test_pyparse.py
+++ b/Lib/idlelib/idle_test/test_pyparse.py
@@ -160,7 +160,7 @@ class PyParseTest(unittest.TestCase):
             TestInfo('\n   def function1(self, a,\n', [0, 1, 2], BRACKET),
             TestInfo('())\n', [0, 1], NONE),                    # Extra closer.
             TestInfo(')(\n', [0, 1], BRACKET),                  # Extra closer.
-            # For the mismatched example, it doesn't look like contination.
+            # For the mismatched example, it doesn't look like continuation.
             TestInfo('{)(]\n', [0, 1], NONE),                   # Mismatched.
             )
 

--- a/Lib/idlelib/search.py
+++ b/Lib/idlelib/search.py
@@ -80,7 +80,7 @@ class SearchDialog(SearchDialogBase):
         If no search was previously run, open a new search dialog.  In
         this case, no search is done.
 
-        If a seach was previously run, the search dialog won't be
+        If a search was previously run, the search dialog won't be
         shown and the options from the previous search (including the
         search pattern) will be used to find the next occurrence
         of the pattern.  Next is relative based on direction.

--- a/Lib/idlelib/searchbase.py
+++ b/Lib/idlelib/searchbase.py
@@ -36,7 +36,7 @@ class SearchDialogBase:
         text (Text searched): set in open(), only used in subclasses().
         ent (ry): created in make_entry() called from create_entry().
         row (of grid): 0 in create_widgets(), +1 in make_entry/frame().
-        default_command: set in subclasses, used in create_widgers().
+        default_command: set in subclasses, used in create_widgets().
 
         title (of dialog): class attribute, override in subclasses.
         icon (of dialog): ditto, use unclear if cannot minimize dialog.

--- a/Lib/idlelib/squeezer.py
+++ b/Lib/idlelib/squeezer.py
@@ -6,7 +6,7 @@ Worse, this can cause IDLE to become very slow, even to the point of being
 completely unusable.
 
 This extension will automatically replace long texts with a small button.
-Double-cliking this button will remove it and insert the original text instead.
+Double-clicking this button will remove it and insert the original text instead.
 Middle-clicking will copy the text to the clipboard. Right-clicking will open
 the text in a separate viewing window.
 

--- a/Lib/idlelib/undo.py
+++ b/Lib/idlelib/undo.py
@@ -2,7 +2,7 @@ import string
 
 from idlelib.delegator import Delegator
 
-# tkintter import not needed because module does not create widgets,
+# tkinter import not needed because module does not create widgets,
 # although many methods operate on text widget arguments.
 
 #$ event <<redo>>


### PR DESCRIPTION
extenstons -> extensions
Attrbutes -> Attributes
delagator -> delegator
diplayable -> displayable
corresonding -> corresponding
examime -> examine
contination -> continuation
seach -> search
create_widgers -> create_widgets
Double-cliking -> Double-clicking
tkintter -> tkinter