### PR TITLE
[3.7] bpo-37642: Update max and min offset in datetime module (GH-14878)

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -2226,7 +2226,7 @@ class timezone(tzinfo):
         raise TypeError("fromutc() argument must be a datetime instance"
                         " or None")
 
-    _maxoffset = timedelta(hours=23, minutes=59)
+    _maxoffset = timedelta(hours=24, microseconds=-1)
     _minoffset = -_maxoffset
 
     @staticmethod
@@ -2250,8 +2250,11 @@ class timezone(tzinfo):
         return f'UTC{sign}{hours:02d}:{minutes:02d}'
 
 timezone.utc = timezone._create(timedelta(0))
-timezone.min = timezone._create(timezone._minoffset)
-timezone.max = timezone._create(timezone._maxoffset)
+# bpo-37642: These attributes are rounded to the nearest minute for backwards
+# compatibility, even though the constructor will accept a wider range of
+# values. This may change in the future.
+timezone.min = timezone._create(-timedelta(hours=23, minutes=59))
+timezone.max = timezone._create(timedelta(hours=23, minutes=59))
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 # Some time zone algebra.  For a datetime x, let

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -388,6 +388,31 @@ class TestTimeZone(unittest.TestCase):
         tz_copy = copy.deepcopy(tz)
         self.assertIs(tz_copy, tz)
 
+    def test_offset_boundaries(self):
+        # Test timedeltas close to the boundaries
+        time_deltas = [
+            timedelta(hours=23, minutes=59),
+            timedelta(hours=23, minutes=59, seconds=59),
+            timedelta(hours=23, minutes=59, seconds=59, microseconds=999999),
+        ]
+        time_deltas.extend([-delta for delta in time_deltas])
+
+        for delta in time_deltas:
+            with self.subTest(test_type='good', delta=delta):
+                timezone(delta)
+
+        # Test timedeltas on and outside the boundaries
+        bad_time_deltas = [
+            timedelta(hours=24),
+            timedelta(hours=24, microseconds=1),
+        ]
+        bad_time_deltas.extend([-delta for delta in bad_time_deltas])
+
+        for delta in bad_time_deltas:
+            with self.subTest(test_type='bad', delta=delta):
+                with self.assertRaises(ValueError):
+                    timezone(delta)
+
 
 #############################################################################
 # Base class for testing a particular aspect of timedelta, time, date and

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1835,3 +1835,4 @@ Doug Zongker
 Peter Åstrand
 Zheao Li
 Geoff Shannon
+Ngalim Siregar

--- a/Misc/NEWS.d/next/Library/2019-07-21-20-59-31.bpo-37642.L61Bvy.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-21-20-59-31.bpo-37642.L61Bvy.rst
@@ -1,0 +1,3 @@
+Allowed the pure Python implementation of :class:`datetime.timezone` to represent
+sub-minute offsets close to minimum and maximum boundaries, specifically in the
+ranges (23:59, 24:00) and (-23:59, 24:00). Patch by Ngalim Siregar


### PR DESCRIPTION
This fixes an inconsistency between the Python and C implementations of
the datetime module. The pure python version of the code was not
accepting offsets greater than 23:59 but less than 24:00. This is an
accidental legacy of the original implementation, which was put in place
before tzinfo allowed sub-minute time zone offsets.

GH-14878

(cherry picked from commit 92c7e30adf5c81a54d6e5e555a6bdfaa60157a0d)


<!-- issue-number: [bpo-37642](https://bugs.python.org/issue37642) -->
https://bugs.python.org/issue37642
<!-- /issue-number -->
