### PR TITLE
bpo-37150: Throw ValueError if FileType class object was passed in add_argument

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1361,6 +1361,10 @@ class _ActionsContainer(object):
         if not callable(type_func):
             raise ValueError('%r is not callable' % (type_func,))
 
+        if type_func is FileType:
+            raise ValueError('%r is a FileType class object, instance of it'
+                             ' must be passed' % (type_func,))
+
         # raise an error if the metavar does not match the type
         if hasattr(self, "_get_formatter"):
             try:

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1619,6 +1619,24 @@ class TestFileTypeOpenArgs(TestCase):
                 m.assert_called_with('foo', *args)
 
 
+class TestFileTypeMissingInitialization(TestCase):
+    """
+    Test that add_argument throws an error if FileType class
+    object was passed instead of instance of FileType
+    """
+
+    def test(self):
+        parser = argparse.ArgumentParser()
+        with self.assertRaises(ValueError) as cm:
+            parser.add_argument('-x', type=argparse.FileType)
+
+        self.assertEqual(
+            '%r is a FileType class object, instance of it must be passed'
+            % (argparse.FileType,),
+            str(cm.exception)
+        )
+
+
 class TestTypeCallable(ParserTestCase):
     """Test some callables as option/argument types"""
 

--- a/Misc/NEWS.d/next/Library/2019-06-04-14-44-41.bpo-37150.TTzHxj.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-04-14-44-41.bpo-37150.TTzHxj.rst
@@ -1,0 +1,1 @@
+`argparse._ActionsContainer.add_argument` now throws error, if someone accidentally pass FileType class object instead of instance of FileType as `type` argument


### PR DESCRIPTION
There is a possibility that someone (like me) can accidentally omit parentheses with `FileType` arguments after `FileType`, and the parser will contain wrong file until someone will try to use it. 

Example:
```python
parser = argparse.ArgumentParser()
parser.add_argument('-x', type=argparse.FileType)
```

<!-- issue-number: [bpo-37150](https://bugs.python.org/issue37150) -->
https://bugs.python.org/issue37150
<!-- /issue-number -->
