### PR TITLE
bpo-37372: Fix unpickling certain datetime.time objects from Python 2

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3288,11 +3288,11 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
 
     def test_compat_unpickle(self):
         tests = [
-            b"cdatetime\ntime\n(S'\\x14;\\x10\\x00\\x10\\x00'\ntR.",
-            b'cdatetime\ntime\n(U\x06\x14;\x10\x00\x10\x00tR.',
-            b'\x80\x02cdatetime\ntime\nU\x06\x14;\x10\x00\x10\x00\x85R.',
+            b"cdatetime\ntime\n(S'\\x14;\\x19\\x00\\x10\\x00'\ntR.",
+            b'cdatetime\ntime\n(U\x06\x14;\x19\x00\x10\x00tR.',
+            b'\x80\x02cdatetime\ntime\nU\x06\x14;\x19\x00\x10\x00\x85R.',
         ]
-        args = 20, 59, 16, 64**2
+        args = 20, 59, 25, 64**2
         expected = self.theclass(*args)
         for data in tests:
             for loads in pickle_loads:
@@ -3673,21 +3673,21 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
 
     def test_compat_unpickle(self):
         tests = [
-            b"cdatetime\ntime\n(S'\\x05\\x06\\x07\\x01\\xe2@'\n"
+            b"cdatetime\ntime\n(S'\\x05\\x16\\x17\\x01\\xe2@'\n"
             b"ctest.datetimetester\nPicklableFixedOffset\n(tR"
             b"(dS'_FixedOffset__offset'\ncdatetime\ntimedelta\n"
             b"(I-1\nI68400\nI0\ntRs"
             b"S'_FixedOffset__dstoffset'\nNs"
             b"S'_FixedOffset__name'\nS'cookie'\nsbtR.",
 
-            b'cdatetime\ntime\n(U\x06\x05\x06\x07\x01\xe2@'
+            b'cdatetime\ntime\n(U\x06\x05\x16\x17\x01\xe2@'
             b'ctest.datetimetester\nPicklableFixedOffset\n)R'
             b'}(U\x14_FixedOffset__offsetcdatetime\ntimedelta\n'
             b'(J\xff\xff\xff\xffJ0\x0b\x01\x00K\x00tR'
             b'U\x17_FixedOffset__dstoffsetN'
             b'U\x12_FixedOffset__nameU\x06cookieubtR.',
 
-            b'\x80\x02cdatetime\ntime\nU\x06\x05\x06\x07\x01\xe2@'
+            b'\x80\x02cdatetime\ntime\nU\x06\x05\x16\x17\x01\xe2@'
             b'ctest.datetimetester\nPicklableFixedOffset\n)R'
             b'}(U\x14_FixedOffset__offsetcdatetime\ntimedelta\n'
             b'J\xff\xff\xff\xffJ0\x0b\x01\x00K\x00\x87R'
@@ -3696,7 +3696,7 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
         ]
 
         tinfo = PicklableFixedOffset(-300, 'cookie')
-        expected = self.theclass(5, 6, 7, 123456, tzinfo=tinfo)
+        expected = self.theclass(5, 22, 23, 123456, tzinfo=tinfo)
         for data in tests:
             for loads in pickle_loads:
                 derived = loads(data, encoding='latin1')

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3288,12 +3288,18 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
 
     def test_compat_unpickle(self):
         tests = [
-            (b"cdatetime\ntime\n(S'\\x14;\\x10\\x00\\x10\\x00'\ntR.", (20, 59, 16, 64**2)),
-            (b'cdatetime\ntime\n(U\x06\x14;\x10\x00\x10\x00tR.', (20, 59, 16, 64**2)),
-            (b'\x80\x02cdatetime\ntime\nU\x06\x14;\x10\x00\x10\x00\x85R.', (20, 59, 16, 64**2)),
-            (b"cdatetime\ntime\n(S'\\x14;\\x19\\x00\\x10\\x00'\ntR.", (20, 59, 25, 64**2)),
-            (b'cdatetime\ntime\n(U\x06\x14;\x19\x00\x10\x00tR.', (20, 59, 25, 64**2)),
-            (b'\x80\x02cdatetime\ntime\nU\x06\x14;\x19\x00\x10\x00\x85R.', (20, 59, 25, 64**2)),
+            (b"cdatetime\ntime\n(S'\\x14;\\x10\\x00\\x10\\x00'\ntR.",
+             (20, 59, 16, 64**2)),
+            (b'cdatetime\ntime\n(U\x06\x14;\x10\x00\x10\x00tR.',
+             (20, 59, 16, 64**2)),
+            (b'\x80\x02cdatetime\ntime\nU\x06\x14;\x10\x00\x10\x00\x85R.',
+             (20, 59, 16, 64**2)),
+            (b"cdatetime\ntime\n(S'\\x14;\\x19\\x00\\x10\\x00'\ntR.",
+             (20, 59, 25, 64**2)),
+            (b'cdatetime\ntime\n(U\x06\x14;\x19\x00\x10\x00tR.',
+             (20, 59, 25, 64**2)),
+            (b'\x80\x02cdatetime\ntime\nU\x06\x14;\x19\x00\x10\x00\x85R.',
+             (20, 59, 25, 64**2)),
         ]
         for i, (data, args) in enumerate(tests):
             with self.subTest(i=i):

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3288,16 +3288,19 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
 
     def test_compat_unpickle(self):
         tests = [
-            b"cdatetime\ntime\n(S'\\x14;\\x19\\x00\\x10\\x00'\ntR.",
-            b'cdatetime\ntime\n(U\x06\x14;\x19\x00\x10\x00tR.',
-            b'\x80\x02cdatetime\ntime\nU\x06\x14;\x19\x00\x10\x00\x85R.',
+            (b"cdatetime\ntime\n(S'\\x14;\\x10\\x00\\x10\\x00'\ntR.", (20, 59, 16, 64**2)),
+            (b'cdatetime\ntime\n(U\x06\x14;\x10\x00\x10\x00tR.', (20, 59, 16, 64**2)),
+            (b'\x80\x02cdatetime\ntime\nU\x06\x14;\x10\x00\x10\x00\x85R.', (20, 59, 16, 64**2)),
+            (b"cdatetime\ntime\n(S'\\x14;\\x19\\x00\\x10\\x00'\ntR.", (20, 59, 25, 64**2)),
+            (b'cdatetime\ntime\n(U\x06\x14;\x19\x00\x10\x00tR.', (20, 59, 25, 64**2)),
+            (b'\x80\x02cdatetime\ntime\nU\x06\x14;\x19\x00\x10\x00\x85R.', (20, 59, 25, 64**2)),
         ]
