### PR TITLE
bpo-36833: Add tests for Datetime C API Macros

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -5963,7 +5963,7 @@ class CapiTest(unittest.TestCase):
     def test_get_datetime_object_macros(self):
         class DateTimeSubclass(datetime):
             pass
-    
+
         exp_dt = datetime(1993, 8, 26, 22, 12, 55, 99999)
         exp_dts = DateTimeSubclass(1993, 8, 26, 22, 12, 55, 99999)
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -5920,24 +5920,24 @@ class CapiTest(unittest.TestCase):
         class TimeDeltaSubclass(timedelta):
             pass
 
-        exp_td = timedelta(1)
-        exp_tds = TimeDeltaSubclass(1)
+        exp_delta = timedelta(26, 55, 99999)
+        exp_delta_s = TimeDeltaSubclass(26, 55, 99999)
 
-        days, seconds, microseconds = _testcapi.get_fields_from_delta(exp_td)
-        days_s, seconds_s, microseconds_s = _testcapi.get_fields_from_delta(exp_tds)
+        days, seconds, microseconds = _testcapi.get_fields_from_delta(exp_delta)
+        days_s, seconds_s, microseconds_s = _testcapi.get_fields_from_delta(exp_delta_s)
 
         with self.subTest(testname="PyDateTime_DELTA_GET_DAYS"):
-            self.assertEqual(days, exp_dt.days)
-            self.assertEqual(days_s, exp_tds.days)
+            self.assertEqual(days, exp_delta.days)
+            self.assertEqual(days_s, exp_delta_s.days)
 
         with self.subTest(testname="PyDateTime_DELTA_GET_SECONDS"):
-            self.assertEqual(seconds, exp_td.seconds)
-            self.assertEqual(seconds_s, exp_tds.seconds)
+            self.assertEqual(seconds, exp_delta.seconds)
+            self.assertEqual(seconds_s, exp_delta_s.seconds)
 
         with self.subTest(testname="PyDateTime_DELTA_GET_MICROSECONDS"):
-            self.assertEqual(microseconds, exp_td.microseconds)
-            self.assertEqual(microseconds_s, exp_tds.microseconds)
-    
+            self.assertEqual(microseconds, exp_delta.microseconds)
+            self.assertEqual(microseconds_s, exp_delta_s.microseconds)
+
     def test_get_date_object_macros(self):
         class DateSubclass(date):
             pass
@@ -5980,7 +5980,7 @@ class CapiTest(unittest.TestCase):
 
         with self.subTest(testname="PyDateTime_DATE_GET_SECOND"):
             self.assertEqual(second, exp_dt.second)
-            self.assertEqual(minute_s, exp_dts.second)
+            self.assertEqual(second_s, exp_dts.second)
 
         with self.subTest(testname="PyDateTime_DATE_GET_MICROSECOND"):
             self.assertEqual(microsecond, exp_dt.microsecond)
@@ -5990,8 +5990,8 @@ class CapiTest(unittest.TestCase):
         class TimeSubclass(time):
             pass
 
-        exp_t = time(12, 30)
-        exp_ts = TimeSubclass(12, 30)
+        exp_t = time(12, 30, 20, 10)
+        exp_ts = TimeSubclass(12, 30, 20, 10)
 
         hour, minute, second, microsecond = _testcapi.get_fields_from_time(exp_t)
         hour_s, minute_s, second_s, microsecond_s = _testcapi.get_fields_from_time(exp_ts)
@@ -6006,7 +6006,7 @@ class CapiTest(unittest.TestCase):
 
         with self.subTest(testname="PyDateTime_TIME_GET_SECOND"):
             self.assertEqual(second, exp_t.second)
-            self.assertEqual(minute_s, exp_ts.second)
+            self.assertEqual(second_s, exp_ts.second)
 
         with self.subTest(testname="PyDateTime_TIME_GET_MICROSECOND"):
             self.assertEqual(microsecond, exp_t.microsecond)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -5916,6 +5916,102 @@ class CapiTest(unittest.TestCase):
 
                 self.assertEqual(dt1.astimezone(timezone.utc), dt_utc)
 
