### PR TITLE
bpo-37758: Clean out vestigial script-bits from test_unicodedata.

### DIFF
--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -1,4 +1,4 @@
-""" Test script for the unicodedata module.
+""" Tests for the unicodedata module.
 
     Written by Marc-Andre Lemburg (mal@lemburg.com).
 
@@ -6,16 +6,12 @@
 
 """
 
-import sys
-import unittest
 import hashlib
+import sys
+import unicodedata
+import unittest
 from test.support import script_helper
 
-encoding = 'utf-8'
-errors = 'surrogatepass'
-
-
-### Run tests
 
 class UnicodeMethodsTest(unittest.TestCase):
 
@@ -61,20 +57,12 @@ class UnicodeMethodsTest(unittest.TestCase):
                 (char + 'ABC').title(),
 
                 ]
-            h.update(''.join(data).encode(encoding, errors))
+            h.update(''.join(data).encode('utf-8', 'surrogatepass'))
         result = h.hexdigest()
         self.assertEqual(result, self.expectedchecksum)
 
 class UnicodeDatabaseTest(unittest.TestCase):
-
-    def setUp(self):
-        # In case unicodedata is not available, this will raise an ImportError,
-        # but the other test cases will still be run
-        import unicodedata
-        self.db = unicodedata
-
-    def tearDown(self):
-        del self.db
+    db = unicodedata
 
 class UnicodeFunctionsTest(UnicodeDatabaseTest):
 


### PR DESCRIPTION
This file started life as a script, before conversion to a
`unittest` test file.  Clear out some legacies of that conversion
that are a bit confusing about how it works.

Most notably, it's unlikely there's still a good reason to try
to recover from `unicodedata` failing to import -- as there was
when that logic was first added, when the module was very new.
So take that out entirely.  Keep `self.db` working, though, to
avoid a noisy diff.


<!-- issue-number: [bpo-37758](https://bugs.python.org/issue37758) -->
https://bugs.python.org/issue37758
<!-- /issue-number -->
