### PR TITLE
bpo-26219: remove unused code

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1117,9 +1117,6 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
                 assert(co_opt_offset <= co->co_opcache_size); \
                 co_opcache = &co->co_opcache[co_opt_offset - 1]; \
                 assert(co_opcache != NULL); \
-                if (co_opcache->optimized < 0) { \
-                    co_opcache = NULL; \
-                } \
             } \
         } \
     } while (0)


### PR DESCRIPTION
This code causing compiler warning was for deoptimization,
which is removed from PR-12884.

<!-- issue-number: [bpo-26219](https://bugs.python.org/issue26219) -->
https://bugs.python.org/issue26219
<!-- /issue-number -->
