### PR TITLE
bpo-37207: Use PEP 590 vectorcall to speed up range(), list() and dict() by about 30%

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-09-10-54-31.bpo-37207.bLjgLR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-09-10-54-31.bpo-37207.bLjgLR.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``range()``, ``list()`` and ``dict()`` by about 30%, by
+using the PEP 590 ``vectorcall`` calling convention.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3293,7 +3293,7 @@ dict_vectorcall(
 {
     size_t nargs = PyVectorcall_NARGS(nargsf);
     if (nargs > 1) {
-        PyErr_Format(PyExc_TypeError, "dict() expected at most one argument, got %zd", nargs);
+        PyErr_Format(PyExc_TypeError, "dict() expected at most 1 argument, got %zu", nargs);
         return NULL;
     }
     assert(PyType_Check(type));

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3319,13 +3319,13 @@ dict_vectorcall(PyObject *type, PyObject * const*args,
             Py_DECREF(self);
             return NULL;
         }
-        args += 1;
+        args++;
     }
     if (kwnames == NULL) {
         return self;
     }
     Py_ssize_t items = PyTuple_GET_SIZE(kwnames);
-    for(Py_ssize_t index = 0; index < items; index++) {
+    for (Py_ssize_t index = 0; index < items; index++) {
         int err = PyDict_SetItem(self, PyTuple_GET_ITEM(kwnames, index), args[index]);
         if (err < 0) {
             Py_DECREF(self);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3287,9 +3287,8 @@ dict_init(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
-dict_vectorcall(
-    PyObject *type, PyObject * const*args,
-    size_t nargsf, PyObject *kwnames)
+dict_vectorcall(PyObject *type, PyObject * const*args,
+                size_t nargsf, PyObject *kwnames)
 {
     size_t nargs = PyVectorcall_NARGS(nargsf);
     if (nargs > 1) {

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2726,6 +2726,35 @@ list___init___impl(PyListObject *self, PyObject *iterable)
     return 0;
 }
 
+static PyObject *
+list_vectorcall(
+    PyObject *type, PyObject * const*args,
+    size_t nargsf, PyObject *kwnames)
+{
+    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
+        PyErr_Format(PyExc_TypeError, "list() takes no keyword arguments");
+        return NULL;
+    }
+    size_t nargs = PyVectorcall_NARGS(nargsf);
+    if (nargs > 1) {
+        PyErr_Format(PyExc_TypeError, "list() expected at most one argument, got %zd", nargs);
+        return NULL;
+    }
+
+    assert(PyType_Check(type));
+    PyObject *list = PyType_GenericAlloc((PyTypeObject *)type, 0);
+    if (list == NULL) {
+        return NULL;
+    }
+    PyObject *iterator = nargs ? args[0] : NULL;
+    if (list___init___impl((PyListObject *)list, iterator)) {
+        Py_DECREF(list);
+        return NULL;
+    }
+    return list;
+}
+
+
 /*[clinic input]
 list.__sizeof__
 
@@ -3041,6 +3070,7 @@ PyTypeObject PyList_Type = {
     PyType_GenericAlloc,                        /* tp_alloc */
     PyType_GenericNew,                          /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
+    .tp_vectorcall = list_vectorcall,
 };
 
 /*********************** List Iterator **************************/

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2737,7 +2737,7 @@ list_vectorcall(
     }
     size_t nargs = PyVectorcall_NARGS(nargsf);
     if (nargs > 1) {
-        PyErr_Format(PyExc_TypeError, "list() expected at most one argument, got %zd", nargs);
+        PyErr_Format(PyExc_TypeError, "list() expected at most 1 argument, got %zu", nargs);
         return NULL;
     }
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2727,9 +2727,8 @@ list___init___impl(PyListObject *self, PyObject *iterable)
 }
 
 static PyObject *
-list_vectorcall(
-    PyObject *type, PyObject * const*args,
-    size_t nargsf, PyObject *kwnames)
+list_vectorcall(PyObject *type, PyObject * const*args,
+                size_t nargsf, PyObject *kwnames)
 {
     if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
         PyErr_Format(PyExc_TypeError, "list() takes no keyword arguments");

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -136,7 +136,7 @@ range_vectorcall(
     }
     switch(nargs) {
         case 0:
-            PyErr_Format(PyExc_TypeError, "range()range expected 1 arguments, got 0");
+            PyErr_Format(PyExc_TypeError, "range() expected 1 arguments, got 0");
             return NULL;
         case 1:
             stop = PyNumber_Index(args[0]);
@@ -168,7 +168,7 @@ range_vectorcall(
             }
             break;
         default:
-            PyErr_Format(PyExc_TypeError, "range() expected at most 3 arguments, got %zd", nargs);
+            PyErr_Format(PyExc_TypeError, "range() expected at most 3 arguments, got %zu", nargs);
             return NULL;
     }
     obj = make_range_object(type, start, stop, step);

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -123,9 +123,8 @@ range_new(PyTypeObject *type, PyObject *args, PyObject *kw)
 
 
 static PyObject *
-range_vectorcall(
-    PyTypeObject *type, PyObject *const *args,
-    size_t nargsf, PyObject *kwnames)
+range_vectorcall(PyTypeObject *type, PyObject *const *args,
+                 size_t nargsf, PyObject *kwnames)
 {
     rangeobject *obj;
     size_t nargs = PyVectorcall_NARGS(nargsf);

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -151,7 +151,6 @@ range_vectorcall(
             step = args[2];
             //Intentional fall through
         case 2:
-            step = validate_step(step);  /* Caution, this can clear exceptions */
             /* Convert borrowed refs to owned refs */
             start = PyNumber_Index(args[0]);
             if (!start)
@@ -161,6 +160,7 @@ range_vectorcall(
                 Py_DECREF(start);
                 return NULL;
             }
+            step = validate_step(step);  /* Caution, this can clear exceptions */
             if (!step) {
                 Py_DECREF(start);
                 Py_DECREF(stop);

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -762,7 +762,7 @@ PyTypeObject PyRange_Type = {
         0,                      /* tp_init */
         0,                      /* tp_alloc */
         range_new,              /* tp_new */
-        .tp_vectorcall = range_vectorcall
+        .tp_vectorcall = (vectorcallfunc)range_vectorcall
 };
 
 /*********************** range Iterator **************************/

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5170,6 +5170,11 @@ inherit_slots(PyTypeObject *type, PyTypeObject *base)
             !(type->tp_flags & Py_TPFLAGS_HEAPTYPE))
         {
             type->tp_flags |= _Py_TPFLAGS_HAVE_VECTORCALL;
+            /* Also inherit tp_vectorcall if tp_call of the
+            * metaclass is type.__call__ */
+            if (Py_TYPE(type)->tp_call == PyType_Type.tp_call) {
+                type->tp_vectorcall = base->tp_vectorcall;
+            }
         }
         COPYSLOT(tp_call);
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-37207](https://bugs.python.org/issue37207) -->
https://bugs.python.org/issue37207
<!-- /issue-number -->
