### PR TITLE
bpo-37691: Let math.dist() accept sequences and iterables for coordinates

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -400,7 +400,8 @@ Trigonometric functions
 .. function:: dist(p, q)
 
    Return the Euclidean distance between two points *p* and *q*, each
-   given as a tuple of coordinates.  The two tuples must be the same size.
+   given as a sequence (or iterable) of coordinates.  The two points
+   must have the same dimension.
 
    Roughly equivalent to::
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -833,6 +833,10 @@ class MathTests(unittest.TestCase):
                     sqrt(sum((px - qx) ** 2.0 for px, qx in zip(p, q)))
                 )
 
+        # Test non-tuple inputs
+        self.assertEqual(dist([1.0, 2.0, 3.0], [4.0, 2.0, -1.0]), 5.0)
+        self.assertEqual(dist(iter([1.0, 2.0, 3.0]), iter([4.0, 2.0, -1.0])), 5.0)
+
         # Test allowable types (those with __float__)
         self.assertEqual(dist((14.0, 1.0), (2.0, -4.0)), 13.0)
         self.assertEqual(dist((14, 1), (2, -4)), 13)
@@ -873,8 +877,6 @@ class MathTests(unittest.TestCase):
             dist((1, 2, 3), (4, 5, 6), (7, 8, 9))
         with self.assertRaises(TypeError):         # Scalars not allowed
             dist(1, 2)
-        with self.assertRaises(TypeError):         # Lists not allowed
-            dist([1, 2, 3], [4, 5, 6])
         with self.assertRaises(TypeError):         # Reject values without __float__
             dist((1.1, 'string', 2.2), (1, 2, 3))
         with self.assertRaises(ValueError):        # Check dimension agree

--- a/Misc/NEWS.d/next/Library/2019-07-26-22-30-01.bpo-37691.1Li3rx.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-26-22-30-01.bpo-37691.1Li3rx.rst
@@ -1,0 +1,2 @@
+Let math.dist() accept coordinates as sequences (or iterables) rather than
+just tuples.

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -319,15 +319,7 @@ math_dist(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("dist", nargs, 2, 2)) {
         goto exit;
     }
-    if (!PyTuple_Check(args[0])) {
-        _PyArg_BadArgument("dist", 1, "tuple", args[0]);
-        goto exit;
-    }
     p = args[0];
-    if (!PyTuple_Check(args[1])) {
-        _PyArg_BadArgument("dist", 2, "tuple", args[1]);
-        goto exit;
-    }
     q = args[1];
     return_value = math_dist_impl(module, p, q);
 
@@ -720,4 +712,4 @@ math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0eb1e76a769cdd30 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4125131c06ce153e input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -297,8 +297,8 @@ PyDoc_STRVAR(math_dist__doc__,
 "\n"
 "Return the Euclidean distance between two points p and q.\n"
 "\n"
-"The points should be specified as tuples of coordinates.\n"
-"Both tuples must be the same size.\n"
+"The points should be specified as sequences (or iterables) of\n"
+"coordinates.  Both inputs must have the same dimension.\n"
 "\n"
 "Roughly equivalent to:\n"
 "    sqrt(sum((px - qx) ** 2.0 for px, qx in zip(p, q)))");
@@ -712,4 +712,4 @@ math_comb(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4125131c06ce153e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f93cfe13ab2fdb4e input=a9049054013a1b77]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2431,8 +2431,8 @@ math.dist
 
 Return the Euclidean distance between two points p and q.
 
-The points should be specified as tuples of coordinates.
-Both tuples must be the same size.
+The points should be specified as sequences (or iterables) of
+coordinates.  Both inputs should should have the same dimension.
 
 Roughly equivalent to:
     sqrt(sum((px - qx) ** 2.0 for px, qx in zip(p, q)))
@@ -2466,8 +2466,8 @@ math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
             return NULL;
         }
         q_allocated = 1;
-    }    
-    
+    }
+
     m = PyTuple_GET_SIZE(p);
     n = PyTuple_GET_SIZE(q);
     if (m != n) {

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2440,7 +2440,7 @@ Roughly equivalent to:
 
 static PyObject *
 math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
-/*[clinic end generated code: output=56bd9538d06bbcfe input=937122eaa5f19272]*/
+/*[clinic end generated code: output=56bd9538d06bbcfe input=8c83c07c7a524664]*/
 {
     PyObject *item;
     double max = 0.0;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2411,10 +2411,12 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
     }
     for (i=0 ; i < n ; i++) {
         x = vec[i];
+        assert(Py_IS_FINITE(x) && fabs(x) <= max);
         x /= max;
         x = x*x;
         oldcsum = csum;
         csum += x;
+        assert(csum >= x);
         frac += (oldcsum - csum) + x;
     }
     return max * sqrt(csum - 1.0 + frac);

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2432,7 +2432,7 @@ math.dist
 Return the Euclidean distance between two points p and q.
 
 The points should be specified as sequences (or iterables) of
-coordinates.  Both inputs should should have the same dimension.
+coordinates.  Both inputs must have the same dimension.
 
 Roughly equivalent to:
     sqrt(sum((px - qx) ** 2.0 for px, qx in zip(p, q)))
@@ -2440,7 +2440,7 @@ Roughly equivalent to:
 
 static PyObject *
 math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
-/*[clinic end generated code: output=56bd9538d06bbcfe input=8c83c07c7a524664]*/
+/*[clinic end generated code: output=56bd9538d06bbcfe input=74e85e1b6092e68e]*/
 {
     PyObject *item;
     double max = 0.0;


### PR DESCRIPTION


<!-- issue-number: [bpo-37691](https://bugs.python.org/issue37691) -->
https://bugs.python.org/issue37691
<!-- /issue-number -->
