### PR TITLE
bpo-37531: Enhance regrtest multiprocess timeout

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-08-20-19-24-19.bpo-37531.wRoXfU.rst
+++ b/Misc/NEWS.d/next/Tests/2019-08-20-19-24-19.bpo-37531.wRoXfU.rst
@@ -1,0 +1,3 @@
+Enhance regrtest multiprocess timeout: write a message when killing a worker
+process, catch popen.kill() and popen.wait() exceptions, put a timeout on the
+second call to popen.communicate().


### PR DESCRIPTION
* Write a message when killing a process
* Catch exceptions when calling popen.kill()
* Put a timeout when calling popen.communicate() after killing the
  process
* Put a timeout when calling popen.wait()

<!-- issue-number: [bpo-37531](https://bugs.python.org/issue37531) -->
https://bugs.python.org/issue37531
<!-- /issue-number -->
