### PR TITLE
bpo-9938: Add optional keyword argument exit_on_error to argparse.ArgumentParser

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -659,7 +659,7 @@ exit_on_error
 Normally, when you pass an wrong argument list to the :meth:`~ArgumentParser.parse_args`
 method of an :class:`ArgumentParser`, it will exit with error info.
 
-If user would like catch error by themselves, they can enable this feature by setting
+If the user would like catch errors manually, they can enable this feature by setting
 ``exit_on_error`` to ``False``::
 
    >>> parser = argparse.ArgumentParser(exit_on_error=False)

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -179,8 +179,8 @@ ArgumentParser objects
    * allow_abbrev_ - Allows long options to be abbreviated if the
      abbreviation is unambiguous. (default: ``True``)
 
-   * exit_on_error_ - Determines whether or not argparser exits with error info
-     when an error occur. (default: ``True``)
+   * exit_on_error_ - Determines whether or not ArgumentParser exits with
+     error info when an error occur. (default: ``True``)
 
    .. versionchanged:: 3.5
       *allow_abbrev* parameter was added.
@@ -659,7 +659,7 @@ exit_on_error
 Normally, when you pass an invalid argument list to the :meth:`~ArgumentParser.parse_args`
 method of an :class:`ArgumentParser`, it will exit with error info.
 
-If the user would like catch errors manually, they can enable this feature by setting
+If the user would like catch errors manually, the feature can be enable by setting
 ``exit_on_error`` to ``False``::
 
    >>> parser = argparse.ArgumentParser(exit_on_error=False)

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -656,7 +656,7 @@ the help options::
 exit_on_error
 ^^^^^^^^^^^^^
 
-Normally, when you pass an wrong argument list to the :meth:`~ArgumentParser.parse_args`
+Normally, when you pass an invalid argument list to the :meth:`~ArgumentParser.parse_args`
 method of an :class:`ArgumentParser`, it will exit with error info.
 
 If the user would like catch errors manually, they can enable this feature by setting

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -142,7 +142,7 @@ ArgumentParser objects
                           formatter_class=argparse.HelpFormatter, \
                           prefix_chars='-', fromfile_prefix_chars=None, \
                           argument_default=None, conflict_handler='error', \
-                          add_help=True, allow_abbrev=True)
+                          add_help=True, allow_abbrev=True, exit_on_error=True)
 
    Create a new :class:`ArgumentParser` object. All parameters should be passed
    as keyword arguments. Each parameter has its own more detailed description
@@ -179,12 +179,18 @@ ArgumentParser objects
    * allow_abbrev_ - Allows long options to be abbreviated if the
      abbreviation is unambiguous. (default: ``True``)
 
+   * exit_on_error_ - Determines whether or not argparser exits with error
+     when an error occur. (default: ``True``)
+
    .. versionchanged:: 3.5
       *allow_abbrev* parameter was added.
 
    .. versionchanged:: 3.8
       In previous versions, *allow_abbrev* also disabled grouping of short
       flags such as ``-vv`` to mean ``-v -v``.
+
+   .. versionchanged:: 3.9
+      *exit_on_error* parameter was added.
 
 The following sections describe how each of these are used.
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -179,7 +179,7 @@ ArgumentParser objects
    * allow_abbrev_ - Allows long options to be abbreviated if the
      abbreviation is unambiguous. (default: ``True``)
 
