### PR TITLE
bpo-37500: Make sure dead code does not generate bytecode but also detect syntax errors

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -701,14 +701,35 @@ if 1:
     # bytecode for dead code blocks. See bpo-37500 for more context.
     @support.cpython_only
     def test_dead_blocks_do_not_generate_bytecode(self):
-        def unused_block():
+        def unused_block_if():
             if 0:
                 return 42
-        opcodes = list(dis.get_instructions(unused_block))
-        self.assertEqual(2, len(opcodes))
-        self.assertEqual('LOAD_CONST', opcodes[0].opname)
-        self.assertEqual(None, opcodes[0].argval)
-        self.assertEqual('RETURN_VALUE', opcodes[1].opname)
+
+        def unused_block_while():
+            while 0:
+                return 42
+
+        def unused_block_if_else():
+            if 1:
+                return None
+            else:
+                return 42
+
+        def unused_block_while_else():
+            while 1:
+                return None
+            else:
+                return 42
+
+        funcs = [unused_block_if, unused_block_while,
+                 unused_block_if_else, unused_block_while_else]
+
+        for func in funcs:
+            opcodes = list(dis.get_instructions(func))
+            self.assertEqual(2, len(opcodes))
+            self.assertEqual('LOAD_CONST', opcodes[0].opname)
+            self.assertEqual(None, opcodes[0].argval)
+            self.assertEqual('RETURN_VALUE', opcodes[1].opname)
 
 
 class TestExpressionStackSize(unittest.TestCase):

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -697,6 +697,19 @@ if 1:
         # complex statements.
         compile("if a: b\n" * 200000, "<dummy>", "exec")
 
+    # Multiple users rely on the fact that CPython does not generate
+    # bytecode for dead code blocks. See bpo-37500 for more context.
+    @support.cpython_only
+    def test_dead_blocks_do_not_generate_bytecode(self):
+        def unused_block():
+            if 0:
+                return 42
+        opcodes = list(dis.get_instructions(unused_block))
+        self.assertEqual(2, len(opcodes))
+        self.assertEqual('LOAD_CONST', opcodes[0].opname)
+        self.assertEqual(None, opcodes[0].argval)
+        self.assertEqual('RETURN_VALUE', opcodes[1].opname)
+
 
 class TestExpressionStackSize(unittest.TestCase):
     # These tests check that the computed stack size for a code object

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -699,10 +699,10 @@ class SyntaxTestCase(unittest.TestCase):
     def test_yield_outside_function(self):
         self._check_error("if 0: yield",                "outside function")
         self._check_error("if 0: yield\nelse:  x=1",    "outside function")
-        self._check_error("class C:\n    if 0: yield",  "outside function")
         self._check_error("if 1: pass\nelse: yield",    "outside function")
         self._check_error("while 0: yield",             "outside function")
         self._check_error("while 0: yield\nelse:  x=1", "outside function")
+        self._check_error("class C:\n  if 0: yield",    "outside function")
         self._check_error("class C:\n  if 1: pass\n  else: yield",
                           "outside function")
         self._check_error("class C:\n  while 0: yield", "outside function")
@@ -712,14 +712,15 @@ class SyntaxTestCase(unittest.TestCase):
     def test_return_outside_function(self):
         self._check_error("if 0: return",                "outside function")
         self._check_error("if 0: return\nelse:  x=1",    "outside function")
-        self._check_error("class C:\n    if 0: return",  "outside function")
         self._check_error("if 1: pass\nelse: return",    "outside function")
         self._check_error("while 0: return",             "outside function")
         self._check_error("class C:\n  if 0: return",    "outside function")
-        self._check_error("class C:\n  if 0: return\n  else: x= 1",
-                          "outside function")
         self._check_error("class C:\n  while 0: return", "outside function")
         self._check_error("class C:\n  while 0: return\n  else:  x=1",
+                          "outside function")
+        self._check_error("class C:\n  if 0: return\n  else: x= 1",
+                          "outside function")
+        self._check_error("class C:\n  if 1: pass\n  else: return",
                           "outside function")
 
     def test_break_outside_loop(self):

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -697,35 +697,43 @@ class SyntaxTestCase(unittest.TestCase):
         self._check_error("break", "outside loop")
 
     def test_yield_outside_function(self):
