### PR TITLE
bpo-37420: os.sched_setaffinity does not handle errors during iteration.

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2560,6 +2560,12 @@ class PidTests(unittest.TestCase):
         status = os.waitpid(pid, 0)
         self.assertEqual(status, (pid, 0))
 
+class AffinityTests(unittest.TestCase):
+
+    @unittest.skipUnless(hasattr(os, 'sched_setaffinity'), "test needs os.sched_setaffinity")
+    def test_os_sched_setaffinity_error(self):
+        bad_iter = map(int, "0X")
+        self.assertRaises(ValueError, os.sched_setaffinity, 0, bad_iter)
 
 class SpawnTests(unittest.TestCase):
     def create_args(self, *, with_env=False, use_bytes=False):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2560,6 +2560,7 @@ class PidTests(unittest.TestCase):
         status = os.waitpid(pid, 0)
         self.assertEqual(status, (pid, 0))
 
+
 class SpawnTests(unittest.TestCase):
     def create_args(self, *, with_env=False, use_bytes=False):
         self.exitcode = 17

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2560,13 +2560,6 @@ class PidTests(unittest.TestCase):
         status = os.waitpid(pid, 0)
         self.assertEqual(status, (pid, 0))
 
-class AffinityTests(unittest.TestCase):
-
-    @unittest.skipUnless(hasattr(os, 'sched_setaffinity'), "test needs os.sched_setaffinity")
-    def test_os_sched_setaffinity_error(self):
-        bad_iter = map(int, "0X")
-        self.assertRaises(ValueError, os.sched_setaffinity, 0, bad_iter)
-
 class SpawnTests(unittest.TestCase):
     def create_args(self, *, with_env=False, use_bytes=False):
         self.exitcode = 17

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1368,6 +1368,7 @@ class PosixTester(unittest.TestCase):
         self.assertEqual(posix.sched_getaffinity(0), mask)
         self.assertRaises(OSError, posix.sched_setaffinity, 0, [])
         self.assertRaises(ValueError, posix.sched_setaffinity, 0, [-10])
+        self.assertRaises(ValueError, posix.sched_setaffinity, 0, map(int, "0X"))
         self.assertRaises(OverflowError, posix.sched_setaffinity, 0, [1<<128])
         self.assertRaises(OSError, posix.sched_setaffinity, -1, mask)
 

--- a/Misc/NEWS.d/next/Library/2019-06-26-22-25-05.bpo-37420.CxFJ09.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-26-22-25-05.bpo-37420.CxFJ09.rst
@@ -1,0 +1,2 @@
+:func:`os.sched_setaffinity` now correctly handles errors that arise during iteration over its ``mask`` argument.
+Patch by Brandt Bucher.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6415,6 +6415,10 @@ os_sched_setaffinity_impl(PyObject *module, pid_t pid, PyObject *mask)
     }
     Py_CLEAR(iterator);
 
+    if (PyErr_Occurred()) {
+        goto error;
+    }
+
     if (sched_setaffinity(pid, setsize, cpu_set)) {
         posix_error();
         goto error;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6413,11 +6413,10 @@ os_sched_setaffinity_impl(PyObject *module, pid_t pid, PyObject *mask)
         }
         CPU_SET_S(cpu, setsize, cpu_set);
     }
-    Py_CLEAR(iterator);
-
     if (PyErr_Occurred()) {
         goto error;
     }
+    Py_CLEAR(iterator);
 
     if (sched_setaffinity(pid, setsize, cpu_set)) {
         posix_error();


### PR DESCRIPTION
This is related to [bpo-37417](https://bugs.python.org/issue37417): `os.sched_setaffinity` doesn't properly handle errors that arise during iteration of the `mask` argument:

```py
Python 3.9.0a0 (heads/master:d52a83a, Jun 26 2019, 15:13:41) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> bad_iter = map(int, "0X")
>>> os.sched_setaffinity(0, bad_iter)
ValueError: invalid literal for int() with base 10: 'X'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: <built-in function sched_setaffinity> returned a result with an error set
```

It looks like this bug is also present on all versions of Python 3. I've attached a patch with a fix and a regression test.


<!-- issue-number: [bpo-37420](https://bugs.python.org/issue37420) -->
https://bugs.python.org/issue37420
<!-- /issue-number -->
