### PR TITLE
bpo-37785: argparse uses %s in gettext calls causing xgettext warnings

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1207,8 +1207,9 @@ class FileType(object):
             return open(string, self._mode, self._bufsize, self._encoding,
                         self._errors)
         except OSError as e:
-            message = _("can't open '%s': %s")
-            raise ArgumentTypeError(message % (string, e))
+            args = {'filename': string, 'error': e}
+            message = _("can't open '%(filename)s': %(error)s")
+            raise ArgumentTypeError(message % (args))
 
     def __repr__(self):
         args = self._mode, self._bufsize

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1209,7 +1209,7 @@ class FileType(object):
         except OSError as e:
             args = {'filename': string, 'error': e}
             message = _("can't open '%(filename)s': %(error)s")
-            raise ArgumentTypeError(message % (args))
+            raise ArgumentTypeError(message % args)
 
     def __repr__(self):
         args = self._mode, self._bufsize

--- a/Misc/NEWS.d/next/Library/2019-08-07-14-49-22.bpo-37785.y7OlT8.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-07-14-49-22.bpo-37785.y7OlT8.rst
@@ -1,0 +1,1 @@
+Fix xgettext warnings in the argparse module.

--- a/Misc/NEWS.d/next/Library/2019-08-07-14-49-22.bpo-37785.y7OlT8.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-07-14-49-22.bpo-37785.y7OlT8.rst
@@ -1,1 +1,1 @@
-Fix xgettext warnings in the argparse module.
+Fix xgettext warnings in :mod:`argparse`.


### PR DESCRIPTION
Running xgettext on argparse.py (of any currently supported Python 3.x) return following warning:

./Lib/argparse.py: warning: 'msgid' format string with unnamed arguments cannot be properly localized: The translator cannot reorder the arguments. Please consider using a format string with named arguments, and a mapping instead of a tuple for the arguments.

<!-- issue-number: [bpo-37785](https://bugs.python.org/issue37785) -->
https://bugs.python.org/issue37785
<!-- /issue-number -->
