### PR TITLE
bpo-25433: Streamline whitespace documentation

### DIFF
--- a/Doc/c-api/conversion.rst
+++ b/Doc/c-api/conversion.rst
@@ -56,7 +56,7 @@ The following functions provide locale-independent string to number conversions.
    Convert a string ``s`` to a :c:type:`double`, raising a Python
    exception on failure.  The set of accepted strings corresponds to
    the set of strings accepted by Python's :func:`float` constructor,
-   except that ``s`` must not have leading or trailing whitespace.
+   except that ``s`` must not have leading or trailing :term:`whitespace`.
    The conversion is independent of the current locale.
 
    If ``endptr`` is ``NULL``, convert the whole string.  Raise

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -255,7 +255,7 @@ the Python configuration.
 
 .. c:function:: int Py_UNICODE_ISSPACE(Py_UNICODE ch)
 
-   Return ``1`` or ``0`` depending on whether *ch* is a whitespace character.
+   Return ``1`` or ``0`` depending on whether *ch* is a :term:`whitespace` character.
 
 
 .. c:function:: int Py_UNICODE_ISLOWER(Py_UNICODE ch)
@@ -1287,7 +1287,7 @@ These are the UTF-7 codec APIs:
 
    If *base64SetO* is nonzero, "Set O" (punctuation that has no otherwise
    special meaning) will be encoded in base-64.  If *base64WhiteSpace* is
-   nonzero, whitespace will be encoded in base-64.  Both are set to zero for the
+   nonzero, :term:`whitespace` will be encoded in base-64.  Both are set to zero for the
    Python "utf-7" codec.
 
    .. deprecated-removed:: 3.3 4.0
@@ -1576,7 +1576,7 @@ They all return *NULL* or ``-1`` if an exception occurs.
 .. c:function:: PyObject* PyUnicode_Split(PyObject *s, PyObject *sep, Py_ssize_t maxsplit)
 
    Split a string giving a list of Unicode strings.  If *sep* is *NULL*, splitting
-   will be done at all whitespace substrings.  Otherwise, splits occur at the given
+   will be done at all :term:`whitespace` substrings.  Otherwise, splits occur at the given
    separator.  At most *maxsplit* splits will be done.  If negative, no limit is
    set.  Separators are not included in the resulting list.
 

--- a/Doc/distutils/apiref.rst
+++ b/Doc/distutils/apiref.rst
@@ -1559,7 +1559,7 @@ lines, and joining lines with backslashes.
    commonly want to do when processing a text file  that has some line-by-line
    syntax: strip comments (as long as ``#``  is your comment character), skip blank
    lines, join adjacent lines by escaping the newline (ie. backslash at end of
-   line), strip leading and/or trailing whitespace.  All of these are optional and
+   line), strip leading and/or trailing :term:`whitespace`.  All of these are optional and
    independently controllable.
 
    The class provides a :meth:`warn` method so you can generate  warning messages
@@ -1675,7 +1675,7 @@ lines, and joining lines with backslashes.
       Push *line* (a string) onto an internal buffer that will be checked by future
       :meth:`readline` calls.  Handy for implementing a parser with line-at-a-time
       lookahead. Note that lines that are "unread" with :meth:`unreadline` are not
-      subsequently re-cleansed (whitespace  stripped, or whatever) when read with
+      subsequently re-cleansed (:term:`whitespace` stripped, or whatever) when read with
       :meth:`readline`. If multiple calls are made to :meth:`unreadline` before a call
       to :meth:`readline`, the lines will be returned most in most recent first order.
 

--- a/Doc/distutils/configfile.rst
+++ b/Doc/distutils/configfile.rst
@@ -126,7 +126,7 @@ own :file:`setup.cfg`:
                doc/
                examples/
 
-Note that the ``doc_files`` option is simply a whitespace-separated string
+Note that the ``doc_files`` option is simply a :term:`whitespace`-separated string
 split across multiple lines for readability.
 
 

--- a/Doc/distutils/setupscript.rst
+++ b/Doc/distutils/setupscript.rst
@@ -391,7 +391,7 @@ number.  The accepted comparison operators are::
     <=   >=   !=
 
 These can be combined by using multiple qualifiers separated by commas (and
-optional whitespace).  In this case, all of the qualifiers must be matched; a
+optional :term:`whitespace`).  In this case, all of the qualifiers must be matched; a
 logical AND is used to combine the evaluations.
 
 Let's look at a bunch of examples:

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -977,7 +977,7 @@ Is there an equivalent to Perl's chomp() for removing trailing newlines from str
 
 You can use ``S.rstrip("\r\n")`` to remove all occurrences of any line
 terminator from the end of the string ``S`` without removing other trailing
-whitespace.  If the string ``S`` represents more than one line, with several
+:term:`whitespace`.  If the string ``S`` represents more than one line, with several
 empty lines at the end, the line terminators for all the blank lines will
 be removed::
 
@@ -997,7 +997,7 @@ Is there a scanf() or sscanf() equivalent?
 Not as such.
 
 For simple input parsing, the easiest approach is usually to split the line into
