### PR TITLE
bpo-37412: Fix test_os.test_getcwd_long_path() on macOS

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -106,8 +106,7 @@ class MiscTests(unittest.TestCase):
         dirname = dirname + ('a' * (dirlen - len(dirname)))
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with support.change_cwd(tmpdir):
-                path = tmpdir
+            with support.change_cwd(tmpdir) as path:
                 expected = path
 
                 while True:


### PR DESCRIPTION


<!-- issue-number: [bpo-37412](https://bugs.python.org/issue37412) -->
https://bugs.python.org/issue37412
<!-- /issue-number -->
