### PR TITLE
bpo-36027: Really fix "incompatible pointer type" compiler warning

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4243,7 +4243,7 @@ long_invmod(PyLongObject *a, PyLongObject *n)
 
     Py_DECREF(c);
     Py_DECREF(n);
-    if (long_compare(a, (PyObject *)_PyLong_One)) {
+    if (long_compare(a, (PyLongObject *)_PyLong_One)) {
         /* a != 1; we don't have an inverse. */
         Py_DECREF(a);
         Py_DECREF(b);


### PR DESCRIPTION
Apologies for the earlier hasty attempt.


<!-- issue-number: [bpo-36027](https://bugs.python.org/issue36027) -->
https://bugs.python.org/issue36027
<!-- /issue-number -->
