### PR TITLE
bpo-39452: Improve the __main__ module documentation

### DIFF
--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -1,25 +1,24 @@
-
-:mod:`__main__` --- Top-level script environment
-================================================
+:mod:`__main__` --- Top-level code environment
+==============================================
 
 .. module:: __main__
-   :synopsis: The environment where the top-level script is run.
+   :synopsis: The environment where top-level code is run.
 
 --------------
 
-``'__main__'`` is the name of the scope in which top-level code executes.
-A module's __name__ is set equal to ``'__main__'`` when read from
-standard input, a script, or from an interactive prompt.
+``'__main__'`` is the name of the environment where top-level code is run. A
+module's ``__name__`` is set equal to ``'__main__'`` when the module is run
+from the file system, from standard input or from the module namespace (with
+the :option:`-m` command line switch), but not when it is imported.
 
-A module can discover whether or not it is running in the main scope by
+A module can discover whether or not it is running in the main environment by
 checking its own ``__name__``, which allows a common idiom for conditionally
-executing code in a module when it is run as a script or with ``python
--m`` but not when it is imported::
+executing code in a module when it is not imported::
 
+   # Execute only if the module is not imported.
    if __name__ == "__main__":
-       # execute only if run as a script
        main()
 
-For a package, the same effect can be achieved by including a
-``__main__.py`` module, the contents of which will be executed when the
-module is run with ``-m``.
+For a package, the same effect can be achieved by including a __main__.py
+module, the contents of which will be executed when the package is run from the
+file system or from the module namespace, but not when it is imported.

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -9,7 +9,8 @@
 ``'__main__'`` is the name of the environment where top-level code is run. A
 module's ``__name__`` is set equal to ``'__main__'`` when the module is run
 from the file system, from standard input or from the module namespace (with
-the :option:`-m` command line switch), but not when it is imported.
+the :option:`-m` command line switch or the :func:`runpy.run_module` function),
+but not when it is imported.
 
 A module can discover whether or not it is running in the main environment by
 checking its own ``__name__``, which allows a common idiom for conditionally

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -6,21 +6,21 @@
 
 --------------
 
-``'__main__'`` is the name of the environment where top-level code is run. A 
-module's ``__name__`` is set equal to ``'__main__'`` when the module is 
-initialized from an interactive prompt, from standard input, from a file 
-argument, from a :option:`-c` argument or from a :option:`-m` argument, but not 
+``'__main__'`` is the name of the environment where top-level code is run. A
+module's ``__name__`` is set equal to ``'__main__'`` when the module is
+initialized from an interactive prompt, from standard input, from a file
+argument, from a :option:`-c` argument or from a :option:`-m` argument, but not
 when it is initialized from an import statement.
 
-A module can discover whether or not it is running in the main environment by 
-checking its own ``__name__``, which allows a common idiom for conditionally 
+A module can discover whether or not it is running in the main environment by
+checking its own ``__name__``, which allows a common idiom for conditionally
 executing code when the module is not initialized from an import statement::
 
     if __name__ == '__main__':
         # Execute when the module is not initialized from an import statement.
         main()
 
-For a package, the same effect can be achieved by including a __main__.py 
-module, the contents of which will be executed when the package is initialized 
-from a file argument or from a :option:`-m` argument, but not when it is 
+For a package, the same effect can be achieved by including a __main__.py
+module, the contents of which will be executed when the package is initialized
+from a file argument or from a :option:`-m` argument, but not when it is
 initialized from an import statement.

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -7,19 +7,20 @@
 --------------
 
 ``'__main__'`` is the name of the environment where top-level code is run. A
-module's ``__name__`` is set equal to ``'__main__'`` when the module is run
-from the file system, from standard input or from the module namespace (with
-the :option:`-m` command line switch or the :func:`runpy.run_module` function),
-but not when it is imported.
+module's ``__name__`` is set equal to ``'__main__'`` when the module is
+initialized from an interactive prompt, from standard input, from a file
+argument, from a :option:`-c` argument or from a :option:`-m` argument, but
+not when it is initialized from an import statement.
 
 A module can discover whether or not it is running in the main environment by
 checking its own ``__name__``, which allows a common idiom for conditionally
-executing code in a module when it is not imported::
+executing code when the module is not initialized from an import statement::
 
-   # Execute only if the module is not imported.
-   if __name__ == "__main__":
-       main()
+    if __name__ == '__main__':
+        # Execute when the module is not initialized from an import statement.
+        main()
 
 For a package, the same effect can be achieved by including a __main__.py
-module, the contents of which will be executed when the package is run from the
-file system or from the module namespace, but not when it is imported.
+module, the contents of which will be executed when the package is initialized
+from a file argument or from a :option:`-m` argument, but not when it is
+initialized from an import statement.

--- a/Doc/library/__main__.rst
+++ b/Doc/library/__main__.rst
@@ -6,21 +6,21 @@
 
 --------------
 
-``'__main__'`` is the name of the environment where top-level code is run. A
-module's ``__name__`` is set equal to ``'__main__'`` when the module is
-initialized from an interactive prompt, from standard input, from a file
-argument, from a :option:`-c` argument or from a :option:`-m` argument, but
-not when it is initialized from an import statement.
+``'__main__'`` is the name of the environment where top-level code is run. A 
+module's ``__name__`` is set equal to ``'__main__'`` when the module is 
+initialized from an interactive prompt, from standard input, from a file 
+argument, from a :option:`-c` argument or from a :option:`-m` argument, but not 
+when it is initialized from an import statement.
 
-A module can discover whether or not it is running in the main environment by
-checking its own ``__name__``, which allows a common idiom for conditionally
+A module can discover whether or not it is running in the main environment by 
+checking its own ``__name__``, which allows a common idiom for conditionally 
 executing code when the module is not initialized from an import statement::
 
     if __name__ == '__main__':
         # Execute when the module is not initialized from an import statement.
         main()
 
-For a package, the same effect can be achieved by including a __main__.py
-module, the contents of which will be executed when the package is initialized
-from a file argument or from a :option:`-m` argument, but not when it is
+For a package, the same effect can be achieved by including a __main__.py 
+module, the contents of which will be executed when the package is initialized 
+from a file argument or from a :option:`-m` argument, but not when it is 
 initialized from an import statement.


### PR DESCRIPTION
This PR will apply the following changes on the [`__main__` module documentation](https://docs.python.org/3/library/__main__.html):

- replace an incorrect use of "script" with "code";
- replace incorrect and inconsistent uses of "scope" with "environment";
- add missing cases where the `__main__` module is also initialized (when using the `-c` and `-m` arguments);
- replace the ambiguous "when it is imported" by "not initialized from an import statement" since using a `-m` argument also performs import for instance;
- add missing cases for the conditional execution of the `if` body (all the cases when the module is not initialized from an import statement);
- make the `if` block comment [PEP 8](https://www.python.org/dev/peps/pep-0008/#comments)-compliant (capital initialised, period ended);
- add a missing case for the conditional execution of the \_\_main__.py submodule of a package (when the package is initialized from a file argument).

<!-- issue-number: [bpo-39452](https://bugs.python.org/issue39452) -->
https://bugs.python.org/issue39452
<!-- /issue-number -->