### PR TITLE
bpo-36373: Deprecate explicit loop parameter in all public asyncio APIs [queue]

### DIFF
--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -32,6 +32,10 @@ Queue
    the queue is always known and can be returned by calling the
    :meth:`qsize` method.
 
+   .. deprecated-removed:: 3.8 3.10
+      The *loop* parameter.
+
+
    This class is :ref:`not thread safe <asyncio-multithreading>`.
 
    .. attribute:: maxsize

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -2,6 +2,7 @@ __all__ = ('Queue', 'PriorityQueue', 'LifoQueue', 'QueueFull', 'QueueEmpty')
 
 import collections
 import heapq
+import warnings
 
 from . import events
 from . import locks
@@ -34,6 +35,9 @@ class Queue:
             self._loop = events.get_event_loop()
         else:
             self._loop = loop
+            warnings.warn("The loop argument is deprecated since Python 3.8, "
+                          "and scheduled for removal in Python 3.10.",
+                          DeprecationWarning, stacklevel=2)
         self._maxsize = maxsize
 
         # Futures.


### PR DESCRIPTION
This PR deprecate explicit loop parameters in all public asyncio APIs

This issues is split to be easier to review.

fourth step: queue.py

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36373](https://bugs.python.org/issue36373) -->
https://bugs.python.org/issue36373
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov