### PR TITLE
[2.7] bpo-37124: Fix reference leak in test_msilib (GH-13750)

### DIFF
--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -45,6 +45,7 @@ class MsiDatabaseTestCase(unittest.TestCase):
 
     def test_directory_start_component_keyfile(self):
         db, db_path = init_database()
+        self.addCleanup(msilib._directories.clear)
         feature = msilib.Feature(db, 0, 'Feature', 'A feature', 'Python')
         cab = msilib.CAB('CAB')
         dir = msilib.Directory(db, cab, None, TESTFN, 'TARGETDIR',


### PR DESCRIPTION
(cherry picked from commit c0295dba259accc4b247beb22a0b2cc2f31d9850)

<!-- issue-number: [bpo-37124](https://bugs.python.org/issue37124) -->
https://bugs.python.org/issue37124
<!-- /issue-number -->
