### PR TITLE
show concrete example of data to write in csv module docs

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -502,9 +502,9 @@ iterable container ``rows``::
        writer = csv.writer(f)
        writer.writerows(rows)
        
-   #produces some.csv with
-   #0,1,2,3,4
-   #5,6,7,8,9
+   # produces some.csv with
+   # 0,1,2,3,4
+   # 5,6,7,8,9
 
 Since :func:`open` is used to open a CSV file for reading, the file
 will by default be decoded into unicode using the system default

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -493,12 +493,18 @@ Reading a file with an alternate format::
        for row in reader:
            print(row)
 
-The corresponding simplest possible writing example is::
+The corresponding simplest possible writing example is using an 
+iterable container ``rows``::
 
    import csv
+   rows = [list(range(5)), list(range(5,10))]
    with open('some.csv', 'w', newline='') as f:
        writer = csv.writer(f)
-       writer.writerows(someiterable)
+       writer.writerows(rows)
+       
+   #produces some.csv with
+   #0,1,2,3,4
+   #5,6,7,8,9
 
 Since :func:`open` is used to open a CSV file for reading, the file
 will by default be decoded into unicode using the system default

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -493,7 +493,7 @@ Reading a file with an alternate format::
        for row in reader:
            print(row)
 
-The corresponding simplest possible writing example is using an 
+The corresponding simplest possible writing example is using an
 iterable container ``rows``::
 
    import csv
@@ -501,7 +501,7 @@ iterable container ``rows``::
    with open('some.csv', 'w', newline='') as f:
        writer = csv.writer(f)
        writer.writerows(rows)
-       
+
    # produces some.csv with
    # 0,1,2,3,4
    # 5,6,7,8,9


### PR DESCRIPTION
Sending this PR to improve the python documentation on the csv module [here](https://docs.python.org/3/library/csv.html#examples). I personally believe that the current version
```
import csv
with open('some.csv', 'w', newline='') as f:
    writer = csv.writer(f)
    writer.writerows(someiterable)
```
would be more digestiable with a concrete example of `someiterable`. I therefor propose this PR.

My apologies if the format of the PR violates any guidelines. I simply couldn't figure out which rules to follow for enhancing the documentation. If there is such a document, please forward it to me.
