### PR TITLE
bpo-37473: Don't import importlib ASAP in tests

### DIFF
--- a/Lib/test/libregrtest/__init__.py
+++ b/Lib/test/libregrtest/__init__.py
@@ -1,5 +1,2 @@
-# We import importlib *ASAP* in order to test #15386
-import importlib
-
 from test.libregrtest.cmdline import _parse_args, RESOURCE_NAMES, ALL_RESOURCES
 from test.libregrtest.main import main

--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -6,9 +6,6 @@ Script to run Python regression tests.
 Run this script with -h or --help for documentation.
 """
 
-# We import importlib *ASAP* in order to test #15386
-import importlib
-
 import os
 import sys
 from test.libregrtest import main

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1,24 +1,22 @@
-# We import importlib *ASAP* in order to test #15386
-import importlib
+import builtins
+import contextlib
+import errno
+import glob
 import importlib.util
 from importlib._bootstrap_external import _get_sourcefile
-import builtins
 import marshal
 import os
 import py_compile
 import random
 import shutil
-import subprocess
 import stat
+import subprocess
 import sys
+import textwrap
 import threading
 import time
 import unittest
-import unittest.mock as mock
-import textwrap
-import errno
-import contextlib
-import glob
+from unittest import mock
 
 import test.support
 from test.support import (


### PR DESCRIPTION
[bpo-15386](https://bugs.python.org/issue15386), [bpo-37473](https://bugs.python.org/issue37473): test_import, regrtest and libregrtest no longer
import importlib as soon as possible, as the first import, "to test
[bpo-15386](https://bugs.python.org/issue15386)".

Sort test_import imports.

<!-- issue-number: [bpo-37473](https://bugs.python.org/issue37473) -->
https://bugs.python.org/issue37473
<!-- /issue-number -->
