### PR TITLE
bpo-37363: Document internal audit events

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -301,8 +301,9 @@ Initializing and finalizing the interpreter
    than once; this can happen if an application calls :c:func:`Py_Initialize` and
    :c:func:`Py_FinalizeEx` more than once.
 
-   .. versionadded:: 3.6
+   .. audit-event:: cpython._PySys_ClearAuditHooks "" c._PySys_ClearAuditHooks
 
+   .. versionadded:: 3.6
 
 .. c:function:: void Py_Finalize()
 
@@ -992,7 +993,7 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    be held, but may be held if it is necessary to serialize calls to this
    function.
 
-   .. audit-event:: cpython.PyInterpreterState_New NULL
+   .. audit-event:: cpython.PyInterpreterState_New "" c.PyInterpreterState_New
 
 
 .. c:function:: void PyInterpreterState_Clear(PyInterpreterState *interp)
@@ -1000,7 +1001,7 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    Reset all information in an interpreter state object.  The global interpreter
    lock must be held.
 
-   .. audit-event:: cpython.PyInterpreterState_Clear NULL
+   .. audit-event:: cpython.PyInterpreterState_Clear "" c.PyInterpreterState_Clear
 
 
 .. c:function:: void PyInterpreterState_Delete(PyInterpreterState *interp)

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -301,7 +301,7 @@ Initializing and finalizing the interpreter
    than once; this can happen if an application calls :c:func:`Py_Initialize` and
    :c:func:`Py_FinalizeEx` more than once.
 
-   .. audit-event:: cpython._PySys_ClearAuditHooks "" c._PySys_ClearAuditHooks
+   .. audit-event:: cpython._PySys_ClearAuditHooks "" c.Py_FinalizeEx
 
    .. versionadded:: 3.6
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -992,11 +992,15 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    be held, but may be held if it is necessary to serialize calls to this
    function.
 
+   .. audit-event:: cpython.PyInterpreterState_New NULL
+
 
 .. c:function:: void PyInterpreterState_Clear(PyInterpreterState *interp)
 
    Reset all information in an interpreter state object.  The global interpreter
    lock must be held.
+
+   .. audit-event:: cpython.PyInterpreterState_Clear NULL
 
 
 .. c:function:: void PyInterpreterState_Delete(PyInterpreterState *interp)

--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -335,15 +335,6 @@ accessible to C code.  They all work with the current interpreter thread's
    .. versionadded:: 3.8
 
 
-.. c:function:: void _PySys_ClearAuditHooks()
-
-   Clears all audit hooks. The function is an internal implementation detail
-   and only mentioned here to document the associated auditing event.
-
-   .. audit-event:: cpython._PySys_ClearAuditHooks NULL
-
-   .. versionadded:: 3.8
-
 .. _processcontrol:
 
 Process Control

--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -335,6 +335,15 @@ accessible to C code.  They all work with the current interpreter thread's
    .. versionadded:: 3.8
 
 
+.. c:function:: void _PySys_ClearAuditHooks()
+
+   Clears all audit hooks. The function is an internal implementation detail
+   and only mentioned here to document the associated auditing event.
+
+   .. audit-event:: cpython._PySys_ClearAuditHooks NULL
+
+   .. versionadded:: 3.8
+
 .. _processcontrol:
 
 Process Control


### PR DESCRIPTION
Three internal cpython events were not documented, yet.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-37363](https://bugs.python.org/issue37363) -->
https://bugs.python.org/issue37363
<!-- /issue-number -->
