### PR TITLE
bpo-37256: Wording in Request class docs

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -227,7 +227,7 @@ The following classes are provided:
    is not None, ``Content-Type: application/x-www-form-urlencoded`` will
    be added as a default.
 
-   The final two arguments are only of interest for correct handling
+   The next two arguments are only of interest for correct handling
    of third-party HTTP cookies:
 
    *origin_req_host* should be the request-host of the origin

--- a/Misc/NEWS.d/next/Documentation/2019-07-16-14-48-12.bpo-37256.qJTrBb.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-07-16-14-48-12.bpo-37256.qJTrBb.rst
@@ -1,0 +1,1 @@
+change wording in Request class

--- a/Misc/NEWS.d/next/Documentation/2019-07-16-14-48-12.bpo-37256.qJTrBb.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-07-16-14-48-12.bpo-37256.qJTrBb.rst
@@ -1,1 +1,1 @@
-change wording in Request class
+Fix wording of arguments for :class:`Request` in :mod:`urllib.request`


### PR DESCRIPTION
change wording in `Request` class documentation

<!-- issue-number: [bpo-37256](https://bugs.python.org/issue37256) -->
https://bugs.python.org/issue37256
<!-- /issue-number -->