-whitespace-delimited words using the :meth:`~str.split` method of string objects
+:term:`whitespace`-delimited words using the :meth:`~str.split` method of string objects
 and then convert decimal strings to numeric values using :func:`int` or
 :func:`float`.  ``split()`` supports an optional "sep" parameter which is useful
 if the line uses something other than whitespace as a separator.

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -271,7 +271,7 @@ this respect, and is easily configured to use spaces: Take :menuselection:`Tools
 size" to 4, and select the "Insert spaces" radio button.
 
 Python raises :exc:`IndentationError` or :exc:`TabError` if mixed tabs
-and spaces are causing problems in leading whitespace.
+and spaces are causing problems in leading :term:`whitespace`.
 You may also run the :mod:`tabnanny` module to check a directory tree
 in batch mode.
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1146,9 +1146,8 @@ Glossary
 
    whitespace
       Characters that represent horizontal or vertical space.
-      In ASCII context, Python recognizes these characters as whitespace:
-
-      "\t\n\v\f\r " (tab, newline, vertical tab, form feed, carriage return, space)
+      In ASCII context, Python recognizes these characters as whitespace: space and
+      ``\t\n\v\f\r`` (tab, newline, vertical tab, form feed, carriage return).
 
       In Unicode context, whitespace characters are those
       characters defined in the Unicode character database as "Other" or "Separator"

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1144,6 +1144,18 @@ Glossary
       A computer defined entirely in software.  Python's virtual machine
       executes the :term:`bytecode` emitted by the bytecode compiler.
 
+   whitespace
+      Characters that represent horizontal or vertical space.
+      In ASCII context, Python recognizes these characters as whitespace:
+
+      "\t\n\v\f\r " (tab, newline, vertical tab, form feed, carriage return, space)
+
+      In Unicode context, whitespace characters are those
+      characters defined in the Unicode character database as "Other" or "Separator"
+      and those with bidirectional property being one of "WS", "B", or "S".
+
+      This is used, for example, to split or strip strings.
+
    Zen of Python
       Listing of Python design principles and philosophies that are helpful in
       understanding and using the language.  The listing can be found by typing

--- a/Doc/howto/functional.rst
+++ b/Doc/howto/functional.rst
@@ -328,7 +328,7 @@ Generator expressions and list comprehensions
 Two common operations on an iterator's output are 1) performing some operation
 for every element, 2) selecting a subset of elements that meet some condition.
 For example, given a list of strings, you might want to strip off trailing
-whitespace from each line or extract all the strings containing a given
+:term:`whitespace` from each line or extract all the strings containing a given
 substring.
 
 List comprehensions and generator expressions (short form: "listcomps" and

--- a/Doc/howto/regex.rst
+++ b/Doc/howto/regex.rst
@@ -110,7 +110,7 @@ meaning: ``\[`` or ``\\``.
 Some of the special sequences beginning with ``'\'`` represent
 predefined sets of characters that are often useful, such as the set
 of digits, the set of letters, or the set of anything that isn't
-whitespace.
+:term:`whitespace`.
 
 Let's take an example: ``\w`` matches any alphanumeric character.  If
 the regex pattern is expressed in bytes, this is equivalent to the
@@ -134,11 +134,11 @@ category in the Unicode database.
    Matches any non-digit character; this is equivalent to the class ``[^0-9]``.
 
 ``\s``
-   Matches any whitespace character; this is equivalent to the class ``[
+   Matches any :term:`whitespace` character; this is equivalent to the class ``[
    \t\n\r\f\v]``.
 
 ``\S``
-   Matches any non-whitespace character; this is equivalent to the class ``[^
+   Matches any non-:term:`whitespace` character; this is equivalent to the class ``[^
    \t\n\r\f\v]``.
 
 ``\w``
@@ -150,7 +150,7 @@ category in the Unicode database.
    ``[^a-zA-Z0-9_]``.
 
 These sequences can be included inside a character class.  For example,
-``[\s,.]`` is a character class that will match any whitespace character, or
+``[\s,.]`` is a character class that will match any :term:`whitespace` character, or
 ``','`` or ``'.'``.
 
 The final metacharacter in this section is ``.``.  It matches anything except a
@@ -637,7 +637,7 @@ of each one.
 
    This flag allows you to write regular expressions that are more readable by
    granting you more flexibility in how you can format them.  When this flag has
-   been specified, whitespace within the RE string is ignored, except when the
+   been specified, :term:`whitespace` within the RE string is ignored, except when the
    whitespace is in a character class or preceded by an unescaped backslash; this
    lets you organize and indent the RE more clearly.  This flag also lets you put
    comments within a RE that will be ignored by the engine; comments are marked by
@@ -743,7 +743,7 @@ given location, they can obviously be matched an infinite number of times.
 ``\b``
    Word boundary.  This is a zero-width assertion that matches only at the
    beginning or end of a word.  A word is defined as a sequence of alphanumeric
-   characters, so the end of a word is indicated by whitespace or a
+   characters, so the end of a word is indicated by :term:`whitespace` or a
    non-alphanumeric character.
 
    The following example matches ``class`` only when it's a complete word; it won't
@@ -1082,7 +1082,7 @@ The :meth:`~re.Pattern.split` method of a pattern splits a string apart
 wherever the RE matches, returning a list of the pieces. It's similar to the
 :meth:`~str.split` method of strings but provides much more generality in the
 delimiters that you can split by; string :meth:`!split` only supports splitting by
-whitespace or by a fixed string.  As you'd expect, there's a module-level
+:term:`whitespace` or by a fixed string.  As you'd expect, there's a module-level
 :func:`re.split` function, too.
 
 

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -505,7 +505,7 @@ out.  If you supply the :const:`re.ASCII` flag to
 
 Similarly, ``\w`` matches a wide variety of Unicode characters but
 only ``[a-zA-Z0-9_]`` in bytes or if :const:`re.ASCII` is supplied,
-and ``\s`` will match either Unicode whitespace characters or
+and ``\s`` will match either Unicode :term:`whitespace` characters or
 ``[ \t\n\r\f\v]``.
 
 

--- a/Doc/library/2to3.rst
+++ b/Doc/library/2to3.rst
@@ -434,7 +434,7 @@ and off individually.  They are described here in more detail.
 
 .. 2to3fixer:: ws_comma
 
-   Removes excess whitespace from comma separated items.  This fixer is
+   Removes excess :term:`whitespace` from comma separated items.  This fixer is
    optional.
 
 .. 2to3fixer:: xrange

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -425,7 +425,7 @@ should not be line-wrapped::
    optional arguments:
     -h, --help  show this help message and exit
 
-:class:`RawTextHelpFormatter` maintains whitespace for all sorts of help text,
+:class:`RawTextHelpFormatter` maintains :term:`whitespace` for all sorts of help text,
 including argument descriptions. However, multiple new lines are replaced with
 one. If you wish to preserve multiple blank lines, add spaces between the
 newlines.

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1295,7 +1295,7 @@ async/await code consider using the high-level
    *protocol* is an object instantiated by the *protocol_factory*.
 
 .. note::
-   It is the application's responsibility to ensure that all whitespace
+   It is the application's responsibility to ensure that all :term:`whitespace`
    and special characters are quoted appropriately to avoid `shell injection
    <https://en.wikipedia.org/wiki/Shell_injection#Shell_injection>`_
    vulnerabilities. The :func:`shlex.quote` function can be used to

--- a/Doc/library/asyncio-subprocess.rst
+++ b/Doc/library/asyncio-subprocess.rst
@@ -88,7 +88,7 @@ Creating Subprocesses
 
 .. important::
 
-   It is the application's responsibility to ensure that all whitespace and
+   It is the application's responsibility to ensure that all :term:`whitespace` and
    special characters are quoted appropriately to avoid `shell injection
    <https://en.wikipedia.org/wiki/Shell_injection#Shell_injection>`_
    vulnerabilities. The :func:`shlex.quote` function can be used to properly

--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -192,7 +192,7 @@ The modern interface provides:
 
    *ignorechars* should be a :term:`bytes-like object` or ASCII string
    containing characters to ignore
-   from the input. This should only contain whitespace characters, and by
+   from the input. This should only contain :term:`whitespace` characters, and by
    default contains all whitespace characters in ASCII.
 
    .. versionadded:: 3.4

--- a/Doc/library/binascii.rst
+++ b/Doc/library/binascii.rst
@@ -37,7 +37,7 @@ The :mod:`binascii` module defines the following functions:
 
    Convert a single line of uuencoded data back to binary and return the binary
    data. Lines normally contain 45 (binary) bytes, except for the last line. Line
-   data may be followed by whitespace.
+   data may be followed by :term:`whitespace`.
 
 
 .. function:: b2a_uu(data, *, backtick=False)
