### PR TITLE
bpo-37479: on Enum subclasses with mixins, __format__ uses overridden __str__

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -741,9 +741,9 @@ Some rules:
 5. :ref:`Formatted string literals <f-strings>`, :meth:`str.format`,
    and :func:`format` will use the mixed-in type's :meth:`__format__`
    unless :meth:`__str__` or :meth:`__format__` is overridden in the subclass,
-   In which case the overridden methods or :class:`Enum` methods will be used.
-   If the :class:`Enum` class's :func:`str` or :func:`repr` is desired, use the
-   `!s` or `!r` format codes.
+   in which case the overridden methods or :class:`Enum` methods will be used.
+   Use the !s and !r format codes to force usage of the :class:Enum class's
+   :func:str and :func:repr methods.
 
 When to use :meth:`__new__` vs. :meth:`__init__`
 ------------------------------------------------

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -743,7 +743,7 @@ Some rules:
    unless :meth:`__str__` or :meth:`__format__` is overridden in the subclass,
    in which case the overridden methods or :class:`Enum` methods will be used.
    Use the !s and !r format codes to force usage of the :class:`Enum` class's
-   :func:`str` and :func:`repr` methods.
+   :meth:`__str__` and :meth:`__repr__` methods.
 
 When to use :meth:`__new__` vs. :meth:`__init__`
 ------------------------------------------------

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -742,8 +742,8 @@ Some rules:
    and :func:`format` will use the mixed-in type's :meth:`__format__`
    unless :meth:`__str__` or :meth:`__format__` is overridden in the subclass,
    in which case the overridden methods or :class:`Enum` methods will be used.
-   Use the !s and !r format codes to force usage of the :class:Enum class's
-   :func:str and :func:repr methods.
+   Use the !s and !r format codes to force usage of the :class:`Enum` class's
+   :func:`str` and :func:`repr` methods.
 
 When to use :meth:`__new__` vs. :meth:`__init__`
 ------------------------------------------------

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -739,9 +739,11 @@ Some rules:
    :meth:`__str__` and :meth:`__repr__` respectively; other codes (such as
    `%i` or `%h` for IntEnum) treat the enum member as its mixed-in type.
 5. :ref:`Formatted string literals <f-strings>`, :meth:`str.format`,
-   and :func:`format` will use the mixed-in
-   type's :meth:`__format__`.  If the :class:`Enum` class's :func:`str` or
-   :func:`repr` is desired, use the `!s` or `!r` format codes.
+   and :func:`format` will use the mixed-in type's :meth:`__format__`
+   unless :meth:`__str__` or :meth:`__format__` is overridden in the subclass,
+   In which case the overridden methods or :class:`Enum` methods will be used.
+   If the :class:`Enum` class's :func:`str` or :func:`repr` is desired, use the
+   `!s` or `!r` format codes.
 
 When to use :meth:`__new__` vs. :meth:`__init__`
 ------------------------------------------------

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -622,8 +622,9 @@ class Enum(metaclass=EnumMeta):
         # we can get strange results with the Enum name showing up instead of
         # the value
 
-        # pure Enum branch
-        if self._member_type_ is object:
+        # pure Enum branch, or branch with __str__ explicitly overridden
+        str_overridden = type(self).__str__ != Enum.__str__
+        if self._member_type_ is object or str_overridden:
             cls = str
             val = str(self)
         # mix-in branch

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -445,22 +445,54 @@ class TestEnum(unittest.TestCase):
         self.assertEqual('{:<20}'.format(Season.SPRING),
                          '{:<20}'.format(str(Season.SPRING)))
 
-    def test_str_enum_custom(self):
-        class TestIntWithStrOverride(IntEnum):
-            one = 1
-            two = 2
+    def test_str_override_enum(self):
+        class EnumWithStrOverrides(Enum):
+            one = auto()
+            two = auto()
+
+            def __str__(self):
+                return 'Str!'
+        self.assertEqual(str(EnumWithStrOverrides.one), 'Str!')
+        self.assertEqual('{}'.format(EnumWithStrOverrides.one), 'Str!')
+
+    def test_str_and_format_override_enum(self):
+        class EnumWithStrFormatOverrides(Enum):
+            one = auto()
+            two = auto()
+            def __str__(self):
+                return 'Str!'
+            def __format__(self, spec):
+                return 'Format!'
+        self.assertEqual(str(EnumWithStrFormatOverrides.one), 'Str!')
+        self.assertEqual('{}'.format(EnumWithStrFormatOverrides.one), 'Format!')
+
+    def test_str_override_mixin(self):
+        class MixinEnumWithStrOverride(float, Enum):
+            one = 1.0
+            two = 2.0
             def __str__(self):
                 return 'Overridden!'
