### PR TITLE
bpo-34543: Fix SystemErrors and segfaults with uninitialized Structs

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -652,6 +652,17 @@ class StructTest(unittest.TestCase):
         s2 = struct.Struct(s.format.encode())
         self.assertEqual(s2.format, s.format)
 
+    def test_uninitialized_struct(self):
+        s = struct.Struct.__new__(struct.Struct)
+        with self.assertRaises(ValueError):
+            s.format
+        with self.assertRaises(ValueError):
+            s.size
+        for meth in s.iter_unpack, s.pack, s.unpack, s.unpack_from:
+            self.assertRaises(ValueError, meth, b'0')
+        self.assertRaises(ValueError, s.pack_into, bytearray(1), 0, b'0')
+        self.assertRaises(ValueError, s.__sizeof__)
+
 
 class UnpackIteratorTest(unittest.TestCase):
     """

--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-14-16-32-15.bpo-34543.2Sguv-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-14-16-32-15.bpo-34543.2Sguv-.rst
@@ -1,0 +1,2 @@
+Fix :exc:`SystemError`\ s and segfaults with uninitialized
+:class:`struct.Struct`\ s.


### PR DESCRIPTION


<!-- issue-number: [bpo-34543](https://bugs.python.org/issue34543) -->
https://bugs.python.org/issue34543
<!-- /issue-number -->
