### PR TITLE
bpo-26806: IDLE should run without docstrings

### DIFF
--- a/Lib/idlelib/idle_test/test_run.py
+++ b/Lib/idlelib/idle_test/test_run.py
@@ -292,6 +292,14 @@ class TestSysRecursionLimitWrappers(unittest.TestCase):
         new_reclimit = sys.getrecursionlimit()
         self.assertEqual(new_reclimit, orig_reclimit)
 
+    def test_fixdoc(self):
+        def func(): "docstring"
+        run.fixdoc(func, "more")
+        self.assertEqual(func.__doc__, "docstring\n\nmore")
+        func.__doc__ = None
+        run.fixdoc(func, "more")
+        self.assertEqual(func.__doc__, "more")
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -307,7 +307,12 @@ def fix_scaling(root):
                 font['size'] = round(-0.75*size)
 
 
+def fixdoc(fun, text):
+    tem = (fun.__doc__ + '\n\n') if fun.__doc__ is not None else ''
+    fun.__doc__ = tem + textwrap.fill(textwrap.dedent(text))
+
 RECURSIONLIMIT_DELTA = 30
+
 def install_recursionlimit_wrappers():
     """Install wrappers to always add 30 to the recursion limit."""
     # see: bpo-26806
@@ -328,23 +333,18 @@ def install_recursionlimit_wrappers():
                 "recursion limit must be greater or equal than 1")
 
         return setrecursionlimit.__wrapped__(limit + RECURSIONLIMIT_DELTA)
-    if setrecursionlimit.__doc__ is not None:
-        setrecursionlimit.__doc__ += (
-            "\n\n" + textwrap.fill(textwrap.dedent(f"""\
+
+    fixdoc(setrecursionlimit, f"""\
             This IDLE wrapper adds {RECURSIONLIMIT_DELTA} to prevent possible
-            uninterruptible loops.
-            """)))
+            uninterruptible loops.""")
 
     @functools.wraps(sys.getrecursionlimit)
     def getrecursionlimit():
         return getrecursionlimit.__wrapped__() - RECURSIONLIMIT_DELTA
 
-    if getrecursionlimit.__doc__ is not None:
-        getrecursionlimit.__doc__ += (
-            "\n\n" + textwrap.fill(textwrap.dedent(f"""\
+    fixdoc(getrecursionlimit, f"""\
             This IDLE wrapper subtracts {RECURSIONLIMIT_DELTA} to compensate
-            for the {RECURSIONLIMIT_DELTA} IDLE adds when setting the limit.
-            """)))
+            for the {RECURSIONLIMIT_DELTA} IDLE adds when setting the limit.""")
 
     # add the delta to the default recursion limit, to compensate
     sys.setrecursionlimit(sys.getrecursionlimit() + RECURSIONLIMIT_DELTA)

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -328,20 +328,23 @@ def install_recursionlimit_wrappers():
                 "recursion limit must be greater or equal than 1")
 
         return setrecursionlimit.__wrapped__(limit + RECURSIONLIMIT_DELTA)
-
-    setrecursionlimit.__doc__ += "\n\n" + textwrap.fill(textwrap.dedent(f"""\
-        This IDLE wrapper adds {RECURSIONLIMIT_DELTA} to prevent possible
-        uninterruptible loops.
-        """).strip())
+    if setrecursionlimit.__doc__ is not None:
+        setrecursionlimit.__doc__ += (
+            "\n\n" + textwrap.fill(textwrap.dedent(f"""\
+            This IDLE wrapper adds {RECURSIONLIMIT_DELTA} to prevent possible
+            uninterruptible loops.
+            """)))
 
     @functools.wraps(sys.getrecursionlimit)
     def getrecursionlimit():
         return getrecursionlimit.__wrapped__() - RECURSIONLIMIT_DELTA
 
-    getrecursionlimit.__doc__ += "\n\n" + textwrap.fill(textwrap.dedent(f"""\
-        This IDLE wrapper subtracts {RECURSIONLIMIT_DELTA} to compensate for
-        the {RECURSIONLIMIT_DELTA} IDLE adds when setting the limit.
-        """).strip())
+    if getrecursionlimit.__doc__ is not None:
+        getrecursionlimit.__doc__ += (
+            "\n\n" + textwrap.fill(textwrap.dedent(f"""\
+            This IDLE wrapper subtracts {RECURSIONLIMIT_DELTA} to compensate
+            for the {RECURSIONLIMIT_DELTA} IDLE adds when setting the limit.
+            """)))
 
     # add the delta to the default recursion limit, to compensate
     sys.setrecursionlimit(sys.getrecursionlimit() + RECURSIONLIMIT_DELTA)


### PR DESCRIPTION
After fcf1d00, IDLE startup failed with python compiled without docstrings.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-26806](https://bugs.python.org/issue26806) -->
https://bugs.python.org/issue26806
<!-- /issue-number -->
