### PR TITLE
Replace usage of the obscure PEM_read_bio_X509_AUX with the more standard PEM_read_bio_X509

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1822,7 +1822,7 @@ _ssl__test_decode_cert_impl(PyObject *module, PyObject *path)
         goto fail0;
     }
 
-    x = PEM_read_bio_X509_AUX(cert,NULL, NULL, NULL);
+    x = PEM_read_bio_X509(cert, NULL, NULL, NULL);
     if (x == NULL) {
         PyErr_SetString(PySSLErrorObject,
                         "Error decoding PEM-encoded file");


### PR DESCRIPTION
X509_AUX is an odd, note widely used, OpenSSL extension to the X509 file format. This function doesn't actually use any of the extra metadata that it parses, so just use the standard API.

Automerge-Triggered-By: @tiran