### PR TITLE
bpo-37764: Fix infinite loop when parsing unstructured email headers.

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1039,7 +1039,10 @@ def get_encoded_word(value):
         raise errors.HeaderParseError(
             "expected encoded word but found {}".format(value))
     remstr = ''.join(remainder)
-    if len(remstr) > 1 and remstr[0] in hexdigits and remstr[1] in hexdigits and tok.count('?') < 2:
+    if (len(remstr) > 1 and
+        remstr[0] in hexdigits and
+        remstr[1] in hexdigits and
+        tok.count('?') < 2):
         # The ? after the CTE was followed by an encoded word escape (=XX).
         rest, *remainder = remstr.split('?=', 1)
         tok = tok + '?=' + rest

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1101,14 +1101,14 @@ def get_unstructured(value):
             token, value = get_fws(value)
             unstructured.append(token)
             continue
-        header_parse_error = False
+        encoded_format_invalid = False
         if value.startswith('=?'):
             try:
                 token, value = get_encoded_word(value)
             except errors.HeaderParseError as e:
                 if "encoded word format invalid" in str(e):
                     unstructured.defects.append(errors.InvalidHeaderDefect(str(e)))
-                    header_parse_error = True
+                    encoded_format_invalid = True
             else:
                 have_ws = True
                 if len(unstructured) > 0:
@@ -1126,7 +1126,7 @@ def get_unstructured(value):
         # Split in the middle of an atom if there is a rfc2047 encoded word
         # which does not have WSP on both sides. The defect will be registered
         # the next time through the loop.
-        if not header_parse_error and rfc2047_matcher.search(tok):
+        if not encoded_format_invalid and rfc2047_matcher.search(tok):
             tok, *remainder = value.partition('=?')
         vtext = ValueTerminal(tok, 'vtext')
         _validate_xtext(vtext)

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1054,7 +1054,7 @@ def get_encoded_word(value):
     try:
         text, charset, lang, defects = _ew.decode('=?' + tok + '?=')
     except ValueError:
