### PR TITLE
bpo-36084: Add threading Native ID information to What's New documentation

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -371,7 +371,7 @@ since it is impossible to detect the termination of alien threads.
          system-wide) from the time the thread is created until the thread
          has been terminated.
 
-      .. availability:: Require :func:`get_native_id` function.
+      .. availability:: Requires :func:`get_native_id` function.
 
       .. versionadded:: 3.8
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -770,8 +770,8 @@ threading
 
 * Add a new
   :func:`threading.get_native_id` function and a :data:`~threading.Thread.native_id`
-  attribute to the :class:`threading.Thread` class. These return a thread's native
-  integral identifier (``TID``) provided by the OS (kernel).
+  attribute to the :class:`threading.Thread` class. These return the native
+  integral Thread ID of the current thread assigned by the kernel.
   This feature is only available on certain platforms, see
   :func:`get_native_id <threading.get_native_id>` for more information.
   (Contributed by Jake Tesler in :issue:`36084`.)

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -763,10 +763,18 @@ in a standardized and extensible format, and offers several other benefits.
 threading
 ---------
 
-Add a new :func:`threading.excepthook` function which handles uncaught
-:meth:`threading.Thread.run` exception. It can be overridden to control how
-uncaught :meth:`threading.Thread.run` exceptions are handled.
-(Contributed by Victor Stinner in :issue:`1230540`.)
+* Add a new :func:`threading.excepthook` function which handles uncaught
+  :meth:`threading.Thread.run` exception. It can be overridden to control how
+  uncaught :meth:`threading.Thread.run` exceptions are handled.
+  (Contributed by Victor Stinner in :issue:`1230540`.)
+
+* Add a new
+  :func:`threading.get_native_id` function and a :data:`~threading.Thread.native_id`
+  attribute to the :class:`threading.Thread` class. These return a thread's native
+  integral identifier (``TID``) provided by the OS (kernel).
+  This feature is only available on certain platforms, see
+  :func:`get_native_id <threading.get_native_id>` for more information.
+  (Contributed by Jake Tesler in :issue:`36084`.)
 
 
 tokenize

--- a/Misc/NEWS.d/next/Documentation/2019-07-24-22-46-04.bpo-36084.2rmo4T.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-07-24-22-46-04.bpo-36084.2rmo4T.rst
@@ -1,0 +1,1 @@
+Add Threading Native ID info to What's New doc

--- a/Misc/NEWS.d/next/Documentation/2019-07-24-22-46-04.bpo-36084.2rmo4T.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-07-24-22-46-04.bpo-36084.2rmo4T.rst
@@ -1,1 +1,0 @@
-Add Threading Native ID info to What's New doc


### PR DESCRIPTION
This PR includes a minor documentation change. It adds a short blurb to the "What's New in Python 3.8" doc about the new Threading module Native ID functionality (`threading.get_native_id()`, et al.)

If this PR for [`:master`](/python/cpython/tree/master/) is approved, I will create a backport PR for the [`:3.8`](/python/cpython/tree/3.8/) branch.

See #13463 ([bpo-36084](https://bugs.python.org/issue36084)) for more information.

cc @vstinner, @pitrou 

<!-- issue-number: [bpo-36084](https://bugs.python.org/issue36084) -->
https://bugs.python.org/issue36084
<!-- /issue-number -->
