### PR TITLE
[3.8] bpo-37191: Avoid declaration-after-statement in header included from Python.h

### DIFF
--- a/Misc/NEWS.d/next/C API/2019-06-07-10-47-37.bpo-37191.iGL1_K.rst
+++ b/Misc/NEWS.d/next/C API/2019-06-07-10-47-37.bpo-37191.iGL1_K.rst
@@ -1,0 +1,3 @@
+Python.h does not need compiler support for intermingled declarations (GCC's
+``-Wdeclaration-after-statement``), which were added in 3.8.0 Beta 1. Note
+that in Python 3.9, intermingled declarations will be needed again.


### PR DESCRIPTION
When compiled with GCC's -Werror=declaration-after-statement ("intermingled declarations" in PEP7), cpython/abstract.h (included from <Python.h>) errors on vectorcall helper functions added in 3.8.0 Beta 1.

It's well within our rights to ignore this: since 3.6 we require intermingled declarations.
But, when re-compiling Fedora we've seen several projects fail with this warning (so far: pygobject3, python-dbus, xen; more will likely come).

@ambv: Dear Release Manager, should we patch 3.8 to avoid this? The patch is simple, and it would give projects that we(re) dutifully tested with the Alphas one more release to adapt.

I don't think it's worth changing for 3.9 (but if we do we should test it).

<!-- issue-number: [bpo-37191](https://bugs.python.org/issue37191) -->
https://bugs.python.org/issue37191
<!-- /issue-number -->