-        raise errors.HeaderParseError(
+        raise errors.InvalidEwError(
             "encoded word format invalid: '{}'".format(ew.cte))
     ew.charset = charset
     ew.lang = lang
@@ -1108,9 +1108,12 @@ def get_unstructured(value):
         if value.startswith('=?'):
             try:
                 token, value = get_encoded_word(value)
-            except errors.HeaderParseError as e:
-                if "encoded word format invalid" in str(e):
-                    valid_ew = False
+            except errors.InvalidEwError:
+                valid_ew = False
+            except errors.HeaderParseError:
+                # XXX: Need to figure out how to register defects when
+                # appropriate here.
+                pass
             else:
                 have_ws = True
                 if len(unstructured) > 0:

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1104,13 +1104,13 @@ def get_unstructured(value):
             token, value = get_fws(value)
             unstructured.append(token)
             continue
-        encoded_format_invalid = False
+        valid_ew = True
         if value.startswith('=?'):
             try:
                 token, value = get_encoded_word(value)
             except errors.HeaderParseError as e:
                 if "encoded word format invalid" in str(e):
-                    encoded_format_invalid = True
+                    valid_ew = False
             else:
                 have_ws = True
                 if len(unstructured) > 0:
@@ -1128,7 +1128,7 @@ def get_unstructured(value):
         # Split in the middle of an atom if there is a rfc2047 encoded word
         # which does not have WSP on both sides. The defect will be registered
         # the next time through the loop.
-        if not encoded_format_invalid and rfc2047_matcher.search(tok):
+        if valid_ew and rfc2047_matcher.search(tok):
             tok, *remainder = value.partition('=?')
         vtext = ValueTerminal(tok, 'vtext')
         _validate_xtext(vtext)

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1107,7 +1107,6 @@ def get_unstructured(value):
                 token, value = get_encoded_word(value)
             except errors.HeaderParseError as e:
                 if "encoded word format invalid" in str(e):
-                    unstructured.defects.append(errors.InvalidHeaderDefect(str(e)))
                     encoded_format_invalid = True
             else:
                 have_ws = True

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -935,6 +935,10 @@ class EWWhiteSpaceTerminal(WhiteSpaceTerminal):
         return ''
 
 
+class _InvalidEwError(errors.HeaderParseError):
+    """Invalid encoded word found while parsing headers."""
+
+
 # XXX these need to become classes and used as instances so
 # that a program can't change them in a parse tree and screw
 # up other parse trees.  Maybe should have  tests for that, too.
@@ -1054,7 +1058,7 @@ def get_encoded_word(value):
     try:
         text, charset, lang, defects = _ew.decode('=?' + tok + '?=')
     except ValueError:
-        raise errors.InvalidEwError(
+        raise _InvalidEwError(
             "encoded word format invalid: '{}'".format(ew.cte))
     ew.charset = charset
     ew.lang = lang
@@ -1108,7 +1112,7 @@ def get_unstructured(value):
         if value.startswith('=?'):
             try:
                 token, value = get_encoded_word(value)
-            except errors.InvalidEwError:
+            except _InvalidEwError:
                 valid_ew = False
             except errors.HeaderParseError:
                 # XXX: Need to figure out how to register defects when

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1128,6 +1128,9 @@ def get_unstructured(value):
         # Split in the middle of an atom if there is a rfc2047 encoded word
         # which does not have WSP on both sides. The defect will be registered
         # the next time through the loop.
+        # This needs to only be performed when the encoded word is valid;
+        # otherwise, performing it on an invalid encoded word can cause
+        # the parser to go in an infinite loop.
         if valid_ew and rfc2047_matcher.search(tok):
             tok, *remainder = value.partition('=?')
         vtext = ValueTerminal(tok, 'vtext')

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1039,7 +1039,7 @@ def get_encoded_word(value):
         raise errors.HeaderParseError(
             "expected encoded word but found {}".format(value))
     remstr = ''.join(remainder)
-    if len(remstr) > 1 and remstr[0] in hexdigits and remstr[1] in hexdigits:
+    if len(remstr) > 1 and remstr[0] in hexdigits and remstr[1] in hexdigits and tok.count('?') < 2:
         # The ? after the CTE was followed by an encoded word escape (=XX).
         rest, *remainder = remstr.split('?=', 1)
         tok = tok + '?=' + rest

--- a/Lib/email/errors.py
+++ b/Lib/email/errors.py
@@ -17,10 +17,6 @@ class HeaderParseError(MessageParseError):
     """Error while parsing headers."""
 
 
-class InvalidEwError(HeaderParseError):
-    """Invalid encoded word found while parsing headers."""
-
-
 class BoundaryError(MessageParseError):
     """Couldn't find terminating boundary."""
 

--- a/Lib/email/errors.py
+++ b/Lib/email/errors.py
@@ -17,6 +17,10 @@ class HeaderParseError(MessageParseError):
     """Error while parsing headers."""
 
 
+class InvalidEwError(HeaderParseError):
+    """Invalid encoded word found while parsing headers."""
+
+
 class BoundaryError(MessageParseError):
     """Couldn't find terminating boundary."""
 

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -386,8 +386,8 @@ class TestParser(TestParserMixin, TestEmailBase):
     def test_get_unstructured_without_trailing_whitespace_hang_case(self):
         self._test_get_x(self._get_unst,
             '=?utf-8?q?somevalue?=aa',
-            '=?utf-8?q?somevalue?=aa',
-            '=?utf-8?q?somevalue?=aa',
+            'somevalueaa',
+            'somevalueaa',
             [errors.InvalidHeaderDefect],
             '')
 

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -391,7 +391,7 @@ class TestParser(TestParserMixin, TestEmailBase):
             [errors.InvalidHeaderDefect],
             '')
 
-    def test_get_unstructured_invalid_encoded_word(self):
+    def test_get_unstructured_invalid_ew(self):
         self._test_get_x(self._get_unst,
             '=?utf-8?q?=somevalue?=',
             '=?utf-8?q?=somevalue?=',

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -390,7 +390,7 @@ class TestParser(TestParserMixin, TestEmailBase):
             'somevalueaa',
             [errors.InvalidHeaderDefect],
             '')
-    
+
     def test_get_unstructured_invalid_encoded_word(self):
         self._test_get_x(self._get_unst,
             '=?utf-8?q?=somevalue?=',

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -395,7 +395,7 @@ class TestParser(TestParserMixin, TestEmailBase):
         self._test_get_x(self._get_unst,
             '=?utf-8?q?=somevalue?=',
             '=?utf-8?q?=somevalue?=',
-            '=?utf-8?q?=somevalue?='
+            '=?utf-8?q?=somevalue?=',
             [errors.InvalidHeaderDefect],
             '')
 

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -396,7 +396,7 @@ class TestParser(TestParserMixin, TestEmailBase):
             '=?utf-8?q?=somevalue?=',
             '=?utf-8?q?=somevalue?=',
             '=?utf-8?q?=somevalue?=',
-            [errors.InvalidHeaderDefect],
+            [],
             '')
 
     # get_qp_ctext

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -383,6 +383,14 @@ class TestParser(TestParserMixin, TestEmailBase):
             [errors.InvalidHeaderDefect],
             '')
 
