### PR TITLE
bpo-37742: Return the root logger when logging.getLogger('root') is c…

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2024,10 +2024,9 @@ def getLogger(name=None):
 
     If no name is specified, return the root logger.
     """
-    if name:
-        return Logger.manager.getLogger(name)
-    else:
+    if not name or name == root.name:
         return root
+    return Logger.manager.getLogger(name)
 
 def critical(msg, *args, **kwargs):
     """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2024,7 +2024,7 @@ def getLogger(name=None):
 
     If no name is specified, return the root logger.
     """
-    if not name or name == root.name:
+    if not name or isinstance(name, str) and name == root.name:
         return root
     return Logger.manager.getLogger(name)
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4856,6 +4856,7 @@ class LoggerTest(BaseTest):
         self.assertIs(root, logging.root)
         self.assertIs(root, logging.getLogger(None))
         self.assertIs(root, logging.getLogger(''))
+        self.assertIs(root, logging.getLogger('root'))
         self.assertIs(root, logging.getLogger('foo').root)
         self.assertIs(root, logging.getLogger('foo.bar').root)
         self.assertIs(root, logging.getLogger('foo').parent)

--- a/Misc/NEWS.d/next/Library/2019-08-02-14-01-25.bpo-37742.f4Xn9S.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-02-14-01-25.bpo-37742.f4Xn9S.rst
@@ -1,0 +1,5 @@
+The logging.getLogger() API now returns the root logger when passed the name
+'root', whereas previously it returned a non-root logger named 'root'. This
+could affect cases where user code explicitly wants a non-root logger named
+'root', or instantiates a logger using logging.getLogger(__name__) in some
+top-level module called 'root.py'.


### PR DESCRIPTION
…alled.

<!-- issue-number: [bpo-37742](https://bugs.python.org/issue37742) -->
https://bugs.python.org/issue37742
<!-- /issue-number -->
