### PR TITLE
bpo-18374: fix wrong col_offset of some ast.BinOp instances

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -576,6 +576,36 @@ class AST_Tests(unittest.TestCase):
         with support.swap_attr(unicodedata, 'normalize', bad_normalize):
             self.assertRaises(TypeError, ast.parse, '\u03D5')
 
+    def test_issue18374_binop_col_offset(self):
+        tree = ast.parse('4+5+6+7')
+        parent_binop = tree.body[0].value
+        child_binop = parent_binop.left
+        grandchild_binop = child_binop.left
+        self.assertEqual(parent_binop.col_offset, 0)
+        self.assertEqual(parent_binop.end_col_offset, 7)
+        self.assertEqual(child_binop.col_offset, 0)
+        self.assertEqual(child_binop.end_col_offset, 5)
+        self.assertEqual(grandchild_binop.col_offset, 0)
+        self.assertEqual(grandchild_binop.end_col_offset, 3)
+
+        tree = ast.parse('4+5-\\\n 6-7')
+        parent_binop = tree.body[0].value
+        child_binop = parent_binop.left
+        grandchild_binop = child_binop.left
+        self.assertEqual(parent_binop.col_offset, 0)
+        self.assertEqual(parent_binop.lineno, 1)
+        self.assertEqual(parent_binop.end_col_offset, 4)
+        self.assertEqual(parent_binop.end_lineno, 2)
+
+        self.assertEqual(child_binop.col_offset, 0)
+        self.assertEqual(parent_binop.lineno, 1)
+        self.assertEqual(child_binop.end_col_offset, 2)
+        self.assertEqual(parent_binop.end_lineno, 2)
+
+        self.assertEqual(grandchild_binop.col_offset, 0)
+        self.assertEqual(parent_binop.lineno, 1)
+        self.assertEqual(grandchild_binop.end_col_offset, 3)
+        self.assertEqual(parent_binop.end_lineno, 2)
 
 class ASTHelpers_Test(unittest.TestCase):
     maxDiff = None

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -178,6 +178,7 @@ Nikolay Bogoychev
 David Bolen
 Wouter Bolsterlee
 Gawain Bolton
+Carl Friedrich Bolz-Tereick
 Forest Bond
 Gregory Bond
 Médéric Boquien

--- a/Misc/NEWS.d/next/Library/2019-07-05-21-46-45.bpo-18374.qgE0H3.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-05-21-46-45.bpo-18374.qgE0H3.rst
@@ -1,0 +1,2 @@
+Fix the ``.col_offset`` attribute of nested :class:`ast.BinOp` instances
+which had a too large value in some situations.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -2645,7 +2645,7 @@ ast_for_binop(struct compiling *c, const node *n)
             return NULL;
 
         tmp_result = BinOp(result, newoperator, tmp,
-                           LINENO(next_oper), next_oper->n_col_offset,
+                           LINENO(n), n->n_col_offset,
                            CHILD(n, i * 2 + 2)->n_end_lineno,
                            CHILD(n, i * 2 + 2)->n_end_col_offset,
                            c->c_arena);


### PR DESCRIPTION
Nested BinOp instances (e.g. a+b+c) had a wrong col_offset for the second BinOp (e.g. 2 instead of 0 in the example). Fix it by using the correct st node to copy the line and col_offset from in ast.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-18374](https://bugs.python.org/issue18374) -->
https://bugs.python.org/issue18374
<!-- /issue-number -->
