### PR TITLE
bpo-35545: Skip `test_asyncio.test_create_connection_ipv6_scope` on AIX

### DIFF
--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1298,7 +1298,8 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             t.close()
             test_utils.run_briefly(self.loop)  # allow transport to close
 
-    @unittest.skipIf(sys.platform.startswith('aix'), "getaddrinfo() different on AIX")
+    @unittest.skipIf(sys.platform.startswith('aix'),
+                    "bpo-25545: IPv6 scope id and getaddrinfo() behave differently on AIX")
     @patch_socket
     def test_create_connection_ipv6_scope(self, m_socket):
         m_socket.getaddrinfo = socket.getaddrinfo

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1298,6 +1298,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             t.close()
             test_utils.run_briefly(self.loop)  # allow transport to close
 
+    @unittest.skipIf(sys.platform.startswith('aix'), "getaddrinfo() different on AIX")
     @patch_socket
     def test_create_connection_ipv6_scope(self, m_socket):
         m_socket.getaddrinfo = socket.getaddrinfo

--- a/Misc/NEWS.d/next/Tests/2019-06-12-11-02-06.bpo-35545.s63eHE.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-12-11-02-06.bpo-35545.s63eHE.rst
@@ -1,0 +1,4 @@
+Skip `test_asyncio.test_create_connection_ipv6_scope` on AIX 
+because "getaddrinfo()" behaves different on AIX
+
+Patch by M. Felt

--- a/Misc/NEWS.d/next/Tests/2019-06-12-11-02-06.bpo-35545.s63eHE.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-12-11-02-06.bpo-35545.s63eHE.rst
@@ -1,4 +1,0 @@
-Skip `test_asyncio.test_create_connection_ipv6_scope` on AIX 
-because "getaddrinfo()" behaves different on AIX
-
-Patch by M. Felt


### PR DESCRIPTION
because "getaddrinfo()" behaves different on AIX

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35545](https://bugs.python.org/issue35545) -->
https://bugs.python.org/issue35545
<!-- /issue-number -->
