### PR TITLE
Fix indentation in logging.handlers.setStream

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -109,7 +109,6 @@ sends logging output to a disk file.  It inherits the output functionality from
 
       Closes the file.
 
-
    .. method:: emit(record)
 
       Outputs the record to the file.

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -68,7 +68,7 @@ and :meth:`flush` methods).
 
       :return: the old stream, if the stream was changed, or *None* if it wasn't.
 
-   .. versionadded:: 3.7
+      .. versionadded:: 3.7
 
 
 .. versionchanged:: 3.2


### PR DESCRIPTION
See commit https://github.com/python/cpython/commit/2543f50033208c1a8df04999082b11aa09e82a04