### PR TITLE
Correct typos in the codecs module documentation

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -841,8 +841,8 @@ The design is such that one can use the factory functions returned by the
    code calling :meth:`read` and :meth:`write`, while *Reader* and *Writer*
    work on the backend — the data in *stream*.
 
-   You can use these objects to do transparent transcodings from e.g. Latin-1
-   to UTF-8 and back.
+   You can use these objects to do transparent transcodings, e.g., from Latin-1
+	to UTF-8 and back.
 
    The *stream* argument must be a file-like object.
 
@@ -1293,7 +1293,7 @@ encodings.
 | raw_unicode_escape |         | Latin-1 encoding with     |
 |                    |         | ``\uXXXX`` and            |
 |                    |         | ``\UXXXXXXXX`` for other  |
-|                    |         | code points. Existing     |
+|                    |         | code points.  Existing    |
 |                    |         | backslashes are not       |
 |                    |         | escaped in any way.       |
 |                    |         | It is used in the Python  |
@@ -1301,7 +1301,7 @@ encodings.
 +--------------------+---------+---------------------------+
 | undefined          |         | Raises an exception for   |
 |                    |         | all conversions, even     |
-|                    |         | empty strings. The error  |
+|                    |         | empty strings.  The error |
 |                    |         | handler is ignored.       |
 +--------------------+---------+---------------------------+
 | unicode_escape     |         | Encoding suitable as the  |
@@ -1309,8 +1309,8 @@ encodings.
 |                    |         | literal in ASCII-encoded  |
 |                    |         | Python source code,       |
 |                    |         | except that quotes are    |
-|                    |         | not escaped. Decodes from |
-|                    |         | Latin-1 source code.      |
+|                    |         | not escaped.  Decodes     |
+|                    |         | from Latin-1 source code. |
 |                    |         | Beware that Python source |
 |                    |         | code actually uses UTF-8  |
 |                    |         | by default.               |
@@ -1438,7 +1438,7 @@ names (:mod:`http.client` then also transparently sends an IDNA hostname in the
 :mailheader:`Host` field if it sends that field at all).
 
 When receiving host names from the wire (such as in reverse name lookup), no
-automatic conversion to Unicode is performed: Applications wishing to present
+automatic conversion to Unicode is performed: applications wishing to present
 such host names to the user should decode them to Unicode.
 
 The module :mod:`encodings.idna` also implements the nameprep procedure, which
@@ -1489,7 +1489,7 @@ This module implements the ANSI codepage (CP_ACP).
    :synopsis: UTF-8 codec with BOM signature
 .. moduleauthor:: Walter Dörwald
 
-This module implements a variant of the UTF-8 codec: on encoding a UTF-8 encoded
-BOM will be prepended to the UTF-8 encoded bytes. For the stateful encoder this
-is only done once (on the first write to the byte stream).  For decoding an
+This module implements a variant of the UTF-8 codec.  On encoding, a UTF-8 encoded
+BOM will be prepended to the UTF-8 encoded bytes.  For the stateful encoder this
+is only done once (on the first write to the byte stream).  On decoding, an
 optional UTF-8 encoded BOM at the start of the data will be skipped.

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -568,7 +568,7 @@ define in order to be compatible with the Python codec registry.
       implementation should make sure that ``0`` is the most common
       state. (States that are more complicated than integers can be converted
       into an integer by marshaling/pickling the state and encoding the bytes
-      of the resulting string into an integer).
+      of the resulting string into an integer.)
 
 
    .. method:: setstate(state)

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -780,8 +780,8 @@ compatible with the Python codec registry.
       Read all lines available on the input stream and return them as a list of
       lines.
 
-      Line-endings are implemented using the codec's decoder method and are
-      included in the list entries if *keepends* is true.
+      Line-endings are implemented using the codec's :meth:`decode` method and
+      are included in the list entries if *keepends* is true.
 
       *sizehint*, if given, is passed as the *size* argument to the stream's
       :meth:`read` method.

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1470,7 +1470,7 @@ functions can be used directly if desired.
 .. module:: encodings.mbcs
    :synopsis: Windows ANSI codepage
 
-Encode operand according to the ANSI codepage (CP_ACP).
+This module implements the ANSI codepage (CP_ACP).
 
 .. availability:: Windows only.
 
@@ -1489,7 +1489,7 @@ Encode operand according to the ANSI codepage (CP_ACP).
    :synopsis: UTF-8 codec with BOM signature
 .. moduleauthor:: Walter Dörwald
 
-This module implements a variant of the UTF-8 codec: On encoding a UTF-8 encoded
+This module implements a variant of the UTF-8 codec: on encoding a UTF-8 encoded
 BOM will be prepended to the UTF-8 encoded bytes. For the stateful encoder this
 is only done once (on the first write to the byte stream).  For decoding an
 optional UTF-8 encoded BOM at the start of the data will be skipped.

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1274,11 +1274,11 @@ encodings.
 |                    |         | Only ``errors='strict'``  |
 |                    |         | is supported.             |
 +--------------------+---------+---------------------------+
-| mbcs               | ansi,   | Windows only: Encode      |
+| mbcs               | ansi,   | Windows only: Encodes the |
 |                    | dbcs    | operand according to the  |
 |                    |         | ANSI codepage (CP_ACP)    |
 +--------------------+---------+---------------------------+
-| oem                |         | Windows only: Encode      |
+| oem                |         | Windows only: Encodes the |
 |                    |         | operand according to the  |
 |                    |         | OEM codepage (CP_OEMCP)   |
 |                    |         |                           |
@@ -1299,7 +1299,7 @@ encodings.
 |                    |         | It is used in the Python  |
 |                    |         | pickle protocol.          |
 +--------------------+---------+---------------------------+
-| undefined          |         | Raise an exception for    |
+| undefined          |         | Raises an exception for   |
 |                    |         | all conversions, even     |
 |                    |         | empty strings. The error  |
 |                    |         | handler is ignored.       |
@@ -1335,10 +1335,10 @@ to :class:`bytes` mappings.  They are not supported by :meth:`bytes.decode`
 +----------------------+------------------+------------------------------+------------------------------+
 | Codec                | Aliases          | Purpose                      | Encoder / decoder            |
 +======================+==================+==============================+==============================+
-| base64_codec [#b64]_ | base64, base_64  | Convert operand to multiline | :meth:`base64.encodebytes` / |
-|                      |                  | MIME base64 (the result      | :meth:`base64.decodebytes`   |
-|                      |                  | always includes a trailing   |                              |
-|                      |                  | ``'\n'``)                    |                              |
+| base64_codec [#b64]_ | base64, base_64  | Converts the operand to      | :meth:`base64.encodebytes` / |
+|                      |                  | multiline MIME base64 (the   | :meth:`base64.decodebytes`   |
+|                      |                  | result always includes a     |                              |
+|                      |                  | trailing ``'\n'``)           |                              |
 |                      |                  |                              |                              |
 |                      |                  | .. versionchanged:: 3.4      |                              |
 |                      |                  |    accepts any               |                              |
@@ -1346,22 +1346,22 @@ to :class:`bytes` mappings.  They are not supported by :meth:`bytes.decode`
 |                      |                  |    as input for encoding and |                              |
 |                      |                  |    decoding                  |                              |
 +----------------------+------------------+------------------------------+------------------------------+
-| bz2_codec            | bz2              | Compress the operand         | :meth:`bz2.compress` /       |
+| bz2_codec            | bz2              | Compresses the operand       | :meth:`bz2.compress` /       |
 |                      |                  | using bz2                    | :meth:`bz2.decompress`       |
 +----------------------+------------------+------------------------------+------------------------------+
-| hex_codec            | hex              | Convert operand to           | :meth:`binascii.b2a_hex` /   |
+| hex_codec            | hex              | Converts the operand to      | :meth:`binascii.b2a_hex` /   |
 |                      |                  | hexadecimal                  | :meth:`binascii.a2b_hex`     |
 |                      |                  | representation, with two     |                              |
 |                      |                  | digits per byte              |                              |
 +----------------------+------------------+------------------------------+------------------------------+
-| quopri_codec         | quopri,          | Convert operand to MIME      | :meth:`quopri.encode` with   |
+| quopri_codec         | quopri,          | Converts the operand to MIME | :meth:`quopri.encode` with   |
 |                      | quotedprintable, | quoted printable             | ``quotetabs=True`` /         |
 |                      | quoted_printable |                              | :meth:`quopri.decode`        |
 +----------------------+------------------+------------------------------+------------------------------+
-| uu_codec             | uu               | Convert the operand using    | :meth:`uu.encode` /          |
+| uu_codec             | uu               | Converts the operand using   | :meth:`uu.encode` /          |
 |                      |                  | uuencode                     | :meth:`uu.decode`            |
 +----------------------+------------------+------------------------------+------------------------------+
-| zlib_codec           | zip, zlib        | Compress the operand         | :meth:`zlib.compress` /      |
+| zlib_codec           | zip, zlib        | Compresses the operand       | :meth:`zlib.compress` /      |
 |                      |                  | using gzip                   | :meth:`zlib.decompress`      |
 +----------------------+------------------+------------------------------+------------------------------+
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -22,10 +22,10 @@
 
 This module defines base classes for standard Python codecs (encoders and
 decoders) and provides access to the internal Python codec registry, which
-manages the codec and error handling lookup process.  Most standard codecs
+manages the codec and error handling lookup process. Most standard codecs
 are :term:`text encodings <text encoding>`, which encode text to bytes,
 but there are also codecs provided that encode text to text, and bytes to
-bytes.  Custom codecs may encode and decode between arbitrary types, but some
+bytes. Custom codecs may encode and decode between arbitrary types, but some
 module features are restricted to use specifically with
 :term:`text encodings <text encoding>`, or with codecs that encode to
 :class:`bytes`.
@@ -37,20 +37,20 @@ any codec:
 
    Encodes *obj* using the codec registered for *encoding*.
 
-   *Errors* may be given to set the desired error handling scheme.  The
+   *Errors* may be given to set the desired error handling scheme. The
    default error handler is ``'strict'`` meaning that encoding errors raise
    :exc:`ValueError` (or a more codec specific subclass, such as
-   :exc:`UnicodeEncodeError`).  Refer to :ref:`codec-base-classes` for more
+   :exc:`UnicodeEncodeError`). Refer to :ref:`codec-base-classes` for more
    information on codec error handling.
 
 .. function:: decode(obj, encoding='utf-8', errors='strict')
 
    Decodes *obj* using the codec registered for *encoding*.
 
-   *Errors* may be given to set the desired error handling scheme.  The
+   *Errors* may be given to set the desired error handling scheme. The
    default error handler is ``'strict'`` meaning that decoding errors raise
    :exc:`ValueError` (or a more codec specific subclass, such as
-   :exc:`UnicodeDecodeError`).  Refer to :ref:`codec-base-classes` for more
+   :exc:`UnicodeDecodeError`). Refer to :ref:`codec-base-classes` for more
    information on codec error handling.
 
 The full details for each codec can also be looked up directly:
@@ -60,14 +60,14 @@ The full details for each codec can also be looked up directly:
    Looks up the codec info in the Python codec registry and returns a
    :class:`CodecInfo` object as defined below.
 
-   Encodings are first looked up in the registry's cache.  If not found, the list of
-   registered search functions is scanned.  If no :class:`CodecInfo` object is
-   found, a :exc:`LookupError` is raised.  Otherwise, the :class:`CodecInfo` object
+   Encodings are first looked up in the registry's cache. If not found, the list of
+   registered search functions is scanned. If no :class:`CodecInfo` object is
+   found, a :exc:`LookupError` is raised. Otherwise, the :class:`CodecInfo` object
    is stored in the cache and returned to the caller.
 
 .. class:: CodecInfo(encode, decode, streamreader=None, streamwriter=None, incrementalencoder=None, incrementaldecoder=None, name=None)
 
-   Codec details when looking up the codec registry.  The constructor
+   Codec details when looking up the codec registry. The constructor
    arguments are stored in attributes of the same name:
 
 
