### PR TITLE
bpo-37403: Touch up venv docs

### DIFF
--- a/Doc/tutorial/venv.rst
+++ b/Doc/tutorial/venv.rst
@@ -50,6 +50,12 @@ This will create the ``tutorial-env`` directory if it doesn't exist,
 and also create directories inside it containing a copy of the Python
 interpreter, the standard library, and various supporting files.
 
+A common directory location for a virtual environment is ``.venv``.
+This name keeps the directory typically hidden in your shell and thus
+out of the way while giving it a name that explains why the directory
+exists. It also prevents clashing with ``.env`` environment variable
+definition files that some tooling supports.
+
 Once you've created a virtual environment, you may activate it.
 
 On Windows, run::

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -6,12 +6,13 @@ command ``venv``::
 Running this command creates the target directory (creating any parent
 directories that don't exist already) and places a ``pyvenv.cfg`` file in it
 with a ``home`` key pointing to the Python installation from which the command
-was run.  It also creates a ``bin`` (or ``Scripts`` on Windows) subdirectory
-containing a copy/symlink of the Python binary/binaries (as appropriate for the
-platform or arguments used at environment creation time). It also creates an
-(initially empty) ``lib/pythonX.Y/site-packages`` subdirectory
-(on Windows, this is ``Lib\site-packages``). If an existing
-directory is specified, it will be re-used.
+was run (a common name for the target directory is ``.venv``).  It also creates
+a ``bin`` (or ``Scripts`` on Windows) subdirectory containing a copy/symlink
+of the Python binary/binaries (as appropriate for the platform or arguments
+used at environment creation time). It also creates an (initially empty)
+``lib/pythonX.Y/site-packages`` subdirectory (on Windows, this is
+``Lib\site-packages``). If an existing directory is specified, it will be
+re-used.
 
 .. deprecated:: 3.6
    ``pyvenv`` was the recommended tool for creating virtual environments for
@@ -101,11 +102,13 @@ directory containing the virtual environment):
 +-------------+-----------------+-----------------------------------------+
 | Platform    | Shell           | Command to activate virtual environment |
 +=============+=================+=========================================+
-| Posix       | bash/zsh        | $ source <venv>/bin/activate            |
+| POSIX       | bash/zsh        | $ source <venv>/bin/activate            |
 +-------------+-----------------+-----------------------------------------+
 |             | fish            | $ . <venv>/bin/activate.fish            |
 +-------------+-----------------+-----------------------------------------+
 |             | csh/tcsh        | $ source <venv>/bin/activate.csh        |
++-------------+-----------------+-----------------------------------------+
+|             | PowerShell Core | $ <venv>/bin/Activate.ps1               |
 +-------------+-----------------+-----------------------------------------+
 | Windows     | cmd.exe         | C:\\> <venv>\\Scripts\\activate.bat     |
 +-------------+-----------------+-----------------------------------------+
@@ -127,3 +130,7 @@ when the virtual environment is created.
 
 .. versionadded:: 3.4
    ``fish`` and ``csh`` activation scripts.
+
+.. versionadded:: 3.8
+   PowerShell activation scripts installed under POSIX for PowerShell Core
+   support.


### PR DESCRIPTION
Add a versionadded for PowerShell Core and note that `.venv` is a common virtual environment name.

<!-- issue-number: [bpo-37403](https://bugs.python.org/issue37403) -->
https://bugs.python.org/issue37403
<!-- /issue-number -->
