### PR TITLE
bpo-37424: Avoid a hang in subprocess.run timeout output capture

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -752,11 +752,6 @@ class Popen(object):
         if not isinstance(bufsize, int):
             raise TypeError("bufsize must be an integer")
 
-        # If True, kill/terminate/send_signal will send the signal to
-        # os.getpgid(self.pid) on platforms with that concept IF the
-        # group is not our own process group.
-        self.__signal_process_group = shell and hasattr(os, 'getpgid')
-
         if _mswindows:
             if preexec_fn is not None:
                 raise ValueError("preexec_fn is not supported on Windows "
@@ -1933,15 +1928,7 @@ class Popen(object):
             """Send a signal to the process."""
             # Skip signalling a process that we know has already died.
             if self.returncode is None:
-                if self.__signal_process_group:
-                    pgid = os.getpgid(self.pid)
-                    if pgid == os.getpgid(os.getpid()):
-                        # Never killpg our own process group.
-                        os.kill(self.pid, sig)
-                    else:
-                        os.killpg(pgid, sig)
-                else:
-                    os.kill(self.pid, sig)
+                os.kill(self.pid, sig)
 
         def terminate(self):
             """Terminate the process with SIGTERM

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -489,17 +489,20 @@ def run(*popenargs,
     with Popen(*popenargs, **kwargs) as process:
         try:
             stdout, stderr = process.communicate(input, timeout=timeout)
-        except TimeoutExpired:
+        except TimeoutExpired as exc:
             process.kill()
-            # The timeout here is to avoid waiting around _forever_ if
-            # the kill failed to deal with all processes holding the
-            # output file handles open.  Otherwise we could hang until
-            # those processes terminate before continuing with our timeout.
-            # See https://bugs.python.org/issue37424.
-            stdout, stderr = process.communicate(
-                    timeout=_get_cleanup_timeout(timeout))
-            raise TimeoutExpired(process.args, timeout, output=stdout,
-                                 stderr=stderr)
+            if _mswindows:
+                # Windows accumulates the output in a single blocking
+                # read() call run on child threads, with the timeout
+                # being done in a join() on those threads.  communicate()
+                # _after_ kill() is required to collect that and add it
+                # to the exception.
+                exc.stdout, exc.stderr = process.communicate()
+            else:
+                # POSIX _communicate already populated the output so
+                # far into the TimeourExpired exception.
+                process.wait()
+            raise
         except:  # Including KeyboardInterrupt, communicate handled that.
             process.kill()
             # We don't call process.wait() as .__exit__ does that for us.
@@ -509,11 +512,6 @@ def run(*popenargs,
             raise CalledProcessError(retcode, process.args,
                                      output=stdout, stderr=stderr)
     return CompletedProcess(process.args, retcode, stdout, stderr)
-
-
-def _get_cleanup_timeout(timeout):  # For test injection.
-    if timeout is not None:
-        return timeout/20
 
 
 def list2cmdline(seq):
@@ -1066,12 +1064,16 @@ class Popen(object):
             return endtime - _time()
 
 
-    def _check_timeout(self, endtime, orig_timeout):
+    def _check_timeout(self, endtime, orig_timeout, stdout_seq, stderr_seq,
+                       skip_check_and_raise=False):
         """Convenience for checking if a timeout has expired."""
         if endtime is None:
             return
-        if _time() > endtime:
-            raise TimeoutExpired(self.args, orig_timeout)
+        if skip_check_and_raise or _time() > endtime:
+            raise TimeoutExpired(
+                    self.args, orig_timeout,
+                    output=b''.join(stdout_seq) if stdout_seq else None,
+                    stderr=b''.join(stderr_seq) if stderr_seq else None)
 
 
     def wait(self, timeout=None):
@@ -1859,10 +1861,15 @@ class Popen(object):
                 while selector.get_map():
                     timeout = self._remaining_time(endtime)
                     if timeout is not None and timeout < 0:
-                        raise TimeoutExpired(self.args, orig_timeout)
+                        self._check_timeout(endtime, orig_timeout,
+                                            stdout, stderr,
+                                            skip_check_and_raise=True)
+                        raise RuntimeError(  # Impossible :)
+                            '_check_timeout(..., skip_check_and_raise=True) '
+                            'failed to raise TimeoutExpired.')
 
                     ready = selector.select(timeout)
-                    self._check_timeout(endtime, orig_timeout)
+                    self._check_timeout(endtime, orig_timeout, stdout, stderr)
 
                     # XXX Rewrite these to use non-blocking I/O on the file
                     # objects; they are no longer using C stdio!

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -500,7 +500,7 @@ def run(*popenargs,
                 exc.stdout, exc.stderr = process.communicate()
             else:
                 # POSIX _communicate already populated the output so
-                # far into the TimeourExpired exception.
+                # far into the TimeoutExpired exception.
                 process.wait()
             raise
         except:  # Including KeyboardInterrupt, communicate handled that.

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1566,15 +1566,11 @@ class RunFuncTestCase(BaseTestCase):
         self.assertIn('capture_output', c.exception.args[0])
 
     @unittest.skipIf(mswindows, "requires posix like 'sleep' shell command")
-    @mock.patch("subprocess._get_cleanup_timeout")
-    def test_run_with_shell_timeout_and_capture_output_explicit_session(
-            self, mock_get_cleanup_timeout):
+    def test_run_with_shell_timeout_and_capture_output_explicit_session(self):
         """Test from https://bugs.python.org/issue37424 with a session."""
         # This test is about ensuring that the cleanup_timeout was not
         # needed, that the grandchild process holding the output handles
-        # open actually died.  Thus we force a high cleanup time that'll
-        # obviously fail our timing test.
-        mock_get_cleanup_timeout.return_value = 3.1415926
+        # open actually died.
         before_secs = time.monotonic()
         try:
             subprocess.run('sleep 4', shell=True, timeout=0.1,

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1566,25 +1566,6 @@ class RunFuncTestCase(BaseTestCase):
         self.assertIn('capture_output', c.exception.args[0])
 
     @unittest.skipIf(mswindows, "requires posix like 'sleep' shell command")
-    def test_run_with_shell_timeout_and_capture_output_explicit_session(self):
-        """Test from https://bugs.python.org/issue37424 with a session."""
-        # This test is about ensuring that the cleanup_timeout was not
-        # needed, that the grandchild process holding the output handles
-        # open actually died.
-        before_secs = time.monotonic()
-        try:
-            subprocess.run('sleep 4', shell=True, timeout=0.1,
-                           capture_output=True, start_new_session=True)
-        except subprocess.TimeoutExpired as exc:
-            after_secs = time.monotonic()
-            stacks = traceback.format_exc()  # assertRaises doesn't give this.
-        else:
-            self.fail("TimeoutExpired not raised.")
-        self.assertLess(after_secs - before_secs, 2,
-                        msg="TimeoutExpired was delayed! Bad traceback:\n```\n"
-                        f"{stacks}```")
-
-    @unittest.skipIf(mswindows, "requires posix like 'sleep' shell command")
     def test_run_with_shell_timeout_and_capture_output(self):
         """Output capturing after a timeout mustn't hang forever on open filehandles."""
         before_secs = time.monotonic()

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1565,6 +1565,10 @@ class RunFuncTestCase(BaseTestCase):
         self.assertIn('stderr', c.exception.args[0])
         self.assertIn('capture_output', c.exception.args[0])
 
+    # This test _might_ wind up a bit fragile on loaded build+test machines
+    # as it depends on the timing with wide enough margins for normal situations
+    # but does assert that it happened "soon enough" to believe the right thing
+    # happened.
     @unittest.skipIf(mswindows, "requires posix like 'sleep' shell command")
     def test_run_with_shell_timeout_and_capture_output(self):
         """Output capturing after a timeout mustn't hang forever on open filehandles."""

--- a/Misc/NEWS.d/next/Library/2019-07-04-13-00-20.bpo-37424.0i1MR-.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-04-13-00-20.bpo-37424.0i1MR-.rst
@@ -1,0 +1,5 @@
+Fixes a possible hang when using a timeout on `subprocess.run()` while
+capturing output.  If the child process spawned its own children or
+otherwise connected its stdout or stderr handles with another process, we
+could hang after the timeout was reached and our child was killed when
+attempting to read final output from the pipes.


### PR DESCRIPTION
Fixes a possible hang when using a timeout on `subprocess.run()` while
capturing output.  If the child process spawned its own children or otherwise
connected its stdout or stderr handles with another process, we could hang
after the timeout was reached and our child was killed when attempting to read
final output from the pipes.

<!-- issue-number: [bpo-37424](https://bugs.python.org/issue37424) -->
https://bugs.python.org/issue37424
<!-- /issue-number -->
