### PR TITLE
bpo-36511: clean up python process before deploy

### DIFF
--- a/Tools/buildbot/remoteDeploy.bat
+++ b/Tools/buildbot/remoteDeploy.bat
@@ -24,11 +24,18 @@ if NOT "%REMOTE_PYTHON_DIR:~-1,1%"=="\" (set REMOTE_PYTHON_DIR=%REMOTE_PYTHON_DI
 echo PYTHON_SOURCE = %PYTHON_SOURCE%
 echo REMOTE_PYTHON_DIR = %REMOTE_PYTHON_DIR%
 
+REM stop Python processes and remove existing files if found
+ssh %SSH_SERVER% "kill python.exe"
+ssh %SSH_SERVER% "kill python_d.exe"
 ssh %SSH_SERVER% "if EXIST %REMOTE_PYTHON_DIR% (rd %REMOTE_PYTHON_DIR% /s/q)"
+
+REM Create Python directories
 ssh %SSH_SERVER% "md %REMOTE_PYTHON_DIR%PCBuild\arm32"
 ssh %SSH_SERVER% "md %REMOTE_PYTHON_DIR%temp"
 ssh %SSH_SERVER% "md %REMOTE_PYTHON_DIR%Modules"
 ssh %SSH_SERVER% "md %REMOTE_PYTHON_DIR%PC"
+
+REM Copy Python files
 for /f "USEBACKQ" %%i in (`dir PCbuild\*.bat /b`) do @scp PCBuild\%%i "%SSH_SERVER%:%REMOTE_PYTHON_DIR%PCBuild"
 for /f "USEBACKQ" %%i in (`dir PCbuild\*.py /b`) do @scp PCBuild\%%i "%SSH_SERVER%:%REMOTE_PYTHON_DIR%PCBuild"
 for /f "USEBACKQ" %%i in (`dir PCbuild\arm32\*.exe /b`) do @scp PCBuild\arm32\%%i "%SSH_SERVER%:%REMOTE_PYTHON_DIR%PCBuild\arm32"


### PR DESCRIPTION
If the previous buildbot test times out, there will be orphaned python processes that prevent deploy from working.  Kill python.exe processes before trying to clean remote test directory

@zooba @zware 

<!-- issue-number: [bpo-36511](https://bugs.python.org/issue36511) -->
https://bugs.python.org/issue36511
<!-- /issue-number -->
