### PR TITLE
bpo-38110: Use fdwalk for os.closerange() when available.

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-09-11-14-49-20.bpo-38110.A19Y-q.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-11-14-49-20.bpo-38110.A19Y-q.rst
@@ -1,0 +1,2 @@
+The os.closewalk() implementation now uses the libc fdwalk() API on
+platforms where it is available.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8420,7 +8420,7 @@ os_closerange_impl(PyObject *module, int fd_low, int fd_high)
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
 #ifdef HAVE_FDWALK
-    lohi[0] = fd_low;
+    lohi[0] = Py_MAX(fd_low, 0);
     lohi[1] = fd_high;
     fdwalk(_fdwalk_close_func, lohi);
 #else

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8383,6 +8383,21 @@ os_close_impl(PyObject *module, int fd)
 }
 
 
+#ifdef HAVE_FDWALK
+static int
+_fdwalk_close_func(void *lohi, int fd)
+{
+    int lo = ((int *)lohi)[0];
+    int hi = ((int *)lohi)[1];
+
+    if (fd >= hi)
+        return 1;
+    else if (fd >= lo)
+        close(fd);
+    return 0;
+}
+#endif /* HAVE_FDWALK */
+
 /*[clinic input]
 os.closerange
 
@@ -8397,11 +8412,21 @@ static PyObject *
 os_closerange_impl(PyObject *module, int fd_low, int fd_high)
 /*[clinic end generated code: output=0ce5c20fcda681c2 input=5855a3d053ebd4ec]*/
 {
+#ifdef HAVE_FDWALK
+    int lohi[2];
+#else
     int i;
+#endif
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
+#ifdef HAVE_FDWALK
+    lohi[0] = fd_low;
+    lohi[1] = fd_high;
+    fdwalk(_fdwalk_close_func, lohi);
+#else
     for (i = Py_MAX(fd_low, 0); i < fd_high; i++)
         close(i);
+#endif
     _Py_END_SUPPRESS_IPH
     Py_END_ALLOW_THREADS
     Py_RETURN_NONE;

--- a/configure
+++ b/configure
@@ -11488,7 +11488,7 @@ fi
 for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  clock confstr copy_file_range ctermid dup3 execv explicit_bzero explicit_memset \
  faccessat fchmod fchmodat fchown fchownat \
- fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
+ fdwalk fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
  futimens futimes gai_strerror getentropy \
  getgrgid_r getgrnam_r \
  getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \

--- a/configure.ac
+++ b/configure.ac
@@ -3538,7 +3538,7 @@ fi
 AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  clock confstr copy_file_range ctermid dup3 execv explicit_bzero explicit_memset \
  faccessat fchmod fchmodat fchown fchownat \
- fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
+ fdwalk fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
  futimens futimes gai_strerror getentropy \
  getgrgid_r getgrnam_r \
  getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -341,6 +341,9 @@
 /* Define to 1 if you have the `fdopendir' function. */
 #undef HAVE_FDOPENDIR
 
+/* Define to 1 if you have the `fdwalk' function. */
+#undef HAVE_FDWALK
+
 /* Define to 1 if you have the `fexecve' function. */
 #undef HAVE_FEXECVE
 


### PR DESCRIPTION
Use fdwalk() on platforms that support it to implement os.closerange().

<!-- issue-number: [bpo-38110](https://bugs.python.org/issue38110) -->
https://bugs.python.org/issue38110
<!-- /issue-number -->
