### PR TITLE
bpo-36502: Correct documentation of `str.isspace`.

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1763,9 +1763,13 @@ expression support in the :mod:`re` module).
 .. method:: str.isspace()
 
    Return true if there are only whitespace characters in the string and there is
-   at least one character, false otherwise.  Whitespace characters  are those
-   characters defined in the Unicode character database as "Other" or "Separator"
-   and those with bidirectional property being one of "WS", "B", or "S".
+   at least one character, false otherwise.
+
+   A character is *whitespace* if in the Unicode character database
+   (see :mod:`unicodedata`), either its general category is ``Zs``
+   ("Separator, space"), or its bidirectional class is one of ``WS``,
+   ``B``, or ``S``.
+
 
 .. method:: str.istitle()
 

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -625,7 +625,7 @@ class UnicodeTest(string_tests.CommonTest,
 
     @support.requires_resource('cpu')
     def test_isspace_invariant(self):
-        for codepoint in range(0x110000):
+        for codepoint in range(sys.maxunicode + 1):
             char = chr(codepoint)
             bidirectional = unicodedata.bidirectional(char)
             category = unicodedata.category(char)

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -12,6 +12,7 @@ import operator
 import struct
 import sys
 import textwrap
+import unicodedata
 import unittest
 import warnings
 from test import support, string_tests
@@ -617,7 +618,14 @@ class UnicodeTest(string_tests.CommonTest,
         self.checkequalnofix(True, '\u2000', 'isspace')
         self.checkequalnofix(True, '\u200a', 'isspace')
         self.checkequalnofix(False, '\u2014', 'isspace')
-        # apparently there are no non-BMP spaces chars in Unicode 6
+        for i in range(0x10000):
+            char = chr(i)
+            bidirectional = unicodedata.bidirectional(char)
+            category = unicodedata.category(char)
+            self.assertEqual(char.isspace(),
+                             (bidirectional in ('WS', 'B', 'S')
+                              or category == 'Zs'))
+        # There are no non-BMP whitespace chars as of Unicode 12.
         for ch in ['\U00010401', '\U00010427', '\U00010429', '\U0001044E',
                    '\U0001F40D', '\U0001F46F']:
             self.assertFalse(ch.isspace(), '{!a} is not space.'.format(ch))

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -12,7 +12,6 @@ import operator
 import struct
 import sys
 import textwrap
-import unicodedata
 import unittest
 import warnings
 from test import support, string_tests
@@ -618,13 +617,6 @@ class UnicodeTest(string_tests.CommonTest,
         self.checkequalnofix(True, '\u2000', 'isspace')
         self.checkequalnofix(True, '\u200a', 'isspace')
         self.checkequalnofix(False, '\u2014', 'isspace')
-        for i in range(0x10000):
-            char = chr(i)
-            bidirectional = unicodedata.bidirectional(char)
-            category = unicodedata.category(char)
-            self.assertEqual(char.isspace(),
-                             (bidirectional in ('WS', 'B', 'S')
-                              or category == 'Zs'))
         # There are no non-BMP whitespace chars as of Unicode 12.
         for ch in ['\U00010401', '\U00010427', '\U00010429', '\U0001044E',
                    '\U0001F40D', '\U0001F46F']:

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -12,6 +12,7 @@ import operator
 import struct
 import sys
 import textwrap
+import unicodedata
 import unittest
 import warnings
 from test import support, string_tests
@@ -621,6 +622,16 @@ class UnicodeTest(string_tests.CommonTest,
         for ch in ['\U00010401', '\U00010427', '\U00010429', '\U0001044E',
                    '\U0001F40D', '\U0001F46F']:
             self.assertFalse(ch.isspace(), '{!a} is not space.'.format(ch))
+
+    @support.requires_resource('cpu')
+    def test_isspace_invariant(self):
+        for codepoint in range(0x110000):
+            char = chr(codepoint)
+            bidirectional = unicodedata.bidirectional(char)
+            category = unicodedata.category(char)
+            self.assertEqual(char.isspace(),
+                             (bidirectional in ('WS', 'B', 'S')
+                              or category == 'Zs'))
 
     def test_isalnum(self):
         super().test_isalnum()

--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -14,6 +14,10 @@ from test.support import script_helper
 encoding = 'utf-8'
 errors = 'surrogatepass'
 
+def all_chars():
+    '''Each Unicode codepoint, as a one-character string.'''
+    for codepoint in range(0x110000):
+        yield chr(codepoint)
 
 ### Run tests
 
@@ -101,6 +105,14 @@ class UnicodeFunctionsTest(UnicodeDatabaseTest):
             h.update(''.join(data).encode("ascii"))
         result = h.hexdigest()
         self.assertEqual(result, self.expectedchecksum)
+
+    def test_isspace_invariant(self):
+        for char in all_chars():
+            bidirectional = self.db.bidirectional(char)
+            category = self.db.category(char)
+            self.assertEqual(char.isspace(),
+                             (bidirectional in ('WS', 'B', 'S')
+                              or category == 'Zs'))
 
     def test_digit(self):
         self.assertEqual(self.db.digit('A', None), None)

--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -14,10 +14,6 @@ from test.support import script_helper
 encoding = 'utf-8'
 errors = 'surrogatepass'
 
-def all_chars():
-    '''Each Unicode codepoint, as a one-character string.'''
-    for codepoint in range(0x110000):
-        yield chr(codepoint)
 
 ### Run tests
 
@@ -105,14 +101,6 @@ class UnicodeFunctionsTest(UnicodeDatabaseTest):
             h.update(''.join(data).encode("ascii"))
         result = h.hexdigest()
         self.assertEqual(result, self.expectedchecksum)
-
-    def test_isspace_invariant(self):
-        for char in all_chars():
-            bidirectional = self.db.bidirectional(char)
-            category = self.db.category(char)
-            self.assertEqual(char.isspace(),
-                             (bidirectional in ('WS', 'B', 'S')
-                              or category == 'Zs'))
 
     def test_digit(self):
         self.assertEqual(self.db.digit('A', None), None)


### PR DESCRIPTION
The documented definition was much broader than the real one:
there are tons of characters with general category "Other",
and we don't (and shouldn't) treat most of them as whitespace.

Rewrite the definition to agree with the comment on
_PyUnicode_IsWhitespace, and with the logic in makeunicodedata.py,
which is what generates that function and so ultimately governs.

Add suitable breadcrumbs so that a reader who wants to pin down
exactly what this definition means (what's a "bidirectional class"
of "B"?) can do so.  The `unicodedata` module documentation is an
appropriate central place for our references to Unicode's own copious
documentation, so point there.

Also add to the `isspace` test a thorough check that the
implementation agrees with the intended definition.


<!-- issue-number: [bpo-36502](https://bugs.python.org/issue36502) -->
https://bugs.python.org/issue36502
<!-- /issue-number -->
