### PR TITLE
Make asyncio stream sendfile fail on error (was hung)

### DIFF
--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -1656,22 +1656,25 @@ os.close(fd)
 
         async def serve_callback(stream):
             data = await stream.readline()
-            self.assertEqual(data, b'begin\n')
+            await stream.write(b'ack-' + data)
             data = await stream.readline()
-            self.assertEqual(data, b'data\n')
+            await stream.write(b'ack-' + data)
             data = await stream.readline()
-            self.assertEqual(data, b'end\n')
-            await stream.write(b'done\n')
+            await stream.write(b'ack-' + data)
             await stream.close()
 
         async def do_connect(host, port):
             stream = await asyncio.connect(host, port)
             await stream.write(b'begin\n')
+            data = await stream.readline()
+            self.assertEqual(b'ack-begin\n', data)
             with open(support.TESTFN, 'rb') as fp:
                 await stream.sendfile(fp)
+            data = await stream.readline()
+            self.assertEqual(b'ack-data\n', data)
             await stream.write(b'end\n')
             data = await stream.readline()
-            self.assertEqual(data, b'done\n')
+            self.assertEqual(data, b'ack-end\n')
             await stream.close()
 
         async def test():


### PR DESCRIPTION
@aixtools it should convert hang on AIX into a failure.
Fixing the failure is another task

A note about the change:
before assertion in stream server callback (`serve_callback()`) stopped the callback itself but was not propagated to test itself. 
The test was hanging as a result.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
