### PR TITLE
bpo-37156: Fix libssl DLL tag in MSI sources

### DIFF
--- a/Tools/msi/msi.props
+++ b/Tools/msi/msi.props
@@ -87,15 +87,16 @@
             PyArchExt=$(PyArchExt);
             PyTestExt=$(PyTestExt);
             OptionalFeatureName=$(OutputName);
+            ssltag=-1_1;
         </DefineConstants>
         <DefineConstants Condition="'$(CRTRedist)' != ''">
             $(DefineConstants);CRTRedist=$(CRTRedist);
         </DefineConstants>
         <DefineConstants Condition="$(Platform) != 'x64'">
-            $(DefineConstants);Suffix32=-32;ssltag=-1_1;
+            $(DefineConstants);Suffix32=-32;
         </DefineConstants>
         <DefineConstants Condition="$(Platform) == 'x64'">
-            $(DefineConstants);Suffix32=;ssltag=-1_1-x64;
+            $(DefineConstants);Suffix32=;
         </DefineConstants>
     </PropertyGroup>
 


### PR DESCRIPTION


<!-- issue-number: [bpo-37156](https://bugs.python.org/issue37156) -->
https://bugs.python.org/issue37156
<!-- /issue-number -->
