### PR TITLE
Update ftplib.all_errors documentation to match code

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -144,7 +144,7 @@ The module defines the following items:
    The set of all exceptions (as a tuple) that methods of :class:`FTP`
    instances may raise as a result of problems with the FTP connection (as
    opposed to programming errors made by the caller).  This set includes the
-   four exceptions listed above as well as :exc:`OSError`.
+   four exceptions listed above as well as :exc:`OSError` and :exc:`EOFError`.
 
 
 .. seealso::


### PR DESCRIPTION
The documentation doesn't mention the `EOFError` that https://github.com/python/cpython/blob/master/Lib/ftplib.py#L66 includes

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
