### PR TITLE
bpo-37885: venv: Don't produce unbound variable warning on deactivate

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -9,6 +9,7 @@ import ensurepip
 import os
 import os.path
 import re
+import shutil
 import struct
 import subprocess
 import sys
@@ -359,6 +360,25 @@ class BasicTest(BaseTest):
             'print(pool.apply_async("Python".lower).get(3)); '
             'pool.terminate()'])
         self.assertEqual(out.strip(), "python".encode())
+
+    @unittest.skipIf(os.name == 'nt', 'not relevant on Windows')
+    def test_deactivate_with_strict_bash_opts(self):
+        bash = shutil.which("bash")
+        if bash is None:
+            self.skipTest("bash required for this test")
+        rmtree(self.env_dir)
+        builder = venv.EnvBuilder(clear=True)
+        builder.create(self.env_dir)
+        activate = os.path.join(self.env_dir, self.bindir, "activate")
+        test_script = os.path.join(self.env_dir, "test_strict.sh")
+        with open(test_script, "w") as f:
+            f.write("set -euo pipefail\n"
+                    f"source {activate}\n"
+                    "deactivate\n")
+        out, err = check_output([bash, test_script])
+        self.assertEqual(out, "".encode())
+        self.assertEqual(err, "".encode())
+
 
 @requireVenvCreate
 class EnsurePipTest(BaseTest):

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -324,7 +324,7 @@ class BasicTest(BaseTest):
             'import sys; print(sys.executable)'])
         self.assertEqual(out.strip(), envpy.encode())
 
-    @unittest.skipUnless(os.name == 'nt', 'only relevant on Windows')
+    @unittest.skipUnless(sys.platform == 'win32', 'only relevant on Windows')
     def test_unicode_in_batch_file(self):
         """
         Test handling of Unicode paths

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -324,7 +324,7 @@ class BasicTest(BaseTest):
             'import sys; print(sys.executable)'])
         self.assertEqual(out.strip(), envpy.encode())
 
-    @unittest.skipUnless(sys.platform == 'win32', 'only relevant on Windows')
+    @unittest.skipUnless(os.name == 'nt', 'only relevant on Windows')
     def test_unicode_in_batch_file(self):
         """
         Test handling of Unicode paths

--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -28,7 +28,7 @@ deactivate () {
     fi
 
     unset VIRTUAL_ENV
-    if [ ! "$1" = "nondestructive" ] ; then
+    if [ ! "${1:-}" = "nondestructive" ] ; then
     # Self destruct!
         unset -f deactivate
     fi

--- a/Misc/NEWS.d/next/Library/2019-08-19-10-31-41.bpo-37885.4Nc9sp.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-19-10-31-41.bpo-37885.4Nc9sp.rst
@@ -1,0 +1,1 @@
+venv: Don't generate unset variable warning on deactivate.


### PR DESCRIPTION
Before, running deactivate from a bash shell configured to treat undefined variables as errors (`set -u`) would produce a warning:

``` 
$ python3 -m venv test
$ source test/bin/activate
(test) $ deactivate
-bash: $1: unbound variable
```

<!-- issue-number: [bpo-37885](https://bugs.python.org/issue37885) -->
https://bugs.python.org/issue37885
<!-- /issue-number -->
