### PR TITLE
bpo-37324: Remove ABC aliases from collections

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -33,11 +33,6 @@ Python's general purpose built-in containers, :class:`dict`, :class:`list`,
 :class:`UserString`     wrapper around string objects for easier string subclassing
 =====================   ====================================================================
 
-.. deprecated-removed:: 3.3 3.9
-    Moved :ref:`collections-abstract-base-classes` to the :mod:`collections.abc` module.
-    For backwards compatibility, they continue to be visible in this module through
-    Python 3.8.
-
 
 :class:`ChainMap` objects
 -------------------------

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -122,9 +122,13 @@ Deprecated
 Removed
 =======
 
-``_dummy_thread`` and ``dummy_threading`` modules have been removed. These
-modules were deprecated since Python 3.7 which requires threading support.
-(Contributed by Victor Stinner in :issue:`37312`.)
+* ``_dummy_thread`` and ``dummy_threading`` modules have been removed. These
+   modules were deprecated since Python 3.7 which requires threading support.
+   (Contributed by Victor Stinner in :issue:`37312`.)
+
+* Remove deprecated aliases to :ref:`collections-abstract-base-classes` from
+  the :mod:`collections` module.
+  (Contributed by Victor Stinner in :issue:`37324`.)
 
 
 Porting to Python 3.9

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -39,21 +39,6 @@ except ImportError:
     pass
 
 
-def __getattr__(name):
-    # For backwards compatibility, continue to make the collections ABCs
-    # through Python 3.6 available through the collections module.
-    # Note, no new collections ABCs were added in Python 3.7
-    if name in _collections_abc.__all__:
-        obj = getattr(_collections_abc, name)
-        import warnings
-        warnings.warn("Using or importing the ABCs from 'collections' instead "
-                      "of from 'collections.abc' is deprecated since Python 3.3,"
-                      "and in 3.9 it will stop working",
-                      DeprecationWarning, stacklevel=2)
-        globals()[name] = obj
-        return obj
-    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
-
 ################################################################################
 ### OrderedDict
 ################################################################################

--- a/Misc/NEWS.d/next/Library/2019-06-17-22-44-17.bpo-37324.jB-9_U.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-17-22-44-17.bpo-37324.jB-9_U.rst
@@ -1,0 +1,2 @@
+Remove deprecated aliases to :ref:`collections-abstract-base-classes` from
+the :mod:`collections` module.


### PR DESCRIPTION
Remove deprecated aliases to Abstract Base Classes from the
collections module.

<!-- issue-number: [bpo-37324](https://bugs.python.org/issue37324) -->
https://bugs.python.org/issue37324
<!-- /issue-number -->
