### PR TITLE
bpo-18049: Sync thread stack size to main thread size on macOS

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1057,8 +1057,6 @@ class ThreadingExceptionTests(BaseTestCase):
         lock = threading.Lock()
         self.assertRaises(RuntimeError, lock.release)
 
-    @unittest.skipUnless(sys.platform == 'darwin' and test.support.python_is_optimized(),
-                         'test macosx problem')
     def test_recursion_limit(self):
         # Issue 9670
         # test that excessive recursion within a non-main thread causes

--- a/Misc/NEWS.d/next/macOS/2019-07-13-15-58-18.bpo-18049.MklhQQ.rst
+++ b/Misc/NEWS.d/next/macOS/2019-07-13-15-58-18.bpo-18049.MklhQQ.rst
@@ -1,0 +1,2 @@
+Increase stack size of threads to 16MB on macOS, to match the stack size of
+the main thread. This avoids crashes on deep recursion in threads.

--- a/Misc/NEWS.d/next/macOS/2019-07-13-15-58-18.bpo-18049.MklhQQ.rst
+++ b/Misc/NEWS.d/next/macOS/2019-07-13-15-58-18.bpo-18049.MklhQQ.rst
@@ -1,2 +1,3 @@
-Increase stack size of threads to 16MB on macOS, to match the stack size of
-the main thread. This avoids crashes on deep recursion in threads.
+Increase the default stack size of threads from 5MB to 16MB on macOS, to
+match the stack size of the main thread. This avoids crashes on deep recursion
+in threads.

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -40,7 +40,8 @@
  */
 #if defined(__APPLE__) && defined(THREAD_STACK_SIZE) && THREAD_STACK_SIZE == 0
 #undef  THREAD_STACK_SIZE
-#define THREAD_STACK_SIZE       0x500000
+/* Note: This matches the value of -Wl,-stack_size in configure.ac */
+#define THREAD_STACK_SIZE       0x1000000
 #endif
 #if defined(__FreeBSD__) && defined(THREAD_STACK_SIZE) && THREAD_STACK_SIZE == 0
 #undef  THREAD_STACK_SIZE

--- a/configure
+++ b/configure
@@ -9528,6 +9528,8 @@ then
 		# Issue #18075: the default maximum stack size (8MBytes) is too
 		# small for the default recursion limit. Increase the stack size
 		# to ensure that tests don't crash
+		# Note: This matches the value of THREAD_STACK_SIZE in
+		# thread_pthread.h
 		LINKFORSHARED="-Wl,-stack_size,1000000 $LINKFORSHARED"
 
 		if test "$enable_framework"

--- a/configure.ac
+++ b/configure.ac
@@ -2686,6 +2686,8 @@ then
 		# Issue #18075: the default maximum stack size (8MBytes) is too
 		# small for the default recursion limit. Increase the stack size
 		# to ensure that tests don't crash
+		# Note: This matches the value of THREAD_STACK_SIZE in
+		# thread_pthread.h
 		LINKFORSHARED="-Wl,-stack_size,1000000 $LINKFORSHARED"
 
 		if test "$enable_framework"


### PR DESCRIPTION
This changeset increases the size of the stack
for threads on macOS to the size of the stack
of the main thread and reenables the relevant
recursion test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-18049](https://bugs.python.org/issue18049) -->
https://bugs.python.org/issue18049
<!-- /issue-number -->
