### PR TITLE
bpo-33408: Enable AF_UNIX support in Windows

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -494,7 +494,12 @@ if hasattr(_socket, "socketpair"):
 else:
 
     # Origin: https://gist.github.com/4325783, by Geert Jansen.  Public domain.
-    def socketpair(family=AF_UNIX, type=SOCK_STREAM, proto=0):
+    def socketpair(family=None, type=SOCK_STREAM, proto=0):
+        if family is None:
+            try:
+                family = AF_UNIX
+            except NameError:
+                family = AF_INET
         if family == AF_INET:
             host = _LOCALHOST
         elif family == AF_INET6:

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -494,11 +494,14 @@ if hasattr(_socket, "socketpair"):
 else:
 
     # Origin: https://gist.github.com/4325783, by Geert Jansen.  Public domain.
-    def socketpair(family=AF_INET, type=SOCK_STREAM, proto=0):
+    def socketpair(family=AF_UNIX, type=SOCK_STREAM, proto=0):
         if family == AF_INET:
             host = _LOCALHOST
         elif family == AF_INET6:
             host = _LOCALHOST_V6
+        elif family == AF_UNIX:
+            from uuid import uuid4
+            host = os.path.join(os.environ['TEMP'],  str(uuid4()))
         else:
             raise ValueError("Only AF_INET and AF_INET6 socket address families "
                              "are supported")
@@ -511,7 +514,10 @@ else:
         # setblocking(False) that prevents us from having to create a thread.
         lsock = socket(family, type, proto)
         try:
-            lsock.bind((host, 0))
+            if family == AF_UNIX:
+                lsock.bind(host)
+            else:
+                lsock.bind((host, 0))
             lsock.listen()
             # On IPv6, ignore flow_info and scope_id
             addr, port = lsock.getsockname()[:2]
@@ -519,7 +525,10 @@ else:
             try:
                 csock.setblocking(False)
                 try:
-                    csock.connect((addr, port))
+                    if family == AF_UNIX:
+                        csock.connect(host)
+                    else:
+                        csock.connect((addr, port))
                 except (BlockingIOError, InterruptedError):
                     pass
                 csock.setblocking(True)
@@ -529,6 +538,8 @@ else:
                 raise
         finally:
             lsock.close()
+            if family == AF_UNIX:
+                os.unlink(host)
         return (ssock, csock)
     __all__.append("socketpair")
 

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -447,6 +447,10 @@ class TCPServer(BaseServer):
         BaseServer.__init__(self, server_address, RequestHandlerClass)
         self.socket = socket.socket(self.address_family,
                                     self.socket_type)
+
+        if sys.platform == 'win32' and self.address_family == socket.AF_UNIX:
+            self.allow_reuse_address = False
+
         if bind_and_activate:
             try:
                 self.server_bind()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4631,7 +4631,7 @@ class TestInvalidFamily(unittest.TestCase):
 
     @unittest.skipUnless(WIN32, "skipped on non-Windows platforms")
     def test_invalid_family_win32(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(OSError):
             multiprocessing.connection.Listener('/var/test.pipe')
 
 #

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1687,6 +1687,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.assertEqual('CLOSED', protocol.state)
 
     @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), 'No UNIX Sockets')
+    @unittest.skipIf(sys.platform == 'win32', 'datagrams not supported')
     def test_create_datagram_endpoint_sock_unix(self):
         fut = self.loop.create_datagram_endpoint(
             lambda: MyDatagramProto(create_future=True, loop=self.loop),
@@ -1698,6 +1699,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.assertEqual('CLOSED', protocol.state)
 
     @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), 'No UNIX Sockets')
+    @unittest.skipIf(sys.platform == 'win32', 'datagrams not supported')
     def test_create_datagram_endpoint_existing_sock_unix(self):
         with test_utils.unix_socket_path() as path:
             sock = socket.socket(socket.AF_UNIX, type=socket.SOCK_DGRAM)

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -469,7 +469,12 @@ class BaseServer(asyncore.dispatcher):
     def __init__(self, family, addr, handler=BaseTestHandler):
         asyncore.dispatcher.__init__(self)
         self.create_socket(family)
-        self.set_reuse_addr()
+        if sys.platform == 'win32' and family == socket.AF_UNIX:
+            # calling set_reuse_addr() on Windows with family AF_UNIX results in:
+            # OSError: [WinError 10045] The attempted operation is not supported for the type of object referenced
+            pass
+        else:
+            self.set_reuse_addr()
         bind_af_aware(self.socket, addr)
         self.listen(5)
         self.handler = handler

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1978,6 +1978,7 @@ class _BasePathTest(object):
         self.assertIs((P / 'fileA\x00').is_socket(), False)
 
     @unittest.skipUnless(hasattr(socket, "AF_UNIX"), "Unix sockets required")
