### PR TITLE
[WIP] bpo-28708: Add setsize keywoard-only parameter to select.select()

### DIFF
--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -114,7 +114,7 @@ The module defines the following:
    :ref:`kevent-objects` below for the methods supported by kevent objects.
 
 
-.. function:: select(rlist, wlist, xlist[, timeout])
+.. function:: select(rlist, wlist, xlist[, timeout], *, setsize=FD_SETSIZE)
 
    This is a straightforward interface to the Unix :c:func:`select` system call.
    The first three arguments are sequences of 'waitable objects': either
@@ -157,12 +157,21 @@ The module defines the following:
       library, and does not handle file descriptors that don't originate from
       WinSock.
 
+   .. versionchanged:: 3.9
+      Added *setsize* parameter.
+
    .. versionchanged:: 3.5
       The function is now retried with a recomputed timeout when interrupted by
       a signal, except if the signal handler raises an exception (see
       :pep:`475` for the rationale), instead of raising
       :exc:`InterruptedError`.
 
+
+.. attribute:: FD_SETSIZE
+
+   Set size used by :func:`select.select` by default.
+
+   .. versionadded:: 3.9
 
 .. attribute:: PIPE_BUF
 

--- a/Misc/NEWS.d/next/Library/2019-06-05-18-05-58.bpo-28708.jgeS7X.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-05-18-05-58.bpo-28708.jgeS7X.rst
@@ -1,0 +1,3 @@
+Add *setsize* keywoard-only parameter to :func:`select.select`. It becomes
+possible to configure the set size used internally by :func:`select.select`
+at runtime.

--- a/Modules/clinic/selectmodule.c.h
+++ b/Modules/clinic/selectmodule.c.h
@@ -3,7 +3,7 @@ preserve
 [clinic start generated code]*/
 
 PyDoc_STRVAR(select_select__doc__,
-"select($module, rlist, wlist, xlist, timeout=None, /)\n"
+"select($module, rlist, wlist, xlist, timeout=None, /, *, setsize=-1)\n"
 "--\n"
 "\n"
 "Wait until one or more file descriptors are ready for some kind of I/O.\n"
@@ -30,33 +30,53 @@ PyDoc_STRVAR(select_select__doc__,
 "descriptors can be used.");
 
 #define SELECT_SELECT_METHODDEF    \
-    {"select", (PyCFunction)(void(*)(void))select_select, METH_FASTCALL, select_select__doc__},
+    {"select", (PyCFunction)(void(*)(void))select_select, METH_FASTCALL|METH_KEYWORDS, select_select__doc__},
 
 static PyObject *
 select_select_impl(PyObject *module, PyObject *rlist, PyObject *wlist,
-                   PyObject *xlist, PyObject *timeout_obj);
+                   PyObject *xlist, PyObject *timeout_obj, int setsize_int);
 
 static PyObject *
-select_select(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+select_select(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "", "", "", "setsize", NULL};
+    static _PyArg_Parser _parser = {NULL, _keywords, "select", 0};
+    PyObject *argsbuf[5];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 3;
     PyObject *rlist;
     PyObject *wlist;
     PyObject *xlist;
     PyObject *timeout_obj = Py_None;
+    int setsize_int = FD_SETSIZE;
 
-    if (!_PyArg_CheckPositional("select", nargs, 3, 4)) {
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 3, 4, 0, argsbuf);
+    if (!args) {
         goto exit;
     }
     rlist = args[0];
     wlist = args[1];
     xlist = args[2];
     if (nargs < 4) {
-        goto skip_optional;
+        goto skip_optional_posonly;
     }
+    noptargs--;
     timeout_obj = args[3];
-skip_optional:
-    return_value = select_select_impl(module, rlist, wlist, xlist, timeout_obj);
+skip_optional_posonly:
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    if (PyFloat_Check(args[4])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    setsize_int = _PyLong_AsInt(args[4]);
+    if (setsize_int == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+skip_optional_kwonly:
+    return_value = select_select_impl(module, rlist, wlist, xlist, timeout_obj, setsize_int);
 
 exit:
     return return_value;
@@ -1215,4 +1235,4 @@ exit:
 #ifndef SELECT_KQUEUE_CONTROL_METHODDEF
     #define SELECT_KQUEUE_CONTROL_METHODDEF
 #endif /* !defined(SELECT_KQUEUE_CONTROL_METHODDEF) */
-/*[clinic end generated code: output=03041f3d09b04a3d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c3e31d14dbc86fd9 input=a9049054013a1b77]*/


### PR DESCRIPTION
It becomes possible to configure the set size used internally by
select.select() at runtime.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-28708](https://bugs.python.org/issue28708) -->
https://bugs.python.org/issue28708
<!-- /issue-number -->
