### PR TITLE
bpo-29505: Fix interpreter in fuzzing targets to be relocatable

### DIFF
--- a/Modules/_xxtestfuzz/fuzzer.c
+++ b/Modules/_xxtestfuzz/fuzzer.c
@@ -88,6 +88,14 @@ static int _run_fuzz(const uint8_t *data, size_t size, int(*fuzzer)(const char* 
 /* CPython generates a lot of leak warnings for whatever reason. */
 int __lsan_is_turned_off(void) { return 1; }
 
+wchar_t wide_program_name[NAME_MAX];
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    wchar_t* wide_program_name = Py_DecodeLocale(*argv[0], NULL);
+    Py_SetProgramName(wide_program_name);
+    return 0;
+}
+
 /* Fuzz test interface.
    This returns the bitwise or of all fuzz test's return values.
 


### PR DESCRIPTION
Trying to get python fully checked into oss-fuzz, see https://github.com/google/oss-fuzz/pull/2493 and the abandoned https://github.com/google/oss-fuzz/pull/731

One of the concerns in the old pull request was that the python build will be moved from the `--prefix` it is installed in to another directory. This was causing the fuzz targets (which are essentially just programs with embedded python interpreters) to throw:
```
Fatal Python error: Py_Initialize: Unable to get the locale encoding
ModuleNotFoundError: No module named 'encodings'
```

As it turns out the fuzz targets were missing a call to `Py_SetProgramName` which is what [_testembed.c does](https://github.com/python/cpython/blob/65e5860fcc8ffe66f3c325d5484112f3b6540e8c/Programs/_testembed.c#L17-L29). I am not an expert in the import machinery at all but I'm assuming the `Py_SetProgramName` call is essential to setting up the right prefixes internally as the [docs](https://docs.python.org/3/c-api/init.html#c.Py_GetExecPrefix) somewhat suggest: 

> This is derived through a number of complicated rules from the program name set with
> Py_SetProgramName() and some environment variables; "

If so, the docs can probably be improved in this regard.

---
Potential reviewers: @gpshead @alex (skip-news label can be applied)

<!-- issue-number: [bpo-29505](https://bugs.python.org/issue29505) -->
https://bugs.python.org/issue29505
<!-- /issue-number -->
