### PR TITLE
bpo-29548: no longer use PyEval_Call* functions

### DIFF
--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -208,7 +208,7 @@ call_with_frame(const char *funcname, int lineno, PyObject* func, PyObject* args
 {
     PyObject *res;
 
-    res = PyEval_CallObject(func, args);
+    res = PyObject_Call(func, args, NULL);
     if (res == NULL) {
         _PyTraceback_Add(funcname, __FILE__, lineno);
         XML_StopParser(self->itself, XML_FALSE);

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1667,8 +1667,7 @@ _PyErr_CheckSignals(void)
             _Py_atomic_store_relaxed(&Handlers[i].tripped, 0);
 
             if (arglist) {
-                result = PyEval_CallObject(Handlers[i].func,
-                                           arglist);
+                result = PyObject_Call(Handlers[i].func, arglist, NULL);
                 Py_DECREF(arglist);
             }
             if (!result) {

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -457,7 +457,16 @@ PyEval_CallObjectWithKeywords(PyObject *callable,
 PyObject *
 PyObject_CallObject(PyObject *callable, PyObject *args)
 {
-    return PyEval_CallObjectWithKeywords(callable, args, NULL);
+    assert(!PyErr_Occurred());
+    if (args == NULL) {
+        return _PyObject_CallNoArg(callable);
+    }
+    if (!PyTuple_Check(args)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "argument list must be a tuple");
+        return NULL;
+    }
+    return PyObject_Call(callable, args, NULL);
 }
 
 

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -416,7 +416,7 @@ _PyCodec_EncodeInternal(PyObject *object,
     if (args == NULL)
         goto onError;
 
-    result = PyEval_CallObject(encoder, args);
+    result = PyObject_Call(encoder, args, NULL);
     if (result == NULL) {
         wrap_codec_error("encoding", encoding);
         goto onError;
@@ -462,7 +462,7 @@ _PyCodec_DecodeInternal(PyObject *object,
     if (args == NULL)
         goto onError;
 
-    result = PyEval_CallObject(decoder,args);
+    result = PyObject_Call(decoder, args, NULL);
     if (result == NULL) {
         wrap_codec_error("decoding", encoding);
         goto onError;


### PR DESCRIPTION
The `PyEval_Call*` functions should not be used anymore. This fixes the last few places where they are called within CPython.

CC @methane 

<!-- issue-number: [bpo-29548](https://bugs.python.org/issue29548) -->
https://bugs.python.org/issue29548
<!-- /issue-number -->
