### PR TITLE
bpo-37760: Constant-fold some old options in makeunicodedata.

### DIFF
--- a/Tools/unicode/makeunicodedata.py
+++ b/Tools/unicode/makeunicodedata.py
@@ -916,10 +916,7 @@ class UnicodeData:
     #  ISO-comment, uppercase, lowercase, titlecase, ea-width, (16)
     #  derived-props] (17)
 
-    def __init__(self, version,
-                 linebreakprops=False,
-                 expand=1,
-                 cjk_check=True):
+    def __init__(self, version, cjk_check=True):
         self.changed = []
         table = [None] * 0x110000
         with open_data(UNICODE_DATA, version) as file:
@@ -934,26 +931,25 @@ class UnicodeData:
         cjk_ranges_found = []
 
         # expand first-last ranges
-        if expand:
-            field = None
-            for i in range(0, 0x110000):
-                s = table[i]
-                if s:
-                    if s[1][-6:] == "First>":
-                        s[1] = ""
-                        field = s
-                    elif s[1][-5:] == "Last>":
-                        if s[1].startswith("<CJK Ideograph"):
-                            cjk_ranges_found.append((field[0],
-                                                     s[0]))
-                        s[1] = ""
-                        field = None
-                elif field:
-                    f2 = field[:]
-                    f2[0] = "%X" % i
-                    table[i] = f2
-            if cjk_check and cjk_ranges != cjk_ranges_found:
-                raise ValueError("CJK ranges deviate: have %r" % cjk_ranges_found)
+        field = None
+        for i in range(0, 0x110000):
+            s = table[i]
+            if s:
+                if s[1][-6:] == "First>":
+                    s[1] = ""
+                    field = s
+                elif s[1][-5:] == "Last>":
+                    if s[1].startswith("<CJK Ideograph"):
+                        cjk_ranges_found.append((field[0],
+                                                 s[0]))
+                    s[1] = ""
+                    field = None
+            elif field:
+                f2 = field[:]
+                f2[0] = "%X" % i
+                table[i] = f2
+        if cjk_check and cjk_ranges != cjk_ranges_found:
+            raise ValueError("CJK ranges deviate: have %r" % cjk_ranges_found)
 
         # public attributes
         self.filename = UNICODE_DATA % ''


### PR DESCRIPTION
The `expand` option was introduced in 2000 in commit fad27aee1.
It appears to have been always set since it was committed, and
what it does is tell the code to do something essential.  So,
just always do that, and cut the option.

Also cut the `linebreakprops` option, which isn't consulted anymore.


<!-- issue-number: [bpo-37760](https://bugs.python.org/issue37760) -->
https://bugs.python.org/issue37760
<!-- /issue-number -->
