### PR TITLE
bpo-37419: Fix possible segfaults when passing large sequences to os.posix_spawn()

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5377,7 +5377,7 @@ parse_file_actions(PyObject *file_actions,
         return -1;
     }
 
-    for (int i = 0; i < PySequence_Fast_GET_SIZE(seq); ++i) {
+    for (Py_ssize_t i = 0; i < PySequence_Fast_GET_SIZE(seq); ++i) {
         file_action = PySequence_Fast_GET_ITEM(seq, i);
         Py_INCREF(file_action);
         if (!PyTuple_Check(file_action) || !PyTuple_GET_SIZE(file_action)) {


### PR DESCRIPTION
Switch the type of i to Py_ssize_t.



<!-- issue-number: [bpo-37419](https://bugs.python.org/issue37419) -->
https://bugs.python.org/issue37419
<!-- /issue-number -->
