### PR TITLE
[3.8] bpo-35766: compile(): rename feature_version parameter (GH-13994)

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -45,7 +45,7 @@ def parse(source, filename='<unknown>', mode='exec', *,
         feature_version = -1
     # Else it should be an int giving the minor version for 3.x.
     return compile(source, filename, mode, flags,
-                   feature_version=feature_version)
+                   _feature_version=feature_version)
 
 
 def literal_eval(node_or_string):

--- a/Lib/test/test_type_comments.py
+++ b/Lib/test/test_type_comments.py
@@ -228,8 +228,9 @@ class TypeCommentTests(unittest.TestCase):
                          feature_version=feature_version)
 
     def parse_all(self, source, minver=lowest, maxver=highest, expected_regex=""):
-        for feature_version in range(self.lowest, self.highest + 1):
-            if minver <= feature_version <= maxver:
+        for version in range(self.lowest, self.highest + 1):
+            feature_version = (3, version)
+            if minver <= version <= maxver:
                 try:
                     yield self.parse(source, feature_version)
                 except SyntaxError as err:

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -696,7 +696,8 @@ compile as builtin_compile
     flags: int = 0
     dont_inherit: bool(accept={int}) = False
     optimize: int = -1
-    feature_version: int = -1
+    *
+    _feature_version as feature_version: int = -1
 
 Compile source into a code object that can be executed by exec() or eval().
 
@@ -716,7 +717,7 @@ static PyObject *
 builtin_compile_impl(PyObject *module, PyObject *source, PyObject *filename,
                      const char *mode, int flags, int dont_inherit,
                      int optimize, int feature_version)
-/*[clinic end generated code: output=b0c09c84f116d3d7 input=5fcc30651a6acaa9]*/
+/*[clinic end generated code: output=b0c09c84f116d3d7 input=40171fb92c1d580d]*/
 {
     PyObject *source_copy;
     const char *str;

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -151,7 +151,7 @@ exit:
 
 PyDoc_STRVAR(builtin_compile__doc__,
 "compile($module, /, source, filename, mode, flags=0,\n"
-"        dont_inherit=False, optimize=-1, feature_version=-1)\n"
+"        dont_inherit=False, optimize=-1, *, _feature_version=-1)\n"
 "--\n"
 "\n"
 "Compile source into a code object that can be executed by exec() or eval().\n"
@@ -179,7 +179,7 @@ static PyObject *
 builtin_compile(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"source", "filename", "mode", "flags", "dont_inherit", "optimize", "feature_version", NULL};
+    static const char * const _keywords[] = {"source", "filename", "mode", "flags", "dont_inherit", "optimize", "_feature_version", NULL};
     static _PyArg_Parser _parser = {NULL, _keywords, "compile", 0};
     PyObject *argsbuf[7];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 3;
@@ -191,7 +191,7 @@ builtin_compile(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObj
     int optimize = -1;
     int feature_version = -1;
 
-    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 3, 7, 0, argsbuf);
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 3, 6, 0, argsbuf);
     if (!args) {
         goto exit;
     }
@@ -257,6 +257,10 @@ builtin_compile(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObj
             goto skip_optional_pos;
         }
     }
+skip_optional_pos:
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
     if (PyFloat_Check(args[6])) {
         PyErr_SetString(PyExc_TypeError,
                         "integer argument expected, got float" );
@@ -266,7 +270,7 @@ builtin_compile(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObj
     if (feature_version == -1 && PyErr_Occurred()) {
         goto exit;
     }
-skip_optional_pos:
+skip_optional_kwonly:
     return_value = builtin_compile_impl(module, source, filename, mode, flags, dont_inherit, optimize, feature_version);
 
 exit:
@@ -845,4 +849,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3f690311ac556c31 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e173df340a9e4516 input=a9049054013a1b77]*/


### PR DESCRIPTION
Rename compile() feature_version parameter to _feature_version and
convert it to a keyword-only parameter.

Update also test_type_comments to pass feature_version as a tuple.

(cherry picked from commit efdf6ca90f7702824e7aeee1ceca949e7c20288a)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35766](https://bugs.python.org/issue35766) -->
https://bugs.python.org/issue35766
<!-- /issue-number -->
