### PR TITLE
bpo-37151: remove special case for PyCFunction from PyObject_Call

### DIFF
--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -39,7 +39,7 @@ PyAPI_FUNC(int) PyCFunction_GetFlags(PyObject *);
 #define PyCFunction_GET_FLAGS(func) \
         (((PyCFunctionObject *)func) -> m_ml -> ml_flags)
 #endif
-PyAPI_FUNC(PyObject *) PyCFunction_Call(PyObject *, PyObject *, PyObject *);
+Py_DEPRECATED(3.9) PyAPI_FUNC(PyObject *) PyCFunction_Call(PyObject *, PyObject *, PyObject *);
 
 struct PyMethodDef {
     const char  *ml_name;   /* The name of the built-in function/method */

--- a/Misc/NEWS.d/next/C API/2019-07-16-11-02-00.bpo-37151.YKfuNA.rst
+++ b/Misc/NEWS.d/next/C API/2019-07-16-11-02-00.bpo-37151.YKfuNA.rst
@@ -1,1 +1,1 @@
-``PyCFunction_Call`` is now an alias of :c:func:`PyObject_Call`.
+``PyCFunction_Call`` is now a deprecated alias of :c:func:`PyObject_Call`.

--- a/Misc/NEWS.d/next/C API/2019-07-16-11-02-00.bpo-37151.YKfuNA.rst
+++ b/Misc/NEWS.d/next/C API/2019-07-16-11-02-00.bpo-37151.YKfuNA.rst
@@ -1,0 +1,1 @@
+``PyCFunction_Call`` is now an alias of :c:func:`PyObject_Call`.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -5,9 +5,6 @@
 #include "frameobject.h"
 
 
-static PyObject *
-cfunction_call_varargs(PyObject *func, PyObject *args, PyObject *kwargs);
-
 static PyObject *const *
 _PyStack_UnpackDict(PyObject *const *args, Py_ssize_t nargs, PyObject *kwargs,
                     PyObject **p_kwnames);
@@ -236,11 +233,6 @@ PyObject_Call(PyObject *callable, PyObject *args, PyObject *kwargs)
     if (_PyVectorcall_Function(callable) != NULL) {
         return PyVectorcall_Call(callable, args, kwargs);
     }
-    else if (PyCFunction_Check(callable)) {
-        /* This must be a METH_VARARGS function, otherwise we would be
-         * in the previous case */
-        return cfunction_call_varargs(callable, args, kwargs);
-    }
     else {
         call = callable->ob_type->tp_call;
         if (call == NULL) {
@@ -361,60 +353,6 @@ _PyFunction_Vectorcall(PyObject *func, PyObject* const* stack,
                                     nkwargs, 1,
                                     d, (int)nd, kwdefs,
                                     closure, name, qualname);
-}
-
-
-/* --- PyCFunction call functions --------------------------------- */
-
-static PyObject *
-cfunction_call_varargs(PyObject *func, PyObject *args, PyObject *kwargs)
-{
-    assert(!PyErr_Occurred());
-    assert(kwargs == NULL || PyDict_Check(kwargs));
-
-    PyCFunction meth = PyCFunction_GET_FUNCTION(func);
-    PyObject *self = PyCFunction_GET_SELF(func);
-    PyObject *result;
-
-    assert(PyCFunction_GET_FLAGS(func) & METH_VARARGS);
-    if (PyCFunction_GET_FLAGS(func) & METH_KEYWORDS) {
-        if (Py_EnterRecursiveCall(" while calling a Python object")) {
-            return NULL;
-        }
-
-        result = (*(PyCFunctionWithKeywords)(void(*)(void))meth)(self, args, kwargs);
-
-        Py_LeaveRecursiveCall();
-    }
-    else {
-        if (kwargs != NULL && PyDict_GET_SIZE(kwargs) != 0) {
-            PyErr_Format(PyExc_TypeError, "%.200s() takes no keyword arguments",
-                         ((PyCFunctionObject*)func)->m_ml->ml_name);
-            return NULL;
-        }
-
-        if (Py_EnterRecursiveCall(" while calling a Python object")) {
-            return NULL;
-        }
-
-        result = (*meth)(self, args);
-
-        Py_LeaveRecursiveCall();
-    }
-
-    return _Py_CheckFunctionResult(func, result, NULL);
-}
-
-
-PyObject *
-PyCFunction_Call(PyObject *func, PyObject *args, PyObject *kwargs)
-{
-    /* For METH_VARARGS, we cannot use vectorcall as the vectorcall pointer
-     * is NULL. This is intentional, since vectorcall would be slower. */
-    if (PyCFunction_GET_FLAGS(func) & METH_VARARGS) {
-        return cfunction_call_varargs(func, args, kwargs);
-    }
-    return PyVectorcall_Call(func, args, kwargs);
 }
 
 

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -253,6 +253,13 @@ PyObject_Call(PyObject *callable, PyObject *args, PyObject *kwargs)
 }
 
 
+PyObject *
+PyCFunction_Call(PyObject *callable, PyObject *args, PyObject *kwargs)
+{
+    return PyObject_Call(callable, args, kwargs);
+}
+
+
 /* --- PyFunction call functions ---------------------------------- */
 
 static PyObject* _Py_HOT_FUNCTION

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -28,6 +28,8 @@ static PyObject * cfunction_vectorcall_NOARGS(
     PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames);
 static PyObject * cfunction_vectorcall_O(
     PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames);
+static PyObject * cfunction_call(
+    PyObject *func, PyObject *args, PyObject *kwargs);
 
 
 PyObject *
@@ -312,7 +314,7 @@ PyTypeObject PyCFunction_Type = {
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
     (hashfunc)meth_hash,                        /* tp_hash */
-    PyCFunction_Call,                           /* tp_call */
+    cfunction_call,                             /* tp_call */
     0,                                          /* tp_str */
     PyObject_GenericGetAttr,                    /* tp_getattro */
     0,                                          /* tp_setattro */
@@ -484,8 +486,8 @@ cfunction_vectorcall_O(
 }
 
 
-PyObject *
-PyCFunction_Call(PyObject *func, PyObject *args, PyObject *kwargs)
+static PyObject *
+cfunction_call(PyObject *func, PyObject *args, PyObject *kwargs)
 {
     assert(!PyErr_Occurred());
     assert(kwargs == NULL || PyDict_Check(kwargs));

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4997,7 +4997,7 @@ do_call_core(PyThreadState *tstate, PyObject *func, PyObject *callargs, PyObject
     PyObject *result;
 
     if (PyCFunction_Check(func)) {
-        C_TRACE(result, PyCFunction_Call(func, callargs, kwdict));
+        C_TRACE(result, PyObject_Call(func, callargs, kwdict));
         return result;
     }
     else if (Py_TYPE(func) == &PyMethodDescr_Type) {

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1564,7 +1564,7 @@ class Frame(object):
             return False
 
         if (caller.startswith('cfunction_vectorcall_') or
-            caller == 'cfunction_call_varargs'):
+            caller == 'PyCFunction_Call'):
             arg_name = 'func'
             # Within that frame:
             #   "func" is the local containing the PyObject* of the

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1564,7 +1564,7 @@ class Frame(object):
             return False
 
         if (caller.startswith('cfunction_vectorcall_') or
-            caller == 'PyCFunction_Call'):
+            caller == 'cfunction_call'):
             arg_name = 'func'
             # Within that frame:
             #   "func" is the local containing the PyObject* of the


### PR DESCRIPTION
The function `PyObject_Call` contains a special case for calling instances of `PyCFunction` with `METH_VARARGS`. This is to avoid a double recursion check: `cfunction_call_varargs` already calls `Py_EnterRecursiveCall`, so `PyObject_Call` should not. We can simplify this by removing the recursion check from `cfunction_call_varargs` and removing the special case from `PyObject_Call`.

In addition, we fold `cfunction_call_varargs` into `PyCFunction_Call` and move it back to `Objects/methodobject.c` which already contains the vectorcall functions of `PyCFunction`.

<!-- issue-number: [bpo-37151](https://bugs.python.org/issue37151) -->
https://bugs.python.org/issue37151
<!-- /issue-number -->
