### PR TITLE
bpo-37181: fix test_regrtest failures on Windows arm64

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -616,7 +616,9 @@ class ProgramsTestCase(BaseTestCase):
         # Tools\buildbot\test.bat
         script = os.path.join(ROOT_DIR, 'Tools', 'buildbot', 'test.bat')
         test_args = ['--testdir=%s' % self.tmptestdir]
-        if platform.architecture()[0] == '64bit':
+        if platform.machine() == 'ARM64':
+            test_args.append('-arm64') # ARM 64-bit build
+        elif platform.architecture()[0] == '64bit':
             test_args.append('-x64')   # 64-bit build
         if not Py_DEBUG:
             test_args.append('+d')     # Release build, use python.exe
@@ -629,7 +631,9 @@ class ProgramsTestCase(BaseTestCase):
         if not os.path.isfile(script):
             self.skipTest(f'File "{script}" does not exist')
         rt_args = ["-q"]             # Quick, don't run tests twice
-        if platform.architecture()[0] == '64bit':
+        if platform.machine() == 'ARM64':
+            rt_args.append('-arm64') # ARM 64-bit build
+        elif platform.architecture()[0] == '64bit':
             rt_args.append('-x64')   # 64-bit build
         if Py_DEBUG:
             rt_args.append('-d')     # Debug build, use python_d.exe

--- a/PCbuild/rt.bat
+++ b/PCbuild/rt.bat
@@ -39,6 +39,7 @@ if "%1"=="-O" (set dashO=-O)     & shift & goto CheckOpts
 if "%1"=="-q" (set qmode=yes)    & shift & goto CheckOpts
 if "%1"=="-d" (set suffix=_d)    & shift & goto CheckOpts
 if "%1"=="-x64" (set prefix=%pcbuild%amd64) & shift & goto CheckOpts
+if "%1"=="-arm64" (set prefix=%pcbuild%arm64) & shift & goto CheckOpts
 if "%1"=="-arm32" (set prefix=%pcbuild%arm32) & shift & goto CheckOpts
 if NOT "%1"=="" (set regrtestargs=%regrtestargs% %1) & shift & goto CheckOpts
 

--- a/Tools/buildbot/test.bat
+++ b/Tools/buildbot/test.bat
@@ -9,6 +9,7 @@ set arm32_ssh=
 
 :CheckOpts
 if "%1"=="-x64" (set rt_opts=%rt_opts% %1) & shift & goto CheckOpts
+if "%1"=="-arm64" (set rt_opts=%rt_opts% %1) & shift & goto CheckOpts
 if "%1"=="-arm32" (set rt_opts=%rt_opts% %1) & (set arm32_ssh=true) & shift & goto CheckOpts
 if "%1"=="-d" (set rt_opts=%rt_opts% %1) & shift & goto CheckOpts
 if "%1"=="-O" (set rt_opts=%rt_opts% %1) & shift & goto CheckOpts
@@ -17,7 +18,6 @@ if "%1"=="+d" (set rt_opts=%rt_opts:-d=%) & shift & goto CheckOpts
 if "%1"=="+q" (set rt_opts=%rt_opts:-q=%) & shift & goto CheckOpts
 if NOT "%1"=="" (set regrtest_args=%regrtest_args% %1) & shift & goto CheckOpts
 
-echo on
 if "%arm32_ssh%"=="true" goto :Arm32Ssh
 
 call "%here%..\..\PCbuild\rt.bat" %rt_opts% -uall -rwW --slowest --timeout=1200 --fail-env-changed %regrtest_args%


### PR DESCRIPTION
This change fixes test_regrtest failures on arm64 and prepares for buildbot support on arm64.

@zooba 


<!-- issue-number: [bpo-37181](https://bugs.python.org/issue37181) -->
https://bugs.python.org/issue37181
<!-- /issue-number -->
