### PR TITLE
[3.8] bpo-37253: Document PyCompilerFlags.cf_feature_version (GH-14019)

### DIFF
--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -388,11 +388,22 @@ the same library that the Python runtime is using.
 
    Whenever ``PyCompilerFlags *flags`` is *NULL*, :attr:`cf_flags` is treated as
    equal to ``0``, and any modification due to ``from __future__ import`` is
-   discarded.  ::
+   discarded.
 
-      struct PyCompilerFlags {
-          int cf_flags;
-      }
+   .. c:member:: int cf_flags
+
+      Compiler flags.
+
+   .. c:member:: int cf_feature_version;
+
+      *cf_feature_version* is the minor Python version. It should be
+      initialized to ``PY_MINOR_VERSION``.
+
+      The field is ignored by default, it is used if and only if
+      ``PyCF_ONLY_AST`` flag is set in *cf_flags*.
+
+   .. versionchanged:: 3.8
+      Added *cf_feature_version* field.
 
 
 .. c:var:: int CO_FUTURE_DIVISION

--- a/Doc/c-api/veryhigh.rst
+++ b/Doc/c-api/veryhigh.rst
@@ -394,7 +394,7 @@ the same library that the Python runtime is using.
 
       Compiler flags.
 
-   .. c:member:: int cf_feature_version;
+   .. c:member:: int cf_feature_version
 
       *cf_feature_version* is the minor Python version. It should be
       initialized to ``PY_MINOR_VERSION``.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1293,6 +1293,11 @@ Changes in the Python API
 Changes in the C API
 --------------------
 
+* The :c:type:`PyCompilerFlags` structure gets a new *cf_feature_version*
+  field. It should be initialized to ``PY_MINOR_VERSION``. The field is ignored
+  by default, it is used if and only if ``PyCF_ONLY_AST`` flag is set in
+  *cf_flags*.
+
 * The :c:func:`PyEval_ReInitThreads` function has been removed from the C API.
   It should not be called explicitly: use :c:func:`PyOS_AfterFork_Child`
   instead.


### PR DESCRIPTION


<!-- issue-number: [bpo-37253](https://bugs.python.org/issue37253) -->
https://bugs.python.org/issue37253
<!-- /issue-number -->
