### PR TITLE
bpo-37628: Fix IDLE config sample sizes

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -33,6 +33,7 @@ from idlelib.codecontext import CodeContext
 from idlelib.parenmatch import ParenMatch
 from idlelib.format import FormatParagraph
 from idlelib.squeezer import Squeezer
+from idlelib.textview import ScrollableTextFrame
 
 changes = ConfigChanges()
 # Reload changed options in the following classes.
@@ -194,7 +195,7 @@ class ConfigDialog(Toplevel):
 
     def destroy(self):
         global font_sample_text
-        font_sample_text = self.fontpage.font_sample.get('1.0', 'end')
+        font_sample_text = self.fontpage.font_sample.text.get('1.0', 'end')
         self.grab_release()
         super().destroy()
 
@@ -556,8 +557,11 @@ class FontPage(Frame):
                 frame_font_param, variable=self.font_bold,
                 onvalue=1, offvalue=0, text='Bold')
         # frame_sample.
-        self.font_sample = Text(frame_sample, width=20, height=20)
-        self.font_sample.insert(END, font_sample_text)
+        # self.font_sample = Text(frame_sample, width=20, height=20)
+        # self.font_sample.insert(END, font_sample_text)
+        self.font_sample = ScrollableTextFrame(frame_sample)
+        self.font_sample.text.config(wrap='word', width=1, height=1)
+        self.font_sample.text.insert('1.0', font_sample_text)
         # frame_indent.
         indent_title = Label(
                 frame_indent, justify=LEFT,
@@ -568,8 +572,9 @@ class FontPage(Frame):
 
         # Grid and pack widgets:
         self.columnconfigure(1, weight=1)
+        self.rowconfigure(2, weight=1)
         frame_font.grid(row=0, column=0, padx=5, pady=5)
-        frame_sample.grid(row=0, column=1, rowspan=2, padx=5, pady=5,
+        frame_sample.grid(row=0, column=1, rowspan=3, padx=5, pady=5,
                           sticky='nsew')
         frame_indent.grid(row=1, column=0, padx=5, pady=5, sticky='ew')
         # frame_font.
@@ -657,7 +662,7 @@ class FontPage(Frame):
         font_name = self.font_name.get()
         font_weight = tkFont.BOLD if self.font_bold.get() else tkFont.NORMAL
         new_font = (font_name, self.font_size.get(), font_weight)
-        self.font_sample['font'] = new_font
+        self.font_sample.text['font'] = new_font
         self.highlight_sample['font'] = new_font
 
     def load_tab_cfg(self):

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -557,8 +557,8 @@ class FontPage(Frame):
                 frame_font_param, variable=self.font_bold,
                 onvalue=1, offvalue=0, text='Bold')
         # frame_sample.
-        font_sample_scrollable_frame = ScrollableTextFrame(frame_sample)
-        self.font_sample = font_sample_scrollable_frame.text
+        font_sample__frame = ScrollableTextFrame(frame_sample)
+        self.font_sample = font_sample__frame.text
         self.font_sample.config(wrap=NONE, width=1, height=1)
         self.font_sample.insert(END, font_sample_text)
         # frame_indent.
@@ -586,7 +586,7 @@ class FontPage(Frame):
         self.sizelist.pack(side=LEFT, anchor=W)
         self.bold_toggle.pack(side=LEFT, anchor=W, padx=20)
         # frame_sample.
-        font_sample_scrollable_frame.pack(expand=TRUE, fill=BOTH)
+        font_sample__frame.pack(expand=TRUE, fill=BOTH)
         # frame_indent.
         indent_title.pack(side=TOP, anchor=W, padx=5)
         self.indent_scale.pack(side=TOP, padx=5, fill=X)

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -195,7 +195,7 @@ class ConfigDialog(Toplevel):
 
     def destroy(self):
         global font_sample_text
-        font_sample_text = self.fontpage.font_sample.text.get('1.0', 'end')
+        font_sample_text = self.fontpage.font_sample.get('1.0', 'end')
         self.grab_release()
         super().destroy()
 
@@ -557,11 +557,10 @@ class FontPage(Frame):
                 frame_font_param, variable=self.font_bold,
                 onvalue=1, offvalue=0, text='Bold')
         # frame_sample.
