### PR TITLE
bpo-37803: pdb: fix handling of options (--help / --version)

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1656,7 +1656,7 @@ To let the script run up to a given line X in the debugged file, use
 def main():
     import getopt
 
-    opts, args = getopt.getopt(sys.argv[1:], 'mhc:', ['--help', '--command='])
+    opts, args = getopt.getopt(sys.argv[1:], 'mhc:', ['help', 'command='])
 
     if not args:
         print(_usage)

--- a/Misc/NEWS.d/next/Tools-Demos/2019-09-12-16-15-55.bpo-37803.chEizy.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2019-09-12-16-15-55.bpo-37803.chEizy.rst
@@ -1,0 +1,1 @@
+pdb's ``--help`` and ``--version`` long options now work.


### PR DESCRIPTION
The "--" should not be included with long options passed to
getopt.getopt.

Fixes https://bugs.python.org/issue37803

<!-- issue-number: [bpo-37803](https://bugs.python.org/issue37803) -->
https://bugs.python.org/issue37803
<!-- /issue-number -->

Appears to be a problem from the beginning when added in 3.2 (e023091815).