### PR TITLE
bpo-37410: subprocess closes the process handle when done

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1306,6 +1306,7 @@ class Popen(object):
             self._handle.Close()
             self._handle = None
 
+
         def _internal_poll(self, _deadstate=None,
                 _WaitForSingleObject=_winapi.WaitForSingleObject,
                 _WAIT_OBJECT_0=_winapi.WAIT_OBJECT_0,
@@ -1322,6 +1323,7 @@ class Popen(object):
                     exitcode = _GetExitCodeProcess(self._handle)
                     self._set_returncode(exitcode)
             return self.returncode
+
 
         def _wait(self, timeout):
             """Internal implementation of wait() on Windows."""

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1314,6 +1314,8 @@ class Popen(object):
             if self.returncode is None:
                 if _WaitForSingleObject(self._handle, 0) == _WAIT_OBJECT_0:
                     self.returncode = _GetExitCodeProcess(self._handle)
+                    self._handle.Close()
+                    self._handle = None
             return self.returncode
 
 

--- a/Misc/NEWS.d/next/Library/2019-06-26-13-54-40.bpo-37410.H2R9oS.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-26-13-54-40.bpo-37410.H2R9oS.rst
@@ -1,0 +1,3 @@
+On Windows, :class:`subprocess.Popen` now closes the process handle when the
+process completes. Previously, it was only closed when the Popen object was
+destroyed.


### PR DESCRIPTION
On Windows, subprocess.Popen now closes the process handle when the
process completes. Previously, it was only closed when the Popen
object was destroyed.

<!-- issue-number: [bpo-37410](https://bugs.python.org/issue37410) -->
https://bugs.python.org/issue37410
<!-- /issue-number -->
