### PR TITLE
bpo-37300: a Py_XINCREF in classobject.c are not necessary

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-16-02-38-25.bpo-37300.WJkgKV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-16-02-38-25.bpo-37300.WJkgKV.rst
@@ -1,1 +1,1 @@
-a Py_XINCREF in classobject.c are not necessary
+Remove an unnecssary Py_XINCREF in classobject.c.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-16-02-38-25.bpo-37300.WJkgKV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-16-02-38-25.bpo-37300.WJkgKV.rst
@@ -1,0 +1,1 @@
+a Py_XINCREF in classobject.c are not necessary

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -67,7 +67,7 @@ PyMethod_New(PyObject *func, PyObject *self)
     im->im_weakreflist = NULL;
     Py_INCREF(func);
     im->im_func = func;
-    Py_XINCREF(self);
+    Py_INCREF(self);
     im->im_self = self;
     _PyObject_GC_TRACK(im);
     return (PyObject *)im;


### PR DESCRIPTION


<!-- issue-number: [bpo-37300](https://bugs.python.org/issue37300) -->
https://bugs.python.org/issue37300
<!-- /issue-number -->
