### PR TITLE
bpo-37166: inspect.findsource() no longer triggers IndexError...

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -861,7 +861,10 @@ def findsource(object):
     if iscode(object):
         if not hasattr(object, 'co_firstlineno'):
             raise OSError('could not find function definition')
-        lnum = object.co_firstlineno - 1
+        lnum = min(
+            object.co_firstlineno - 1,
+            len(lines) - 1
+        )
         pat = re.compile(r'^(\s*def\s)|(\s*async\s+def\s)|(.*(?<!\w)lambda(:|\s))|^(\s*@)')
         while lnum > 0:
             if pat.match(lines[lnum]): break

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -861,10 +861,7 @@ def findsource(object):
     if iscode(object):
         if not hasattr(object, 'co_firstlineno'):
             raise OSError('could not find function definition')
-        lnum = min(
-            object.co_firstlineno - 1,
-            len(lines) - 1
-        )
+        lnum = min(object.co_firstlineno - 1, len(lines) - 1)
         pat = re.compile(r'^(\s*def\s)|(\s*async\s+def\s)|(.*(?<!\w)lambda(:|\s))|^(\s*@)')
         while lnum > 0:
             if pat.match(lines[lnum]): break

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -689,6 +689,28 @@ class TestBuggyCases(GetSourceBase):
         finally:
             del linecache.cache[co.co_filename]
 
+    def test_findsource_code_too_short(self):
+        lines = [
+            "",
+            "",
+            "",
+            "def foo(): pass",
+        ]
+        co = compile("\n".join(lines), "f.py", "exec")
+        linecache.cache[co.co_filename] = (
+            1, None, lines, co.co_filename
+        )
+        try:
+            _, lnum = inspect.findsource(co)
+            self.assertEqual(lnum, 3)
+            linecache.cache[co.co_filename] = (
+                1, None, [""] * lnum, co.co_filename
+            )
+            _, lnum = inspect.findsource(co)
+            self.assertEqual(lnum, 0)  # maybe OSError?
+        finally:
+            del linecache.cache[co.co_filename]
+
     def test_findsource_without_filename(self):
         for fname in ['', '<string>']:
             co = compile('x=1', fname, "exec")

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -689,28 +689,6 @@ class TestBuggyCases(GetSourceBase):
         finally:
             del linecache.cache[co.co_filename]
 
-    def test_findsource_code_too_short(self):
-        lines = [
-            "",
-            "",
-            "",
-            "def foo(): pass",
-        ]
-        co = compile("\n".join(lines), "f.py", "exec")
-        linecache.cache[co.co_filename] = (
-            1, None, lines, co.co_filename
-        )
-        try:
-            _, lnum = inspect.findsource(co)
-            self.assertEqual(lnum, 3)
-            linecache.cache[co.co_filename] = (
-                1, None, [""] * lnum, co.co_filename
-            )
-            _, lnum = inspect.findsource(co)
-            self.assertEqual(lnum, 0)  # maybe OSError?
-        finally:
-            del linecache.cache[co.co_filename]
-
     def test_findsource_without_filename(self):
         for fname in ['', '<string>']:
             co = compile('x=1', fname, "exec")

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -137,6 +137,7 @@ Michał Bednarski
 Ian Beer
 Stefan Behnel
 Reimer Behrends
+Michał Bejda
 Ben Bell
 Thomas Bellman
 Alexander “Саша” Belopolsky

--- a/Misc/NEWS.d/next/Library/2019-06-05-14-47-06.bpo-37166.cDr9zg.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-05-14-47-06.bpo-37166.cDr9zg.rst
@@ -1,0 +1,2 @@
+inspect.findsource() no longer triggers IndexError when co_firstlineno is
+larger than the size of the linecache entry

--- a/Misc/NEWS.d/next/Library/2019-06-05-14-47-06.bpo-37166.cDr9zg.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-05-14-47-06.bpo-37166.cDr9zg.rst
@@ -1,2 +1,4 @@
-inspect.findsource() no longer triggers IndexError when co_firstlineno is
-larger than the size of the linecache entry
+:func:`inspect.findsource` no longer triggers :exc:`IndexError` when
+`co_firstlineno` is larger than the size of the :mod:`linecache` entry.
+This used to be possible when the source file was modified after the
+code object creation.


### PR DESCRIPTION
...when co_firstlineno is larger than the size of the linecache entry

<!-- issue-number: [bpo-37166](https://bugs.python.org/issue37166) -->
https://bugs.python.org/issue37166
<!-- /issue-number -->
