### PR TITLE
fix link to time function from time_ns doc

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -608,7 +608,7 @@ Functions
 
 .. function:: time_ns() -> int
 
-   Similar to :func:`time` but returns time as an integer number of nanoseconds
+   Similar to :func:`~time.time` but returns time as an integer number of nanoseconds
    since the epoch_.
 
    .. versionadded:: 3.7


### PR DESCRIPTION
Because mod, func, class, etc all share one namespace, :func:time creates a link to the time module doc page rather than the time.time function.

Automerge-Triggered-By: @merwok