### PR TITLE
[3.8] bpo-36974: separate vectorcall functions for each calling convention (GH-13781)

### DIFF
--- a/Include/descrobject.h
+++ b/Include/descrobject.h
@@ -91,9 +91,6 @@ PyAPI_FUNC(PyObject *) PyDescr_NewMember(PyTypeObject *,
 PyAPI_FUNC(PyObject *) PyDescr_NewGetSet(PyTypeObject *,
                                                struct PyGetSetDef *);
 #ifndef Py_LIMITED_API
-
-PyAPI_FUNC(PyObject *) _PyMethodDescr_Vectorcall(
-        PyObject *descrobj, PyObject *const *args, size_t nargsf, PyObject *kwnames);
 PyAPI_FUNC(PyObject *) PyDescr_NewWrapper(PyTypeObject *,
                                                 struct wrapperbase *, void *);
 #define PyDescr_IsData(d) (Py_TYPE(d)->tp_descr_set != NULL)

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -46,11 +46,6 @@ PyAPI_FUNC(PyObject *) _PyCFunction_FastCallDict(PyObject *func,
     PyObject *const *args,
     Py_ssize_t nargs,
     PyObject *kwargs);
-
-PyAPI_FUNC(PyObject *) _PyCFunction_Vectorcall(PyObject *func,
-    PyObject *const *stack,
-    size_t nargsf,
-    PyObject *kwnames);
 #endif
 
 struct PyMethodDef {

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -586,6 +586,8 @@ class TestPEP590(unittest.TestCase):
                 return super().__call__(*args)
 
         calls += [
+            (dict.update, ({},), {"key":True}, None),
+            ({}.update, ({},), {"key":True}, None),
             (MethodDescriptorHeap(), (0,), {}, True),
             (MethodDescriptorOverridden(), (0,), {}, 'new'),
             (MethodDescriptorSuper(), (0,), {}, True),

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -850,10 +850,10 @@ id(42)
         # called, so test a variety of calling conventions.
         for py_name, py_args, c_name, expected_frame_number in (
             ('gmtime', '', 'time_gmtime', 1),  # METH_VARARGS
-            ('len', '[]', 'builtin_len', 2),  # METH_O
-            ('locals', '', 'builtin_locals', 2),  # METH_NOARGS
-            ('iter', '[]', 'builtin_iter', 2),  # METH_FASTCALL
-            ('sorted', '[]', 'builtin_sorted', 2),  # METH_FASTCALL|METH_KEYWORDS
+            ('len', '[]', 'builtin_len', 1),  # METH_O
+            ('locals', '', 'builtin_locals', 1),  # METH_NOARGS
+            ('iter', '[]', 'builtin_iter', 1),  # METH_FASTCALL
+            ('sorted', '[]', 'builtin_sorted', 1),  # METH_FASTCALL|METH_KEYWORDS
         ):
             with self.subTest(c_name):
                 cmd = ('from time import gmtime\n'  # (not always needed)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-11-12-59-38.bpo-36974.bVYmSA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-11-12-59-38.bpo-36974.bVYmSA.rst
@@ -1,0 +1,2 @@
+Implemented separate vectorcall functions for every calling convention of
+builtin functions and methods. This improves performance for calls.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -206,7 +206,7 @@ PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *kwargs)
         Py_DECREF(kwnames);
     }
 
-    return result;
+    return _Py_CheckFunctionResult(callable, result, NULL);
 }
 
 
@@ -719,25 +719,6 @@ no_keyword_error:
 
 exit:
     Py_LeaveRecursiveCall();
-    return result;
-}
-
-
-PyObject *
-_PyCFunction_Vectorcall(PyObject *func,
-                        PyObject *const *args, size_t nargsf,
-                        PyObject *kwnames)
-{
-    PyObject *result;
-
-    assert(func != NULL);
-    assert(PyCFunction_Check(func));
-    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
-
-    result = _PyMethodDef_RawFastCallKeywords(((PyCFunctionObject*)func)->m_ml,
-                                              PyCFunction_GET_SELF(func),
-                                              args, nargs, kwnames);
-    result = _Py_CheckFunctionResult(func, result, NULL);
     return result;
 }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4943,7 +4943,7 @@ trace_call_function(PyThreadState *tstate,
 {
     PyObject *x;
     if (PyCFunction_Check(func)) {
-        C_TRACE(x, _PyCFunction_Vectorcall(func, args, nargs, kwnames));
+        C_TRACE(x, _PyObject_Vectorcall(func, args, nargs, kwnames));
         return x;
     }
     else if (Py_TYPE(func) == &PyMethodDescr_Type && nargs > 0) {
@@ -4959,9 +4959,9 @@ trace_call_function(PyThreadState *tstate,
         if (func == NULL) {
             return NULL;
         }
-        C_TRACE(x, _PyCFunction_Vectorcall(func,
-                                           args+1, nargs-1,
-                                           kwnames));
+        C_TRACE(x, _PyObject_Vectorcall(func,
+                                        args+1, nargs-1,
+                                        kwnames));
         Py_DECREF(func);
         return x;
     }
@@ -5023,10 +5023,10 @@ do_call_core(PyThreadState *tstate, PyObject *func, PyObject *callargs, PyObject
                 return NULL;
             }
 
-            C_TRACE(result, _PyCFunction_FastCallDict(func,
-                                                      &_PyTuple_ITEMS(callargs)[1],
-                                                      nargs - 1,
-                                                      kwdict));
+            C_TRACE(result, _PyObject_FastCallDict(func,
+                                                   &_PyTuple_ITEMS(callargs)[1],
+                                                   nargs - 1,
+                                                   kwdict));
             Py_DECREF(func);
             return result;
         }

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1563,9 +1563,8 @@ class Frame(object):
         if not caller:
             return False
 
-        if caller in ('_PyCFunction_FastCallDict',
-                      '_PyCFunction_Vectorcall',
-                      'cfunction_call_varargs'):
+        if (caller.startswith('cfunction_vectorcall_') or
+            caller == 'cfunction_call_varargs'):
             arg_name = 'func'
             # Within that frame:
             #   "func" is the local containing the PyObject* of the


### PR DESCRIPTION
Backport #13781 (part of the PEP 590 implementation) to 3.8 to fix a performance regression, see [bpo-37562](https://bugs.python.org/issue37562).

CC @vstinner @pablogsal @ambv 

<!-- issue-number: [bpo-36974](https://bugs.python.org/issue36974) -->
https://bugs.python.org/issue36974
<!-- /issue-number -->