@@ -79,7 +79,7 @@ The full details for each codec can also be looked up directly:
    .. attribute:: encode
                   decode
 
-      The stateless encoding and decoding functions.  These must be
+      The stateless encoding and decoding functions. These must be
       functions or methods which have the same interface as
       the :meth:`~Codec.encode` and :meth:`~Codec.decode` methods of Codec
       instances (see :ref:`Codec Interface <codec-objects>`).
@@ -92,13 +92,13 @@ The full details for each codec can also be looked up directly:
       Incremental encoder and decoder classes or factory functions.
       These have to provide the interface defined by the base classes
       :class:`IncrementalEncoder` and :class:`IncrementalDecoder`,
-      respectively.  Incremental codecs can maintain state.
+      respectively. Incremental codecs can maintain state.
 
 
    .. attribute:: streamwriter
                   streamreader
 
-      Stream writer and reader classes or factory functions.  These have to
+      Stream writer and reader classes or factory functions. These have to
       provide the interface defined by the base classes
       :class:`StreamWriter` and :class:`StreamReader`, respectively.
       Stream codecs can maintain state.
@@ -158,9 +158,9 @@ function:
 
 .. function:: register(search_function)
 
-   Register a codec search function.  Search functions are expected to take one
+   Register a codec search function. Search functions are expected to take one
    argument, being the encoding name in all lower case letters, and return a
-   :class:`CodecInfo` object.  In case a search function cannot find
+   :class:`CodecInfo` object. In case a search function cannot find
    a given encoding, it should return ``None``.
 
    .. note::
@@ -191,7 +191,7 @@ wider range of codecs when working with binary files:
    Any encoding that encodes to and decodes from bytes is allowed, and
    the data types supported by the file methods depend on the codec used.
 
-   *errors* may be given to define the error handling.  It defaults to ``'strict'``
+   *errors* may be given to define the error handling. It defaults to ``'strict'``
    which causes a :exc:`ValueError` to be raised in case an encoding error occurs.
 
    *buffering* has the same meaning as for the built-in :func:`open` function.
@@ -201,18 +201,18 @@ wider range of codecs when working with binary files:
 .. function:: EncodedFile(file, data_encoding, file_encoding=None, errors='strict')
 
    Return a :class:`StreamRecoder` instance, a wrapped version of *file*
-   which provides transparent transcoding.  The original file is closed
+   which provides transparent transcoding. The original file is closed
    when the wrapped version is closed.
 
    Data written to the wrapped file is decoded according to the given
    *data_encoding* and then written to the original file as bytes using
-   *file_encoding*.  Bytes read from the original file are decoded
+   *file_encoding*. Bytes read from the original file are decoded
    according to *file_encoding*, and the result is encoded
    using *data_encoding*.
 
    If *file_encoding* is not given, it defaults to *data_encoding*.
 
-   *errors* may be given to define the error handling.  It defaults to
+   *errors* may be given to define the error handling. It defaults to
    ``'strict'``, which causes :exc:`ValueError` to be raised in case an encoding
    error occurs.
 
@@ -220,24 +220,24 @@ wider range of codecs when working with binary files:
 .. function:: iterencode(iterator, encoding, errors='strict', **kwargs)
 
    Uses an incremental encoder to iteratively encode the input provided by
-   *iterator*.  This function is a :term:`generator`.
+   *iterator*. This function is a :term:`generator`.
    The *errors* argument (as well as any
    other keyword argument) is passed through to the incremental encoder.
 
    This function requires that the codec accept text :class:`str` objects
-   to encode.  Therefore it does not support bytes-to-bytes encoders such as
+   to encode. Therefore it does not support bytes-to-bytes encoders such as
    ``base64_codec``.
 
 
 .. function:: iterdecode(iterator, encoding, errors='strict', **kwargs)
 
    Uses an incremental decoder to iteratively decode the input provided by
-   *iterator*.  This function is a :term:`generator`.
+   *iterator*. This function is a :term:`generator`.
    The *errors* argument (as well as any
    other keyword argument) is passed through to the incremental decoder.
 
    This function requires that the codec accept :class:`bytes` objects
-   to decode.  Therefore it does not support text-to-text encoders such as
+   to decode. Therefore it does not support text-to-text encoders such as
    ``rot_13``, although ``rot_13`` may be used equivalently with
    :func:`iterencode`.
 
@@ -258,13 +258,13 @@ and writing to platform dependent files:
           BOM_UTF32_LE
 
    These constants define various byte sequences,
-   being Unicode byte order marks (BOMs) for several encodings.  They are
+   being Unicode byte order marks (BOMs) for several encodings. They are
    used in UTF-16 and UTF-32 data streams to indicate the byte order used,
    and in UTF-8 as a Unicode signature. :const:`BOM_UTF16` is either
    :const:`BOM_UTF16_BE` or :const:`BOM_UTF16_LE` depending on the platform's
    native byte order, :const:`BOM` is an alias for :const:`BOM_UTF16`,
    :const:`BOM_LE` for :const:`BOM_UTF16_LE` and :const:`BOM_BE` for
-   :const:`BOM_UTF16_BE`.  The others represent the BOM in UTF-8 and UTF-32
+   :const:`BOM_UTF16_BE`. The others represent the BOM in UTF-8 and UTF-32
    encodings.
 
 
@@ -278,9 +278,9 @@ interfaces for working with codec objects, and can also be used as the basis
 for custom codec implementations.
 
 Each codec has to define four interfaces to make it usable as codec in Python:
-stateless encoder, stateless decoder, stream reader and stream writer.  The
+stateless encoder, stateless decoder, stream reader and stream writer. The
 stream reader and writers typically reuse the stateless encoder/decoder to
-implement the file protocols.  Codec authors also need to define how the
+implement the file protocols. Codec authors also need to define how the
 codec will handle encoding and decoding errors.
 
 
@@ -384,15 +384,15 @@ handler:
    in case of an error, when *name* is specified as the errors parameter.
 
    For encoding, *error_handler* will be called with a :exc:`UnicodeEncodeError`
-   instance, which contains information about the location of the error.  The
+   instance, which contains information about the location of the error. The
    error handler must either raise this or a different exception, or return a
    tuple with a replacement for the unencodable part of the input and a position
-   where encoding should continue.  The replacement may be either :class:`str` or
+   where encoding should continue. The replacement may be either :class:`str` or
    :class:`bytes`.  If the replacement is bytes, the encoder will simply copy
-   them into the output buffer.  If the replacement is a string, the encoder will
+   them into the output buffer. If the replacement is a string, the encoder will
    encode the replacement.  Encoding continues on original input at the
-   specified position.  Negative position values will be treated as being
-   relative to the end of the input string.  If the resulting position is out of
+   specified position. Negative position values will be treated as being
+   relative to the end of the input string. If the resulting position is out of
    bound an :exc:`IndexError` will be raised.
 
    Decoding and translating works similarly, except :exc:`UnicodeDecodeError` or
@@ -473,7 +473,7 @@ function interfaces of the stateless encoder and decoder:
    The *errors* argument defines the error handling to apply.
    It defaults to ``'strict'`` handling.
 
-   The method may not store state in the :class:`Codec` instance.  Use
+   The method may not store state in the :class:`Codec` instance. Use
    :class:`StreamWriter` for codecs which have to keep state in order to make
    encoding efficient.
 
@@ -495,7 +495,7 @@ function interfaces of the stateless encoder and decoder:
    The *errors* argument defines the error handling to apply.
    It defaults to ``'strict'`` handling.
 
-   The method may not store state in the :class:`Codec` instance.  Use
+   The method may not store state in the :class:`Codec` instance. Use
    :class:`StreamReader` for codecs which have to keep state in order to make
    decoding efficient.
 
@@ -507,11 +507,11 @@ Incremental Encoding and Decoding
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :class:`IncrementalEncoder` and :class:`IncrementalDecoder` classes provide
-the basic interface for incremental encoding and decoding.  Encoding/decoding the
+the basic interface for incremental encoding and decoding. Encoding/decoding the
 input isn't done with one call to the stateless encoder/decoder function, but
 with multiple calls to the
 :meth:`~IncrementalEncoder.encode`/:meth:`~IncrementalDecoder.decode` method of
-the incremental encoder/decoder.  The incremental encoder/decoder keeps track of
+the incremental encoder/decoder. The incremental encoder/decoder keeps track of
 the encoding/decoding process during method calls.
 
 The joined output of calls to the
@@ -526,7 +526,7 @@ IncrementalEncoder Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :class:`IncrementalEncoder` class is used for encoding an input in multiple
-steps.  It defines the following methods which every incremental encoder must
+steps. It defines the following methods which every incremental encoder must
 define in order to be compatible with the Python codec registry.
 
 
@@ -534,12 +534,12 @@ define in order to be compatible with the Python codec registry.
 
    Constructor for an :class:`IncrementalEncoder` instance.
 
-   All incremental encoders must provide this constructor interface.  They are free
+   All incremental encoders must provide this constructor interface. They are free
    to add additional keyword arguments, but only the ones defined here are used by
    the Python codec registry.
 
    The :class:`IncrementalEncoder` may implement different error handling schemes
-   by providing the *errors* keyword argument.  See :ref:`error-handlers` for
+   by providing the *errors* keyword argument. See :ref:`error-handlers` for
    possible values.
 
    The *errors* argument will be assigned to an attribute of the same name.
@@ -551,20 +551,20 @@ define in order to be compatible with the Python codec registry.
    .. method:: encode(object[, final])
 
       Encodes *object* (taking the current state of the encoder into account)
-      and returns the resulting encoded object.  If this is the last call to
+      and returns the resulting encoded object. If this is the last call to
       :meth:`encode` *final* must be true (the default is false).
 
 
    .. method:: reset()
 
-      Reset the encoder to the initial state.  The output is discarded: call
+      Reset the encoder to the initial state. The output is discarded: call
       ``.encode(object, final=True)``, passing an empty byte or text string
       if necessary, to reset the encoder and to get the output.
 
 
    .. method:: getstate()
 
-      Return the current state of the encoder which must be an integer.  The
+      Return the current state of the encoder which must be an integer. The
       implementation should make sure that ``0`` is the most common
       state. (States that are more complicated than integers can be converted
       into an integer by marshaling/pickling the state and encoding the bytes
@@ -583,7 +583,7 @@ IncrementalDecoder Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :class:`IncrementalDecoder` class is used for decoding an input in multiple
-steps.  It defines the following methods which every incremental decoder must
+steps. It defines the following methods which every incremental decoder must
 define in order to be compatible with the Python codec registry.
 
 
@@ -591,12 +591,12 @@ define in order to be compatible with the Python codec registry.
 
    Constructor for an :class:`IncrementalDecoder` instance.
 
-   All incremental decoders must provide this constructor interface.  They are free
+   All incremental decoders must provide this constructor interface. They are free
    to add additional keyword arguments, but only the ones defined here are used by
    the Python codec registry.
 
    The :class:`IncrementalDecoder` may implement different error handling schemes
-   by providing the *errors* keyword argument.  See :ref:`error-handlers` for
+   by providing the *errors* keyword argument. See :ref:`error-handlers` for
    possible values.
 
    The *errors* argument will be assigned to an attribute of the same name.
@@ -608,10 +608,10 @@ define in order to be compatible with the Python codec registry.
    .. method:: decode(object[, final])
 
       Decodes *object* (taking the current state of the decoder into account)
-      and returns the resulting decoded object.  If this is the last call to
-      :meth:`decode` *final* must be true (the default is false).  If *final* is
+      and returns the resulting decoded object. If this is the last call to
+      :meth:`decode` *final* must be true (the default is false). If *final* is
       true the decoder must decode the input completely and must flush all
-      buffers.  If this isn't possible (e.g. because of incomplete byte sequences
+      buffers. If this isn't possible (e.g. because of incomplete byte sequences
       at the end of the input) it must initiate error handling just like in the
       stateless case (which might raise an exception).
 
@@ -623,9 +623,9 @@ define in order to be compatible with the Python codec registry.
 
    .. method:: getstate()
 
-      Return the current state of the decoder.  This must be a tuple with two
+      Return the current state of the decoder. This must be a tuple with two
       items, the first must be the buffer containing the still undecoded
