### PR TITLE
bpo-37153: test_venv.test_mutiprocessing() calls pool.terminate()

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -325,8 +325,10 @@ class BasicTest(BaseTest):
         envpy = os.path.join(os.path.realpath(self.env_dir),
                              self.bindir, self.exe)
         out, err = check_output([envpy, '-c',
-            'from multiprocessing import Pool; ' +
-            'print(Pool(1).apply_async("Python".lower).get(3))'])
+            'from multiprocessing import Pool; '
+            'pool = Pool(1); '
+            'print(pool.apply_async("Python".lower).get(3)); '
+            'pool.terminate()'])
         self.assertEqual(out.strip(), "python".encode())
 
 @requireVenvCreate

--- a/Misc/NEWS.d/next/Tests/2019-06-04-18-30-39.bpo-37153.711INB.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-04-18-30-39.bpo-37153.711INB.rst
@@ -1,0 +1,2 @@
+``test_venv.test_mutiprocessing()`` now explicitly calls
+``pool.terminate()`` to wait until the pool completes.


### PR DESCRIPTION
test_venv.test_mutiprocessing() now explicitly calls pool.terminate()
to wait until the pool completes.

<!-- issue-number: [bpo-37153](https://bugs.python.org/issue37153) -->
https://bugs.python.org/issue37153
<!-- /issue-number -->
