### PR TITLE
bpo-36707: Document "m" removed from sys.abiflags

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -16,6 +16,10 @@ always available.
    On POSIX systems where Python was built with the standard ``configure``
    script, this contains the ABI flags as specified by :pep:`3149`.
 
+   .. versionchanged:: 3.8
+      Default flags became an empty string (``m`` flag for pymalloc has been
+      removed).
+
    .. versionadded:: 3.2
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -962,8 +962,8 @@ Build and C API Changes
   Example of changes:
 
   * Only ``python3.8`` program is installed, ``python3.8m`` program is gone.
-  * Only ``python3.8-config`` script is installed, no ``python3.8m-config`` is
-    gone.
+  * Only ``python3.8-config`` script is installed, ``python3.8m-config`` script
+    is gone.
   * The ``m`` flag has been removed from the suffix of dynamic library
     filenames: extension modules in the standard library as well as those
     produced and installed by third-party packages, like those downloaded from

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -965,7 +965,9 @@ Build and C API Changes
   * Only ``python3.8-config`` script is installed, no ``python3.8m-config`` is
     gone.
   * The ``m`` flag has been removed from the suffix of dynamic library
-    filenames. On Linux, for example, the Python 3.7 suffix
+    filenames: extension modules in the standard library as well as those
+    produced and installed by third-party packages, like those downloaded from
+    PyPI. On Linux, for example, the Python 3.7 suffix
     ``.cpython-37m-x86_64-linux-gnu.so`` became
     ``.cpython-38-x86_64-linux-gnu.so`` in Python 3.8.
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -955,6 +955,20 @@ Optimizations
 Build and C API Changes
 =======================
 
+* Default :data:`sys.abiflags` became an empty string: the ``m`` flag for
+  pymalloc became useless (builds with and without pymalloc are ABI compatible)
+  and so has been removed. (Contributed by Victor Stinner in :issue:`36707`.)
+
+  Example of changes:
+
+  * Only ``python3.8`` program is installed, ``python3.8m`` program is gone.
+  * Only ``python3.8-config`` script is installed, no ``python3.8m-config`` is
+    gone.
+  * The ``m`` flag has been removed from the suffix of dynamic library
+    filenames. On Linux, for example, the Python 3.7 suffix
+    ``.cpython-37m-x86_64-linux-gnu.so`` became
+    ``.cpython-38-x86_64-linux-gnu.so`` in Python 3.8.
+
 * The header files have been reorganized to better separate the different kinds
   of APIs:
 


### PR DESCRIPTION


<!-- issue-number: [bpo-36707](https://bugs.python.org/issue36707) -->
https://bugs.python.org/issue36707
<!-- /issue-number -->
