### PR TITLE
bpo-37501: Fix test failures when CPython is built without docstrings

### DIFF
--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -1,6 +1,7 @@
 "Test calltip, coverage 60%"
 
 from idlelib import calltip
+from test.support import requires_docstrings
 import unittest
 import textwrap
 import types
@@ -48,6 +49,7 @@ class Get_argspecTest(unittest.TestCase):
     # but a red buildbot is better than a user crash (as has happened).
     # For a simple mismatch, change the expected output to the actual.
 
+    @requires_docstrings
     def test_builtins(self):
 
         def tiptest(obj, out):
@@ -136,6 +138,7 @@ non-overlapping occurrences o...''')
         f.__doc__ = 'a'*300
         self.assertEqual(get_spec(f), f"()\n{'a'*(calltip._MAX_COLS-3) + '...'}")
 
+    @requires_docstrings
     def test_multiline_docstring(self):
         # Test fewer lines than max.
         self.assertEqual(get_spec(range),

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -923,13 +923,17 @@ class CoroutineTest(unittest.TestCase):
         self.assertEqual(inspect.getcoroutinestate(coro_b), inspect.CORO_CLOSED)
         self.assertIsNone(coro_b.cr_await)
 
-    def test_corotype_1(self):
+    @support.requires_docstrings
+    def test_corotype_docstrings(self):
         ct = types.CoroutineType
         self.assertIn('into coroutine', ct.send.__doc__)
         self.assertIn('inside coroutine', ct.close.__doc__)
         self.assertIn('in coroutine', ct.throw.__doc__)
         self.assertIn('of the coroutine', ct.__dict__['__name__'].__doc__)
         self.assertIn('of the coroutine', ct.__dict__['__qualname__'].__doc__)
+
+    def test_corotype_1(self):
+        ct = types.CoroutineType
         self.assertEqual(ct.__name__, 'coroutine')
 
         async def f(): pass

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -9,6 +9,7 @@ import inspect
 import builtins
 import unittest
 from unittest.mock import Mock
+from test.support import requires_docstrings
 from typing import ClassVar, Any, List, Union, Tuple, Dict, Generic, TypeVar, Optional
 from collections import deque, OrderedDict, namedtuple
 from functools import total_ordering
@@ -858,6 +859,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(C(10).bar, 5)
         self.assertEqual(C(10).i, 10)
 
+    @requires_docstrings
     def test_post_init(self):
         # Just make sure it gets called
         @dataclass
@@ -2976,6 +2978,7 @@ class TestMakeDataclass(unittest.TestCase):
         self.assertEqual(C.y, 10)
         self.assertEqual(C.z, 20)
 
+    @requires_docstrings
     def test_other_params(self):
         C = make_dataclass('C',
                            [('x', int),

--- a/Lib/test/test_importlib/extension/test_loader.py
+++ b/Lib/test/test_importlib/extension/test_loader.py
@@ -10,6 +10,7 @@ import unittest
 import importlib.util
 import importlib
 from test.support.script_helper import assert_python_failure
+from test.support import HAVE_DOCSTRINGS, MISSING_C_DOCSTRINGS
 
 class LoaderTests(abc.LoaderTests):
 
@@ -265,7 +266,9 @@ class MultiPhaseExtensionModuleTests(abc.LoaderTests):
             with self.subTest(name):
                 module = self.load_module_by_name(name)
                 self.assertEqual(module.__name__, name)
-                self.assertEqual(module.__doc__, "Module named in %s" % lang)
+                if HAVE_DOCSTRINGS:
+                    self.assertEqual(module.__doc__,
+                                     "Module named in %s" % lang)
 
     @unittest.skipIf(not hasattr(sys, 'gettotalrefcount'),
             '--with-pydebug has to be enabled for this test')

--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -1,7 +1,7 @@
 # Test the module type
 import unittest
 import weakref
-from test.support import gc_collect, requires_type_collecting
+from test.support import gc_collect, requires_type_collecting, HAVE_DOCSTRINGS
 from test.support.script_helper import assert_python_ok
 
 import sys
@@ -28,7 +28,8 @@ class ModuleTests(unittest.TestCase):
             self.fail("__name__ = %s" % repr(s))
         except AttributeError:
             pass
-        self.assertEqual(foo.__doc__, ModuleType.__doc__)
+        if HAVE_DOCSTRINGS:
+            self.assertEqual(foo.__doc__, ModuleType.__doc__)
 
     def test_uninitialized_missing_getattr(self):
         # Issue 8297

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -778,6 +778,7 @@ class PydocDocTest(unittest.TestCase):
         methods = pydoc.allmethods(TestClass)
         self.assertDictEqual(methods, expected)
 
+    @requires_docstrings
     def test_method_aliases(self):
         class A:
             def tkraise(self, aboveThis=None):

--- a/Misc/NEWS.d/next/Tests/2019-07-04-21-32-52.bpo-37501.mY6Qg3.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-04-21-32-52.bpo-37501.mY6Qg3.rst
@@ -1,0 +1,1 @@
+Fix test failures when CPython is built without docstrings.


### PR DESCRIPTION


<!-- issue-number: [bpo-37501](https://bugs.python.org/issue37501) -->
https://bugs.python.org/issue37501
<!-- /issue-number -->
