### PR TITLE
Modify helper class in pickletest, to be a context manager

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -81,14 +81,14 @@ class ExtensionSaver:
     # there is one).
     def __init__(self, code):
         self.code = code
+        self.pair = None
 
     def __enter__(self):
-        code = self.code
-        if code in copyreg._inverted_registry:
-            self.pair = copyreg._inverted_registry[code]
-            copyreg.remove_extension(self.pair[0], self.pair[1], code)
-        else:
-            self.pair = None
+        if self.code not in copyreg._inverted_registry:
+            return
+
+        self.pair = copyreg._inverted_registry[self.code]
+        copyreg.remove_extension(self.pair[0], self.pair[1], self.code)
 
     # Restore previous registration for code.
     def __exit__(self):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -91,7 +91,7 @@ class ExtensionSaver:
         copyreg.remove_extension(self.pair[0], self.pair[1], self.code)
 
     # Restore previous registration for code.
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         code = self.code
         curpair = copyreg._inverted_registry.get(code)
         if curpair is not None:


### PR DESCRIPTION
This allows for cleaner code style and minimizes the possibility of using the helper incorrectly.

Not sure if we'd want a b.p.o. issue for this.