### PR TITLE
bpo-37706: Disable 3 IDLE scrollbar tests on Mac.

### DIFF
--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -1,4 +1,6 @@
 """Test sidebar, coverage 93%"""
+import idlelib.sidebar
+from sys import platform
 from itertools import chain
 import unittest
 import unittest.mock
@@ -7,7 +9,6 @@ import tkinter as tk
 
 from idlelib.delegator import Delegator
 from idlelib.percolator import Percolator
-import idlelib.sidebar
 
 
 class Dummy_editwin:
@@ -239,6 +240,7 @@ class LineNumbersTest(unittest.TestCase):
         self.assert_sidebar_n_lines(1)
         self.assertEqual(get_width(), 1)
 
+    @unittest.skipIf(platform == 'darwin', 'test tk version dependent')
     def test_click_selection(self):
         self.linenumber.show_sidebar()
         self.text.insert('1.0', 'one\ntwo\nthree\nfour\n')
@@ -252,14 +254,15 @@ class LineNumbersTest(unittest.TestCase):
 
         self.assertEqual(self.get_selection(), ('2.0', '3.0'))
 
-    def test_drag_selection(self):
+    @unittest.skipIf(platform == 'darwin', 'test tk version dependent')
+    def test_drag_selection_down(self):
         self.linenumber.show_sidebar()
-        self.text.insert('1.0', 'one\ntwo\nthree\nfour\n')
+        self.text.insert('1.0', 'one\ntwo\nthree\nfour\nfive\n')
         self.root.update()
 
-        # Drag from the first line to the third line.
-        start_x, start_y = self.get_line_screen_position(1)
-        end_x, end_y = self.get_line_screen_position(3)
+        # Drag from the second line to the fourth line.
+        start_x, start_y = self.get_line_screen_position(2)
+        end_x, end_y = self.get_line_screen_position(4)
         self.linenumber.sidebar_text.event_generate('<Button-1>',
                                                     x=start_x, y=start_y)
         self.linenumber.sidebar_text.event_generate('<B1-Motion>',
@@ -269,8 +272,27 @@ class LineNumbersTest(unittest.TestCase):
         self.linenumber.sidebar_text.event_generate('<ButtonRelease-1>',
                                                     x=end_x, y=end_y)
         self.root.update()
+        self.assertEqual(self.get_selection(), ('2.0', '5.0'))
 
-        self.assertEqual(self.get_selection(), ('1.0', '4.0'))
+    @unittest.skipIf(platform == 'darwin', 'test tk version dependent')
+    def test_drag_selection_up(self):
+        self.linenumber.show_sidebar()
+        self.text.insert('1.0', 'one\ntwo\nthree\nfour\nfive\n')
+        self.root.update()
+
+        # Drag from the fourth line to the second line.
+        start_x, start_y = self.get_line_screen_position(4)
+        end_x, end_y = self.get_line_screen_position(2)
+        self.linenumber.sidebar_text.event_generate('<Button-1>',
+                                                    x=start_x, y=start_y)
+        self.linenumber.sidebar_text.event_generate('<B1-Motion>',
+                                                    x=start_x, y=start_y)
+        self.linenumber.sidebar_text.event_generate('<B1-Motion>',
+                                                    x=end_x, y=end_y)
+        self.linenumber.sidebar_text.event_generate('<ButtonRelease-1>',
+                                                    x=end_x, y=end_y)
+        self.root.update()
+        self.assertEqual(self.get_selection(), ('2.0', '5.0'))
 
     def test_scroll(self):
         self.linenumber.show_sidebar()


### PR DESCRIPTION
They pass with tk 8.5.9 (Azure) but fail with the 8.6.x we install.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37706](https://bugs.python.org/issue37706) -->
https://bugs.python.org/issue37706
<!-- /issue-number -->
