### PR TITLE
Revert "bpo-37788: Fix a reference leak if a thread is not joined"

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -761,14 +761,6 @@ class ThreadTests(BaseTestCase):
                 # Daemon threads must never add it to _shutdown_locks.
                 self.assertNotIn(tstate_lock, threading._shutdown_locks)
 
-    def test_leak_without_join(self):
-        # bpo-37788: Test that a thread which is not joined explicitly
-        # does not leak. Test written for reference leak checks.
-        def noop(): pass
-        with support.wait_threads_exit():
-            threading.Thread(target=noop).start()
-            # Thread.join() is not called
-
 
 class ThreadJoinOnShutdown(BaseTestCase):
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -806,16 +806,6 @@ class Thread:
         # For debugging and _after_fork()
         _dangling.add(self)
 
-    def __del__(self):
-        if not self._initialized:
-            return
-        lock = self._tstate_lock
-        if lock is not None and not self.daemon:
-            # ensure that self._tstate_lock is not in _shutdown_locks
-            # if join() was not called explicitly
-            with _shutdown_locks_lock:
-                _shutdown_locks.discard(lock)
-
     def _reset_internal_locks(self, is_alive):
         # private!  Called by _after_fork() to reset our internal locks as
         # they may be in an invalid state leading to a deadlock or crash.

--- a/Misc/NEWS.d/next/Library/2019-08-12-17-21-10.bpo-37788.F0tR05.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-12-17-21-10.bpo-37788.F0tR05.rst
@@ -1,1 +1,0 @@
-Fix a reference leak if a thread is not joined.


### PR DESCRIPTION
Reverts python/cpython#15228

<!-- issue-number: [bpo-37788](https://bugs.python.org/issue37788) -->
https://bugs.python.org/issue37788
<!-- /issue-number -->
