### PR TITLE
bpo-37137, asyncio: add BaseEventLoop.wait_executor_on_close

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -140,11 +140,17 @@ Running and stopping the loop
    The loop must not be running when this function is called.
    Any pending callbacks will be discarded.
 
-   This method clears all queues and shuts down the executor, but does
-   not wait for the executor to finish.
+   This method clears all queues and shuts down the default executor. By
+   default, it waits for the default executor to finish. Set
+   *loop.wait_executor_on_close* to ``False`` to not wait for the executor.
 
    This method is idempotent and irreversible.  No other methods
    should be called after the event loop is closed.
+
+   .. versionchanged:: 3.8
+      The method now waits for the default executor to finish by default.
+      Added *loop.wait_executor_on_close* attribute.
+
 
 .. coroutinemethod:: loop.shutdown_asyncgens()
 

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -380,6 +380,8 @@ class Server(events.AbstractServer):
 class BaseEventLoop(events.AbstractEventLoop):
 
     def __init__(self):
+        # If true, close() waits for the default executor to finish
+        self.wait_executor_on_close = True
         self._timer_cancelled_count = 0
         self._closed = False
         self._stopping = False
@@ -635,7 +637,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         executor = self._default_executor
         if executor is not None:
             self._default_executor = None
-            executor.shutdown(wait=False)
+            executor.shutdown(wait=self.wait_executor_on_close)
 
     def is_closed(self):
         """Returns True if the event loop was closed."""

--- a/Misc/NEWS.d/next/Library/2019-06-03-22-54-15.bpo-34037.fKNAbH.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-03-22-54-15.bpo-34037.fKNAbH.rst
@@ -1,0 +1,4 @@
+:mod:`asyncio`: ``loop.close()`` now waits for the default executor to
+finish by default. Set ``loop.wait_executor_on_close`` attribute to
+``False`` to opt-in for Python 3.7 behavior (not wait for the executor to
+finish).


### PR DESCRIPTION
Add BaseEventLoop.wait_executor_on_close attribute: true by default.

loop.close() now waits for the default executor to finish by default.
Set loop.wait_executor_on_close attribute to False to not wait for
the executor.

<!-- issue-number: [bpo-37137](https://bugs.python.org/issue37137) -->
https://bugs.python.org/issue37137
<!-- /issue-number -->
