### PR TITLE
[2.7] bpo-36742: Fix urlparse.urlsplit() error message for Unicode URL

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -649,7 +649,7 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "netloc u'\u30d7:80' contains invalid characters "
                          "under NFKC normalization")
-        self.assertIsInstance(cm.exception.message, str)
+        self.assertIsInstance(cm.exception.args[0], str)
 
         for scheme in [u"http", u"https", u"ftp"]:
             for netloc in [u"netloc{}false.netloc", u"n{}user@netloc"]:

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -644,12 +644,8 @@ class UrlParseTestCase(unittest.TestCase):
         # bpo-36742: Verify port separators are ignored when they
         # existed prior to decomposition
         urlparse.urlsplit(u'http://\u30d5\u309a:80')
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             urlparse.urlsplit(u'http://\u30d5\u309a\ufe1380')
-        self.assertEqual(str(cm.exception),
-                         "netloc u'\u30d7:80' contains invalid characters "
-                         "under NFKC normalization")
-        self.assertIsInstance(cm.exception.args[0], str)
 
         for scheme in [u"http", u"https", u"ftp"]:
             for netloc in [u"netloc{}false.netloc", u"n{}user@netloc"]:
@@ -659,6 +655,15 @@ class UrlParseTestCase(unittest.TestCase):
                         print "Checking %r" % url
                     with self.assertRaises(ValueError):
                         urlparse.urlsplit(url)
+
+        # check error message: invalid netloc must be formated with repr()
+        # to get an ASCII error message
+        with self.assertRaises(ValueError) as cm:
+            urlparse.urlsplit(u'http://example.com\uFF03@bing.com')
+        self.assertEqual(str(cm.exception),
+                         "netloc u'example.com\\uff03@bing.com' contains invalid characters "
+                         "under NFKC normalization")
+        self.assertIsInstance(cm.exception.args[0], str)
 
 def test_main():
     test_support.run_unittest(UrlParseTestCase)

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -644,8 +644,12 @@ class UrlParseTestCase(unittest.TestCase):
         # bpo-36742: Verify port separators are ignored when they
         # existed prior to decomposition
         urlparse.urlsplit(u'http://\u30d5\u309a:80')
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             urlparse.urlsplit(u'http://\u30d5\u309a\ufe1380')
+        self.assertEqual(str(cm.exception),
+                         "netloc u'\u30d7:80' contains invalid characters "
+                         "under NFKC normalization")
+        self.assertIsInstance(cm.exception.message, str)
 
         for scheme in [u"http", u"https", u"ftp"]:
             for netloc in [u"netloc{}false.netloc", u"n{}user@netloc"]:

--- a/Lib/urlparse.py
+++ b/Lib/urlparse.py
@@ -180,8 +180,9 @@ def _checknetloc(netloc):
         return
     for c in '/?#@:':
         if c in netloc2:
-            raise ValueError(u"netloc '" + netloc + u"' contains invalid " +
-                             u"characters under NFKC normalization")
+            raise ValueError("netloc %r contains invalid characters "
+                             "under NFKC normalization"
+                             % netloc2)
 
 def urlsplit(url, scheme='', allow_fragments=True):
     """Parse a URL into 5 components:

--- a/Lib/urlparse.py
+++ b/Lib/urlparse.py
@@ -182,7 +182,7 @@ def _checknetloc(netloc):
         if c in netloc2:
             raise ValueError("netloc %r contains invalid characters "
                              "under NFKC normalization"
-                             % netloc2)
+                             % netloc)
 
 def urlsplit(url, scheme='', allow_fragments=True):
     """Parse a URL into 5 components:

--- a/Misc/NEWS.d/next/Library/2019-06-10-12-02-45.bpo-36742.UEdHXJ.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-10-12-02-45.bpo-36742.UEdHXJ.rst
@@ -1,0 +1,3 @@
+:func:`urlparse.urlsplit` error message for invalid ``netloc`` according to
+NFKC normalization is now a :class:`str` string, rather than a
+:class:`unicode` string, to prevent error when displaying the error.


### PR DESCRIPTION
If urlparse.urlsplit() detects an invalid netloc according to NFKC
normalization, the error message type is now str rather than unicode,
and use repr() to format the URL, to prevent <exception str() failed>
when display the error message.

<!-- issue-number: [bpo-36742](https://bugs.python.org/issue36742) -->
https://bugs.python.org/issue36742
<!-- /issue-number -->
