### PR TITLE
bpo-37288: Fix Windows build when --no-tkinter is specified

### DIFF
--- a/PCbuild/python.vcxproj
+++ b/PCbuild/python.vcxproj
@@ -150,10 +150,10 @@ $(_PGOPath)
       <LicenseFiles Include="$(PySourcePath)LICENSE;
                              $(PySourcePath)PC\crtlicense.txt;
                              $(bz2Dir)LICENSE;
-                             $(opensslOutDir)LICENSE;
-                             $(tcltkDir)tcllicense.terms;
+                             $(opensslOutDir)LICENSE;" />
+      <LicenseFiles Include="$(tcltkDir)tcllicense.terms;
                              $(tcltkDir)tklicense.terms;
-                             $(tcltkDir)tixlicense.terms" />
+                             $(tcltkDir)tixlicense.terms" Condition="$(IncludeTkinter)" />
       <_LicenseFiles Include="@(LicenseFiles)">
         <Content>$([System.IO.File]::ReadAllText(%(FullPath)))</Content>
       </_LicenseFiles>


### PR DESCRIPTION
@zooba

<!-- issue-number: [bpo-37288](https://bugs.python.org/issue37288) -->
https://bugs.python.org/issue37288
<!-- /issue-number -->
