### PR TITLE
bpo-37549: os.dup() fails for standard streams on Windows 7

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3476,6 +3476,11 @@ class FDInheritanceTests(unittest.TestCase):
         self.addCleanup(os.close, fd2)
         self.assertEqual(os.get_inheritable(fd2), False)
 
+    def test_dup_standard_stream(self):
+        fd = os.dup(1)
+        self.addCleanup(os.close, fd)
+        self.assertGreater(fd, 0)
+
     @unittest.skipUnless(sys.platform == 'win32', 'win32-specific test')
     def test_dup_nul(self):
         # os.dup() was creating inheritable fds for character files.

--- a/Misc/NEWS.d/next/Windows/2019-08-22-09-04-44.bpo-37549.TpKI3M.rst
+++ b/Misc/NEWS.d/next/Windows/2019-08-22-09-04-44.bpo-37549.TpKI3M.rst
@@ -1,0 +1,1 @@
+:func:`os.dup` no longer fails for standard streams on Windows 7.

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1134,11 +1134,18 @@ set_inheritable(int fd, int inheritable, int raise, int *atomic_flag_works)
         flags = HANDLE_FLAG_INHERIT;
     else
         flags = 0;
-    if (!SetHandleInformation(handle, HANDLE_FLAG_INHERIT, flags)) {
+
+    /* This check can be removed once support for Windows 7 ends. */
+#define CONSOLE_PSEUDOHANDLE(handle) (((ULONG_PTR)(handle) & 0x3) == 0x3 && \
+        GetFileType(handle) == FILE_TYPE_CHAR)
+
+    if (!CONSOLE_PSEUDOHANDLE(handle) &&
+        !SetHandleInformation(handle, HANDLE_FLAG_INHERIT, flags)) {
         if (raise)
             PyErr_SetFromWindowsErr(0);
         return -1;
     }
+#undef CONSOLE_PSEUDOHANDLE
     return 0;
 
 #else


### PR DESCRIPTION


<!-- issue-number: [bpo-37549](https://bugs.python.org/issue37549) -->
https://bugs.python.org/issue37549
<!-- /issue-number -->
