### PR TITLE
bpo-37560: Add exception handler in FieldStorage cleanup

### DIFF
--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -483,7 +483,10 @@ class FieldStorage:
         return self
 
     def __exit__(self, *args):
-        self.file.close()
+        try:
+            self.file.close()
+        except AttributeError:
+            pass
 
     def __repr__(self):
         """Return a printable representation."""

--- a/Lib/test/test_cgi.py
+++ b/Lib/test/test_cgi.py
@@ -365,11 +365,8 @@ Larry
 
     def test_fieldstorage_exit_context(self):
         fs = cgi.FieldStorage()
-        try:
-            with fs:
-                fs.bytes_read = 0
-        except AttributeError:
-            self.fail('clean up raises exception')
+        with fs:
+            fs.bytes_read = 0
 
     _qs_result = {
         'key1': 'value1',

--- a/Lib/test/test_cgi.py
+++ b/Lib/test/test_cgi.py
@@ -363,6 +363,14 @@ Larry
         with self.assertRaisesRegex(ValueError, 'I/O operation on closed file'):
             fs.file.read()
 
+    def test_fieldstorage_exit_context(self):
+        fs = cgi.FieldStorage()
+        try:
+            with fs:
+                fs.bytes_read = 0
+        except AttributeError:
+            self.fail('clean up raises exception')
+
     _qs_result = {
         'key1': 'value1',
         'key2': ['value2x', 'value2y'],

--- a/Misc/NEWS.d/next/Library/2019-07-17-15-52-19.bpo-37560.S4BYfK.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-17-15-52-19.bpo-37560.S4BYfK.rst
@@ -1,0 +1,1 @@
+Add exception handler for :class:`FieldStorage` in :mod:`cgi.FieldStorage` at method `__exit__`


### PR DESCRIPTION
Add exception handler on `FieldStorage` at `__exit__` method

<!-- issue-number: [bpo-37560](https://bugs.python.org/issue37560) -->
https://bugs.python.org/issue37560
<!-- /issue-number -->
