### PR TITLE
bpo-36502: Update link to UAX #44, the Unicode doc on the UCD.

### DIFF
--- a/Doc/library/unicodedata.rst
+++ b/Doc/library/unicodedata.rst
@@ -22,7 +22,7 @@ this database is compiled from the `UCD version 12.1.0
 
 The module uses the same names and symbols as defined by Unicode
 Standard Annex #44, `"Unicode Character Database"
-<http://www.unicode.org/reports/tr44/tr44-6.html>`_.  It defines the
+<http://www.unicode.org/reports/tr44/>`_.  It defines the
 following functions:
 
 

--- a/Doc/library/unicodedata.rst
+++ b/Doc/library/unicodedata.rst
@@ -22,7 +22,7 @@ this database is compiled from the `UCD version 12.1.0
 
 The module uses the same names and symbols as defined by Unicode
 Standard Annex #44, `"Unicode Character Database"
-<http://www.unicode.org/reports/tr44/>`_.  It defines the
+<https://www.unicode.org/reports/tr44/>`_.  It defines the
 following functions:
 
 


### PR DESCRIPTION
The link we have points to the version from Unicode 6.0.0, dated 2010.
There have been numerous updates to it since then:
  https://www.unicode.org/reports/tr44/#Modifications

Change the link to one that points to the current version.


<!-- issue-number: [bpo-36502](https://bugs.python.org/issue36502) -->
https://bugs.python.org/issue36502
<!-- /issue-number -->