-      input.  The second must be an integer and can be additional state
+      input. The second must be an integer and can be additional state
       info. (The implementation should make sure that ``0`` is the most common
       additional state info.) If this additional state info is ``0`` it must be
       possible to set the decoder to the state which has no input buffered and
@@ -648,7 +648,7 @@ Stream Encoding and Decoding
 
 The :class:`StreamWriter` and :class:`StreamReader` classes provide generic
 working interfaces which can be used to implement new encoding submodules very
-easily.  See :mod:`encodings.utf_8` for an example of how this is done.
+easily. See :mod:`encodings.utf_8` for an example of how this is done.
 
 
 .. _stream-writer-objects:
@@ -665,7 +665,7 @@ compatible with the Python codec registry.
 
    Constructor for a :class:`StreamWriter` instance.
 
-   All stream writers must provide this constructor interface.  They are free to add
+   All stream writers must provide this constructor interface. They are free to add
    additional keyword arguments, but only the ones defined here are used by the
    Python codec registry.
 
@@ -673,7 +673,7 @@ compatible with the Python codec registry.
    text or binary data, as appropriate for the specific codec.
 
    The :class:`StreamWriter` may implement different error handling schemes by
-   providing the *errors* keyword argument.  See :ref:`error-handlers` for
+   providing the *errors* keyword argument. See :ref:`error-handlers` for
    the standard error handlers the underlying stream codec may support.
 
    The *errors* argument will be assigned to an attribute of the same name.
@@ -688,7 +688,7 @@ compatible with the Python codec registry.
    .. method:: writelines(list)
 
       Writes the concatenated list of strings to the stream (possibly by reusing
-      the :meth:`write` method).  The standard bytes-to-bytes codecs
+      the :meth:`write` method). The standard bytes-to-bytes codecs
       do not support this method.
 
 
@@ -719,7 +719,7 @@ compatible with the Python codec registry.
 
    Constructor for a :class:`StreamReader` instance.
 
-   All stream readers must provide this constructor interface.  They are free to add
+   All stream readers must provide this constructor interface. They are free to add
    additional keyword arguments, but only the ones defined here are used by the
    Python codec registry.
 
@@ -727,7 +727,7 @@ compatible with the Python codec registry.
    text or binary data, as appropriate for the specific codec.
 
    The :class:`StreamReader` may implement different error handling schemes by
-   providing the *errors* keyword argument.  See :ref:`error-handlers` for
+   providing the *errors* keyword argument. See :ref:`error-handlers` for
    the standard error handlers the underlying stream codec may support.
 
    The *errors* argument will be assigned to an attribute of the same name.
@@ -743,14 +743,14 @@ compatible with the Python codec registry.
       Decodes data from the stream and returns the resulting object.
 
       The *chars* argument indicates the number of decoded
-      code points or bytes to return.  The :func:`read` method will
+      code points or bytes to return. The :func:`read` method will
       never return more data than requested, but it might return less,
       if there is not enough available.
 
       The *size* argument indicates the approximate maximum
       number of encoded bytes or code points to read
-      for decoding.  The decoder can modify this setting as
-      appropriate.  The default value -1 indicates to read and decode as much as
+      for decoding. The decoder can modify this setting as
+      appropriate. The default value -1 indicates to read and decode as much as
       possible.  This parameter is intended to
       prevent having to decode huge files in one step.
 
@@ -814,11 +814,11 @@ The design is such that one can use the factory functions returned by the
 
    Creates a :class:`StreamReaderWriter` instance. *stream* must be a file-like
    object. *Reader* and *Writer* must be factory functions or classes providing the
-   :class:`StreamReader` and :class:`StreamWriter` interface resp.  Error handling
+   :class:`StreamReader` and :class:`StreamWriter` interface resp. Error handling
    is done in the same way as defined for the stream readers and writers.
 
 :class:`StreamReaderWriter` instances define the combined interfaces of
-:class:`StreamReader` and :class:`StreamWriter` classes.  They inherit all other
+:class:`StreamReader` and :class:`StreamWriter` classes. They inherit all other
 methods and attributes from the underlying stream.
 
 
@@ -841,7 +841,7 @@ The design is such that one can use the factory functions returned by the
    code calling :meth:`read` and :meth:`write`, while *Reader* and *Writer*
    work on the backend — the data in *stream*.
 
-   You can use these objects to do transparent transcodings, e.g., from Latin-1
+   You can use these objects to do transparent transcodings from e.g. Latin-1
    to UTF-8 and back.
 
    The *stream* argument must be a file-like object.
@@ -856,7 +856,7 @@ The design is such that one can use the factory functions returned by the
 
 
 :class:`StreamRecoder` instances define the combined interfaces of
-:class:`StreamReader` and :class:`StreamWriter` classes.  They inherit all other
+:class:`StreamReader` and :class:`StreamWriter` classes. They inherit all other
 methods and attributes from the underlying stream.
 
 
@@ -878,49 +878,49 @@ collectivity referred to as :term:`text encodings <text encoding>`.
 The simplest text encoding (called ``'latin-1'`` or ``'iso-8859-1'``) maps
 the code points 0--255 to the bytes ``0x0``--``0xff``, which means that a string
 object that contains code points above ``U+00FF`` can't be encoded with this
-codec.  Doing so will raise a :exc:`UnicodeEncodeError` that looks
+codec. Doing so will raise a :exc:`UnicodeEncodeError` that looks
 like the following (although the details of the error message may differ):
 ``UnicodeEncodeError: 'latin-1' codec can't encode character '\u1234' in
 position 3: ordinal not in range(256)``.
 
 There's another group of encodings (the so called charmap encodings) that choose
 a different subset of all Unicode code points and how these code points are
-mapped to the bytes ``0x0``--``0xff``.  To see how this is done simply open
+mapped to the bytes ``0x0``--``0xff``. To see how this is done simply open
 e.g. :file:`encodings/cp1252.py` (which is an encoding that is used primarily on
-Windows).  There's a string constant with 256 characters that shows you which
+Windows). There's a string constant with 256 characters that shows you which
 character is mapped to which byte value.
 
 All of these encodings can only encode 256 of the 1114112 code points
-defined in Unicode.  A simple and straightforward way that can store each Unicode
-code point, is to store each code point as four consecutive bytes.  There are two
-possibilities: store the bytes in big endian or in little endian order.  These
-two encodings are called ``UTF-32-BE`` and ``UTF-32-LE`` respectively.  Their
+defined in Unicode. A simple and straightforward way that can store each Unicode
+code point, is to store each code point as four consecutive bytes. There are two
+possibilities: store the bytes in big endian or in little endian order. These
+two encodings are called ``UTF-32-BE`` and ``UTF-32-LE`` respectively. Their
 disadvantage is that if e.g. you use ``UTF-32-BE`` on a little endian machine you
 will always have to swap bytes on encoding and decoding. ``UTF-32`` avoids this
-problem: bytes will always be in natural endianness.  When these bytes are read
-by a CPU with a different endianness, then bytes have to be swapped though.  To
+problem: bytes will always be in natural endianness. When these bytes are read
+by a CPU with a different endianness, then bytes have to be swapped though. To
 be able to detect the endianness of a ``UTF-16`` or ``UTF-32`` byte sequence,
-there's the so called BOM ("Byte Order Mark").  This is the Unicode character
-``U+FEFF``.  This character can be prepended to every ``UTF-16`` or ``UTF-32``
-byte sequence.  The byte swapped version of this character (``0xFFFE``) is an
-illegal character that may not appear in a Unicode text.  So when the
+there's the so called BOM ("Byte Order Mark"). This is the Unicode character
+``U+FEFF``. This character can be prepended to every ``UTF-16`` or ``UTF-32``
+byte sequence. The byte swapped version of this character (``0xFFFE``) is an
+illegal character that may not appear in a Unicode text. So when the
 first character in an ``UTF-16`` or ``UTF-32`` byte sequence
 appears to be a ``U+FFFE`` the bytes have to be swapped on decoding.
 Unfortunately the character ``U+FEFF`` had a second purpose as
 a ``ZERO WIDTH NO-BREAK SPACE``: a character that has no width and doesn't allow
-a word to be split.  It can e.g. be used to give hints to a ligature algorithm.
+a word to be split. It can e.g. be used to give hints to a ligature algorithm.
 With Unicode 4.0 using ``U+FEFF`` as a ``ZERO WIDTH NO-BREAK SPACE`` has been
-deprecated (with ``U+2060`` (``WORD JOINER``) assuming this role).  Nevertheless
+deprecated (with ``U+2060`` (``WORD JOINER``) assuming this role). Nevertheless
 Unicode software still must be able to handle ``U+FEFF`` in both roles: as a BOM
 it's a device to determine the storage layout of the encoded bytes, and vanishes
 once the byte sequence has been decoded into a string; as a ``ZERO WIDTH
 NO-BREAK SPACE`` it's a normal character that will be decoded like any other.
 
 There's another encoding that is able to encoding the full range of Unicode
-characters: UTF-8.  UTF-8 is an 8-bit encoding, which means there are no issues
-with byte order in UTF-8.  Each byte in a UTF-8 byte sequence consists of two
-parts: marker bits (the most significant bits) and payload bits.  The marker bits
-are a sequence of zero to four ``1`` bits followed by a ``0`` bit.  Unicode characters are
+characters: UTF-8. UTF-8 is an 8-bit encoding, which means there are no issues
+with byte order in UTF-8. Each byte in a UTF-8 byte sequence consists of two
+parts: marker bits (the most significant bits) and payload bits. The marker bits
+are a sequence of zero to four ``1`` bits followed by a ``0`` bit. Unicode characters are
 encoded like this (with x being payload bits, which when concatenated give the
 Unicode character):
 
@@ -943,14 +943,14 @@ the decoded string (even if it's the first character) is treated as a ``ZERO
 WIDTH NO-BREAK SPACE``.
 
 Without external information it's impossible to reliably determine which
-encoding was used for encoding a string.  Each charmap encoding can
-decode any random byte sequence.  However that's not possible with UTF-8, as
+encoding was used for encoding a string. Each charmap encoding can
+decode any random byte sequence. However that's not possible with UTF-8, as
 UTF-8 byte sequences have a structure that doesn't allow arbitrary byte
-sequences.  To increase the reliability with which a UTF-8 encoding can be
+sequences. To increase the reliability with which a UTF-8 encoding can be
 detected, Microsoft invented a variant of UTF-8 (that Python 2.5 calls
 ``"utf-8-sig"``) for its Notepad program: Before any of the Unicode characters
 is written to the file, a UTF-8 encoded BOM (which looks like this as a byte
-sequence: ``0xef``, ``0xbb``, ``0xbf``) is written.  As it's rather improbable
+sequence: ``0xef``, ``0xbb``, ``0xbf``) is written. As it's rather improbable
 that any charmap encoded file starts with these byte values (which would e.g.
 map to
 
@@ -959,10 +959,10 @@ map to
    | INVERTED QUESTION MARK
 
 in iso-8859-1), this increases the probability that a ``utf-8-sig`` encoding can be
-correctly guessed from the byte sequence.  So here the BOM is not used to be able
+correctly guessed from the byte sequence. So here the BOM is not used to be able
 to determine the byte order used for generating the byte sequence, but as a
-signature that helps in guessing the encoding.  On encoding the utf-8-sig codec
-will write ``0xef``, ``0xbb``, ``0xbf`` as the first three bytes to the file.  On
+signature that helps in guessing the encoding. On encoding the utf-8-sig codec
+will write ``0xef``, ``0xbb``, ``0xbf`` as the first three bytes to the file. On
 decoding ``utf-8-sig`` will skip those three bytes if they appear as the first
 three bytes in the file.  In UTF-8, the use of the BOM is discouraged and
 should generally be avoided.
@@ -974,10 +974,10 @@ Standard Encodings
 ------------------
 
 Python comes with a number of codecs built-in, either implemented as C functions
-or with dictionaries as mapping tables.  The following table lists the codecs by
+or with dictionaries as mapping tables. The following table lists the codecs by
 name, together with a few common aliases, and the languages for which the
