### PR TITLE
bpo-37421: Fix test_shutil: don't leak temporary files

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -124,7 +124,7 @@ def supports_file2file_sendfile():
 
         with open(srcname, "rb") as src:
             with tempfile.NamedTemporaryFile("wb", delete=False) as dst:
-                dstname = f.name
+                dstname = dst.name
                 infd = src.fileno()
                 outfd = dst.fileno()
                 try:
@@ -878,8 +878,9 @@ class TestShutil(unittest.TestCase):
 
         flag = []
         src = tempfile.mkdtemp()
+        self.addCleanup(support.rmtree, src)
         dst = tempfile.mktemp()
-        self.addCleanup(shutil.rmtree, src)
+        self.addCleanup(support.rmtree, dst)
         with open(os.path.join(src, 'foo'), 'w') as f:
             f.close()
         shutil.copytree(src, dst, copy_function=custom_cpfun)

--- a/Misc/NEWS.d/next/Tests/2019-06-27-00-37-59.bpo-37421.rVJb3x.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-27-00-37-59.bpo-37421.rVJb3x.rst
@@ -1,0 +1,1 @@
+Fix test_shutil to no longer leak temporary files.


### PR DESCRIPTION
* Fix typo in supports_file2file_sendfile(); ensure that dst is
  removed
* Fix test_copytree_custom_copy_function(): remove dst tree.
  Use support.rmtree() rather than shutil.rmtree() to remove
  temporary directories: support tries harder.

<!-- issue-number: [bpo-37421](https://bugs.python.org/issue37421) -->
https://bugs.python.org/issue37421
<!-- /issue-number -->
