### PR TITLE
bpo-37219: Remove errorneous optimization for differencing an empty set

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -895,6 +895,12 @@ class TestBasicOps:
             self.assertEqual(self.set, copy,
                              "%s != %s" % (self.set, copy))
 
+    def test_issue_37219(self):
+        with self.assertRaises(TypeError):
+            set().difference(123)
+        with self.assertRaises(TypeError):
+            set().difference_update(123)
+
 #------------------------------------------------------------------------------
 
 class TestBasicOpsEmpty(TestBasicOps, unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-10-23-18-31.bpo-37219.jPSufq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-10-23-18-31.bpo-37219.jPSufq.rst
@@ -1,0 +1,1 @@
+Remove errorneous optimization for empty set differences.

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1456,10 +1456,6 @@ PyDoc_STRVAR(isdisjoint_doc,
 static int
 set_difference_update_internal(PySetObject *so, PyObject *other)
 {
-    if (PySet_GET_SIZE(so) == 0) {
-        return 0;
-    }
-
     if ((PyObject *)so == other)
         return set_clear_internal(so);
 
@@ -1533,10 +1529,6 @@ set_difference(PySetObject *so, PyObject *other)
     setentry *entry;
     Py_ssize_t pos = 0, other_size;
     int rv;
-
-    if (PySet_GET_SIZE(so) == 0) {
-        return set_copy(so, NULL);
-    }
 
     if (PyAnySet_Check(other)) {
         other_size = PySet_GET_SIZE(other);


### PR DESCRIPTION


<!-- issue-number: [bpo-37219](https://bugs.python.org/issue37219) -->
https://bugs.python.org/issue37219
<!-- /issue-number -->
