### PR TITLE
bpo-37612: always call linkat() from os.link(), if available

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-07-19-09-57-18.bpo-37612.yjjxx-.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-19-09-57-18.bpo-37612.yjjxx-.rst
@@ -1,0 +1,1 @@
+fix os.link() on platforms (like Linux) where the system link() function does not follow symlinks

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3512,15 +3512,11 @@ os_link_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
 #else
     Py_BEGIN_ALLOW_THREADS
 #ifdef HAVE_LINKAT
-    if ((src_dir_fd != DEFAULT_DIR_FD) ||
-        (dst_dir_fd != DEFAULT_DIR_FD) ||
-        (!follow_symlinks))
-        result = linkat(src_dir_fd, src->narrow,
-            dst_dir_fd, dst->narrow,
-            follow_symlinks ? AT_SYMLINK_FOLLOW : 0);
-    else
+    result = linkat(src_dir_fd, src->narrow, dst_dir_fd, dst->narrow,
+                    follow_symlinks ? AT_SYMLINK_FOLLOW : 0);
+#else
+    result = link(src->narrow, dst->narrow);
 #endif /* HAVE_LINKAT */
-        result = link(src->narrow, dst->narrow);
     Py_END_ALLOW_THREADS
 
     if (result)


### PR DESCRIPTION
The issue with link() is, that POSIX does not define its behavior regarding symbolic links:

"If path1 names a symbolic link, it is implementation-defined whether link() follows the symbolic link, or creates a new link to the symbolic link itself."

And it is indeed implemented differently on e.g. Linux and NetBSD. So, it makes no sense to call link(), where linkat() is available.

<!-- issue-number: [bpo-37612](https://bugs.python.org/issue37612) -->
https://bugs.python.org/issue37612
<!-- /issue-number -->
