### PR TITLE
bpo-37621: Don't emit NEWLINE tokens on blank line continuations

### DIFF
--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -951,17 +951,18 @@ async def f():
     NUMBER     '1'           (2, 0) (2, 1)
     """)
         self.check_tokenize("""x = 1
-\
+\\
 
 y = 1""", """\
     NAME       'x'           (1, 0) (1, 1)
     OP         '='           (1, 2) (1, 3)
     NUMBER     '1'           (1, 4) (1, 5)
     NEWLINE    '\\n'          (1, 5) (1, 6)
-    NL         '\\n'          (2, 0) (2, 1)
-    NAME       'y'           (3, 0) (3, 1)
-    OP         '='           (3, 2) (3, 3)
-    NUMBER     '1'           (3, 4) (3, 5)
+    NL         '\\n'          (2, 1) (2, 2)
+    NL         '\\n'          (3, 0) (3, 1)
+    NAME       'y'           (4, 0) (4, 1)
+    OP         '='           (4, 2) (4, 3)
+    NUMBER     '1'           (4, 4) (4, 5)
     """)
 
 class GenerateTokensTest(TokenizeTest):

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -944,6 +944,26 @@ async def f():
     DEDENT     ''            (7, 0) (7, 0)
     """)
 
+    def test_linecont(self):
+        self.check_tokenize("x = \\\n1", """\
+    NAME       'x'           (1, 0) (1, 1)
+    OP         '='           (1, 2) (1, 3)
+    NUMBER     '1'           (2, 0) (2, 1)
+    """)
+        self.check_tokenize("""x = 1
+\
+
+y = 1""", """\
+    NAME       'x'           (1, 0) (1, 1)
+    OP         '='           (1, 2) (1, 3)
+    NUMBER     '1'           (1, 4) (1, 5)
+    NEWLINE    '\\n'          (1, 5) (1, 6)
+    NL         '\\n'          (2, 0) (2, 1)
+    NAME       'y'           (3, 0) (3, 1)
+    OP         '='           (3, 2) (3, 3)
+    NUMBER     '1'           (3, 4) (3, 5)
+    """)
+
 class GenerateTokensTest(TokenizeTest):
     def check_tokenize(self, s, expected):
         # Format the tokens in s in a table format.
@@ -1593,6 +1613,10 @@ class TestRoundtrip(TestCase):
                              "# This also\n")
         self.check_roundtrip("# Comment \\\n"
                              "x = 0")
+        self.check_roundtrip("x = 1\n"
+                             "\\\n"
+                             "\n"
+                             "y = 1")
 
     def test_string_concatenation(self):
         # Two string literals on the same line

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -964,6 +964,22 @@ y = 1""", """\
     OP         '='           (4, 2) (4, 3)
     NUMBER     '1'           (4, 4) (4, 5)
     """)
+        self.check_tokenize("""def f(x):
+    \\
+  return x""", """\
+    NAME       'def'         (1, 0) (1, 3)
+    NAME       'f'           (1, 4) (1, 5)
+    OP         '('           (1, 5) (1, 6)
+    NAME       'x'           (1, 6) (1, 7)
+    OP         ')'           (1, 7) (1, 8)
+    OP         ':'           (1, 8) (1, 9)
+    NEWLINE    '\\n'          (1, 9) (1, 10)
+    NL         '\\n'          (2, 5) (2, 6)
+    INDENT     '  '          (3, 0) (3, 2)
+    NAME       'return'      (3, 2) (3, 8)
+    NAME       'x'           (3, 9) (3, 10)
+    DEDENT     ''            (4, 0) (4, 0)
+    """)
 
 class GenerateTokensTest(TokenizeTest):
     def check_tokenize(self, s, expected):

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -503,6 +503,11 @@ def _tokenize(readline, encoding):
                 yield TokenInfo(NL, line[pos:],
                            (lnum, pos), (lnum, len(line)), line)
                 continue
+            elif line[pos] == '\\':
+                if pos + 1 != max and line[pos + 1] in '\r\n':
+                    yield TokenInfo(NL, line[pos + 1:],
+                               (lnum, pos + 1), (lnum, len(line)), line)
+                    continue
 
             if column > indents[-1]:           # count indents or dedents
                 indents.append(column)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-18-17-12-05.bpo-37621.I52Xe-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-18-17-12-05.bpo-37621.I52Xe-.rst
@@ -1,0 +1,1 @@
+Tokenizer no longer emits NEWLINE token on empty continuation lines.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1700,8 +1700,13 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
         } else {
             tok_backup(tok, c);
         }
-        tok->cont_line = 1;
-        goto again; /* Read next line */
+        if (blankline && tok->level == 0) {
+            tok->atbol = 1;
+        }
+        else {
+            tok->cont_line = 1;
+        }
+        goto nextline; /* Read next line */
     }
 
     /* Check for two-character token */

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1136,7 +1136,6 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
                 break;
             }
         }
-        tok_backup(tok, c);
         if (c == '#' || c == '\n') {
             /* Lines with only whitespace and/or comments
                shouldn't affect the indentation and are
@@ -1149,8 +1148,21 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
             else {
                 blankline = 1; /* Ignore completely */
             }
+            tok_backup(tok, c);
             /* We can't jump back right here since we still
                may need to skip to the end of a comment */
+        }
+        else if (c == '\\') {
+            c = tok_nextc(tok);
+            if (c == '\n') {
+                /* Line continuation of a blank line */
+                blankline = 1;
+            }
+            tok_backup(tok, c);
+            tok_backup(tok, '\\');
+        }
+        else {
+            tok_backup(tok, c);
         }
         if (!blankline && tok->level == 0) {
             if (col == tok->indstack[tok->indent]) {


### PR DESCRIPTION
<!-- issue-number: [bpo-37621](https://bugs.python.org/issue37621) -->
https://bugs.python.org/issue37621
<!-- /issue-number -->
