### PR TITLE
bpo-16637: libpython: interpret string as integer literal

### DIFF
--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1392,7 +1392,7 @@ class wrapperobject(PyObjectPtr):
 
 
 def int_from_int(gdbval):
-    return int(str(gdbval))
+    return int(gdbval)
 
 
 def stringify(val):


### PR DESCRIPTION
This fixes the exception `ValueError: invalid literal for int() with base 10`
if `str(gdbval)` returns a hexadecimal value (e.g. '0xa0').

See https://docs.python.org/3/library/functions.html#int for more information.

<!-- issue-number: [bpo-16637](https://bugs.python.org/issue16637) -->
https://bugs.python.org/issue16637
<!-- /issue-number -->
