### PR TITLE
bpo-33416: Document changes in PyNode_AddChild and PyParser_AddToken

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1457,6 +1457,8 @@ Changes in the C API
 * The :c:func:`PyCode_New` has a new parameter in the second position (*posonlyargcount*)
   to support :pep:`570`, indicating the number of positional-only arguments.
 
+* The functions :c:func:`PyNode_AddChild` and :c:func:`PyParser_AddToken` now accept
+  two additional ``int`` arguments *end_lineno* and *end_col_offset*.
 
 CPython bytecode changes
 ------------------------


### PR DESCRIPTION
I didn't find any entries in the docs about these functions, so I just mentioned them, in "What's New".

<!-- issue-number: [bpo-33416](https://bugs.python.org/issue33416) -->
https://bugs.python.org/issue33416
<!-- /issue-number -->
