### PR TITLE
bpo-37603: tok_nextc() now also updates multi_line_start on REALLOC()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-16-12-03-28.bpo-37603.9vJahv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-16-12-03-28.bpo-37603.9vJahv.rst
@@ -1,0 +1,2 @@
+Fix Python parser crash: when the tokenizer grows its internal buffer using
+REALLOC(), update also tok->multi_line_start.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -969,6 +969,7 @@ tok_nextc(struct tok_state *tok)
                 tok->buf = newbuf;
                 tok->cur = tok->buf + cur;
                 tok->line_start = tok->cur;
+                tok->multi_line_start = tok->cur;
                 tok->inp = tok->buf + curvalid;
                 tok->end = tok->buf + newsize;
                 tok->start = curstart < 0 ? NULL :


### PR DESCRIPTION
Fix Python parser crash: when the tokenizer grows its internal buffer
using REALLOC(), update also tok->multi_line_start.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37603](https://bugs.python.org/issue37603) -->
https://bugs.python.org/issue37603
<!-- /issue-number -->
