### PR TITLE
bpo-18299: extending a kill_on_os_error() in Popen

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -723,6 +723,11 @@ Instances of the :class:`Popen` class have the following methods:
    On Windows :meth:`kill` is an alias for :meth:`terminate`.
 
 
+.. method:: Popen.kill_on_error()
+
+   Kills the child when a python error raised.
+
+
 The following attributes are also available:
 
 .. attribute:: Popen.args

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -723,9 +723,15 @@ Instances of the :class:`Popen` class have the following methods:
    On Windows :meth:`kill` is an alias for :meth:`terminate`.
 
 
-.. method:: Popen.kill_on_error()
+.. method:: Popen.kill_on_os_error()
 
-   Kills the child when a python error raised.
+   Kills the subprocess when the parent process touch off a race condition and
+   subprocess hanged. One of practical case can be found in:
+   https://bugs.python.org/issue25122::
+
+      proc = subprocess.Popen(...)
+      with proc.kill_on_os_error():
+          proc.communicate()
 
 
 The following attributes are also available:

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1886,7 +1886,7 @@ class Popen(object):
             if subprocess touch off a race condition.
             One of practical case can be found in:
             https://bugs.python.org/issue25122
-            
+
             For example:
             proc = subprocess.Popen(...)
             with proc.kill_on_os_error():
@@ -1904,7 +1904,7 @@ class Popen(object):
                 try:
                     self.kill()
                 except:
-                    # catch all possible errors. 
+                    # catch all possible errors.
                     pass
                 self.wait()
                 raise

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1879,3 +1879,25 @@ class Popen(object):
             """Kill the process with SIGKILL
             """
             self.send_signal(signal.SIGKILL)
+ 
+        @contextlib.contextmanager
+        def kill_on_error(self):
+            """Using context manager to kill subprocess if
+            a python exception is raised   
+            """
+            try:
+                yield self
+            except:
+                if self.stdin:
+                    self.stdin.close()
+                if self.stdout:
+                    self.stdout.close()
+                if self.stderr:
+                    self.stderr.close()
+                try:
+                    self.kill()
+                except OSError:
+                    # process already terminated
+                    pass
+                self.wait()
+                raise

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1879,12 +1879,11 @@ class Popen(object):
             """Kill the process with SIGKILL
             """
             self.send_signal(signal.SIGKILL)
- 
+
         @contextlib.contextmanager
         def kill_on_error(self):
             """Using context manager to kill subprocess if
-            a python exception is raised   
-            """
+            a python exception is raised."""
             try:
                 yield self
             except:

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1901,6 +1901,10 @@ class Popen(object):
                     self.stdout.close()
                 if self.stderr:
                     self.stderr.close()
-                self.kill()
+                try:
+                    self.kill()
+                except:
+                    # catch all possible errors. 
+                    pass
                 self.wait()
                 raise

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2814,6 +2814,11 @@ class POSIXProcessTestCase(BaseTestCase):
 
         self.assertEqual(returncode, -3)
 
+    def test_kill_on_error(self):
+        """Test Popen.kill_on_error() behavior when proc raise a Error"""
+        proc = subprocess.Popen([sys.executable, '-c', 'pass'])
+        with proc.kill_on_error() as p:
+            self.assertEqual(proc, p)
 
 @unittest.skipUnless(mswindows, "Windows specific tests")
 class Win32ProcessTestCase(BaseTestCase):

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2814,10 +2814,10 @@ class POSIXProcessTestCase(BaseTestCase):
 
         self.assertEqual(returncode, -3)
 
-    def test_kill_on_error(self):
-        """Test Popen.kill_on_error() behavior when proc raise a Error"""
+    def test_kill_on_os_error(self):
+        """Test Popen.kill_on_os_error() behavior in with code block"""
         proc = subprocess.Popen([sys.executable, '-c', 'pass'])
-        with proc.kill_on_error() as p:
+        with proc.kill_on_os_error() as p:
             self.assertEqual(proc, p)
 
 @unittest.skipUnless(mswindows, "Windows specific tests")

--- a/Misc/NEWS.d/next/Library/2019-06-08-16-22-58.bpo-18299.ATjNd2.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-08-16-22-58.bpo-18299.ATjNd2.rst
@@ -1,1 +1,2 @@
-subprocess.Popen add the kill_on_error function which could kill process when a python error raised.
+subprocess.Popen add the kill_on_os_error function which could kill subprocess
+when subprocesses touch off a race condition.

--- a/Misc/NEWS.d/next/Library/2019-06-08-16-22-58.bpo-18299.ATjNd2.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-08-16-22-58.bpo-18299.ATjNd2.rst
@@ -1,0 +1,1 @@
+subprocess.Popen add the kill_on_error function which could kill process when a python error raised.


### PR DESCRIPTION
Using context manager kill subprocess if a python's exception raised.

<!-- issue-number: [bpo-18299](https://bugs.python.org/issue18299) -->
https://bugs.python.org/issue18299
<!-- /issue-number -->
