### PR TITLE
bpo-37653: Fix make install

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1431,8 +1431,6 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 			*CVS) ;; \
 			*.py[co]) ;; \
 			*.orig) ;; \
-			# bpo-37468: Don't install distutils/command/wininst-*.exe files used \
-			# by distutils bdist_wininst: bdist_wininst only works on Windows. \
 			*wininst-*.exe) ;; \
 			*~) ;; \
 			*) \


### PR DESCRIPTION
The sub-target, `libinstall`, was broken by line continuations in shell script comments included in commit e8692818afd731c1b7e925c626ac8200b1f1c31e. Fixed by removing the troublesome comments.

(If we really need these comments, we can add them as "Make comments" above the `libinstall` target instead.)

<!-- issue-number: [bpo-37653](https://bugs.python.org/issue37653) -->
https://bugs.python.org/issue37653
<!-- /issue-number -->
