### PR TITLE
bpo-37151: remove _PyCFunction_FastCallDict

### DIFF
--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -42,11 +42,6 @@ PyAPI_FUNC(int) PyCFunction_GetFlags(PyObject *);
 PyAPI_FUNC(PyObject *) PyCFunction_Call(PyObject *, PyObject *, PyObject *);
 
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyCFunction_FastCallDict(PyObject *func,
-    PyObject *const *args,
-    Py_ssize_t nargs,
-    PyObject *kwargs);
-
 PyAPI_FUNC(PyObject *) _PyCFunction_Vectorcall(PyObject *func,
     PyObject *const *stack,
     size_t nargsf,

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -496,24 +496,6 @@ exit:
 
 
 PyObject *
-_PyCFunction_FastCallDict(PyObject *func,
-                          PyObject *const *args, Py_ssize_t nargs,
-                          PyObject *kwargs)
-{
-    PyObject *result;
-
-    assert(func != NULL);
-    assert(PyCFunction_Check(func));
-
-    result = _PyMethodDef_RawFastCallDict(((PyCFunctionObject*)func)->m_ml,
-                                          PyCFunction_GET_SELF(func),
-                                          args, nargs, kwargs);
-    result = _Py_CheckFunctionResult(func, result, NULL);
-    return result;
-}
-
-
-PyObject *
 _PyMethodDef_RawFastCallKeywords(PyMethodDef *method, PyObject *self,
                                  PyObject *const *args, Py_ssize_t nargs,
                                  PyObject *kwnames)

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5018,10 +5018,10 @@ do_call_core(PyThreadState *tstate, PyObject *func, PyObject *callargs, PyObject
                 return NULL;
             }
 
-            C_TRACE(result, _PyCFunction_FastCallDict(func,
-                                                      &_PyTuple_ITEMS(callargs)[1],
-                                                      nargs - 1,
-                                                      kwdict));
+            C_TRACE(result, _PyObject_FastCallDict(func,
+                                                   &_PyTuple_ITEMS(callargs)[1],
+                                                   nargs - 1,
+                                                   kwdict));
             Py_DECREF(func);
             return result;
         }

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1563,8 +1563,7 @@ class Frame(object):
         if not caller:
             return False
 
-        if caller in ('_PyCFunction_FastCallDict',
-                      '_PyCFunction_Vectorcall',
+        if caller in ('_PyCFunction_Vectorcall',
                       'cfunction_call_varargs'):
             arg_name = 'func'
             # Within that frame:


### PR DESCRIPTION
The function `_PyCFunction_FastCallDict` is currently used in exactly one place, namely in the profiling branch of `do_call_core`. Its use can easily be replaced by `_PyObject_FastCallDict` and then we can remove `_PyCFunction_FastCallDict`.

CC @encukou @methane 

<!-- issue-number: [bpo-37151](https://bugs.python.org/issue37151) -->
https://bugs.python.org/issue37151
<!-- /issue-number -->
