### PR TITLE
bpo-36279: Ensure os.wait3() rusage is initialized

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-04-12-24-18.bpo-36279.8Zy7jZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-04-12-24-18.bpo-36279.8Zy7jZ.rst
@@ -1,0 +1,1 @@
+Fix potential use of uninitialized memory in :func:`os.wait3`.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7464,6 +7464,12 @@ wait_helper(pid_t pid, int status, struct rusage *ru)
     if (pid == -1)
         return posix_error();
 
+    // If wait succeeded but no child was ready to report status, ru will not
+    // have been populated.
+    if (pid == 0) {
+        memset(ru, 0, sizeof(*ru));
+    }
+
     if (struct_rusage == NULL) {
         PyObject *m = PyImport_ImportModuleNoBlock("resource");
         if (m == NULL)


### PR DESCRIPTION
Co-Authored-By: David Wilson <dw@botanicus.net>


<!-- issue-number: [bpo-36279](https://bugs.python.org/issue36279) -->
https://bugs.python.org/issue36279
<!-- /issue-number -->
