### PR TITLE
 bpo-36373: Deprecate explicit loop parameter in all public asyncio APIs [locks]

### DIFF
--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -59,6 +59,9 @@ Lock
        finally:
            lock.release()
 
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
+
    .. coroutinemethod:: acquire()
 
       Acquire the lock.
@@ -100,6 +103,10 @@ Event
    with the :meth:`set` method and reset to *false* with the
    :meth:`clear` method.  The :meth:`wait` method blocks until the
    flag is set to *true*.  The flag is set to *false* initially.
+
+
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
 
    .. _asyncio_example_sync_event:
 
@@ -172,6 +179,10 @@ Condition
    The optional *lock* argument must be a :class:`Lock` object or
    ``None``.  In the latter case a new Lock object is created
    automatically.
+
+
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
 
    The preferred way to use a Condition is an :keyword:`async with`
    statement::
@@ -269,6 +280,10 @@ Semaphore
    internal counter (``1`` by default). If the given value is
    less than ``0`` a :exc:`ValueError` is raised.
 
+
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
+
    The preferred way to use a Semaphore is an :keyword:`async with`
    statement::
 
@@ -321,6 +336,9 @@ BoundedSemaphore
    a :exc:`ValueError` in :meth:`~Semaphore.release` if it
    increases the internal counter above the initial *value*.
 
+
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
 
 ---------
 

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -163,6 +163,7 @@ class Lock(_ContextManagerMixin):
         if loop is None:
             self._loop = events.get_event_loop()
         else:
+            self._loop = loop
             warnings.warn("The loop argument is deprecated since Python 3.8, "
                           "and scheduled for removal in Python 3.10.",
                           DeprecationWarning, stacklevel=2)
@@ -258,6 +259,7 @@ class Event:
         if loop is None:
             self._loop = events.get_event_loop()
         else:
+            self._loop = loop
             warnings.warn("The loop argument is deprecated since Python 3.8, "
                           "and scheduled for removal in Python 3.10.",
                           DeprecationWarning, stacklevel=2)
@@ -324,6 +326,7 @@ class Condition(_ContextManagerMixin):
         if loop is None:
             self._loop = events.get_event_loop()
         else:
+            self._loop = loop
             warnings.warn("The loop argument is deprecated since Python 3.8, "
                           "and scheduled for removal in Python 3.10.",
                           DeprecationWarning, stacklevel=2)
@@ -454,6 +457,7 @@ class Semaphore(_ContextManagerMixin):
         if loop is None:
             self._loop = events.get_event_loop()
         else:
+            self._loop = loop
             warnings.warn("The loop argument is deprecated since Python 3.8, "
                           "and scheduled for removal in Python 3.10.",
                           DeprecationWarning, stacklevel=2)

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -160,10 +160,12 @@ class Lock(_ContextManagerMixin):
     def __init__(self, *, loop=None):
         self._waiters = None
         self._locked = False
-        if loop is not None:
-            self._loop = loop
-        else:
+        if loop is None:
             self._loop = events.get_event_loop()
+        else:
+            warnings.warn("The loop argument is deprecated since Python 3.8, "
+                          "and scheduled for removal in Python 3.10.",
+                          DeprecationWarning, stacklevel=2)
 
     def __repr__(self):
         res = super().__repr__()
@@ -253,10 +255,12 @@ class Event:
     def __init__(self, *, loop=None):
         self._waiters = collections.deque()
         self._value = False
-        if loop is not None:
-            self._loop = loop
-        else:
+        if loop is None:
             self._loop = events.get_event_loop()
+        else:
+            warnings.warn("The loop argument is deprecated since Python 3.8, "
+                          "and scheduled for removal in Python 3.10.",
+                          DeprecationWarning, stacklevel=2)
 
     def __repr__(self):
         res = super().__repr__()
@@ -317,10 +321,12 @@ class Condition(_ContextManagerMixin):
     """
 
     def __init__(self, lock=None, *, loop=None):
-        if loop is not None:
-            self._loop = loop
-        else:
+        if loop is None:
             self._loop = events.get_event_loop()
+        else:
+            warnings.warn("The loop argument is deprecated since Python 3.8, "
+                          "and scheduled for removal in Python 3.10.",
+                          DeprecationWarning, stacklevel=2)
 
         if lock is None:
             lock = Lock(loop=self._loop)
@@ -445,10 +451,12 @@ class Semaphore(_ContextManagerMixin):
             raise ValueError("Semaphore initial value must be >= 0")
         self._value = value
         self._waiters = collections.deque()
-        if loop is not None:
-            self._loop = loop
-        else:
+        if loop is None:
             self._loop = events.get_event_loop()
+        else:
+            warnings.warn("The loop argument is deprecated since Python 3.8, "
+                          "and scheduled for removal in Python 3.10.",
+                          DeprecationWarning, stacklevel=2)
 
     def __repr__(self):
         res = super().__repr__()
@@ -508,6 +516,11 @@ class BoundedSemaphore(Semaphore):
     """
 
     def __init__(self, value=1, *, loop=None):
+        if loop:
+            warnings.warn("The loop argument is deprecated since Python 3.8, "
+                          "and scheduled for removal in Python 3.10.",
+                          DeprecationWarning, stacklevel=2)
+
         self._bound_value = value
         super().__init__(value, loop=loop)
 

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1720,19 +1720,20 @@ class SubprocessTestsMixin:
         connect = self.loop.subprocess_exec(
                         functools.partial(MySubprocessProtocol, self.loop),
                         sys.executable, prog)
-        transp, proto = self.loop.run_until_complete(connect)
-        self.assertIsInstance(proto, MySubprocessProtocol)
-        self.loop.run_until_complete(proto.connected)
-        self.assertEqual('CONNECTED', proto.state)
+        with self.assertWarns(DeprecationWarning):
+            transp, proto = self.loop.run_until_complete(connect)
+            self.assertIsInstance(proto, MySubprocessProtocol)
+            self.loop.run_until_complete(proto.connected)
+            self.assertEqual('CONNECTED', proto.state)
 
-        stdin = transp.get_pipe_transport(0)
-        stdin.write(b'Python The Winner')
-        self.loop.run_until_complete(proto.got_data[1].wait())
-        with test_utils.disable_logger():
-            transp.close()
-        self.loop.run_until_complete(proto.completed)
-        self.check_killed(proto.returncode)
-        self.assertEqual(b'Python The Winner', proto.data[1])
+            stdin = transp.get_pipe_transport(0)
+            stdin.write(b'Python The Winner')
+            self.loop.run_until_complete(proto.got_data[1].wait())
+            with test_utils.disable_logger():
+                transp.close()
+            self.loop.run_until_complete(proto.completed)
+            self.check_killed(proto.returncode)
+            self.assertEqual(b'Python The Winner', proto.data[1])
 
     def test_subprocess_interactive(self):
         prog = os.path.join(os.path.dirname(__file__), 'echo.py')
