### PR TITLE
bpo-37421: _test_multiprocessing calls _run_finalizers()

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5651,6 +5651,9 @@ def install_tests_in_module_dict(remote_globs, start_method):
         if need_sleep:
             time.sleep(0.5)
         multiprocessing.process._cleanup()
+        # bpo-37421: Explicitly call _run_finalizers() to remove immediately
+        # temporary directories created by multiprocessing.util.get_temp_dir().
+        multiprocessing.util._run_finalizers()
         test.support.gc_collect()
 
     remote_globs['setUpModule'] = setUpModule

--- a/Misc/NEWS.d/next/Tests/2019-07-01-19-57-26.bpo-37421.NFH1f0.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-01-19-57-26.bpo-37421.NFH1f0.rst
@@ -1,0 +1,2 @@
+multiprocessing tests now explicitly call ``_run_finalizers()`` to
+immediately remove temporary directories created by tests.


### PR DESCRIPTION
_test_multiprocessing now calls explicitly _run_finalizers() to
remove temporary directories created by
multiprocessing.util.get_temp_dir(), so regrtest can properly detects
if a test file leaks temporary files.

<!-- issue-number: [bpo-37421](https://bugs.python.org/issue37421) -->
https://bugs.python.org/issue37421
<!-- /issue-number -->
