### PR TITLE
bpo-37359: Add --cleanup option to python3 -m test

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -272,8 +272,10 @@ def _create_parser():
     group.add_argument('--junit-xml', dest='xmlpath', metavar='FILENAME',
                        help='writes JUnit-style XML results to the specified '
                             'file')
-    group.add_argument('--tempdir', dest='tempdir', metavar='PATH',
+    group.add_argument('--tempdir', metavar='PATH',
                        help='override the working directory for the test run')
+    group.add_argument('--cleanup', action='store_true',
+                       help='remove old test_python_* directories')
     return parser
 
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1156,6 +1156,21 @@ class ArgsTestCase(BaseTestCase):
                                   fail_env_changed=True)
         self.assertIn("Warning -- Unraisable exception", output)
 
+    def test_cleanup(self):
+        dirname = os.path.join(self.tmptestdir, "test_python_123")
+        os.mkdir(dirname)
+        filename = os.path.join(self.tmptestdir, "test_python_456")
+        open(filename, "wb").close()
+        names = [dirname, filename]
+
+        cmdargs = ['-m', 'test',
+                   '--tempdir=%s' % self.tmptestdir,
+                   '--cleanup']
+        self.run_python(cmdargs)
+
+        for name in names:
+            self.assertFalse(os.path.exists(name), name)
+
 
 class TestUtils(unittest.TestCase):
     def test_format_duration(self):

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1104,6 +1104,11 @@ TESTTIMEOUT=	1200
 
 .PHONY: test testall testuniversal buildbottest pythoninfo
 
+# Remove "test_python_*" directories of previous failed test jobs.
+# Pass TESTOPTS options because it can contain --tempdir option.
+cleantest: build_all
+	$(TESTRUNNER) $(TESTOPTS) --cleanup
+
 # Run a basic set of regression tests.
 # This excludes some tests that are particularly resource-intensive.
 test:		@DEF_MAKE_RULE@ platform

--- a/Misc/NEWS.d/next/Tests/2019-06-24-10-47-07.bpo-37359.CkdtyO.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-24-10-47-07.bpo-37359.CkdtyO.rst
@@ -1,0 +1,4 @@
+Add --cleanup option to python3 -m test to remove ``test_python_*``
+directories of previous failed jobs. Add "make cleantest" to run
+``python3 -m test --cleanup``.
+


### PR DESCRIPTION
regrtest: Add --cleanup option to remove "test_python_*" directories
of previous failed jobs.

<!-- issue-number: [bpo-37359](https://bugs.python.org/issue37359) -->
https://bugs.python.org/issue37359
<!-- /issue-number -->
