### PR TITLE
bpo-35389: platform.platform() calls libc_ver() without executable

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -1202,7 +1202,7 @@ def platform(aliased=0, terse=0):
 
     elif system in ('Linux',):
         # check for libc vs. glibc
-        libcname, libcversion = libc_ver(sys.executable)
+        libcname, libcversion = libc_ver()
         platform = _platform(system, release, machine, processor,
                              'with',
                              libcname+libcversion)


### PR DESCRIPTION
When libc_ver() is called with an executable, the
os.confstr('CS_GNU_LIBC_VERSION') fast-path cannot be taken. Modify
platform.platform() to call libc_ver() without executable, instead of
calling libc_ver(sys.executable), since sys.executable is already the
default value.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35389](https://bugs.python.org/issue35389) -->
https://bugs.python.org/issue35389
<!-- /issue-number -->