+        self.assertEqual(str(MixinEnumWithStrOverride.one), 'Overridden!')
+        self.assertEqual('{}'.format(MixinEnumWithStrOverride.one), 'Overridden!')
 
-        self.assertEqual(str(TestIntWithStrOverride.one), 'Overridden!')
-        self.assertEqual('{}'.format(TestIntWithStrOverride.one), 'Overridden!')
+    def test_str_and_format_override_mixin(self):
+        class MixinWithStrFormatOverrides(float, Enum):
+            one = 1.0
+            two = 2.0
+            def __str__(self):
+                return 'Str!'
+            def __format__(self, spec):
+                return 'Format!'
+        self.assertEqual(str(MixinWithStrFormatOverrides.one), 'Str!')
+        self.assertEqual('{}'.format(MixinWithStrFormatOverrides.one), 'Format!')
 
-    def test_format_enum_custom(self):
+    def test_format_override_mixin(self):
         class TestFloat(float, Enum):
             one = 1.0
             two = 2.0
             def __format__(self, spec):
                 return 'TestFloat success!'
+        self.assertEqual(str(TestFloat.one), 'TestFloat.one')
         self.assertEqual('{}'.format(TestFloat.one), 'TestFloat success!')
 
     def assertFormatIsValue(self, spec, member):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -456,7 +456,7 @@ class TestEnum(unittest.TestCase):
         self.assertEqual('{}'.format(EnumWithStrOverrides.one), 'Str!')
 
     def test_format_override_enum(self):
-        class EnumWithFormatOverride(float, Enum):
+        class EnumWithFormatOverride(Enum):
             one = 1.0
             two = 2.0
             def __format__(self, spec):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -445,6 +445,16 @@ class TestEnum(unittest.TestCase):
         self.assertEqual('{:<20}'.format(Season.SPRING),
                          '{:<20}'.format(str(Season.SPRING)))
 
+    def test_str_enum_custom(self):
+        class TestIntWithStrOverride(IntEnum):
+            one = 1
+            two = 2
+            def __str__(self):
+                return 'Overridden!'
+
+        self.assertEqual(str(TestIntWithStrOverride.one), 'Overridden!')
+        self.assertEqual('{}'.format(TestIntWithStrOverride.one), 'Overridden!')
+
     def test_format_enum_custom(self):
         class TestFloat(float, Enum):
             one = 1.0

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -455,6 +455,15 @@ class TestEnum(unittest.TestCase):
         self.assertEqual(str(EnumWithStrOverrides.one), 'Str!')
         self.assertEqual('{}'.format(EnumWithStrOverrides.one), 'Str!')
 
+    def test_format_override_enum(self):
+        class EnumWithFormatOverride(float, Enum):
+            one = 1.0
+            two = 2.0
+            def __format__(self, spec):
+                return 'Format!!'
+        self.assertEqual(str(EnumWithFormatOverride.one), 'EnumWithFormatOverride.one')
+        self.assertEqual('{}'.format(EnumWithFormatOverride.one), 'Format!!')
+
     def test_str_and_format_override_enum(self):
         class EnumWithStrFormatOverrides(Enum):
             one = auto()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -356,6 +356,7 @@ Tom Culliton
 Raúl Cumplido
 Antonio Cuni
 Brian Curtin
+Jason Curtis
 Paul Dagnelie
 Lisandro Dalcin
 Darren Dale

--- a/Misc/NEWS.d/next/Library/2019-07-02-12-43-57.bpo-37479.O53a5S.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-02-12-43-57.bpo-37479.O53a5S.rst
@@ -1,0 +1,2 @@
+When `Enum.__str__` is overridden in a derived class, the override will be
+used by `Enum.__format__` regardless of whether mixin classes are present.


### PR DESCRIPTION


<!-- issue-number: [bpo-37479](https://bugs.python.org/issue37479) -->
https://bugs.python.org/issue37479
<!-- /issue-number -->
