### PR TITLE
gh-81930: modified is_global to handle multicast addresses

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1044,10 +1044,11 @@ class _BaseNetwork(_IPAddressBase):
 
         Returns:
             A boolean, True if the address is not reserved per
-            iana-ipv4-special-registry or iana-ipv6-special-registry.
+            iana-ipv4-special-registry or iana-ipv6-special-registry
+            and is not a multicast address.
 
         """
-        return not self.is_private
+        return (not self.is_private and not self.is_multicast)
 
     @property
     def is_unspecified(self):
@@ -1282,7 +1283,9 @@ class IPv4Address(_BaseV4, _BaseAddress):
     @property
     @functools.lru_cache()
     def is_global(self):
-        return self not in self._constants._public_network and not self.is_private
+        return (self not in self._constants._public_network and
+                not self.is_private and
+                not self.is_multicast)
 
     @property
     def is_multicast(self):
@@ -1471,7 +1474,8 @@ class IPv4Network(_BaseV4, _BaseNetwork):
         """
         return (not (self.network_address in IPv4Network('100.64.0.0/10') and
                     self.broadcast_address in IPv4Network('100.64.0.0/10')) and
-                not self.is_private)
+                not self.is_private and
+                not self.is_multicast)
 
 
 class _IPv4Constants:
@@ -1905,10 +1909,10 @@ class IPv6Address(_BaseV6, _BaseAddress):
 
         Returns:
             A boolean, true if the address is not reserved per
-            iana-ipv6-special-registry.
+            iana-ipv6-special-registry and is not a multicast address
 
         """
-        return not self.is_private
+        return (not self.is_private and not self.is_multicast)
 
     @property
     def is_unspecified(self):


### PR DESCRIPTION
[bpo-37749](https://bugs.python.org/issue37749): is_global now checks to see if an address or network is a multicast address. Since multicast is not publicly routed, this method now returns false if the provided address is a multicast address. 

Prior to this change is_global returned true for all multicast addresses.

From issue-37749:

When using the ipaddress library, all multicast addresses and networks return True when using the is_global method for their respective classes. I believe there are two possible fixes for this.

1) In practice no multicast addresses are globally routable. If our definition of is_global means the address is globally routable, then I propose adding not is_multicast to each class's is_global logic. 

2) RFC 5771 (IPv4) and RFCs 4291 and 7346 (IPv6) both have guidelines for what MAY be routed on the public internet (as mentioned above multicast is not routed globally in practice). Logic following those guidelines should be added.

IPv4: 224.0.1.0/24, AD-HOC I, II and III addresses 224.0.2.0 - 224.0.255.255, 224.3.0.0 - 224.4.255.255, and 233.252.0.0 - 233.255.255.255

IPv6: Multicast addresses with 0xE in the SCOPE field


<!-- issue-number: [bpo-37749](https://bugs.python.org/issue37749) -->
https://bugs.python.org/issue37749
<!-- /issue-number -->

<!-- gh-issue-number: gh-81930 -->
* Issue: gh-81930
<!-- /gh-issue-number -->
