### PR TITLE
bpo-37827: IDLE shell handling of \r and \b control chars

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -752,11 +752,13 @@ with 300 the default.
 A Tk Text widget, and hence IDLE's Shell, displays characters (codepoints) in
 the BMP (Basic Multilingual Plane) subset of Unicode.  Which characters are
 displayed with a proper glyph and which with a replacement box depends on the
-operating system and installed fonts.  Tab characters cause the following text
-to begin after the next tab stop. (They occur every 8 'characters').  Newline
-characters cause following text to appear on a new line.  Other control
-characters are ignored or displayed as a space, box, or something else,
-depending on the operating system and font.  (Moving the text cursor through
+OS and installed fonts.  Tab characters (``\t``) cause the following text to
+begin after the next tab stop.  (They occur every 8 'characters').  Newline
+characters (``\n``) cause following text to appear on a new line.  Carriage-
+return characters (``\r``) move the cursor back to the beginning of the current
+line, and backspace characters (``\b``) move the cursor back one character.
+Other control characters are ignored or displayed as a space, a box, or
+something else, depending on the OS and font.  (Moving the text cursor through
 such output with arrow keys may exhibit some surprising spacing behavior.) ::
 
    >>> s = 'a\tb\a<\x02><\r>\bc\nd'  # Enter 22 chars.
@@ -764,7 +766,7 @@ such output with arrow keys may exhibit some surprising spacing behavior.) ::
    14
    >>> s  # Display repr(s)
    'a\tb\x07<\x02><\r>\x08c\nd'
-   >>> print(s, end='')  # Display s as is.
+   >>> print(s)  # Send s to the output
    # Result varies by OS and font.  Try it.
 
 The ``repr`` function is used for interactive echo of expression

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1033,6 +1033,11 @@ tab of the configuration dialog.  Line numbers for an existing
 window are shown and hidden in the Options menu.
 (Contributed by Tal Einat and Saimadhav Heblikar in :issue:`17535`.)
 
+In the shell, ``\r`` and ``\b`` control characters in output are now handled
+much like in terminals, i.e. moving the cursor position.  This allows common
+uses of these control characters, such as progress indicators, to be displayed
+properly rather than flooding the output and eventually slowing the shell down
+to a crawl.  (Contributed by Tal Einat in :issue:`37827`.)
 
 importlib
 ---------

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -610,6 +610,12 @@ tab of the configuration dialog.  Line numbers for an existing
 window are shown and hidden in the Options menu.
 (Contributed by Tal Einat and Saimadhav Heblikar in :issue:`17535`.)
 
+In the shell, ``\r`` and ``\b`` control characters in output are now handled
+much like in terminals, i.e. moving the cursor position.  This allows common
+uses of these control characters, such as progress indicators, to be displayed
+properly rather than flooding the output and eventually slowing the shell down
+to a crawl.  (Contributed by Tal Einat in :issue:`37827`.)
+
 The changes above have been backported to 3.7 maintenance releases.
 
 

--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -48,45 +48,45 @@ class TestProcessControlChars(unittest.TestCase):
     def test_empty_written(self):
         self.check('', '', 0, (False, '', 0))
         self.check('a', '', 0, (False, '', 0))
-        self.check('a', '', 1, (False, '', 1))
+        self.check('a', '', 1, (False, '', 0))
         for cursor in range(4):
             with self.subTest(cursor=cursor):
-                self.check('abc', '', cursor, (False, '', cursor))
+                self.check('abc', '', cursor, (False, '', 0))
 
     def test_empty_existing(self):
-        self.check('', 'a', 0, (False, 'a', 1))
-        self.check('', 'ab', 0, (False, 'ab', 2))
-        self.check('', 'abc', 0, (False, 'abc', 3))
+        self.check('', 'a', 0, (False, 'a', 0))
+        self.check('', 'ab', 0, (False, 'ab', 0))
+        self.check('', 'abc', 0, (False, 'abc', 0))
 
     def test_simple_cursor(self):
