### PR TITLE
bpo-37148: Fix asyncio test that check for warning when running the test suite with huntleaks

### DIFF
--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -1229,10 +1229,14 @@ os.close(fd)
         self.assertEqual(messages, [])
 
     def test_stream_reader_create_warning(self):
+        with contextlib.suppress(AttributeError):
+            del asyncio.StreamReader
         with self.assertWarns(DeprecationWarning):
             asyncio.StreamReader
 
     def test_stream_writer_create_warning(self):
+        with contextlib.suppress(AttributeError):
+            del asyncio.StreamWriter
         with self.assertWarns(DeprecationWarning):
             asyncio.StreamWriter
 


### PR DESCRIPTION


<!-- issue-number: [bpo-37148](https://bugs.python.org/issue37148) -->
https://bugs.python.org/issue37148
<!-- /issue-number -->
