### PR TITLE
[2.7] bpo-37188: Fix a divide-by-zero in arrays of size-0 objects (GH-13881)

### DIFF
--- a/Lib/ctypes/test/test_arrays.py
+++ b/Lib/ctypes/test/test_arrays.py
@@ -134,6 +134,21 @@ class ArrayTestCase(unittest.TestCase):
         t2 = my_int * 1
         self.assertIs(t1, t2)
 
+    def test_empty_element_struct(self):
+        class EmptyStruct(Structure):
+            _fields_ = []
+
+        obj = (EmptyStruct * 2)()  # bpo37188: Floating point exception
+        self.assertEqual(sizeof(obj), 0)
+
+    def test_empty_element_array(self):
+        class EmptyArray(Array):
+            _type_ = c_int
+            _length_ = 0
+
+        obj = (EmptyArray * 2)()  # bpo37188: Floating point exception
+        self.assertEqual(sizeof(obj), 0)
+
     def test_bpo36504_signed_int_overflow(self):
         # The overflow check in PyCArrayType_new() could cause signed integer
         # overflow.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1534,7 +1534,7 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     }
 
     itemsize = itemdict->size;
-    if (length > PY_SSIZE_T_MAX / itemsize) {
+    if (itemsize != 0 && length > PY_SSIZE_T_MAX / itemsize) {
         PyErr_SetString(PyExc_OverflowError,
                         "array too large");
         Py_DECREF(stgdict);


### PR DESCRIPTION
`itemsize` can be zero when `_type_` is an empty struct or length-0 array.

This line used to be `length * itemsize < 0`, which didn't exhibit this problem.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37188](https://bugs.python.org/issue37188) -->
https://bugs.python.org/issue37188
<!-- /issue-number -->
