### PR TITLE
bpo-37823: Fixed link to Telnet.open() method in telnetlib library documentation

### DIFF
--- a/Doc/library/telnetlib.rst
+++ b/Doc/library/telnetlib.rst
@@ -29,7 +29,7 @@ Character), EL (Erase Line), GA (Go Ahead), SB (Subnegotiation Begin).
 .. class:: Telnet(host=None, port=0[, timeout])
 
    :class:`Telnet` represents a connection to a Telnet server. The instance is
-   initially not connected by default; the :meth:`open` method must be used to
+   initially not connected by default; the :meth:`~Telnet.open` method must be used to
    establish a connection.  Alternatively, the host name and optional port
    number can be passed to the constructor too, in which case the connection to
    the server will be established before the constructor returns.  The optional


### PR DESCRIPTION
This PR fixes a wrong link in the telnetlib library: the link to the open() method of the Telnet class linked to the wrong method. 

<!-- issue-number: [bpo-37823](https://bugs.python.org/issue37823) -->
https://bugs.python.org/issue37823
<!-- /issue-number -->
