### PR TITLE
bpo-37151: use PyVectorcall_Call for all calls of "method"

### DIFF
--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -330,17 +330,6 @@ method_traverse(PyMethodObject *im, visitproc visit, void *arg)
 }
 
 static PyObject *
-method_call(PyObject *method, PyObject *args, PyObject *kwargs)
-{
-    PyObject *self, *func;
-
-    self = PyMethod_GET_SELF(method);
-    func = PyMethod_GET_FUNCTION(method);
-
-    return _PyObject_Call_Prepend(func, self, args, kwargs);
-}
-
-static PyObject *
 method_descr_get(PyObject *meth, PyObject *obj, PyObject *cls)
 {
     Py_INCREF(meth);
@@ -362,7 +351,7 @@ PyTypeObject PyMethod_Type = {
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
     (hashfunc)method_hash,                      /* tp_hash */
-    method_call,                                /* tp_call */
+    PyVectorcall_Call,                          /* tp_call */
     0,                                          /* tp_str */
     method_getattro,                            /* tp_getattro */
     PyObject_GenericSetAttr,                    /* tp_setattro */


### PR DESCRIPTION
There is no reason to have a specific implementation of `tp_call` (which won't be used anyway). Just use `tp_call=PyVectorcall_Call`.

<!-- issue-number: [bpo-37151](https://bugs.python.org/issue37151) -->
https://bugs.python.org/issue37151
<!-- /issue-number -->
