### PR TITLE
bpo-37553: SendfileUsingSendTest tests timeout too short for Windows …

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5769,7 +5769,8 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
     FILESIZE = (10 * 1024 * 1024)  # 10 MiB
     BUFSIZE = 8192
     FILEDATA = b""
-    TIMEOUT = 2
+    # bpo-37553: This is taking longer than 2 seconds on Windows ARM32 buildbot
+    TIMEOUT = 10 if sys.platform == 'win32' and platform.machine() == 'ARM' else 2
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
The timeout error reproduces very infrequently when test_socket tests are run manually on a Raspberry Pi 3 running Windows IoT Core.  I was able to determine that this timeout is the one causing the failure by making it smaller (0.01 seconds) which caused the tests in question to fail every time.  

I would like to increase the timeout only if the test machine is running Windows ARM32 (aka ARM).

@zooba

<!-- issue-number: [bpo-37553](https://bugs.python.org/issue37553) -->
https://bugs.python.org/issue37553
<!-- /issue-number -->
