### PR TITLE
bpo-37451: remove redundant code in _testcapimodule.c

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1860,8 +1860,6 @@ unicode_aswidechar(PyObject *self, PyObject *args)
 
     if (size < buflen)
         buflen = size + 1;
-    else
-        buflen = size;
     result = PyUnicode_FromWideChar(buffer, buflen);
     PyMem_Free(buffer);
     if (result == NULL)


### PR DESCRIPTION


<!-- issue-number: [bpo-37451](https://bugs.python.org/issue37451) -->
https://bugs.python.org/issue37451
<!-- /issue-number -->
