### PR TITLE
bpo-37555: Update _CallList.__contains__ to respect ANY

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -348,7 +348,7 @@ class _CallList(list):
         self_list = list(self)
         other_list = list(other)
         # checking equality both directions is necessary for ANY to work
-        return self_list == other_list or other_list == self_list
+        return self_list.__eq__(other_list) or other_list.__eq__(self_list)
 
 
 def _check_and_set_parent(parent, value, name, new_name):
@@ -2412,8 +2412,8 @@ class _Call(tuple):
         self_params = self_args, self_kwargs
         other_params = other_args, other_kwargs
         return (
-            self_params == other_params
-            or other_params == self_params
+            self_params.__eq__(other_params)
+            or other_params.__eq__(self_params)
         )
 
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -814,7 +814,8 @@ class NonCallableMock(Base):
             else:
                 name, args, kwargs = _call
             try:
-                return call(name, sig.bind(*args, **kwargs))
+                bound_call = sig.bind(*args, **kwargs)
+                return call(name, bound_call.args, bound_call.kwargs)
             except TypeError as e:
                 return e.with_traceback(None)
         else:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -337,12 +337,18 @@ class _CallList(list):
 
         for i in range(0, len_self - len_value + 1):
             sub_list = self[i:i+len_value]
-            if sub_list == value:
+            if value == sub_list:
                 return True
         return False
 
     def __repr__(self):
         return pprint.pformat(list(self))
+
+    def __eq__(self, other):
+        self_list = list(self)
+        other_list = list(other)
+        # checking equality both directions is necessary for ANY to work
+        return self_list.__eq__(other_list) or other_list.__eq__(self_list)
 
 
 def _check_and_set_parent(parent, value, name, new_name):
@@ -2293,7 +2299,6 @@ def _format_call_signature(name, args, kwargs):
     return message % formatted_args
 
 
-
 class _Call(tuple):
     """
     A tuple for holding the results of a call to a mock, either in the form
@@ -2403,8 +2408,12 @@ class _Call(tuple):
         if self_name and other_name != self_name:
             return False
 
-        # this order is important for ANY to work!
-        return (other_args, other_kwargs) == (self_args, self_kwargs)
+        self_params = self_args, self_kwargs
+        other_params = other_args, other_kwargs
+        return (
+            self_params.__eq__(other_params)
+            or other_params.__eq__(self_params)
+        )
 
 
     __ne__ = object.__ne__

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -337,7 +337,7 @@ class _CallList(list):
 
         for i in range(0, len_self - len_value + 1):
             sub_list = self[i:i+len_value]
-            if sub_list == value:
+            if value == sub_list:
                 return True
         return False
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -348,7 +348,7 @@ class _CallList(list):
         self_list = list(self)
         other_list = list(other)
         # checking equality both directions is necessary for ANY to work
-        return self_list.__eq__(other_list) or other_list.__eq__(self_list)
+        return self_list == other_list or other_list == self_list
 
 
 def _check_and_set_parent(parent, value, name, new_name):
@@ -2411,8 +2411,8 @@ class _Call(tuple):
         self_params = self_args, self_kwargs
         other_params = other_args, other_kwargs
         return (
-            self_params.__eq__(other_params)
-            or other_params.__eq__(self_params)
+            self_params == other_params
+            or other_params == self_params
         )
 
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -337,18 +337,12 @@ class _CallList(list):
 
         for i in range(0, len_self - len_value + 1):
             sub_list = self[i:i+len_value]
-            if value == sub_list:
+            if sub_list == value:
                 return True
         return False
 
     def __repr__(self):
         return pprint.pformat(list(self))
-
-    def __eq__(self, other):
-        self_list = list(self)
-        other_list = list(other)
-        # checking equality both directions is necessary for ANY to work
-        return self_list == other_list or other_list == self_list
 
 
 def _check_and_set_parent(parent, value, name, new_name):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -337,12 +337,18 @@ class _CallList(list):
 
         for i in range(0, len_self - len_value + 1):
             sub_list = self[i:i+len_value]
-            if sub_list == value:
+            if value == sub_list:
                 return True
         return False
 
     def __repr__(self):
         return pprint.pformat(list(self))
+
+    def __eq__(self, other):
+        self_list = list(self)
+        other_list = list(other)
+        # checking equality both directions is necessary for ANY to work
+        return self_list == other_list or other_list == self_list
 
 
 def _check_and_set_parent(parent, value, name, new_name):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -337,7 +337,7 @@ class _CallList(list):
 
         for i in range(0, len_self - len_value + 1):
             sub_list = self[i:i+len_value]
-            if value == sub_list:
+            if sub_list == value:
                 return True
         return False
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -820,7 +820,7 @@ class NonCallableMock(Base):
             else:
                 name, args, kwargs = _call
             try:
-                return name, sig.bind(*args, **kwargs)
+                return call(name, sig.bind(*args, **kwargs))
             except TypeError as e:
                 return e.with_traceback(None)
         else:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -337,18 +337,12 @@ class _CallList(list):
 
         for i in range(0, len_self - len_value + 1):
             sub_list = self[i:i+len_value]
-            if value == sub_list:
+            if sub_list == value:
                 return True
         return False
 
     def __repr__(self):
         return pprint.pformat(list(self))
-
-    def __eq__(self, other):
-        self_list = list(self)
-        other_list = list(other)
-        # checking equality both directions is necessary for ANY to work
-        return self_list.__eq__(other_list) or other_list.__eq__(self_list)
 
 
 def _check_and_set_parent(parent, value, name, new_name):
@@ -2300,6 +2294,7 @@ def _format_call_signature(name, args, kwargs):
     return message % formatted_args
 
 
+
 class _Call(tuple):
     """
     A tuple for holding the results of a call to a mock, either in the form
