### PR TITLE
bpo-37120: Fix _ssl get_num_tickets()

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3641,7 +3641,7 @@ set_maximum_version(PySSLContext *self, PyObject *arg, void *c)
 static PyObject *
 get_num_tickets(PySSLContext *self, void *c)
 {
-    return PyLong_FromLong(SSL_CTX_get_num_tickets(self->ctx));
+    return PyLong_FromSize_t(SSL_CTX_get_num_tickets(self->ctx));
 }
 
 static int


### PR DESCRIPTION
Replace PyLong_FromLong() with PyLong_FromSize_t():
SSL_CTX_get_num_tickets() return type is size_t.

<!-- issue-number: [bpo-37120](https://bugs.python.org/issue37120) -->
https://bugs.python.org/issue37120
<!-- /issue-number -->
