### PR TITLE
bpo-37669: Make mock_open return per-file-name content

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2750,9 +2750,9 @@ def mock_open(mock=None, read_data='', data=()):
     `read_data` is a string for the `read`, `readline` and `readlines` of the
     file handle to return.  This is an empty string by default.
 
-    `data` is any value acceptable for `dict` constructor. The keys
+    `data` is any value acceptable for the `dict` constructor. The keys
     represent file names. If a file name, found in `data`, is
-    mock-opened, and the value matching the file name in `data` will
+    mock-opened, then the value matching the file name in `data` will
     be used instead of `read_data`. The default is an empty tuple.
     """
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1749,6 +1749,17 @@ class MockTest(unittest.TestCase):
         self.assertEqual([], h.readlines())
         self.assertEqual([], h.readlines())
 
+    def test_mock_open_multiple_content(self):
+        _open = mock.mock_open(
+            read_data='foo',
+            data={'file1': 'abc', 'file2': 'xyz'})
+        file1 = _open('file1').read()
+        file2 = _open('file2').read()
+        default_file = _open('other_file').read()
+        self.assertEqual('foo', default_file)
+        self.assertEqual('abc', file1)
+        self.assertEqual('xyz', file2)
+
     def test_mock_parents(self):
         for Klass in Mock, MagicMock:
             m = Klass()

--- a/Misc/NEWS.d/next/Library/2019-07-24-17-20-27.bpo-37669.CpdSTm.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-24-17-20-27.bpo-37669.CpdSTm.rst
@@ -1,0 +1,2 @@
+:func:`unittest.mock.mock_open` is now able to mock reading of multiple
+files with different contents.


### PR DESCRIPTION
This change should allow people to have different contents available through mock_open handles.
Some new items in the file may be poorly named or documentation about them unclear. Feel free to tell me.

With this change I should be able to perform this kind of test with a mock_open.
```python
with open("file1") as file1:
    assert file1.read() == "data1"

with open("file2") as file2:
    assert file2.read() == "data2"
```

<!-- issue-number: [bpo-37669](https://bugs.python.org/issue37669) -->
https://bugs.python.org/issue37669
<!-- /issue-number -->
