### PR TITLE
bpo-37421: Fix test_distutils.test_build_ext()

### DIFF
--- a/Lib/distutils/tests/support.py
+++ b/Lib/distutils/tests/support.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 import sysconfig
 from copy import deepcopy
+import test.support
 
 from distutils import log
 from distutils.log import DEBUG, INFO, WARN, ERROR, FATAL
@@ -64,8 +65,8 @@ class TempdirManager(object):
         os.chdir(self.old_cwd)
         super().tearDown()
         while self.tempdirs:
-            d = self.tempdirs.pop()
-            shutil.rmtree(d, os.name in ('nt', 'cygwin'))
+            tmpdir = self.tempdirs.pop()
+            test.support.rmtree(tmpdir)
 
     def mkdtemp(self):
         """Create a temporary directory that will be cleaned up.

--- a/Misc/NEWS.d/next/Tests/2019-07-03-00-05-28.bpo-37421.ORGRSG.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-03-00-05-28.bpo-37421.ORGRSG.rst
@@ -1,0 +1,3 @@
+test_distutils.test_build_ext() is now able to remove the temporary
+directory on Windows: don't import the newly built C extension ("xx") in the
+current process, but test it in a separated process.


### PR DESCRIPTION
test_distutils.test_build_ext() is now able to remove the temporary
directory on Windows: don't import the newly built C extension ("xx")
in the current process, but test it in a separated process.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37421](https://bugs.python.org/issue37421) -->
https://bugs.python.org/issue37421
<!-- /issue-number -->
