### PR TITLE
bpo-34631: Update OpenSSL to 1.1.1c in macOS installer

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -215,9 +215,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.1.0j",
-              url="https://www.openssl.org/source/openssl-1.1.0j.tar.gz",
-              checksum='b4ca5b78ae6ae79da80790b30dbedbdc',
+              name="OpenSSL 1.1.1c",
+              url="https://www.openssl.org/source/openssl-1.1.1c.tar.gz",
+              checksum='15e21da6efe8aa0e0768ffd8cd37a5f6',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,
@@ -810,6 +810,16 @@ def build_universal_openssl(basedir, archList):
             "ppc": ["darwin-ppc-cc"],
             "ppc64": ["darwin64-ppc-cc"],
         }
+
+        # Somewhere between OpenSSL 1.1.0j and 1.1.1c, changes cause the
+        # "enable-ec_nistp_64_gcc_128" option to get compile errors when
+        # building on our 10.6 gcc-4.2 environment.  There have been other
+        # reports of projects running into this when using older compilers.
+        # So, for now, do not try to use "enable-ec_nistp_64_gcc_128" when
+        # building for 10.6.
+        if getDeptargetTuple() == (10, 6):
+            arch_opts['x86_64'].remove('enable-ec_nistp_64_gcc_128')
+
         configure_opts = [
             "no-idea",
             "no-mdc2",

--- a/Misc/NEWS.d/next/macOS/2019-06-18-00-30-40.bpo-34631.vSifcv.rst
+++ b/Misc/NEWS.d/next/macOS/2019-06-18-00-30-40.bpo-34631.vSifcv.rst
@@ -1,0 +1,1 @@
+Updated OpenSSL to 1.1.1c in macOS installer.


### PR DESCRIPTION


<!-- issue-number: [bpo-34631](https://bugs.python.org/issue34631) -->
https://bugs.python.org/issue34631
<!-- /issue-number -->
