### PR TITLE
bpo-34001: Fix test_ssl with LibreSSL

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1109,6 +1109,7 @@ class ContextTests(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(ssl.SSLContext, 'minimum_version'),
                          "required OpenSSL 1.1.0g")
+    @unittest.skipIf(IS_LIBRESSL, "see bpo-34001")
     def test_min_max_version(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         # OpenSSL default is MINIMUM_SUPPORTED, however some vendors like
@@ -3731,8 +3732,8 @@ class ThreadedTests(unittest.TestCase):
                 self.assertEqual(s.version(), 'TLSv1.1')
 
         # client 1.0, server 1.2 (mismatch)
-        server_context.minimum_version = ssl.TLSVersion.TLSv1_2
         server_context.maximum_version = ssl.TLSVersion.TLSv1_2
+        server_context.minimum_version = ssl.TLSVersion.TLSv1_2
         client_context.maximum_version = ssl.TLSVersion.TLSv1
         client_context.maximum_version = ssl.TLSVersion.TLSv1
         with ThreadedEchoServer(context=server_context) as server:

--- a/Misc/NEWS.d/next/Tests/2019-06-03-20-47-10.bpo-34001.KvYx9z.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-03-20-47-10.bpo-34001.KvYx9z.rst
@@ -1,0 +1,2 @@
+Make test_ssl pass with LibreSSL. LibreSSL handles minimum and maximum TLS
+version differently than OpenSSL.


### PR DESCRIPTION


<!-- issue-number: [bpo-34001](https://bugs.python.org/issue34001) -->
https://bugs.python.org/issue34001
<!-- /issue-number -->
