### PR TITLE
bpo-37392: Remove sys.setcheckinterval()

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -551,14 +551,6 @@ always available.
    .. versionadded:: 3.7
 
 
-.. function:: getcheckinterval()
-
-   Return the interpreter's "check interval"; see :func:`setcheckinterval`.
-
-   .. deprecated:: 3.2
-      Use :func:`getswitchinterval` instead.
-
-
 .. function:: getdefaultencoding()
 
    Return the name of the current default string encoding used by the Unicode
@@ -1139,21 +1131,6 @@ always available.
    assigned to either variable, its :func:`str` is re-evaluated each time the
    interpreter prepares to read a new interactive command; this can be used to
    implement a dynamic prompt.
-
-
-.. function:: setcheckinterval(interval)
-
-   Set the interpreter's "check interval".  This integer value determines how often
-   the interpreter checks for periodic things such as thread switches and signal
-   handlers.  The default is ``100``, meaning the check is performed every 100
-   Python virtual instructions. Setting it to a larger value may increase
-   performance for programs using threads.  Setting it to a value ``<=`` 0 checks
-   every virtual instruction, maximizing responsiveness as well as overhead.
-
-   .. deprecated:: 3.2
-      This function doesn't have an effect anymore, as the internal logic for
-      thread switching and asynchronous tasks has been rewritten.  Use
-      :func:`setswitchinterval` instead.
 
 
 .. function:: setdlopenflags(n)

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -122,6 +122,11 @@ Deprecated
 Removed
 =======
 
