### PR TITLE
bpo-37223: io.BufferedWrite.close() don't call flush() if already closed

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1196,7 +1196,7 @@ class CommonBufferedTests:
         b.close()
         b.close()
         b.close()
-        self.assertRaises(ValueError, b.flush)
+        self.assertRaisesRegex(ValueError, 'closed', b.flush)
 
     def test_unseekable(self):
         bufio = self.tp(self.MockUnseekableIO(b"A" * 10))
@@ -1896,6 +1896,12 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
 
         # if b is already closed, b.flush() must not be called
         b.close()
+
+    def test_closed_write(self):
+        raw = self.MockRawIO()
+        b = self.tp(raw)
+        b.close()
+        self.assertRaisesRegex(ValueError, 'closed', b.write, b'abc')
 
 
 class CBufferedWriterTest(BufferedWriterTest, SizeofTest):

--- a/Misc/NEWS.d/next/Library/2019-06-12-04-33-59.bpo-37223.oZqbr9.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-12-04-33-59.bpo-37223.oZqbr9.rst
@@ -1,0 +1,3 @@
+:class:`io.BufferedWrite.close` no longer call its
+:meth:`~io.BufferedWrite.flush` method if :class:`~io.BufferedWrite.close` has
+already been closed.


### PR DESCRIPTION
The close() method of io buffered files no longer call flush()
if the file is already closed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37223](https://bugs.python.org/issue37223) -->
https://bugs.python.org/issue37223
<!-- /issue-number -->
