### PR TITLE
Fix compiler warning in new code.

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1215,7 +1215,7 @@ _Py_GetAllocatedBlocks(void)
     /* add up allocated blocks for used pools */
     for (uint i = 0; i < maxarenas; ++i) {
         /* Skip arenas which are not allocated. */
-        if (arenas[i].address == NULL) {
+        if (arenas[i].address == 0) {
             continue;
         }
 


### PR DESCRIPTION
Fix compiler warning in new code.

uintptr_t is an integer type, and can't be compared to NULL directly.
