### PR TITLE
bpo-36607: Eliminate RuntimeError raised by asyncio.all_tasks()

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-06-11-13-52-04.bpo-36607.5_mJkQ.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-11-13-52-04.bpo-36607.5_mJkQ.rst
@@ -1,0 +1,2 @@
+Eliminate :exc:`RuntimeError` raised by :func:`asyncio.all_tasks()` if
+internal tasks weak set is changed by another thread during iteration.


### PR DESCRIPTION
If internal tasks weak set is changed by another thread during iteration.


<!-- issue-number: [bpo-36607](https://bugs.python.org/issue36607) -->
https://bugs.python.org/issue36607
<!-- /issue-number -->
