### PR TITLE
bpo-15913 : Add PyBuffer_SizeFromFormat()

### DIFF
--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -463,7 +463,7 @@ Buffer-related functions
 .. c:function:: Py_ssize_t PyBuffer_SizeFromFormat(const char *format)
 
    Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`. on success, the
-   size of the return *format* and -1 Otherwise.
+   size of the return *format*. Otherwise, raise an exception and return -1 on error.
 
    .. versionadded:: 3.9
 

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -462,8 +462,8 @@ Buffer-related functions
 
 .. c:function:: Py_ssize_t PyBuffer_SizeFromFormat(const char *format)
 
-   Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`. on success, the
-   size of the return *format*. Otherwise, raise an exception and return -1 on error.
+   Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`. 
+   On error, raise an exception and return -1.
 
    .. versionadded:: 3.9
 

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -462,7 +462,7 @@ Buffer-related functions
 
 .. c:function:: Py_ssize_t PyBuffer_SizeFromFormat(const char *format)
 
-   Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`. 
+   Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`.
    On error, raise an exception and return -1.
 
    .. versionadded:: 3.9

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -463,6 +463,8 @@ Buffer-related functions
 .. c:function:: Py_ssize_t PyBuffer_SizeFromFormat(const char *format)
 
    Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`.
+   
+   .. versionchanged:: 3.9
 
 
 .. c:function:: int PyBuffer_IsContiguous(Py_buffer *view, char order)

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -462,9 +462,10 @@ Buffer-related functions
 
 .. c:function:: Py_ssize_t PyBuffer_SizeFromFormat(const char *format)
 
-   Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`.
+   Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`. on success, the
+   size of the *format* is returned. Otherwise, return -1.
 
-   .. versionchanged:: 3.9
+   .. versionadded:: 3.9
 
 
 .. c:function:: int PyBuffer_IsContiguous(Py_buffer *view, char order)

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -463,7 +463,7 @@ Buffer-related functions
 .. c:function:: Py_ssize_t PyBuffer_SizeFromFormat(const char *format)
 
    Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`.
-   
+
    .. versionchanged:: 3.9
 
 

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -460,10 +460,9 @@ Buffer-related functions
    :c:func:`PyObject_GetBuffer`.
 
 
-.. c:function:: Py_ssize_t PyBuffer_SizeFromFormat(const char *)
+.. c:function:: Py_ssize_t PyBuffer_SizeFromFormat(const char *format)
 
    Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`.
-   This function is not yet implemented.
 
 
 .. c:function:: int PyBuffer_IsContiguous(Py_buffer *view, char order)

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -463,7 +463,7 @@ Buffer-related functions
 .. c:function:: Py_ssize_t PyBuffer_SizeFromFormat(const char *format)
 
    Return the implied :c:data:`~Py_buffer.itemsize` from :c:data:`~Py_buffer.format`. on success, the
-   size of the *format* is returned. Otherwise, return -1.
+   size of the return *format* and -1 Otherwise.
 
    .. versionadded:: 3.9
 

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -206,7 +206,7 @@ PyAPI_FUNC(void *) PyBuffer_GetPointer(Py_buffer *view, Py_ssize_t *indices);
 
 /* Return the implied itemsize of the data-format area from a
    struct-style description. */
