### PR TITLE
bpo-37414: Remove sys.callstats()

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -139,6 +139,11 @@ Deprecated
 Removed
 =======
 
+* The undocumented ``sys.callstats()`` function has been removed. Since Python
+  3.7, it was deprecated and always returned ``None``. It required a special
+  build option ``CALL_PROFILE`` which was already removed in Python 3.7.
+  (Contributed by Victor Stinner in :issue:`37414`.)
+
 * The ``sys.getcheckinterval()`` and ``sys.setcheckinterval()`` functions have
   been removed. They were deprecated since Python 3.2. Use
   :func:`sys.getswitchinterval` and :func:`sys.setswitchinterval` instead.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-26-17-27-26.bpo-37414.o6Lnbc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-26-17-27-26.bpo-37414.o6Lnbc.rst
@@ -1,0 +1,3 @@
+The undocumented ``sys.callstats()`` function has been removed. Since Python
+3.7, it was deprecated and always returned ``None``. It required a special
+build option ``CALL_PROFILE`` which was already removed in Python 3.7.

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -879,43 +879,6 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(sys_callstats__doc__,
-"callstats($module, /)\n"
-"--\n"
-"\n"
-"Return a tuple of function call statistics.\n"
-"\n"
-"A tuple is returned only if CALL_PROFILE was defined when Python was\n"
-"built.  Otherwise, this returns None.\n"
-"\n"
-"When enabled, this function returns detailed, implementation-specific\n"
-"details about the number of function calls executed. The return value\n"
-"is a 11-tuple where the entries in the tuple are counts of:\n"
-"0. all function calls\n"
-"1. calls to PyFunction_Type objects\n"
-"2. PyFunction calls that do not create an argument tuple\n"
-"3. PyFunction calls that do not create an argument tuple\n"
-"   and bypass PyEval_EvalCodeEx()\n"
-"4. PyMethod calls\n"
-"5. PyMethod calls on bound methods\n"
-"6. PyType calls\n"
-"7. PyCFunction calls\n"
-"8. generator calls\n"
-"9. All other calls\n"
-"10. Number of stack pops performed by call_function()");
-
-#define SYS_CALLSTATS_METHODDEF    \
-    {"callstats", (PyCFunction)sys_callstats, METH_NOARGS, sys_callstats__doc__},
-
-static PyObject *
-sys_callstats_impl(PyObject *module);
-
-static PyObject *
-sys_callstats(PyObject *module, PyObject *Py_UNUSED(ignored))
-{
-    return sys_callstats_impl(module);
-}
-
 PyDoc_STRVAR(sys__debugmallocstats__doc__,
 "_debugmallocstats($module, /)\n"
 "--\n"
@@ -1026,4 +989,4 @@ sys_getandroidapilevel(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=022614f3794666ae input=a9049054013a1b77]*/
+/*[clinic end generated code: output=acef77d2bb8f6da9 input=a9049054013a1b77]*/

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1779,44 +1779,6 @@ sys_call_tracing_impl(PyObject *module, PyObject *func, PyObject *funcargs)
     return _PyEval_CallTracing(func, funcargs);
 }
 
-/*[clinic input]
-sys.callstats
-
-Return a tuple of function call statistics.
-
-A tuple is returned only if CALL_PROFILE was defined when Python was
-built.  Otherwise, this returns None.
-
-When enabled, this function returns detailed, implementation-specific
-details about the number of function calls executed. The return value
-is a 11-tuple where the entries in the tuple are counts of:
-0. all function calls
-1. calls to PyFunction_Type objects
-2. PyFunction calls that do not create an argument tuple
-3. PyFunction calls that do not create an argument tuple
-   and bypass PyEval_EvalCodeEx()
-4. PyMethod calls
-5. PyMethod calls on bound methods
-6. PyType calls
-7. PyCFunction calls
-8. generator calls
-9. All other calls
-10. Number of stack pops performed by call_function()
-[clinic start generated code]*/
-
-static PyObject *
-sys_callstats_impl(PyObject *module)
-/*[clinic end generated code: output=edc4a74957fa8def input=d447d8d224d5d175]*/
-{
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                      "sys.callstats() has been deprecated in Python 3.7 "
-                      "and will be removed in the future", 1) < 0) {
-        return NULL;
-    }
-
-    Py_RETURN_NONE;
-}
-
 
 #ifdef __cplusplus
 extern "C" {
@@ -1910,7 +1872,6 @@ static PyMethodDef sys_methods[] = {
     {"audit",           (PyCFunction)(void(*)(void))sys_audit, METH_FASTCALL, audit_doc },
     {"breakpointhook",  (PyCFunction)(void(*)(void))sys_breakpointhook,
      METH_FASTCALL | METH_KEYWORDS, breakpointhook_doc},
-    SYS_CALLSTATS_METHODDEF
     SYS__CLEAR_TYPE_CACHE_METHODDEF
     SYS__CURRENT_FRAMES_METHODDEF
     SYS_DISPLAYHOOK_METHODDEF


### PR DESCRIPTION
Remove the undocumented sys.callstats() function. Since Python 3.7,
it was deprecated and always returned None. It required a special
build option CALL_PROFILE which was already removed in Python 3.7.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37414](https://bugs.python.org/issue37414) -->
https://bugs.python.org/issue37414
<!-- /issue-number -->
