### PR TITLE
[3.7] bpo-37269: Correctly optimise conditionals with constant booleans (GH-14071)

### DIFF
--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -311,6 +311,13 @@ class TestTranforms(BytecodeTestCase):
                 self.assertFalse(instr.opname.startswith('BINARY_'))
                 self.assertFalse(instr.opname.startswith('BUILD_'))
 
+    def test_condition_with_binop_with_bools(self):
+        def f():
+            if True or False:
+                return 1
+            return 0
+        self.assertEqual(f(), 1)
+
 
 class TestBuglets(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-14-06-32-33.bpo-37269.SjVVAe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-14-06-32-33.bpo-37269.SjVVAe.rst
@@ -1,0 +1,2 @@
+Fix a bug in the peephole optimizer that was not treating correctly constant
+conditions with binary operators. Patch by Pablo Galindo.

--- a/Python/peephole.c
+++ b/Python/peephole.c
@@ -313,6 +313,11 @@ PyCode_Optimize(PyObject *code, PyObject* consts, PyObject *names,
                     fill_nops(codestr, op_start, nexti + 1);
                     cumlc = 0;
                 } else if (is_true == 0) {
+                    if (i > 1 &&
+                        (_Py_OPCODE(codestr[i - 1]) == POP_JUMP_IF_TRUE ||
+                         _Py_OPCODE(codestr[i - 1]) == POP_JUMP_IF_FALSE)) {
+                        break;
+                    }
                     h = get_arg(codestr, nexti) / sizeof(_Py_CODEUNIT);
                     tgt = find_op(codestr, codelen, h);
                     fill_nops(codestr, op_start, tgt);


### PR DESCRIPTION


<!-- issue-number: [bpo-37269](https://bugs.python.org/issue37269) -->
https://bugs.python.org/issue37269
<!-- /issue-number -->
