### PR TITLE
bpo-37147: f-string debugging f"{x=[}" adds [filename:lineno] as prefix

### DIFF
--- a/Misc/NEWS.d/next/C API/2019-06-04-09-09-39.bpo-37147.Ty7fZw.rst
+++ b/Misc/NEWS.d/next/C API/2019-06-04-09-09-39.bpo-37147.Ty7fZw.rst
@@ -1,0 +1,1 @@
+f-string debugging f"{x=[}" adds [filename:lineno] as prefix


### PR DESCRIPTION
From this idea [0] by Karthikeyan Singaravelan and added to his code in hack [1].
```
name = "karthikeyan"
print(f"{name =[}")
print(f"{name=[}")
print(f"{age = [}")
print(f"{age= [}")
```
```
[prog.py:2] name ='karthikeyan'
[prog.py:3] name='karthikeyan'
[prog.py:4] name = 'karthikeyan'
[prog.py:5] name= 'karthikeyan'
```
[0] https://tirkarthi.github.io/programming/2019/05/08/f-string-debugging.html
[1] https://github.com/tirkarthi/cpython/commit/d0fcbe67f6bb8ad60744b0a4973c4dc69fda65a9

<!-- issue-number: [bpo-37147](https://bugs.python.org/issue37147) -->
https://bugs.python.org/issue37147
<!-- /issue-number -->
