### PR TITLE
gh-74379: Allow to load buffer objects with json.loads()

### DIFF
--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -25,7 +25,7 @@ Encoding basic Python object hierarchies::
     >>> io.getvalue()
     '["streaming API"]'
 
-Compact encoding::
+Compact encdetect_encodingoding::
 
     >>> import json
     >>> mydict = {'4': 5, '6': 7}
@@ -242,12 +242,13 @@ _default_decoder = JSONDecoder(object_hook=None, object_pairs_hook=None)
 
 
 def detect_encoding(b):
-    bstartswith = b.startswith
-    if bstartswith((codecs.BOM_UTF32_BE, codecs.BOM_UTF32_LE)):
-        return 'utf-32'
-    if bstartswith((codecs.BOM_UTF16_BE, codecs.BOM_UTF16_LE)):
-        return 'utf-16'
-    if bstartswith(codecs.BOM_UTF8):
+    for prefix in (codecs.BOM_UTF32_BE, codecs.BOM_UTF32_LE):
+        if b[:len(prefix)] == prefix:
+            return 'utf-32'
+    for prefix in (codecs.BOM_UTF16_BE, codecs.BOM_UTF16_LE):
+        if b[:len(prefix)] == prefix:
+            return 'utf-16'
+    if b[:len(codecs.BOM_UTF8)] == codecs.BOM_UTF8:
         return 'utf-8-sig'
 
     if len(b) >= 4:
@@ -337,11 +338,14 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
             raise JSONDecodeError("Unexpected UTF-8 BOM (decode using utf-8-sig)",
                                   s, 0)
     else:
-        if not isinstance(s, (bytes, bytearray)):
-            raise TypeError(f'the JSON object must be str, bytes or bytearray, '
-                            f'not {s.__class__.__name__}')
-        s = s.decode(detect_encoding(s), 'surrogatepass')
-
+        if not isinstance(s, (bytes, bytearray, memoryview)):
+            try:
+                s = memoryview(s)
+            except TypeError:
+                raise TypeError('the JSON object must be str, bytes or '
+                                'bytearray or memoryview compatible object, '
+                                'not {!r}'.format(s.__class__.__name__))
+        s = str(s, detect_encoding(s), 'surrogatepass')
     if "encoding" in kw:
         import warnings
         warnings.warn(

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -25,7 +25,7 @@ Encoding basic Python object hierarchies::
     >>> io.getvalue()
     '["streaming API"]'
 
-Compact encdetect_encodingoding::
+Compact encoding::
 
     >>> import json
     >>> mydict = {'4': 5, '6': 7}

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -1,3 +1,4 @@
+import array
 import decimal
 from io import StringIO
 from collections import OrderedDict
@@ -19,6 +20,15 @@ class TestDecode:
         self.assertEqual(self.loads('{}'), {})
         self.assertEqual(self.loads('[]'), [])
         self.assertEqual(self.loads('""'), "")
+
+    def test_memoryview(self):
+        data = memoryview(b'{"key": "val"}')
+        self.assertEqual(self.loads(data), {"key": "val"})
+
+    def test_buffer(self):
+        data = array.array('B')
+        data.frombytes(b'{"key": "val"}')
+        self.assertEqual(self.loads(data), {"key": "val"})
 
     def test_object_pairs_hook(self):
         s = '{"xkd":1, "kcw":2, "art":3, "hxm":4, "qrt":5, "pad":6, "hoy":7}'

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -841,6 +841,7 @@ Sanyam Khurana
 Mads Kiilerich
 Jason Killen
 Jan Kim
+Nikolay Kim
 Taek Joo Kim
 Sam Kimbrel
 Tomohiko Kinebuchi

--- a/Misc/NEWS.d/next/Library/2019-07-27-11-52-22.bpo-30193.D-PYaS.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-27-11-52-22.bpo-30193.D-PYaS.rst
@@ -1,0 +1,2 @@
+Allow to load buffer objects with `json.loads()`. Patch by Nikolay Kim
+<fafhrd91@gmail.com>.


### PR DESCRIPTION
Revival of https://github.com/python/cpython/pull/1334 updated to current master



<!-- issue-number: [bpo-30193](https://bugs.python.org/issue30193) -->
https://bugs.python.org/issue30193
<!-- /issue-number -->

<!-- gh-issue-number: gh-74379 -->
* Issue: gh-74379
<!-- /gh-issue-number -->
