### PR TITLE
bpo-37399: Correctly attach tail text to the last element/comment/pi

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2954,6 +2954,66 @@ class TreeBuilderTest(unittest.TestCase):
         self.assertEqual(b.pi('target'), (len('target'), None))
         self.assertEqual(b.pi('pitarget', ' text '), (len('pitarget'), ' text '))
 
+    def test_late_tail(self):
+        # Issue #37399: The tail of an ignored comment could overwrite the text before it.
+        class TreeBuilderSubclass(ET.TreeBuilder):
+            pass
+
+        xml = "<a>text<!-- comment -->tail</a>"
+        a = ET.fromstring(xml)
+        self.assertEqual(a.text, "texttail")
+
+        parser = ET.XMLParser(target=TreeBuilderSubclass())
+        parser.feed(xml)
+        a = parser.close()
+        self.assertEqual(a.text, "texttail")
+
+        xml = "<a>text<?pi data?>tail</a>"
+        a = ET.fromstring(xml)
+        self.assertEqual(a.text, "texttail")
+
+        xml = "<a>text<?pi data?>tail</a>"
+        parser = ET.XMLParser(target=TreeBuilderSubclass())
+        parser.feed(xml)
+        a = parser.close()
+        self.assertEqual(a.text, "texttail")
+
+    def test_late_tail_mix_pi_comments(self):
+        # Issue #37399: The tail of an ignored comment could overwrite the text before it.
+        # Test appending tails to comments/pis.
+        class TreeBuilderSubclass(ET.TreeBuilder):
+            pass
+
+        xml = "<a>text<?pi1?><!-- comment --><?pi2?>tail</a>"
+        parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
+        parser.feed(xml)
+        a = parser.close()
+        self.assertEqual(a[0].text, ' comment ')
+        self.assertEqual(a[0].tail, 'tail')
+        self.assertEqual(a.text, "text")
+
+        parser = ET.XMLParser(target=TreeBuilderSubclass(insert_comments=True))
+        parser.feed(xml)
+        a = parser.close()
+        self.assertEqual(a[0].text, ' comment ')
+        self.assertEqual(a[0].tail, 'tail')
+        self.assertEqual(a.text, "text")
+
+        xml = "<a>text<!-- comment --><?pi data?>tail</a>"
+        parser = ET.XMLParser(target=ET.TreeBuilder(insert_pis=True))
+        parser.feed(xml)
+        a = parser.close()
+        self.assertEqual(a[0].text, 'pi data')
+        self.assertEqual(a[0].tail, 'tail')
+        self.assertEqual(a.text, "text")
+
+        parser = ET.XMLParser(target=TreeBuilderSubclass(insert_pis=True))
+        parser.feed(xml)
+        a = parser.close()
+        self.assertEqual(a[0].text, 'pi data')
+        self.assertEqual(a[0].tail, 'tail')
+        self.assertEqual(a.text, "text")
+
     def test_treebuilder_elementfactory_none(self):
         parser = ET.XMLParser(target=ET.TreeBuilder(element_factory=None))
         parser.feed(self.sample1)

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2984,35 +2984,35 @@ class TreeBuilderTest(unittest.TestCase):
         class TreeBuilderSubclass(ET.TreeBuilder):
             pass
 
-        xml = "<a>text<?pi1?><!-- comment --><?pi2?>tail</a>"
+        xml = "<a>text<?pi1?> <!-- comment -->\n<?pi2?>tail</a>"
         parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
         parser.feed(xml)
         a = parser.close()
         self.assertEqual(a[0].text, ' comment ')
-        self.assertEqual(a[0].tail, 'tail')
-        self.assertEqual(a.text, "text")
+        self.assertEqual(a[0].tail, '\ntail')
+        self.assertEqual(a.text, "text ")
 
         parser = ET.XMLParser(target=TreeBuilderSubclass(insert_comments=True))
         parser.feed(xml)
         a = parser.close()
         self.assertEqual(a[0].text, ' comment ')
-        self.assertEqual(a[0].tail, 'tail')
-        self.assertEqual(a.text, "text")
+        self.assertEqual(a[0].tail, '\ntail')
+        self.assertEqual(a.text, "text ")
 
-        xml = "<a>text<!-- comment --><?pi data?>tail</a>"
+        xml = "<a>text<!-- comment -->\n<?pi data?>tail</a>"
         parser = ET.XMLParser(target=ET.TreeBuilder(insert_pis=True))
         parser.feed(xml)
         a = parser.close()
         self.assertEqual(a[0].text, 'pi data')
         self.assertEqual(a[0].tail, 'tail')
