### PR TITLE
bpo-37779 : Add information about the overriding behavior of ConfigParser.read

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -136,6 +136,26 @@ sections [1]_.  Note also that keys in sections are
 case-insensitive and stored in lowercase [1]_.
 
 
+If we need to read several configurations, each one having more priority than the previous one, we can use the same :class:`ConfigParser` instance to override previous defined data and keep not redefined data.
+
+.. doctest::
+
+   >>> config = configparser.ConfigParser()
+   >>> config.read('example.ini')
+   ['example.ini']
+   >>> config['topsecret.server.com']['Port']
+   '50022'
+   >>> config.read_string("[topsecret.server.com]\nPort=48484")
+   >>> config['topsecret.server.com']['Port']
+   '48484'
+   >>> config.read_dict({"topsecret.server.com": {"Port": 21212}})
+   >>> config['topsecret.server.com']['Port']
+   '21212'
+   >>> config['topsecret.server.com']['ForwardX11']
+   'no'
+
+This behaviour is equivalent to a :meth:`ConfigParser.read` call with several files passed to ``filenames`` parameter.
+
 Supported Datatypes
 -------------------
 

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -142,18 +142,18 @@ configuration while the previously existing keys are retained.
 
 .. doctest::
 
-   >>> config = configparser.ConfigParser()
-   >>> config.read('example.ini')
+   >>> another_config = configparser.ConfigParser()
+   >>> another_config.read('example.ini')
    ['example.ini']
-   >>> config['topsecret.server.com']['Port']
+   >>> another_config['topsecret.server.com']['Port']
    '50022'
-   >>> config.read_string("[topsecret.server.com]\nPort=48484")
-   >>> config['topsecret.server.com']['Port']
+   >>> another_config.read_string("[topsecret.server.com]\nPort=48484")
+   >>> another_config['topsecret.server.com']['Port']
    '48484'
-   >>> config.read_dict({"topsecret.server.com": {"Port": 21212}})
-   >>> config['topsecret.server.com']['Port']
+   >>> another_config.read_dict({"topsecret.server.com": {"Port": 21212}})
+   >>> another_config['topsecret.server.com']['Port']
    '21212'
-   >>> config['topsecret.server.com']['ForwardX11']
+   >>> another_config['topsecret.server.com']['ForwardX11']
    'no'
 
 This behaviour is equivalent to a :meth:`ConfigParser.read` call with several

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -156,7 +156,7 @@ used to override previously defined properties and retain existing ones.
    'no'
 
 This behaviour is equivalent to a :meth:`ConfigParser.read` call with several
-files passed to ``filenames`` parameter.
+files passed to *filenames* parameter.
 
 
 Supported Datatypes

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -136,7 +136,9 @@ sections [1]_.  Note also that keys in sections are
 case-insensitive and stored in lowercase [1]_.
 
 
-If we need to read several configurations, each one having more priority than the previous one, we can use the same :class:`ConfigParser` instance to override previous defined data and keep not redefined data.
+   If it is necessary to read several configurations, with each one having more 
+   priority than the previous one, an instance of :class:`ConfigParser` can be 
+   used to override previously defined properties and retain existing ones.
 
 .. doctest::
 

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -135,9 +135,10 @@ involves the ``DEFAULT`` section which provides default values for all other
 sections [1]_.  Note also that keys in sections are
 case-insensitive and stored in lowercase [1]_.
 
-If it is necessary to read several configurations, with each one having more
-priority than the previous one, an instance of :class:`ConfigParser` can be
-used to override previously defined properties and retain existing ones.
+It is possible to read several configurations into a single
+:class:`ConfigParser`, where the most recently added configuration has the
+highest priority. Any conflicting keys are taken from the more recent
+configuration while the previously existing keys are retained.
 
 .. doctest::
 

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -155,8 +155,9 @@ used to override previously defined properties and retain existing ones.
    >>> config['topsecret.server.com']['ForwardX11']
    'no'
 
+This behaviour is equivalent to a :meth:`ConfigParser.read` call with several
+files passed to ``filenames`` parameter.
 
-This behaviour is equivalent to a :meth:`ConfigParser.read` call with several files passed to ``filenames`` parameter.
 
 Supported Datatypes
 -------------------

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -135,10 +135,9 @@ involves the ``DEFAULT`` section which provides default values for all other
 sections [1]_.  Note also that keys in sections are
 case-insensitive and stored in lowercase [1]_.
 
-
-   If it is necessary to read several configurations, with each one having more 
-   priority than the previous one, an instance of :class:`ConfigParser` can be 
-   used to override previously defined properties and retain existing ones.
+If it is necessary to read several configurations, with each one having more
+priority than the previous one, an instance of :class:`ConfigParser` can be
+used to override previously defined properties and retain existing ones.
 
 .. doctest::
 
@@ -155,6 +154,7 @@ case-insensitive and stored in lowercase [1]_.
    '21212'
    >>> config['topsecret.server.com']['ForwardX11']
    'no'
+
 
 This behaviour is equivalent to a :meth:`ConfigParser.read` call with several files passed to ``filenames`` parameter.
 

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -156,7 +156,7 @@ used to override previously defined properties and retain existing ones.
    'no'
 
 This behaviour is equivalent to a :meth:`ConfigParser.read` call with several
-files passed to *filenames* parameter.
+files passed to the *filenames* parameter.
 
 
 Supported Datatypes


### PR DESCRIPTION
This PR adds documentation about the ability to override values when `ConfigParser.read()`, `.read_string()`, `.read_dict()` are called several times from the same instance of `ConfigParser`.


<!-- issue-number: [bpo-37779](https://bugs.python.org/issue37779) -->
https://bugs.python.org/issue37779
<!-- /issue-number -->