@@ -79,7 +79,7 @@ The :mod:`binascii` module defines the following functions:
    encoding.  The return value is the converted line(s). If the optional argument
    *quotetabs* is present and true, all tabs and spaces will be encoded.   If the
    optional argument *istext* is present and true, newlines are not encoded but
-   trailing whitespace will be encoded. If the optional argument *header* is
+   trailing :term:`whitespace` will be encoded. If the optional argument *header* is
    present and true, spaces will be encoded as underscores per :rfc:`1522`. If the
    optional argument *header* is present and false, newline characters will be
    encoded as well; otherwise linefeed conversion might corrupt the binary data
@@ -182,7 +182,7 @@ The :mod:`binascii` module defines the following functions:
    :exc:`Error` exception is raised.
 
    Similar functionality (accepting only text string arguments, but more
-   liberal towards whitespace) is also accessible using the
+   liberal towards :term:`whitespace`) is also accessible using the
    :meth:`bytes.fromhex` class method.
 
 .. exception:: Error

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -79,7 +79,7 @@ A :class:`Cmd` instance has the following methods:
    completing of commands args is done by calling :meth:`complete_foo` with
    arguments *text*, *line*, *begidx*, and *endidx*.  *text* is the string prefix
    we are attempting to match: all returned matches must begin with it. *line* is
-   the current input line with leading whitespace removed, *begidx* and *endidx*
+   the current input line with leading :term:`whitespace` removed, *begidx* and *endidx*
    are the beginning and ending indexes of the prefix text, which could be used to
    provide different completion depending upon which position the argument is in.
 

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -816,7 +816,7 @@ they add the ability to access fields by name instead of position index.
 
     The *field_names* are a sequence of strings such as ``['x', 'y']``.
     Alternatively, *field_names* can be a single string with each fieldname
-    separated by whitespace and/or commas, for example ``'x y'`` or ``'x, y'``.
+    separated by :term:`whitespace` and/or commas, for example ``'x y'`` or ``'x, y'``.
 
     Any valid Python identifier may be used for a fieldname except for names
     starting with an underscore.  Valid identifiers consist of letters, digits,

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -231,7 +231,7 @@ Supported INI File Structure
 A configuration file consists of sections, each led by a ``[section]`` header,
 followed by key/value entries separated by a specific string (``=`` or ``:`` by
 default [1]_).  By default, section names are case sensitive but keys are not
-[1]_.  Leading and trailing whitespace is removed from keys and values.
+[1]_.  Leading and trailing :term:`whitespace` is removed from keys and values.
 Values can be omitted, in which case the key/value delimiter may also be left
 out.  Values can also span multiple lines, as long as they are indented deeper
 than the first line of the value.  Depending on the parser's mode, blank lines
@@ -1154,7 +1154,7 @@ ConfigParser Objects
          cfgparser = ConfigParser()
          cfgparser.optionxform = str
 
-      Note that when reading configuration files, whitespace around the option
+      Note that when reading configuration files, :term:`whitespace` around the option
       names is stripped before :meth:`optionxform` is called.
 
 

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -382,7 +382,7 @@ Dialects support the following attributes:
 
 .. attribute:: Dialect.skipinitialspace
 
-   When :const:`True`, whitespace immediately following the *delimiter* is ignored.
+   When :const:`True`, :term:`whitespace` immediately following the *delimiter* is ignored.
    The default is :const:`False`.
 
 

--- a/Doc/library/curses.ascii.rst
+++ b/Doc/library/curses.ascii.rst
@@ -115,7 +115,7 @@ C library:
 
 .. function:: isblank(c)
 
-   Checks for an ASCII whitespace character; space or horizontal tab.
+   Checks for an ASCII :term:`whitespace` character; space or horizontal tab.
 
 
 .. function:: iscntrl(c)

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -350,7 +350,7 @@ Decimal objects
    *value* can be an integer, string, tuple, :class:`float`, or another :class:`Decimal`
    object. If no *value* is given, returns ``Decimal('0')``.  If *value* is a
    string, it should conform to the decimal numeric string syntax after leading
-   and trailing whitespace characters, as well as underscores throughout, are removed::
+   and trailing :term:`whitespace` characters, as well as underscores throughout, are removed::
 
       sign           ::=  '+' | '-'
       digit          ::=  '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
@@ -1084,7 +1084,7 @@ In addition to the three supplied contexts, new contexts can be created with the
          Decimal('4.44')
 
       This method implements the to-number operation of the IBM specification.
-      If the argument is a string, no leading or trailing whitespace or
+      If the argument is a string, no leading or trailing :term:`whitespace` or
       underscores are permitted.
 
    .. method:: create_decimal_from_float(f)

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -31,7 +31,7 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
    Obershelp under the hyperbolic name "gestalt pattern matching."  The idea is to
    find the longest contiguous matching subsequence that contains no "junk"
    elements; these "junk" elements are ones that are uninteresting in some
