### PR TITLE
bpo-37730: Fix usage of NotImplemented instead of NotImplementedError in docs

### DIFF
--- a/Doc/library/winreg.rst
+++ b/Doc/library/winreg.rst
@@ -456,7 +456,7 @@ This module offers the following functions:
    *key* is an already open key, or one of the predefined :ref:`HKEY_* constants
    <hkey-constants>`.
 
-   Will generally raise :exc:`NotImplemented` if executed on a 32-bit operating
+   Will generally raise :exc:`NotImplementedError` if executed on a 32-bit operating
    system.
 
    If the key is not on the reflection list, the function succeeds but has no
@@ -471,7 +471,7 @@ This module offers the following functions:
    *key* is an already open key, or one of the predefined :ref:`HKEY_* constants
    <hkey-constants>`.
 
-   Will generally raise :exc:`NotImplemented` if executed on a 32-bit operating
+   Will generally raise :exc:`NotImplementedError` if executed on a 32-bit operating
    system.
 
    Restoring reflection for a key does not affect reflection of any subkeys.
@@ -486,7 +486,7 @@ This module offers the following functions:
 
    Returns ``True`` if reflection is disabled.
 
-   Will generally raise :exc:`NotImplemented` if executed on a 32-bit
+   Will generally raise :exc:`NotImplementedError` if executed on a 32-bit
    operating system.
 
 

--- a/PC/clinic/winreg.c.h
+++ b/PC/clinic/winreg.c.h
@@ -1029,7 +1029,7 @@ PyDoc_STRVAR(winreg_DisableReflectionKey__doc__,
 "  key\n"
 "    An already open key, or any one of the predefined HKEY_* constants.\n"
 "\n"
-"Will generally raise NotImplemented if executed on a 32bit OS.\n"
+"Will generally raise NotImplementedError if executed on a 32bit OS.\n"
 "\n"
 "If the key is not on the reflection list, the function succeeds but has\n"
 "no effect.  Disabling reflection for a key does not affect reflection\n"
@@ -1065,7 +1065,7 @@ PyDoc_STRVAR(winreg_EnableReflectionKey__doc__,
 "  key\n"
 "    An already open key, or any one of the predefined HKEY_* constants.\n"
 "\n"
-"Will generally raise NotImplemented if executed on a 32bit OS.\n"
+"Will generally raise NotImplementedError if executed on a 32bit OS.\n"
 "Restoring reflection for a key does not affect reflection of any\n"
 "subkeys.");
 
@@ -1099,7 +1099,7 @@ PyDoc_STRVAR(winreg_QueryReflectionKey__doc__,
 "  key\n"
 "    An already open key, or any one of the predefined HKEY_* constants.\n"
 "\n"
-"Will generally raise NotImplemented if executed on a 32bit OS.");
+"Will generally raise NotImplementedError if executed on a 32bit OS.");
 
 #define WINREG_QUERYREFLECTIONKEY_METHODDEF    \
     {"QueryReflectionKey", (PyCFunction)winreg_QueryReflectionKey, METH_O, winreg_QueryReflectionKey__doc__},
@@ -1121,4 +1121,4 @@ winreg_QueryReflectionKey(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=1204d20c543b5b4a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=015afbbd690eb59d input=a9049054013a1b77]*/

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -1702,7 +1702,7 @@ winreg.DisableReflectionKey
 
 Disables registry reflection for 32bit processes running on a 64bit OS.
 
-Will generally raise NotImplemented if executed on a 32bit OS.
+Will generally raise NotImplementedError if executed on a 32bit OS.
 
 If the key is not on the reflection list, the function succeeds but has
 no effect.  Disabling reflection for a key does not affect reflection
@@ -1711,7 +1711,7 @@ of any subkeys.
 
 static PyObject *
 winreg_DisableReflectionKey_impl(PyObject *module, HKEY key)
-/*[clinic end generated code: output=830cce504cc764b4 input=a6c9e5ca5410193c]*/
+/*[clinic end generated code: output=830cce504cc764b4 input=70bece2dee02e073]*/
 {
     HMODULE hMod;
     typedef LONG (WINAPI *RDRKFunc)(HKEY);
@@ -1749,14 +1749,14 @@ winreg.EnableReflectionKey
 
 Restores registry reflection for the specified disabled key.
 
-Will generally raise NotImplemented if executed on a 32bit OS.
+Will generally raise NotImplementedError if executed on a 32bit OS.
 Restoring reflection for a key does not affect reflection of any
 subkeys.
 [clinic start generated code]*/
 
 static PyObject *
 winreg_EnableReflectionKey_impl(PyObject *module, HKEY key)
-/*[clinic end generated code: output=86fa1385fdd9ce57 input=7748abbacd1e166a]*/
+/*[clinic end generated code: output=86fa1385fdd9ce57 input=eeae770c6eb9f559]*/
 {
     HMODULE hMod;
     typedef LONG (WINAPI *RERKFunc)(HKEY);
@@ -1794,12 +1794,12 @@ winreg.QueryReflectionKey
 
 Returns the reflection state for the specified key as a bool.
 
-Will generally raise NotImplemented if executed on a 32bit OS.
+Will generally raise NotImplementedError if executed on a 32bit OS.
 [clinic start generated code]*/
 
 static PyObject *
 winreg_QueryReflectionKey_impl(PyObject *module, HKEY key)
-/*[clinic end generated code: output=4e774af288c3ebb9 input=9f325eacb5a65d88]*/
+/*[clinic end generated code: output=4e774af288c3ebb9 input=a98fa51d55ade186]*/
 {
     HMODULE hMod;
     typedef LONG (WINAPI *RQRKFunc)(HKEY, BOOL *);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

As mentioned in the BPO, there are some instances where NotImplemented is used when NotImplementedError was meant to be. This is the example I found after running `rg -e NotImplemented[^E] Doc/`, all other usages looked correct.

I have updated the `Doc/library/winreg.rst` file, and then noticed that the Clinic comments for `PC/winreg.c` were also incorrect. I updated these and ran `python3 Tools/clinic/clinic.py PC/winreg.c` to generate the new output. This is my first time fixing the docs here so if I have missed a step

<!-- issue-number: [bpo-37730](https://bugs.python.org/issue37730) -->
https://bugs.python.org/issue37730
<!-- /issue-number -->
