### PR TITLE
bpo-37732: Fix GCC warning in _PyObject_Malloc()

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1628,9 +1628,6 @@ pymalloc_alloc(void *ctx, size_t nbytes)
          * available:  use a free pool.
          */
         bp = allocate_from_new_pool(size);
-        if (UNLIKELY(bp == NULL)) {
-            return NULL;
-        }
     }
 
     return (void *)bp;

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1580,35 +1580,35 @@ allocate_from_new_pool(uint size)
 
 /* pymalloc allocator
 
-   Return 1 if pymalloc allocated memory and wrote the pointer into *ptr_p.
+   Return a pointer to newly allocated memory if pymalloc allocated memory.
 
-   Return 0 if pymalloc failed to allocate the memory block: on bigger
+   Return NULL if pymalloc failed to allocate the memory block: on bigger
    requests, on error in the code below (as a last chance to serve the request)
    or when the max memory limit has been reached.
 */
-static inline int
-pymalloc_alloc(void *ctx, void **ptr_p, size_t nbytes)
+static inline void*
+pymalloc_alloc(void *ctx, size_t nbytes)
 {
 #ifdef WITH_VALGRIND
     if (UNLIKELY(running_on_valgrind == -1)) {
         running_on_valgrind = RUNNING_ON_VALGRIND;
     }
     if (UNLIKELY(running_on_valgrind)) {
-        return 0;
+        return NULL;
     }
 #endif
 
     if (UNLIKELY(nbytes == 0)) {
-        return 0;
+        return NULL;
     }
     if (UNLIKELY(nbytes > SMALL_REQUEST_THRESHOLD)) {
-        return 0;
+        return NULL;
     }
 
     uint size = (uint)(nbytes - 1) >> ALIGNMENT_SHIFT;
     poolp pool = usedpools[size + size];
     block *bp;
-    
+
     if (LIKELY(pool != pool->nextpool)) {
         /*
          * There is a used pool for this size class.
@@ -1616,6 +1616,7 @@ pymalloc_alloc(void *ctx, void **ptr_p, size_t nbytes)
          */
         ++pool->ref.count;
         bp = pool->freeblock;
+        assert(bp != NULL);
 
         if (UNLIKELY((pool->freeblock = *(block **)bp) == NULL)) {
             // Reached the end of the free list, try to extend it.
@@ -1628,21 +1629,19 @@ pymalloc_alloc(void *ctx, void **ptr_p, size_t nbytes)
          */
         bp = allocate_from_new_pool(size);
         if (UNLIKELY(bp == NULL)) {
-            return 0;
+            return NULL;
         }
     }
 
-    assert(bp != NULL);
-    *ptr_p = (void *)bp;
-    return 1;
+    return (void *)bp;
 }
 
 
 static void *
 _PyObject_Malloc(void *ctx, size_t nbytes)
 {
-    void* ptr;
-    if (LIKELY(pymalloc_alloc(ctx, &ptr, nbytes))) {
+    void* ptr = pymalloc_alloc(ctx, nbytes);
+    if (LIKELY(ptr != NULL)) {
         return ptr;
     }
 
@@ -1657,12 +1656,11 @@ _PyObject_Malloc(void *ctx, size_t nbytes)
 static void *
 _PyObject_Calloc(void *ctx, size_t nelem, size_t elsize)
 {
-    void* ptr;
-
     assert(elsize == 0 || nelem <= (size_t)PY_SSIZE_T_MAX / elsize);
     size_t nbytes = nelem * elsize;
 
-    if (LIKELY(pymalloc_alloc(ctx, &ptr, nbytes))) {
+    void* ptr = pymalloc_alloc(ctx, nbytes);
+    if (LIKELY(ptr != NULL)) {
         memset(ptr, 0, nbytes);
         return ptr;
     }
@@ -1711,8 +1709,8 @@ insert_to_freepool(poolp pool)
      * are no arenas in usable_arenas with that value.
      */
     struct arena_object* lastnf = nfp2lasta[nf];
-    assert((nf == 0 && lastnf == NULL) || 
-           (nf > 0 && 
+    assert((nf == 0 && lastnf == NULL) ||
+           (nf > 0 &&
             lastnf != NULL &&
             lastnf->nfreepools == nf &&
             (lastnf->nextarena == NULL ||


### PR DESCRIPTION
pymalloc_alloc() now returns directly the pointer, return NULL on
memory allocation error.

allocate_from_new_pool() already uses NULL as marker for "allocation
failed".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37732](https://bugs.python.org/issue37732) -->
https://bugs.python.org/issue37732
<!-- /issue-number -->
