### PR TITLE
bpo-29535: make datetime hashes non-deterministic

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -2115,7 +2115,12 @@ class datetime(date):
             if tzoff is None:
                 self._hashcode = hash(t._getstate()[0])
             else:
-                self._hashcode = hash((t - tzoff)._getstate()[0])
+                try:
+                    t_with_offset = t - tzoff
+                except OverflowError:
+                    # t - tzoff is less than 0, which can't be represented as a datetime, so we use t + tzoff instead.
+                    t_with_offset = t + tzoff
+                self._hashcode = hash(t_with_offset._getstate()[0])
         return self._hashcode
 
     # Pickle support.

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1379,10 +1379,11 @@ class time:
                               timedelta(hours=1))
                 assert not m % timedelta(minutes=1), "whole minute"
                 m //= timedelta(minutes=1)
-                if 0 <= h < 24:
-                    self._hashcode = hash(time(h, m, self.second, self.microsecond))
-                else:
-                    self._hashcode = hash((h, m, self.second, self.microsecond))
+                if h < 0:
+                    h = -1 * h
+                if h >= 24:
+                    h = h - 24
+                self._hashcode = hash(time(h, m, self.second, self.microsecond))
         return self._hashcode
 
     # Conversion to string

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -2115,9 +2115,7 @@ class datetime(date):
             if tzoff is None:
                 self._hashcode = hash(t._getstate()[0])
             else:
-                days = _ymd2ord(self.year, self.month, self.day)
-                seconds = self.hour * 3600 + self.minute * 60 + self.second
-                self._hashcode = hash(timedelta(days, seconds, self.microsecond) - tzoff)
+                self._hashcode = hash((t - tzoff)._getstate()[0])
         return self._hashcode
 
     # Pickle support.

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -329,11 +329,11 @@ class DatetimeDatetimeTests(DatetimeFastTests, unittest.TestCase):
 class DatetimeDatetimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
-class DatetimeTimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
-    repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
-
 class DatetimeTimeFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))
+
+class DatetimeTimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
+    repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
 
 class DatetimeDatePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.date(1066, 10, 14))

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -329,8 +329,8 @@ class DatetimeDatetimeTests(DatetimeFastTests, unittest.TestCase):
 class DatetimeDatetimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
-# class DatetimeTimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
-#     repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
+class DatetimeTimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
+    repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
 
 class DatetimeTimeFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -332,6 +332,9 @@ class DatetimeDatetimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase
 class DatetimeDatetimeWithTimezoneUnderflowFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 1, 1, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
 
+class DatetimeDatetimeWithTimezoneOverflowFastTests(DatetimeFastTests, unittest.TestCase):
+    repr_ = repr(datetime.datetime(datetime.MAXYEAR, 12, 31, tzinfo=datetime.timezone(datetime.timedelta(minutes=-1439))))
+
 class DatetimeTimeFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))
 
@@ -340,6 +343,9 @@ class DatetimeTimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
 
 class DatetimeTimeWithTimezoneUnderflowFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
+
+class DatetimeTimeWithTimezoneOverflowFastTests(DatetimeFastTests, unittest.TestCase):
+    repr_ = repr(datetime.time(23, 59, 59, tzinfo=datetime.timezone(datetime.timedelta(minutes=-1439))))
 
 class DatetimeDatePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.date(1066, 10, 14))
@@ -350,8 +356,11 @@ class DatetimeDatetimePureTests(DatetimePureTests, unittest.TestCase):
 class DatetimeDatetimeWithTimezonePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
-class DatetimeDatetimeWithTimezoneUnderflowPureTests(DatetimeFastTests, unittest.TestCase):
+class DatetimeDatetimeWithTimezoneUnderflowPureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 1, 1, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
+
+class DatetimeDatetimeWithTimezoneOverflowPureTests(DatetimePureTests, unittest.TestCase):
+    repr_ = repr(datetime.datetime(datetime.MAXYEAR, 12, 31, tzinfo=datetime.timezone(datetime.timedelta(minutes=-1439))))
 
 class DatetimeTimePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))