-        args = 20, 59, 25, 64**2
-        expected = self.theclass(*args)
-        for data in tests:
-            for loads in pickle_loads:
-                derived = loads(data, encoding='latin1')
-                self.assertEqual(derived, expected)
+        for i, (data, args) in enumerate(tests):
+            with self.subTest(i=i):
+                expected = self.theclass(*args)
+                for loads in pickle_loads:
+                    derived = loads(data, encoding='latin1')
+                    self.assertEqual(derived, expected)
 
     def test_bool(self):
         # time is always True.
@@ -3673,21 +3676,21 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
 
     def test_compat_unpickle(self):
         tests = [
-            b"cdatetime\ntime\n(S'\\x05\\x16\\x17\\x01\\xe2@'\n"
+            b"cdatetime\ntime\n(S'\\x05\\x06\\x07\\x01\\xe2@'\n"
             b"ctest.datetimetester\nPicklableFixedOffset\n(tR"
             b"(dS'_FixedOffset__offset'\ncdatetime\ntimedelta\n"
             b"(I-1\nI68400\nI0\ntRs"
             b"S'_FixedOffset__dstoffset'\nNs"
             b"S'_FixedOffset__name'\nS'cookie'\nsbtR.",
 
-            b'cdatetime\ntime\n(U\x06\x05\x16\x17\x01\xe2@'
+            b'cdatetime\ntime\n(U\x06\x05\x06\x07\x01\xe2@'
             b'ctest.datetimetester\nPicklableFixedOffset\n)R'
             b'}(U\x14_FixedOffset__offsetcdatetime\ntimedelta\n'
             b'(J\xff\xff\xff\xffJ0\x0b\x01\x00K\x00tR'
             b'U\x17_FixedOffset__dstoffsetN'
             b'U\x12_FixedOffset__nameU\x06cookieubtR.',
 
-            b'\x80\x02cdatetime\ntime\nU\x06\x05\x16\x17\x01\xe2@'
+            b'\x80\x02cdatetime\ntime\nU\x06\x05\x06\x07\x01\xe2@'
             b'ctest.datetimetester\nPicklableFixedOffset\n)R'
             b'}(U\x14_FixedOffset__offsetcdatetime\ntimedelta\n'
             b'J\xff\xff\xff\xffJ0\x0b\x01\x00K\x00\x87R'
@@ -3696,7 +3699,7 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
         ]
 
         tinfo = PicklableFixedOffset(-300, 'cookie')
-        expected = self.theclass(5, 22, 23, 123456, tzinfo=tinfo)
+        expected = self.theclass(5, 6, 7, 123456, tzinfo=tinfo)
         for data in tests:
             for loads in pickle_loads:
                 derived = loads(data, encoding='latin1')

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -162,6 +162,7 @@ Roy Bixler
 Daniel Black
 Jonathan Black
 Renaud Blanch
+Justin Blanchard
 Mike Bland
 Martin Bless
 Pablo Bleyer

--- a/Misc/NEWS.d/next/Library/2019-06-22-12-30-00.bpo-37372.kIKqZ6.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-22-12-30-00.bpo-37372.kIKqZ6.rst
@@ -1,0 +1,1 @@
+Fix errors unpickling certain datetime.time objects from Python 2.

--- a/Misc/NEWS.d/next/Library/2019-06-22-12-30-00.bpo-37372.kIKqZ6.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-22-12-30-00.bpo-37372.kIKqZ6.rst
@@ -1,1 +1,2 @@
-Fix errors unpickling certain datetime.time objects from Python 2.
+Fix error unpickling datetime.time objects from Python 2 with seconds>=24.
+Patch by Justin Blanchard.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4079,7 +4079,7 @@ time_new(PyTypeObject *type, PyObject *args, PyObject *kw)
                 return NULL;
             }
             if (PyUnicode_GET_LENGTH(state) == _PyDateTime_TIME_DATASIZE &&
-                (0x7F & PyUnicode_READ_CHAR(state, 2)) < 24)
+                (0x7F & PyUnicode_READ_CHAR(state, 0)) < 24)
             {
                 state = PyUnicode_AsLatin1String(state);
                 if (state == NULL) {


### PR DESCRIPTION
Fix for: https://bugs.python.org/issue37372 "datetime.time unpickling fails in case of python2 pickle with seconds>=24". Thanks!

<!-- issue-number: [bpo-37372](https://bugs.python.org/issue37372) -->
https://bugs.python.org/issue37372
<!-- /issue-number -->
