### PR TITLE
bpo-38145: Fix short option 'd' in command 'bdist_dumb'

### DIFF
--- a/Lib/distutils/command/bdist_dumb.py
+++ b/Lib/distutils/command/bdist_dumb.py
@@ -16,7 +16,7 @@ class bdist_dumb(Command):
 
     description = "create a \"dumb\" built distribution"
 
-    user_options = [('bdist-dir=', 'd',
+    user_options = [('bdist-dir=', 'b',
                      "temporary directory for creating the distribution"),
                     ('plat-name=', 'p',
                      "platform name to embed in generated filenames "


### PR DESCRIPTION
In the 'distutils' command 'bdist_dumb', the short option 'd' is used
for both the 'bdist-dir' and 'dist-dir' options.

The bdist-dir option appeared first on 2000-05-13 in commit:
ba0506b3492a13f5c8cec7598bf2b5f9735ac7b2

The dist-dir option appeared then on 2000-07-05 in commit:
c4eb84accb1ac1e09ea78bc3af81acdbe9499fb8

There appears to have been no version released between these two
commits, so most likely the global behaviour of the command has
stayed consistent.

The short option d actually triggers the dist-dir option, not the
bdist-dir option.

It is therefore safe to change the short option for bdist-dir. A
choice consistent with other similar distutils commands is 'b'.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
