### PR TITLE
bpo-37409: fix relative import with no parent

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -162,7 +162,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, __import__, 'sys', name='sys')
         # relative import with no parent package, issue37409
         self.assertRaises(ImportError, __import__, '',
-                          {'__package__': None, '__name__': '__main__'},
+                          {'__package__': None, '__spec__': None, '__name__': '__main__'},
                           {}, ('foo',), 1)
         # embedded null character
         self.assertRaises(ModuleNotFoundError, __import__, 'string\x00')

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -163,7 +163,7 @@ class BuiltinTest(unittest.TestCase):
         # relative import with no parent package, issue37409
         self.assertRaises(ImportError, __import__, '',
                           {'__package__': None, '__spec__': None, '__name__': '__main__'},
-                          {}, ('foo',), 1)
+                          locals={}, fromlist=('foo',), level=1)
         # embedded null character
         self.assertRaises(ModuleNotFoundError, __import__, 'string\x00')
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -160,7 +160,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, __import__, 1, 2, 3, 4)
         self.assertRaises(ValueError, __import__, '')
         self.assertRaises(TypeError, __import__, 'sys', name='sys')
-        # relative import with no parent package, issue37409
+        # Relative import outside of a package with no __package__ or __spec__ (bpo-37409).
         self.assertRaises(ImportError, __import__, '',
                           {'__package__': None, '__spec__': None, '__name__': '__main__'},
                           locals={}, fromlist=('foo',), level=1)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -160,6 +160,10 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, __import__, 1, 2, 3, 4)
         self.assertRaises(ValueError, __import__, '')
         self.assertRaises(TypeError, __import__, 'sys', name='sys')
+        # relative import with no parent package, issue37409
+        self.assertRaises(ImportError, __import__, '',
+                          {'__package__': None, '__name__': '__main__'},
+                          {}, ('foo',), 1)
         # embedded null character
         self.assertRaises(ModuleNotFoundError, __import__, 'string\x00')
 

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -775,6 +775,11 @@ class RelativeImportTests(unittest.TestCase):
         ns = dict(__package__=object())
         self.assertRaises(TypeError, check_relative)
 
+    def test_import_shadowed_by_global(self):
+        # Regression test for https://bugs.python.org/issue37409
+        script_helper.assert_python_failure('-W', 'ignore', '-c',
+            "foo = 1; from . import foo")
+
     def test_absolute_import_without_future(self):
         # If explicit relative import syntax is used, then do not try
         # to perform an absolute import in the face of failure.

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -776,7 +776,7 @@ class RelativeImportTests(unittest.TestCase):
         self.assertRaises(TypeError, check_relative)
 
     def test_import_shadowed_by_global(self):
-        # Regression test for https://bugs.python.org/issue37409
+        # bpo-37409
         script_helper.assert_python_failure('-W', 'ignore', '-c',
             "foo = 1; from . import foo")
 

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -775,7 +775,7 @@ class RelativeImportTests(unittest.TestCase):
         ns = dict(__package__=object())
         self.assertRaises(TypeError, check_relative)
 
-    def test_import_shadowed_by_global(self):
+    def test_parentless_import_shadowed_by_global(self):
         # bpo-37409
         script_helper.assert_python_failure('-W', 'ignore', '-c',
             "foo = 1; from . import foo")

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -776,7 +776,7 @@ class RelativeImportTests(unittest.TestCase):
         self.assertRaises(TypeError, check_relative)
 
     def test_parentless_import_shadowed_by_global(self):
-        # bpo-37409
+        # Test as if this were done from the REPL where this error most commonly occurs (bpo-37409).
         script_helper.assert_python_failure('-W', 'ignore', '-c',
             "foo = 1; from . import foo")
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -964,6 +964,7 @@ Alain Leufroy
 Mark Levinson
 Mark Levitt
 Ivan Levkivskyi
+Ben Lewis
 William Lewis
 Akira Li
 Robert Li

--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-06-23-39-05.bpo-37409.1qwzn2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-06-23-39-05.bpo-37409.1qwzn2.rst
@@ -1,0 +1,1 @@
+Ensure explicit relative imports from interactive sessions and scripts (having no parent package) always raise ImportError, rather than treating the current module as the package.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-06-23-39-05.bpo-37409.1qwzn2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-06-23-39-05.bpo-37409.1qwzn2.rst
@@ -1,1 +1,2 @@
 Ensure explicit relative imports from interactive sessions and scripts (having no parent package) always raise ImportError, rather than treating the current module as the package.
+Patch by Ben Lewis.

--- a/Python/import.c
+++ b/Python/import.c
@@ -1647,11 +1647,9 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
             if (dot == -2) {
                 goto error;
             }
-
-            if (dot == -1) {
-                dot = 0;
+            else if (dot == -1) {
+                goto no_parent_error;
             }
-
             PyObject *substr = PyUnicode_Substring(package, 0, dot);
             if (substr == NULL) {
                 goto error;
@@ -1662,10 +1660,7 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
 
     last_dot = PyUnicode_GET_LENGTH(package);
     if (last_dot == 0) {
-        _PyErr_SetString(tstate, PyExc_ImportError,
-                         "attempted relative import "
-                         "with no known parent package");
-        goto error;
+        goto no_parent_error;
     }
 
     for (level_up = 1; level_up < level; level_up += 1) {
@@ -1691,7 +1686,13 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
     Py_DECREF(base);
     return abs_name;
 
+  no_parent_error:
+
+    _PyErr_SetString(tstate, PyExc_ImportError,
+                     "attempted relative import "
+                     "with no known parent package");
   error:
+
     Py_XDECREF(package);
     return NULL;
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -1648,13 +1648,15 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
                 goto error;
             }
 
-            if (dot >= 0) {
-                PyObject *substr = PyUnicode_Substring(package, 0, dot);
-                if (substr == NULL) {
-                    goto error;
-                }
-                Py_SETREF(package, substr);
+            if (dot == -1) {
+                dot = 0;
             }
+
+            PyObject *substr = PyUnicode_Substring(package, 0, dot);
+            if (substr == NULL) {
+                goto error;
+            }
+            Py_SETREF(package, substr);
         }
     }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -1687,7 +1687,6 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
     return abs_name;
 
   no_parent_error:
-
     _PyErr_SetString(tstate, PyExc_ImportError,
                      "attempted relative import "
                      "with no known parent package");

--- a/Python/import.c
+++ b/Python/import.c
@@ -1690,6 +1690,7 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
     _PyErr_SetString(tstate, PyExc_ImportError,
                      "attempted relative import "
                      "with no known parent package");
+
   error:
 
     Py_XDECREF(package);

--- a/Python/import.c
+++ b/Python/import.c
@@ -1692,7 +1692,6 @@ resolve_name(PyThreadState *tstate, PyObject *name, PyObject *globals, int level
                      "with no known parent package");
 
   error:
-
     Py_XDECREF(package);
     return NULL;
 }


### PR DESCRIPTION
`builtins.__import__` was missing a check to flag that if no dot was found in the `__name__` of a module that isn't explicitly a submodule of a package then a relative import is incorrect.

<!-- issue-number: [bpo-37409](https://bugs.python.org/issue37409) -->
https://bugs.python.org/issue37409
<!-- /issue-number -->
