### PR TITLE
bpo-37253: Remove PyAST_obj2mod_ex() function

### DIFF
--- a/Include/Python-ast.h
+++ b/Include/Python-ast.h
@@ -707,7 +707,6 @@ type_ignore_ty _Py_TypeIgnore(int lineno, string tag, PyArena *arena);
 
 PyObject* PyAST_mod2obj(mod_ty t);
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode);
-mod_ty PyAST_obj2mod_ex(PyObject* ast, PyArena* arena, int mode, int feature_version);
 int PyAST_Check(PyObject* obj);
 
 #ifdef __cplusplus

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1191,11 +1191,6 @@ PyObject* PyAST_mod2obj(mod_ty t)
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
-    return PyAST_obj2mod_ex(ast, arena, mode, PY_MINOR_VERSION);
-}
-
-mod_ty PyAST_obj2mod_ex(PyObject* ast, PyArena* arena, int mode, int feature_version)
-{
     mod_ty res;
     PyObject *req_type[3];
     char *req_name[] = {"Module", "Expression", "Interactive"};
@@ -1280,7 +1275,6 @@ def main(srcfile, dump_module=False):
             f.write("\n")
             f.write("PyObject* PyAST_mod2obj(mod_ty t);\n")
             f.write("mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode);\n")
-            f.write("mod_ty PyAST_obj2mod_ex(PyObject* ast, PyArena* arena, int mode, int feature_version);\n")
             f.write("int PyAST_Check(PyObject* obj);\n")
             f.write('\n')
             f.write('#ifdef __cplusplus\n')

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -8991,11 +8991,6 @@ PyObject* PyAST_mod2obj(mod_ty t)
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
-    return PyAST_obj2mod_ex(ast, arena, mode, PY_MINOR_VERSION);
-}
-
-mod_ty PyAST_obj2mod_ex(PyObject* ast, PyArena* arena, int mode, int feature_version)
-{
     mod_ty res;
     PyObject *req_type[3];
     char *req_name[] = {"Module", "Expression", "Interactive"};


### PR DESCRIPTION
PyAST_obj2mod_ex() is similar to PyAST_obj2mod() with an additional
'feature_version' parameter which is unused.

<!-- issue-number: [bpo-37253](https://bugs.python.org/issue37253) -->
https://bugs.python.org/issue37253
<!-- /issue-number -->
