### PR TITLE
bpo-26219: Fix compiler warning in _PyCode_InitOpcache()

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -282,7 +282,7 @@ _PyCode_InitOpcache(PyCodeObject *co)
         co->co_opcache = NULL;
     }
 
-    co->co_opcache_size = opts;
+    co->co_opcache_size = (unsigned char)opts;
     return 0;
 }
 


### PR DESCRIPTION
Fix MSVC warning:

    objects\codeobject.c(285): warning C4244: '=':
    conversion from 'Py_ssize_t' to 'unsigned char',
    possible loss of data

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-26219](https://bugs.python.org/issue26219) -->
https://bugs.python.org/issue26219
<!-- /issue-number -->
