### PR TITLE
[3.8] bpo-37206: fix docstring of dict.pop()

### DIFF
--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -116,42 +116,6 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(dict_pop__doc__,
-"pop($self, key, default=None, /)\n"
-"--\n"
-"\n"
-"Remove specified key and return the corresponding value.\n"
-"\n"
-"If key is not found, default is returned if given, otherwise KeyError is raised");
-
-#define DICT_POP_METHODDEF    \
-    {"pop", (PyCFunction)(void(*)(void))dict_pop, METH_FASTCALL, dict_pop__doc__},
-
-static PyObject *
-dict_pop_impl(PyDictObject *self, PyObject *key, PyObject *default_value);
-
-static PyObject *
-dict_pop(PyDictObject *self, PyObject *const *args, Py_ssize_t nargs)
-{
-    PyObject *return_value = NULL;
-    PyObject *key;
-    PyObject *default_value = NULL;
-
-    if (!_PyArg_CheckPositional("pop", nargs, 1, 2)) {
-        goto exit;
-    }
-    key = args[0];
-    if (nargs < 2) {
-        goto skip_optional;
-    }
-    default_value = args[1];
-skip_optional:
-    return_value = dict_pop_impl(self, key, default_value);
-
-exit:
-    return return_value;
-}
-
 PyDoc_STRVAR(dict_popitem__doc__,
 "popitem($self, /)\n"
 "--\n"
@@ -190,4 +154,4 @@ dict___reversed__(PyDictObject *self, PyObject *Py_UNUSED(ignored))
 {
     return dict___reversed___impl(self);
 }
-/*[clinic end generated code: output=0fd5cafc61a51d3c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=676532dcc941d399 input=a9049054013a1b77]*/

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2987,23 +2987,37 @@ dict_clear(PyDictObject *mp, PyObject *Py_UNUSED(ignored))
     Py_RETURN_NONE;
 }
 
-/*[clinic input]
-dict.pop
+/*
+We don't use Argument Clinic for dict.pop because it doesn't support
+custom signature for now.
+*/
+PyDoc_STRVAR(dict_pop__doc__,
+"D.pop(k[,d]) -> v, remove specified key and return the corresponding value.\n\
+If key is not found, d is returned if given, otherwise KeyError is raised");
 
-    key: object
-    default: object = NULL
-    /
-
-Remove specified key and return the corresponding value.
-
-If key is not found, default is returned if given, otherwise KeyError is raised
-[clinic start generated code]*/
+#define DICT_POP_METHODDEF    \
+    {"pop", (PyCFunction)(void(*)(void))dict_pop, METH_FASTCALL, dict_pop__doc__},
 
 static PyObject *
-dict_pop_impl(PyDictObject *self, PyObject *key, PyObject *default_value)
-/*[clinic end generated code: output=3abb47b89f24c21c input=016f6a000e4e633b]*/
+dict_pop(PyDictObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
-    return _PyDict_Pop((PyObject*)self, key, default_value);
+    PyObject *return_value = NULL;
+    PyObject *key;
+    PyObject *default_value = NULL;
+
+    if (!_PyArg_CheckPositional("pop", nargs, 1, 2)) {
+        goto exit;
+    }
+    key = args[0];
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    default_value = args[1];
+skip_optional:
+    return_value = _PyDict_Pop((PyObject*)self, key, default_value);
+
+exit:
+    return return_value;
 }
 
 /*[clinic input]


### PR DESCRIPTION
Stop using Argument Clinic for dict.pop().
It reuses code generated by clinic, but docstring is reverted.

<!-- issue-number: [bpo-37206](https://bugs.python.org/issue37206) -->
https://bugs.python.org/issue37206
<!-- /issue-number -->
