### PR TITLE
bpo-37169: Rewrite _PyObject_IsFreed() unit tests

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-06-07-12-23-15.bpo-37169.yfXTFg.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-07-12-23-15.bpo-37169.yfXTFg.rst
@@ -1,0 +1,1 @@
+Rewrite ``_PyObject_IsFreed()`` unit tests.


### PR DESCRIPTION
Replace two Python function calls with a single one to ensure that no
memory allocation is done between the invalid object is created and
when _PyObject_IsFreed() is called.

<!-- issue-number: [bpo-37169](https://bugs.python.org/issue37169) -->
https://bugs.python.org/issue37169
<!-- /issue-number -->
