### PR TITLE
bpo-10945: Drop support for bdist_wininst on non-Windows systems

### DIFF
--- a/Doc/distutils/builtdist.rst
+++ b/Doc/distutils/builtdist.rst
@@ -315,7 +315,8 @@ or the :command:`bdist` command with the :option:`!--formats` option::
 
 If you have a pure module distribution (only containing pure Python modules and
 packages), the resulting installer will be version independent and have a name
-like :file:`foo-1.0.win32.exe`.
+like :file:`foo-1.0.win32.exe`. Note that creating ``wininst`` binary
+distributions in only supported on Windows systems.
 
 If you have a non-pure distribution, the extensions can only be created on a
 Windows platform, and will be Python version dependent. The installer filename
@@ -340,9 +341,6 @@ version number.  This can be changed to another text by using the
 
 The installer file will be written to the "distribution directory" --- normally
 :file:`dist/`, but customizable with the :option:`!--dist-dir` option.
-
-   .. versionchanged:: 3.9
-      Creating ``wininst`` binary distributions in only supported on Windows.
 
 .. _cross-compile-windows:
 

--- a/Doc/distutils/builtdist.rst
+++ b/Doc/distutils/builtdist.rst
@@ -315,8 +315,7 @@ or the :command:`bdist` command with the :option:`!--formats` option::
 
 If you have a pure module distribution (only containing pure Python modules and
 packages), the resulting installer will be version independent and have a name
-like :file:`foo-1.0.win32.exe`.  These installers can even be created on Unix
-platforms or Mac OS X.
+like :file:`foo-1.0.win32.exe`.
 
 If you have a non-pure distribution, the extensions can only be created on a
 Windows platform, and will be Python version dependent. The installer filename
@@ -341,6 +340,9 @@ version number.  This can be changed to another text by using the
 
 The installer file will be written to the "distribution directory" --- normally
 :file:`dist/`, but customizable with the :option:`!--dist-dir` option.
+
+   .. versionchanged:: 3.9
+      Creating ``wininst`` binary distributions in only supported on Windows.
 
 .. _cross-compile-windows:
 

--- a/Lib/distutils/command/bdist_wininst.py
+++ b/Lib/distutils/command/bdist_wininst.py
@@ -4,7 +4,6 @@ Implements the Distutils 'bdist_wininst' command: create a windows installer
 exe-program."""
 
 import sys, os
-import platform
 from distutils.core import Command
 from distutils.util import get_platform
 from distutils.dir_util import create_tree, remove_tree

--- a/Lib/distutils/command/bdist_wininst.py
+++ b/Lib/distutils/command/bdist_wininst.py
@@ -56,7 +56,8 @@ class bdist_wininst(Command):
     boolean_options = ['keep-temp', 'no-target-compile', 'no-target-optimize',
                        'skip-build']
 
-    _unsupported = platform.system() != "Windows"
+    # bpo-10945: bdist_wininst requires mbcs encoding only available on Windows
+    _unsupported = (sys.platform != "win32")
 
     def initialize_options(self):
         self.bdist_dir = None

--- a/Lib/distutils/command/bdist_wininst.py
+++ b/Lib/distutils/command/bdist_wininst.py
@@ -4,6 +4,7 @@ Implements the Distutils 'bdist_wininst' command: create a windows installer
 exe-program."""
 
 import sys, os
+import platform
 from distutils.core import Command
 from distutils.util import get_platform
 from distutils.dir_util import create_tree, remove_tree
@@ -54,6 +55,8 @@ class bdist_wininst(Command):
 
     boolean_options = ['keep-temp', 'no-target-compile', 'no-target-optimize',
                        'skip-build']
+
+    _unsupported = platform.system() != "Windows"
 
     def initialize_options(self):
         self.bdist_dir = None

--- a/Misc/NEWS.d/next/Windows/2019-07-01-12-38-48.bpo-10945.s0YBHG.rst
+++ b/Misc/NEWS.d/next/Windows/2019-07-01-12-38-48.bpo-10945.s0YBHG.rst
@@ -1,0 +1,2 @@
+Officially drop support for creating bdist_wininst installers on non-Windows
+systems.


### PR DESCRIPTION
bdist_wininst depends on MBCS codec, unavailable on non-Windows,
and bdist_wininst have not worked since at least Python 3.2, possibly
never on py3k.

Here we document that bdist_wininst is only supported on Windows
and we mark it _unsupported otherwise to skip tests.

Distributors of Python 3 can now safely drop the bdist_wininst .exe files
without the need to skip bdist_wininst related tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-10945](https://bugs.python.org/issue10945) -->
https://bugs.python.org/issue10945
<!-- /issue-number -->
