### PR TITLE
[2.7] bpo-37177: make IDLE's search dialogs transient (GH-13869)

### DIFF
--- a/Lib/idlelib/SearchDialogBase.py
+++ b/Lib/idlelib/SearchDialogBase.py
@@ -52,6 +52,7 @@ class SearchDialogBase:
         else:
             self.top.deiconify()
             self.top.tkraise()
+        self.top.transient(text.winfo_toplevel())
         if searchphrase:
             self.ent.delete(0,"end")
             self.ent.insert("end",searchphrase)
@@ -64,6 +65,7 @@ class SearchDialogBase:
         "Put dialog away for later use."
         if self.top:
             self.top.grab_release()
+            self.top.transient('')
             self.top.withdraw()
 
     def create_widgets(self):

--- a/Lib/idlelib/idle_test/test_searchdialogbase.py
+++ b/Lib/idlelib/idle_test/test_searchdialogbase.py
@@ -6,7 +6,7 @@ testing skipping of suite when self.needwrapbutton is false.
 '''
 import unittest
 from test.test_support import requires
-from Tkinter import Tk, Toplevel, Frame ## BooleanVar, StringVar
+from Tkinter import Text, Tk, Toplevel, Frame ## BooleanVar, StringVar
 from idlelib import SearchEngine as se
 from idlelib import SearchDialogBase as sdb
 from idlelib.idle_test.mock_idle import Func
@@ -45,9 +45,10 @@ class SearchDialogBaseTest(unittest.TestCase):
         # open calls create_widgets, which needs default_command
         self.dialog.default_command = None
 
-        # Since text parameter of .open is not used in base class,
-        # pass dummy 'text' instead of tk.Text().
-        self.dialog.open('text')
+        toplevel = Toplevel(self.root)
+        self.addCleanup(toplevel.destroy)
+        text = Text(toplevel)
+        self.dialog.open(text)
         self.assertEqual(self.dialog.top.state(), 'normal')
         self.dialog.close()
         self.assertEqual(self.dialog.top.state(), 'withdrawn')

--- a/Lib/idlelib/idle_test/test_searchdialogbase.py
+++ b/Lib/idlelib/idle_test/test_searchdialogbase.py
@@ -53,7 +53,7 @@ class SearchDialogBaseTest(unittest.TestCase):
         self.dialog.close()
         self.assertEqual(self.dialog.top.state(), 'withdrawn')
 
-        self.dialog.open('text', searchphrase="hello")
+        self.dialog.open(text, searchphrase="hello")
         self.assertEqual(self.dialog.ent.get(), 'hello')
         self.dialog.close()
 

--- a/Misc/NEWS.d/next/IDLE/2019-06-07-00-17-41.bpo-37177.voU6pQ.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-06-07-00-17-41.bpo-37177.voU6pQ.rst
@@ -1,0 +1,2 @@
+Properly 'attach' search dialogs to their main window so that they behave
+like other dialogs and do not get hidden behind their main window.


### PR DESCRIPTION
This avoids the search dialogs being hidden behind the editor window..

(cherry picked from commit 554450fb4e95066e825bdb4a2d544a490daeebdc)

<!-- issue-number: [bpo-37177](https://bugs.python.org/issue37177) -->
https://bugs.python.org/issue37177
<!-- /issue-number -->
