### PR TITLE
bpo-26967: fix flag grouping with allow_abbrev=False

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -182,6 +182,10 @@ ArgumentParser objects
    .. versionchanged:: 3.5
       *allow_abbrev* parameter was added.
 
+   .. versionchanged:: 3.8
+      In previous versions, *allow_abbrev* also disabled grouping of short
+      flags such as ``-vv`` to mean ``-v -v``.
+
 The following sections describe how each of these are used.
 
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2130,7 +2130,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 action = self._option_string_actions[option_string]
                 return action, option_string, explicit_arg
 
-        if self.allow_abbrev:
+        if self.allow_abbrev or not arg_string.startswith('--'):
             # search through all possible prefixes of the option string
             # and all actions in the parser for possible interpretations
             option_tuples = self._get_option_tuples(arg_string)

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -786,6 +786,25 @@ class TestOptionalsDisallowLongAbbreviation(ParserTestCase):
         ('--foonly 7 --foodle --foo 2', NS(foo='2', foodle=True, foonly='7')),
     ]
 
+
+class TestDisallowLongAbbreviationAllowsShortGrouping(ParserTestCase):
+    """Do not allow abbreviations of long options at all"""
+
+    parser_signature = Sig(allow_abbrev=False)
+    argument_signatures = [
+        Sig('-r'),
+        Sig('-c', action='count'),
+    ]
+    failures = ['-r', '-c -r']
+    successes = [
+        ('', NS(r=None, c=None)),
+        ('-ra', NS(r='a', c=None)),
+        ('-rcc', NS(r='cc', c=None)),
+        ('-cc', NS(r=None, c=2)),
+        ('-cc -ra', NS(r='a', c=2)),
+        ('-ccrcc', NS(r='cc', c=2)),
+    ]
+
 # ================
 # Positional tests
 # ================

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -641,6 +641,7 @@ Travis B. Hartwell
 Shane Harvey
 Larry Hastings
 Tim Hatch
+Zac Hatfield-Dodds
 Shane Hathaway
 Michael Haubenwallner
 Janko Hauser

--- a/Misc/NEWS.d/next/Library/2019-06-23-12-46-10.bpo-26967.xEuem1.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-23-12-46-10.bpo-26967.xEuem1.rst
@@ -1,0 +1,3 @@
+An :class:`~argparse.ArgumentParser` with ``allow_abbrev=False`` no longer
+disables grouping of short flags, such as ``-vv``, but only disables
+abbreviation of long flags as documented. Patch by Zac Hatfield-Dodds.


### PR DESCRIPTION
The `allow_abbrev` option for ArgumentParser is documented and intended to disable support for unique prefixes of --options, which may sometimes be ambiguous due to deferred parsing.

However, the initial implementation also broke parsing of grouped short flags, such as `-ab` meaning `-a -b` (or `-a=b`).  Checking the argument for a leading `--` before rejecting it fixes this.

This was prompted by pytest-dev/pytest#5469, so a backport to at least 3.8 would be great :smile:  
And this is my first PR to CPython, so please let me know if I've missed anything!

<!-- issue-number: [bpo-26967](https://bugs.python.org/issue26967) -->
https://bugs.python.org/issue26967
<!-- /issue-number -->
