### PR TITLE
bpo-32793: Fix a duplicate debug message in smtplib

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -333,8 +333,6 @@ class SMTP:
                     raise OSError("nonnumeric port")
         if not port:
             port = self.default_port
-        if self.debuglevel > 0:
-            self._print_debug('connect:', (host, port))
         sys.audit("smtplib.connect", self, host, port)
         self.sock = self._get_socket(host, port, self.timeout)
         self.file = None

--- a/Misc/NEWS.d/next/Library/2019-08-20-05-17-32.bpo-32793.cgpXl6.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-20-05-17-32.bpo-32793.cgpXl6.rst
@@ -1,0 +1,1 @@
+Fix a duplicated debug message when :meth:`smtplib.SMTP.connect` is called.


### PR DESCRIPTION
_get_socket() already prints a debug message for the host and port.


<!-- issue-number: [bpo-32793](https://bugs.python.org/issue32793) -->
https://bugs.python.org/issue32793
<!-- /issue-number -->


Automerge-Triggered-By: @maxking