### PR TITLE
bpo-35134: Add Include/cpython/import.h header file

### DIFF
--- a/Include/cpython/import.h
+++ b/Include/cpython/import.h
@@ -1,0 +1,57 @@
+#ifndef Py_CPYTHON_IMPORT_H
+#  error "this header file must not be included directly"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+PyMODINIT_FUNC PyInit__imp(void);
+
+PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
+
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
+PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *name,
+                                                 PyObject *modules);
+PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);
+PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
+
+PyAPI_FUNC(void) _PyImport_AcquireLock(void);
+PyAPI_FUNC(int) _PyImport_ReleaseLock(void);
+
+PyAPI_FUNC(PyObject *) _PyImport_FindBuiltin(
+    const char *name,            /* UTF-8 encoded string */
+    PyObject *modules
+    );
+PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObject(PyObject *, PyObject *);
+PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObjectEx(PyObject *, PyObject *,
+                                                       PyObject *);
+PyAPI_FUNC(int) _PyImport_FixupBuiltin(
+    PyObject *mod,
+    const char *name,            /* UTF-8 encoded string */
+    PyObject *modules
+    );
+PyAPI_FUNC(int) _PyImport_FixupExtensionObject(PyObject*, PyObject *,
+                                               PyObject *, PyObject *);
+
+struct _inittab {
+    const char *name;           /* ASCII encoded string */
+    PyObject* (*initfunc)(void);
+};
+PyAPI_DATA(struct _inittab *) PyImport_Inittab;
+PyAPI_FUNC(int) PyImport_ExtendInittab(struct _inittab *newtab);
+
+struct _frozen {
+    const char *name;                 /* ASCII encoded string */
+    const unsigned char *code;
+    int size;
+};
+
+/* Embedding apps may change this pointer to point to their favorite
+   collection of frozen modules: */
+
+PyAPI_DATA(const struct _frozen *) PyImport_FrozenModules;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Include/import.h
+++ b/Include/import.h
@@ -1,4 +1,3 @@
-
 /* Module definition and import interface */
 
 #ifndef Py_IMPORT_H
