### PR TITLE
gh-81831: tempfile: flock(LOCK_SH) on temporary directories

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-07-22-07-14-35.bpo-37650.H6Klu9.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-22-07-14-35.bpo-37650.H6Klu9.rst
@@ -1,0 +1,3 @@
+Use flock(LOCK_SH) on TemporaryDirectory files as per `the official systemd
+recommendations <https://systemd.io/TEMPORARY_DIRECTORIES.html#automatic-clean-up>`_ in order to
+avoid systemd-tmpfiles from cleaning up the contents of a TemporaryDirectory before ready.


### PR DESCRIPTION
This avoids systemd-tmpfiles cleaning up the directory contents before the directory is ready to be removed.

<!-- issue-number: [bpo-37650](https://bugs.python.org/issue37650) -->
https://bugs.python.org/issue37650
<!-- /issue-number -->

<!-- gh-issue-number: gh-81831 -->
* Issue: gh-81831
<!-- /gh-issue-number -->