-encoding is likely used.  Neither the list of aliases nor the list of languages
-is meant to be exhaustive.  Notice that spelling alternatives that only differ in
+encoding is likely used. Neither the list of aliases nor the list of languages
+is meant to be exhaustive. Notice that spelling alternatives that only differ in
 case or use a hyphen instead of an underscore are also valid aliases; therefore,
 e.g. ``'utf-8'`` is a valid alias for the ``'utf_8'`` codec.
 
@@ -988,15 +988,15 @@ e.g. ``'utf-8'`` is a valid alias for the ``'utf_8'`` codec.
    recognized by CPython for a limited set of (case insensitive)
    aliases: utf-8, utf8, latin-1, latin1, iso-8859-1, iso8859-1, mbcs
    (Windows only), ascii, us-ascii, utf-16, utf16, utf-32, utf32, and
-   the same using underscores instead of dashes.  Using alternative
+   the same using underscores instead of dashes. Using alternative
    aliases for these encodings may result in slower execution.
 
    .. versionchanged:: 3.6
       Optimization opportunity recognized for us-ascii.
 
-Many of the character sets support the same languages.  They vary in individual
+Many of the character sets support the same languages. They vary in individual
 characters (e.g. whether the EURO SIGN is supported or not), and in the
-assignment of characters to code positions.  For the European languages in
+assignment of characters to code positions. For the European languages in
 particular, the following variants typically exist:
 
 * an ISO 8859 codeset
@@ -1293,7 +1293,7 @@ encodings.
 | raw_unicode_escape |         | Latin-1 encoding with     |
 |                    |         | ``\uXXXX`` and            |
 |                    |         | ``\UXXXXXXXX`` for other  |
-|                    |         | code points.  Existing    |
+|                    |         | code points. Existing     |
 |                    |         | backslashes are not       |
 |                    |         | escaped in any way.       |
 |                    |         | It is used in the Python  |
@@ -1301,7 +1301,7 @@ encodings.
 +--------------------+---------+---------------------------+
 | undefined          |         | Raises an exception for   |
 |                    |         | all conversions, even     |
-|                    |         | empty strings.  The error |
+|                    |         | empty strings. The error  |
 |                    |         | handler is ignored.       |
 +--------------------+---------+---------------------------+
 | unicode_escape     |         | Encoding suitable as the  |
@@ -1309,8 +1309,8 @@ encodings.
 |                    |         | literal in ASCII-encoded  |
 |                    |         | Python source code,       |
 |                    |         | except that quotes are    |
-|                    |         | not escaped.  Decodes     |
-|                    |         | from Latin-1 source code. |
+|                    |         | not escaped. Decodes from |
+|                    |         | Latin-1 source code.      |
 |                    |         | Beware that Python source |
 |                    |         | code actually uses UTF-8  |
 |                    |         | by default.               |
@@ -1410,21 +1410,21 @@ mapping.  It is not supported by :meth:`str.encode` (which only produces
 
 This module implements :rfc:`3490` (Internationalized Domain Names in
 Applications) and :rfc:`3492` (Nameprep: A Stringprep Profile for
-Internationalized Domain Names (IDN)).  It builds upon the ``punycode`` encoding
+Internationalized Domain Names (IDN)). It builds upon the ``punycode`` encoding
 and :mod:`stringprep`.
 
 These RFCs together define a protocol to support non-ASCII characters in domain
-names.  A domain name containing non-ASCII characters (such as
+names. A domain name containing non-ASCII characters (such as
 ``www.Alliancefrançaise.nu``) is converted into an ASCII-compatible encoding
-(ACE, such as ``www.xn--alliancefranaise-npb.nu``).  The ACE form of the domain
+(ACE, such as ``www.xn--alliancefranaise-npb.nu``). The ACE form of the domain
 name is then used in all places where arbitrary characters are not allowed by
 the protocol, such as DNS queries, HTTP :mailheader:`Host` fields, and so
-on.  This conversion is carried out in the application; if possible invisible to
+on. This conversion is carried out in the application; if possible invisible to
 the user: The application should transparently convert Unicode domain labels to
 IDNA on the wire, and convert back ACE labels to Unicode before presenting them
 to the user.
 
-Python supports this conversion in several ways: the ``idna`` codec performs
+Python supports this conversion in several ways:  the ``idna`` codec performs
 conversion between Unicode and ACE, separating an input string into labels
 based on the separator characters defined in :rfc:`section 3.1 of RFC 3490 <3490#section-3.1>`
 and converting each label to ACE as required, and conversely separating an input
@@ -1432,24 +1432,24 @@ byte string into labels based on the ``.`` separator and converting any ACE
 labels found into unicode.  Furthermore, the :mod:`socket` module
 transparently converts Unicode host names to ACE, so that applications need not
 be concerned about converting host names themselves when they pass them to the
-socket module.  On top of that, modules that have host names as function
+socket module. On top of that, modules that have host names as function
 parameters, such as :mod:`http.client` and :mod:`ftplib`, accept Unicode host
 names (:mod:`http.client` then also transparently sends an IDNA hostname in the
 :mailheader:`Host` field if it sends that field at all).
 
 When receiving host names from the wire (such as in reverse name lookup), no
-automatic conversion to Unicode is performed: applications wishing to present
+automatic conversion to Unicode is performed: Applications wishing to present
 such host names to the user should decode them to Unicode.
 
 The module :mod:`encodings.idna` also implements the nameprep procedure, which
 performs certain normalizations on host names, to achieve case-insensitivity of
-international domain names, and to unify similar characters.  The nameprep
+international domain names, and to unify similar characters. The nameprep
 functions can be used directly if desired.
 
 
 .. function:: nameprep(label)
 
-   Return the nameprepped version of *label*.  The implementation currently assumes
+   Return the nameprepped version of *label*. The implementation currently assumes
    query strings, so ``AllowUnassigned`` is true.
 
 
@@ -1489,7 +1489,7 @@ This module implements the ANSI codepage (CP_ACP).
    :synopsis: UTF-8 codec with BOM signature
 .. moduleauthor:: Walter Dörwald
 
-This module implements a variant of the UTF-8 codec.  On encoding, a UTF-8 encoded
-BOM will be prepended to the UTF-8 encoded bytes.  For the stateful encoder this
-is only done once (on the first write to the byte stream).  On decoding, an
+This module implements a variant of the UTF-8 codec: on encoding a UTF-8 encoded
+BOM will be prepended to the UTF-8 encoded bytes. For the stateful encoder this
+is only done once (on the first write to the byte stream).  For decoding an
 optional UTF-8 encoded BOM at the start of the data will be skipped.

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1145,7 +1145,7 @@ particular, the following variants typically exist:
 | iso2022_kr      | csiso2022kr, iso2022kr,        | Korean                         |
 |                 | iso-2022-kr                    |                                |
 +-----------------+--------------------------------+--------------------------------+
-| latin_1         | iso-8859-1, iso8859-1, 8859,   | West Europe                    |
+| latin_1         | iso-8859-1, iso8859-1, 8859,   | Western Europe                 |
 |                 | cp819, latin, latin1, L1       |                                |
 +-----------------+--------------------------------+--------------------------------+
 | iso8859_2       | iso-8859-2, latin2, L2         | Central and Eastern Europe     |

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -22,10 +22,10 @@
 
 This module defines base classes for standard Python codecs (encoders and
 decoders) and provides access to the internal Python codec registry, which
-manages the codec and error handling lookup process. Most standard codecs
+manages the codec and error handling lookup process.  Most standard codecs
 are :term:`text encodings <text encoding>`, which encode text to bytes,
 but there are also codecs provided that encode text to text, and bytes to
-bytes. Custom codecs may encode and decode between arbitrary types, but some
+bytes.  Custom codecs may encode and decode between arbitrary types, but some
 module features are restricted to use specifically with
 :term:`text encodings <text encoding>`, or with codecs that encode to
 :class:`bytes`.
@@ -37,20 +37,20 @@ any codec:
 
    Encodes *obj* using the codec registered for *encoding*.
 
-   *Errors* may be given to set the desired error handling scheme. The
+   *Errors* may be given to set the desired error handling scheme.  The
    default error handler is ``'strict'`` meaning that encoding errors raise
    :exc:`ValueError` (or a more codec specific subclass, such as
-   :exc:`UnicodeEncodeError`). Refer to :ref:`codec-base-classes` for more
+   :exc:`UnicodeEncodeError`).  Refer to :ref:`codec-base-classes` for more
    information on codec error handling.
 
 .. function:: decode(obj, encoding='utf-8', errors='strict')
 
    Decodes *obj* using the codec registered for *encoding*.
 
-   *Errors* may be given to set the desired error handling scheme. The
+   *Errors* may be given to set the desired error handling scheme.  The
    default error handler is ``'strict'`` meaning that decoding errors raise
    :exc:`ValueError` (or a more codec specific subclass, such as
-   :exc:`UnicodeDecodeError`). Refer to :ref:`codec-base-classes` for more
+   :exc:`UnicodeDecodeError`).  Refer to :ref:`codec-base-classes` for more
    information on codec error handling.
 
 The full details for each codec can also be looked up directly:
@@ -60,14 +60,14 @@ The full details for each codec can also be looked up directly:
    Looks up the codec info in the Python codec registry and returns a
    :class:`CodecInfo` object as defined below.
 
-   Encodings are first looked up in the registry's cache. If not found, the list of
-   registered search functions is scanned. If no :class:`CodecInfo` object is
-   found, a :exc:`LookupError` is raised. Otherwise, the :class:`CodecInfo` object
+   Encodings are first looked up in the registry's cache.  If not found, the list of
+   registered search functions is scanned.  If no :class:`CodecInfo` object is
+   found, a :exc:`LookupError` is raised.  Otherwise, the :class:`CodecInfo` object
    is stored in the cache and returned to the caller.
 
 .. class:: CodecInfo(encode, decode, streamreader=None, streamwriter=None, incrementalencoder=None, incrementaldecoder=None, name=None)
 
-   Codec details when looking up the codec registry. The constructor
+   Codec details when looking up the codec registry.  The constructor
    arguments are stored in attributes of the same name:
 
 
@@ -79,7 +79,7 @@ The full details for each codec can also be looked up directly:
    .. attribute:: encode
                   decode
 
-      The stateless encoding and decoding functions. These must be
+      The stateless encoding and decoding functions.  These must be
       functions or methods which have the same interface as
       the :meth:`~Codec.encode` and :meth:`~Codec.decode` methods of Codec
       instances (see :ref:`Codec Interface <codec-objects>`).
@@ -92,13 +92,13 @@ The full details for each codec can also be looked up directly:
       Incremental encoder and decoder classes or factory functions.
       These have to provide the interface defined by the base classes
       :class:`IncrementalEncoder` and :class:`IncrementalDecoder`,
-      respectively. Incremental codecs can maintain state.
+      respectively.  Incremental codecs can maintain state.
 
 
    .. attribute:: streamwriter
                   streamreader
 
-      Stream writer and reader classes or factory functions. These have to
+      Stream writer and reader classes or factory functions.  These have to
       provide the interface defined by the base classes
       :class:`StreamWriter` and :class:`StreamReader`, respectively.
       Stream codecs can maintain state.
@@ -158,9 +158,9 @@ function:
 
 .. function:: register(search_function)
 
-   Register a codec search function. Search functions are expected to take one
+   Register a codec search function.  Search functions are expected to take one
    argument, being the encoding name in all lower case letters, and return a
-   :class:`CodecInfo` object. In case a search function cannot find
+   :class:`CodecInfo` object.  In case a search function cannot find
    a given encoding, it should return ``None``.
 
    .. note::
@@ -191,7 +191,7 @@ wider range of codecs when working with binary files:
    Any encoding that encodes to and decodes from bytes is allowed, and
    the data types supported by the file methods depend on the codec used.
 
-   *errors* may be given to define the error handling. It defaults to ``'strict'``
+   *errors* may be given to define the error handling.  It defaults to ``'strict'``
    which causes a :exc:`ValueError` to be raised in case an encoding error occurs.
 
    *buffering* has the same meaning as for the built-in :func:`open` function.
