### PR TITLE
bpo-37268: test_parser fails when run with -Werror

### DIFF
--- a/Lib/test/test_parser.py
+++ b/Lib/test/test_parser.py
@@ -1,5 +1,9 @@
 import copy
-import parser
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', 'The parser module is deprecated',
+                            DeprecationWarning)
+    import parser
 import pickle
 import unittest
 import operator


### PR DESCRIPTION
Use warnings.filterwarnings() when importing the deprecated parser
module.

@pablogsal 

<!-- issue-number: [bpo-37268](https://bugs.python.org/issue37268) -->
https://bugs.python.org/issue37268
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal