### PR TITLE
bpo-36511 fix failures in Windows Python arm32 buildbot tests

### DIFF
--- a/Lib/test/libregrtest/win_utils.py
+++ b/Lib/test/libregrtest/win_utils.py
@@ -25,6 +25,7 @@ class WindowsLoadTracker():
 
     def __init__(self):
         self.load = 0.0
+        self.p = None
         self.start()
 
     def start(self):

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -695,7 +695,10 @@ if 1:
     def test_stack_overflow(self):
         # bpo-31113: Stack overflow when compile a long sequence of
         # complex statements.
-        compile("if a: b\n" * 200000, "<dummy>", "exec")
+        try:
+            compile("if a: b\n" * 200000, "<dummy>", "exec")
+        except MemoryError:
+            pass
 
     # Multiple users rely on the fact that CPython does not generate
     # bytecode for dead code blocks. See bpo-37500 for more context.

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -695,10 +695,7 @@ if 1:
     def test_stack_overflow(self):
         # bpo-31113: Stack overflow when compile a long sequence of
         # complex statements.
-        try:
-            compile("if a: b\n" * 200000, "<dummy>", "exec")
-        except MemoryError:
-            pass
+        compile("if a: b\n" * 200000, "<dummy>", "exec")
 
     # Multiple users rely on the fact that CPython does not generate
     # bytecode for dead code blocks. See bpo-37500 for more context.

--- a/Tools/buildbot/remoteDeploy.bat
+++ b/Tools/buildbot/remoteDeploy.bat
@@ -36,6 +36,7 @@ for /f "USEBACKQ" %%i in (`dir PCbuild\arm32\*.pyd /b`) do @scp PCBuild\arm32\%%
 for /f "USEBACKQ" %%i in (`dir PCbuild\arm32\*.dll /b`) do @scp PCBuild\arm32\%%i "%SSH_SERVER%:%REMOTE_PYTHON_DIR%PCBuild\arm32"
 scp -r "%PYTHON_SOURCE%Include" "%SSH_SERVER%:%REMOTE_PYTHON_DIR%Include"
 scp -r "%PYTHON_SOURCE%Lib" "%SSH_SERVER%:%REMOTE_PYTHON_DIR%Lib"
+scp -r "%PYTHON_SOURCE%Parser" "%SSH_SERVER%:%REMOTE_PYTHON_DIR%Parser"
 scp -r "%PYTHON_SOURCE%Tools" "%SSH_SERVER%:%REMOTE_PYTHON_DIR%Tools"
 scp "%PYTHON_SOURCE%Modules\Setup" "%SSH_SERVER%:%REMOTE_PYTHON_DIR%Modules"
 scp "%PYTHON_SOURCE%PC\pyconfig.h" "%SSH_SERVER%:%REMOTE_PYTHON_DIR%PC"


### PR DESCRIPTION
@zooba, @zware 

win_utils.py:  If an exception is thrown during WindowsLoadTracker creation, which is expected on Windows ARM32, then when WindowsLoadTracker.close( ) is called then self.p is not defined.  This change ensures that self.p is always initialized.

test_compile.py: test_stack_overflow throws a MemoryException randomly on Windows arm32.  I believe this test is running out of memory because the arm32 test hardware only has 1 GB of RAM.  What is the best way to fix this?  Is handling the MemoryException ok? or does that cover up a real problem?

remoteDeploy.bat:  the files in the Parser directory are needed to prevent warnings when running test_asdl_parser.

Please let me know if I should split this into multiple PRs or create new issue(s).

Thanks,
Paul

<!-- issue-number: [bpo-36511](https://bugs.python.org/issue36511) -->
https://bugs.python.org/issue36511
<!-- /issue-number -->
