### PR TITLE
Fix typo in re.escape documentation

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -942,7 +942,7 @@ form.
       >>> print('|'.join(map(re.escape, sorted(operators, reverse=True))))
       /|\-|\+|\*\*|\*
 
-   This functions must not be used for the replacement string in :func:`sub`
+   This function must not be used for the replacement string in :func:`sub`
    and :func:`subn`, only backslashes should be escaped.  For example::
 
       >>> digits_re = r'\d+'


### PR DESCRIPTION
# Fix typo in `re.escape` documentation

There is no issue associated with this because it's a simple typo in the documentation.