-        self.assertEqual(a.text, "text")
+        self.assertEqual(a.text, "text\n")
 
         parser = ET.XMLParser(target=TreeBuilderSubclass(insert_pis=True))
         parser.feed(xml)
         a = parser.close()
         self.assertEqual(a[0].text, 'pi data')
         self.assertEqual(a[0].tail, 'tail')
-        self.assertEqual(a.text, "text")
+        self.assertEqual(a.text, "text\n")
 
     def test_treebuilder_elementfactory_none(self):
         parser = ET.XMLParser(target=ET.TreeBuilder(element_factory=None))

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3636,7 +3636,7 @@ expat_pi_handler(XMLParserObject* self, const XML_Char* target_in,
         /* shortcut */
         TreeBuilderObject *target = (TreeBuilderObject*) self->target;
 
-        if (target->events_append && target->pi_event_obj || target->insert_pis) {
+        if ((target->events_append && target->pi_event_obj) || target->insert_pis) {
             pi_target = PyUnicode_DecodeUTF8(target_in, strlen(target_in), "strict");
             if (!pi_target)
                 goto error;

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -2884,7 +2884,7 @@ treebuilder_handle_end(TreeBuilderObject* self, PyObject* tag)
 LOCAL(PyObject*)
 treebuilder_handle_comment(TreeBuilderObject* self, PyObject* text)
 {
-    PyObject* comment = NULL;
+    PyObject* comment;
     PyObject* this;
 
     if (treebuilder_flush_data(self) < 0) {
@@ -2923,7 +2923,7 @@ treebuilder_handle_comment(TreeBuilderObject* self, PyObject* text)
 LOCAL(PyObject*)
 treebuilder_handle_pi(TreeBuilderObject* self, PyObject* target, PyObject* text)
 {
-    PyObject* pi = NULL;
+    PyObject* pi;
     PyObject* this;
     PyObject* stack[2] = {target, text};
 
@@ -3532,8 +3532,8 @@ expat_end_ns_handler(XMLParserObject* self, const XML_Char* prefix_in)
 static void
 expat_comment_handler(XMLParserObject* self, const XML_Char* comment_in)
 {
-    PyObject* comment = NULL;
-    PyObject* res = NULL;
+    PyObject* comment;
+    PyObject* res;
 
     if (PyErr_Occurred())
         return;
@@ -3547,16 +3547,17 @@ expat_comment_handler(XMLParserObject* self, const XML_Char* comment_in)
             return; /* parser will look for errors */
 
         res = treebuilder_handle_comment(target,  comment);
+        Py_XDECREF(res);
+        Py_DECREF(comment);
     } else if (self->handle_comment) {
         comment = PyUnicode_DecodeUTF8(comment_in, strlen(comment_in), "strict");
         if (!comment)
             return;
 
         res = _PyObject_CallOneArg(self->handle_comment, comment);
+        Py_XDECREF(res);
+        Py_DECREF(comment);
     }
-
-    Py_XDECREF(res);
-    Py_DECREF(comment);
 }
 
 static void
@@ -3624,7 +3625,7 @@ static void
 expat_pi_handler(XMLParserObject* self, const XML_Char* target_in,
                  const XML_Char* data_in)
 {
-    PyObject* pi_target = NULL;
+    PyObject* pi_target;
     PyObject* data;
     PyObject* res;
     PyObject* stack[2];

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -2649,7 +2649,8 @@ treebuilder_extend_element_text_or_tail(PyObject *element, PyObject **data,
     /*  Fallback for the non-Element / non-trivial cases. */
     {
         int r;
-        PyObject *joined, *previous = _PyObject_GetAttrId(element, name);
+        PyObject* joined;
+        PyObject* previous = _PyObject_GetAttrId(element, name);
         if (!previous)
             return -1;
         joined = list_join(*data);
@@ -2660,11 +2661,12 @@ treebuilder_extend_element_text_or_tail(PyObject *element, PyObject **data,
         if (previous != Py_None) {
             PyObject *tmp = PyNumber_Add(previous, joined);
             Py_DECREF(joined);
-            if (!tmp) {
-                Py_DECREF(previous);
+            Py_DECREF(previous);
+            if (!tmp)
                 return -1;
-            }
             joined = tmp;
+        } else {
+            Py_DECREF(previous);
         }
 
         r = _PyObject_SetAttrId(element, name, joined);


### PR DESCRIPTION
Correctly attach tail text to the last element/comment/pi, even when comments or pis are discarded.
Also fixes the insertion of PIs when "insert_pis=True" is configured for a TreeBuilder.

<!-- issue-number: [bpo-37399](https://bugs.python.org/issue37399) -->
https://bugs.python.org/issue37399
<!-- /issue-number -->
