### PR TITLE
bpo-34443: Use __qualname__ instead of __name__ in enum exception messages.

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -577,7 +577,7 @@ class Enum(metaclass=EnumMeta):
         if isinstance(result, cls):
             return result
         else:
-            ve_exc = ValueError("%r is not a valid %s" % (value, cls.__name__))
+            ve_exc = ValueError("%r is not a valid %s" % (value, cls.__qualname__))
             if result is None and exc is None:
                 raise ve_exc
             elif exc is None:
@@ -599,7 +599,7 @@ class Enum(metaclass=EnumMeta):
 
     @classmethod
     def _missing_(cls, value):
-        raise ValueError("%r is not a valid %s" % (value, cls.__name__))
+        raise ValueError("%r is not a valid %s" % (value, cls.__qualname__))
 
     def __repr__(self):
         return "<%s.%s: %r>" % (
@@ -706,7 +706,7 @@ class Flag(Enum):
             # verify all bits are accounted for
             _, extra_flags = _decompose(cls, value)
             if extra_flags:
-                raise ValueError("%r is not a valid %s" % (value, cls.__name__))
+                raise ValueError("%r is not a valid %s" % (value, cls.__qualname__))
             # construct a singleton enum pseudo-member
             pseudo_member = object.__new__(cls)
             pseudo_member._name_ = None
@@ -780,7 +780,7 @@ class IntFlag(int, Flag):
     @classmethod
     def _missing_(cls, value):
         if not isinstance(value, int):
-            raise ValueError("%r is not a valid %s" % (value, cls.__name__))
+            raise ValueError("%r is not a valid %s" % (value, cls.__qualname__))
         new_member = cls._create_pseudo_member_(value)
         return new_member
 

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2260,12 +2260,13 @@ class TestFlag(unittest.TestCase):
             d = 4
             f = 6
         # Bizarre.c | Bizarre.d
-        self.assertRaisesRegex(ValueError, "5 is not a valid Bizarre", Bizarre, 5)
-        self.assertRaisesRegex(ValueError, "5 is not a valid Bizarre", Bizarre, 5)
-        self.assertRaisesRegex(ValueError, "2 is not a valid Bizarre", Bizarre, 2)
-        self.assertRaisesRegex(ValueError, "2 is not a valid Bizarre", Bizarre, 2)
-        self.assertRaisesRegex(ValueError, "1 is not a valid Bizarre", Bizarre, 1)
-        self.assertRaisesRegex(ValueError, "1 is not a valid Bizarre", Bizarre, 1)
+        name = "TestFlag.test_cascading_failure.<locals>.Bizarre"
+        self.assertRaisesRegex(ValueError, "5 is not a valid " + name, Bizarre, 5)
+        self.assertRaisesRegex(ValueError, "5 is not a valid " + name, Bizarre, 5)
+        self.assertRaisesRegex(ValueError, "2 is not a valid " + name, Bizarre, 2)
+        self.assertRaisesRegex(ValueError, "2 is not a valid " + name, Bizarre, 2)
+        self.assertRaisesRegex(ValueError, "1 is not a valid " + name, Bizarre, 1)
+        self.assertRaisesRegex(ValueError, "1 is not a valid " + name, Bizarre, 1)
 
     def test_duplicate_auto(self):
         class Dupes(Enum):

--- a/Misc/NEWS.d/next/Library/2019-07-17-11-10-08.bpo-34443.OFnGqz.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-17-11-10-08.bpo-34443.OFnGqz.rst
@@ -1,2 +1,2 @@
-Exceptions from :mod:`enum` now use the `__qualname` of the enum class in
-the exception message instead of the `__name__`.
+Exceptions from :mod:`enum` now use the ``__qualname`` of the enum class in
+the exception message instead of the ``__name__``.

--- a/Misc/NEWS.d/next/Library/2019-07-17-11-10-08.bpo-34443.OFnGqz.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-17-11-10-08.bpo-34443.OFnGqz.rst
@@ -1,0 +1,2 @@
+Exceptions from :mod:`enum` now use the `__qualname` of the enum class in
+the exception message instead of the `__name__`.


### PR DESCRIPTION


<!-- issue-number: [bpo-34443](https://bugs.python.org/issue34443) -->
https://bugs.python.org/issue34443
<!-- /issue-number -->
