### PR TITLE
bpo-37538: Zipfile refactor

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -407,7 +407,7 @@ class AbstractTestsWithSourceFile:
             def write(self, data):
                 nonlocal count
                 if count is not None:
-                    if count == stop:
+                    if (count > stop):
                         raise OSError
                     count += 1
                 super().write(data)
@@ -424,11 +424,12 @@ class AbstractTestsWithSourceFile:
                     with zipfp.open('file2', 'w') as f:
                         f.write(b'data2')
                 except OSError:
-                    stop += 1
+                    pass
                 else:
                     break
                 finally:
                     count = None
+                stop += 1
             with zipfile.ZipFile(io.BytesIO(testfile.getvalue())) as zipfp:
                 self.assertEqual(zipfp.namelist(), ['file1'])
                 self.assertEqual(zipfp.read('file1'), b'data1')

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1289,7 +1289,8 @@ class OtherTests(unittest.TestCase):
         with zipfile.ZipFile(TESTFN2, 'w') as orig_zip:
             for data in 'abcdefghijklmnop':
                 zinfo = zipfile.ZipInfo(data)
-                zinfo.flag_bits |= 0x08  # Include an extended local header.
+                # Include an extended local header.
+                zinfo.flag_bits |= zipfile._MASK_USE_DATA_DESCRIPTOR
                 orig_zip.writestr(zinfo, data)
 
     def test_close(self):

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1720,6 +1720,10 @@ class OtherTests(unittest.TestCase):
                 self.assertEqual(fp.tell(), len(txt))
                 fp.seek(0, os.SEEK_SET)
                 self.assertEqual(fp.tell(), 0)
+                # Read the file completely to definitely call any eof
+                # integrity checks (crc) and make sure they still pass.
+                fp.read()
+
         # Check seek on memory file
         data = io.BytesIO()
         with zipfile.ZipFile(data, mode="w") as zipf:
@@ -1737,6 +1741,9 @@ class OtherTests(unittest.TestCase):
                 self.assertEqual(fp.tell(), len(txt))
                 fp.seek(0, os.SEEK_SET)
                 self.assertEqual(fp.tell(), 0)
+                # Read the file completely to definitely call any eof
+                # integrity checks (crc) and make sure they still pass.
+                fp.read()
 
     def tearDown(self):
         unlink(TESTFN)
@@ -1894,6 +1901,44 @@ class DecryptionTests(unittest.TestCase):
         self.assertRaises(TypeError, self.zip.read, "test.txt", "python")
         self.assertRaises(TypeError, self.zip.open, "test.txt", pwd="python")
         self.assertRaises(TypeError, self.zip.extract, "test.txt", pwd="python")
+
+    def test_seek_tell(self):
+        self.zip.setpassword(b"python")
+        txt = self.plain
+        test_word = b'encryption'
+        bloc = txt.find(test_word)
+        bloc_len = len(test_word)
+        with self.zip.open("test.txt", "r") as fp:
+            fp.seek(bloc, os.SEEK_SET)
+            self.assertEqual(fp.tell(), bloc)
+            fp.seek(-bloc, os.SEEK_CUR)
+            self.assertEqual(fp.tell(), 0)
+            fp.seek(bloc, os.SEEK_CUR)
+            self.assertEqual(fp.tell(), bloc)
+            self.assertEqual(fp.read(bloc_len), txt[bloc:bloc+bloc_len])
+
+            # Make sure that the second read after seeking back beyond
+            # _readbuffer returns the same content (ie. rewind to the start of
+            # the file to read forward to the required position).
+            old_read_size = fp.MIN_READ_SIZE
+            fp.MIN_READ_SIZE = 1
+            fp._readbuffer = b''
+            fp._offset = 0
+            fp.seek(0, os.SEEK_SET)
+            self.assertEqual(fp.tell(), 0)
+            fp.seek(bloc, os.SEEK_CUR)
+            self.assertEqual(fp.read(bloc_len), txt[bloc:bloc+bloc_len])
+            fp.MIN_READ_SIZE = old_read_size
+
+            fp.seek(0, os.SEEK_END)
+            self.assertEqual(fp.tell(), len(txt))
+            fp.seek(0, os.SEEK_SET)
+            self.assertEqual(fp.tell(), 0)
+
+            # Read the file completely to definitely call any eof integrity
+            # checks (crc) and make sure they still pass.
+            fp.read()
+
 
 class AbstractTestsWithRandomBinaryFiles:
     @classmethod

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1942,8 +1942,6 @@ class ZipFile:
             raise ValueError('open() requires mode "r" or "w"')
         if pwd and not isinstance(pwd, bytes):
             raise TypeError("pwd: expected bytes, got %s" % type(pwd).__name__)
-        if pwd and (mode == "w"):
-            raise ValueError("pwd is only supported for reading files")
         if not self.fp:
             raise ValueError(
                 "Attempt to use ZIP archive that was already closed")