@@ -2409,12 +2404,8 @@ class _Call(tuple):
         if self_name and other_name != self_name:
             return False
 
-        self_params = self_args, self_kwargs
-        other_params = other_args, other_kwargs
-        return (
-            self_params.__eq__(other_params)
-            or other_params.__eq__(self_params)
-        )
+        # this order is important for ANY to work!
+        return (other_args, other_kwargs) == (self_args, self_kwargs)
 
 
     __ne__ = object.__ne__

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -864,7 +864,7 @@ class NonCallableMock(Base):
         def _error_message():
             msg = self._format_mock_failure_message(args, kwargs)
             return msg
-        expected = self._call_matcher(_Call((args, kwargs)))
+        expected = self._call_matcher(_Call((args, kwargs), two=True))
         actual = self._call_matcher(self.call_args)
         if actual != expected:
             cause = expected if isinstance(expected, Exception) else None
@@ -2171,9 +2171,9 @@ class AsyncMockMixin(Base):
         Assert the mock has ever been awaited with the specified arguments.
         """
         expected = self._call_matcher(_Call((args, kwargs), two=True))
+        cause = expected if isinstance(expected, Exception) else None
         actual = [self._call_matcher(c) for c in self.await_args_list]
-        if expected not in _AnyComparer(actual):
-            cause = expected if isinstance(expected, Exception) else None
+        if cause or expected not in _AnyComparer(actual):
             expected_string = self._format_mock_call_signature(args, kwargs)
             raise AssertionError(
                 '%s await not found' % expected_string

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -864,7 +864,7 @@ class NonCallableMock(Base):
         def _error_message():
             msg = self._format_mock_failure_message(args, kwargs)
             return msg
-        expected = self._call_matcher(_Call((args, kwargs)))
+        expected = self._call_matcher(_Call((args, kwargs), two=True))
         actual = self._call_matcher(self.call_args)
         if actual != expected:
             cause = expected if isinstance(expected, Exception) else None
@@ -927,9 +927,9 @@ class NonCallableMock(Base):
         `assert_called_with` and `assert_called_once_with` that only pass if
         the call is the most recent one."""
         expected = self._call_matcher(_Call((args, kwargs), two=True))
-        cause = expected if isinstance(expected, Exception) else None
         actual = [self._call_matcher(c) for c in self.call_args_list]
