### PR TITLE
bpo-37448: Add radix tree implementation for obmalloc address_in_range().

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-29-16-27-23.bpo-37448.QI5V97.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-29-16-27-23.bpo-37448.QI5V97.rst
@@ -1,0 +1,8 @@
+Add radix tree implementation of obmalloc's address_in_range().  Use it
+by default on 64-bit platforms.  The radix tree eliminates the
+(slightly) memory unsanitary behavior of the current address_in_range()
+approach.  It also has the small advantage of easily allowing larger
+pool sizes.  The current address_in_range() requires that pools be no
+larger than the OS page size.
+
+Co-authored-by: Tim Peters <tim.peters@gmail.com>

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-29-16-27-23.bpo-37448.QI5V97.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-29-16-27-23.bpo-37448.QI5V97.rst
@@ -1,8 +1,0 @@
-Add radix tree implementation of obmalloc's address_in_range().  Use it
-by default on 64-bit platforms.  The radix tree eliminates the
-(slightly) memory unsanitary behavior of the current address_in_range()
-approach.  It also has the small advantage of easily allowing larger
-pool sizes.  The current address_in_range() requires that pools be no
-larger than the OS page size.
-
-Co-authored-by: Tim Peters <tim.peters@gmail.com>

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-21-14-19-35.bpo-37448.btl7vO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-21-14-19-35.bpo-37448.btl7vO.rst
@@ -1,12 +1,15 @@
-Add a radix tree to track used obmalloc arenas. Use to replace the old
-implementation of address_in_range(). The radix tree approach makes it easy
-to increase pool sizes beyond the OS page size. Boosting the pool and arena
-size allows obmalloc to handle a significantly higher percentage of requests
-from its ultra-fast paths.
+Add a radix tree based memory map to track in-use obmalloc arenas. Use to
+replace the old implementation of address_in_range(). The radix tree
+approach makes it easy to increase pool sizes beyond the OS page size.
+Boosting the pool and arena size allows obmalloc to handle a significantly
+higher percentage of requests from its ultra-fast paths.
 
 It also has the advantage of eliminating the memory unsanitary behavior of
 the previous address_in_range(). The old address_in_range() was marked with
 the annotations _Py_NO_SANITIZE_ADDRESS, _Py_NO_SANITIZE_THREAD, and
 _Py_NO_SANITIZE_MEMORY. Those annotations are no longer needed.
+
+To disable the radix tree map, set a preprocessor flag as follows:
+`-DWITH_PYMALLOC_RADIX_TREE=0`.
 
 Co-authored-by: Tim Peters <tim.peters@gmail.com>

--- a/Misc/NEWS.d/next/Core and Builtins/2021-02-21-14-19-35.bpo-37448.btl7vO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2021-02-21-14-19-35.bpo-37448.btl7vO.rst
@@ -1,0 +1,12 @@
+Add a radix tree to track used obmalloc arenas. Use to replace the old
+implementation of address_in_range(). The radix tree approach makes it easy
+to increase pool sizes beyond the OS page size. Boosting the pool and arena
+size allows obmalloc to handle a significantly higher percentage of requests
+from its ultra-fast paths.
+
+It also has the advantage of eliminating the memory unsanitary behavior of
+the previous address_in_range(). The old address_in_range() was marked with
+the annotations _Py_NO_SANITIZE_ADDRESS, _Py_NO_SANITIZE_THREAD, and
+_Py_NO_SANITIZE_MEMORY. Those annotations are no longer needed.
+
+Co-authored-by: Tim Peters <tim.peters@gmail.com>

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2955,15 +2955,18 @@ arena_map_mark_used(uintptr_t arena_base, int is_used)
          * again (do the full tree traversal).
          */
         n_hi->arenas[i3].tail_hi = is_used ? tail : 0;
-        uintptr_t arena_base_next = arena_base + ARENA_SIZE;
-        arena_map3_t *n_lo = arena_map_get((block *)arena_base_next, is_used);
-        if (n_lo == NULL) {
-            assert(is_used); /* otherwise should already exist */
-            n_hi->arenas[i3].tail_hi = 0;
-            return 0; /* failed to allocate space for node */
+        uintptr_t arena_next = arena_base + ARENA_SIZE;
+        /* check for overflow of arena_next */
+        if (arena_next > arena_base) {
+            arena_map3_t *n_lo = arena_map_get((block *)arena_next, is_used);
+            if (n_lo == NULL) {
+                assert(is_used); /* otherwise should already exist */
+                n_hi->arenas[i3].tail_hi = 0;
+                return 0; /* failed to allocate space for node */
+            }
+            int i3_next = MAP3_INDEX(arena_next);
+            n_lo->arenas[i3_next].tail_lo = is_used ? tail : 0;
         }
-        int i3_next = MAP3_INDEX(arena_base_next);
-        n_lo->arenas[i3_next].tail_lo = is_used ? tail : 0;
     }
     return 1;
 }

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -907,8 +907,8 @@ static int running_on_valgrind = -1;
  * Arenas are allocated with mmap() on systems supporting anonymous memory
  * mappings to reduce heap fragmentation.
  */
-#define ARENA_BITS              18
-#define ARENA_SIZE              (1 << ARENA_BITS)     /* 256 KiB */
+#define ARENA_BITS              20
+#define ARENA_SIZE              (1 << ARENA_BITS)     /* 1 MiB */
 #define ARENA_SIZE_MASK         (ARENA_SIZE - 1)
 
 #ifdef WITH_MEMORY_LIMITS