@@ -361,6 +370,9 @@ class DatetimeTimeWithTimezonePureTests(DatetimePureTests, unittest.TestCase):
 
 class DatetimeTimeWithTimezoneUnderflowPureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.time(0, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
+
+class DatetimeTimeWithTimezoneOverflowPureTests(DatetimePureTests, unittest.TestCase):
+    repr_ = repr(datetime.time(23, 59, 59, tzinfo=datetime.timezone(datetime.timedelta(minutes=-1439))))
 
 
 class HashDistributionTestCase(unittest.TestCase):

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -310,11 +310,11 @@ class MemoryviewHashRandomizationTests(StringlikeHashRandomizationTests,
     def test_empty_string(self):
         self.assertEqual(hash(memoryview(b"")), 0)
 
-class DatetimePureTests(HashRandomizationTests):
+class DatetimeFastTests(HashRandomizationTests):
     def get_hash_command(self, repr_):
         return 'import datetime; print(hash(%s))' % repr_
 
-class DatetimeFastTests(HashRandomizationTests):
+class DatetimePureTests(HashRandomizationTests):
     def get_hash_command(self, repr_):
         return """from test.support import import_fresh_module;
 datetime = import_fresh_module('datetime', blocked=['_datetime'])

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -329,6 +329,9 @@ class DatetimeDatetimeTests(DatetimeFastTests, unittest.TestCase):
 # class DatetimeDatetimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
 #     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
+# class DatetimeTimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
+#     repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
+
 class DatetimeTimeFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))
 
@@ -343,6 +346,9 @@ class DatetimeDatetimeWithTimezonePureTests(DatetimePureTests, unittest.TestCase
 
 class DatetimeTimePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))
+
+class DatetimeTimeWithTimezonePureTests(DatetimePureTests, unittest.TestCase):
+    repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
 
 
 class HashDistributionTestCase(unittest.TestCase):

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -326,8 +326,8 @@ class DatetimeDateTests(DatetimeFastTests, unittest.TestCase):
 class DatetimeDatetimeTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7))
 
-# class DatetimeDatetimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
-#     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
+class DatetimeDatetimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
+    repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
 # class DatetimeTimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
 #     repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -329,7 +329,7 @@ class DatetimeDatetimeTests(DatetimeFastTests, unittest.TestCase):
 class DatetimeDatetimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
-class DatetimeDatetimeWithNegativeTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
+class DatetimeDatetimeWithTimezoneUnderflowFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 1, 1, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
 
 class DatetimeTimeFastTests(DatetimeFastTests, unittest.TestCase):
@@ -338,7 +338,7 @@ class DatetimeTimeFastTests(DatetimeFastTests, unittest.TestCase):
 class DatetimeTimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
 
-class DatetimeTimeWithNegativeTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
+class DatetimeTimeWithTimezoneUnderflowFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
 
 class DatetimeDatePureTests(DatetimePureTests, unittest.TestCase):
@@ -350,7 +350,7 @@ class DatetimeDatetimePureTests(DatetimePureTests, unittest.TestCase):
 class DatetimeDatetimeWithTimezonePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
-class DatetimeDatetimeWithNegativeTimezonePureTests(DatetimeFastTests, unittest.TestCase):
+class DatetimeDatetimeWithTimezoneUnderflowPureTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 1, 1, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
 
 class DatetimeTimePureTests(DatetimePureTests, unittest.TestCase):
@@ -359,7 +359,7 @@ class DatetimeTimePureTests(DatetimePureTests, unittest.TestCase):
 class DatetimeTimeWithTimezonePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
 
-class DatetimeTimeWithNegativeTimezonePureTests(DatetimePureTests, unittest.TestCase):
+class DatetimeTimeWithTimezoneUnderflowPureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.time(0, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
 
 

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -326,6 +326,9 @@ class DatetimeDateTests(DatetimeFastTests, unittest.TestCase):
 class DatetimeDatetimeTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7))
 
+# class DatetimeDatetimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
+#     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
+
 class DatetimeTimeFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))
 
@@ -334,6 +337,9 @@ class DatetimeDatePureTests(DatetimePureTests, unittest.TestCase):
 
 class DatetimeDatetimePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7))
+
+class DatetimeDatetimeWithTimezonePureTests(DatetimePureTests, unittest.TestCase):
+    repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
 class DatetimeTimePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -329,11 +329,17 @@ class DatetimeDatetimeTests(DatetimeFastTests, unittest.TestCase):
 class DatetimeDatetimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
+class DatetimeDatetimeWithNegativeTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
+    repr_ = repr(datetime.datetime(1, 1, 1, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
+
 class DatetimeTimeFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))
 
 class DatetimeTimeWithTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
+
+class DatetimeTimeWithNegativeTimezoneFastTests(DatetimeFastTests, unittest.TestCase):
+    repr_ = repr(datetime.time(0, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
 
 class DatetimeDatePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.date(1066, 10, 14))
@@ -344,11 +350,17 @@ class DatetimeDatetimePureTests(DatetimePureTests, unittest.TestCase):
 class DatetimeDatetimeWithTimezonePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7, datetime.timezone.utc))
 
+class DatetimeDatetimeWithNegativeTimezonePureTests(DatetimeFastTests, unittest.TestCase):
+    repr_ = repr(datetime.datetime(1, 1, 1, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
+
 class DatetimeTimePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))
 
 class DatetimeTimeWithTimezonePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.time(0, 0, 0, 0, datetime.timezone.utc))
+
+class DatetimeTimeWithNegativeTimezonePureTests(DatetimePureTests, unittest.TestCase):
+    repr_ = repr(datetime.time(0, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(minutes=1439))))
 
 
 class HashDistributionTestCase(unittest.TestCase):

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -192,7 +192,7 @@ class HashRandomizationTests:
         # two runs should return different hashes
         run1 = self.get_hash(self.repr_, seed='random')
         run2 = self.get_hash(self.repr_, seed='random')
-        self.assertNotEqual(run1, run2)
+        self.assertNotEqual(run1, run2, self.repr_)
 
 class StringlikeHashRandomizationTests(HashRandomizationTests):
     repr_ = None
@@ -310,17 +310,32 @@ class MemoryviewHashRandomizationTests(StringlikeHashRandomizationTests,
     def test_empty_string(self):
         self.assertEqual(hash(memoryview(b"")), 0)
 
-class DatetimeTests(HashRandomizationTests):
+class DatetimePureTests(HashRandomizationTests):
     def get_hash_command(self, repr_):
         return 'import datetime; print(hash(%s))' % repr_
 
-class DatetimeDateTests(DatetimeTests, unittest.TestCase):
+class DatetimeFastTests(HashRandomizationTests):
+    def get_hash_command(self, repr_):
+        return """from test.support import import_fresh_module;
+datetime = import_fresh_module('datetime', blocked=['_datetime'])
+print(hash(%s))""" % repr_
+
+class DatetimeDateTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.date(1066, 10, 14))
 
-class DatetimeDatetimeTests(DatetimeTests, unittest.TestCase):
+class DatetimeDatetimeTests(DatetimeFastTests, unittest.TestCase):
     repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7))
 
-class DatetimeTimeTests(DatetimeTests, unittest.TestCase):
+class DatetimeTimeFastTests(DatetimeFastTests, unittest.TestCase):
+    repr_ = repr(datetime.time(0))
+
+class DatetimeDatePureTests(DatetimePureTests, unittest.TestCase):
+    repr_ = repr(datetime.date(1066, 10, 14))
+
+class DatetimeDatetimePureTests(DatetimePureTests, unittest.TestCase):
+    repr_ = repr(datetime.datetime(1, 2, 3, 4, 5, 6, 7))
+
+class DatetimeTimePureTests(DatetimePureTests, unittest.TestCase):
     repr_ = repr(datetime.time(0))
 
 

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -192,7 +192,7 @@ class HashRandomizationTests:
         # two runs should return different hashes
         run1 = self.get_hash(self.repr_, seed='random')
         run2 = self.get_hash(self.repr_, seed='random')
-        self.assertNotEqual(run1, run2, self.repr_)
+        self.assertNotEqual(run1, run2)
 
 class StringlikeHashRandomizationTests(HashRandomizationTests):
     repr_ = None

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4397,7 +4397,8 @@ time_hash(PyDateTime_Time *self)
                 Py_DECREF(offset);
                 return -1;
             }
-            self->hashcode = PyObject_Hash(temp2);
+            self->hashcode = self->hashcode = generic_hash(
+                (unsigned char *)temp2, _PyDateTime_TIME_DATASIZE);
             Py_DECREF(temp2);
         }
         Py_DECREF(offset);
@@ -5675,7 +5676,6 @@ datetime_hash(PyDateTime_DateTime *self)
             return -1;
 
         /* Reduce this to a hash of another object. */
-        // todo fix datetime
         if (offset == Py_None)
             self->hashcode = generic_hash(
                 (unsigned char *)self->data, _PyDateTime_DATETIME_DATASIZE);


### PR DESCRIPTION
This PR does the following:
- Make the hash of datetime.datetime (with a timezone) non-deterministic in the Python datetime lib.
- Make the hash of datetime.datetime (with a timezone) non-deterministic in the C datetime lib.
- Make the hash of datetime.datetime (with a timezone) non-deterministic in the C datetime lib.
- Make the hash of datetime.time (with a timezone such that either _1) time - timezone < 0 [underflow] or 2) time - timezone > max_time [overflow]_ non-deterministic in the Python datetime lib.
- Make sure datetime tests in test_hash.py cover both the C datetime lib and the Python datetime lib (previously they covered only the C datetime lib), and cover the cases above.

<!-- issue-number: [bpo-29535](https://bugs.python.org/issue29535) -->
https://bugs.python.org/issue29535
<!-- /issue-number -->
