### PR TITLE
Docs: Clarify BNF description in "introduction.rst"

### DIFF
--- a/Doc/reference/introduction.rst
+++ b/Doc/reference/introduction.rst
@@ -98,7 +98,7 @@ notation.  This uses the following style of definition:
    lc_letter: "a"..."z"
 
 The first line says that a ``name`` is an ``lc_letter`` followed by a sequence
-of zero or more ``lc_letter``\ s or underscores.  An ``lc_letter`` in turn is
+of zero or more ``lc_letter``\ s and/or underscores.  An ``lc_letter`` in turn is
 any of the single characters ``'a'`` through ``'z'``.  (This rule is actually
 adhered to for the names defined in lexical and grammar rules in this document.)
 

--- a/Doc/reference/introduction.rst
+++ b/Doc/reference/introduction.rst
@@ -98,7 +98,7 @@ notation.  This uses the following style of definition:
    lc_letter: "a"..."z"
 
 The first line says that a ``name`` is an ``lc_letter`` followed by a sequence
-of zero or more ``lc_letter``\ s and underscores.  An ``lc_letter`` in turn is
+of zero or more ``lc_letter``\ s or underscores.  An ``lc_letter`` in turn is
 any of the single characters ``'a'`` through ``'z'``.  (This rule is actually
 adhered to for the names defined in lexical and grammar rules in this document.)
 


### PR DESCRIPTION
The text below describes the change proposal to the "Notation" section of "Doc/reference/introduction.rst".

In reference to the section describing the first line of BNF notation, "name: lc_letter (lc_letter | "\_")*", the section states "a name is an lc_letter followed by a sequence of zero or more lc_letters and underscores" there is an issue with the usage of "and" in "lc_letters and underscores". While this usage of "and" is grammatically correct in English context, if the reader interprets it literally in the context of BNF notation or computer science, "lc_letters and underscores" would translate to (lc_letter & "\_"), which would entirely change the meaning of that line. 

Therefore, I would suggest changing "lc_letters and underscores" to "lc_letters or underscores". This ensures the reader clearly understands the logical disjunction operator is being utilized and does not misunderstand "and" to be the conjunction operator since the English word "and" can mean either of them, depending on the context. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