-        self.check('abc', 'def', 0, (True, 'def', 3))
-        self.check('abc', 'def', 1, (True, 'adef', 4))
-        self.check('abc', 'def', 2, (True, 'abdef', 5))
+        self.check('abc', 'def', 0, (False, 'def', 0))
+        self.check('abc', 'def', 1, (False, 'def', 0))
+        self.check('abc', 'def', 2, (False, 'def', 0))
 
-        self.check('abc', 'def', 3, (False, 'def', 6))
+        self.check('abc', 'def', 3, (False, 'def', 0))
 
     def test_carriage_return(self):
-        self.check('', 'a\rb', 0, (False, 'b', 1))
-        self.check('', 'abc\rd', 0, (False, 'dbc', 1))
+        self.check('', 'a\rb', 0, (False, 'b', 0))
+        self.check('', 'abc\rd', 0, (False, 'dbc', 2))
 
     def test_carriage_return_doesnt_delete(self):
         # \r should only move the cursor to the beginning of the current line
-        self.check('', 'a\r', 0, (False, 'a', 0))
-        self.check('', 'abc\r', 0, (False, 'abc', 0))
+        self.check('', 'a\r', 0, (False, 'a', 1))
+        self.check('', 'abc\r', 0, (False, 'abc', 3))
 
     def test_backspace(self):
-        self.check('', '\ba', 0, (False, 'a', 1))
-        self.check('', 'a\bb', 0, (False, 'b', 1))
-        self.check('', 'ab\bc', 0, (False, 'ac', 2))
-        self.check('', 'ab\bc\bd', 0, (False, 'ad', 2))
+        self.check('', '\ba', 0, (False, 'a', 0))
+        self.check('', 'a\bb', 0, (False, 'b', 0))
+        self.check('', 'ab\bc', 0, (False, 'ac', 0))
+        self.check('', 'ab\bc\bd', 0, (False, 'ad', 0))
 
     def test_backspace_doesnt_delete(self):
         # \b should only move the cursor one place earlier
-        self.check('', 'a\b', 0, (False, 'a', 0))
-        self.check('', 'a\b\b', 0, (False, 'a', 0))
-        self.check('', 'ab\b\b', 0, (False, 'ab', 0))
+        self.check('', 'a\b', 0, (False, 'a', 1))
+        self.check('', 'a\b\b', 0, (False, 'a', 1))
+        self.check('', 'ab\b\b', 0, (False, 'ab', 2))
         self.check('', 'ab\b\bc', 0, (False, 'cb', 1))
-        self.check('', 'abc\b\bd', 0, (False, 'adc', 2))
+        self.check('', 'abc\b\bd', 0, (False, 'adc', 1))
         self.check('', 'ab\bc\b', 0, (False, 'ac', 1))
 
     def test_newline(self):
@@ -94,9 +94,9 @@ class TestProcessControlChars(unittest.TestCase):
         self.check('abc', '\n', 3, (False, '\n', 0))
 
     def test_newline_and_carriage_return(self):
-        self.check('abc', '\n\rdef', 3, (False, '\ndef', 3))
-        self.check('abc', 'd\n\ref', 3, (False, 'd\nef', 2))
-        self.check('abc', 'de\n\rf', 3, (False, 'de\nf', 1))
+        self.check('abc', '\n\rdef', 3, (False, '\ndef', 0))
+        self.check('abc', 'd\n\ref', 3, (False, 'd\nef', 0))
+        self.check('abc', 'de\n\rf', 3, (False, 'de\nf', 0))
         self.check('abc', 'def\n\r', 3, (False, 'def\n', 0))
 
 

--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -38,5 +38,63 @@ class PyShellFileListTest(unittest.TestCase):
 ##        self.assertIsInstance(ps, pyshell.PyShell)
 
 
