### PR TITLE
bpo-37348: optimize decoding ASCII string

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-23-00-26-30.bpo-37348.pp8P-x.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-23-00-26-30.bpo-37348.pp8P-x.rst
@@ -1,0 +1,2 @@
+Optimized decoding short ASCII string with UTF-8 and ascii codecs.
+``b"foo".decode()`` is about 15% faster.  Patch by Inada Naoki.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -265,7 +265,7 @@ unicode_fill(enum PyUnicode_Kind kind, void *data, Py_UCS4 value,
 /* Forward declaration */
 static inline int
 _PyUnicodeWriter_WriteCharInline(_PyUnicodeWriter *writer, Py_UCS4 ch);
-static inline int
+static inline void
 _PyUnicodeWriter_InitWithBuffer(_PyUnicodeWriter *writer, PyObject *buffer);
 static PyObject *
 unicode_encode_utf8(PyObject *unicode, _Py_error_handler error_handler,
@@ -13514,7 +13514,7 @@ _PyUnicodeWriter_Init(_PyUnicodeWriter *writer)
 }
 
 // Initialize _PyUnicodeWriter with initial buffer
-static inline int
+static inline void
 _PyUnicodeWriter_InitWithBuffer(_PyUnicodeWriter *writer, PyObject *buffer)
 {
     memset(writer, 0, sizeof(*writer));

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -4908,6 +4908,7 @@ unicode_decode_utf8(const char *s, Py_ssize_t size,
     // Use _PyUnicodeWriter after fast path is failed.
     _PyUnicodeWriter writer;
     _PyUnicodeWriter_Init(&writer);
+    writer.min_length = size;
     writer.buffer = u;
     writer.pos = s - starts;
     _PyUnicodeWriter_Update(&writer);
@@ -7009,6 +7010,7 @@ PyUnicode_DecodeASCII(const char *s,
 
     _PyUnicodeWriter writer;
     _PyUnicodeWriter_Init(&writer);
+    writer.min_length = size;
     writer.buffer = u;
     writer.pos = outpos;
     _PyUnicodeWriter_Update(&writer);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -6459,7 +6459,7 @@ PyUnicode_DecodeRawUnicodeEscape(const char *s,
        length after conversion to the true value. (But decoding error
        handler might have to resize the string) */
     _PyUnicodeWriter_Init(&writer);
-     writer.min_length = size;
+    writer.min_length = size;
     if (_PyUnicodeWriter_Prepare(&writer, size, 127) < 0) {
         goto onError;
     }


### PR DESCRIPTION
Use `_PyUnicode_Writer` only after `ascii_decode` is failed.

<!-- issue-number: [bpo-37348](https://bugs.python.org/issue37348) -->
https://bugs.python.org/issue37348
<!-- /issue-number -->
