### PR TITLE
Less harsh implementation for issubclass()

### DIFF
--- a/Lib/_py_abc.py
+++ b/Lib/_py_abc.py
@@ -1,5 +1,5 @@
 from _weakrefset import WeakSet
-
+from warnings import warn
 
 def get_cache_token():
     """Returns the current ABC cache token.
@@ -108,7 +108,8 @@ class ABCMeta(type):
     def __subclasscheck__(cls, subclass):
         """Override for issubclass(subclass, cls)."""
         if not isinstance(subclass, type):
-            raise TypeError('issubclass() arg 1 must be a class')
+            warn('issubclass() arg 1 is not a class. Returning False.')
+            return False
         # Check cache
         if subclass in cls._abc_cache:
             return True


### PR DESCRIPTION
Apologies if this does not fully conform to the contrib guidelines (please close it if so), but I think this is a trivial change, and likely does not need any discussion on bugs.python.org.

When trying to write tests for one of my libraries, I wanted to ensure a certain input param is a proper subclass, and to ensure it fails for invalid input, I ran tests with not-class inputs like a string etc. This has been discussed in #5944 and #6188, where the decision was raise an error requiring a class-type input. I think this could be made less *harsh* by simply returning False, while issuing a warning.

I'm not a cpython expert and not sure warnings module is available in that environment, I put it in there to give an idea of the ideal behaviour of issubclass I'd expect. Apologies if this does not fully conform to the contrib guidelines -please close it if so. Thank you for the consideration.