### PR TITLE
closes bpo-37554: Remove `q:q` in os.rst documentation

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2098,7 +2098,7 @@ features:
 
    On Windows, if *dst* exists a :exc:`FileExistsError` is always raised.
 
-   On Unix, if *src* is a file and *dst* is a directory or vice-versa, anq:q
+   On Unix, if *src* is a file and *dst* is a directory or vice-versa, an
    :exc:`IsADirectoryError` or a :exc:`NotADirectoryError` will be raised
    respectively.  If both are directories and *dst* is empty, *dst* will be
    silently replaced.  If *dst* is a non-empty directory, an :exc:`OSError`


### PR DESCRIPTION



<!-- issue-number: [bpo-37554](https://bugs.python.org/issue37554) -->
https://bugs.python.org/issue37554
<!-- /issue-number -->
