### PR TITLE
bpo-37459: importlib docs improperly reference get_resource_loader()

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -500,7 +500,7 @@ ABC hierarchy::
     packages or a module).
 
     Loaders that wish to support resource reading are expected to
-    provide a method called ``get_resource_loader(fullname)`` which
+    provide a method called ``get_resource_reader()`` which
     returns an object implementing this ABC's interface. If the module
     specified by fullname is not a package, this method should return
     :const:`None`. An object compatible with this ABC should only be

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -500,7 +500,7 @@ ABC hierarchy::
     packages or a module).
 
     Loaders that wish to support resource reading are expected to
-    provide a method called ``get_resource_reader()`` which
+    provide a method called ``get_resource_reader(fullname)`` which
     returns an object implementing this ABC's interface. If the module
     specified by fullname is not a package, this method should return
     :const:`None`. An object compatible with this ABC should only be


### PR DESCRIPTION
Gregory Szorc: "The documentation in importlib.rst says that a loader should implement `get_resource_loader(fullname)`. This is the only occurrence of `get_resource_loader` in the CPython source tree. It should be changed to `get_resource_reader()`."

<!-- issue-number: [bpo-37459](https://bugs.python.org/issue37459) -->
https://bugs.python.org/issue37459
<!-- /issue-number -->
