### PR TITLE
Minor documentation fixes on library/enum

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -383,8 +383,8 @@ enumeration, with the exception of special methods (:meth:`__str__`,
 variable names listed in :attr:`_ignore_`.
 
 Note:  if your enumeration defines :meth:`__new__` and/or :meth:`__init__` then
-whatever value(s) were given to the enum member will be passed into those
-methods.  See `Planet`_ for an example.
+whatever value(s) given to the enum member will be passed into those methods.
+See `Planet`_ for an example.
 
 
 Restricted Enum subclassing
@@ -730,8 +730,7 @@ Some rules:
 2. While :class:`Enum` can have members of any type, once you mix in an
    additional type, all the members must have values of that type, e.g.
    :class:`int` above.  This restriction does not apply to mix-ins which only
-   add methods and don't specify another data type such as :class:`int` or
-   :class:`str`.
+   add methods and don't specify another data type.
 3. When another data type is mixed in, the :attr:`value` attribute is *not the
    same* as the enum member itself, although it is equivalent and will compare
    equal.
@@ -1054,7 +1053,7 @@ Supported ``_sunder_`` names
 
 - ``_missing_`` -- a lookup function used when a value is not found; may be
   overridden
-- ``_ignore_`` -- a list of names, either as a :func:`list` or a :func:`str`,
+- ``_ignore_`` -- a list of names, either as a :class:`list` or a :class:`str`,
   that will not be transformed into members, and will be removed from the final
   class
 - ``_order_`` -- used in Python 2/3 code to ensure member order is consistent

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -730,7 +730,7 @@ Some rules:
 2. While :class:`Enum` can have members of any type, once you mix in an
    additional type, all the members must have values of that type, e.g.
    :class:`int` above.  This restriction does not apply to mix-ins which only
-   add methods and don't specify another data type.
+   add methods and don't specify another type.
 3. When another data type is mixed in, the :attr:`value` attribute is *not the
    same* as the enum member itself, although it is equivalent and will compare
    equal.

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -383,7 +383,7 @@ enumeration, with the exception of special methods (:meth:`__str__`,
 variable names listed in :attr:`_ignore_`.
 
 Note:  if your enumeration defines :meth:`__new__` and/or :meth:`__init__` then
-whatever value(s) given to the enum member will be passed into those methods.
+any value(s) given to the enum member will be passed into those methods.
 See `Planet`_ for an example.
 
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1770,6 +1770,7 @@ Steve Weber
 Corran Webster
 Glyn Webster
 Phil Webster
+Antoine Wecxsteen
 Stefan Wehr
 Zack Weinberg
 Bob Weiner


### PR DESCRIPTION
This PR fixes 3 minor issues in library/enum doc:

- l.386: extra "were" that make the sentence incorrect.
- l.732: I believe this is a bad example.
- l.1056 typo: we're referring here to _list_ and _str_ as objects, not callables.