### PR TITLE
bpo-36231:  Support building on macOS without /usr/include

### DIFF
--- a/Misc/NEWS.d/next/macOS/2019-06-03-05-49-49.bpo-36231.RfmW_p.rst
+++ b/Misc/NEWS.d/next/macOS/2019-06-03-05-49-49.bpo-36231.RfmW_p.rst
@@ -1,0 +1,3 @@
+Support building Python on macOS without /usr/include installed. As of macOS
+10.14, system header files are only available within an SDK provided by
+either the Command Line Tools or the Xcode app.

--- a/setup.py
+++ b/setup.py
@@ -125,19 +125,57 @@ def sysroot_paths(make_vars, subdirs):
                 break
     return dirs
 
+MACOS_SDK_ROOT = None
 
 def macosx_sdk_root():
+    """Return the directory of the current macOS SDK.
+
+    If no SDK was explicitly configured, call the compiler to find which
+    include files paths are being searched by default.  Use '/' if the
+    compiler is searching /usr/include (meaning system header files are
+    installed) or use the root of an SDK if that is being searched.
+    (The SDK may be supplied via Xcode or via the Command Line Tools).
+    The SDK paths used by Apple-supplied tool chains depend on the
+    setting of various variables; see the xcrun man page for more info.
     """
-    Return the directory of the current OSX SDK,
-    or '/' if no SDK was specified.
-    """
+    global MACOS_SDK_ROOT
+
+    # If already called, return cached result.
+    if MACOS_SDK_ROOT:
+        return MACOS_SDK_ROOT
+
     cflags = sysconfig.get_config_var('CFLAGS')
     m = re.search(r'-isysroot\s+(\S+)', cflags)
-    if m is None:
-        sysroot = '/'
+    if m is not None:
+        MACOS_SDK_ROOT = m.group(1)
     else:
-        sysroot = m.group(1)
-    return sysroot
+        MACOS_SDK_ROOT = '/'
+        cc = sysconfig.get_config_var('CC')
+        tmpfile = '/tmp/setup_sdk_root.%d' % os.getpid()
+        try:
+            os.unlink(tmpfile)
+        except:
+            pass
+        ret = os.system('%s -E -v - </dev/null 2>%s 1>/dev/null' % (cc, tmpfile))
+        in_incdirs = False
+        try:
+            if ret >> 8 == 0:
+                with open(tmpfile) as fp:
+                    for line in fp.readlines():
+                        if line.startswith("#include <...>"):
+                            in_incdirs = True
+                        elif line.startswith("End of search list"):
+                            in_incdirs = False
+                        elif in_incdirs:
+                            line = line.strip()
+                            if line == '/usr/include':
+                                MACOS_SDK_ROOT = '/'
+                            elif line.endswith(".sdk/usr/include"):
+                                MACOS_SDK_ROOT = line[:-12]
+        finally:
+            os.unlink(tmpfile)
+
+    return MACOS_SDK_ROOT
 
 
 def is_macosx_sdk_path(path):


### PR DESCRIPTION
Apple has been trying to discourage the use of installing and compiling with system header files in `/usr/include`.  Instead, the favored approach is to use header files from within a macOS SDK.  For the most part, the Apple-supplied toolchain handles this transparently as long as the toolchain is doing the searching for header files.  Unfortunately, the top-level `setup.py` used to build the Python interpreter does some searching for various header files on its own and, with the removal in macOS 10.14 of the option to install system headers, the Python build may now fail to build several standard library modules that depend on third-party libraries shipped with macOS, for example, sqlite3.

The search behavior of the toolchain is also conditioned by the setting of various environment variables or by the use of `xcrun`, i.e. it is possible to change SDK locations at build time (`man xcrun` has more information).  And non-Apple compilers might be in use so `xcrun` might not give the correct results.  If an SDK is not explicitly specified at `./configure` time or via `CFLAGS`, the solution used here is to rely on using the `-v` output from the compiler preprocessor to find the include file paths that are actually being used (this technique is used elsewhere in `setup.py`) and from them derive an SDK root for `setup.py` to use in its searches.  There is a bit of a bootstrap issue in that much of the standard library is not yet available when `setup.py` is running (it's trying to build the non-builtin modules) so the code here has to make do with a few hacks.

<!-- issue-number: [bpo-36231](https://bugs.python.org/issue36231) -->
https://bugs.python.org/issue36231
<!-- /issue-number -->
