### PR TITLE
bpo-37893: raise ValueError in pow if exponent is negative and modulus is +-1

### DIFF
--- a/Lib/test/test_pow.py
+++ b/Lib/test/test_pow.py
@@ -48,7 +48,7 @@ class PowTest(unittest.TestCase):
         for i in range(il, ih+1):
             for j in range(jl, jh+1):
                 for k in range(kl, kh+1):
-                    if k != 0:
+                    if abs(k) not in {0, 1}:
                         if type == float or j < 0:
                             self.assertRaises(TypeError, pow, type(i), j, k)
                             continue
@@ -123,6 +123,9 @@ class PowTest(unittest.TestCase):
     def test_negative_exponent(self):
         for a in range(-50, 50):
             for m in range(-50, 50):
+                if abs(m) == 1:
+                    continue
+
                 with self.subTest(a=a, m=m):
                     if m != 0 and math.gcd(a, m) == 1:
                         # Exponent -1 should give an inverse, with the
@@ -143,6 +146,11 @@ class PowTest(unittest.TestCase):
                             pow(a, -2, m)
                         with self.assertRaises(ValueError):
                             pow(a, -1001, m)
+
+    def test_negative_exponent_with_mod_one(self):
+        for mod in (-1, 1):
+            with self.assertRaises(ValueError):
+                pow(2, -1, mod)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-20-19-43-56.bpo-37893.Y08HwF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-20-19-43-56.bpo-37893.Y08HwF.rst
@@ -1,0 +1,2 @@
+Raise a ValueError if exponent is negative and modulus is +-1 in pow
+function.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4335,7 +4335,7 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
 
         /* if exponent < 0 and abs(modulus) == 1:
                raise ValueError */
-        if ((Py_SIZE(b) < 0) && (c->ob_digit[0] == 1)) {
+        if ((Py_SIZE(b) < 0) && (Py_SIZE(c) == 1) && (c->ob_digit[0] == 1)) {
             PyErr_SetString(PyExc_ValueError,
                             "Can't use negative exponent with modulus +-1.");
             goto Error;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4298,7 +4298,6 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
         Py_DECREF(b);
         Py_RETURN_NOTIMPLEMENTED;
     }
-
     if (Py_SIZE(b) < 0 && c == NULL) {
         /* if exponent is negative and there's no modulus:
                return a float.  This works because we know
@@ -4332,6 +4331,14 @@ long_pow(PyObject *v, PyObject *w, PyObject *x)
             _PyLong_Negate(&c);
             if (c == NULL)
                 goto Error;
+        }
+
+        /* if exponent < 0 and abs(modulus) == 1:
+               raise ValueError */
+        if ((Py_SIZE(b) < 0) && (c->ob_digit[0] == 1)) {
+            PyErr_SetString(PyExc_ValueError,
+                            "Can't use negative exponent with modulus +-1.");
+            goto Error;
         }
 
         /* if modulus == 1:


### PR DESCRIPTION
Check modulus and the exponent and if there is a case like exponent is negative and abs(modulus) is 1, raise a ValueError

<!-- issue-number: [bpo-37893](https://bugs.python.org/issue37893) -->
https://bugs.python.org/issue37893
<!-- /issue-number -->
