### PR TITLE
bpo-37268: Add deprecation notice and a DeprecationWarning for the parser module

### DIFF
--- a/Doc/library/parser.rst
+++ b/Doc/library/parser.rst
@@ -25,11 +25,11 @@ from this.  This is better than trying to parse and modify an arbitrary Python
 code fragment as a string because parsing is performed in a manner identical to
 the code forming the application.  It is also faster.
 
-.. note::
+.. warning::
 
-   From Python 2.5 onward, it's much more convenient to cut in at the Abstract
-   Syntax Tree (AST) generation and compilation stage, using the :mod:`ast`
-   module.
+   The parser module is deprecated and will be removed in future versions of
+   Python. For the majority of use cases you can leverage the Abstract Syntax
+   Tree (AST) generation and compilation stage, using the :mod:`ast` module.
 
 There are a few things to note about this module which are important to making
 use of the data structures created.  This is not a tutorial on editing the parse

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -142,6 +142,10 @@ Deprecated
   Python versions it will raise a :exc:`TypeError` for all floats.
   (Contributed by Serhiy Storchaka in :issue:`37315`.)
 
+* The :mod:`parser` module is deprecated and will be removed in future versions
+  of Python. For the majority of use cases users can leverage the Abstract Syntax
+  Tree (AST) generation and compilation stage, using the :mod:`ast` module.
+
 
 Removed
 =======

--- a/Lib/test/test_parser.py
+++ b/Lib/test/test_parser.py
@@ -6,6 +6,7 @@ import operator
 import struct
 from test import support
 from test.support.script_helper import assert_python_failure
+from test.support.script_helper import assert_python_ok
 
 #
 #  First, we test that we can generate trees from valid source fragments,
@@ -986,6 +987,14 @@ class OtherParserCase(unittest.TestCase):
         # See bug #12264
         with self.assertRaises(TypeError):
             parser.expr("a", "b")
+
+
+class TestDeprecation(unittest.TestCase):
+    def test_deprecation_message(self):
+        code = "def f():\n  import parser\n\nf()"
+        rc, out, err = assert_python_ok('-c', code)
+        self.assertIn(b'<string>:2: DeprecationWarning', err)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2019-07-30-01-27-29.bpo-37268.QDmA44.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-30-01-27-29.bpo-37268.QDmA44.rst
@@ -1,0 +1,2 @@
+The :mod:`parser` module is deprecated and will be removed in future
+versions of Python.

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -1158,6 +1158,12 @@ PyInit_parser(void)
 {
     PyObject *module, *copyreg;
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+            "The parser module is deprecated and will be removed "
+            "in future versions of Python", 7) != 0) {
+        return NULL;
+    }
+
     if (PyType_Ready(&PyST_Type) < 0)
         return NULL;
     module = PyModule_Create(&parsermodule);


### PR DESCRIPTION
Deprecate the parser module and add a deprecation warning triggered on import and a warning block in the documentation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37268](https://bugs.python.org/issue37268) -->
https://bugs.python.org/issue37268
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal