### PR TITLE
bpo-37558: Shared memory tests are failing due to double slashes

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3990,7 +3990,7 @@ class _TestSharedMemory(BaseTestCase):
 
             # Create a shared_memory segment, and send the segment name
             sm = shared_memory.SharedMemory(create=True, size=10)
-            sys.stdout.write(sm._name + '\\n')
+            sys.stdout.write(sm.name + '\\n')
             sys.stdout.flush()
             time.sleep(100)
         '''

--- a/Misc/NEWS.d/next/Tests/2019-07-11-10-33-56.bpo-37558.SKHRsL.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-11-10-33-56.bpo-37558.SKHRsL.rst
@@ -1,0 +1,1 @@
+Fix test_shared_memory_cleaned_after_process_termination name handling


### PR DESCRIPTION
With the addition of shared memory into Python 3.8, we now have three tests failing on Solaris, namely `test_multiprocessing_fork`, `test_multiprocessing_forkserver` and `test_multiprocessing_spawn`. The reason seems to be incorrect name handling which results in two slashes being prepended.

<!-- issue-number: [bpo-37558](https://bugs.python.org/issue37558) -->
https://bugs.python.org/issue37558
<!-- /issue-number -->
