### PR TITLE
bpo-37320: Remove openfp() of aifc, sunau and wave

### DIFF
--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -59,13 +59,6 @@ The :mod:`sunau` module defines the following functions:
    or ``'wb'`` returns an :class:`AU_write` object.
 
 
-.. function:: openfp(file, mode)
-
-   A synonym for :func:`.open`, maintained for backwards compatibility.
-
-   .. deprecated-removed:: 3.7 3.9
-
-
 The :mod:`sunau` module defines the following exception:
 
 .. exception:: Error

--- a/Doc/library/wave.rst
+++ b/Doc/library/wave.rst
@@ -47,13 +47,6 @@ The :mod:`wave` module defines the following function and exception:
    .. versionchanged:: 3.4
       Added support for unseekable files.
 
-.. function:: openfp(file, mode)
-
-   A synonym for :func:`.open`, maintained for backwards compatibility.
-
-   .. deprecated-removed:: 3.7 3.9
-
-
 .. exception:: Error
 
    An error raised when something is impossible because it violates the WAV

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -122,9 +122,14 @@ Deprecated
 Removed
 =======
 
-``_dummy_thread`` and ``dummy_threading`` modules have been removed. These
-modules were deprecated since Python 3.7 which requires threading support.
-(Contributed by Victor Stinner in :issue:`37312`.)
+* ``_dummy_thread`` and ``dummy_threading`` modules have been removed. These
+  modules were deprecated since Python 3.7 which requires threading support.
+  (Contributed by Victor Stinner in :issue:`37312`.)
+
+* ``aifc.openfp()`` alias to ``aifc.open()``, ``sunau.openfp()`` alias to
+  ``sunau.open()``, and ``wave.openfp()`` alias to ``wave.open()`` have been
+  removed. They were deprecated since Python 3.7.
+  (Contributed by Victor Stinner in :issue:`37320`.)
 
 
 Porting to Python 3.9

--- a/Lib/aifc.py
+++ b/Lib/aifc.py
@@ -138,7 +138,7 @@ import struct
 import builtins
 import warnings
 
-__all__ = ["Error", "open", "openfp"]
+__all__ = ["Error", "open"]
 
 class Error(Exception):
     pass
@@ -920,10 +920,6 @@ def open(f, mode=None):
     else:
         raise Error("mode must be 'r', 'rb', 'w', or 'wb'")
 
-def openfp(f, mode=None):
-    warnings.warn("aifc.openfp is deprecated since Python 3.7. "
-                  "Use aifc.open instead.", DeprecationWarning, stacklevel=2)
-    return open(f, mode=mode)
 
 if __name__ == '__main__':
     import sys

