### PR TITLE
bpo-28292: Mark calendar.py helper functions as private.

### DIFF
--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -127,18 +127,18 @@ def monthrange(year, month):
     return day1, ndays
 
 
-def monthlen(year, month):
+def _monthlen(year, month):
     return mdays[month] + (month == February and isleap(year))
 
 
-def prevmonth(year, month):
+def _prevmonth(year, month):
     if month == 1:
         return year-1, 12
     else:
         return year, month-1
 
 
-def nextmonth(year, month):
+def _nextmonth(year, month):
     if month == 12:
         return year+1, 1
     else:
@@ -207,13 +207,13 @@ class Calendar(object):
         day1, ndays = monthrange(year, month)
         days_before = (day1 - self.firstweekday) % 7
         days_after = (self.firstweekday - day1 - ndays) % 7
-        y, m = prevmonth(year, month)
-        end = monthlen(y, m) + 1
+        y, m = _prevmonth(year, month)
+        end = _monthlen(y, m) + 1
         for d in range(end-days_before, end):
             yield y, m, d
         for d in range(1, ndays + 1):
             yield year, month, d
-        y, m = nextmonth(year, month)
+        y, m = _nextmonth(year, month)
         for d in range(1, days_after + 1):
             yield y, m, d
 

--- a/Misc/NEWS.d/next/Library/2019-08-04-11-47-58.bpo-28292.vkihH5.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-04-11-47-58.bpo-28292.vkihH5.rst
@@ -1,0 +1,3 @@
+Mark calendar.py helper functions as being private.  The follows PEP 8
+guidance to maintain the style conventions in the module and it addresses a
+known case of user confusion.


### PR DESCRIPTION


<!-- issue-number: [bpo-28292](https://bugs.python.org/issue28292) -->
https://bugs.python.org/issue28292
<!-- /issue-number -->
