### PR TITLE
 bpo-37335: Fix unexpected ASCII aliases in locale coercion tests

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-06-28-13-55-58.bpo-37335.LLzOx8.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-28-13-55-58.bpo-37335.LLzOx8.rst
@@ -1,0 +1,2 @@
+Improve locale coercion tests by using codec lookup instead of more fragile
+replace().


### PR DESCRIPTION
Solaris uses '646' as an alias for ASCII encoding and thus all the locale coercion tests are failing. This patch fixes the problem by using codecs lookup to normalize encoding names and thus prevent these problems.

<!-- issue-number: [bpo-37335](https://bugs.python.org/issue37335) -->
https://bugs.python.org/issue37335
<!-- /issue-number -->