+    def test_get_delta_object_macros(self):
+        class TimeDeltaSubclass(timedelta):
+            pass
+
+        exp_td = timedelta(1)
+        exp_tds = TimeDeltaSubclass(1)
+
+        days, seconds, microseconds = _testcapi.get_fields_from_delta(exp_td)
+        days_s, seconds_s, microseconds_s = _testcapi.get_fields_from_delta(exp_tds)
+
+        with self.subTest(testname="PyDateTime_DELTA_GET_DAYS"):
+            self.assertEqual(days, exp_dt.days)
+            self.assertEqual(days_s, exp_tds.days)
+
+        with self.subTest(testname="PyDateTime_DELTA_GET_SECONDS"):
+            self.assertEqual(seconds, exp_td.seconds)
+            self.assertEqual(seconds_s, exp_tds.seconds)
+
+        with self.subTest(testname="PyDateTime_DELTA_GET_MICROSECONDS"):
+            self.assertEqual(microseconds, exp_td.microseconds)
+            self.assertEqual(microseconds_s, exp_tds.microseconds)
+    
+    def test_get_date_object_macros(self):
+        class DateSubclass(date):
+            pass
+
+        exp_dt = date(2000, 1, 2)
+        exp_dts = DateSubclass(2000, 1, 2)
+
+        year, month, day = _testcapi.get_fields_from_date(exp_dt)
+        year_s, month_s, day_s = _testcapi.get_fields_from_date(exp_dts)
+
+        with self.subTest(testname="PyDateTime_GET_YEAR"):
+            self.assertEqual(year, exp_dt.year)
+            self.assertEqual(year_s, exp_dts.year)
+
+        with self.subTest(testname="PyDateTime_GET_MONTH"):
+            self.assertEqual(month, exp_dt.month)
+            self.assertEqual(month_s, exp_dts.month)
+
+        with self.subTest(testname="PyDateTime_GET_DAY"):
+            self.assertEqual(day, exp_dt.day)
+            self.assertEqual(day_s, exp_dts.day)
+
+    def test_get_datetime_object_macros(self):
+        class DateTimeSubclass(datetime):
+            pass
+    
+        exp_dt = datetime(1993, 8, 26, 22, 12, 55, 99999)
+        exp_dts = DateTimeSubclass(1993, 8, 26, 22, 12, 55, 99999)
+
+        hour, minute, second, microsecond = _testcapi.get_fields_from_datetime(exp_dt)
+        hour_s, minute_s, second_s, microsecond_s = _testcapi.get_fields_from_datetime(exp_dts)
+
+        with self.subTest(testname="PyDateTime_DATE_GET_HOUR"):
+            self.assertEqual(hour, exp_dt.hour)
+            self.assertEqual(hour_s, exp_dts.hour)
+
+        with self.subTest(testname="PyDateTime_DATE_GET_MINUTE"):
+            self.assertEqual(minute, exp_dt.minute)
+            self.assertEqual(minute_s, exp_dts.minute)
+
+        with self.subTest(testname="PyDateTime_DATE_GET_SECOND"):
+            self.assertEqual(second, exp_dt.second)
+            self.assertEqual(minute_s, exp_dts.second)
+
+        with self.subTest(testname="PyDateTime_DATE_GET_MICROSECOND"):
+            self.assertEqual(microsecond, exp_dt.microsecond)
+            self.assertEqual(microsecond_s, exp_dts.microsecond)
+
+    def test_get_time_object_macros(self):
+        class TimeSubclass(time):
+            pass
+
+        exp_t = time(12, 30)
+        exp_ts = TimeSubclass(12, 30)
+
+        hour, minute, second, microsecond = _testcapi.get_fields_from_time(exp_t)
+        hour_s, minute_s, second_s, microsecond_s = _testcapi.get_fields_from_time(exp_ts)
+
+        with self.subTest(testname="PyDateTime_TIME_GET_HOUR"):
+            self.assertEqual(hour, exp_t.hour)
+            self.assertEqual(hour_s, exp_ts.hour)
+
+        with self.subTest(testname="PyDateTime_TIME_GET_MINUTE"):
+            self.assertEqual(minute, exp_t.minute)
+            self.assertEqual(minute_s, exp_ts.minute)
+
+        with self.subTest(testname="PyDateTime_TIME_GET_SECOND"):
+            self.assertEqual(second, exp_t.second)
+            self.assertEqual(minute_s, exp_ts.second)
+
+        with self.subTest(testname="PyDateTime_TIME_GET_MICROSECOND"):
+            self.assertEqual(microsecond, exp_t.microsecond)
+            self.assertEqual(microsecond_s, exp_ts.microsecond)
+
     def test_timezones_offset_zero(self):
         utc0, utc1, non_utc = _testcapi.get_timezones_offset_zero()
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -5916,7 +5916,7 @@ class CapiTest(unittest.TestCase):
 
                 self.assertEqual(dt1.astimezone(timezone.utc), dt_utc)
 
-    def test_get_delta_object_macros(self):
+    def test_PyDateTime_DELTA_GET(self):
         class TimeDeltaSubclass(timedelta):
             pass
 
@@ -5930,7 +5930,7 @@ class CapiTest(unittest.TestCase):
                     self.assertEqual(seconds, d.seconds)
                     self.assertEqual(microseconds, d.microseconds)
 
-    def test_get_date_object_macros(self):
+    def test_PyDateTime_GET(self):
         class DateSubclass(date):
             pass
 
@@ -5944,7 +5944,7 @@ class CapiTest(unittest.TestCase):
                     self.assertEqual(month, d.month)
                     self.assertEqual(day, d.day)
 
-    def test_get_datetime_object_macros(self):
+    def test_PyDateTime_DATE_GET(self):
         class DateTimeSubclass(datetime):
             pass
 
@@ -5960,7 +5960,7 @@ class CapiTest(unittest.TestCase):
                     self.assertEqual(second, d.second)
                     self.assertEqual(microsecond, d.microsecond)
 
-    def test_get_time_object_macros(self):
+    def test_PyDateTime_TIME_GET(self):
         class TimeSubclass(time):
             pass
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -5920,97 +5920,60 @@ class CapiTest(unittest.TestCase):
         class TimeDeltaSubclass(timedelta):
             pass
 
-        exp_delta = timedelta(26, 55, 99999)
-        exp_delta_s = TimeDeltaSubclass(26, 55, 99999)
+        for klass in [timedelta, TimeDeltaSubclass]:
+            for args in [(26, 55, 99999), (26, 55, 99999)]:
+                d = klass(*args)
+                with self.subTest(cls=klass, date=args):
+                    days, seconds, microseconds = _testcapi.get_fields_from_delta(d)
 
-        days, seconds, microseconds = _testcapi.get_fields_from_delta(exp_delta)
-        days_s, seconds_s, microseconds_s = _testcapi.get_fields_from_delta(exp_delta_s)
-
-        with self.subTest(testname="PyDateTime_DELTA_GET_DAYS"):
-            self.assertEqual(days, exp_delta.days)
-            self.assertEqual(days_s, exp_delta_s.days)
-
-        with self.subTest(testname="PyDateTime_DELTA_GET_SECONDS"):
-            self.assertEqual(seconds, exp_delta.seconds)
-            self.assertEqual(seconds_s, exp_delta_s.seconds)
-
-        with self.subTest(testname="PyDateTime_DELTA_GET_MICROSECONDS"):
-            self.assertEqual(microseconds, exp_delta.microseconds)
-            self.assertEqual(microseconds_s, exp_delta_s.microseconds)
+                    self.assertEqual(days, d.days)
+                    self.assertEqual(seconds, d.seconds)
+                    self.assertEqual(microseconds, d.microseconds)
 
     def test_get_date_object_macros(self):
         class DateSubclass(date):
             pass
 
-        exp_dt = date(2000, 1, 2)
-        exp_dts = DateSubclass(2000, 1, 2)
+        for klass in [date, DateSubclass]:
+            for args in [(2000, 1, 2), (2012, 2, 29)]:
+                d = klass(*args)
+                with self.subTest(cls=klass, date=args):
+                    year, month, day = _testcapi.get_fields_from_date(d)
 
