### PR TITLE
bpo-37661: fix venv activation script rigged prompt check

### DIFF
--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -309,6 +309,7 @@ class EnvBuilder:
         text = text.replace('__VENV_DIR__', context.env_dir)
         text = text.replace('__VENV_NAME__', context.env_name)
         text = text.replace('__VENV_PROMPT__', context.prompt)
+        text = text.replace('__VENV_DEFAULT_PROMPT__', '(%s) ' % context.env_name)
         text = text.replace('__VENV_BIN_NAME__', context.bin_name)
         text = text.replace('__VENV_PYTHON__', context.env_exe)
         return text

--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -54,7 +54,7 @@ fi
 
 if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT:-}" ] ; then
     _OLD_VIRTUAL_PS1="${PS1:-}"
-    if [ "x__VENV_PROMPT__" != x ] ; then
+    if [[ "y__VENV_PROMPT__" != "y__VENV_DEFAULT_PROMPT__" && "x__VENV_PROMPT__" != x ]] ; then
 	PS1="__VENV_PROMPT__${PS1:-}"
     else
     if [ "`basename \"$VIRTUAL_ENV\"`" = "__" ] ; then

--- a/Lib/venv/scripts/posix/activate.fish
+++ b/Lib/venv/scripts/posix/activate.fish
@@ -52,7 +52,7 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
         set -l old_status $status
 
         # Prompt override?
-        if test -n "__VENV_PROMPT__"
+        if test "__VENV_PROMPT__" != "__VENV_DEFAULT_PROMPT__" -a -n "__VENV_PROMPT__"
             printf "%s%s" "__VENV_PROMPT__" (set_color normal)
         else
             # ...Otherwise, prepend env

--- a/Misc/NEWS.d/next/Library/2019-07-24-11-21-12.bpo-37661.ZviM4n.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-24-11-21-12.bpo-37661.ZviM4n.rst
@@ -1,0 +1,3 @@
+Due to the prompt context always being set to a truthy value the string
+substitution for the script files was always done to produce a check that
+would never fail, impacting the colouring of shells.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
[bpo-37661](https://bugs.python.org/issue37661): Added short circuiting logic to the checks performed in the two scripts affected, this required adding another string substitution `__VENV_DEFAULT_PROMPT__` which would evaluate to the default case used when formatting the `__VENV_PROMPT__` flag.

I'm a little paranoid given this is my first contribution, I ran a passing test suite and tested the expressions evaluated in the checks directly but not the actual scripts themselves so I'd love if someone could confirm the correctness of this patch.

<!-- issue-number: [bpo-37661](https://bugs.python.org/issue37661) -->
https://bugs.python.org/issue37661
<!-- /issue-number -->
