### PR TITLE
bpo-37251: MagicMock with function spec used as a spec in mock.patch should return a MagicMock

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -46,7 +46,8 @@ FILTER_DIR = True
 _safe_super = super
 
 def _is_async_obj(obj):
-    if getattr(obj, '__code__', None):
+    code = getattr(obj, '__code__', None)
+    if isinstance(code, CodeType):
         return asyncio.iscoroutinefunction(obj) or inspect.isawaitable(obj)
     else:
         return False

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -321,6 +321,13 @@ class AsyncSpecSetTest(unittest.TestCase):
         self.assertIsInstance(mock.normal_method, MagicMock)
         self.assertIsInstance(mock, MagicMock)
 
+    def test_magicmock_lambda_spec(self):
+        mock_obj = MagicMock()
+        mock_obj.mock_func = MagicMock(spec=lambda x: x)
+
+        with patch.object(mock_obj, "mock_func") as cm:
+            self.assertIsInstance(cm, MagicMock)
+
 
 class AsyncArguments(unittest.TestCase):
     def test_add_return_value(self):

--- a/Misc/NEWS.d/next/Library/2019-06-15-21-52-23.bpo-37251.dYzQt6.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-15-21-52-23.bpo-37251.dYzQt6.rst
@@ -1,0 +1,3 @@
+:class:`unittest.mock.MagicMock` with function as spec used as a spec to
+:func:`unittest.mock.patch` should return a
+:class:`unittest.mock.MagicMock`. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
MagicMock with a function spec will have `__code__` object. When it is used a spec to `mock.patch` then `__code__` object which is a MagicMock is used to detect if it's a coroutine. `MagicMock.__code__ & 128` returns another MagicMock which is evaluated to True and returned as a coroutine incorrectly. Hence check `__code__` to be a `CodeType` to make sure MagicMock with `__code__` is not detected as coroutine.

<!-- issue-number: [bpo-37251](https://bugs.python.org/issue37251) -->
https://bugs.python.org/issue37251
<!-- /issue-number -->