-   sense, such as blank lines or whitespace.  (Handling junk is an
+   sense, such as blank lines or :term:`whitespace`.  (Handling junk is an
    extension to the Ratcliff and Obershelp algorithm.) The same
    idea is then applied recursively to the pieces of the sequences to the left and
    to the right of the matching subsequence.  This does not yield minimal edit
@@ -232,7 +232,7 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
 
    *charjunk*: A function that accepts a character (a string of length 1), and
    returns if the character is junk, or false if not. The default is module-level
-   function :func:`IS_CHARACTER_JUNK`, which filters out whitespace characters (a
+   function :func:`IS_CHARACTER_JUNK`, which filters out :term:`whitespace` characters (a
    blank or tab; it's a bad idea to include newline in this!).
 
    :file:`Tools/scripts/ndiff.py` is a command-line front-end to this function.

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -327,7 +327,7 @@ but doctest isn't trying to do an exact emulation of any specific Python shell.
 
 Any expected output must immediately follow the final ``'>>> '`` or ``'... '``
 line containing the code, and the expected output (if any) extends to the next
-``'>>> '`` or all-whitespace line.
+``'>>> '`` or all-:term:`whitespace` line.
 
 The fine print:
 
@@ -550,7 +550,7 @@ doctest decides whether actual output matches an example's expected output:
 
 .. data:: NORMALIZE_WHITESPACE
 
-   When specified, all sequences of whitespace (blanks and newlines) are treated as
+   When specified, all sequences of :term:`whitespace` are treated as
    equal.  Any sequence of whitespace within the expected output will match any
    sequence of whitespace within the actual output. By default, whitespace must
    match exactly. :const:`NORMALIZE_WHITESPACE` is especially useful when a line of

--- a/Doc/library/email.errors.rst
+++ b/Doc/library/email.errors.rst
@@ -35,7 +35,7 @@ The following exception classes are defined in the :mod:`email.errors` module:
    :class:`~email.header.Header` may raise this error for certain base64
    decoding errors, and when an attempt is made to create a header that appears
    to contain an embedded header (that is, there is what is supposed to be a
-   continuation line that has no leading whitespace and looks like a header).
+   continuation line that has no leading :term:`whitespace` and looks like a header).
 
 
 .. exception:: BoundaryError()

--- a/Doc/library/email.header.rst
+++ b/Doc/library/email.header.rst
@@ -82,7 +82,7 @@ Here is the :class:`Header` class description:
    first line of a long, split header.
 
    Optional *continuation_ws* must be :rfc:`2822`\ -compliant folding
-   whitespace, and is usually either a space or a hard tab character.  This
+   :term:`whitespace`, and is usually either a space or a hard tab character.  This
    character will be prepended to continuation lines.  *continuation_ws*
    defaults to a single space character.
 

--- a/Doc/library/email.headerregistry.rst
+++ b/Doc/library/email.headerregistry.rst
@@ -246,7 +246,7 @@ variant, :attr:`~.BaseHeader.max_count` is set to 1.
 
    .. attribute:: version
 
-      The version number as a string, with any whitespace and/or comments
+      The version number as a string, with any :term:`whitespace` and/or comments
       removed.
 
    .. attribute:: major

--- a/Doc/library/email.policy.rst
+++ b/Doc/library/email.policy.rst
@@ -295,7 +295,7 @@ added matters.  To illustrate::
       The email package calls this method with a list of strings, each string
       ending with the line separation characters found in the source being
       parsed.  The first line includes the field header name and separator.
-      All whitespace in the source is preserved.  The method should return the
+      All :term:`whitespace` in the source is preserved.  The method should return the
       ``(name, value)`` tuple that is to be stored in the ``Message`` to
       represent the parsed header.
 
@@ -454,7 +454,7 @@ added matters.  To illustrate::
 
 
       The name is parsed as everything up to the '``:``' and returned
-      unmodified.  The value is determined by stripping leading whitespace off
+      unmodified.  The value is determined by stripping leading :term:`whitespace` off
       the remainder of the first line, joining all subsequent lines together,
       and stripping any trailing carriage return or linefeed characters.
 
@@ -604,7 +604,7 @@ The header objects and their attributes are described in
    .. method:: header_source_parse(sourcelines)
 
       The name is parsed as everything up to the '``:``' and returned
-      unmodified.  The value is determined by stripping leading whitespace off
+      unmodified.  The value is determined by stripping leading :term:`whitespace` off
       the remainder of the first line, joining all subsequent lines together,
       and stripping any trailing carriage return or linefeed characters.
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -466,7 +466,7 @@ The semantics of this API resemble :class:`~collections.namedtuple`. The first
 argument of the call to :class:`Enum` is the name of the enumeration.
 
 The second argument is the *source* of enumeration member names.  It can be a
-whitespace-separated string of names, a sequence of names, a sequence of
+:term:`whitespace`-separated string of names, a sequence of names, a sequence of
 2-tuples with key/value pairs, or a mapping (e.g. dictionary) of names to
 values.  The last two options enable assigning arbitrary values to
 enumerations; the others auto-assign increasing integers starting with 1 (use
@@ -512,7 +512,7 @@ The complete signature is::
 
 :value: What the new Enum class will record as its name.
 
-:names: The Enum members.  This can be a whitespace or comma separated string
+:names: The Enum members.  This can be a :term:`whitespace` or comma separated string
   (values will start at 1 unless otherwise specified)::
 
     'RED GREEN BLUE' | 'RED,GREEN,BLUE' | 'RED, GREEN, BLUE'

--- a/Doc/library/formatter.rst
+++ b/Doc/library/formatter.rst
@@ -80,7 +80,7 @@ The following attributes are defined for formatter instance objects:
 
 .. method:: formatter.add_flowing_data(data)
 
-   Provide data which should be formatted with collapsed whitespace. Whitespace
+   Provide data which should be formatted with collapsed :term:`whitespace`. Whitespace
    from preceding and successive calls to :meth:`add_flowing_data` is considered as
    well when the whitespace collapse is performed.  The data which is passed to
    this method is expected to be word-wrapped by the output device.  Note that any
@@ -119,7 +119,7 @@ The following attributes are defined for formatter instance objects:
 
 .. method:: formatter.flush_softspace()
 
-   Send any pending whitespace buffered from a previous call to
+   Send any pending :term:`whitespace` buffered from a previous call to
    :meth:`add_flowing_data` to the associated writer object.  This should be called
    before any direct manipulation of the writer object.
 
@@ -298,7 +298,7 @@ typically be provided by the application.
 
    Output character data which may be word-wrapped and re-flowed as needed.  Within
    any sequence of calls to this method, the writer may assume that spans of
-   multiple whitespace characters have been collapsed to single space characters.
+   multiple :term:`whitespace` characters have been collapsed to single space characters.
 
 
 .. method:: writer.send_literal_data(data)

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -45,7 +45,7 @@ another rational number, or from a string.
    decimal digits.  In addition, any string that represents a finite
    value and is accepted by the :class:`float` constructor is also
    accepted by the :class:`Fraction` constructor.  In either form the
-   input string may also have leading and/or trailing whitespace.
+   input string may also have leading and/or trailing :term:`whitespace`.
    Here are some examples::
 
       >>> from fractions import Fraction

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -327,7 +327,7 @@ are always available.  They are listed here in alphabetical order.
 
    .. note::
 
-      When converting from a string, the string must not contain whitespace
+      When converting from a string, the string must not contain :term:`whitespace`
       around the central ``+`` or ``-`` operator.  For example,
       ``complex('1+2j')`` is fine, but ``complex('1 + 2j')`` raises
       :exc:`ValueError`.
@@ -570,7 +570,7 @@ are always available.  They are listed here in alphabetical order.
    Return a floating point number constructed from a number or string *x*.
 
    If the argument is a string, it should contain a decimal number, optionally
-   preceded by a sign, and optionally embedded in whitespace.  The optional
+   preceded by a sign, and optionally embedded in :term:`whitespace`.  The optional
    sign may be ``'+'`` or ``'-'``; a ``'+'`` sign has no effect on the value
    produced.  The argument may also be a string representing a NaN
    (not-a-number), or a positive or negative infinity.  More precisely, the
@@ -804,7 +804,7 @@ are always available.  They are listed here in alphabetical order.
    :class:`bytes`, or :class:`bytearray` instance representing an :ref:`integer
    literal <integers>` in radix *base*.  Optionally, the literal can be
    preceded by ``+`` or ``-`` (with no space in between) and surrounded by
-   whitespace.  A base-n literal consists of the digits 0 to n-1, with ``a``
+   :term:`whitespace`.  A base-n literal consists of the digits 0 to n-1, with ``a``
    to ``z`` (or ``A`` to ``Z``) having
    values 10 to 35.  The default *base* is 10. The allowed values are 0 and 2--36.
    Base-2, -8, and -16 literals can be optionally prefixed with ``0b``/``0B``,

--- a/Doc/library/html.parser.rst
+++ b/Doc/library/html.parser.rst
@@ -115,7 +115,7 @@ The output will then be:
 
    Return the text of the most recently opened start tag.  This should not normally
    be needed for structured processing, but may be useful in dealing with HTML "as
-   deployed" or for re-generating input with minimal changes (whitespace between
+   deployed" or for re-generating input with minimal changes (:term:`whitespace` between
    attributes can be preserved, etc.).
 
 

--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -132,7 +132,7 @@ provides three different variants:
    .. attribute:: server_version
 
       Specifies the server software version.  You may want to override this. The
-      format is multiple whitespace-separated strings, where each string is of
+      format is multiple :term:`whitespace`-separated strings, where each string is of
       the form name[/version]. For example, ``'BaseHTTP/0.2'``.
 
    .. attribute:: sys_version

--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -197,7 +197,7 @@ Format Paragraph
    paragraph will be formatted to less than N columns, where N defaults to 72.
 
 Strip trailing whitespace
-   Remove trailing space and other whitespace characters after the last
+   Remove trailing space and other :term:`whitespace` characters after the last
    non-whitespace character of a line by applying str.rstrip to each line,
    including lines within multiline strings.
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -533,7 +533,7 @@ Retrieving source code
    Clean up indentation from docstrings that are indented to line up with blocks
    of code.
 
-   All leading whitespace is removed from the first line.  Any leading whitespace
+   All leading :term:`whitespace` is removed from the first line.  Any leading whitespace
    that can be uniformly removed from the second line onwards is removed.  Empty
    lines at the beginning and end are subsequently removed.  Also, all tabs are
    expanded to spaces.

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -168,7 +168,7 @@ Basic Usage
    If specified, *separators* should be an ``(item_separator, key_separator)``
    tuple.  The default is ``(', ', ': ')`` if *indent* is ``None`` and
    ``(',', ': ')`` otherwise.  To get the most compact JSON representation,
-   you should specify ``(',', ':')`` to eliminate whitespace.
+   you should specify ``(',', ':')`` to eliminate :term:`whitespace`.
 
    .. versionchanged:: 3.4
       Use ``(',', ': ')`` as default if *indent* is not ``None``.
@@ -448,7 +448,7 @@ Encoders and Decoders
    If specified, *separators* should be an ``(item_separator, key_separator)``
    tuple.  The default is ``(', ', ': ')`` if *indent* is ``None`` and
    ``(',', ': ')`` otherwise.  To get the most compact JSON representation,
-   you should specify ``(',', ':')`` to eliminate whitespace.
+   you should specify ``(',', ':')`` to eliminate :term:`whitespace`.
 
    .. versionchanged:: 3.4
       Use ``(',', ': ')`` as default if *indent* is not ``None``.

--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -540,7 +540,7 @@ according to the locale.  For (Unicode) text strings these are done according
 to the character value only, while for byte strings, the conversions and
 classifications are done according to the ASCII value of the byte, and bytes
 whose high bit is set (i.e., non-ASCII bytes) are never converted or considered
-part of a character class such as letter or whitespace.
+part of a character class such as letter or :term:`whitespace`.
 
 
 .. _embedding-locale:

--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -85,6 +85,6 @@ Instances of :class:`~netrc.netrc` have public instance variables:
 .. note::
 
    Passwords are limited to a subset of the ASCII character set.  All ASCII
-   punctuation is allowed in passwords, however, note that whitespace and
+   punctuation is allowed in passwords, however, note that :term:`whitespace` and
    non-printable characters are not allowed in passwords.  This is a limitation
    of the way the .netrc file is parsed and may be removed in the future.

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -210,7 +210,7 @@ The commands recognized by the debugger are listed below.  Most commands can be
 abbreviated to one or two letters as indicated; e.g. ``h(elp)`` means that
 either ``h`` or ``help`` can be used to enter the help command (but not ``he``
 or ``hel``, nor ``H`` or ``Help`` or ``HELP``).  Arguments to commands must be
-separated by whitespace (spaces or tabs).  Optional arguments are enclosed in
+separated by :term:`whitespace` (spaces or tabs).  Optional arguments are enclosed in
 square brackets (``[]``) in the command syntax; the square brackets must not be
 typed.  Alternatives in the command syntax are separated by a vertical bar
 (``|``).

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -369,7 +369,7 @@ otherwise stated.
 .. method:: xmlparser.CharacterDataHandler(data)
 
    Called for character data.  This will be called for normal character data, CDATA
-   marked content, and ignorable whitespace.  Applications which must distinguish
+   marked content, and ignorable :term:`whitespace`.  Applications which must distinguish
    these cases can use the :attr:`StartCdataSectionHandler`,
    :attr:`EndCdataSectionHandler`, and :attr:`ElementDeclHandler` callbacks to
    collect the required information.
@@ -714,7 +714,7 @@ The ``errors`` module has the following attributes:
 
 .. data:: XML_ERROR_JUNK_AFTER_DOC_ELEMENT
 
-   Something other than whitespace occurred after the document element.
+   Something other than :term:`whitespace` occurred after the document element.
 
 
 .. data:: XML_ERROR_MISPLACED_XML_PI

--- a/Doc/library/quopri.rst
+++ b/Doc/library/quopri.rst
@@ -36,7 +36,7 @@ sending a graphics file.
    data to the *output* file. *input* and *output* must be
    :term:`binary file objects <file object>`. *quotetabs*, a
    non-optional flag which controls whether to encode embedded spaces
-   and tabs; when true it encodes such embedded whitespace, and when
+   and tabs; when true it encodes such embedded :term:`whitespace`, and when
    false it leaves them unencoded.
    Note that spaces and tabs appearing at the end of lines are always encoded,
    as per :rfc:`1521`.  *header* is a flag which controls if spaces are encoded

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -502,20 +502,20 @@ character ``'$'``.
 
 ``\s``
    For Unicode (str) patterns:
-      Matches Unicode whitespace characters (which includes
+      Matches Unicode :term:`whitespace` characters (which includes
       ``[ \t\n\r\f\v]``, and also many other characters, for example the
       non-breaking spaces mandated by typography rules in many
       languages). If the :const:`ASCII` flag is used, only
       ``[ \t\n\r\f\v]`` is matched.
 
    For 8-bit (bytes) patterns:
-      Matches characters considered whitespace in the ASCII character set;
+      Matches characters considered :term:`whitespace` in the ASCII character set;
       this is equivalent to ``[ \t\n\r\f\v]``.
 
 .. index:: single: \S; in regular expressions
 
 ``\S``
-   Matches any character which is not a whitespace character. This is
+   Matches any character which is not a :term:`whitespace` character. This is
    the opposite of ``\s``. If the :const:`ASCII` flag is used this
    becomes the equivalent of ``[^ \t\n\r\f\v]``.
 

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -257,7 +257,7 @@ variables which either control lexical analysis or can be used for debugging:
 
 .. attribute:: shlex.whitespace_split
 
-   If ``True``, tokens will only be split in :term:`whitespace`s.  This is useful, for
+   If ``True``, tokens will only be split on :term:`whitespace`.  This is useful, for
    example, for parsing command lines with :class:`~shlex.shlex`, getting
    tokens in a similar way to shell arguments.  When used in combination with
    :attr:`punctuation_chars`, tokens will be split on whitespace in addition to

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -257,7 +257,7 @@ variables which either control lexical analysis or can be used for debugging:
 
 .. attribute:: shlex.whitespace_split
 
-   If ``True``, tokens will only be split in whitespaces.  This is useful, for
+   If ``True``, tokens will only be split in :term:`whitespace`s.  This is useful, for
    example, for parsing command lines with :class:`~shlex.shlex`, getting
    tokens in a similar way to shell arguments.  When used in combination with
    :attr:`punctuation_chars`, tokens will be split on whitespace in addition to
@@ -345,7 +345,7 @@ following rules.
   ``Separate``);
 
 * If :attr:`~shlex.whitespace_split` is ``False``, any character not
-  declared to be a word character, whitespace, or a quote will be returned as
+  declared to be a word character, :term:`whitespace`, or a quote will be returned as
   a single-character token. If it is ``True``, :class:`~shlex.shlex` will only
   split words in whitespaces;
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -594,7 +594,7 @@ debugging, and in numerical work.
 
    Class method to return the float represented by a hexadecimal
    string *s*.  The string *s* may have leading and trailing
-   whitespace.
+   :term:`whitespace`.
 
 
 Note that :meth:`float.hex` is an instance method, while
@@ -1407,10 +1407,10 @@ written in a variety of ways:
 * Double quotes: ``"allows embedded 'single' quotes"``.
 * Triple quoted: ``'''Three single quotes'''``, ``"""Three double quotes"""``
 
-Triple quoted strings may span multiple lines - all associated whitespace will
+Triple quoted strings may span multiple lines - all associated :term:`whitespace` will
 be included in the string literal.
 
-String literals that are part of a single expression and have only whitespace
+String literals that are part of a single expression and have only :term:`whitespace`
 between them will be implicitly converted to a single string literal. That
 is, ``("spam " "eggs") == "spam eggs"``.
 
@@ -1762,10 +1762,8 @@ expression support in the :mod:`re` module).
 
 .. method:: str.isspace()
 
-   Return true if there are only whitespace characters in the string and there is
-   at least one character, false otherwise.  Whitespace characters  are those
-   characters defined in the Unicode character database as "Other" or "Separator"
-   and those with bidirectional property being one of "WS", "B", or "S".
+   Return true if there are only :term:`whitespace` characters in the string and there is
+   at least one character, false otherwise.
 
 .. method:: str.istitle()
 
@@ -1808,7 +1806,7 @@ expression support in the :mod:`re` module).
 
    Return a copy of the string with leading characters removed.  The *chars*
    argument is a string specifying the set of characters to be removed.  If omitted
