### PR TITLE
bpo-37353: Documentation - Updated note in parser.rst about backwards compatiblity

### DIFF
--- a/Doc/library/parser.rst
+++ b/Doc/library/parser.rst
@@ -51,7 +51,8 @@ Python version to another as source text will always allow correct parse trees
 to be created in the target version, with the only restriction being that
 migrating to an older version of the interpreter will not support more recent
 language constructs.  The parse trees are not typically compatible from one
-version to another, whereas source code has always been forward-compatible.
+version to another, though source code has usually been forward-compatible within
+a major release series.
 
 Each element of the sequences returned by :func:`st2list` or :func:`st2tuple`
 has a simple form.  Sequences representing non-terminal elements in the grammar


### PR DESCRIPTION
Backward compatiblity of source code isn't always guaranteed.
Issue: [37353](https://bugs.python.org/issue37353)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37353](https://bugs.python.org/issue37353) -->
https://bugs.python.org/issue37353
<!-- /issue-number -->
