### PR TITLE
Fix assertions regarding magic methods function body that was not executed

### DIFF
--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -361,17 +361,14 @@ class AsyncArguments(unittest.TestCase):
 
 
 class AsyncContextManagerTest(unittest.TestCase):
+
     class WithAsyncContextManager:
-        def __init__(self):
-            self.entered = False
-            self.exited = False
 
         async def __aenter__(self, *args, **kwargs):
-            self.entered = True
             return self
 
         async def __aexit__(self, *args, **kwargs):
-            self.exited = True
+            pass
 
     def test_magic_methods_are_async_mocks(self):
         mock = MagicMock(self.WithAsyncContextManager())
@@ -390,11 +387,7 @@ class AsyncContextManagerTest(unittest.TestCase):
             return result
 
         result = asyncio.run(use_context_manager())
-        self.assertFalse(instance.entered)
-        self.assertFalse(instance.exited)
         self.assertTrue(called)
-        self.assertTrue(mock_instance.entered)
-        self.assertTrue(mock_instance.exited)
         self.assertTrue(mock_instance.__aenter__.called)
         self.assertTrue(mock_instance.__aexit__.called)
         self.assertIsNot(mock_instance, result)


### PR DESCRIPTION
The context manager object supplied to `MagicMock` has the magic methods `__aenter__` and `__aexit__` called with mock call registered but the actual function body was not executed. Since `MagicMock` is always True the attributes entered and exited returned a `MagicMock` that asserted to True in the test. 