+    def test_get_unstructured_without_trailing_whitespace_hang_case(self):
+        self._test_get_x(self._get_unst,
+            '=?utf-8?q?somevalue?=aa',
+            '=?utf-8?q?somevalue?=aa',
+            '=?utf-8?q?somevalue?=aa',
+            [errors.InvalidHeaderDefect],
+            '')
+
     # get_qp_ctext
 
     def test_get_qp_ctext_only(self):

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -390,6 +390,14 @@ class TestParser(TestParserMixin, TestEmailBase):
             'somevalueaa',
             [errors.InvalidHeaderDefect],
             '')
+    
+    def test_get_unstructured_invalid_encoded_word(self):
+        self._test_get_x(self._get_unst,
+            '=?utf-8?q?=somevalue?=',
+            '=?utf-8?q?=somevalue?=',
+            '=?utf-8?q?=somevalue?='
+            [errors.InvalidHeaderDefect],
+            '')
 
     # get_qp_ctext
 

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -5381,6 +5381,27 @@ Content-Type: application/x-foo;
         eq(language, 'en-us')
         eq(s, 'My Document For You')
 
+    def test_should_not_hang_on_invalid_ew_messages(self):
+        messages = ["""From: user@host.com
+To: user@host.com
+Bad-Header:
+ =?us-ascii?Q?LCSwrV11+IB0rSbSker+M9vWR7wEDSuGqmHD89Gt=ea0nJFSaiz4vX3XMJPT4vrE?=
+ =?us-ascii?Q?xGUZeOnp0o22pLBB7CYLH74Js=wOlK6Tfru2U47qR?=
+ =?us-ascii?Q?72OfyEY2p2=2FrA9xNFyvH+fBTCmazxwzF8nGkK6D?=
+
+Hello!
+""", """From: ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ <xxx@xxx>
+To: "xxx" <xxx@xxx>
+Subject:   ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+MIME-Version: 1.0
+Content-Type: text/plain; charset="windows-1251";
+Content-Transfer-Encoding: 8bit
+
+ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+"""]
+        for m in messages:
+            with self.subTest(m=m):
+                msg = email.message_from_string(m)
 
 
 # Tests to ensure that signed parts of an email are completely preserved, as

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1332,6 +1332,7 @@ Burton Radons
 Abhilash Raj
 Shorya Raj
 Dhushyanth Ramasamy
+Ashwin Ramaswami
 Jeff Ramnani
 Bayard Randel
 Varpu Rantala

--- a/Misc/NEWS.d/next/Security/2019-08-27-01-13-05.bpo-37764.qv67PQ.rst
+++ b/Misc/NEWS.d/next/Security/2019-08-27-01-13-05.bpo-37764.qv67PQ.rst
@@ -1,0 +1,1 @@
+Fixes email._header_value_parser.get_unstructured going into an infinite loop for a specific case in which the email header does not have trailing whitespace, and the case in which it contains an invalid encoded word. Patch by Ashwin Ramaswami.


### PR DESCRIPTION
Fixes a case in which email._header_value_parser.get_unstructured hangs the system for some invalid headers. This covers the cases in which the header contains either:
- a case without trailing whitespace
- an invalid encoded word

https://bugs.python.org/issue37764

This fix should also be backported to 3.7 and 3.8

<!-- issue-number: [bpo-37764](https://bugs.python.org/issue37764) -->
https://bugs.python.org/issue37764
<!-- /issue-number -->


Automerge-Triggered-By: @maxking