### PR TITLE
bpo-37915: Fix comparison between tzinfo objects and timezone objects

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -413,6 +413,9 @@ class TestTimeZone(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     timezone(delta)
 
+    def test_comparison_with_tzinfo(self):
+        self.assertNotEqual(timezone.utc, tzinfo())
+        self.assertNotEqual(timezone(timedelta(hours=1)), tzinfo())
 
 #############################################################################
 # Base class for testing a particular aspect of timedelta, time, date and

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -414,6 +414,8 @@ class TestTimeZone(unittest.TestCase):
                     timezone(delta)
 
     def test_comparison_with_tzinfo(self):
+        # Constructing tzinfo objects directly should not be done by users
+        # and serves only to check the bug described in bpo-37915
         self.assertNotEqual(timezone.utc, tzinfo())
         self.assertNotEqual(timezone(timedelta(hours=1)), tzinfo())
 

--- a/Misc/NEWS.d/next/Library/2019-08-22-16-13-27.bpo-37915.xyoZI5.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-22-16-13-27.bpo-37915.xyoZI5.rst
@@ -1,0 +1,3 @@
+Fix a segmentation fault that appear when comparing instances of
+``datetime.timezone`` and ``datetime.tzinfo`` objects. Patch by Pablo
+Galindo.

--- a/Misc/NEWS.d/next/Library/2019-08-22-16-13-27.bpo-37915.xyoZI5.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-22-16-13-27.bpo-37915.xyoZI5.rst
@@ -1,3 +1,3 @@
-Fix a segmentation fault that appear when comparing instances of
+Fix a segmentation fault that appeared when comparing instances of
 ``datetime.timezone`` and ``datetime.tzinfo`` objects. Patch by Pablo
 Galindo.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -32,6 +32,8 @@
 #define PyTZInfo_Check(op) PyObject_TypeCheck(op, &PyDateTime_TZInfoType)
 #define PyTZInfo_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TZInfoType)
 
+#define PyTimezone_Check(op) PyObject_TypeCheck(op, &PyDateTime_TimeZoneType)
+#define PyTimezone_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TimeZoneType)
 
 /*[clinic input]
 module datetime
@@ -3745,7 +3747,7 @@ timezone_richcompare(PyDateTime_TimeZone *self,
 {
     if (op != Py_EQ && op != Py_NE)
         Py_RETURN_NOTIMPLEMENTED;
-    if (!PyTZInfo_Check(other)) {
+    if (!PyTimezone_Check(other)) {
         Py_RETURN_NOTIMPLEMENTED;
     }
     return delta_richcompare(self->offset, other->offset, op);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -33,7 +33,6 @@
 #define PyTZInfo_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TZInfoType)
 
 #define PyTimezone_Check(op) PyObject_TypeCheck(op, &PyDateTime_TimeZoneType)
-#define PyTimezone_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TimeZoneType)
 
 /*[clinic input]
 module datetime


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37915](https://bugs.python.org/issue37915) -->
https://bugs.python.org/issue37915
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal