### PR TITLE
bpo-37456: Slash ('/') is now part of syntax

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -800,10 +800,6 @@ an error::
      File "<stdin>", line 1, in <module>
    TypeError: pow() takes no keyword arguments
 
-Note that as of this writing this is only documentational and no valid syntax
-in Python, although there is :pep:`570`, which proposes a syntax for
-position-only parameters in Python.
-
 
 Numbers and strings
 ===================

--- a/Misc/NEWS.d/next/Documentation/2019-07-06-17-51-36.bpo-37456.lgAQHn.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-07-06-17-51-36.bpo-37456.lgAQHn.rst
@@ -1,0 +1,1 @@
+Slash ('/') is now part of syntax.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37456](https://bugs.python.org/issue37456) -->
https://bugs.python.org/issue37456
<!-- /issue-number -->
