### PR TITLE
bpo-37461: Fix infinite loop in parsing of specially crafted email headers

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2494,11 +2494,11 @@ def get_parameter(value):
         # Treat the rest of value as bare quoted string content.
         v = Value()
         while value:
-            if value[0] == '"':
+            if value[0] in WSP:
+                token, value = get_fws(value)
+            elif value[0] == '"':
                 token = ValueTerminal('"', 'DQUOTE')
                 value = value[1:]
-            elif value[0] in WSP:
-                token, value = get_fws(value)
             else:
                 token, value = get_qcontent(value)
             v.append(token)

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2494,7 +2494,10 @@ def get_parameter(value):
         # Treat the rest of value as bare quoted string content.
         v = Value()
         while value:
-            if value[0] in WSP:
+            if value[0] == '"':
+                token = ValueTerminal('"', 'DQUOTE')
+                value = value[1:]
+            elif value[0] in WSP:
                 token, value = get_fws(value)
             else:
                 token, value = get_qcontent(value)

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2710,6 +2710,13 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             # Defects are apparent missing *0*, and two 'out of sequence'.
             [errors.InvalidHeaderDefect]*3),
 
+        # bpo-37461: Check that we don't go into an infinite loop.
+        'extra_dquote': (
+            'r*="\'a\'\\"""',
+            ' r="\\""',
+            'r*=\'a\'"',
+            [('r', '"')],
+            [errors.InvalidHeaderDefect]*2),
     }
 
 @parameterize

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2712,7 +2712,7 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
 
         # bpo-37461: Check that we don't go into an infinite loop.
         'extra_dquote': (
-            'r*="\'a\'\\"""',
+            'r*="\'a\'\\"',
             ' r="\\""',
             'r*=\'a\'"',
             [('r', '"')],

--- a/Misc/NEWS.d/next/Security/2019-07-16-08-11-00.bpo-37461.1Ahz7O.rst
+++ b/Misc/NEWS.d/next/Security/2019-07-16-08-11-00.bpo-37461.1Ahz7O.rst
@@ -1,0 +1,2 @@
+Fix an inifite loop when parsing specially crafted email headers. Patch by
+Abhilash Raj.


### PR DESCRIPTION
Some crafted email header would cause the get_parameter method to run in an
infinite loop causing a DoS attack surface when parsing those headers. This
patch fixes that by making sure the DQUOTE character is handled to prevent
going into an infinite loop.

<!-- issue-number: [bpo-37461](https://bugs.python.org/issue37461) -->
https://bugs.python.org/issue37461
<!-- /issue-number -->
