### PR TITLE
gh-73055: Set class module to caller module in ABCMeta.__new__

### DIFF
--- a/Lib/_py_abc.py
+++ b/Lib/_py_abc.py
@@ -1,3 +1,4 @@
+import sys
 from _weakrefset import WeakSet
 
 
@@ -33,6 +34,18 @@ class ABCMeta(type):
     _abc_invalidation_counter = 0
 
     def __new__(mcls, name, bases, namespace, /, **kwargs):
+
+        if '__module__' not in namespace:
+            try:
+                # Set __module__ to the frame where the class is created
+                module = sys._getframe(1).f_globals.get('__name__', '__main__')
+            except (AttributeError, ValueError):
+                # Bypass for environments where sys._getframe is not defined (e.g. Jython)
+                # or sys._getframe is not defined for arguments greater than 0 (IronPython)
+                pass
+            else:
+                namespace['__module__'] = module
+
         cls = super().__new__(mcls, name, bases, namespace, **kwargs)
         # Compute set of abstract method names
         abstracts = {name

--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -3,6 +3,7 @@
 
 """Abstract Base Classes (ABCs) according to PEP 3119."""
 
+import sys
 
 def abstractmethod(funcobj):
     """A decorator indicating abstract methods.
@@ -82,6 +83,18 @@ else:
         even via super()).
         """
         def __new__(mcls, name, bases, namespace, **kwargs):
+
+            if '__module__' not in namespace:
+                try:
+                    # Set __module__ to the frame where the class is created
+                    module = sys._getframe(1).f_globals.get('__name__', '__main__')
+                except (AttributeError, ValueError):
+                    # Bypass for environments where sys._getframe is not defined (e.g. Jython)
+                    # or sys._getframe is not defined for arguments greater than 0 (IronPython)
+                    pass
+                else:
+                    namespace['__module__'] = module
+
             cls = super().__new__(mcls, name, bases, namespace, **kwargs)
             _abc_init(cls)
             return cls

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -9,10 +9,11 @@
 import unittest
 
 import abc
+import pickle
 import _py_abc
 from inspect import isabstract
 
-def test_factory(abc_ABCMeta, abc_get_cache_token):
+def test_factory(abc_ABCMeta, abc_get_cache_token, abc_to_pickle):
     class TestLegacyAPI(unittest.TestCase):
 
         def test_abstractproperty_basics(self):
@@ -477,6 +478,12 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             ABC = abc_ABCMeta('ABC', (), {'__module__': 'some.module'})
             self.assertEqual(ABC.__module__, 'some.module')
 
+        def test_pickling_instance_of_dynamically_defined_ABC(self):
+            obj = abc_to_pickle()
+            obj_unpickled = pickle.loads(pickle.dumps(obj))
+            self.assertEqual(type(obj_unpickled), type(obj))
+            self.assertDictEqual(obj_unpickled.__dict__, obj.__dict__)
+
 
     class TestABCWithInitSubclass(unittest.TestCase):
         def test_works_with_init_subclass(self):
@@ -494,10 +501,16 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             self.assertEqual(saved_kwargs, dict(x=1, y=2, __module__='some.module'))
     return TestLegacyAPI, TestABC, TestABCWithInitSubclass
 
+# types used for pickle test
+ABCToPickle_C = abc.ABCMeta('ABCToPickle_C', (), {'data': 123})
+ABCToPickle_Py = _py_abc.ABCMeta('ABCToPickle_Py', (), {'data': 123})
+
 TestLegacyAPI_Py, TestABC_Py, TestABCWithInitSubclass_Py = test_factory(abc.ABCMeta,
-                                                                        abc.get_cache_token)
+                                                                        abc.get_cache_token,
+                                                                        ABCToPickle_C)
 TestLegacyAPI_C, TestABC_C, TestABCWithInitSubclass_C = test_factory(_py_abc.ABCMeta,
-                                                                     _py_abc.get_cache_token)
+                                                                     _py_abc.get_cache_token,
+                                                                     ABCToPickle_Py)
 
 if __name__ == "__main__":
     unittest.main()

