### PR TITLE
bpo-1047397: prevent repr/getattr exceptions in cgitb

### DIFF
--- a/Lib/cgitb.py
+++ b/Lib/cgitb.py
@@ -95,7 +95,7 @@ class _safe_call:
             return self.failval
 
 def _pydoc_repr(value, sub='html'):
-    return getattr(pydoc, 'html').repr(value)
+    return getattr(pydoc, sub).repr(value)
 
 _safe_getattr = _safe_call(getattr, __GETATTR_FAILED__)
 _safe_html_repr = _safe_call(_pydoc_repr, __HTML_REPR_FAILED__)

--- a/Misc/NEWS.d/next/Library/2019-08-31-20-34-54.bpo-1047397._tntDc.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-31-20-34-54.bpo-1047397._tntDc.rst
@@ -1,0 +1,2 @@
+Prevent getattr/repr exceptions from losing the original exception in cgitb.
+Original patch by R Becker, updated by R James.


### PR DESCRIPTION
Robin Becker's patch, slightly tweaked (for rotting) and tidied.  Basically it wraps calls to getattr and repr while inspecting the code for which the traceback is being generated to prevent them from causing more exceptions.

<!-- issue-number: [bpo-1047397](https://bugs.python.org/issue1047397) -->
https://bugs.python.org/issue1047397
<!-- /issue-number -->
