### PR TITLE
bpo-37130: Path('..').name now returns ''

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -381,6 +381,12 @@ Pure paths provide the following methods and properties:
       >>> PureWindowsPath('//some/share').name
       ''
 
+   Trailing dots are not considered as filenames::
+
+      >>> PurePosixPath('..').name
+      ''
+
+
 
 .. data:: PurePath.suffix
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -381,11 +381,10 @@ Pure paths provide the following methods and properties:
       >>> PureWindowsPath('//some/share').name
       ''
 
-   Trailing dots are not considered as filenames::
+   Special directories ``'.'`` and ``'..'`` are considered to be unnamed::
 
       >>> PurePosixPath('..').name
       ''
-
 
 
 .. data:: PurePath.suffix

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -789,7 +789,8 @@ class PurePath(object):
     def name(self):
         """The final path component, if any."""
         parts = self._parts
-        if len(parts) == (1 if (self._drv or self._root) else 0):
+        if (len(parts) == (1 if (self._drv or self._root) else 0)
+            or parts[-1] == '..'):
             return ''
         return parts[-1]
 
@@ -816,11 +817,16 @@ class PurePath(object):
     def stem(self):
         """The final path component, minus its last suffix."""
         name = self.name
-        i = name.rfind('.')
-        if 0 < i < len(name) - 1:
-            return name[:i]
-        else:
-            return name
+        if name:
+            i = name.rfind('.')
+            if 0 < i < len(name) - 1:
+                return name[:i]
+            else:
+                return name
+        elif self._parts:
+            if self._parts[-1] == '..':
+                return '..'
+        return ''
 
     def with_name(self, name):
         """Return a new path with the file name changed."""

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -483,6 +483,7 @@ class _BasePurePathTest(object):
         P = self.cls
         self.assertEqual(P('').name, '')
         self.assertEqual(P('.').name, '')
+        self.assertEqual(P('..').name, '')
         self.assertEqual(P('/').name, '')
         self.assertEqual(P('a/b').name, 'b')
         self.assertEqual(P('/a/b').name, 'b')
@@ -514,6 +515,7 @@ class _BasePurePathTest(object):
         P = self.cls
         self.assertEqual(P('').suffixes, [])
         self.assertEqual(P('.').suffixes, [])
+        self.assertEqual(P('..').suffixes, [])
         self.assertEqual(P('/').suffixes, [])
         self.assertEqual(P('a/b').suffixes, [])
         self.assertEqual(P('/a/b').suffixes, [])
@@ -553,6 +555,7 @@ class _BasePurePathTest(object):
         self.assertEqual(P('/a/Dot ending.').with_name('d.xml'), P('/a/d.xml'))
         self.assertRaises(ValueError, P('').with_name, 'd.xml')
         self.assertRaises(ValueError, P('.').with_name, 'd.xml')
+        self.assertRaises(ValueError, P('..').with_name, 'd.xml')
         self.assertRaises(ValueError, P('/').with_name, 'd.xml')
         self.assertRaises(ValueError, P('a/b').with_name, '')
         self.assertRaises(ValueError, P('a/b').with_name, '/c')
@@ -571,6 +574,7 @@ class _BasePurePathTest(object):
         # Path doesn't have a "filename" component.
         self.assertRaises(ValueError, P('').with_suffix, '.gz')
         self.assertRaises(ValueError, P('.').with_suffix, '.gz')
+        self.assertRaises(ValueError, P('..').with_suffix, '.gz')
         self.assertRaises(ValueError, P('/').with_suffix, '.gz')
         # Invalid suffix.
         self.assertRaises(ValueError, P('a/b').with_suffix, 'gz')
@@ -989,6 +993,7 @@ class PureWindowsPathTest(_BasePurePathTest, unittest.TestCase):
         # Path doesn't have a "filename" component.
         self.assertRaises(ValueError, P('').with_suffix, '.gz')
         self.assertRaises(ValueError, P('.').with_suffix, '.gz')
+        self.assertRaises(ValueError, P('..').with_suffix, '.gz')
         self.assertRaises(ValueError, P('/').with_suffix, '.gz')
         self.assertRaises(ValueError, P('//My/Share').with_suffix, '.gz')
         # Invalid suffix.


### PR DESCRIPTION
To be consistent with the behavior of Path('.').name that returns an
empty string, the name property will check for the case of '..' dir.
Consequently .with_suffix() and .with_name() will raise 'has an empty name'
exception.
The .stem property test already handling it,  '..' becomes a hard-coded
special case.

- updated documentation of .name
- added '..' case in .name()
- added '..' cases in related tests
- added special case for .stem()

<!-- issue-number: [bpo-37130](https://bugs.python.org/issue37130) -->
https://bugs.python.org/issue37130
<!-- /issue-number -->