-        self._check_error("if 0: yield",               "outside function")
-        self._check_error("class C:\n    if 0: yield", "outside function")
-        self._check_error("if 1: pass\nelse: yield",   "outside function")
-        self._check_error("while 0: yield",            "outside function")
-        self._check_error("class C:\n  if 0: yield", "outside function")
+        self._check_error("if 0: yield",                "outside function")
+        self._check_error("if 0: yield\nelse:  x=1",    "outside function")
+        self._check_error("class C:\n    if 0: yield",  "outside function")
+        self._check_error("if 1: pass\nelse: yield",    "outside function")
+        self._check_error("while 0: yield",             "outside function")
+        self._check_error("while 0: yield\nelse:  x=1", "outside function")
         self._check_error("class C:\n  if 1: pass\n  else: yield",
                           "outside function")
         self._check_error("class C:\n  while 0: yield", "outside function")
+        self._check_error("class C:\n  while 0: yield\n  else:  x = 1",
+                          "outside function")
 
     def test_return_outside_function(self):
-        self._check_error("if 0: return",               "outside function")
-        self._check_error("class C:\n    if 0: return", "outside function")
-        self._check_error("if 1: pass\nelse: return",   "outside function")
-        self._check_error("while 0: return",            "outside function")
-        self._check_error("class C:\n  if 0: return", "outside function")
-        self._check_error("class C:\n  if 1: pass\n  else: return",
+        self._check_error("if 0: return",                "outside function")
+        self._check_error("if 0: return\nelse:  x=1",    "outside function")
+        self._check_error("class C:\n    if 0: return",  "outside function")
+        self._check_error("if 1: pass\nelse: return",    "outside function")
+        self._check_error("while 0: return",             "outside function")
+        self._check_error("class C:\n  if 0: return",    "outside function")
+        self._check_error("class C:\n  if 0: return\n  else: x= 1",
                           "outside function")
         self._check_error("class C:\n  while 0: return", "outside function")
+        self._check_error("class C:\n  while 0: return\n  else:  x=1",
+                          "outside function")
 
     def test_break_outside_loop(self):
-        self._check_error("if 0: break",                "outside loop")
-        self._check_error("if 1: pass\nelse: break",   "outside loop")
+        self._check_error("if 0: break",             "outside loop")
+        self._check_error("if 0: break\nelse:  x=1",  "outside loop")
+        self._check_error("if 1: pass\nelse: break", "outside loop")
         self._check_error("class C:\n  if 0: break", "outside loop")
         self._check_error("class C:\n  if 1: pass\n  else: break",
                           "outside loop")
 
     def test_continue_outside_loop(self):
-        self._check_error("if 0: continue",     "not properly in loop")
-        self._check_error("if 1: pass\nelse: continue",   "not properly in loop")
+        self._check_error("if 0: continue",             "not properly in loop")
+        self._check_error("if 0: continue\nelse:  x=1", "not properly in loop")
+        self._check_error("if 1: pass\nelse: continue", "not properly in loop")
         self._check_error("class C:\n  if 0: continue", "not properly in loop")
         self._check_error("class C:\n  if 1: pass\n  else: continue",
                           "not properly in loop")

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -699,16 +699,36 @@ class SyntaxTestCase(unittest.TestCase):
     def test_yield_outside_function(self):
         self._check_error("if 0: yield",               "outside function")
         self._check_error("class C:\n    if 0: yield", "outside function")
+        self._check_error("if 1: pass\nelse: yield",   "outside function")
+        self._check_error("while 0: yield",            "outside function")
+        self._check_error("class C:\n  if 0: yield", "outside function")
+        self._check_error("class C:\n  if 1: pass\n  else: yield",
+                          "outside function")
+        self._check_error("class C:\n  while 0: yield", "outside function")
 
     def test_return_outside_function(self):
         self._check_error("if 0: return",               "outside function")
         self._check_error("class C:\n    if 0: return", "outside function")
+        self._check_error("if 1: pass\nelse: return",   "outside function")
+        self._check_error("while 0: return",            "outside function")
+        self._check_error("class C:\n  if 0: return", "outside function")
+        self._check_error("class C:\n  if 1: pass\n  else: return",
+                          "outside function")
+        self._check_error("class C:\n  while 0: return", "outside function")
 
     def test_break_outside_loop(self):
         self._check_error("if 0: break",                "outside loop")
+        self._check_error("if 1: pass\nelse: break",   "outside loop")
+        self._check_error("class C:\n  if 0: break", "outside loop")
+        self._check_error("class C:\n  if 1: pass\n  else: break",
+                          "outside loop")
 
     def test_continue_outside_loop(self):
         self._check_error("if 0: continue",     "not properly in loop")
+        self._check_error("if 1: pass\nelse: continue",   "not properly in loop")
+        self._check_error("class C:\n  if 0: continue", "not properly in loop")
+        self._check_error("class C:\n  if 1: pass\n  else: continue",
+                          "not properly in loop")
 
     def test_unexpected_indent(self):
         self._check_error("foo()\n bar()\n", "unexpected indent",

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -53,21 +53,51 @@ basic.events = [(0, 'call'),
 # following that clause?
 
 
-# The entire "while 0:" statement is optimized away.  No code
-# exists for it, so the line numbers skip directly from "del x"
-# to "x = 1".
-def arigo_example():
+# Some constructs like "while 0:", "if 0:" or "if 1:...else:..." are optimized
+# away.  No code # exists for them, so the line numbers skip directly from
+# "del x" to "x = 1".
+def arigo_example0():
     x = 1
     del x
     while 0:
         pass
     x = 1
 
-arigo_example.events = [(0, 'call'),
+arigo_example0.events = [(0, 'call'),
                         (1, 'line'),
                         (2, 'line'),
                         (5, 'line'),
                         (5, 'return')]
+
+def arigo_example1():
+    x = 1
+    del x
+    if 0:
+        pass
+    x = 1
+
+arigo_example1.events = [(0, 'call'),
+                        (1, 'line'),
+                        (2, 'line'),
+                        (5, 'line'),
+                        (5, 'return')]
+
+def arigo_example2():
+    x = 1
+    del x
+    if 1:
+        x = 1
+    else:
+        pass
+    return None
+
+arigo_example2.events = [(0, 'call'),
+                        (1, 'line'),
+                        (2, 'line'),
+                        (4, 'line'),
+                        (7, 'line'),
+                        (7, 'return')]
+
 
 # check that lines consisting of just one instruction get traced:
 def one_instr_line():
@@ -349,8 +379,12 @@ class TraceTestCase(unittest.TestCase):
 
     def test_01_basic(self):
         self.run_test(basic)
-    def test_02_arigo(self):
-        self.run_test(arigo_example)
+    def test_02_arigo0(self):
+        self.run_test(arigo_example0)
+    def test_02_arigo1(self):
+        self.run_test(arigo_example1)
+    def test_02_arigo2(self):
+        self.run_test(arigo_example2)
     def test_03_one_instr(self):
         self.run_test(one_instr_line)
     def test_04_no_pop_blocks(self):

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1178,9 +1178,6 @@ compiler_add_o(struct compiler *c, PyObject *dict, PyObject *o)
 {
     PyObject *v;
     Py_ssize_t arg;
-    if (!c->c_emit_bytecode) {
-        return 1;
-    }
 
     v = PyDict_GetItemWithError(dict, o);
     if (!v) {
@@ -1316,6 +1313,10 @@ merge_consts_recursive(struct compiler *c, PyObject *o)
 static Py_ssize_t
 compiler_add_const(struct compiler *c, PyObject *o)
 {
+    if (!c->c_emit_bytecode) {
+        return 0;
+    }
+
     PyObject *key = merge_consts_recursive(c, o);
     if (key == NULL) {
         return -1;
@@ -1329,6 +1330,10 @@ compiler_add_const(struct compiler *c, PyObject *o)
 static int
 compiler_addop_load_const(struct compiler *c, PyObject *o)
 {
+    if (!c->c_emit_bytecode) {
+        return 1;
+    }
+
     Py_ssize_t arg = compiler_add_const(c, o);
     if (arg < 0)
         return 0;
@@ -1339,6 +1344,10 @@ static int
 compiler_addop_o(struct compiler *c, int opcode, PyObject *dict,
                      PyObject *o)
 {
+    if (!c->c_emit_bytecode) {
+        return 1;
+    }
+
     Py_ssize_t arg = compiler_add_o(c, dict, o);
     if (arg < 0)
         return 0;
@@ -1350,6 +1359,11 @@ compiler_addop_name(struct compiler *c, int opcode, PyObject *dict,
                     PyObject *o)
 {
     Py_ssize_t arg;
+
+    if (!c->c_emit_bytecode) {
+        return 1;
+    }
+
     PyObject *mangled = _Py_Mangle(c->u->u_private, o);
     if (!mangled)
         return 0;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2580,12 +2580,11 @@ compiler_if(struct compiler *c, stmt_ty s)
      * constant = 1: "if 1", "if 2", ...
      * constant = -1: rest */
     if (constant == 0) {
+        BEGIN_DO_NOT_EMIT_BYTECODE
+        VISIT_SEQ(c, stmt, s->v.If.body);
+        END_DO_NOT_EMIT_BYTECODE
         if (s->v.If.orelse) {
             VISIT_SEQ(c, stmt, s->v.If.orelse);
-        } else{
-            BEGIN_DO_NOT_EMIT_BYTECODE
-            VISIT_SEQ(c, stmt, s->v.If.body);
-            END_DO_NOT_EMIT_BYTECODE
         }
     } else if (constant == 1) {
         VISIT_SEQ(c, stmt, s->v.If.body);
@@ -2703,12 +2702,11 @@ compiler_while(struct compiler *c, stmt_ty s)
     int constant = expr_constant(s->v.While.test);
 
     if (constant == 0) {
+        BEGIN_DO_NOT_EMIT_BYTECODE
+        VISIT_SEQ(c, stmt, s->v.While.body);
+        END_DO_NOT_EMIT_BYTECODE
         if (s->v.While.orelse) {
             VISIT_SEQ(c, stmt, s->v.While.orelse);
-        } else {
-            BEGIN_DO_NOT_EMIT_BYTECODE
-            VISIT_SEQ(c, stmt, s->v.While.body);
-            END_DO_NOT_EMIT_BYTECODE
         }
         return 1;
     }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -161,9 +161,10 @@ struct compiler {
     int c_optimize;              /* optimization level */
     int c_interactive;           /* true if in interactive mode */
     int c_nestlevel;
-    int c_emit_bytecode;         /* The compiler won't emmit any bytecode
+    int c_emit_bytecode;         /* The compiler won't emit any bytecode
                                     if this flag is false. This can be used
-                                    to visit nodes to check only errors. */
+                                    to temporarily visit nodes without emitting
+                                    bytecode to check only errors. */
 
     PyObject *c_const_cache;     /* Python dict holding all constants,
                                     including names tuple */

--- a/Python/peephole.c
+++ b/Python/peephole.c
@@ -306,11 +306,18 @@ PyCode_Optimize(PyObject *code, PyObject* consts, PyObject *names,
             case LOAD_CONST:
                 cumlc = lastlc + 1;
                 if (nextop != POP_JUMP_IF_FALSE  ||
-                    !ISBASICBLOCK(blocks, op_start, i + 1)  ||
-                    !PyObject_IsTrue(PyList_GET_ITEM(consts, get_arg(codestr, i))))
+                    !ISBASICBLOCK(blocks, op_start, i + 1)) {
                     break;
-                fill_nops(codestr, op_start, nexti + 1);
-                cumlc = 0;
+                }
+                PyObject* cnt = PyList_GET_ITEM(consts, get_arg(codestr, i));
+                int is_true = PyObject_IsTrue(cnt);
+                if (is_true == -1) {
+                    goto exitError;
+                }
+                if (is_true == 1) {
+                    fill_nops(codestr, op_start, nexti + 1);
+                    cumlc = 0;
+                }
                 break;
 
                 /* Try to fold tuples of constants.

--- a/Python/peephole.c
+++ b/Python/peephole.c
@@ -306,18 +306,11 @@ PyCode_Optimize(PyObject *code, PyObject* consts, PyObject *names,
             case LOAD_CONST:
                 cumlc = lastlc + 1;
                 if (nextop != POP_JUMP_IF_FALSE  ||
-                    !ISBASICBLOCK(blocks, op_start, i + 1)) {
+                    !ISBASICBLOCK(blocks, op_start, i + 1)  ||
+                    !PyObject_IsTrue(PyList_GET_ITEM(consts, get_arg(codestr, i))))
                     break;
-                }
-                PyObject* cnt = PyList_GET_ITEM(consts, get_arg(codestr, i));
-                int is_true = PyObject_IsTrue(cnt);
-                if (is_true == -1) {
-                    goto exitError;
-                }
-                if (is_true == 1) {
-                    fill_nops(codestr, op_start, nexti + 1);
-                    cumlc = 0;
-                }
+                fill_nops(codestr, op_start, nexti + 1);
+                cumlc = 0;
                 break;
 
                 /* Try to fold tuples of constants.


### PR DESCRIPTION
https://bugs.python.org/issue37500

Add a new field to the compiler structure that allows to be configured
so no bytecode is emitted. In this way is possible to detect errors by
walking the nodes while preserving optimizations.

<!-- issue-number: [bpo-37500](https://bugs.python.org/issue37500) -->
https://bugs.python.org/issue37500
<!-- /issue-number -->