@@ -918,8 +918,8 @@ static int running_on_valgrind = -1;
 /*
  * Size of the pools used for small blocks.  Must be a power of 2.
  */
-#define POOL_BITS               12                  /* 4 KiB */
-#define POOL_SIZE               (1 << POOL_BITS)    /* 4 KiB */
+#define POOL_BITS               14                  /* 16 KiB */
+#define POOL_SIZE               (1 << POOL_BITS)
 #define POOL_SIZE_MASK          (POOL_SIZE - 1)
 
 #define MAX_POOLS_IN_ARENA  (ARENA_SIZE / POOL_SIZE)

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2967,22 +2967,20 @@ arena_map_mark_used(uintptr_t arena_base, int is_used)
          * again (do the full tree traversal).
          */
         n_hi->arenas[i3].tail_hi = is_used ? tail : 0;
-        uintptr_t arena_next = arena_base + ARENA_SIZE;
-        /* If arena_base is a legit arena address, so is arena_next - 1
-         * (last address in arena).  If arena_next overflows then it
+        uintptr_t arena_base_next = arena_base + ARENA_SIZE;
+        /* If arena_base is a legit arena address, so is arena_base_next - 1
+         * (last address in arena).  If arena_base_next overflows then it
          * must overflow to 0.  However, that would mean arena_base was
          * "ideal" and we should not be in this case. */
-        assert(arena_base < arena_next);
-        if (arena_next > arena_base) {
-            arena_map3_t *n_lo = arena_map_get((block *)arena_next, is_used);
-            if (n_lo == NULL) {
-                assert(is_used); /* otherwise should already exist */
-                n_hi->arenas[i3].tail_hi = 0;
-                return 0; /* failed to allocate space for node */
-            }
-            int i3_next = MAP3_INDEX(arena_next);
-            n_lo->arenas[i3_next].tail_lo = is_used ? tail : 0;
+        assert(arena_base < arena_base_next);
+        arena_map3_t *n_lo = arena_map_get((block *)arena_base_next, is_used);
+        if (n_lo == NULL) {
+            assert(is_used); /* otherwise should already exist */
+            n_hi->arenas[i3].tail_hi = 0;
+            return 0; /* failed to allocate space for node */
         }
+        int i3_next = MAP3_INDEX(arena_base_next);
+        n_lo->arenas[i3_next].tail_lo = is_used ? tail : 0;
     }
     return 1;
 }

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2956,7 +2956,11 @@ arena_map_mark_used(uintptr_t arena_base, int is_used)
          */
         n_hi->arenas[i3].tail_hi = is_used ? tail : 0;
         uintptr_t arena_next = arena_base + ARENA_SIZE;
-        /* check for overflow of arena_next */
+        /* If arena_base is a legit arena address, so is arena_next - 1
+         * (last address in arena).  If arena_next overflows then it
+         * must overflow to 0.  However, that would mean arena_base was
+         * "ideal" and we should not be in this case. */
+        assert(arena_base < arena_next);
         if (arena_next > arena_base) {
             arena_map3_t *n_lo = arena_map_get((block *)arena_next, is_used);
             if (n_lo == NULL) {

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -907,8 +907,12 @@ static int running_on_valgrind = -1;
  * Arenas are allocated with mmap() on systems supporting anonymous memory
  * mappings to reduce heap fragmentation.
  */
-#define ARENA_BITS              20
-#define ARENA_SIZE              (1 << ARENA_BITS)     /* 1 MiB */
+#if SIZEOF_VOID_P > 4
+#define ARENA_BITS              20                    /* 1 MiB */
+#else
+#define ARENA_BITS              18                    /* 256 KiB */
+#endif
+#define ARENA_SIZE              (1 << ARENA_BITS)
 #define ARENA_SIZE_MASK         (ARENA_SIZE - 1)
 
 #ifdef WITH_MEMORY_LIMITS
@@ -918,7 +922,11 @@ static int running_on_valgrind = -1;
 /*
  * Size of the pools used for small blocks.  Must be a power of 2.
  */
+#if SIZEOF_VOID_P > 4
 #define POOL_BITS               14                  /* 16 KiB */
+#else
+#define POOL_BITS               12                  /* 4 KiB */
+#endif
 #define POOL_SIZE               (1 << POOL_BITS)
 #define POOL_SIZE_MASK          (POOL_SIZE - 1)
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2978,7 +2978,7 @@ arena_map_is_marked(block *p)
         return 0;
     }
     int i3 = MAP3_INDEX(p);
-    /* in order to fit tail into 32-bits, ARENA_BITS must be <= 32 */
+    /* ARENA_BITS must be < 32 so that the tail is a non-negative int32_t. */
     int32_t hi = n->arenas[i3].tail_hi;
     int32_t lo = n->arenas[i3].tail_lo;
     int32_t tail = (int32_t)(AS_UINT(p) & ARENA_MASK);


### PR DESCRIPTION
The radix tree approach is a relatively simple and memory sanitary
alternative to the current (slightly) unsanitary address_in_range().
The radix tree is currently only implemented for 64-bit platforms.
Adding a 32-bit version would be relatively easy.


<!-- issue-number: [bpo-37448](https://bugs.python.org/issue37448) -->
https://bugs.python.org/issue37448
<!-- /issue-number -->