@@ -7,9 +6,6 @@
 extern "C" {
 #endif
 
-#ifndef Py_LIMITED_API
-PyMODINIT_FUNC PyInit__imp(void);
-#endif /* !Py_LIMITED_API */
 PyAPI_FUNC(long) PyImport_GetMagicNumber(void);
 PyAPI_FUNC(const char *) PyImport_GetMagicTag(void);
 PyAPI_FUNC(PyObject *) PyImport_ExecCodeModule(
@@ -38,14 +34,6 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
 PyAPI_FUNC(PyObject *) PyImport_GetModule(PyObject *name);
-#endif
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
-PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *name,
-                                                 PyObject *modules);
-PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);
-PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(
@@ -94,35 +82,6 @@ PyAPI_FUNC(int) PyImport_ImportFrozenModule(
     const char *name            /* UTF-8 encoded string */
     );
 
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _PyImport_AcquireLock(void);
-PyAPI_FUNC(int) _PyImport_ReleaseLock(void);
-
-PyAPI_FUNC(void) _PyImport_ReInitLock(void);
-
-PyAPI_FUNC(PyObject *) _PyImport_FindBuiltin(
-    const char *name,            /* UTF-8 encoded string */
-    PyObject *modules
-    );
-PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObject(PyObject *, PyObject *);
-PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObjectEx(PyObject *, PyObject *,
-                                                       PyObject *);
-PyAPI_FUNC(int) _PyImport_FixupBuiltin(
-    PyObject *mod,
-    const char *name,            /* UTF-8 encoded string */
-    PyObject *modules
-    );
-PyAPI_FUNC(int) _PyImport_FixupExtensionObject(PyObject*, PyObject *,
-                                               PyObject *, PyObject *);
-
-struct _inittab {
-    const char *name;           /* ASCII encoded string */
-    PyObject* (*initfunc)(void);
-};
-PyAPI_DATA(struct _inittab *) PyImport_Inittab;
-PyAPI_FUNC(int) PyImport_ExtendInittab(struct _inittab *newtab);
-#endif /* Py_LIMITED_API */
-
 PyAPI_DATA(PyTypeObject) PyNullImporter_Type;
 
 PyAPI_FUNC(int) PyImport_AppendInittab(
@@ -131,16 +90,9 @@ PyAPI_FUNC(int) PyImport_AppendInittab(
     );
 
 #ifndef Py_LIMITED_API
-struct _frozen {
-    const char *name;                 /* ASCII encoded string */
-    const unsigned char *code;
-    int size;
-};
-
-/* Embedding apps may change this pointer to point to their favorite
-   collection of frozen modules: */
-
-PyAPI_DATA(const struct _frozen *) PyImport_FrozenModules;
+#  define Py_CPYTHON_IMPORT_H
+#  include  "cpython/import.h"
+#  undef Py_CPYTHON_IMPORT_H
 #endif
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -1,0 +1,14 @@
+#ifndef Py_LIMITED_API
+#ifndef Py_INTERNAL_IMPORT_H
+#define Py_INTERNAL_IMPORT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void _PyImport_ReInitLock(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_IMPORT_H */
+#endif /* !Py_LIMITED_API */

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1054,6 +1054,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/cpython/abstract.h \
 		$(srcdir)/Include/cpython/dictobject.h \
 		$(srcdir)/Include/cpython/fileobject.h \
+		$(srcdir)/Include/cpython/import.h \
 		$(srcdir)/Include/cpython/initconfig.h \
 		$(srcdir)/Include/cpython/interpreteridobject.h \
 		$(srcdir)/Include/cpython/object.h \
@@ -1077,6 +1078,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_getopt.h \
 		$(srcdir)/Include/internal/pycore_gil.h \
 		$(srcdir)/Include/internal/pycore_hamt.h \
+		$(srcdir)/Include/internal/pycore_import.h \
 		$(srcdir)/Include/internal/pycore_initconfig.h \
 		$(srcdir)/Include/internal/pycore_object.h \
 		$(srcdir)/Include/internal/pycore_pathconfig.h \

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -36,6 +36,7 @@
 #endif
 
 #include "pycore_ceval.h"     /* _PyEval_ReInitThreads() */
+#include "pycore_import.h"    /* _PyImport_ReInitLock() */
 #include "pycore_pystate.h"   /* _PyRuntime */
 #include "pythread.h"
 #include "structmember.h"

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -129,6 +129,7 @@
     <ClInclude Include="..\Include\cpython\abstract.h" />
     <ClInclude Include="..\Include\cpython\dictobject.h" />
     <ClInclude Include="..\Include\cpython\fileobject.h" />
+    <ClInclude Include="..\Include\cpython\import.h" />
     <ClInclude Include="..\Include\cpython\initconfig.h" />
     <ClInclude Include="..\Include\cpython\object.h" />
     <ClInclude Include="..\Include\cpython\objimpl.h" />
@@ -158,14 +159,15 @@
     <ClInclude Include="..\Include\import.h" />
     <ClInclude Include="..\Include\internal\pycore_accu.h" />
     <ClInclude Include="..\Include\internal\pycore_atomic.h" />
-    <ClInclude Include="..\Include\internal\pycore_code.h" />
     <ClInclude Include="..\Include\internal\pycore_ceval.h" />
+    <ClInclude Include="..\Include\internal\pycore_code.h" />
     <ClInclude Include="..\Include\internal\pycore_condvar.h" />
     <ClInclude Include="..\Include\internal\pycore_context.h" />
     <ClInclude Include="..\Include\internal\pycore_fileutils.h" />
     <ClInclude Include="..\Include\internal\pycore_getopt.h" />
     <ClInclude Include="..\Include\internal\pycore_gil.h" />
     <ClInclude Include="..\Include\internal\pycore_hamt.h" />
+    <ClInclude Include="..\Include\internal\pycore_import.h" />
     <ClInclude Include="..\Include\internal\pycore_initconfig.h" />
     <ClInclude Include="..\Include\internal\pycore_object.h" />
     <ClInclude Include="..\Include\internal\pycore_pathconfig.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClInclude Include="..\Include\cpython\fileobject.h">
       <Filter>Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\cpython\import.h">
+      <Filter>Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\cpython\initconfig.h">
       <Filter>Include</Filter>
     </ClInclude>
@@ -199,6 +202,9 @@
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_hamt.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_import.h">
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_initconfig.h">


### PR DESCRIPTION
* Add Include/cpython/import.h and Include/internal/pycore_import.h
  header files.
* Move _PyImport_ReInitLock() to the internal C API. Don't export the
  symbol anymore.

<!-- issue-number: [bpo-35134](https://bugs.python.org/issue35134) -->
https://bugs.python.org/issue35134
<!-- /issue-number -->
