### PR TITLE
bpo-37289: Add a test for if with ifexpr in the peephole optimizer to detect regressions

### DIFF
--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -421,6 +421,14 @@ class TestTranforms(BytecodeTestCase):
             return 0
         self.assertEqual(f(), 1)
 
+    def test_if_with_if_expression(self):
+        # Check bpo-37289
+        def f():
+            if True if f.__code__ else None:
+                return True
+            return False
+        self.assertTrue(f())
+
 
 class TestBuglets(unittest.TestCase):
 

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -423,11 +423,11 @@ class TestTranforms(BytecodeTestCase):
 
     def test_if_with_if_expression(self):
         # Check bpo-37289
-        def f():
-            if True if f.__code__ else None:
+        def f(x):
+            if (True if x else False):
                 return True
             return False
-        self.assertTrue(f())
+        self.assertTrue(f(True))
 
 
 class TestBuglets(unittest.TestCase):


### PR DESCRIPTION


<!-- issue-number: [bpo-37289](https://bugs.python.org/issue37289) -->
https://bugs.python.org/issue37289
<!-- /issue-number -->
