### PR TITLE
bpo-37579: Return NotImplemented in Python implementation of __eq__ to match C implementation of datetime for timedelta and time

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -733,7 +733,7 @@ class timedelta:
         if isinstance(other, timedelta):
             return self._cmp(other) == 0
         else:
-            return False
+            return NotImplemented
 
     def __le__(self, other):
         if isinstance(other, timedelta):
@@ -1310,7 +1310,7 @@ class time:
         if isinstance(other, time):
             return self._cmp(other, allow_mixed=True) == 0
         else:
-            return False
+            return NotImplemented
 
     def __le__(self, other):
         if isinstance(other, time):

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -30,7 +30,6 @@ from datetime import tzinfo
 from datetime import time
 from datetime import timezone
 from datetime import date, datetime
-from unittest.mock import ANY
 import time as _time
 
 import _testcapi
@@ -53,6 +52,19 @@ OTHERSTUFF = (10, 34.5, "abc", {}, [], ())
 # XXX Copied from test_float.
 INF = float("inf")
 NAN = float("nan")
+
+
+class ComparesEqualClass(object):
+    """
+    A class that is always equal to whatever you compare it to.
+    """
+
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
 
 #############################################################################
 # module tests
@@ -400,10 +412,12 @@ class HarmlessMixedComparison:
         self.assertIn(me, [1, 20, [], me])
         self.assertIn([], [me, 1, 20, []])
 
-        # Comparison over a type other that is not object's type should return
-        # NotImplemented and fallback to other.__eq__. In this case ANY.__eq__
-        # always returns True.
-        self.assertEqual(me, ANY)
+        # Comparison to objects of unsupported types should return
+        # NotImplemented which falls back to the right hand side's __eq__
+        # method. In this case, ComparesEqualClass.__eq__ always returns True.
+        # ComparesEqualClass.__ne__ always returns False.
+        self.assertTrue(me == ComparesEqualClass())
+        self.assertFalse(me != ComparesEqualClass())
 
     def test_harmful_mixed_comparison(self):
         me = self.theclass(1, 1, 1)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -30,6 +30,7 @@ from datetime import tzinfo
 from datetime import time
 from datetime import timezone
 from datetime import date, datetime
+from unittest.mock import ANY
 import time as _time
 
 import _testcapi
@@ -398,6 +399,11 @@ class HarmlessMixedComparison:
 
         self.assertIn(me, [1, 20, [], me])
         self.assertIn([], [me, 1, 20, []])
+
+        # Comparison over a type other that is not object's type should return
+        # NotImplemented and fallback to other.__eq__. In this case ANY.__eq__
+        # always returns True.
+        self.assertEqual(me, ANY)
 
     def test_harmful_mixed_comparison(self):
         me = self.theclass(1, 1, 1)

--- a/Misc/NEWS.d/next/Library/2019-07-13-10-59-43.bpo-37579.B1Tq9i.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-13-10-59-43.bpo-37579.B1Tq9i.rst
@@ -1,0 +1,4 @@
+Return :exc:`NotImplemented` in Python implementation of ``__eq__`` for
+:class:`~datetime.timedelta` and :class:`~datetime.time` when the other
+object being compared is not of the same type to match C implementation.
+Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
When the other object being compared is not the same type then :exc:`NotImplemented` is returned in C implementation of `datetime.timedelta` and `datetime.time`. Change the Python implementation to match the C implementation

<!-- issue-number: [bpo-37579](https://bugs.python.org/issue37579) -->
https://bugs.python.org/issue37579
<!-- /issue-number -->
