### PR TITLE
bpo-35031: also disable TLS 1.3 for test_start_tls_server_1 on macOS

### DIFF
--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -498,11 +498,13 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
 
         server_context = test_utils.simple_server_sslcontext()
         client_context = test_utils.simple_client_sslcontext()
-        if sys.platform.startswith('freebsd') or sys.platform.startswith('win'):
+        if (sys.platform.startswith('freebsd')
+                or sys.platform.startswith('win')
+                or sys.platform.startswith('darwin')):
             # bpo-35031: Some FreeBSD and Windows buildbots fail to run this test
             # as the eof was not being received by the server if the payload
             # size is not big enough. This behaviour only appears if the
-            # client is using TLS1.3.
+            # client is using TLS1.3.  Also seen on macOS.
             client_context.options |= ssl.OP_NO_TLSv1_3
         answer = None
 


### PR DESCRIPTION


<!-- issue-number: [bpo-35031](https://bugs.python.org/issue35031) -->
https://bugs.python.org/issue35031
<!-- /issue-number -->
