### PR TITLE
bpo-29446: Improve tkinter 'import *' situation

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -32,12 +32,12 @@ tk.mainloop()
 
 import enum
 import sys
+import types
 
 import _tkinter # If this fails your Python may not be configured for Tk
 TclError = _tkinter.TclError
 from tkinter.constants import *
 import re
-
 
 wantobjects = 1
 
@@ -4568,6 +4568,10 @@ def _test():
     root.deiconify()
     root.mainloop()
 
+
+__all__ = [name for name, obj in globals().items()
+           if not name.startswith('_') and not isinstance(obj, types.ModuleType)
+           and name not in {'wantobjects'}]
 
 if __name__ == '__main__':
     _test()

--- a/Lib/tkinter/colorchooser.py
+++ b/Lib/tkinter/colorchooser.py
@@ -21,6 +21,8 @@
 
 from tkinter.commondialog import Dialog
 
+__all__ = ["Chooser", "askcolor"]
+
 
 #
 # color chooser class

--- a/Lib/tkinter/commondialog.py
+++ b/Lib/tkinter/commondialog.py
@@ -8,15 +8,15 @@
 # written by Fredrik Lundh, May 1997
 #
 
-from tkinter import *
+from tkinter import Frame
 
 
 class Dialog:
 
-    command  = None
+    command = None
 
     def __init__(self, master=None, **options):
-        self.master  = master
+        self.master = master
         self.options = options
         if not master and options.get('parent'):
             self.master = options['parent']

--- a/Lib/tkinter/commondialog.py
+++ b/Lib/tkinter/commondialog.py
@@ -8,6 +8,8 @@
 # written by Fredrik Lundh, May 1997
 #
 
+__all__ = ["Dialog"]
+
 from tkinter import Frame
 
 

--- a/Lib/tkinter/dialog.py
+++ b/Lib/tkinter/dialog.py
@@ -1,7 +1,8 @@
 # dialog.py -- Tkinter interface to the tk_dialog script.
 
-from tkinter import *
-from tkinter import _cnfmerge
+from tkinter import _cnfmerge, Widget, TclError, Button, Pack
+
+__all__ = ["Dialog"]
 
 DIALOG_ICON = 'questhead'
 

--- a/Lib/tkinter/dnd.py
+++ b/Lib/tkinter/dnd.py
@@ -99,8 +99,9 @@ active; it will never call dnd_commit().
 
 """
 
-
 import tkinter
+
+__all__ = ["dnd_start", "DndHandler"]
 
 
 # The factory function

--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -11,8 +11,9 @@ to the native file dialogues available in Tk 4.2 and newer, and the
 directory dialogue available in Tk 8.3 and newer.
 These interfaces were written by Fredrik Lundh, May 1997.
 """