-        year, month, day = _testcapi.get_fields_from_date(exp_dt)
-        year_s, month_s, day_s = _testcapi.get_fields_from_date(exp_dts)
-
-        with self.subTest(testname="PyDateTime_GET_YEAR"):
-            self.assertEqual(year, exp_dt.year)
-            self.assertEqual(year_s, exp_dts.year)
-
-        with self.subTest(testname="PyDateTime_GET_MONTH"):
-            self.assertEqual(month, exp_dt.month)
-            self.assertEqual(month_s, exp_dts.month)
-
-        with self.subTest(testname="PyDateTime_GET_DAY"):
-            self.assertEqual(day, exp_dt.day)
-            self.assertEqual(day_s, exp_dts.day)
+                    self.assertEqual(year, d.year)
+                    self.assertEqual(month, d.month)
+                    self.assertEqual(day, d.day)
 
     def test_get_datetime_object_macros(self):
         class DateTimeSubclass(datetime):
             pass
 
-        exp_dt = datetime(1993, 8, 26, 22, 12, 55, 99999)
-        exp_dts = DateTimeSubclass(1993, 8, 26, 22, 12, 55, 99999)
+        for klass in [datetime, DateTimeSubclass]:
+            for args in [(1993, 8, 26, 22, 12, 55, 99999),
+                         (1993, 8, 26, 22, 12, 55, 99999)]:
+                d = klass(*args)
+                with self.subTest(cls=klass, date=args):
+                    hour, minute, second, microsecond = _testcapi.get_fields_from_datetime(d)
 
-        hour, minute, second, microsecond = _testcapi.get_fields_from_datetime(exp_dt)
-        hour_s, minute_s, second_s, microsecond_s = _testcapi.get_fields_from_datetime(exp_dts)
-
-        with self.subTest(testname="PyDateTime_DATE_GET_HOUR"):
-            self.assertEqual(hour, exp_dt.hour)
-            self.assertEqual(hour_s, exp_dts.hour)
-
-        with self.subTest(testname="PyDateTime_DATE_GET_MINUTE"):
-            self.assertEqual(minute, exp_dt.minute)
-            self.assertEqual(minute_s, exp_dts.minute)
-
-        with self.subTest(testname="PyDateTime_DATE_GET_SECOND"):
-            self.assertEqual(second, exp_dt.second)
-            self.assertEqual(second_s, exp_dts.second)
-
-        with self.subTest(testname="PyDateTime_DATE_GET_MICROSECOND"):
-            self.assertEqual(microsecond, exp_dt.microsecond)
-            self.assertEqual(microsecond_s, exp_dts.microsecond)
+                    self.assertEqual(hour, d.hour)
+                    self.assertEqual(minute, d.minute)
+                    self.assertEqual(second, d.second)
+                    self.assertEqual(microsecond, d.microsecond)
 
     def test_get_time_object_macros(self):
         class TimeSubclass(time):
             pass
 
-        exp_t = time(12, 30, 20, 10)
-        exp_ts = TimeSubclass(12, 30, 20, 10)
+        for klass in [time, TimeSubclass]:
+            for args in [(12, 30, 20, 10), (12, 30, 20, 10)]:
+                d = klass(*args)
+                with self.subTest(cls=klass, date=args):
+                    hour, minute, second, microsecond = _testcapi.get_fields_from_time(d)
 
-        hour, minute, second, microsecond = _testcapi.get_fields_from_time(exp_t)
-        hour_s, minute_s, second_s, microsecond_s = _testcapi.get_fields_from_time(exp_ts)
-
-        with self.subTest(testname="PyDateTime_TIME_GET_HOUR"):
-            self.assertEqual(hour, exp_t.hour)
-            self.assertEqual(hour_s, exp_ts.hour)
-
-        with self.subTest(testname="PyDateTime_TIME_GET_MINUTE"):
-            self.assertEqual(minute, exp_t.minute)
-            self.assertEqual(minute_s, exp_ts.minute)
-
-        with self.subTest(testname="PyDateTime_TIME_GET_SECOND"):
-            self.assertEqual(second, exp_t.second)
-            self.assertEqual(second_s, exp_ts.second)
-
-        with self.subTest(testname="PyDateTime_TIME_GET_MICROSECOND"):
-            self.assertEqual(microsecond, exp_t.microsecond)
-            self.assertEqual(microsecond_s, exp_ts.microsecond)
+                    self.assertEqual(hour, d.hour)
+                    self.assertEqual(minute, d.minute)
+                    self.assertEqual(second, d.second)
+                    self.assertEqual(microsecond, d.microsecond)
 
     def test_timezones_offset_zero(self):
         utc0, utc1, non_utc = _testcapi.get_timezones_offset_zero()

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -5924,7 +5924,7 @@ class CapiTest(unittest.TestCase):
             for args in [(26, 55, 99999), (26, 55, 99999)]:
                 d = klass(*args)
                 with self.subTest(cls=klass, date=args):
-                    days, seconds, microseconds = _testcapi.get_fields_from_delta(d)
+                    days, seconds, microseconds = _testcapi.PyDateTime_DELTA_GET(d)
 
                     self.assertEqual(days, d.days)
                     self.assertEqual(seconds, d.seconds)
@@ -5938,7 +5938,7 @@ class CapiTest(unittest.TestCase):
             for args in [(2000, 1, 2), (2012, 2, 29)]:
                 d = klass(*args)
                 with self.subTest(cls=klass, date=args):
-                    year, month, day = _testcapi.get_fields_from_date(d)
+                    year, month, day = _testcapi.PyDateTime_GET(d)
 
                     self.assertEqual(year, d.year)
                     self.assertEqual(month, d.month)
@@ -5953,7 +5953,7 @@ class CapiTest(unittest.TestCase):
                          (1993, 8, 26, 22, 12, 55, 99999)]:
                 d = klass(*args)
                 with self.subTest(cls=klass, date=args):
