### PR TITLE
bpo-27513: email.utils.getaddresses() now handles Header objects

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -109,7 +109,7 @@ def formataddr(pair, charset='utf-8'):
 
 def getaddresses(fieldvalues):
     """Return a list of (REALNAME, EMAIL) for each fieldvalue."""
-    all = COMMASPACE.join(fieldvalues)
+    all = COMMASPACE.join(str(v) for v in fieldvalues)
     a = _AddressList(all)
     return a.addresslist
 

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3265,9 +3265,8 @@ Foo
 
     def test_getaddresses_header_obj(self):
         """Test the handling of a Header object."""
-        eq = self.assertEqual
         addrs = utils.getaddresses([Header('Al Person <aperson@dom.ain>')])
-        eq(addrs[0][1], 'aperson@dom.ain')
+        self.assertEqual(addrs[0][1], 'aperson@dom.ain')
 
     def test_make_msgid_collisions(self):
         # Test make_msgid uniqueness, even with multiple threads

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3263,6 +3263,12 @@ Foo
         addrs = utils.getaddresses(['User ((nested comment)) <foo@bar.com>'])
         eq(addrs[0][1], 'foo@bar.com')
 
+    def test_getaddresses_header_obj(self):
+        """Test the handling of a Header object."""
+        eq = self.assertEqual
+        addrs = utils.getaddresses([Header('Al Person <aperson@dom.ain>')])
+        eq(addrs[0][1], 'aperson@dom.ain')
+
     def test_make_msgid_collisions(self):
         # Test make_msgid uniqueness, even with multiple threads
         class MsgidsThread(Thread):

--- a/Misc/NEWS.d/next/Library/2019-06-03-23-53-25.bpo-27513.qITN7d.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-03-23-53-25.bpo-27513.qITN7d.rst
@@ -1,2 +1,3 @@
-:func:`email.charset.getaddresses` can now handle
-:class:`~email.header.Header` objects.
+:func:`email.utils.getaddresses` now accepts
+:class:`email.header.Header` objects along with string values.
+Patch by Zackery Spytz.

--- a/Misc/NEWS.d/next/Library/2019-06-03-23-53-25.bpo-27513.qITN7d.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-03-23-53-25.bpo-27513.qITN7d.rst
@@ -1,0 +1,2 @@
+:func:`email.charset.getaddresses` can now handle
+:class:`~email.header.Header` objects.


### PR DESCRIPTION
getaddresses() should be able to handle a Header object if passed
one.

<!-- issue-number: [bpo-27513](https://bugs.python.org/issue27513) -->
https://bugs.python.org/issue27513
<!-- /issue-number -->
