### PR TITLE
bpo-7202: Parse command global options

### DIFF
--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -26,8 +26,6 @@ from distutils.debug import DEBUG
 # to look for a Python module named after the command.
 command_re = re.compile(r'^[a-zA-Z]([a-zA-Z0-9_]*)$')
 
-longopt_revxlate = str.maketrans('_', '-')
-
 
 def _ensure_list(value, fieldname):
     if isinstance(value, str):
@@ -607,9 +605,10 @@ Common commands: (see '--help-commands' for more)
         # holding pen, the 'command_options' dictionary.
         opt_dict = self.get_option_dict(command)
         for (name, value) in vars(opts).items():
-            opt_name = name.translate(longopt_revxlate)
-            if (  opt_name in global_option_names
-                  and opt_name not in command_option_names):
+            # Translate Python identifiers into long options names.
+            opt_name = name.replace('_', '-')
+            if (opt_name in global_option_names and
+                    opt_name not in command_option_names):
                 alias = self.negative_opt.get(name)
                 try:
                     if alias:

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -490,6 +490,14 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
                   if line.strip() != '']
         self.assertTrue(output)
 
+    def test_parse_command_opts(self):
+        dist = Distribution()
+        sys.argv = ["setup.py", "build", "--quiet"]
+        dist.parse_command_line()
+        # Note: the `quiet` option is an alias that negatively affects the
+        # `verbose` option value, that is `True` by default
+        self.assertFalse(dist.verbose)
+        self.assertTrue("verbose" not in dist.get_option_dict("build"))
 
     def test_read_metadata(self):
         attrs = {"name": "package",

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -497,7 +497,7 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
         # Note: the `quiet` option is an alias that negatively affects the
         # `verbose` option value, that is `True` by default
         self.assertFalse(dist.verbose)
-        self.assertTrue("verbose" not in dist.get_option_dict("build"))
+        self.assertNotIn("verbose", dist.get_option_dict("build"))
 
     def test_read_metadata(self):
         attrs = {"name": "package",


### PR DESCRIPTION
Add the ability to parse command global options.

If a command has a global option (except help) it will be reapplied to
the distribtuion object.

If a command has a global option (except help) but also defines it as
a local command option, it will not be reapplied to the distribtuion
object.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-7202](https://bugs.python.org/issue7202) -->
https://bugs.python.org/issue7202
<!-- /issue-number -->