@@ -201,18 +201,18 @@ wider range of codecs when working with binary files:
 .. function:: EncodedFile(file, data_encoding, file_encoding=None, errors='strict')
 
    Return a :class:`StreamRecoder` instance, a wrapped version of *file*
-   which provides transparent transcoding. The original file is closed
+   which provides transparent transcoding.  The original file is closed
    when the wrapped version is closed.
 
    Data written to the wrapped file is decoded according to the given
    *data_encoding* and then written to the original file as bytes using
-   *file_encoding*. Bytes read from the original file are decoded
+   *file_encoding*.  Bytes read from the original file are decoded
    according to *file_encoding*, and the result is encoded
    using *data_encoding*.
 
    If *file_encoding* is not given, it defaults to *data_encoding*.
 
-   *errors* may be given to define the error handling. It defaults to
+   *errors* may be given to define the error handling.  It defaults to
    ``'strict'``, which causes :exc:`ValueError` to be raised in case an encoding
    error occurs.
 
@@ -220,24 +220,24 @@ wider range of codecs when working with binary files:
 .. function:: iterencode(iterator, encoding, errors='strict', **kwargs)
 
    Uses an incremental encoder to iteratively encode the input provided by
-   *iterator*. This function is a :term:`generator`.
+   *iterator*.  This function is a :term:`generator`.
    The *errors* argument (as well as any
    other keyword argument) is passed through to the incremental encoder.
 
    This function requires that the codec accept text :class:`str` objects
-   to encode. Therefore it does not support bytes-to-bytes encoders such as
+   to encode.  Therefore it does not support bytes-to-bytes encoders such as
    ``base64_codec``.
 
 
 .. function:: iterdecode(iterator, encoding, errors='strict', **kwargs)
 
    Uses an incremental decoder to iteratively decode the input provided by
-   *iterator*. This function is a :term:`generator`.
+   *iterator*.  This function is a :term:`generator`.
    The *errors* argument (as well as any
    other keyword argument) is passed through to the incremental decoder.
 
    This function requires that the codec accept :class:`bytes` objects
-   to decode. Therefore it does not support text-to-text encoders such as
+   to decode.  Therefore it does not support text-to-text encoders such as
    ``rot_13``, although ``rot_13`` may be used equivalently with
    :func:`iterencode`.
 
@@ -258,13 +258,13 @@ and writing to platform dependent files:
           BOM_UTF32_LE
 
    These constants define various byte sequences,
-   being Unicode byte order marks (BOMs) for several encodings. They are
+   being Unicode byte order marks (BOMs) for several encodings.  They are
    used in UTF-16 and UTF-32 data streams to indicate the byte order used,
    and in UTF-8 as a Unicode signature. :const:`BOM_UTF16` is either
    :const:`BOM_UTF16_BE` or :const:`BOM_UTF16_LE` depending on the platform's
    native byte order, :const:`BOM` is an alias for :const:`BOM_UTF16`,
    :const:`BOM_LE` for :const:`BOM_UTF16_LE` and :const:`BOM_BE` for
-   :const:`BOM_UTF16_BE`. The others represent the BOM in UTF-8 and UTF-32
+   :const:`BOM_UTF16_BE`.  The others represent the BOM in UTF-8 and UTF-32
    encodings.
 
 
@@ -278,9 +278,9 @@ interfaces for working with codec objects, and can also be used as the basis
 for custom codec implementations.
 
 Each codec has to define four interfaces to make it usable as codec in Python:
-stateless encoder, stateless decoder, stream reader and stream writer. The
+stateless encoder, stateless decoder, stream reader and stream writer.  The
 stream reader and writers typically reuse the stateless encoder/decoder to
-implement the file protocols. Codec authors also need to define how the
+implement the file protocols.  Codec authors also need to define how the
 codec will handle encoding and decoding errors.
 
 
@@ -384,15 +384,15 @@ handler:
    in case of an error, when *name* is specified as the errors parameter.
 
    For encoding, *error_handler* will be called with a :exc:`UnicodeEncodeError`
-   instance, which contains information about the location of the error. The
+   instance, which contains information about the location of the error.  The
    error handler must either raise this or a different exception, or return a
    tuple with a replacement for the unencodable part of the input and a position
-   where encoding should continue. The replacement may be either :class:`str` or
+   where encoding should continue.  The replacement may be either :class:`str` or
    :class:`bytes`.  If the replacement is bytes, the encoder will simply copy
-   them into the output buffer. If the replacement is a string, the encoder will
+   them into the output buffer.  If the replacement is a string, the encoder will
    encode the replacement.  Encoding continues on original input at the
-   specified position. Negative position values will be treated as being
-   relative to the end of the input string. If the resulting position is out of
+   specified position.  Negative position values will be treated as being
+   relative to the end of the input string.  If the resulting position is out of
    bound an :exc:`IndexError` will be raised.
 
    Decoding and translating works similarly, except :exc:`UnicodeDecodeError` or
@@ -473,7 +473,7 @@ function interfaces of the stateless encoder and decoder:
    The *errors* argument defines the error handling to apply.
    It defaults to ``'strict'`` handling.
 
-   The method may not store state in the :class:`Codec` instance. Use
+   The method may not store state in the :class:`Codec` instance.  Use
    :class:`StreamWriter` for codecs which have to keep state in order to make
    encoding efficient.
 
@@ -495,7 +495,7 @@ function interfaces of the stateless encoder and decoder:
    The *errors* argument defines the error handling to apply.
    It defaults to ``'strict'`` handling.
 
-   The method may not store state in the :class:`Codec` instance. Use
+   The method may not store state in the :class:`Codec` instance.  Use
    :class:`StreamReader` for codecs which have to keep state in order to make
    decoding efficient.
 
@@ -507,11 +507,11 @@ Incremental Encoding and Decoding
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :class:`IncrementalEncoder` and :class:`IncrementalDecoder` classes provide
-the basic interface for incremental encoding and decoding. Encoding/decoding the
+the basic interface for incremental encoding and decoding.  Encoding/decoding the
 input isn't done with one call to the stateless encoder/decoder function, but
 with multiple calls to the
 :meth:`~IncrementalEncoder.encode`/:meth:`~IncrementalDecoder.decode` method of
-the incremental encoder/decoder. The incremental encoder/decoder keeps track of
+the incremental encoder/decoder.  The incremental encoder/decoder keeps track of
 the encoding/decoding process during method calls.
 
 The joined output of calls to the
@@ -526,7 +526,7 @@ IncrementalEncoder Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :class:`IncrementalEncoder` class is used for encoding an input in multiple
-steps. It defines the following methods which every incremental encoder must
+steps.  It defines the following methods which every incremental encoder must
 define in order to be compatible with the Python codec registry.
 
 
@@ -534,12 +534,12 @@ define in order to be compatible with the Python codec registry.
 
    Constructor for an :class:`IncrementalEncoder` instance.
 
-   All incremental encoders must provide this constructor interface. They are free
+   All incremental encoders must provide this constructor interface.  They are free
    to add additional keyword arguments, but only the ones defined here are used by
    the Python codec registry.
 
    The :class:`IncrementalEncoder` may implement different error handling schemes
-   by providing the *errors* keyword argument. See :ref:`error-handlers` for
+   by providing the *errors* keyword argument.  See :ref:`error-handlers` for
    possible values.
 
    The *errors* argument will be assigned to an attribute of the same name.
@@ -551,20 +551,20 @@ define in order to be compatible with the Python codec registry.
    .. method:: encode(object[, final])
 
       Encodes *object* (taking the current state of the encoder into account)
-      and returns the resulting encoded object. If this is the last call to
+      and returns the resulting encoded object.  If this is the last call to
       :meth:`encode` *final* must be true (the default is false).
 
 
    .. method:: reset()
 
-      Reset the encoder to the initial state. The output is discarded: call
+      Reset the encoder to the initial state.  The output is discarded: call
       ``.encode(object, final=True)``, passing an empty byte or text string
       if necessary, to reset the encoder and to get the output.
 
 
    .. method:: getstate()
 
-      Return the current state of the encoder which must be an integer. The
+      Return the current state of the encoder which must be an integer.  The
       implementation should make sure that ``0`` is the most common
       state. (States that are more complicated than integers can be converted
       into an integer by marshaling/pickling the state and encoding the bytes
@@ -583,7 +583,7 @@ IncrementalDecoder Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :class:`IncrementalDecoder` class is used for decoding an input in multiple
-steps. It defines the following methods which every incremental decoder must
+steps.  It defines the following methods which every incremental decoder must
 define in order to be compatible with the Python codec registry.
 
 
@@ -591,12 +591,12 @@ define in order to be compatible with the Python codec registry.
 
    Constructor for an :class:`IncrementalDecoder` instance.
 
-   All incremental decoders must provide this constructor interface. They are free
+   All incremental decoders must provide this constructor interface.  They are free
    to add additional keyword arguments, but only the ones defined here are used by
    the Python codec registry.
 
    The :class:`IncrementalDecoder` may implement different error handling schemes
-   by providing the *errors* keyword argument. See :ref:`error-handlers` for
+   by providing the *errors* keyword argument.  See :ref:`error-handlers` for
    possible values.
 
    The *errors* argument will be assigned to an attribute of the same name.
@@ -608,10 +608,10 @@ define in order to be compatible with the Python codec registry.
    .. method:: decode(object[, final])
 
       Decodes *object* (taking the current state of the decoder into account)
-      and returns the resulting decoded object. If this is the last call to
-      :meth:`decode` *final* must be true (the default is false). If *final* is
+      and returns the resulting decoded object.  If this is the last call to
+      :meth:`decode` *final* must be true (the default is false).  If *final* is
       true the decoder must decode the input completely and must flush all
-      buffers. If this isn't possible (e.g. because of incomplete byte sequences
+      buffers.  If this isn't possible (e.g. because of incomplete byte sequences
       at the end of the input) it must initiate error handling just like in the
       stateless case (which might raise an exception).
 
@@ -623,9 +623,9 @@ define in order to be compatible with the Python codec registry.
 
    .. method:: getstate()
 
-      Return the current state of the decoder. This must be a tuple with two
+      Return the current state of the decoder.  This must be a tuple with two
       items, the first must be the buffer containing the still undecoded
-      input. The second must be an integer and can be additional state
+      input.  The second must be an integer and can be additional state
       info. (The implementation should make sure that ``0`` is the most common
       additional state info.) If this additional state info is ``0`` it must be
       possible to set the decoder to the state which has no input buffered and
@@ -648,7 +648,7 @@ Stream Encoding and Decoding
 
 The :class:`StreamWriter` and :class:`StreamReader` classes provide generic
 working interfaces which can be used to implement new encoding submodules very
-easily. See :mod:`encodings.utf_8` for an example of how this is done.
+easily.  See :mod:`encodings.utf_8` for an example of how this is done.
 
 
 .. _stream-writer-objects:
@@ -665,7 +665,7 @@ compatible with the Python codec registry.
 
    Constructor for a :class:`StreamWriter` instance.
 
-   All stream writers must provide this constructor interface. They are free to add
+   All stream writers must provide this constructor interface.  They are free to add
    additional keyword arguments, but only the ones defined here are used by the
    Python codec registry.
 
@@ -673,7 +673,7 @@ compatible with the Python codec registry.
    text or binary data, as appropriate for the specific codec.
 
    The :class:`StreamWriter` may implement different error handling schemes by
-   providing the *errors* keyword argument. See :ref:`error-handlers` for
+   providing the *errors* keyword argument.  See :ref:`error-handlers` for
    the standard error handlers the underlying stream codec may support.
 
    The *errors* argument will be assigned to an attribute of the same name.
@@ -688,7 +688,7 @@ compatible with the Python codec registry.
    .. method:: writelines(list)
 
       Writes the concatenated list of strings to the stream (possibly by reusing
-      the :meth:`write` method). The standard bytes-to-bytes codecs
+      the :meth:`write` method).  The standard bytes-to-bytes codecs
       do not support this method.
 
 
