### PR TITLE
bpo-37210: Fix pure Python pickle: proto 5 requires _pickle.PickleBuffer

### DIFF
--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -203,6 +203,13 @@ class PyChainDispatchTableTests(AbstractDispatchTableTests):
         return collections.ChainMap({}, pickle.dispatch_table)
 
 
+class PyPicklerHookTests(AbstractHookTests):
+    class CustomPyPicklerClass(pickle._Pickler,
+                               AbstractCustomPicklerClass):
+        pass
+    pickler_class = CustomPyPicklerClass
+
+
 if has_c_implementation:
     class CPickleTests(AbstractPickleModuleTests):
         from _pickle import dump, dumps, load, loads, Pickler, Unpickler
@@ -254,12 +261,6 @@ if has_c_implementation:
         pickler_class = pickle.Pickler
         def get_dispatch_table(self):
             return collections.ChainMap({}, pickle.dispatch_table)
-
-    class PyPicklerHookTests(AbstractHookTests):
-        class CustomPyPicklerClass(pickle._Pickler,
-                                   AbstractCustomPicklerClass):
-            pass
-        pickler_class = CustomPyPicklerClass
 
     class CPicklerHookTests(AbstractHookTests):
         class CustomCPicklerClass(_pickle.Pickler, AbstractCustomPicklerClass):

--- a/Misc/NEWS.d/next/Library/2019-06-12-16-10-50.bpo-37210.r4yMg6.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-12-16-10-50.bpo-37210.r4yMg6.rst
@@ -1,0 +1,3 @@
+Fix pure Python implementation of :mod:`pickle`: it failed with
+:exc:`ModuleNotFoundError` on importing ``_pickle.PickleBuffer``. If
+``_pickle.PickleBuffer`` is missing, disable ``PickleBuffer`` support.

--- a/Misc/NEWS.d/next/Library/2019-06-12-16-10-50.bpo-37210.r4yMg6.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-12-16-10-50.bpo-37210.r4yMg6.rst
@@ -1,3 +1,1 @@
-Fix pure Python implementation of :mod:`pickle`: it failed with
-:exc:`ModuleNotFoundError` on importing ``_pickle.PickleBuffer``. If
-``_pickle.PickleBuffer`` is missing, disable ``PickleBuffer`` support.
+Allow pure Python implementation of :mod:`pickle` to work even when the C :mod:`_pickle` module is unavailable.


### PR DESCRIPTION
Fix pure Python implementation of pickle: it failed with
ModuleNotFoundError on importing _pickle.PickleBuffer. If
_pickle.PickleBuffer is missing, change HIGHEST_PROTOCOL from 5 to 4
and disable PickleBuffer support.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37210](https://bugs.python.org/issue37210) -->
https://bugs.python.org/issue37210
<!-- /issue-number -->
