### PR TITLE
[3.7] bpo-37335: Add alias for ASCII encoding

### DIFF
--- a/Lib/test/test_c_locale_coercion.py
+++ b/Lib/test/test_c_locale_coercion.py
@@ -134,10 +134,12 @@ class EncodingDetails(_EncodingDetails):
 
         * Some platforms report ASCII as ANSI_X3.4-1968
         * Some platforms report ASCII as US-ASCII
+        * Some platforms report ASCII as 646
         * Some platforms report UTF-8 instead of utf-8
         """
         data = data.replace(b"ANSI_X3.4-1968", b"ascii")
         data = data.replace(b"US-ASCII", b"ascii")
+        data = data.replace(b"646", b"ascii")
         data = data.lower()
         return data
 

--- a/Misc/NEWS.d/next/Tests/2019-06-19-10-03-59.bpo-37335.w9hyAA.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-19-10-03-59.bpo-37335.w9hyAA.rst
@@ -1,0 +1,1 @@
+Fix locale coercion tests on Solaris by adding 646 ASCII alias.


### PR DESCRIPTION
Solaris uses '646' as an alias for ASCII encoding and thus all the locale coercion tests are failing. This simple patch fixes the problem.

This is a second PR into a correct branch (this is 3.7 only change). Original one is here #11195 


<!-- issue-number: [bpo-37335](https://bugs.python.org/issue37335) -->
https://bugs.python.org/issue37335
<!-- /issue-number -->
