### PR TITLE
bpo-36889: Replace deprecation warning with RuntimeError

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -1293,10 +1293,8 @@ class Stream:
                  is_server_side=False,
                  _asyncio_internal=False):
         if not _asyncio_internal:
-            warnings.warn(f"{self.__class__} should be instaniated "
-                          "by asyncio internals only, "
-                          "please avoid its creation from user code",
-                          DeprecationWarning)
+            raise RuntimeError(f"{self.__class__} should be instantiated "
+                               "by asyncio internals only")
         self._mode = mode
         self._transport = transport
         self._protocol = protocol

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -1779,6 +1779,12 @@ os.close(fd)
 
         self.loop.run_until_complete(test())
 
+    def test_stream_ctor_forbidden(self):
+        with self.assertRaisesRegex(RuntimeError,
+                                    "should be instantiated "
+                                    "by asyncio internals only"):
+            asyncio.Stream(asyncio.StreamMode.READWRITE)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
asyncio.Stream is a new class, there is no reason for deprecation period

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36889](https://bugs.python.org/issue36889) -->
https://bugs.python.org/issue36889
<!-- /issue-number -->
