### PR TITLE
[3.8] bpo-37194: Complete PyObject_CallXXX() docs (GH-14156)

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -261,7 +261,8 @@ Object Protocol
    *args* must not be *NULL*, use an empty tuple if no arguments are needed.
    If no named arguments are needed, *kwargs* can be *NULL*.
 
-   Returns the result of the call on success, or *NULL* on failure.
+   Return the result of the call on success, or raise an exception and return
+   *NULL* on failure.
 
    This is the equivalent of the Python expression:
    ``callable(*args, **kwargs)``.
@@ -272,7 +273,8 @@ Object Protocol
    Call a callable Python object *callable*, with arguments given by the
    tuple *args*.  If no arguments are needed, then *args* can be *NULL*.
 
-   Returns the result of the call on success, or *NULL* on failure.
+   Return the result of the call on success, or raise an exception and return
+   *NULL* on failure.
 
    This is the equivalent of the Python expression: ``callable(*args)``.
 
@@ -283,7 +285,8 @@ Object Protocol
    The C arguments are described using a :c:func:`Py_BuildValue` style format
    string.  The format can be *NULL*, indicating that no arguments are provided.
 
-   Returns the result of the call on success, or *NULL* on failure.
+   Return the result of the call on success, or raise an exception and return
+   *NULL* on failure.
 
    This is the equivalent of the Python expression: ``callable(*args)``.
 
@@ -302,7 +305,8 @@ Object Protocol
 
    The format can be *NULL*, indicating that no arguments are provided.
 
-   Returns the result of the call on success, or *NULL* on failure.
+   Return the result of the call on success, or raise an exception and return
+   *NULL* on failure.
 
    This is the equivalent of the Python expression:
    ``obj.name(arg1, arg2, ...)``.
@@ -320,7 +324,8 @@ Object Protocol
    :c:type:`PyObject\*` arguments.  The arguments are provided as a variable number
    of parameters followed by *NULL*.
 
-   Returns the result of the call on success, or *NULL* on failure.
+   Return the result of the call on success, or raise an exception and return
+   *NULL* on failure.
 
    This is the equivalent of the Python expression:
    ``callable(arg1, arg2, ...)``.
@@ -331,7 +336,9 @@ Object Protocol
    Calls a method of the Python object *obj*, where the name of the method is given as a
    Python string object in *name*.  It is called with a variable number of
    :c:type:`PyObject\*` arguments.  The arguments are provided as a variable number
-   of parameters followed by *NULL*. Returns the result of the call on success, or
+   of parameters followed by *NULL*.
+
+   Return the result of the call on success, or raise an exception and return
    *NULL* on failure.
 
 
@@ -355,7 +362,8 @@ Object Protocol
    *kwnames* must contain only objects of type ``str`` (not a subclass),
    and all keys must be unique.
 
-   Return the result of the call on success, or *NULL* on failure.
+   Return the result of the call on success, or raise an exception and return
+   *NULL* on failure.
 
    This uses the vectorcall protocol if the callable supports it;
    otherwise, the arguments are converted to use


### PR DESCRIPTION
Mention explicitly that PyObject_CallXXX() functions raise an
exception an failure.

(cherry picked from commit 1ce2656f13e726b3b99d4c968926908cff1f460a)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37194](https://bugs.python.org/issue37194) -->
https://bugs.python.org/issue37194
<!-- /issue-number -->
