### PR TITLE
Remove redundant check from arraymodule b_getitem

### DIFF
--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -185,9 +185,7 @@ in bounds; that's the responsibility of the caller.
 static PyObject *
 b_getitem(arrayobject *ap, Py_ssize_t i)
 {
-    long x = ((char *)ap->ob_item)[i];
-    if (x >= 128)
-        x -= 256;
+    long x = ((signed char *)ap->ob_item)[i];
     return PyLong_FromLong(x);
 }
 


### PR DESCRIPTION
The `arraymodule`'s `b_getitem` function returns a `PyLong` converted 
from `arrayobject`'s array, by dereferencing a pointer to `char`.

When the `char` type is `signed char`, the `if (x >= 128) x -= 256;` comparison/code is redundant because a `signed char` will have a value of `[-128, 127]` and so `x` will never be greater or equal than 128.

This check was indeed needed for situations where a given compiler would assume `char` being `unsigned char` which would make `x` in `[0, 256]` range.

However, the check can be removed if we cast the `ob_item` into a signed char pointer (`signed char*`) instead of `char*`.

This PR/commit introduces this change.

This issue has been found with Semmle's [LGTM](https://lgtm.com/).