### PR TITLE
Revert "bpo-34037, asyncio: add BaseEventLoop.wait_executor_on_close (GH-13786)"

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -140,17 +140,11 @@ Running and stopping the loop
    The loop must not be running when this function is called.
    Any pending callbacks will be discarded.
 
-   This method clears all queues and shuts down the default executor. By
-   default, it waits for the default executor to finish. Set
-   *loop.wait_executor_on_close* to ``False`` to not wait for the executor.
+   This method clears all queues and shuts down the executor, but does
+   not wait for the executor to finish.
 
    This method is idempotent and irreversible.  No other methods
    should be called after the event loop is closed.
-
-   .. versionchanged:: 3.8
-      The method now waits for the default executor to finish by default.
-      Added *loop.wait_executor_on_close* attribute.
-
 
 .. coroutinemethod:: loop.shutdown_asyncgens()
 

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -380,8 +380,6 @@ class Server(events.AbstractServer):
 class BaseEventLoop(events.AbstractEventLoop):
 
     def __init__(self):
-        # If true, close() waits for the default executor to finish
-        self.wait_executor_on_close = True
         self._timer_cancelled_count = 0
         self._closed = False
         self._stopping = False
@@ -637,7 +635,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         executor = self._default_executor
         if executor is not None:
             self._default_executor = None
-            executor.shutdown(wait=self.wait_executor_on_close)
+            executor.shutdown(wait=False)
 
     def is_closed(self):
         """Returns True if the event loop was closed."""

--- a/Misc/NEWS.d/next/Library/2019-06-03-22-54-15.bpo-34037.fKNAbH.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-03-22-54-15.bpo-34037.fKNAbH.rst
@@ -1,4 +1,0 @@
-:mod:`asyncio`: ``loop.close()`` now waits for the default executor to
-finish by default. Set ``loop.wait_executor_on_close`` attribute to
-``False`` to opt-in for Python 3.7 behavior (not wait for the executor to
-finish).


### PR DESCRIPTION
This reverts commit 0f0a30f4da4b529e0f7df857b9f575b231b32758.

We need to revert this before b1 due to it being a new documented public API.

<!-- issue-number: [bpo-34037](https://bugs.python.org/issue34037) -->
https://bugs.python.org/issue34037
<!-- /issue-number -->
