### PR TITLE
bpo-24935: On all posix systems, not just Darwin, set LDSHARED (if not set) according to CC

### DIFF
--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -193,10 +193,10 @@ def customize_compiler(compiler):
 
         if 'CC' in os.environ:
             newcc = os.environ['CC']
-            if (sys.platform == 'darwin'
+            if (os.name == 'posix'
                     and 'LDSHARED' not in os.environ
                     and ldshared.startswith(cc)):
-                # On OS X, if CC is overridden, use that as the default
+                # On POSIX systems, if CC is overridden, use that as the default
                 #       command for LDSHARED as well
                 ldshared = newcc + ldshared[len(cc):]
             cc = newcc


### PR DESCRIPTION
This patch is slightly different from https://bugs.python.org/issue24935
, except that we now handle LDSHARED according to CC on all posix
systems, not just Darwin or Linux.

<!-- issue-number: [bpo-24935](https://bugs.python.org/issue24935) -->
https://bugs.python.org/issue24935
<!-- /issue-number -->
