### PR TITLE
bpo-36261: email example was misusing preamble field

### DIFF
--- a/Doc/includes/email-mime.py
+++ b/Doc/includes/email-mime.py
@@ -14,7 +14,7 @@ msg['Subject'] = 'Our family reunion'
 # family = the list of all recipients' email addresses
 msg['From'] = me
 msg['To'] = ', '.join(family)
-msg.preamble = 'Our family reunion'
+msg.preamble = 'You will not see this in a MIME-aware mail reader.\n'
 
 # Open the files in binary mode.  Use imghdr to figure out the
 # MIME subtype for each specific image.


### PR DESCRIPTION


<!-- issue-number: [bpo-36261](https://bugs.python.org/issue36261) -->
https://bugs.python.org/issue36261
<!-- /issue-number -->
