### PR TITLE
bpo-35766: Change format for feature_version to (major, minor)

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -126,7 +126,7 @@ The abstract grammar is currently defined as follows:
 Apart from the node classes, the :mod:`ast` module defines these utility functions
 and classes for traversing abstract syntax trees:
 
-.. function:: parse(source, filename='<unknown>', mode='exec', *, type_comments=False, feature_version=-1)
+.. function:: parse(source, filename='<unknown>', mode='exec', *, type_comments=False, feature_version=None)
 
    Parse the source into an AST node.  Equivalent to ``compile(source,
    filename, mode, ast.PyCF_ONLY_AST)``.
@@ -145,11 +145,12 @@ and classes for traversing abstract syntax trees:
    modified to correspond to :pep:`484` "signature type comments",
    e.g. ``(str, int) -> List[str]``.
 
-   Also, setting ``feature_version`` to the minor version of an
-   earlier Python 3 version will attempt to parse using that version's
-   grammar.  For example, setting ``feature_version=4`` will allow
-   the use of ``async`` and ``await`` as variable names.  The lowest
-   supported value is 4; the highest is ``sys.version_info[1]``.
+   Also, setting ``feature_version`` to a tuple ``(major, minor)``
+   will attempt to parse using that Python version's grammar.
+   Currently ``major`` must equal to ``3``.  For example, setting
+   ``feature_version=(3, 4)`` will allow the use of ``async`` and
+   ``await`` as variable names.  The lowest supported version is
+   ``(3, 4)``; the highest is ``sys.version_info[0:2]``.
 
    .. warning::
       It is possible to crash the Python interpreter with a

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -378,9 +378,9 @@ The :func:`ast.parse` function has some new flags:
 * ``mode='func_type'`` can be used to parse :pep:`484` "signature type
   comments" (returned for function definition AST nodes);
 
-* ``feature_version=N`` allows specifying the minor version of an
-  earlier Python 3 version.  (For example, ``feature_version=4`` will
-  treat ``async`` and ``await`` as non-reserved words.)
+* ``feature_version=(3, N)`` allows specifying an earlier Python 3
+  version.  (For example, ``feature_version=(3, 4)`` will treat
+  ``async`` and ``await`` as non-reserved words.)
 
 New function :func:`ast.get_source_segment` returns the source code
 for a specific AST node.

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -28,7 +28,7 @@ from _ast import *
 
 
 def parse(source, filename='<unknown>', mode='exec', *,
-          type_comments=False, feature_version=-1):
+          type_comments=False, feature_version=None):
     """
     Parse the source into an AST node.
     Equivalent to compile(source, filename, mode, PyCF_ONLY_AST).
@@ -37,6 +37,13 @@ def parse(source, filename='<unknown>', mode='exec', *,
     flags = PyCF_ONLY_AST
     if type_comments:
         flags |= PyCF_TYPE_COMMENTS
+    if isinstance(feature_version, tuple):
+        major, minor = feature_version  # Should be a 2-tuple.
+        assert major == 3
+        feature_version = minor
+    elif feature_version is None:
+        feature_version = -1
+    # Else it should be an int giving the minor version for 3.x.
     return compile(source, filename, mode, flags,
                    feature_version=feature_version)
 

--- a/Misc/NEWS.d/next/Library/2019-06-11-16-41-40.bpo-35766.v1Kj-T.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-11-16-41-40.bpo-35766.v1Kj-T.rst
@@ -1,0 +1,1 @@
+Change the format of feature_version to be a (major, minor) tuple.


### PR DESCRIPTION
(A single int is still allowed, but undocumented.)


<!-- issue-number: [bpo-35766](https://bugs.python.org/issue35766) -->
https://bugs.python.org/issue35766
<!-- /issue-number -->
