### PR TITLE
Separate import for each module

### DIFF
--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1,7 +1,8 @@
 #! /usr/bin/env python
 """Generate C code from an ASDL description."""
 
-import os, sys
+import os
+import sys
 
 import asdl
 


### PR DESCRIPTION
Used separate imports for os and sys. This change as per PEP8 import guidelines: https://www.python.org/dev/peps/pep-0008/#imports