### PR TITLE
bpo-37405: socket.getsockname() returns string instead of tuple

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1927,7 +1927,7 @@ class BasicCANTest(unittest.TestCase):
             address = ('', )
             s.bind(address)
             self.assertEqual(s.getsockname(), address)
-        
+
     def testTooLongInterfaceName(self):
         # most systems limit IFNAMSIZ to 16, take 1024 to be sure
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1921,13 +1921,13 @@ class BasicCANTest(unittest.TestCase):
     def testBindAny(self):
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
             s.bind(('', ))
-            
+
     def testBind(self):
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
             address = ('', )
             s.bind(address)
             self.assertEqual(s.getsockname(), address)
-            
+        
     def testTooLongInterfaceName(self):
         # most systems limit IFNAMSIZ to 16, take 1024 to be sure
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1921,12 +1921,7 @@ class BasicCANTest(unittest.TestCase):
     def testBindAny(self):
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
             s.bind(('', ))
-
-    def testBind(self):
-        with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
-            address = ('', )
-            s.bind(address)
-            self.assertEqual(s.getsockname(), address)
+            self.assertIsInstance(s.getsockname(), tuple)
 
     def testTooLongInterfaceName(self):
         # most systems limit IFNAMSIZ to 16, take 1024 to be sure

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1921,7 +1921,13 @@ class BasicCANTest(unittest.TestCase):
     def testBindAny(self):
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
             s.bind(('', ))
-
+            
+    def testBind(self):
+        with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
+            address = ('', )
+            s.bind(address)
+            self.assertEqual(s.getsockname(), address)
+            
     def testTooLongInterfaceName(self):
         # most systems limit IFNAMSIZ to 16, take 1024 to be sure
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1920,8 +1920,9 @@ class BasicCANTest(unittest.TestCase):
 
     def testBindAny(self):
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
-            s.bind(('', ))
-            self.assertIsInstance(s.getsockname(), tuple)
+            address = ('', )
+            s.bind(address)
+            self.assertEqual(s.getsockname(), address)
 
     def testTooLongInterfaceName(self):
         # most systems limit IFNAMSIZ to 16, take 1024 to be sure

--- a/Misc/NEWS.d/next/Library/2019-09-11-20-27-41.bpo-37405.MG5xiY.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-11-20-27-41.bpo-37405.MG5xiY.rst
@@ -1,4 +1,2 @@
 Fixed regression bug for socket.getsockname() for non-CAN_ISOTP AF_CAN
-address family sockets by returning a tuple instead of string. The second
-item of the returned tuple is now empty instead of the integer value of the
-family.
+address family sockets by returning a 1-tuple instead of string.

--- a/Misc/NEWS.d/next/Library/2019-09-11-20-27-41.bpo-37405.MG5xiY.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-11-20-27-41.bpo-37405.MG5xiY.rst
@@ -1,0 +1,4 @@
+Fixed regression bug for socket.getsockname() for non-CAN_ISOTP AF_CAN
+address family sockets by returning a tuple instead of string. The second
+item of the returned tuple is now empty instead of the integer value of the
+family.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1513,8 +1513,9 @@ makesockaddr(SOCKET_T sockfd, struct sockaddr *addr, size_t addrlen, int proto)
 #endif /* CAN_ISOTP */
           default:
           {
-              return Py_BuildValue("O&", PyUnicode_DecodeFSDefault,
-                                        ifname);
+              return Py_BuildValue("O&h", PyUnicode_DecodeFSDefault,
+                                        ifname,
+                                        a->can_family);
           }
         }
     }

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1513,9 +1513,8 @@ makesockaddr(SOCKET_T sockfd, struct sockaddr *addr, size_t addrlen, int proto)
 #endif /* CAN_ISOTP */
           default:
           {
-              return Py_BuildValue("O&h", PyUnicode_DecodeFSDefault,
-                                        ifname,
-                                        a->can_family);
+              return Py_BuildValue("(O&)", PyUnicode_DecodeFSDefault,
+                                        ifname);
           }
         }
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37405](https://bugs.python.org/issue37405) -->
https://bugs.python.org/issue37405
<!-- /issue-number -->
