### PR TITLE
bpo-37587: Make json.loads faster for long strings

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-07-13-16-02-48.bpo-37587.fd-1aF.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-13-16-02-48.bpo-37587.fd-1aF.rst
@@ -1,0 +1,1 @@
+Make json.loads faster for long strings. (Patch by Marco Paolini)

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -434,19 +434,20 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
     while (1) {
         /* Find the end of the string or the next escape */
         Py_UCS4 c = 0;
-        next = end;
-        /* This is a tight loop in a hot path so we try to avoid
-           MOV from the register variable into memory. See bpo-37587 */
-        for (Py_UCS4 c_in = 0; next < len; next++) {
-            c_in = PyUnicode_READ(kind, buf, next);
-            if (c_in == '"' || c_in == '\\') {
-                c = c_in;
+        Py_ssize_t invalid = -1;
+        for (next = end; next < len; next++) {
+            c = PyUnicode_READ(kind, buf, next);
+            if (c == '"' || c == '\\') {
                 break;
             }
-            else if (c_in <= 0x1f && strict) {
-                raise_errmsg("Invalid control character at", pystr, next);
-                goto bail;
-            }
+            /* Defer the strict error until outside this (hot) loop. */
+            /* See bpo-37587 */
+            if (c <= 0x1f && invalid < 0)
+              invalid = next;
+        }
+        if (strict && invalid >= 0) {
+            raise_errmsg("Invalid control character at", pystr, invalid);
+            goto bail;
         }
         if (!(c == '"' || c == '\\')) {
             raise_errmsg("Unterminated string starting at", pystr, begin);

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -434,21 +434,15 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
     while (1) {
         /* Find the end of the string or the next escape */
         Py_UCS4 c = 0;
-        Py_ssize_t invalid = -1;
         for (next = end; next < len; next++) {
             c = PyUnicode_READ(kind, buf, next);
             if (c == '"' || c == '\\') {
                 break;
             }
-            /* Defer the strict error until outside this (hot) loop. */
-            /* See bpo-37587 */
-            if (c <= 0x1f && invalid < 0) {
-                invalid = next;
+            else if (c <= 0x1f && strict) {
+                raise_errmsg("Invalid control character at", pystr, next);
+                goto bail;
             }
-        }
-        if (strict && invalid >= 0) {
-            raise_errmsg("Invalid control character at", pystr, invalid);
-            goto bail;
         }
         if (!(c == '"' || c == '\\')) {
             raise_errmsg("Unterminated string starting at", pystr, begin);

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -442,8 +442,9 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             }
             /* Defer the strict error until outside this (hot) loop. */
             /* See bpo-37587 */
-            if (c <= 0x1f && invalid < 0)
-              invalid = next;
+            if (c <= 0x1f && invalid < 0) {
+                invalid = next;
+            }
         }
         if (strict && invalid >= 0) {
             raise_errmsg("Invalid control character at", pystr, invalid);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.
Make json.loads faster for long strings
# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37587](https://bugs.python.org/issue37587) -->
https://bugs.python.org/issue37587
<!-- /issue-number -->
