### PR TITLE
bpo-37348 : add _PyUnicode_FROM_ASCII

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -561,6 +561,9 @@ PyAPI_FUNC(PyObject*) _PyUnicode_FromASCII(
     const char *buffer,
     Py_ssize_t size);
 
+/* Convenient wrapper for _PyUnicode_FromASCII */
+#define _PyUnicode_FROM_ASCII(s) _PyUnicode_FromASCII((s), strlen(s))
+
 /* Compute the maximum character of the substring unicode[start:end].
    Return 127 for an empty string. */
 PyAPI_FUNC(Py_UCS4) _PyUnicode_FindMaxChar (

--- a/Misc/NEWS.d/next/C API/2019-06-20-20-43-01.bpo-37348.AyxQi8.rst
+++ b/Misc/NEWS.d/next/C API/2019-06-20-20-43-01.bpo-37348.AyxQi8.rst
@@ -1,0 +1,2 @@
+New ``_PyUnicode_FROM_ASCII`` macro is added.  It wraps
+``_PyUnicode_FromASCII`` with ``strlen``.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2390,7 +2390,7 @@ TaskObj_finalize(TaskObj *task)
         goto finally;
     }
 
-    message = PyUnicode_FromString("Task was destroyed but it is pending!");
+    message = _PyUnicode_FROM_ASCII("Task was destroyed but it is pending!");
     if (message == NULL) {
         goto finally;
     }

--- a/Modules/_blake2/blake2b_impl.c
+++ b/Modules/_blake2/blake2b_impl.c
@@ -348,7 +348,7 @@ static PyMethodDef py_blake2b_methods[] = {
 static PyObject *
 py_blake2b_get_name(BLAKE2bObject *self, void *closure)
 {
-    return PyUnicode_FromString("blake2b");
+    return _PyUnicode_FROM_ASCII("blake2b");
 }
 
 

--- a/Modules/_blake2/blake2s_impl.c
+++ b/Modules/_blake2/blake2s_impl.c
@@ -348,7 +348,7 @@ static PyMethodDef py_blake2s_methods[] = {
 static PyObject *
 py_blake2s_get_name(BLAKE2sObject *self, void *closure)
 {
-    return PyUnicode_FromString("blake2s");
+    return _PyUnicode_FROM_ASCII("blake2s");
 }
 
 

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1358,7 +1358,7 @@ deque_repr(PyObject *deque)
     if (i != 0) {
         if (i < 0)
             return NULL;
-        return PyUnicode_FromString("[...]");
+        return _PyUnicode_FROM_ASCII("[...]");
     }
 
     aslist = PySequence_List(deque);
@@ -2097,7 +2097,7 @@ defdict_repr(defdictobject *dd)
     if (baserepr == NULL)
         return NULL;
     if (dd->default_factory == NULL)
-        defrepr = PyUnicode_FromString("None");
+        defrepr = _PyUnicode_FROM_ASCII("None");
     else
     {
         int status = Py_ReprEnter(dd->default_factory);
@@ -2106,7 +2106,7 @@ defdict_repr(defdictobject *dd)
                 Py_DECREF(baserepr);
                 return NULL;
             }
-            defrepr = PyUnicode_FromString("...");
+            defrepr = _PyUnicode_FROM_ASCII("...");
         }
         else
             defrepr = PyObject_Repr(dd->default_factory);

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -952,7 +952,7 @@ void _ctypes_extend_error(PyObject *exc_class, const char *fmt, ...)
     cls_str = PyObject_Str(tp);
     if (cls_str) {
         PyUnicode_AppendAndDel(&s, cls_str);
-        PyUnicode_AppendAndDel(&s, PyUnicode_FromString(": "));
+        PyUnicode_AppendAndDel(&s, _PyUnicode_FROM_ASCII(": "));
         if (s == NULL)
             goto error;
     } else
@@ -962,7 +962,7 @@ void _ctypes_extend_error(PyObject *exc_class, const char *fmt, ...)
         PyUnicode_AppendAndDel(&s, msg_str);
     else {
         PyErr_Clear();
-        PyUnicode_AppendAndDel(&s, PyUnicode_FromString("???"));
+        PyUnicode_AppendAndDel(&s, _PyUnicode_FROM_ASCII("???"));
     }
     if (s == NULL)
         goto error;
@@ -1250,7 +1250,7 @@ static PyObject *format_error(PyObject *self, PyObject *args)
         result = PyUnicode_FromWideChar(lpMsgBuf, wcslen(lpMsgBuf));
         LocalFree(lpMsgBuf);
     } else {
-        result = PyUnicode_FromString("<no description>");
+        result = _PyUnicode_FROM_ASCII("<no description>");
     }
     return result;
 }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2537,7 +2537,7 @@ delta_bool(PyDateTime_Delta *self)
 static PyObject *
 delta_repr(PyDateTime_Delta *self)
 {
-    PyObject *args = PyUnicode_FromString("");
+    PyObject *args = _PyUnicode_FROM_ASCII("");
 
     if (args == NULL) {
         return NULL;
@@ -2571,7 +2571,7 @@ delta_repr(PyDateTime_Delta *self)
     }
 
     if (PyUnicode_GET_LENGTH(args) == 0) {
-        Py_SETREF(args, PyUnicode_FromString("0"));
+        Py_SETREF(args, _PyUnicode_FROM_ASCII("0"));
         if (args == NULL) {
             return NULL;
         }
@@ -3806,7 +3806,7 @@ timezone_str(PyDateTime_TimeZone *self)
            (GET_TD_DAYS(self->offset) == 0 &&
             GET_TD_SECONDS(self->offset) == 0 &&
             GET_TD_MICROSECONDS(self->offset) == 0))
-        return PyUnicode_FromString("UTC");
+        return _PyUnicode_FROM_ASCII("UTC");
     /* Offset is normalized, so it is negative if days < 0 */
     if (GET_TD_DAYS(self->offset) < 0) {
         sign = '-';

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3455,10 +3455,10 @@ PyDec_AsFloat(PyObject *dec)
             return NULL;
         }
         if (mpd_isnegative(MPD(dec))) {
-            s = PyUnicode_FromString("-nan");
+            s = _PyUnicode_FROM_ASCII("-nan");
         }
         else {
-            s = PyUnicode_FromString("nan");
+            s = _PyUnicode_FROM_ASCII("nan");
         }
     }
     else {
@@ -3550,7 +3550,7 @@ PyDec_AsTuple(PyObject *dec, PyObject *dummy UNUSED)
     }
 
     if (mpd_isinfinite(x)) {
-        expt = PyUnicode_FromString("F");
+        expt = _PyUnicode_FROM_ASCII("F");
         if (expt == NULL) {
             goto out;
         }
@@ -5565,7 +5565,7 @@ PyInit__decimal(void)
     CHECK_INT(PyType_Ready(&PyDecSignalDictMixin_Type));
     CHECK_INT(PyType_Ready(&PyDecContextManager_Type));
 
-    ASSIGN_PTR(obj, PyUnicode_FromString("decimal"));
+    ASSIGN_PTR(obj, _PyUnicode_FROM_ASCII("decimal"));
     CHECK_INT(PyDict_SetItemString(PyDec_Type.tp_dict, "__module__", obj));
     CHECK_INT(PyDict_SetItemString(PyDecContext_Type.tp_dict,
                                    "__module__", obj));
@@ -5591,7 +5591,7 @@ PyInit__decimal(void)
                                  "namedtuple", "(ss)", "DecimalTuple",
                                  "sign digits exponent"));
 
