### PR TITLE
bpo-37134: Add PEP570 notation to the signature of byte{array}.translate

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2736,8 +2736,8 @@ arbitrary binary data.
    The prefix(es) to search for may be any :term:`bytes-like object`.
 
 
-.. method:: bytes.translate(table, delete=b'')
-            bytearray.translate(table, delete=b'')
+.. method:: bytes.translate(table, /, delete=b'')
+            bytearray.translate(table, /, delete=b'')
 
    Return a copy of the bytes or bytearray object where all bytes occurring in
    the optional argument *delete* are removed, and the remaining bytes have


### PR DESCRIPTION


<!-- issue-number: [bpo-37134](https://bugs.python.org/issue37134) -->
https://bugs.python.org/issue37134
<!-- /issue-number -->
