### PR TITLE
[3.7] bpo-37579: Improve equality behavior for pure Python datetime and time (GH-14726)

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -718,7 +718,7 @@ class timedelta:
         if isinstance(other, timedelta):
             return self._cmp(other) == 0
         else:
-            return False
+            return NotImplemented
 
     def __le__(self, other):
         if isinstance(other, timedelta):
@@ -1261,7 +1261,7 @@ class time:
         if isinstance(other, time):
             return self._cmp(other, allow_mixed=True) == 0
         else:
-            return False
+            return NotImplemented
 
     def __le__(self, other):
         if isinstance(other, time):

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -53,6 +53,19 @@ OTHERSTUFF = (10, 34.5, "abc", {}, [], ())
 INF = float("inf")
 NAN = float("nan")
 
+
+class ComparesEqualClass(object):
+    """
+    A class that is always equal to whatever you compare it to.
+    """
+
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+
 #############################################################################
 # module tests
 
@@ -398,6 +411,13 @@ class HarmlessMixedComparison:
 
         self.assertIn(me, [1, 20, [], me])
         self.assertIn([], [me, 1, 20, []])
+
+        # Comparison to objects of unsupported types should return
+        # NotImplemented which falls back to the right hand side's __eq__
+        # method. In this case, ComparesEqualClass.__eq__ always returns True.
+        # ComparesEqualClass.__ne__ always returns False.
+        self.assertTrue(me == ComparesEqualClass())
+        self.assertFalse(me != ComparesEqualClass())
 
     def test_harmful_mixed_comparison(self):
         me = self.theclass(1, 1, 1)

--- a/Misc/NEWS.d/next/Library/2019-07-13-10-59-43.bpo-37579.B1Tq9i.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-13-10-59-43.bpo-37579.B1Tq9i.rst
@@ -1,0 +1,4 @@
+Return :exc:`NotImplemented` in Python implementation of ``__eq__`` for
+:class:`~datetime.timedelta` and :class:`~datetime.time` when the other
+object being compared is not of the same type to match C implementation.
+Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
Returns NotImplemented for timedelta and time in __eq__ for different types in Python implementation, which matches the C implementation.

This also adds tests to enforce that these objects will fall back to the right hand side's __eq__ and/or __ne__ implementation.

[bpo-37579](https://bugs.python.org/issue37579)
(cherry picked from commit e6b46aafad3427463d6264a68824df4797e682f1)

Co-authored-by: Xtreak <tir.karthi@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37579](https://bugs.python.org/issue37579) -->
https://bugs.python.org/issue37579
<!-- /issue-number -->
