### PR TITLE
[bpo-16512](https://bugs.python.org/issue16512): Improve jpeg detection in imghdr

### DIFF
--- a/Lib/imghdr.py
+++ b/Lib/imghdr.py
@@ -14,10 +14,10 @@ def what(file, h=None):
         if h is None:
             if isinstance(file, (str, PathLike)):
                 f = open(file, 'rb')
-                h = f.read()
+                h = f.read(32)
             else:
                 location = file.tell()
-                h = file.read()
+                h = file.read(32)
                 file.seek(location)
         for tf in tests:
             res = tf(h, f)
@@ -35,8 +35,8 @@ def what(file, h=None):
 tests = []
 
 def test_jpeg(h, f):
-    """JPEG data in JFIF or Exif format"""
-    if h.startswith(b'\xFF\xD8') and h.endswith(b'\xFF\xD9'):
+    """JPEG data """
+    if h.startswith(b'\xFF\xD8'):
         return 'jpeg'
 
 tests.append(test_jpeg)

--- a/Lib/imghdr.py
+++ b/Lib/imghdr.py
@@ -14,10 +14,10 @@ def what(file, h=None):
         if h is None:
             if isinstance(file, (str, PathLike)):
                 f = open(file, 'rb')
-                h = f.read(32)
+                h = f.read()
             else:
                 location = file.tell()
-                h = file.read(32)
+                h = file.read()
                 file.seek(location)
         for tf in tests:
             res = tf(h, f)
@@ -36,7 +36,7 @@ tests = []
 
 def test_jpeg(h, f):
     """JPEG data in JFIF or Exif format"""
-    if h[6:10] in (b'JFIF', b'Exif'):
+    if h.startswith(b'\xFF\xD8') and h.endswith(b'\xFF\xD9'):
         return 'jpeg'
 
 tests.append(test_jpeg)

--- a/Lib/test/test_imghdr.py
+++ b/Lib/test/test_imghdr.py
@@ -79,7 +79,7 @@ class TestImghdr(unittest.TestCase):
             imghdr.what()
         with self.assertRaises(AttributeError):
             imghdr.what(None)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AttributeError):
             imghdr.what(self.testfile, 1)
         with self.assertRaises(AttributeError):
             imghdr.what(os.fsencode(self.testfile))


### PR DESCRIPTION
Some valid jpeg files are not detected by imghdr.what

The proposed fix implements the solution proposed at
https://stackoverflow.com/questions/46802866/how-to-detect-if-the-jpg-jpeg-image-file-is-corruptedincomplete.

We detect the JPEG file by checking it starts with the Start of image
sequence xFFxD8, and ends with the end of image sequence xFFxD9.

In order to do so, we load the entire file in memory.

<!-- issue-number: [bpo-16512](https://bugs.python.org/issue16512) -->
https://bugs.python.org/issue16512
<!-- /issue-number -->
