### PR TITLE
bpo-37421: test_winconsoleio doesn't leak temp file anymore

### DIFF
--- a/Lib/test/test_winconsoleio.py
+++ b/Lib/test/test_winconsoleio.py
@@ -25,14 +25,12 @@ class WindowsConsoleIOTests(unittest.TestCase):
         self.assertRaisesRegex(ValueError,
             "negative file descriptor", ConIO, -1)
 
-        fd, _ = tempfile.mkstemp()
-        try:
+        with tempfile.TemporaryFile() as tmpfile:
+            fd = tmpfile.fileno()
             # Windows 10: "Cannot open non-console file"
             # Earlier: "Cannot open console output buffer for reading"
             self.assertRaisesRegex(ValueError,
                 "Cannot open (console|non-console file)", ConIO, fd)
-        finally:
-            os.close(fd)
 
         try:
             f = ConIO(0)

--- a/Misc/NEWS.d/next/Tests/2019-07-02-23-20-35.bpo-37421.HCkKWz.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-02-23-20-35.bpo-37421.HCkKWz.rst
@@ -1,0 +1,2 @@
+test_winconsoleio doesn't leak a temporary file anymore: use
+tempfile.TemporaryFile() to remove it when the test completes.


### PR DESCRIPTION
test_winconsoleio doesn't leak a temporary file anymore: use
tempfile.TemporaryFile() to remove it when the test completes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37421](https://bugs.python.org/issue37421) -->
https://bugs.python.org/issue37421
<!-- /issue-number -->
