### PR TITLE
bpo-37421: test_concurrent_futures stop ForkServer

### DIFF
--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -1309,6 +1309,9 @@ def tearDownModule():
 
     # cleanup multiprocessing
     multiprocessing.process._cleanup()
+    # Stop the ForkServer process if it's running
+    from multiprocessing import forkserver
+    forkserver._forkserver._stop()
     # bpo-37421: Explicitly call _run_finalizers() to remove immediately
     # temporary directories created by multiprocessing.util.get_temp_dir().
     multiprocessing.util._run_finalizers()

--- a/Misc/NEWS.d/next/Tests/2019-07-08-10-11-36.bpo-37421.OY77go.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-08-10-11-36.bpo-37421.OY77go.rst
@@ -1,0 +1,2 @@
+test_concurrent_futures now explicitly stops the ForkServer instance if it's
+running.


### PR DESCRIPTION
test_concurrent_futures now explicitly stops the ForkServer instance
if it's running.

<!-- issue-number: [bpo-37421](https://bugs.python.org/issue37421) -->
https://bugs.python.org/issue37421
<!-- /issue-number -->
