### PR TITLE
bpo-37466: Move casting prompt after its validation in _raw_input()

### DIFF
--- a/Lib/getpass.py
+++ b/Lib/getpass.py
@@ -132,8 +132,8 @@ def _raw_input(prompt="", stream=None, input=None):
         stream = sys.stderr
     if not input:
         input = sys.stdin
-    prompt = str(prompt)
     if prompt:
+        prompt = str(prompt)
         try:
             stream.write(prompt)
         except UnicodeEncodeError:


### PR DESCRIPTION
I think it is more efficient to cast `variable prompt` into string after its validation.
Because If it is None or empty string then it is not used. 

```
import timeit

MAX = 10000000


start = timeit.default_timer()
for i in range(MAX):
    _raw_input()

end = timeit.default_timer()

print('estimated : {}'.format(end - start))

```
I tested on 10 millions inputs with above code.
and the result is as follows.
```
Before:
    estimated : 5.060587857999053
    estimated : 5.0425375679988065
    estimated : 4.850400277999142
    estimated : 4.888060468998447
    estimated : 4.849542597999971
    estimated : 4.822679259999859
    estimated : 5.053791769001691
    estimated : 4.914149145999545
    estimated : 4.9584080040003755
    estimated : 4.944711199001176

After:
    estimated : 4.014042392998817
    estimated : 3.987057284997718
    estimated : 4.081281360999128
    estimated : 4.06813505899845
    estimated : 4.040622504999192
    estimated : 4.1239150339970365
    estimated : 4.174400065003283
    estimated : 4.015272281998477
    estimated : 4.034917910001241
    estimated : 4.08582956799728
```

<!-- issue-number: [bpo-37466](https://bugs.python.org/issue37466) -->
https://bugs.python.org/issue37466
<!-- /issue-number -->
