### PR TITLE
bpo-18748: Fix _pyio.IOBase destructor (closed case)

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -405,6 +405,16 @@ class IOBase(metaclass=abc.ABCMeta):
 
     def __del__(self):
         """Destructor.  Calls close()."""
+        try:
+            closed = self.closed
+        except Exception:
+            # If getting closed fails, then the object is probably
+            # in an unusable state, so ignore.
+            return
+
+        if closed:
+            return
+
         if _IOBASE_EMITS_UNRAISABLE:
             self.close()
         else:

--- a/Misc/NEWS.d/next/Library/2019-06-11-01-54-19.bpo-18748.ADqCkq.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-11-01-54-19.bpo-18748.ADqCkq.rst
@@ -1,2 +1,2 @@
 :class:`_pyio.IOBase` destructor now does nothing if getting the ``closed``
-attribute fails to better mimick :class`_io.IOBase` finalizer.
+attribute fails to better mimick :class:`_io.IOBase` finalizer.

--- a/Misc/NEWS.d/next/Library/2019-06-11-01-54-19.bpo-18748.ADqCkq.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-11-01-54-19.bpo-18748.ADqCkq.rst
@@ -1,0 +1,2 @@
+:class:`_pyio.IOBase` destructor now does nothing if getting the ``closed``
+attribute fails to better mimick :class`_io.IOBase` finalizer.


### PR DESCRIPTION
_pyio.IOBase destructor now does nothing if getting the closed
attribute fails to better mimick _io.IOBase finalizer.

<!-- issue-number: [bpo-18748](https://bugs.python.org/issue18748) -->
https://bugs.python.org/issue18748
<!-- /issue-number -->
