### PR TITLE
Typo fix in file Include/object.h

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -337,8 +337,8 @@ given type object has a specified feature.
 /* NOTE: The following flags reuse lower bits (removed as part of the
  * Python 3.0 transition). */
 
-/* The following flag is kept for compatibility.  Starting with 3.8,
- * binary compatibility of C extensions accross feature releases of
+/* The following flag is kept for compatibility. Starting with 3.8,
+ * binary compatibility of C extensions across feature releases of
  * Python is not supported anymore, except when using the stable ABI.
  */
 


### PR DESCRIPTION
* accross -> across
* Extra space removed in comment