### PR TITLE
bpo-37247: Swap build_ext and build_py commands

### DIFF
--- a/Lib/distutils/command/build.py
+++ b/Lib/distutils/command/build.py
@@ -150,8 +150,8 @@ class build(Command):
         return self.distribution.has_scripts()
 
 
-    sub_commands = [('build_py',      has_pure_modules),
-                    ('build_clib',    has_c_libraries),
+    sub_commands = [('build_clib',    has_c_libraries),
                     ('build_ext',     has_ext_modules),
+                    ('build_py',      has_pure_modules),
                     ('build_scripts', has_scripts),
                    ]


### PR DESCRIPTION
Currently when building an extension which lists a SWIG interface (.i) file as a source file, SWIG creates the files correctly in the build_ext command. Unfortunately this command is run after the build_py command, so the python files (.py) created in the build_ext command are never copied to the installation.

Swapping the build_ext and build_py commands in the sub_commands attribute of the build command fixes this issue.

<!-- issue-number: [bpo-37247](https://bugs.python.org/issue37247) -->
https://bugs.python.org/issue37247
<!-- /issue-number -->
