### PR TITLE
bpo-37729: gc: write stats at once

### DIFF
--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -962,11 +962,11 @@ clear_freelists(void)
     (void)PyContext_ClearFreeList();
 }
 
-// This function is called at start of collect() if DEBUG_STATS is enabled.
+// Show stats for objects in each gennerations.
 static void
-show_stats(struct _gc_runtime_state *state, int generation)
+show_stats_each_generations(struct _gc_runtime_state *state)
 {
-    char buf[512];
+    char buf[100];
     size_t pos = 0;
 
     for (int i = 0; i < NUM_GENERATIONS && pos < sizeof(buf); i++) {
@@ -975,10 +975,9 @@ show_stats(struct _gc_runtime_state *state, int generation)
     }
 
     PySys_WriteStderr(
-        "gc: collecting generation %d...\n"
         "gc: objects in each generation:%s\n"
         "gc: objects in permanent generation: %zd\n",
-        generation, buf, gc_list_size(&state->permanent_generation.head));
+        buf, gc_list_size(&state->permanent_generation.head));
 }
 
 /* This is the main function.  Read this to understand how the
@@ -998,7 +997,8 @@ collect(struct _gc_runtime_state *state, int generation,
     _PyTime_t t1 = 0;   /* initialize to prevent a compiler warning */
 
     if (state->debug & DEBUG_STATS) {
-        show_stats(state, generation);
+        PySys_WriteStderr("gc: collecting generation %d...\n", generation);
+        show_stats_each_generations(state);
         t1 = _PyTime_GetMonotonicClock();
     }
 

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -962,6 +962,25 @@ clear_freelists(void)
     (void)PyContext_ClearFreeList();
 }
 
+// This function is called at start of collect() if DEBUG_STATS is enabled.
+static void
+show_stats(struct _gc_runtime_state *state, int generation)
+{
+    char buf[512];
+    size_t pos = 0;
+
+    for (int i = 0; i < NUM_GENERATIONS && pos < sizeof(buf); i++) {
+        pos += PyOS_snprintf(buf+pos, sizeof(buf)-pos,
+                             " %zd", gc_list_size(GEN_HEAD(state, i)));
+    }
+
+    PySys_WriteStderr(
+        "gc: collecting generation %d...\n"
+        "gc: objects in each generation:%s\n"
+        "gc: objects in permanent generation: %zd\n",
+        generation, buf, gc_list_size(&state->permanent_generation.head));
+}
+
 /* This is the main function.  Read this to understand how the
  * collection process works. */
 static Py_ssize_t
@@ -979,17 +998,8 @@ collect(struct _gc_runtime_state *state, int generation,
     _PyTime_t t1 = 0;   /* initialize to prevent a compiler warning */
 
     if (state->debug & DEBUG_STATS) {
-        PySys_WriteStderr("gc: collecting generation %d...\n",
-                          generation);
-        PySys_WriteStderr("gc: objects in each generation:");
-        for (i = 0; i < NUM_GENERATIONS; i++)
-            PySys_FormatStderr(" %zd",
-                              gc_list_size(GEN_HEAD(state, i)));
-        PySys_WriteStderr("\ngc: objects in permanent generation: %zd",
-                         gc_list_size(&state->permanent_generation.head));
+        show_stats(state, generation);
         t1 = _PyTime_GetMonotonicClock();
-
-        PySys_WriteStderr("\n");
     }
 
     if (PyDTrace_GC_START_ENABLED())
@@ -1103,16 +1113,16 @@ collect(struct _gc_runtime_state *state, int generation,
             debug_cycle("uncollectable", FROM_GC(gc));
     }
     if (state->debug & DEBUG_STATS) {
-        _PyTime_t t2 = _PyTime_GetMonotonicClock();
+        double d = _PyTime_AsSecondsDouble(_PyTime_GetMonotonicClock() - t1);
 
-        if (m == 0 && n == 0)
-            PySys_WriteStderr("gc: done");
-        else
-            PySys_FormatStderr(
-                "gc: done, %zd unreachable, %zd uncollectable",
-                n+m, n);
-        PySys_WriteStderr(", %.4fs elapsed\n",
-                          _PyTime_AsSecondsDouble(t2 - t1));
+        if (m == 0 && n == 0) {
+            PySys_WriteStderr("gc: done, %.4fs elapsed\n", d);
+        }
+        else {
+            PySys_WriteStderr(
+                "gc: done, %zd unreachable, %zd uncollectable, %.4fs elapsed\n",
+                n+m, n, d);
+        }
     }
 
     /* Append instances in the uncollectable set to a Python

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -971,10 +971,11 @@ show_stats_each_generations(struct _gc_runtime_state *state)
 
     for (int i = 0; i < NUM_GENERATIONS && pos < sizeof(buf); i++) {
         pos += PyOS_snprintf(buf+pos, sizeof(buf)-pos,
-                             " %zd", gc_list_size(GEN_HEAD(state, i)));
+                             " %"PY_FORMAT_SIZE_T"d",
+                             gc_list_size(GEN_HEAD(state, i)));
     }
 
-    PySys_WriteStderr(
+    PySys_FormatStderr(
         "gc: objects in each generation:%s\n"
         "gc: objects in permanent generation: %zd\n",
         buf, gc_list_size(&state->permanent_generation.head));

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1114,15 +1114,9 @@ collect(struct _gc_runtime_state *state, int generation,
     }
     if (state->debug & DEBUG_STATS) {
         double d = _PyTime_AsSecondsDouble(_PyTime_GetMonotonicClock() - t1);
-
-        if (m == 0 && n == 0) {
-            PySys_WriteStderr("gc: done, %.4fs elapsed\n", d);
-        }
-        else {
-            PySys_WriteStderr(
-                "gc: done, %zd unreachable, %zd uncollectable, %.4fs elapsed\n",
-                n+m, n, d);
-        }
+        PySys_FormatStderr(
+            "gc: done, %zd unreachable, %zd uncollectable, %.4fs elapsed\n",
+            n+m, n, d);
     }
 
     /* Append instances in the uncollectable set to a Python


### PR DESCRIPTION
gc used several PySys_WriteStderr() calls to write stats.
This caused stats mixed up when stderr is shared by multiple
threads or processes.

```
gc: collecting generation 0...
gc: objects in each generation: 782 0 7759
gc: objects in permanent generation: 0gc: collecting generation 0...

gc: objects in each generation: 782 0 7764
gc: objects in permanent generation: 0gc: done, 781 unreachable, 0 uncollectable, 0.0001s elapsed

gc: done, 781 unreachable, 0 uncollectable, 0.0000s elapsed
```

<!-- issue-number: [bpo-37729](https://bugs.python.org/issue37729) -->
https://bugs.python.org/issue37729
<!-- /issue-number -->
