### PR TITLE
bpo-37366: add onitem callback argument to shutil.rmtree()

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -336,6 +336,25 @@ class TestShutil(unittest.TestCase):
         finally:
             os.lstat = orig_lstat
 
+    def test_rmtree_onitem(self):
+        # bpo-37366
+        #
+        # verify that shutil.rmtree() calls its
+        # onitem parameter before traversing each
+        # directory entry.
+        def _onitem(path):
+            self.assertTrue(os.path.exists(path))
+            self.assertEqual(path, paths.pop(0))
+
+        paths = [TESTFN,
+                 os.path.join(TESTFN, 'foo'),
+                 os.path.join(TESTFN, 'foo', 'bar')]
+        os.mkdir(paths[0])
+        os.mkdir(paths[1])
+        write_file(paths[2], 'Hello world!')
+        shutil.rmtree(TESTFN, onitem=_onitem)
+        self.assertEqual(paths, [])
+
     @support.skip_unless_symlink
     def test_copymode_follow_symlinks(self):
         tmp_dir = self.mkdtemp()

--- a/Misc/NEWS.d/next/Library/2019-06-26-16-31-48.bpo-37366.w0kkD0.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-26-16-31-48.bpo-37366.w0kkD0.rst
@@ -1,0 +1,4 @@
+:func:`shutil.rmtree` is extended to accept an *onitem* callback argument
+that gets called for each directory entry as they are enumerated.  This
+allows entries to be made "deletable" before attempting to delete them.
+Patch by Jeffrey Kintscher.


### PR DESCRIPTION
Add an "onitem" callback paramter to shutil.rmtree() that, if provided, gets called for each directory entry as it is encountered.  This allows the caller to perform any required special handling of individual directory entries (e.g. unmounting a mount point, closing a file, shutting down a named pipe, etc.) before rmtree() attempts to remove them.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37366](https://bugs.python.org/issue37366) -->
https://bugs.python.org/issue37366
<!-- /issue-number -->
