### PR TITLE
bpo-37223, test_io: silence last 'Exception ignored in:'

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2070,6 +2070,11 @@ class BufferedRWPairTest(unittest.TestCase):
 
         # Silence destructor error
         writer.close = lambda: None
+        writer = None
+
+        with support.catch_unraisable_exception():
+            pair = None
+            support.gc_collect()
 
     def test_reader_writer_close_error_on_close(self):
         def reader_close():


### PR DESCRIPTION
Use catch_unraisable_exception() to ignore 'Exception ignored in:'
error when the internal BufferedWriter of the BufferedRWPair is
destroyed. The C implementation doesn't give access to the
BufferedWriter, so just ignore the warning instead.

<!-- issue-number: [bpo-37223](https://bugs.python.org/issue37223) -->
https://bugs.python.org/issue37223
<!-- /issue-number -->
