### PR TITLE
bpo-37244: Increase robustness of test_resource_tracker

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5013,7 +5013,7 @@ class TestResourceTracker(unittest.TestCase):
 
                 deadline = time.monotonic() + 60
                 while time.monotonic() < deadline:
-                    time.sleep(2.0)
+                    time.sleep(.5)
                     try:
                         _resource_unlink(name2, rtype)
                     except OSError as e:

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5010,12 +5010,21 @@ class TestResourceTracker(unittest.TestCase):
                 _resource_unlink(name1, rtype)
                 p.terminate()
                 p.wait()
-                time.sleep(2.0)
-                with self.assertRaises(OSError) as ctx:
-                    _resource_unlink(name2, rtype)
-                # docs say it should be ENOENT, but OSX seems to give EINVAL
-                self.assertIn(
-                    ctx.exception.errno, (errno.ENOENT, errno.EINVAL))
+
+                deadline = time.monotonic() + 60
+                while time.monotonic() < deadline:
+                    time.sleep(2.0)
+                    try:
+                        _resource_unlink(name2, rtype)
+                    except OSError as e:
+                        # docs say it should be ENOENT, but OSX seems to give
+                        # EINVAL
+                        self.assertIn(e.errno, (errno.ENOENT, errno.EINVAL))
+                        break
+                else:
+                    raise AssertionError(
+                        f"A {rtype} resource was leaked after a process was "
+                        f"abruptly terminated.")
                 err = p.stderr.read().decode('utf-8')
                 p.stderr.close()
                 expected = ('resource_tracker: There appear to be 2 leaked {} '


### PR DESCRIPTION
Attempt to fix the buildbot failures reported in the original bpo issue.
From the failure tracebacks, I suspect it is only because the cleanup time given to the `resource_tracker` was not high enough (2 seconds). I increased it to to 60 seconds.

cc @vstinner :) 

<!-- issue-number: [bpo-37244](https://bugs.python.org/issue37244) -->
https://bugs.python.org/issue37244
<!-- /issue-number -->