-        # self.font_sample = Text(frame_sample, width=20, height=20)
-        # self.font_sample.insert(END, font_sample_text)
-        self.font_sample = ScrollableTextFrame(frame_sample)
-        self.font_sample.text.config(wrap='word', width=1, height=1)
-        self.font_sample.text.insert('1.0', font_sample_text)
+        font_sample_scrollable_frame = ScrollableTextFrame(frame_sample)
+        self.font_sample = font_sample_scrollable_frame.text
+        self.font_sample.config(wrap='word', width=1, height=1)
+        self.font_sample.insert(END, font_sample_text)
         # frame_indent.
         indent_title = Label(
                 frame_indent, justify=LEFT,
@@ -587,7 +586,7 @@ class FontPage(Frame):
         self.sizelist.pack(side=LEFT, anchor=W)
         self.bold_toggle.pack(side=LEFT, anchor=W, padx=20)
         # frame_sample.
-        self.font_sample.pack(expand=TRUE, fill=BOTH)
+        font_sample_scrollable_frame.pack(expand=TRUE, fill=BOTH)
         # frame_indent.
         indent_title.pack(side=TOP, anchor=W, padx=5)
         self.indent_scale.pack(side=TOP, padx=5, fill=X)
@@ -662,7 +661,7 @@ class FontPage(Frame):
         font_name = self.font_name.get()
         font_weight = tkFont.BOLD if self.font_bold.get() else tkFont.NORMAL
         new_font = (font_name, self.font_size.get(), font_weight)
-        self.font_sample.text['font'] = new_font
+        self.font_sample['font'] = new_font
         self.highlight_sample['font'] = new_font
 
     def load_tab_cfg(self):

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -557,8 +557,8 @@ class FontPage(Frame):
                 frame_font_param, variable=self.font_bold,
                 onvalue=1, offvalue=0, text='Bold')
         # frame_sample.
-        font_sample__frame = ScrollableTextFrame(frame_sample)
-        self.font_sample = font_sample__frame.text
+        font_sample_frame = ScrollableTextFrame(frame_sample)
+        self.font_sample = font_sample_frame.text
         self.font_sample.config(wrap=NONE, width=1, height=1)
         self.font_sample.insert(END, font_sample_text)
         # frame_indent.
@@ -586,7 +586,7 @@ class FontPage(Frame):
         self.sizelist.pack(side=LEFT, anchor=W)
         self.bold_toggle.pack(side=LEFT, anchor=W, padx=20)
         # frame_sample.
-        font_sample__frame.pack(expand=TRUE, fill=BOTH)
+        font_sample_frame.pack(expand=TRUE, fill=BOTH)
         # frame_indent.
         indent_title.pack(side=TOP, anchor=W, padx=5)
         self.indent_scale.pack(side=TOP, padx=5, fill=X)

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -559,7 +559,7 @@ class FontPage(Frame):
         # frame_sample.
         font_sample_scrollable_frame = ScrollableTextFrame(frame_sample)
         self.font_sample = font_sample_scrollable_frame.text
