### PR TITLE
bpo-35814: Allow unpacking in r.h.s of annotated assignment expressions

### DIFF
--- a/Grammar/Grammar
+++ b/Grammar/Grammar
@@ -84,7 +84,7 @@ small_stmt: (expr_stmt | del_stmt | pass_stmt | flow_stmt |
              import_stmt | global_stmt | nonlocal_stmt | assert_stmt)
 expr_stmt: testlist_star_expr (annassign | augassign (yield_expr|testlist) |
                      [('=' (yield_expr|testlist_star_expr))+ [TYPE_COMMENT]] )
-annassign: ':' test ['=' (yield_expr|testlist)]
+annassign: ':' test ['=' (yield_expr|testlist_star_expr)]
 testlist_star_expr: (test|star_expr) (',' (test|star_expr))* [',']
 augassign: ('+=' | '-=' | '*=' | '@=' | '/=' | '%=' | '&=' | '|=' | '^=' |
             '<<=' | '>>=' | '**=' | '//=')

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -454,6 +454,10 @@ class GrammarTests(unittest.TestCase):
         exec(stmt, ns)
         self.assertEqual(list(ns['f']()), [None])
 
+        ns = {"a": 1, 'b': (2, 3, 4), "c":5, "Tuple": typing.Tuple}
+        exec('x: Tuple[int, ...] = a,*b,c', ns)
+        self.assertEqual(ns['x'], (1, 2, 3, 4, 5))
+
     def test_funcdef(self):
         ### [decorators] 'def' NAME parameters ['->' test] ':' suite
         ### decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-03-00-51-02.bpo-35814.Cf7sGY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-03-00-51-02.bpo-35814.Cf7sGY.rst
@@ -1,0 +1,2 @@
+Allow unpacking in the right hand side of annotated assignments. In
+particular, ``t: Tuple[int, ...] = x, y, *z`` is now allowed.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -3398,7 +3398,7 @@ ast_for_expr_stmt(struct compiling *c, const node *n)
         }
         else {
             ch = CHILD(ann, 3);
-            if (TYPE(ch) == testlist) {
+            if (TYPE(ch) == testlist_star_expr) {
                 expr3 = ast_for_testlist(c, ch);
             }
             else {

--- a/Python/graminit.c
+++ b/Python/graminit.c
@@ -742,7 +742,7 @@ static const arc arcs_17_2[2] = {
     {0, 2},
 };
 static const arc arcs_17_3[2] = {
-    {47, 4},
+    {81, 4},
     {84, 4},
 };
 static const arc arcs_17_4[1] = {


### PR DESCRIPTION
<!-- issue-number: [bpo-35814](https://bugs.python.org/issue35814) -->
https://bugs.python.org/issue35814
<!-- /issue-number -->