+class TestProcessControlChars(unittest.TestCase):
+    def check(self, existing, string, cursor, expected):
+        self.assertEqual(
+            pyshell.PyShell._process_control_chars(existing, string, cursor),
+            expected,
+        )
+
+    def test_empty_written(self):
+        self.check('', '', 0, (False, '', 0))
+        self.check('a', '', 0, (False, '', 0))
+        self.check('a', '', 1, (False, '', 1))
+        for cursor in range(4):
+            with self.subTest(cursor=cursor):
+                self.check('abc', '', cursor, (False, '', cursor))
+
+    def test_empty_existing(self):
+        self.check('', 'a', 0, (False, 'a', 1))
+        self.check('', 'ab', 0, (False, 'ab', 2))
+        self.check('', 'abc', 0, (False, 'abc', 3))
+
+    def test_simple_cursor(self):
+        self.check('abc', 'def', 0, (True, 'def', 3))
+        self.check('abc', 'def', 1, (True, 'adef', 4))
+        self.check('abc', 'def', 2, (True, 'abdef', 5))
+
+        self.check('abc', 'def', 3, (False, 'def', 6))
+
+    def test_carriage_return(self):
+        self.check('', 'a\rb', 0, (False, 'b', 1))
+        self.check('', 'abc\rd', 0, (False, 'dbc', 1))
+
+    def test_carriage_return_doesnt_delete(self):
+        # \r should only move the cursor to the beginning of the current line
+        self.check('', 'a\r', 0, (False, 'a', 0))
+        self.check('', 'abc\r', 0, (False, 'abc', 0))
+
+    def test_backspace(self):
+        self.check('', '\ba', 0, (False, 'a', 1))
+        self.check('', 'a\bb', 0, (False, 'b', 1))
+        self.check('', 'ab\bc', 0, (False, 'ac', 2))
+        self.check('', 'ab\bc\bd', 0, (False, 'ad', 2))
+
+    def test_backspace_doesnt_delete(self):
+        # \b should only move the cursor one place earlier
+        self.check('', 'a\b', 0, (False, 'a', 0))
+        self.check('', 'a\b\b', 0, (False, 'a', 0))
+        self.check('', 'ab\b\b', 0, (False, 'ab', 0))
+        self.check('', 'ab\b\bc', 0, (False, 'cb', 1))
+        self.check('', 'abc\b\bd', 0, (False, 'adc', 2))
+        self.check('', 'ab\bc\b', 0, (False, 'ac', 1))
+
+    def test_newline(self):
+        self.check('abc', '\n\rdef', 3, (False, '\ndef', 3))
+        self.check('abc', 'd\n\ref', 3, (False, 'd\nef', 2))
+        self.check('abc', 'de\n\rf', 3, (False, 'de\nf', 1))
+        self.check('abc', 'def\n\r', 3, (False, 'def\n', 0))
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -90,6 +90,10 @@ class TestProcessControlChars(unittest.TestCase):
         self.check('', 'ab\bc\b', 0, (False, 'ac', 1))
 
     def test_newline(self):
+        self.check('', '\n', 0, (False, '\n', 0))
+        self.check('abc', '\n', 3, (False, '\n', 0))
+
+    def test_newline_and_carriage_return(self):
         self.check('abc', '\n\rdef', 3, (False, '\ndef', 3))
         self.check('abc', 'd\n\ref', 3, (False, 'd\nef', 2))
         self.check('abc', 'de\n\rf', 3, (False, 'de\nf', 1))

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -1409,15 +1409,16 @@ class PyShell(OutputWindow):
 
         idx = 0
         while m is not None:
-            string_part = string[idx:m.start()]
-            write(string_part)
+            if m.start() > idx:
+                string_part = string[idx:m.start()]
+                write(string_part)
 
-            # We never write before the last newline, so we must keep
-            # track of the last newline written.
-            new_str_last_newline = string_part.rfind('\n')
-            if new_str_last_newline >= 0:
-                last_linestart = \
-                    cursor - len(string_part) + new_str_last_newline + 1
+                # We never write before the last newline, so we must keep
+                # track of the last newline written.
+                new_str_last_newline = string_part.rfind('\n')
+                if new_str_last_newline >= 0:
+                    last_linestart = \
+                        cursor - len(string_part) + new_str_last_newline + 1
 
             # Process a sequence of control characters. This assumes
             # that they are all '\r' and/or '\b' characters.
