### PR TITLE
Added example snippet for str.isupper()

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1779,6 +1779,20 @@ expression support in the :mod:`re` module).
    Return true if all cased characters [4]_ in the string are uppercase and
    there is at least one cased character, false otherwise.
 
+      >>> s = 'BANANA'
+      >>> s.isupper()
+      True
+      >>> s = 'banana'
+      >>> s.isupper()
+      False
+      >>> s = 'baNana'
+      >>> s.isupper()
+      False
+      >>> s = ' '
+      >>> s.isupper()
+      False
+
+
 
 .. method:: str.join(iterable)
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1779,17 +1779,13 @@ expression support in the :mod:`re` module).
    Return true if all cased characters [4]_ in the string are uppercase and
    there is at least one cased character, false otherwise.
 
-      >>> s = 'BANANA'
-      >>> s.isupper()
+      >>> 'BANANA'.isupper()
       True
-      >>> s = 'banana'
-      >>> s.isupper()
+      >>> 'banana'.isupper()
       False
-      >>> s = 'baNana'
-      >>> s.isupper()
+      >>> 'baNana'.isupper()
       False
-      >>> s = ' '
-      >>> s.isupper()
+      >>> ' '.isupper()
       False
 
 


### PR DESCRIPTION
Hi Team,

I have added an example snippet for the `str.isupper()` method in the documentation.

This is my first contribution and pull request. Please let me know if I am doing it correctly. I am a bit unsure about whether I should have run any tests for making changes to the documentation.

EDIT: Just finished signing the CLA.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
