### PR TITLE
bpo-37201: fix test_distutils failures for Windows ARM64

### DIFF
--- a/Lib/distutils/_msvccompiler.py
+++ b/Lib/distutils/_msvccompiler.py
@@ -93,6 +93,7 @@ PLAT_SPEC_TO_RUNTIME = {
     'x86' : 'x86',
     'x86_amd64' : 'x64',
     'x86_arm' : 'arm',
+    'x86_arm64' : 'arm64'
 }
 
 def _find_vcvarsall(plat_spec):
@@ -190,6 +191,7 @@ PLAT_TO_VCVARS = {
     'win32' : 'x86',
     'win-amd64' : 'x86_amd64',
     'win-arm32' : 'x86_arm',
+    'win-arm64' : 'x86_arm64'
 }
 
 # A set containing the DLLs that are guaranteed to be available for

--- a/Lib/distutils/tests/test_bdist_wininst.py
+++ b/Lib/distutils/tests/test_bdist_wininst.py
@@ -7,7 +7,7 @@ from test.support import run_unittest
 from distutils.command.bdist_wininst import bdist_wininst
 from distutils.tests import support
 
-@unittest.skipIf(sys.platform == 'win32' and platform.machine() == 'ARM64', 
+@unittest.skipIf(sys.platform == 'win32' and platform.machine() == 'ARM64',
     'bdist_wininst is not supported in this install')
 @unittest.skipIf(getattr(bdist_wininst, '_unsupported', False),
     'bdist_wininst is not supported in this install')

--- a/Lib/distutils/tests/test_bdist_wininst.py
+++ b/Lib/distutils/tests/test_bdist_wininst.py
@@ -1,19 +1,20 @@
 """Tests for distutils.command.bdist_wininst."""
+import sys
+import platform
 import unittest
-import sys, platform
 from test.support import run_unittest
 
 from distutils.command.bdist_wininst import bdist_wininst
 from distutils.tests import support
 
+@unittest.skipIf(sys.platform == 'win32' and platform.machine() == 'ARM64', 
+    'bdist_wininst is not supported in this install')
 @unittest.skipIf(getattr(bdist_wininst, '_unsupported', False),
     'bdist_wininst is not supported in this install')
 class BuildWinInstTestCase(support.TempdirManager,
                            support.LoggingSilencer,
                            unittest.TestCase):
 
-    @unittest.skipIf(sys.platform == 'win32' and platform.machine() == 'ARM64', 
-                    "No wininst-14.0-arm64.exe")
     def test_get_exe_bytes(self):
 
         # issue5731: command was broken on non-windows platforms

--- a/Lib/distutils/tests/test_bdist_wininst.py
+++ b/Lib/distutils/tests/test_bdist_wininst.py
@@ -1,5 +1,6 @@
 """Tests for distutils.command.bdist_wininst."""
 import unittest
+import sys, platform
 from test.support import run_unittest
 
 from distutils.command.bdist_wininst import bdist_wininst
@@ -11,6 +12,8 @@ class BuildWinInstTestCase(support.TempdirManager,
                            support.LoggingSilencer,
                            unittest.TestCase):
 
+    @unittest.skipIf(sys.platform == 'win32' and platform.machine() == 'ARM64', 
+                    "No wininst-14.0-arm64.exe")
     def test_get_exe_bytes(self):
 
         # issue5731: command was broken on non-windows platforms

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -40,6 +40,8 @@ def get_host_platform():
             return 'win-amd64'
         if '(arm)' in sys.version.lower():
             return 'win-arm32'
+        if '(arm64)' in sys.version.lower():
+            return 'win-arm64'
         return sys.platform
 
     # Set for cross builds explicitly

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -628,6 +628,8 @@ def get_platform():
             return 'win-amd64'
         if '(arm)' in sys.version.lower():
             return 'win-arm32'
+        if '(arm64)' in sys.version.lower():
+            return 'win-arm64'
         return sys.platform
 
     if os.name != "posix" or not hasattr(os, 'uname'):

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -122,13 +122,13 @@ WIN32 is still required for the locale module.
 #if defined(_M_X64) || defined(_M_AMD64)
 #if defined(__INTEL_COMPILER)
 #define COMPILER ("[ICC v." _Py_STRINGIZE(__INTEL_COMPILER) " 64 bit (amd64) with MSC v." _Py_STRINGIZE(_MSC_VER) " CRT]")
-#elif defined(_M_ARM64)
-#define COMPILER _Py_PASTE_VERSION("64 bit (ARM)")
-#define PYD_PLATFORM_TAG "win_arm64"
 #else
 #define COMPILER _Py_PASTE_VERSION("64 bit (AMD64)")
 #endif /* __INTEL_COMPILER */
 #define PYD_PLATFORM_TAG "win_amd64"
+#elif defined(_M_ARM64)
+#define COMPILER _Py_PASTE_VERSION("64 bit (ARM64)")
+#define PYD_PLATFORM_TAG "win_arm64"
 #else
 #define COMPILER _Py_PASTE_VERSION("64 bit (Unknown)")
 #endif


### PR DESCRIPTION
There are a few places where ARM64 is not correctly specified in order for distutils to work for on-target builds using Visual Studio (32-bit x86 emulation).

@zooba 

<!-- issue-number: [bpo-37201](https://bugs.python.org/issue37201) -->
https://bugs.python.org/issue37201
<!-- /issue-number -->
