### PR TITLE
bpo-15987: Add ast.AST class richcompare methods 

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -3,6 +3,7 @@ import dis
 import os
 import random
 import sys
+import tokenize
 import unittest
 import warnings
 import weakref
@@ -694,7 +695,7 @@ class AST_Tests(unittest.TestCase):
         for module in files:
             with self.subTest(module):
                 fn = os.path.join(STDLIB, module)
-                with open(fn) as fp:
+                with tokenize.open(fn) as fp:
                     source = fp.read()
                 a = ast.parse(source, fn)
                 b = ast.parse(source, fn)

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -670,6 +670,12 @@ class AST_Tests(unittest.TestCase):
             next_constant = constants[next_index]
             self.assertNotEqual(ast.Constant(constant), ast.Constant(next_constant))
 
+        same_looking_literal_cases = [{1, 1.0, True, 1+0j}, {0, 0.0, False, 0+0j}]
+        for same_looking_literals for same_looking_literal_cases:
+            for literal in same_looking_literals:
+                for same_looking_literal in same_looking_literals - {literal}:
+                    self.assertNotEqual(ast.Constant(literal), ast.Constant(same_looking_literal))
+
     def test_compare_operators(self):
         self.assertEqual(ast.Add(), ast.Add())
         self.assertEqual(ast.Sub(), ast.Sub())

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1,6 +1,7 @@
 import ast
 import dis
 import os
+import random
 import sys
 import unittest
 import warnings
@@ -666,12 +667,13 @@ class AST_Tests(unittest.TestCase):
     def test_compare_literals(self):
         constants = (-20, 20, 20.0, 1, 1.0, True, 0, False, frozenset(), tuple(), "ABCD", "abcd", "中文字", 1e1000, -1e1000)
         for next_index, constant in enumerate(constants[:-1], 1):
-            self.assertEqual(ast.Constant(constant), ast.Constant(constant))
             next_constant = constants[next_index]
-            self.assertNotEqual(ast.Constant(constant), ast.Constant(next_constant))
+            with self.subTest(literal=constant, next_literal=next_constant):
+                self.assertEqual(ast.Constant(constant), ast.Constant(constant))
+                self.assertNotEqual(ast.Constant(constant), ast.Constant(next_constant))
 
         same_looking_literal_cases = [{1, 1.0, True, 1+0j}, {0, 0.0, False, 0+0j}]
-        for same_looking_literals for same_looking_literal_cases:
+        for same_looking_literals in same_looking_literal_cases:
             for literal in same_looking_literals:
                 for same_looking_literal in same_looking_literals - {literal}:
                     self.assertNotEqual(ast.Constant(literal), ast.Constant(same_looking_literal))
@@ -684,7 +686,7 @@ class AST_Tests(unittest.TestCase):
         self.assertNotEqual(ast.Add(), ast.Constant())
 
     def test_compare_stdlib(self):
-        if test.support.is_resource_enabled("cpu"):
+        if support.is_resource_enabled("cpu"):
             files = STDLIB_FILES
         else:
             files = random.sample(STDLIB_FILES, 10)

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -691,7 +691,7 @@ class AST_Tests(unittest.TestCase):
         else:
             files = random.sample(STDLIB_FILES, 10)
 
-        for module in STDLIB_FILES:
+        for module in files:
             with self.subTest(module):
                 fn = os.path.join(STDLIB, module)
                 with open(fn) as fp:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1043,6 +1043,7 @@ Jason Lowe
 Tony Lownds
 Ray Loyzaga
 Kang-Hao (Kenny) Lu
+Louie Lu
 Lukas Lueg
 Loren Luke
 Fredrik Lundh

