### PR TITLE
bpo-35814: Update the annotated assignment docs

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -329,7 +329,8 @@ Annotated assignment statements
 statement, of a variable or attribute annotation and an optional assignment statement:
 
 .. productionlist::
-   annotated_assignment_stmt: `augtarget` ":" `expression` ["=" `expression`]
+   annotated_assignment_stmt: `augtarget` ":" `expression`
+                            : ["=" (`expression_list` | `yield_expression`)]
 
 The difference from normal :ref:`assignment` is that only single target and
 only single right hand side value is allowed.
@@ -365,6 +366,11 @@ target, then the interpreter evaluates the target except for the last
       The proposal that added the :mod:`typing` module to provide a standard
       syntax for type annotations that can be used in static analysis tools and
       IDEs.
+
+.. versionchanged:: 3.8
+   Now annotated assignments allow same expressions in the right hand side as
+   the augmented assignments. Previously, some expressions (like un-parenthesized
+   tuple expressions) caused a syntax error.
 
 
 .. _assert:


### PR DESCRIPTION
cc @gvanrossum @rhettinger 

Btw, when writing this I am now thinking is there a reason why we don't allow also star expressions in the r.h.s. of annotated assignments (so that it mirrors normal assignment, not augmented assignment)? For example `t: Tuple[int, ...] = x, y, *z` is a `SyntaxError`. Should we try allowing this? Or is it too late in the release cycle?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35814](https://bugs.python.org/issue35814) -->
https://bugs.python.org/issue35814
<!-- /issue-number -->