+    @unittest.skipIf(sys.platform == 'win32', "stat doesn't detect sockets")
     def test_is_socket_true(self):
         P = self.cls(BASE, 'mysock')
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5276,8 +5276,14 @@ class TestUnixDomain(unittest.TestCase):
                 raise
 
     def testUnbound(self):
-        # Issue #30205 (note getsockname() can return None on OS X)
-        self.assertIn(self.sock.getsockname(), ('', None))
+        if sys.platform == 'win32':
+            # Getting the name of unbound socket on Windows
+            # raises an exception
+            self.assertRaises(OSError, self.sock.getsockname)
+        else:
+            # Issue #30205 (note getsockname() can return None on OS X)
+            name = self.sock.getsockname()
+            self.assertIn(name, ('', None))
 
     def testStrAddr(self):
         # Test binding to and retrieving a normal string pathname.
@@ -5293,6 +5299,7 @@ class TestUnixDomain(unittest.TestCase):
         self.addCleanup(support.unlink, path)
         self.assertEqual(self.sock.getsockname(), path)
 
+    @unittest.skipIf(sys.platform == 'win32', "ASCII path name required on Windows")
     def testSurrogateescapeBind(self):
         # Test binding to a valid non-ASCII pathname, with the
         # non-ASCII bytes supplied using surrogateescape encoding.

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -8,6 +8,7 @@ import os
 import select
 import signal
 import socket
+import sys
 import tempfile
 import threading
 import unittest
@@ -232,12 +233,14 @@ class SocketServerTest(unittest.TestCase):
                             self.dgram_examine)
 
     @requires_unix_sockets
+    @unittest.skipIf(sys.platform == 'win32', "no datagram support")
     def test_UnixDatagramServer(self):
         self.run_server(socketserver.UnixDatagramServer,
                         socketserver.DatagramRequestHandler,
                         self.dgram_examine)
 
     @requires_unix_sockets
+    @unittest.skipIf(sys.platform == 'win32', "no datagram support")
     def test_ThreadingUnixDatagramServer(self):
         self.run_server(socketserver.ThreadingUnixDatagramServer,
                         socketserver.DatagramRequestHandler,

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -194,6 +194,7 @@ class TestFilemode:
                 break
 
     @skip_unless_bind_unix_socket
+    @unittest.skipIf(sys.platform == 'win32', "stat and lstat don't detect sockets")
     def test_socket(self):
         with socket.socket(socket.AF_UNIX) as s:
             s.bind(TESTFN)

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -357,6 +357,8 @@ typedef struct {
 
 /* IMPORTANT: make sure the list ordered by descending build_number */
 static FlagRuntimeInfo win_runtime_flags[] = {
+    /* available starting with Windows 10 1803 */
+    {17134, "AF_UNIX"},
     /* available starting with Windows 10 1709 */
     {16299, "TCP_KEEPIDLE"},
     {16299, "TCP_KEEPINTVL"},

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -41,6 +41,8 @@ typedef int socklen_t;
 
 #ifdef HAVE_SYS_UN_H
 # include <sys/un.h>
+#elif HAVE_AFUNIX_H
+# include <afunix.h>
 #else
 # undef AF_UNIX
 #endif

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -610,6 +610,9 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* Define if you have the <sys/un.h> header file.  */
 /* #define HAVE_SYS_UN_H 1 */
 
+/* Define if you have the <afunix.h> header file.  */
+#define HAVE_AFUNIX_H 1
+
 /* Define if you have the <sys/utime.h> header file.  */
 /* #define HAVE_SYS_UTIME_H 1 */
 


### PR DESCRIPTION
These changes are incomplete, but this seems like a good point to get feedback on what I've learned so far.

Tests in test_asyncio are failing because create_unix_server and create_unix_connection are not implemented for Windows on the ProactorEventLoop class.  

Linux implements create_unix_server and create_unix_connection on the _UnixEventSelectorLoop class, and the implementation cannot be simply copied because Linux uses signals, which don't exist for Windows. Windows appears to uses IO completion ports to achieve the same results.



<!-- issue-number: [bpo-33408](https://bugs.python.org/issue33408) -->
https://bugs.python.org/issue33408
<!-- /issue-number -->
