### PR TITLE
bpo-37571: Remove extra space in ctypes docs

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1183,7 +1183,7 @@ Another example that may behave different from what one would expect is this::
    b'abc def ghi'
    >>> s.value is s.value
    False
-    >>>
+   >>>
 
 .. note::
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37571](https://bugs.python.org/issue37571) -->
https://bugs.python.org/issue37571
<!-- /issue-number -->
