### PR TITLE
bpo-37421: multiprocessing tests now stop ForkServer

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5650,7 +5650,13 @@ def install_tests_in_module_dict(remote_globs, start_method):
         # Sleep 500 ms to give time to child processes to complete.
         if need_sleep:
             time.sleep(0.5)
+
         multiprocessing.process._cleanup()
+
+        # Stop the ForkServer process if it's running
+        from multiprocessing import forkserver
+        forkserver._forkserver._stop()
+
         # bpo-37421: Explicitly call _run_finalizers() to remove immediately
         # temporary directories created by multiprocessing.util.get_temp_dir().
         multiprocessing.util._run_finalizers()

--- a/Misc/NEWS.d/next/Tests/2019-07-05-14-47-55.bpo-37421.n8o2to.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-05-14-47-55.bpo-37421.n8o2to.rst
@@ -1,0 +1,3 @@
+multiprocessing tests now stop the ForkServer instance if it's running: close
+the "alive" file descriptor to ask the server to stop and then remove its UNIX
+address.


### PR DESCRIPTION
multiprocessing tests now stop the ForkServer instance if it's
running: kill the process, remove its UNIX address and close its
"alive" file descriptor.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37421](https://bugs.python.org/issue37421) -->
https://bugs.python.org/issue37421
<!-- /issue-number -->
