### PR TITLE
Fix punctuation in `os.execvpe` docstring.

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -568,7 +568,7 @@ def execvpe(file, args, env):
     """execvpe(file, args, env)
 
     Execute the executable file (which is searched for along $PATH)
-    with argument list args and environment env , replacing the
+    with argument list args and environment env, replacing the
     current process.
     args may be a list or tuple of strings. """
     _execvpe(file, args, env)


### PR DESCRIPTION
Fix punctuation in `os.execvpe` docstring.