### PR TITLE
bpo-37417: Fix error handling in bytearray.extend.

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1592,6 +1592,11 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(ValueError, x.translate, b"1", 1)
         self.assertRaises(TypeError, x.translate, b"1"*256, 1)
 
+    def test_bytearray_extend_error(self):
+        array = bytearray()
+        bad_iter = map(int, "X")
+        self.assertRaises(ValueError, array.extend, bad_iter)
+
     def test_construct_singletons(self):
         for const in None, Ellipsis, NotImplemented:
             tp = type(const)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-26-18-41-00.bpo-37417.VsZeHL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-26-18-41-00.bpo-37417.VsZeHL.rst
@@ -1,0 +1,2 @@
+:meth:`bytearray.extend` now correctly handles errors that arise during iteration.
+Patch by Brandt Bucher.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1698,6 +1698,10 @@ bytearray_extend(PyByteArrayObject *self, PyObject *iterable_of_ints)
     }
     Py_DECREF(bytearray_obj);
 
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
`bytearray.extend` doesn't properly handle errors that arise during iteration of the argument:

```py
Python 3.9.0a0 (heads/master:5150d32, Jun 26 2019, 10:55:32) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> array = bytearray()
>>> bad_iter = map(int, "X")
>>> array.extend(bad_iter)
ValueError: invalid literal for int() with base 10: 'X'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: <method 'extend' of 'bytearray' objects> returned a result with an error set
```

As far as I can tell, this bug is present on all versions of Python 3. This patch adds a fix and a regression test.

<!-- issue-number: [bpo-37417](https://bugs.python.org/issue37417) -->
https://bugs.python.org/issue37417
<!-- /issue-number -->
