### PR TITLE
[3.7] bpo-37279: Fix asyncio sendfile support when  extra data are sent in fallback mode. (GH-14075).

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -827,7 +827,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                 read = await self.run_in_executor(None, file.readinto, view)
                 if not read:
                     break  # EOF
-                await self.sock_sendall(sock, view)
+                await self.sock_sendall(sock, view[:read])
                 total_sent += read
             return total_sent
         finally:
@@ -1082,7 +1082,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                 if not read:
                     return total_sent  # EOF
                 await proto.drain()
-                transp.write(view)
+                transp.write(view[:read])
                 total_sent += read
         finally:
             if total_sent > 0 and hasattr(file, 'seek'):

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2117,7 +2117,8 @@ class SubprocessTestsMixin:
 
 class SendfileBase:
 
-    DATA = b"SendfileBaseData" * (1024 * 8)  # 128 KiB
+    # 128 KiB plus small unaligned to buffer chunk
+    DATA = b"SendfileBaseData" * (1024 * 8 + 1)
 
     # Reduce socket buffer size to test on relative small data sets.
     BUF_SIZE = 4 * 1024   # 4 KiB

--- a/Misc/NEWS.d/next/Library/2019-06-14-13-25-56.bpo-37279.OHlW6l.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-14-13-25-56.bpo-37279.OHlW6l.rst
@@ -1,0 +1,2 @@
+Fix asyncio sendfile support when sendfile sends extra data in fallback
+mode.


### PR DESCRIPTION


(cherry picked from commit ef2152354f03a165c5e3adb53e2276934fabd50a)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37279](https://bugs.python.org/issue37279) -->
https://bugs.python.org/issue37279
<!-- /issue-number -->
