### PR TITLE
bpo-37849: IDLE: fix completion window positioning above line

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,11 @@ Released on 2019-10-20?
 ======================================
 
 
+bpo-37849: Fix completions list appearing too high or low when shown
+above the current line.
+
+bpo-36419: Refactor autocompete and improve testing.
+
 bpo-37748: Reorder the Run menu.  Put the most common choice,
 Run Module, at the top.
 
@@ -231,9 +236,6 @@ the tested module and perform at least one test.  Check and record the
 coverage of each test.
 
 bpo-33856: Add 'help' to Shell's initial welcome message.
-
-bpo-37849: Fix completions list appearing too high or low when shown
-above the current line.
 
 
 What's New in IDLE 3.7.0 (since 3.6.0)

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -232,6 +232,9 @@ coverage of each test.
 
 bpo-33856: Add 'help' to Shell's initial welcome message.
 
+bpo-37849: Fix completions list appearing too high or low when shown
+above the current line.
+
 
 What's New in IDLE 3.7.0 (since 3.6.0)
 Released on 2018-06-27

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -52,10 +52,12 @@ class AutoCompleteWindow:
         # (for example, he clicked the list)
         self.userwantswindow = None
         # event ids
-        self.hideid = self.keypressid = self.listupdateid = self.winconfigid \
-        = self.keyreleaseid = self.doubleclickid                         = None
+        self.hideid = self.keypressid = self.listupdateid = \
+            self.winconfigid = self.keyreleaseid = self.doubleclickid = None
         # Flag set if last keypress was a tab
         self.lastkey_was_tab = False
+        # Flag set to avoid recursive <Configure> callback invocations.
+        self.is_configuring = False
 
     def _change_start(self, newstart):
         min_len = min(len(self.start), len(newstart))
@@ -223,12 +225,18 @@ class AutoCompleteWindow:
         self.widget.event_add(KEYRELEASE_VIRTUAL_EVENT_NAME,KEYRELEASE_SEQUENCE)
         self.listupdateid = listbox.bind(LISTUPDATE_SEQUENCE,
                                          self.listselect_event)
+        self.is_configuring = False
         self.winconfigid = acw.bind(WINCONFIG_SEQUENCE, self.winconfig_event)
         self.doubleclickid = listbox.bind(DOUBLECLICK_SEQUENCE,
                                           self.doubleclick_event)
         return None
 
     def winconfig_event(self, event):
+        if self.is_configuring:
+            # Avoid running on recursive <Configure> callback invocations.
+            return
+
+        self.is_configuring = True
         if not self.is_active():
             return
         # Position the completion list window
@@ -236,6 +244,7 @@ class AutoCompleteWindow:
         text.see(self.startindex)
         x, y, cx, cy = text.bbox(self.startindex)
         acw = self.autocompletewindow
+        acw.update()
         acw_width, acw_height = acw.winfo_width(), acw.winfo_height()
         text_width, text_height = text.winfo_width(), text.winfo_height()
         new_x = text.winfo_rootx() + min(x, max(0, text_width - acw_width))
@@ -255,6 +264,8 @@ class AutoCompleteWindow:
             # otherwise mouse button double click will not be able to used.
             acw.unbind(WINCONFIG_SEQUENCE, self.winconfigid)
             self.winconfigid = None
+
+        self.is_configuring = False
 
     def _hide_event_check(self):
         if not self.autocompletewindow:

--- a/Misc/NEWS.d/next/IDLE/2019-08-14-09-43-15.bpo-37849.-bcYF3.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-08-14-09-43-15.bpo-37849.-bcYF3.rst
@@ -1,1 +1,2 @@
-Fixed completions list appearing too high when shown above the current line.
+Fixed completions list appearing too high or low when shown above
+the current line.

--- a/Misc/NEWS.d/next/IDLE/2019-08-14-09-43-15.bpo-37849.-bcYF3.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-08-14-09-43-15.bpo-37849.-bcYF3.rst
@@ -1,0 +1,1 @@
+Fixed completions list appearing too high when shown above the current line.


### PR DESCRIPTION
This also adds a mechanism to avoid multiple, recursive invocations of the "\<Configure\>" event handler, required due to the added `.update()` call.

<!-- issue-number: [bpo-37849](https://bugs.python.org/issue37849) -->
https://bugs.python.org/issue37849
<!-- /issue-number -->
