### PR TITLE
bpo-37812: Make the small-int alloc optimization unconditional.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-10-14-15-48.bpo-37812.jkh0Wp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-10-14-15-48.bpo-37812.jkh0Wp.rst
@@ -1,0 +1,6 @@
+The "small int" optimization is now unconditionally enabled.  This
+optimization was introduced in Python 1.0.1, and means that :class:`int`
+values from -5 to 256 are pre-initialized rather than constructed on demand.
+The option was always enabled unless certain never-documented preprocessor
+macros were defined to 0 at build time; now it is always enabled,
+simplifying the logic.  Patch by Greg Price.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-10-14-15-48.bpo-37812.jkh0Wp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-10-14-15-48.bpo-37812.jkh0Wp.rst
@@ -1,6 +1,6 @@
 The "small int" optimization is now unconditionally enabled.  This
 optimization was introduced in Python 1.0.1, and means that :class:`int`
-values from -5 to 256 are pre-initialized rather than constructed on demand.
-The option was always enabled unless certain never-documented preprocessor
-macros were defined to 0 at build time; now it is always enabled,
-simplifying the logic.  Patch by Greg Price.
+values from -5 through 256 are pre-initialized rather than constructed on
+demand.  The option was always enabled unless certain never-documented
+preprocessor macros were defined to 0 at build time; now it is always
+enabled, simplifying the logic.  Patch by Greg Price.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -34,7 +34,6 @@ _Py_IDENTIFIER(big);
 PyObject *_PyLong_Zero = NULL;
 PyObject *_PyLong_One = NULL;
 
-#if NSMALLNEGINTS + NSMALLPOSINTS > 0
 /* Small integers are preallocated in this array so that they
    can be shared.
    The integers that are preallocated are those in the range
@@ -77,10 +76,6 @@ maybe_small_long(PyLongObject *v)
     }
     return v;
 }
-#else
-#define CHECK_SMALL_INT(ival)
-#define maybe_small_long(val) (val)
-#endif
 
 /* If a freshly-allocated int is already shared, it must
    be a small integer, so negating it must go to PyLong_FromLong */
@@ -5808,7 +5803,6 @@ PyLong_GetInfo(void)
 int
 _PyLong_Init(void)
 {
-#if NSMALLNEGINTS + NSMALLPOSINTS > 0
     int ival, size;
     PyLongObject *v = small_ints;
 
@@ -5836,7 +5830,7 @@ _PyLong_Init(void)
         Py_SIZE(v) = size;
         v->ob_digit[0] = (digit)abs(ival);
     }
-#endif
+
     _PyLong_Zero = PyLong_FromLong(0);
     if (_PyLong_Zero == NULL)
         return 0;
@@ -5862,12 +5856,11 @@ PyLong_Fini(void)
        reinitializations will fail. */
     Py_CLEAR(_PyLong_One);
     Py_CLEAR(_PyLong_Zero);
-#if NSMALLNEGINTS + NSMALLPOSINTS > 0
+
     int i;
     PyLongObject *v = small_ints;
     for (i = 0; i < NSMALLNEGINTS + NSMALLPOSINTS; i++, v++) {
         _Py_DEC_REFTOTAL;
         _Py_ForgetReference((PyObject*)v);
     }
-#endif
 }


### PR DESCRIPTION
This optimization was added in 1993 (commit 842d2ccdc), and we've
been running with it ever since.  I think at this point it's fair
to say that it's no longer experimental.  That lets us simplify
the code by removing a number of `#ifdef`s.

In particular this will help us simplify the usage of CHECK_SMALL_INT.



<!-- issue-number: [bpo-37812](https://bugs.python.org/issue37812) -->
https://bugs.python.org/issue37812
<!-- /issue-number -->
