### PR TITLE
bpo-37189: Export old PyRun_XXX() functions

### DIFF
--- a/Include/pythonrun.h
+++ b/Include/pythonrun.h
@@ -9,7 +9,6 @@ extern "C" {
 
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) PyRun_SimpleStringFlags(const char *, PyCompilerFlags *);
-PyAPI_FUNC(int) PyRun_AnyFileFlags(FILE *, const char *, PyCompilerFlags *);
 PyAPI_FUNC(int) PyRun_AnyFileExFlags(
     FILE *fp,
     const char *filename,       /* decoded from the filesystem encoding */
@@ -122,7 +121,7 @@ PyAPI_FUNC(struct symtable *) Py_SymtableString(
 PyAPI_FUNC(const char *) _Py_SourceAsString(
     PyObject *cmd,
     const char *funcname,
-    const char *what, 
+    const char *what,
     PyCompilerFlags *cf,
     PyObject **cmd_copy);
 
@@ -143,6 +142,23 @@ PyAPI_FUNC(void) PyErr_PrintEx(int);
 PyAPI_FUNC(void) PyErr_Display(PyObject *, PyObject *, PyObject *);
 
 #ifndef Py_LIMITED_API
+/* A function flavor is also exported by libpython. It is required when
+    libpython is accessed directly rather than using header files which defines
+    macros below. On Windows, for example, PyAPI_FUNC() uses dllexport to
+    export functions in pythonXX.dll. */
+PyAPI_FUNC(PyObject *) PyRun_String(const char *str, int s, PyObject *g, PyObject *l);
+PyAPI_FUNC(int) PyRun_AnyFile(FILE *fp, const char *name);
+PyAPI_FUNC(int) PyRun_AnyFileEx(FILE *fp, const char *name, int closeit);
+PyAPI_FUNC(int) PyRun_AnyFileFlags(FILE *, const char *, PyCompilerFlags *);
+PyAPI_FUNC(int) PyRun_SimpleString(const char *s);
+PyAPI_FUNC(int) PyRun_SimpleFile(FILE *f, const char *p);
+PyAPI_FUNC(int) PyRun_SimpleFileEx(FILE *f, const char *p, int c);
+PyAPI_FUNC(int) PyRun_InteractiveOne(FILE *f, const char *p);
+PyAPI_FUNC(int) PyRun_InteractiveLoop(FILE *f, const char *p);
+PyAPI_FUNC(PyObject *) PyRun_File(FILE *fp, const char *p, int s, PyObject *g, PyObject *l);
+PyAPI_FUNC(PyObject *) PyRun_FileEx(FILE *fp, const char *p, int s, PyObject *g, PyObject *l, int c);
+PyAPI_FUNC(PyObject *) PyRun_FileFlags(FILE *fp, const char *p, int s, PyObject *g, PyObject *l, PyCompilerFlags *flags);
+
 /* Use macros for a bunch of old variants */
 #define PyRun_String(str, s, g, l) PyRun_StringFlags(str, s, g, l, NULL)
 #define PyRun_AnyFile(fp, name) PyRun_AnyFileExFlags(fp, name, 0, NULL)

--- a/Misc/NEWS.d/next/Build/2019-06-17-09-40-59.bpo-37189.j5ebdT.rst
+++ b/Misc/NEWS.d/next/Build/2019-06-17-09-40-59.bpo-37189.j5ebdT.rst
@@ -1,0 +1,3 @@
+Many ``PyRun_XXX()`` functions like :c:func:`PyRun_String` were no longer
+exported in ``libpython38.dll`` by mistake. Export them again to fix the ABI
+compatibiliy.


### PR DESCRIPTION
Many PyRun_XXX() functions like PyRun_String() were no longer
exported in libpython38.dll by mistake. Export them again to fix the
ABI compatibiliy.

<!-- issue-number: [bpo-37189](https://bugs.python.org/issue37189) -->
https://bugs.python.org/issue37189
<!-- /issue-number -->
