### PR TITLE
bpo-36027 bpo-36974: Fix "incompatible pointer type" compiler warnings

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5854,7 +5854,7 @@ MethodDescriptor_vectorcall(PyObject *callable, PyObject *const *args,
 static PyObject *
 MethodDescriptor_new(PyTypeObject* type, PyObject* args, PyObject *kw)
 {
-    MethodDescriptorObject *op = type->tp_alloc(type, 0);
+    MethodDescriptorObject *op = (MethodDescriptorObject *)type->tp_alloc(type, 0);
     op->vectorcall = MethodDescriptor_vectorcall;
     return (PyObject *)op;
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4243,7 +4243,7 @@ long_invmod(PyLongObject *a, PyLongObject *n)
 
     Py_DECREF(c);
     Py_DECREF(n);
-    if (long_compare(a, _PyLong_One)) {
+    if (long_compare(a, (PyObject *)_PyLong_One)) {
         /* a != 1; we don't have an inverse. */
         Py_DECREF(a);
         Py_DECREF(b);


### PR DESCRIPTION

<!-- issue-number: [bpo-36027](https://bugs.python.org/issue36027) -->
https://bugs.python.org/issue36027
<!-- /issue-number -->

https://bugs.python.org/issue36974