@@ -1965,7 +1963,7 @@ class ZipFile:
 
         if mode == 'w':
             return self._open_to_write(
-                zinfo, force_zip64=force_zip64, **kwargs
+                zinfo, force_zip64=force_zip64, pwd=pwd, **kwargs
             )
 
         if self._writing:
@@ -1995,10 +1993,12 @@ class ZipFile:
             zef_file.close()
             raise
 
-    def get_zipwritefile(self, zinfo, zip64, **kwargs):
+    def get_zipwritefile(self, zinfo, zip64, pwd, **kwargs):
+        if pwd:
+            raise ValueError("pwd is only supported for reading files")
         return self.zipwritefile_cls(self, zinfo, zip64)
 
-    def _open_to_write(self, zinfo, force_zip64=False, **kwargs):
+    def _open_to_write(self, zinfo, force_zip64=False, pwd=None, **kwargs):
         if force_zip64 and not self._allowZip64:
             raise ValueError(
                 "force_zip64 is True, but allowZip64 was False when opening "
@@ -2036,7 +2036,7 @@ class ZipFile:
         self._writecheck(zinfo)
         self._didModify = True
         self._writing = True
-        return self.get_zipwritefile(zinfo, zip64, **kwargs)
+        return self.get_zipwritefile(zinfo, zip64, pwd, **kwargs)
 
     def extract(self, member, path=None, pwd=None):
         """Extract a member from the archive to the current working directory,

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -453,10 +453,10 @@ class ZipInfo (object):
         return self.flag_bits & _MASK_STRONG_ENCRYPTION
 
     @property
-    def use_datadescripter(self):
-        """Returns True if datadescripter is in use.
+    def use_datadescriptor(self):
+        """Returns True if datadescriptor is in use.
 
-        If bit 3 of flags is set, the data descripter is must exist.  It is
+        If bit 3 of flags is set, the data descriptor is must exist.  It is
         byte aligned and immediately follows the last byte of compressed data.
 
         crc-32                          4 bytes
@@ -470,7 +470,7 @@ class ZipInfo (object):
         dt = self.date_time
         dosdate = (dt[0] - 1980) << 9 | dt[1] << 5 | dt[2]
         dostime = dt[3] << 11 | dt[4] << 5 | (dt[5] // 2)
-        if self.use_datadescripter:
+        if self.use_datadescriptor:
             # Set these to zero because we write them after the file data
             CRC = compress_size = file_size = 0
         else:
@@ -678,7 +678,7 @@ class CRCZipDecrypter(BaseDecrypter):
         header = fileobj.read(self.encryption_header_length)
         h = self.decrypt(header[0:12])
 
-        if self.zinfo.use_datadescripter:
+        if self.zinfo.use_datadescriptor:
             # compare against the file type from extended local headers
             check_byte = (self.zinfo._raw_time >> 8) & 0xff
         else:
@@ -1308,7 +1308,7 @@ class _ZipWriteFile(io.BufferedIOBase):
             self._zinfo.file_size = self._file_size
 
             # Write updated header info
-            if self._zinfo.use_datadescripter:
+            if self._zinfo.use_datadescriptor:
                 # Write CRC and file sizes after the file data
                 fmt = '<LLQQ' if self._zip64 else '<LLLL'
                 self._fileobj.write(struct.pack(fmt, _DD_SIGNATURE, self._zinfo.CRC,

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -565,14 +565,16 @@ class ZipInfo (object):
             compress_size = self.compress_size
             file_size = self.file_size
 
+        extra = _strip_extra(self.extra, (EXTRA_ZIP64,))
         # There are reports that windows 7 can only read zip 64 archives if the
         # zip 64 extra block is the first extra block present.
         min_version = 0
-        (extra,
+        (zip64_extra,
          file_size,
          compress_size,
          zip64_min_version,
          ) = self.zip64_local_header(zip64, file_size, compress_size)
+        extra = zip64_extra + extra
         min_version = min(min_version, zip64_min_version)
 
         if self.compress_type == ZIP_BZIP2:

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1497,6 +1497,7 @@ class _ZipWriteFile(io.BufferedIOBase):
         self._compress_size = 0
         self._crc = 0
 
+        self.write_local_header()
     @property
     def _fileobj(self):
         return self._zipfile.fp
@@ -1519,6 +1520,8 @@ class _ZipWriteFile(io.BufferedIOBase):
     def writable(self):
         return True
 
+    def write_local_header(self):
+        self.fp.write(zinfo.FileHeader(zip64))
     def write(self, data):
         if self.closed:
             raise ValueError('I/O operation on closed file.')
@@ -1974,9 +1977,6 @@ class ZipFile:
 
         self._writecheck(zinfo)
         self._didModify = True
-
-        self.fp.write(zinfo.FileHeader(zip64))
-
         self._writing = True
         return self.zipwritefile_cls(self, zinfo, zip64)
 

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1575,7 +1575,7 @@ class _ZipWriteFile(io.BufferedIOBase):
         self._crc = crc32(data, self._crc)
         if self._compressor:
             data = self._compressor.compress(data)
-            self._compress_size += len(data)
+        self._compress_size += len(data)
         self._fileobj.write(data)
         return nbytes
 
@@ -1589,9 +1589,7 @@ class _ZipWriteFile(io.BufferedIOBase):
                 buf = self._compressor.flush()
                 self._compress_size += len(buf)
                 self._fileobj.write(buf)
-                self._zinfo.compress_size = self._compress_size
-            else:
-                self._zinfo.compress_size = self._file_size
+            self._zinfo.compress_size = self._compress_size
             self._zinfo.CRC = self._crc
             self._zinfo.file_size = self._file_size
 

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1101,6 +1101,9 @@ class ZipExtFile(io.BufferedIOBase):
         [encryption header]
         [file data]
         [data descriptor]
+
+    For symmetry, the _ZipWriteFile class is responsible for writing the same
+    sections.
     """
 
     # Max size supported by decompressor.
@@ -1498,6 +1501,7 @@ class _ZipWriteFile(io.BufferedIOBase):
         self._crc = 0
 
         self.write_local_header()
+
     @property
     def _fileobj(self):
         return self._zipfile.fp
@@ -1521,7 +1525,8 @@ class _ZipWriteFile(io.BufferedIOBase):
         return True
 
     def write_local_header(self):
-        self.fp.write(zinfo.FileHeader(zip64))
+        self._fileobj.write(self._zinfo.FileHeader(self._zip64))
+
     def write(self, data):
         if self.closed:
             raise ValueError('I/O operation on closed file.')
@@ -1577,7 +1582,6 @@ class _ZipWriteFile(io.BufferedIOBase):
             self._zipfile.NameToInfo[self._zinfo.filename] = self._zinfo
         finally:
             self._zipfile._writing = False
-
 
 
 class ZipFile:

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -187,6 +187,11 @@ _DD_SIGNATURE = 0x08074b50
 
 _EXTRA_FIELD_STRUCT = struct.Struct('<HH')
 
+# Extensible data field codes:
+# Zip64 extended information extra field
+EXTRA_ZIP64 = 0x0001
+
+
 def _strip_extra(extra, xids):
     # Remove Extra Fields with specified IDs.
     unpack = _EXTRA_FIELD_STRUCT.unpack
@@ -485,7 +490,7 @@ class ZipInfo (object):
             tp, ln = unpack('<HH', extra[:4])
             if ln+4 > len(extra):
                 raise BadZipFile("Corrupt extra field %04x (size=%d)" % (tp, ln))
-            if tp == 0x0001:
+            if tp == EXTRA_ZIP64:
                 if ln >= 24:
                     counts = unpack('<QQQ', extra[4:28])
                 elif ln == 16:

--- a/Misc/NEWS.d/next/Library/2019-07-26-09-33-51.bpo-37538.yPF58-.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-26-09-33-51.bpo-37538.yPF58-.rst
@@ -1,0 +1,1 @@
+Refactor :mod:`zipfile` module to ease extending functionality in subclasses and fix seeking in encrypted files.


### PR DESCRIPTION
This pull request aims to make ZipFile easier to subclass and extend.

The general goals of the refactor were to:
- Add hooks for extending the way zipfile works to enable a subclass to 
  add AES encryption without having to duplicate most of the zipfile
  module. This included adding hooks to:
    - Read and write new "extra" data records in the central file directory
      and local header records.
    - Provide a mechanism to substitute ZipInfo, ZipExtFile and ZipWriteFile
      classes used in a subclass of ZipFile to ease use of subclassed ZipInfo,
      ZipExtFile or ZipWriteFile. This avoids having to rewrite large parts of
      the zipfile module if we only want to change the behaviour of a small
      part of one of those classes.
- Contain all code that reads the header, contents and tail of a file in the
  archive to within ZipExtFile. Previously reading the header and some other
  things were done in the ZipFile class before handing the rest of the
  processing to ZipExtFile.
- Contain all code that writes the header, contents and tail of a file in the
  archive to within ZipWriteFile. Previously reading the header and some other
  things were done in the ZipFile class before handing the rest of the
  processing to ZipExtFile.
- Move generation of local file header and central directory record content to
  the ZipInfo class to be alongside the data that it is packing.
- Add comments to provide context from the zip spec. Replace explicit numbers
  to variables with explanatory names or adding comments.

This patch contains some bug fixes (seeking an encrypted file) that were made
possible by the refactor.

Happy for suggestions to improve this patch.

<!-- issue-number: [bpo-37538](https://bugs.python.org/issue37538) -->
https://bugs.python.org/issue37538
<!-- /issue-number -->
