### PR TITLE
bpo-37337: Fix a GCC 9 warning in Objects/descrobject.c

### DIFF
--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1047,7 +1047,7 @@ mappingproxy_copy(mappingproxyobject *pp, PyObject *Py_UNUSED(ignored))
             to the underlying mapping */
 
 static PyMethodDef mappingproxy_methods[] = {
-    {"get",       (PyCFunction)mappingproxy_get,        METH_FASTCALL,
+    {"get",       (PyCFunction)(void(*)(void))mappingproxy_get, METH_FASTCALL,
      PyDoc_STR("D.get(k[,d]) -> D[k] if k in D, else d."
                "  d defaults to None.")},
     {"keys",      (PyCFunction)mappingproxy_keys,       METH_NOARGS,


### PR DESCRIPTION
Commit b1263d5a60d3f7ab02dd28409fff59b3815a3f67 causes GCC 9.1.0 to
give a warning in Objects/descrobject.c.

```
Objects/descrobject.c:1050:19: warning: cast between incompatible function types from ‘PyObject * (*)(mappingproxyobject *, PyObject * const*, Py_ssize_t)’ {aka ‘struct _object * (*)(struct <anonymous> *, struct _object * const*, long int)’} to ‘PyObject * (*)(PyObject *, PyObject *)’ {aka ‘struct _object * (*)(struct _object *, struct _object *)’} [-Wcast-function-type]
 1050 |     {"get",       (PyCFunction)mappingproxy_get,        METH_FASTCALL,
      |                   ^
```


<!-- issue-number: [bpo-37337](https://bugs.python.org/issue37337) -->
https://bugs.python.org/issue37337
<!-- /issue-number -->