@@ -719,7 +719,7 @@ compatible with the Python codec registry.
 
    Constructor for a :class:`StreamReader` instance.
 
-   All stream readers must provide this constructor interface. They are free to add
+   All stream readers must provide this constructor interface.  They are free to add
    additional keyword arguments, but only the ones defined here are used by the
    Python codec registry.
 
@@ -727,7 +727,7 @@ compatible with the Python codec registry.
    text or binary data, as appropriate for the specific codec.
 
    The :class:`StreamReader` may implement different error handling schemes by
-   providing the *errors* keyword argument. See :ref:`error-handlers` for
+   providing the *errors* keyword argument.  See :ref:`error-handlers` for
    the standard error handlers the underlying stream codec may support.
 
    The *errors* argument will be assigned to an attribute of the same name.
@@ -743,14 +743,14 @@ compatible with the Python codec registry.
       Decodes data from the stream and returns the resulting object.
 
       The *chars* argument indicates the number of decoded
-      code points or bytes to return. The :func:`read` method will
+      code points or bytes to return.  The :func:`read` method will
       never return more data than requested, but it might return less,
       if there is not enough available.
 
       The *size* argument indicates the approximate maximum
       number of encoded bytes or code points to read
-      for decoding. The decoder can modify this setting as
-      appropriate. The default value -1 indicates to read and decode as much as
+      for decoding.  The decoder can modify this setting as
+      appropriate.  The default value -1 indicates to read and decode as much as
       possible.  This parameter is intended to
       prevent having to decode huge files in one step.
 
@@ -814,11 +814,11 @@ The design is such that one can use the factory functions returned by the
 
    Creates a :class:`StreamReaderWriter` instance. *stream* must be a file-like
    object. *Reader* and *Writer* must be factory functions or classes providing the
-   :class:`StreamReader` and :class:`StreamWriter` interface resp. Error handling
+   :class:`StreamReader` and :class:`StreamWriter` interface resp.  Error handling
    is done in the same way as defined for the stream readers and writers.
 
 :class:`StreamReaderWriter` instances define the combined interfaces of
-:class:`StreamReader` and :class:`StreamWriter` classes. They inherit all other
+:class:`StreamReader` and :class:`StreamWriter` classes.  They inherit all other
 methods and attributes from the underlying stream.
 
 
@@ -841,7 +841,7 @@ The design is such that one can use the factory functions returned by the
    code calling :meth:`read` and :meth:`write`, while *Reader* and *Writer*
    work on the backend — the data in *stream*.
 
-   You can use these objects to do transparent transcodings from e.g. Latin-1
+   You can use these objects to do transparent transcodings, e.g., from Latin-1
    to UTF-8 and back.
 
    The *stream* argument must be a file-like object.
@@ -856,7 +856,7 @@ The design is such that one can use the factory functions returned by the
 
 
 :class:`StreamRecoder` instances define the combined interfaces of
-:class:`StreamReader` and :class:`StreamWriter` classes. They inherit all other
+:class:`StreamReader` and :class:`StreamWriter` classes.  They inherit all other
 methods and attributes from the underlying stream.
 
 
@@ -878,49 +878,49 @@ collectivity referred to as :term:`text encodings <text encoding>`.
 The simplest text encoding (called ``'latin-1'`` or ``'iso-8859-1'``) maps
 the code points 0--255 to the bytes ``0x0``--``0xff``, which means that a string
 object that contains code points above ``U+00FF`` can't be encoded with this
-codec. Doing so will raise a :exc:`UnicodeEncodeError` that looks
+codec.  Doing so will raise a :exc:`UnicodeEncodeError` that looks
 like the following (although the details of the error message may differ):
 ``UnicodeEncodeError: 'latin-1' codec can't encode character '\u1234' in
 position 3: ordinal not in range(256)``.
 
 There's another group of encodings (the so called charmap encodings) that choose
 a different subset of all Unicode code points and how these code points are
-mapped to the bytes ``0x0``--``0xff``. To see how this is done simply open
+mapped to the bytes ``0x0``--``0xff``.  To see how this is done simply open
 e.g. :file:`encodings/cp1252.py` (which is an encoding that is used primarily on
-Windows). There's a string constant with 256 characters that shows you which
+Windows).  There's a string constant with 256 characters that shows you which
 character is mapped to which byte value.
 
 All of these encodings can only encode 256 of the 1114112 code points
-defined in Unicode. A simple and straightforward way that can store each Unicode
-code point, is to store each code point as four consecutive bytes. There are two
-possibilities: store the bytes in big endian or in little endian order. These
-two encodings are called ``UTF-32-BE`` and ``UTF-32-LE`` respectively. Their
+defined in Unicode.  A simple and straightforward way that can store each Unicode
+code point, is to store each code point as four consecutive bytes.  There are two
+possibilities: store the bytes in big endian or in little endian order.  These
+two encodings are called ``UTF-32-BE`` and ``UTF-32-LE`` respectively.  Their
 disadvantage is that if e.g. you use ``UTF-32-BE`` on a little endian machine you
 will always have to swap bytes on encoding and decoding. ``UTF-32`` avoids this
-problem: bytes will always be in natural endianness. When these bytes are read
-by a CPU with a different endianness, then bytes have to be swapped though. To
+problem: bytes will always be in natural endianness.  When these bytes are read
+by a CPU with a different endianness, then bytes have to be swapped though.  To
 be able to detect the endianness of a ``UTF-16`` or ``UTF-32`` byte sequence,
-there's the so called BOM ("Byte Order Mark"). This is the Unicode character
-``U+FEFF``. This character can be prepended to every ``UTF-16`` or ``UTF-32``
-byte sequence. The byte swapped version of this character (``0xFFFE``) is an
-illegal character that may not appear in a Unicode text. So when the
+there's the so called BOM ("Byte Order Mark").  This is the Unicode character
+``U+FEFF``.  This character can be prepended to every ``UTF-16`` or ``UTF-32``
+byte sequence.  The byte swapped version of this character (``0xFFFE``) is an
+illegal character that may not appear in a Unicode text.  So when the
 first character in an ``UTF-16`` or ``UTF-32`` byte sequence
 appears to be a ``U+FFFE`` the bytes have to be swapped on decoding.
 Unfortunately the character ``U+FEFF`` had a second purpose as
 a ``ZERO WIDTH NO-BREAK SPACE``: a character that has no width and doesn't allow
-a word to be split. It can e.g. be used to give hints to a ligature algorithm.
+a word to be split.  It can e.g. be used to give hints to a ligature algorithm.
 With Unicode 4.0 using ``U+FEFF`` as a ``ZERO WIDTH NO-BREAK SPACE`` has been
-deprecated (with ``U+2060`` (``WORD JOINER``) assuming this role). Nevertheless
+deprecated (with ``U+2060`` (``WORD JOINER``) assuming this role).  Nevertheless
 Unicode software still must be able to handle ``U+FEFF`` in both roles: as a BOM
 it's a device to determine the storage layout of the encoded bytes, and vanishes
 once the byte sequence has been decoded into a string; as a ``ZERO WIDTH
 NO-BREAK SPACE`` it's a normal character that will be decoded like any other.
 
 There's another encoding that is able to encoding the full range of Unicode
-characters: UTF-8. UTF-8 is an 8-bit encoding, which means there are no issues
-with byte order in UTF-8. Each byte in a UTF-8 byte sequence consists of two
-parts: marker bits (the most significant bits) and payload bits. The marker bits
-are a sequence of zero to four ``1`` bits followed by a ``0`` bit. Unicode characters are
+characters: UTF-8.  UTF-8 is an 8-bit encoding, which means there are no issues
+with byte order in UTF-8.  Each byte in a UTF-8 byte sequence consists of two
+parts: marker bits (the most significant bits) and payload bits.  The marker bits
+are a sequence of zero to four ``1`` bits followed by a ``0`` bit.  Unicode characters are
 encoded like this (with x being payload bits, which when concatenated give the
 Unicode character):
 
@@ -943,14 +943,14 @@ the decoded string (even if it's the first character) is treated as a ``ZERO
 WIDTH NO-BREAK SPACE``.
 
 Without external information it's impossible to reliably determine which
-encoding was used for encoding a string. Each charmap encoding can
-decode any random byte sequence. However that's not possible with UTF-8, as
+encoding was used for encoding a string.  Each charmap encoding can
+decode any random byte sequence.  However that's not possible with UTF-8, as
 UTF-8 byte sequences have a structure that doesn't allow arbitrary byte
-sequences. To increase the reliability with which a UTF-8 encoding can be
+sequences.  To increase the reliability with which a UTF-8 encoding can be
 detected, Microsoft invented a variant of UTF-8 (that Python 2.5 calls
 ``"utf-8-sig"``) for its Notepad program: Before any of the Unicode characters
 is written to the file, a UTF-8 encoded BOM (which looks like this as a byte
-sequence: ``0xef``, ``0xbb``, ``0xbf``) is written. As it's rather improbable
+sequence: ``0xef``, ``0xbb``, ``0xbf``) is written.  As it's rather improbable
 that any charmap encoded file starts with these byte values (which would e.g.
 map to
 
@@ -959,10 +959,10 @@ map to
    | INVERTED QUESTION MARK
 
 in iso-8859-1), this increases the probability that a ``utf-8-sig`` encoding can be
-correctly guessed from the byte sequence. So here the BOM is not used to be able
+correctly guessed from the byte sequence.  So here the BOM is not used to be able
 to determine the byte order used for generating the byte sequence, but as a
-signature that helps in guessing the encoding. On encoding the utf-8-sig codec
-will write ``0xef``, ``0xbb``, ``0xbf`` as the first three bytes to the file. On
+signature that helps in guessing the encoding.  On encoding the utf-8-sig codec
+will write ``0xef``, ``0xbb``, ``0xbf`` as the first three bytes to the file.  On
 decoding ``utf-8-sig`` will skip those three bytes if they appear as the first
 three bytes in the file.  In UTF-8, the use of the BOM is discouraged and
 should generally be avoided.
@@ -974,10 +974,10 @@ Standard Encodings
 ------------------
 
 Python comes with a number of codecs built-in, either implemented as C functions
-or with dictionaries as mapping tables. The following table lists the codecs by
+or with dictionaries as mapping tables.  The following table lists the codecs by
 name, together with a few common aliases, and the languages for which the
-encoding is likely used. Neither the list of aliases nor the list of languages
-is meant to be exhaustive. Notice that spelling alternatives that only differ in
+encoding is likely used.  Neither the list of aliases nor the list of languages
+is meant to be exhaustive.  Notice that spelling alternatives that only differ in
 case or use a hyphen instead of an underscore are also valid aliases; therefore,
 e.g. ``'utf-8'`` is a valid alias for the ``'utf_8'`` codec.
 
@@ -988,15 +988,15 @@ e.g. ``'utf-8'`` is a valid alias for the ``'utf_8'`` codec.
    recognized by CPython for a limited set of (case insensitive)
    aliases: utf-8, utf8, latin-1, latin1, iso-8859-1, iso8859-1, mbcs
    (Windows only), ascii, us-ascii, utf-16, utf16, utf-32, utf32, and
-   the same using underscores instead of dashes. Using alternative
+   the same using underscores instead of dashes.  Using alternative
    aliases for these encodings may result in slower execution.
 
    .. versionchanged:: 3.6
       Optimization opportunity recognized for us-ascii.
 
-Many of the character sets support the same languages. They vary in individual
+Many of the character sets support the same languages.  They vary in individual
 characters (e.g. whether the EURO SIGN is supported or not), and in the
-assignment of characters to code positions. For the European languages in
+assignment of characters to code positions.  For the European languages in
 particular, the following variants typically exist:
 
 * an ISO 8859 codeset
@@ -1293,7 +1293,7 @@ encodings.
 | raw_unicode_escape |         | Latin-1 encoding with     |
 |                    |         | ``\uXXXX`` and            |
 |                    |         | ``\UXXXXXXXX`` for other  |
-|                    |         | code points. Existing     |
+|                    |         | code points.  Existing    |
 |                    |         | backslashes are not       |
 |                    |         | escaped in any way.       |
 |                    |         | It is used in the Python  |