-                    hour, minute, second, microsecond = _testcapi.get_fields_from_datetime(d)
+                    hour, minute, second, microsecond = _testcapi.PyDateTime_DATE_GET(d)
 
                     self.assertEqual(hour, d.hour)
                     self.assertEqual(minute, d.minute)
@@ -5968,7 +5968,7 @@ class CapiTest(unittest.TestCase):
             for args in [(12, 30, 20, 10), (12, 30, 20, 10)]:
                 d = klass(*args)
                 with self.subTest(cls=klass, date=args):
-                    hour, minute, second, microsecond = _testcapi.get_fields_from_time(d)
+                    hour, minute, second, microsecond = _testcapi.PyDateTime_TIME_GET(d)
 
                     self.assertEqual(hour, d.hour)
                     self.assertEqual(minute, d.minute)

--- a/Misc/NEWS.d/next/Tests/2019-07-18-14-52-58.bpo-36833.Zoe9ek.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-18-14-52-58.bpo-36833.Zoe9ek.rst
@@ -1,0 +1,18 @@
+Added test for the following Untested macros with no corresponding API module:
+
+- `PyDateTime_GET_YEAR`
+- `PyDateTime_GET_MONTH`
+- `PyDateTime_GET_DAY`
+- `PyDateTime_DATE_GET_HOUR`
+- `PyDateTime_DATE_GET_MINUTE`
+- `PyDateTime_DATE_GET_SECOND`
+- `PyDateTime_DATE_GET_MICROSECOND`
+
+- `PyDateTime_TIME_GET_HOUR`
+- `PyDateTime_TIME_GET_MINUTE`
+- `PyDateTime_TIME_GET_SECOND`
+- `PyDateTime_TIME_GET_MICROSECOND`
+
+- `PyDateTime_DELTA_GET_DAYS`
+- `PyDateTime_DELTA_GET_SECONDS`
+- `PyDateTime_DELTA_GET_MICROSECONDS`

--- a/Misc/NEWS.d/next/Tests/2019-07-18-14-52-58.bpo-36833.Zoe9ek.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-18-14-52-58.bpo-36833.Zoe9ek.rst
@@ -1,18 +1,1 @@
-Added test for the following Untested macros with no corresponding API module:
-
-- `PyDateTime_GET_YEAR`
-- `PyDateTime_GET_MONTH`
-- `PyDateTime_GET_DAY`
-- `PyDateTime_DATE_GET_HOUR`
-- `PyDateTime_DATE_GET_MINUTE`
-- `PyDateTime_DATE_GET_SECOND`
-- `PyDateTime_DATE_GET_MICROSECOND`
-
-- `PyDateTime_TIME_GET_HOUR`
-- `PyDateTime_TIME_GET_MINUTE`
-- `PyDateTime_TIME_GET_SECOND`
-- `PyDateTime_TIME_GET_MICROSECOND`
-
-- `PyDateTime_DELTA_GET_DAYS`
-- `PyDateTime_DELTA_GET_SECONDS`
-- `PyDateTime_DELTA_GET_MICROSECONDS`
+Added tests for the macros with no corresponding API module.

