### PR TITLE
Fix unintialized pointer warning in Objects/obmalloc.c

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1643,6 +1643,7 @@ _PyObject_Malloc(void *ctx, size_t nbytes)
 {
     void* ptr;
     if (LIKELY(pymalloc_alloc(ctx, &ptr, nbytes))) {
+        memset(ptr, 0, nbytes);
         return ptr;
     }
 


### PR DESCRIPTION
Steps to reproduce, check compilation logs:
```
make clean;make
```

![warning-2019-08-15 01-15-06](https://user-images.githubusercontent.com/8244993/63058048-5dc03800-bf09-11e9-9e8c-252f584896c8.png)