### PR TITLE
bpo-37216: Fix filename in mac using document

### DIFF
--- a/Doc/using/mac.rst
+++ b/Doc/using/mac.rst
@@ -25,7 +25,7 @@ there.
 
 What you get after installing is a number of things:
 
-* A :file:`MacPython 3.6` folder in your :file:`Applications` folder. In here
+* A :file:`Python 3.6` folder in your :file:`Applications` folder. In here
   you find IDLE, the development environment that is a standard part of official
   Python distributions; PythonLauncher, which handles double-clicking Python
   scripts from the Finder; and the "Build Applet" tool, which allows you to


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
The python folder name is wrong in mac using document. 

$ ls /Applications | grep Python
Python 2.7
Python 3.5
Python 3.6
Python 3.7

And my system version is macOS Mojave Version 10.14.5(18F132)
$uname -v
Darwin Kernel Version 18.6.0: Thu Apr 25 23:16:27 PDT 2019; root:xnu-4903.261.4~2/RELEASE_X86_64

This commit should be backport to 2.7, 3.5, 3.6. 
DO NOT backport to 3.7 and 3.8 because i  create another PR to fix the filename and version in branch 3.7 and 3.8.
See: 
[#13963 for 3.7](https://github.com/python/cpython/pull/13963), 
[#13964 for 3.8](https://github.com/python/cpython/pull/13964)
[#13966 for 3.9](https://github.com/python/cpython/pull/13966)


<!-- issue-number: [bpo-37216](https://bugs.python.org/issue37216) -->
https://bugs.python.org/issue37216
<!-- /issue-number -->
