### PR TITLE
bpo-27379: In order to keep backward compatibility, update SocketType's type

### DIFF
--- a/Lib/_compat_pickle.py
+++ b/Lib/_compat_pickle.py
@@ -199,7 +199,6 @@ NAME_MAPPING.update({
     ('__builtin__', 'basestring'): ('builtins', 'str'),
     ('exceptions', 'StandardError'): ('builtins', 'Exception'),
     ('UserDict', 'UserDict'): ('collections', 'UserDict'),
-    ('socket', '_socketobject'): ('socket', 'SocketType'),
 })
 
 REVERSE_NAME_MAPPING.update({
@@ -221,7 +220,6 @@ REVERSE_NAME_MAPPING.update({
         ('SimpleHTTPServer', 'SimpleHTTPRequestHandler'),
     ('http.server', 'CGIHTTPRequestHandler'):
         ('CGIHTTPServer', 'CGIHTTPRequestHandler'),
-    ('_socket', 'socket'): ('socket', '_socketobject'),
 })
 
 PYTHON3_OSERROR_EXCEPTIONS = (

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -61,7 +61,7 @@ EAGAIN = getattr(errno, 'EAGAIN', 11)
 EWOULDBLOCK = getattr(errno, 'EWOULDBLOCK', 11)
 
 __all__ = ["fromfd", "getfqdn", "create_connection", "create_server",
-           "has_dualstack_ipv6", "AddressFamily", "SocketKind"]
+           "has_dualstack_ipv6", "AddressFamily", "SocketKind", "SocketType"]
 __all__.extend(os._get_exports_list(_socket))
 
 # Set up the socket.AF_* socket.SOCK_* constants as members of IntEnums for
@@ -541,6 +541,7 @@ The arguments are the same as for socket() except the default family is AF_UNIX
 if defined on the platform; otherwise, the default is AF_INET.
 """
 
+SocketType = socket
 _blocking_errnos = { EAGAIN, EWOULDBLOCK }
 
 class SocketIO(io.RawIOBase):

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -801,8 +801,7 @@ def requireSocket(*args):
 class GeneralModuleTests(unittest.TestCase):
 
     def test_SocketType_is_socketobject(self):
-        import _socket
-        self.assertTrue(socket.SocketType is _socket.socket)
+        self.assertTrue(socket.SocketType is socket.socket)
         s = socket.socket()
         self.assertIsInstance(s, socket.SocketType)
         s.close()

--- a/Misc/NEWS.d/next/Library/2019-07-13-07-23-14.bpo-27379.EIMrFY.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-13-07-23-14.bpo-27379.EIMrFY.rst
@@ -1,0 +1,1 @@
+Update SocketType to keep back compatible

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7088,10 +7088,6 @@ PyInit__socket(void)
     Py_INCREF(socket_timeout);
     PyModule_AddObject(m, "timeout", socket_timeout);
     Py_INCREF((PyObject *)&sock_type);
-    if (PyModule_AddObject(m, "SocketType",
-                           (PyObject *)&sock_type) != 0)
-        return NULL;
-    Py_INCREF((PyObject *)&sock_type);
     if (PyModule_AddObject(m, "socket",
                            (PyObject *)&sock_type) != 0)
         return NULL;


### PR DESCRIPTION


<!-- issue-number: [bpo-27379](https://bugs.python.org/issue27379) -->
https://bugs.python.org/issue27379
<!-- /issue-number -->
