### PR TITLE
bpo-37520: Correct behavior for zipfile.Path.parent

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -2514,5 +2514,16 @@ class TestPath(unittest.TestCase):
             assert (root / 'a').parent.at == ''
             assert (root / 'a' / 'b').parent.at == 'a/'
 
+    def test_dir_parent(self):
+        for zipfile_abcde in self.zipfile_abcde():
+            root = zipfile.Path(zipfile_abcde)
+            assert (root / 'b').parent.at == ''
+            assert (root / 'b/').parent.at == ''
+
+    def test_missing_dir_parent(self):
+        for zipfile_abcde in self.zipfile_abcde():
+            root = zipfile.Path(zipfile_abcde)
+            assert (root / 'missing dir/').parent.at == ''
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -2236,7 +2236,7 @@ class Path:
 
     @property
     def parent(self):
-        parent_at = posixpath.dirname(self.at)
+        parent_at = posixpath.dirname(self.at.rstrip('/'))
         if parent_at:
             parent_at += '/'
         return self._next(parent_at)

--- a/Misc/NEWS.d/next/Library/2019-07-07-21-09-08.bpo-37520.Gg0KD6.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-07-21-09-08.bpo-37520.Gg0KD6.rst
@@ -1,0 +1,1 @@
+Correct behavior for zipfile.Path.parent when the path object identifies a subdirectory.


### PR DESCRIPTION


<!-- issue-number: [bpo-37520](https://bugs.python.org/issue37520) -->
https://bugs.python.org/issue37520
<!-- /issue-number -->