-        self.font_sample.config(wrap='word', width=1, height=1)
+        self.font_sample.config(wrap=NONE, width=1, height=1)
         self.font_sample.insert(END, font_sample_text)
         # frame_indent.
         indent_title = Label(

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -874,7 +874,7 @@ class HighPage(Frame):
         for texttag in text_and_tags:
             text.insert(END, texttag[0], texttag[1])
         n_lines = len(text.get('1.0', END).splitlines())
-        for lineno in range(1, n_lines + 1):
+        for lineno in range(1, n_lines):
             text.insert(f'{lineno}.0',
                         f'{lineno:{len(str(n_lines))}d} ',
                         'linenumber')

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -845,9 +845,11 @@ class HighPage(Frame):
         frame_theme = LabelFrame(self, borderwidth=2, relief=GROOVE,
                                  text=' Highlighting Theme ')
         # frame_custom.
-        text = self.highlight_sample = Text(
-                frame_custom, relief=SOLID, borderwidth=1,
-                font=('courier', 12, ''), cursor='hand2', width=21, height=13,
+        sample_frame = ScrollableTextFrame(
+                frame_custom, relief=SOLID, borderwidth=1)
+        text = self.highlight_sample = sample_frame.text
+        text.configure(
+                font=('courier', 12, ''), cursor='hand2', width=1, height=1,
                 takefocus=FALSE, highlightthickness=0, wrap=NONE)
         text.bind('<Double-Button-1>', lambda e: 'break')
         text.bind('<B1-Motion>', lambda e: 'break')
@@ -925,9 +927,9 @@ class HighPage(Frame):
         frame_custom.pack(side=LEFT, padx=5, pady=5, expand=TRUE, fill=BOTH)
         frame_theme.pack(side=TOP, padx=5, pady=5, fill=X)
         # frame_custom.
-        self.frame_color_set.pack(side=TOP, padx=5, pady=5, expand=TRUE, fill=X)
+        self.frame_color_set.pack(side=TOP, padx=5, pady=5, fill=X)
         frame_fg_bg_toggle.pack(side=TOP, padx=5, pady=0)
-        self.highlight_sample.pack(
+        sample_frame.pack(
                 side=TOP, padx=5, pady=5, expand=TRUE, fill=BOTH)
         self.button_set_color.pack(side=TOP, expand=TRUE, fill=X, padx=8, pady=4)
         self.targetlist.pack(side=TOP, expand=TRUE, fill=X, padx=8, pady=3)

--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -349,7 +349,7 @@ _undo_delegator_spec = {
 ViewWindow_spec = {
     'file': 'textview',
     'kwds': {'title': 'Test textview',
-             'text': 'The quick brown fox jumps over the lazy dog.\n'*35,
+             'contents': 'The quick brown fox jumps over the lazy dog.\n'*35,
              '_htest': True},
     'msg': "Test for read-only property of text.\n"
            "Select text, scroll window, close"

--- a/Lib/idlelib/idle_test/test_textview.py
+++ b/Lib/idlelib/idle_test/test_textview.py
@@ -6,12 +6,12 @@ Using mock Text would not change this.  Other mocks are used to retrieve
 information about calls.
 """
 from idlelib import textview as tv
-import unittest
 from test.support import requires
 requires('gui')
 
 import os
-from tkinter import Tk, CHAR, NONE, WORD
+import unittest
+from tkinter import Tk, TclError, CHAR, NONE, WORD
 from tkinter.ttk import Button
 from idlelib.idle_test.mock_idle import Func
 from idlelib.idle_test.mock_tk import Mbox_func
@@ -68,6 +68,13 @@ class ViewWindowTest(unittest.TestCase):
         del view.destroy  # Unmask real function.
         view.destroy()
 
+
+class AutoHideScrollbarTest(unittest.TestCase):
+    # Method set is tested in ScrollableTextFrameTest
+    def test_forbidden_geometry(self):
+        scroll = tv.AutoHideScrollbar(root)
+        self.assertRaises(TclError, scroll.pack)
+        self.assertRaises(TclError, scroll.place)
 
 class ScrollableTextFrameTest(unittest.TestCase):
 

--- a/Lib/idlelib/idle_test/test_textview.py
+++ b/Lib/idlelib/idle_test/test_textview.py
@@ -82,36 +82,35 @@ class ScrollableTextFrameTest(unittest.TestCase):
         cls.root.destroy()
         del cls.root
 
-    def setUp(self):
-        self.frame = tv.ScrollableTextFrame(root)
-        self.text = self.frame.text
-
-    def tearDown(self):
-        self.frame.update_idletasks()
-        self.frame.destroy()
+    def make_frame(self, wrap=NONE, **kwargs):
+        frame = tv.ScrollableTextFrame(self.root, wrap=wrap, **kwargs)
+        def cleanup_frame():
+            frame.update_idletasks()
+            frame.destroy()
+        self.addCleanup(cleanup_frame)
+        return frame
 
     def test_line1(self):
-        self.text.insert('1.0', 'test text')
-        self.assertEqual(self.text.get('1.0', '1.end'), 'test text')
+        frame = self.make_frame()
+        frame.text.insert('1.0', 'test text')
+        self.assertEqual(frame.text.get('1.0', '1.end'), 'test text')
 
     def test_horiz_scrollbar(self):
         # The horizontal scrollbar should be shown/hidden according to
         # the 'wrap' setting: It should only be shown when 'wrap' is
         # set to NONE.
 
-        # Check initial state.
-        wrap = self.text.cget('wrap')
-        self.assertEqual(self.frame.xscroll is not None, wrap == NONE)
+        # wrap = NONE -> with horizontal scrolling
+        frame = self.make_frame(wrap=NONE)
+        self.assertEqual(frame.text.cget('wrap'), NONE)
+        self.assertIsNotNone(frame.xscroll)
 
-        # Check after updating the 'wrap' setting in various ways.
-        self.text.config(wrap=NONE)
-        self.assertIsNotNone(self.frame.xscroll)
-        self.text.configure(wrap=CHAR)
-        self.assertIsNone(self.frame.xscroll)
-        self.text['wrap'] = NONE
-        self.assertIsNotNone(self.frame.xscroll)
-        self.text['wrap'] = WORD
-        self.assertIsNone(self.frame.xscroll)
+        # wrap != NONE -> no horizontal scrolling
+        for wrap in [CHAR, WORD]:
+            with self.subTest(wrap=wrap):
+                frame = self.make_frame(wrap=wrap)
+                self.assertEqual(frame.text.cget('wrap'), wrap)
+                self.assertIsNone(frame.xscroll)
 
 
 class ViewFrameTest(unittest.TestCase):

--- a/Lib/idlelib/idle_test/test_textview.py
+++ b/Lib/idlelib/idle_test/test_textview.py
@@ -11,7 +11,7 @@ from test.support import requires
 requires('gui')
 
 import os
-from tkinter import Tk
+from tkinter import Tk, CHAR, NONE, WORD
 from tkinter.ttk import Button
 from idlelib.idle_test.mock_idle import Func
 from idlelib.idle_test.mock_tk import Mbox_func
@@ -69,13 +69,58 @@ class ViewWindowTest(unittest.TestCase):
         view.destroy()
 
 
-class TextFrameTest(unittest.TestCase):
+class ScrollableTextFrameTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         cls.root = root = Tk()
         root.withdraw()
-        cls.frame = tv.TextFrame(root, 'test text')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.root.update_idletasks()
+        cls.root.destroy()
+        del cls.root
+
+    def setUp(self):
+        self.frame = tv.ScrollableTextFrame(root)
+        self.text = self.frame.text
+
+    def tearDown(self):
+        self.frame.update_idletasks()
+        self.frame.destroy()
+
+    def test_line1(self):
+        self.text.insert('1.0', 'test text')
+        self.assertEqual(self.text.get('1.0', '1.end'), 'test text')
+
+    def test_horiz_scrollbar(self):
+        # The horizontal scrollbar should be shown/hidden according to
+        # the 'wrap' setting: It should only be shown when 'wrap' is
+        # set to NONE.
+
+        # Check initial state.
+        wrap = self.text.cget('wrap')
+        self.assertEqual(self.frame.xscroll is not None, wrap == NONE)
+
+        # Check after updating the 'wrap' setting in various ways.
+        self.text.config(wrap=NONE)
+        self.assertIsNotNone(self.frame.xscroll)
+        self.text.configure(wrap=CHAR)
+        self.assertIsNone(self.frame.xscroll)
+        self.text['wrap'] = NONE
+        self.assertIsNotNone(self.frame.xscroll)
+        self.text['wrap'] = WORD
+        self.assertIsNone(self.frame.xscroll)
+
+
+class ViewFrameTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.root = root = Tk()
+        root.withdraw()
+        cls.frame = tv.ViewFrame(root, 'test text')
 
     @classmethod
     def tearDownClass(cls):

--- a/Lib/idlelib/idle_test/test_textview.py
+++ b/Lib/idlelib/idle_test/test_textview.py
@@ -76,6 +76,7 @@ class AutoHideScrollbarTest(unittest.TestCase):
         self.assertRaises(TclError, scroll.pack)
         self.assertRaises(TclError, scroll.place)
 
+
 class ScrollableTextFrameTest(unittest.TestCase):
 
     @classmethod

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -64,7 +64,7 @@ class ScrollableTextFrame(Frame):
         """
         super().__init__(master, **kwargs)
 
-        @add_config_callback(self._config_callback)
+        @add_config_callback(self._handle_wrap)
         class TextWithConfigHook(Text):
             pass
         self.text = TextWithConfigHook(self)
@@ -81,13 +81,13 @@ class ScrollableTextFrame(Frame):
 
         # horizontal scrollbar
         self.xscroll = None
-        self._set_wrapping(self.text.cget('wrap'))
+        self._set_xscroll(self.text.cget('wrap'))
 
-    def _config_callback(self, cnf):
+    def _handle_wrap(self, cnf):
         if 'wrap' in cnf:
-            self._set_wrapping(cnf['wrap'])
+            self._set_xscroll(cnf['wrap'])
 
-    def _set_wrapping(self, wrap):
+    def _set_xscroll(self, wrap):
         """show/hide the horizontal scrollbar as per the 'wrap' setting"""
         # show the scrollbar only when wrap is set to NONE
         if wrap == NONE and self.xscroll is None:

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -29,7 +29,7 @@ class AutoHiddenScrollbar(Scrollbar):
         raise TclError(f'{self.__class__.__name__} does not support "place"')
 
 
-def add_config_hook(config_callback):
+def add_config_callback(config_callback):
     """Class decorator adding a configuration callback for Tk widgets"""
     def decorator(cls):
         class WidgetWithConfigHook(cls):
@@ -64,7 +64,7 @@ class ScrollableTextFrame(Frame):
         """
         super().__init__(master, **kwargs)
 
-        @add_config_hook(self._config_callback)
+        @add_config_callback(self._config_callback)
         class TextWithConfigHook(Text):
             pass
         self.text = TextWithConfigHook(self)

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -10,7 +10,7 @@ from functools import update_wrapper
 from idlelib.colorizer import color_config
 
 
-class AutoHiddenScrollbar(Scrollbar):
+class AutoHideScrollbar(Scrollbar):
     """A scrollbar that is automatically hidden when not needed.
 
     Only the grid geometry manager is supported.
@@ -48,12 +48,12 @@ class ScrollableTextFrame(Frame):
         super().__init__(master, **kwargs)
 
         text = self.text = Text(self, wrap=wrap)
-        self.text.grid(row=0, column=0, sticky=NSEW)
+        text.grid(row=0, column=0, sticky=NSEW)
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
         # vertical scrollbar
-        self.yscroll = AutoHiddenScrollbar(self, orient=VERTICAL,
+        self.yscroll = AutoHideScrollbar(self, orient=VERTICAL,
                                            takefocus=False,
                                            command=text.yview)
         self.yscroll.grid(row=0, column=1, sticky=NS)
@@ -61,7 +61,7 @@ class ScrollableTextFrame(Frame):
 
         # horizontal scrollbar - only when wrap is set to NONE
         if wrap == NONE:
-            self.xscroll = AutoHiddenScrollbar(self, orient=HORIZONTAL,
+            self.xscroll = AutoHideScrollbar(self, orient=HORIZONTAL,
                                                takefocus=False,
                                                command=text.xview)
             self.xscroll.grid(row=1, column=0, sticky=EW)

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -2,7 +2,7 @@
 
 """
 from tkinter import Toplevel, Text, TclError,\
-    HORIZONTAL, VERTICAL, N, S, E, W, NSEW, NONE, WORD, SUNKEN
+    HORIZONTAL, VERTICAL, NS, EW, NSEW, NONE, WORD, SUNKEN
 from tkinter.ttk import Frame, Scrollbar, Button
 from tkinter.messagebox import showerror
 
@@ -76,8 +76,8 @@ class ScrollableTextFrame(Frame):
         self.yscroll = AutoHiddenScrollbar(self, orient=VERTICAL,
                                            takefocus=False,
                                            command=self.text.yview)
+        self.yscroll.grid(row=0, column=1, sticky=NS)
         self.text['yscrollcommand'] = self.yscroll.set
-        self.yscroll.grid(row=0, column=1, sticky=N+S)
 
         # horizontal scrollbar
         self.xscroll = None
@@ -94,8 +94,8 @@ class ScrollableTextFrame(Frame):
             self.xscroll = AutoHiddenScrollbar(self, orient=HORIZONTAL,
                                                takefocus=False,
                                                command=self.text.xview)
+            self.xscroll.grid(row=1, column=0, sticky=EW)
             self.text['xscrollcommand'] = self.xscroll.set
-            self.xscroll.grid(row=1, column=0, sticky=E+W)
         elif wrap != NONE and self.xscroll is not None:
             self.text['xscrollcommand'] = ''
             self.xscroll.grid_forget()

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -105,11 +105,11 @@ class ScrollableTextFrame(Frame):
 
 class ViewFrame(Frame):
     "Display TextFrame and Close button."
-    def __init__(self, parent, text, wrap='word'):
+    def __init__(self, parent, contents, wrap='word'):
         """Create a frame for viewing text with a "Close" button.
 
         parent - parent widget for this frame
-        text - text to display
+        contents - text to display
         wrap - type of text wrapping to use ('word', 'char' or 'none')
 
         The Text widget is accessible via the 'text' attribute.
@@ -120,12 +120,12 @@ class ViewFrame(Frame):
         self.bind('<Escape>', self.ok)
         self.textframe = ScrollableTextFrame(self, relief=SUNKEN, height=700)
 
-        self.text = self.textframe.text
-        self.text.configure(wrap=wrap, highlightthickness=0)
-        self.text.insert('1.0', text)
-        color_config(self.text)
-        self.text['state'] = 'disabled'
-        self.text.focus_set()
+        text = self.text = self.textframe.text
+        text.configure(wrap=wrap, highlightthickness=0)
+        text.insert('1.0', contents)
+        color_config(text)
+        text['state'] = 'disabled'
+        text.focus_set()
 
         self.button_ok = button_ok = Button(
                 self, text='Close', command=self.ok, takefocus=False)
@@ -140,7 +140,7 @@ class ViewFrame(Frame):
 class ViewWindow(Toplevel):
     "A simple text viewer dialog for IDLE."
 
-    def __init__(self, parent, title, text, modal=True, wrap=WORD,
+    def __init__(self, parent, title, contents, modal=True, wrap=WORD,
                  *, _htest=False, _utest=False):
         """Show the given text in a scrollable window with a 'close' button.
 
@@ -149,7 +149,7 @@ class ViewWindow(Toplevel):
 
         parent - parent of this dialog
         title - string which is title of popup dialog
-        text - text to display in dialog
+        contents - text to display in dialog
         wrap - type of text wrapping to use ('word', 'char' or 'none')
         _htest - bool; change box location when running htest.
         _utest - bool; don't wait_window when running unittest.
@@ -162,7 +162,7 @@ class ViewWindow(Toplevel):
         self.geometry(f'=750x500+{x}+{y}')
 
         self.title(title)
-        self.viewframe = ViewFrame(self, text, wrap=wrap)
+        self.viewframe = ViewFrame(self, contents, wrap=wrap)
         self.protocol("WM_DELETE_WINDOW", self.ok)
         self.button_ok = button_ok = Button(self, text='Close',
                                             command=self.ok, takefocus=False)
@@ -182,18 +182,18 @@ class ViewWindow(Toplevel):
         self.destroy()
 
 
-def view_text(parent, title, text, modal=True, wrap='word', _utest=False):
+def view_text(parent, title, contents, modal=True, wrap='word', _utest=False):
     """Create text viewer for given text.
 
     parent - parent of this dialog
     title - string which is the title of popup dialog
-    text - text to display in this dialog
+    contents - text to display in this dialog
     wrap - type of text wrapping to use ('word', 'char' or 'none')
     modal - controls if users can interact with other windows while this
             dialog is displayed
     _utest - bool; controls wait_window on unittest
     """
-    return ViewWindow(parent, title, text, modal, wrap=wrap, _utest=_utest)
+    return ViewWindow(parent, title, contents, modal, wrap=wrap, _utest=_utest)
 
 
 def view_file(parent, title, filename, encoding, modal=True, wrap='word',

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -88,10 +88,9 @@ class ViewFrame(Frame):
         self.textframe = ScrollableTextFrame(self, relief=SUNKEN, height=700)
 
         text = self.text = self.textframe.text
-        text.configure(wrap=wrap, highlightthickness=0)
         text.insert('1.0', contents)
+        text.configure(wrap=wrap, highlightthickness=0, state='disabled')
         color_config(text)
-        text['state'] = 'disabled'
         text.focus_set()
 
         self.button_ok = button_ok = Button(

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -67,7 +67,7 @@ class ScrollableTextFrame(Frame):
         @add_config_callback(self._handle_wrap)
         class TextWithConfigHook(Text):
             pass
-        self.text = TextWithConfigHook(self)
+        text = self.text = TextWithConfigHook(self)
         self.text.grid(row=0, column=0, sticky=NSEW)
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
@@ -75,9 +75,9 @@ class ScrollableTextFrame(Frame):
         # vertical scrollbar
         self.yscroll = AutoHiddenScrollbar(self, orient=VERTICAL,
                                            takefocus=False,
-                                           command=self.text.yview)
+                                           command=text.yview)
         self.yscroll.grid(row=0, column=1, sticky=NS)
-        self.text['yscrollcommand'] = self.yscroll.set
+        text['yscrollcommand'] = self.yscroll.set
 
         # horizontal scrollbar
         self.xscroll = None
@@ -89,15 +89,17 @@ class ScrollableTextFrame(Frame):
 
     def _set_xscroll(self, wrap):
         """show/hide the horizontal scrollbar as per the 'wrap' setting"""
+        text = self.text
+
         # show the scrollbar only when wrap is set to NONE
         if wrap == NONE and self.xscroll is None:
             self.xscroll = AutoHiddenScrollbar(self, orient=HORIZONTAL,
                                                takefocus=False,
-                                               command=self.text.xview)
+                                               command=text.xview)
             self.xscroll.grid(row=1, column=0, sticky=EW)
-            self.text['xscrollcommand'] = self.xscroll.set
+            text['xscrollcommand'] = self.xscroll.set
         elif wrap != NONE and self.xscroll is not None:
-            self.text['xscrollcommand'] = ''
+            text['xscrollcommand'] = ''
             self.xscroll.grid_forget()
             self.xscroll.destroy()
             self.xscroll = None

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -54,16 +54,16 @@ class ScrollableTextFrame(Frame):
 
         # vertical scrollbar
         self.yscroll = AutoHideScrollbar(self, orient=VERTICAL,
-                                           takefocus=False,
-                                           command=text.yview)
+                                         takefocus=False,
+                                         command=text.yview)
         self.yscroll.grid(row=0, column=1, sticky=NS)
         text['yscrollcommand'] = self.yscroll.set
 
         # horizontal scrollbar - only when wrap is set to NONE
         if wrap == NONE:
             self.xscroll = AutoHideScrollbar(self, orient=HORIZONTAL,
-                                               takefocus=False,
-                                               command=text.xview)
+                                             takefocus=False,
+                                             command=text.xview)
             self.xscroll.grid(row=1, column=0, sticky=EW)
             text['xscrollcommand'] = self.xscroll.set
         else:

--- a/Misc/NEWS.d/next/IDLE/2019-07-26-17-51-13.bpo-37628.kX4AUF.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-07-26-17-51-13.bpo-37628.kX4AUF.rst
@@ -1,0 +1,1 @@
+Settings dialog no longer expands with font size.


### PR DESCRIPTION
This fixes the issue where setting a large font size makes the config dialog grow, in some cases making it unusable by pushing the dialog buttons (e.g. "Ok", "Cancel") off-screen.

Tested on Windows 10 and Ubuntu 18.10.

<!-- issue-number: [bpo-37628](https://bugs.python.org/issue37628) -->
https://bugs.python.org/issue37628
<!-- /issue-number -->
