### PR TITLE
bpo-37763: Teach setup.py to pick up "-isystem <dir>" from $CPPFLAGS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -634,7 +634,8 @@ class PyBuildExt(build_ext):
         for env_var, arg_name, dir_list in (
                 ('LDFLAGS', '-R', self.compiler.runtime_library_dirs),
                 ('LDFLAGS', '-L', self.compiler.library_dirs),
-                ('CPPFLAGS', '-I', self.compiler.include_dirs)):
+                ('CPPFLAGS', '-I', self.compiler.include_dirs),
+                ('CPPFLAGS', '-isystem', self.compiler.include_dirs)):
             env_val = sysconfig.get_config_var(env_var)
             if env_val:
                 parser = argparse.ArgumentParser()


### PR DESCRIPTION
When (cross-)compiling, setup.py will pick up header search dirs from
$CPPFLAGS and lib search dirs from $LDFLAGS. However, the code only
looks at the -I options in $CPPFLAGS to find header search dirs.

Using the -isystem option (instead of -I) to pass header search dirs is
also a valid option, but this is currently unsupported by setup.py.

This patch adds handling of -isystem options, so that these are picked
up the same way that -I options currently are.

<!-- issue-number: [bpo-37763](https://bugs.python.org/issue37763) -->
https://bugs.python.org/issue37763
<!-- /issue-number -->
