### PR TITLE
[3.8] bpo-37169: Rewrite _PyObject_IsFreed() unit tests (GH-13888)

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-06-07-12-23-15.bpo-37169.yfXTFg.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-07-12-23-15.bpo-37169.yfXTFg.rst
@@ -1,0 +1,1 @@
+Rewrite ``_PyObject_IsFreed()`` unit tests.


### PR DESCRIPTION
Replace two Python function calls with a single one to ensure that no
memory allocation is done between the invalid object is created and
when _PyObject_IsFreed() is called.

(cherry picked from commit 3bf0f3ad2046ac674d8e8a2c074a5a8b3327797d)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37169](https://bugs.python.org/issue37169) -->
https://bugs.python.org/issue37169
<!-- /issue-number -->
