### PR TITLE
bpo-37619: don't ignore wrapper descriptors for wrong class

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4653,6 +4653,18 @@ order (MRO) for bases """
         self.assertEqual(x["y"], 42)
         self.assertEqual(x, -x)
 
+    def test_wrong_class_slot_wrapper(self):
+        # Check bpo-37619: a wrapper descriptor taken from the wrong class
+        # should raise an exception instead of silently being ignored
+        class A(int):
+            __eq__ = str.__eq__
+            __add__ = str.__add__
+        a = A()
+        with self.assertRaises(TypeError):
+            a == a
+        with self.assertRaises(TypeError):
+            a + a
+
     def test_slot_shadows_class_variable(self):
         with self.assertRaises(ValueError) as cm:
             class X:

--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-18-11-50-49.bpo-37619.X6Lulo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-18-11-50-49.bpo-37619.X6Lulo.rst
@@ -1,0 +1,3 @@
+When adding a wrapper descriptor from one class to a different class
+(for example, setting ``__add__ = str.__add__`` on an ``int`` subclass),
+an exception is correctly raised when the operator is called.


### PR DESCRIPTION


<!-- issue-number: [bpo-37619](https://bugs.python.org/issue37619) -->
https://bugs.python.org/issue37619
<!-- /issue-number -->
