### PR TITLE
bpo-37640: Fix telnetlib crash in Python3 while receiving un-printable characters from server

### DIFF
--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -38,6 +38,9 @@ import socket
 import selectors
 from time import monotonic as _time
 
+# get current python version
+is_py_3 = sys.version_info >= (3, 6)
+
 __all__ = ["Telnet"]
 
 # Tunable parameters
@@ -552,7 +555,11 @@ class Telnet:
                             print('*** Connection closed by remote host ***')
                             return
                         if text:
-                            sys.stdout.write(text.decode('ascii'))
+                            if is_py_3:
+                                # fix UnicodeError while receiving unprintable characters from server
+                                sys.stdout.buffer.write(text)
+                            else:
+                                sys.stdout.write(text.decode('ascii'))
                             sys.stdout.flush()
                     elif key.fileobj is sys.stdin:
                         line = sys.stdin.readline().encode('ascii')
@@ -579,7 +586,11 @@ class Telnet:
                 print('*** Connection closed by remote host ***')
                 return
             if data:
-                sys.stdout.write(data.decode('ascii'))
+                if is_py_3:
+                    # fix UnicodeError while receiving unpritable characters from server
+                    sys.stdout.buffer.write(data)
+                else:
+                    sys.stdout.write(data.decode('ascii'))
             else:
                 sys.stdout.flush()
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
[bpo-37640](https://bugs.python.org/issue37640): telnetlib crash in Python3 while receiving un-printable characters from server
```

Where: [bpo-37640](https://bugs.python.org/issue37640) refers to the issue number in the https://bugs.python.org/issue37640.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-37640](https://bugs.python.org/issue37640) -->
https://bugs.python.org/issue37640
<!-- /issue-number -->
