### PR TITLE
bpo-12144: Handle cookies with expires attribute in CookieJar.make_cookies

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -1593,6 +1593,7 @@ class CookieJar:
         headers = response.info()
         rfc2965_hdrs = headers.get_all("Set-Cookie2", [])
         ns_hdrs = headers.get_all("Set-Cookie", [])
+        self._policy._now = self._now = int(time.time())
 
         rfc2965 = self._policy.rfc2965
         netscape = self._policy.netscape
@@ -1672,8 +1673,6 @@ class CookieJar:
         _debug("extract_cookies: %s", response.info())
         self._cookies_lock.acquire()
         try:
-            self._policy._now = self._now = int(time.time())
-
             for cookie in self.make_cookies(response, request):
                 if self._policy.set_ok(cookie, request):
                     _debug(" setting cookie: %s", cookie)

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -585,6 +585,15 @@ class CookieTests(unittest.TestCase):
         # if expires is in future, keep cookie...
         c = CookieJar()
         future = time2netscape(time.time()+3600)
+
+        with test.support.check_no_warnings(self):
+            headers = [f"Set-Cookie: FOO=BAR; path=/; expires={future}"]
+            req = urllib.request.Request("http://www.coyote.com/")
+            res = FakeResponse(headers, "http://www.coyote.com/")
+            cookies = c.make_cookies(res, req)
+            self.assertEqual(len(cookies), 1)
+            self.assertEqual(time2netscape(cookies[0].expires), future)
+
         interact_netscape(c, "http://www.acme.com/", 'spam="bar"; expires=%s' %
                           future)
         self.assertEqual(len(c), 1)

--- a/Misc/NEWS.d/next/Library/2019-06-08-23-26-58.bpo-12144.Z7mz-q.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-08-23-26-58.bpo-12144.Z7mz-q.rst
@@ -1,0 +1,2 @@
+Ensure cookies with ``expires`` attribute are handled in
+:meth:`CookieJar.make_cookies`.


### PR DESCRIPTION
Handle time comparison for cookies with `expires` attribute when `CookieJar.make_cookies` is called.

Co-authored-by: Demian Brecht <demianbrecht@gmail.com>

<!-- issue-number: [bpo-12144](https://bugs.python.org/issue12144) -->
https://bugs.python.org/issue12144
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov