### PR TITLE
tbpo-36402: Fix threading.Thread._stop()

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -965,7 +965,7 @@ class Thread:
         self._tstate_lock = None
         if not self.daemon:
             with _shutdown_locks_lock:
-                _shutdown_locks.discard(self._tstate_lock)
+                _shutdown_locks.discard(lock)
 
     def _delete(self):
         "Remove current thread from the dict of currently running threads."


### PR DESCRIPTION
Remove the _tstate_lock frm _shutdown_locks, don't remove None.

<!-- issue-number: [bpo-36402](https://bugs.python.org/issue36402) -->
https://bugs.python.org/issue36402
<!-- /issue-number -->
