### PR TITLE
"size" parameter for "read_bytes", "read_text" for large files

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1194,19 +1194,29 @@ class Path(PurePath):
         return io.open(self, mode, buffering, encoding, errors, newline,
                        opener=self._opener)
 
-    def read_bytes(self):
+    def _read(self, f, size):
+        if size > 0:
+            return f.read(size)
+        elif size < 0:
+            size = -size
+            f.seek(0, os.SEEK_END)
+            f.seek(f.tell() - size, os.SEEK_SET)
+            return f.read(size)
+        return f.read()
+    
+    def read_bytes(self, size=0):
         """
         Open the file in bytes mode, read it, and close the file.
         """
         with self.open(mode='rb') as f:
-            return f.read()
+            return self._read(f, size)
 
-    def read_text(self, encoding=None, errors=None):
+    def read_text(self, size=0, encoding=None, errors=None):
         """
         Open the file in text mode, read it, and close the file.
         """
         with self.open(mode='r', encoding=encoding, errors=errors) as f:
-            return f.read()
+            return self._read(f, size)
 
     def write_bytes(self, data):
         """


### PR DESCRIPTION
Added parameter "size" to functions "read_bytes", "read_text" 
if size > 0 then bytes from beginning
if size < 0 then bytes from end
I some case when you need to know first bites in large file to no read it all

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
