### PR TITLE
Add missing single quote in io.TextIOWrapper.reconfigure documentation

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -945,7 +945,7 @@ Text I/O
       *errors*, *newline*, *line_buffering* and *write_through*.
 
       Parameters not specified keep current settings, except
-      ``errors='strict`` is used when *encoding* is specified but
+      ``errors='strict'`` is used when *encoding* is specified but
       *errors* is not specified.
 
       It is not possible to change the encoding or newline if some data


### PR DESCRIPTION
Add a missing single quote character in the documentation for `io.TextIOWrapper.reconfigure`.
