### PR TITLE
Add missing space to warning message

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -47,7 +47,7 @@ def __getattr__(name):
         obj = getattr(_collections_abc, name)
         import warnings
         warnings.warn("Using or importing the ABCs from 'collections' instead "
-                      "of from 'collections.abc' is deprecated since Python 3.3,"
+                      "of from 'collections.abc' is deprecated since Python 3.3, "
                       "and in 3.9 it will stop working",
                       DeprecationWarning, stacklevel=2)
         globals()[name] = obj


### PR DESCRIPTION
This was introduced in GH-13409 when changing the message text.

cc @Carreau 

This should probably go to the 3.8 branch as well?