### PR TITLE
Fix docs for assert_called and assert_called_once

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -286,7 +286,7 @@ the *new_callable* argument to :func:`patch`.
     used to set attributes on the mock after it is created. See the
     :meth:`configure_mock` method for details.
 
-    .. method:: assert_called(*args, **kwargs)
+    .. method:: assert_called()
 
         Assert that the mock was called at least once.
 
@@ -297,7 +297,7 @@ the *new_callable* argument to :func:`patch`.
 
         .. versionadded:: 3.6
 
-    .. method:: assert_called_once(*args, **kwargs)
+    .. method:: assert_called_once()
 
         Assert that the mock was called exactly once.
 


### PR DESCRIPTION
The code that this part of the docs documents is: https://github.com/python/cpython/blob/7d44e7a4563072d0fad00427b76b94cad61c38ae/Lib/unittest/mock.py#L838-L846