### PR TITLE
bpo-26219: Fix compiler warning

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -261,7 +261,8 @@ _PyCode_InitOpcache(PyCodeObject *co)
 
         // TODO: LOAD_METHOD, LOAD_ATTR
         if (opcode == LOAD_GLOBAL) {
-            co->co_opcache_map[i] = ++opts;
+            opts++;
+            co->co_opcache_map[i] = (unsigned char)opts;
             if (opts > 254) {
                 break;
             }


### PR DESCRIPTION
Fix this warning with MSVC:

    objects\codeobject.c(264): warning C4244: '=':
    conversion from 'Py_ssize_t' to 'unsigned char', possible loss of data

<!-- issue-number: [bpo-26219](https://bugs.python.org/issue26219) -->
https://bugs.python.org/issue26219
<!-- /issue-number -->
