### PR TITLE
bpo-36266: Add module name in ImportError when DLL not found on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-08-08-18-05-27.bpo-36266.x4eZU3.rst
+++ b/Misc/NEWS.d/next/Windows/2019-08-08-18-05-27.bpo-36266.x4eZU3.rst
@@ -1,0 +1,1 @@
+Add the module name in the formatted error message when DLL load fail happens during module import in :c:func:`_PyImport_FindSharedFuncptrWindows()`. Patch by Srinivas Nyayapati.

--- a/Misc/NEWS.d/next/Windows/2019-08-08-18-05-27.bpo-36266.x4eZU3.rst
+++ b/Misc/NEWS.d/next/Windows/2019-08-08-18-05-27.bpo-36266.x4eZU3.rst
@@ -1,1 +1,1 @@
-Add the module name in the formatted error message when DLL load fail happens during module import in :c:func:`_PyImport_FindSharedFuncptrWindows()`. Patch by Srinivas Nyayapati.
+Add the module name in the formatted error message when DLL load fail happens during module import in ``_PyImport_FindSharedFuncptrWindows()``. Patch by Srinivas Nyayapati.

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -240,8 +240,8 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
                This should not happen if called correctly. */
             if (theLength == 0) {
                 message = PyUnicode_FromFormat(
-                    "DLL load failed with error code %u",
-                    errorCode);
+                    "While importing %s, DLL load failed with error code %u",
+                    shortname, errorCode);
             } else {
                 /* For some reason a \r\n
                    is appended to the text */
@@ -251,8 +251,8 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
                     theLength -= 2;
                     theInfo[theLength] = '\0';
                 }
-                message = PyUnicode_FromString(
-                    "DLL load failed: ");
+                message = PyUnicode_FromFormat(
+                    "While importing %s, DLL load failed: ", shortname);
 
                 PyUnicode_AppendAndDel(&message,
                     PyUnicode_FromWideChar(

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -240,8 +240,8 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
                This should not happen if called correctly. */
             if (theLength == 0) {
                 message = PyUnicode_FromFormat(
-                    "While importing %s, DLL load failed with error code %u",
-                    shortname, errorCode);
+                    "DLL load failed with error code %u while importing %s",
+                    errorCode, shortname);
             } else {
                 /* For some reason a \r\n
                    is appended to the text */
@@ -252,7 +252,7 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
                     theInfo[theLength] = '\0';
                 }
                 message = PyUnicode_FromFormat(
-                    "While importing %s, DLL load failed: ", shortname);
+                    "DLL load failed while importing %s: ", shortname);
 
                 PyUnicode_AppendAndDel(&message,
                     PyUnicode_FromWideChar(


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36266](https://bugs.python.org/issue36266) -->
https://bugs.python.org/issue36266
<!-- /issue-number -->
