### PR TITLE
bpo-32554: Deprecate hashing arbitrary types in random.seed()

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -88,8 +88,8 @@ Bookkeeping functions
 
    .. deprecated:: 3.9
       In the future, the *seed* must be one of the following types:
-      :class:`NoneType`, :class:`int`, :class:`float`, :class:`str`,
-      :class:`bytes`, or :class:`bytearray'.
+      *NoneType*, :class:`int`, :class:`float`, :class:`str`,
+      :class:`bytes`, or :class:`bytearray`.
 
 .. function:: getstate()
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -324,7 +324,7 @@ Alternative Generator
    .. deprecated:: 3.9
       In the future, the *seed* must be one of the following types:
       :class:`NoneType`, :class:`int`, :class:`float`, :class:`str`,
-      :class:`bytes`, or :class:`bytearray'.
+      :class:`bytes`, or :class:`bytearray`.
 
 .. class:: SystemRandom([seed])
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -86,6 +86,11 @@ Bookkeeping functions
    .. versionchanged:: 3.2
       Moved to the version 2 scheme which uses all of the bits in a string seed.
 
+   .. deprecated:: 3.9
+      In the future, the *seed* must be one of the following types:
+      :class:`NoneType`, :class:`int`, :class:`float`, :class:`str`,
+      :class:`bytes`, or :class:`bytearray'.
+
 .. function:: getstate()
 
    Return an object capturing the current internal state of the generator.  This
@@ -315,6 +320,11 @@ Alternative Generator
 
    Class that implements the default pseudo-random number generator used by the
    :mod:`random` module.
+
+   .. deprecated:: 3.9
+      In the future, the *seed* must be one of the following types:
+      :class:`NoneType`, :class:`int`, :class:`float`, :class:`str`,
+      :class:`bytes`, or :class:`bytearray'.
 
 .. class:: SystemRandom([seed])
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -169,6 +169,12 @@ Deprecated
   of Python. For the majority of use cases users can leverage the Abstract Syntax
   Tree (AST) generation and compilation stage, using the :mod:`ast` module.
 
+* The :mod:`random` module currently accepts any hashable type as a
+  possible seed value.  Unfortunately, some of those types are not
+  guaranteed to have a deterministic hash value.  After Python 3.9,
+  the module will restrict its seeds to *None*, :class:`int`,
+  :class:`float`, :class:`str`, :class:`bytes`, and :class:`bytearray'.
+
 
 Removed
 =======

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -173,7 +173,7 @@ Deprecated
   possible seed value.  Unfortunately, some of those types are not
   guaranteed to have a deterministic hash value.  After Python 3.9,
   the module will restrict its seeds to *None*, :class:`int`,
-  :class:`float`, :class:`str`, :class:`bytes`, and :class:`bytearray'.
+  :class:`float`, :class:`str`, :class:`bytes`, and :class:`bytearray`.
 
 
 Removed

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -155,7 +155,8 @@ class Random(_random.Random):
         elif not isinstance(a, (type(None), int, float, str, bytes, bytearray)):
             _warn('Seeding based on hashing is deprecated\n'
                   'since Python 3.9 and will be removed in a subsequent '
-                  'version. The only \nsupported seed types are: None, '
+                  'version. The only \n'
+                  'supported seed types are: None, '
                   'int, float, str, bytes, and bytearray.',
                   DeprecationWarning, 2)
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -121,7 +121,10 @@ class Random(_random.Random):
                 break
 
     def seed(self, a=None, version=2):
-        """Initialize internal state from hashable object.
+        """Initialize internal state from a seed.
+
+        The only supported seed types are None, int, float,
+        str, bytes, and bytearray.
 
         None or no argument seeds from current time or from an operating
         system specific randomness source if available.
@@ -143,11 +146,18 @@ class Random(_random.Random):
             x ^= len(a)
             a = -2 if x == -1 else x
 
-        if version == 2 and isinstance(a, (str, bytes, bytearray)):
+        elif version == 2 and isinstance(a, (str, bytes, bytearray)):
             if isinstance(a, str):
                 a = a.encode()
             a += _sha512(a).digest()
             a = int.from_bytes(a, 'big')
+
+        elif not isinstance(a, (type(None), int, float, str, bytes, bytearray)):
+            _warn('Seeding based on hashing is deprecated\n'
+                  'since Python 3.9 and will be removed in a subsequent '
+                  'version. The only \nsupported seed types are: None, '
+                  'int, float, str, bytes, and bytearray.',
+                  DeprecationWarning, 2)
 
         super().seed(a)
         self.gauss_next = None

--- a/Misc/NEWS.d/next/Library/2019-08-22-01-49-05.bpo-32554.4xiXyM.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-22-01-49-05.bpo-32554.4xiXyM.rst
@@ -1,0 +1,1 @@
+Deprecate having random.seed() call hash on arbitrary types.


### PR DESCRIPTION


<!-- issue-number: [bpo-32554](https://bugs.python.org/issue32554) -->
https://bugs.python.org/issue32554
<!-- /issue-number -->
