### PR TITLE
bpo-37229: Add compare_function to bisect functions

### DIFF
--- a/Lib/bisect.py
+++ b/Lib/bisect.py
@@ -1,18 +1,20 @@
 """Bisection algorithms."""
 
-def insort_right(a, x, lo=0, hi=None):
+def insort_right(a, x, lo=0, hi=None, compare_function=None):
     """Insert item x in list a, and keep it sorted assuming a is sorted.
 
     If x is already in a, insert it to the right of the rightmost x.
 
     Optional args lo (default 0) and hi (default len(a)) bound the
     slice of a to be searched.
+    By default, comparison is done via __lt__ (such as a < b).
+    compare_function can be supplied to provide an alternative boolean comparison of the same order.
     """
 
-    lo = bisect_right(a, x, lo, hi)
+    lo = bisect_right(a, x, lo, hi, compare_function)
     a.insert(lo, x)
 
-def bisect_right(a, x, lo=0, hi=None):
+def bisect_right(a, x, lo=0, hi=None, compare_function=None):
     """Return the index where to insert item x in list a, assuming a is sorted.
 
     The return value i is such that all e in a[:i] have e <= x, and all e in
@@ -21,6 +23,8 @@ def bisect_right(a, x, lo=0, hi=None):
 
     Optional args lo (default 0) and hi (default len(a)) bound the
     slice of a to be searched.
+    By default, comparison is done via __lt__ (such as a < b).
+    compare_function can be supplied to provide an alternative boolean comparison of the same order.
     """
 
     if lo < 0:
@@ -29,24 +33,26 @@ def bisect_right(a, x, lo=0, hi=None):
         hi = len(a)
     while lo < hi:
         mid = (lo+hi)//2
-        if x < a[mid]: hi = mid
+        if x < a[mid] if compare_function is None else compare_function(x, a[mid]): hi = mid
         else: lo = mid+1
     return lo
 
-def insort_left(a, x, lo=0, hi=None):
+def insort_left(a, x, lo=0, hi=None, compare_function=None):
     """Insert item x in list a, and keep it sorted assuming a is sorted.
 
     If x is already in a, insert it to the left of the leftmost x.
 
     Optional args lo (default 0) and hi (default len(a)) bound the
     slice of a to be searched.
+    By default, comparison is done via __lt__ (such as a < b).
+    compare_function can be supplied to provide an alternative boolean comparison of the same order.
     """
 
-    lo = bisect_left(a, x, lo, hi)
+    lo = bisect_left(a, x, lo, hi, compare_function)
     a.insert(lo, x)
 
 
-def bisect_left(a, x, lo=0, hi=None):
+def bisect_left(a, x, lo=0, hi=None, compare_function=None):
     """Return the index where to insert item x in list a, assuming a is sorted.
 
     The return value i is such that all e in a[:i] have e < x, and all e in
@@ -55,6 +61,8 @@ def bisect_left(a, x, lo=0, hi=None):
 
     Optional args lo (default 0) and hi (default len(a)) bound the
     slice of a to be searched.
+    By default, comparison is done via __lt__ (such as a < b).
+    compare_function can be supplied to provide an alternative boolean comparison of the same order.
     """
 
     if lo < 0:
@@ -63,7 +71,7 @@ def bisect_left(a, x, lo=0, hi=None):
         hi = len(a)
     while lo < hi:
         mid = (lo+hi)//2
-        if a[mid] < x: lo = mid+1
+        if a[mid] < x if compare_function is None else compare_function(a[mid], x): lo = mid+1
         else: hi = mid
     return lo
 

--- a/Lib/test/test_bisect.py
+++ b/Lib/test/test_bisect.py
@@ -199,6 +199,26 @@ class TestBisect:
         self.module.insort(a=data, x=25, lo=1, hi=3)
         self.assertEqual(data, [10, 20, 25, 25, 25, 30, 40, 50])
 
+    def test_compare_function(self):
+        def compare_function(c1, c2):
+            return c1.n < c2.n
+
+        class CustomClass:
+            def __init__(self, n):
+                self.n = n
+
+            def __eq__(self, other):
+                return self.n == other.n
+
+        data = [CustomClass(n) for n in (10, 20, 30, 40, 50)]
+        self.assertEqual(self.module.bisect_left(a=data, x=CustomClass(25), lo=1, hi=3, compare_function=compare_function), 2)
+        self.assertEqual(self.module.bisect_right(a=data, x=CustomClass(25), lo=1, hi=3, compare_function=compare_function), 2)
+        self.assertEqual(self.module.bisect(a=data, x=CustomClass(25), lo=1, hi=3, compare_function=compare_function), 2)
+        self.module.insort_left(a=data, x=CustomClass(25), lo=1, hi=3, compare_function=compare_function)
+        self.module.insort_right(a=data, x=CustomClass(25), lo=1, hi=3, compare_function=compare_function)
+        self.module.insort(a=data, x=CustomClass(25), lo=1, hi=3, compare_function=compare_function)
+        self.assertEqual(data, [CustomClass(10), CustomClass(20), CustomClass(25), CustomClass(25), CustomClass(25), CustomClass(30), CustomClass(40), CustomClass(50)])
+
 class TestBisectPython(TestBisect, unittest.TestCase):
     module = py_bisect
 


### PR DESCRIPTION
All of bisect's functions (insort_{left,right}, bisect_{left,right}) can only use comparison of objects via `__lt__`.
They should support providing a custom comparison function.

<!-- issue-number: [bpo-37229](https://bugs.python.org/issue37229) -->
https://bugs.python.org/issue37229
<!-- /issue-number -->
