### PR TITLE
[2.7] bpo-37329: valgrind: ignore _PyWarnings_Init false alarms

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-18-15-08-32.bpo-37329.7XVDRv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-18-15-08-32.bpo-37329.7XVDRv.rst
@@ -1,0 +1,3 @@
+valgrind: suppress a false alarm in memory leak checks. _PyWarnings_Init()
+only allocates memory once at startup but it is not released at exit. Ignore
+this issue to be able to catch other bugs more easily.

--- a/Misc/valgrind-python.supp
+++ b/Misc/valgrind-python.supp
@@ -104,7 +104,7 @@
 }
 
 {
-   bpo-37329: _PyWarnings_Init allocates memory at startup, but does't release it at exit
+   bpo-37329: _PyWarnings_Init allocates memory at startup, but doesn't release it at exit
    Memcheck:Leak
    fun:malloc
    ...

--- a/Misc/valgrind-python.supp
+++ b/Misc/valgrind-python.supp
@@ -103,6 +103,14 @@
    fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
 }
 
+{
+   bpo-37329: _PyWarnings_Init allocates memory at startup, but does't release it at exit
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:_PyWarnings_Init
+}
+
 #
 # Non-python specific leaks
 #


### PR DESCRIPTION
_PyWarnings_Init() only allocates memory once at startup but it is
not released at exit. Ignore this issue to be able to catch other
bugs more easily.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37329](https://bugs.python.org/issue37329) -->
https://bugs.python.org/issue37329
<!-- /issue-number -->
