### PR TITLE
Turn assertion into a comment to clarify its purpose.

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1527,10 +1527,10 @@ Here's Python code equivalent to the C implementation below:
         a = 1
         d = 0
         for s in reversed(range(c.bit_length())):
+            # Loop invariant: (a-1)**2 < (n >> 2*(c - d)) < (a+1)**2
             e = d
             d = c >> s
             a = (a << d - e - 1) + (n >> 2*c - e - d + 1) // a
-            assert (a-1)**2 < n >> 2*(c - d) < (a+1)**2
 
         return a - (a*a > n)
 


### PR DESCRIPTION
There's an `assert` in the `math.isqrt` equivalent Python code (which is in a comment in `Modules/mathmodule.c`). This trivial PR changes that `assert` to a comment in order to:

- better clarify the intent of the original `assert` (it's a loop invariant)
- better match the C code (which has no such assertion in it)
- avoid copy-and-pasted Python code being unnecessarily slow - the checks in the assert could easily dominate the running time

Also adds redundant parentheses for readability.