### PR TITLE
bpo-37547: Fix a compiler warning in Modules/_io/winconsoleio.c

### DIFF
--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -205,7 +205,7 @@ _io__WindowsConsoleIO_close_impl(winconsoleio *self)
     int rc;
     _Py_IDENTIFIER(close);
     res = _PyObject_CallMethodIdOneArg((PyObject*)&PyRawIOBase_Type,
-                                       &PyId_close, self);
+                                       &PyId_close, (PyObject*)self);
     if (!self->closehandle) {
         self->handle = INVALID_HANDLE_VALUE;
         return res;


### PR DESCRIPTION
The compiler warning was introduced in
59ad110d7a7784d53d0b502eebce0346597a6bef.


<!-- issue-number: [bpo-37547](https://bugs.python.org/issue37547) -->
https://bugs.python.org/issue37547
<!-- /issue-number -->
