### PR TITLE
gh-81989: Deprecate passing a single argument to super()

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1640,6 +1640,9 @@ are always available.  They are listed here in alphabetical order.
    :func:`super`, see `guide to using super()
    <https://rhettinger.wordpress.com/2011/05/26/super-considered-super/>`_.
 
+   .. deprecated:: 3.9
+      Calling :func:`super` with one argument.
+
 
 .. _func-tuple:
 .. function:: tuple([iterable])

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -159,6 +159,9 @@ Deprecated
   of Python. For the majority of use cases users can leverage the Abstract Syntax
   Tree (AST) generation and compilation stage, using the :mod:`ast` module.
 
+* Passing a single argument to the :func:`super` function is deprecated.  In
+  future Python versions, this will raise an exception.
+
 
 Removed
 =======

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -541,7 +541,9 @@ class ClassPropertiesAndMethods(unittest.TestCase):
                     name = "_%s__super" % name
                 else:
                     name = "__super"
-                setattr(cls, name, super(cls))
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', DeprecationWarning)
+                    setattr(cls, name, super(cls))
                 return cls
         class A(metaclass=autosuper):
             def meth(self):

--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -317,6 +317,11 @@ class TestSuper(unittest.TestCase):
         for i in range(1000):
             super.__init__(sp, int, i)
 
+    def test_super_one_arg_deprecation(self):
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   'Passing 1 argument'):
+            super(int)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1288,7 +1288,7 @@ class SizeofTest(unittest.TestCase):
         # slice
         check(slice(0), size('3P'))
         # super
-        check(super(int), size('3P'))
+        check(super(), size('3P'))
         # tuple
         check((), vsize(''))
         check((1,2,3), vsize('') + 3*self.P)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-10-23-14-11.bpo-37808.0eUraj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-10-23-14-11.bpo-37808.0eUraj.rst
@@ -1,0 +1,1 @@
+Deprecate passing a single argument to :func:`super`.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7822,6 +7822,12 @@ super_init(PyObject *self, PyObject *args, PyObject *kwds)
     if (!PyArg_ParseTuple(args, "|O!O:super", &PyType_Type, &type, &obj))
         return -1;
 
+    if (PyTuple_GET_SIZE(args) == 1 &&
+        PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "Passing 1 argument to super() is deprecated", 1) < 0) {
+        return -1;
+    }
+
     if (type == NULL) {
         /* Call super(), without args -- fill in from __class__
            and first local variable on the stack. */


### PR DESCRIPTION


<!-- issue-number: [bpo-37808](https://bugs.python.org/issue37808) -->
https://bugs.python.org/issue37808
<!-- /issue-number -->


<!-- gh-issue-number: gh-81989 -->
* Issue: gh-81989
<!-- /gh-issue-number -->
