### PR TITLE
bpo-37344 - Allow plistlib to parse data with leading whitespaces

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -996,7 +996,7 @@ def loads(value, *, fmt=None, use_builtin_types=True, dict_type=dict):
     """Read a .plist file from a bytes object.
     Return the unpacked root object (which usually is a dictionary).
     """
-    fp = BytesIO(value)
+    fp = BytesIO(value.lstrip())
     return load(
         fp, fmt=fmt, use_builtin_types=use_builtin_types, dict_type=dict_type)
 

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -486,6 +486,11 @@ class TestPlistlib(unittest.TestCase):
         self.assertRaises(ValueError, plistlib.loads,
                           b"<plist><integer>not real</integer></plist>")
 
+    def test_leadingwhitspaces(self):
+        self.assertEqual(plistlib.loads(b"   <plist><integer>1</integer></plist>"), 1)
+        data = plistlib.dumps(1, fmt=plistlib.FMT_XML)
+        self.assertEqual(plistlib.loads(b"  " + data), 1)
+
     def test_xml_encodings(self):
         base = TESTDATA[plistlib.FMT_XML]
 

--- a/Misc/NEWS.d/next/Library/2019-06-20-21-00-00.bpo-37344.jhg10i.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-20-21-00-00.bpo-37344.jhg10i.rst
@@ -1,0 +1,1 @@
+``plistlib.loads`` can parse valid data with leading whitespaces


### PR DESCRIPTION
`xml` detection fails if the `header` contains leading whitespaces as mentioned in the [issue](https://bugs.python.org/issue37344#msg346090)
Applying an `lstrip()` on `header` while checking. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37344](https://bugs.python.org/issue37344) -->
https://bugs.python.org/issue37344
<!-- /issue-number -->
