### PR TITLE
bpo-37322: Fix again test_ssl.test_pha_required_nocert() ResourceWarning

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2382,7 +2382,6 @@ class ThreadedEchoServer(threading.Thread):
                         if self.server.chatty and support.verbose:
                             sys.stdout.write(err.args[1])
                         # test_pha_required_nocert is expecting this exception
-                        self.close()
                         raise ssl.SSLError('tlsv13 alert certificate required')
                 except OSError:
                     if self.server.chatty:
@@ -2460,6 +2459,7 @@ class ThreadedEchoServer(threading.Thread):
                 handler = self.ConnectionHandler(self, newconn, connaddr)
                 handler.start()
                 handler.join()
+                handler.close()
             except socket.timeout:
                 pass
             except KeyboardInterrupt:


### PR DESCRIPTION
test_ssl.test_pha_required_nocert(): only close the TLS connection at
the server side once the handler completed.

<!-- issue-number: [bpo-37322](https://bugs.python.org/issue37322) -->
https://bugs.python.org/issue37322
<!-- /issue-number -->
