### PR TITLE
[2.7] bpo-34631: Updated OpenSSL to 1.0.2s in macOS installer.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -213,9 +213,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.0.2q",
-              url="https://www.openssl.org/source/openssl-1.0.2q.tar.gz",
-              checksum='7563e1ce046cb21948eeb6ba1a0eb71c',
+              name="OpenSSL 1.0.2s",
+              url="https://www.openssl.org/source/openssl-1.0.2s.tar.gz",
+              checksum='98ec4e085962689b91d25e1dcdfc14a2',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2019-06-18-05-39-01.bpo-34631.StdZhE.rst
+++ b/Misc/NEWS.d/next/macOS/2019-06-18-05-39-01.bpo-34631.StdZhE.rst
@@ -1,0 +1,1 @@
+Updated OpenSSL to 1.0.2s in macOS installer.


### PR DESCRIPTION


<!-- issue-number: [bpo-34631](https://bugs.python.org/issue34631) -->
https://bugs.python.org/issue34631
<!-- /issue-number -->
