### PR TITLE
bpo-37421: test_concurrent_futures cleans up multiprocessing

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-07-02-23-29-06.bpo-37421.WEfc5A.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-02-23-29-06.bpo-37421.WEfc5A.rst
@@ -1,0 +1,2 @@
+test_concurrent_futures now cleans up multiprocessing to remove immediately
+temporary directories created by multiprocessing.util.get_temp_dir().


### PR DESCRIPTION
test_concurrent_futures now cleans up multiprocessing to remove
immediately temporary directories created by
multiprocessing.util.get_temp_dir().

The test now uses setUpModule() and tearDownModule().

<!-- issue-number: [bpo-37421](https://bugs.python.org/issue37421) -->
https://bugs.python.org/issue37421
<!-- /issue-number -->
