### PR TITLE
bpo-36161: Use thread-safe function ttyname_r instead of unsafe one ttyname

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-07-20-01-17-43.bpo-36161.Fzf-f9.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-20-01-17-43.bpo-36161.Fzf-f9.rst
@@ -1,1 +1,1 @@
-Use ttyname_r instead of ttyname for thread safety
+In :mod:`posix`, use ``ttyname_r`` instead of ``ttyname`` for thread safety.

--- a/Misc/NEWS.d/next/Library/2019-07-20-01-17-43.bpo-36161.Fzf-f9.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-20-01-17-43.bpo-36161.Fzf-f9.rst
@@ -1,0 +1,1 @@
+Use ttyname_r instead of ttyname for thread safety


### PR DESCRIPTION
Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36161](https://bugs.python.org/issue36161) -->
https://bugs.python.org/issue36161
<!-- /issue-number -->
