### PR TITLE
bpo-36511: fix -u parameters

### DIFF
--- a/Tools/buildbot/test.bat
+++ b/Tools/buildbot/test.bat
@@ -27,7 +27,7 @@ call "%here%..\..\PCbuild\rt.bat" %rt_opts% -uall -rwW --slowest --timeout=1200 
 exit /b %ERRORLEVEL%
 
 :Arm32Ssh
-set dashU=-unetwork,decimal,subprocess,urlfetch,tzdata
+set dashU=-unetwork -udecimal -usubprocess -uurlfetch -utzdata
 if "%SSH_SERVER%"=="" goto :Arm32SshHelp
 if "%PYTHON_SOURCE%"=="" (set PYTHON_SOURCE=%here%..\..\)
 if "%REMOTE_PYTHON_DIR%"=="" (set REMOTE_PYTHON_DIR=C:\python\)


### PR DESCRIPTION
Based on the buildbot log output 
-unetwork,decimal,subprocess,urlfetch,tzdata 
is being transformed to 
-unetwork decimal subprocess urlfetch tzdata

Notice the missing commas.  I don't know if this is causing the current failures but it seems incorrect.
Also, I'm not sure why this didn't go in the build master config instead of the .bat file.  Maybe it should be moved if this fixes something.

@zooba @zware 

<!-- issue-number: [bpo-36511](https://bugs.python.org/issue36511) -->
https://bugs.python.org/issue36511
<!-- /issue-number -->