@@ -1301,7 +1301,7 @@ encodings.
 +--------------------+---------+---------------------------+
 | undefined          |         | Raises an exception for   |
 |                    |         | all conversions, even     |
-|                    |         | empty strings. The error  |
+|                    |         | empty strings.  The error |
 |                    |         | handler is ignored.       |
 +--------------------+---------+---------------------------+
 | unicode_escape     |         | Encoding suitable as the  |
@@ -1309,8 +1309,8 @@ encodings.
 |                    |         | literal in ASCII-encoded  |
 |                    |         | Python source code,       |
 |                    |         | except that quotes are    |
-|                    |         | not escaped. Decodes from |
-|                    |         | Latin-1 source code.      |
+|                    |         | not escaped.  Decodes     |
+|                    |         | from Latin-1 source code. |
 |                    |         | Beware that Python source |
 |                    |         | code actually uses UTF-8  |
 |                    |         | by default.               |
@@ -1410,21 +1410,21 @@ mapping.  It is not supported by :meth:`str.encode` (which only produces
 
 This module implements :rfc:`3490` (Internationalized Domain Names in
 Applications) and :rfc:`3492` (Nameprep: A Stringprep Profile for
-Internationalized Domain Names (IDN)). It builds upon the ``punycode`` encoding
+Internationalized Domain Names (IDN)).  It builds upon the ``punycode`` encoding
 and :mod:`stringprep`.
 
 These RFCs together define a protocol to support non-ASCII characters in domain
-names. A domain name containing non-ASCII characters (such as
+names.  A domain name containing non-ASCII characters (such as
 ``www.Alliancefrançaise.nu``) is converted into an ASCII-compatible encoding
-(ACE, such as ``www.xn--alliancefranaise-npb.nu``). The ACE form of the domain
+(ACE, such as ``www.xn--alliancefranaise-npb.nu``).  The ACE form of the domain
 name is then used in all places where arbitrary characters are not allowed by
 the protocol, such as DNS queries, HTTP :mailheader:`Host` fields, and so
-on. This conversion is carried out in the application; if possible invisible to
+on.  This conversion is carried out in the application; if possible invisible to
 the user: The application should transparently convert Unicode domain labels to
 IDNA on the wire, and convert back ACE labels to Unicode before presenting them
 to the user.
 
-Python supports this conversion in several ways:  the ``idna`` codec performs
+Python supports this conversion in several ways: the ``idna`` codec performs
 conversion between Unicode and ACE, separating an input string into labels
 based on the separator characters defined in :rfc:`section 3.1 of RFC 3490 <3490#section-3.1>`
 and converting each label to ACE as required, and conversely separating an input
@@ -1432,24 +1432,24 @@ byte string into labels based on the ``.`` separator and converting any ACE
 labels found into unicode.  Furthermore, the :mod:`socket` module
 transparently converts Unicode host names to ACE, so that applications need not
 be concerned about converting host names themselves when they pass them to the
-socket module. On top of that, modules that have host names as function
+socket module.  On top of that, modules that have host names as function
 parameters, such as :mod:`http.client` and :mod:`ftplib`, accept Unicode host
 names (:mod:`http.client` then also transparently sends an IDNA hostname in the
 :mailheader:`Host` field if it sends that field at all).
 
 When receiving host names from the wire (such as in reverse name lookup), no
-automatic conversion to Unicode is performed: Applications wishing to present
+automatic conversion to Unicode is performed: applications wishing to present
 such host names to the user should decode them to Unicode.
 
 The module :mod:`encodings.idna` also implements the nameprep procedure, which
 performs certain normalizations on host names, to achieve case-insensitivity of
-international domain names, and to unify similar characters. The nameprep
+international domain names, and to unify similar characters.  The nameprep
 functions can be used directly if desired.
 
 
 .. function:: nameprep(label)
 
-   Return the nameprepped version of *label*. The implementation currently assumes
+   Return the nameprepped version of *label*.  The implementation currently assumes
    query strings, so ``AllowUnassigned`` is true.
 
 
@@ -1489,7 +1489,7 @@ This module implements the ANSI codepage (CP_ACP).
    :synopsis: UTF-8 codec with BOM signature
 .. moduleauthor:: Walter Dörwald
 
-This module implements a variant of the UTF-8 codec: on encoding a UTF-8 encoded
-BOM will be prepended to the UTF-8 encoded bytes. For the stateful encoder this
-is only done once (on the first write to the byte stream).  For decoding an
+This module implements a variant of the UTF-8 codec.  On encoding, a UTF-8 encoded
+BOM will be prepended to the UTF-8 encoded bytes.  For the stateful encoder this
+is only done once (on the first write to the byte stream).  On decoding, an
 optional UTF-8 encoded BOM at the start of the data will be skipped.

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -1254,7 +1254,7 @@ no meaning outside Python. These are listed in the tables below based on the
 expected input and output types (note that while text encodings are the most
 common use case for codecs, the underlying codec infrastructure supports
 arbitrary data transforms rather than just text encodings). For asymmetric
-codecs, the stated purpose describes the encoding direction.
+codecs, the stated meaning describes the encoding direction.
 
 Text Encodings
 ^^^^^^^^^^^^^^

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -292,7 +292,7 @@ Error Handlers
 
 To simplify and standardize error handling,
 codecs may implement different error handling schemes by
-accepting the *errors* string argument.  The following string values are
+accepting the *errors* string argument. The following string values are
 defined and implemented by all standard Python codecs:
 
 .. tabularcolumns:: |l|L|
@@ -301,11 +301,11 @@ defined and implemented by all standard Python codecs:
 | Value                   | Meaning                                       |
 +=========================+===============================================+
 | ``'strict'``            | Raise :exc:`UnicodeError` (or a subclass);    |
-|                         | this is the default.  Implemented in          |
+|                         | this is the default. Implemented in           |
 |                         | :func:`strict_errors`.                        |
 +-------------------------+-----------------------------------------------+
 | ``'ignore'``            | Ignore the malformed data and continue        |
-|                         | without further notice.  Implemented in       |
+|                         | without further notice. Implemented in        |
 |                         | :func:`ignore_errors`.                        |
 +-------------------------+-----------------------------------------------+
 
@@ -327,11 +327,11 @@ The following error handlers are only applicable to
 |                         | marker; Python will use the official          |
 |                         | ``U+FFFD`` REPLACEMENT CHARACTER for the      |
 |                         | built-in codecs on decoding, and '?' on       |
-|                         | encoding.  Implemented in                     |
+|                         | encoding. Implemented in                      |
 |                         | :func:`replace_errors`.                       |
 +-------------------------+-----------------------------------------------+
 | ``'xmlcharrefreplace'`` | Replace with the appropriate XML character    |
-|                         | reference (only for encoding).  Implemented   |
+|                         | reference (only for encoding). Implemented    |
 |                         | in :func:`xmlcharrefreplace_errors`.          |
 +-------------------------+-----------------------------------------------+
 | ``'backslashreplace'``  | Replace with backslashed escape sequences.    |
@@ -339,12 +339,12 @@ The following error handlers are only applicable to
 |                         | :func:`backslashreplace_errors`.              |
 +-------------------------+-----------------------------------------------+
 | ``'namereplace'``       | Replace with ``\N{...}`` escape sequences     |
-|                         | (only for encoding).  Implemented in          |
+|                         | (only for encoding). Implemented in           |
 |                         | :func:`namereplace_errors`.                   |
 +-------------------------+-----------------------------------------------+
 | ``'surrogateescape'``   | On decoding, replace byte with individual     |
 |                         | surrogate code ranging from ``U+DC80`` to     |
-|                         | ``U+DCFF``.  This code will then be turned    |
+|                         | ``U+DCFF``. This code will then be turned     |
 |                         | back into the same byte when the              |
 |                         | ``'surrogateescape'`` error handler is used   |
 |                         | when encoding the data.  (See :pep:`383` for  |
@@ -357,7 +357,7 @@ In addition, the following error handler is specific to the given codecs:
 | Value             | Codecs                 | Meaning                                   |
 +===================+========================+===========================================+
 |``'surrogatepass'``| utf-8, utf-16, utf-32, | Allow encoding and decoding of surrogate  |
-|                   | utf-16-be, utf-16-le,  | codes.  These codecs normally treat the   |
+|                   | utf-16-be, utf-16-le,  | codes. These codecs normally treat the    |
 |                   | utf-32-be, utf-32-le   | presence of surrogates as an error.       |
 +-------------------+------------------------+-------------------------------------------+
 
@@ -388,9 +388,9 @@ handler:
    error handler must either raise this or a different exception, or return a
    tuple with a replacement for the unencodable part of the input and a position
    where encoding should continue. The replacement may be either :class:`str` or
-   :class:`bytes`.  If the replacement is bytes, the encoder will simply copy
+   :class:`bytes`. If the replacement is bytes, the encoder will simply copy
    them into the output buffer. If the replacement is a string, the encoder will
-   encode the replacement.  Encoding continues on original input at the
+   encode the replacement. Encoding continues on original input at the
    specified position. Negative position values will be treated as being
    relative to the end of the input string. If the resulting position is out of
    bound an :exc:`IndexError` will be raised.
@@ -484,7 +484,7 @@ function interfaces of the stateless encoder and decoder:
 .. method:: Codec.decode(input[, errors])
 
    Decodes the object *input* and returns a tuple (output object, length
-   consumed).  For instance, for a :term:`text encoding`, decoding converts
+   consumed). For instance, for a :term:`text encoding`, decoding converts
    a bytes object encoded using a particular
    character set encoding to a string object.
 
@@ -751,7 +751,7 @@ compatible with the Python codec registry.
       number of encoded bytes or code points to read
       for decoding. The decoder can modify this setting as
       appropriate. The default value -1 indicates to read and decode as much as
-      possible.  This parameter is intended to
+      possible. This parameter is intended to
       prevent having to decode huge files in one step.
 
       The *firstline* flag indicates that
@@ -791,7 +791,7 @@ compatible with the Python codec registry.
 
       Resets the codec buffers used for keeping state.
 
-      Note that no stream repositioning should take place.  This method is
+      Note that no stream repositioning should take place. This method is
       primarily intended to be able to recover from decoding errors.
 
 
@@ -869,7 +869,7 @@ Strings are stored internally as sequences of code points in
 range ``0x0``--``0x10FFFF``.  (See :pep:`393` for
 more details about the implementation.)
 Once a string object is used outside of CPU and memory, endianness
-and how these arrays are stored as bytes become an issue.  As with other
+and how these arrays are stored as bytes become an issue. As with other
 codecs, serialising a string into a sequence of bytes is known as *encoding*,
 and recreating the string from the sequence of bytes is known as *decoding*.
 There are a variety of different text serialisation codecs, which are
@@ -964,7 +964,7 @@ to determine the byte order used for generating the byte sequence, but as a
 signature that helps in guessing the encoding. On encoding the utf-8-sig codec
 will write ``0xef``, ``0xbb``, ``0xbf`` as the first three bytes to the file. On
 decoding ``utf-8-sig`` will skip those three bytes if they appear as the first
-three bytes in the file.  In UTF-8, the use of the BOM is discouraged and
+three bytes in the file. In UTF-8, the use of the BOM is discouraged and
 should generally be avoided.
 
 
@@ -984,7 +984,7 @@ e.g. ``'utf-8'`` is a valid alias for the ``'utf_8'`` codec.
 .. impl-detail::
 
    Some common encodings can bypass the codecs lookup machinery to
-   improve performance.  These optimization opportunities are only
+   improve performance. These optimization opportunities are only
    recognized by CPython for a limited set of (case insensitive)
    aliases: utf-8, utf8, latin-1, latin1, iso-8859-1, iso8859-1, mbcs
    (Windows only), ascii, us-ascii, utf-16, utf16, utf-32, utf32, and
@@ -1250,10 +1250,10 @@ Python Specific Encodings
 -------------------------
 
 A number of predefined codecs are specific to Python, so their codec names have
-no meaning outside Python.  These are listed in the tables below based on the
+no meaning outside Python. These are listed in the tables below based on the
 expected input and output types (note that while text encodings are the most
 common use case for codecs, the underlying codec infrastructure supports
-arbitrary data transforms rather than just text encodings).  For asymmetric
+arbitrary data transforms rather than just text encodings). For asymmetric
 codecs, the stated purpose describes the encoding direction.
 
 Text Encodings
