### PR TITLE
bpo-37278: Fix test_asyncio ProactorLoopCtrlC

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-06-14-12-21-47.bpo-37278.z0HUOr.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-14-12-21-47.bpo-37278.z0HUOr.rst
@@ -1,0 +1,2 @@
+Fix test_asyncio ProactorLoopCtrlC: join the thread to prevent leaking a
+running thread and leaking a reference.


### PR DESCRIPTION
Join the thread to prevent leaking a running thread and leaking a
reference.

Cleanup also the test:

* asyncioWindowsProactorEventLoopPolicy became the default policy,
  there is no need to set it manually.
* Only start the thread once the loop is running.
* Use a shorter sleep in the thread (100 ms rather than 1 sec).
* Use close_loop(loop) rather than loop.close().
* Use longer variable names.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37278](https://bugs.python.org/issue37278) -->
https://bugs.python.org/issue37278
<!-- /issue-number -->
