### PR TITLE
bpo-33826: add __filename__ to Python-defined classes for introspection

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -788,6 +788,7 @@ Custom classes
       single: __bases__ (class attribute)
       single: __doc__ (class attribute)
       single: __annotations__ (class attribute)
+      single: __filename__ (class attribute)
 
    Special attributes: :attr:`~definition.__name__` is the class name; :attr:`__module__` is
    the module name in which the class was defined; :attr:`~object.__dict__` is the
@@ -796,7 +797,7 @@ Custom classes
    base class list; :attr:`__doc__` is the class's documentation string,
    or ``None`` if undefined; :attr:`__annotations__` (optional) is a dictionary
    containing :term:`variable annotations <variable annotation>` collected during
-   class body execution.
+   class body execution; :attr:`__filename__` is the filename in which the class was defined. It may be missing, e.g., for built-in or C-defined classes.
 
 Class instances
    .. index::

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -658,6 +658,8 @@ def getfile(object):
             return object.__file__
         raise TypeError('{!r} is a built-in module'.format(object))
     if isclass(object):
+        if hasattr(object, '__filename__'):
+            return object.__filename__
         if hasattr(object, '__module__'):
             object = sys.modules.get(object.__module__)
             if getattr(object, '__file__', None):

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4844,8 +4844,8 @@ class DictProxyTests(unittest.TestCase):
         self.assertNotIsInstance(it, list)
         keys = list(it)
         keys.sort()
-        self.assertEqual(keys, ['__dict__', '__doc__', '__module__',
-                                '__weakref__', 'meth'])
+        self.assertEqual(keys, ['__dict__', '__doc__', '__filename__',
+                                '__module__', '__weakref__', 'meth'])
 
     @unittest.skipIf(hasattr(sys, 'gettrace') and sys.gettrace(),
                         'trace function introduces __local__')
@@ -4854,7 +4854,7 @@ class DictProxyTests(unittest.TestCase):
         it = self.C.__dict__.values()
         self.assertNotIsInstance(it, list)
         values = list(it)
-        self.assertEqual(len(values), 5)
+        self.assertEqual(len(values), 6)
 
     @unittest.skipIf(hasattr(sys, 'gettrace') and sys.gettrace(),
                         'trace function introduces __local__')
@@ -4864,8 +4864,8 @@ class DictProxyTests(unittest.TestCase):
         self.assertNotIsInstance(it, list)
         keys = [item[0] for item in it]
         keys.sort()
-        self.assertEqual(keys, ['__dict__', '__doc__', '__module__',
-                                '__weakref__', 'meth'])
+        self.assertEqual(keys, ['__dict__', '__doc__', '__filename__',
+                                '__module__', '__weakref__', 'meth'])
 
     def test_dict_type_with_metaclass(self):
         # Testing type of __dict__ when metaclass set...

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -520,8 +520,7 @@ class TestRetrievingSourceCode(GetSourceBase):
                 raise AttributeError
         class C(metaclass=CM):
             pass
-        with self.assertRaises(TypeError):
-            inspect.getfile(C)
+        self.assertEqual(inspect.getfile(C), __file__)
 
     def test_getfile_broken_repr(self):
         class ErrorRepr:

--- a/Lib/test/test_metaclass.py
+++ b/Lib/test/test_metaclass.py
@@ -145,7 +145,8 @@ Use a __prepare__ method that returns an instrumented dict.
 
     >>> class LoggingDict(dict):
     ...     def __setitem__(self, key, value):
-    ...         print("d[%r] = %r" % (key, value))
+    ...         if key != '__filename__':
+    ...             print("d[%r] = %r" % (key, value))
     ...         dict.__setitem__(self, key, value)
     ...
     >>> class Meta(type):
@@ -169,7 +170,7 @@ Use a metaclass that doesn't derive from type.
 
     >>> def meta(name, bases, namespace, **kwds):
     ...     print("meta:", name, bases)
-    ...     print("ns:", sorted(namespace.items()))
+    ...     print("ns:", sorted([(k, v) for k, v in namespace.items() if k != "__filename__"]))
     ...     print("kw:", sorted(kwds.items()))
     ...     return namespace
     ...
@@ -182,7 +183,7 @@ Use a metaclass that doesn't derive from type.
     kw: []
     >>> type(C) is dict
     True
-    >>> print(sorted(C.items()))
+    >>> print(sorted([(k, v) for k, v in C.items() if k != "__filename__"]))
     [('__module__', 'test.test_metaclass'), ('__qualname__', 'C'), ('a', 42), ('b', 24)]
     >>>
 

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -41,9 +41,9 @@ if test.support.HAVE_DOCSTRINGS:
     expected_data_docstrings = (
         'dictionary for instance variables (if defined)',
         'list of weak references to the object (if defined)',
-        ) * 2
+        )
 else:
