### PR TITLE
bpo-37794: MSVCCompiler: Replace /Ox with /O2

### DIFF
--- a/Lib/distutils/_msvccompiler.py
+++ b/Lib/distutils/_msvccompiler.py
@@ -278,7 +278,7 @@ class MSVCCompiler(CCompiler) :
         # use /MT[d] to build statically, then switch from libucrt[d].lib to ucrt[d].lib
         # later to dynamically link to ucrtbase but not vcruntime.
         self.compile_options = [
-            '/nologo', '/Ox', '/W3', '/GL', '/DNDEBUG'
+            '/nologo', '/O2', '/W3', '/GL', '/DNDEBUG'
         ]
         self.compile_options.append('/MD' if self._vcruntime_redist else '/MT')
 

--- a/Lib/distutils/msvc9compiler.py
+++ b/Lib/distutils/msvc9compiler.py
@@ -400,13 +400,13 @@ class MSVCCompiler(CCompiler) :
 
         self.preprocess_options = None
         if self.__arch == "x86":
-            self.compile_options = [ '/nologo', '/Ox', '/MD', '/W3',
+            self.compile_options = [ '/nologo', '/O2', '/MD', '/W3',
                                      '/DNDEBUG']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',
                                           '/Z7', '/D_DEBUG']
         else:
             # Win64
-            self.compile_options = [ '/nologo', '/Ox', '/MD', '/W3', '/GS-' ,
+            self.compile_options = [ '/nologo', '/O2', '/MD', '/W3', '/GS-' ,
                                      '/DNDEBUG']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3', '/GS-',
                                           '/Z7', '/D_DEBUG']

--- a/Lib/distutils/msvccompiler.py
+++ b/Lib/distutils/msvccompiler.py
@@ -283,13 +283,13 @@ class MSVCCompiler(CCompiler) :
 
         self.preprocess_options = None
         if self.__arch == "Intel":
-            self.compile_options = [ '/nologo', '/Ox', '/MD', '/W3', '/GX' ,
+            self.compile_options = [ '/nologo', '/O2', '/MD', '/W3', '/GX' ,
                                      '/DNDEBUG']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3', '/GX',
                                           '/Z7', '/D_DEBUG']
         else:
             # Win64
-            self.compile_options = [ '/nologo', '/Ox', '/MD', '/W3', '/GS-' ,
+            self.compile_options = [ '/nologo', '/O2', '/MD', '/W3', '/GS-' ,
                                      '/DNDEBUG']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3', '/GS-',
                                           '/Z7', '/D_DEBUG']

--- a/Misc/NEWS.d/next/Library/2019-08-08-20-04-58.bpo-37794.mTM2Kt.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-08-20-04-58.bpo-37794.mTM2Kt.rst
@@ -1,0 +1,1 @@
+:class:`distutils.MSVCCompiler` now uses ``/O2`` switch instead of ``/Ox``.


### PR DESCRIPTION
The /O2 is a superset of /Ox with additional /GF and /Gy switches which
enables strings and functions deduplication and almost always are
favorable optimizations without downsides.

https://docs.microsoft.com/en-us/cpp/build/reference/ox-full-optimization


<!-- issue-number: [bpo-37794](https://bugs.python.org/issue37794) -->
https://bugs.python.org/issue37794
<!-- /issue-number -->
