### PR TITLE
bpo-32178: Fix IndexError trying to parse 'To' header starting with ':'.

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -561,6 +561,8 @@ class DisplayName(Phrase):
     @property
     def display_name(self):
         res = TokenList(self)
+        if len(res) == 0:
+            return res.value
         if res[0].token_type == 'cfws':
             res.pop(0)
         else:
@@ -582,7 +584,7 @@ class DisplayName(Phrase):
             for x in self:
                 if x.token_type == 'quoted-string':
                     quote = True
-        if quote:
+        if self and quote:
             pre = post = ''
             if self[0].token_type=='cfws' or self[0][0].token_type=='cfws':
                 pre = ' '

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -584,7 +584,7 @@ class DisplayName(Phrase):
             for x in self:
                 if x.token_type == 'quoted-string':
                     quote = True
-        if self and quote:
+        if len(self) != 0 and quote:
             pre = post = ''
             if self[0].token_type=='cfws' or self[0][0].token_type=='cfws':
                 pre = ' '

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -1700,6 +1700,12 @@ class TestParser(TestParserMixin, TestEmailBase):
         self.assertEqual(display_name[3].comments, ['with trailing comment'])
         self.assertEqual(display_name.display_name, 'simple phrase.')
 
+    def test_get_display_name_bpo_32178(self):
+        display_name = self._test_get_x(
+            parser.get_display_name,
+            ':Foo ', '', '', [errors.InvalidHeaderDefect], ':Foo ')
+        self.assertEqual(display_name.value, '')
+
     # get_name_addr
 
     def test_get_name_addr_angle_addr_only(self):

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -1700,7 +1700,9 @@ class TestParser(TestParserMixin, TestEmailBase):
         self.assertEqual(display_name[3].comments, ['with trailing comment'])
         self.assertEqual(display_name.display_name, 'simple phrase.')
 
-    def test_get_display_name_bpo_32178(self):
+    def test_get_display_name_for_invalid_address_field(self):
+        # bpo-32178: Test that address fields starting with `:` don't cause
+        # IndexError when parsing the display name.
         display_name = self._test_get_x(
             parser.get_display_name,
             ':Foo ', '', '', [errors.InvalidHeaderDefect], ':Foo ')

--- a/Misc/NEWS.d/next/Library/2019-07-30-22-41-05.bpo-32178.X-IFLe.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-30-22-41-05.bpo-32178.X-IFLe.rst
@@ -1,0 +1,1 @@
+Fix IndexError trying to parse invalid address fields starting with ``:``.

--- a/Misc/NEWS.d/next/Library/2019-07-30-22-41-05.bpo-32178.X-IFLe.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-30-22-41-05.bpo-32178.X-IFLe.rst
@@ -1,1 +1,1 @@
-Fix IndexError trying to parse invalid address fields starting with ``:``.
+Fix IndexError in :mod:`email` package when trying to parse invalid address fields starting with ``:``.


### PR DESCRIPTION
This should fix the IndexError trying to retrieve `DisplayName.display_name` and `DisplayName.value` when the `value` is basically an empty string.



<!-- issue-number: [bpo-32178](https://bugs.python.org/issue32178) -->
https://bugs.python.org/issue32178
<!-- /issue-number -->


Automerge-Triggered-By: @maxking