### PR TITLE
[3.8] bpo-37316: mmap.mmap() passes the wrong variable to PySys_Audit() (GH-14152)

### DIFF
--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -261,6 +261,13 @@ def test_cantrace():
     assertSequenceEqual(["call"] * 4, traced)
 
 
+def test_mmap():
+    import mmap
+    with TestHook() as hook:
+        mmap.mmap(-1, 8)
+        assertEqual(hook.seen[0][1][:2], (-1, 8))
+
+
 if __name__ == "__main__":
     from test.libregrtest.setup import suppress_msvcrt_asserts
     suppress_msvcrt_asserts(False)

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -74,6 +74,9 @@ class AuditTest(unittest.TestCase):
     def test_cantrace(self):
         self.do_test("test_cantrace")
 
+    def test_mmap(self):
+        self.do_test("test_mmap")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-17-03-53-16.bpo-37316.LytDX_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-17-03-53-16.bpo-37316.LytDX_.rst
@@ -1,0 +1,1 @@
+Fix the :c:func:`PySys_Audit` call in :class:`mmap.mmap`.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1154,7 +1154,7 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
     }
 
     if (PySys_Audit("mmap.__new__", "ini" _Py_PARSE_OFF_T,
-                    fileno, map_size, access, offset) < 0) {
+                    fd, map_size, access, offset) < 0) {
         return NULL;
     }
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -160,6 +160,7 @@ PySys_Audit(const char *event, const char *argFormat, ...)
         va_list args;
         va_start(args, argFormat);
         eventArgs = Py_VaBuildValue(argFormat, args);
+        va_end(args);
         if (eventArgs && !PyTuple_Check(eventArgs)) {
             PyObject *argTuple = PyTuple_Pack(1, eventArgs);
             Py_DECREF(eventArgs);


### PR DESCRIPTION


<!-- issue-number: [bpo-37316](https://bugs.python.org/issue37316) -->
https://bugs.python.org/issue37316
<!-- /issue-number -->
