### PR TITLE
bpo-37252: Fix devpoll tests

### DIFF
--- a/Lib/test/test_devpoll.py
+++ b/Lib/test/test_devpoll.py
@@ -109,7 +109,7 @@ class DevPollTests(unittest.TestCase):
         # operations must fail with ValueError("I/O operation on closed ...")
         self.assertRaises(ValueError, devpoll.modify, fd, select.POLLIN)
         self.assertRaises(ValueError, devpoll.poll)
-        self.assertRaises(ValueError, devpoll.register, fd, fd, select.POLLIN)
+        self.assertRaises(ValueError, devpoll.register, fd, select.POLLIN)
         self.assertRaises(ValueError, devpoll.unregister, fd)
 
     def test_fd_non_inheritable(self):
@@ -122,9 +122,9 @@ class DevPollTests(unittest.TestCase):
         w, r = os.pipe()
         pollster.register(w)
         # Issue #17919
-        self.assertRaises(OverflowError, pollster.register, 0, -1)
+        self.assertRaises(ValueError, pollster.register, 0, -1)
         self.assertRaises(OverflowError, pollster.register, 0, 1 << 64)
-        self.assertRaises(OverflowError, pollster.modify, 1, -1)
+        self.assertRaises(ValueError, pollster.modify, 1, -1)
         self.assertRaises(OverflowError, pollster.modify, 1, 1 << 64)
 
     @cpython_only

--- a/Misc/NEWS.d/next/Tests/2019-06-12-14-30-29.bpo-37252.4o-uLs.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-12-14-30-29.bpo-37252.4o-uLs.rst
@@ -1,0 +1,2 @@
+Fix assertions in ``test_close`` and ``test_events_mask_overflow`` devpoll
+tests.


### PR DESCRIPTION
test_devpoll currently ends with two failures with Python 3.8 on Solaris.

First one is wrong number of arguments to devpoll.register function (which thrown the same error as expected in 3.7 but now acts differently).

Second one is that register and modify no longer throw OverflowError when negative number is given as second argument, but rather a ValueError. I am not sure whether this is just a small semantics change or some bigger problem (documentation doesn't mention what error should be thrown).

So I fixed it by changing the expected thrown error but there might be other problem as well.

<!-- issue-number: [bpo-37252](https://bugs.python.org/issue37252) -->
https://bugs.python.org/issue37252
<!-- /issue-number -->
