### PR TITLE
bpo-27452: IDLE: Cleanup config.py code

### DIFF
--- a/Lib/idlelib/idle_test/test_config.py
+++ b/Lib/idlelib/idle_test/test_config.py
@@ -159,19 +159,6 @@ class IdleUserConfParserTest(unittest.TestCase):
         self.assertFalse(parser.IsEmpty())
         self.assertCountEqual(parser.sections(), ['Foo'])
 
-    def test_remove_file(self):
-        with tempfile.TemporaryDirectory() as tdir:
-            path = os.path.join(tdir, 'test.cfg')
-            parser = self.new_parser(path)
-            parser.RemoveFile()  # Should not raise exception.
-
-            parser.AddSection('Foo')
-            parser.SetOption('Foo', 'bar', 'true')
-            parser.Save()
-            self.assertTrue(os.path.exists(path))
-            parser.RemoveFile()
-            self.assertFalse(os.path.exists(path))
-
     def test_save(self):
         with tempfile.TemporaryDirectory() as tdir:
             path = os.path.join(tdir, 'test.cfg')

--- a/Misc/NEWS.d/next/IDLE/2019-07-03-22-47-44.bpo-27452.nePPLi.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-07-03-22-47-44.bpo-27452.nePPLi.rst
@@ -1,0 +1,1 @@
+Cleanup ``config.py`` by inlining ``RemoveFile`` and simplifying the handling of ``file`` in ``CreateConfigHandlers``.


### PR DESCRIPTION
* Remove `RemoveFile` method.
* Simplify `CreateConfigHandlers` handling of `__file__`.

Patch by Terry Reedy.

<!-- issue-number: [bpo-27452](https://bugs.python.org/issue27452) -->
https://bugs.python.org/issue27452
<!-- /issue-number -->
