### PR TITLE
gh-47169: Use the symbolic errno name in OSError error messages

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1285,6 +1285,13 @@ class ExceptionTests(unittest.TestCase):
                 next(i)
                 next(i)
 
+    def test_OSError_errno_error_message(self):
+        # The symbolic errno name should be shown in the error message of
+        # OSError and its subclasses.
+        with self.assertRaisesRegex(OSError,
+                f'Errno {errno.errorcode[errno.ENOENT]}'):
+            open('non-existent')
+
 
 class ImportErrorTests(unittest.TestCase):
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -292,8 +292,7 @@ class ExceptionTests(unittest.TestCase):
             w = OSError(9, 'foo', 'bar')
             self.assertEqual(w.errno, 9)
             self.assertEqual(w.winerror, None)
-            self.assertEqual(str(w),
-                f"[Errno {errno.errorcode[errno.EBADF]}] foo: 'bar'")
+            self.assertEqual(str(w), "[Errno EBADF] foo: 'bar'")
             # ERROR_PATH_NOT_FOUND (win error 3) becomes ENOENT (2)
             w = OSError(0, 'foo', 'bar', 3)
             self.assertEqual(w.errno, 2)
@@ -1289,8 +1288,7 @@ class ExceptionTests(unittest.TestCase):
     def test_OSError_errno_error_message(self):
         # The symbolic errno name should be shown in the error message of
         # OSError and its subclasses.
-        with self.assertRaisesRegex(OSError,
-                f'Errno {errno.errorcode[errno.ENOENT]}'):
+        with self.assertRaisesRegex(OSError, 'Errno ENOENT'):
             open('non-existent')
 
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -292,7 +292,8 @@ class ExceptionTests(unittest.TestCase):
             w = OSError(9, 'foo', 'bar')
             self.assertEqual(w.errno, 9)
             self.assertEqual(w.winerror, None)
-            self.assertEqual(str(w), "[Errno 9] foo: 'bar'")
+            self.assertEqual(str(w),
+                f"[Errno {errno.errorcode[errno.EBADF]}] foo: 'bar'")
             # ERROR_PATH_NOT_FOUND (win error 3) becomes ENOENT (2)
             w = OSError(0, 'foo', 'bar', 3)
             self.assertEqual(w.errno, 2)

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -291,7 +291,7 @@ class WakeupSignalTests(unittest.TestCase):
             if ('Exception ignored when trying to write to the signal wakeup fd'
                 not in err):
                 raise AssertionError(err)
-            if f'OSError: [Errno {errno.errorcode[errno.EBADF]}]' not in err:
+            if 'OSError: [Errno EBADF]' not in err:
                 raise AssertionError(err)
         else:
             raise AssertionError("ZeroDivisionError not raised")

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -291,7 +291,7 @@ class WakeupSignalTests(unittest.TestCase):
             if ('Exception ignored when trying to write to the signal wakeup fd'
                 not in err):
                 raise AssertionError(err)
-            if ('OSError: [Errno %d]' % errno.EBADF) not in err:
+            if f'OSError: [Errno {errno.errorcode[errno.EBADF]}]' not in err:
                 raise AssertionError(err)
         else:
             raise AssertionError("ZeroDivisionError not raised")

--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -234,7 +234,7 @@ class TestCheck(TestCase):
     def test_when_no_file(self):
         """A python file which does not exist actually in system."""
         path = 'no_file.py'
