### PR TITLE
bpo-37732 : Fix unintialized pointer warning in Objects/obmalloc.c

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1641,7 +1641,7 @@ pymalloc_alloc(void *ctx, void **ptr_p, size_t nbytes)
 static void *
 _PyObject_Malloc(void *ctx, size_t nbytes)
 {
-    void* ptr;
+    void* ptr = NULL;
     if (LIKELY(pymalloc_alloc(ctx, &ptr, nbytes))) {
         return ptr;
     }


### PR DESCRIPTION
* Initialize ptr with NULL pointer while declaring

![warning-2019-08-15 01-15-06](https://user-images.githubusercontent.com/8244993/63123987-e7363f80-bfc7-11e9-961e-d452037684c7.png)


<!-- issue-number: [bpo-37732](https://bugs.python.org/issue37732) -->
https://bugs.python.org/issue37732
<!-- /issue-number -->
