### PR TITLE
bpo-11671: add header validation from http.client to wsgiref.headers.Headers

### DIFF
--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -525,14 +525,16 @@ class HeaderTests(TestCase):
             '\r\n'
         )
 
-    def testDisallowNewlines(self):
+    def testValidateHeaders(self):
         h = Headers([])
-        self.assertRaises(AssertionError, h.add_header, 'foo', 'bar\rbaz: bat')
-        self.assertRaises(AssertionError, h.add_header, 'foo', 'bar\nbaz: bat')
-        self.assertRaises(AssertionError, h.add_header, 'foo:\rbar', 'baz')
-        self.assertRaises(AssertionError, h.add_header, 'foo:\nbar', 'baz')
-        self.assertRaises(AssertionError, h.add_header, 'foo', 'bar', baz='bat\rqux: spam')
-        self.assertRaises(AssertionError, h.add_header, 'foo', 'bar', baz='bat\nqux: spam')
+        self.assertRaises(ValueError, h.add_header, 'foo', 'bar\rbaz: bat')
+        self.assertRaises(ValueError, h.add_header, 'foo', 'bar\nbaz: bat')
+        self.assertRaises(ValueError, h.add_header, 'foo: bar', 'baz')
+        self.assertRaises(ValueError, h.add_header, 'foo:\rbar', 'baz')
+        self.assertRaises(ValueError, h.add_header, 'foo:\nbar', 'baz')
+        self.assertRaises(ValueError, h.add_header, 'foo', 'bar\nbaz: bat')
+        self.assertRaises(ValueError, h.add_header, 'foo', 'bar', baz='bat\rqux: spam')
+        self.assertRaises(ValueError, h.add_header, 'foo', 'bar', baz='bat\nqux: spam')
 
 class ErrorHandler(BaseCGIHandler):
     """Simple handler subclass for testing BaseHandler"""

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -541,20 +541,22 @@ class HeaderTests(TestCase):
         ('ValidName', 'Invalid\nValue'),
         ('ValidName', 'InvalidValue\r\n'),
         ('ValidName', 'InvalidValue\r'),
-        ('ValidName', 'InvalidValue\n')
+        ('ValidName', 'InvalidValue\n'),
+        (b'InvalidName', 'ValidValue', AssertionError),
+        ('ValidName', b'InvalidValue', AssertionError)
     )
 
     def test_add_header_validation(self):
         h = Headers([])
-        for name, value in self.validation_cases:
-            with self.subTest((name, value)):
-                with self.assertRaisesRegex(ValueError, 'Invalid header'):
+        for name, value, *exception in self.validation_cases:
+            with self.subTest((name, value, exception)):
+                with self.assertRaises(exception[0]) if len(exception) else self.assertRaisesRegex(ValueError, 'Invalid header'):
                     h.add_header(name, value)
 
     def test_initialize_validation(self):
-        for name, value in self.validation_cases:
-            with self.subTest((name, value)):
-                with self.assertRaisesRegex(ValueError, 'Invalid header'):
+        for name, value, *exception in self.validation_cases:
+            with self.subTest((name, value, exception)):
+                with self.assertRaises(exception[0]) if len(exception) else self.assertRaisesRegex(ValueError, 'Invalid header'):
                     Headers([(name, value)])
 
 class ErrorHandler(BaseCGIHandler):

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -525,6 +525,15 @@ class HeaderTests(TestCase):
             '\r\n'
         )
 
+    def testDisallowNewlines(self):
+        h = Headers([])
+        self.assertRaises(AssertionError, h.add_header, 'foo', 'bar\rbaz: bat')
+        self.assertRaises(AssertionError, h.add_header, 'foo', 'bar\nbaz: bat')
+        self.assertRaises(AssertionError, h.add_header, 'foo:\rbar', 'baz')
+        self.assertRaises(AssertionError, h.add_header, 'foo:\nbar', 'baz')
+        self.assertRaises(AssertionError, h.add_header, 'foo', 'bar', baz='bat\rqux: spam')
+        self.assertRaises(AssertionError, h.add_header, 'foo', 'bar', baz='bat\nqux: spam')
+
 class ErrorHandler(BaseCGIHandler):
     """Simple handler subclass for testing BaseHandler"""
 

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -525,16 +525,37 @@ class HeaderTests(TestCase):
             '\r\n'
         )
 
