### PR TITLE
bpo-37322: Fix test_ssl.test_pha_required_nocert() ResourceWarning

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2382,6 +2382,7 @@ class ThreadedEchoServer(threading.Thread):
                         if self.server.chatty and support.verbose:
                             sys.stdout.write(err.args[1])
                         # test_pha_required_nocert is expecting this exception
+                        self.close()
                         raise ssl.SSLError('tlsv13 alert certificate required')
                 except OSError:
                     if self.server.chatty:


### PR DESCRIPTION
Close the TLS connection in test_pha_required_nocert() of test_ssl to
fix a ResourceWarning.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37322](https://bugs.python.org/issue37322) -->
https://bugs.python.org/issue37322
<!-- /issue-number -->
