### PR TITLE
bpo-37328: remove deprecated HTMLParser.unescape

### DIFF
--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -9,7 +9,6 @@
 
 
 import re
-import warnings
 import _markupbase
 
 from html import unescape
@@ -461,10 +460,3 @@ class HTMLParser(_markupbase.ParserBase):
 
     def unknown_decl(self, data):
         pass
-
-    # Internal -- helper to remove special character quoting
-    def unescape(self, s):
-        warnings.warn('The unescape method is deprecated and will be removed '
-                      'in 3.5, use html.unescape() instead.',
-                      DeprecationWarning, stacklevel=2)
-        return unescape(s)

--- a/Lib/test/test_htmlparser.py
+++ b/Lib/test/test_htmlparser.py
@@ -573,13 +573,6 @@ text
         for html, expected in data:
             self._run_check(html, expected)
 
-    def test_unescape_method(self):
-        from html import unescape
-        p = self.get_collector()
-        with self.assertWarns(DeprecationWarning):
-            s = '&quot;&#34;&#x22;&quot&#34&#x22&#bad;'
-            self.assertEqual(p.unescape(s), unescape(s))
-
     def test_broken_comments(self):
         html = ('<! not really a comment >'
                 '<! not a comment either -->'

--- a/Misc/NEWS.d/next/Library/2019-06-18-15-31-33.bpo-37328.2PW1-l.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-18-15-31-33.bpo-37328.2PW1-l.rst
@@ -1,0 +1,2 @@
+``HTMLParser.unescape`` is removed.  It was undocumented and deprecated
+since Python 3.4.


### PR DESCRIPTION
It is deprecated since Python 3.4


<!-- issue-number: [bpo-37328](https://bugs.python.org/issue37328) -->
https://bugs.python.org/issue37328
<!-- /issue-number -->
