### PR TITLE
Add some placeholder notes for major 3.8 features

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -51,6 +51,14 @@ For full details, see the :ref:`changelog <changelog>`.
    Prerelease users should be aware that this document is currently in draft
    form. It will be updated substantially as Python 3.8 moves towards release,
    so it's worth checking back even after reading earlier versions.
+   
+   Some notable items not yet covered here:
+   
+   * :pep:`574` - Pickle protocol 5 with out-of-band data buffer support
+   * :pep:`578` - Runtime audit hooks for potentially sensitive operations
+   * `python -m asyncio` runs a natively async REPL
+   * ...
+   
 
 
 Summary -- Release highlights

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -51,14 +51,13 @@ For full details, see the :ref:`changelog <changelog>`.
    Prerelease users should be aware that this document is currently in draft
    form. It will be updated substantially as Python 3.8 moves towards release,
    so it's worth checking back even after reading earlier versions.
-   
+
    Some notable items not yet covered here:
-   
+
    * :pep:`574` - Pickle protocol 5 with out-of-band data buffer support
    * :pep:`578` - Runtime audit hooks for potentially sensitive operations
-   * `python -m asyncio` runs a natively async REPL
+   * ``python -m asyncio`` runs a natively async REPL
    * ...
-   
 
 
 Summary -- Release highlights


### PR DESCRIPTION
With the beta here, it's useful to have the What's New call out
some items we'd like feedback on, even if it doesn't have full
descriptions of them yet.
