### PR TITLE
bpo-35518: Skip test that relies on a deceased network service.

### DIFF
--- a/Lib/test/test_timeout.py
+++ b/Lib/test/test_timeout.py
@@ -150,6 +150,7 @@ class TCPTimeoutTestCase(TimeoutTestCase):
     def tearDown(self):
         self.sock.close()
 
+    @unittest.skipIf(True, 'need to replace these hosts; see bpo-35518')
     def testConnectTimeout(self):
         # Testing connect timeout is tricky: we need to have IP connectivity
         # to a host that silently drops our packets.  We can't simulate this


### PR DESCRIPTION
If this service had thoroughly vanished, we could just ignore the
test until someone gets around to either recreating such a service
or redesigning the test to somehow work locally.  The
`support.transient_internet` mechanism catches the failure to
resolve the domain name, and skips the test.

But in fact the domain snakebite.net does still exist, as do its
nameservers -- and they can be quite slow to reply.  As a result
this test can easily take 20-30s before it gets auto-skipped.

So, skip the test explicitly up front.


<!-- issue-number: [bpo-35518](https://bugs.python.org/issue35518) -->
https://bugs.python.org/issue35518
<!-- /issue-number -->
