### PR TITLE
bpo-37641 preserve relative file location in embeddable zip

### DIFF
--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -288,18 +288,17 @@ def _compile_one_py(src, dest, name, optimize, checked=True):
         return None
 
 
-def _py_temp_compile(src, ns, dest_dir=None, checked=True):
+def _py_temp_compile(src, name, ns, dest_dir=None, checked=True):
     if not ns.precompile or src not in PY_FILES or src.parent in DATA_DIRS:
         return None
-
-    dest = (dest_dir or ns.temp) / (src.stem + ".py")
+    dest = (dest_dir or ns.temp) / (src.stem + ".pyc")
     return _compile_one_py(
-        src, dest.with_suffix(".pyc"), dest, optimize=2, checked=checked
+        src, dest, name, optimize=2, checked=checked
     )
 
 
 def _write_to_zip(zf, dest, src, ns, checked=True):
-    pyc = _py_temp_compile(src, ns, checked=checked)
+    pyc = _py_temp_compile(src, dest, ns, checked=checked)
     if pyc:
         try:
             zf.write(str(pyc), dest.with_suffix(".pyc"))

--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -287,7 +287,7 @@ def _compile_one_py(src, dest, name, optimize, checked=True):
         log_warning("Failed to compile {}", src)
         return None
 
-
+# name argument added to address bpo-37641
 def _py_temp_compile(src, name, ns, dest_dir=None, checked=True):
     if not ns.precompile or src not in PY_FILES or src.parent in DATA_DIRS:
         return None


### PR DESCRIPTION
Previously, pyc files in the embeddable distribution reported their
location as <build path>/<file stem>.py. This causes a little confusion
when interpreting stack traces as the file is in a (almost certainly)
incorrect location, and lacks the full relative path to Lib (e.g.
email/mime/image.py will only show image.py).

This change preserves the Lib relative location of the source file as a
path so that stack traces are (hopefully) less misleading and more
informative.


<!-- issue-number: [bpo-37641](https://bugs.python.org/issue37641) -->
https://bugs.python.org/issue37641
<!-- /issue-number -->
