### PR TITLE
[3.7] bpo-37335: Fix unexpected ASCII aliases in locale coercion tests

### DIFF
--- a/Lib/test/test_c_locale_coercion.py
+++ b/Lib/test/test_c_locale_coercion.py
@@ -119,12 +119,12 @@ class EncodingDetails(_EncodingDetails):
         stream_info = 2*[_stream.format("surrogateescape")]
         # stderr should always use backslashreplace
         stream_info.append(_stream.format("backslashreplace"))
-        expected_lang = env_vars.get("LANG", "not set").lower()
+        expected_lang = env_vars.get("LANG", "not set")
         if coercion_expected:
-            expected_lc_ctype = CLI_COERCION_TARGET.lower()
+            expected_lc_ctype = CLI_COERCION_TARGET
         else:
-            expected_lc_ctype = env_vars.get("LC_CTYPE", "not set").lower()
-        expected_lc_all = env_vars.get("LC_ALL", "not set").lower()
+            expected_lc_ctype = env_vars.get("LC_CTYPE", "not set")
+        expected_lc_all = env_vars.get("LC_ALL", "not set")
         env_info = expected_lang, expected_lc_ctype, expected_lc_all
         return dict(cls(fs_encoding, *stream_info, *env_info)._asdict())
 
@@ -147,8 +147,7 @@ class EncodingDetails(_EncodingDetails):
         if not result.rc == 0:
             result.fail(py_cmd)
         # All subprocess outputs in this test case should be pure ASCII
-        adjusted_output = result.out.lower()
-        stdout_lines = adjusted_output.decode("ascii").splitlines()
+        stdout_lines = result.out.decode("ascii").splitlines()
         child_encoding_details = dict(cls(*stdout_lines)._asdict())
         stderr_lines = result.err.decode("ascii").rstrip().splitlines()
         return child_encoding_details, stderr_lines

--- a/Misc/NEWS.d/next/Tests/2019-06-28-16-54-46.bpo-37335.LLzOx8.rst
+++ b/Misc/NEWS.d/next/Tests/2019-06-28-16-54-46.bpo-37335.LLzOx8.rst
@@ -1,0 +1,2 @@
+Improve locale coercion tests by using codec lookup instead of more fragile
+replace().


### PR DESCRIPTION
Solaris uses '646' as an alias for ASCII encoding and thus all the locale coercion tests are failing. This patch fixes the problem by using codecs lookup to normalize encoding names and thus prevent these problems.

<!-- issue-number: [bpo-37335](https://bugs.python.org/issue37335) -->
https://bugs.python.org/issue37335
<!-- /issue-number -->
