### PR TITLE
bpo-37624: Document weight assumptions for random.choices()

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -160,7 +160,8 @@ Functions for sequences
 
    The *weights* or *cum_weights* can use any numeric type that interoperates
    with the :class:`float` values returned by :func:`random` (that includes
-   integers, floats, and fractions but excludes decimals).
+   integers, floats, and fractions but excludes decimals).  Weights are
+   assumed to be non-negative.
 
    For a given seed, the :func:`choices` function with equal weighting
    typically produces a different sequence than repeated calls to


### PR DESCRIPTION


<!-- issue-number: [bpo-37624](https://bugs.python.org/issue37624) -->
https://bugs.python.org/issue37624
<!-- /issue-number -->
