### PR TITLE
bpo-37857: Invalidate cache when log level changed directly

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1410,14 +1410,16 @@ class Logger(Filterer):
 
     @level.setter
     def level(self, level):
-        self._level = level
-        self.manager._clear_cache()
+        warnings.warn("Use the setLevel() method to set the log level",
+                      DeprecationWarning, stacklevel=2)
+        self.setLevel(level)
 
     def setLevel(self, level):
         """
         Set the logging level of this logger.  level must be an int or a str.
         """
-        self.level = _checkLevel(level)
+        self._level = _checkLevel(level)
+        self.manager._clear_cache()
 
     def debug(self, msg, *args, **kwargs):
         """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1681,8 +1681,8 @@ class Logger(Filterer):
         """
         logger = self
         while logger:
-            if logger.level:
-                return logger.level
+            if logger._level:
+                return logger._level
             logger = logger.parent
         return NOTSET
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1397,19 +1397,27 @@ class Logger(Filterer):
         """
         Filterer.__init__(self)
         self.name = name
-        self.level = _checkLevel(level)
+        self._level = _checkLevel(level)
         self.parent = None
         self.propagate = True
         self.handlers = []
         self.disabled = False
         self._cache = {}
 
+    @property
+    def level(self):
+        return self._level
+
+    @level.setter
+    def level(self, level):
+        self._level = level
+        self.manager._clear_cache()
+
     def setLevel(self, level):
         """
         Set the logging level of this logger.  level must be an int or a str.
         """
         self.level = _checkLevel(level)
-        self.manager._clear_cache()
 
     def debug(self, msg, *args, **kwargs):
         """

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -173,9 +173,10 @@ def _handle_existing_loggers(existing, child_loggers, disable_existing):
     for log in existing:
         logger = root.manager.loggerDict[log]
         if log in child_loggers:
-            logger.level = logging.NOTSET
-            logger.handlers = []
-            logger.propagate = True
+            if not isinstance(logger, logging.PlaceHolder):
+                logger.setLevel(logging.NOTSET)
+                logger.handlers = []
+                logger.propagate = True
         else:
             logger.disabled = disable_existing
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4315,7 +4315,7 @@ class BasicConfigTest(unittest.TestCase):
         logging._handlers.clear()
         logging._handlers.update(self.saved_handlers)
         logging._handlerList[:] = self.saved_handler_list
-        logging.root.level = self.original_logging_level
+        logging.root.setLevel(self.original_logging_level)
 
     def test_no_kwargs(self):
         logging.basicConfig()

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4906,6 +4906,13 @@ class LoggerTest(BaseTest):
         # Ensure logger2 uses parent logger's effective level
         self.assertFalse(logger2.isEnabledFor(logging.ERROR))
 
+        # Ensure setting level directly still clears cache
+        self.assertEqual(logger2._cache, {logging.ERROR: False})
+        logger2.level = logging.ERROR
+        self.assertEqual(logger2._cache, {})
+        self.assertTrue(logger2.isEnabledFor(logging.ERROR))
+        self.assertEqual(logger2._cache, {logging.ERROR: True})
+
         # Set level to NOTSET and ensure caches are empty
         logger2.setLevel(logging.NOTSET)
         self.assertEqual(logger2.getEffectiveLevel(), logging.CRITICAL)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4908,7 +4908,9 @@ class LoggerTest(BaseTest):
 
         # Ensure setting level directly still clears cache
         self.assertEqual(logger2._cache, {logging.ERROR: False})
-        logger2.level = logging.ERROR
+        with warnings.catch_warnings(record=True) as w:
+            logger2.level = logging.ERROR
+            self.assertEqual(1, len(w))
         self.assertEqual(logger2._cache, {})
         self.assertTrue(logger2.isEnabledFor(logging.ERROR))
         self.assertEqual(logger2._cache, {logging.ERROR: True})

--- a/Misc/NEWS.d/next/Library/2019-08-14-16-17-57.bpo-37857.Ganisd.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-14-16-17-57.bpo-37857.Ganisd.rst
@@ -1,0 +1,2 @@
+Setting the ``level`` attribute of a ``logger.Logger`` (instead of calling
+``setLevel()``) no longer causes cache inconsistency.

--- a/Misc/NEWS.d/next/Library/2019-09-20-12-25-33.bpo-37857.s-Emp8.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-20-12-25-33.bpo-37857.s-Emp8.rst
@@ -1,0 +1,2 @@
+Setting the ``level`` attribute of a ``logger.Logger`` is deprecated. The
+log level should only ever be set using the ``setLevel()`` method.


### PR DESCRIPTION
[bpo-37857](https://bugs.python.org/issue37857)

While the logging level of a Logger should really be changed only by calling the `setLevel()` method, there exists code in the wild that changes it by setting the public `level` attribute directly. Prior to
Python 3.7, this worked correctly.

The addition of caching to `Logger.isEnabledFor()` by the fix for [bpo-30962](https://bugs.python.org/issue30962), #2752, means that direct changes to the level now leave the cache in a state inconsistent with the Logger - an extraordinarily difficult thing to debug.

Make `level` a property that invalidates the cache when set. This ensures that existing application code will continue to work as it did with previous versions of Python.

<!-- issue-number: [bpo-37857](https://bugs.python.org/issue37857) -->
https://bugs.python.org/issue37857
<!-- /issue-number -->
