### PR TITLE
[3.8] bpo-9949: Call normpath() in realpath() and avoid unnecessary prefixes (GH-15369)

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -458,7 +458,8 @@ def normpath(path):
         # in the case of paths with these prefixes:
         # \\.\ -> device names
         # \\?\ -> literal paths
-        # do not do any normalization, but return the path unchanged
+        # do not do any normalization, but return the path
+        # unchanged apart from the call to os.fspath()
         return path
     path = path.replace(altsep, sep)
     prefix, path = splitdrive(path)
@@ -575,7 +576,7 @@ else:
         return abspath(tail)
 
     def realpath(path):
-        path = os.fspath(path)
+        path = normpath(path)
         if isinstance(path, bytes):
             prefix = b'\\\\?\\'
             unc_prefix = b'\\\\?\\UNC\\'
@@ -586,6 +587,7 @@ else:
             unc_prefix = '\\\\?\\UNC\\'
             new_unc_prefix = '\\\\'
             cwd = os.getcwd()
+        did_not_exist = not exists(path)
         had_prefix = path.startswith(prefix)
         path = _getfinalpathname_nonstrict(path)
         # The path returned by _getfinalpathname will always start with \\?\ -
@@ -603,7 +605,10 @@ else:
                 if _getfinalpathname(spath) == path:
                     path = spath
             except OSError as ex:
-                pass
+                # If the path does not exist and originally did not exist, then
+                # strip the prefix anyway.
+                if ex.winerror in {2, 3} and did_not_exist:
+                    path = spath
         return path
 
 

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -333,11 +333,11 @@ class TestNtpath(unittest.TestCase):
         self.assertEqual(ntpath.realpath(ABSTFN + "1\\.."),
                          ntpath.dirname(ABSTFN))
         self.assertEqual(ntpath.realpath(ABSTFN + "1\\..\\x"),
-                         ntpath.dirname(P + ABSTFN) + "\\x")
+                         ntpath.dirname(ABSTFN) + "\\x")
         os.symlink(ABSTFN + "x", ABSTFN + "y")
         self.assertEqual(ntpath.realpath(ABSTFN + "1\\..\\"
                                          + ntpath.basename(ABSTFN) + "y"),
-                         P + ABSTFN + "x")
+                         ABSTFN + "x")
         self.assertIn(ntpath.realpath(ABSTFN + "1\\..\\"
                                       + ntpath.basename(ABSTFN) + "1"),
                       expected)


### PR DESCRIPTION


<!-- issue-number: [bpo-9949](https://bugs.python.org/issue9949) -->
https://bugs.python.org/issue9949
<!-- /issue-number -->


Automerge-Triggered-By: @zooba