### PR TITLE
bpo-37374: Do not escape quotes in minidom inside text segments

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -5,6 +5,7 @@ import pickle
 import io
 from test import support
 import unittest
+from xml.etree import ElementTree
 
 import xml.dom.minidom
 
@@ -1662,6 +1663,15 @@ class MinidomTest(unittest.TestCase):
         self.checkWholeText(dom1.getElementsByTagName('node')[0].firstChild, '</data>')
         dom2 = parseString(dom1.toprettyxml())
         self.checkWholeText(dom2.getElementsByTagName('node')[0].firstChild, '</data>')
+
+    def testQuoteEscape(self):
+        text = ElementTree.Element('text')
+        text.text = 'f&oo"b<a>r'
+        xml_string = ElementTree.tostring(text)
+        xml_tree = parseString(xml_string)
+        output = xml_tree.toprettyxml(indent='  ')
+        self.assertEqual(output.splitlines()[1], xml_string.decode('utf8'))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -300,6 +300,13 @@ def _in_document(node):
         node = node.parentNode
     return False
 
+def _write_text_data(writer, data):
+    "Writes datachars of text node to writer."
+    if data:
+        data = data.replace("&", "&amp;").replace("<", "&lt;"). \
+                    replace(">", "&gt;")
+        writer.write(data)
+
 def _write_data(writer, data):
     "Writes datachars to writer."
     if data:
@@ -1110,7 +1117,7 @@ class Text(CharacterData):
         return newText
 
     def writexml(self, writer, indent="", addindent="", newl=""):
-        _write_data(writer, "%s%s%s" % (indent, self.data, newl))
+        _write_text_data(writer, "%s%s%s" % (indent, self.data, newl))
 
     # DOM Level 3 (WD 9 April 2002)
 

--- a/Misc/NEWS.d/next/Library/2019-06-22-14-18-39.bpo-14312.3SBbwB.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-22-14-18-39.bpo-14312.3SBbwB.rst
@@ -1,0 +1,1 @@
+:mod:`minidom` does not escape quotes anymore inside text nodes.


### PR DESCRIPTION
Addressing the issue: https://bugs.python.org/issue37374

<!-- issue-number: [bpo-37374](https://bugs.python.org/issue37374) -->
https://bugs.python.org/issue37374
<!-- /issue-number -->
