### PR TITLE
bpo-37571: Add 'b' to prevent the TypeError exception.

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1178,9 +1178,9 @@ the root-object's underlying buffer.
 Another example that may behave different from what one would expect is this::
 
    >>> s = c_char_p()
-   >>> s.value = "abc def ghi"
+   >>> s.value = b"abc def ghi"
    >>> s.value
-   'abc def ghi'
+   b'abc def ghi'
    >>> s.value is s.value
    False
    >>>

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1183,7 +1183,12 @@ Another example that may behave different from what one would expect is this::
    b'abc def ghi'
    >>> s.value is s.value
    False
-   >>>
+    >>>
+
+.. note::
+
+   Objects instantiated from :class:`c_char_p` can only have their value set to bytes
+   or integers.
 
 Why is it printing ``False``?  ctypes instances are objects containing a memory
 block plus some :term:`descriptor`\s accessing the contents of the memory.


### PR DESCRIPTION
In Python3 is not be able to assign a _str_ to a _c_char_p_, so the 'b' is essential to prevent the TypeError exception.


<!-- issue-number: [bpo-37571](https://bugs.python.org/issue37571) -->
https://bugs.python.org/issue37571
<!-- /issue-number -->
