### PR TITLE
[2.7] bpo-37396, PCbuild: Include "_d" in "Killing any running ..." message

### DIFF
--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -127,7 +127,7 @@ foreach (System.Diagnostics.Process p in System.Diagnostics.Process.GetProcesses
   </UsingTask>
 
   <Target Name="KillPython" BeforeTargets="PrepareForBuild" Condition="'$(KillPython)' == 'true'">
-    <Message Text="Killing any running python.exe instances..." Importance="high" />
+    <Message Text="Killing any running python$(PyDebugExt).exe instances..." Importance="high" />
     <KillPython FileName="$(OutDir)python$(PyDebugExt).exe" />
   </Target>
 


### PR DESCRIPTION
Add $(PyDebugExt) in "Killing any running python$(PyDebugExt).exe
instances...".

<!-- issue-number: [bpo-37396](https://bugs.python.org/issue37396) -->
https://bugs.python.org/issue37396
<!-- /issue-number -->
