### PR TITLE
[3.8] Update What's New in Python 3.8 (GH-14253)

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -998,7 +998,7 @@ Build and C API Changes
 * The :c:func:`PyByteArray_Init` and :c:func:`PyByteArray_Fini` functions have
   been removed. They did nothing since Python 2.7.4 and Python 3.2.0, were
   excluded from the limited API (stable ABI), and were not documented.
-  (Contributed by Victor Stinner in :issue:`32980`.)
+  (Contributed by Victor Stinner in :issue:`35713`.)
 
 * The result of :c:func:`PyExceptionClass_Name` is now of type
   ``const char *`` rather of ``char *``.


### PR DESCRIPTION
Fix bpo number of PyByteArray_Init removal

(cherry picked from commit c68e3fb15d29607a1af2c19ebec552a87c24cb48)