--- a/Lib/sunau.py
+++ b/Lib/sunau.py
@@ -104,7 +104,7 @@ is destroyed.
 """
 
 from collections import namedtuple
-import warnings
+
 
 _sunau_params = namedtuple('_sunau_params',
                            'nchannels sampwidth framerate nframes comptype compname')
@@ -524,8 +524,3 @@ def open(f, mode=None):
         return Au_write(f)
     else:
         raise Error("mode must be 'r', 'rb', 'w', or 'wb'")
-
-def openfp(f, mode=None):
-    warnings.warn("sunau.openfp is deprecated since Python 3.7. "
-                  "Use sunau.open instead.", DeprecationWarning, stacklevel=2)
-    return open(f, mode=mode)

--- a/Lib/test/audiotests.py
+++ b/Lib/test/audiotests.py
@@ -1,7 +1,6 @@
 from test.support import findfile, TESTFN, unlink
 import array
 import io
-from unittest import mock
 import pickle
 
 

--- a/Lib/test/audiotests.py
+++ b/Lib/test/audiotests.py
@@ -50,17 +50,6 @@ class AudioTests:
             self.assertEqual(pickle.loads(dump), params)
 
 
-class AudioMiscTests(AudioTests):
-
-    def test_openfp_deprecated(self):
-        arg = "arg"
-        mode = "mode"
-        with mock.patch(f"{self.module.__name__}.open") as mock_open, \
-             self.assertWarns(DeprecationWarning):
-            self.module.openfp(arg, mode=mode)
-            mock_open.assert_called_with(arg, mode=mode)
-
-
 class AudioWriteTests(AudioTests):
 
     def create_file(self, testfile):

--- a/Lib/test/test_aifc.py
+++ b/Lib/test/test_aifc.py
@@ -143,13 +143,12 @@ class AifcALAWTest(AifcTest, unittest.TestCase):
         frames = byteswap(frames, 2)
 
 
-class AifcMiscTest(audiotests.AudioMiscTests, unittest.TestCase):
-    module = aifc
-
+class AifcMiscTest(unittest.TestCase):
     def test_skipunknown(self):
         #Issue 2245
         #This file contains chunk types aifc doesn't recognize.
-        self.f = aifc.open(findfile('Sine-1000Hz-300ms.aif'))
+        f = aifc.open(findfile('Sine-1000Hz-300ms.aif'))
+        f.close()
 
     def test_close_opened_files_on_error(self):
         non_aifc_file = findfile('pluck-pcm8.wav', subdir='audiodata')
@@ -172,7 +171,8 @@ class AifcMiscTest(audiotests.AudioMiscTests, unittest.TestCase):
         f.setparams((1, 1, 1, 1, b'NONE', b''))
         f.close()
 
-        f = self.f = aifc.open(TESTFN, 'rb')
+        f = aifc.open(TESTFN, 'rb')
+        self.addCleanup(f.close)
         params = f.getparams()
         self.assertEqual(params.nchannels, f.getnchannels())
         self.assertEqual(params.sampwidth, f.getsampwidth())
@@ -208,7 +208,8 @@ class AifcMiscTest(audiotests.AudioMiscTests, unittest.TestCase):
         fout.setmark(2, 0, b'even')
         fout.writeframes(b'\x00')
         fout.close()
-        f = self.f = aifc.open(TESTFN, 'rb')
+        f = aifc.open(TESTFN, 'rb')
+        self.addCleanup(f.close)
         self.assertEqual(f.getmarkers(), [(1, 0, b'odd'), (2, 0, b'even')])
         self.assertEqual(f.getmark(1), (1, 0, b'odd'))
         self.assertEqual(f.getmark(2), (2, 0, b'even'))

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -225,9 +225,7 @@ class PyclbrTest(TestCase):
         cm('random', ignore=('Random',))  # from _random import Random as CoreGenerator
         cm('cgi', ignore=('log',))      # set with = in module
         cm('pickle', ignore=('partial', 'PickleBuffer'))
-        # TODO(briancurtin): openfp is deprecated as of 3.7.
-        # Update this once it has been removed.
-        cm('aifc', ignore=('openfp', '_aifc_params'))  # set with = in module
+        cm('aifc', ignore=('_aifc_params',))  # set with = in module
         cm('sre_parse', ignore=('dump', 'groups', 'pos')) # from sre_constants import *; property
         cm('pdb')
         cm('pydoc', ignore=('input', 'output',)) # properties

--- a/Lib/test/test_sunau.py
+++ b/Lib/test/test_sunau.py
@@ -119,10 +119,6 @@ class SunauULAWTest(SunauTest, unittest.TestCase):
         frames = byteswap(frames, 2)
 
 
-class SunauMiscTests(audiotests.AudioMiscTests, unittest.TestCase):
-    module = sunau
-
-
 class SunauLowLevelTest(unittest.TestCase):
 
     def test_read_bad_magic_number(self):

--- a/Lib/test/test_wave.py
+++ b/Lib/test/test_wave.py
@@ -105,9 +105,7 @@ class WavePCM32Test(WaveTest, unittest.TestCase):
         frames = byteswap(frames, 4)
 
 
-class MiscTestCase(audiotests.AudioMiscTests, unittest.TestCase):
-    module = wave
-
+class MiscTestCase(unittest.TestCase):
     def test__all__(self):
         blacklist = {'WAVE_FORMAT_PCM'}
         support.check__all__(self, wave, blacklist=blacklist)

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -71,9 +71,15 @@ The close() method is called automatically when the class instance
 is destroyed.
 """
 
+from chunk import Chunk
+from collections import namedtuple
+import audioop
 import builtins
+import struct
+import sys
 
-__all__ = ["open", "openfp", "Error", "Wave_read", "Wave_write"]
+
+__all__ = ["open", "Error", "Wave_read", "Wave_write"]
 
 class Error(Exception):
     pass
@@ -81,13 +87,6 @@ class Error(Exception):
 WAVE_FORMAT_PCM = 0x0001
 
 _array_fmts = None, 'b', 'h', None, 'i'
-
-import audioop
-import struct
-import sys
-from chunk import Chunk
-from collections import namedtuple
-import warnings
 
 _wave_params = namedtuple('_wave_params',
                      'nchannels sampwidth framerate nframes comptype compname')
@@ -512,8 +511,3 @@ def open(f, mode=None):
         return Wave_write(f)
     else:
         raise Error("mode must be 'r', 'rb', 'w', or 'wb'")
-
-def openfp(f, mode=None):
-    warnings.warn("wave.openfp is deprecated since Python 3.7. "
-                  "Use wave.open instead.", DeprecationWarning, stacklevel=2)
-    return open(f, mode=mode)

--- a/Misc/NEWS.d/next/Library/2019-06-17-22-10-37.bpo-37320.ffieYa.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-17-22-10-37.bpo-37320.ffieYa.rst
@@ -1,0 +1,3 @@
+``aifc.openfp()`` alias to ``aifc.open()``, ``sunau.openfp()`` alias to
+``sunau.open()``, and ``wave.openfp()`` alias to ``wave.open()`` have been
+removed. They were deprecated since Python 3.7.


### PR DESCRIPTION
aifc.openfp() alias to aifc.open(), sunau.openfp() alias to
sunau.open(), and wave.openfp() alias to wave.open() have been
removed. They were deprecated since Python 3.7.

<!-- issue-number: [bpo-37320](https://bugs.python.org/issue37320) -->
https://bugs.python.org/issue37320
<!-- /issue-number -->
