### PR TITLE
bpo-37623: namedtuple integration with importlib create_module

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -310,7 +310,7 @@ try:
 except ImportError:
     _tuplegetter = lambda index, doc: property(_itemgetter(index), doc=doc)
 
-def namedtuple(typename, field_names, *, rename=False, defaults=None, module=None):
+def namedtuple(typename, field_names, *, rename=False, defaults=None, module=None, spec=None):
     """Returns a new subclass of tuple with named fields.
 
     >>> Point = namedtuple('Point', ['x', 'y'])
@@ -467,6 +467,9 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
             pass
     if module is not None:
         result.__module__ = module
+
+    if spec is not None:
+        result.__spec__ = spec
 
     return result
 


### PR DESCRIPTION
# [bpo-37623](https://bugs.python.org/issue37623): namedtuple integration with importlib create_module

Here is an example of what I'm trying to accomplish, it's for loading simple json but it could be expanded a bit to help python users streamline their interactions with a json-heavy world. 

https://gist.github.com/captain-kark/81c60a1d6935fa50226dd87723e57a89

This opens to the door to give users the ability to define decoders and encoders for their project's modules that contain uniform sets of json files, instead of thinking about individual files all the time.

<!-- issue-number: [bpo-37623](https://bugs.python.org/issue37623) -->
https://bugs.python.org/issue37623
<!-- /issue-number -->
