### PR TITLE
[WIP] bpo-37409: Regression tests for builtins/importlib __import__ divergence

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -160,6 +160,10 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, __import__, 1, 2, 3, 4)
         self.assertRaises(ValueError, __import__, '')
         self.assertRaises(TypeError, __import__, 'sys', name='sys')
+        # relative import with no parent package, issue37409
+        self.assertRaises(ImportError, __import__, '',
+                          {'__package__': None, '__name__': '__main__'},
+                          {}, ('foo',), 1)
         # embedded null character
         self.assertRaises(ModuleNotFoundError, __import__, 'string\x00')
 

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -775,6 +775,17 @@ class RelativeImportTests(unittest.TestCase):
         ns = dict(__package__=object())
         self.assertRaises(TypeError, check_relative)
 
+    def test_import_from_beyond_toplevel(self):
+        # Regression test for https://bugs.python.org/issue37444
+        with self.assertRaises(ImportError):
+            from .......... import foo
+
+    @cpython_only
+    def test_import_shadowed_by_global(self):
+        # Regression test for https://bugs.python.org/issue37409
+        assert subprocess.call([sys.executable, '-c',
+            "foo = 'x'; from . import foo"])
+
     def test_absolute_import_without_future(self):
         # If explicit relative import syntax is used, then do not try
         # to perform an absolute import in the face of failure.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -964,6 +964,7 @@ Alain Leufroy
 Mark Levinson
 Mark Levitt
 Ivan Levkivskyi
+Ben Lewis
 William Lewis
 Akira Li
 Robert Li


### PR DESCRIPTION
https://bugs.python.org/issue37409

related:
https://bugs.python.org/issue37444

Presently these tests fail, need to fix `builtins.__import__` to behave like `importlib.__import__`.

<!-- issue-number: [bpo-37409](https://bugs.python.org/issue37409) -->
https://bugs.python.org/issue37409
<!-- /issue-number -->
