### PR TITLE
gh-81530: Allow specification of custom environmental variables in EnvBuilder

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -355,6 +355,8 @@ class BasicTest(BaseTest):
 
     @requireVenvCreate
     @unittest.skipUnless(os.name == 'posix', 'only works on POSIX')
+    @unittest.skipUnless(os.environ.get('SHELL') is not None,
+                         'only works if SHELL is set')
     def test_custom_env(self):
         rmtree(self.env_dir)
         builder = venv.EnvBuilder(environmental_variables={'FOO' : 'BAR'})

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -353,6 +353,22 @@ class BasicTest(BaseTest):
             'pool.terminate()'])
         self.assertEqual(out.strip(), "python".encode())
 
+    @requireVenvCreate
+    @unittest.skipUnless(os.name == 'posix', 'only works on POSIX')
+    def test_custom_env(self):
+        rmtree(self.env_dir)
+        builder = venv.EnvBuilder(environmental_variables={'FOO' : 'BAR'})
+        builder.create(self.env_dir)
+        with EnvironmentVarGuard() as envvars:
+            echo_foo = (envvars.get('FOO', '')+'\n').encode()
+            activate = os.path.join(self.env_dir, self.bindir, 'activate')
+            out, err = check_output([envvars['SHELL'], '-c',
+                f'echo "$FOO" '
+                f'&& source {activate} && echo "$FOO" '
+                f'&& deactivate && echo "$FOO"'])
+            self.assertEqual(out, b''.join((echo_foo, b'BAR\n', echo_foo)))
+
+
 @requireVenvCreate
 class EnsurePipTest(BaseTest):
     """Test venv module installation of pip."""

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -497,18 +497,19 @@ def main(args=None):
         else:
             key_re = re.compile(r'.+')
 
-        for opt in options.env_vars:
-            pair = opt.split('=')
-            if len(pair) == 2 and pair[0] and pair[1]:
-                key, value = pair
-            else:
-                raise ValueError('env-vars must be provided as KEY=VALUE')
+        if options.env_vars:
+            for opt in options.env_vars:
+                pair = opt.split('=')
+                if len(pair) == 2 and pair[0] and pair[1]:
+                    key, value = pair
+                else:
+                    raise ValueError('env-vars must be provided as KEY=VALUE')
 
-            if not key_re.fullmatch(key):
-                raise ValueError(f'{key} is not a valid environmental '
-                                 f'variable name')
-            else:
-                env_vars[key] = value
+                if not key_re.fullmatch(key):
+                    raise ValueError(f'{key} is not a valid environmental '
+                                     f'variable name')
+                else:
+                    env_vars[key] = value
 
         builder = EnvBuilder(system_site_packages=options.system_site,
                              clear=options.clear,

--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -14,6 +14,8 @@ deactivate () {
         unset _OLD_VIRTUAL_PYTHONHOME
     fi
 
+    __VENV_DEACTIVATE_EXTRAS__
+
     # This should detect bash and zsh, which have a hash command that must
     # be called to get it to forget past commands.  Without forgetting
     # past commands the $PATH changes we made may not be respected
@@ -43,6 +45,8 @@ export VIRTUAL_ENV
 _OLD_VIRTUAL_PATH="$PATH"
 PATH="$VIRTUAL_ENV/__VENV_BIN_NAME__:$PATH"
 export PATH
+
+__VENV_ACTIVATE_EXTRAS__
 
 # unset PYTHONHOME if set
 # this will fail if PYTHONHOME is set to the empty string (which is bad anyway)

--- a/Misc/NEWS.d/next/Library/2019-06-20-09-16-05.bpo-37349.i22P93.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-20-09-16-05.bpo-37349.i22P93.rst
@@ -1,0 +1,1 @@
+Allow EnvBuilder to set enviromental variable.


### PR DESCRIPTION
* Adds argument `--env-vars` to `venv` 
  * Accepts `KEY=VALUE`
  * Verifies validity of `KEY` as environment variable
* Adds argument `environmental_variables: Optional[Dict[str, str]]` to `EnvBuilder.__init__`
  * Modifies `<env>/bin/activate` to set and restore `environmental_variables` on activate / deactivate
  

<!-- issue-number: [bpo-37349](https://bugs.python.org/issue37349) -->
https://bugs.python.org/issue37349
<!-- /issue-number -->

<!-- gh-issue-number: gh-81530 -->
* Issue: gh-81530
<!-- /gh-issue-number -->