-    ASSIGN_PTR(obj, PyUnicode_FromString("decimal"));
+    ASSIGN_PTR(obj, _PyUnicode_FROM_ASCII("decimal"));
     CHECK_INT(PyDict_SetItemString(DecimalTuple->tp_dict, "__module__", obj));
     Py_CLEAR(obj);
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3455,10 +3455,10 @@ PyDec_AsFloat(PyObject *dec)
             return NULL;
         }
         if (mpd_isnegative(MPD(dec))) {
-            s = _PyUnicode_FROM_ASCII("-nan");
+            s = PyUnicode_FromString("-nan");
         }
         else {
-            s = _PyUnicode_FROM_ASCII("nan");
+            s = PyUnicode_FromString("nan");
         }
     }
     else {
@@ -3550,7 +3550,7 @@ PyDec_AsTuple(PyObject *dec, PyObject *dummy UNUSED)
     }
 
     if (mpd_isinfinite(x)) {
-        expt = _PyUnicode_FROM_ASCII("F");
+        expt = PyUnicode_FromString("F");
         if (expt == NULL) {
             goto out;
         }
@@ -5565,7 +5565,7 @@ PyInit__decimal(void)
     CHECK_INT(PyType_Ready(&PyDecSignalDictMixin_Type));
     CHECK_INT(PyType_Ready(&PyDecContextManager_Type));
 
-    ASSIGN_PTR(obj, _PyUnicode_FROM_ASCII("decimal"));
+    ASSIGN_PTR(obj, PyUnicode_FromString("decimal"));
     CHECK_INT(PyDict_SetItemString(PyDec_Type.tp_dict, "__module__", obj));
     CHECK_INT(PyDict_SetItemString(PyDecContext_Type.tp_dict,
                                    "__module__", obj));
@@ -5591,7 +5591,7 @@ PyInit__decimal(void)
                                  "namedtuple", "(ss)", "DecimalTuple",
                                  "sign digits exponent"));
 
