### PR TITLE
bpo-37421: Fix multiprocessing get_temp_dir() finalizer

### DIFF
--- a/Lib/multiprocessing/util.py
+++ b/Lib/multiprocessing/util.py
@@ -106,6 +106,11 @@ def log_to_stderr(level=None):
 # Function returning a temp directory which will be removed on exit
 #
 
+def _remove_temp_dir(rmtree, tempdir):
+    rmtree(tempdir)
+    process.current_process()._config['tempdir'] = None
+
+
 def get_temp_dir():
     # get name of a temp directory which will be automatically cleaned up
     tempdir = process.current_process()._config.get('tempdir')
@@ -113,7 +118,10 @@ def get_temp_dir():
         import shutil, tempfile
         tempdir = tempfile.mkdtemp(prefix='pymp-')
         info('created temp directory %s', tempdir)
-        Finalize(None, shutil.rmtree, args=[tempdir], exitpriority=-100)
+        # keep a strong reference to shutil.rmtree(), since the finalizer
+        # can be called late during Python shutdown
+        Finalize(None, _remove_temp_dir, args=(shutil.rmtree, tempdir),
+                 exitpriority=-100)
         process.current_process()._config['tempdir'] = tempdir
     return tempdir
 

--- a/Lib/multiprocessing/util.py
+++ b/Lib/multiprocessing/util.py
@@ -108,8 +108,12 @@ def log_to_stderr(level=None):
 
 def _remove_temp_dir(rmtree, tempdir):
     rmtree(tempdir)
-    process.current_process()._config['tempdir'] = None
 
+    current_process = process.current_process()
+    # current_process() can be None if the finalizer is called
+    # late during Python finalization
+    if current_process is not None:
+        current_process._config['tempdir'] = None
 
 def get_temp_dir():
     # get name of a temp directory which will be automatically cleaned up

--- a/Misc/NEWS.d/next/Library/2019-07-03-12-47-52.bpo-37421.gR5hC8.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-03-12-47-52.bpo-37421.gR5hC8.rst
@@ -1,0 +1,4 @@
+Fix :func:`multiprocessing.util.get_temp_dir` finalizer: clear also the
+'tempdir' configuration of the current process, so next call to
+``get_temp_dir()`` will create a new temporary directory, rather than
+reusing the removed temporary directory.


### PR DESCRIPTION
Fix multiprocessing.util.get_temp_dir() finalizer: clear also the
'tempdir' configuration of the current process, so next call to
get_temp_dir() will create a new temporary directory, rather than
reusing the removed temporary directory.

<!-- issue-number: [bpo-37421](https://bugs.python.org/issue37421) -->
https://bugs.python.org/issue37421
<!-- /issue-number -->
