### PR TITLE
bpo-34282: Remove deprecated _convert method

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -464,12 +464,6 @@ class EnumMeta(type):
         module_globals[name] = cls
         return cls
 
-    def _convert(cls, *args, **kwargs):
-        import warnings
-        warnings.warn("_convert is deprecated and will be removed in 3.9, use "
-                      "_convert_ instead.", DeprecationWarning, stacklevel=2)
-        return cls._convert_(*args, **kwargs)
-
     @staticmethod
     def _get_mixins_(bases):
         """Returns the type for creating enum members, and the first inherited

--- a/Misc/NEWS.d/next/Library/2019-06-04-15-39-14.bpo-34282.aAK54n.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-04-15-39-14.bpo-34282.aAK54n.rst
@@ -1,0 +1,1 @@
+Remove ``Enum._convert`` method, deprecated in 3.8.


### PR DESCRIPTION



<!-- issue-number: [bpo-34282](https://bugs.python.org/issue34282) -->
https://bugs.python.org/issue34282
<!-- /issue-number -->
