### PR TITLE
bpo-37400: Fix test_os.test_chown()

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-06-25-16-02-43.bpo-37400.cx_EWv.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-25-16-02-43.bpo-37400.cx_EWv.rst
@@ -1,0 +1,2 @@
+Fix test_os.test_chown(): use os.getgroups() rather than grp.getgrall()
+to get groups. Rename also the test to test_chown_gid().


### PR DESCRIPTION
Use os.getgroups() rather than pwd.getpwall() to get groups.
Rename also test_chown() to test_chown_gid().

<!-- issue-number: [bpo-37400](https://bugs.python.org/issue37400) -->
https://bugs.python.org/issue37400
<!-- /issue-number -->