@@ -1431,8 +1432,9 @@ class PyShell(OutputWindow):
             m = _control_char_re.search(string, idx)
 
         # Handle rest of output after final control character.
-        rewrite |= cursor < orig_cursor
-        write(string[idx:])
+        if idx < len(string):
+            rewrite |= cursor < orig_cursor
+            write(string[idx:])
         buffer.seek(0, 2)  # seek to end
         buffer_len = buffer.tell()
 

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -1387,22 +1387,25 @@ class PyShell(OutputWindow):
         def write(string):
             nonlocal buffer, cursor, rewrite
             rewrite |= cursor < orig_cursor
+
+            string_first_newline = string.find('\n')
             buffer.seek(0, 2)  # seek to end
             end = buffer.tell()
             buffer.seek(cursor)
-            string_first_newline = string.find('\n')
-            # Split the string only if we have to in order to overwrite
-            # just part of the first line.
             if (
                     string_first_newline >= 0 and
                     cursor + string_first_newline < end
             ):
+                # We must split the string in order to overwrite just
+                # part of the first line.
                 buffer.write(string[:string_first_newline])
                 buffer.seek(0, 2)  # seek to end
                 buffer.write(string[string_first_newline:])
             else:
                 buffer.write(string)
+
             cursor = buffer.tell()
+            return
 
         idx = 0
         while m is not None:
@@ -1429,7 +1432,6 @@ class PyShell(OutputWindow):
 
         # Handle rest of output after final control character.
         rewrite |= cursor < orig_cursor
-        buffer.seek(cursor)
         write(string[idx:])
         buffer.seek(0, 2)  # seek to end
         buffer_len = buffer.tell()

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -1280,12 +1280,14 @@ class PyShell(OutputWindow):
         self.io.reset_undo()
 
     def show_warning(self, msg):
+        print(f"BEFORE WARNING: iomark={text.index('iomark')}, end={text.index('end')}")
         width = self.interp.tkconsole.width
         wrapper = TextWrapper(width=width, tabsize=8, expand_tabs=True)
         wrapped_msg = '\n'.join(wrapper.wrap(msg))
         if not wrapped_msg.endswith('\n'):
             wrapped_msg += '\n'
         self.per.bottom.insert("iomark linestart", wrapped_msg, "stderr")
+        print(f"AFTER WARNING:  iomark={text.index('iomark')}, end={text.index('end')}")
 
     def resetoutput(self):
         source = self.text.get("iomark", "end-1c")
@@ -1371,7 +1373,7 @@ class PyShell(OutputWindow):
                 res = string
             last_linestart = string.rfind('\n')
             if last_linestart >= 0:
-                cursor = len(string) - last_linestart + 1
+                cursor = len(string) - (last_linestart + 1)
             else:
                 cursor += len(string)
             return rewrite, res, cursor

--- a/Misc/NEWS.d/next/IDLE/2019-08-13-10-34-26.bpo-37827.S6vxP3.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-08-13-10-34-26.bpo-37827.S6vxP3.rst
@@ -1,0 +1,2 @@
+Emulate terminal handling of ``\r`` and ``\b`` control characters in shell
+outoput.


### PR DESCRIPTION
This is a first working version, looking for some user testing and feedback!

This allows most progress bars to just work in IDLE, rather than flooding the shell window and sometimes slowing it down to a crawl. More generally, this makes IDLE's shell behave more similarly to a plain Python shell in a terminal.

Note that some progress bar libraries, e.g. tqdm, now "just work"!

In some cases some integration might be required; for example, TensorFlow does several checks on the `sys.stdout` file-like object to decide whether to use these control characters. Hacking TensorFlow to override that check makes it work as intended in the IDLE shell with this change.

Note that this also currently includes a subtle change which attempts to avoid clobbering the user input when output is written after a command has finished executing, e.g. by a separate thread. But that's not the main addition here.

<!-- issue-number: [bpo-37827](https://bugs.python.org/issue37827) -->
https://bugs.python.org/issue37827
<!-- /issue-number -->