### PR TITLE
bpo-37207: enable vectorcall for type.__call__

### DIFF
--- a/Misc/NEWS.d/next/C API/2019-07-07-10-37-07.bpo-37207.SlVNky.rst
+++ b/Misc/NEWS.d/next/C API/2019-07-07-10-37-07.bpo-37207.SlVNky.rst
@@ -1,0 +1,3 @@
+The vectorcall protocol is now enabled for ``type`` objects: set
+``tp_vectorcall`` to a vectorcall function to be used instead of ``tp_new``
+and ``tp_init`` when calling the class itself.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3614,7 +3614,7 @@ PyTypeObject PyType_Type = {
     sizeof(PyHeapTypeObject),                   /* tp_basicsize */
     sizeof(PyMemberDef),                        /* tp_itemsize */
     (destructor)type_dealloc,                   /* tp_dealloc */
-    0,                                          /* tp_vectorcall_offset */
+    offsetof(PyTypeObject, tp_vectorcall),      /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
@@ -3629,7 +3629,8 @@ PyTypeObject PyType_Type = {
     (setattrofunc)type_setattro,                /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE | Py_TPFLAGS_TYPE_SUBCLASS,         /* tp_flags */
+    Py_TPFLAGS_BASETYPE | Py_TPFLAGS_TYPE_SUBCLASS |
+    _Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
     type_doc,                                   /* tp_doc */
     (traverseproc)type_traverse,                /* tp_traverse */
     (inquiry)type_clear,                        /* tp_clear */


### PR DESCRIPTION
Base PR for other PRs that want to play with `type.__call__` such as #13930 and #14589.

The author is really @markshannon I just made the PR.

<!-- issue-number: [bpo-37207](https://bugs.python.org/issue37207) -->
https://bugs.python.org/issue37207
<!-- /issue-number -->


Automerge-Triggered-By: @encukou