### PR TITLE
Use sys.maxunicode and MAX_UNICODE constants

### DIFF
--- a/Objects/stringlib/codecs.h
+++ b/Objects/stringlib/codecs.h
@@ -220,10 +220,10 @@ STRINGLIB(utf8_decode)(const char **inptr, const char *end,
             }
             ch = (ch << 18) + (ch2 << 12) + (ch3 << 6) + ch4 -
                  ((0xF0 << 18) + (0x80 << 12) + (0x80 << 6) + 0x80);
-            assert ((ch > 0xFFFF) && (ch <= 0x10FFFF));
+            assert ((ch > 0xFFFF) && (ch <= MAX_UNICODE));
             s += 4;
             if (STRINGLIB_MAX_CHAR <= 0xFFFF ||
-                (STRINGLIB_MAX_CHAR < 0x10FFFF && ch > STRINGLIB_MAX_CHAR))
+                (STRINGLIB_MAX_CHAR < MAX_UNICODE && ch > STRINGLIB_MAX_CHAR))
                 /* Out-of-range */
                 goto Return;
             *p++ = ch;

--- a/Objects/stringlib/find_max_char.h
+++ b/Objects/stringlib/find_max_char.h
@@ -54,7 +54,7 @@ STRINGLIB(find_max_char)(const STRINGLIB_CHAR *begin, const STRINGLIB_CHAR *end)
 #define MAX_CHAR_ASCII 0x7f
 #define MAX_CHAR_UCS1  0xff
 #define MAX_CHAR_UCS2  0xffff
-#define MAX_CHAR_UCS4  0x10ffff
+#define MAX_CHAR_UCS4  MAX_UNICODE
 
 Py_LOCAL_INLINE(Py_UCS4)
 STRINGLIB(find_max_char)(const STRINGLIB_CHAR *begin, const STRINGLIB_CHAR *end)

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -90,8 +90,9 @@ NOTE: In the interpreter's initialization phase, some globals are currently
 extern "C" {
 #endif
 
-/* Maximum code point of Unicode 6.0: 0x10ffff (1,114,111) */
+/* Maximum code point of Unicode 12.0: 0x10ffff (1,114,111) */
 #define MAX_UNICODE 0x10ffff
+#define MAX_UNICODE_RANGE "range(0x110000)"
 
 #ifdef Py_DEBUG
 #  define _PyUnicode_CHECK(op) _PyUnicode_CheckConsistency(op, 0)
@@ -469,13 +470,13 @@ unicode_check_encoding_errors(const char *encoding, const char *errors)
 }
 
 
-/* The max unicode value is always 0x10FFFF while using the PEP-393 API.
+/* The max unicode value is always MAX_UNICODE while using the PEP-393 API.
    This function is kept for backward compatibility with the old API. */
 Py_UNICODE
 PyUnicode_GetMax(void)
 {
 #ifdef Py_UNICODE_WIDE
-    return 0x10FFFF;
+    return MAX_UNICODE;
 #else
     /* This is actually an illegal character, so it should
        not be passed to unichr. */
@@ -2771,7 +2772,7 @@ unicode_fromformat_arg(_PyUnicodeWriter *writer,
         int ordinal = va_arg(*vargs, int);
         if (ordinal < 0 || ordinal > MAX_UNICODE) {
             PyErr_SetString(PyExc_OverflowError,
-                            "character argument not in range(0x110000)");
+                            "character argument not in " MAX_UNICODE_RANGE);
             return NULL;
         }
         if (_PyUnicodeWriter_WriteCharInline(writer, ordinal) < 0)
@@ -3209,7 +3210,7 @@ PyUnicode_FromOrdinal(int ordinal)
 {
     if (ordinal < 0 || ordinal > MAX_UNICODE) {
         PyErr_SetString(PyExc_ValueError,
-                        "chr() arg not in range(0x110000)");
+                        "chr() arg not in " MAX_UNICODE_RANGE);
         return NULL;
     }
 
@@ -5562,13 +5563,13 @@ PyUnicode_DecodeUTF32Stateful(const char *s,
             endinpos = ((const char *)e) - starts;
         }
         else {
-            if (ch < 0x110000) {
+            if (ch <= MAX_UNICODE) {
                 if (_PyUnicodeWriter_WriteCharInline(&writer, ch) < 0)
                     goto onError;
                 q += 4;
                 continue;
             }
-            errmsg = "code point not in range(0x110000)";
+            errmsg = "code point not in " MAX_UNICODE_RANGE;
             startinpos = ((const char *)q) - starts;
             endinpos = startinpos + 4;
         }
@@ -13677,7 +13678,7 @@ _PyUnicodeWriter_PrepareKindInternal(_PyUnicodeWriter *writer,
     {
     case PyUnicode_1BYTE_KIND: maxchar = 0xff; break;
     case PyUnicode_2BYTE_KIND: maxchar = 0xffff; break;
-    case PyUnicode_4BYTE_KIND: maxchar = 0x10ffff; break;
+    case PyUnicode_4BYTE_KIND: maxchar = MAX_UNICODE; break;
     default:
         Py_UNREACHABLE();
     }
@@ -14496,7 +14497,7 @@ formatchar(PyObject *v)
 
         if (x < 0 || x > MAX_UNICODE) {
             PyErr_SetString(PyExc_OverflowError,
-                            "%c arg not in range(0x110000)");
+                            "%c arg not in " MAX_UNICODE_RANGE);
             return (Py_UCS4) -1;
         }
 


### PR DESCRIPTION
Modify unicodeobject.c and test_unicode.py to use MAX_UNICODE and
sys.maxunicode constants, rather than hardcoded constants.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
