### PR TITLE
[WIP] bpo-36402: Fix test_threading.test_threads_join_2()

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -888,8 +888,10 @@ class SubinterpThreadingTests(BaseTestCase):
                 os.write(%d, b"x")
             threading.Thread(target=f).start()
             """ % (w,)
-        ret = test.support.run_in_subinterp(code)
-        self.assertEqual(ret, 0)
+        import subprocess
+        proc = subprocess.run([sys.executable, "-c", code], stderr=subprocess.PIPE, pass_fds=[w])
+        self.assertEqual(proc.stderr, b'', proc)
+        self.assertEqual(proc.returncode, 0, proc)
         # The thread was joined properly.
         self.assertEqual(os.read(r, 1), b"x")
 

--- a/Misc/NEWS.d/next/Tests/2019-06-10-22-45-26.bpo-36402.QqZnfC.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-10-22-45-26.bpo-36402.QqZnfC.rst
@@ -1,0 +1,2 @@
+Fix ``test_threading.test_threads_join_2()``: run the test into a
+subprocess, rather than in a subinterpreter, to avoid a race condition.


### PR DESCRIPTION
Fix test_threading.test_threads_join_2(): run the test into a
subprocess, rather than in a subinterpreter, to avoid a race
condition.

<!-- issue-number: [bpo-36402](https://bugs.python.org/issue36402) -->
https://bugs.python.org/issue36402
<!-- /issue-number -->
