### PR TITLE
bpo-37599: Remove a vague statement in documentation of Integer Objects

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -42,7 +42,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
    The current implementation keeps an array of integer objects for all integers
    between ``-5`` and ``256``, when you create an int in that range you actually
-   just get back a reference to the existing object. So it should be possible to
+    just get back a reference to the existing object.
    change the value of ``1``.
 
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -42,7 +42,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
    The current implementation keeps an array of integer objects for all integers
    between ``-5`` and ``256``, when you create an int in that range you actually
-    just get back a reference to the existing object.
+   just get back a reference to the existing object.
 
 
 .. c:function:: PyObject* PyLong_FromUnsignedLong(unsigned long v)

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -43,7 +43,6 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    The current implementation keeps an array of integer objects for all integers
    between ``-5`` and ``256``, when you create an int in that range you actually
     just get back a reference to the existing object.
-   change the value of ``1``.
 
 
 .. c:function:: PyObject* PyLong_FromUnsignedLong(unsigned long v)

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -43,8 +43,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    The current implementation keeps an array of integer objects for all integers
    between ``-5`` and ``256``, when you create an int in that range you actually
    just get back a reference to the existing object. So it should be possible to
-   change the value of ``1``.  I suspect the behaviour of Python in this case is
-   undefined. :-)
+   change the value of ``1``.
 
 
 .. c:function:: PyObject* PyLong_FromUnsignedLong(unsigned long v)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

In current Python document (3.7 - 3.9) there is such statement in documentation of Integer Objects:

> The current implementation keeps an array of integer objects for all integers between ``-5`` and ``256``, when you create an int in that range you actually just get back a reference to the existing object. So it should be possible to change the value of ``1``.  I suspect the behaviour of Python in this case is undefined. :-)

The last sentence is vague. It is inappropriate to write "I suspect" in documentation. And as the statements ahead has already clarified the sense that this is "a current implementation", **the last sentence should be removed**.

https://bugs.python.org/issue37599

<!-- issue-number: [bpo-37599](https://bugs.python.org/issue37599) -->
https://bugs.python.org/issue37599
<!-- /issue-number -->

---

Edit: Change "irresponsible" to "inappropriate" to avoid pejoratives, according to <https://bugs.python.org/msg348019>.