@@ -1740,47 +1741,52 @@ class SubprocessTestsMixin:
         connect = self.loop.subprocess_exec(
                         functools.partial(MySubprocessProtocol, self.loop),
                         sys.executable, prog)
-        transp, proto = self.loop.run_until_complete(connect)
-        self.assertIsInstance(proto, MySubprocessProtocol)
-        self.loop.run_until_complete(proto.connected)
-        self.assertEqual('CONNECTED', proto.state)
 
-        stdin = transp.get_pipe_transport(0)
-        stdin.write(b'Python ')
-        self.loop.run_until_complete(proto.got_data[1].wait())
-        proto.got_data[1].clear()
-        self.assertEqual(b'Python ', proto.data[1])
+        with self.assertWarns(DeprecationWarning):
+            transp, proto = self.loop.run_until_complete(connect)
+            self.assertIsInstance(proto, MySubprocessProtocol)
+            self.loop.run_until_complete(proto.connected)
+            self.assertEqual('CONNECTED', proto.state)
 
-        stdin.write(b'The Winner')
-        self.loop.run_until_complete(proto.got_data[1].wait())
-        self.assertEqual(b'Python The Winner', proto.data[1])
+            stdin = transp.get_pipe_transport(0)
+            stdin.write(b'Python ')
+            self.loop.run_until_complete(proto.got_data[1].wait())
+            proto.got_data[1].clear()
+            self.assertEqual(b'Python ', proto.data[1])
 
-        with test_utils.disable_logger():
-            transp.close()
-        self.loop.run_until_complete(proto.completed)
-        self.check_killed(proto.returncode)
+            stdin.write(b'The Winner')
+            self.loop.run_until_complete(proto.got_data[1].wait())
+            self.assertEqual(b'Python The Winner', proto.data[1])
+
+            with test_utils.disable_logger():
+                transp.close()
+            self.loop.run_until_complete(proto.completed)
+            self.check_killed(proto.returncode)
 
     def test_subprocess_shell(self):
-        connect = self.loop.subprocess_shell(
-                        functools.partial(MySubprocessProtocol, self.loop),
-                        'echo Python')
-        transp, proto = self.loop.run_until_complete(connect)
-        self.assertIsInstance(proto, MySubprocessProtocol)
-        self.loop.run_until_complete(proto.connected)
+        with self.assertWarns(DeprecationWarning):
+            connect = self.loop.subprocess_shell(
+                            functools.partial(MySubprocessProtocol, self.loop),
+                            'echo Python')
+            transp, proto = self.loop.run_until_complete(connect)
+            self.assertIsInstance(proto, MySubprocessProtocol)
+            self.loop.run_until_complete(proto.connected)
 
-        transp.get_pipe_transport(0).close()
-        self.loop.run_until_complete(proto.completed)
-        self.assertEqual(0, proto.returncode)
-        self.assertTrue(all(f.done() for f in proto.disconnects.values()))
-        self.assertEqual(proto.data[1].rstrip(b'\r\n'), b'Python')
-        self.assertEqual(proto.data[2], b'')
-        transp.close()
+            transp.get_pipe_transport(0).close()
+            self.loop.run_until_complete(proto.completed)
+            self.assertEqual(0, proto.returncode)
+            self.assertTrue(all(f.done() for f in proto.disconnects.values()))
+            self.assertEqual(proto.data[1].rstrip(b'\r\n'), b'Python')
+            self.assertEqual(proto.data[2], b'')
+            transp.close()
 
     def test_subprocess_exitcode(self):
         connect = self.loop.subprocess_shell(
                         functools.partial(MySubprocessProtocol, self.loop),
                         'exit 7', stdin=None, stdout=None, stderr=None)
-        transp, proto = self.loop.run_until_complete(connect)
+
+        with self.assertWarns(DeprecationWarning):
+            transp, proto = self.loop.run_until_complete(connect)
         self.assertIsInstance(proto, MySubprocessProtocol)
         self.loop.run_until_complete(proto.completed)
         self.assertEqual(7, proto.returncode)
@@ -1790,7 +1796,8 @@ class SubprocessTestsMixin:
         connect = self.loop.subprocess_shell(
                         functools.partial(MySubprocessProtocol, self.loop),
                         'exit 7', stdin=None, stdout=None, stderr=None)
-        transp, proto = self.loop.run_until_complete(connect)
+        with self.assertWarns(DeprecationWarning):
+            transp, proto = self.loop.run_until_complete(connect)
         self.assertIsInstance(proto, MySubprocessProtocol)
         self.assertIsNone(transp.get_pipe_transport(0))
         self.assertIsNone(transp.get_pipe_transport(1))
@@ -1805,14 +1812,16 @@ class SubprocessTestsMixin:
         connect = self.loop.subprocess_exec(
                         functools.partial(MySubprocessProtocol, self.loop),
                         sys.executable, prog)
-        transp, proto = self.loop.run_until_complete(connect)
-        self.assertIsInstance(proto, MySubprocessProtocol)
-        self.loop.run_until_complete(proto.connected)
 
-        transp.kill()
-        self.loop.run_until_complete(proto.completed)
-        self.check_killed(proto.returncode)
-        transp.close()
+        with self.assertWarns(DeprecationWarning):
+            transp, proto = self.loop.run_until_complete(connect)
+            self.assertIsInstance(proto, MySubprocessProtocol)
+            self.loop.run_until_complete(proto.connected)
+
+            transp.kill()
+            self.loop.run_until_complete(proto.completed)
+            self.check_killed(proto.returncode)
+            transp.close()
 
     def test_subprocess_terminate(self):
         prog = os.path.join(os.path.dirname(__file__), 'echo.py')
@@ -1820,14 +1829,16 @@ class SubprocessTestsMixin:
         connect = self.loop.subprocess_exec(
                         functools.partial(MySubprocessProtocol, self.loop),
                         sys.executable, prog)
-        transp, proto = self.loop.run_until_complete(connect)
-        self.assertIsInstance(proto, MySubprocessProtocol)
-        self.loop.run_until_complete(proto.connected)
 
-        transp.terminate()
-        self.loop.run_until_complete(proto.completed)
-        self.check_terminated(proto.returncode)
-        transp.close()
+        with self.assertWarns(DeprecationWarning):
+            transp, proto = self.loop.run_until_complete(connect)
+            self.assertIsInstance(proto, MySubprocessProtocol)
+            self.loop.run_until_complete(proto.connected)
+
+            transp.terminate()
+            self.loop.run_until_complete(proto.completed)
+            self.check_terminated(proto.returncode)
+            transp.close()
 
     @unittest.skipIf(sys.platform == 'win32', "Don't have SIGHUP")
     def test_subprocess_send_signal(self):
@@ -1841,14 +1852,16 @@ class SubprocessTestsMixin:
             connect = self.loop.subprocess_exec(
                             functools.partial(MySubprocessProtocol, self.loop),
                             sys.executable, prog)
-            transp, proto = self.loop.run_until_complete(connect)
-            self.assertIsInstance(proto, MySubprocessProtocol)
-            self.loop.run_until_complete(proto.connected)
 
