### PR TITLE
bpo-28459: Fix _pyio on Cygwin where the msvcrt module is not built

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -10,8 +10,13 @@ import stat
 import sys
 # Import _thread instead of threading to reduce startup cost
 from _thread import allocate_lock as Lock
-if sys.platform in {'win32', 'cygwin'}:
+if sys.platform == 'win32':
     from msvcrt import setmode as _setmode
+elif sys.platform == 'cygwin':
+    import ctypes
+    _cygwin1 = ctypes.CDLL('cygwin1.dll')
+    def _setmode(fd, mode):
+        return _cygwin1._setmode(ctypes.c_int(fd), ctypes.c_int(mode))
 else:
     _setmode = None
 

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -875,9 +875,10 @@ main (int argc, char **argv) {
     def library_filename(self, libname, lib_type='static',     # or 'shared'
                          strip_dir=0, output_dir=''):
         assert output_dir is not None
-        if lib_type not in ("static", "shared", "dylib", "xcode_stub"):
-            raise ValueError(
-                  "'lib_type' must be \"static\", \"shared\", \"dylib\", or \"xcode_stub\"")
+        if lib_type not in ("static", "shared", "dylib", "xcode_stub",
+                            "implib"):
+            raise ValueError("'lib_type' must be \"static\", \"shared\", "
+                             "\"dylib\", \"xcode_stub\", or \"implib\"")
         fmt = getattr(self, lib_type + "_lib_format")
         ext = getattr(self, lib_type + "_lib_extension")
 

--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -77,8 +77,9 @@ class UnixCCompiler(CCompiler):
     shared_lib_extension = ".so"
     dylib_lib_extension = ".dylib"
     xcode_stub_lib_extension = ".tbd"
+    implib_lib_extension = ".dll.a"
     static_lib_format = shared_lib_format = dylib_lib_format = "lib%s%s"
-    xcode_stub_lib_format = dylib_lib_format
+    implib_lib_format = xcode_stub_lib_format = dylib_lib_format
     if sys.platform == "cygwin":
         exe_extension = ".exe"
 
@@ -266,6 +267,7 @@ class UnixCCompiler(CCompiler):
         shared_f = self.library_filename(lib, lib_type='shared')
         dylib_f = self.library_filename(lib, lib_type='dylib')
         xcode_stub_f = self.library_filename(lib, lib_type='xcode_stub')
+        implib_f = self.library_filename(lib, lib_type='implib')
         static_f = self.library_filename(lib, lib_type='static')
 
         if sys.platform == 'darwin':
@@ -301,6 +303,7 @@ class UnixCCompiler(CCompiler):
             dylib = os.path.join(dir, dylib_f)
             static = os.path.join(dir, static_f)
             xcode_stub = os.path.join(dir, xcode_stub_f)
+            implib = os.path.join(dir, implib_f)
 
             if sys.platform == 'darwin' and (
                 dir.startswith('/System/') or (
@@ -310,6 +313,7 @@ class UnixCCompiler(CCompiler):
                 dylib = os.path.join(sysroot, dir[1:], dylib_f)
                 static = os.path.join(sysroot, dir[1:], static_f)
                 xcode_stub = os.path.join(sysroot, dir[1:], xcode_stub_f)
+                implib = os.path.join(sysroot, dir[1:], implib_f)
 
             # We're second-guessing the linker here, with not much hard
             # data to go on: GCC seems to prefer the shared library, so I'm
@@ -319,6 +323,8 @@ class UnixCCompiler(CCompiler):
                 return dylib
             elif os.path.exists(xcode_stub):
                 return xcode_stub
+            elif os.path.exists(implib):
+                return implib
             elif os.path.exists(shared):
                 return shared
             elif os.path.exists(static):

--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -296,8 +296,6 @@ class UnixCCompiler(CCompiler):
             else:
                 sysroot = m.group(1)
 
-
-
         for dir in dirs:
             shared = os.path.join(dir, shared_f)
             dylib = os.path.join(dir, dylib_f)

--- a/Misc/NEWS.d/next/Library/2017-10-28-01-07-44.bpo-4032.RvZFlS.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-28-01-07-44.bpo-4032.RvZFlS.rst
@@ -1,0 +1,2 @@
+Add .dll.a to UnixCCompiler to allow the UnixCCompiler.find_library_file to
+correctly find DLL import libs on Cygwin. Patch by Masayuki Yamamoto.


### PR DESCRIPTION
Patch for [bpo-28459](https://bugs.python.org/issue28459), a long-standing issue on Cygwin especially for running some of the test suite since it uses `_pyio`.

This PR is based on top of #4153 which needs to be merged before this issue can be fixed, as the fix relies on ctypes, and the ctypes module can't be built without #4153.


<!-- issue-number: [bpo-28459](https://bugs.python.org/issue28459) -->
https://bugs.python.org/issue28459
<!-- /issue-number -->
