### PR TITLE
bpo-36888: Increase timeout in test_parent_process

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -301,7 +301,7 @@ class _TestProcess(BaseTestCase):
             target=self._test_create_grandchild_process, args=(wconn, ))
         p.start()
 
-        if not rconn.poll(timeout=5):
+        if not rconn.poll(timeout=60):
             raise AssertionError("Could not communicate with child process")
         parent_process_status = rconn.recv()
         self.assertEqual(parent_process_status, "alive")
@@ -309,7 +309,7 @@ class _TestProcess(BaseTestCase):
         p.terminate()
         p.join()
 
-        if not rconn.poll(timeout=5):
+        if not rconn.poll(timeout=60):
             raise AssertionError("Could not communicate with child process")
         parent_process_status = rconn.recv()
         self.assertEqual(parent_process_status, "not alive")
@@ -318,7 +318,7 @@ class _TestProcess(BaseTestCase):
     def _test_create_grandchild_process(cls, wconn):
         p = cls.Process(target=cls._test_report_parent_status, args=(wconn, ))
         p.start()
-        time.sleep(100)
+        time.sleep(300)
 
     @classmethod
     def _test_report_parent_status(cls, wconn):


### PR DESCRIPTION
Attempt to fix the buildbot failures reported in the original bpo issue.

We (@tomMoral and I) suspect that the `AssertionError` comes from the child process and the grand-child processes taking more than 5 seconds to get up and running, making the following calls to `rconn.poll(timeout=5)` return `False`. 

The proposed fix here is therefore to give more time for the child processes to start by increasing the timeout in the `rconn.poll` calls.

We also increase the life-span of the child process to make sure the it is not dead when the grand-child process starts executing.

cc @vstinner :)

<!-- issue-number: [bpo-36888](https://bugs.python.org/issue36888) -->
https://bugs.python.org/issue36888
<!-- /issue-number -->
