### PR TITLE
Doc: Keep the venv/* exclude pattern.

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -48,8 +48,10 @@ highlight_language = 'python3'
 needs_sphinx = '1.8'
 
 # Ignore any .rst files in the venv/ directory.
-venvdir = os.getenv('VENVDIR', 'venv')
-exclude_patterns = [venvdir+'/*', 'README.rst']
+exclude_patterns = ['venv/*', 'README.rst']
+venvdir = os.getenv('VENVDIR')
+if venvdir is not None:
+    exclude_patterns.append(venvdir + '/*')
 
 # Disable Docutils smartquotes for several translations
 smartquotes_excludes = {


### PR DESCRIPTION
In case it has been previously created.