-    expected_data_docstrings = ('', '', '', '')
+    expected_data_docstrings = ('', '')
 
 expected_text_pattern = """
 NAME
@@ -69,6 +69,11 @@ CLASSES
      |  __dict__%s
      |\x20\x20
      |  __weakref__%s
+     |\x20\x20
+     |  ----------------------------------------------------------------------
+     |  Data and other attributes defined here:
+     |\x20\x20
+     |  __filename__ = '%s'
 \x20\x20\x20\x20
     class B(builtins.object)
      |  Data descriptors defined here:
@@ -83,6 +88,8 @@ CLASSES
      |  NO_MEANING = 'eggs'
      |\x20\x20
      |  __annotations__ = {'NO_MEANING': <class 'str'>}
+     |\x20\x20
+     |  __filename__ = '%s'
 \x20\x20\x20\x20
     class C(builtins.object)
      |  Methods defined here:
@@ -103,6 +110,11 @@ CLASSES
      |\x20\x20
      |  __weakref__
      |      list of weak references to the object (if defined)
+     |\x20\x20
+     |  ----------------------------------------------------------------------
+     |  Data and other attributes defined here:
+     |\x20\x20
+     |  __filename__ = '%s'
 
 FUNCTIONS
     doc_func()
@@ -177,6 +189,10 @@ Data descriptors defined here:<br>
 <dl><dt><strong>__weakref__</strong></dt>
 <dd><tt>%s</tt></dd>
 </dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__filename__</strong> = '%s'</dl>
+
 </td></tr></table> <p>
 <table width="100%%" cellspacing=0 cellpadding=2 border=0 summary="section">
 <tr bgcolor="#ffc8d8">
@@ -196,6 +212,8 @@ Data and other attributes defined here:<br>
 <dl><dt><strong>NO_MEANING</strong> = 'eggs'</dl>
 
 <dl><dt><strong>__annotations__</strong> = {'NO_MEANING': &lt;class 'str'&gt;}</dl>
+
+<dl><dt><strong>__filename__</strong> = '%s'</dl>
 
 </td></tr></table> <p>
 <table width="100%%" cellspacing=0 cellpadding=2 border=0 summary="section">
@@ -219,6 +237,10 @@ Data descriptors defined here:<br>
 <dl><dt><strong>__weakref__</strong></dt>
 <dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
 </dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__filename__</strong> = '%s'</dl>
+
 </td></tr></table></td></tr></table><p>
 <table width="100%%" cellspacing=0 cellpadding=2 border=0 summary="section">
 <tr bgcolor="#eeaa77">
@@ -278,6 +300,11 @@ class DA(builtins.object)
  |  __weakref__%s
  |\x20\x20
  |  ham
+ |\x20\x20
+ |  ----------------------------------------------------------------------
+ |  Data and other attributes defined here:
+ |\x20\x20
+ |  __filename__ = '%s'
  |\x20\x20
  |  ----------------------------------------------------------------------
  |  Data and other attributes inherited from Meta:
@@ -430,7 +457,11 @@ class PydocDocTest(unittest.TestCase):
         mod_url = urllib.parse.quote(mod_file)
         expected_html = expected_html_pattern % (
                         (mod_url, mod_file, doc_loc) +
-                        expected_html_data_docstrings)
+                        expected_html_data_docstrings +
+                        (mod_file,) +
+                        expected_html_data_docstrings +
+                        (mod_file, mod_file)
+                        )
         self.assertEqual(result, expected_html)
 
     @unittest.skipIf(sys.flags.optimize >= 2,
@@ -443,7 +474,9 @@ class PydocDocTest(unittest.TestCase):
         expected_text = expected_text_pattern % (
                         (doc_loc,) +
                         expected_text_data_docstrings +
-                        (inspect.getabsfile(pydoc_mod),))
+                        (inspect.getabsfile(pydoc_mod),) +
+                        expected_text_data_docstrings +
+                        3*(inspect.getabsfile(pydoc_mod),))
         self.assertEqual(expected_text, result)
 
     def test_text_enum_member_with_value_zero(self):
@@ -658,7 +691,6 @@ class PydocDocTest(unittest.TestCase):
         old_pattern = expected_text_pattern
         getpager_old = pydoc.getpager
         getpager_new = lambda: (lambda x: x)
-        self.maxDiff = None
 
         buf = StringIO()
         helper = pydoc.Helper(output=buf)
@@ -680,7 +712,9 @@ class PydocDocTest(unittest.TestCase):
                 expected_text = expected_help_pattern % (
                                 (doc_loc,) +
                                 expected_text_data_docstrings +
-                                (inspect.getabsfile(pydoc_mod),))
+                                (inspect.getabsfile(pydoc_mod),) +
+                                expected_text_data_docstrings +
+                                3*(inspect.getabsfile(pydoc_mod),))
                 self.assertEqual('', output.getvalue())
                 self.assertEqual('', err.getvalue())
                 self.assertEqual(expected_text, result)
@@ -814,6 +848,11 @@ class B(A)
  |      Configure resources of an item TAGORID.
  |\x20\x20
  |  ----------------------------------------------------------------------
+ |  Data and other attributes defined here:
+ |\x20\x20
+ |  __filename__ = '%s'
+ |\x20\x20
+ |  ----------------------------------------------------------------------
  |  Methods inherited from A:
  |\x20\x20
  |  a_size(self)
@@ -832,7 +871,7 @@ class B(A)
  |\x20\x20
  |  __weakref__
  |      list of weak references to the object (if defined)
-''' % __name__)
+''' % (__name__, __file__))
 
         doc = pydoc.render_doc(B, renderer=pydoc.HTMLDoc())
         self.assertEqual(doc, '''\
@@ -859,6 +898,10 @@ Methods defined here:<br>
 <dl><dt><a name="B-itemconfigure"><strong>itemconfigure</strong></a>(self, tagOrId, cnf=None, **kw)</dt><dd><tt>Configure&nbsp;resources&nbsp;of&nbsp;an&nbsp;item&nbsp;TAGORID.</tt></dd></dl>
 
 <hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__filename__</strong> = '%s'</dl>
+
+<hr>
 Methods inherited from A:<br>
 <dl><dt><a name="B-a_size"><strong>a_size</strong></a>(self)</dt><dd><tt>Return&nbsp;size</tt></dd></dl>
 
@@ -875,7 +918,7 @@ Data descriptors inherited from A:<br>
 <dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
 </dl>
 </td></tr></table>\
-''' % __name__)
+''' % (__name__, __file__))
 
 
 class PydocImportTest(PydocBaseTest):
@@ -1380,6 +1423,8 @@ class TestHelper(unittest.TestCase):
                          sorted(keyword.kwlist))
 
 class PydocWithMetaClasses(unittest.TestCase):
+    maxDiff = None
+
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
     @unittest.skipIf(hasattr(sys, 'gettrace') and sys.gettrace(),
@@ -1400,7 +1445,7 @@ class PydocWithMetaClasses(unittest.TestCase):
         helper = pydoc.Helper(output=output)
         helper(DA)
         expected_text = expected_dynamicattribute_pattern % (
-                (__name__,) + expected_text_data_docstrings[:2])
+                (__name__,) + expected_text_data_docstrings + (__file__,))
         result = output.getvalue().strip()
         self.assertEqual(expected_text, result)
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -942,8 +942,8 @@ class _TypingEllipsis:
 _TYPING_INTERNALS = ['__parameters__', '__orig_bases__',  '__orig_class__',
                      '_is_protocol', '_is_runtime_protocol']
 
-_SPECIAL_NAMES = ['__abstractmethods__', '__annotations__', '__dict__', '__doc__',
-                  '__init__', '__module__', '__new__', '__slots__',
+_SPECIAL_NAMES = ['__abstractmethods__', '__annotations__', '__filename__', '__dict__',
+                  '__doc__', '__init__', '__module__', '__new__', '__slots__',
                   '__subclasshook__', '__weakref__']
 
 # These special attributes will be not collected as protocol members.
@@ -1587,7 +1587,7 @@ _prohibited = ('__new__', '__init__', '__slots__', '__getnewargs__',
                '_fields', '_field_defaults', '_field_types',
                '_make', '_replace', '_asdict', '_source')
 
-_special = ('__module__', '__name__', '__qualname__', '__annotations__')
+_special = ('__filename__', '__module__', '__name__', '__qualname__', '__annotations__')
 
 
 class NamedTupleMeta(type):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1715,6 +1715,7 @@ Mike Verdone
 Jaap Vermeulen
 Nikita Vetoshkin
 Al Vezza
+Thomas Viehmann
 Petr Viktorin
 Jacques A. Vidrine
 John Viega

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-07-16-30-57.bpo-33826.gkACSC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-07-16-30-57.bpo-33826.gkACSC.rst
@@ -1,0 +1,1 @@
+Add __filename__ attribute to classes for enhanced introspection.


### PR DESCRIPTION
This adds an attribute `__filename__` to classes. It enables introspection in IPython/Jupyter using inspect.getsource().


<!-- issue-number: [bpo-33826](https://bugs.python.org/issue33826) -->
https://bugs.python.org/issue33826
<!-- /issue-number -->
