### PR TITLE
bpo-6839: removed unnecessary file name encoding test from ZipFile.open()

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1497,7 +1497,7 @@ class ZipFile:
             if fheader[_FH_SIGNATURE] != stringFileHeader:
                 raise BadZipFile("Bad magic number for file header")
 
-            fname = zef_file.read(fheader[_FH_FILENAME_LENGTH])
+            zef_file.read(fheader[_FH_FILENAME_LENGTH])
             if fheader[_FH_EXTRA_FIELD_LENGTH]:
                 zef_file.read(fheader[_FH_EXTRA_FIELD_LENGTH])
 
@@ -1508,17 +1508,6 @@ class ZipFile:
             if zinfo.flag_bits & 0x40:
                 # strong encryption
                 raise NotImplementedError("strong encryption (flag bit 6)")
-
-            if zinfo.flag_bits & 0x800:
-                # UTF-8 filename
-                fname_str = fname.decode("utf-8")
-            else:
-                fname_str = fname.decode("cp437")
-
-            if fname_str != zinfo.orig_filename:
-                raise BadZipFile(
-                    'File name in directory %r and header %r differ.'
-                    % (zinfo.orig_filename, fname))
 
             # check for encrypted flag & handle password
             is_encrypted = zinfo.flag_bits & 0x1


### PR DESCRIPTION
When attempting to open a ZIP file with `ZipFile.open()`, a BadZipFile exception is raised. The origin of the exception is an unnecessary file name encoding test.

```python
            if zinfo.flag_bits & 0x800:
                # UTF-8 filename
                fname_str = fname.decode("utf-8")
            else:
                fname_str = fname.decode("cp437")

            if fname_str != zinfo.orig_filename:
                raise BadZipFile(
                    'File name in directory %r and header %r differ.'
                    % (zinfo.orig_filename, fname))
```

Two clear problems with this test:

1. The test supports only the UTF-8 and [CP437](https://en.wikipedia.org/wiki/Code_page_437) encodings.
2. On Windows, the test always fails due to path separator differences.

Two risks with this solution:

1. This test might be relevant to whomever is using CP437.
2. This test might be relevant on non-Windows platforms.

This issue has been open and unresolved for nearly 10 years, requiring users to subclass ZipFile when working with ZIP files on Windows platforms. This issue affects every version of Python since at least 2.7.

<!-- issue-number: [bpo-6839](https://bugs.python.org/issue6839) -->
https://bugs.python.org/issue6839
<!-- /issue-number -->
