### PR TITLE
bpo-18374: fix tests to check the correct thing about line numbers

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -598,14 +598,14 @@ class AST_Tests(unittest.TestCase):
         self.assertEqual(parent_binop.end_lineno, 2)
 
         self.assertEqual(child_binop.col_offset, 0)
-        self.assertEqual(parent_binop.lineno, 1)
+        self.assertEqual(child_binop.lineno, 1)
         self.assertEqual(child_binop.end_col_offset, 2)
-        self.assertEqual(parent_binop.end_lineno, 2)
+        self.assertEqual(child_binop.end_lineno, 2)
 
         self.assertEqual(grandchild_binop.col_offset, 0)
-        self.assertEqual(parent_binop.lineno, 1)
+        self.assertEqual(grandchild_binop.lineno, 1)
         self.assertEqual(grandchild_binop.end_col_offset, 3)
-        self.assertEqual(parent_binop.end_lineno, 2)
+        self.assertEqual(grandchild_binop.end_lineno, 1)
 
 class ASTHelpers_Test(unittest.TestCase):
     maxDiff = None


### PR DESCRIPTION
@ilevkivskyi here's the promised fix.

Should I also try to do the backport to 3.7? (the automated merging fails because the `end_lineno` and  `end_col_offset` didn't exist in 3.7).

<!-- issue-number: [bpo-18374](https://bugs.python.org/issue18374) -->
https://bugs.python.org/issue18374
<!-- /issue-number -->
