### PR TITLE
bpo-36338: Reject hostname with [ at position > 0

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -531,6 +531,19 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(p.hostname, b"fe80::822a:a8ff:fe49:470c%tESt")
         self.assertEqual(p.netloc, b'[FE80::822a:a8ff:fe49:470c%tESt]:1234')
 
+    def test_urlsplit_prevents_hostname_injection(self):
+        cases = [
+            # bpo-36338: Ensure that [ is at position 0 of hostname
+            'http://good.com[bad.com]',
+            b'http://good.com[bad.com]',
+        ]
+        for case in cases:
+            with self.assertRaises(ValueError, msg=case):
+                urllib.parse.urlsplit(case)
+
+            with self.assertRaises(ValueError, msg=case):
+                urllib.parse.urlparse(case)
+
     def test_urlsplit_attributes(self):
         url = "HTTP://WWW.PYTHON.ORG/doc/#frag"
         p = urllib.parse.urlsplit(url)

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -436,7 +436,8 @@ def urlsplit(url, scheme='', allow_fragments=True):
             if url[:2] == '//':
                 netloc, url = _splitnetloc(url, 2)
                 if (('[' in netloc and ']' not in netloc) or
-                        (']' in netloc and '[' not in netloc)):
+                        (']' in netloc and '[' not in netloc) or
+                        ('[' in netloc and netloc.index('[') != 0)):
                     raise ValueError("Invalid IPv6 URL")
             if allow_fragments and '#' in url:
                 url, fragment = url.split('#', 1)

--- a/Misc/NEWS.d/next/Security/2019-07-22-13-33-37.bpo-36338.MJll68.rst
+++ b/Misc/NEWS.d/next/Security/2019-07-22-13-33-37.bpo-36338.MJll68.rst
@@ -1,0 +1,1 @@
+Raise ValueError when parsing hostname with ``[`` in position > 0, e.g. ``good.com[malicious.com]``, that would otherwise return a hostname of ``malicious.com``.


### PR DESCRIPTION
Before:

    >>> urlparse('http://good.com[malicious.com]/aoeu').hostname
    'malicious.com'

After:

    >>> urlparse('http://good.com[malicious.com]/aoeu')
    ValueError: Invalid IPv6 URL

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36338](https://bugs.python.org/issue36338) -->
https://bugs.python.org/issue36338
<!-- /issue-number -->
