### PR TITLE
bpo-37144: Convert path-like object to regular path

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -349,7 +349,7 @@ class _Stream:
             fileobj = _StreamProxy(fileobj)
             comptype = fileobj.getcomptype()
 
-        self.name     = name or ""
+        self.name     = os.path.abspath(name) if name else ""
         self.mode     = mode
         self.comptype = comptype
         self.fileobj  = fileobj

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1454,6 +1454,7 @@ class TarFile(object):
         self.mode = mode
         self._mode = modes[mode]
 
+        name = os.fspath(name) if name else None
         if not fileobj:
             if self.mode == "a" and not os.path.exists(name):
                 # Create nonexistent files in append mode.
@@ -1469,7 +1470,6 @@ class TarFile(object):
                 self._mode = fileobj.mode
             self._extfileobj = True
 
-        name = os.fspath(name) if name else None
         self.name = os.path.abspath(name) if name else None
         self.fileobj = fileobj
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1468,7 +1468,9 @@ class TarFile(object):
             if hasattr(fileobj, "mode"):
                 self._mode = fileobj.mode
             self._extfileobj = True
-        self.name = os.fspath(name) if name else None
+
+        name = os.fspath(name) if name else None
+        self.name = os.path.abspath(name) if name else None
         self.fileobj = fileobj
 
         # Init attributes.
@@ -1938,12 +1940,13 @@ class TarFile(object):
            excluded from the archive.
         """
         self._check("awx")
+        name = os.fspath(name)
 
         if arcname is None:
             arcname = name
 
         # Skip if somebody tries to archive the archive...
-        if self.name is not None and os.fspath(name) == self.name:
+        if self.name is not None and os.path.abspath(name) == self.name:
             self._dbg(2, "tarfile: Skipped %r" % name)
             return
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -349,7 +349,7 @@ class _Stream:
             fileobj = _StreamProxy(fileobj)
             comptype = fileobj.getcomptype()
 
-        self.name     = os.path.abspath(name) if name else ""
+        self.name     = os.fspath(name) if name else ""
         self.mode     = mode
         self.comptype = comptype
         self.fileobj  = fileobj

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1468,7 +1468,7 @@ class TarFile(object):
             if hasattr(fileobj, "mode"):
                 self._mode = fileobj.mode
             self._extfileobj = True
-        self.name = os.path.abspath(name) if name else None
+        self.name = os.fspath(name) if name else None
         self.fileobj = fileobj
 
         # Init attributes.
@@ -1943,7 +1943,7 @@ class TarFile(object):
             arcname = name
 
         # Skip if somebody tries to archive the archive...
-        if self.name is not None and os.path.abspath(name) == self.name:
+        if self.name is not None and os.fspath(name) == self.name:
             self._dbg(2, "tarfile: Skipped %r" % name)
             return
 

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1421,11 +1421,13 @@ class StreamWriteTest(WriteTestBase, unittest.TestCase):
         finally:
             os.umask(original_umask)
 
-class GzipStreamWriteTest(GzipTest, StreamWriteTest):
     def test_open_by_path_object(self):
-        # Test for issue #37144: open gzip for stream write by path-like object
-        tar = tarfile.open(pathlib.Path(self.tarname), self.mode)
+        # Test for issue #37144: broken open for stream write by path-like object
+        tar = tarfile.open(pathlib.Path(tmpname), self.mode)
         tar.close()
+
+class GzipStreamWriteTest(GzipTest, StreamWriteTest):
+    pass
 
 class Bz2StreamWriteTest(Bz2Test, StreamWriteTest):
     decompressor = bz2.BZ2Decompressor if bz2 else None

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1422,7 +1422,10 @@ class StreamWriteTest(WriteTestBase, unittest.TestCase):
             os.umask(original_umask)
 
 class GzipStreamWriteTest(GzipTest, StreamWriteTest):
-    pass
+    def test_open_by_path_object(self):
+        # Test for issue #37144: open gzip for stream write by path-like object
+        tar = tarfile.open(pathlib.Path(self.tarname), self.mode)
+        tar.close()
 
 class Bz2StreamWriteTest(Bz2Test, StreamWriteTest):
     decompressor = bz2.BZ2Decompressor if bz2 else None

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1368,7 +1368,7 @@ class WriteTest(WriteTestBase, unittest.TestCase):
 
             f = BadFile()
             with self.assertRaises(exctype):
-                tar = tarfile.open(tmpname, self.mode, fileobj=f,
+                tarfile.open(tmpname, self.mode, fileobj=f,
                                    format=tarfile.PAX_FORMAT,
                                    pax_headers={'non': 'empty'})
             self.assertFalse(f.closed)

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1422,9 +1422,10 @@ class StreamWriteTest(WriteTestBase, unittest.TestCase):
             os.umask(original_umask)
 
     def test_open_by_path_object(self):
-        # Test for issue #37144: broken open for stream write by path-like object
-        tar = tarfile.open(pathlib.Path(tmpname), self.mode)
-        tar.close()
+        # Test for issue #37144:
+        # broken open for stream write by path-like object
+        with tarfile.open(pathlib.Path(tmpname), self.mode):
+            pass
 
 class GzipStreamWriteTest(GzipTest, StreamWriteTest):
     pass

--- a/Misc/NEWS.d/next/Library/2019-06-04-16-50-56.bpo-37144.Yu8j2L.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-04-16-50-56.bpo-37144.Yu8j2L.rst
@@ -1,0 +1,1 @@
+Now `tarfile.open(path, 'w|gz')` works for path-like objects


### PR DESCRIPTION
Steps to reproduce the issue:

1. Create gzipped tar.
```sh
echo "test" > test
tar -cvzf test.tar.gz test
``` 
2. Try to pass path-like object in `tarfile.open`:
```python
import tarfile
import pathlib
path = pathlib.Path('test.tar.gz')
tarfile.open(path, 'w|gz')
```
Result will be:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/tarfile.py", line 1599, in open
    stream = _Stream(name, filemode, comptype, fileobj, bufsize)
  File "/usr/lib/python3.6/tarfile.py", line 382, in __init__
    self._init_write_gz()
  File "/usr/lib/python3.6/tarfile.py", line 430, in _init_write_gz
    if self.name.endswith(".gz"):
AttributeError: 'PosixPath' object has no attribute 'endswith'
```


<!-- issue-number: [bpo-37144](https://bugs.python.org/issue37144) -->
https://bugs.python.org/issue37144
<!-- /issue-number -->
