### PR TITLE
bpo-37624: random.choices has unexpected behavior with negative weights

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -397,6 +397,8 @@ class Random(_random.Random):
                 _int = int
                 n += 0.0    # convert to float for a small speed improvement
                 return [population[_int(random() * n)] for i in _repeat(None, k)]
+            if weights and min(weights)<0:
+                raise ValueError('Cannot have negative weights')
             cum_weights = list(_accumulate(weights))
         elif weights is not None:
             raise TypeError('Cannot specify both weights and cumulative weights')

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -227,6 +227,10 @@ class TestBasicOps:
         with self.assertRaises(IndexError):
             choices([], cum_weights=[], k=5)
 
+        # Test negative weights raise error
+        with self.assertRaises(ValueError):
+            choices("abcdefg", weights=(1,1,-1,1,1,0,1), k=20)
+
     def test_choices_subnormal(self):
         # Subnormal weights would occassionally trigger an IndexError
         # in choices() when the value returned by random() was large

--- a/Misc/NEWS.d/next/Library/2019-07-19-03-49-09.bpo-37624.z4u3wy.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-19-03-49-09.bpo-37624.z4u3wy.rst
@@ -1,0 +1,1 @@
+ValueError in random.choices with negative weights. Patch by Aldwin Pollefeyt


### PR DESCRIPTION



<!-- issue-number: [bpo-37624](https://bugs.python.org/issue37624) -->
https://bugs.python.org/issue37624
<!-- /issue-number -->
