### PR TITLE
bpo-37788: fix reference leak caused by threading._shutdown_locks

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1352,6 +1352,11 @@ class MiscTestCase(unittest.TestCase):
         support.check__all__(self, threading, ('threading', '_thread'),
                              extra=extra, blacklist=blacklist)
 
+    def test_without_join(self):
+        # Test that a thread without join does not leak references.
+        # Use a debug build and run "python -m test -R: test_threading"
+        threading.Thread().start()
+
 
 class InterruptMainTests(unittest.TestCase):
     def test_interrupt_main_subthread(self):

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -911,7 +911,7 @@ class Thread:
         Set a lock object which will be released by the interpreter when
         the underlying thread state (see pystate.h) gets deleted.
         """
-        self._tstate_lock = _set_sentinel()
+        self._tstate_lock = _set_sentinel(_shutdown_locks_lock, _shutdown_locks)
         self._tstate_lock.acquire()
 
         if not self.daemon:


### PR DESCRIPTION
If a program creates non-daemon threads but does not join them, the global set `threading._shutdown_locks` accumulates the shutdown locks of the threads. 

This pull request adds a test case for non-daemon threads without join. The test must not leak references, if called with `python -m test -R: test_threading`.

This pull request also fixes the reference leak. The `tstate->on_delete`-hook now discards per thread shutdown locks from threading._shutdown_locks.

<!-- issue-number: [bpo-37788](https://bugs.python.org/issue37788) -->
https://bugs.python.org/issue37788
<!-- /issue-number -->
