### PR TITLE
bpo-37239: add headless development preset layout

### DIFF
--- a/PC/layout/support/options.py
+++ b/PC/layout/support/options.py
@@ -67,6 +67,21 @@ PRESETS = {
         "help": "Windows IoT Core",
         "options": ["stable", "pip"],
     },
+    "headless": {
+        "help": "headless development kit package",
+        "options": [
+            "stable",
+            "pip",
+            "distutils",
+            "tests",
+            "tools",
+            "venv",
+            "dev",
+            "symbols",
+            "bdist-wininst",
+            "chm",
+        ],
+    },
     "default": {
         "help": "development kit package",
         "options": [


### PR DESCRIPTION
Add preset-headless preset which has everything that preset-default has minus tcltk and idle.
I think this is needed for Windows server and test scenarios.

@zooba 

<!-- issue-number: [bpo-37239](https://bugs.python.org/issue37239) -->
https://bugs.python.org/issue37239
<!-- /issue-number -->
