### PR TITLE
bpo-37236: pragma optimize off for _Py_c_quot on Windows arm64

### DIFF
--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -55,6 +55,7 @@ _Py_c_prod(Py_complex a, Py_complex b)
     return r;
 }
 
+/* Avoid bad optimization on Windows ARM64 until the compiler is fixed */
 #ifdef _M_ARM64
 #pragma optimize("", off)
 #endif

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -55,6 +55,9 @@ _Py_c_prod(Py_complex a, Py_complex b)
     return r;
 }
 
+#ifdef _M_ARM64
+#pragma optimize("", off)
+#endif
 Py_complex
 _Py_c_quot(Py_complex a, Py_complex b)
 {
@@ -112,6 +115,9 @@ _Py_c_quot(Py_complex a, Py_complex b)
     }
     return r;
 }
+#ifdef _M_ARM64
+#pragma optimize("", on)
+#endif
 
 Py_complex
 _Py_c_pow(Py_complex a, Py_complex b)


### PR DESCRIPTION
There is a compiler optimization error on Windows ARM64 that causes test_truediv (test.test_complex.ComplexTest) to fail with ZeroDivisionError: complex division by zero.

Adding a pragma optimize around the affected function fixes the issue.  I am also submitting a report to the compiler team

@zooba 

<!-- issue-number: [bpo-37236](https://bugs.python.org/issue37236) -->
https://bugs.python.org/issue37236
<!-- /issue-number -->
