### PR TITLE
[2.7] bpo-37730: Fix usage of NotImplemented instead of NotImplementedError in docs. (GH-15062).

### DIFF
--- a/Doc/library/_winreg.rst
+++ b/Doc/library/_winreg.rst
@@ -427,7 +427,7 @@ This module offers the following functions:
    *key* is an already open key, or one of the predefined
    :ref:`HKEY_* constants <hkey-constants>`.
 
-   Will generally raise :exc:`NotImplemented` if executed on a 32-bit
+   Will generally raise :exc:`NotImplementedError` if executed on a 32-bit
    operating system.
 
    If the key is not on the reflection list, the function succeeds but has no
@@ -442,7 +442,7 @@ This module offers the following functions:
    *key* is an already open key, or one of the predefined
    :ref:`HKEY_* constants <hkey-constants>`.
 
-   Will generally raise :exc:`NotImplemented` if executed on a 32-bit
+   Will generally raise :exc:`NotImplementedError` if executed on a 32-bit
    operating system.
 
    Restoring reflection for a key does not affect reflection of any subkeys.
@@ -457,7 +457,7 @@ This module offers the following functions:
 
    Returns ``True`` if reflection is disabled.
 
-   Will generally raise :exc:`NotImplemented` if executed on a 32-bit
+   Will generally raise :exc:`NotImplementedError` if executed on a 32-bit
    operating system.
 
 

--- a/PC/_winreg.c
+++ b/PC/_winreg.c
@@ -322,19 +322,19 @@ PyDoc_STRVAR(SetValueEx_doc,
 
 PyDoc_STRVAR(DisableReflectionKey_doc,
 "Disables registry reflection for 32-bit processes running on a 64-bit\n"
-"Operating System.  Will generally raise NotImplemented if executed on\n"
+"Operating System.  Will generally raise NotImplementedError if executed on\n"
 "a 32-bit Operating System.\n"
 "If the key is not on the reflection list, the function succeeds but has no effect.\n"
 "Disabling reflection for a key does not affect reflection of any subkeys.");
 
 PyDoc_STRVAR(EnableReflectionKey_doc,
 "Restores registry reflection for the specified disabled key.\n"
-"Will generally raise NotImplemented if executed on a 32-bit Operating System.\n"
+"Will generally raise NotImplementedError if executed on a 32-bit Operating System.\n"
 "Restoring reflection for a key does not affect reflection of any subkeys.");
 
 PyDoc_STRVAR(QueryReflectionKey_doc,
 "bool = QueryReflectionKey(hkey) - Determines the reflection state for the specified key.\n"
-"Will generally raise NotImplemented if executed on a 32-bit Operating System.\n");
+"Will generally raise NotImplementedError if executed on a 32-bit Operating System.\n");
 
 /* PyHKEY docstrings */
 PyDoc_STRVAR(PyHKEY_doc,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
(cherry picked from commit ed5e8e06cbf766e89d6c58a882ee024abb5b2ed7)


<!-- issue-number: [bpo-37730](https://bugs.python.org/issue37730) -->
https://bugs.python.org/issue37730
<!-- /issue-number -->
