### PR TITLE
bpo-32381: .pyc files with non-ASCII paths cannot be reopened on Windows

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -438,6 +438,15 @@ class CmdLineTest(unittest.TestCase):
             self.assertEqual(b"", out)
             self.assertEqual(b"", err)
 
+    def test_issue32381(self):
+        # On Windows, a .pyc file with a non-ASCII path could not be reopened.
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'ߢߢscript')
+            py_compile.compile(script_name, doraise=True)
+            pyc_file = support.make_legacy_pyc(script_name)
+            self._check_script(pyc_file, pyc_file, pyc_file, script_dir, None,
+                               importlib.machinery.SourcelessFileLoader)
+
     @contextlib.contextmanager
     def setup_test_pkg(self, *args):
         with support.temp_dir() as script_dir, \

--- a/Misc/NEWS.d/next/Windows/2019-07-10-22-45-57.bpo-32381.w2sqTK.rst
+++ b/Misc/NEWS.d/next/Windows/2019-07-10-22-45-57.bpo-32381.w2sqTK.rst
@@ -1,0 +1,1 @@
+``.pyc`` files with non-ASCII paths can now be reopened on Windows.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1365,7 +1365,7 @@ _Py_wfopen(const wchar_t *path, const wchar_t *mode)
     return f;
 }
 
-/* Wrapper to fopen().
+/* Open a file.
 
    The file descriptor is created non-inheritable.
 
@@ -1377,14 +1377,13 @@ _Py_fopen(const char *pathname, const char *mode)
         return NULL;
     }
 
-    FILE *f = fopen(pathname, mode);
-    if (f == NULL)
-        return NULL;
-    if (make_non_inheritable(fileno(f)) < 0) {
-        fclose(f);
+    PyObject *path = PyUnicode_DecodeFSDefault(pathname);
+    if (path == NULL) {
         return NULL;
     }
-    return f;
+    FILE *ret = _Py_fopen_obj(path, mode);
+    Py_DECREF(path);
+    return ret;
 }
 
 /* Open a file. Call _wfopen() on Windows, or encode the path to the filesystem


### PR DESCRIPTION


<!-- issue-number: [bpo-32381](https://bugs.python.org/issue32381) -->
https://bugs.python.org/issue32381
<!-- /issue-number -->
