### PR TITLE
bpo-37198: Fix bug in locale

### DIFF
--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -490,6 +490,8 @@ def _parse_localename(localename):
 
     if '.' in code:
         return tuple(code.split('.')[:2])
+    if '_' in code:
+        return code, None
     elif code == 'C':
         return None, None
     raise ValueError('unknown locale: %s' % localename)


### PR DESCRIPTION
[bpo-37198](https://bugs.python.org/issue37198): Fix bug in locale - if locale doesn't have encoding associated with it the parsing fails.

<!-- issue-number: [bpo-37198](https://bugs.python.org/issue37198) -->
https://bugs.python.org/issue37198
<!-- /issue-number -->