--- a/abc_bench.py
+++ b/abc_bench.py
@@ -1,0 +1,56 @@
+import csv
+import timeit
+
+
+def median(x):
+    n = len(x)
+    middle = n // 2
+    sx = sorted(x)
+    if n % 2:
+        return sx[middle]
+    else:
+        return (sx[middle] + sx[middle - 1]) / 2
+
+
+implementations = {"C": "import abc",
+                   "Py": "import _py_abc"}
+statements = {
+    "C": {
+        "master": "abc.ABCMeta('ABC_C', (), {'__module__': __name__})",
+        "fix": "abc.ABCMeta('ABC_C', (), {})"
+    },
+    "Py": {
+        "master": "_py_abc.ABCMeta('ABC_Py', (), {'__module__': __name__})",
+        "fix": "_py_abc.ABCMeta('ABC_Py', (), {})"
+    }
+}
+
+repeat = 50000
+number = 1
+
+data = {}
+for imp, setup in implementations.items():
+    for branch, stmt in statements[imp].items():
+        print("timing {} - {} implementation of ABCMeta...".format(branch, imp))
+        times = timeit.repeat(stmt, setup=setup, repeat=repeat, number=number)
+        header = "{}_{}".format(branch, imp)
+        data[header] = times
+
+
+for imp in implementations:
+    t_master = median(data["master_{}".format(imp)])
+    t_fix = median(data["fix_{}".format(imp)])
+
+    absdiff = t_fix - t_master
+    slowdown = (t_fix - t_master) / t_master
+
+    print("{} implementation".format(imp))
+    print("    Absolute difference:", 1000 * absdiff, "ms")
+    print("    Slowdown:", 100 * slowdown, "%")
+
+print("Dumping to CSV file...")
+with open("abc_bench.csv", "w") as csvfile:
+    writer = csv.writer(csvfile)
+    data = [[header] + times for header, times in data.items()]
+    for row in zip(*data):
+        writer.writerow(row)


### PR DESCRIPTION
Hello, this is a PR to the bug reported in [bpo-28869](https://bugs.python.org/issue28869) (https://bugs.python.org/issue28869).

### Issues:
* `__module__` attribute is set differently depending on whether a metaclass is explicitly called or invoked in a class statement.
* This causes a pickling error when dumping an instance of a class that was defined by calling `ABCMeta` directly, because it attempts to look for the class in `abc` rather than the module the class was defined in.

### Solution:
If the `__module__` variable is not found in the namespace variable, inspect and use the module of the caller. This follows the same pattern used in `namedtuple`. Values set via `__init_subclass__` take precedence.

There were concerns that inspection might slow down further ABCs creation, so I also did some benchmarking and got these results:

```
C implementation
    Absolute difference: 0.00115500006359 ms
    Slowdown: 4.61538495086 %
Py implementation
    Absolute difference: 0.00129000000015 ms
    Slowdown: 3.67301613313 %
```

Notes:
* The values reported above are the median execution times measured using `timeit.repeat` with 50,000 repetitions.
* I used `ABCMeta('ABC', (), {'__module__': __name__})` as a proxy for the original implementation.
* Script was run on a laptop with Intel Core i7-3537U CPU @ 2.00GHz, 8GB RAM, running Ubuntu 16.04.

**Is 3~5% considered a significant drop in performance?**

I temporarily commited the script for benchmarking in the root directory for sharing purposes. This will be removed in a future commit.

Also, following the discussion in the bpo thread regarding the pickle documentation, since this issue is not limited to `ABCMeta`, I propose to add the following paragraph (highlighted in bold) in the "What can be pickled and unpickled?" section:


> ...
Note that functions (built-in and user-defined) are pickled by "fully qualified"
name reference, not by value. [2]  This means that only the function name is
pickled, along with the name of the module the function is defined in.  Neither
the function's code, nor any of its function attributes are pickled.  Thus the
defining module must be importable in the unpickling environment, and the module
must contain the named object, otherwise an exception will be raised. [3]
>
> **When pickling instances of classes defined dynamically (i.e. classes defined by calling
``type()`` (or any other metaclass) directly) you might need to set the ``__module__`` 
attribute of the class to the module where the class was defined in. This is the case when 
the class creation and the call to ``type()``  reside in different modules.**

**Would this be an appropriate explanation?**

<!-- issue-number: [bpo-28869](https://bugs.python.org/issue28869) -->
https://bugs.python.org/issue28869
<!-- /issue-number -->

<!-- gh-issue-number: gh-73055 -->
* Issue: gh-73055
<!-- /gh-issue-number -->
