### PR TITLE
bpo-29750: support non-ASCII passwords in smtplib

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -417,6 +417,7 @@ class SMTP:
 
     def docmd(self, cmd, args=""):
         """Send a command, and return its response code."""
+
         self.putcmd(cmd, args)
         return self.getreply()
 
@@ -627,7 +628,7 @@ class SMTP:
         mechanism = mechanism.upper()
         initial_response = (authobject() if initial_response_ok else None)
         if initial_response is not None:
-            response = encode_base64(initial_response.encode('ascii'), eol='')
+            response = encode_base64(initial_response.encode('utf-8'), eol='')
             (code, resp) = self.docmd("AUTH", mechanism + " " + response)
         else:
             (code, resp) = self.docmd("AUTH", mechanism)
@@ -635,7 +636,7 @@ class SMTP:
         if code == 334:
             challenge = base64.decodebytes(resp)
             response = encode_base64(
-                authobject(challenge).encode('ascii'), eol='')
+                authobject(challenge).encode('utf-8'), eol='')
             (code, resp) = self.docmd(response)
         if code in (235, 503):
             return (code, resp)
@@ -648,7 +649,7 @@ class SMTP:
         if challenge is None:
             return None
         return self.user + " " + hmac.HMAC(
-            self.password.encode('ascii'), challenge, 'md5').hexdigest()
+            self.password.encode('utf-8'), challenge, 'md5').hexdigest()
 
     def auth_plain(self, challenge=None):
         """ Authobject to use with PLAIN authentication. Requires self.user and

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -417,7 +417,6 @@ class SMTP:
 
     def docmd(self, cmd, args=""):
         """Send a command, and return its response code."""
-
         self.putcmd(cmd, args)
         return self.getreply()
 

--- a/Misc/NEWS.d/next/Library/2019-08-01-04-13-26.bpo-29750.jJGCMv.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-01-04-13-26.bpo-29750.jJGCMv.rst
@@ -1,0 +1,1 @@
+Let smtplib support non-ASCII passwords


### PR DESCRIPTION
issue: https://bugs.python.org/issue29750

I updated the PR based on the review from https://github.com/python/cpython/pull/8938

<!-- issue-number: [bpo-29750](https://bugs.python.org/issue29750) -->
https://bugs.python.org/issue29750
<!-- /issue-number -->