-    def testValidateHeaders(self):
+    validation_cases = (
+        ('Invalid\r\nName', 'ValidValue'),
+        ('Invalid\rName', 'ValidValue'),
+        ('Invalid\nName', 'ValidValue'),
+        ('\r\nInvalidName', 'ValidValue'),
+        ('\rInvalidName', 'ValidValue'),
+        ('\nInvalidName', 'ValidValue'),
+        (' InvalidName', 'ValidValue'),
+        ('\tInvalidName', 'ValidValue'),
+        ('Invalid:Name', 'ValidValue'),
+        (':InvalidName', 'ValidValue'),
+        ('ValidName', 'Invalid\r\nValue'),
+        ('ValidName', 'Invalid\rValue'),
+        ('ValidName', 'Invalid\nValue'),
+        ('ValidName', 'InvalidValue\r\n'),
+        ('ValidName', 'InvalidValue\r'),
+        ('ValidName', 'InvalidValue\n')
+    )
+
+    def test_add_header_validation(self):
         h = Headers([])
-        self.assertRaises(ValueError, h.add_header, 'foo', 'bar\rbaz: bat')
-        self.assertRaises(ValueError, h.add_header, 'foo', 'bar\nbaz: bat')
-        self.assertRaises(ValueError, h.add_header, 'foo: bar', 'baz')
-        self.assertRaises(ValueError, h.add_header, 'foo:\rbar', 'baz')
-        self.assertRaises(ValueError, h.add_header, 'foo:\nbar', 'baz')
-        self.assertRaises(ValueError, h.add_header, 'foo', 'bar\nbaz: bat')
-        self.assertRaises(ValueError, h.add_header, 'foo', 'bar', baz='bat\rqux: spam')
-        self.assertRaises(ValueError, h.add_header, 'foo', 'bar', baz='bat\nqux: spam')
+        for name, value in self.validation_cases:
+            with self.subTest((name, value)):
+                with self.assertRaisesRegex(ValueError, 'Invalid header'):
+                    h.add_header(name, value)
+
+    def test_initialize_validation(self):
+        for name, value in self.validation_cases:
+            with self.subTest((name, value)):
+                with self.assertRaisesRegex(ValueError, 'Invalid header'):
+                    Headers([(name, value)])
 
 class ErrorHandler(BaseCGIHandler):
     """Simple handler subclass for testing BaseHandler"""

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -34,12 +34,9 @@ class Headers:
         headers = headers if headers is not None else []
         if type(headers) is not list:
             raise TypeError("Headers must be a list of name/value tuples")
+        self._headers = []
         for header, value in headers:
-            if not _is_legal_header_name(header.encode('ascii')):
-                raise ValueError('Invalid header name %r' % (header,))
-            if _is_illegal_header_value(value.encode('ascii')):
-                raise ValueError('Invalid header value %r' % (value,))
-        self._headers = headers
+            self.add_header(header, value)
         if __debug__:
             for k, v in headers:
                 self._convert_string_type(k)

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -187,5 +187,4 @@ class Headers:
             else:
                 v = self._convert_string_type(v)
                 parts.append(_formatparam(k.replace('_', '-'), v))
-        self._headers.append((self._convert_string_type(_name),
-                              "; ".join(parts)))
+        self._headers.append((self._convert_string_type(_name), "; ".join(parts)))

--- a/Misc/NEWS.d/next/Security/2019-08-27-01-08-25.bpo-11671.wfJY-D.rst
+++ b/Misc/NEWS.d/next/Security/2019-08-27-01-08-25.bpo-11671.wfJY-D.rst
@@ -1,1 +1,1 @@
-Add header validation in wsgiref.headers.Headers to disallow invalid characters in header names and values. Patch by Ashwin Ramaswami, initial patch by Devin Cook.
+Add validation in wsgiref.headers.Headers to disallow invalid characters in header names and values. Patch by Ashwin Ramaswami, initial patch by Devin Cook.

--- a/Misc/NEWS.d/next/Security/2019-08-27-01-08-25.bpo-11671.wfJY-D.rst
+++ b/Misc/NEWS.d/next/Security/2019-08-27-01-08-25.bpo-11671.wfJY-D.rst
@@ -1,0 +1,1 @@
+Add header validation in wsgiref.headers.Headers to disallow invalid characters in header names and values. Patch by Ashwin Ramaswami, initial patch by Devin Cook.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Adds header validation to disallow invalid characters in header names and values. This also fixes https://bugs.python.org/issue28778

I based this off the initial patch in [bpo-11671](https://bugs.python.org/issue11671), with a few changes:
- only check whether headers are valid upon class initialization or calling add_header
- use regex's from http.client, so that it disallows spaces in header names too

I know that http.client's regex (added in [bpo-22928](https://bugs.python.org/issue22928), a112a8ae47813f75aa8ad27ee8c42a7c2e937d13) is not RFC compliant, but it seemed better to at least make both libraries have the same behavior with regards to header validation.

<!-- issue-number: [bpo-11671](https://bugs.python.org/issue11671) -->
https://bugs.python.org/issue11671
<!-- /issue-number -->
