### PR TITLE
bpo-36918, test_urllib: Silence FakeHTTPConnection destructor errors

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -90,6 +90,12 @@ def fakehttp(fakedata):
         def connect(self):
             self.sock = FakeSocket(self.fakedata)
             type(self).fakesock = self.sock
+
+        def close(self):
+            # bpo-36918: Don't bother to track exactly I/O references
+            # of FakeSocket: do nothing to silence finalizer exception
+            pass
+
     FakeHTTPConnection.fakedata = fakedata
 
     return FakeHTTPConnection


### PR DESCRIPTION
Implement FakeHTTPConnection.close() to silence destructor errors.

Co-Authored-By: Xtreak <tir.karthi@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36918](https://bugs.python.org/issue36918) -->
https://bugs.python.org/issue36918
<!-- /issue-number -->
