### PR TITLE
bpo-37194: Add PyObject_CallNoArgs() rationale

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -255,7 +255,8 @@ Object Protocol
 
 .. c:function:: PyObject* PyObject_CallNoArgs(PyObject *callable)
 
-   Call a callable Python object *callable* without any arguments.
+   Call a callable Python object *callable* without any arguments. It is the
+   most efficient way to call a callable Python object without any argument.
 
    Return the result of the call on success, or raise an exception and return
    *NULL* on failure.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -103,7 +103,10 @@ Build and C API Changes
 =======================
 
 * Add a new public :c:func:`PyObject_CallNoArgs` function to the C API:
-  call a callable Python object without any arguments.
+  call a callable Python object without any arguments. It is the most efficient
+  way to call a callable Python object without any argument.
+  (Contributed by Victor Stinner in :issue:`37194`.)
+
 
 
 Deprecated


### PR DESCRIPTION
Explain in the doc why PyObject_CallNoArgs() should be preferred over
other existing ways to call a function without any arguments.

<!-- issue-number: [bpo-37194](https://bugs.python.org/issue37194) -->
https://bugs.python.org/issue37194
<!-- /issue-number -->