--- a/Misc/NEWS.d/next/Library/2019-07-20-16-02-36.bpo-15987.sQtFns.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-20-16-02-36.bpo-15987.sQtFns.rst
@@ -1,0 +1,2 @@
+Provide a way to compare AST nodes for equality recursively. Patch by Louie
+Lu, Flavian Hautbois and Batuhan Taskaya.

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -853,6 +853,7 @@ static PyType_Slot AST_type_slots[] = {
     {Py_tp_new, PyType_GenericNew},
     {Py_tp_free, PyObject_GC_Del},
     {Py_tp_richcompare, ast_richcompare},
+    {Py_tp_hash, (hashfunc)_Py_HashPointer},
     {0, 0},
 };
 

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -742,6 +742,56 @@ ast_type_reduce(PyObject *self, PyObject *unused)
     return Py_BuildValue("O()", Py_TYPE(self));
 }
 
+static PyObject *
+ast_richcompare(PyObject *self, PyObject *other, int op)
+{
+    int i, len;
+    PyObject *fields, *key, *a = Py_None, *b = Py_None;
+    /* Check operator */
+    if ((op != Py_EQ && op != Py_NE) ||
+         !PyAST_Check(self) ||
+         !PyAST_Check(other)) {
+        Py_RETURN_NOTIMPLEMENTED;
+    }
+    /* Compare types */
+    if (Py_TYPE(self) != Py_TYPE(other)) {
+        if (op == Py_EQ)
+            Py_RETURN_FALSE;
+        else
+            Py_RETURN_TRUE;
+    }
+    /* Compare fields */
+    fields = PyObject_GetAttrString(self, "_fields");
+    len = PySequence_Size(fields);
+    for (i = 0; i < len; ++i) {
+        key = PySequence_GetItem(fields, i);
+        if (PyObject_HasAttr(self, key))
+            a = PyObject_GetAttr(self, key);
+        if (PyObject_HasAttr(other, key))
+            b = PyObject_GetAttr(other, key);
+        /* Check filed value type */
+        if (Py_TYPE(a) != Py_TYPE(b)) {
+            if (op == Py_EQ) {
+                Py_RETURN_FALSE;
+            }
+        }
+        if (op == Py_EQ) {
+            if (!PyObject_RichCompareBool(a, b, Py_EQ)) {
+                Py_RETURN_FALSE;
+            }
+        }
+        else if (op == Py_NE) {
+            if (PyObject_RichCompareBool(a, b, Py_NE)) {
+                Py_RETURN_TRUE;
+            }
+        }
+    }
+    if (op == Py_EQ)
+        Py_RETURN_TRUE;
+    else
+        Py_RETURN_FALSE;
+}
+
 static PyMemberDef ast_type_members[] = {
     {"__dictoffset__", T_PYSSIZET, offsetof(AST_object, dict), READONLY},
     {NULL}  /* Sentinel */
@@ -770,6 +820,7 @@ static PyType_Slot AST_type_slots[] = {
     {Py_tp_alloc, PyType_GenericAlloc},
     {Py_tp_new, PyType_GenericNew},
     {Py_tp_free, PyObject_GC_Del},
+    {Py_tp_richcompare, ast_richcompare},
     {0, 0},
 };
 

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1180,56 +1180,83 @@ ast_type_reduce(PyObject *self, PyObject *unused)
 static PyObject *
 ast_richcompare(PyObject *self, PyObject *other, int op)
 {
-    int i, len;
-    PyObject *fields, *key, *a = Py_None, *b = Py_None;
+    Py_ssize_t i, numfields = 0;
+    PyObject *fields, *key = NULL;
+
     /* Check operator */
     if ((op != Py_EQ && op != Py_NE) ||
-         !PyAST_Check(self) ||
-         !PyAST_Check(other)) {
+         !PyAST_Check(self) || !PyAST_Check(other)) {
         Py_RETURN_NOTIMPLEMENTED;
     }
+
     /* Compare types */
     if (Py_TYPE(self) != Py_TYPE(other)) {
-        if (op == Py_EQ) {
-            Py_RETURN_FALSE;
-        }
-        else {
-            Py_RETURN_TRUE;
+        Py_RETURN_RICHCOMPARE(Py_TYPE(self), Py_TYPE(other), op);
+    }
+
+    if (_PyObject_LookupAttr((PyObject*)Py_TYPE(self), astmodulestate_global->_fields, &fields) < 0) {
+        return NULL;
+    }
+    if (fields) {
+        numfields = PySequence_Size(fields);
+        if (numfields == -1) {
+            goto fail;
         }
     }
+
+    PyObject *a, *b;
     /* Compare fields */
-    fields = PyObject_GetAttrString(self, "_fields");
-    len = PySequence_Size(fields);
-    for (i = 0; i < len; ++i) {
+    for (i = 0; i < numfields; i++) {
         key = PySequence_GetItem(fields, i);
-        if (PyObject_HasAttr(self, key))
-            a = PyObject_GetAttr(self, key);
-        if (PyObject_HasAttr(other, key))
-            b = PyObject_GetAttr(other, key);
-        /* Check filed value type */
+        if (!key) {
+            goto fail;
+        }
+        if (!PyObject_HasAttr(self, key) || !PyObject_HasAttr(other, key)) {
+            Py_DECREF(key);
+            goto unsuccessful;
+        }
+        Py_DECREF(key);
+
+        a = PyObject_GetAttr(self, key);
+        b = PyObject_GetAttr(other, key);
+        if (!a || !b) {
+            goto unsuccessful;
+        }
+
+        /* Ensure they belong to the same type */
         if (Py_TYPE(a) != Py_TYPE(b)) {
-            if (op == Py_EQ) {
-                Py_RETURN_FALSE;
-            }
-            else {
-                Py_RETURN_TRUE;
-            }
+            goto unsuccessful;
         }
-        if (op == Py_EQ) {
-            if (!PyObject_RichCompareBool(a, b, Py_EQ)) {
-                Py_RETURN_FALSE;
-            }
+
+        if (!PyObject_RichCompareBool(a, b, Py_EQ)) {
+            goto unsuccessful;
         }
-        else if (op == Py_NE) {
-            if (PyObject_RichCompareBool(a, b, Py_NE)) {
-                Py_RETURN_TRUE;
-            }
-        }
+        Py_DECREF(a);
+        Py_DECREF(b);
     }
-    if (op == Py_EQ)
+    Py_DECREF(fields);
+
+    if (op == Py_EQ) {
         Py_RETURN_TRUE;
-    else
+    }
+    else {
         Py_RETURN_FALSE;
+    }
+
+  unsuccessful:
+    Py_XDECREF(a);
+    Py_XDECREF(b);
+    Py_DECREF(fields);
+    if (op == Py_EQ) {
+        Py_RETURN_FALSE;
+    }
+    else {
+        Py_RETURN_TRUE;
+    }
+
+  fail:
+    Py_DECREF(fields);
+    return NULL;
 }
 
 static PyMemberDef ast_type_members[] = {

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1190,10 +1190,12 @@ ast_richcompare(PyObject *self, PyObject *other, int op)
     }
     /* Compare types */
     if (Py_TYPE(self) != Py_TYPE(other)) {
-        if (op == Py_EQ)
+        if (op == Py_EQ) {
             Py_RETURN_FALSE;
-        else
+        }
+        else {
             Py_RETURN_TRUE;
+        }
     }
     /* Compare fields */
     fields = PyObject_GetAttrString(self, "_fields");
@@ -1208,6 +1210,9 @@ ast_richcompare(PyObject *self, PyObject *other, int op)
         if (Py_TYPE(a) != Py_TYPE(b)) {
             if (op == Py_EQ) {
                 Py_RETURN_FALSE;
+            }
+            else {
+                Py_RETURN_TRUE;
             }
         }
         if (op == Py_EQ) {

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1288,6 +1288,7 @@ static PyType_Slot AST_type_slots[] = {
     {Py_tp_new, PyType_GenericNew},
     {Py_tp_free, PyObject_GC_Del},
     {Py_tp_richcompare, ast_richcompare},
+    {Py_tp_hash, (hashfunc)_Py_HashPointer},
     {0, 0},
 };
 


### PR DESCRIPTION
Recreation of https://github.com/python/cpython/pull/1368, updated to current master.

<!-- issue-number: [bpo-15987](https://bugs.python.org/issue15987) -->
https://bugs.python.org/issue15987
<!-- /issue-number -->
