### PR TITLE
bpo-37203: Correct classmethod Python emulation in the Descriptor HowTo Guide

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -437,7 +437,4 @@ Using the non-data descriptor protocol, a pure Python version of
         def __get__(self, obj, klass=None):
             if klass is None:
                 klass = type(obj)
-            def newfunc(*args):
-                return self.f(klass, *args)
-            return newfunc
-
+            return types.MethodType(self.f, klass)


### PR DESCRIPTION
With the current Python equivalent `ClassMethod` implementation of `classmethod` given in Raymond Hettinger's _[Descriptor HowTo Guide](https://docs.python.org/3/howto/descriptor.html)_, the following code snippet:

```
class A:
    @ClassMethod
    def f(cls, *, x):
        pass

print(A.f)
A.f(x=3)
```

prints:

> <function ClassMethod.\_\_get\_\_.<locals>.newfunc at 0x106b76268>

and raises:

> TypeError: newfunc() got an unexpected keyword argument 'x'

instead of only printing:

> <bound method A.f of <class '\_\_main\_\_.A'>>

like the `@classmethod` decorator would do.

So the `ClassMethod` implementation fails in two regards:
* it does not return a bound method to a class;
* it does not handle keyword-only parameters.

With this PR `ClassMethod` will correctly emulate `classmethod`. This approach (`types.MethodType`) is already used in the Python equivalent `Function` implementation of functions given earlier in the same guide.

<!-- issue-number: [bpo-37203](https://bugs.python.org/issue37203) -->
https://bugs.python.org/issue37203
<!-- /issue-number -->