### PR TITLE
gh-81483: Add an "onerror" callback parameter to the tempfile.TemporaryDirectory member functions

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -114,7 +114,7 @@ The module defines the following user-callable items:
       Added *errors* parameter.
 
 
-.. function:: TemporaryDirectory(suffix=None, prefix=None, dir=None)
+.. function:: TemporaryDirectory(suffix=None, prefix=None, dir=None, onerror=None)
 
    This function securely creates a temporary directory using the same rules as :func:`mkdtemp`.
    The resulting object can be used as a context manager (see
@@ -128,10 +128,23 @@ The module defines the following user-callable items:
    the :keyword:`with` statement, if there is one.
 
    The directory can be explicitly cleaned up by calling the
-   :func:`cleanup` method.
+   :func:`cleanup` method.  It also accepts an optional *onerror* parameter that
+   will be used instead of the *onerror* parameter passed to
+   :func:`TemporaryDirectory`.
+
+   If *onerror* is provided, it must be a callable that accepts three
+   parameters: *function*, *path*, and *excinfo*.
+
+   The first parameter, *function*, is the function which raised the exception;
+   it depends on the platform and implementation.  The second parameter,
+   *path*, will be the path name passed to *function*.  The third parameter,
+   *excinfo*, will be the exception information returned by
+   :func:`sys.exc_info`.  Exceptions raised by *onerror* will not be caught.
 
    .. versionadded:: 3.2
 
+   .. versionchanged:: 3.9
+      Added *onerror* parameters.
 
 .. function:: mkstemp(suffix=None, prefix=None, dir=None, text=False)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -86,6 +86,16 @@ New Modules
 Improved Modules
 ================
 
+tempfile
+--------
+
+The :func:`TemporaryDirectory` function now accepts an optional *onerror*
+parameter with the same functionality as the :func:`shutil.rmtree` function's
+*onerror* parameter.  The :func:`cleanup` method of the object returned
+by :func:`TemporaryDirectory` also accepts an optional *onerror* parameter
+that will be used in place of the :func:`TemporaryDirectory` *onerror*
+parameter.  (Contributed by Jeffrey Kintscher in :issue:`37302`.)
+
 threading
 ---------
 

--- a/Misc/NEWS.d/next/Library/2019-06-21-11-41-00.bpo-37302.fTzd6N.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-21-11-41-00.bpo-37302.fTzd6N.rst
@@ -1,0 +1,3 @@
+The :func:`TemporaryDirectory` function now accepts an optional *onerror*
+parameter with the same functionality as the :func:`shutil.rmtree`
+function's *onerror* parameter.  Patch by Jeffrey Kintscher.


### PR DESCRIPTION
This PR adds an "onerror" callback parameter to the tempfile.TemporaryDirectory() member functions so that the caller can perform special handling for directory items that it can't automatically delete.  The caller created the undeletable directory entries, so it is reasonable to believe the caller may know how to unmake what they made.

The provided test cases create a filesystem image and mount it within the temporary directory to force an error in the underlying shutil.rmtree() call during cleanup that triggers calls to the new onerror parameters.  The test cases are provided for macOS because Windows and Linux require special user privileges to create and/or mount/unmount a filesystem image.  This method was chosen to simulate the cleanup problems described in [bpo-36422](https://bugs.python.org/issue36422).

I am open to suggestions on how to force errors on those systems or in a portable manner.  The usual trick of changing directory entry permissions won't work because tempfile.TemporaryDirectory() has heuristics to handle that case.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37302](https://bugs.python.org/issue37302) -->
https://bugs.python.org/issue37302
<!-- /issue-number -->


<!-- gh-issue-number: gh-81483 -->
* Issue: gh-81483
<!-- /gh-issue-number -->
