### PR TITLE
gh-74940: Allow fallback to UTF-8 encoding on systems with no locales installed.

### DIFF
--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -962,7 +962,7 @@ locale_alias = {
     'c.ascii':                              'C',
     'c.en':                                 'C',
     'c.iso88591':                           'en_US.ISO8859-1',
-    'c.utf8':                               'en_US.UTF-8',
+    'c.utf8':                               'C.UTF-8',
     'c_c':                                  'C',
     'c_c.c':                                'C',
     'ca':                                   'ca_ES.ISO8859-1',

--- a/Misc/NEWS.d/next/Library/2023-04-25-22-06-00.gh-issue-74940.TOacQ9.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-25-22-06-00.gh-issue-74940.TOacQ9.rst
@@ -1,0 +1,2 @@
+The C.UTF-8 locale is no longer converted to en_US.UTF-8, enabling the use
+of UTF-8 encoding on systems which have no locales installed.


### PR DESCRIPTION
This change removes the alias of the 'C' locale to 'en_US'.  Because of this alias, it is currently impossible for an application to use setlocale() to specify a UTF-8 locale on a system that has no locales installed, but which supports the C.UTF-8 locale/encoding.

<!-- issue-number: [bpo-30755](https://bugs.python.org/issue30755) -->
https://bugs.python.org/issue30755
<!-- /issue-number -->


<!-- gh-issue-number: gh-74940 -->
* Issue: gh-74940
<!-- /gh-issue-number -->
