### PR TITLE
Update itertools docs

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -913,9 +913,3 @@ which incur interpreter overhead.
            result.append(pool[-1-n])
        return tuple(result)
 
-Note, many of the above recipes can be optimized by replacing global lookups
-with local variables defined as default values.  For example, the
-*dotproduct* recipe can be written as::
-
-   def dotproduct(vec1, vec2, sum=sum, map=map, mul=operator.mul):
-       return sum(map(mul, vec1, vec2))

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -691,6 +691,12 @@ Itertools Recipes
 This section shows recipes for creating an extended toolset using the existing
 itertools as building blocks.
 
+Substantially all of these recipes and many, many others can be installed from
+the `more-itertools project <https://pypi.org/project/more-itertools/>`_ found
+on the Python Package Index::
+
+    pip install more-itertools
+
 The extended tools offer the same high performance as the underlying toolset.
 The superior memory performance is kept by processing elements one at a time
 rather than bringing the whole iterable into memory all at once. Code volume is


### PR DESCRIPTION
* Now that global lookups are faster, the optimization suggestion is less relevant.
* Add link to the *more-itertools* project so that the recipes can be installed directly.