-__all__ = ["FileDialog", "LoadFileDialog", "SaveFileDialog", "Open", "SaveAs",
-           "Directory", "askopenfilename", "asksaveasfilename", "askopenfilenames",
+__all__ = ["FileDialog", "LoadFileDialog", "SaveFileDialog",
+           "Open", "SaveAs", "Directory",
+           "askopenfilename", "asksaveasfilename", "askopenfilenames",
            "askopenfile", "askopenfiles", "asksaveasfile", "askdirectory"]
 
 import fnmatch

--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -11,13 +11,15 @@ to the native file dialogues available in Tk 4.2 and newer, and the
 directory dialogue available in Tk 8.3 and newer.
 These interfaces were written by Fredrik Lundh, May 1997.
 """
+__all__ = ["FileDialog", "LoadFileDialog", "SaveFileDialog", "Open", "SaveAs",
+           "Directory", "askopenfilename", "asksaveasfilename", "askopenfilenames",
+           "askopenfile", "askopenfiles", "asksaveasfile", "askdirectory"]
 
+import fnmatch
+import os
 from tkinter import *
 from tkinter.dialog import Dialog
 from tkinter import commondialog
-
-import os
-import fnmatch
 
 
 dialogstates = {}

--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -17,7 +17,10 @@ __all__ = ["FileDialog", "LoadFileDialog", "SaveFileDialog", "Open", "SaveAs",
 
 import fnmatch
 import os
-from tkinter import *
+from tkinter import (
+    Frame, LEFT, YES, BOTTOM, Entry, TOP, Button, Tk, X,
+    Toplevel, RIGHT, Y, END, Listbox, BOTH, Scrollbar,
+)
 from tkinter.dialog import Dialog
 from tkinter import commondialog
 

--- a/Lib/tkinter/font.py
+++ b/Lib/tkinter/font.py
@@ -7,8 +7,8 @@ import itertools
 import tkinter
 
 __version__ = "0.9"
-__all__ = ["NORMAL", "ROMAN", "BOLD", "ITALIC", "nametofont", "Font", "families",
-           "names"]
+__all__ = ["NORMAL", "ROMAN", "BOLD", "ITALIC",
+           "nametofont", "Font", "families", "names"]
 
 # weight/slant
 NORMAL = "normal"

--- a/Lib/tkinter/font.py
+++ b/Lib/tkinter/font.py
@@ -3,11 +3,12 @@
 # written by Fredrik Lundh, February 1998
 #
 
-__version__ = "0.9"
-
 import itertools
 import tkinter
 
+__version__ = "0.9"
+__all__ = ["NORMAL", "ROMAN", "BOLD", "ITALIC", "nametofont", "Font", "families",
+           "names"]
 
 # weight/slant
 NORMAL = "normal"

--- a/Lib/tkinter/messagebox.py
+++ b/Lib/tkinter/messagebox.py
@@ -24,6 +24,9 @@
 
 from tkinter.commondialog import Dialog
 
+__all__ = ["showinfo", "showwarning", "showerror", "askquestion", "askokcancel",
+           "askyesno", "askyesnocancel", "askretrycancel"]
+
 #
 # constants
 

--- a/Lib/tkinter/messagebox.py
+++ b/Lib/tkinter/messagebox.py
@@ -24,8 +24,9 @@
 
 from tkinter.commondialog import Dialog
 
-__all__ = ["showinfo", "showwarning", "showerror", "askquestion", "askokcancel",
-           "askyesno", "askyesnocancel", "askretrycancel"]
+__all__ = ["showinfo", "showwarning", "showerror",
+           "askquestion", "askokcancel", "askyesno",
+           "askyesnocancel", "askretrycancel"]
 
 #
 # constants

--- a/Lib/tkinter/scrolledtext.py
+++ b/Lib/tkinter/scrolledtext.py
@@ -11,10 +11,10 @@ Most methods calls are inherited from the Text widget; Pack, Grid and
 Place methods are redirected to the Frame widget however.
 """
 
-__all__ = ['ScrolledText']
-
 from tkinter import Frame, Text, Scrollbar, Pack, Grid, Place
 from tkinter.constants import RIGHT, LEFT, Y, BOTH
+
+__all__ = ['ScrolledText']
 
 
 class ScrolledText(Text):

--- a/Lib/tkinter/test/test_tkinter/test_misc.py
+++ b/Lib/tkinter/test/test_tkinter/test_misc.py
@@ -7,6 +7,20 @@ support.requires('gui')
 
 class MiscTest(AbstractTkTest, unittest.TestCase):
 
+    def test_all(self):
+        self.assertIn("Widget", tkinter.__all__)
+        # Check that variables from tkinter.constants are also in tkinter.__all__
+        self.assertIn("CASCADE", tkinter.__all__)
+        self.assertIsNotNone(tkinter.CASCADE)
+        # Check that sys, re, and constants are not in tkinter.__all__
+        self.assertNotIn("re", tkinter.__all__)
+        self.assertNotIn("sys", tkinter.__all__)
+        self.assertNotIn("constants", tkinter.__all__)
+        # Check that an underscored functions is not in tkinter.__all__
+        self.assertNotIn("_tkerror", tkinter.__all__)
+        # Check that wantobjects is not in tkinter.__all__
+        self.assertNotIn("wantobjects", tkinter.__all__)
+
     def test_repr(self):
         t = tkinter.Toplevel(self.root, name='top')
         f = tkinter.Frame(t, name='child')

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -649,6 +649,7 @@ Zac Hatfield-Dodds
 Shane Hathaway
 Michael Haubenwallner
 Janko Hauser
+Flavian Hautbois
 Rycharde Hawkes
 Ben Hayden
 Jochen Hayek

--- a/Misc/NEWS.d/next/Library/2019-07-19-16-06-48.bpo-29446.iXGuoi.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-19-16-06-48.bpo-29446.iXGuoi.rst
@@ -1,0 +1,1 @@
+Make `from tkinter import *` import only the expected objects.


### PR DESCRIPTION
A pull request for [this issue](https://bugs.python.org/issue29446).

@ericvsmith recommended using `__all__ = [name for name, obj in globals().items() if not name.startswith('_') and not isinstance(obj, types.ModuleType) and name not in {'wantobjects'}]`.

Also added __all__ in submodules of tkinter.

Side note: Interestingly, `idlelib/editor.py` was using `sys` and `re` from `tkinter` instead of importing them. There may be more modules that use "from tkinter import *"

<!-- issue-number: [bpo-29446](https://bugs.python.org/issue29446) -->
https://bugs.python.org/issue29446
<!-- /issue-number -->
