### PR TITLE
Update What's New in Python 3.9

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1001,7 +1001,7 @@ Build and C API Changes
 * The :c:func:`PyByteArray_Init` and :c:func:`PyByteArray_Fini` functions have
   been removed. They did nothing since Python 2.7.4 and Python 3.2.0, were
   excluded from the limited API (stable ABI), and were not documented.
-  (Contributed by Victor Stinner in :issue:`32980`.)
+  (Contributed by Victor Stinner in :issue:`35713`.)
 
 * The result of :c:func:`PyExceptionClass_Name` is now of type
   ``const char *`` rather of ``char *``.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -124,6 +124,7 @@ Removed
 
 * The C function ``PyImport_Cleanup()`` has been removed. It was documented as:
   "Empty the module table.  For internal use only."
+  (Contributed by Victor Stinner in :issue:`36710`.)
 
 * ``_dummy_thread`` and ``dummy_threading`` modules have been removed. These
   modules were deprecated since Python 3.7 which requires threading support.


### PR DESCRIPTION
* Mention bpo of PyImport_Cleanup removal
* Fix bpo number of PyByteArray_Init removal