### PR TITLE
bpo-29312: use METH_FASTCALL for dict.update

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -142,9 +142,11 @@ class DictTest(unittest.TestCase):
         d.update({2:20})
         d.update({1:1, 2:2, 3:3})
         self.assertEqual(d, {1:1, 2:2, 3:3})
+        d.update(([i,i] for i in range(4,6)), key="value")
+        self.assertEqual(d, {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 'key': 'value'})
 
         d.update()
-        self.assertEqual(d, {1:1, 2:2, 3:3})
+        self.assertEqual(d, {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 'key': 'value'})
 
         self.assertRaises((TypeError, AttributeError), d.update, None)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-29312](https://bugs.python.org/issue29312) -->
https://bugs.python.org/issue29312
<!-- /issue-number -->
