### PR TITLE
bpo-24053: Add EXIT_SUCCESS and EXIT_FAILURE values in the sys module

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1613,6 +1613,26 @@ always available.
    .. versionadded:: 3.2
 
 
+.. data:: EXIT_SUCCESS
+
+    An int you can use to indicate your program ended gracefully.
+
+    .. code-block:: python
+
+        sys.exit(sys.EXIT_SUCCESS)
+
+    .. versionadded:: 3.10
+
+.. data:: EXIT_FAILURE
+
+    An int you can use to indicate your program encountered an error.
+
+    .. code-block:: python
+
+        sys.exit(sys.EXIT_FAILURE)
+
+    .. versionadded:: 3.10
+
 .. rubric:: Citations
 
 .. [C99] ISO/IEC 9899:1999.  "Programming languages -- C."  A public draft of this standard is available at http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf\ .

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -154,6 +154,17 @@ class SysModuleTest(unittest.TestCase):
         self.assertEqual(out, b'')
         self.assertEqual(err, b'')
 
+        # test EXIT_SUCCESS and EXIT_FAILURE constants
+        self.assertNotEqual(sys.EXIT_SUCCESS, sys.EXIT_FAILURE)
+        rc, out, err = assert_python_ok('-c', 'import sys; sys.exit(sys.EXIT_SUCCESS)')
+        self.assertEqual(rc, sys.EXIT_SUCCESS)
+        self.assertEqual(out, b'')
+        self.assertEqual(err, b'')
+        rc, out, err = assert_python_failure('-c', 'import sys; sys.exit(sys.EXIT_FAILURE)')
+        self.assertEqual(rc, sys.EXIT_FAILURE)
+        self.assertEqual(out, b'')
+        self.assertEqual(err, b'')
+
         def check_exit_message(code, expected, **env_vars):
             rc, out, err = assert_python_failure('-c', code, **env_vars)
             self.assertEqual(rc, 1)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-14-12-40-19.bpo-24053.jVpLIJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-14-12-40-19.bpo-24053.jVpLIJ.rst
@@ -1,0 +1,1 @@
+Add EXIT_FAILURE and EXIT_SUCCESS in the sys module.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2959,6 +2959,9 @@ _PySys_Create(PyThreadState *tstate, PyObject **sysmod_p)
         return _PyStatus_ERR("failed to create a module object");
     }
 
+    PyModule_AddIntMacro(sysmod, EXIT_SUCCESS);
+    PyModule_AddIntMacro(sysmod, EXIT_FAILURE);
+
     PyObject *sysdict = PyModule_GetDict(sysmod);
     if (sysdict == NULL) {
         return _PyStatus_ERR("can't initialize sys dict");


### PR DESCRIPTION
This pull request adds EXIT_SUCCESS and EXIT_FAILURE constants in the sys module.


<!-- issue-number: [bpo-24053](https://bugs.python.org/issue24053) -->
https://bugs.python.org/issue24053
<!-- /issue-number -->
