### PR TITLE
logging.Formatter docs: Add missing `validate` parameter, clarify `style` parameter

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -538,8 +538,11 @@ The useful mapping keys in a :class:`LogRecord` are given in the section on
 
    The *style* parameter can be one of '%', '{' or '$' and determines how
    the format string will be merged with its data: using one of %-formatting,
-   :meth:`str.format` or :class:`string.Template`. See :ref:`formatting-styles`
-   for more information on using {- and $-formatting for log messages.
+   :meth:`str.format` or :class:`string.Template`. This only applies to the
+   format string *fmt* (e.g. ``'%(message)s'`` or ``{message}``), not to the
+   actual log messages passed to ``Logger.debug`` etc; see
+   :ref:`formatting-styles` for more information on using {- and $-formatting
+   for log messages.
 
    .. versionchanged:: 3.2
       The *style* parameter was added.

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -528,7 +528,7 @@ The useful mapping keys in a :class:`LogRecord` are given in the section on
 :ref:`logrecord-attributes`.
 
 
-.. class:: Formatter(fmt=None, datefmt=None, style='%')
+.. class:: Formatter(fmt=None, datefmt=None, style='%', validate=True)
 
    Returns a new instance of the :class:`Formatter` class.  The instance is
    initialized with a format string for the message as a whole, as well as a


### PR DESCRIPTION
* The `validate` parameter was missing from the constructor's signature (it was already documented in the text lower down, but missing from the signature).
* Clarify that the `style` parameter is for the `fmt` parameter, not for log messages. On my first read of the documentation I thought this was saying that `logging` had built-in support for `{format}` style log messages.
