### PR TITLE
Swap 'if' branches so content matches to condition in importlib example

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1640,14 +1640,14 @@ import, then you should use :func:`importlib.util.find_spec`.
 
   if name in sys.modules:
       print(f"{name!r} already in sys.modules")
-  elif (spec := importlib.util.find_spec(name)) is None:
-      print(f"can't find the {name!r} module")
-  else:
+  elif (spec := importlib.util.find_spec(name)) is not None:
       # If you chose to perform the actual import ...
       module = importlib.util.module_from_spec(spec)
       sys.modules[name] = module
       spec.loader.exec_module(module)
       print(f"{name!r} has been imported")
+  else:
+      print(f"can't find the {name!r} module")
 
 
 Importing a source file directly


### PR DESCRIPTION
Prior to this change the guard on an 'elif' used an assignment expression whose value was used in a later 'else' block, causing some confusion for people.

(Discussion on Twitter: https://twitter.com/brettsky/status/1153861041068994566.)

Automerge-Triggered-By: @brettcannon