### PR TITLE
bpo-37616: Fix incorrect zip path for 3.10 prep

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-21-11-11-58.bpo-37616.0pEhuj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-21-11-11-58.bpo-37616.0pEhuj.rst
@@ -1,0 +1,1 @@
+Update `getpath` detect zip path in :mod:`sys.path`

--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-21-11-11-58.bpo-37616.0pEhuj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-21-11-11-58.bpo-37616.0pEhuj.rst
@@ -1,1 +1,2 @@
-Update `getpath` detect zip path in :mod:`sys.path`
+Update ``Module/getpath.c`` read python zip path if python
+version size more than 2 digit.

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -1284,7 +1284,7 @@ calculate_read_pyenv(PyCalculatePath *calculate)
 static PyStatus
 calculate_zip_path(PyCalculatePath *calculate)
 {
-    const wchar_t *lib_python = L"lib/python00.zip";
+    const wchar_t *lib_python = L"lib/python000.zip";
 
     if (calculate->prefix_found > 0) {
         /* Use the reduced prefix returned by Py_GetPrefix()
@@ -1307,10 +1307,16 @@ calculate_zip_path(PyCalculatePath *calculate)
         return _PyStatus_NO_MEMORY();
     }
 
-    /* Replace "00" with version */
-    size_t len = wcslen(calculate->zip_path);
-    calculate->zip_path[len - 6] = VERSION[0];
-    calculate->zip_path[len - 5] = VERSION[2];
+    /* Replace "000" with version */
+    size_t bufsz = wcslen(calculate->zip_path);
+    calculate->zip_path[bufsz - 7] = VERSION[0];
+    calculate->zip_path[bufsz - 6] = VERSION[2];
+    if (sizeof(VERSION) == 5) {
+      calculate->zip_path[bufsz - 5] = VERSION[3];
+    }
+    else {
+      memmove(&calculate->zip_path[bufsz - 5], &calculate->zip_path[bufsz - 4], bufsz);
+    }
 
     return _PyStatus_OK();
 }

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -1312,10 +1312,11 @@ calculate_zip_path(PyCalculatePath *calculate)
     calculate->zip_path[bufsz - 7] = VERSION[0];
     calculate->zip_path[bufsz - 6] = VERSION[2];
     if (sizeof(VERSION) == 5) {
-      calculate->zip_path[bufsz - 5] = VERSION[3];
+        calculate->zip_path[bufsz - 5] = VERSION[3];
     }
     else {
-      memmove(&calculate->zip_path[bufsz - 5], &calculate->zip_path[bufsz - 4], bufsz);
+        memmove(&calculate->zip_path[bufsz - 5],
+            &calculate->zip_path[bufsz - 4], bufsz);
     }
 
     return _PyStatus_OK();


### PR DESCRIPTION
[3.10 prep] fix incorrect zip path

<!-- issue-number: [bpo-37616](https://bugs.python.org/issue37616) -->
https://bugs.python.org/issue37616
<!-- /issue-number -->
