### PR TITLE
bpo-36922: use Py_TPFLAGS_METHOD_DESCRIPTOR in lookup_maybe_method()

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4647,9 +4647,11 @@ order (MRO) for bases """
     def test_mixing_slot_wrappers(self):
         class X(dict):
             __setattr__ = dict.__setitem__
+            __neg__ = dict.copy
         x = X()
         x.y = 42
         self.assertEqual(x["y"], 42)
+        self.assertEqual(x, -x)
 
     def test_slot_shadows_class_variable(self):
         with self.assertRaises(ValueError) as cm:

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-06-13-59-52.bpo-36922.EMZ3TF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-06-13-59-52.bpo-36922.EMZ3TF.rst
@@ -1,0 +1,1 @@
+Slot functions optimize any callable with ``Py_TPFLAGS_METHOD_DESCRIPTOR`` instead of only instances of ``function``.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1412,7 +1412,7 @@ lookup_maybe_method(PyObject *self, _Py_Identifier *attrid, int *unbound)
         return NULL;
     }
 
-    if (PyFunction_Check(res)) {
+    if (PyType_HasFeature(Py_TYPE(res), Py_TPFLAGS_METHOD_DESCRIPTOR)) {
         /* Avoid temporary PyMethodObject */
         *unbound = 1;
         Py_INCREF(res);


### PR DESCRIPTION
`lookup_maybe_method` is an obvious place where the use case of `Py_TPFLAGS_METHOD_DESCRIPTOR` applies.

IMHO, this is safe enough for 3.8 but the reviewer should judge that.

CC @encukou  @vstinner 

<!-- issue-number: [bpo-36922](https://bugs.python.org/issue36922) -->
https://bugs.python.org/issue36922
<!-- /issue-number -->
