### PR TITLE
bpo-25172: Raise appropriate ImportError msg when crypt module used on Windows

### DIFF
--- a/Lib/crypt.py
+++ b/Lib/crypt.py
@@ -1,6 +1,15 @@
 """Wrapper to the POSIX crypt library call and associated functionality."""
 
-import _crypt
+import sys as _sys
+
+try:
+    import _crypt
+except ModuleNotFoundError:
+    if _sys.platform == 'win32':
+        raise ImportError("The crypt module is not supported on Windows")
+    else:
+        raise ImportError("The required _crypt module was not built as part of CPython")
+        
 import string as _string
 from random import SystemRandom as _SystemRandom
 from collections import namedtuple as _namedtuple

--- a/Lib/crypt.py
+++ b/Lib/crypt.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:
         raise ImportError("The crypt module is not supported on Windows")
     else:
         raise ImportError("The required _crypt module was not built as part of CPython")
-        
+
 import string as _string
 from random import SystemRandom as _SystemRandom
 from collections import namedtuple as _namedtuple

--- a/Misc/NEWS.d/next/Windows/2019-08-06-18-09-18.bpo-25172.Akreij.rst
+++ b/Misc/NEWS.d/next/Windows/2019-08-06-18-09-18.bpo-25172.Akreij.rst
@@ -1,1 +1,1 @@
-Trying to import the crypt module on Windows will result in an ImportError with a message explaining that the module isn't supported on Windows. On other platforms, if the underlying _crypt module is not available, the ImportError will include a message explaining the problem.
+Trying to import the :mod:`crypt` module on Windows will result in an :exc:`ImportError` with a message explaining that the module isn't supported on Windows. On other platforms, if the underlying ``_crypt`` module is not available, the ImportError will include a message explaining the problem.

--- a/Misc/NEWS.d/next/Windows/2019-08-06-18-09-18.bpo-25172.Akreij.rst
+++ b/Misc/NEWS.d/next/Windows/2019-08-06-18-09-18.bpo-25172.Akreij.rst
@@ -1,0 +1,1 @@
+The crypt module is not supported on Windows. If anybody tries to use it by importing the module, they will see an ImportError with a message saying its not supported on Windows. One will also see an appropriate error message on any other platform if the crypt module is not found or built.

--- a/Misc/NEWS.d/next/Windows/2019-08-06-18-09-18.bpo-25172.Akreij.rst
+++ b/Misc/NEWS.d/next/Windows/2019-08-06-18-09-18.bpo-25172.Akreij.rst
@@ -1,1 +1,1 @@
-The crypt module is not supported on Windows. If anybody tries to use it by importing the module, they will see an ImportError with a message saying its not supported on Windows. One will also see an appropriate error message on any other platform if the crypt module is not found or built.
+Trying to import the crypt module on Windows will result in an ImportError with a message explaining that the module isn't supported on Windows. On other platforms, if the underlying _crypt module is not available, the ImportError will include a message explaining the problem.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
[bpo-25172](https://bugs.python.org/issue25172): Raise appropriate ImportError msg when crypt module used on Windows
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-25172](https://bugs.python.org/issue25172) -->
https://bugs.python.org/issue25172
<!-- /issue-number -->
