### PR TITLE
[3.7] bpo-34621: backwards-compatible pickle UUID with is_safe=unknown

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -205,12 +205,14 @@ class UUID:
         self.__dict__['is_safe'] = is_safe
 
     def __getstate__(self):
-        state = self.__dict__
+        state = self.__dict__.copy()
         if self.is_safe != SafeUUID.unknown:
             # is_safe is a SafeUUID instance.  Return just its value, so that
             # it can be un-pickled in older Python versions without SafeUUID.
-            state = state.copy()
             state['is_safe'] = self.is_safe.value
+        else:
+            # omit is_safe when it is "unknown"
+            del state['is_safe']
         return state
 
     def __setstate__(self, state):

--- a/Misc/NEWS.d/next/Library/2019-08-04-22-06-54.bpo-34621.E2EWkw.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-04-22-06-54.bpo-34621.E2EWkw.rst
@@ -1,0 +1,2 @@
+Fixed unpickle-ability in older Python versions (<3.7) of UUID objects with
+``is_safe`` set to ``SafeUUID.unknown``.


### PR DESCRIPTION
Our previous fix for UUID pickling backwards-compatibility has a bug, where `SafeUUID.unknown` is set in the `is_safe` field of the `__getstate__` state, rather than `is_safe` being omitted. This fixes that.

Note that this doesn't happen in 3.8+, where the implementation is different due to the change of `UUID` to use slots.

<!-- issue-number: [bpo-34621](https://bugs.python.org/issue34621) -->
https://bugs.python.org/issue34621
<!-- /issue-number -->
