### PR TITLE
Improve threading.daemon docstring

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1107,8 +1107,7 @@ class Thread:
         main thread is not a daemon thread and therefore all threads created in
         the main thread default to daemon = False.
 
-        The entire Python program exits when no alive non-daemon threads are
-        left.
+        The entire Python program exits when only daemon threads are left.
 
         """
         assert self._initialized, "Thread.__init__() not called"


### PR DESCRIPTION
Rephrase and clarify that "the entire Python program exits when only daemon threads are left". This matches the documentation at https://docs.python.org/3/library/threading.html#thread-objects.