### PR TITLE
[3.7] bpo-34711: Return HTTPStatus.NOT_FOUND if path.endswith(/) and not a directory (GH-9687)

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -692,6 +692,14 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             else:
                 return self.list_directory(path)
         ctype = self.guess_type(path)
+        # check for trailing "/" which should return 404. See Issue17324
+        # The test for this was added in test_httpserver.py
+        # However, some OS platforms accept a trailingSlash as a filename
+        # See discussion on python-dev and Issue34711 regarding
+        # parseing and rejection of filenames with a trailing slash
+        if path.endswith("/"):
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
         try:
             f = open(path, 'rb')
         except OSError:

--- a/Misc/NEWS.d/next/Library/2018-10-03-09-25-02.bpo-34711.HeOmKR.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-03-09-25-02.bpo-34711.HeOmKR.rst
@@ -1,0 +1,3 @@
+http.server ensures it reports HTTPStatus.NOT_FOUND when the local path ends with "/"
+and is not a directory, even if the underlying OS (e.g. AIX) accepts such paths as a
+valid file reference. Patch by Michael Felt.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34711](https://bugs.python.org/issue34711) -->
https://bugs.python.org/issue34711
<!-- /issue-number -->
