### PR TITLE
bpo-37609: Add device path support in ntpath splitdrive

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -171,7 +171,7 @@ def is_drive_path(path, colon):
 
 
 def is_extended_unc(path, colon):
-    return path[2] in ['?', '.'] and path[-2] != colon
+    return path[2] in ['?', '.'] and path[-2] != colon and path[4:7] == 'UNC'
 
 
 def get_separator(path):

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -146,7 +146,9 @@ def splitdrive(p):
                 return p[:0], p
             if is_extended_unc(normp, colon):
                 start = normp.find(sep, index + 1)
-                index = normp.find(sep, start + 1)
+                drive_colon = normp.find(colon, index + 1)
+                if drive_colon == -1 or drive_colon > start:
+                    index = normp.find(sep, start + 1)
             index2 = normp.find(sep, index + 1)
             # a UNC path can't have two slashes in a row
             # (after the initial two)

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -84,6 +84,11 @@ class TestNtpath(unittest.TestCase):
         # Issue #19911: UNC part containing U+0130
         self.assertEqual(ntpath.splitdrive('//conky/MOUNTPOİNT/foo/bar'),
                          ('//conky/MOUNTPOİNT', '/foo/bar'))
+        # Issue #37609: UNC device path
+        self.assertEqual(ntpath.splitdrive('//?/UNC/localhost/C$/foo/bar'),
+                         ('//?/UNC/localhost/C$', '/foo/bar'))
+        self.assertEqual(ntpath.splitdrive('//./UNC/localhost/C$/foo/bar'),
+                         ('//./UNC/localhost/C$', '/foo/bar'))
 
     def test_split(self):
         tester('ntpath.split("c:\\foo\\bar")', ('c:\\foo', 'bar'))

--- a/Misc/NEWS.d/next/Library/2019-07-18-14-39-59.bpo-37609.1ZYNbG.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-18-14-39-59.bpo-37609.1ZYNbG.rst
@@ -1,0 +1,1 @@
+Add support for unc device path in :mod:`ntpath.splitdrive`

--- a/Misc/NEWS.d/next/Library/2019-07-18-14-39-59.bpo-37609.1ZYNbG.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-18-14-39-59.bpo-37609.1ZYNbG.rst
@@ -1,1 +1,1 @@
-Add support for unc device path in :mod:`ntpath.splitdrive`
+Add support for unc device path in :func:`ntpath.splitdrive`


### PR DESCRIPTION
Add device path support in `ntpath.splitdrive`

<!-- issue-number: [bpo-37609](https://bugs.python.org/issue37609) -->
https://bugs.python.org/issue37609
<!-- /issue-number -->
