### PR TITLE
bpo-37667: Only setup PGO tests when PGO is actually enabled.

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -215,8 +215,9 @@ class Regrtest:
 
         removepy(self.tests)
 
-        # add default PGO tests if no tests are specified
-        setup_pgo_tests(self.ns)
+        if self.ns.pgo:
+            # add default PGO tests if no tests are specified
+            setup_pgo_tests(self.ns)
 
         stdtests = STDTESTS[:]
         nottests = NOTTESTS.copy()


### PR DESCRIPTION
We're skipping all but 40 of the tests when running the test suite now as of https://github.com/python/cpython/commit/2406672984e4c1b18629e615edad52928a72ffcc

OOPS :)

<!-- issue-number: [bpo-37667](https://bugs.python.org/issue37667) -->
https://bugs.python.org/issue37667
<!-- /issue-number -->


Automerge-Triggered-By: @gpshead