### PR TITLE
 bpo-37774: use Py_LIKELY/Py_UNLIKELY for vectorcall 

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -64,7 +64,7 @@ _PyVectorcall_Function(PyObject *callable)
 {
     assert(callable != NULL);
     PyTypeObject *tp = Py_TYPE(callable);
-    if (!PyType_HasFeature(tp, _Py_TPFLAGS_HAVE_VECTORCALL)) {
+    if (!Py_LIKELY(PyType_HasFeature(tp, _Py_TPFLAGS_HAVE_VECTORCALL))) {
         return NULL;
     }
     assert(PyCallable_Check(callable));

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -103,8 +103,10 @@
 #define Py_UNREACHABLE() abort()
 
 
-/* If we're using GCC, use __builtin_expect() */
-#if defined(__GNUC__) && (__GNUC__ > 2)
+/* If we are using GCC, use __builtin_expect(). There is no need to check
+ * the GCC version since old versions that don't have __builtin_expect()
+ * can't compile CPython anyway */
+#if defined(__GNUC__)
 #  define Py_UNLIKELY(value) __builtin_expect(!!(value), 0)
 #  define Py_LIKELY(value) __builtin_expect(!!(value), 1)
 #else

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -102,4 +102,15 @@
 
 #define Py_UNREACHABLE() abort()
 
+
+/* If we're using GCC, use __builtin_expect() */
+#if defined(__GNUC__) && (__GNUC__ > 2)
+#  define Py_UNLIKELY(value) __builtin_expect(!!(value), 0)
+#  define Py_LIKELY(value) __builtin_expect(!!(value), 1)
+#else
+#  define Py_UNLIKELY(value) (!!(value))
+#  define Py_LIKELY(value) (!!(value))
+#endif
+
+
 #endif /* Py_PYMACRO_H */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4975,7 +4975,7 @@ call_function(PyThreadState *tstate, PyObject ***pp_stack, Py_ssize_t oparg, PyO
     Py_ssize_t nargs = oparg - nkwargs;
     PyObject **stack = (*pp_stack) - nargs - nkwargs;
 
-    if (tstate->use_tracing) {
+    if (Py_UNLIKELY(tstate->use_tracing)) {
         x = trace_call_function(tstate, func, stack, nargs, kwnames);
     }
     else {


### PR DESCRIPTION
CC @markshannon @methane 

<!-- issue-number: [bpo-37774](https://bugs.python.org/issue37774) -->
https://bugs.python.org/issue37774
<!-- /issue-number -->
