### PR TITLE
bpo-35943: PyImport_GetModule() can return partially-initialized module

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-07-31-15-52-51.bpo-35943.-KswoB.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-31-15-52-51.bpo-35943.-KswoB.rst
@@ -1,1 +1,2 @@
 The function :c:func:`PyImport_GetModule` now ensures any module it returns is fully initialized.
+Patch by Joannah Nanjekye

--- a/Misc/NEWS.d/next/Library/2019-07-31-15-52-51.bpo-35943.-KswoB.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-31-15-52-51.bpo-35943.-KswoB.rst
@@ -1,1 +1,1 @@
-Added optimization to prevent `PyImport_GetModule()` from returning partially-initialized module.
+The function :c:func:`PyImport_GetModule` now ensures any module it returns is fully initialized.

--- a/Misc/NEWS.d/next/Library/2019-07-31-15-52-51.bpo-35943.-KswoB.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-31-15-52-51.bpo-35943.-KswoB.rst
@@ -1,0 +1,1 @@
+Added optimization to prevent `PyImport_GetModule()` from returning partially-initialized module.

--- a/Misc/NEWS.d/next/Library/2019-07-31-15-52-51.bpo-35943.-KswoB.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-31-15-52-51.bpo-35943.-KswoB.rst
@@ -1,2 +1,2 @@
 The function :c:func:`PyImport_GetModule` now ensures any module it returns is fully initialized.
-Patch by Joannah Nanjekye
+Patch by Joannah Nanjekye.

--- a/Python/import.c
+++ b/Python/import.c
@@ -397,9 +397,9 @@ import_ensure_initialized(PyThreadState *tstate, PyObject *mod, PyObject *name)
     _Py_IDENTIFIER(_lock_unlock_module);
 
     /* Optimization: only call _bootstrap._lock_unlock_module() if
-        __spec__._initializing is true.
-        NOTE: because of this, initializing must be set *before*
-        stuffing the new module in sys.modules.
+       __spec__._initializing is true.
+       NOTE: because of this, initializing must be set *before*
+       stuffing the new module in sys.modules.
     */
     spec = _PyObject_GetAttrId(mod, &PyId___spec__);
     if (_PyModuleSpec_IsInitializing(spec)) {
@@ -1785,18 +1785,18 @@ import_find_and_load(PyThreadState *tstate, PyObject *abs_name)
 PyObject *
 PyImport_GetModule(PyObject *name)
 {
-   PyThreadState *tstate = _PyThreadState_GET();
-   PyObject *mod = NULL;
+    PyThreadState *tstate = _PyThreadState_GET();
+    PyObject *mod = NULL;
 
-   mod = import_get_module(tstate, name);
-   if (mod != NULL && mod != Py_None) {
-       if (import_ensure_initialized(tstate, mod, name) < 0) {
-            Py_XDECREF(mod);
+    mod = import_get_module(tstate, name);
+    if (mod != NULL && mod != Py_None) {
+        if (import_ensure_initialized(tstate, mod, name) < 0) {
+            Py_DECREF(mod);
             remove_importlib_frames(tstate);
             return NULL;
-       }
-   }
-   return mod;
+        }
+    }
+    return mod;
 }
 
 PyObject *

--- a/Python/import.c
+++ b/Python/import.c
@@ -1786,7 +1786,7 @@ PyObject *
 PyImport_GetModule(PyObject *name)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    PyObject *mod = NULL;
+    PyObject *mod;
 
     mod = import_get_module(tstate, name);
     if (mod != NULL && mod != Py_None) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -402,10 +402,6 @@ import_ensure_initialized(PyThreadState *tstate, PyObject *mod, PyObject *name)
        stuffing the new module in sys.modules.
     */
     spec = _PyObject_GetAttrId(mod, &PyId___spec__);
-    if (spec == NULL) {
-        PyErr_Clear();
-        return 0;
-    }
     int busy = _PyModuleSpec_IsInitializing(spec);
     Py_DECREF(spec);
     if (busy) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -403,11 +403,9 @@ import_ensure_initialized(PyThreadState *tstate, PyObject *mod, PyObject *name)
     */
     spec = _PyObject_GetAttrId(mod, &PyId___spec__);
     int busy = _PyModuleSpec_IsInitializing(spec);
-    Py_DECREF(spec);
+    Py_XDECREF(spec);
     if (busy) {
-        /*
-           Wait until module is done importing.
-        */
+        /* Wait until module is done importing. */
         PyObject *value = _PyObject_CallMethodIdOneArg(
             interp->importlib, &PyId__lock_unlock_module, name);
         if (value == NULL) {


### PR DESCRIPTION
Added optimization to prevent `PyImport_GetModule()` from returning partially-initialized module.

<!-- issue-number: [bpo-35943](https://bugs.python.org/issue35943) -->
https://bugs.python.org/issue35943
<!-- /issue-number -->
