### PR TITLE
bpo-29412: Fix indexError when parsing a header value ending unexpectedly

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1360,15 +1360,21 @@ def get_word(value):
         leader, value = get_cfws(value)
     else:
         leader = None
-    if value[0]=='"':
-        token, value = get_quoted_string(value)
-    elif value[0] in SPECIALS:
-        raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
-                                      "but found '{}'".format(value))
+    if value:
+        if value[0]=='"':
+            token, value = get_quoted_string(value)
+        elif value[0] in SPECIALS:
+            raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
+                                          "but found '{}'".format(value))
+        else:
+            token, value = get_atom(value)
+        if leader is not None:
+            token[:0] = [leader]
     else:
         token, value = get_atom(value)
     if leader is not None:
         token[:0] = [leader]
+
     return token, value
 
 def get_phrase(value):

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1361,8 +1361,8 @@ def get_word(value):
     else:
         leader = None
     if not value:
-        raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
-                                      "but found nothing.")
+        raise errors.HeaderParseError(
+            "Expected 'atom' or 'quoted-string' but found nothing.")
     if value[0]=='"':
         token, value = get_quoted_string(value)
     elif value[0] in SPECIALS:

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1366,12 +1366,12 @@ def get_word(value):
     if value[0]=='"':
         token, value = get_quoted_string(value)
     elif value[0] in SPECIALS:
-        raise errors.HeaderParseError((value))
+        raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
+                                      "but found '{}'".format(value))
     else:
         token, value = get_atom(value)
     if leader is not None:
         token[:0] = [leader]
-
     return token, value
 
 def get_phrase(value):

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1360,16 +1360,13 @@ def get_word(value):
         leader, value = get_cfws(value)
     else:
         leader = None
-    if value:
-        if value[0]=='"':
-            token, value = get_quoted_string(value)
-        elif value[0] in SPECIALS:
-            raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
-                                          "but found '{}'".format(value))
-        else:
-            token, value = get_atom(value)
-        if leader is not None:
-            token[:0] = [leader]
+    if not value:
+        raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
+                                      "but found nothing.")
+    if value[0]=='"':
+        token, value = get_quoted_string(value)
+    elif value[0] in SPECIALS:
+        raise errors.HeaderParseError((value))
     else:
         token, value = get_atom(value)
     if leader is not None:

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -930,6 +930,20 @@ class TestParser(TestParserMixin, TestEmailBase):
         self.assertEqual(word.token_type, 'atom')
         self.assertEqual(word[0].token_type, 'cfws')
 
+    def test_get_word_all_CFWS(self):
+        word = self._test_get_x(parser.get_word,
+                                '(Recipients list suppressed',
+                                str(parser.CFWSList([parser.Comment([
+                                    parser.WhiteSpaceTerminal('Recipients', 'ptext'),
+                                    parser.WhiteSpaceTerminal(' ', 'fws'),
+                                    parser.WhiteSpaceTerminal('list', 'ptext'),
+                                    parser.WhiteSpaceTerminal(' ', 'fws'),
+                                    parser.WhiteSpaceTerminal('suppressed', 'ptext')
+                                    ])])),
+                                    ' ', [], ''
+                                )
+        self.assertEqual(word.token_type, 'cfws')
+
     def test_get_word_qs_yields_qs(self):
         word = self._test_get_x(parser.get_word,
             '"bar " (bang) ah', '"bar " (bang) ', 'bar  ', [], 'ah')
@@ -2342,6 +2356,17 @@ class TestParser(TestParserMixin, TestEmailBase):
 
 
     # get_address_list
+
+    def test_get_address_list_CFWS(self):
+        address_list = self._test_get_x(parser.get_address_list,
+                                        '(Recipient list suppressed)',
+                                        '(Recipient list suppressed)',
+                                        ' ',
+                                        [errors.ObsoleteHeaderDefect],  # no content in address list
+                                        '')
+        self.assertEqual(address_list.token_type, 'address-list')
+        self.assertEqual(len(address_list.mailboxes), 0)
+        self.assertEqual(address_list.mailboxes, address_list.all_mailboxes)
 
     def test_get_address_list_mailboxes_simple(self):
         address_list = self._test_get_x(parser.get_address_list,

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -931,18 +931,10 @@ class TestParser(TestParserMixin, TestEmailBase):
         self.assertEqual(word[0].token_type, 'cfws')
 
     def test_get_word_all_CFWS(self):
-        word = self._test_get_x(parser.get_word,
-                                '(Recipients list suppressed',
-                                str(parser.CFWSList([parser.Comment([
-                                    parser.WhiteSpaceTerminal('Recipients', 'ptext'),
-                                    parser.WhiteSpaceTerminal(' ', 'fws'),
-                                    parser.WhiteSpaceTerminal('list', 'ptext'),
-                                    parser.WhiteSpaceTerminal(' ', 'fws'),
-                                    parser.WhiteSpaceTerminal('suppressed', 'ptext')
-                                    ])])),
-                                    ' ', [], ''
-                                )
-        self.assertEqual(word.token_type, 'cfws')
+        # bpo-29412: Test that we don't raise IndexError when parsing CFWS only
+        # token.
+        with self.assertRaises(errors.HeaderParseError):
+            parser.get_word('(Recipients list suppressed')
 
     def test_get_word_qs_yields_qs(self):
         word = self._test_get_x(parser.get_word,

--- a/Misc/NEWS.d/next/Library/2019-06-25-19-27-25.bpo-29412.n4Zqdh.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-25-19-27-25.bpo-29412.n4Zqdh.rst
@@ -1,0 +1,2 @@
+Fix IndexError in parsing a header value with only comments in some headers.
+Patch by Abhilash Raj.

--- a/Misc/NEWS.d/next/Library/2019-06-25-19-27-25.bpo-29412.n4Zqdh.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-25-19-27-25.bpo-29412.n4Zqdh.rst
@@ -1,2 +1,2 @@
-Fix IndexError in parsing a header value with only comments in some headers.
-Patch by Abhilash Raj.
+Fix IndexError in parsing a header value ending unexpectedly. Patch by Abhilash
+Raj.


### PR DESCRIPTION
When parsing a word, if the value is None, we should raise `HeaderParseError` instead of continuing silently. This helps fix the IndexError.

Part of the patch is from GH-6907, so thanks to @TyrannosourceExe.

<!-- issue-number: [bpo-29412](https://bugs.python.org/issue29412) -->
https://bugs.python.org/issue29412
<!-- /issue-number -->
