### PR TITLE
bpo-37462: Default for "top" argument in "os.walk()"

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -275,7 +275,7 @@ def renames(old, new):
 
 __all__.extend(["makedirs", "removedirs", "renames"])
 
-def walk(top, topdown=True, onerror=None, followlinks=False):
+def walk(top=".", topdown=True, onerror=None, followlinks=False):
     """Directory tree generator.
 
     For each directory in the directory tree rooted at top (including top

--- a/Misc/NEWS.d/next/Library/2019-07-01-06-35-38.bpo-37462.K7IN-H.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-01-06-35-38.bpo-37462.K7IN-H.rst
@@ -1,0 +1,1 @@
+The os.walk() function now uses the current directory as the default option when one is not specified.


### PR DESCRIPTION
Currently, os.walk() can't be utilized without specifying a starting directory. This change uses the current working directory as the starting point for os.walk() when one is not specified. Reasoning for this change is described in further detail on the issue page. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-37462](https://bugs.python.org/issue37462) -->
https://bugs.python.org/issue37462
<!-- /issue-number -->
