### PR TITLE
bpo-37334: Add a cancel method to asyncio Queues

### DIFF
--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -89,7 +89,7 @@ Queue
 
       Return the number of items in the queue.
 
-   .. method:: cancel()
+   .. method:: close()
 
       Cancel all currently waiting :meth:`get` or :meth:`put`
       coroutines.

--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -89,6 +89,11 @@ Queue
 
       Return the number of items in the queue.
 
+   .. method:: cancel()
+
+      Cancel all currently waiting :meth:`get` or :meth:`put`
+      coroutines.
+
    .. method:: task_done()
 
       Indicate that a formerly enqueued task is complete.

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -215,6 +215,13 @@ class Queue(mixins._LoopBoundMixin):
         if self._unfinished_tasks > 0:
             await self._finished.wait()
 
+    def cancel(self):
+        """Cancel all getters and putters currently waiting"""
+        for fut in self._putters:
+            fut.cancel()
+        for fut in self._getters:
+            fut.cancel()
+
 
 class PriorityQueue(Queue):
     """A subclass of Queue; retrieves entries in priority order (lowest first).

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -215,7 +215,7 @@ class Queue(mixins._LoopBoundMixin):
         if self._unfinished_tasks > 0:
             await self._finished.wait()
 
-    def cancel(self):
+    def close(self):
         """Cancel all getters and putters currently waiting"""
         for fut in self._putters:
             fut.cancel()

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -300,12 +300,15 @@ class QueueGetTests(_QueueTestBase):
     def test_close_get(self):
         queue = asyncio.Queue(loop=self.loop)
 
-        getter = self.loop.create_task(queue.get())
+        get1 = self.loop.create_task(queue.get())
+        get2 = self.loop.create_task(queue.get())
         test_utils.run_briefly(self.loop)
+        queue.put_nowait(3)
         queue.close()
+        self.assertEqual(self.loop.run_until_complete(get1), 3)
         test_utils.run_briefly(self.loop)
         with self.assertRaises(asyncio.CancelledError):
-            self.loop.run_until_complete(getter)
+            self.loop.run_until_complete(get2)
 
 
 class QueuePutTests(_QueueTestBase):

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -298,7 +298,7 @@ class QueueGetTests(_QueueTestBase):
         self.assertEqual(len(queue._getters), 0)
 
     def test_close_get(self):
-        queue = asyncio.Queue(loop=self.loop)
+        queue = asyncio.Queue()
 
         get1 = self.loop.create_task(queue.get())
         get2 = self.loop.create_task(queue.get())
@@ -589,7 +589,7 @@ class QueuePutTests(_QueueTestBase):
             loop.run_until_complete(put_task)
 
     def test_close_put(self):
-        queue = asyncio.Queue(1, loop=self.loop)
+        queue = asyncio.Queue(1)
         queue.put_nowait(1)
 
         putter = self.loop.create_task(queue.put(1))

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -297,6 +297,16 @@ class QueueGetTests(_QueueTestBase):
         self.loop.run_until_complete(self.loop.create_task(consumer(queue)))
         self.assertEqual(len(queue._getters), 0)
 
+    def test_cancel_get(self):
+        queue = asyncio.Queue(loop=self.loop)
+
+        getter = self.loop.create_task(queue.get())
+        test_utils.run_briefly(self.loop)
+        queue.cancel()
+        test_utils.run_briefly(self.loop)
+        with self.assertRaises(asyncio.CancelledError):
+            self.loop.run_until_complete(getter)
+
 
 class QueuePutTests(_QueueTestBase):
 
@@ -574,6 +584,18 @@ class QueuePutTests(_QueueTestBase):
         # If the ValueError is silenced we should catch a CancelledError.
         with self.assertRaises(asyncio.CancelledError):
             loop.run_until_complete(put_task)
+
+    def test_cancel_put(self):
+        queue = asyncio.Queue(1, loop=self.loop)
+        queue.put_nowait(1)
+
+        putter = self.loop.create_task(queue.put(1))
+        test_utils.run_briefly(self.loop)
+        queue.cancel()
+        test_utils.run_briefly(self.loop)
+        with self.assertRaises(asyncio.CancelledError):
+            self.loop.run_until_complete(putter)
+
 
 
 class LifoQueueTests(_QueueTestBase):

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -297,12 +297,12 @@ class QueueGetTests(_QueueTestBase):
         self.loop.run_until_complete(self.loop.create_task(consumer(queue)))
         self.assertEqual(len(queue._getters), 0)
 
-    def test_cancel_get(self):
+    def test_close_get(self):
         queue = asyncio.Queue(loop=self.loop)
 
         getter = self.loop.create_task(queue.get())
         test_utils.run_briefly(self.loop)
-        queue.cancel()
+        queue.close()
         test_utils.run_briefly(self.loop)
         with self.assertRaises(asyncio.CancelledError):
             self.loop.run_until_complete(getter)
@@ -585,13 +585,13 @@ class QueuePutTests(_QueueTestBase):
         with self.assertRaises(asyncio.CancelledError):
             loop.run_until_complete(put_task)
 
-    def test_cancel_put(self):
+    def test_close_put(self):
         queue = asyncio.Queue(1, loop=self.loop)
         queue.put_nowait(1)
 
         putter = self.loop.create_task(queue.put(1))
         test_utils.run_briefly(self.loop)
-        queue.cancel()
+        queue.close()
         test_utils.run_briefly(self.loop)
         with self.assertRaises(asyncio.CancelledError):
             self.loop.run_until_complete(putter)

--- a/Misc/NEWS.d/next/Library/2019-11-21-11-32-00.bpo-37334.3i2oAq.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-21-11-32-00.bpo-37334.3i2oAq.rst
@@ -1,0 +1,1 @@
+Add a close() method to asyncio queues


### PR DESCRIPTION
When working with queues, it is not uncommon that at some point the producer stops producing data for good, or the consumer stops consuming, for example because a network connection broke down or some user simply closed the session.

In this situation it is very useful to simply cancel all the waiting getters and putters. A simple method can do that, Queue.close.

<!-- issue-number: [bpo-37334](https://bugs.python.org/issue37334) -->
https://bugs.python.org/issue37334
<!-- /issue-number -->