-PyAPI_FUNC(int) PyBuffer_SizeFromFormat(const char *);
+PyAPI_FUNC(int) PyBuffer_SizeFromFormat(const char *format);
 
 /* Implementation in memoryobject.c */
 PyAPI_FUNC(int) PyBuffer_ToContiguous(void *buf, Py_buffer *view,

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -206,7 +206,7 @@ PyAPI_FUNC(void *) PyBuffer_GetPointer(Py_buffer *view, Py_ssize_t *indices);
 
 /* Return the implied itemsize of the data-format area from a
    struct-style description. */
-PyAPI_FUNC(int) PyBuffer_SizeFromFormat(const char *);
+PyAPI_FUNC(Py_ssize_t) PyBuffer_SizeFromFormat(const char *format);
 
 /* Implementation in memoryobject.c */
 PyAPI_FUNC(int) PyBuffer_ToContiguous(void *buf, Py_buffer *view,

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -206,7 +206,7 @@ PyAPI_FUNC(void *) PyBuffer_GetPointer(Py_buffer *view, Py_ssize_t *indices);
 
 /* Return the implied itemsize of the data-format area from a
    struct-style description. */
-PyAPI_FUNC(int) PyBuffer_SizeFromFormat(const char *format);
+PyAPI_FUNC(int) PyBuffer_SizeFromFormat(const char *);
 
 /* Implementation in memoryobject.c */
 PyAPI_FUNC(int) PyBuffer_ToContiguous(void *buf, Py_buffer *view,

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4422,7 +4422,7 @@ class TestBufferProtocol(unittest.TestCase):
         # basic tests
         for format in ("i", "3s", "0i", " "):
             self.assertEqual(_testcapi.pybuffer_size_from_format(format),
-                             struct.calcsize(format))
+                             struct.calcsize(format.encode()))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4418,7 +4418,6 @@ class TestBufferProtocol(unittest.TestCase):
         self.assertRaises(BufferError, memoryview, x)
 
     @support.cpython_only
-    @unittest.skipUnless(_testcapi, 'requires _testcapi')
     def test_pybuffer_size_from_format(self):
         # basic tests
         for format in ("i", "3s", "0i", " "):

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4422,7 +4422,7 @@ class TestBufferProtocol(unittest.TestCase):
         # basic tests
         for format in ("i", "3s", "0i", " "):
             self.assertEqual(_testcapi.pybuffer_size_from_format(format),
-                struct.calcsize(format.encode()))
+                            struct.calcsize(format))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -43,6 +43,11 @@ try:
 except ImportError:
     numpy_array = None
 
+try:
+    import _testcapi
+except ImportError:
+    _testcapi = None
+
 
 SHORT_TEST = True
 
@@ -4412,21 +4417,13 @@ class TestBufferProtocol(unittest.TestCase):
         x = ndarray([1,2,3], shape=[3], flags=ND_GETBUF_FAIL)
         self.assertRaises(BufferError, memoryview, x)
 
-    # Test PyBuffer_SizeFromFormat()
     @support.cpython_only
+    @unittest.skipUnless(_testcapi, 'requires _testcapi')
     def test_pybuffer_size_from_format(self):
-        from _testcapi import pybuffer_size_from_format
-
         # basic tests
         for format in ("i", "3s", "0i", " "):
-            self.assertEqual(pybuffer_size_from_format(format.encode()),
+            self.assertEqual(_testcapi.pybuffer_size_from_format(format),
                 struct.calcsize(format))
-
-        # invalid tests
-        for format in ("nn", "xxx", "xx"):
-            self.assertEqual(pybuffer_size_from_format(format.encode()),
-                struct.calcsize(format))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4422,7 +4422,7 @@ class TestBufferProtocol(unittest.TestCase):
         # basic tests
         for format in ("i", "3s", "0i", " "):
             self.assertEqual(_testcapi.pybuffer_size_from_format(format),
-                            struct.calcsize(format))
+                             struct.calcsize(format))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4423,7 +4423,7 @@ class TestBufferProtocol(unittest.TestCase):
         # basic tests
         for format in ("i", "3s", "0i", " "):
             self.assertEqual(_testcapi.pybuffer_size_from_format(format),
-                struct.calcsize(format))
+                struct.calcsize(format.encode()))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4412,6 +4412,22 @@ class TestBufferProtocol(unittest.TestCase):
         x = ndarray([1,2,3], shape=[3], flags=ND_GETBUF_FAIL)
         self.assertRaises(BufferError, memoryview, x)
 
