### PR TITLE
bpo-37804: Remove the deprecated method threading.Thread.isAlive()

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -186,6 +186,10 @@ Removed
   removed. They were deprecated since Python 3.7.
   (Contributed by Victor Stinner in :issue:`37320`.)
 
+* The :meth:`~threading.Thread.isAlive()` method of :class:`threading.Thread`
+  has been removed. It was deprecated since Python 3.8.
+  Use :meth:`~threading.Thread.is_alive()` instead.
+  (Contributed by Dong-hee Na in :issue:`37804`.)
 
 Porting to Python 3.9
 =====================

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -422,8 +422,6 @@ class ThreadTests(BaseTestCase):
         t.setDaemon(True)
         t.getName()
         t.setName("name")
-        with self.assertWarnsRegex(DeprecationWarning, 'use is_alive()'):
-            t.isAlive()
         e = threading.Event()
         e.isSet()
         threading.activeCount()

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1088,16 +1088,6 @@ class Thread:
         self._wait_for_tstate_lock(False)
         return not self._is_stopped
 
-    def isAlive(self):
-        """Return whether the thread is alive.
-
-        This method is deprecated, use is_alive() instead.
-        """
-        import warnings
-        warnings.warn('isAlive() is deprecated, use is_alive() instead',
-                      DeprecationWarning, stacklevel=2)
-        return self.is_alive()
-
     @property
     def daemon(self):
         """A boolean value indicating whether this thread is a daemon thread.

--- a/Misc/NEWS.d/next/Library/2019-08-12-23-07-47.bpo-37804.Ene6L-.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-12-23-07-47.bpo-37804.Ene6L-.rst
@@ -1,0 +1,2 @@
+Remove the deprecated method `threading.Thread.isAlive()`. Patch by Dong-hee
+Na.


### PR DESCRIPTION


<!-- issue-number: [bpo-37804](https://bugs.python.org/issue37804) -->
https://bugs.python.org/issue37804
<!-- /issue-number -->
