### PR TITLE
bpo-37685: Use singletons ALWAYS_EQ and NEVER_EQ in more tests.

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3123,6 +3123,8 @@ class _NEVER_EQ:
         return False
     def __ne__(self, other):
         return True
+    def __hash__(self):
+        return 1
 
 NEVER_EQ = _NEVER_EQ()
 

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1472,9 +1472,6 @@ class TestCollectionABCs(ABCTestCase):
 
     def test_issue26915(self):
         # Container membership test should check identity first
-        class CustomEqualObject:
-            def __eq__(self, other):
-                return False
         class CustomSequence(Sequence):
             def __init__(self, seq):
                 self._seq = seq
@@ -1484,7 +1481,7 @@ class TestCollectionABCs(ABCTestCase):
                 return len(self._seq)
 
         nan = float('nan')
-        obj = CustomEqualObject()
+        obj = support.NEVER_EQ
         seq = CustomSequence([nan, obj, nan])
         containers = [
             seq,

--- a/Lib/test/test_compare.py
+++ b/Lib/test/test_compare.py
@@ -1,4 +1,5 @@
 import unittest
+from test.support import ALWAYS_EQ
 
 class Empty:
     def __repr__(self):
@@ -13,13 +14,6 @@ class Cmp:
 
     def __eq__(self, other):
         return self.arg == other
-
-class Anything:
-    def __eq__(self, other):
-        return True
-
-    def __ne__(self, other):
-        return False
 
 class ComparisonTest(unittest.TestCase):
     set1 = [2, 2.0, 2, 2+0j, Cmp(2.0)]
@@ -113,11 +107,11 @@ class ComparisonTest(unittest.TestCase):
 
     def test_issue_1393(self):
         x = lambda: None
-        self.assertEqual(x, Anything())
-        self.assertEqual(Anything(), x)
+        self.assertEqual(x, ALWAYS_EQ)
+        self.assertEqual(ALWAYS_EQ, x)
         y = object()
-        self.assertEqual(y, Anything())
-        self.assertEqual(Anything(), y)
+        self.assertEqual(y, ALWAYS_EQ)
+        self.assertEqual(ALWAYS_EQ, y)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_contains.py
+++ b/Lib/test/test_contains.py
@@ -1,5 +1,6 @@
 from collections import deque
 import unittest
+from test.support import NEVER_EQ
 
 
 class base_set:
@@ -69,13 +70,7 @@ class TestContains(unittest.TestCase):
         # containment and equality tests involving elements that are
         # not necessarily equal to themselves
 
-        class MyNonReflexive(object):
-            def __eq__(self, other):
-                return False
-            def __hash__(self):
-                return 28
-
-        values = float('nan'), 1, None, 'abc', MyNonReflexive()
+        values = float('nan'), 1, None, 'abc', NEVER_EQ
         constructors = list, tuple, dict.fromkeys, set, frozenset, deque
         for constructor in constructors:
             container = constructor(values)

--- a/Lib/test/test_dict_version.py
+++ b/Lib/test/test_dict_version.py
@@ -98,20 +98,25 @@ class DictVersionTests(unittest.TestCase):
         value2 = AlwaysEqual()
         self.assertTrue(value1 == value2)
         self.assertFalse(value1 != value2)
+        self.assertIsNot(value1, value2)
 
         d = self.new_dict()
         self.check_version_changed(d, d.__setitem__, 'key', value1)
+        self.assertIs(d['key'], value1)
 
         # setting a key to a value equal to the current value
         # with dict.__setitem__() must change the version
         self.check_version_changed(d, d.__setitem__, 'key', value2)
+        self.assertIs(d['key'], value2)
 
         # setting a key to a value equal to the current value
         # with dict.update() must change the version
         self.check_version_changed(d, d.update, key=value1)
+        self.assertIs(d['key'], value1)
 
         d2 = self.new_dict(key=value2)
         self.check_version_changed(d, d.update, d2)
+        self.assertIs(d['key'], value2)
 
     def test_setdefault(self):
         d = self.new_dict()

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -9,6 +9,7 @@ from enum import Enum, IntEnum, EnumMeta, Flag, IntFlag, unique, auto
 from io import StringIO
 from pickle import dumps, loads, PicklingError, HIGHEST_PROTOCOL
 from test import support
+from test.support import ALWAYS_EQ
 from datetime import timedelta
 
 
@@ -1509,13 +1510,10 @@ class TestEnum(unittest.TestCase):
         self.assertEqual(list(map(int, Color)), [1, 2, 3])
 
     def test_equality(self):
-        class AlwaysEqual:
-            def __eq__(self, other):
-                return True
         class OrdinaryEnum(Enum):
             a = 1
-        self.assertEqual(AlwaysEqual(), OrdinaryEnum.a)
-        self.assertEqual(OrdinaryEnum.a, AlwaysEqual())
+        self.assertEqual(ALWAYS_EQ, OrdinaryEnum.a)
+        self.assertEqual(OrdinaryEnum.a, ALWAYS_EQ)
 
     def test_ordered_mixin(self):
         class OrderedEnum(Enum):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -25,7 +25,7 @@ except ImportError:
     ThreadPoolExecutor = None
 
 from test.support import run_unittest, TESTFN, DirsOnSysPath, cpython_only
-from test.support import MISSING_C_DOCSTRINGS, cpython_only
+from test.support import MISSING_C_DOCSTRINGS, ALWAYS_EQ
 from test.support.script_helper import assert_python_ok, assert_python_failure
 from test import inspect_fodder as mod
 from test import inspect_fodder2 as mod2
@@ -117,10 +117,6 @@ async def coroutine_function_example(self):
 def gen_coroutine_function_example(self):
     yield
     return 'spam'
-
-class EqualsToAll:
-    def __eq__(self, other):
-        return True
 
 class TestPredicates(IsTestBase):
 
@@ -2978,8 +2974,8 @@ class TestSignatureObject(unittest.TestCase):
         def foo(a, *, b:int) -> float: pass
         self.assertFalse(inspect.signature(foo) == 42)
         self.assertTrue(inspect.signature(foo) != 42)
-        self.assertTrue(inspect.signature(foo) == EqualsToAll())
-        self.assertFalse(inspect.signature(foo) != EqualsToAll())
+        self.assertTrue(inspect.signature(foo) == ALWAYS_EQ)
+        self.assertFalse(inspect.signature(foo) != ALWAYS_EQ)
 
         def bar(a, *, b:int) -> float: pass
         self.assertTrue(inspect.signature(foo) == inspect.signature(bar))
@@ -3246,8 +3242,8 @@ class TestParameterObject(unittest.TestCase):
         self.assertFalse(p != p)
         self.assertFalse(p == 42)
         self.assertTrue(p != 42)
-        self.assertTrue(p == EqualsToAll())
-        self.assertFalse(p != EqualsToAll())
+        self.assertTrue(p == ALWAYS_EQ)
+        self.assertFalse(p != ALWAYS_EQ)
 
         self.assertTrue(p == P('foo', default=42,
                                kind=inspect.Parameter.KEYWORD_ONLY))
@@ -3584,8 +3580,8 @@ class TestBoundArguments(unittest.TestCase):
         ba = inspect.signature(foo).bind(1)
         self.assertTrue(ba == ba)
         self.assertFalse(ba != ba)
-        self.assertTrue(ba == EqualsToAll())
-        self.assertFalse(ba != EqualsToAll())
+        self.assertTrue(ba == ALWAYS_EQ)
+        self.assertFalse(ba != ALWAYS_EQ)
 
         ba2 = inspect.signature(foo).bind(1)
         self.assertTrue(ba == ba2)

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -4,6 +4,7 @@ import unittest
 import sys
 import pickle
 import itertools
+from test.support import ALWAYS_EQ
 
 # pure Python implementations (3 args only), for comparison
 def pyrange(start, stop, step):
@@ -289,11 +290,7 @@ class RangeTest(unittest.TestCase):
         self.assertRaises(ValueError, range(1, 2**100, 2).index, 2**87)
         self.assertEqual(range(1, 2**100, 2).index(2**87+1), 2**86)
 
-        class AlwaysEqual(object):
-            def __eq__(self, other):
-                return True
-        always_equal = AlwaysEqual()
-        self.assertEqual(range(10).index(always_equal), 0)
+        self.assertEqual(range(10).index(ALWAYS_EQ), 0)
 
     def test_user_index_method(self):
         bignum = 2*sys.maxsize
@@ -344,11 +341,7 @@ class RangeTest(unittest.TestCase):
         self.assertEqual(range(1, 2**100, 2).count(2**87), 0)
         self.assertEqual(range(1, 2**100, 2).count(2**87+1), 1)
 
-        class AlwaysEqual(object):
-            def __eq__(self, other):
-                return True
-        always_equal = AlwaysEqual()
-        self.assertEqual(range(10).count(always_equal), 10)
+        self.assertEqual(range(10).count(ALWAYS_EQ), 10)
 
         self.assertEqual(len(range(sys.maxsize, sys.maxsize+10)), 10)
 
@@ -429,9 +422,7 @@ class RangeTest(unittest.TestCase):
         self.assertIn(True, range(3))
         self.assertIn(1+0j, range(3))
 
-        class C1:
-            def __eq__(self, other): return True
-        self.assertIn(C1(), range(3))
+        self.assertIn(ALWAYS_EQ, range(3))
 
         # Objects are never coerced into other types for comparison.
         class C2:

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -634,17 +634,12 @@ class OpenerDirectorTests(unittest.TestCase):
             [("http_error_302")],
             ]
         handlers = add_ordered_mock_handlers(o, meth_spec)
-
-        class Unknown:
-            def __eq__(self, other):
-                return True
-
         req = Request("http://example.com/")
         o.open(req)
         assert len(o.calls) == 2
         calls = [(handlers[0], "http_open", (req,)),
                  (handlers[2], "http_error_302",
-                  (req, Unknown(), 302, "", {}))]
+                  (req, support.ALWAYS_EQ, 302, "", {}))]
         for expected, got in zip(calls, o.calls):
             handler, method_name, args = expected
             self.assertEqual((handler, method_name), got[:2])


### PR DESCRIPTION


<!-- issue-number: [bpo-37685](https://bugs.python.org/issue37685) -->
https://bugs.python.org/issue37685
<!-- /issue-number -->
