### PR TITLE
bpo-37438: Added default argument for set in configparser doc string

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -129,7 +129,7 @@ ConfigParser -- responsible for parsing a list of
     remove_option(section, option)
         Remove the given option from the given section.
 
-    set(section, option, value)
+    set(section, option, value=None)
         Set the given option.
 
     write(fp, space_around_delimiters=True)


### PR DESCRIPTION
Issue: [37438](https://bugs.python.org/issue37438)
Code: [Definition of `set` in configparser](https://github.com/python/cpython/blob/db4d7ddb012ef8f087a8eb2a5b8a672d04a48e1a/Lib/configparser.py#L889)

In the code mentioned above default value of argument `value` is None. This will use `dict_type` as a default value.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37438](https://bugs.python.org/issue37438) -->
https://bugs.python.org/issue37438
<!-- /issue-number -->
