### PR TITLE
bpo-36710: Remove PyImport_Cleanup() function

### DIFF
--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -223,21 +223,6 @@ Importing Modules
    Return a new reference to the finder object.
 
 
-.. c:function:: void _PyImport_Init()
-
-   Initialize the import mechanism.  For internal use only.
-
-
-.. c:function:: void PyImport_Cleanup()
-
-   Empty the module table.  For internal use only.
-
-
-.. c:function:: void _PyImport_Fini()
-
-   Finalize the import mechanism.  For internal use only.
-
-
 .. c:function:: int PyImport_ImportFrozenModuleObject(PyObject *name)
 
    Load a frozen module named *name*.  Return ``1`` for success, ``0`` if the

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -122,6 +122,9 @@ Deprecated
 Removed
 =======
 
+* The C function ``PyImport_Cleanup()`` has been removed. It was documented as:
+  "Empty the module table.  For internal use only."
+
 * ``_dummy_thread`` and ``dummy_threading`` modules have been removed. These
   modules were deprecated since Python 3.7 which requires threading support.
   (Contributed by Victor Stinner in :issue:`37312`.)

--- a/Include/import.h
+++ b/Include/import.h
@@ -72,7 +72,6 @@ PyAPI_FUNC(PyObject *) PyImport_ImportModuleLevelObject(
 PyAPI_FUNC(PyObject *) PyImport_GetImporter(PyObject *path);
 PyAPI_FUNC(PyObject *) PyImport_Import(PyObject *name);
 PyAPI_FUNC(PyObject *) PyImport_ReloadModule(PyObject *m);
-PyAPI_FUNC(void) PyImport_Cleanup(void);
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(int) PyImport_ImportFrozenModuleObject(
     PyObject *name

--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -11,6 +11,7 @@ PyAPI_FUNC(PyObject *) _PyImport_FindBuiltin(
     );
 
 extern void _PyImport_ReInitLock(void);
+extern void _PyImport_Cleanup(PyThreadState *tstate);
 
 #ifdef __cplusplus
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -413,9 +413,8 @@ static const char * const sys_files[] = {
 /* Un-initialize things, as good as we can */
 
 void
-PyImport_Cleanup(void)
+_PyImport_Cleanup(PyThreadState *tstate)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
     PyInterpreterState *interp = tstate->interp;
     PyObject *modules = interp->modules;
     if (modules == NULL) {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1225,7 +1225,7 @@ Py_FinalizeEx(void)
     _PySys_ClearAuditHooks();
 
     /* Destroy all modules */
-    PyImport_Cleanup();
+    _PyImport_Cleanup(tstate);
 
     /* Print debug stats if any */
     _PyEval_Fini();
@@ -1589,7 +1589,7 @@ Py_EndInterpreter(PyThreadState *tstate)
     if (tstate != interp->tstate_head || tstate->next != NULL)
         Py_FatalError("Py_EndInterpreter: not the last thread");
 
-    PyImport_Cleanup();
+    _PyImport_Cleanup(tstate);
     PyInterpreterState_Clear(interp);
     PyThreadState_Swap(NULL);
     PyInterpreterState_Delete(interp);


### PR DESCRIPTION
* Rename PyImport_Cleanup() to _PyImport_Cleanup() and move it to the
  internal C API. Add 'tstate' parameters.
* Remove documentation of _PyImport_Init(), PyImport_Cleanup(),
  _PyImport_Fini(). All three were documented as "For internal use
  only.".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36710](https://bugs.python.org/issue36710) -->
https://bugs.python.org/issue36710
<!-- /issue-number -->
