### PR TITLE
bpo-37370: AF_UNIX should be supported on Windows

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5094,8 +5094,14 @@ class TestUnixDomain(unittest.TestCase):
                 raise
 
     def testUnbound(self):
-        # Issue #30205 (note getsockname() can return None on OS X)
-        self.assertIn(self.sock.getsockname(), ('', None))
+        if sys.platform == 'win32':
+            # Getting the name of unbound socket on Windows
+            # raises an exception
+            self.assertRaises(OSError, self.sock.getsockname)
+        else:
+            # Issue #30205 (note getsockname() can return None on OS X)
+            name = self.sock.getsockname()
+            self.assertIn(name, ('', None))
 
     def testStrAddr(self):
         # Test binding to and retrieving a normal string pathname.
@@ -5111,6 +5117,7 @@ class TestUnixDomain(unittest.TestCase):
         self.addCleanup(support.unlink, path)
         self.assertEqual(self.sock.getsockname(), path)
 
+    @unittest.skipIf(sys.platform == 'win32', "ASCII path name required on Windows")
     def testSurrogateescapeBind(self):
         # Test binding to a valid non-ASCII pathname, with the
         # non-ASCII bytes supplied using surrogateescape encoding.

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -8,6 +8,7 @@ import os
 import select
 import signal
 import socket
+import sys
 import tempfile
 import threading
 import unittest
@@ -232,12 +233,14 @@ class SocketServerTest(unittest.TestCase):
                             self.dgram_examine)
 
     @requires_unix_sockets
+    @unittest.skipIf(sys.platform == 'win32', "no datagram support")
     def test_UnixDatagramServer(self):
         self.run_server(socketserver.UnixDatagramServer,
                         socketserver.DatagramRequestHandler,
                         self.dgram_examine)
 
     @requires_unix_sockets
+    @unittest.skipIf(sys.platform == 'win32', "no datagram support")
     def test_ThreadingUnixDatagramServer(self):
         self.run_server(socketserver.ThreadingUnixDatagramServer,
                         socketserver.DatagramRequestHandler,

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -41,6 +41,8 @@ typedef int socklen_t;
 
 #ifdef HAVE_SYS_UN_H
 # include <sys/un.h>
+#elif HAVE_AFUNIX_H
+# include <afunix.h>
 #else
 # undef AF_UNIX
 #endif

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -610,6 +610,9 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* Define if you have the <sys/un.h> header file.  */
 /* #define HAVE_SYS_UN_H 1 */
 
+/* Define if you have the <afunix.h> header file.  */
+#define HAVE_AFUNIX_H 1
+
 /* Define if you have the <sys/utime.h> header file.  */
 /* #define HAVE_SYS_UTIME_H 1 */
 


### PR DESCRIPTION
AF_UNIX has been supported on windows since version 1803 (build 17134)
see https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/

Enabling support for AF_UNIX will enable better peer-to-peer connectivity scenarios for Azure IoT Edge.  The changes to enable AF_UNIX on Windows seem small and low risk.

I need feedback on these proposed changes

@zooba 


<!-- issue-number: [bpo-37370](https://bugs.python.org/issue37370) -->
https://bugs.python.org/issue37370
<!-- /issue-number -->
