### PR TITLE
bpo-37223: Second call to BufferedWrite.close() does nothing

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-06-12-22-56-49.bpo-37223.ILECyA.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-12-22-56-49.bpo-37223.ILECyA.rst
@@ -1,0 +1,5 @@
+When :meth:`io.BufferedReader.close` or :meth:`io.BufferedWrite.close` is
+called twice, the second call now does nothing. Previously, the ``flush()``
+method and ``raw.close()`` were called at the second call. Moreover, even if
+``close()`` raises an exception, the file is now considered as closed (even if
+the raw file is not considered as closed).

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -482,7 +482,11 @@ static PyObject *
 buffered_closed_get(buffered *self, void *context)
 {
     CHECK_INITIALIZED(self)
-    return PyObject_GetAttr(self->raw, _PyIO_str_closed);
+    int closed = IS_CLOSED(self);
+    if (closed < 0) {
+        return NULL;
+    }
+    return PyBool_FromLong(closed);
 }
 
 static PyObject *
@@ -495,7 +499,7 @@ buffered_close(buffered *self, PyObject *args)
     if (!ENTER_BUFFERED(self))
         return NULL;
 
-    r = buffered_closed(self);
+    r = IS_CLOSED(self);
     if (r < 0)
         goto end;
     if (r > 0) {


### PR DESCRIPTION
When io.BufferedWrite.close() is called twice, the second call now
does nothing. Previously, the flush() method and raw.close() were
called at the second call.

Moreover, even if close() raises an exception, the file is now
considered as closed.

<!-- issue-number: [bpo-37223](https://bugs.python.org/issue37223) -->
https://bugs.python.org/issue37223
<!-- /issue-number -->
