### PR TITLE
Use "kwargs" argument name in documentation

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -544,9 +544,9 @@ The :mod:`functools` module defines the following functions:
       >>> from functools import wraps
       >>> def my_decorator(f):
       ...     @wraps(f)
-      ...     def wrapper(*args, **kwds):
+      ...     def wrapper(*args, **kwargs):
       ...         print('Calling decorated function')
-      ...         return f(*args, **kwds)
+      ...         return f(*args, **kwargs)
       ...     return wrapper
       ...
       >>> @my_decorator


### PR DESCRIPTION
I've seen the vast majority of documentation and examples use `**kwargs` to name the keyword arguments. This change brings this part of the docs in line with what most users should expect.