### PR TITLE
bpo-29535: Remove promize about hash randomization of datetime objects.

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1445,8 +1445,8 @@ Basic customization
 
    .. note::
 
-      By default, the :meth:`__hash__` values of str, bytes and datetime
-      objects are "salted" with an unpredictable random value.  Although they
+      By default, the :meth:`__hash__` values of str and bytes objects are
+      "salted" with an unpredictable random value.  Although they
       remain constant within an individual Python process, they are not
       predictable between repeated invocations of Python.
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -302,7 +302,7 @@ Miscellaneous options
    randomization is enabled by default.
 
    On previous versions of Python, this option turns on hash randomization,
-   so that the :meth:`__hash__` values of str, bytes and datetime
+   so that the :meth:`__hash__` values of str and bytes objects
    are "salted" with an unpredictable random value.  Although they remain
    constant within an individual Python process, they are not predictable
    between repeated invocations of Python.
@@ -625,7 +625,7 @@ conflict.
 .. envvar:: PYTHONHASHSEED
 
    If this variable is not set or set to ``random``, a random value is used
-   to seed the hashes of str, bytes and datetime objects.
+   to seed the hashes of str and bytes objects.
 
    If :envvar:`PYTHONHASHSEED` is set to an integer value, it is used as a fixed
    seed for generating the hash() of the types covered by the hash

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -431,7 +431,7 @@ If this is set to a comma-separated string it is equivalent to
 specifying the \fB\-W\fP option for each separate value.
 .IP PYTHONHASHSEED
 If this variable is set to "random", a random value is used to seed the hashes
-of str, bytes and datetime objects.
+of str and bytes objects.
 
 If PYTHONHASHSEED is set to an integer value, it is used as a fixed seed for
 generating the hash() of the types covered by the hash randomization.  Its

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -83,8 +83,8 @@ static const char usage_5[] =
 "PYTHONFAULTHANDLER: dump the Python traceback on fatal errors.\n";
 static const char usage_6[] =
 "PYTHONHASHSEED: if this variable is set to 'random', a random value is used\n"
-"   to seed the hashes of str, bytes and datetime objects.  It can also be\n"
-"   set to an integer in the range [0,4294967295] to get hash values with a\n"
+"   to seed the hashes of str and bytes objects.  It can also be set to an\n"
+"   integer in the range [0,4294967295] to get hash values with a\n"
 "   predictable seed.\n"
 "PYTHONMALLOC: set the Python memory allocators and/or install debug hooks\n"
 "   on Python memory allocators. Use PYTHONMALLOC=debug to install debug\n"


### PR DESCRIPTION


<!-- issue-number: [bpo-29535](https://bugs.python.org/issue29535) -->
https://bugs.python.org/issue29535
<!-- /issue-number -->