-   or ``None``, the *chars* argument defaults to removing whitespace.  The *chars*
+   or ``None``, the *chars* argument defaults to removing :term:`whitespace`.  The *chars*
    argument is not a prefix; rather, all combinations of its values are stripped::
 
       >>> '   spacious   '.lstrip()
@@ -1879,7 +1877,7 @@ expression support in the :mod:`re` module).
 
    Return a list of the words in the string, using *sep* as the delimiter string.
    If *maxsplit* is given, at most *maxsplit* splits are done, the *rightmost*
-   ones.  If *sep* is not specified or ``None``, any whitespace string is a
+   ones.  If *sep* is not specified or ``None``, any :term:`whitespace` string is a
    separator.  Except for splitting from the right, :meth:`rsplit` behaves like
    :meth:`split` which is described in detail below.
 
@@ -1888,7 +1886,7 @@ expression support in the :mod:`re` module).
 
    Return a copy of the string with trailing characters removed.  The *chars*
    argument is a string specifying the set of characters to be removed.  If omitted
-   or ``None``, the *chars* argument defaults to removing whitespace.  The *chars*
+   or ``None``, the *chars* argument defaults to removing :term:`whitespace`.  The *chars*
    argument is not a suffix; rather, all combinations of its values are stripped::
 
       >>> '   spacious   '.rstrip()
