### PR TITLE
bpo-37829 Added an example of dict() function with positional and keyword argum…

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4210,7 +4210,8 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
       >>> c = dict(zip(['one', 'two', 'three'], [1, 2, 3]))
       >>> d = dict([('two', 2), ('one', 1), ('three', 3)])
       >>> e = dict({'three': 3, 'one': 1, 'two': 2})
-      >>> a == b == c == d == e
+      >>> f = dict({'one': 1, 'three': 3}, two=2)
+      >>> a == b == c == d == e == f
       True
 
    Providing keyword arguments as in the first example only works for keys that


### PR DESCRIPTION
The following use of the dict() function with both positional and keyword arguments  does follow from the description, but probably needs it's own example:

`dict({'a': 1}, b=2) == {'a': 1, 'b': 2}`

<!-- issue-number: [bpo-37829](https://bugs.python.org/issue37829) -->
https://bugs.python.org/issue37829
<!-- /issue-number -->
