### PR TITLE
bpo-37193: remove thread objects which finished process its request

### DIFF
--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -652,11 +652,13 @@ class ThreadingMixIn:
         except Exception:
             self.handle_error(request, client_address)
         finally:
-            self.shutdown_request(request)
-            thread = threading.current_thread()
-            with self._threads_lock:
-                if self._threads and not thread.daemon:
-                    self._threads.remove(thread)
+            try:
+                self.shutdown_request(request)
+            finally:
+                thread = threading.current_thread()
+                with self._threads_lock:
+                    if self._threads and not thread.daemon:
+                        self._threads.remove(thread)
 
     def process_request(self, request, client_address):
         """Start a new thread to process the request."""

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -663,7 +663,10 @@ class ThreadingMixIn:
         if not thread.daemon:
             with self._threads_lock:
                 if self._threads is not None:
-                    self._threads.remove(thread)
+                    try:
+                        self._threads.remove(thread)
+                    except ValueError:
+                        pass
 
     def process_request(self, request, client_address):
         """Start a new thread to process the request."""

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -652,6 +652,11 @@ class ThreadingMixIn:
             self.handle_error(request, client_address)
         finally:
             self.shutdown_request(request)
+            t = threading.current_thread()
+            try:
+                self._threads.remove(t)
+            except AttributeError:
+                pass
 
     def process_request(self, request, client_address):
         """Start a new thread to process the request."""

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -639,7 +639,7 @@ class ThreadingMixIn:
     # For non-daemonic threads, list of threading.Threading objects
     # used by server_close() to wait for all threads completion.
     _threads = None
-    _threads_lock = threading.Lock()
+    _threads_lock = None
 
     def process_request_thread(self, request, client_address):
         """Same as in BaseServer but as a thread.
@@ -661,6 +661,8 @@ class ThreadingMixIn:
         """Remove a current thread from threads list."""
         thread = threading.current_thread()
         if not thread.daemon:
+            if self._threads_lock is None:
+                self._threads_lock = threading.Lock()
             with self._threads_lock:
                 if self._threads is not None:
                     try:
@@ -674,6 +676,8 @@ class ThreadingMixIn:
                              args = (request, client_address))
         t.daemon = self.daemon_threads
         if not t.daemon and self.block_on_close:
+            if self._threads_lock is None:
+                self._threads_lock = threading.Lock()
             with self._threads_lock:
                 if self._threads is None:
                     self._threads = []
@@ -683,6 +687,8 @@ class ThreadingMixIn:
     def server_close(self):
         super().server_close()
         if self.block_on_close:
+            if self._threads_lock is None:
+                self._threads_lock = threading.Lock()
             with self._threads_lock:
                 threads = self._threads
                 self._threads = None

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -654,7 +654,8 @@ class ThreadingMixIn:
             self.shutdown_request(request)
             thread = threading.current_thread()
             try:
-                self._threads.remove(thread)
+                if not thread.daemon:
+                    self._threads.remove(thread)
             except AttributeError:
                 pass
 

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -652,9 +652,9 @@ class ThreadingMixIn:
             self.handle_error(request, client_address)
         finally:
             self.shutdown_request(request)
-            t = threading.current_thread()
+            thread = threading.current_thread()
             try:
-                self._threads.remove(t)
+                self._threads.remove(thread)
             except AttributeError:
                 pass
 

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -655,11 +655,15 @@ class ThreadingMixIn:
             try:
                 self.shutdown_request(request)
             finally:
-                thread = threading.current_thread()
-                if not thread.daemon:
-                    with self._threads_lock:
-                        if self._threads is not None:
-                            self._threads.remove(thread)
+                self._remove_thread()
+
+    def _remove_thread(self):
+        """Remove a current thread from threads list."""
+        thread = threading.current_thread()
+        if not thread.daemon:
+            with self._threads_lock:
+                if self._threads is not None:
+                    self._threads.remove(thread)
 
     def process_request(self, request, client_address):
         """Start a new thread to process the request."""

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -676,8 +676,8 @@ class ThreadingMixIn:
     def server_close(self):
         super().server_close()
         if self.block_on_close:
-            threads = self._threads
             with self._threads_lock:
+                threads = self._threads
                 self._threads = None
             if threads:
                 for thread in threads:

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -656,9 +656,10 @@ class ThreadingMixIn:
                 self.shutdown_request(request)
             finally:
                 thread = threading.current_thread()
-                with self._threads_lock:
-                    if self._threads and not thread.daemon:
-                        self._threads.remove(thread)
+                if not thread.daemon:
+                    with self._threads_lock:
+                        if self._threads is not None:
+                            self._threads.remove(thread)
 
     def process_request(self, request, client_address):
         """Start a new thread to process the request."""

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -688,7 +688,7 @@ class ThreadingMixIn:
     block_on_close = True
     # Threads object
     # used by server_close() to wait for all threads completion.
-    _threads = None
+    _threads = _NoThreads()
 
     def process_request_thread(self, request, client_address):
         """Same as in BaseServer but as a thread.
