### PR TITLE
bpo-37702: Fix SSL certificate-store-handles leak

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-07-29-16-49-31.bpo-37702.Lj2f5e.rst
+++ b/Misc/NEWS.d/next/Windows/2019-07-29-16-49-31.bpo-37702.Lj2f5e.rst
@@ -1,0 +1,1 @@
+Fix memory leak in ssl certification.

--- a/Misc/NEWS.d/next/Windows/2019-07-29-16-49-31.bpo-37702.Lj2f5e.rst
+++ b/Misc/NEWS.d/next/Windows/2019-07-29-16-49-31.bpo-37702.Lj2f5e.rst
@@ -1,1 +1,2 @@
-Fix memory leak in ssl certification.
+Fix memory leak on Windows in creating an SSLContext object or
+running urllib.request.urlopen('https://...').

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5805,7 +5805,7 @@ _ssl_enum_crls_impl(PyObject *module, const char *store_name)
        with CertCloseStore using CERT_CLOSE_STORE_FORCE_FLAG,
        the collection store must be closed before its sibling stores.
       (https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certaddstoretocollection) */
-    success = CertCloseStore(hCollectionStore, CERT_CLOSE_STORE_FORCE_FLAG);
+    BOOL success = CertCloseStore(hCollectionStore, CERT_CLOSE_STORE_FORCE_FLAG);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] == NULL) {
             continue;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5580,10 +5580,9 @@ ssl_collect_certificates(const char *store_name,
         }
     }
     if (storesAdded == 0) {
-        CertCloseStore(hCollectionStore, CERT_CLOSE_STORE_FORCE_FLAG);
+        CertCloseStore(hCollectionStore, 0);
         return NULL;
     }
-
     return hCollectionStore;
 }
 
@@ -5695,16 +5694,12 @@ _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
     Py_XDECREF(keyusage);
     Py_XDECREF(tup);
 
-    /* When a collection store and its sibling stores are closed
-       with CertCloseStore using CERT_CLOSE_STORE_FORCE_FLAG,
-       the collection store must be closed before its sibling stores.
-      (https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certaddstoretocollection) */
-    BOOL success = CertCloseStore(hCollectionStore, CERT_CLOSE_STORE_FORCE_FLAG);
+    BOOL success = CertCloseStore(hCollectionStore, 0);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] == NULL) {
             continue;
         }
-        if (!CertCloseStore(system_store_handles[i], CERT_CLOSE_STORE_FORCE_FLAG)) {
+        if (!CertCloseStore(system_store_handles[i], 0)) {
             success = 0;
         }
     }
@@ -5713,7 +5708,6 @@ _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
         Py_XDECREF(result);
         return PyErr_SetFromWindowsErr(GetLastError());
     }
-
     return result;
 }
 
@@ -5799,16 +5793,12 @@ _ssl_enum_crls_impl(PyObject *module, const char *store_name)
     Py_XDECREF(enc);
     Py_XDECREF(tup);
 
-    /* When a collection store and its sibling stores are closed
-       with CertCloseStore using CERT_CLOSE_STORE_FORCE_FLAG,
-       the collection store must be closed before its sibling stores.
-      (https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certaddstoretocollection) */
-    BOOL success = CertCloseStore(hCollectionStore, CERT_CLOSE_STORE_FORCE_FLAG);
+    BOOL success = CertCloseStore(hCollectionStore, 0);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] == NULL) {
             continue;
         }
-        if (!CertCloseStore(system_store_handles[i], CERT_CLOSE_STORE_FORCE_FLAG)) {
+        if (!CertCloseStore(system_store_handles[i], 0)) {
             success = 0;
         }
     }

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5697,9 +5697,9 @@ _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
     Py_XDECREF(keyusage);
     Py_XDECREF(tup);
 
-    /* CertCloseStore() has no option to close all handles together.
-       And if CERT_CLOSE_STORE_FORCE_FLAG (not recommended) is used,
-       hCollectionStore must be closed before hSystemStore. (bpo-37702) */
+    /* CertCloseStore() can't close handles together with any argument.
+       In case of using CERT_CLOSE_STORE_FORCE_FLAG (not recommended),
+       we must close hCollectionStore before hSystemStore. (bpo-37702) */
     BOOL success = CertCloseStore(hCollectionStore, 0);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] &&
@@ -5797,9 +5797,9 @@ _ssl_enum_crls_impl(PyObject *module, const char *store_name)
     Py_XDECREF(enc);
     Py_XDECREF(tup);
 
