### PR TITLE
ISSUE smtpd: staling connect

### DIFF
--- a/Lib/smtpd.py
+++ b/Lib/smtpd.py
@@ -658,6 +658,8 @@ class SMTPServer(asyncore.dispatcher):
                 localaddr, remoteaddr), file=DEBUGSTREAM)
 
     def handle_accepted(self, conn, addr):
+        import logging
+        logging.error('never reached')
         print('Incoming connection from %s' % repr(addr), file=DEBUGSTREAM)
         channel = self.channel_class(self,
                                      conn,

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -371,6 +371,7 @@ class SMTP:
         self.send(str)
 
     def getreply(self):
+        import logging
         """Get a reply from the server.
 
         Returns a tuple consisting of:
@@ -388,6 +389,7 @@ class SMTP:
             self.file = self.sock.makefile('rb')
         while 1:
             try:
+                logging.error('staling here')
                 line = self.file.readline(_MAXLINE + 1)
             except OSError as e:
                 self.close()


### PR DESCRIPTION
Marking points identified during dbg tracing.

# 3.7 Issue resolution: SMTP components

Following script stals/hangs. According to my tracing done, in the smtpd component. The concept of the script is baseline of my unit testing for [1], so not hypothetical:

```python
import logging
import sys
logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)

from smtpd import DebuggingServer as TestMailServer
import threading
from notifiers import get_notifier
import time
import itertools as it

mail_server = threading.Thread(target=TestMailServer, args=(("localhost", 2500), None))
mail_server.daemon = True
mail_server.start()

time.sleep(2)


for msg in it.repeat('copy', 100):
    print(msg)
    get_notifier('email').notify(from_='cherusk@localhost',
                                 to='root@localhost',
                                 message=msg,
                                 subject='TST',
                                 host='localhost',
                                 port=2500,
                                 tls=False,
                                 ssl=False,
                                 html=False,
                                 username="some",
                                 password='pw'
                                 )
```
I evaluated that on several platforms(FED29, UBUNTU-Latest), same symptoms. Also, on network stack I saw a clean TCP handshake happening, also cleanly ACKed by the smptd. So, presumption is that it's something in the dispatcher.



[1]  https://github.com/cherusk/tw_timeliness/blob/master/test/time_engine_test.py