@@ -708,10 +708,8 @@ class ThreadingMixIn:
 
     def process_request(self, request, client_address):
         """Start a new thread to process the request."""
-        vars(self).setdefault(
-            '_threads',
-            _Threads() if self.block_on_close else _NoThreads(),
-        )
+        if self.block_on_close:
+            vars(self).setdefault('_threads', _Threads())
         t = threading.Thread(target = self.process_request_thread,
                              args = (request, client_address))
         t.daemon = self.daemon_threads

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -630,6 +630,9 @@ if hasattr(os, "fork"):
 
 
 class _Threads(list):
+    """
+    Joinable list of all non-daemon threads.
+    """
     def __init__(self):
         self._lock = threading.Lock()
 
@@ -662,6 +665,9 @@ class _Threads(list):
 
 
 class _NoThreads:
+    """
+    Degenerate version of _Threads.
+    """
     def append(self, thread):
         pass
 

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -276,6 +276,13 @@ class SocketServerTest(unittest.TestCase):
             t.join()
             s.server_close()
 
+    def test_close_immediately(self):
+        class MyServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+            pass
+
+        server = MyServer((HOST, 0), lambda: None)
+        server.server_close()
+
     def test_tcpserver_bind_leak(self):
         # Issue #22435: the server socket wouldn't be closed if bind()/listen()
         # failed.

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -490,6 +490,23 @@ class MiscTestCase(unittest.TestCase):
         self.assertEqual(server.shutdown_called, 1)
         server.server_close()
 
+    def test_threads_reaped(self):
+        """
+        In #37193, users reported a memory leak
+        due to the saving of every request thread. Ensure that the
+        threads are cleaned up after the requests complete.
+        """
+        class MyServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+            pass
+
+        server = MyServer((HOST, 0), socketserver.StreamRequestHandler)
+        for n in range(10):
+            with socket.create_connection(server.server_address):
+                server.handle_request()
+        [thread.join() for thread in server._threads]
+        self.assertEqual(len(server._threads), 0)
+        server.server_close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-06-12-21-23-20.bpo-37193.wJximU.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-12-21-23-20.bpo-37193.wJximU.rst
@@ -1,0 +1,2 @@
+Fixed memory leak in ``socketserver.ThreadingMixIn`` introduced in Python
+3.7.


### PR DESCRIPTION
In ThreadingMixIn class, it hold child processes on list (self._threads variable) to join it when server is closed.
This list also contain thread objects which finished its process.
And it will be extended eternally.
So Memory usage keep increasing while running server until server_close() called in spite of all threads finished to process request in real time and computer resource is enough to process all request.
This PR remove thread objects after finished to avoid it.

<!-- issue-number: [bpo-37193](https://bugs.python.org/issue37193) -->
https://bugs.python.org/issue37193
<!-- /issue-number -->
