### PR TITLE
bpo-19865: ctypes.create_unicode_buffer() fails on non-BMP strings on Windows

### DIFF
--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -274,11 +274,15 @@ def create_unicode_buffer(init, size=None):
     """
     if isinstance(init, str):
         if size is None:
-            size = len(init)+1
             if sizeof(c_wchar) == 2:
-                for c in init:
-                    if ord(c) > 0xFFFF:
-                        size += 1
+                # UTF-16 requires a surrogate pair (2 wchar_t) for non-BMP
+                # characters (outside [U+0000; U+FFFF] range). +1 for trailing
+                # NUL character.
+                size = sum(2 if ord(c) > 0xFFFF else 1 for c in init) + 1
+            else:
+                # 32-bit wchar_t (1 wchar_t per Unicode character). +1 for
+                # trailing NUL character.
+                size = len(init) + 1
         buftype = c_wchar * size
         buf = buftype()
         buf.value = init

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -275,6 +275,10 @@ def create_unicode_buffer(init, size=None):
     if isinstance(init, str):
         if size is None:
             size = len(init)+1
+            if sizeof(c_wchar) == 2:
+                for c in init:
+                    if ord(c) > 0xFFFF:
+                        size += 1
         buftype = c_wchar * size
         buf = buftype()
         buf.value = init

--- a/Lib/ctypes/test/test_buffers.py
+++ b/Lib/ctypes/test/test_buffers.py
@@ -60,5 +60,13 @@ class StringBufferTestCase(unittest.TestCase):
         self.assertEqual(b[::2], "ac")
         self.assertEqual(b[::5], "a")
 
+    @need_symbol('c_wchar')
+    def test_create_unicode_buffer_non_bmp(self):
+        b = create_unicode_buffer('\U00010000\U00100000')
+        expected = 5 if sizeof(c_wchar) == 2 else 3
+        self.assertEqual(len(b), expected)
+        self.assertEqual(b[-1], '\0')
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/ctypes/test/test_buffers.py
+++ b/Lib/ctypes/test/test_buffers.py
@@ -62,10 +62,11 @@ class StringBufferTestCase(unittest.TestCase):
 
     @need_symbol('c_wchar')
     def test_create_unicode_buffer_non_bmp(self):
-        b = create_unicode_buffer('\U00010000\U00100000')
         expected = 5 if sizeof(c_wchar) == 2 else 3
-        self.assertEqual(len(b), expected)
-        self.assertEqual(b[-1], '\0')
+        for s in '\U00010000\U00100000', '\U00010000\U0010ffff':
+            b = create_unicode_buffer(s)
+            self.assertEqual(len(b), expected)
+            self.assertEqual(b[-1], '\0')
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2019-06-14-08-30-16.bpo-19865.FRGH4I.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-14-08-30-16.bpo-19865.FRGH4I.rst
@@ -1,0 +1,2 @@
+:func:`ctypes.create_unicode_buffer()` no longer fails on non-BMP strings on
+Windows.

--- a/Misc/NEWS.d/next/Library/2019-06-14-08-30-16.bpo-19865.FRGH4I.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-14-08-30-16.bpo-19865.FRGH4I.rst
@@ -1,2 +1,2 @@
-:func:`ctypes.create_unicode_buffer()` no longer fails on non-BMP strings on
-Windows.
+:func:`ctypes.create_unicode_buffer()` now also supports non-BMP characters
+on platforms with 16-bit :c:type:`wchar_t` (for example, Windows and AIX).


### PR DESCRIPTION
The unit test is based on some of the tests in test_unicode.py that check for `sizeof(c_wchar) == 2`.

<!-- issue-number: [bpo-19865](https://bugs.python.org/issue19865) -->
https://bugs.python.org/issue19865
<!-- /issue-number -->
