### PR TITLE
bpo-37367: octal escapes applied inconsistently throughout the interpreter and lib

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -14,7 +14,7 @@ import pickle
 import tempfile
 import textwrap
 import unittest
-from ast import literal_eval as _literal_eval
+import ast
 
 import test.support
 import test.string_tests
@@ -964,25 +964,27 @@ class BaseBytesTest:
         self.assertEqual(c, b'hllo')
 
     def test_octal_values(self):
-        # bpo-37367: verify that octal values greater than 255
-        # raise ValueError
+        # bpo-37367: verify that octal escape sequences
+        # with values greater than 255 raise ValueError
 
-        # test 1- and 2- digit octal values (i.e. no leading zeroes)
+        # test 1- and 2- digit octal escape sequences
+        # (i.e. no leading zeroes)
         for i in range(0o00, 0o77):
             v = "b'\\{0:o}'".format(i)
-            self.type2test(_literal_eval(v))
-            self.assertEqual(ord(_literal_eval(v)), i)
+            self.type2test(ast.literal_eval(v))
+            self.assertEqual(ord(ast.literal_eval(v)), i)
 
-        # test 3-digit octal values (including leading zeroes)
+        # test 3-digit octal escape sequences
+        # (including leading zeroes)
         for i in range(0o00, 0o400):
             v = "b'\\{0:03o}'".format(i)
-            self.type2test(_literal_eval(v))
-            self.assertEqual(ord(_literal_eval(v)), i)
+            self.type2test(ast.literal_eval(v))
+            self.assertEqual(ord(ast.literal_eval(v)), i)
 
         raised = 0
         for i in range(0o400, 0o1000):
             try:
-                self.type2test(_literal_eval("b'\\{0:o}'".format(i)))
+                self.type2test(ast.literal_eval("b'\\{0:o}'".format(i)))
             except SyntaxError as e:
                 # ast.literal_eval() raises SyntaxError and
                 # mentions the underlying ValueError in
@@ -991,11 +993,11 @@ class BaseBytesTest:
                                              "must be in range(0, 256)", 0),
                                  0)
                 raised = raised + 1
-        self.assertEqual(raised, 256)
+        self.assertEqual(raised, 0o1000-0o400)
 
         # test 4-digit octal value (4th digit should be treated as literal)
-        self.assertEqual(_literal_eval("b'\\1234'"), b'S4')
-        self.assertRaises(SyntaxError, _literal_eval, "b'\\4321'")
+        self.assertEqual(ast.literal_eval("b'\\1234'"), b'S4')
+        self.assertRaises(SyntaxError, ast.literal_eval, "b'\\4321'")
 
         # specific case mentioned in bpo-37367
         self.assertRaises(SyntaxError, eval, "ord(b'\\407')")

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1174,7 +1174,7 @@ class EscapeDecodeTest(unittest.TestCase):
         check(br"[\418]", b"[!8]")
         check(br"[\101]", b"[A]")
         check(br"[\1010]", b"[A0]")
-        check(br"[\501]", b"[A]")
+        self.assertRaises(ValueError, decode, br"[\501]")
         check(br"[\x41]", b"[A]")
         check(br"[\x410]", b"[A0]")
         for i in range(97, 123):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-08-19-08-38.bpo-37367.SVtBhh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-08-19-08-38.bpo-37367.SVtBhh.rst
@@ -1,2 +1,2 @@
-Byte strings containing octal values greater than 255 will now raise
-ValueError.  Patch by (Jeffrey Kintscher).
+Byte strings containing octal escape sequences with values greater than 255
+will now raise ValueError.  Patch by Jeffrey Kintscher.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-08-19-08-38.bpo-37367.SVtBhh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-08-19-08-38.bpo-37367.SVtBhh.rst
@@ -1,0 +1,2 @@
+Byte strings containing octal values greater than 255 will now raise
+ValueError.  Patch by (Jeffrey Kintscher).

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1185,6 +1185,11 @@ PyObject *_PyBytes_DecodeEscape(const char *s,
                 if (s < end && '0' <= *s && *s <= '7')
                     c = (c<<3) + *s++ - '0';
             }
+            if (c > 255) {
+                PyErr_Format(PyExc_ValueError,
+                             "octal value must be in range(0, 256)");
+                goto failed;
+            }
             *p++ = c;
             break;
         case 'x':


### PR DESCRIPTION
Add a range check for octal values in byte strings that raises ValueError if the value is more than 255 (0o377).

Tests for all 1-, 2-, and 3-digit octal values are provided (both valid and error cases).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37367](https://bugs.python.org/issue37367) -->
https://bugs.python.org/issue37367
<!-- /issue-number -->
