### PR TITLE
bpo-37631: Append $(EXTRA_CFLAGS) to $(CFLAGS_NODIST) as well

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -95,7 +95,7 @@ CONFIGURE_LDFLAGS=	@LDFLAGS@
 # command line to append to these values without stomping the pre-set
 # values.
 PY_CFLAGS=	$(BASECFLAGS) $(OPT) $(CONFIGURE_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS)
-PY_CFLAGS_NODIST=$(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST) -I$(srcdir)/Include/internal
+PY_CFLAGS_NODIST=$(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST) $(EXTRA_CFLAGS) -I$(srcdir)/Include/internal
 # Both CPPFLAGS and LDFLAGS need to contain the shell's value for setup.py to
 # be able to build extension modules using the directories specified in the
 # environment variables

--- a/Misc/NEWS.d/next/Build/2019-07-30-12-11-38.bpo-37631.ysP4XJ.rst
+++ b/Misc/NEWS.d/next/Build/2019-07-30-12-11-38.bpo-37631.ysP4XJ.rst
@@ -1,0 +1,6 @@
+The ``$(EXTRA_CFLAGS)`` are appended to ``$(CFLAGS_NODIST)`` and not only to
+``$(CFLAGS)``. This makes sure that any conflicting ``$(EXTRA_CFLAGS)`` are
+used at the end of the flags chain and hence take precedence.
+
+For example ``CFLAGS_NODIST="-O2" EXTRA_CFLAGS="-Og"`` now results in an
+optimized build instead of the debug one.


### PR DESCRIPTION
Previously, the $(EXTRA_CFLAGS) were only appended to $(CFLAGS),
hence any conflicting $(CFLAGS_NODIST) would override them,
as $(CFLAGS_NODIST) is appended to $(CFLAGS).

For example `CFLAGS_NODIST="-O2" EXTRA_CFLAGS="-Og"` would result in optimized
build instead of the debug one.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37631](https://bugs.python.org/issue37631) -->
https://bugs.python.org/issue37631
<!-- /issue-number -->
