### PR TITLE
bpo-37468: make install no longer install wininst-*.exe files

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1419,6 +1419,8 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 			echo $(INSTALL_DATA) $$i $(LIBDEST); \
 		fi; \
 	done
+	@# bpo-37468: Don't install distutils/command/wininst-*.exe files used
+	@# by distutils bdist_wininst: bdist_wininst only works on Windows.
 	@for d in $(LIBSUBDIRS); \
 	do \
 		a=$(srcdir)/Lib/$$d; \
@@ -1431,6 +1433,7 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 			*CVS) ;; \
 			*.py[co]) ;; \
 			*.orig) ;; \
+			*wininst-*.exe) ;; \
 			*~) ;; \
 			*) \
 				if test -d $$i; then continue; fi; \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1419,8 +1419,6 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 			echo $(INSTALL_DATA) $$i $(LIBDEST); \
 		fi; \
 	done
-	@# bpo-37468: Don't install distutils/command/wininst-*.exe files used
-	@# by distutils bdist_wininst: bdist_wininst only works on Windows.
 	@for d in $(LIBSUBDIRS); \
 	do \
 		a=$(srcdir)/Lib/$$d; \
@@ -1433,6 +1431,8 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 			*CVS) ;; \
 			*.py[co]) ;; \
 			*.orig) ;; \
+			# bpo-37468: Don't install distutils/command/wininst-*.exe files used \
+			# by distutils bdist_wininst: bdist_wininst only works on Windows. \
 			*wininst-*.exe) ;; \
 			*~) ;; \
 			*) \

--- a/Misc/NEWS.d/next/Build/2019-07-01-14-39-40.bpo-37468.trbQ-_.rst
+++ b/Misc/NEWS.d/next/Build/2019-07-01-14-39-40.bpo-37468.trbQ-_.rst
@@ -1,0 +1,2 @@
+``make install`` no longer installs ``wininst-*.exe`` files used by
+distutils bdist_wininst: bdist_wininst only works on Windows.


### PR DESCRIPTION
make install no longer installs "wininst-*.exe" files used by
distutils bdist_wininst: bdist_wininst only works on Windows.

<!-- issue-number: [bpo-37468](https://bugs.python.org/issue37468) -->
https://bugs.python.org/issue37468
<!-- /issue-number -->
