### PR TITLE
bpo-20443: Fix calculate_program_full_path() warning

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -761,7 +761,7 @@ calculate_program_full_path(const PyConfig *config,
       * absolutize() should help us out below
       */
     else if(0 == _NSGetExecutablePath(execpath, &nsexeclength) &&
-            _Py_isabs(execpath))
+            (wchar_t)execpath[0] == SEP)
     {
         size_t len;
         wchar_t *path = Py_DecodeLocale(execpath, &len);


### PR DESCRIPTION
Don't call _Py_isabs() with a bytes string (char*), the function
expects as wide string.

<!-- issue-number: [bpo-20443](https://bugs.python.org/issue20443) -->
https://bugs.python.org/issue20443
<!-- /issue-number -->
