### PR TITLE
bpo-37163: Make the obj argument of dataclasses.replace() a positional-only.

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -356,7 +356,7 @@ Module-level decorators, classes, and functions
          def add_one(self):
              return self.x + 1
 
-.. function:: replace(instance, **changes)
+.. function:: replace(instance, /, **changes)
 
    Creates a new object of the same type of ``instance``, replacing
    fields with values from ``changes``.  If ``instance`` is not a Data

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1206,7 +1206,7 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
                      unsafe_hash=unsafe_hash, frozen=frozen)
 
 
-def replace(obj, **changes):
+def replace(obj, /, **changes):
     """Return a new object replacing specified fields with new values.
 
     This is especially useful for frozen classes.  Example usage:

--- a/Misc/NEWS.d/next/Library/2019-06-19-10-35-53.bpo-37163.9pPg2F.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-19-10-35-53.bpo-37163.9pPg2F.rst
@@ -1,0 +1,1 @@
+The *obj* argument of :func:`dataclasses.replace` is positional-only now.


### PR DESCRIPTION


<!-- issue-number: [bpo-37163](https://bugs.python.org/issue37163) -->
https://bugs.python.org/issue37163
<!-- /issue-number -->
