### PR TITLE
bpo-37758: Cut always-constant conditionals on sys.maxunicode.

### DIFF
--- a/Lib/test/test_bigaddrspace.py
+++ b/Lib/test/test_bigaddrspace.py
@@ -55,7 +55,7 @@ class BytesTest(unittest.TestCase):
 
 class StrTest(unittest.TestCase):
 
-    unicodesize = 2 if sys.maxunicode < 65536 else 4
+    unicodesize = 4
 
     @bigaddrspacetest
     def test_concat(self):

--- a/Tools/unicode/mkstringprep.py
+++ b/Tools/unicode/mkstringprep.py
@@ -1,8 +1,5 @@
-import re, sys
+import re
 from unicodedata import ucd_3_2_0 as unicodedata
-
-if sys.maxunicode == 65535:
-    raise RuntimeError("need UCS-4 Python")
 
 def gen_category(cats):
     for i in range(0, 0x110000):


### PR DESCRIPTION
Since PEP 393 in Python 3.3, this value is always 0x10ffff, the
maximum codepoint in Unicode; there's no longer such a thing as a
UCS-2 build of Python, which couldn't properly represent some
characters.

There are a couple of spots left where we still condition on the value
of this constant.  Take them out.


<!-- issue-number: [bpo-37758](https://bugs.python.org/issue37758) -->
https://bugs.python.org/issue37758
<!-- /issue-number -->
