### PR TITLE
bpo-35621: Fix tests when SafeChildWatcher is expected instead of ThreadedChildWatcher

### DIFF
--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -1825,6 +1825,7 @@ class PolicyTests(unittest.TestCase):
 
         def f():
             policy.set_event_loop(policy.new_event_loop())
+
             self.assertIsInstance(policy.get_event_loop(),
                                   asyncio.AbstractEventLoop)
             watcher = policy.get_child_watcher()

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -1824,6 +1824,7 @@ class PolicyTests(unittest.TestCase):
     def test_get_child_watcher_thread(self):
 
         def f():
+            policy.set_event_loop(policy.new_event_loop())
             self.assertIsInstance(policy.get_event_loop(),
                                   asyncio.AbstractEventLoop)
             watcher = policy.get_child_watcher()
@@ -1835,7 +1836,6 @@ class PolicyTests(unittest.TestCase):
 
         policy = self.create_policy()
         policy.set_child_watcher(asyncio.SafeChildWatcher())
-        policy.set_event_loop(policy.new_event_loop())
 
         th = threading.Thread(target=f)
         th.start()

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -1824,8 +1824,6 @@ class PolicyTests(unittest.TestCase):
     def test_get_child_watcher_thread(self):
 
         def f():
-            policy.set_event_loop(policy.new_event_loop())
-
             self.assertIsInstance(policy.get_event_loop(),
                                   asyncio.AbstractEventLoop)
             watcher = policy.get_child_watcher()
@@ -1836,6 +1834,8 @@ class PolicyTests(unittest.TestCase):
             policy.get_event_loop().close()
 
         policy = self.create_policy()
+        policy.set_child_watcher(asyncio.SafeChildWatcher())
+        policy.set_event_loop(policy.new_event_loop())
 
         th = threading.Thread(target=f)
         th.start()


### PR DESCRIPTION


<!-- issue-number: [bpo-35621](https://bugs.python.org/issue35621) -->
https://bugs.python.org/issue35621
<!-- /issue-number -->
