### PR TITLE
[3.8] bpo-32924: Fix the Show Source url in 3.8 documentation.

### DIFF
--- a/Doc/tools/templates/customsourcelink.html
+++ b/Doc/tools/templates/customsourcelink.html
@@ -4,7 +4,7 @@
     <ul class="this-page-menu">
       <li><a href="{{ pathto('bugs') }}">{% trans %}Report a Bug{% endtrans %}</a></li>
       <li>
-        <a href="https://github.com/python/cpython/blob/master/Doc/{{ sourcename|replace('.rst.txt', '.rst') }}"
+        <a href="https://github.com/python/cpython/blob/{{ version }}/Doc/{{ sourcename|replace('.rst.txt', '.rst') }}"
             rel="nofollow">{{ _('Show Source') }}
         </a>
       </li>


### PR DESCRIPTION
The "Show Source" link in Python 3.8 docs is pointing
to the master branch. It should point to the 3.8 branch.


<!-- issue-number: [bpo-32924](https://bugs.python.org/issue32924) -->
https://bugs.python.org/issue32924
<!-- /issue-number -->
