### PR TITLE
bpo-33326: Convert lists to frozenset on opcode module for faster indexing

### DIFF
--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -214,3 +214,8 @@ jrel_op('CALL_FINALLY', 162)
 def_op('POP_FINALLY', 163)
 
 del def_op, name_op, jrel_op, jabs_op
+
+for container in __all__:
+    obj = locals()[container]
+    if isinstance(obj, list):
+        locals()[container] = frozenset(obj)


### PR DESCRIPTION
Convert lists to frozenset on opcode module for faster indexing

<!-- issue-number: [bpo-33326](https://bugs.python.org/issue33326) -->
https://bugs.python.org/issue33326
<!-- /issue-number -->
