### PR TITLE
bpo-37342: Fix the incorrect nb_index's type in typeobj documentation

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -285,7 +285,7 @@ sub-slots
    +---------------------------------------------------------+-----------------------------------+--------------+
    | :c:member:`~PyNumberMethods.nb_inplace_true_divide`     | :c:type:`binaryfunc`              | __truediv__  |
    +---------------------------------------------------------+-----------------------------------+--------------+
-   | :c:member:`~PyNumberMethods.nb_index`                   | :c:type:`unaryfunc`              | __index__    |
+   | :c:member:`~PyNumberMethods.nb_index`                   | :c:type:`unaryfunc`               | __index__    |
    +---------------------------------------------------------+-----------------------------------+--------------+
    | :c:member:`~PyNumberMethods.nb_matrix_multiply`         | :c:type:`binaryfunc`              | __matmul__   |
    |                                                         |                                   | __rmatmul__  |

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -285,7 +285,7 @@ sub-slots
    +---------------------------------------------------------+-----------------------------------+--------------+
    | :c:member:`~PyNumberMethods.nb_inplace_true_divide`     | :c:type:`binaryfunc`              | __truediv__  |
    +---------------------------------------------------------+-----------------------------------+--------------+
-   | :c:member:`~PyNumberMethods.nb_index`                   | :c:type:`binaryfunc`              | __index__    |
+   | :c:member:`~PyNumberMethods.nb_index`                   | :c:type:`unaryfunc`              | __index__    |
    +---------------------------------------------------------+-----------------------------------+--------------+
    | :c:member:`~PyNumberMethods.nb_matrix_multiply`         | :c:type:`binaryfunc`              | __matmul__   |
    |                                                         |                                   | __rmatmul__  |

--- a/Misc/NEWS.d/next/Documentation/2019-06-19-18-49-22.bpo-37342.sBr2GZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-06-19-18-49-22.bpo-37342.sBr2GZ.rst
@@ -1,1 +1,0 @@
-Fix a type Error in typeobj.rst

--- a/Misc/NEWS.d/next/Documentation/2019-06-19-18-49-22.bpo-37342.sBr2GZ.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-06-19-18-49-22.bpo-37342.sBr2GZ.rst
@@ -1,0 +1,1 @@
+Fix a type Error in typeobj.rst


### PR DESCRIPTION
It was listed as `binaryfunc`. It should be `unaryfunc`.