### PR TITLE
bpo-37280: Use threadpool for reading from file in sendfile fallback mode

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1141,7 +1141,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                     if blocksize <= 0:
                         return total_sent
                 view = memoryview(buf)[:blocksize]
-                read = file.readinto(view)
+                read = await self.run_in_executor(None, file.readinto, view)
                 if not read:
                     return total_sent  # EOF
                 await proto.drain()

--- a/Misc/NEWS.d/next/Library/2019-06-14-13-30-47.bpo-37280.Fxur0F.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-14-13-30-47.bpo-37280.Fxur0F.rst
@@ -1,0 +1,1 @@
+Use threadpool for reading from file for sendfile fallback mode.


### PR DESCRIPTION
We do it for `loop.sock_sendfile()`, there is no reason to call blocking code for `loop.sendfile()`

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37280](https://bugs.python.org/issue37280) -->
https://bugs.python.org/issue37280
<!-- /issue-number -->
