### PR TITLE
bpo-37585: Add support for PyDictValues in dictview_richcompare

### DIFF
--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -68,9 +68,15 @@ class DictSetTest(unittest.TestCase):
 
     def test_dict_values(self):
         d = {1: 10, "a": "ABC"}
+        e = d.copy()
+        f = {1: 11, "a": "CBA"}
         values = d.values()
+
         self.assertEqual(set(values), {10, "ABC"})
         self.assertEqual(len(values), 2)
+        self.assertEqual(d.values(), d.values())
+        self.assertEqual(d.values(), e.values())
+        self.assertNotEqual(d.values(), f.values())
 
     def test_dict_repr(self):
         d = {1: 10, "a": "ABC"}

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4044,10 +4044,10 @@ dictview_richcompare(PyObject *self, PyObject *other, int op)
     PyObject *result;
 
     assert(self != NULL);
-    assert(PyDictViewSet_Check(self));
+    assert(PyDictViewSet_Check(self) || PyDictValues_Check(self));
     assert(other != NULL);
 
-    if (!PyAnySet_Check(other) && !PyDictViewSet_Check(other))
+    if (!PyAnySet_Check(other) && !(PyDictViewSet_Check(other) || PyDictValues_Check(other)))
         Py_RETURN_NOTIMPLEMENTED;
 
     len_self = PyObject_Size(self);
@@ -4527,7 +4527,7 @@ PyTypeObject PyDictValues_Type = {
     0,                                          /* tp_doc */
     (traverseproc)dictview_traverse,            /* tp_traverse */
     0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
+    dictview_richcompare,                       /* tp_richcompare */
     0,                                          /* tp_weaklistoffset */
     (getiterfunc)dictvalues_iter,               /* tp_iter */
     0,                                          /* tp_iternext */


### PR DESCRIPTION
This enables running `a.values() == b.values()` and get the expected
results.

Comparing dicts in this manner works for both `.keys()` and for
`.items()`, so this adds symmetry between the different variants.

<!-- issue-number: [bpo-37585](https://bugs.python.org/issue37585) -->
https://bugs.python.org/issue37585
<!-- /issue-number -->
