### PR TITLE
bpo-29548: deprecate PyEval_Call* functions

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -8,25 +8,25 @@ extern "C" {
 /* Interface to random parts in ceval.c */
 
 /* PyEval_CallObjectWithKeywords(), PyEval_CallObject(), PyEval_CallFunction
- * and PyEval_CallMethod are kept for backward compatibility: PyObject_Call(),
- * PyObject_CallFunction() and PyObject_CallMethod() are recommended to call
- * a callable object.
+ * and PyEval_CallMethod are deprecated. Since they are officially part of the
+ * stable ABI (PEP 384), they must be kept for backward compatibility.
+ * PyObject_Call(), PyObject_CallFunction() and PyObject_CallMethod() are
+ * recommended to call a callable object.
  */
 
-PyAPI_FUNC(PyObject *) PyEval_CallObjectWithKeywords(
+Py_DEPRECATED(3.9) PyAPI_FUNC(PyObject *) PyEval_CallObjectWithKeywords(
     PyObject *callable,
     PyObject *args,
     PyObject *kwargs);
 
-/* Inline this */
+/* Deprecated since PyEval_CallObjectWithKeywords is deprecated */
 #define PyEval_CallObject(callable, arg) \
     PyEval_CallObjectWithKeywords(callable, arg, (PyObject *)NULL)
 
-PyAPI_FUNC(PyObject *) PyEval_CallFunction(PyObject *callable,
-                                           const char *format, ...);
-PyAPI_FUNC(PyObject *) PyEval_CallMethod(PyObject *obj,
-                                         const char *name,
-                                         const char *format, ...);
+Py_DEPRECATED(3.9) PyAPI_FUNC(PyObject *) PyEval_CallFunction(
+    PyObject *callable, const char *format, ...);
+Py_DEPRECATED(3.9) PyAPI_FUNC(PyObject *) PyEval_CallMethod(
+    PyObject *obj, const char *name, const char *format, ...);
 
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(void) PyEval_SetProfile(Py_tracefunc, PyObject *);

--- a/Misc/NEWS.d/next/C API/2019-07-17-09-50-50.bpo-29548.5wIptQ.rst
+++ b/Misc/NEWS.d/next/C API/2019-07-17-09-50-50.bpo-29548.5wIptQ.rst
@@ -1,0 +1,3 @@
+The functions ``PyEval_CallObject``, ``PyEval_CallFunction``,
+``PyEval_CallMethod`` and ``PyEval_CallObjectWithKeywords`` are deprecated.
+Use :c:func:`PyObject_Call` and its variants instead.


### PR DESCRIPTION
CC @methane 

<!-- issue-number: [bpo-29548](https://bugs.python.org/issue29548) -->
https://bugs.python.org/issue29548
<!-- /issue-number -->