+* The ``sys.getcheckinterval()`` and ``sys.setcheckinterval()`` functions have
+  been removed. They were deprecated since Python 3.2. Use
+  :func:`sys.getswitchinterval` and :func:`sys.setswitchinterval` instead.
+  (Contributed by Victor Stinner in :issue:`37392`.)
+
 * The C function ``PyImport_Cleanup()`` has been removed. It was documented as:
   "Empty the module table.  For internal use only."
   (Contributed by Victor Stinner in :issue:`36710`.)

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -82,9 +82,6 @@ struct _is {
     PyObject *builtins;
     PyObject *importlib;
 
-    /* Used in Python/sysmodule.c. */
-    int check_interval;
-
     /* Used in Modules/_threadmodule.c. */
     long num_threads;
     /* Support for runtime thread stack size tuning.

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -159,15 +159,6 @@ class SysModuleTest(unittest.TestCase):
     # testing sys.settrace() is done in test_sys_settrace.py
     # testing sys.setprofile() is done in test_sys_setprofile.py
 
-    def test_setcheckinterval(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            self.assertRaises(TypeError, sys.setcheckinterval)
-            orig = sys.getcheckinterval()
-            for n in 0, 100, 120, orig: # orig last to restore starting state
-                sys.setcheckinterval(n)
-                self.assertEqual(sys.getcheckinterval(), n)
-
     def test_switchinterval(self):
         self.assertRaises(TypeError, sys.setswitchinterval)
         self.assertRaises(TypeError, sys.setswitchinterval, "a")

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-25-01-45-06.bpo-37392.J3JhIx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-25-01-45-06.bpo-37392.J3JhIx.rst
@@ -1,0 +1,4 @@
+Remove ``sys.getcheckinterval()`` and ``sys.setcheckinterval()`` functions.
+They were deprecated since Python 3.2. Use :func:`sys.getswitchinterval` and
+:func:`sys.setswitchinterval` instead. Remove also ``check_interval`` field of
+the ``PyInterpreterState`` structure.

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -281,62 +281,6 @@ sys_getprofile(PyObject *module, PyObject *Py_UNUSED(ignored))
     return sys_getprofile_impl(module);
 }
 
-PyDoc_STRVAR(sys_setcheckinterval__doc__,
-"setcheckinterval($module, n, /)\n"
-"--\n"
-"\n"
-"Set the async event check interval to n instructions.\n"
-"\n"
-"This tells the Python interpreter to check for asynchronous events\n"
-"every n instructions.\n"
-"\n"
-"This also affects how often thread switches occur.");
-
-#define SYS_SETCHECKINTERVAL_METHODDEF    \
-    {"setcheckinterval", (PyCFunction)sys_setcheckinterval, METH_O, sys_setcheckinterval__doc__},
-
-static PyObject *
-sys_setcheckinterval_impl(PyObject *module, int n);
-
-static PyObject *
-sys_setcheckinterval(PyObject *module, PyObject *arg)
-{
-    PyObject *return_value = NULL;
-    int n;
-
-    if (PyFloat_Check(arg)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
-    n = _PyLong_AsInt(arg);
-    if (n == -1 && PyErr_Occurred()) {
-        goto exit;
-    }
-    return_value = sys_setcheckinterval_impl(module, n);
-
-exit:
-    return return_value;
-}
-
-PyDoc_STRVAR(sys_getcheckinterval__doc__,
-"getcheckinterval($module, /)\n"
-"--\n"
-"\n"
-"Return the current check interval; see sys.setcheckinterval().");
-
-#define SYS_GETCHECKINTERVAL_METHODDEF    \
-    {"getcheckinterval", (PyCFunction)sys_getcheckinterval, METH_NOARGS, sys_getcheckinterval__doc__},
-
-static PyObject *
-sys_getcheckinterval_impl(PyObject *module);
-
-static PyObject *
-sys_getcheckinterval(PyObject *module, PyObject *Py_UNUSED(ignored))
-{
-    return sys_getcheckinterval_impl(module);
-}
-
 PyDoc_STRVAR(sys_setswitchinterval__doc__,
 "setswitchinterval($module, interval, /)\n"
 "--\n"
@@ -1082,4 +1026,4 @@ sys_getandroidapilevel(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=43c4fde7b5783d8d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=022614f3794666ae input=a9049054013a1b77]*/

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -203,7 +203,6 @@ PyInterpreterState_New(void)
 
     memset(interp, 0, sizeof(*interp));
     interp->id_refcount = -1;
-    interp->check_interval = 100;
 
     PyStatus status = PyConfig_InitPythonConfig(&interp->config);
     if (_PyStatus_EXCEPTION(status)) {

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1025,56 +1025,6 @@ sys_getprofile_impl(PyObject *module)
     return temp;
 }
 
-/*[clinic input]
-sys.setcheckinterval
-
-    n: int
-    /
-
-Set the async event check interval to n instructions.
-
-This tells the Python interpreter to check for asynchronous events
-every n instructions.
-
-This also affects how often thread switches occur.
-[clinic start generated code]*/
-
-static PyObject *
-sys_setcheckinterval_impl(PyObject *module, int n)
-/*[clinic end generated code: output=3f686cef07e6e178 input=7a35b17bf22a6227]*/
-{
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                     "sys.getcheckinterval() and sys.setcheckinterval() "
-                     "are deprecated.  Use sys.setswitchinterval() "
-                     "instead.", 1) < 0) {
-        return NULL;
-    }
-
-    PyThreadState *tstate = _PyThreadState_GET();
-    tstate->interp->check_interval = n;
-    Py_RETURN_NONE;
-}
-
-/*[clinic input]
-sys.getcheckinterval
-
-Return the current check interval; see sys.setcheckinterval().
-[clinic start generated code]*/
-
-static PyObject *
-sys_getcheckinterval_impl(PyObject *module)
-/*[clinic end generated code: output=1b5060bf2b23a47c input=4b6589cbcca1db4e]*/
-{
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                     "sys.getcheckinterval() and sys.setcheckinterval() "
-                     "are deprecated.  Use sys.getswitchinterval() "
-                     "instead.", 1) < 0) {
-        return NULL;
-    }
-
-    PyThreadState *tstate = _PyThreadState_GET();
-    return PyLong_FromLong(tstate->interp->check_interval);
-}
 
 /*[clinic input]
 sys.setswitchinterval
@@ -1990,8 +1940,6 @@ static PyMethodDef sys_methods[] = {
     SYS_INTERN_METHODDEF
     SYS_IS_FINALIZING_METHODDEF
     SYS_MDEBUG_METHODDEF
-    SYS_SETCHECKINTERVAL_METHODDEF
-    SYS_GETCHECKINTERVAL_METHODDEF
     SYS_SETSWITCHINTERVAL_METHODDEF
     SYS_GETSWITCHINTERVAL_METHODDEF
     SYS_SETDLOPENFLAGS_METHODDEF
@@ -2430,7 +2378,6 @@ getrefcount() -- return the reference count for an object (plus one :-)\n\
 getrecursionlimit() -- return the max recursion depth for the interpreter\n\
 getsizeof() -- return the size of an object in bytes\n\
 gettrace() -- get the global debug tracing function\n\
-setcheckinterval() -- control how often the interpreter checks for events\n\
 setdlopenflags() -- set the flags to be used for dlopen() calls\n\
 setprofile() -- set the global profiling function\n\
 setrecursionlimit() -- set the max recursion depth for the interpreter\n\

--- a/Tools/ccbench/ccbench.py
+++ b/Tools/ccbench/ccbench.py
@@ -541,10 +541,12 @@ def main():
                       help="run I/O bandwidth tests")
     parser.add_option("-i", "--interval",
                       action="store", type="int", dest="check_interval", default=None,
-                      help="sys.setcheckinterval() value")
+                      help="sys.setcheckinterval() value "
+                           "(Python 3.8 and older)")
     parser.add_option("-I", "--switch-interval",
                       action="store", type="float", dest="switch_interval", default=None,
-                      help="sys.setswitchinterval() value")
+                      help="sys.setswitchinterval() value "
+                           "(Python 3.2 and newer)")
     parser.add_option("-n", "--num-threads",
                       action="store", type="int", dest="nthreads", default=4,
                       help="max number of threads in tests")


### PR DESCRIPTION
Remove sys.getcheckinterval() and sys.setcheckinterval() functions.
They were deprecated since Python 3.2. Use sys.getswitchinterval()
and sys.setswitchinterval() instead.

Remove also check_interval field of the PyInterpreterState structure.

<!-- issue-number: [bpo-37392](https://bugs.python.org/issue37392) -->
https://bugs.python.org/issue37392
<!-- /issue-number -->
