### PR TITLE
bpo-37684: Improved list.extend example in datastructures docs

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -26,7 +26,7 @@ objects:
    :noindex:
 
    Extend the list by appending all the items from the iterable.  Equivalent to
-   ``a[len(a):] = iterable``.
+   ``for x in iterable: a.append(x)``.
 
 
 .. method:: list.insert(i, x)


### PR DESCRIPTION
The current example is not a good equivalent in regards to `list.extend`'s atomicity (or lack thereof).

Please add skip news label, thanks.

<!-- issue-number: [bpo-37684](https://bugs.python.org/issue37684) -->
https://bugs.python.org/issue37684
<!-- /issue-number -->
