### PR TITLE
bpo-37723: fix performance regression on regular expression parsing

### DIFF
--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -432,11 +432,9 @@ def _escape(source, escape, state):
 def _uniq(items):
     if len(set(items)) == len(items):
         return items
-    newitems = []
-    for item in items:
-        if item not in newitems:
-            newitems.append(item)
-    return newitems
+    seen_items = set()
+    seen_items_add = seen_items.add
+    return [item for item in items if not (item in seen_items or seen_items_add(item))]
 
 def _parse_sub(source, state, verbose, nested):
     # parse an alternation: a|b|c

--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -430,11 +430,7 @@ def _escape(source, escape, state):
     raise source.error("bad escape %s" % escape, len(escape))
 
 def _uniq(items):
-    if len(set(items)) == len(items):
-        return items
-    seen_items = set()
-    seen_items_add = seen_items.add
-    return [item for item in items if not (item in seen_items or seen_items_add(item))]
+    return list(dict.fromkeys(items))
 
 def _parse_sub(source, state, verbose, nested):
     # parse an alternation: a|b|c

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1707,6 +1707,7 @@ Michael Urman
 Hector Urtubia
 Lukas Vacek
 Ville Vainio
+Yann Vaginay
 Andi Vajda
 Case Van Horsen
 John Mark Vandenberg

--- a/Misc/NEWS.d/next/Library/2019-07-31-16-49-01.bpo-37723.zq6tw8.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-31-16-49-01.bpo-37723.zq6tw8.rst
@@ -1,0 +1,1 @@
+Fix performance regression on regular expression parsing

--- a/Misc/NEWS.d/next/Library/2019-07-31-16-49-01.bpo-37723.zq6tw8.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-31-16-49-01.bpo-37723.zq6tw8.rst
@@ -1,1 +1,2 @@
-Fix performance regression on regular expression parsing
+Fix performance regression on regular expression parsing with huge
+character sets. Patch by Yann Vaginay.


### PR DESCRIPTION
On complex cases, parsing regular expressions takes much, much longer on Python >= 3.7

Example (ipython):

```python
In [1]: import re
In [2]: char_list = ''.join([chr(i) for i in range(0xffff)])
In [3]: long_char_list = char_list * 10
In [4]: pattern = f'[{re.escape(long_char_list)}]'
In [5]: %time compiled = re.compile(pattern)
```

The test was run on Amazon Linux AMI 2017.03.

On Python 3.6.1, the regexp compiled in ~2.6 seconds:
```
CPU times: user 2.59 s, sys: 30 ms, total: 2.62 s
Wall time: 2.64 s
```

On Python 3.7.3, the regexp compiled in ~15 minutes **(~350x increase in this case)**:
```
CPU times: user 15min 6s, sys: 240 ms, total: 15min 7s
Wall time: 15min 9s
```

Doing some profiling with cProfile shows that the issue is caused by `sre_parse._uniq` function, which does not exist in Python <= 3.6.

The complexity of this function is on average `O(N^2)` but can be easily reduced to `O(N)`.

The issue might not be noticeable with simple regexps, but programs like text tokenizers - which use complex regexps - might really be impacted by this regression.

<!-- issue-number: [bpo-37723](https://bugs.python.org/issue37723) -->
https://bugs.python.org/issue37723
<!-- /issue-number -->
