### PR TITLE
gh-81427: Check expiry with current timestamp in DefaultCookiePolicy

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -1125,7 +1125,7 @@ class DefaultCookiePolicy(CookiePolicy):
         return True
 
     def return_ok_expires(self, cookie, request):
-        if cookie.is_expired(self._now):
+        if cookie.is_expired():
             _debug("   cookie expired")
             return False
         return True

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -629,6 +629,25 @@ class CookieTests(unittest.TestCase):
 
         # XXX RFC 2965 expiry rules (some apply to V0 too)
 
+    def test_cookie_expiry(self):
+        delay = 1
+        current_time = time.time()
+        future = time2netscape(current_time + delay)
+        url = "http://www.acme.com"
+        req = urllib.request.Request(url)
+        headers = [f"Set-Cookie: a=b; expires={future};"]
+        res = FakeResponse(headers, url)
+        policy = DefaultCookiePolicy()
+        new_policy = DefaultCookiePolicy()
+        jar = CookieJar(policy=policy)
+        jar.extract_cookies(res, req)
+        cookie = jar.make_cookies(res, req)[0]
+
+        time.sleep(delay)
+        self.assertTrue(cookie.is_expired())
+        self.assertFalse(policy.return_ok(cookie, req))
+        self.assertFalse(new_policy.return_ok(cookie, req))
+
     def test_default_path(self):
         # RFC 2965
         pol = DefaultCookiePolicy(rfc2965=True)

--- a/Misc/NEWS.d/next/Library/2019-07-30-21-36-51.bpo-37246.FEf4sf.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-30-21-36-51.bpo-37246.FEf4sf.rst
@@ -1,0 +1,2 @@
+Update :mod:`DefaultCookiePolicy` in `http.cookiejar` to check expiry with
+current timestamp.


### PR DESCRIPTION
Update DefaultCookiePolicy to check expiry using current timestamp

<!-- issue-number: [bpo-37246](https://bugs.python.org/issue37246) -->
https://bugs.python.org/issue37246
<!-- /issue-number -->

<!-- gh-issue-number: gh-81427 -->
* Issue: gh-81427
<!-- /gh-issue-number -->
