### PR TITLE
bpo-37707: Exclude expensive unit tests from PGO task

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -643,6 +643,7 @@ class Regrtest:
             input("Press any key to continue...")
 
         support.PGO = self.ns.pgo
+        support.PGO_EXTENDED = self.ns.pgo_extended
 
         setup_tests(self.ns)
 

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2281,6 +2281,7 @@ class AbstractPickleTests(unittest.TestCase):
     FRAME_SIZE_MIN = 4
     FRAME_SIZE_TARGET = 64 * 1024
 
+    @support.skip_if_pgo_task
     def check_frame_opcodes(self, pickled):
         """
         Check the arguments of FRAME opcodes in a protocol 4+ pickle.
@@ -2328,6 +2329,7 @@ class AbstractPickleTests(unittest.TestCase):
         elif frameless_start is not None:
             self.assertLess(pos - frameless_start, self.FRAME_SIZE_MIN)
 
+    @support.skip_if_pgo_task
     def test_framing_many_objects(self):
         obj = list(range(10**5))
         for proto in range(4, pickle.HIGHEST_PROTOCOL + 1):
@@ -2417,6 +2419,7 @@ class AbstractPickleTests(unittest.TestCase):
                                 count_opcode(pickle.FRAME, pickled))
                 self.assertEqual(obj, self.loads(some_frames_pickle))
 
+    @support.skip_if_pgo_task
     def test_framed_write_sizes_with_delayed_writer(self):
         class ChunkAccumulator:
             """Accumulate pickler output in a list of raw chunks."""

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -973,6 +973,10 @@ SAVEDCWD = os.getcwd()
 # useful for PGO
 PGO = False
 
+# Set by libregrtest/main.py if we are running the extended (time consuming)
+# PGO task.  If this is True, PGO is also True.
+PGO_EXTENDED = False
+
 @contextlib.contextmanager
 def temp_dir(path=None, quiet=False):
     """Return a context manager that creates a temporary directory.
@@ -2639,9 +2643,9 @@ def skip_unless_xattr(test):
     return test if ok else unittest.skip(msg)(test)
 
 def skip_if_pgo_task(test):
-    """Skip decorator for tests that should not run in PGO task"""
-    ok = not PGO
-    msg = "Not run for PGO task"
+    """Skip decorator for tests not run in (non-extended) PGO task"""
+    ok = not PGO or PGO_EXTENDED
+    msg = "Not run for (non-extended) PGO task"
     return test if ok else unittest.skip(msg)(test)
 
 _bind_nix_socket_error = None

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2638,6 +2638,12 @@ def skip_unless_xattr(test):
     msg = "no non-broken extended attribute support"
     return test if ok else unittest.skip(msg)(test)
 
+def skip_if_pgo_task(test):
+    """Skip decorator for tests that should not run in PGO task"""
+    ok = not PGO
+    msg = "Not run for PGO task"
+    return test if ok else unittest.skip(msg)(test)
+
 _bind_nix_socket_error = None
 def skip_unless_bind_unix_socket(test):
     """Decorator for tests requiring a functional bind() for unix sockets."""

--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -643,6 +643,7 @@ class BZ2CompressorTest(BaseTest):
         data += bz2c.flush()
         self.assertEqual(ext_decompress(data), self.TEXT)
 
+    @support.skip_if_pgo_task
     @bigmemtest(size=_4G + 100, memuse=2)
     def testCompress4G(self, size):
         # "Test BZ2Compressor.compress()/flush() with >4GiB input"
@@ -701,6 +702,7 @@ class BZ2DecompressorTest(BaseTest):
         self.assertRaises(EOFError, bz2d.decompress, b"anything")
         self.assertRaises(EOFError, bz2d.decompress, b"")
 
+    @support.skip_if_pgo_task
     @bigmemtest(size=_4G + 100, memuse=3.3)
     def testDecompress4G(self, size):
         # "Test BZ2Decompressor.decompress() with >4GiB input"

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -2062,6 +2062,7 @@ class RegressionTests(unittest.TestCase):
         self.assertRaises(AssertionError, list, cycle(gen1()))
         self.assertEqual(hist, [0,1])
 
+    @support.skip_if_pgo_task
     def test_long_chain_of_empty_iterables(self):
         # Make sure itertools.chain doesn't run into recursion limits when
         # dealing with long chains of empty iterables. Even with a high

--- a/Lib/test/test_lzma.py
+++ b/Lib/test/test_lzma.py
@@ -333,6 +333,7 @@ class CompressorDecompressorTestCase(unittest.TestCase):
 
     # Test with inputs larger than 4GiB.
 
+    @support.skip_if_pgo_task
     @bigmemtest(size=_4G + 100, memuse=2)
     def test_compressor_bigmem(self, size):
         lzc = LZMACompressor()
@@ -344,6 +345,7 @@ class CompressorDecompressorTestCase(unittest.TestCase):
         finally:
             ddata = None
 
+    @support.skip_if_pgo_task
     @bigmemtest(size=_4G + 100, memuse=3)
     def test_decompressor_bigmem(self, size):
         lzd = LZMADecompressor()

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -14,6 +14,7 @@ import pickle
 import random
 import sys
 import unittest
+from test import support
 
 from decimal import Decimal
 from fractions import Fraction
@@ -2462,6 +2463,7 @@ class TestNormalDist(unittest.TestCase):
         self.assertEqual(X.cdf(float('Inf')), 1.0)
         self.assertTrue(math.isnan(X.cdf(float('NaN'))))
 
+    @support.skip_if_pgo_task
     def test_inv_cdf(self):
         NormalDist = statistics.NormalDist
 

--- a/Misc/NEWS.d/next/Build/2019-07-29-11-36-16.bpo-37707.Sm-dGk.rst
+++ b/Misc/NEWS.d/next/Build/2019-07-29-11-36-16.bpo-37707.Sm-dGk.rst
@@ -1,0 +1,3 @@
+Mark some individual tests to skip when --pgo is used.  The tests marked
+increase the PGO task time significantly and likely don't help improve
+optimization of the final executable.


### PR DESCRIPTION
Mark some individual tests to skip when --pgo is used.  The tests
marked increase the PGO task time significantly and likely don't
help improve optimization of the final executable.

Marked tests:

    pickletester
      check_frame_opcodes
      test_framing_many_objects

    test_bz2
      testCompress4G
      testDecompress4G

    test_itertools
      test_long_chain_of_empty_iterables

    test_lzma
      test_compressor_bigmem
      test_decompressor_bigmem

    test_statistics
      test_inv_cdf


<!-- issue-number: [bpo-37707](https://bugs.python.org/issue37707) -->
https://bugs.python.org/issue37707
<!-- /issue-number -->