+    # Test PyBuffer_SizeFromFormat()
+    @support.cpython_only
+    def test_pybuffer_size_from_format(self):
+        from ctypes import pythonapi
+        PyBuffer_SizeFromFormat = pythonapi.PyBuffer_SizeFromFormat
+
+        # basic tests
+        self.assertIs(PyBuffer_SizeFromFormat("abc") > 0 , True)
+
+        #invalid input
+        self.assertRaises(struct.error, PyBuffer_SizeFromFormat, b'gg')
+
+        #Empty strings
+        self.assertIs(PyBuffer_SizeFromFormat('') > 0 , True)
+        self.assertIs(PyBuffer_SizeFromFormat('%s') > 0 , True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4415,20 +4415,17 @@ class TestBufferProtocol(unittest.TestCase):
     # Test PyBuffer_SizeFromFormat()
     @support.cpython_only
     def test_pybuffer_size_from_format(self):
-        from ctypes import pythonapi
-        PyBuffer_SizeFromFormat = pythonapi.PyBuffer_SizeFromFormat
+        from _testcapi import pybuffer_size_from_format
 
         # basic tests
-        self.assertIs(PyBuffer_SizeFromFormat("3si") > 0 , True)
-        self.assertIs(PyBuffer_SizeFromFormat("3s") > 0 , True)
-        self.assertIs(PyBuffer_SizeFromFormat("0i") > 0 , True)
+        for format in ("i", "3s", "0i", " "):
+            self.assertEqual(pybuffer_size_from_format(format.encode()),
+                struct.calcsize(format))
 
-        #invalid input
-        self.assertRaises(struct.error, PyBuffer_SizeFromFormat, b'gg')
-
-        #Empty strings
-        self.assertIs(PyBuffer_SizeFromFormat('') > 0 , True)
-        self.assertIs(PyBuffer_SizeFromFormat('%s') > 0 , True)
+        # invalid tests
+        for format in ("nn", "xxx", "xx"):
+            self.assertEqual(pybuffer_size_from_format(format.encode()),
+                struct.calcsize(format))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4419,7 +4419,9 @@ class TestBufferProtocol(unittest.TestCase):
         PyBuffer_SizeFromFormat = pythonapi.PyBuffer_SizeFromFormat
 
         # basic tests
-        self.assertIs(PyBuffer_SizeFromFormat("abc") > 0 , True)
+        self.assertIs(PyBuffer_SizeFromFormat("3si") > 0 , True)
+        self.assertIs(PyBuffer_SizeFromFormat("3s") > 0 , True)
+        self.assertIs(PyBuffer_SizeFromFormat("0i") > 0 , True)
 
         #invalid input
         self.assertRaises(struct.error, PyBuffer_SizeFromFormat, b'gg')

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4420,7 +4420,7 @@ class TestBufferProtocol(unittest.TestCase):
     @support.cpython_only
     def test_pybuffer_size_from_format(self):
         # basic tests
-        for format in ("i", "3s", "0i", " "):
+        for format in ('', 'ii', '3s'):
             self.assertEqual(_testcapi.PyBuffer_SizeFromFormat(format),
                              struct.calcsize(format))
 

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4419,10 +4419,9 @@ class TestBufferProtocol(unittest.TestCase):
 
     @support.cpython_only
     def test_pybuffer_size_from_format(self):
-        nitems = randrange(1, 30)
-        for fmt, _, _ in iter_format(nitems):
-            self.assertEqual(_testcapi.pybuffer_size_from_format(fmt),
-                             struct.calcsize(fmt))
-
+        # basic tests
+        for format in ("i", "3s", "0i", " "):
+            self.assertEqual(_testcapi.PyBuffer_SizeFromFormat(format),
+                             struct.calcsize(format))
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4423,5 +4423,7 @@ class TestBufferProtocol(unittest.TestCase):
         for format in ("i", "3s", "0i", " "):
             self.assertEqual(_testcapi.PyBuffer_SizeFromFormat(format),
                              struct.calcsize(format))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4419,10 +4419,10 @@ class TestBufferProtocol(unittest.TestCase):
 
     @support.cpython_only
     def test_pybuffer_size_from_format(self):
-        # basic tests
-        for format in ("i", "3s", "0i", " "):
-            self.assertEqual(_testcapi.pybuffer_size_from_format(format),
-                             struct.calcsize(format.encode()))
+        nitems = randrange(1, 30)
+        for fmt, _, _ in iter_format(nitems):
+            self.assertEqual(_testcapi.pybuffer_size_from_format(fmt),
+                             struct.calcsize(fmt))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-06-20-52-38.bpo-15913.5Sg5cv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-06-20-52-38.bpo-15913.5Sg5cv.rst
@@ -1,1 +1,1 @@
-`PyBuffer_SizeFromFormat()` now added.
+:c:func:`PyBuffer_SizeFromFormat()` now added.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-06-20-52-38.bpo-15913.5Sg5cv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-06-20-52-38.bpo-15913.5Sg5cv.rst
@@ -1,0 +1,1 @@
+`PyBuffer_SizeFromFormat()` now added.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-06-20-52-38.bpo-15913.5Sg5cv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-06-20-52-38.bpo-15913.5Sg5cv.rst
@@ -1,1 +1,3 @@
-:c:func:`PyBuffer_SizeFromFormat()` now added.
+Implement :c:func:`PyBuffer_SizeFromFormat()` function (previously
+documented but not implemented): call :func:`struct.calcsize`.
+Patch by Joannah Nanjekye.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3306,13 +3306,19 @@ static PyObject *
 pybuffer_size_from_format(PyObject *self, PyObject *args)
 {
     const char *format;
+    Py_ssize_t result;
 
     if (!PyArg_ParseTuple(args, "s:pybuffer_size_from_format",
                           &format)) {
         return NULL;
     }
 
-    return PyLong_FromSsize_t(PyBuffer_SizeFromFormat(format));
+    result = PyBuffer_SizeFromFormat(format);
+    if (result == -1) {
+        return NULL;
+    }
+
+    return PyLong_FromSsize_t(result);
 }
 
 /* Test that the fatal error from not having a current thread doesn't

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3301,17 +3301,18 @@ getbuffer_with_null_view(PyObject* self, PyObject *obj)
     Py_RETURN_NONE;
 }
 
-/* test PyBuffer_SizeFromFormat() */
-static Py_ssize_t
-pybuffer_size_from_format(PyObject* self, PyObject *args)
+/* PyBuffer_SizeFromFormat() */
+static PyObject *
+pybuffer_size_from_format(PyObject *self, PyObject *args)
 {
     const char *format;
 
     if (!PyArg_ParseTuple(args, "s:pybuffer_size_from_format",
-                          &format))
-        return -1;
+                          &format)) {
+        return NULL;
+    }
 
