### PR TITLE
bpo-37504: Fix documentation build with texinfo builder

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -16,7 +16,7 @@ SPHINXERRORHANDLING = -W
 ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees -D latex_elements.papersize=$(PAPER) \
                 $(SPHINXOPTS) $(SPHINXERRORHANDLING) . build/$(BUILDER) $(SOURCES)
 
-.PHONY: help build html htmlhelp latex text changes linkcheck \
+.PHONY: help build html htmlhelp latex text texinfo changes linkcheck \
 	suspicious coverage doctest pydoc-topics htmlview clean dist check serve \
 	autobuild-dev autobuild-stable venv
 
@@ -29,6 +29,7 @@ help:
 	@echo "  htmlhelp   to make HTML files and a HTML help project"
 	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
 	@echo "  text       to make plain text files"
+	@echo "  texinfo    to make Texinfo file"
 	@echo "  epub       to make EPUB files"
 	@echo "  changes    to make an overview over all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
@@ -84,6 +85,11 @@ latex: build
 text: BUILDER = text
 text: build
 	@echo "Build finished; the text files are in build/text."
+
+texinfo: BUILDER = texinfo
+texinfo: build
+	@echo "Build finished; the python.texi file is in build/texinfo."
+	@echo "Run \`make info' in that directory to run it through makeinfo."
 
 epub: BUILDER = epub
 epub: build
@@ -178,6 +184,17 @@ dist:
 	rm -rf build/epub
 	make epub
 	cp -pPR build/epub/Python.epub dist/python-$(DISTVERSION)-docs.epub
+
+	# archive the texinfo build
+	rm -rf build/texinfo
+	make texinfo
+	make info --directory=build/texinfo
+	cp -pPR build/texinfo dist/python-$(DISTVERSION)-docs-texinfo
+	tar -C dist -cf dist/python-$(DISTVERSION)-docs-texinfo.tar python-$(DISTVERSION)-docs-texinfo
+	bzip2 -9 -k dist/python-$(DISTVERSION)-docs-texinfo.tar
+	(cd dist; zip -q -r -9 python-$(DISTVERSION)-docs-texinfo.zip python-$(DISTVERSION)-docs-texinfo)
+	rm -r dist/python-$(DISTVERSION)-docs-texinfo
+	rm dist/python-$(DISTVERSION)-docs-texinfo.tar
 
 check:
 	$(PYTHON) tools/rstlint.py -i tools -i $(VENVDIR) -i README.rst

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -536,6 +536,7 @@ def process_audit_events(app, doctree, fromdocname):
         nodes.colspec(colwidth=30),
         nodes.colspec(colwidth=55),
         nodes.colspec(colwidth=15),
+        cols=3,
     )
     head = nodes.thead()
     body = nodes.tbody()


### PR DESCRIPTION
In the table model used by docutils, the `cols` attribute of `tgroup` nodes is [mandatory][1]. It is used in texinfo builder [here][2].

Here is a screenshot proving that this change works:
![Screenshot of `info` showing the Python documentation](https://user-images.githubusercontent.com/1381584/60742263-4cccf000-9f75-11e9-971a-28e727761aa4.png)

[1]: https://www.oasis-open.org/specs/tm9901.htm#AEN348
[2]: https://github.com/sphinx-doc/sphinx/blob/v2.1.2/sphinx/writers/texinfo.py#L1129

<!-- issue-number: [bpo-37504](https://bugs.python.org/issue37504) -->
https://bugs.python.org/issue37504
<!-- /issue-number -->
