### PR TITLE
bpo-37266: Daemon threads are now denied in subinterpreters

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -272,6 +272,8 @@ since it is impossible to detect the termination of alien threads.
    base class constructor (``Thread.__init__()``) before doing anything else to
    the thread.
 
+   Daemon threads must not be used in subinterpreters.
+
    .. versionchanged:: 3.3
       Added the *daemon* argument.
 
@@ -285,6 +287,12 @@ since it is impossible to detect the termination of alien threads.
 
       This method will raise a :exc:`RuntimeError` if called more than once
       on the same thread object.
+
+      Raise a :exc:`RuntimeError` if the thread is a daemon thread and the
+      method is called from a subinterpreter.
+
+      .. versionchanged:: 3.9
+         In a subinterpreter, spawning a daemon thread now raises an exception.
 
    .. method:: run()
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -86,6 +86,14 @@ New Modules
 Improved Modules
 ================
 
+threading
+---------
+
+In a subinterpreter, spawning a daemon thread now raises an exception. Daemon
+threads were never supported in subinterpreters. Previously, the subinterpreter
+finalization crashed with a Pyton fatal error if a daemon thread was still
+running.
+
 
 Optimizations
 =============

--- a/Lib/_dummy_thread.py
+++ b/Lib/_dummy_thread.py
@@ -161,3 +161,7 @@ def interrupt_main():
     else:
         global _interrupt
         _interrupt = True
+
+
+def _is_main_interpreter():
+    return True

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -958,6 +958,7 @@ class SubinterpThreadingTests(BaseTestCase):
         ret = test.support.run_in_subinterp(code)
         self.assertEqual(ret, 0)
         # The thread was joined properly.
+        os.set_blocking(r, False)
         self.assertEqual(os.read(r, 1), b"x")
 
     def test_threads_join_2(self):
@@ -997,6 +998,7 @@ class SubinterpThreadingTests(BaseTestCase):
         ret = test.support.run_in_subinterp(code)
         self.assertEqual(ret, 0)
         # The thread was joined properly.
+        os.set_blocking(r, False)
         self.assertEqual(os.read(r, 1), b"x")
 
     def test_daemon_thread(self):
@@ -1016,12 +1018,15 @@ class SubinterpThreadingTests(BaseTestCase):
             try:
                 thread.start()
             except RuntimeError as exc:
-                print("ok: %s" % exc, file=channel)
+                print("ok: %s" % exc, file=channel, flush=True)
             else:
                 thread.join()
-                print("fail: RuntimeError not raised", file=channel)
+                print("fail: RuntimeError not raised", file=channel, flush=True)
         """)
         ret = test.support.run_in_subinterp(code)
+        self.assertEqual(ret, 0)
+
+        os.set_blocking(r, False)
         msg = os.read(r, 100).decode().rstrip()
         self.assertEqual("ok: daemon thread are not supported "
                          "in subinterpreters", msg)

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -34,6 +34,7 @@ _start_new_thread = _thread.start_new_thread
 _allocate_lock = _thread.allocate_lock
 _set_sentinel = _thread._set_sentinel
 get_ident = _thread.get_ident
+_is_main_interpreter = _thread._is_main_interpreter
 try:
     get_native_id = _thread.get_native_id
     _HAVE_THREAD_NATIVE_ID = True
@@ -846,6 +847,11 @@ class Thread:
 
         if self._started.is_set():
             raise RuntimeError("threads can only be started once")
+
+        if self.daemon and not _is_main_interpreter():
+            raise RuntimeError("daemon thread are not supported "
+                               "in subinterpreters")
+
         with _active_limbo_lock:
             _limbo[self] = self
         try:

--- a/Misc/NEWS.d/next/Library/2019-06-13-11-59-52.bpo-37266.goLjef.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-13-11-59-52.bpo-37266.goLjef.rst
@@ -1,0 +1,4 @@
+In a subinterpreter, spawning a daemon thread now raises an exception. Daemon
+threads were never supported in subinterpreters. Previously, the subinterpreter
+finalization crashed with a Pyton fatal error if a daemon thread was still
+running.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -8,6 +8,14 @@
 #include "structmember.h" /* offsetof */
 #include "pythread.h"
 
+#include "clinic/_threadmodule.c.h"
+
+/*[clinic input]
+module _thread
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=be8dbe5cc4b16df7]*/
+
+
 static PyObject *ThreadError;
 static PyObject *str_dict;
 
@@ -1442,6 +1450,21 @@ PyDoc_STRVAR(excepthook_doc,
 \n\
 Handle uncaught Thread.run() exception.");
 
+/*[clinic input]
+_thread._is_main_interpreter
+
+Return True if the current interpreter is the main Python interpreter.
+[clinic start generated code]*/
+
+static PyObject *
+_thread__is_main_interpreter_impl(PyObject *module)
+/*[clinic end generated code: output=7dd82e1728339adc input=cc1eb00fd4598915]*/
+{
+    _PyRuntimeState *runtime = &_PyRuntime;
+    PyInterpreterState *interp = _PyRuntimeState_GetThreadState(runtime)->interp;
+    return PyBool_FromLong(interp == runtime->interpreters.main);
+}
+
 static PyMethodDef thread_methods[] = {
     {"start_new_thread",        (PyCFunction)thread_PyThread_start_new_thread,
      METH_VARARGS, start_new_doc},
@@ -1471,6 +1494,7 @@ static PyMethodDef thread_methods[] = {
      METH_NOARGS, _set_sentinel_doc},
     {"_excepthook",              thread_excepthook,
      METH_O, excepthook_doc},
+    _THREAD__IS_MAIN_INTERPRETER_METHODDEF
     {NULL,                      NULL}           /* sentinel */
 };
 

--- a/Modules/clinic/_threadmodule.c.h
+++ b/Modules/clinic/_threadmodule.c.h
@@ -1,0 +1,22 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(_thread__is_main_interpreter__doc__,
+"_is_main_interpreter($module, /)\n"
+"--\n"
+"\n"
+"Return True if the current interpreter is the main Python interpreter.");
+
+#define _THREAD__IS_MAIN_INTERPRETER_METHODDEF    \
+    {"_is_main_interpreter", (PyCFunction)_thread__is_main_interpreter, METH_NOARGS, _thread__is_main_interpreter__doc__},
+
+static PyObject *
+_thread__is_main_interpreter_impl(PyObject *module);
+
+static PyObject *
+_thread__is_main_interpreter(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _thread__is_main_interpreter_impl(module);
+}
+/*[clinic end generated code: output=505840d1b9101789 input=a9049054013a1b77]*/


### PR DESCRIPTION
In a subinterpreter, spawning a daemon thread now raises an
exception. Daemon threads were never supported in subinterpreters.
Previously, the subinterpreter finalization crashed with a Pyton
fatal error if a daemon thread was still running.

* Add _thread._is_main_interpreter()
* threading.Thread.start() now raises RuntimeError if the thread is a
  daemon thread and the method is called from a subinterpreter.
* The _thread module now uses Argument Clinic the new function.
* Use textwrap.dedent() in test_threading.SubinterpThreadingTests

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37266](https://bugs.python.org/issue37266) -->
https://bugs.python.org/issue37266
<!-- /issue-number -->
