### PR TITLE
bpo-37556 Extend help to include latest overrides

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-07-11-06-11-09.bpo-37556.sygMUU.rst
+++ b/Misc/NEWS.d/next/Windows/2019-07-11-06-11-09.bpo-37556.sygMUU.rst
@@ -1,0 +1,1 @@
+Extend py.exe help to mention overrides via venv, shebang, environmental variables & ini files.

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -1415,21 +1415,21 @@ usage:\n\
 %ls [launcher-args] [python-args] [script [script-args]]\n\n", argv[0]);
     fputws(L"\
 Launcher arguments:\n\n\
--2     : Launch the latest* Python 2.x version\n\
--3     : Launch the latest* Python 3.x version\n\
+-2     : Launch the latest Python 2.x version\n\
+-3     : Launch the latest Python 3.x version\n\
 -X.Y   : Launch the specified Python version\n", stdout);
     if (canDo64bit) {
         fputws(L"\
      The above all default to 64 bit if a matching 64 bit python is present*.\n\
 -X.Y-32: Launch the specified 32bit Python version\n\
--X-32  : Launch the latest* 32bit Python X version\n\
+-X-32  : Launch the latest 32bit Python X version\n\
 -X.Y-64: Launch the specified 64bit Python version\n\
--X-64  : Launch the latest* 64bit Python X version", stdout);
+-X-64  : Launch the latest 64bit Python X version", stdout);
     }
     fputws(L"\n-0  --list       : List the available pythons", stdout);
     fputws(L"\n-0p --list-paths : List with paths", stdout);
     fputws(L"\n\n If no script is specified the specified interpreter is opened.", stdout);
-    fputws(L"\n*If an exact version is not given latest can be overriden by:", stdout);
+    fputws(L"\nIf an exact version is not given latest can be overriden by:", stdout);
     fputws(L"\n An active virtual environment", stdout);
     fputws(L"\n A shebang line in the script (if present)", stdout);
     fputws(L"\n Matching PY_PYTHON[n] Enviroment variable(s)", stdout);

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -1433,7 +1433,7 @@ Launcher arguments:\n\n\
     fputws(L"\nany of the following, (in priority order):", stdout);
     fputws(L"\n An active virtual environment", stdout);
     fputws(L"\n A shebang line in the script (if present)", stdout);
-    fputws(L"\n Matching PY_PYTHON2 or 3 Enviroment variable", stdout);
+    fputws(L"\n With -2 or -3 flag a matching PY_PYTHON2 or PY_PYTHON3 Enviroment variable", stdout);
     fputws(L"\n A PY_PYTHON Enviroment variable", stdout);
     fputws(L"\n From [defaults] in py.ini in your %LOCALAPPDATA%\\py.ini", stdout);
     fputws(L"\n From [defaults] in py.ini beside py.exe (use `where py` to locate)", stdout);

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -1420,7 +1420,7 @@ Launcher arguments:\n\n\
 -X.Y   : Launch the specified Python version\n", stdout);
     if (canDo64bit) {
         fputws(L"\
-     The above all default to 64 bit if a matching 64 bit python is present*.\n\
+     The above all default to 64 bit if a matching 64 bit python is present.\n\
 -X.Y-32: Launch the specified 32bit Python version\n\
 -X-32  : Launch the latest 32bit Python X version\n\
 -X.Y-64: Launch the specified 64bit Python version\n\

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -1412,22 +1412,29 @@ show_help_text(wchar_t ** argv)
 Python Launcher for Windows Version %ls\n\n", version_text);
     fwprintf(stdout, L"\
 usage:\n\
-%ls [launcher-args] [python-args] script [script-args]\n\n", argv[0]);
+%ls [launcher-args] [python-args] [script [script-args]]\n\n", argv[0]);
     fputws(L"\
 Launcher arguments:\n\n\
--2     : Launch the latest Python 2.x version\n\
--3     : Launch the latest Python 3.x version\n\
+-2     : Launch the latest* Python 2.x version\n\
+-3     : Launch the latest* Python 3.x version\n\
 -X.Y   : Launch the specified Python version\n", stdout);
     if (canDo64bit) {
         fputws(L"\
-     The above all default to 64 bit if a matching 64 bit python is present.\n\
+     The above all default to 64 bit if a matching 64 bit python is present*.\n\
 -X.Y-32: Launch the specified 32bit Python version\n\
--X-32  : Launch the latest 32bit Python X version\n\
+-X-32  : Launch the latest* 32bit Python X version\n\
 -X.Y-64: Launch the specified 64bit Python version\n\
--X-64  : Launch the latest 64bit Python X version", stdout);
+-X-64  : Launch the latest* 64bit Python X version", stdout);
     }
     fputws(L"\n-0  --list       : List the available pythons", stdout);
     fputws(L"\n-0p --list-paths : List with paths", stdout);
+    fputws(L"\n\n If no script is specified the specified interpreter is opened.", stdout);
+    fputws(L"\n*If an exact version is not given latest can be overriden by:", stdout);
+    fputws(L"\n An active virtual environment", stdout);
+    fputws(L"\n A shebang line in the script (if present)", stdout);
+    fputws(L"\n Matching PY_PYTHON[n] Enviroment variable(s)", stdout);
+    fputws(L"\n From [defaults] in py.ini in your %LOCALAPPDATA%\\py.ini", stdout);
+    fputws(L"\n From [defaults] in py.ini beside py.exe (use where py to locate)", stdout);
     fputws(L"\n\nThe following help text is from Python:\n\n", stdout);
     fflush(stdout);
 }

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -1429,12 +1429,14 @@ Launcher arguments:\n\n\
     fputws(L"\n-0  --list       : List the available pythons", stdout);
     fputws(L"\n-0p --list-paths : List with paths", stdout);
     fputws(L"\n\n If no script is specified the specified interpreter is opened.", stdout);
-    fputws(L"\nIf an exact version is not given latest can be overriden by:", stdout);
+    fputws(L"\nIf an exact version is not given, using the latest version can be overridden by", stdout);
+    fputws(L"\nany of the following, (in priority order):", stdout);
     fputws(L"\n An active virtual environment", stdout);
     fputws(L"\n A shebang line in the script (if present)", stdout);
-    fputws(L"\n Matching PY_PYTHON[n] Enviroment variable(s)", stdout);
+    fputws(L"\n Matching PY_PYTHON2 or 3 Enviroment variable", stdout);
+    fputws(L"\n A PY_PYTHON Enviroment variable", stdout);
     fputws(L"\n From [defaults] in py.ini in your %LOCALAPPDATA%\\py.ini", stdout);
-    fputws(L"\n From [defaults] in py.ini beside py.exe (use where py to locate)", stdout);
+    fputws(L"\n From [defaults] in py.ini beside py.exe (use `where py` to locate)", stdout);
     fputws(L"\n\nThe following help text is from Python:\n\n", stdout);
     fflush(stdout);
 }


### PR DESCRIPTION
Modify the help in cpython/PC/launcher.c to show users that "latest" can be overridden by shebang, PY_PYTHON[n] or py.ini files. Also show that script [args] is optional by enclosing in square brackets.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37556](https://bugs.python.org/issue37556) -->
https://bugs.python.org/issue37556
<!-- /issue-number -->


Automerge-Triggered-By: @zooba