### PR TITLE
bpo-37491: Fix IndexError when parsing unexpectedly ending quoted-string.

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1191,7 +1191,7 @@ def get_bare_quoted_string(value):
             "expected '\"' but found '{}'".format(value))
     bare_quoted_string = BareQuotedString()
     value = value[1:]
-    if value[0] == '"':
+    if value and value[0] == '"':
         token, value = get_qcontent(value)
         bare_quoted_string.append(token)
     while value and value[0] != '"':

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -522,6 +522,10 @@ class TestParser(TestParserMixin, TestEmailBase):
         self._test_get_x(parser.get_bare_quoted_string,
                          '""', '""', '', [], '')
 
+    def test_get_bare_quoted_string_missing_endquotes(self):
+        self._test_get_x(parser.get_bare_quoted_string,
+                         '"', '""', '', [errors.InvalidHeaderDefect], '')
+
     def test_get_bare_quoted_string_following_wsp_preserved(self):
         self._test_get_x(parser.get_bare_quoted_string,
              '"foo"\t bar', '"foo"', 'foo', [], '\t bar')

--- a/Misc/NEWS.d/next/Library/2019-07-17-06-54-43.bpo-37491.op0aMs.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-17-06-54-43.bpo-37491.op0aMs.rst
@@ -1,0 +1,2 @@
+Fix ``IndexError`` when parsing email headers with unexpectedly ending
+bare-quoted string value. Patch by Abhilash Raj.


### PR DESCRIPTION
This exception was caused because the input ended unexpectedly with only one
single quote instead of a pair with some value inside it.



<!-- issue-number: [bpo-37491](https://bugs.python.org/issue37491) -->
https://bugs.python.org/issue37491
<!-- /issue-number -->