-            transp.send_signal(signal.SIGHUP)
-            self.loop.run_until_complete(proto.completed)
-            self.assertEqual(-signal.SIGHUP, proto.returncode)
-            transp.close()
+            with self.assertWarns(DeprecationWarning):
+                transp, proto = self.loop.run_until_complete(connect)
+                self.assertIsInstance(proto, MySubprocessProtocol)
+                self.loop.run_until_complete(proto.connected)
+
+                transp.send_signal(signal.SIGHUP)
+                self.loop.run_until_complete(proto.completed)
+                self.assertEqual(-signal.SIGHUP, proto.returncode)
+                transp.close()
         finally:
             signal.signal(signal.SIGHUP, old_handler)
 
@@ -1858,19 +1871,21 @@ class SubprocessTestsMixin:
         connect = self.loop.subprocess_exec(
                         functools.partial(MySubprocessProtocol, self.loop),
                         sys.executable, prog)
-        transp, proto = self.loop.run_until_complete(connect)
-        self.assertIsInstance(proto, MySubprocessProtocol)
-        self.loop.run_until_complete(proto.connected)
 
-        stdin = transp.get_pipe_transport(0)
-        stdin.write(b'test')
+        with self.assertWarns(DeprecationWarning):
+            transp, proto = self.loop.run_until_complete(connect)
+            self.assertIsInstance(proto, MySubprocessProtocol)
+            self.loop.run_until_complete(proto.connected)
 
-        self.loop.run_until_complete(proto.completed)
+            stdin = transp.get_pipe_transport(0)
+            stdin.write(b'test')
 
-        transp.close()
-        self.assertEqual(b'OUT:test', proto.data[1])
-        self.assertTrue(proto.data[2].startswith(b'ERR:test'), proto.data[2])
-        self.assertEqual(0, proto.returncode)
+            self.loop.run_until_complete(proto.completed)
+
+            transp.close()
+            self.assertEqual(b'OUT:test', proto.data[1])
+            self.assertTrue(proto.data[2].startswith(b'ERR:test'), proto.data[2])
+            self.assertEqual(0, proto.returncode)
 
     def test_subprocess_stderr_redirect_to_stdout(self):
         prog = os.path.join(os.path.dirname(__file__), 'echo2.py')
@@ -1878,22 +1893,24 @@ class SubprocessTestsMixin:
         connect = self.loop.subprocess_exec(
                         functools.partial(MySubprocessProtocol, self.loop),
                         sys.executable, prog, stderr=subprocess.STDOUT)
-        transp, proto = self.loop.run_until_complete(connect)
-        self.assertIsInstance(proto, MySubprocessProtocol)
-        self.loop.run_until_complete(proto.connected)
 
-        stdin = transp.get_pipe_transport(0)
-        self.assertIsNotNone(transp.get_pipe_transport(1))
-        self.assertIsNone(transp.get_pipe_transport(2))
+        with self.assertWarns(DeprecationWarning):
+            transp, proto = self.loop.run_until_complete(connect)
+            self.assertIsInstance(proto, MySubprocessProtocol)
+            self.loop.run_until_complete(proto.connected)
 
-        stdin.write(b'test')
-        self.loop.run_until_complete(proto.completed)
-        self.assertTrue(proto.data[1].startswith(b'OUT:testERR:test'),
-                        proto.data[1])
-        self.assertEqual(b'', proto.data[2])
+            stdin = transp.get_pipe_transport(0)
+            self.assertIsNotNone(transp.get_pipe_transport(1))
+            self.assertIsNone(transp.get_pipe_transport(2))
 
-        transp.close()
-        self.assertEqual(0, proto.returncode)
+            stdin.write(b'test')
+            self.loop.run_until_complete(proto.completed)
+            self.assertTrue(proto.data[1].startswith(b'OUT:testERR:test'),
+                            proto.data[1])
+            self.assertEqual(b'', proto.data[2])
+
+            transp.close()
+            self.assertEqual(0, proto.returncode)
 
     def test_subprocess_close_client_stream(self):
         prog = os.path.join(os.path.dirname(__file__), 'echo3.py')
@@ -1901,32 +1918,33 @@ class SubprocessTestsMixin:
         connect = self.loop.subprocess_exec(
                         functools.partial(MySubprocessProtocol, self.loop),
                         sys.executable, prog)
-        transp, proto = self.loop.run_until_complete(connect)
-        self.assertIsInstance(proto, MySubprocessProtocol)
-        self.loop.run_until_complete(proto.connected)
+        with self.assertWarns(DeprecationWarning):
+            transp, proto = self.loop.run_until_complete(connect)
+            self.assertIsInstance(proto, MySubprocessProtocol)
+            self.loop.run_until_complete(proto.connected)
 
-        stdin = transp.get_pipe_transport(0)
-        stdout = transp.get_pipe_transport(1)
-        stdin.write(b'test')
-        self.loop.run_until_complete(proto.got_data[1].wait())
-        self.assertEqual(b'OUT:test', proto.data[1])
+            stdin = transp.get_pipe_transport(0)
+            stdout = transp.get_pipe_transport(1)
+            stdin.write(b'test')
+            self.loop.run_until_complete(proto.got_data[1].wait())
+            self.assertEqual(b'OUT:test', proto.data[1])
 
-        stdout.close()
-        self.loop.run_until_complete(proto.disconnects[1])
-        stdin.write(b'xxx')
-        self.loop.run_until_complete(proto.got_data[2].wait())
-        if sys.platform != 'win32':
-            self.assertEqual(b'ERR:BrokenPipeError', proto.data[2])
-        else:
-            # After closing the read-end of a pipe, writing to the
-            # write-end using os.write() fails with errno==EINVAL and
-            # GetLastError()==ERROR_INVALID_NAME on Windows!?!  (Using
-            # WriteFile() we get ERROR_BROKEN_PIPE as expected.)
-            self.assertEqual(b'ERR:OSError', proto.data[2])
-        with test_utils.disable_logger():
-            transp.close()
-        self.loop.run_until_complete(proto.completed)
-        self.check_killed(proto.returncode)
+            stdout.close()
+            self.loop.run_until_complete(proto.disconnects[1])
+            stdin.write(b'xxx')
+            self.loop.run_until_complete(proto.got_data[2].wait())
+            if sys.platform != 'win32':
+                self.assertEqual(b'ERR:BrokenPipeError', proto.data[2])
+            else:
+                # After closing the read-end of a pipe, writing to the
+                # write-end using os.write() fails with errno==EINVAL and
+                # GetLastError()==ERROR_INVALID_NAME on Windows!?!  (Using
+                # WriteFile() we get ERROR_BROKEN_PIPE as expected.)
+                self.assertEqual(b'ERR:OSError', proto.data[2])
+            with test_utils.disable_logger():
+                transp.close()
+            self.loop.run_until_complete(proto.completed)
+            self.check_killed(proto.returncode)
 
     def test_subprocess_wait_no_same_group(self):
         # start the new process in a new session
