### PR TITLE
Update asyncio.ensure_future() documentation

### DIFF
--- a/Doc/library/asyncio-future.rst
+++ b/Doc/library/asyncio-future.rst
@@ -37,7 +37,7 @@ Future Functions
    * a :class:`Task` object wrapping *obj*, if *obj* is a
      coroutine (:func:`iscoroutine` is used for the test);
      in this case the coroutine will be scheduled by
-    ``ensure_future()``.
+     ``ensure_future()``.
 
    * a :class:`Task` object that would await on *obj*, if *obj* is an
      awaitable (:func:`inspect.isawaitable` is used for the test.)

--- a/Doc/library/asyncio-future.rst
+++ b/Doc/library/asyncio-future.rst
@@ -28,8 +28,8 @@ Future Functions
 
 .. function:: ensure_future(obj, \*, loop=None)
 
-   Schedule the execution of a :ref:`coroutine object <coroutine>`: wrap it in
-   a future. Return a :class:`Task` object.
+   Schedule the execution of a :term:`coroutine object <coroutine>` and wrap it
+   in a future. Return a :class:`Task` object.
 
    Return:
 

--- a/Doc/library/asyncio-future.rst
+++ b/Doc/library/asyncio-future.rst
@@ -28,9 +28,6 @@ Future Functions
 
 .. function:: ensure_future(obj, \*, loop=None)
 
-   Schedule the execution of a :term:`coroutine object <coroutine>` and wrap it
-   in a future. Return a :class:`Task` object.
-
    Return:
 
    * *obj* argument as is, if *obj* is a :class:`Future`,
@@ -38,7 +35,9 @@ Future Functions
      is used for the test.)
 
    * a :class:`Task` object wrapping *obj*, if *obj* is a
-     coroutine (:func:`iscoroutine` is used for the test.)
+     coroutine (:func:`iscoroutine` is used for the test);
+     in this case the coroutine will be scheduled by
+    ``ensure_future()``.
 
    * a :class:`Task` object that would await on *obj*, if *obj* is an
      awaitable (:func:`inspect.isawaitable` is used for the test.)

--- a/Doc/library/asyncio-future.rst
+++ b/Doc/library/asyncio-future.rst
@@ -28,6 +28,9 @@ Future Functions
 
 .. function:: ensure_future(obj, \*, loop=None)
 
+   Schedule the execution of a :ref:`coroutine object <coroutine>`: wrap it in
+   a future. Return a :class:`Task` object.
+
    Return:
 
    * *obj* argument as is, if *obj* is a :class:`Future`,


### PR DESCRIPTION
Added back mention that ensure_future actually scheduled obj. This documentation just mentions what ensure_future returns, so I did not realize that ensure_future also schedules obj.