-   * exit_on_error_ - Determines whether or not argparser exits with error
+   * exit_on_error_ - Determines whether or not argparser exits with an error
      when an error occur. (default: ``True``)
 
    .. versionchanged:: 3.5

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -660,7 +660,7 @@ Normally, when you pass an wrong argument list to the :meth:`~ArgumentParser.par
 method of an :class:`ArgumentParser`, it will exit with error info.
 
 If user would like catch error by themselves, they can enable this feature by setting
-``exit_on_error`` to ``False``:
+``exit_on_error`` to ``False``::
 
    >>> parser = argparse.ArgumentParser(exit_on_error=False)
    >>> parser.add_argument('--integers', type=int)

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -180,7 +180,7 @@ ArgumentParser objects
      abbreviation is unambiguous. (default: ``True``)
 
    * exit_on_error_ - Determines whether or not ArgumentParser exits with
-     error info when an error occur. (default: ``True``)
+     error info when an error occurs. (default: ``True``)
 
    .. versionchanged:: 3.5
       *allow_abbrev* parameter was added.

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -179,7 +179,7 @@ ArgumentParser objects
    * allow_abbrev_ - Allows long options to be abbreviated if the
      abbreviation is unambiguous. (default: ``True``)
 
-   * exit_on_error_ - Determines whether or not argparser exits with error
+   * exit_on_error_ - Determines whether or not argparser exits with error info
      when an error occur. (default: ``True``)
 
    .. versionchanged:: 3.5
@@ -651,6 +651,28 @@ the help options::
 
    optional arguments:
      +h, ++help  show this help message and exit
+
+
+exit_on_error
+^^^^^^^^^^^^^
+
+Normally, when you pass an wrong argument list to the :meth:`~ArgumentParser.parse_args`
+method of an :class:`ArgumentParser`, it will exit with error info.
+
+If user would like catch error by themselves, they can enable this feature by setting
+``exit_on_error`` to ``False``:
+
+   >>> parser = argparse.ArgumentParser(exit_on_error=False)
+   >>> parser.add_argument('--integers', type=int)
+   _StoreAction(option_strings=['--integers'], dest='integers', nargs=None, const=None, default=None, type=<class 'int'>, choices=None, help=None, metavar=None)
+   >>> try:
+   ...     parser.parse_args('--integers a'.split())
+   ... except argparse.ArgumentError:
+   ...     print('Catching an argumentError')
+   ...
+   Catching an argumentError
+
+.. versionadded:: 3.9
 
 
 The add_argument() method

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1623,7 +1623,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         - conflict_handler -- String indicating how to handle conflicts
         - add_help -- Add a -h/-help option
         - allow_abbrev -- Allow long options to be abbreviated unambiguously
-        - exit_on_error -- Determines whether or not argparser exits with
+        - exit_on_error -- Determines whether or not argparser exits with an
             error when an error occurs
     """
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1623,6 +1623,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         - conflict_handler -- String indicating how to handle conflicts
         - add_help -- Add a -h/-help option
         - allow_abbrev -- Allow long options to be abbreviated unambiguously
+        - exit_on_error -- Determines whether or not argparser exits with
+            error when an error occurs
     """
 
     def __init__(self,

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1623,7 +1623,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         - conflict_handler -- String indicating how to handle conflicts
         - add_help -- Add a -h/-help option
         - allow_abbrev -- Allow long options to be abbreviated unambiguously
-        - exit_on_error -- Determines whether or not argparser exits with
+        - exit_on_error -- Determines whether or not ArgumentParser exits with
             error info when an error occurs
     """
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5230,7 +5230,7 @@ class TestExitOnError(TestCase):
 
     def test_exit_on_error_with_good_args(self):
         ns = self.parser.parse_args('--integers 4'.split())
-        self.assertEqual(ns, argparse.Namespace(integers=4)) 
+        self.assertEqual(ns, argparse.Namespace(integers=4))
 
     def test_exit_on_error_with_bad_args(self):
         with self.assertRaises(argparse.ArgumentError):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5222,6 +5222,21 @@ class TestWrappingMetavar(TestCase):
             '''))
 
 
+class TestExitOnError(TestCase):
+
+    def setUp(self):
+        self.parser = argparse.ArgumentParser(exit_on_error=False)
+        self.parser.add_argument('--integers', metavar='N', type=int)
+
+    def test_exit_on_error_with_good_args(self):
+        ns = self.parser.parse_args('--integers 4'.split())
+        self.assertEqual(ns, argparse.Namespace(integers=4)) 
+
+    def test_exit_on_error_with_bad_args(self):
+        with self.assertRaises(argparse.ArgumentError):
+            self.parser.parse_args('--integers a'.split())
+
+
 def test_main():
     support.run_unittest(__name__)
     # Remove global references to avoid looking like we have refleaks.

--- a/Misc/NEWS.d/next/Library/2019-08-21-16-38-56.bpo-9938.t3G7N9.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-21-16-38-56.bpo-9938.t3G7N9.rst
@@ -1,1 +1,1 @@
-Add ``exit_on_error`` in :class:`ArgumentParser`.
+Add optional keyword argument ``exit_on_error`` for :class:`ArgumentParser`.

--- a/Misc/NEWS.d/next/Library/2019-08-21-16-38-56.bpo-9938.t3G7N9.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-21-16-38-56.bpo-9938.t3G7N9.rst
@@ -1,0 +1,1 @@
+Add ``exit_on_error`` in :class:`ArgumentParser`.


### PR DESCRIPTION
 Co-Authored-by: Xuanji Li <xuanji@gmail.com>

<!-- issue-number: [bpo-9938](https://bugs.python.org/issue9938) -->
https://bugs.python.org/issue9938
<!-- /issue-number -->


Automerge-Triggered-By: @matrixise