### PR TITLE
bpo-37845: Fixed SSLCertVerificationError when Certifications are published with DNS Names that may start with white spaces

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -286,7 +286,7 @@ def _dnsname_match(dn, hostname):
         return False
 
     # Make sure there are no mistake "white space" present
-    #dn = dn.strip()
+    dn = dn.strip()
 
     wildcards = dn.count('*')
     # speed up common case w/o wildcards

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -285,6 +285,9 @@ def _dnsname_match(dn, hostname):
     if not dn:
         return False
 
+    # Make sure there are no mistake "white space" present
+    #dn = dn.strip()
+
     wildcards = dn.count('*')
     # speed up common case w/o wildcards
     if not wildcards:


### PR DESCRIPTION
[bpo-37845](https://bugs.python.org/issue37845):  
Fixed: SSLCertVerificationError("partial wildcards in leftmost label are not supported: '   *.x.y.com'.")
by invoking strip() on dn (Domain Name) object when _dnsname_match() is performed.

In a big company, the certification publish process may be  out of the hand of the programmer.
In my case, only my App had this problem while all other none-python Apps didn't suffer the same.

SecOps wouldn't republish fixed certifications because of white spaces in DNS names that my Python App wouldn't handle.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37845](https://bugs.python.org/issue37845) -->
https://bugs.python.org/issue37845
<!-- /issue-number -->