-    /* CertCloseStore() has no option to close all handles together.
-       And if CERT_CLOSE_STORE_FORCE_FLAG (not recommended) is used,
-       hCollectionStore must be closed before hSystemStore. (bpo-37702) */
+    /* CertCloseStore() can't close handles together with any argument.
+       In case of using CERT_CLOSE_STORE_FORCE_FLAG (not recommended),
+       we must close hCollectionStore before hSystemStore. (bpo-37702) */
     BOOL success = CertCloseStore(hCollectionStore, 0);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] &&

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5697,13 +5697,13 @@ _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
     Py_XDECREF(keyusage);
     Py_XDECREF(tup);
 
-    /* CertCloseStore() can't close handles together with any argument.
+    /* CertCloseStore() with any argument can't close handles together.
        In case of using CERT_CLOSE_STORE_FORCE_FLAG (not recommended),
-       we must close hCollectionStore before hSystemStore. (bpo-37702) */
+       we must close hCollectionStore before we close each hSystemStore. */
     BOOL success = CertCloseStore(hCollectionStore, 0);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] &&
-            !CertCloseStore(system_store_handles[i], 0)) {
+                !CertCloseStore(system_store_handles[i], 0)) {
             success = 0;
         }
     }
@@ -5797,13 +5797,13 @@ _ssl_enum_crls_impl(PyObject *module, const char *store_name)
     Py_XDECREF(enc);
     Py_XDECREF(tup);
 
-    /* CertCloseStore() can't close handles together with any argument.
+    /* CertCloseStore() with any argument can't close handles together.
        In case of using CERT_CLOSE_STORE_FORCE_FLAG (not recommended),
-       we must close hCollectionStore before hSystemStore. (bpo-37702) */
+       we must close hCollectionStore before we close each hSystemStore. */
     BOOL success = CertCloseStore(hCollectionStore, 0);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] &&
-            !CertCloseStore(system_store_handles[i], 0)) {
+                !CertCloseStore(system_store_handles[i], 0)) {
             success = 0;
         }
     }

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5694,6 +5694,7 @@ _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
     Py_XDECREF(keyusage);
     Py_XDECREF(tup);
 
+    /* There's no function argument to close all handles together. (bpo-37702) */
     BOOL success = CertCloseStore(hCollectionStore, 0);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] == NULL) {
@@ -5793,6 +5794,7 @@ _ssl_enum_crls_impl(PyObject *module, const char *store_name)
     Py_XDECREF(enc);
     Py_XDECREF(tup);
 
+    /* There's no function argument to close all handles together. (bpo-37702) */
     BOOL success = CertCloseStore(hCollectionStore, 0);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] == NULL) {

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5630,7 +5630,6 @@ _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
         CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY,
         CERT_SYSTEM_STORE_SERVICES,
         CERT_SYSTEM_STORE_USERS};
-    BOOL success;
     size_t i, system_stores_count = sizeof(system_stores) / sizeof(DWORD);
     HCERTSTORE system_store_handles[sizeof(system_stores) / sizeof(DWORD)];
 
@@ -5700,7 +5699,7 @@ _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
        with CertCloseStore using CERT_CLOSE_STORE_FORCE_FLAG,
        the collection store must be closed before its sibling stores.
       (https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certaddstoretocollection) */
-    success = CertCloseStore(hCollectionStore, CERT_CLOSE_STORE_FORCE_FLAG);
+    BOOL success = CertCloseStore(hCollectionStore, CERT_CLOSE_STORE_FORCE_FLAG);
     for (i = 0; i < system_stores_count; i++) {
         if (system_store_handles[i] == NULL) {
             continue;
@@ -5746,7 +5745,6 @@ _ssl_enum_crls_impl(PyObject *module, const char *store_name)
         CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY,
         CERT_SYSTEM_STORE_SERVICES,
         CERT_SYSTEM_STORE_USERS};
-    BOOL success;
     size_t i, system_stores_count = sizeof(system_stores) / sizeof(DWORD);
     HCERTSTORE system_store_handles[sizeof(system_stores) / sizeof(DWORD)];
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5553,8 +5553,7 @@ static DWORD system_stores[] = {
     CERT_SYSTEM_STORE_USERS
 };
 
-#define SYSTEM_STORES_COUNT sizeof(system_stores) / sizeof(DWORD)
-
+#define SYSTEM_STORES_COUNT (sizeof(system_stores) / sizeof(DWORD))
 
 static HCERTSTORE
 ssl_collect_certificates(const char *store_name,


### PR DESCRIPTION
In Windows, CertCloseStore(hCollectionStore,[any option]) closes only hCollectionStore.
To avoid out-of-memory, CertCloseStore() shuld be called to each hSystemStore
which was added to hCollectionStore.

I think CERT_CLOSE_STORE_FORCE_FLAG is rare option and not much needed.
MSDN says CertCloseStore(handle, 0) is ideal and works fine for me.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37702](https://bugs.python.org/issue37702) -->
https://bugs.python.org/issue37702
<!-- /issue-number -->
