### PR TITLE
bpo-37502: handle default parameter for buffers argument of pickle.loads

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2765,6 +2765,11 @@ class AbstractPickleTests(unittest.TestCase):
             with self.assertRaises(pickle.UnpicklingError):
                 self.loads(data, buffers=[])
 
+    def test_inband_accept_default_buffers_argument(self):
+        for proto in range(5, pickle.HIGHEST_PROTOCOL + 1):
+            data_pickled = self.dumps(1, proto, buffer_callback=None)
+            data = self.loads(data_pickled, buffers=None)
+
     @unittest.skipIf(np is None, "Test needs Numpy")
     def test_buffers_numpy(self):
         def check_no_copy(x, y):

--- a/Misc/NEWS.d/next/Library/2019-07-08-03-15-04.bpo-37502.qZGC4g.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-08-03-15-04.bpo-37502.qZGC4g.rst
@@ -1,0 +1,1 @@
+pickle.loads() no longer raises TypeError when the buffers argument is set to None

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1653,7 +1653,7 @@ _Unpickler_SetInputEncoding(UnpicklerObject *self,
 static int
 _Unpickler_SetBuffers(UnpicklerObject *self, PyObject *buffers)
 {
-    if (buffers == NULL) {
+    if (buffers == NULL || buffers == Py_None) {
         self->buffers = NULL;
     }
     else {


### PR DESCRIPTION


<!-- issue-number: [bpo-37502](https://bugs.python.org/issue37502) -->
https://bugs.python.org/issue37502
<!-- /issue-number -->
