### PR TITLE
[bpo-37433] Fix `SyntaxError` indicator printing too many spaces for multi-line strings

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -613,6 +613,20 @@ class CmdLineTest(unittest.TestCase):
             self.assertNotIn("\f", text)
             self.assertIn("\n    1 + 1 = 2\n    ^", text)
 
+    def test_syntaxerror_multi_line_fstring(self):
+        script = 'foo = f"""{}\nfoo"""\n'
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script', script)
+            exitcode, stdout, stderr = assert_python_failure(script_name)
+            self.assertEqual(
+                stderr.splitlines()[-3:],
+                [
+                    b'    foo = f"""{}',
+                    b'          ^',
+                    b'SyntaxError: f-string: empty expression not allowed',
+                ],
+            )
+
     def test_consistent_sys_path_for_direct_execution(self):
         # This test case ensures that the following all give the same
         # sys.path configuration:

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-27-15-01-14.bpo-37433.amNGqr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-27-15-01-14.bpo-37433.amNGqr.rst
@@ -1,0 +1,1 @@
+Fix ``SyntaxError`` indicator printing too many spaces for multi-line strings - by Anthony Sottile.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -956,6 +956,7 @@ tok_nextc(struct tok_state *tok)
             while (!done) {
                 Py_ssize_t curstart = tok->start == NULL ? -1 :
                           tok->start - tok->buf;
+                Py_ssize_t cur_multi_line_start = tok->multi_line_start - tok->buf;
                 Py_ssize_t curvalid = tok->inp - tok->buf;
                 Py_ssize_t newsize = curvalid + BUFSIZ;
                 char *newbuf = tok->buf;
@@ -968,6 +969,7 @@ tok_nextc(struct tok_state *tok)
                 }
                 tok->buf = newbuf;
                 tok->cur = tok->buf + cur;
+                tok->multi_line_start = tok->buf + cur_multi_line_start;
                 tok->line_start = tok->cur;
                 tok->inp = tok->buf + curvalid;
                 tok->end = tok->buf + newsize;


### PR DESCRIPTION


<!-- issue-number: [bpo-37433](https://bugs.python.org/issue37433) -->
https://bugs.python.org/issue37433
<!-- /issue-number -->