@@ -1921,7 +1919,7 @@ expression support in the :mod:`re` module).
       ['1', '2', '', '3', '']
 
    If *sep* is not specified or is ``None``, a different splitting algorithm is
-   applied: runs of consecutive whitespace are regarded as a single separator,
+   applied: runs of consecutive :term:`whitespace` are regarded as a single separator,
    and the result will contain no empty strings at the start or end if the
    string has leading or trailing whitespace.  Consequently, splitting an empty
    string or a string consisting of just whitespace with a ``None`` separator
@@ -2015,7 +2013,7 @@ expression support in the :mod:`re` module).
 
    Return a copy of the string with the leading and trailing characters removed.
    The *chars* argument is a string specifying the set of characters to be removed.
-   If omitted or ``None``, the *chars* argument defaults to removing whitespace.
+   If omitted or ``None``, the *chars* argument defaults to removing :term:`whitespace`.
    The *chars* argument is not a prefix or suffix; rather, all combinations of its
    values are stripped::
 
@@ -2391,7 +2389,7 @@ data and are closely related to string objects in a variety of other ways.
 
       This :class:`bytes` class method returns a bytes object, decoding the
       given string object.  The string must contain two hexadecimal digits per
-      byte, with ASCII whitespace being ignored.
+      byte, with ASCII :term:`whitespace` being ignored.
 
       >>> bytes.fromhex('2Ef0 F1f2  ')
       b'.\xf0\xf1\xf2'
@@ -2485,7 +2483,7 @@ objects.
 
       This :class:`bytearray` class method returns bytearray object, decoding
       the given string object.  The string must contain two hexadecimal digits
-      per byte, with ASCII whitespace being ignored.
+      per byte, with ASCII :term:`whitespace` being ignored.
 
       >>> bytearray.fromhex('2Ef0 F1f2  ')
       bytearray(b'.\xf0\xf1\xf2')
@@ -2812,7 +2810,7 @@ produce new objects.
    *chars* argument is a binary sequence specifying the set of byte values to
    be removed - the name refers to the fact this method is usually used with
    ASCII characters.  If omitted or ``None``, the *chars* argument defaults
-   to removing ASCII whitespace.  The *chars* argument is not a prefix;
+   to removing ASCII :term:`whitespace`.  The *chars* argument is not a prefix;
    rather, all combinations of its values are stripped::
 
       >>> b'   spacious   '.lstrip()
@@ -2849,7 +2847,7 @@ produce new objects.
    Split the binary sequence into subsequences of the same type, using *sep*
    as the delimiter string. If *maxsplit* is given, at most *maxsplit* splits
    are done, the *rightmost* ones.  If *sep* is not specified or ``None``,
