### PR TITLE
bpo-37386: Conditionally skip test_large_file_ops

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -604,10 +604,15 @@ class IOTest(unittest.TestCase):
             support.requires(
                 'largefile',
                 'test requires %s bytes and a long time to run' % self.LARGE)
-        with self.open(support.TESTFN, "w+b", 0) as f:
-            self.large_file_ops(f)
-        with self.open(support.TESTFN, "w+b") as f:
-            self.large_file_ops(f)
+        try:
+            with self.open(support.TESTFN, "w+b", 0) as f:
+                self.large_file_ops(f)
+            with self.open(support.TESTFN, "w+b") as f:
+                self.large_file_ops(f)
+        except OSError as e:
+            if e.errno == errno.ENOSPC:
+                self.skipTest("No space left on device")
+            raise
 
     def test_with_open(self):
         for bufsize in (0, 100):


### PR DESCRIPTION
Skip the test if `write()` fails with `errno.ENOSPC`: "OSError: [Errno
28] No space left on device".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37386](https://bugs.python.org/issue37386) -->
https://bugs.python.org/issue37386
<!-- /issue-number -->
