### PR TITLE
bpo-32912: Revert SyntaxWarning on invalid escape sequences.

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -594,11 +594,9 @@ escape sequences only recognized in string literals fall into the category of
 unrecognized escapes for bytes literals.
 
    .. versionchanged:: 3.6
-      Unrecognized escape sequences produce a :exc:`DeprecationWarning`.
-
-   .. versionchanged:: 3.8
-      Unrecognized escape sequences produce a :exc:`SyntaxWarning`.  In
-      some future version of Python they will be a :exc:`SyntaxError`.
+      Unrecognized escape sequences produce a :exc:`DeprecationWarning`.  In
+      a future Python version they will be a :exc:`SyntaxWarning` and
+      eventually a :exc:`SyntaxError`.
 
 Even in a raw literal, quotes can be escaped with a backslash, but the
 backslash remains in the result; for example, ``r"\""`` is a valid string

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -414,11 +414,6 @@ Other Language Changes
   and :keyword:`return` statements.
   (Contributed by David Cuthbert and Jordan Chapman in :issue:`32117`.)
 
-* A backslash-character pair that is not a valid escape sequence generates
-  a :exc:`DeprecationWarning` since Python 3.6. In Python 3.8 it generates
-  a :exc:`SyntaxWarning` instead.
-  (Contributed by Serhiy Storchaka in :issue:`32912`.)
-
 * The compiler now produces a :exc:`SyntaxWarning` in some cases when a comma
   is missed before tuple or list.  For example::
 

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -649,7 +649,7 @@ non-important content
         self.assertEqual(f'2\x203', '2 3')
         self.assertEqual(f'\x203', ' 3')
 
-        with self.assertWarns(SyntaxWarning):  # invalid escape sequence
+        with self.assertWarns(DeprecationWarning):  # invalid escape sequence
             value = eval(r"f'\{6*7}'")
         self.assertEqual(value, '\\42')
         self.assertEqual(f'\\{6*7}', '\\42')

--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-06-14-03-59.bpo-32912.UDwSMJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-06-14-03-59.bpo-32912.UDwSMJ.rst
@@ -1,0 +1,3 @@
+Reverted :issue:`32912`: emitting :exc:`SyntaxWarning` instead of
+:exc:`DeprecationWarning` for invalid escape sequences in string and bytes
+literals.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4671,12 +4671,12 @@ warn_invalid_escape_sequence(struct compiling *c, const node *n,
     if (msg == NULL) {
         return -1;
     }
-    if (PyErr_WarnExplicitObject(PyExc_SyntaxWarning, msg,
+    if (PyErr_WarnExplicitObject(PyExc_DeprecationWarning, msg,
                                    c->c_filename, LINENO(n),
                                    NULL, NULL) < 0)
     {
-        if (PyErr_ExceptionMatches(PyExc_SyntaxWarning)) {
-            /* Replace the SyntaxWarning exception with a SyntaxError
+        if (PyErr_ExceptionMatches(PyExc_DeprecationWarning)) {
+            /* Replace the DeprecationWarning exception with a SyntaxError
                to get a more accurate error report */
             PyErr_Clear();
             ast_error(c, n, "%U", msg);


### PR DESCRIPTION
DeprecationWarning will continue to be emitted for invalid escape
sequences in string and bytes literals just as it did in 3.7.

SyntaxWarning may be emitted in the future. But per mailing list
discussion, we don't yet know when because we haven't settled on how to
do so in a non-disruptive manner.

(Applies 4c5b6bac2408f879231c7cd38d67657dd4804e7c to the master branch).
(This is https://github.com/python/cpython/pull/15142 for master/3.9)

<!-- issue-number: [bpo-32912](https://bugs.python.org/issue32912) -->
https://bugs.python.org/issue32912
<!-- /issue-number -->


Automerge-Triggered-By: @gpshead