### PR TITLE
bpo-37726: prefer argparse over getopt

### DIFF
--- a/Doc/tutorial/stdlib.rst
+++ b/Doc/tutorial/stdlib.rst
@@ -86,7 +86,7 @@ Take, for example, the below snippet of code::
    >>> greeting = ["Hi", "Hello", "Greetings! its very nice to meet you"][args.verbose % 3]
    >>> print(f'{greeting}, {args.name}')
    >>> if not args.verbose:
-   >>>     print('Try running this again with multiple `-v` flags!')
+   >>>     print('Try running this again with multiple "-v" flags!')
 
 .. _tut-stderr:
 

--- a/Doc/tutorial/stdlib.rst
+++ b/Doc/tutorial/stdlib.rst
@@ -78,29 +78,15 @@ It should always be preferred over directly processing ``sys.argv`` manually.
 Take, for example, the below snippet of code::
 
    >>> import argparse
-   >>> parser = argparse.ArgumentParser(description='An argparse example.')
-   >>> parser.add_argument('name', help='The name of someone to greet.')
-   >>> args = parser.parse_args()
-   >>> print(f'Hello, {args.name}!')
-
-The three lines of code needed for creating the command line argument formula
-are simple to read and understand and are easy to extend in terms of your
-applications functionality.
-
-What if you wanted to provide a default value?
-
-::
-
    >>> from getpass import getuser
+   >>> parser = argparse.ArgumentParser(description='An argparse example.')
    >>> parser.add_argument('name', nargs='?', default=getuser(), help='The name of someone to greet.')
-
-How about if you wanted to control how verbose you are with your output?
-
-::
-
-  >>> parser.add_argument('--verbose', '-v', action='count')
-  >>> greeting = ["Hi", "Hello", "Greetings! its very nice to meet you"][args.verbose % 3]
-  >>> print(f'{greeting}, {args.name}')
+   >>> parser.add_argument('--verbose', '-v', action='count')
+   >>> args = parser.parse_args()
+   >>> greeting = ["Hi", "Hello", "Greetings! its very nice to meet you"][args.verbose % 3]
+   >>> print(f'{greeting}, {args.name}')
+   >>> if not args.verbose:
+   >>>     print('Try running this again with multiple `-v` flags!')
 
 .. _tut-stderr:
 

--- a/Doc/tutorial/stdlib.rst
+++ b/Doc/tutorial/stdlib.rst
@@ -72,7 +72,7 @@ three`` at the command line::
    >>> print(sys.argv)
    ['demo.py', 'one', 'two', 'three']
 
-The :mod:`argparse` module provides a mechanism to process command line arguments,
+The :mod:`argparse` module provides a mechanism to process command line arguments.
 It should always be preferred over directly processing ``sys.argv`` manually.
 
 Take, for example, the below snippet of code::

--- a/Doc/tutorial/stdlib.rst
+++ b/Doc/tutorial/stdlib.rst
@@ -72,10 +72,35 @@ three`` at the command line::
    >>> print(sys.argv)
    ['demo.py', 'one', 'two', 'three']
 
-The :mod:`getopt` module processes *sys.argv* using the conventions of the Unix
-:func:`getopt` function.  More powerful and flexible command line processing is
-provided by the :mod:`argparse` module.
+The :mod:`argparse` module provides a mechanism to process command line arguments,
+It should always be preferred over directly processing ``sys.argv`` manually.
 
+Take, for example, the below snippet of code::
+
+   >>> import argparse
+   >>> parser = argparse.ArgumentParser(description='An argparse example.')
+   >>> parser.add_argument('name', help='The name of someone to greet.')
+   >>> args = parser.parse_args()
+   >>> print(f'Hello, {args.name}!')
+
+The three lines of code needed for creating the command line argument formula
+are simple to read and understand and are easy to extend in terms of your
+applications functionality.
+
+What if you wanted to provide a default value?
+
+::
+
+   >>> from getpass import getuser
+   >>> parser.add_argument('name', nargs='?', default=getuser(), help='The name of someone to greet.')
+
+How about if you wanted to control how verbose you are with your output?
+
+::
+
+  >>> parser.add_argument('--verbose', '-v', action='count')
+  >>> greeting = ["Hi", "Hello", "Greetings! its very nice to meet you"][args.verbose % 3]
+  >>> print(f'{greeting}, {args.name}')
 
 .. _tut-stderr:
 

--- a/Misc/NEWS.d/next/Documentation/2019-07-31-11-40-06.bpo-37726.h-3o9a.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-07-31-11-40-06.bpo-37726.h-3o9a.rst
@@ -1,0 +1,2 @@
+Stop recommending getopt in the tutorial for command line argument parsing
+and promote argparse.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
[bpo-37726](https://bugs.python.org/issue37726): prefer argparse over getopt in tutorial

The tutorial section on "command line arguments" recommended using getopt for argument parsing and referenced argparse as the fancy alternative.

The topic was raised in the python-ideas by Andrew and Guido created the issue and tagged it with the new "newcomer friendly" tag.

This is my first doc change so I'd greatly appreciate a review and especially criticism, if I did something wrong point it out so I can avoid repeating it.

<!-- issue-number: [bpo-37726](https://bugs.python.org/issue37726) -->
https://bugs.python.org/issue37726
<!-- /issue-number -->