-   any subsequence consisting solely of ASCII whitespace is a separator.
+   any subsequence consisting solely of ASCII :term:`whitespace` is a separator.
    Except for splitting from the right, :meth:`rsplit` behaves like
    :meth:`split` which is described in detail below.
 
@@ -2861,7 +2859,7 @@ produce new objects.
    *chars* argument is a binary sequence specifying the set of byte values to
    be removed - the name refers to the fact this method is usually used with
    ASCII characters.  If omitted or ``None``, the *chars* argument defaults to
-   removing ASCII whitespace.  The *chars* argument is not a suffix; rather,
+   removing ASCII :term:`whitespace`.  The *chars* argument is not a suffix; rather,
    all combinations of its values are stripped::
 
       >>> b'   spacious   '.rstrip()
@@ -2906,11 +2904,11 @@ produce new objects.
       [b'1', b'2', b'', b'3', b'']
 
    If *sep* is not specified or is ``None``, a different splitting algorithm
-   is applied: runs of consecutive ASCII whitespace are regarded as a single
+   is applied: runs of consecutive ASCII :term:`whitespace` are regarded as a single
    separator, and the result will contain no empty strings at the start or
-   end if the sequence has leading or trailing whitespace.  Consequently,
+   end if the sequence has leading or trailing :term:`whitespace`.  Consequently,
    splitting an empty sequence or a sequence consisting solely of ASCII
-   whitespace without a specified separator returns ``[]``.
+   :term:`whitespace` without a specified separator returns ``[]``.
 
    For example::
 
@@ -2930,7 +2928,7 @@ produce new objects.
    removed. The *chars* argument is a binary sequence specifying the set of
    byte values to be removed - the name refers to the fact this method is
    usually used with ASCII characters.  If omitted or ``None``, the *chars*
-   argument defaults to removing ASCII whitespace. The *chars* argument is
+   argument defaults to removing ASCII :term:`whitespace`. The *chars* argument is
    not a prefix or suffix; rather, all combinations of its values are
    stripped::
 
@@ -3073,10 +3071,8 @@ place, and instead produce new objects.
 .. method:: bytes.isspace()
             bytearray.isspace()
 
-   Return true if all bytes in the sequence are ASCII whitespace and the
-   sequence is not empty, false otherwise.  ASCII whitespace characters are
-   those byte values in the sequence ``b' \t\n\r\x0b\f'`` (space, tab, newline,
-   carriage return, vertical tab, form feed).
+   Return true if all bytes in the sequence are ASCII :term:`whitespace` and the
+   sequence is not empty, false otherwise.
 
 
 .. method:: bytes.istitle()

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -67,7 +67,7 @@ The constants defined in this module are:
 
 .. data:: whitespace
 
-   A string containing all ASCII characters that are considered whitespace.
+   A string containing all ASCII characters that are considered :term:`whitespace`.
    This includes the characters space, tab, linefeed, return, formfeed, and
    vertical tab.
 
@@ -839,6 +839,6 @@ Helper functions
    Split the argument into words using :meth:`str.split`, capitalize each word
    using :meth:`str.capitalize`, and join the capitalized words using
    :meth:`str.join`.  If the optional second argument *sep* is absent
-   or ``None``, runs of whitespace characters are replaced by a single space
+   or ``None``, runs of :term:`whitespace` characters are replaced by a single space
    and leading and trailing whitespace are removed, otherwise *sep* is used to
    split and join the words.

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -300,7 +300,7 @@ A format character may be preceded by an integral repeat count.  For example,
 the format string ``'4h'`` means exactly the same as ``'hhhh'``.
 
 Whitespace characters between formats are ignored; a count and its format must
-not contain whitespace though.
+not contain :term:`whitespace` though.
 
 For the ``'s'`` format character, the count is interpreted as the length of the
 bytes, not a repeat count like for the other format characters; for example,

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -373,7 +373,7 @@ functions.
          >>> p = subprocess.Popen(args) # Success!
 
       Note in particular that options (such as *-input*) and arguments (such
-      as *eggs.txt*) that are separated by whitespace in the shell go in separate
+      as *eggs.txt*) that are separated by :term:`whitespace` in the shell go in separate
       list elements, while arguments that need quoting or backslash escaping when
       used in the shell (such as filenames containing spaces or the *echo* command
       shown above) are single list elements.
@@ -641,7 +641,7 @@ Unlike some other popen functions, this implementation will never
 implicitly call a system shell.  This means that all characters,
 including shell metacharacters, can safely be passed to child processes.
 If the shell is invoked explicitly, via ``shell=True``, it is the application's
-responsibility to ensure that all whitespace and metacharacters are
+responsibility to ensure that all :term:`whitespace` and metacharacters are
 quoted appropriately to avoid
 `shell injection <https://en.wikipedia.org/wiki/Shell_injection#Shell_injection>`_
 vulnerabilities.

--- a/Doc/library/tabnanny.rst
+++ b/Doc/library/tabnanny.rst
@@ -29,7 +29,7 @@ described below.
    If *file_or_dir* is a directory and not a symbolic link, then recursively
    descend the directory tree named by *file_or_dir*, checking all :file:`.py`
    files along the way.  If *file_or_dir* is an ordinary Python source file, it
-   is checked for whitespace related problems.  The diagnostic messages are
+   is checked for :term:`whitespace` related problems.  The diagnostic messages are
    written to standard output using the :func:`print` function.
 
 
@@ -42,7 +42,7 @@ described below.
 .. data:: filename_only
 
    Flag indicating whether to print only the filenames of files containing
-   whitespace related problems.  This is set to true by the ``-q`` option if called
+   :term:`whitespace` related problems.  This is set to true by the ``-q`` option if called
    as a script.
 
 

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -126,7 +126,7 @@ instance is not reused, so for applications that process many text
 strings using :func:`wrap` and/or :func:`fill`, it may be more efficient to
 create your own :class:`TextWrapper` object.
 
-Text is preferably wrapped on :term:`whitespace`s and right after the hyphens in
+Text is preferably wrapped on :term:`whitespace` and right after the hyphens in
 hyphenated words; only then will long words be broken if necessary, unless
 :attr:`TextWrapper.break_long_words` is set to false.
 
@@ -255,7 +255,7 @@ hyphenated words; only then will long words be broken if necessary, unless
 
    .. attribute:: break_on_hyphens
 
-      (default: ``True``) If true, wrapping will occur preferably on :term:`whitespace`s
+      (default: ``True``) If true, wrapping will occur preferably on :term:`whitespace`
       and right after hyphens in compound words, as it is customary in English.
       If false, only whitespaces will be considered as potentially good places
       for line breaks, but you need to set :attr:`break_long_words` to false if

--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -45,7 +45,7 @@ functions should be good enough; otherwise, you should use an instance of
 
    Collapse and truncate the given *text* to fit in the given *width*.
 
