### PR TITLE
bpo-37449: Move ensurepip off of pkgutil and to importlib.resources

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -1,8 +1,10 @@
 import os
 import os.path
-import pkgutil
 import sys
 import tempfile
+from . import _bundled
+
+from importlib.resources import read_binary
 
 
 __all__ = ["version", "bootstrap"]
@@ -96,9 +98,9 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         additional_paths = []
         for project, version in _PROJECTS:
             wheel_name = "{}-{}-py2.py3-none-any.whl".format(project, version)
-            whl = pkgutil.get_data(
-                "ensurepip",
-                "_bundled/{}".format(wheel_name),
+            whl = read_binary(
+                _bundled,
+                wheel_name,
             )
             with open(os.path.join(tmpdir, wheel_name), "wb") as fp:
                 fp.write(whl)

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -2,8 +2,8 @@ import os
 import os.path
 import sys
 import tempfile
-
 from importlib import resources
+
 from . import _bundled
 
 

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -2,9 +2,10 @@ import os
 import os.path
 import sys
 import tempfile
+
+from importlib import resources
 from . import _bundled
 
-from importlib.resources import read_binary
 
 
 __all__ = ["version", "bootstrap"]
@@ -98,7 +99,7 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         additional_paths = []
         for project, version in _PROJECTS:
             wheel_name = "{}-{}-py2.py3-none-any.whl".format(project, version)
-            whl = read_binary(
+            whl = resources.read_binary(
                 _bundled,
                 wheel_name,
             )

--- a/Misc/NEWS.d/next/Library/2019-08-04-17-22-33.bpo-37449.ycbL2z.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-04-17-22-33.bpo-37449.ycbL2z.rst
@@ -1,0 +1,2 @@
+`ensurepip` now uses `importlib.resources.read_binary()` to read data instead of `pkgutil.get_data()`.
+Patch by Joannah Nanjekye.


### PR DESCRIPTION
Move ensurepip off of pkgutil and to importlib.resources.

<!-- issue-number: [bpo-37449](https://bugs.python.org/issue37449) -->
https://bugs.python.org/issue37449
<!-- /issue-number -->


Automerge-Triggered-By: @ericsnowcurrently