### PR TITLE
[3.7] bpo-37738: Fix curses addch(str, color_pair) (GH-15071)

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-08-01-17-11-16.bpo-37738.A3WWcT.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-01-17-11-16.bpo-37738.A3WWcT.rst
@@ -1,0 +1,2 @@
+Fix the implementation of curses ``addch(str, color_pair)``: pass the color
+pair to ``setcchar()``, instead of always passing 0 as the color pair.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -178,6 +178,18 @@ static char *screen_encoding = NULL;
 
 /* Utility Functions */
 
+static inline int
+color_pair_to_attr(short color_number)
+{
+    return ((int)color_number << 8);
+}
+
+static inline short
+attr_to_color_pair(int attr)
+{
+    return (short)((attr & A_COLOR) >> 8);
+}
+
 /*
  * Check the return code from a curses function and return None
  * or raise an exception as appropriate.  These are exported using the
@@ -614,7 +626,7 @@ curses_window_addch_impl(PyCursesWindowObject *self, int group_left_1, int y,
     if (type == 2) {
         funcname = "add_wch";
         wstr[1] = L'\0';
-        setcchar(&wcval, wstr, attr, 0, NULL);
+        setcchar(&wcval, wstr, attr, attr_to_color_pair(attr), NULL);
         if (coordinates_group)
             rtn = mvwadd_wch(cwself->win,y,x, &wcval);
         else {
@@ -2204,7 +2216,7 @@ PyCurses_color_pair(PyObject *self, PyObject *args)
     PyCursesInitialisedColor;
 
     if (!PyArg_ParseTuple(args, "i:color_pair", &n)) return NULL;
-    return PyLong_FromLong((long) (n << 8));
+    return PyLong_FromLong(color_pair_to_attr(n));
 }
 
 static PyObject *
@@ -2802,7 +2814,7 @@ PyCurses_pair_number(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    return PyLong_FromLong((long) ((n & A_COLOR) >> 8));
+    return PyLong_FromLong(attr_to_color_pair(n));
 }
 
 static PyObject *


### PR DESCRIPTION
Fix the implementation of curses addch(str, color_pair): pass the
color pair to setcchar(), instead of always passing 0 as the color
pair.

(cherry picked from commit 077af8c2c93dd71086e2c5e5ff1e634b6da8f214)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37738](https://bugs.python.org/issue37738) -->
https://bugs.python.org/issue37738
<!-- /issue-number -->