-   First the whitespace in *text* is collapsed (all whitespace is replaced by
+   First the :term:`whitespace` in *text* is collapsed (all whitespace is replaced by
    single spaces).  If the result fits in the *width*, it is returned.
    Otherwise, enough words are dropped from the end so that the remaining words
    plus the :attr:`placeholder` fit within :attr:`width`::
@@ -68,7 +68,7 @@ functions should be good enough; otherwise, you should use an instance of
 
 .. function:: dedent(text)
 
-   Remove any common leading whitespace from every line in *text*.
+   Remove any common leading :term:`whitespace` from every line in *text*.
 
    This can be used to make triple-quoted strings line up with the left edge of the
    display, while still presenting them in the source code in indented form.
@@ -126,7 +126,7 @@ instance is not reused, so for applications that process many text
 strings using :func:`wrap` and/or :func:`fill`, it may be more efficient to
 create your own :class:`TextWrapper` object.
 
-Text is preferably wrapped on whitespaces and right after the hyphens in
+Text is preferably wrapped on :term:`whitespace`s and right after the hyphens in
 hyphenated words; only then will long words be broken if necessary, unless
 :attr:`TextWrapper.break_long_words` is set to false.
 
@@ -177,7 +177,7 @@ hyphenated words; only then will long words be broken if necessary, unless
    .. attribute:: replace_whitespace
 
       (default: ``True``) If true, after tab expansion but before wrapping,
-      the :meth:`wrap` method will replace each whitespace character
+      the :meth:`wrap` method will replace each :term:`whitespace` character
       with a single space.  The whitespace characters replaced are
       as follows: tab, newline, vertical tab, formfeed, and carriage
       return (``'\t\n\v\f\r'``).
@@ -198,7 +198,7 @@ hyphenated words; only then will long words be broken if necessary, unless
 
    .. attribute:: drop_whitespace
 
-      (default: ``True``) If true, whitespace at the beginning and ending of
+      (default: ``True``) If true, :term:`whitespace` at the beginning and ending of
       every line (after wrapping but before indenting) is dropped.
       Whitespace at the beginning of the paragraph, however, is not dropped
       if non-whitespace follows it.  If whitespace being dropped takes up an
@@ -255,7 +255,7 @@ hyphenated words; only then will long words be broken if necessary, unless
 
    .. attribute:: break_on_hyphens
 
-      (default: ``True``) If true, wrapping will occur preferably on whitespaces
+      (default: ``True``) If true, wrapping will occur preferably on :term:`whitespace`s
       and right after hyphens in compound words, as it is customary in English.
       If false, only whitespaces will be considered as potentially good places
       for line breaks, but you need to set :attr:`break_long_words` to false if

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -631,7 +631,7 @@ Functions
       affect the output of functions like :func:`localtime` without calling
       :func:`tzset`, this behavior should not be relied on.
 
-      The :envvar:`TZ` environment variable should contain no whitespace.
+      The :envvar:`TZ` environment variable should contain no :term:`whitespace`.
 
    The standard format of the :envvar:`TZ` environment variable is (whitespace
    added for clarity)::

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -101,7 +101,7 @@ The module defines the following functions:
    :attr:`~FrameSummary.name`, and :attr:`~FrameSummary.line` representing the
    information that is usually printed for a stack trace.  The
    :attr:`~FrameSummary.line` is a string with leading and trailing
-   whitespace stripped; if the source is not available it is ``None``.
+   :term:`whitespace` stripped; if the source is not available it is ``None``.
 
 
 .. function:: extract_stack(f=None, limit=None)

--- a/Doc/library/xml.dom.rst
+++ b/Doc/library/xml.dom.rst
@@ -793,13 +793,13 @@ Represents a processing instruction in the XML document; this inherits from the
 
 .. attribute:: ProcessingInstruction.target
 
-   The content of the processing instruction up to the first whitespace character.
+   The content of the processing instruction up to the first :term:`whitespace` character.
    This is a read-only attribute.
 
 
 .. attribute:: ProcessingInstruction.data
 
-   The content of the processing instruction following the first whitespace
+   The content of the processing instruction following the first :term:`whitespace`
    character.
 
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -486,7 +486,7 @@ Functions
    byte-by-byte comparisons and digital signatures.  It reduced the freedom
    that XML serializers have and instead generates a more constrained XML
    representation.  The main restrictions regard the placement of namespace
-   declarations, the ordering of attributes, and ignorable whitespace.
+   declarations, the ordering of attributes, and ignorable :term:`whitespace`.
 
    This function takes an XML data string (*xml_data*) or a file path or
    file-like object (*from_file*) as input, converts it to the canonical
@@ -509,7 +509,7 @@ Functions
    The configuration *options* are as follows:
 
    - *with_comments*: set to true to include comments (default: false)
-   - *strip_text*: set to true to strip whitespace before and after text content
+   - *strip_text*: set to true to strip :term:`whitespace` before and after text content
                    (default: false)
    - *rewrite_prefixes*: set to true to replace namespace prefixes by "n{number}"
                          (default: false)

--- a/Doc/library/xml.sax.handler.rst
+++ b/Doc/library/xml.sax.handler.rst
@@ -309,7 +309,7 @@ events in the input document:
 
 .. method:: ContentHandler.ignorableWhitespace(whitespace)
 
-   Receive notification of ignorable whitespace in element content.
+   Receive notification of ignorable :term:`whitespace` in element content.
 
    Validating Parsers must use this method to report each chunk of ignorable
    whitespace (see the W3C XML 1.0 recommendation, section 2.10): non-validating

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -48,7 +48,7 @@ additional methods of invocation:
   appropriately named script from that directory.
 * When called with ``-c command``, it executes the Python statement(s) given as
   *command*.  Here *command* may contain multiple statements separated by
-  newlines. Leading whitespace is significant in Python statements!
+  newlines. Leading :term:`whitespace` is significant in Python statements!
 * When called with ``-m module-name``, the given module is located on the
   Python module path and executed as a script.
 
@@ -62,7 +62,7 @@ source.
 .. cmdoption:: -c <command>
 
    Execute the Python code in *command*.  *command* can be one or more
-   statements separated by newlines, with significant leading whitespace as in
+   statements separated by newlines, with significant leading :term:`whitespace` as in
    normal module code.
 
    If this option is given, the first element of :data:`sys.argv` will be


### PR DESCRIPTION
Add a "whitespace" definition to the glossary and link to it from every documentation regarding whitespae.

As requested in [bpo-25433](https://bugs.python.org/issue25433), whitespace should be explained only once and all other places should point to this documentation instead of either explaining the term themselves or just stating "whitespace" without an explanation.

No NEWS entry added since this already comes with the code part in https://github.com/python/cpython/pull/14771 .
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-25433](https://bugs.python.org/issue25433) -->
https://bugs.python.org/issue25433
<!-- /issue-number -->
