### PR TITLE
gh-81451: Manage memory lifetime for all type-related objects.

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -128,6 +128,9 @@ The following functions and structs are used to create
 
    This function calls :c:func:`PyType_Ready` on the new type.
 
+   Until Python 3.9, the memory backing the ``Py_tp_methods``, ``Py_tp_getset``,
+   and :c:member:`PyType_Spec.name` must outlive the returned type.
+
    .. versionadded:: 3.3
 
 .. c:function:: PyObject* PyType_FromSpec(PyType_Spec *spec)

--- a/Include/bltinmodule.h
+++ b/Include/bltinmodule.h
@@ -8,6 +8,10 @@ PyAPI_DATA(PyTypeObject) PyFilter_Type;
 PyAPI_DATA(PyTypeObject) PyMap_Type;
 PyAPI_DATA(PyTypeObject) PyZip_Type;
 
+#ifdef Py_BUILD_CORE
+PyObject* _PyBuiltin_Print(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -282,12 +282,20 @@ typedef struct _heaptypeobject {
     PyBufferProcs as_buffer;
     PyObject *ht_name, *ht_slots, *ht_qualname;
     struct _dictkeysobject *ht_cached_keys;
-    /* here are optional user slots, followed by the members. */
+    /* here are optional user slots, followed by the offsets of the object members. */
 } PyHeapTypeObject;
 
-/* access macro to the members which are floating "behind" the object */
-#define PyHeapType_GET_MEMBERS(etype) \
-    ((PyMemberDef *)(((char *)etype) + Py_TYPE(etype)->tp_basicsize))
+#ifdef Py_BUILD_CORE
+typedef struct {
+    Py_ssize_t offset;
+    int flags;
+} _PyObject_MemberSlot;
+
+/* access macro to the offsets of the object type members which are floating
+   "behind" the object */
+#define _PyHeapType_GET_OBJECT_MEMBER_OFFSETS(etype)                     \
+    ((_PyObject_MemberSlot *)(((char *)etype) + Py_TYPE(etype)->tp_basicsize))
+#endif
 
 PyAPI_FUNC(const char *) _PyType_Name(PyTypeObject *);
 PyAPI_FUNC(PyObject *) _PyType_Lookup(PyTypeObject *, PyObject *);

--- a/Include/descrobject.h
+++ b/Include/descrobject.h
@@ -52,18 +52,24 @@ typedef struct {
 
 typedef struct {
     PyDescr_COMMON;
-    PyMethodDef *d_method;
+    PyCFunctionBase d_base;
     vectorcallfunc vectorcall;
 } PyMethodDescrObject;
 
 typedef struct {
     PyDescr_COMMON;
-    struct PyMemberDef *d_member;
+    int d_member_type;
+    Py_ssize_t d_offset;
+    int d_flags;
+    PyObject *d_doc;
 } PyMemberDescrObject;
 
 typedef struct {
     PyDescr_COMMON;
-    PyGetSetDef *d_getset;
+    getter d_get;
+    setter d_set;
+    PyObject *d_doc;
+    void *d_closure;
 } PyGetSetDescrObject;
 
 typedef struct {

--- a/Include/structmember.h
+++ b/Include/structmember.h
@@ -67,6 +67,11 @@ typedef struct PyMemberDef {
 PyAPI_FUNC(PyObject *) PyMember_GetOne(const char *, struct PyMemberDef *);
 PyAPI_FUNC(int) PyMember_SetOne(char *, struct PyMemberDef *, PyObject *);
 
+#ifdef Py_BUILD_CORE
+PyAPI_FUNC(PyObject *) _PyMemberDescr_GetOne(const char *, PyMemberDescrObject *);
+PyAPI_FUNC(int) _PyMemberDescr_SetOne(char *, PyMemberDescrObject *, PyObject *);
+#endif
+
 
 #ifdef __cplusplus
 }

--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -86,39 +86,39 @@ _ProfileOutput['print_stats'] = """\
         8    0.312    0.039    0.400    0.050 profilee.py:88(helper2)
         8    0.064    0.008    0.080    0.010 profilee.py:98(subhelper)"""
 _ProfileOutput['print_callers'] = """\
-profilee.py:110(__getattr__)                      <-      16    0.016    0.016  profilee.py:98(subhelper)
-profilee.py:25(testfunc)                          <-       1    0.270    1.000  <string>:1(<module>)
-profilee.py:35(factorial)                         <-       1    0.014    0.130  profilee.py:25(testfunc)
-                                                        20/3    0.130    0.147  profilee.py:35(factorial)
-                                                           2    0.006    0.040  profilee.py:84(helper2_indirect)
-profilee.py:48(mul)                               <-      20    0.020    0.020  profilee.py:35(factorial)
-profilee.py:55(helper)                            <-       2    0.040    0.600  profilee.py:25(testfunc)
-profilee.py:73(helper1)                           <-       4    0.116    0.120  profilee.py:55(helper)
-profilee.py:84(helper2_indirect)                  <-       2    0.000    0.140  profilee.py:55(helper)
-profilee.py:88(helper2)                           <-       6    0.234    0.300  profilee.py:55(helper)
-                                                           2    0.078    0.100  profilee.py:84(helper2_indirect)
-profilee.py:98(subhelper)                         <-       8    0.064    0.080  profilee.py:88(helper2)
-{built-in method builtins.hasattr}                <-       4    0.000    0.004  profilee.py:73(helper1)
-                                                           8    0.000    0.008  profilee.py:88(helper2)
-{built-in method sys.exc_info}                    <-       4    0.000    0.000  profilee.py:73(helper1)
-{method 'append' of 'list' objects}               <-       4    0.000    0.000  profilee.py:73(helper1)"""
+profilee.py:110(__getattr__)         <-      16    0.016    0.016  profilee.py:98(subhelper)
+profilee.py:25(testfunc)             <-       1    0.270    1.000  <string>:1(<module>)
+profilee.py:35(factorial)            <-       1    0.014    0.130  profilee.py:25(testfunc)
+                                           20/3    0.130    0.147  profilee.py:35(factorial)
+                                              2    0.006    0.040  profilee.py:84(helper2_indirect)
+profilee.py:48(mul)                  <-      20    0.020    0.020  profilee.py:35(factorial)
+profilee.py:55(helper)               <-       2    0.040    0.600  profilee.py:25(testfunc)
+profilee.py:73(helper1)              <-       4    0.116    0.120  profilee.py:55(helper)
+profilee.py:84(helper2_indirect)     <-       2    0.000    0.140  profilee.py:55(helper)
+profilee.py:88(helper2)              <-       6    0.234    0.300  profilee.py:55(helper)
+                                              2    0.078    0.100  profilee.py:84(helper2_indirect)
+profilee.py:98(subhelper)            <-       8    0.064    0.080  profilee.py:88(helper2)
+{built-in method builtins.hasattr}   <-       4    0.000    0.004  profilee.py:73(helper1)
+                                              8    0.000    0.008  profilee.py:88(helper2)
+{built-in method sys.exc_info}       <-       4    0.000    0.000  profilee.py:73(helper1)
+{method 'append' of 'list' objects}  <-       4    0.000    0.000  profilee.py:73(helper1)"""
 _ProfileOutput['print_callees'] = """\
-<string>:1(<module>)                              ->       1    0.270    1.000  profilee.py:25(testfunc)
-profilee.py:110(__getattr__)                      ->
-profilee.py:25(testfunc)                          ->       1    0.014    0.130  profilee.py:35(factorial)
-                                                           2    0.040    0.600  profilee.py:55(helper)
-profilee.py:35(factorial)                         ->    20/3    0.130    0.147  profilee.py:35(factorial)
-                                                          20    0.020    0.020  profilee.py:48(mul)
-profilee.py:48(mul)                               ->
-profilee.py:55(helper)                            ->       4    0.116    0.120  profilee.py:73(helper1)
-                                                           2    0.000    0.140  profilee.py:84(helper2_indirect)
-                                                           6    0.234    0.300  profilee.py:88(helper2)
-profilee.py:73(helper1)                           ->       4    0.000    0.004  {built-in method builtins.hasattr}
-profilee.py:84(helper2_indirect)                  ->       2    0.006    0.040  profilee.py:35(factorial)
-                                                           2    0.078    0.100  profilee.py:88(helper2)
-profilee.py:88(helper2)                           ->       8    0.064    0.080  profilee.py:98(subhelper)
-profilee.py:98(subhelper)                         ->      16    0.016    0.016  profilee.py:110(__getattr__)
-{built-in method builtins.hasattr}                ->      12    0.012    0.012  profilee.py:110(__getattr__)"""
+<string>:1(<module>)                 ->       1    0.270    1.000  profilee.py:25(testfunc)
+profilee.py:110(__getattr__)         ->
+profilee.py:25(testfunc)             ->       1    0.014    0.130  profilee.py:35(factorial)
+                                              2    0.040    0.600  profilee.py:55(helper)
+profilee.py:35(factorial)            ->    20/3    0.130    0.147  profilee.py:35(factorial)
+                                             20    0.020    0.020  profilee.py:48(mul)
+profilee.py:48(mul)                  ->
+profilee.py:55(helper)               ->       4    0.116    0.120  profilee.py:73(helper1)
+                                              2    0.000    0.140  profilee.py:84(helper2_indirect)
+                                              6    0.234    0.300  profilee.py:88(helper2)
+profilee.py:73(helper1)              ->       4    0.000    0.004  {built-in method builtins.hasattr}
+profilee.py:84(helper2_indirect)     ->       2    0.006    0.040  profilee.py:35(factorial)
+                                              2    0.078    0.100  profilee.py:88(helper2)
+profilee.py:88(helper2)              ->       8    0.064    0.080  profilee.py:98(subhelper)
+profilee.py:98(subhelper)            ->      16    0.016    0.016  profilee.py:110(__getattr__)
+{built-in method builtins.hasattr}   ->      12    0.012    0.012  profilee.py:110(__getattr__)"""
 
 if __name__ == "__main__":
     main()

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1080,7 +1080,7 @@ class SizeofTest(unittest.TestCase):
         # buffer
         # XXX
         # builtin_function_or_method
-        check(len, size('5P'))
+        check(len, size('8Pi'))
         # bytearray
         samples = [b'', b'u'*100000]
         for sample in samples:
@@ -1111,15 +1111,15 @@ class SizeofTest(unittest.TestCase):
         # complex
         check(complex(0,1), size('2d'))
         # method_descriptor (descriptor object)
-        check(str.lower, size('3PPP'))
+        check(str.lower, size('3P4PiP'))
         # classmethod_descriptor (descriptor object)
         # XXX
         # member_descriptor (descriptor object)
         import datetime
-        check(datetime.timedelta.days, size('3PP'))
+        check(datetime.timedelta.days, size('3PiniP'))
         # getset_descriptor (descriptor object)
         import collections
-        check(collections.defaultdict.default_factory, size('3PP'))
+        check(collections.defaultdict.default_factory, size('3P4P'))
         # wrapper_descriptor (descriptor object)
         check(int.__add__, size('3P2P'))
         # method-wrapper (descriptor object)

--- a/Misc/NEWS.d/next/C API/2019-06-18-00-55-12.bpo-37270.2z98X7.rst
+++ b/Misc/NEWS.d/next/C API/2019-06-18-00-55-12.bpo-37270.2z98X7.rst
@@ -1,0 +1,6 @@
+Ensure that all of the memory needed by a type created with
+:c:func:`PyType_FromSpec` or :c:func:`PyType_FromSpecWithBases` is managed by
+Python. Previously, the memory referred to by ``Py_tp_methods``,
+``Py_tp_getset``, ``Py_tp_members`` and the various ``char*`` fields they
+contained needed to outlive the type. Now, these arrays and strings are copied
+and managed by the type itself.

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -132,42 +132,40 @@ normalizeUserObj(PyObject *obj)
         if (modname != NULL) {
             if (!_PyUnicode_EqualToASCIIString(modname, "builtins")) {
                 PyObject *result;
-                result = PyUnicode_FromFormat("<%U.%s>", modname,
-                                              fn->m_ml->ml_name);
+                result = PyUnicode_FromFormat("<%U.%S>", modname,
+                                              fn->m_base.name);
                 Py_DECREF(modname);
                 return result;
             }
             Py_DECREF(modname);
         }
-        return PyUnicode_FromFormat("<%s>", fn->m_ml->ml_name);
+        return PyUnicode_FromFormat("<%S>", fn->m_base.name);
     }
     else {
         /* built-in method: try to return
             repr(getattr(type(__self__), __name__))
         */
         PyObject *self = fn->m_self;
-        PyObject *name = PyUnicode_FromString(fn->m_ml->ml_name);
+        PyObject *name = fn->m_base.name;
         PyObject *modname = fn->m_module;
 
-        if (name != NULL) {
-            PyObject *mo = _PyType_Lookup(Py_TYPE(self), name);
-            Py_XINCREF(mo);
-            Py_DECREF(name);
-            if (mo != NULL) {
-                PyObject *res = PyObject_Repr(mo);
-                Py_DECREF(mo);
-                if (res != NULL)
-                    return res;
-            }
+        PyObject *mo = _PyType_Lookup(Py_TYPE(self), name);
+        Py_XINCREF(mo);
+        if (mo != NULL) {
+            PyObject *res = PyObject_Repr(mo);
+            Py_DECREF(mo);
+            if (res != NULL)
+                return res;
         }
+
         /* Otherwise, use __module__ */
         PyErr_Clear();
         if (modname != NULL && PyUnicode_Check(modname))
-            return PyUnicode_FromFormat("<built-in method %S.%s>",
-                                        modname,  fn->m_ml->ml_name);
+            return PyUnicode_FromFormat("<built-in method %S.%S>",
+                                        modname,  fn->m_base.name);
         else
-            return PyUnicode_FromFormat("<built-in method %s>",
-                                        fn->m_ml->ml_name);
+            return PyUnicode_FromFormat("<built-in method %S>",
+                                        fn->m_base.name);
     }
 }
 
@@ -409,7 +407,7 @@ profiler_callback(PyObject *self, PyFrameObject *frame, int what,
         if ((((ProfilerObject *)self)->flags & POF_BUILTINS)
             && PyCFunction_Check(arg)) {
             ptrace_enter_call(self,
-                              ((PyCFunctionObject *)arg)->m_ml,
+                              &((PyCFunctionObject *)arg)->m_base,
                               arg);
         }
         break;
@@ -421,7 +419,7 @@ profiler_callback(PyObject *self, PyFrameObject *frame, int what,
         if ((((ProfilerObject *)self)->flags & POF_BUILTINS)
             && PyCFunction_Check(arg)) {
             ptrace_leave_call(self,
-                              ((PyCFunctionObject *)arg)->m_ml);
+                              &((PyCFunctionObject *)arg)->m_base);
         }
         break;
 

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -5,6 +5,7 @@
 #include <ctype.h>
 #include "structmember.h" /* we need the offsetof() macro from there */
 #include "longintrepr.h"
+#include "bltinmodule.h"
 
 
 
@@ -840,7 +841,7 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
 
         if (op_slot == NB_SLOT(nb_rshift) &&
             PyCFunction_Check(v) &&
-            strcmp(((PyCFunctionObject *)v)->m_ml->ml_name, "print") == 0)
+            PyCFunction_GET_FUNCTION(v) == (PyCFunction)_PyBuiltin_Print)
         {
             PyErr_Format(PyExc_TypeError,
                 "unsupported operand type(s) for %.100s: "

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1812,8 +1812,8 @@ builtin_pow_impl(PyObject *module, PyObject *x, PyObject *y, PyObject *z)
 
 
 /* AC: cannot convert yet, waiting for *args support */
-static PyObject *
-builtin_print(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+PyObject *
+_PyBuiltin_Print(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     static const char * const _keywords[] = {"sep", "end", "file", "flush", 0};
     static struct _PyArg_Parser _parser = {"|OOOO:print", _keywords, 0};
@@ -2740,7 +2740,7 @@ static PyMethodDef builtin_methods[] = {
     BUILTIN_OCT_METHODDEF
     BUILTIN_ORD_METHODDEF
     BUILTIN_POW_METHODDEF
-    {"print",           (PyCFunction)(void(*)(void))builtin_print,      METH_FASTCALL | METH_KEYWORDS, print_doc},
+    {"print",           (PyCFunction)(void(*)(void))_PyBuiltin_Print,      METH_FASTCALL | METH_KEYWORDS, print_doc},
     BUILTIN_REPR_METHODDEF
     BUILTIN_ROUND_METHODDEF
     BUILTIN_SETATTR_METHODDEF

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4880,7 +4880,7 @@ PyEval_GetFuncName(PyObject *func)
     else if (PyFunction_Check(func))
         return PyUnicode_AsUTF8(((PyFunctionObject*)func)->func_name);
     else if (PyCFunction_Check(func))
-        return ((PyCFunctionObject*)func)->m_ml->ml_name;
+        return PyUnicode_AsUTF8(((PyCFunctionObject*)func)->m_base.name);
     else
         return func->ob_type->tp_name;
 }

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -593,20 +593,20 @@ class PyClassObjectPtr(PyObjectPtr):
 
 
 class BuiltInFunctionProxy(object):
-    def __init__(self, ml_name):
-        self.ml_name = ml_name
+    def __init__(self, name):
+        self.name = name
 
     def __repr__(self):
-        return "<built-in function %s>" % self.ml_name
+        return "<built-in function %s>" % self.name
 
 class BuiltInMethodProxy(object):
-    def __init__(self, ml_name, pyop_m_self):
-        self.ml_name = ml_name
+    def __init__(self, name, pyop_m_self):
+        self.name = name
         self.pyop_m_self = pyop_m_self
 
     def __repr__(self):
         return ('<built-in method %s of %s object at remote 0x%x>'
-                % (self.ml_name,
+                % (self.name,
                    self.pyop_m_self.safe_tp_name(),
                    self.pyop_m_self.as_address())
                 )
@@ -619,17 +619,15 @@ class PyCFunctionObjectPtr(PyObjectPtr):
     _typename = 'PyCFunctionObject'
 
     def proxyval(self, visited):
-        m_ml = self.field('m_ml') # m_ml is a (PyMethodDef*)
-        try:
-            ml_name = m_ml['ml_name'].string()
-        except UnicodeDecodeError:
-            ml_name = '<ml_name:UnicodeDecodeError>'
+        m_base = self.field('m_base')
+        name_ob = PyUnicodeObjectPtr.from_pyobject_ptr(m_base['name'])
+        name = name_ob.proxyval(set())
 
         pyop_m_self = self.pyop_field('m_self')
         if pyop_m_self.is_null():
-            return BuiltInFunctionProxy(ml_name)
+            return BuiltInFunctionProxy(name)
         else:
-            return BuiltInMethodProxy(ml_name, pyop_m_self)
+            return BuiltInMethodProxy(name, pyop_m_self)
 
 
 class PyCodeObjectPtr(PyObjectPtr):


### PR DESCRIPTION
Remove internal usages of PyMethodDef and PyGetSetDef.

For PyMethodDef, change PyCFunctionObject to replace the PyMethodDef* member
with a PyCFunctionBase member. The PyCFunctionBase is a new struct to hold the
managed values of a PyMethodDef. This type is shared between PyCFunction and the
various callable descriptor objects. A PyCFunctionBase is like a PyMethodDef but
replaces the char* members with PyObject* members.

For PyGetSetDef, inline the members on the resulting PyGetSetDescrObject,
replacing all char* members with PyObject* members. The memory for the closure
is *not* managed, adding support for that would likely require an API change and
can be done in a future change.

For the tp_name field, instead of setting it directly to the value of
PyType_Spec.name, set it to the result of PyUnicode_AsUTF8(ht_name), where
ht_name is the PyUnicode object created from the original spec name. This is the
same trick used to properly manage this pointer for heap types when the __name__
is reassigned.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37270](https://bugs.python.org/issue37270) -->
https://bugs.python.org/issue37270
<!-- /issue-number -->

<!-- gh-issue-number: gh-81451 -->
* Issue: gh-81451
<!-- /gh-issue-number -->
