### PR TITLE
bpo-37851: faulthandler allocates its stack on demand

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-08-21-13-43-04.bpo-37851.mIIfD_.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-21-13-43-04.bpo-37851.mIIfD_.rst
@@ -1,0 +1,3 @@
+The :mod:`faulthandler` module no longer allocates its alternative stack at
+Python startup. Now the stack is only allocated at the first faulthandler
+usage.


### PR DESCRIPTION
The faulthandler module no longer allocates its alternative stack at
Python startup. Now the stack is only allocated at the first
faulthandler usage.

faulthandler no longer ignores memory allocation failure when
allocation the stack. sigaltstack() failure now raises an OSError
exception, rather than being ignored.

Moreover, the alternative stack is no longer used if sigaction() is
not available. In practice, sigaltstack() should only be available
when sigaction() is avaialble, so this change should have no effect
in practice.

faulthandler.dump_traceback_later() internal locks are now only
allocated at the first dump_traceback_later() call, rather than
always being allocated at Python startup.

<!-- issue-number: [bpo-37851](https://bugs.python.org/issue37851) -->
https://bugs.python.org/issue37851
<!-- /issue-number -->
