### PR TITLE
bpo-26828: Add __length_hint__() to builtin map iterator

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-27-16-18-00.bpo-37435.LUdu4p.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-27-16-18-00.bpo-37435.LUdu4p.rst
@@ -1,0 +1,2 @@
+The iterator provided by builtin :func:`map` now provides a `__length_hint__`
+method.  Patch by Nicholas Musolino.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Add `__length_hint__()` method to the iterator returned by builtin function `map`.  This method returns a length hint if all the user-supplied arguments to `map` have length hints available.

<!-- issue-number: [bpo-26828](https://bugs.python.org/issue26828) -->
https://bugs.python.org/issue26828
<!-- /issue-number -->
