### PR TITLE
[2.7] bpo-19960: Fix building of zlib on macOS without installed headers

### DIFF
--- a/Misc/NEWS.d/next/macOS/2019-06-20-01-16-16.bpo-19960.LpLUPF.rst
+++ b/Misc/NEWS.d/next/macOS/2019-06-20-01-16-16.bpo-19960.LpLUPF.rst
@@ -1,0 +1,4 @@
+When building 2.7 on macOS without system header files installed in
+``/usr/include``, a few extension modules dependent on system-supplied
+third-party libraries were not being built, most notably zlib.
+

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,15 @@ def add_dir_to_list(dirlist, dir):
     """Add the directory 'dir' to the list 'dirlist' (at the front) if
     1) 'dir' is not already in 'dirlist'
     2) 'dir' actually exists, and is a directory."""
-    if dir is not None and os.path.isdir(dir) and dir not in dirlist:
-        dirlist.insert(0, dir)
+    if dir is not None and dir not in dirlist:
+        if host_platform == 'darwin' and is_macosx_sdk_path(dir):
+            # If in a macOS SDK path, check relative to the SDK root
+            dir_exists = os.path.isdir(
+                os.path.join(macosx_sdk_root(), dir[1:]))
+        else:
+            dir_exists = os.path.isdir(dir)
+        if dir_exists:
+            dirlist.insert(0, dir)
 
 MACOS_SDK_ROOT = None
 


### PR DESCRIPTION
When building 2.7 on macOS without system header files installed in
``/usr/include``, a few extension modules dependent on system-supplied
third-party libraries were not being built, most notably zlib.
This situation arose in the past when building without the Command
Line Tools and the option to install header files in the traditional
system locations (like ``/usr/include``).  As of macOS 10.14, the
header files are only available in an SDK so the problem addressed
here affects most 2.7 builds.


<!-- issue-number: [bpo-19960](https://bugs.python.org/issue19960) -->
https://bugs.python.org/issue19960
<!-- /issue-number -->
