### PR TITLE
bpo-16970: Adding error message for invalid args

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -593,7 +593,10 @@ class HelpFormatter(object):
         elif action.nargs == SUPPRESS:
             result = ''
         else:
-            formats = ['%s' for _ in range(action.nargs)]
+            try:
+                formats = ['%s' for _ in range(action.nargs)]
+            except TypeError:
+                raise ValueError("invalid nargs value")
             result = ' '.join(formats) % get_metavar(action.nargs)
         return result
 
@@ -850,7 +853,7 @@ class _StoreAction(Action):
                  help=None,
                  metavar=None):
         if nargs == 0:
-            raise ValueError('nargs for store actions must be > 0; if you '
+            raise ValueError('nargs for store actions must be != 0; if you '
                              'have nothing to store, actions such as store '
                              'true or store const may be more appropriate')
         if const is not None and nargs != OPTIONAL:
@@ -942,7 +945,7 @@ class _AppendAction(Action):
                  help=None,
                  metavar=None):
         if nargs == 0:
-            raise ValueError('nargs for append actions must be > 0; if arg '
+            raise ValueError('nargs for append actions must be != 0; if arg '
                              'strings are not supplying the value to append, '
                              'the append const action may be more appropriate')
         if const is not None and nargs != OPTIONAL:

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -596,7 +596,7 @@ class HelpFormatter(object):
             try:
                 formats = ['%s' for _ in range(action.nargs)]
             except TypeError:
-                raise ValueError("invalid nargs value")
+                raise ValueError("invalid nargs value") from None
             result = ' '.join(formats) % get_metavar(action.nargs)
         return result
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4263,7 +4263,6 @@ class TestHelpSubparsersWithHelpOrdering(HelpTestCase):
 
 
 class TestHelpMetavarTypeFormatter(HelpTestCase):
-    """"""
 
     def custom_type(string):
         return string
@@ -5149,6 +5148,35 @@ class TestAddArgumentMetavar(TestCase):
 
     def test_nargs_3_metavar_length3(self):
         self.do_test_no_exception(nargs=3, metavar=("1", "2", "3"))
+
+
+class TestInvalidNargs(TestCase):
+
+    EXPECTED_INVALID_MESSAGE = "invalid nargs value"
+    EXPECTED_RANGE_MESSAGE = ("nargs for store actions must be != 0; if you "
+                              "have nothing to store, actions such as store "
+                              "true or store const may be more appropriate")
+
+    def do_test_range_exception(self, nargs):
+        parser = argparse.ArgumentParser()
+        with self.assertRaises(ValueError) as cm:
+            parser.add_argument("--foo", nargs=nargs)
+        self.assertEqual(cm.exception.args[0], self.EXPECTED_RANGE_MESSAGE)
+
+    def do_test_invalid_exception(self, nargs):
+        parser = argparse.ArgumentParser()
+        with self.assertRaises(ValueError) as cm:
+            parser.add_argument("--foo", nargs=nargs)
+        self.assertEqual(cm.exception.args[0], self.EXPECTED_INVALID_MESSAGE)
+
+    # Unit tests for different values of nargs
+
+    def test_nargs_alphabetic(self):
+        self.do_test_invalid_exception(nargs='a')
+        self.do_test_invalid_exception(nargs="abcd")
+
+    def test_nargs_zero(self):
+        self.do_test_range_exception(nargs=0)
 
 # ============================
 # from argparse import * tests

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1874,3 +1874,4 @@ Edison Abahurire
 Geoff Shannon
 Batuhan Taskaya
 Aleksandr Balezin
+Robert Leenders

--- a/Misc/NEWS.d/next/Library/2019-07-19-01-46-56.bpo-16970.GEASf5.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-19-01-46-56.bpo-16970.GEASf5.rst
@@ -1,1 +1,2 @@
 Adding a value error when an invalid value in passed to nargs
+Patch by Robert Leenders

--- a/Misc/NEWS.d/next/Library/2019-07-19-01-46-56.bpo-16970.GEASf5.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-19-01-46-56.bpo-16970.GEASf5.rst
@@ -1,0 +1,1 @@
+Adding a value error when an invalid value in passed to nargs


### PR DESCRIPTION

BPO -16970: Adding error message for invalid args

Applied the patch argparse-v2 patch issue 16970, ran patch check and the test suite, test_argparse with 0 errors

<!-- issue-number: [bpo-16970](https://bugs.python.org/issue16970) -->
https://bugs.python.org/issue16970
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum