### PR TITLE
bpo-37253: Add _PyCompilerFlags_INIT macro

### DIFF
--- a/Include/compile.h
+++ b/Include/compile.h
@@ -30,6 +30,9 @@ typedef struct {
     int cf_flags;  /* bitmask of CO_xxx flags relevant to future */
     int cf_feature_version;  /* minor Python version (PyCF_ONLY_AST) */
 } PyCompilerFlags;
+
+#define _PyCompilerFlags_INIT \
+    (PyCompilerFlags){.cf_flags = 0, .cf_feature_version = PY_MINOR_VERSION}
 #endif
 
 /* Future feature support */

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -524,7 +524,7 @@ pymain_run_python(int *exitcode)
         }
     }
 
-    PyCompilerFlags cf = {.cf_flags = 0, .cf_feature_version = PY_MINOR_VERSION};
+    PyCompilerFlags cf = _PyCompilerFlags_INIT;
 
     pymain_header(config);
     pymain_import_readline(config);

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -336,8 +336,7 @@ parser_newstobject(node *st, int type)
     if (o != 0) {
         o->st_node = st;
         o->st_type = type;
-        o->st_flags.cf_flags = 0;
-        o->st_flags.cf_feature_version = PY_MINOR_VERSION;
+        o->st_flags = _PyCompilerFlags_INIT;
     }
     else {
         PyNode_Free(st);

--- a/Modules/symtablemodule.c
+++ b/Modules/symtablemodule.c
@@ -30,11 +30,10 @@ _symtable_symtable_impl(PyObject *module, PyObject *source,
     struct symtable *st;
     PyObject *t;
     int start;
-    PyCompilerFlags cf;
+    PyCompilerFlags cf = _PyCompilerFlags_INIT;
     PyObject *source_copy = NULL;
 
     cf.cf_flags = PyCF_SOURCE_IS_UTF8;
-    cf.cf_feature_version = PY_MINOR_VERSION;
 
     const char *str = _Py_SourceAsString(source, "symtable", "string or bytes", &cf, &source_copy);
     if (str == NULL) {

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4845,7 +4845,6 @@ fstring_compile_expr(const char *expr_start, const char *expr_end,
                      struct compiling *c, const node *n)
 
 {
-    PyCompilerFlags cf;
     node *mod_n;
     mod_ty mod;
     char *str;
@@ -4887,8 +4886,8 @@ fstring_compile_expr(const char *expr_start, const char *expr_end,
     str[len+1] = ')';
     str[len+2] = 0;
 
+    PyCompilerFlags cf = _PyCompilerFlags_INIT;
     cf.cf_flags = PyCF_ONLY_AST;
-    cf.cf_feature_version = PY_MINOR_VERSION;
     mod_n = PyParser_SimpleParseStringFlagsFilename(str, "<fstring>",
                                                     Py_eval_input, 0);
     if (!mod_n) {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -723,12 +723,11 @@ builtin_compile_impl(PyObject *module, PyObject *source, PyObject *filename,
     const char *str;
     int compile_mode = -1;
     int is_ast;
-    PyCompilerFlags cf;
     int start[] = {Py_file_input, Py_eval_input, Py_single_input, Py_func_type_input};
     PyObject *result;
 
+    PyCompilerFlags cf = _PyCompilerFlags_INIT;
     cf.cf_flags = flags | PyCF_SOURCE_IS_UTF8;
-    cf.cf_feature_version = PY_MINOR_VERSION;
     if (feature_version >= 0 && (flags & PyCF_ONLY_AST)) {
         cf.cf_feature_version = feature_version;
     }
@@ -889,7 +888,6 @@ builtin_eval_impl(PyObject *module, PyObject *source, PyObject *globals,
 {
     PyObject *result, *source_copy;
     const char *str;
-    PyCompilerFlags cf;
 
     if (locals != Py_None && !PyMapping_Check(locals)) {
         PyErr_SetString(PyExc_TypeError, "locals must be a mapping");
@@ -941,8 +939,8 @@ builtin_eval_impl(PyObject *module, PyObject *source, PyObject *globals,
         return PyEval_EvalCode(source, globals, locals);
     }
 
+    PyCompilerFlags cf = _PyCompilerFlags_INIT;
     cf.cf_flags = PyCF_SOURCE_IS_UTF8;
-    cf.cf_feature_version = PY_MINOR_VERSION;
     str = _Py_SourceAsString(source, "eval", "string, bytes or code", &cf, &source_copy);
     if (str == NULL)
         return NULL;
@@ -1032,9 +1030,8 @@ builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
     else {
         PyObject *source_copy;
         const char *str;
-        PyCompilerFlags cf;
+        PyCompilerFlags cf = _PyCompilerFlags_INIT;
         cf.cf_flags = PyCF_SOURCE_IS_UTF8;
-        cf.cf_feature_version = PY_MINOR_VERSION;
         str = _Py_SourceAsString(source, "exec",
                                        "string, bytes or code", &cf,
                                        &source_copy);

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -309,7 +309,7 @@ PyAST_CompileObject(mod_ty mod, PyObject *filename, PyCompilerFlags *flags,
 {
     struct compiler c;
     PyCodeObject *co = NULL;
-    PyCompilerFlags local_flags;
+    PyCompilerFlags local_flags = _PyCompilerFlags_INIT;
     int merged;
     PyConfig *config = &_PyInterpreterState_GET_UNSAFE()->config;
 
@@ -332,8 +332,6 @@ PyAST_CompileObject(mod_ty mod, PyObject *filename, PyCompilerFlags *flags,
     if (c.c_future == NULL)
         goto finally;
     if (!flags) {
-        local_flags.cf_flags = 0;
-        local_flags.cf_feature_version = PY_MINOR_VERSION;
         flags = &local_flags;
     }
     merged = c.c_future->ff_features | flags->cf_flags;

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -91,7 +91,7 @@ PyRun_InteractiveLoopFlags(FILE *fp, const char *filename_str, PyCompilerFlags *
 {
     PyObject *filename, *v;
     int ret, err;
-    PyCompilerFlags local_flags;
+    PyCompilerFlags local_flags = _PyCompilerFlags_INIT;
     int nomem_count = 0;
 #ifdef Py_REF_DEBUG
     int show_ref_count = _PyInterpreterState_Get()->config.show_ref_count;
@@ -105,8 +105,6 @@ PyRun_InteractiveLoopFlags(FILE *fp, const char *filename_str, PyCompilerFlags *
 
     if (flags == NULL) {
         flags = &local_flags;
-        local_flags.cf_flags = 0;
-        local_flags.cf_feature_version = PY_MINOR_VERSION;
     }
     v = _PySys_GetObjectId(&PyId_ps1);
     if (v == NULL) {
@@ -1283,10 +1281,7 @@ _Py_SourceAsString(PyObject *cmd, const char *funcname, const char *what, PyComp
 struct symtable *
 Py_SymtableStringObject(const char *str, PyObject *filename, int start)
 {
-    PyCompilerFlags flags;
-
-    flags.cf_flags = 0;
-    flags.cf_feature_version = PY_MINOR_VERSION;
+    PyCompilerFlags flags = _PyCompilerFlags_INIT;
     return _Py_SymtableStringObjectFlags(str, filename, start, &flags);
 }
 
@@ -1331,7 +1326,7 @@ PyParser_ASTFromStringObject(const char *s, PyObject *filename, int start,
                              PyCompilerFlags *flags, PyArena *arena)
 {
     mod_ty mod;
-    PyCompilerFlags localflags;
+    PyCompilerFlags localflags = _PyCompilerFlags_INIT;
     perrdetail err;
     int iflags = PARSER_FLAGS(flags);
     if (flags && flags->cf_feature_version < 7)
@@ -1341,8 +1336,6 @@ PyParser_ASTFromStringObject(const char *s, PyObject *filename, int start,
                                          &_PyParser_Grammar, start, &err,
                                          &iflags);
     if (flags == NULL) {
-        localflags.cf_flags = 0;
-        localflags.cf_feature_version = PY_MINOR_VERSION;
         flags = &localflags;
     }
     if (n) {
@@ -1379,7 +1372,7 @@ PyParser_ASTFromFileObject(FILE *fp, PyObject *filename, const char* enc,
                            PyArena *arena)
 {
     mod_ty mod;
-    PyCompilerFlags localflags;
+    PyCompilerFlags localflags = _PyCompilerFlags_INIT;
     perrdetail err;
     int iflags = PARSER_FLAGS(flags);
 
@@ -1387,8 +1380,6 @@ PyParser_ASTFromFileObject(FILE *fp, PyObject *filename, const char* enc,
                                        &_PyParser_Grammar,
                                        start, ps1, ps2, &err, &iflags);
     if (flags == NULL) {
-        localflags.cf_flags = 0;
-        localflags.cf_feature_version = PY_MINOR_VERSION;
         flags = &localflags;
     }
     if (n) {


### PR DESCRIPTION
Add a new _PyCompilerFlags_INIT macro to initialize PyCompilerFlags
variables, rather than initializing cf_flags and cf_feature_version
explicitly in each variable.

<!-- issue-number: [bpo-37253](https://bugs.python.org/issue37253) -->
https://bugs.python.org/issue37253
<!-- /issue-number -->
