### PR TITLE
bpo-25810: Clarify eval() docs, it does not keywords (GH-15173)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -454,7 +454,7 @@ are always available.  They are listed here in alphabetical order.
               n += 1
 
 
-.. function:: eval(expression, globals=None, locals=None)
+.. function:: eval(expression[, globals[, locals]])
 
    The arguments are a string and optional globals and locals.  If provided,
    *globals* must be a dictionary.  If provided, *locals* can be any mapping


### PR DESCRIPTION
[bpo-25810](https://bugs.python.org/issue25810): Clarify eval() docs, it does not keywords (GH-15173)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-25810](https://bugs.python.org/issue25810) -->
https://bugs.python.org/issue25810
<!-- /issue-number -->
