### PR TITLE
bpo-36904: Optimize _PyStack_UnpackDict

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -26,24 +26,6 @@ PyAPI_FUNC(PyObject *) _PyStack_AsDict(
     PyObject *const *values,
     PyObject *kwnames);
 
-/* Convert (args, nargs, kwargs: dict) into a (stack, nargs, kwnames: tuple).
-
-   Return 0 on success, raise an exception and return -1 on error.
-
-   Write the new stack into *p_stack. If *p_stack is differen than args, it
-   must be released by PyMem_Free().
-
-   The stack uses borrowed references.
-
-   The type of keyword keys is not checked, these checks should be done
-   later (ex: _PyArg_ParseStackAndKeywords). */
-PyAPI_FUNC(int) _PyStack_UnpackDict(
-    PyObject *const *args,
-    Py_ssize_t nargs,
-    PyObject *kwargs,
-    PyObject *const **p_stack,
-    PyObject **p_kwnames);
-
 /* Suggested size (number of positional arguments) for arrays of PyObject*
    allocated on a C stack to avoid allocating memory on the heap memory. Such
    array is used to pass positional arguments to call functions of the


### PR DESCRIPTION
Optimize, clean up and fix `_PyStack_UnpackDict`:
1. `_PyStack_UnpackDict` is made a static function inside `call.c`.
1. The API is simplified: the new argument vector is returned directly instead of being passed via a pointer.
1. Move the case of no keywords outside of `_PyStack_UnpackDict`, so `_PyStack_UnpackDict` is now only used when there actually are keyword arguments. This speeds up the case of no keywords and it simplifies the code.
1. Allocate the argument vector such that it supports `PY_VECTORCALL_ARGUMENTS_OFFSET`. Tests indicate that `_PyStack_UnpackDict` is responsible for about 60% of cases where `method_vectorcall` needs to do an allocation. With this change, these allocations are no longer needed.
1. Move the freeing code (which is not trivial) to a new function `_PyStack_UnpackDict_Free`.
1. Fix the overflow check by using `Py_ssize_t` instead of `size_t`. In the old code, the overflow check could theoretically overflow (the right hand side could be negative).

CC @encukou @methane 

<!-- issue-number: [bpo-36904](https://bugs.python.org/issue36904) -->
https://bugs.python.org/issue36904
<!-- /issue-number -->