-    ASSIGN_PTR(obj, _PyUnicode_FROM_ASCII("decimal"));
+    ASSIGN_PTR(obj, PyUnicode_FromString("decimal"));
     CHECK_INT(PyDict_SetItemString(DecimalTuple->tp_dict, "__module__", obj));
     Py_CLEAR(obj);
 

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -341,7 +341,7 @@ element_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 static PyObject*
 get_attrib_from_keywords(PyObject *kwds)
 {
-    PyObject *attrib_str = PyUnicode_FromString("attrib");
+    PyObject *attrib_str = _PyUnicode_FROM_ASCII("attrib");
     if (attrib_str == NULL) {
         return NULL;
     }
@@ -4073,7 +4073,7 @@ _elementtree_XMLParser__setevents_impl(XMLParserObject *self,
 
     if (events_to_report == Py_None) {
         /* default is "end" only */
-        target->end_event_obj = PyUnicode_FromString("end");
+        target->end_event_obj = _PyUnicode_FROM_ASCII("end");
         Py_RETURN_NONE;
     }
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -276,10 +276,10 @@ partial_repr(partialobject *pto)
     if (status != 0) {
         if (status < 0)
             return NULL;
-        return PyUnicode_FromString("...");
+        return _PyUnicode_FROM_ASCII("...");
     }
 
-    arglist = PyUnicode_FromString("");
+    arglist = _PyUnicode_FROM_ASCII("");
     if (arglist == NULL)
         goto done;
     /* Pack positional arguments */

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -611,11 +611,11 @@ incrementalnewlinedecoder_newlines_get(nldecoder_object *self, void *context)
 {
     switch (self->seennl) {
     case SEEN_CR:
-        return PyUnicode_FromString("\r");
+        return _PyUnicode_FROM_ASCII("\r");
     case SEEN_LF:
-        return PyUnicode_FromString("\n");
+        return _PyUnicode_FROM_ASCII("\n");
     case SEEN_CRLF:
-        return PyUnicode_FromString("\r\n");
+        return _PyUnicode_FROM_ASCII("\r\n");
     case SEEN_CR | SEEN_LF:
         return Py_BuildValue("ss", "\r", "\n");
     case SEEN_CR | SEEN_CRLF:
@@ -1125,7 +1125,7 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
             */
             if (PyErr_ExceptionMatches(PyExc_ImportError)) {
                 PyErr_Clear();
-                self->encoding = PyUnicode_FromString("ascii");
+                self->encoding = _PyUnicode_FROM_ASCII("ascii");
             }
             else
                 goto error;
@@ -2847,7 +2847,7 @@ textiowrapper_repr(textio *self)
 
     CHECK_INITIALIZED(self);
 
-    res = PyUnicode_FromString("<_io.TextIOWrapper");
+    res = _PyUnicode_FROM_ASCII("<_io.TextIOWrapper");
     if (res == NULL)
         return NULL;
 

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1419,13 +1419,13 @@ encoder_encode_float(PyEncoderObject *s, PyObject *obj)
             return NULL;
         }
         if (i > 0) {
-            return PyUnicode_FromString("Infinity");
+            return _PyUnicode_FROM_ASCII("Infinity");
         }
         else if (i < 0) {
-            return PyUnicode_FromString("-Infinity");
+            return _PyUnicode_FROM_ASCII("-Infinity");
         }
         else {
-            return PyUnicode_FromString("NaN");
+            return _PyUnicode_FROM_ASCII("NaN");
         }
     }
     return PyFloat_Type.tp_repr(obj);

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -1345,7 +1345,7 @@ dotjoinattr(PyObject *attr, PyObject **attrsep)
 {
     if (PyTuple_CheckExact(attr)) {
         if (*attrsep == NULL) {
-            *attrsep = PyUnicode_FromString(".");
+            *attrsep = _PyUnicode_FROM_ASCII(".");
             if (*attrsep == NULL)
                 return NULL;
         }
@@ -1627,7 +1627,7 @@ methodcaller_repr(methodcallerobject *mc)
         }
     }
 
-    sep = PyUnicode_FromString(", ");
+    sep = _PyUnicode_FROM_ASCII(", ");
     if (sep == NULL)
         goto done;
 

--- a/Modules/_sha3/sha3module.c
+++ b/Modules/_sha3/sha3module.c
@@ -414,27 +414,27 @@ SHA3_get_name(SHA3object *self, void *closure)
 {
     PyTypeObject *type = Py_TYPE(self);
     if (type == &SHA3_224type) {
-        return PyUnicode_FromString("sha3_224");
+        return _PyUnicode_FROM_ASCII("sha3_224");
     } else if (type == &SHA3_256type) {
-        return PyUnicode_FromString("sha3_256");
+        return _PyUnicode_FROM_ASCII("sha3_256");
     } else if (type == &SHA3_384type) {
-        return PyUnicode_FromString("sha3_384");
+        return _PyUnicode_FROM_ASCII("sha3_384");
     } else if (type == &SHA3_512type) {
-        return PyUnicode_FromString("sha3_512");
+        return _PyUnicode_FROM_ASCII("sha3_512");
 #ifdef PY_WITH_KECCAK
     } else if (type == &Keccak_224type) {
-        return PyUnicode_FromString("keccak_224");
+        return _PyUnicode_FROM_ASCII("keccak_224");
     } else if (type == &Keccak_256type) {
-        return PyUnicode_FromString("keccak_256");
+        return _PyUnicode_FROM_ASCII("keccak_256");
     } else if (type == &Keccak_384type) {
-        return PyUnicode_FromString("keccak_384");
+        return _PyUnicode_FROM_ASCII("keccak_384");
     } else if (type == &Keccak_512type) {
-        return PyUnicode_FromString("keccak_512");
+        return _PyUnicode_FROM_ASCII("keccak_512");
 #endif
     } else if (type == &SHAKE128type) {
-        return PyUnicode_FromString("shake_128");
+        return _PyUnicode_FROM_ASCII("shake_128");
     } else if (type == &SHAKE256type) {
-        return PyUnicode_FromString("shake_256");
+        return _PyUnicode_FROM_ASCII("shake_256");
     } else {
         PyErr_BadInternalCall();
         return NULL;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -139,7 +139,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     }
 
     if (!isolation_level) {
-        isolation_level = PyUnicode_FromString("");
+        isolation_level = _PyUnicode_FROM_ASCII("");
         if (!isolation_level) {
             return -1;
         }

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -1281,7 +1281,7 @@ pattern_repr(PatternObject *obj)
 
     if (PyList_Size(flag_items) > 0) {
         PyObject *flags_result;
-        PyObject *sep = PyUnicode_FromString("|");
+        PyObject *sep = _PyUnicode_FROM_ASCII("|");
         if (!sep)
             goto done;
         flags_result = PyUnicode_Join(sep, flag_items);

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1310,7 +1310,7 @@ _get_peer_alt_names (X509 *certificate) {
                     goto fail;
                 }
 
-                v = PyUnicode_FromString("DirName");
+                v = _PyUnicode_FROM_ASCII("DirName");
                 if (v == NULL) {
                     Py_DECREF(t);
                     goto fail;
@@ -1335,15 +1335,15 @@ _get_peer_alt_names (X509 *certificate) {
                     goto fail;
                 switch (gntype) {
                 case GEN_EMAIL:
-                    v = PyUnicode_FromString("email");
+                    v = _PyUnicode_FROM_ASCII("email");
                     as = name->d.rfc822Name;
                     break;
                 case GEN_DNS:
-                    v = PyUnicode_FromString("DNS");
+                    v = _PyUnicode_FROM_ASCII("DNS");
                     as = name->d.dNSName;
                     break;
                 case GEN_URI:
-                    v = PyUnicode_FromString("URI");
+                    v = _PyUnicode_FROM_ASCII("URI");
                     as = name->d.uniformResourceIdentifier;
                     break;
                 }
@@ -1366,7 +1366,7 @@ _get_peer_alt_names (X509 *certificate) {
                 if (t == NULL)
                     goto fail;
 
-                v = PyUnicode_FromString("Registered ID");
+                v = _PyUnicode_FROM_ASCII("Registered ID");
                 if (v == NULL) {
                     Py_DECREF(t);
                     goto fail;
@@ -1379,7 +1379,7 @@ _get_peer_alt_names (X509 *certificate) {
                     _setSSLError(NULL, 0, __FILE__, __LINE__);
                     goto fail;
                 } else if (len >= (int)sizeof(buf)) {
-                    v = PyUnicode_FromString("<INVALID>");
+                    v = _PyUnicode_FROM_ASCII("<INVALID>");
                 } else {
                     v = PyUnicode_FromStringAndSize(buf, len);
                 }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1719,7 +1719,7 @@ test_Z_code(PyObject *self, PyObject *Py_UNUSED(ignored))
     if (tuple == NULL)
         return NULL;
 
-    obj = PyUnicode_FromString("test");
+    obj = _PyUnicode_FROM_ASCII("test");
     PyTuple_SET_ITEM(tuple, 0, obj);
     Py_INCREF(Py_None);
     PyTuple_SET_ITEM(tuple, 1, Py_None);
@@ -2304,7 +2304,7 @@ datetime_check_tzinfo(PyObject *self, PyObject *args) {
 static PyObject *
 make_timezones_capi(PyObject *self, PyObject *args) {
     PyObject *offset = PyDelta_FromDSU(0, -18000, 0);
-    PyObject *name = PyUnicode_FromString("EST");
+    PyObject *name = _PyUnicode_FROM_ASCII("EST");
 
     PyObject *est_zone_capi = PyDateTimeAPI->TimeZone_FromTimeZone(offset, name);
     PyObject *est_zone_macro = PyTimeZone_FromOffsetAndName(offset, name);
@@ -2325,7 +2325,7 @@ make_timezones_capi(PyObject *self, PyObject *args) {
 static PyObject *
 get_timezones_offset_zero(PyObject *self, PyObject *args) {
     PyObject *offset = PyDelta_FromDSU(0, 0, 0);
-    PyObject *name = PyUnicode_FromString("");
+    PyObject *name = _PyUnicode_FROM_ASCII("");
 
     // These two should return the UTC singleton
     PyObject *utc_singleton_0 = PyTimeZone_FromOffset(offset);
@@ -5013,7 +5013,7 @@ decode_locale_ex(PyObject *self, PyObject *args)
 static PyObject *
 negative_refcount(PyObject *self, PyObject *Py_UNUSED(args))
 {
-    PyObject *obj = PyUnicode_FromString("negative_refcount");
+    PyObject *obj = _PyUnicode_FROM_ASCII("negative_refcount");
     if (obj == NULL) {
         return NULL;
     }

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -117,7 +117,7 @@ _get_tcl_lib_path()
         }
 
         /* Check expected location for an installed Python first */
-        tcl_library_path = PyUnicode_FromString("\\tcl\\tcl" TCL_VERSION);
+        tcl_library_path = _PyUnicode_FROM_ASCII("\\tcl\\tcl" TCL_VERSION);
         if (tcl_library_path == NULL) {
             return NULL;
         }
@@ -431,7 +431,7 @@ Split(const char *list)
     }
 
     if (argc == 0)
-        v = PyUnicode_FromString("");
+        v = _PyUnicode_FROM_ASCII("");
     else if (argc == 1)
         v = unicodeFromTclString(argv[0]);
     else if ((v = PyTuple_New(argc)) != NULL) {
@@ -2278,7 +2278,7 @@ _tkinter_tkapp_split(TkappObject *self, PyObject *arg)
             return FromObj((PyObject*)self, value);
         }
         if (objc == 0)
-            return PyUnicode_FromString("");
+            return _PyUnicode_FROM_ASCII("");
         if (objc == 1)
             return FromObj((PyObject*)self, objv[0]);
         if (!(v = PyTuple_New(objc)))

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -995,7 +995,7 @@ tracemalloc_init(void)
         return -1;
     }
 
-    unknown_filename = PyUnicode_FromString("<unknown>");
+    unknown_filename = _PyUnicode_FROM_ASCII("<unknown>");
     if (unknown_filename == NULL)
         return -1;
     PyUnicode_InternInPlace(&unknown_filename);

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1134,7 +1134,7 @@ collect(struct _gc_runtime_state *state, int generation,
         }
         else {
             if (gc_str == NULL)
-                gc_str = PyUnicode_FromString("garbage collection");
+                gc_str = _PyUnicode_FROM_ASCII("garbage collection");
             PyErr_WriteUnraisable(gc_str);
             Py_FatalError("unexpected exception during garbage collection");
         }

--- a/Modules/ossaudiodev.c
+++ b/Modules/ossaudiodev.c
@@ -937,13 +937,13 @@ oss_mode_getter(oss_audio_t *self, void *closure)
 {
     switch(self->mode) {
         case O_RDONLY:
-            return PyUnicode_FromString("r");
+            return _PyUnicode_FROM_ASCII("r");
             break;
         case O_RDWR:
-            return PyUnicode_FromString("rw");
+            return _PyUnicode_FROM_ASCII("rw");
             break;
         case O_WRONLY:
-            return PyUnicode_FromString("w");
+            return _PyUnicode_FROM_ASCII("w");
             break;
         default:
             /* From newossobject(), self->mode can only be one

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -466,7 +466,7 @@ parser_compilest(PyST_Object *self, PyObject *args, PyObject *kw)
         goto error;
 
     if (filename == NULL) {
-        filename = PyUnicode_FromString("<syntax-tree>");
+        filename = _PyUnicode_FROM_ASCII("<syntax-tree>");
         if (filename == NULL)
             goto error;
     }

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -414,7 +414,7 @@ unicodedata_UCD_decomposition_impl(PyObject *self, int chr)
     if (self && UCD_Check(self)) {
         const change_record *old = get_old_record(self, c);
         if (old->category_changed == 0)
-            return PyUnicode_FromString(""); /* unassigned */
+            return _PyUnicode_FROM_ASCII(""); /* unassigned */
     }
 
     if (code < 0 || code >= 0x110000)

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2073,7 +2073,7 @@ _common_reduce(PyByteArrayObject *self, int proto)
         if (Py_SIZE(self))
             latin1 = PyUnicode_DecodeLatin1(buf, Py_SIZE(self), NULL);
         else
-            latin1 = PyUnicode_FromString("");
+            latin1 = _PyUnicode_FROM_ASCII("");
         return Py_BuildValue("(O(Ns)N)", Py_TYPE(self), latin1, "latin-1", dict);
     }
     else {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2011,12 +2011,12 @@ dict_repr(PyDictObject *mp)
 
     i = Py_ReprEnter((PyObject *)mp);
     if (i != 0) {
-        return i > 0 ? PyUnicode_FromString("{...}") : NULL;
+        return i > 0 ? _PyUnicode_FROM_ASCII("{...}") : NULL;
     }
 
     if (mp->ma_used == 0) {
         Py_ReprLeave((PyObject *)mp);
-        return PyUnicode_FromString("{}");
+        return _PyUnicode_FROM_ASCII("{}");
     }
 
     _PyUnicodeWriter_Init(&writer);
@@ -4106,7 +4106,7 @@ dictview_repr(_PyDictViewObject *dv)
 
     rc = Py_ReprEnter((PyObject *)dv);
     if (rc != 0) {
-        return rc > 0 ? PyUnicode_FromString("...") : NULL;
+        return rc > 0 ? _PyUnicode_FROM_ASCII("...") : NULL;
     }
     seq = PySequence_List((PyObject *)dv);
     if (seq == NULL) {

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -107,7 +107,7 @@ BaseException_str(PyBaseExceptionObject *self)
 {
     switch (PyTuple_GET_SIZE(self->args)) {
     case 0:
-        return PyUnicode_FromString("");
+        return _PyUnicode_FROM_ASCII("");
     case 1:
         return PyObject_Str(PyTuple_GET_ITEM(self->args, 0));
     default:
@@ -1923,7 +1923,7 @@ UnicodeEncodeError_str(PyObject *self)
 
     if (!uself->object)
         /* Not properly initialized. */
-        return PyUnicode_FromString("");
+        return _PyUnicode_FROM_ASCII("");
 
     /* Get reason and encoding as strings, which they might not be if
        they've been modified after we were constructed. */
@@ -2045,7 +2045,7 @@ UnicodeDecodeError_str(PyObject *self)
 
     if (!uself->object)
         /* Not properly initialized. */
-        return PyUnicode_FromString("");
+        return _PyUnicode_FROM_ASCII("");
 
     /* Get reason and encoding as strings, which they might not be if
        they've been modified after we were constructed. */
@@ -2141,7 +2141,7 @@ UnicodeTranslateError_str(PyObject *self)
 
     if (!uself->object)
         /* Not properly initialized. */
-        return PyUnicode_FromString("");
+        return _PyUnicode_FROM_ASCII("");
 
     /* Get reason as a string, which it might not be if it's been
        modified after we were constructed. */
@@ -2920,7 +2920,7 @@ _set_legacy_print_statement_msg(PySyntaxErrorObject *self, Py_ssize_t start)
         return -1;
     }
 
-    PyObject *strip_sep_obj = PyUnicode_FromString(" \t\r\n");
+    PyObject *strip_sep_obj = _PyUnicode_FROM_ASCII(" \t\r\n");
     if (strip_sep_obj == NULL) {
         Py_DECREF(data);
         return -1;
@@ -3004,7 +3004,7 @@ _check_for_legacy_statements(PySyntaxErrorObject *self, Py_ssize_t start)
         return -1;
     }
     if (match) {
-        PyObject *msg = PyUnicode_FromString("Missing parentheses in call "
+        PyObject *msg = _PyUnicode_FROM_ASCII("Missing parentheses in call "
                                              "to 'exec'");
         if (msg == NULL) {
             return -1;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3005,7 +3005,7 @@ _check_for_legacy_statements(PySyntaxErrorObject *self, Py_ssize_t start)
     }
     if (match) {
         PyObject *msg = _PyUnicode_FROM_ASCII("Missing parentheses in call "
-                                             "to 'exec'");
+                                              "to 'exec'");
         if (msg == NULL) {
             return -1;
         }

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -456,7 +456,7 @@ get_closed(PyStdPrinter_Object *self, void *closure)
 static PyObject *
 get_mode(PyStdPrinter_Object *self, void *closure)
 {
-    return PyUnicode_FromString("w");
+    return _PyUnicode_FROM_ASCII("w");
 }
 
 static PyObject *

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1226,9 +1226,9 @@ float_hex_impl(PyObject *self)
 
     if (x == 0.0) {
         if (copysign(1.0, x) == -1.0)
-            return PyUnicode_FromString("-0x0.0p+0");
+            return _PyUnicode_FROM_ASCII("-0x0.0p+0");
         else
-            return PyUnicode_FromString("0x0.0p+0");
+            return _PyUnicode_FROM_ASCII("0x0.0p+0");
     }
 
     m = frexp(fabs(x), &e);
@@ -1720,11 +1720,11 @@ float___getformat___impl(PyTypeObject *type, const char *typestr)
 
     switch (r) {
     case unknown_format:
-        return PyUnicode_FromString("unknown");
+        return _PyUnicode_FROM_ASCII("unknown");
     case ieee_little_endian_format:
-        return PyUnicode_FromString("IEEE, little-endian");
+        return _PyUnicode_FROM_ASCII("IEEE, little-endian");
     case ieee_big_endian_format:
-        return PyUnicode_FromString("IEEE, big-endian");
+        return _PyUnicode_FROM_ASCII("IEEE, big-endian");
     default:
         Py_FatalError("insane float_format or double_format");
         return NULL;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -388,12 +388,12 @@ list_repr(PyListObject *v)
     _PyUnicodeWriter writer;
 
     if (Py_SIZE(v) == 0) {
-        return PyUnicode_FromString("[]");
+        return _PyUnicode_FROM_ASCII("[]");
     }
 
     i = Py_ReprEnter((PyObject*)v);
     if (i != 0) {
-        return i > 0 ? PyUnicode_FromString("[...]") : NULL;
+        return i > 0 ? _PyUnicode_FROM_ASCII("[...]") : NULL;
     }
 
     _PyUnicodeWriter_Init(&writer);

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -123,7 +123,7 @@ namespace_repr(PyObject *ns)
             goto error;
     }
 
-    separator = PyUnicode_FromString(", ");
+    separator = _PyUnicode_FROM_ASCII(", ");
     if (separator == NULL)
         goto error;
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -514,7 +514,7 @@ PyObject_Repr(PyObject *v)
     }
 #endif
     if (v == NULL)
-        return PyUnicode_FromString("<NULL>");
+        return _PyUnicode_FROM_ASCII("<NULL>");
     if (Py_TYPE(v)->tp_repr == NULL)
         return PyUnicode_FromFormat("<%s object at %p>",
                                     v->ob_type->tp_name, v);
@@ -561,7 +561,7 @@ PyObject_Str(PyObject *v)
     }
 #endif
     if (v == NULL)
-        return PyUnicode_FromString("<NULL>");
+        return _PyUnicode_FROM_ASCII("<NULL>");
     if (PyUnicode_CheckExact(v)) {
 #ifndef Py_DEBUG
         if (PyUnicode_READY(v) < 0)
@@ -1566,7 +1566,7 @@ so there is exactly one (which is indestructible, by the way).
 static PyObject *
 none_repr(PyObject *op)
 {
-    return PyUnicode_FromString("None");
+    return _PyUnicode_FROM_ASCII("None");
 }
 
 /* ARGUSED */
@@ -1684,13 +1684,13 @@ PyObject _Py_NoneStruct = {
 static PyObject *
 NotImplemented_repr(PyObject *op)
 {
-    return PyUnicode_FromString("NotImplemented");
+    return _PyUnicode_FROM_ASCII("NotImplemented");
 }
 
 static PyObject *
 NotImplemented_reduce(PyObject *op, PyObject *Py_UNUSED(ignored))
 {
-    return PyUnicode_FromString("NotImplemented");
+    return _PyUnicode_FROM_ASCII("NotImplemented");
 }
 
 static PyMethodDef notimplemented_methods[] = {

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1383,7 +1383,7 @@ odict_repr(PyODictObject *self)
 
     i = Py_ReprEnter((PyObject *)self);
     if (i != 0) {
-        return i > 0 ? PyUnicode_FromString("...") : NULL;
+        return i > 0 ? _PyUnicode_FROM_ASCII("...") : NULL;
     }
 
     if (PyODict_CheckExact(self)) {

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2391,7 +2391,7 @@ test_c_api(PySetObject *so, PyObject *Py_UNUSED(ignored))
     assert(!PyFrozenSet_CheckExact(ob));
 
     /* so.clear(); so |= set("abc"); */
-    str = PyUnicode_FromString("abc");
+    str = _PyUnicode_FROM_ASCII("abc");
     if (str == NULL)
         return NULL;
     set_clear_internal(so);
@@ -2509,7 +2509,7 @@ test_c_api(PySetObject *so, PyObject *Py_UNUSED(ignored))
 static PyObject *
 dummy_repr(PyObject *op)
 {
-    return PyUnicode_FromString("<dummy key>");
+    return _PyUnicode_FROM_ASCII("<dummy key>");
 }
 
 static void

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -33,13 +33,13 @@ ellipsis_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 static PyObject *
 ellipsis_repr(PyObject *op)
 {
-    return PyUnicode_FromString("Ellipsis");
+    return _PyUnicode_FROM_ASCII("Ellipsis");
 }
 
 static PyObject *
 ellipsis_reduce(PyObject *op, PyObject *Py_UNUSED(ignored))
 {
-    return PyUnicode_FromString("Ellipsis");
+    return _PyUnicode_FROM_ASCII("Ellipsis");
 }
 
 static PyMethodDef ellipsis_methods[] = {

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -270,7 +270,7 @@ tuplerepr(PyTupleObject *v)
 
     n = Py_SIZE(v);
     if (n == 0)
-        return PyUnicode_FromString("()");
+        return _PyUnicode_FROM_ASCII("()");
 
     /* While not mutable, it is still possible to end up with a cycle in a
        tuple through an object that stores itself within a tuple (and thus
@@ -278,7 +278,7 @@ tuplerepr(PyTupleObject *v)
        possible within a type. */
     i = Py_ReprEnter((PyObject *)v);
     if (i != 0) {
-        return i > 0 ? PyUnicode_FromString("(...)") : NULL;
+        return i > 0 ? _PyUnicode_FROM_ASCII("(...)") : NULL;
     }
 
     _PyUnicodeWriter_Init(&writer);

--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -485,7 +485,7 @@ initerr(perrdetail *err_ret, PyObject *filename)
         err_ret->filename = filename;
     }
     else {
-        err_ret->filename = PyUnicode_FromString("<string>");
+        err_ret->filename = _PyUnicode_FROM_ASCII("<string>");
         if (err_ret->filename == NULL) {
             err_ret->error = E_ERROR;
             return -1;

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1805,7 +1805,7 @@ PyTokenizer_FindEncodingFilename(int fd, PyObject *filename)
         tok->filename = filename;
     }
     else {
-        tok->filename = PyUnicode_FromString("<string>");
+        tok->filename = _PyUnicode_FROM_ASCII("<string>");
         if (tok->filename == NULL) {
             fclose(fp);
             PyTokenizer_Free(tok);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -125,7 +125,7 @@ _Warnings_InitState(WarningsState *st)
     }
 
     if (st->default_action == NULL) {
-        st->default_action = PyUnicode_FromString("default");
+        st->default_action = _PyUnicode_FROM_ASCII("default");
         if (st->default_action == NULL) {
             goto error;
         }
@@ -438,7 +438,7 @@ normalize_module(PyObject *filename)
         return NULL;
 
     if (len == 0)
-        return PyUnicode_FromString("<unknown>");
+        return _PyUnicode_FROM_ASCII("<unknown>");
 
     kind = PyUnicode_KIND(filename);
     data = PyUnicode_DATA(filename);
@@ -760,12 +760,12 @@ is_internal_frame(PyFrameObject *frame)
     int contains;
 
     if (importlib_string == NULL) {
-        importlib_string = PyUnicode_FromString("importlib");
+        importlib_string = _PyUnicode_FROM_ASCII("importlib");
         if (importlib_string == NULL) {
             return 0;
         }
 
-        bootstrap_string = PyUnicode_FromString("_bootstrap");
+        bootstrap_string = _PyUnicode_FROM_ASCII("_bootstrap");
         if (bootstrap_string == NULL) {
             Py_DECREF(importlib_string);
             return 0;
@@ -836,7 +836,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
 
     if (f == NULL) {
         globals = _PyInterpreterState_GET_UNSAFE()->sysdict;
-        *filename = PyUnicode_FromString("sys");
+        *filename = _PyUnicode_FROM_ASCII("sys");
         *lineno = 1;
     }
     else {
@@ -878,7 +878,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
         goto handle_error;
     }
     else {
-        *module = PyUnicode_FromString("<string>");
+        *module = _PyUnicode_FROM_ASCII("<string>");
         if (*module == NULL)
             goto handle_error;
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3848,7 +3848,7 @@ format_missing(PyThreadState *tstate, const char *kind,
             return;
         }
         /* Stitch everything up into a nice comma-separated list. */
-        comma = PyUnicode_FromString(", ");
+        comma = _PyUnicode_FROM_ASCII(", ");
         if (comma == NULL) {
             Py_DECREF(tail);
             return;
@@ -3957,7 +3957,7 @@ too_many_positional(PyThreadState *tstate, PyCodeObject *co,
     }
     else {
         /* This will not fail. */
-        kwonly_sig = PyUnicode_FromString("");
+        kwonly_sig = _PyUnicode_FROM_ASCII("");
         assert(kwonly_sig != NULL);
     }
     _PyErr_Format(tstate, PyExc_TypeError,
@@ -4007,7 +4007,7 @@ positional_only_passed_as_keyword(PyThreadState *tstate, PyCodeObject *co,
         }
     }
     if (posonly_conflicts) {
-        PyObject* comma = PyUnicode_FromString(", ");
+        PyObject* comma = _PyUnicode_FROM_ASCII(", ");
         if (comma == NULL) {
             goto fail;
         }
@@ -5212,7 +5212,7 @@ import_from(PyThreadState *tstate, PyObject *v, PyObject *name)
  error:
     pkgpath = PyModule_GetFilenameObject(v);
     if (pkgname == NULL) {
-        pkgname_or_unknown = PyUnicode_FromString("<unknown module name>");
+        pkgname_or_unknown = _PyUnicode_FROM_ASCII("<unknown module name>");
         if (pkgname_or_unknown == NULL) {
             Py_XDECREF(pkgpath);
             return NULL;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3091,7 +3091,7 @@ compiler_from_import(struct compiler *c, stmt_ty s)
     static PyObject *empty_string;
 
     if (!empty_string) {
-        empty_string = PyUnicode_FromString("");
+        empty_string = _PyUnicode_FROM_ASCII("");
         if (!empty_string)
             return 0;
     }

--- a/Python/context.c
+++ b/Python/context.c
@@ -1218,7 +1218,7 @@ typedef struct {
 static PyObject *
 context_token_missing_tp_repr(PyObject *self)
 {
-    return PyUnicode_FromString("<Token.MISSING>");
+    return _PyUnicode_FROM_ASCII("<Token.MISSING>");
 }
 
 

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -595,11 +595,11 @@ PyErr_SetFromErrnoWithFilenameObjects(PyObject *exc, PyObject *filenameObject, P
     }
     else {
         /* Sometimes errno didn't get set */
-        message = PyUnicode_FromString("Error");
+        message = _PyUnicode_FROM_ASCII("Error");
     }
 #else
     if (i == 0)
-        message = PyUnicode_FromString("Error"); /* Sometimes errno didn't get set */
+        message = _PyUnicode_FROM_ASCII("Error"); /* Sometimes errno didn't get set */
     else
     {
         /* Note that the Win32 errors do not lineup with the

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -473,7 +473,7 @@ _hamt_dump_ident(_PyUnicodeWriter *writer, int level)
     PyObject *res = NULL;
     int ret = -1;
 
-    str = PyUnicode_FromString("    ");
+    str = _PyUnicode_FROM_ASCII("    ");
     if (str == NULL) {
         goto error;
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -1980,7 +1980,7 @@ PyImport_ReloadModule(PyObject *m)
    done using whatever import hooks are installed in the current
    environment.
    A dummy list ["__doc__"] is passed as the 4th argument so that
-   e.g. PyImport_Import(PyUnicode_FromString("win32com.client.gencache"))
+   e.g. PyImport_Import(_PyUnicode_FROM_ASCII("win32com.client.gencache"))
    will return <module "gencache"> instead of <module "win32com">. */
 
 PyObject *

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -108,12 +108,12 @@ PyRun_InteractiveLoopFlags(FILE *fp, const char *filename_str, PyCompilerFlags *
     }
     v = _PySys_GetObjectId(&PyId_ps1);
     if (v == NULL) {
-        _PySys_SetObjectId(&PyId_ps1, v = PyUnicode_FromString(">>> "));
+        _PySys_SetObjectId(&PyId_ps1, v = _PyUnicode_FROM_ASCII(">>> "));
         Py_XDECREF(v);
     }
     v = _PySys_GetObjectId(&PyId_ps2);
     if (v == NULL) {
-        _PySys_SetObjectId(&PyId_ps2, v = PyUnicode_FromString("... "));
+        _PySys_SetObjectId(&PyId_ps2, v = _PyUnicode_FROM_ASCII("... "));
         Py_XDECREF(v);
     }
     err = 0;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -484,7 +484,7 @@ sys_breakpointhook(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyOb
 
     if (last_dot == NULL) {
         /* The breakpoint is a built-in, e.g. PYTHONBREAKPOINT=int */
-        modulepath = PyUnicode_FromString("builtins");
+        modulepath = _PyUnicode_FROM_ASCII("builtins");
         attrname = envar;
     }
     else if (last_dot != envar) {
@@ -666,7 +666,7 @@ sys_displayhook(PyObject *module, PyObject *o)
         }
     }
     if (newline == NULL) {
-        newline = PyUnicode_FromString("\n");
+        newline = _PyUnicode_FROM_ASCII("\n");
         if (newline == NULL)
             return NULL;
     }
@@ -2747,10 +2747,10 @@ _PySys_InitCore(_PyRuntimeState *runtime, PyThreadState *tstate,
                         list_builtin_module_names());
 #if PY_BIG_ENDIAN
     SET_SYS_FROM_STRING("byteorder",
-                        PyUnicode_FromString("big"));
+                        _PyUnicode_FROM_ASCII("big"));
 #else
     SET_SYS_FROM_STRING("byteorder",
-                        PyUnicode_FromString("little"));
+                        _PyUnicode_FROM_ASCII("little"));
 #endif
 
 #ifdef MS_COREDLL
@@ -2813,10 +2813,10 @@ _PySys_InitCore(_PyRuntimeState *runtime, PyThreadState *tstate,
     /* float repr style: 0.03 (short) vs 0.029999999999999999 (legacy) */
 #ifndef PY_NO_SHORT_FLOAT_REPR
     SET_SYS_FROM_STRING("float_repr_style",
-                        PyUnicode_FromString("short"));
+                        _PyUnicode_FROM_ASCII("short"));
 #else
     SET_SYS_FROM_STRING("float_repr_style",
-                        PyUnicode_FromString("legacy"));
+                        _PyUnicode_FROM_ASCII("legacy"));
 #endif
 
     SET_SYS_FROM_STRING("thread_info", PyThread_GetInfo());

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -194,9 +194,9 @@ PyThread_GetInfo(void)
 
 #ifdef _POSIX_THREADS
 #ifdef USE_SEMAPHORES
-    value = PyUnicode_FromString("semaphore");
+    value = _PyUnicode_FROM_ASCII("semaphore");
 #else
-    value = PyUnicode_FromString("mutex+cond");
+    value = _PyUnicode_FROM_ASCII("mutex+cond");
 #endif
     if (value == NULL) {
         Py_DECREF(threadinfo);


### PR DESCRIPTION
It is a convenient wrapper for _PyUnicode_FromASCII().
It can be used like PyUnicode_FromString, without a length of the string.

<!-- issue-number: [bpo-37348](https://bugs.python.org/issue37348) -->
https://bugs.python.org/issue37348
<!-- /issue-number -->
