### PR TITLE
Fix PYTHONPATH man page in empty-value case

### DIFF
--- a/Misc/python.man
+++ b/Misc/python.man
@@ -623,6 +623,8 @@ specifying \fB\-O\fP multiple times.
 Augments the default search path for module files.
 The format is the same as the shell's $PATH: one or more directory
 pathnames separated by colons.
+Unlike POSIX $PATH, an unset or empty value will not add the current
+working directory to the search path.
 Non-existent directories are silently ignored.
 The default search path is installation dependent, but generally
 begins with ${prefix}/lib/python<version> (see PYTHONHOME above).


### PR DESCRIPTION
Follow-up to issue 16309: <https://bugs.python.org/issue16309>

(Note that the first message in that issue is slightly mistaken, as
described in msg186700.)

Test Plan:
In a temporary directory, run:

    mkdir x &&
    echo 'import z' >x/x.py &&
    echo 'print("z")' >z.py &&
    printf '%s\n' '#!/bin/sh' 'z' >x/x &&
    printf '%s\n' '#!/bin/sh' 'echo "in z"' >z &&
    chmod +x x/x &&
    chmod +x z &&
    :

Then observe that `PYTHONPATH= python3.7 x/x.py` fails with a
`ModuleNotFoundError`, but `PATH= x/x` successfully prints “in z”. Thus,
the `PATH` and `PYTHONPATH` semantics are different.

wchargin-branch: pythonpath-man-posix-divergence