-        if cause or expected not in _AnyComparer(actual):
+        if expected not in actual:
+            cause = expected if isinstance(expected, Exception) else None
             expected_string = self._format_mock_call_signature(args, kwargs)
             raise AssertionError(
                 '%s call not found' % expected_string
@@ -980,23 +980,6 @@ class NonCallableMock(Base):
         if not self.mock_calls:
             return ""
         return f"\n{prefix}: {safe_repr(self.mock_calls)}."
-
-
-class _AnyComparer(list):
-    """A list which checks if it contains a call which may have an
-    argument of ANY, flipping the components of item and self from
-    their traditional locations so that ANY is guaranteed to be on
-    the left."""
-    def __contains__(self, item):
-        for _call in self:
-            if len(item) != len(_call):
-                continue
-            if all([
-                expected == actual
-                for expected, actual in zip(item, _call)
-            ]):
-                return True
-        return False
 
 
 def _try_iter(obj):
@@ -2172,7 +2155,7 @@ class AsyncMockMixin(Base):
         """
         expected = self._call_matcher(_Call((args, kwargs), two=True))
         actual = [self._call_matcher(c) for c in self.await_args_list]
-        if expected not in _AnyComparer(actual):
+        if expected not in actual:
             cause = expected if isinstance(expected, Exception) else None
             expected_string = self._format_mock_call_signature(args, kwargs)
             raise AssertionError(

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -2,8 +2,8 @@ import asyncio
 import inspect
 import unittest
 
-from unittest.mock import (call, AsyncMock, patch, MagicMock, create_autospec,
-                           _AwaitEvent)
+from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock,
+                           create_autospec, _AwaitEvent)
 
 
 def tearDownModule():
@@ -598,6 +598,30 @@ class AsyncMockAssert(unittest.TestCase):
 
         asyncio.run(self._runnable_test('SomethingElse'))
         self.mock.assert_has_awaits(calls)
+
+    def test_awaits_asserts_with_any(self):
+        class Foo:
+            def __eq__(self, other): pass
+
+        asyncio.run(self._runnable_test(Foo(), 1))
+
+        self.mock.assert_has_awaits([call(ANY, 1)])
+        self.mock.assert_awaited_with(ANY, 1)
+        self.mock.assert_any_await(ANY, 1)
+
+    def test_awaits_asserts_with_spec_and_any(self):
+        class Foo:
+            def __eq__(self, other): pass
+
+        mock_with_spec = AsyncMock(spec=Foo)
+
+        async def _custom_mock_runnable_test(*args):
+            await mock_with_spec(*args)
+
+        asyncio.run(_custom_mock_runnable_test(Foo(), 1))
+        mock_with_spec.assert_has_awaits([call(ANY, 1)])
+        mock_with_spec.assert_awaited_with(ANY, 1)
+        mock_with_spec.assert_any_await(ANY, 1)
 
     def test_assert_has_awaits_ordered(self):
         calls = [call('NormalFoo'), call('baz')]

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -184,6 +184,10 @@ class AsyncAutospecTest(unittest.TestCase):
         spec.assert_awaited_with(1, 2, c=3)
         spec.assert_awaited()
 
+        with self.assertRaises(AssertionError):
+            spec.assert_any_await(e=1)
+
+
     def test_patch_with_autospec(self):
 
         async def test_async():

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -184,10 +184,6 @@ class AsyncAutospecTest(unittest.TestCase):
         spec.assert_awaited_with(1, 2, c=3)
         spec.assert_awaited()
 
-        with self.assertRaises(AssertionError):
-            spec.assert_any_await(e=1)
-
-
     def test_patch_with_autospec(self):
 
         async def test_async():

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -322,16 +322,6 @@ class CallTest(unittest.TestCase):
         kall = call(1).method(2)(3).foo.bar.baz(4)(5).__int__()
         self.assertEqual(kall.call_list(), mock.mock_calls)
 
-    def test_call_list_with_any_comparison_order(self):
-        class Foo:
-            def __eq__(self, other): pass
-            def __ne__(self, other): pass
-
-        mock = MagicMock()
-        mock(Foo())
-
-        self.assertEqual(call(ANY).call_list(), mock.mock_calls)
-        self.assertEqual(mock.mock_calls, call(ANY).call_list())
 
     def test_call_any(self):
         self.assertEqual(call, ANY)
@@ -341,16 +331,6 @@ class CallTest(unittest.TestCase):
         self.assertEqual(m.mock_calls, [ANY])
         self.assertEqual([ANY], m.mock_calls)
 
-    def test_call_any_comparison_order(self):
-        class Foo:
-            def __eq__(self, other): pass
-            def __ne__(self, other): pass
-
-        m = MagicMock()
-        m(Foo())
-
-        self.assertEqual(m.mock_calls[0], call(ANY))
-        self.assertEqual(call(ANY), m.mock_calls[0])
 
     def test_two_args_call(self):
         args = _Call(((1, 2), {'a': 3}), two=True)

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -63,7 +63,19 @@ class AnyTest(unittest.TestCase):
             ]
             self.assertEqual(expected, mock.mock_calls)
             self.assertEqual(mock.mock_calls, expected)
+            mock.assert_has_calls(expected)
 
+    def test_assert_has_calls_with_any_and_spec_set(self):
+        # This is a regression test for bpo-37555
+        class Foo(object):
+            def __eq__(self, other): pass
+            def __ne__(self, other): pass
+
+        mock = Mock(spec_set=Foo)
+        expected = [call(ANY)]
+        mock(Foo())
+
+        mock.assert_has_calls(expected)
 
 
 class CallTest(unittest.TestCase):

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -63,20 +63,29 @@ class AnyTest(unittest.TestCase):
             ]
             self.assertEqual(expected, mock.mock_calls)
             self.assertEqual(mock.mock_calls, expected)
-            mock.assert_has_calls(expected)
 
-    def test_assert_has_calls_with_any_and_spec_set(self):
+    def test_any_no_spec(self):
         # This is a regression test for bpo-37555
-        class Foo(object):
+        class Foo:
             def __eq__(self, other): pass
-            def __ne__(self, other): pass
 
-        mock = Mock(spec_set=Foo)
-        expected = [call(ANY)]
-        mock(Foo())
+        mock = Mock()
+        mock(Foo(), 1)
+        mock.assert_has_calls([call(ANY, 1)])
+        mock.assert_called_with(ANY, 1)
+        mock.assert_any_call(ANY, 1)
 
-        mock.assert_has_calls(expected)
+    def test_any_and_spec_set(self):
+        # This is a regression test for bpo-37555
+        class Foo:
+            def __eq__(self, other): pass
 
+        mock = Mock(spec=Foo)
+
+        mock(Foo(), 1)
+        mock.assert_has_calls([call(ANY, 1)])
+        mock.assert_called_with(ANY, 1)
+        mock.assert_any_call(ANY, 1)
 
 class CallTest(unittest.TestCase):
 

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -322,6 +322,16 @@ class CallTest(unittest.TestCase):
         kall = call(1).method(2)(3).foo.bar.baz(4)(5).__int__()
         self.assertEqual(kall.call_list(), mock.mock_calls)
 
+    def test_call_list_with_any_comparison_order(self):
+        class Foo:
+            def __eq__(self, other): pass
+            def __ne__(self, other): pass
+
+        mock = MagicMock()
+        mock(Foo())
+
+        self.assertEqual(call(ANY).call_list(), mock.mock_calls)
+        self.assertEqual(mock.mock_calls, call(ANY).call_list())
 
     def test_call_any(self):
         self.assertEqual(call, ANY)
@@ -331,6 +341,16 @@ class CallTest(unittest.TestCase):
         self.assertEqual(m.mock_calls, [ANY])
         self.assertEqual([ANY], m.mock_calls)
 
+    def test_call_any_comparison_order(self):
+        class Foo:
+            def __eq__(self, other): pass
+            def __ne__(self, other): pass
+
+        m = MagicMock()
+        m(Foo())
+
+        self.assertEqual(m.mock_calls[0], call(ANY))
+        self.assertEqual(call(ANY), m.mock_calls[0])
 
     def test_two_args_call(self):
         args = _Call(((1, 2), {'a': 3}), two=True)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -496,6 +496,7 @@ Tomer Filiba
 Segev Finer
 Jeffrey Finkelstein
 Russell Finn
+Neal Finne
 Dan Finnie
 Nils Fischbeck
 Frederik Fix
@@ -1699,6 +1700,7 @@ Roger Upole
 Daniel Urban
 Michael Urman
 Hector Urtubia
+Elizabeth Uselton
 Lukas Vacek
 Ville Vainio
 Andi Vajda

--- a/Misc/NEWS.d/next/Library/2019-07-19-20-13-48.bpo-37555.S5am28.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-19-20-13-48.bpo-37555.S5am28.rst
@@ -1,0 +1,4 @@
+Fix `NonCallableMock._call_matcher` returning tuple instead of `_Call` object
+when `self._spec_signature` exists. Additionally fix `__eq__` to be
+commutative on `_Call` and `_CallList`, to better account for `ANY`. Patch by
+Elizabeth Uselton

--- a/Misc/NEWS.d/next/Library/2019-07-19-20-13-48.bpo-37555.S5am28.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-19-20-13-48.bpo-37555.S5am28.rst
@@ -1,4 +1,2 @@
 Fix `NonCallableMock._call_matcher` returning tuple instead of `_Call` object
-when `self._spec_signature` exists. Additionally fix `__eq__` to be
-commutative on `_Call` and `_CallList`, to better account for `ANY`. Patch by
-Elizabeth Uselton
+when `self._spec_signature` exists. Patch by Elizabeth Uselton


### PR DESCRIPTION
Greetings! Long time fan of the language, first time submitting a pull request to it.

I have a test on another project that goes something like:

```
@patch('a.place.to.patch')
def test_a_thing_calls_what_it_should(self, my_mock):
    # Set up logic here
    my_mock.assert_has_calls([
        call(
            ANY,
            Decimal('20')
        ),
        call(
            ANY,
            Decimal('10')
        )
    ])
```

Which fails, where my_mock.call_args_list looks like

```
[(<A Django Model>, Decimal('20')), (<A Django Model>, Decimal('10'))]
```

This seems like wrong behavior. ANY should be happy to be compared to anything, even a random object. I've added a test showing the behavior that fails on master.

Doing some digging, I found that in [mock.py](https://github.com/python/cpython/blob/master/Lib/unittest/mock.py#L349) `_CallList` is overriding `__contains__` and comparing each item in the tuples with what I'd passed in to assert_has_calls on the right, which means that instead of using `ANY.__eq__`, it's calling the Django model's `__eq__` with `ANY` as an argument. Django first checks if the thing it's comparing to is another Django model, and returns False if not. So, `<DjangoModel> == ANY` is False, but `ANY == <DjangoModel>` is True. I know that this could also be considered a bug with Django, and I plan to file one with them too, but I don't see any downside to improving the mock library to be more defensive in honoring `ANY` over any other custom class's overridden `__eq__` method.

More digging and I realized the reason this was only a problem on a mock with a spec. Specifically, when a mock is instantiated with a spec, the `_spec_signature` attribute gets assigned, and when `_spec_signature` is not none, `_call_matcher`, which is used to prep the calls for comparison, returns a `tuple` of a string and a `BoundArguments` object instead of a `_Call` ([link here](https://github.com/python/cpython/blob/master/Lib/unittest/mock.py#L822)). When `_call_matcher` returns `_Call` objects, they use `_Call`'s `__eq__` method, which flips the compared calls around, putting `ANY` on the [left](https://github.com/python/cpython/blob/master/Lib/unittest/mock.py#L2412). When `_call_matcher` returns `tuples`, it doesn't use this logic, and `ANY` remains on the right, not being used for comparison. The simplest fix seemed to be to ensure `_call_matcher` always returned a `_Call` object.

I have verified that there are [several tests](https://github.com/python/cpython/blob/adbf178e49113b2de0042e86a1228560475a65c5/Lib/unittest/test/testmock/testhelpers.py#L338) covering the use of spec signature, which make sure that things continue to match regardless of if they are args or kwargs and break when that logic is broken, and none of them break with my change.

<!-- issue-number: [bpo-37555](https://bugs.python.org/issue37555) -->
https://bugs.python.org/issue37555
<!-- /issue-number -->