-        err = (f"{path!r}: I/O Error: [Errno {errno.ENOENT}] "
+        err = (f"{path!r}: I/O Error: [Errno {errno.errorcode[errno.ENOENT]}] "
               f"{os.strerror(errno.ENOENT)}: {path!r}\n")
         self.verify_tabnanny_check(path, err=err)
 

--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -234,7 +234,7 @@ class TestCheck(TestCase):
     def test_when_no_file(self):
         """A python file which does not exist actually in system."""
         path = 'no_file.py'
-        err = (f"{path!r}: I/O Error: [Errno {errno.errorcode[errno.ENOENT]}] "
+        err = (f"{path!r}: I/O Error: [Errno ENOENT] "
               f"{os.strerror(errno.ENOENT)}: {path!r}\n")
         self.verify_tabnanny_check(path, err=err)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2019-07-27-23-53-57.bpo-2920.kISkdL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-07-27-23-53-57.bpo-2920.kISkdL.rst
@@ -1,0 +1,1 @@
+Use the symbolic ``errno`` name in :exc:`OSError` error messages.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1115,15 +1115,15 @@ OSError_str(PyOSErrorObject *self)
                                     self->winerror ? self->winerror: Py_None,
                                     self->strerror ? self->strerror: Py_None);
 #endif
-    PyObject *str = self->myerrno;
+    PyObject *errnoval = self->myerrno;
     static PyObject *errorcodedict;
     // Try to obtain the symbolic errno name (e.g., ENOENT).
-    if (str != NULL) {
+    if (errnoval != NULL) {
         if (errorcodedict == NULL) {
             PyObject *errnomod = PyImport_ImportModule("errno");
             if (errnomod == NULL) {
                 PyErr_Clear();
-                goto skip;
+                goto formaterrno;
             }
             else {
                 _Py_IDENTIFIER(errorcode);
@@ -1132,33 +1132,33 @@ OSError_str(PyOSErrorObject *self)
                 Py_DECREF(errnomod);
                 if (errorcodedict == NULL) {
                     PyErr_Clear();
-                    goto skip;
+                    goto formaterrno;
                 }
             }
         }
-        PyObject *errnostr = PyDict_GetItem(errorcodedict, str);
+        PyObject *errnostr = PyDict_GetItem(errorcodedict, errnoval);
         if (errnostr != NULL) {
-            str = errnostr;
+            errnoval = errnostr;
         }
     }
 
-skip:
+formaterrno:
     if (self->filename) {
         if (self->filename2) {
             return PyUnicode_FromFormat("[Errno %S] %S: %R -> %R",
-                                        OR_NONE(str),
+                                        OR_NONE(errnoval),
                                         OR_NONE(self->strerror),
                                         self->filename,
                                         self->filename2);
         } else {
             return PyUnicode_FromFormat("[Errno %S] %S: %R",
-                                        OR_NONE(str),
+                                        OR_NONE(errnoval),
                                         OR_NONE(self->strerror),
                                         self->filename);
         }
     }
-    if (str && self->strerror) {
-        return PyUnicode_FromFormat("[Errno %S] %S", str, self->strerror);
+    if (errnoval && self->strerror) {
+        return PyUnicode_FromFormat("[Errno %S] %S", errnoval, self->strerror);
     }
     return BaseException_str((PyBaseExceptionObject *)self);
 }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1115,23 +1115,51 @@ OSError_str(PyOSErrorObject *self)
                                     self->winerror ? self->winerror: Py_None,
                                     self->strerror ? self->strerror: Py_None);
 #endif
+    PyObject *str = self->myerrno;
+    static PyObject *errorcodedict;
+    // Try to obtain the symbolic errno name (e.g., ENOENT).
+    if (str != NULL) {
+        if (errorcodedict == NULL) {
+            PyObject *errnomod = PyImport_ImportModule("errno");
+            if (errnomod == NULL) {
+                PyErr_Clear();
+                goto skip;
+            }
+            else {
+                _Py_IDENTIFIER(errorcode);
+                errorcodedict = _PyObject_GetAttrId(errnomod,
+                                                    &PyId_errorcode);
+                Py_DECREF(errnomod);
+                if (errorcodedict == NULL) {
+                    PyErr_Clear();
+                    goto skip;
+                }
+            }
+        }
+        PyObject *errnostr = PyDict_GetItem(errorcodedict, str);
+        if (errnostr != NULL) {
+            str = errnostr;
+        }
+    }
+
+skip:
     if (self->filename) {
         if (self->filename2) {
             return PyUnicode_FromFormat("[Errno %S] %S: %R -> %R",
-                                        OR_NONE(self->myerrno),
+                                        OR_NONE(str),
                                         OR_NONE(self->strerror),
                                         self->filename,
                                         self->filename2);
         } else {
             return PyUnicode_FromFormat("[Errno %S] %S: %R",
-                                        OR_NONE(self->myerrno),
+                                        OR_NONE(str),
                                         OR_NONE(self->strerror),
                                         self->filename);
         }
     }
-    if (self->myerrno && self->strerror)
-        return PyUnicode_FromFormat("[Errno %S] %S",
-                                    self->myerrno, self->strerror);
+    if (str && self->strerror) {
+        return PyUnicode_FromFormat("[Errno %S] %S", str, self->strerror);
+    }
     return BaseException_str((PyBaseExceptionObject *)self);
 }
 


### PR DESCRIPTION
For example:
```
>>> open('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileNotFoundError: [Errno ENOENT] No such file or directory: ''
```
`ENOENT` is shown instead of the integer value.


<!-- issue-number: [bpo-2920](https://bugs.python.org/issue2920) -->
https://bugs.python.org/issue2920
<!-- /issue-number -->


<!-- gh-issue-number: gh-47169 -->
* Issue: gh-47169
<!-- /gh-issue-number -->