@@ -1293,7 +1293,7 @@ encodings.
 | raw_unicode_escape |         | Latin-1 encoding with     |
 |                    |         | ``\uXXXX`` and            |
 |                    |         | ``\UXXXXXXXX`` for other  |
-|                    |         | code points.  Existing    |
+|                    |         | code points. Existing     |
 |                    |         | backslashes are not       |
 |                    |         | escaped in any way.       |
 |                    |         | It is used in the Python  |
@@ -1301,7 +1301,7 @@ encodings.
 +--------------------+---------+---------------------------+
 | undefined          |         | Raises an exception for   |
 |                    |         | all conversions, even     |
-|                    |         | empty strings.  The error |
+|                    |         | empty strings. The error  |
 |                    |         | handler is ignored.       |
 +--------------------+---------+---------------------------+
 | unicode_escape     |         | Encoding suitable as the  |
@@ -1309,7 +1309,7 @@ encodings.
 |                    |         | literal in ASCII-encoded  |
 |                    |         | Python source code,       |
 |                    |         | except that quotes are    |
-|                    |         | not escaped.  Decodes     |
+|                    |         | not escaped. Decodes      |
 |                    |         | from Latin-1 source code. |
 |                    |         | Beware that Python source |
 |                    |         | code actually uses UTF-8  |
@@ -1326,7 +1326,7 @@ Binary Transforms
 ^^^^^^^^^^^^^^^^^
 
 The following codecs provide binary transforms: :term:`bytes-like object`
-to :class:`bytes` mappings.  They are not supported by :meth:`bytes.decode`
+to :class:`bytes` mappings. They are not supported by :meth:`bytes.decode`
 (which only produces :class:`str` output).
 
 
@@ -1382,7 +1382,7 @@ Text Transforms
 ^^^^^^^^^^^^^^^
 
 The following codec provides a text transform: a :class:`str` to :class:`str`
-mapping.  It is not supported by :meth:`str.encode` (which only produces
+mapping. It is not supported by :meth:`str.encode` (which only produces
 :class:`bytes` output).
 
 .. tabularcolumns:: |l|l|L|
@@ -1429,7 +1429,7 @@ conversion between Unicode and ACE, separating an input string into labels
 based on the separator characters defined in :rfc:`section 3.1 of RFC 3490 <3490#section-3.1>`
 and converting each label to ACE as required, and conversely separating an input
 byte string into labels based on the ``.`` separator and converting any ACE
-labels found into unicode.  Furthermore, the :mod:`socket` module
+labels found into unicode. Furthermore, the :mod:`socket` module
 transparently converts Unicode host names to ACE, so that applications need not
 be concerned about converting host names themselves when they pass them to the
 socket module. On top of that, modules that have host names as function
@@ -1489,7 +1489,7 @@ This module implements the ANSI codepage (CP_ACP).
    :synopsis: UTF-8 codec with BOM signature
 .. moduleauthor:: Walter Dörwald
 
-This module implements a variant of the UTF-8 codec.  On encoding, a UTF-8 encoded
-BOM will be prepended to the UTF-8 encoded bytes.  For the stateful encoder this
-is only done once (on the first write to the byte stream).  On decoding, an
+This module implements a variant of the UTF-8 codec. On encoding, a UTF-8 encoded
+BOM will be prepended to the UTF-8 encoded bytes. For the stateful encoder this
+is only done once (on the first write to the byte stream). On decoding, an
 optional UTF-8 encoded BOM at the start of the data will be skipped.

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -842,7 +842,7 @@ The design is such that one can use the factory functions returned by the
    work on the backend — the data in *stream*.
 
    You can use these objects to do transparent transcodings, e.g., from Latin-1
-	to UTF-8 and back.
+   to UTF-8 and back.
 
    The *stream* argument must be a file-like object.
 

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -347,7 +347,7 @@ The following error handlers are only applicable to
 |                         | ``U+DCFF``. This code will then be turned     |
 |                         | back into the same byte when the              |
 |                         | ``'surrogateescape'`` error handler is used   |
-|                         | when encoding the data.  (See :pep:`383` for  |
+|                         | when encoding the data. (See :pep:`383` for   |
 |                         | more.)                                        |
 +-------------------------+-----------------------------------------------+
 
@@ -866,7 +866,7 @@ Encodings and Unicode
 ---------------------
 
 Strings are stored internally as sequences of code points in
-range ``0x0``--``0x10FFFF``.  (See :pep:`393` for
+range ``0x0``--``0x10FFFF``. (See :pep:`393` for
 more details about the implementation.)
 Once a string object is used outside of CPU and memory, endianness
 and how these arrays are stored as bytes become an issue. As with other
@@ -1266,27 +1266,27 @@ encodings.
 .. tabularcolumns:: |l|p{0.3\linewidth}|p{0.3\linewidth}|
 
 +--------------------+---------+---------------------------+
-| Codec              | Aliases | Purpose                   |
+| Codec              | Aliases | Meaning                   |
 +====================+=========+===========================+
-| idna               |         | Implements :rfc:`3490`,   |
+| idna               |         | Implement :rfc:`3490`,    |
 |                    |         | see also                  |
 |                    |         | :mod:`encodings.idna`.    |
 |                    |         | Only ``errors='strict'``  |
 |                    |         | is supported.             |
 +--------------------+---------+---------------------------+
-| mbcs               | ansi,   | Windows only: Encodes the |
+| mbcs               | ansi,   | Windows only: Encode the  |
 |                    | dbcs    | operand according to the  |
-|                    |         | ANSI codepage (CP_ACP)    |
+|                    |         | ANSI codepage (CP_ACP).   |
 +--------------------+---------+---------------------------+
-| oem                |         | Windows only: Encodes the |
+| oem                |         | Windows only: Encode the  |
 |                    |         | operand according to the  |
-|                    |         | OEM codepage (CP_OEMCP)   |
+|                    |         | OEM codepage (CP_OEMCP).  |
 |                    |         |                           |
 |                    |         | .. versionadded:: 3.6     |
 +--------------------+---------+---------------------------+
-| palmos             |         | Encoding of PalmOS 3.5    |
+| palmos             |         | Encoding of PalmOS 3.5.   |
 +--------------------+---------+---------------------------+
-| punycode           |         | Implements :rfc:`3492`.   |
+| punycode           |         | Implement :rfc:`3492`.    |
 |                    |         | Stateful codecs are not   |
 |                    |         | supported.                |
 +--------------------+---------+---------------------------+
@@ -1299,7 +1299,7 @@ encodings.
 |                    |         | It is used in the Python  |
 |                    |         | pickle protocol.          |
 +--------------------+---------+---------------------------+
-| undefined          |         | Raises an exception for   |
+| undefined          |         | Raise an exception for    |
 |                    |         | all conversions, even     |
 |                    |         | empty strings. The error  |
 |                    |         | handler is ignored.       |
@@ -1309,7 +1309,7 @@ encodings.
 |                    |         | literal in ASCII-encoded  |
 |                    |         | Python source code,       |
 |                    |         | except that quotes are    |
-|                    |         | not escaped. Decodes      |
+|                    |         | not escaped. Decode       |
 |                    |         | from Latin-1 source code. |
 |                    |         | Beware that Python source |
 |                    |         | code actually uses UTF-8  |
@@ -1333,12 +1333,12 @@ to :class:`bytes` mappings. They are not supported by :meth:`bytes.decode`
 .. tabularcolumns:: |l|L|L|L|
 
 +----------------------+------------------+------------------------------+------------------------------+
-| Codec                | Aliases          | Purpose                      | Encoder / decoder            |
+| Codec                | Aliases          | Meaning                      | Encoder / decoder            |
 +======================+==================+==============================+==============================+
-| base64_codec [#b64]_ | base64, base_64  | Converts the operand to      | :meth:`base64.encodebytes` / |
+| base64_codec [#b64]_ | base64, base_64  | Convert the operand to       | :meth:`base64.encodebytes` / |
 |                      |                  | multiline MIME base64 (the   | :meth:`base64.decodebytes`   |
 |                      |                  | result always includes a     |                              |
-|                      |                  | trailing ``'\n'``)           |                              |
+|                      |                  | trailing ``'\n'``).          |                              |
 |                      |                  |                              |                              |
 |                      |                  | .. versionchanged:: 3.4      |                              |
 |                      |                  |    accepts any               |                              |
@@ -1346,23 +1346,23 @@ to :class:`bytes` mappings. They are not supported by :meth:`bytes.decode`
 |                      |                  |    as input for encoding and |                              |
 |                      |                  |    decoding                  |                              |
 +----------------------+------------------+------------------------------+------------------------------+
-| bz2_codec            | bz2              | Compresses the operand       | :meth:`bz2.compress` /       |
-|                      |                  | using bz2                    | :meth:`bz2.decompress`       |
+| bz2_codec            | bz2              | Compress the operand using   | :meth:`bz2.compress` /       |
+|                      |                  | bz2.                         | :meth:`bz2.decompress`       |
 +----------------------+------------------+------------------------------+------------------------------+
-| hex_codec            | hex              | Converts the operand to      | :meth:`binascii.b2a_hex` /   |
+| hex_codec            | hex              | Convert the operand to       | :meth:`binascii.b2a_hex` /   |
 |                      |                  | hexadecimal                  | :meth:`binascii.a2b_hex`     |
 |                      |                  | representation, with two     |                              |
-|                      |                  | digits per byte              |                              |
+|                      |                  | digits per byte.             |                              |
 +----------------------+------------------+------------------------------+------------------------------+
-| quopri_codec         | quopri,          | Converts the operand to MIME | :meth:`quopri.encode` with   |
-|                      | quotedprintable, | quoted printable             | ``quotetabs=True`` /         |
+| quopri_codec         | quopri,          | Convert the operand to MIME  | :meth:`quopri.encode` with   |
+|                      | quotedprintable, | quoted printable.            | ``quotetabs=True`` /         |
 |                      | quoted_printable |                              | :meth:`quopri.decode`        |
 +----------------------+------------------+------------------------------+------------------------------+
-| uu_codec             | uu               | Converts the operand using   | :meth:`uu.encode` /          |
-|                      |                  | uuencode                     | :meth:`uu.decode`            |
+| uu_codec             | uu               | Convert the operand using    | :meth:`uu.encode` /          |
+|                      |                  | uuencode.                    | :meth:`uu.decode`            |
 +----------------------+------------------+------------------------------+------------------------------+
-| zlib_codec           | zip, zlib        | Compresses the operand       | :meth:`zlib.compress` /      |
-|                      |                  | using gzip                   | :meth:`zlib.decompress`      |
+| zlib_codec           | zip, zlib        | Compress the operand using   | :meth:`zlib.compress` /      |
+|                      |                  | gzip.                        | :meth:`zlib.decompress`      |
 +----------------------+------------------+------------------------------+------------------------------+
 
 .. [#b64] In addition to :term:`bytes-like objects <bytes-like object>`,
@@ -1388,10 +1388,11 @@ mapping. It is not supported by :meth:`str.encode` (which only produces
 .. tabularcolumns:: |l|l|L|
 
 +--------------------+---------+---------------------------+
-| Codec              | Aliases | Purpose                   |
+| Codec              | Aliases | Meaning                   |
 +====================+=========+===========================+
-| rot_13             | rot13   | Returns the Caesar-cypher |
-|                    |         | encryption of the operand |
+| rot_13             | rot13   | Return the Caesar-cypher  |
+|                    |         | encryption of the         |
+|                    |         | operand.                  |
 +--------------------+---------+---------------------------+
 
 .. versionadded:: 3.2


### PR DESCRIPTION
This PR will correct typos and punctuation in the [`codecs` module documentation](https://docs.python.org/3/library/codecs.html).