@@ -1940,7 +1958,6 @@ class SubprocessTestsMixin:
         self.assertEqual(7, proto.returncode)
 
     def test_subprocess_exec_invalid_args(self):
-
         async def connect(**kwds):
             await self.loop.subprocess_exec(
                 asyncio.SubprocessProtocol,

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -28,10 +28,12 @@ class LockTests(test_utils.TestCase):
 
     def test_ctor_loop(self):
         loop = mock.Mock()
-        lock = asyncio.Lock(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=loop)
         self.assertIs(lock._loop, loop)
 
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
         self.assertIs(lock._loop, self.loop)
 
     def test_ctor_noloop(self):
@@ -40,7 +42,8 @@ class LockTests(test_utils.TestCase):
         self.assertIs(lock._loop, self.loop)
 
     def test_repr(self):
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
         self.assertTrue(repr(lock).endswith('[unlocked]>'))
         self.assertTrue(RGX_REPR.match(repr(lock)))
 
@@ -55,9 +58,10 @@ class LockTests(test_utils.TestCase):
         self.assertTrue(RGX_REPR.match(repr(lock)))
 
     def test_lock(self):
-        lock = asyncio.Lock(loop=self.loop)
-
         with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
+
+
             @asyncio.coroutine
             def acquire_lock():
                 with self.assertWarns(DeprecationWarning):
@@ -74,14 +78,14 @@ class LockTests(test_utils.TestCase):
     def test_lock_by_with_statement(self):
         loop = asyncio.new_event_loop()  # don't use TestLoop quirks
         self.set_event_loop(loop)
-        primitives = [
-            asyncio.Lock(loop=loop),
-            asyncio.Condition(loop=loop),
-            asyncio.Semaphore(loop=loop),
-            asyncio.BoundedSemaphore(loop=loop),
-        ]
-
         with self.assertWarns(DeprecationWarning):
+            primitives = [
+                asyncio.Lock(loop=loop),
+                asyncio.Condition(loop=loop),
+                asyncio.Semaphore(loop=loop),
+                asyncio.BoundedSemaphore(loop=loop),
+            ]
+
             @asyncio.coroutine
             def test(lock):
                 yield from asyncio.sleep(0.01)
@@ -99,7 +103,8 @@ class LockTests(test_utils.TestCase):
             self.assertFalse(primitive.locked())
 
     def test_acquire(self):
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
         result = []
 
         self.assertTrue(self.loop.run_until_complete(lock.acquire()))
@@ -150,7 +155,8 @@ class LockTests(test_utils.TestCase):
         self.assertTrue(t3.result())
 
     def test_acquire_cancel(self):
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
         self.assertTrue(self.loop.run_until_complete(lock.acquire()))
 
         task = asyncio.Task(lock.acquire(), loop=self.loop)
@@ -175,7 +181,8 @@ class LockTests(test_utils.TestCase):
         # B's waiter; instead, it should move on to C's waiter.
 
         # Setup: A has the lock, b and c are waiting.
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
 
         async def lockit(name, blocker):
             await lock.acquire()
@@ -211,7 +218,8 @@ class LockTests(test_utils.TestCase):
         # Issue 32734
         # Acquire 4 locks, cancel second, release first
         # and 2 locks are taken at once.
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
         lock_count = 0
         call_count = 0
 
@@ -256,7 +264,8 @@ class LockTests(test_utils.TestCase):
         self.assertTrue(t3.cancelled())
 
     def test_finished_waiter_cancelled(self):
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
 
         ta = asyncio.Task(lock.acquire(), loop=self.loop)
         test_utils.run_briefly(self.loop)
@@ -278,12 +287,14 @@ class LockTests(test_utils.TestCase):
         self.assertTrue(tb.cancelled())
 
     def test_release_not_acquired(self):
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
 
         self.assertRaises(RuntimeError, lock.release)
 
     def test_release_no_waiters(self):
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
         self.loop.run_until_complete(lock.acquire())
         self.assertTrue(lock.locked())
 
@@ -291,9 +302,9 @@ class LockTests(test_utils.TestCase):
         self.assertFalse(lock.locked())
 
     def test_context_manager(self):
-        lock = asyncio.Lock(loop=self.loop)
-
         with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
+
             @asyncio.coroutine
             def acquire_lock():
                 with self.assertWarns(DeprecationWarning):
@@ -305,9 +316,9 @@ class LockTests(test_utils.TestCase):
         self.assertFalse(lock.locked())
 
     def test_context_manager_cant_reuse(self):
-        lock = asyncio.Lock(loop=self.loop)
-
         with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
+
             @asyncio.coroutine
             def acquire_lock():
                 with self.assertWarns(DeprecationWarning):
@@ -325,7 +336,8 @@ class LockTests(test_utils.TestCase):
                 pass
 
     def test_context_manager_no_yield(self):
-        lock = asyncio.Lock(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
 
         try:
             with lock:
@@ -346,10 +358,12 @@ class EventTests(test_utils.TestCase):
 
     def test_ctor_loop(self):
         loop = mock.Mock()
-        ev = asyncio.Event(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            ev = asyncio.Event(loop=loop)
         self.assertIs(ev._loop, loop)
 
-        ev = asyncio.Event(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            ev = asyncio.Event(loop=self.loop)
         self.assertIs(ev._loop, self.loop)
 
     def test_ctor_noloop(self):
@@ -358,7 +372,8 @@ class EventTests(test_utils.TestCase):
         self.assertIs(ev._loop, self.loop)
 
     def test_repr(self):
-        ev = asyncio.Event(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            ev = asyncio.Event(loop=self.loop)
         self.assertTrue(repr(ev).endswith('[unset]>'))
         match = RGX_REPR.match(repr(ev))
         self.assertEqual(match.group('extras'), 'unset')
@@ -372,7 +387,8 @@ class EventTests(test_utils.TestCase):
         self.assertTrue(RGX_REPR.match(repr(ev)))
 
     def test_wait(self):
-        ev = asyncio.Event(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            ev = asyncio.Event(loop=self.loop)
         self.assertFalse(ev.is_set())
 
         result = []
@@ -409,14 +425,16 @@ class EventTests(test_utils.TestCase):
         self.assertIsNone(t3.result())
 
     def test_wait_on_set(self):
-        ev = asyncio.Event(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            ev = asyncio.Event(loop=self.loop)
         ev.set()
 
         res = self.loop.run_until_complete(ev.wait())
         self.assertTrue(res)
 
     def test_wait_cancel(self):
-        ev = asyncio.Event(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            ev = asyncio.Event(loop=self.loop)
 
         wait = asyncio.Task(ev.wait(), loop=self.loop)
         self.loop.call_soon(wait.cancel)
@@ -426,7 +444,8 @@ class EventTests(test_utils.TestCase):
         self.assertFalse(ev._waiters)
 
     def test_clear(self):
-        ev = asyncio.Event(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            ev = asyncio.Event(loop=self.loop)
         self.assertFalse(ev.is_set())
 
         ev.set()
@@ -436,7 +455,8 @@ class EventTests(test_utils.TestCase):
         self.assertFalse(ev.is_set())
 
     def test_clear_with_waiters(self):
-        ev = asyncio.Event(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            ev = asyncio.Event(loop=self.loop)
         result = []
 
         async def c1(result):
@@ -472,19 +492,22 @@ class ConditionTests(test_utils.TestCase):
 
     def test_ctor_loop(self):
         loop = mock.Mock()
-        cond = asyncio.Condition(loop=loop)
-        self.assertIs(cond._loop, loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=loop)
+            self.assertIs(cond._loop, loop)
 
-        cond = asyncio.Condition(loop=self.loop)
-        self.assertIs(cond._loop, self.loop)
+            cond = asyncio.Condition(loop=self.loop)
+            self.assertIs(cond._loop, self.loop)
 
     def test_ctor_noloop(self):
-        asyncio.set_event_loop(self.loop)
-        cond = asyncio.Condition()
-        self.assertIs(cond._loop, self.loop)
+        with self.assertWarns(DeprecationWarning):
+            asyncio.set_event_loop(self.loop)
+            cond = asyncio.Condition()
+            self.assertIs(cond._loop, self.loop)
 
     def test_wait(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
         result = []
 
         async def c1(result):
@@ -547,7 +570,8 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(t3.result())
 
     def test_wait_cancel(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
         self.loop.run_until_complete(cond.acquire())
 
         wait = asyncio.Task(cond.wait(), loop=self.loop)
@@ -559,7 +583,8 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(cond.locked())
 
     def test_wait_cancel_contested(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
 
         self.loop.run_until_complete(cond.acquire())
         self.assertTrue(cond.locked())
@@ -585,7 +610,8 @@ class ConditionTests(test_utils.TestCase):
 
     def test_wait_cancel_after_notify(self):
         # See bpo-32841
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
         waited = False
 
         async def wait_on_cond():
@@ -609,13 +635,15 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(waited)
 
     def test_wait_unacquired(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
         self.assertRaises(
             RuntimeError,
             self.loop.run_until_complete, cond.wait())
 
     def test_wait_for(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
         presult = False
 
         def predicate():
@@ -652,7 +680,8 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(t.result())
 
     def test_wait_for_unacquired(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
 
         # predicate can return true immediately
         res = self.loop.run_until_complete(cond.wait_for(lambda: [1, 2, 3]))
@@ -664,7 +693,8 @@ class ConditionTests(test_utils.TestCase):
             cond.wait_for(lambda: False))
 
     def test_notify(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
         result = []
 
         async def c1(result):
@@ -716,7 +746,8 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(t3.result())
 
     def test_notify_all(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
 
         result = []
 
@@ -752,15 +783,18 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(t2.result())
 
     def test_notify_unacquired(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
         self.assertRaises(RuntimeError, cond.notify)
 
     def test_notify_all_unacquired(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
         self.assertRaises(RuntimeError, cond.notify_all)
 
     def test_repr(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
         self.assertTrue('unlocked' in repr(cond))
         self.assertTrue(RGX_REPR.match(repr(cond)))
 
@@ -776,7 +810,8 @@ class ConditionTests(test_utils.TestCase):
         self.assertTrue(RGX_REPR.match(repr(cond)))
 
     def test_context_manager(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
 
         with self.assertWarns(DeprecationWarning):
             @asyncio.coroutine
@@ -790,7 +825,8 @@ class ConditionTests(test_utils.TestCase):
         self.assertFalse(cond.locked())
 
     def test_context_manager_no_yield(self):
-        cond = asyncio.Condition(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            cond = asyncio.Condition(loop=self.loop)
 
         try:
             with cond:
@@ -803,8 +839,9 @@ class ConditionTests(test_utils.TestCase):
         self.assertFalse(cond.locked())
 
     def test_explicit_lock(self):
-        lock = asyncio.Lock(loop=self.loop)
-        cond = asyncio.Condition(lock, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
+            cond = asyncio.Condition(lock, loop=self.loop)
 
         self.assertIs(cond._lock, lock)
         self.assertIs(cond._loop, lock._loop)
@@ -812,10 +849,10 @@ class ConditionTests(test_utils.TestCase):
     def test_ambiguous_loops(self):
         loop = self.new_test_loop()
         self.addCleanup(loop.close)
-
-        lock = asyncio.Lock(loop=self.loop)
-        with self.assertRaises(ValueError):
-            asyncio.Condition(lock, loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            lock = asyncio.Lock(loop=self.loop)
+            with self.assertRaises(ValueError):
+                asyncio.Condition(lock, loop=loop)
 
     def test_timeout_in_block(self):
         loop = asyncio.new_event_loop()
@@ -827,7 +864,8 @@ class ConditionTests(test_utils.TestCase):
                 with self.assertRaises(asyncio.TimeoutError):
                     await asyncio.wait_for(condition.wait(), timeout=0.5)
 
-        loop.run_until_complete(task_timeout())
+        with self.assertWarns(DeprecationWarning):
+            loop.run_until_complete(task_timeout())
 
 
 class SemaphoreTests(test_utils.TestCase):
@@ -838,10 +876,12 @@ class SemaphoreTests(test_utils.TestCase):
 
     def test_ctor_loop(self):
         loop = mock.Mock()
-        sem = asyncio.Semaphore(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(loop=loop)
         self.assertIs(sem._loop, loop)
 
-        sem = asyncio.Semaphore(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(loop=self.loop)
         self.assertIs(sem._loop, self.loop)
 
     def test_ctor_noloop(self):
@@ -850,11 +890,13 @@ class SemaphoreTests(test_utils.TestCase):
         self.assertIs(sem._loop, self.loop)
 
     def test_initial_value_zero(self):
-        sem = asyncio.Semaphore(0, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(0, loop=self.loop)
         self.assertTrue(sem.locked())
 
     def test_repr(self):
-        sem = asyncio.Semaphore(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(loop=self.loop)
         self.assertTrue(repr(sem).endswith('[unlocked, value:1]>'))
         self.assertTrue(RGX_REPR.match(repr(sem)))
 
@@ -872,7 +914,8 @@ class SemaphoreTests(test_utils.TestCase):
         self.assertTrue(RGX_REPR.match(repr(sem)))
 
     def test_semaphore(self):
-        sem = asyncio.Semaphore(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(loop=self.loop)
         self.assertEqual(1, sem._value)
 
         with self.assertWarns(DeprecationWarning):
@@ -895,7 +938,8 @@ class SemaphoreTests(test_utils.TestCase):
         self.assertRaises(ValueError, asyncio.Semaphore, -1)
 
     def test_acquire(self):
-        sem = asyncio.Semaphore(3, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(3, loop=self.loop)
         result = []
 
         self.assertTrue(self.loop.run_until_complete(sem.acquire()))
@@ -956,7 +1000,8 @@ class SemaphoreTests(test_utils.TestCase):
         self.loop.run_until_complete(asyncio.gather(*race_tasks))
 
     def test_acquire_cancel(self):
-        sem = asyncio.Semaphore(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(loop=self.loop)
         self.loop.run_until_complete(sem.acquire())
 
         acquire = asyncio.Task(sem.acquire(), loop=self.loop)
@@ -968,7 +1013,8 @@ class SemaphoreTests(test_utils.TestCase):
                         all(waiter.done() for waiter in sem._waiters))
 
     def test_acquire_cancel_before_awoken(self):
-        sem = asyncio.Semaphore(value=0, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(value=0, loop=self.loop)
 
         t1 = asyncio.Task(sem.acquire(), loop=self.loop)
         t2 = asyncio.Task(sem.acquire(), loop=self.loop)
@@ -990,7 +1036,8 @@ class SemaphoreTests(test_utils.TestCase):
         test_utils.run_briefly(self.loop)
 
     def test_acquire_hang(self):
-        sem = asyncio.Semaphore(value=0, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(value=0, loop=self.loop)
 
         t1 = asyncio.Task(sem.acquire(), loop=self.loop)
         t2 = asyncio.Task(sem.acquire(), loop=self.loop)
@@ -1004,12 +1051,14 @@ class SemaphoreTests(test_utils.TestCase):
         self.assertTrue(sem.locked())
 
     def test_release_not_acquired(self):
-        sem = asyncio.BoundedSemaphore(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.BoundedSemaphore(loop=self.loop)
 
         self.assertRaises(ValueError, sem.release)
 
     def test_release_no_waiters(self):
-        sem = asyncio.Semaphore(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(loop=self.loop)
         self.loop.run_until_complete(sem.acquire())
         self.assertTrue(sem.locked())
 
@@ -1017,9 +1066,9 @@ class SemaphoreTests(test_utils.TestCase):
         self.assertFalse(sem.locked())
 
     def test_context_manager(self):
-        sem = asyncio.Semaphore(2, loop=self.loop)
-
         with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(2, loop=self.loop)
+
             @asyncio.coroutine
             def acquire_lock():
                 with self.assertWarns(DeprecationWarning):
@@ -1035,7 +1084,8 @@ class SemaphoreTests(test_utils.TestCase):
         self.assertEqual(2, sem._value)
 
     def test_context_manager_no_yield(self):
-        sem = asyncio.Semaphore(2, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            sem = asyncio.Semaphore(2, loop=self.loop)
 
         try:
             with sem:

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -44,12 +44,13 @@ class BaseTest(test_utils.TestCase):
 class LockTests(BaseTest):
 
     def test_context_manager_async_with(self):
-        primitives = [
-            asyncio.Lock(loop=self.loop),
-            asyncio.Condition(loop=self.loop),
-            asyncio.Semaphore(loop=self.loop),
-            asyncio.BoundedSemaphore(loop=self.loop),
-        ]
+        with self.assertWarns(DeprecationWarning):
+            primitives = [
+                asyncio.Lock(loop=self.loop),
+                asyncio.Condition(loop=self.loop),
+                asyncio.Semaphore(loop=self.loop),
+                asyncio.BoundedSemaphore(loop=self.loop),
+            ]
 
         async def test(lock):
             await asyncio.sleep(0.01)
@@ -66,12 +67,13 @@ class LockTests(BaseTest):
             self.assertFalse(primitive.locked())
 
     def test_context_manager_with_await(self):
-        primitives = [
-            asyncio.Lock(loop=self.loop),
-            asyncio.Condition(loop=self.loop),
-            asyncio.Semaphore(loop=self.loop),
-            asyncio.BoundedSemaphore(loop=self.loop),
-        ]
+        with self.assertWarns(DeprecationWarning):
+            primitives = [
+                asyncio.Lock(loop=self.loop),
+                asyncio.Condition(loop=self.loop),
+                asyncio.Semaphore(loop=self.loop),
+                asyncio.BoundedSemaphore(loop=self.loop),
+            ]
 
         async def test(lock):
             await asyncio.sleep(0.01)

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -67,7 +67,6 @@ class QueueBasicTests(_QueueTestBase):
 
         with self.assertWarns(DeprecationWarning):
             loop.run_until_complete(add_putter())
-
             q = asyncio.Queue(loop=loop)
         q.put_nowait(1)
         self.assertTrue('_queue=[1]' in fn(q))
@@ -532,7 +531,7 @@ class QueuePutTests(_QueueTestBase):
 
     def test_put_with_waiting_getters(self):
         with self.assertWarns(DeprecationWarning):
-           q = asyncio.Queue(loop=self.loop)
+            q = asyncio.Queue(loop=self.loop)
         t = asyncio.Task(q.get(), loop=self.loop)
         test_utils.run_briefly(self.loop)
         self.loop.run_until_complete(q.put('a'))

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -35,7 +35,8 @@ class QueueBasicTests(_QueueTestBase):
 
         loop = self.new_test_loop(gen)
 
-        q = asyncio.Queue(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=loop)
         self.assertTrue(fn(q).startswith('<Queue'), fn(q))
         id_is_present = hex(id(q)) in fn(q)
         self.assertEqual(expect_id, id_is_present)
@@ -50,7 +51,8 @@ class QueueBasicTests(_QueueTestBase):
             # resume q.get coroutine to finish generator
             q.put_nowait(0)
 
-        loop.run_until_complete(add_getter())
+        with self.assertWarns(DeprecationWarning):
+            loop.run_until_complete(add_getter())
 
         async def add_putter():
             q = asyncio.Queue(maxsize=1, loop=loop)
@@ -63,23 +65,27 @@ class QueueBasicTests(_QueueTestBase):
             # resume q.put coroutine to finish generator
             q.get_nowait()
 
-        loop.run_until_complete(add_putter())
+        with self.assertWarns(DeprecationWarning):
+            loop.run_until_complete(add_putter())
 
-        q = asyncio.Queue(loop=loop)
+            q = asyncio.Queue(loop=loop)
         q.put_nowait(1)
         self.assertTrue('_queue=[1]' in fn(q))
 
     def test_ctor_loop(self):
         loop = mock.Mock()
-        q = asyncio.Queue(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=loop)
         self.assertIs(q._loop, loop)
 
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
         self.assertIs(q._loop, self.loop)
 
     def test_ctor_noloop(self):
         asyncio.set_event_loop(self.loop)
-        q = asyncio.Queue()
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue()
         self.assertIs(q._loop, self.loop)
 
     def test_repr(self):
@@ -89,7 +95,8 @@ class QueueBasicTests(_QueueTestBase):
         self._test_repr_or_str(str, False)
 
     def test_empty(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
         self.assertTrue(q.empty())
         q.put_nowait(1)
         self.assertFalse(q.empty())
@@ -97,15 +104,18 @@ class QueueBasicTests(_QueueTestBase):
         self.assertTrue(q.empty())
 
     def test_full(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
         self.assertFalse(q.full())
 
-        q = asyncio.Queue(maxsize=1, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(maxsize=1, loop=self.loop)
         q.put_nowait(1)
         self.assertTrue(q.full())
 
     def test_order(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
         for i in [1, 3, 2]:
             q.put_nowait(i)
 
@@ -123,7 +133,8 @@ class QueueBasicTests(_QueueTestBase):
 
         loop = self.new_test_loop(gen)
 
-        q = asyncio.Queue(maxsize=2, loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(maxsize=2, loop=loop)
         self.assertEqual(2, q.maxsize)
         have_been_put = []
 
@@ -157,7 +168,8 @@ class QueueBasicTests(_QueueTestBase):
 class QueueGetTests(_QueueTestBase):
 
     def test_blocking_get(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
         q.put_nowait(1)
 
         async def queue_get():
@@ -167,7 +179,8 @@ class QueueGetTests(_QueueTestBase):
         self.assertEqual(1, res)
 
     def test_get_with_putters(self):
-        q = asyncio.Queue(1, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(1, loop=self.loop)
         q.put_nowait(1)
 
         waiter = asyncio.Future(loop=self.loop)
@@ -187,8 +200,9 @@ class QueueGetTests(_QueueTestBase):
 
         loop = self.new_test_loop(gen)
 
-        q = asyncio.Queue(loop=loop)
-        started = asyncio.Event(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=loop)
+            started = asyncio.Event(loop=loop)
         finished = False
 
         async def queue_get():
@@ -212,12 +226,14 @@ class QueueGetTests(_QueueTestBase):
         self.assertAlmostEqual(0.01, loop.time())
 
     def test_nonblocking_get(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
         q.put_nowait(1)
         self.assertEqual(1, q.get_nowait())
 
     def test_nonblocking_get_exception(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
         self.assertRaises(asyncio.QueueEmpty, q.get_nowait)
 
     def test_get_cancelled(self):
@@ -231,7 +247,8 @@ class QueueGetTests(_QueueTestBase):
 
         loop = self.new_test_loop(gen)
 
-        q = asyncio.Queue(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=loop)
 
         async def queue_get():
             return await asyncio.wait_for(q.get(), 0.051)
@@ -246,7 +263,8 @@ class QueueGetTests(_QueueTestBase):
         self.assertAlmostEqual(0.06, loop.time())
 
     def test_get_cancelled_race(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
 
         t1 = asyncio.Task(q.get(), loop=self.loop)
         t2 = asyncio.Task(q.get(), loop=self.loop)
@@ -260,7 +278,8 @@ class QueueGetTests(_QueueTestBase):
         self.assertEqual(t2.result(), 'a')
 
     def test_get_with_waiting_putters(self):
-        q = asyncio.Queue(loop=self.loop, maxsize=1)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop, maxsize=1)
         asyncio.Task(q.put('a'), loop=self.loop)
         asyncio.Task(q.put('b'), loop=self.loop)
         test_utils.run_briefly(self.loop)
@@ -280,7 +299,9 @@ class QueueGetTests(_QueueTestBase):
 
         queue_size = 1
         producer_num_items = 5
-        q = asyncio.Queue(queue_size, loop=self.loop)
+
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(queue_size, loop=self.loop)
 
         self.loop.run_until_complete(
             asyncio.gather(producer(q, producer_num_items),
@@ -301,7 +322,8 @@ class QueueGetTests(_QueueTestBase):
             except asyncio.TimeoutError:
                 pass
 
-        queue = asyncio.Queue(loop=self.loop, maxsize=5)
+        with self.assertWarns(DeprecationWarning):
+            queue = asyncio.Queue(loop=self.loop, maxsize=5)
         self.loop.run_until_complete(self.loop.create_task(consumer(queue)))
         self.assertEqual(len(queue._getters), 0)
 
@@ -309,7 +331,8 @@ class QueueGetTests(_QueueTestBase):
 class QueuePutTests(_QueueTestBase):
 
     def test_blocking_put(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
 
         async def queue_put():
             # No maxsize, won't block.
@@ -326,8 +349,9 @@ class QueuePutTests(_QueueTestBase):
 
         loop = self.new_test_loop(gen)
 
-        q = asyncio.Queue(maxsize=1, loop=loop)
-        started = asyncio.Event(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(maxsize=1, loop=loop)
+            started = asyncio.Event(loop=loop)
         finished = False
 
         async def queue_put():
@@ -349,7 +373,8 @@ class QueuePutTests(_QueueTestBase):
         self.assertAlmostEqual(0.01, loop.time())
 
     def test_nonblocking_put(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
         q.put_nowait(1)
         self.assertEqual(1, q.get_nowait())
 
@@ -360,7 +385,8 @@ class QueuePutTests(_QueueTestBase):
 
         loop = self.new_test_loop(gen)
 
-        q = asyncio.Queue(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=loop)
 
         reader = loop.create_task(q.get())
 
@@ -389,7 +415,8 @@ class QueuePutTests(_QueueTestBase):
         loop = self.new_test_loop(gen)
         loop.set_debug(True)
 
-        q = asyncio.Queue(loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=loop)
 
         reader1 = loop.create_task(q.get())
         reader2 = loop.create_task(q.get())
@@ -418,7 +445,9 @@ class QueuePutTests(_QueueTestBase):
             yield 0.1
 
         loop = self.new_test_loop(gen)
-        q = asyncio.Queue(1, loop=loop)
+
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(1, loop=loop)
 
         q.put_nowait(1)
 
@@ -442,18 +471,21 @@ class QueuePutTests(_QueueTestBase):
         self.assertEqual(q.qsize(), 0)
 
     def test_nonblocking_put_exception(self):
-        q = asyncio.Queue(maxsize=1, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(maxsize=1, loop=self.loop)
         q.put_nowait(1)
         self.assertRaises(asyncio.QueueFull, q.put_nowait, 2)
 
     def test_float_maxsize(self):
-        q = asyncio.Queue(maxsize=1.3, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(maxsize=1.3, loop=self.loop)
         q.put_nowait(1)
         q.put_nowait(2)
         self.assertTrue(q.full())
         self.assertRaises(asyncio.QueueFull, q.put_nowait, 3)
 
-        q = asyncio.Queue(maxsize=1.3, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(maxsize=1.3, loop=self.loop)
 
         async def queue_put():
             await q.put(1)
@@ -462,7 +494,8 @@ class QueuePutTests(_QueueTestBase):
         self.loop.run_until_complete(queue_put())
 
     def test_put_cancelled(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop)
 
         async def queue_put():
             await q.put(1)
@@ -477,7 +510,8 @@ class QueuePutTests(_QueueTestBase):
         self.assertTrue(t.result())
 
     def test_put_cancelled_race(self):
-        q = asyncio.Queue(loop=self.loop, maxsize=1)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.Queue(loop=self.loop, maxsize=1)
 
         put_a = asyncio.Task(q.put('a'), loop=self.loop)
         put_b = asyncio.Task(q.put('b'), loop=self.loop)
@@ -497,7 +531,8 @@ class QueuePutTests(_QueueTestBase):
         self.loop.run_until_complete(put_b)
 
     def test_put_with_waiting_getters(self):
-        q = asyncio.Queue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+           q = asyncio.Queue(loop=self.loop)
         t = asyncio.Task(q.get(), loop=self.loop)
         test_utils.run_briefly(self.loop)
         self.loop.run_until_complete(q.put('a'))
@@ -506,7 +541,8 @@ class QueuePutTests(_QueueTestBase):
     def test_why_are_putters_waiting(self):
         # From issue #265.
 
-        queue = asyncio.Queue(2, loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            queue = asyncio.Queue(2, loop=self.loop)
 
         async def putter(item):
             await queue.put(item)
@@ -532,7 +568,8 @@ class QueuePutTests(_QueueTestBase):
         loop = self.new_test_loop(a_generator)
 
         # Full queue.
-        queue = asyncio.Queue(loop=loop, maxsize=1)
+        with self.assertWarns(DeprecationWarning):
+            queue = asyncio.Queue(loop=loop, maxsize=1)
         queue.put_nowait(1)
 
         # Task waiting for space to put an item in the queue.
@@ -555,7 +592,8 @@ class QueuePutTests(_QueueTestBase):
         loop = self.new_test_loop(gen)
 
         # Full Queue.
-        queue = asyncio.Queue(1, loop=loop)
+        with self.assertWarns(DeprecationWarning):
+            queue = asyncio.Queue(1, loop=loop)
         queue.put_nowait(1)
 
         # Task waiting for space to put a item in the queue.
@@ -578,7 +616,8 @@ class QueuePutTests(_QueueTestBase):
 class LifoQueueTests(_QueueTestBase):
 
     def test_order(self):
-        q = asyncio.LifoQueue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.LifoQueue(loop=self.loop)
         for i in [1, 3, 2]:
             q.put_nowait(i)
 
@@ -589,7 +628,8 @@ class LifoQueueTests(_QueueTestBase):
 class PriorityQueueTests(_QueueTestBase):
 
     def test_order(self):
-        q = asyncio.PriorityQueue(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = asyncio.PriorityQueue(loop=self.loop)
         for i in [1, 3, 2]:
             q.put_nowait(i)
 
@@ -602,11 +642,13 @@ class _QueueJoinTestMixin:
     q_class = None
 
     def test_task_done_underflow(self):
-        q = self.q_class(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = self.q_class(loop=self.loop)
         self.assertRaises(ValueError, q.task_done)
 
     def test_task_done(self):
-        q = self.q_class(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = self.q_class(loop=self.loop)
         for i in range(100):
             q.put_nowait(i)
 
@@ -641,7 +683,8 @@ class _QueueJoinTestMixin:
         self.loop.run_until_complete(asyncio.wait(tasks))
 
     def test_join_empty_queue(self):
-        q = self.q_class(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = self.q_class(loop=self.loop)
 
         # Test that a queue join()s successfully, and before anything else
         # (done twice for insurance).
@@ -653,7 +696,8 @@ class _QueueJoinTestMixin:
         self.loop.run_until_complete(join())
 
     def test_format(self):
-        q = self.q_class(loop=self.loop)
+        with self.assertWarns(DeprecationWarning):
+            q = self.q_class(loop=self.loop)
         self.assertEqual(q._format(), 'maxsize=0')
 
         q._unfinished_tasks = 2

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1231,15 +1231,16 @@ class BaseTaskTests:
             for f in asyncio.as_completed([b, c, a], loop=loop):
                 values.append(await f)
             return values
-
-        res = loop.run_until_complete(self.new_task(loop, foo()))
+        with self.assertWarns(DeprecationWarning):
+            res = loop.run_until_complete(self.new_task(loop, foo()))
         self.assertAlmostEqual(0.15, loop.time())
         self.assertTrue('a' in res[:2])
         self.assertTrue('b' in res[:2])
         self.assertEqual(res[2], 'c')
 
         # Doing it again should take no time and exercise a different path.
-        res = loop.run_until_complete(self.new_task(loop, foo()))
+        with self.assertWarns(DeprecationWarning):
+            res = loop.run_until_complete(self.new_task(loop, foo()))
         self.assertAlmostEqual(0.15, loop.time())
 
     def test_as_completed_with_timeout(self):
@@ -1267,7 +1268,8 @@ class BaseTaskTests:
                     values.append((2, exc))
             return values
 
-        res = loop.run_until_complete(self.new_task(loop, foo()))
+        with self.assertWarns(DeprecationWarning):
+            res = loop.run_until_complete(self.new_task(loop, foo()))
         self.assertEqual(len(res), 2, res)
         self.assertEqual(res[0], (1, 'a'))
         self.assertEqual(res[1][0], 2)
@@ -1294,7 +1296,8 @@ class BaseTaskTests:
                 v = await f
                 self.assertEqual(v, 'a')
 
-        loop.run_until_complete(self.new_task(loop, foo()))
+        with self.assertWarns(DeprecationWarning):
+            loop.run_until_complete(self.new_task(loop, foo()))
 
     def test_as_completed_reverse_wait(self):
 
@@ -1308,7 +1311,9 @@ class BaseTaskTests:
         a = asyncio.sleep(0.05, 'a')
         b = asyncio.sleep(0.10, 'b')
         fs = {a, b}
-        futs = list(asyncio.as_completed(fs, loop=loop))
+
+        with self.assertWarns(DeprecationWarning):
+            futs = list(asyncio.as_completed(fs, loop=loop))
         self.assertEqual(len(futs), 2)
 
         x = loop.run_until_complete(futs[1])
@@ -1333,7 +1338,8 @@ class BaseTaskTests:
         a = asyncio.sleep(0.05, 'a')
         b = asyncio.sleep(0.05, 'b')
         fs = {a, b}
-        futs = list(asyncio.as_completed(fs, loop=loop))
+        with self.assertWarns(DeprecationWarning):
+            futs = list(asyncio.as_completed(fs, loop=loop))
         self.assertEqual(len(futs), 2)
         waiter = asyncio.wait(futs)
         done, pending = loop.run_until_complete(waiter)
@@ -1356,8 +1362,9 @@ class BaseTaskTests:
                     result.append((yield from f))
                 return result
 
-        fut = self.new_task(self.loop, runner())
-        self.loop.run_until_complete(fut)
+        with self.assertWarns(DeprecationWarning):
+            fut = self.new_task(self.loop, runner())
+            self.loop.run_until_complete(fut)
         result = fut.result()
         self.assertEqual(set(result), {'ham', 'spam'})
         self.assertEqual(len(result), 2)


### PR DESCRIPTION
This PR deprecate explicit loop parameters in all public asyncio APIs

This issues is split to be easier to review.

Third step: locks.py

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36373](https://bugs.python.org/issue36373) -->
https://bugs.python.org/issue36373
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov