### PR TITLE
bpo-37253: Fix typo in PyCompilerFlags doc

### DIFF
--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -394,7 +394,7 @@ the same library that the Python runtime is using.
 
       Compiler flags.
 
-   .. c:member:: int cf_feature_version;
+   .. c:member:: int cf_feature_version
 
       *cf_feature_version* is the minor Python version. It should be
       initialized to ``PY_MINOR_VERSION``.


### PR DESCRIPTION
Remove ";" to fix Sphinx formatting.


<!-- issue-number: [bpo-37253](https://bugs.python.org/issue37253) -->
https://bugs.python.org/issue37253
<!-- /issue-number -->
