### PR TITLE
bpo-37178: Allow a one argument form of math.perm()

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -210,13 +210,16 @@ Number-theoretic and representation functions
    of *x* and are floats.
 
 
-.. function:: perm(n, k)
+.. function:: perm(n, k=None)
 
    Return the number of ways to choose *k* items from *n* items
    without repetition and with order.
 
    Evaluates to ``n! / (n - k)!`` when ``k <= n`` and evaluates
    to zero when ``k > n``.
+
+   If *k* is not specified or is None, then *k* defaults to *n*
+   and the function returns ``n!``.
 
    Raises :exc:`TypeError` if either of the arguments are not integers.
    Raises :exc:`ValueError` if either of the arguments are negative.

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1885,8 +1885,13 @@ class IsCloseTests(unittest.TestCase):
             self.assertEqual(perm(n, 1), n)
             self.assertEqual(perm(n, n), factorial(n))
 
+        # Test one argument form
+        for n in range(20):
+            self.assertEqual(perm(n), factorial(n))
+            self.assertEqual(perm(n, None), factorial(n))
+
         # Raises TypeError if any argument is non-integer or argument count is
-        # not 2
+        # not 1 or 2
         self.assertRaises(TypeError, perm, 10, 1.0)
         self.assertRaises(TypeError, perm, 10, decimal.Decimal(1.0))
         self.assertRaises(TypeError, perm, 10, "1")
@@ -1894,7 +1899,7 @@ class IsCloseTests(unittest.TestCase):
         self.assertRaises(TypeError, perm, decimal.Decimal(10.0), 1)
         self.assertRaises(TypeError, perm, "10", 1)
 
-        self.assertRaises(TypeError, perm, 10)
+        self.assertRaises(TypeError, perm)
         self.assertRaises(TypeError, perm, 10, 1, 3)
         self.assertRaises(TypeError, perm)
 

--- a/Misc/NEWS.d/next/Library/2019-06-07-17-11-34.bpo-37178.b1StSv.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-07-17-11-34.bpo-37178.b1StSv.rst
@@ -1,0 +1,2 @@
+For math.perm(n, k), let k default to n, giving the same result as
+factorial.

--- a/Misc/NEWS.d/next/Library/2019-06-07-17-16-09.bpo-37178.Day_oB.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-07-17-16-09.bpo-37178.Day_oB.rst
@@ -1,0 +1,2 @@
+Give math.perm() a one argument form that means the same as
+math.factorial().

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -639,13 +639,16 @@ exit:
 }
 
 PyDoc_STRVAR(math_perm__doc__,
-"perm($module, n, k, /)\n"
+"perm($module, n, k=None, /)\n"
 "--\n"
 "\n"
 "Number of ways to choose k items from n items without repetition and with order.\n"
 "\n"
 "Evaluates to n! / (n - k)! when k <= n and evaluates\n"
 "to zero when k > n.\n"
+"\n"
+"If k is not specified or is None, then k defaults to n\n"
+"and the function returns n!.\n"
 "\n"
 "Raises TypeError if either of the arguments are not integers.\n"
 "Raises ValueError if either of the arguments are negative.");
@@ -661,13 +664,17 @@ math_perm(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *n;
-    PyObject *k;
+    PyObject *k = Py_None;
 
-    if (!_PyArg_CheckPositional("perm", nargs, 2, 2)) {
+    if (!_PyArg_CheckPositional("perm", nargs, 1, 2)) {
         goto exit;
     }
     n = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
     k = args[1];
+skip_optional:
     return_value = math_perm_impl(module, n, k);
 
 exit:
@@ -713,4 +720,4 @@ math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5004266613284dcc input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0eb1e76a769cdd30 input=a9049054013a1b77]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3002,7 +3002,7 @@ math_prod_impl(PyObject *module, PyObject *iterable, PyObject *start)
 math.perm
 
     n: object
-    k: object
+    k: object = None
     /
 
 Number of ways to choose k items from n items without repetition and with order.
@@ -3010,18 +3010,24 @@ Number of ways to choose k items from n items without repetition and with order.
 Evaluates to n! / (n - k)! when k <= n and evaluates
 to zero when k > n.
 
+If k is not specified or is None, then k defaults to n
+and the function returns n!.
+
 Raises TypeError if either of the arguments are not integers.
 Raises ValueError if either of the arguments are negative.
 [clinic start generated code]*/
 
 static PyObject *
 math_perm_impl(PyObject *module, PyObject *n, PyObject *k)
-/*[clinic end generated code: output=e021a25469653e23 input=b2e7729d9a1949cf]*/
+/*[clinic end generated code: output=e021a25469653e23 input=5311c5a00f359b53]*/
 {
     PyObject *result = NULL, *factor = NULL;
     int overflow, cmp;
     long long i, factors;
 
+    if (k == Py_None) {
+        return math_factorial(module, n);
+    }
     n = PyNumber_Index(n);
     if (n == NULL) {
         return NULL;


### PR DESCRIPTION


<!-- issue-number: [bpo-37178](https://bugs.python.org/issue37178) -->
https://bugs.python.org/issue37178
<!-- /issue-number -->
