### PR TITLE
bpo-36689: os.path.commonpath raises ValueError for different drives isn't documented

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -87,9 +87,9 @@ the :mod:`glob` module.)
 .. function:: commonpath(paths)
 
    Return the longest common sub-path of each pathname in the sequence
-   *paths*. Raise :exc:`ValueError` if *paths* contain both absolute 
-   and relative pathnames, the *paths* are on the different drives, or 
-   if *paths* is empty. Unlike :func:`commonprefix`, this returns a 
+   *paths*.  Raise :exc:`ValueError` if *paths* contain both absolute
+   and relative pathnames, the *paths* are on the different drives or
+   if *paths* is empty.  Unlike :func:`commonprefix`, this returns a
    valid path.
 
    .. availability:: Unix, Windows.

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -87,9 +87,10 @@ the :mod:`glob` module.)
 .. function:: commonpath(paths)
 
    Return the longest common sub-path of each pathname in the sequence
-   *paths*.  Raise :exc:`ValueError` if *paths* contains both absolute and relative
-   pathnames, or if *paths* is empty.  Unlike :func:`commonprefix`, this
-   returns a valid path.
+   *paths*. Raise :exc:`ValueError` if *paths* contain both absolute 
+   and relative pathnames, the path are on the different drives, or 
+   if *paths* is empty. Unlike :func:`commonprefix`, this returns a 
+   valid path.
 
    .. availability:: Unix, Windows.
 

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -88,7 +88,7 @@ the :mod:`glob` module.)
 
    Return the longest common sub-path of each pathname in the sequence
    *paths*. Raise :exc:`ValueError` if *paths* contain both absolute 
-   and relative pathnames, the path are on the different drives, or 
+   and relative pathnames, the *paths* are on the different drives, or 
    if *paths* is empty. Unlike :func:`commonprefix`, this returns a 
    valid path.
 


### PR DESCRIPTION
It would raise ValueError("Paths don't have the same drive") if the paths on different drivers, which is not documented.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
os.path.commonpath raises ValueError when the *paths* are in different drivers, but it is not documented.
Update the document according @Windsooon 's suggestion.
It actually raise ValueError according line 355 of [test of path](https://github.com/python/cpython/blob/master/Lib/test/test_ntpath.py) 

<!-- issue-number: [bpo-6689](https://bugs.python.org/issue6689) -->
https://bugs.python.org/issue36689
<!-- /issue-number -->
