### PR TITLE
bpo-37351: Removes libpython38.a from standard Windows distribution

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1461,6 +1461,25 @@ Changes in the C API
 * The functions :c:func:`PyNode_AddChild` and :c:func:`PyParser_AddToken` now accept
   two additional ``int`` arguments *end_lineno* and *end_col_offset*.
 
+.. highlight:: shell
+
+* The :file:`libpython38.a` file to allow MinGW tools to link directly against
+  :file:`python38.dll` is no longer included in the regular Windows distribution.
+  If you require this file, it may be generated with the ``gendef`` and
+  ``dlltool`` tools, which are part of the MinGW binutils package::
+
+      gendef python38.dll > tmp.def
+      dlltool --dllname python38.dll --def tmp.def --output-lib libpython38.a
+
+  The location of an installed :file:`pythonXY.dll` will depend on the
+  installation options and the version and language of Windows. See
+  :ref:`using-on-windows` for more information. The resulting library should be
+  placed in the same directory as :file:`pythonXY.lib`, which is generally the
+  :file:`libs` directory under your Python installation.
+
+.. highlight:: python3
+
+
 CPython bytecode changes
 ------------------------
 

--- a/Misc/NEWS.d/next/Windows/2019-06-20-12-50-32.bpo-37351.asTnVW.rst
+++ b/Misc/NEWS.d/next/Windows/2019-06-20-12-50-32.bpo-37351.asTnVW.rst
@@ -1,0 +1,1 @@
+Removes libpython38.a from standard Windows distribution.

--- a/Tools/msi/README.txt
+++ b/Tools/msi/README.txt
@@ -159,9 +159,7 @@ The following properties may be passed when building these projects.
 
   /p:BuildForRelease=(true|false)
     When true, adds extra verification to ensure a complete installer is
-    produced. For example, binutils is required when building for a release
-    to generate MinGW-compatible libraries, and the build will be aborted if
-    this fails. Defaults to false.
+    produced. Defaults to false.
 
   /p:ReleaseUri=(any URI)
     Used to generate unique IDs for the installers to allow side-by-side

--- a/Tools/msi/dev/dev.wixproj
+++ b/Tools/msi/dev/dev.wixproj
@@ -7,12 +7,6 @@
         <OutputType>Package</OutputType>
     </PropertyGroup>
     <Import Project="..\msi.props" />
-    <PropertyGroup>
-        <DefineConstants Condition="$(BuildForRelease) and $(SuppressMinGWLib) == ''">
-            $(DefineConstants);
-            IncludeMinGWLib=1;
-        </DefineConstants>
-    </PropertyGroup>
     <ItemGroup>
         <Compile Include="dev.wxs" />
         <Compile Include="dev_files.wxs" />
@@ -30,21 +24,6 @@
             <Group>dev_include</Group>
         </InstallFiles>
     </ItemGroup>
-
-    <Target Name="BuildMinGWLib"
-            Inputs="$(BuildPath)$(PyDllName).dll"
-            Outputs="$(BuildPath)lib$(PyDllName).a"
-            AfterTargets="PrepareForBuild"
-            Condition="$(BuildForRelease) and $(SuppressMinGWLib) == ''">
-        <!-- Build libpython##.a as part of this project. This requires gendef and dlltool on the path. -->
-        <PropertyGroup>
-            <_DllToolOpts>-m i386 --as-flags=--32</_DllToolOpts>
-            <_DllToolOpts Condition="$(Platform) == 'x64'">-m i386:x86-64</_DllToolOpts>
-        </PropertyGroup>
-
-        <Exec Command='gendef - "$(BuildPath)$(PyDllName).dll" &gt; "$(IntermediateOutputPath)mingwlib.def"' ContinueOnError="false" />
-        <Exec Command='dlltool --dllname $(PyDllName).dll --def "$(IntermediateOutputPath)mingwlib.def" --output-lib "$(BuildPath)lib$(PyDllName).a" $(_DllToolOpts)' />
-    </Target>
 
     <Import Project="..\msi.targets" />
 </Project>

--- a/Tools/msi/dev/dev.wxs
+++ b/Tools/msi/dev/dev.wxs
@@ -10,9 +10,6 @@
             <ComponentGroupRef Id="dev_include" />
             <ComponentGroupRef Id="dev_pyconfig" />
             <ComponentGroupRef Id="dev_libs" />
-<?ifdef IncludeMinGWLib ?>
-            <ComponentGroupRef Id="dev_mingw" />
-<?endif ?>
             <ComponentRef Id="OptionalFeature" />
         </Feature>
     </Product>

--- a/Tools/msi/dev/dev_files.wxs
+++ b/Tools/msi/dev/dev_files.wxs
@@ -29,14 +29,4 @@
             </Component>
         </ComponentGroup>
     </Fragment>
-    
-    <?ifdef IncludeMinGWLib ?>
-    <Fragment>
-        <ComponentGroup Id="dev_mingw">
-            <Component Id="libs_libpython.a" Directory="libs" Guid="*">
-                <File Id="libs_libpython.a" Name="libpython$(var.MajorVersionNumber)$(var.MinorVersionNumber).a" KeyPath="yes" />
-            </Component>
-        </ComponentGroup>
-    </Fragment>
-    <?endif ?>
 </Wix>


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37351](https://bugs.python.org/issue37351) -->
https://bugs.python.org/issue37351
<!-- /issue-number -->
