### PR TITLE
bpo-37231: remove _PyObject_FastCall_Prepend which is no longer used

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -156,12 +156,6 @@ PyAPI_FUNC(PyObject *) _PyObject_Call_Prepend(
     PyObject *args,
     PyObject *kwargs);
 
-PyAPI_FUNC(PyObject *) _PyObject_FastCall_Prepend(
-    PyObject *callable,
-    PyObject *obj,
-    PyObject *const *args,
-    Py_ssize_t nargs);
-
 /* Like PyObject_CallMethod(), but expect a _Py_Identifier*
    as the method name. */
 PyAPI_FUNC(PyObject *) _PyObject_CallMethodId(PyObject *obj,

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -837,42 +837,6 @@ PyObject_CallObject(PyObject *callable, PyObject *args)
 }
 
 
-/* Positional arguments are obj followed by args:
-   call callable(obj, *args, **kwargs) */
-PyObject *
-_PyObject_FastCall_Prepend(PyObject *callable, PyObject *obj,
-                           PyObject *const *args, Py_ssize_t nargs)
-{
-    PyObject *small_stack[_PY_FASTCALL_SMALL_STACK];
-    PyObject **args2;
-    PyObject *result;
-
-    nargs++;
-    if (nargs <= (Py_ssize_t)Py_ARRAY_LENGTH(small_stack)) {
-        args2 = small_stack;
-    }
-    else {
-        args2 = PyMem_Malloc(nargs * sizeof(PyObject *));
-        if (args2 == NULL) {
-            PyErr_NoMemory();
-            return NULL;
-        }
-    }
-
-    /* use borrowed references */
-    args2[0] = obj;
-    if (nargs > 1) {
-        memcpy(&args2[1], args, (nargs - 1) * sizeof(PyObject *));
-    }
-
-    result = _PyObject_FastCall(callable, args2, nargs);
-    if (args2 != small_stack) {
-        PyMem_Free(args2);
-    }
-    return result;
-}
-
-
 /* Call callable(obj, *args, **kwargs). */
 PyObject *
 _PyObject_Call_Prepend(PyObject *callable,


### PR DESCRIPTION
Thanks to #13973, the private function `_PyObject_FastCall_Prepend` is no longer used, so we can remove it.

Note that the implementation is actually buggy: it contains an off-by-1 error in the condition `nargs <= (Py_ssize_t)Py_ARRAY_LENGTH(small_stack)` (forgetting to reserve space for the prepended argument). Since `nargs` was always at most 2 in all calls of this function, this bug was never noticed.

CC @methane 

<!-- issue-number: [bpo-37231](https://bugs.python.org/issue37231) -->
https://bugs.python.org/issue37231
<!-- /issue-number -->
