### PR TITLE
bpo-37126: Call PyObject_GC_UnTrack in structseq dealloc

### DIFF
--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -64,6 +64,7 @@ structseq_dealloc(PyStructSequence *obj)
 {
     Py_ssize_t i, size;
     PyTypeObject *tp;
+    PyObject_GC_UnTrack(obj);
 
     tp = (PyTypeObject *) Py_TYPE(obj);
     size = REAL_SIZE(obj);


### PR DESCRIPTION


<!-- issue-number: [bpo-37126](https://bugs.python.org/issue37126) -->
https://bugs.python.org/issue37126
<!-- /issue-number -->
