### PR TITLE
bpo-33610: When toggling code-context on, immediately show the current context.

### DIFF
--- a/Lib/idlelib/codecontext.py
+++ b/Lib/idlelib/codecontext.py
@@ -112,12 +112,13 @@ class CodeContext:
                 padx=padx, border=border, relief=SUNKEN, state='disabled')
             self.update_highlight_colors()
             self.context.bind('<ButtonRelease-1>', self.jumptoline)
+            # Get the current context and initiate the recurring update event.
+            self.timer_event()
             # Pack the context widget before and above the text_frame widget,
             # thus ensuring that it will appear directly above text_frame.
             self.context.pack(side=TOP, fill=X, expand=False,
                               before=self.editwin.text_frame)
             menu_status = 'Hide'
-            self.t1 = self.text.after(self.UPDATEINTERVAL, self.timer_event)
         else:
             self.context.destroy()
             self.context = None

--- a/Lib/idlelib/codecontext.py
+++ b/Lib/idlelib/codecontext.py
@@ -63,10 +63,13 @@ class CodeContext:
         """
         self.editwin = editwin
         self.text = editwin.text
+        self._reset()
+
+    def _reset(self):
         self.context = None
+        self.t1 = None
         self.topvisible = 1
         self.info = [(0, -1, "", False)]
-        self.t1 = None
 
     @classmethod
     def reload(cls):
@@ -121,9 +124,8 @@ class CodeContext:
             menu_status = 'Hide'
         else:
             self.context.destroy()
-            self.context = None
             self.text.after_cancel(self.t1)
-            self.t1 = None
+            self._reset()
             menu_status = 'Show'
         self.editwin.update_menu_label(menu='options', index='* Code Context',
                                        label=f'{menu_status} Code Context')

--- a/Lib/idlelib/idle_test/test_codecontext.py
+++ b/Lib/idlelib/idle_test/test_codecontext.py
@@ -135,7 +135,7 @@ class CodeContextTest(unittest.TestCase):
             toggle()
 
         # Toggle on.
-        eq(toggle(), 'break')
+        toggle()
         self.assertIsNotNone(cc.context)
         eq(cc.context['font'], self.text['font'])
         eq(cc.context['fg'], self.highlight_cfg['foreground'])
@@ -145,10 +145,21 @@ class CodeContextTest(unittest.TestCase):
         eq(self.root.tk.call('after', 'info', self.cc.t1)[1], 'timer')
 
         # Toggle off.
-        eq(toggle(), 'break')
+        toggle()
         self.assertIsNone(cc.context)
         eq(cc.editwin.label, 'Show Code Context')
         self.assertIsNone(self.cc.t1)
+
+        # Scroll down and toggle back on.
+        line11_context = '\n'.join(x[2] for x in cc.get_context(11)[0])
+        cc.text.yview(11)
+        toggle()
+        eq(cc.context.get('1.0', 'end-1c'), line11_context)
+
+        # Toggle off and on again.
+        toggle()
+        toggle()
+        eq(cc.context.get('1.0', 'end-1c'), line11_context)
 
     def test_get_context(self):
         eq = self.assertEqual
@@ -329,7 +340,7 @@ class CodeContextTest(unittest.TestCase):
         eq = self.assertEqual
         cc = self.cc
         save_font = cc.text['font']
-        test_font = 'TkFixedFont'
+        test_font = 'TkTextFont'
 
         # Ensure code context is not active.
         if cc.context is not None:

--- a/Misc/NEWS.d/next/IDLE/2019-07-18-10-11-36.bpo-33610.xYqMLg.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-07-18-10-11-36.bpo-33610.xYqMLg.rst
@@ -1,0 +1,1 @@
+Fix code context not showing the correct context when first toggled on.


### PR DESCRIPTION
This avoids a delay of up to 100ms and the accompanying visual artifact.

<!-- issue-number: [bpo-33610](https://bugs.python.org/issue33610) -->
https://bugs.python.org/issue33610
<!-- /issue-number -->
