### PR TITLE
bpo-36002: fail to find -llvm-profdata

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-09-13-14-12-36.bpo-36002.Bcl4oe.rst
+++ b/Misc/NEWS.d/next/Build/2019-09-13-14-12-36.bpo-36002.Bcl4oe.rst
@@ -1,0 +1,2 @@
+Locate ``llvm-profdata`` and ``llvm-ar`` binaries using ``AC_PATH_TOOL``
+rather than ``AC_PATH_TARGET_TOOL``.

--- a/configure.ac
+++ b/configure.ac
@@ -1338,7 +1338,7 @@ if test "$Py_LTO" = 'true' ; then
   case $CC in
     *clang*)
       AC_SUBST(LLVM_AR)
-      AC_PATH_TARGET_TOOL(LLVM_AR, llvm-ar, '', ${llvm_path})
+      AC_PATH_TOOL(LLVM_AR, llvm-ar, '', ${llvm_path})
       AC_SUBST(LLVM_AR_FOUND)
       if test -n "${LLVM_AR}" -a -x "${LLVM_AR}"
       then
@@ -1404,7 +1404,7 @@ AC_SUBST(LLVM_PROF_MERGER)
 AC_SUBST(LLVM_PROF_FILE)
 AC_SUBST(LLVM_PROF_ERR)
 AC_SUBST(LLVM_PROFDATA)
-AC_PATH_TARGET_TOOL(LLVM_PROFDATA, llvm-profdata, '', ${llvm_path})
+AC_PATH_TOOL(LLVM_PROFDATA, llvm-profdata, '', ${llvm_path})
 AC_SUBST(LLVM_PROF_FOUND)
 if test -n "${LLVM_PROFDATA}" -a -x "${LLVM_PROFDATA}"
 then


### PR DESCRIPTION
The llvm-profdata is added using the AC_PATH_TARGET_TOOL in configure.ac.  Per the autoconf documentation for the AC_PATH_TARGET_TOOL, "If the tool cannot be found with a prefix, and if the build and target types are equal, then it is also searched for without a prefix."  However, only the AC_CANONICAL_HOST macro is called in the configure.ac script which means target will be set to '' while host and build are set to the values produced by config.guess.  Thus, when configure attempts to find $target_alias-llvm-profdata, it will search for -llvm-profdata (note leading dash), which will not be found on probably any system.

However, the macro AC_PATH_TOOL will search for the un-prefixed tool (llvm-profdata in this case) if a prefixed version is not found on the path.  This pull request replaces the AC_PATH_TARGET_TOOL macro with the AC_PATH_TOOL macro in configure.ac in two places (for llvm-profdata and llvm-ar).

With this change, Python built and tested satisfactorily using gcc v5.5.0 and clang v3.8.0, both with the --target switch set and without.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36002](https://bugs.python.org/issue36002) -->
https://bugs.python.org/issue36002
<!-- /issue-number -->