--- a/Misc/NEWS.d/next/Tests/2019-07-18-14-52-58.bpo-36833.Zoe9ek.rst
+++ b/Misc/NEWS.d/next/Tests/2019-07-18-14-52-58.bpo-36833.Zoe9ek.rst
@@ -1,1 +1,2 @@
-Added tests for the macros with no corresponding API module.
+Added tests for PyDateTime_xxx_GET_xxx() macros of the C API of
+the :mod:`datetime` module. Patch by Joannah Nanjekye.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2591,24 +2591,25 @@ static PyObject *
 get_fields_from_date(PyObject* self, PyObject *args)
 {
     PyObject *obj = NULL;
-    int *rv = NULL;
+    PyObject *rv;
     int year, month, day;
 
-    if (!PyArg_ParseTuple(args, "p", &obj)) {
+    if (!PyArg_ParseTuple(args, "O", &obj)) {
         return NULL;
     }
-
+    
     year = PyDateTime_GET_YEAR(obj);
     month = PyDateTime_GET_MONTH(obj);
     day = PyDateTime_GET_DAY(obj);
 
-    Py_DecRef(obj);
-
     rv = PyTuple_New(3);
+    if (rv == NULL) {
+        return NULL;
+    }
 
-    PyTuple_SET_ITEM(rv, 0, (PyObject *)year);
-    PyTuple_SET_ITEM(rv, 1, (PyObject *)month);
-    PyTuple_SET_ITEM(rv, 2, (PyObject *)day);
+    PyTuple_SET_ITEM(rv, 0, PyLong_FromSsize_t(year));
+    PyTuple_SET_ITEM(rv, 1, PyLong_FromSsize_t(month));
+    PyTuple_SET_ITEM(rv, 2, PyLong_FromSsize_t(day));
 
     return rv;
 }
@@ -2617,10 +2618,10 @@ static PyObject *
 get_fields_from_datetime(PyObject* self, PyObject *args)
 {
     PyObject *obj = NULL;
-    PyObject *rv = NULL;
+    PyObject *rv;
     int hour, minute, second, microsecond;
 
-    if (!PyArg_ParseTuple(args, "p", &obj)) {
+    if (!PyArg_ParseTuple(args, "O", &obj)) {
         return NULL;
     }
 
@@ -2629,14 +2630,15 @@ get_fields_from_datetime(PyObject* self, PyObject *args)
     second = PyDateTime_DATE_GET_SECOND(obj);
     microsecond = PyDateTime_DATE_GET_MICROSECOND(obj);
 
-    Py_DecRef(obj);
-
     rv = PyTuple_New(4);
+    if (rv == NULL) {
+        return NULL;
+    }
 
-    PyTuple_SET_ITEM(rv, 0, (PyObject *)hour);
-    PyTuple_SET_ITEM(rv, 1, (PyObject *)minute);
-    PyTuple_SET_ITEM(rv, 2, (PyObject *)second);
-    PyTuple_SET_ITEM(rv, 3, (PyObject *)microsecond);
+    PyTuple_SET_ITEM(rv, 0, PyLong_FromSsize_t(hour));
+    PyTuple_SET_ITEM(rv, 1, PyLong_FromSsize_t(minute));
+    PyTuple_SET_ITEM(rv, 2, PyLong_FromSsize_t(second));
+    PyTuple_SET_ITEM(rv, 3, PyLong_FromSsize_t(microsecond));
 
     return rv;
 }
@@ -2645,10 +2647,10 @@ static PyObject *
 get_fields_from_time(PyObject* self, PyObject *args)
 {
     PyObject *obj = NULL;
-    PyObject *rv = NULL;
+    PyObject *rv;
     int hour, minute, second, microsecond;
 
-    if (!PyArg_ParseTuple(args, "p", &obj)) {
+    if (!PyArg_ParseTuple(args, "O", &obj)) {
         return NULL;
     }
 
@@ -2657,14 +2659,15 @@ get_fields_from_time(PyObject* self, PyObject *args)
     second = PyDateTime_TIME_GET_SECOND(obj);
     microsecond = PyDateTime_TIME_GET_MICROSECOND(obj);
 
-    Py_DecRef(obj);
-
     rv = PyTuple_New(4);
+    if (rv == NULL) {
+        return NULL;
+    }
 
-    PyTuple_SET_ITEM(rv, 0, (PyObject *)hour);
-    PyTuple_SET_ITEM(rv, 1, (PyObject *)minute);
-    PyTuple_SET_ITEM(rv, 2, (PyObject *)second);
-    PyTuple_SET_ITEM(rv, 3, (PyObject *)microsecond);
+    PyTuple_SET_ITEM(rv, 0, PyLong_FromSsize_t(hour));
+    PyTuple_SET_ITEM(rv, 1, PyLong_FromSsize_t(minute));
+    PyTuple_SET_ITEM(rv, 2, PyLong_FromSsize_t(second));
+    PyTuple_SET_ITEM(rv, 3, PyLong_FromSsize_t(microsecond));
 
     return rv;
 }
@@ -2673,10 +2676,10 @@ static PyObject *
 get_fields_from_delta(PyObject* self, PyObject *args)
 {
     PyObject *obj = NULL;
-    PyObject *rv = NULL;
+    PyObject *rv;
     int days, seconds, microseconds;
 
-    if (!PyArg_ParseTuple(args, "p", &obj)) {
+    if (!PyArg_ParseTuple(args, "O", &obj)) {
         return NULL;
     }
 
@@ -2684,17 +2687,17 @@ get_fields_from_delta(PyObject* self, PyObject *args)
     seconds = PyDateTime_DELTA_GET_SECONDS(obj);
     microseconds = PyDateTime_DELTA_GET_MICROSECONDS(obj);
 
-    Py_DecRef(obj);
-
     rv = PyTuple_New(3);
+    if (rv == NULL) {
+        return NULL;
+    }
 
-    PyTuple_SET_ITEM(rv, 0, (PyObject *)days);
-    PyTuple_SET_ITEM(rv, 1, (PyObject *)seconds);
-    PyTuple_SET_ITEM(rv, 2, (PyObject *)microseconds);
+    PyTuple_SET_ITEM(rv, 0, PyLong_FromSsize_t(days));
+    PyTuple_SET_ITEM(rv, 1, PyLong_FromSsize_t(seconds));
+    PyTuple_SET_ITEM(rv, 2, PyLong_FromSsize_t(microseconds));
 
     return rv;
 }
-
 
 /* test_thread_state spawns a thread of its own, and that thread releases
  * `thread_done` when it's finished.  The driver code has to know when the

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2587,6 +2587,114 @@ get_datetime_fromtimestamp(PyObject* self, PyObject *args)
     return rv;
 }
 
+static PyObject *
+get_fields_from_date(PyObject* self, PyObject *args)
+{
+    PyObject *obj = NULL;
+    int *rv = NULL;
+    int year, month, day;
+
+    if (!PyArg_ParseTuple(args, "p", &obj)) {
+        return NULL;
+    }
+
+    year = PyDateTime_GET_YEAR(obj);
+    month = PyDateTime_GET_MONTH(obj);
+    day = PyDateTime_GET_DAY(obj);
+
+    Py_DecRef(obj);
+
+    rv = PyTuple_New(3);
+
+    PyTuple_SET_ITEM(rv, 0, (PyObject *)year);
+    PyTuple_SET_ITEM(rv, 1, (PyObject *)month);
+    PyTuple_SET_ITEM(rv, 2, (PyObject *)day);
+
+    return rv;
+}
+
+static PyObject *
+get_fields_from_datetime(PyObject* self, PyObject *args)
+{
+    PyObject *obj = NULL;
+    PyObject *rv = NULL;
+    int hour, minute, second, microsecond;
+
+    if (!PyArg_ParseTuple(args, "p", &obj)) {
+        return NULL;
+    }
+
+    hour = PyDateTime_DATE_GET_HOUR(obj);
+    minute = PyDateTime_DATE_GET_MINUTE(obj);
+    second = PyDateTime_DATE_GET_SECOND(obj);
+    microsecond = PyDateTime_DATE_GET_MICROSECOND(obj);
+
+    Py_DecRef(obj);
+
+    rv = PyTuple_New(4);
+
+    PyTuple_SET_ITEM(rv, 0, (PyObject *)hour);
+    PyTuple_SET_ITEM(rv, 1, (PyObject *)minute);
+    PyTuple_SET_ITEM(rv, 2, (PyObject *)second);
+    PyTuple_SET_ITEM(rv, 3, (PyObject *)microsecond);
+
+    return rv;
+}
+
+static PyObject *
+get_fields_from_time(PyObject* self, PyObject *args)
+{
+    PyObject *obj = NULL;
+    PyObject *rv = NULL;
+    int hour, minute, second, microsecond;
+
+    if (!PyArg_ParseTuple(args, "p", &obj)) {
+        return NULL;
+    }
+
+    hour = PyDateTime_TIME_GET_HOUR(obj);
+    minute = PyDateTime_TIME_GET_MINUTE(obj);
+    second = PyDateTime_TIME_GET_SECOND(obj);
+    microsecond = PyDateTime_TIME_GET_MICROSECOND(obj);
+
+    Py_DecRef(obj);
+
+    rv = PyTuple_New(4);
+
+    PyTuple_SET_ITEM(rv, 0, (PyObject *)hour);
+    PyTuple_SET_ITEM(rv, 1, (PyObject *)minute);
+    PyTuple_SET_ITEM(rv, 2, (PyObject *)second);
+    PyTuple_SET_ITEM(rv, 3, (PyObject *)microsecond);
+
+    return rv;
+}
+
+static PyObject *
+get_fields_from_delta(PyObject* self, PyObject *args)
+{
+    PyObject *obj = NULL;
+    PyObject *rv = NULL;
+    int days, seconds, microseconds;
+
+    if (!PyArg_ParseTuple(args, "p", &obj)) {
+        return NULL;
+    }
+
+    days = PyDateTime_DELTA_GET_DAYS(obj);
+    seconds = PyDateTime_DELTA_GET_SECONDS(obj);
+    microseconds = PyDateTime_DELTA_GET_MICROSECONDS(obj);
+
+    Py_DecRef(obj);
+
+    rv = PyTuple_New(3);
+
+    PyTuple_SET_ITEM(rv, 0, (PyObject *)days);
+    PyTuple_SET_ITEM(rv, 1, (PyObject *)seconds);
+    PyTuple_SET_ITEM(rv, 2, (PyObject *)microseconds);
+
+    return rv;
+}
+
 
 /* test_thread_state spawns a thread of its own, and that thread releases
  * `thread_done` when it's finished.  The driver code has to know when the
@@ -5076,6 +5184,10 @@ static PyMethodDef TestMethods[] = {
     {"get_delta_fromdsu",        get_delta_fromdsu,              METH_VARARGS},
     {"get_date_fromtimestamp",   get_date_fromtimestamp,         METH_VARARGS},
     {"get_datetime_fromtimestamp", get_datetime_fromtimestamp,   METH_VARARGS},
+    {"get_fields_from_date",       get_fields_from_date,         METH_VARARGS},
+    {"get_fields_from_datetime",   get_fields_from_datetime,     METH_VARARGS},
+    {"get_fields_from_time",       get_fields_from_time,         METH_VARARGS},
+    {"get_fields_from_delta",      get_fields_from_delta,        METH_VARARGS},
     {"test_list_api",           test_list_api,                   METH_NOARGS},
     {"test_dict_iteration",     test_dict_iteration,             METH_NOARGS},
     {"dict_getitem_knownhash",  dict_getitem_knownhash,          METH_VARARGS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2607,9 +2607,9 @@ get_fields_from_date(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    PyTuple_SET_ITEM(rv, 0, PyLong_FromSsize_t(year));
-    PyTuple_SET_ITEM(rv, 1, PyLong_FromSsize_t(month));
-    PyTuple_SET_ITEM(rv, 2, PyLong_FromSsize_t(day));
+    PyTuple_SET_ITEM(rv, 0, PyLong_FromLong(year));
+    PyTuple_SET_ITEM(rv, 1, PyLong_FromLong(month));
+    PyTuple_SET_ITEM(rv, 2, PyLong_FromLong(day));
 
     return rv;
 }
@@ -2635,10 +2635,10 @@ get_fields_from_datetime(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    PyTuple_SET_ITEM(rv, 0, PyLong_FromSsize_t(hour));
-    PyTuple_SET_ITEM(rv, 1, PyLong_FromSsize_t(minute));
-    PyTuple_SET_ITEM(rv, 2, PyLong_FromSsize_t(second));
-    PyTuple_SET_ITEM(rv, 3, PyLong_FromSsize_t(microsecond));
+    PyTuple_SET_ITEM(rv, 0, PyLong_FromLong(hour));
+    PyTuple_SET_ITEM(rv, 1, PyLong_FromLong(minute));
+    PyTuple_SET_ITEM(rv, 2, PyLong_FromLong(second));
+    PyTuple_SET_ITEM(rv, 3, PyLong_FromLong(microsecond));
 
     return rv;
 }
@@ -2664,10 +2664,10 @@ get_fields_from_time(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    PyTuple_SET_ITEM(rv, 0, PyLong_FromSsize_t(hour));
-    PyTuple_SET_ITEM(rv, 1, PyLong_FromSsize_t(minute));
-    PyTuple_SET_ITEM(rv, 2, PyLong_FromSsize_t(second));
-    PyTuple_SET_ITEM(rv, 3, PyLong_FromSsize_t(microsecond));
+    PyTuple_SET_ITEM(rv, 0, PyLong_FromLong(hour));
+    PyTuple_SET_ITEM(rv, 1, PyLong_FromLong(minute));
+    PyTuple_SET_ITEM(rv, 2, PyLong_FromLong(second));
+    PyTuple_SET_ITEM(rv, 3, PyLong_FromLong(microsecond));
 
     return rv;
 }
@@ -2692,9 +2692,9 @@ get_fields_from_delta(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    PyTuple_SET_ITEM(rv, 0, PyLong_FromSsize_t(days));
-    PyTuple_SET_ITEM(rv, 1, PyLong_FromSsize_t(seconds));
-    PyTuple_SET_ITEM(rv, 2, PyLong_FromSsize_t(microseconds));
+    PyTuple_SET_ITEM(rv, 0, PyLong_FromLong(days));
+    PyTuple_SET_ITEM(rv, 1, PyLong_FromLong(seconds));
+    PyTuple_SET_ITEM(rv, 2, PyLong_FromLong(microseconds));
 
     return rv;
 }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2596,7 +2596,7 @@ test_PyDateTime_GET(PyObject *self, PyObject *obj)
     month = PyDateTime_GET_MONTH(obj);
     day = PyDateTime_GET_DAY(obj);
 
-    return Py_BuildValue("[lll]", year, month, day);
+    return Py_BuildValue("(lll)", year, month, day);
 }
 
 static PyObject *
@@ -2609,7 +2609,7 @@ test_PyDateTime_DATE_GET(PyObject *self, PyObject *obj)
     second = PyDateTime_DATE_GET_SECOND(obj);
     microsecond = PyDateTime_DATE_GET_MICROSECOND(obj);
 
-    return Py_BuildValue("[llll]", hour, minute, second, microsecond);
+    return Py_BuildValue("(llll)", hour, minute, second, microsecond);
 }
 
 static PyObject *
@@ -2622,7 +2622,7 @@ test_PyDateTime_TIME_GET(PyObject *self, PyObject *obj)
     second = PyDateTime_TIME_GET_SECOND(obj);
     microsecond = PyDateTime_TIME_GET_MICROSECOND(obj);
 
-    return Py_BuildValue("[llll]", hour, minute, second, microsecond);
+    return Py_BuildValue("(llll)", hour, minute, second, microsecond);
 }
 
 static PyObject *
@@ -2634,7 +2634,7 @@ test_PyDateTime_DELTA_GET(PyObject *self, PyObject *obj)
     seconds = PyDateTime_DELTA_GET_SECONDS(obj);
     microseconds = PyDateTime_DELTA_GET_MICROSECONDS(obj);
 
-    return Py_BuildValue("[lll]", days, seconds, microseconds);
+    return Py_BuildValue("(lll)", days, seconds, microseconds);
 }
 
 /* test_thread_state spawns a thread of its own, and that thread releases

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2588,115 +2588,53 @@ get_datetime_fromtimestamp(PyObject* self, PyObject *args)
 }
 
 static PyObject *
-test_PyDateTime_GET(PyObject *self, PyObject *args)
+test_PyDateTime_GET(PyObject *self, PyObject *obj)
 {
-    PyObject *obj = NULL;
-    PyObject *rv;
     int year, month, day;
-
-    if (!PyArg_ParseTuple(args, "O", &obj)) {
-        return NULL;
-    }
 
     year = PyDateTime_GET_YEAR(obj);
     month = PyDateTime_GET_MONTH(obj);
     day = PyDateTime_GET_DAY(obj);
 
-    rv = PyTuple_New(3);
-    if (rv == NULL) {
-        return NULL;
-    }
-
-    PyTuple_SET_ITEM(rv, 0, PyLong_FromLong(year));
-    PyTuple_SET_ITEM(rv, 1, PyLong_FromLong(month));
-    PyTuple_SET_ITEM(rv, 2, PyLong_FromLong(day));
-
-    return rv;
+    return Py_BuildValue("[lll]", year, month, day);
 }
 
 static PyObject *
-test_PyDateTime_DATE_GET(PyObject *self, PyObject *args)
+test_PyDateTime_DATE_GET(PyObject *self, PyObject *obj)
 {
-    PyObject *obj = NULL;
-    PyObject *rv;
     int hour, minute, second, microsecond;
-
-    if (!PyArg_ParseTuple(args, "O", &obj)) {
-        return NULL;
-    }
 
     hour = PyDateTime_DATE_GET_HOUR(obj);
     minute = PyDateTime_DATE_GET_MINUTE(obj);
     second = PyDateTime_DATE_GET_SECOND(obj);
     microsecond = PyDateTime_DATE_GET_MICROSECOND(obj);
 
-    rv = PyTuple_New(4);
-    if (rv == NULL) {
-        return NULL;
-    }
-
-    PyTuple_SET_ITEM(rv, 0, PyLong_FromLong(hour));
-    PyTuple_SET_ITEM(rv, 1, PyLong_FromLong(minute));
-    PyTuple_SET_ITEM(rv, 2, PyLong_FromLong(second));
-    PyTuple_SET_ITEM(rv, 3, PyLong_FromLong(microsecond));
-
-    return rv;
+    return Py_BuildValue("[llll]", hour, minute, second, microsecond);
 }
 
 static PyObject *
-test_PyDateTime_TIME_GET(PyObject *self, PyObject *args)
+test_PyDateTime_TIME_GET(PyObject *self, PyObject *obj)
 {
-    PyObject *obj = NULL;
-    PyObject *rv;
     int hour, minute, second, microsecond;
-
-    if (!PyArg_ParseTuple(args, "O", &obj)) {
-        return NULL;
-    }
 
     hour = PyDateTime_TIME_GET_HOUR(obj);
     minute = PyDateTime_TIME_GET_MINUTE(obj);
     second = PyDateTime_TIME_GET_SECOND(obj);
     microsecond = PyDateTime_TIME_GET_MICROSECOND(obj);
 
-    rv = PyTuple_New(4);
-    if (rv == NULL) {
-        return NULL;
-    }
-
-    PyTuple_SET_ITEM(rv, 0, PyLong_FromLong(hour));
-    PyTuple_SET_ITEM(rv, 1, PyLong_FromLong(minute));
-    PyTuple_SET_ITEM(rv, 2, PyLong_FromLong(second));
-    PyTuple_SET_ITEM(rv, 3, PyLong_FromLong(microsecond));
-
-    return rv;
+    return Py_BuildValue("[llll]", hour, minute, second, microsecond);
 }
 
 static PyObject *
-test_PyDateTime_DELTA_GET(PyObject *self, PyObject *args)
+test_PyDateTime_DELTA_GET(PyObject *self, PyObject *obj)
 {
-    PyObject *obj = NULL;
-    PyObject *rv;
     int days, seconds, microseconds;
-
-    if (!PyArg_ParseTuple(args, "O", &obj)) {
-        return NULL;
-    }
 
     days = PyDateTime_DELTA_GET_DAYS(obj);
     seconds = PyDateTime_DELTA_GET_SECONDS(obj);
     microseconds = PyDateTime_DELTA_GET_MICROSECONDS(obj);
 
-    rv = PyTuple_New(3);
-    if (rv == NULL) {
-        return NULL;
-    }
-
-    PyTuple_SET_ITEM(rv, 0, PyLong_FromLong(days));
-    PyTuple_SET_ITEM(rv, 1, PyLong_FromLong(seconds));
-    PyTuple_SET_ITEM(rv, 2, PyLong_FromLong(microseconds));
-
-    return rv;
+    return Py_BuildValue("[lll]", days, seconds, microseconds);
 }
 
 /* test_thread_state spawns a thread of its own, and that thread releases
@@ -5187,10 +5125,10 @@ static PyMethodDef TestMethods[] = {
     {"get_delta_fromdsu",        get_delta_fromdsu,              METH_VARARGS},
     {"get_date_fromtimestamp",   get_date_fromtimestamp,         METH_VARARGS},
     {"get_datetime_fromtimestamp", get_datetime_fromtimestamp,   METH_VARARGS},
-    {"PyDateTime_GET",             test_PyDateTime_GET,          METH_VARARGS},
-    {"PyDateTime_DATE_GET",        test_PyDateTime_DATE_GET,     METH_VARARGS},
-    {"PyDateTime_TIME_GET",        test_PyDateTime_TIME_GET,     METH_VARARGS},
-    {"PyDateTime_DELTA_GET",       test_PyDateTime_DELTA_GET,        METH_VARARGS},
+    {"PyDateTime_GET",             test_PyDateTime_GET,           METH_O},
+    {"PyDateTime_DATE_GET",        test_PyDateTime_DATE_GET,      METH_O},
+    {"PyDateTime_TIME_GET",        test_PyDateTime_TIME_GET,      METH_O},
+    {"PyDateTime_DELTA_GET",       test_PyDateTime_DELTA_GET,     METH_O},
     {"test_list_api",           test_list_api,                   METH_NOARGS},
     {"test_dict_iteration",     test_dict_iteration,             METH_NOARGS},
     {"dict_getitem_knownhash",  dict_getitem_knownhash,          METH_VARARGS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2588,7 +2588,7 @@ get_datetime_fromtimestamp(PyObject* self, PyObject *args)
 }
 
 static PyObject *
-get_fields_from_date(PyObject* self, PyObject *args)
+get_fields_from_date(PyObject *self, PyObject *args)
 {
     PyObject *obj = NULL;
     PyObject *rv;
@@ -2597,7 +2597,7 @@ get_fields_from_date(PyObject* self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O", &obj)) {
         return NULL;
     }
-    
+
     year = PyDateTime_GET_YEAR(obj);
     month = PyDateTime_GET_MONTH(obj);
     day = PyDateTime_GET_DAY(obj);
@@ -2615,7 +2615,7 @@ get_fields_from_date(PyObject* self, PyObject *args)
 }
 
 static PyObject *
-get_fields_from_datetime(PyObject* self, PyObject *args)
+get_fields_from_datetime(PyObject *self, PyObject *args)
 {
     PyObject *obj = NULL;
     PyObject *rv;
@@ -2644,7 +2644,7 @@ get_fields_from_datetime(PyObject* self, PyObject *args)
 }
 
 static PyObject *
-get_fields_from_time(PyObject* self, PyObject *args)
+get_fields_from_time(PyObject *self, PyObject *args)
 {
     PyObject *obj = NULL;
     PyObject *rv;
@@ -2673,7 +2673,7 @@ get_fields_from_time(PyObject* self, PyObject *args)
 }
 
 static PyObject *
-get_fields_from_delta(PyObject* self, PyObject *args)
+get_fields_from_delta(PyObject *self, PyObject *args)
 {
     PyObject *obj = NULL;
     PyObject *rv;

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2588,7 +2588,7 @@ get_datetime_fromtimestamp(PyObject* self, PyObject *args)
 }
 
 static PyObject *
-get_fields_from_date(PyObject *self, PyObject *args)
+test_PyDateTime_GET(PyObject *self, PyObject *args)
 {
     PyObject *obj = NULL;
     PyObject *rv;
@@ -2615,7 +2615,7 @@ get_fields_from_date(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-get_fields_from_datetime(PyObject *self, PyObject *args)
+test_PyDateTime_DATE_GET(PyObject *self, PyObject *args)
 {
     PyObject *obj = NULL;
     PyObject *rv;
@@ -2644,7 +2644,7 @@ get_fields_from_datetime(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-get_fields_from_time(PyObject *self, PyObject *args)
+test_PyDateTime_TIME_GET(PyObject *self, PyObject *args)
 {
     PyObject *obj = NULL;
     PyObject *rv;
@@ -2673,7 +2673,7 @@ get_fields_from_time(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-get_fields_from_delta(PyObject *self, PyObject *args)
+test_PyDateTime_DELTA_GET(PyObject *self, PyObject *args)
 {
     PyObject *obj = NULL;
     PyObject *rv;
@@ -5187,10 +5187,10 @@ static PyMethodDef TestMethods[] = {
     {"get_delta_fromdsu",        get_delta_fromdsu,              METH_VARARGS},
     {"get_date_fromtimestamp",   get_date_fromtimestamp,         METH_VARARGS},
     {"get_datetime_fromtimestamp", get_datetime_fromtimestamp,   METH_VARARGS},
-    {"get_fields_from_date",       get_fields_from_date,         METH_VARARGS},
-    {"get_fields_from_datetime",   get_fields_from_datetime,     METH_VARARGS},
-    {"get_fields_from_time",       get_fields_from_time,         METH_VARARGS},
-    {"get_fields_from_delta",      get_fields_from_delta,        METH_VARARGS},
+    {"PyDateTime_GET",             test_PyDateTime_GET,          METH_VARARGS},
+    {"PyDateTime_DATE_GET",        test_PyDateTime_DATE_GET,     METH_VARARGS},
+    {"PyDateTime_TIME_GET",        test_PyDateTime_TIME_GET,     METH_VARARGS},
+    {"PyDateTime_DELTA_GET",       test_PyDateTime_DELTA_GET,        METH_VARARGS},
     {"test_list_api",           test_list_api,                   METH_NOARGS},
     {"test_dict_iteration",     test_dict_iteration,             METH_NOARGS},
     {"dict_getitem_knownhash",  dict_getitem_knownhash,          METH_VARARGS},


### PR DESCRIPTION
I have added the missing tests for the Datetime C API Macros.

<!-- issue-number: [bpo-36833](https://bugs.python.org/issue36833) -->
https://bugs.python.org/issue36833
<!-- /issue-number -->