-    return PyBuffer_SizeFromFormat(format);
+    return PyLong_FromSsize_t(PyBuffer_SizeFromFormat(format));
 }
 
 /* Test that the fatal error from not having a current thread doesn't

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3301,6 +3301,19 @@ getbuffer_with_null_view(PyObject* self, PyObject *obj)
     Py_RETURN_NONE;
 }
 
+/* test PyBuffer_SizeFromFormat() */
+static Py_ssize_t
+pybuffer_size_from_format(PyObject* self, PyObject *args)
+{
+    const char *format;
+
+    if (!PyArg_ParseTuple(args, "s:pybuffer_size_from_format",
+                          &format))
+        return -1;
+
+    return PyBuffer_SizeFromFormat(format);
+}
+
 /* Test that the fatal error from not having a current thread doesn't
    cause an infinite loop.  Run via Lib/test/test_capi.py */
 static PyObject *
@@ -5087,6 +5100,7 @@ static PyMethodDef TestMethods[] = {
     {"test_pep3118_obsolete_write_locks", (PyCFunction)test_pep3118_obsolete_write_locks, METH_NOARGS},
 #endif
     {"getbuffer_with_null_view", getbuffer_with_null_view, METH_O},
+    {"pybuffer_size_from_format", (PyCFunction)pybuffer_size_from_format, METH_VARARGS},
     {"test_buildvalue_N",       test_buildvalue_N,               METH_NOARGS},
     {"get_args", get_args, METH_VARARGS},
     {"get_kwargs", (PyCFunction)(void(*)(void))get_kwargs, METH_VARARGS|METH_KEYWORDS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3303,7 +3303,7 @@ getbuffer_with_null_view(PyObject* self, PyObject *obj)
 
 /* PyBuffer_SizeFromFormat() */
 static PyObject *
-pybuffer_size_from_format(PyObject *self, PyObject *args)
+test_PyBuffer_SizeFromFormat(PyObject *self, PyObject *args)
 {
     const char *format;
     Py_ssize_t result;
@@ -5107,7 +5107,7 @@ static PyMethodDef TestMethods[] = {
     {"test_pep3118_obsolete_write_locks", (PyCFunction)test_pep3118_obsolete_write_locks, METH_NOARGS},
 #endif
     {"getbuffer_with_null_view", getbuffer_with_null_view, METH_O},
-    {"pybuffer_size_from_format", (PyCFunction)pybuffer_size_from_format, METH_VARARGS},
+    {"PyBuffer_SizeFromFormat",  test_PyBuffer_SizeFromFormat, METH_VARARGS},
     {"test_buildvalue_N",       test_buildvalue_N,               METH_NOARGS},
     {"get_args", get_args, METH_VARARGS},
     {"get_kwargs", (PyCFunction)(void(*)(void))get_kwargs, METH_VARARGS|METH_KEYWORDS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3308,7 +3308,7 @@ test_PyBuffer_SizeFromFormat(PyObject *self, PyObject *args)
     const char *format;
     Py_ssize_t result;
 
-    if (!PyArg_ParseTuple(args, "s:pybuffer_size_from_format",
+    if (!PyArg_ParseTuple(args, "s:test_PyBuffer_SizeFromFormat",
                           &format)) {
         return NULL;
     }

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -506,7 +506,7 @@ PyBuffer_SizeFromFormat(const char *format)
 
     structmodule = PyImport_ImportModule("struct");
     if (structmodule == NULL) {
-        goto done;
+        return itemsize;
     }
 
     calcsize = PyObject_GetAttrString(structmodule, "calcsize");

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -498,18 +498,18 @@ Py_ssize_t
 PyBuffer_SizeFromFormat(const char *format)
 {
     PyObject *structmodule = NULL;
-    PyObject *Struct = NULL;
+    PyObject *calcsize = NULL;
     PyObject *res = NULL;
     PyObject *fmt = NULL;
     Py_ssize_t itemsize = -1;
 
     structmodule = PyImport_ImportModule("struct");
-    if (structmodule == NULL)
+    if (structmodule == NULL) {
         goto done;
+    }
 
-    Struct = PyObject_GetAttrString(structmodule, "calcsize");
-    Py_DECREF(structmodule);
-    if (Struct == NULL) {
+    calcsize = PyObject_GetAttrString(structmodule, "calcsize");
+    if (calcsize == NULL) {
         goto done;
     }
 
@@ -518,7 +518,7 @@ PyBuffer_SizeFromFormat(const char *format)
         goto done;
     }
 
-    res = PyObject_CallFunctionObjArgs(Struct, fmt, NULL);
+    res = PyObject_CallFunctionObjArgs(calcsize, fmt, NULL);
     if (res == NULL) {
         goto done;
     }
@@ -529,7 +529,8 @@ PyBuffer_SizeFromFormat(const char *format)
     }
 
 done:
-    Py_XDECREF(Struct);
+    Py_DECREF(structmodule);
+    Py_XDECREF(calcsize);
     Py_XDECREF(fmt);
     Py_XDECREF(res);
     return itemsize;

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -7,6 +7,7 @@
 #include "longintrepr.h"
 
 
+
 /* Shorthands to return certain errors */
 
 static PyObject *

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -494,45 +494,45 @@ _Py_add_one_to_index_C(int nd, Py_ssize_t *index, const Py_ssize_t *shape)
     }
 }
 
-int
+Py_ssize_t
 PyBuffer_SizeFromFormat(const char *format)
 {
-    PyObject *structmodule;
+    PyObject *structmodule = NULL;
     PyObject *Struct = NULL;
-    PyObject *structobj = NULL;
+    PyObject *res = NULL;
     PyObject *fmt = NULL;
-    int itemsize;
+    Py_ssize_t itemsize = -1;
 
     structmodule = PyImport_ImportModule("struct");
     if (structmodule == NULL)
-        goto error;
+        goto done;
 
     Struct = PyObject_GetAttrString(structmodule, "calcsize");
     Py_DECREF(structmodule);
-    if (Struct == NULL)
-        goto error;
+    if (Struct == NULL) {
+        goto done;
+    }
 
     fmt = PyBytes_FromString(format);
-    if (fmt == NULL)
-        goto error;
+    if (fmt == NULL) {
+        goto done;
+    }
 
-    structobj = PyObject_CallFunctionObjArgs(Struct, fmt, NULL);
-    if (structobj == NULL)
-        goto error;
+    res = PyObject_CallFunctionObjArgs(Struct, fmt, NULL);
+    if (res == NULL) {
+        goto done;
+    }
 
-    itemsize = (intptr_t)structobj;
-    if (itemsize < 0)
-        goto error;
+    itemsize = PyLong_AsSsize_t(res);
+    if (itemsize < 0) {
+        goto done;
+    }
 
-out:
+done:
     Py_XDECREF(Struct);
     Py_XDECREF(fmt);
-    Py_XDECREF(structobj);
+    Py_XDECREF(res);
     return itemsize;
-
-error:
-    itemsize = -1;
-    goto out;
 }
 
 int

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -7,6 +7,11 @@
 #include "longintrepr.h"
 
 
+/* struct module */
+static PyObject *structmodule = NULL;
+static PyObject *calcsize = NULL;
+
+
 
 /* Shorthands to return certain errors */
 
@@ -493,6 +498,30 @@ _Py_add_one_to_index_C(int nd, Py_ssize_t *index, const Py_ssize_t *shape)
             index[k] = 0;
         }
     }
+}
+
+int
+PyBuffer_SizeFromFormat(const char *format)
+{
+    PyObject *result;
+    int size;
+
+    structmodule = PyImport_ImportModule("struct");
+    if (structmodule == NULL)
+        return NULL;
+
+    calcsize = PyObject_GetAttrString(structmodule, "calcsize");
+    if (calcsize == NULL)
+        return NULL;
+
+    result = PyObject_CallFunctionObjArgs(calcsize, format, NULL);
+    Py_DECREF(calcsize);
+    if (result == NULL)
+        return -1;
+    size = _PyLong_AsInt(result);
+    Py_DECREF(result);
+
+    return size;
 }
 
 int

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -514,7 +514,7 @@ PyBuffer_SizeFromFormat(const char *format)
         goto done;
     }
 
-    fmt = PyBytes_FromString(format);
+    fmt = PyUnicode_FromString(format);
     if (fmt == NULL) {
         goto done;
     }


### PR DESCRIPTION
Added implementation for PyBuffer_SizeFromFormat().

<!-- issue-number: [bpo-15913](https://bugs.python.org/issue15913) -->
https://bugs.python.org/issue15913
<!-- /issue-number -->
