### PR TITLE
bpo-37585: Add clarification to dict.values()

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4354,6 +4354,9 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
       Return a new view of the dictionary's values.  See the
       :ref:`documentation of view objects <dict-views>`.
 
+      Equality comparisons between the values view of two
+      dictionaries will always return ``False``.
+
    Dictionaries compare equal if and only if they have the same ``(key,
    value)`` pairs. Order comparisons ('<', '<=', '>=', '>') raise
    :exc:`TypeError`.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4358,7 +4358,7 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
       will always return ``False``. This also applies when comparing
       ``dict.values()`` to itself::
 
-         >>> d = {'a' : 1}
+         >>> d = {'a': 1}
          >>> d.values() == d.values()
          False
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4355,7 +4355,7 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
       :ref:`documentation of view objects <dict-views>`.
 
       An equality comparison between one ``dict.values()`` view and another
-      will always return ``False``. This also applies when comparing a 
+      will always return ``False``. This also applies when comparing
       ``dict.values()`` to itself::
 
          >>> d = {'a' : 1}

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4354,8 +4354,13 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
       Return a new view of the dictionary's values.  See the
       :ref:`documentation of view objects <dict-views>`.
 
-      Equality comparisons between the values view of two
-      dictionaries will always return ``False``.
+      An equality comparison between one ``dict.values()`` view and another
+      will always return ``False``. This also applies when comparing a 
+      ``dict.values()`` to itself::
+
+         >>> d = {'a' : 1}
+         >>> d.values() == d.values()
+         False
 
    Dictionaries compare equal if and only if they have the same ``(key,
    value)`` pairs. Order comparisons ('<', '<=', '>=', '>') raise

--- a/Misc/NEWS.d/next/Documentation/2019-07-26-05-39-37.bpo-37585.c9vzoQ.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-07-26-05-39-37.bpo-37585.c9vzoQ.rst
@@ -1,0 +1,1 @@
+Add doc clarification for comparing :meth:`dict.values()`

--- a/Misc/NEWS.d/next/Documentation/2019-07-26-05-39-37.bpo-37585.c9vzoQ.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-07-26-05-39-37.bpo-37585.c9vzoQ.rst
@@ -1,1 +1,0 @@
-Add doc clarification for comparing :meth:`dict.values`

--- a/Misc/NEWS.d/next/Documentation/2019-07-26-05-39-37.bpo-37585.c9vzoQ.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-07-26-05-39-37.bpo-37585.c9vzoQ.rst
@@ -1,1 +1,1 @@
-Add doc clarification for comparing :meth:`dict.values()`
+Add doc clarification for comparing :meth:`dict.values`


### PR DESCRIPTION
Based on the [python-dev discussion](https://mail.python.org/archives/list/python-dev@python.org/thread/R2MPDTTMJXAF54SICFSAWPPCCEWAJ7WF/#723CHZBH4ZBKQJOOPXFFX3HYSPDBPDPR) of the ``dict.values()`` method, the most agreed upon course of action seems to be mentioning the equality comparison behavior in the documentation rather than changing the existing one. This will help provide clarification on this behavior to users without requiring modifications to the equality comparison for dictionary views. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37585](https://bugs.python.org/issue37585) -->
https://bugs.python.org/issue37585
<!-- /issue-number -->
