### PR TITLE
bpo-21478: Record calls to parent when autospecced objects are used as child with attach_mock

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -467,10 +467,19 @@ class NonCallableMock(Base):
         Attach a mock as an attribute of this one, replacing its name and
         parent. Calls to the attached mock will be recorded in the
         `method_calls` and `mock_calls` attributes of this one."""
-        mock._mock_parent = None
-        mock._mock_new_parent = None
-        mock._mock_name = ''
-        mock._mock_new_name = None
+
+        # When autospecced object is passed to attach_mock then clear
+        # name and parent of the mock attribute which holds the actual
+        # mock object.
+        if isinstance(mock, FunctionTypes) and hasattr(mock, 'mock'):
+            inner_mock = mock.mock
+        else:
+            inner_mock = mock
+
+        inner_mock._mock_parent = None
+        inner_mock._mock_new_parent = None
+        inner_mock._mock_name = ''
+        inner_mock._mock_new_name = None
 
         setattr(self, attribute, mock)
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1817,13 +1817,13 @@ class MockTest(unittest.TestCase):
         parent = Mock()
 
         with mock.patch(f'{__name__}.something', autospec=True) as mock_func:
-            self.assertEqual('something', mock_func.mock._extract_mock_name())
+            self.assertEqual(mock_func.mock._extract_mock_name(), 'something')
             parent.attach_mock(mock_func, 'child')
             parent.child()
 
             self.assertEqual(parent.mock_calls, [call.child()])
             self.assertIn('mock.child', repr(parent.child.mock))
-            self.assertEqual('mock.child', mock_func.mock._extract_mock_name())
+            self.assertEqual(mock_func.mock._extract_mock_name(), 'mock.child')
 
 
     def test_attribute_deletion(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1812,9 +1812,6 @@ class MockTest(unittest.TestCase):
 
 
     def test_attach_mock_patch_autospec(self):
-        # bpo-21478: attach_mock used with autospecced object should have
-        # should use child's name and record calls to parent when being called
-        # as child and also as standalone functions.
         parent = Mock()
 
         with mock.patch(f'{__name__}.something', autospec=True) as mock_func:
@@ -1918,6 +1915,10 @@ class MockTest(unittest.TestCase):
         self.assertRaises(TypeError, mock.child, 1)
         self.assertEqual(mock.mock_calls, [call.child(1, 2)])
         self.assertIn('mock.child', repr(mock.child.mock))
+
+    def test_parent_propagation_with_autospec_attach_mock(self):
+
+        def foo(a, b): pass
 
         parent = Mock()
         parent.attach_mock(create_autospec(foo, name='bar'), 'child')

--- a/Misc/NEWS.d/next/Library/2019-07-10-23-07-11.bpo-21478.cCw9rF.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-10-23-07-11.bpo-21478.cCw9rF.rst
@@ -1,0 +1,2 @@
+Record calls to parent when autospecced object is attached to a mock using
+:func:`unittest.mock.attach_mock`. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
When autospecced object is passed to `attach_mock` the mock object is stored in the `mock` attribute that has `_mock_name` and `_mock_parent` set. For function types passed check for the mock attribute and clear name and parent of it so that `attach_mock` updates the child with correct name and parent in `_check_and_set_parent`.

<!-- issue-number: [bpo-21478](https://bugs.python.org/issue21478) -->
https://bugs.python.org/issue21478
<!-- /issue-number -->
