### PR TITLE
bpo-29553: Fixed ArgumentParses format_usage for mutually exclusive groups

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -404,13 +404,19 @@ class HelpFormatter(object):
                             inserts[start] += ' ['
                         else:
                             inserts[start] = '['
-                        inserts[end] = ']'
+                        if end in inserts:
+                            inserts[end] += ']'
+                        else:
+                            inserts[end] = ']'
                     else:
                         if start in inserts:
                             inserts[start] += ' ('
                         else:
                             inserts[start] = '('
-                        inserts[end] = ')'
+                        if end in inserts:
+                            inserts[end] += ')'
+                        else:
+                            inserts[end] = ')'
                     for i in range(start + 1, end):
                         inserts[i] = '|'
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2813,6 +2813,43 @@ class TestMutuallyExclusiveOptionalsAndPositionalsMixed(MEMixin, TestCase):
           -c          c help
         '''
 
+class TestMutuallyExclusiveNested(MEMixin, TestCase):
+    def get_parser(self, required):
+        parser = ErrorRaisingArgumentParser(prog='PROG')
+        group = parser.add_mutually_exclusive_group(required=required)
+        group.add_argument('-a')
+        group.add_argument('-b')
+        group2 = group.add_mutually_exclusive_group(required=required)
+        group2.add_argument('-c')
+        group2.add_argument('-d')
+        group3 = group2.add_mutually_exclusive_group(required=required)
+        group3.add_argument('-e')
+        group3.add_argument('-f')
+        return parser
+
+    failures = []
+    successes = []
+    successes_when_not_required = []
+
+    usage_when_not_required = '''\
+        usage: PROG [-h] [-a A | -b B | [-c C | -d D | [-e E | -f F]]]
+        '''
+    usage_when_required = '''\
+        usage: PROG [-h] (-a A | -b B | (-c C | -d D | (-e E | -f F)))
+        '''
+
+    help = '''\
+
+        optional arguments:
+          -h, --help  show this help message and exit
+          -a A
+          -b B
+          -c C
+          -d D
+          -e E
+          -f F
+        '''
+
 # =================================================
 # Mutually exclusive group in parent parser tests
 # =================================================

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2814,6 +2814,7 @@ class TestMutuallyExclusiveOptionalsAndPositionalsMixed(MEMixin, TestCase):
         '''
 
 class TestMutuallyExclusiveNested(MEMixin, TestCase):
+
     def get_parser(self, required):
         parser = ErrorRaisingArgumentParser(prog='PROG')
         group = parser.add_mutually_exclusive_group(required=required)
@@ -2826,10 +2827,6 @@ class TestMutuallyExclusiveNested(MEMixin, TestCase):
         group3.add_argument('-e')
         group3.add_argument('-f')
         return parser
-
-    failures = []
-    successes = []
-    successes_when_not_required = []
 
     usage_when_not_required = '''\
         usage: PROG [-h] [-a A | -b B | [-c C | -d D | [-e E | -f F]]]
@@ -2849,6 +2846,12 @@ class TestMutuallyExclusiveNested(MEMixin, TestCase):
           -e E
           -f F
         '''
+
+    # We are only interested in testing the behavior of format_usage().
+    test_failures_when_not_required = None
+    test_failures_when_required = None
+    test_successes_when_not_required = None
+    test_successes_when_required = None
 
 # =================================================
 # Mutually exclusive group in parent parser tests

--- a/Misc/NEWS.d/next/Library/2019-07-27-10-14-45.bpo-29553.TVeIDe.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-27-10-14-45.bpo-29553.TVeIDe.rst
@@ -1,0 +1,1 @@
+Fixed ArgumentParses format_usage for mutually exclusive groups. Patch by Andrew Nester (@andrewnester)

--- a/Misc/NEWS.d/next/Library/2019-07-27-10-14-45.bpo-29553.TVeIDe.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-27-10-14-45.bpo-29553.TVeIDe.rst
@@ -1,1 +1,2 @@
-Fixed ArgumentParses format_usage for mutually exclusive groups. Patch by Andrew Nester (@andrewnester)
+Fixed :meth:`argparse.ArgumentParser.format_usage` for mutually exclusive groups.
+Patch by Andrew Nester.


### PR DESCRIPTION
Fix for https://bugs.python.org/issue29553

Recreation of https://github.com/python/cpython/pull/117, updated to current master

<!-- issue-number: [bpo-29553](https://bugs.python.org/issue29553) -->
https://bugs.python.org/issue29553
<!-- /issue-number -->
