### PR TITLE
bpo-37393: Fix deprecation warnings in test_ntpath

### DIFF
--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -37,8 +37,6 @@ def tester(fn, wantResult):
         wantResult = os.fsencode(wantResult)
     elif isinstance(wantResult, tuple):
         wantResult = tuple(os.fsencode(r) for r in wantResult)
-
-    gotResult = eval(fn)
     if wantResult != gotResult:
         raise TestFailed("%s should return: %s but returned: %s" \
               %(str(fn), str(wantResult), repr(gotResult)))


### PR DESCRIPTION
eval() was being called an extra time without a filter for
deprecation warnings.


<!-- issue-number: [bpo-37393](https://bugs.python.org/issue37393) -->
https://bugs.python.org/issue37393
<!-- /issue-number -->
