### PR TITLE
bpo-18578: Rename and document test.bytecode_helper as test.support.bytecode_helper

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -1400,3 +1400,33 @@ script execution tests.
    containing the *source*.  If *compiled* is ``True``, both source files will
    be compiled and added to the zip package.  Return a tuple of the full zip
    path and the archive name for the zip file.
+
+
+:mod:`test.support.bytecode_helper` --- Support tools for testing correct bytecode generation
+=============================================================================================
+
+.. module:: test.support.bytecode_helper
+   :synopsis: Support tools for testing correct bytecode generation.
+
+The :mod:`test.support.bytecode_helper` module provides support for testing
+and inspecting bytecode generation.
+
+The module defines the follwing class:
+
+.. class:: BytecodeTestCase(unittest.TestCase)
+
+   This class has custom assertion methods for inspecting bytecode.
+
+.. method:: BytecodeTestCase.get_disassembly_as_string(co)
+
+   Return the disassembly of *co* as string.
+
+
+.. method:: BytecodeTestCase.assertInBytecode(x, opname, argval=_UNSPECIFIED)
+
+   Return instr if *opname* is found, otherwise throws :exc:`AssertionError`.
+
+
+.. method:: BytecodeTestCase.assertNotInBytecode(x, opname, argval=_UNSPECIFIED)
+
+   Throws :exc:`AssertionError` if *opname* is found.

--- a/Lib/test/support/bytecode_helper.py
+++ b/Lib/test/support/bytecode_helper.py
@@ -15,7 +15,7 @@ class BytecodeTestCase(unittest.TestCase):
         return s.getvalue()
 
     def assertInBytecode(self, x, opname, argval=_UNSPECIFIED):
-        """Returns instr if op is found, otherwise throws AssertionError"""
+        """Returns instr if opname is found, otherwise throws AssertionError"""
         for instr in dis.get_instructions(x):
             if instr.opname == opname:
                 if argval is _UNSPECIFIED or instr.argval == argval:
@@ -29,7 +29,7 @@ class BytecodeTestCase(unittest.TestCase):
         self.fail(msg)
 
     def assertNotInBytecode(self, x, opname, argval=_UNSPECIFIED):
-        """Throws AssertionError if op is found"""
+        """Throws AssertionError if opname is found"""
         for instr in dis.get_instructions(x):
             if instr.opname == opname:
                 disassembly = self.get_disassembly_as_string(x)

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1,7 +1,7 @@
 # Minimal tests for dis module
 
 from test.support import captured_stdout
-from test.bytecode_helper import BytecodeTestCase
+from test.support.bytecode_helper import BytecodeTestCase
 import unittest
 import sys
 import dis

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1,7 +1,7 @@
 import dis
 import unittest
 
-from test.bytecode_helper import BytecodeTestCase
+from test.support.bytecode_helper import BytecodeTestCase
 
 def count_instr_recursively(f, opname):
     count = 0

--- a/Misc/NEWS.d/next/Library/2019-08-07-19-34-07.bpo-18578.xfvdb_.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-07-19-34-07.bpo-18578.xfvdb_.rst
@@ -1,0 +1,2 @@
+Renamed and documented `test.bytecode_helper` as `test.support.bytecode_helper`.
+Patch by Joannah Nanjekye.


### PR DESCRIPTION
Co-authored by: Seydou Dia (seydou)

1. Moved from Lib/test/ to Lib/test/support (and imports in tests adjusted accordingly)
2. Documented in Doc/library/test.rst

Also solves [issue37789](https://bugs.python.org/issue37789)

<!-- issue-number: [bpo-18578](https://bugs.python.org/issue18578) -->
https://bugs.python.org/issue18578
<!-- /issue-number -->
