### PR TITLE
bpo-37953: Fix ForwardRef equality checks

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2336,6 +2336,65 @@ class ForwardRefTests(BaseTestCase):
         self.assertEqual(fr, typing.ForwardRef('int'))
         self.assertNotEqual(List['int'], List[int])
 
+    def test_forward_equality_gth(self):
+        c1 = typing.ForwardRef('C')
+        c1_gth = typing.ForwardRef('C')
+        c2 = typing.ForwardRef('C')
+        c2_gth = typing.ForwardRef('C')
+
+        class C:
+            pass
+        def foo(a: c1_gth, b: c2_gth):
+            pass
+
+        self.assertEqual(get_type_hints(foo, globals(), locals()), {'a': C, 'b': C})
+        self.assertEqual(c1, c2)
+        self.assertEqual(c1, c1_gth)
+        self.assertEqual(c1_gth, c2_gth)
+        self.assertEqual(List[c1], List[c1_gth])
+        self.assertNotEqual(List[c1], List[C])
+        self.assertNotEqual(List[c1_gth], List[C])
+        self.assertEquals(Union[c1, c1_gth], Union[c1])
+        self.assertEquals(Union[c1, c1_gth, int], Union[c1, int])
+
+    def test_forward_equality_hash(self):
+        c1 = typing.ForwardRef('int')
+        c1_gth = typing.ForwardRef('int')
+        c2 = typing.ForwardRef('int')
+        c2_gth = typing.ForwardRef('int')
+
+        def foo(a: c1_gth, b: c2_gth):
+            pass
+        get_type_hints(foo, globals(), locals())
+
+        self.assertEqual(hash(c1), hash(c2))
+        self.assertEqual(hash(c1_gth), hash(c2_gth))
+        self.assertEqual(hash(c1), hash(c1_gth))
+
+    def test_forward_equality_namespace(self):
+        class A:
+            pass
+        def namespace1():
+            a = typing.ForwardRef('A')
+            def fun(x: a):
+                pass
+            get_type_hints(fun, globals(), locals())
+            return a
+
+        def namespace2():
+            a = typing.ForwardRef('A')
+
+            class A:
+                pass
+            def fun(x: a):
+                pass
+
+            get_type_hints(fun, globals(), locals())
+            return a
+
+        self.assertEqual(namespace1(), namespace1())
+        self.assertNotEqual(namespace1(), namespace2())
+
     def test_forward_repr(self):
         self.assertEqual(repr(List['int']), "typing.List[ForwardRef('int')]")
 
@@ -2354,6 +2413,64 @@ class ForwardRefTests(BaseTestCase):
 
         self.assertEqual(get_type_hints(foo, globals(), locals()),
                          {'a': Tuple[T]})
+
+    def test_forward_recursion_actually(self):
+        def namespace1():
+            a = typing.ForwardRef('A')
+            A = a
+            def fun(x: a): pass
+
+            ret = get_type_hints(fun, globals(), locals())
+            return a
+
+        def namespace2():
+            a = typing.ForwardRef('A')
+            A = a
+            # class A: pass
+            def fun(x: a): pass
+
+            ret = get_type_hints(fun, globals(), locals())
+            return a
+
+        def cmp(o1, o2):
+            return o1 == o2
+
+        r1 = namespace1()
+        r2 = namespace2()
+        assert r1 is not r2
+        self.assertRaises(RecursionError, cmp, r1, r2)
+
+    def test_union_forward_recursion(self):
+        ValueList = List['Value']
+        Value = Union[str, ValueList]
+
+        class C:
+            foo: List[Value]
+        class D:
+            foo: Union[Value, ValueList]
+        class E:
+            foo: Union[List[Value], ValueList]
+        class F:
+            foo: Union[Value, List[Value], ValueList]
+
+        self.assertEqual(get_type_hints(C, globals(), locals()), get_type_hints(C, globals(), locals()))
+        self.assertEqual(get_type_hints(C, globals(), locals()),
+                         {'foo': List[Union[str, List[Union[str, List['Value']]]]]})
+        self.assertEqual(get_type_hints(D, globals(), locals()),
+                         {'foo': Union[str, List[Union[str, List['Value']]]]})
+        self.assertEqual(get_type_hints(E, globals(), locals()),
+                         {'foo': Union[
+                             List[Union[str, List[Union[str, List['Value']]]]],
+                             List[Union[str, List['Value']]]
+                         ]
+                          })
+        self.assertEqual(get_type_hints(F, globals(), locals()),
+                         {'foo': Union[
+                             str,
+                             List[Union[str, List['Value']]],
+                             List[Union[str, List[Union[str, List['Value']]]]]
+                         ]
+                          })
 
     def test_callable_forward(self):
 
@@ -2734,17 +2851,6 @@ class GetTypeHintTests(BaseTestCase):
                          {'z': ClassVar[CSub], 'y': int, 'b': int,
                           'x': ClassVar[Optional[B]]})
         self.assertEqual(gth(G), {'lst': ClassVar[List[T]]})
-        
-    def test_get_type_hints_retains_forward_equality(self):
-        fr = typing.ForwardRef('int')
-        hsh = hash(fr)
-        
-        def foo(a: fr):
-            pass
-        
-        gth(foo)
-        self.assertEqual(fr, typing.ForwardRef('int'))
-        self.assertEqual(hash(fr), hsh)
 
 
 class GetUtilitiesTestCase(TestCase):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2426,7 +2426,6 @@ class ForwardRefTests(BaseTestCase):
         def namespace2():
             a = typing.ForwardRef('A')
             A = a
-            # class A: pass
             def fun(x: a): pass
 
             ret = get_type_hints(fun, globals(), locals())
@@ -2437,7 +2436,7 @@ class ForwardRefTests(BaseTestCase):
 
         r1 = namespace1()
         r2 = namespace2()
-        assert r1 is not r2
+        self.assertIsNot(r1, r2)
         self.assertRaises(RecursionError, cmp, r1, r2)
 
     def test_union_forward_recursion(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2734,6 +2734,17 @@ class GetTypeHintTests(BaseTestCase):
                          {'z': ClassVar[CSub], 'y': int, 'b': int,
                           'x': ClassVar[Optional[B]]})
         self.assertEqual(gth(G), {'lst': ClassVar[List[T]]})
+        
+    def test_get_type_hints_retains_forward_equality(self):
+        fr = typing.ForwardRef('int')
+        hsh = hash(fr)
+        
+        def foo(a: fr):
+            pass
+        
+        gth(foo)
+        self.assertEqual(fr, typing.ForwardRef('int'))
+        self.assertEqual(hash(fr), hsh)
 
 
 class GetUtilitiesTestCase(TestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -527,7 +527,7 @@ class ForwardRef(_Final, _Immutable, _root=True):
         return self.__forward_arg__ == other.__forward_arg__
 
     def __hash__(self):
-        return hash(self.__forward_arg__)
+        return hash((self.__forward_arg__,))
 
     def __repr__(self):
         return f'ForwardRef({self.__forward_arg__!r})'

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -486,7 +486,7 @@ Literal = _SpecialForm('Literal', doc=
     """)
 
 
-class ForwardRef(_Final, _root=True):
+class ForwardRef(_Final, _Immutable, _root=True):
     """Internal wrapper to hold a forward reference."""
 
     __slots__ = ('__forward_arg__', '__forward_code__',
@@ -524,11 +524,10 @@ class ForwardRef(_Final, _root=True):
     def __eq__(self, other):
         if not isinstance(other, ForwardRef):
             return NotImplemented
-        return (self.__forward_arg__ == other.__forward_arg__ and
-                self.__forward_value__ == other.__forward_value__)
+        return self.__forward_arg__ == other.__forward_arg__
 
     def __hash__(self):
-        return hash((self.__forward_arg__, self.__forward_value__))
+        return hash(self.__forward_arg__)
 
     def __repr__(self):
         return f'ForwardRef({self.__forward_arg__!r})'

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -527,7 +527,7 @@ class ForwardRef(_Final, _Immutable, _root=True):
         return self.__forward_arg__ == other.__forward_arg__
 
     def __hash__(self):
-        return hash((self.__forward_arg__,))
+        return hash(self.__forward_arg__)
 
     def __repr__(self):
         return f'ForwardRef({self.__forward_arg__!r})'

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -524,6 +524,9 @@ class ForwardRef(_Final, _Immutable, _root=True):
     def __eq__(self, other):
         if not isinstance(other, ForwardRef):
             return NotImplemented
+        if self.__forward_evaluated__ and other.__forward_evaluated__:
+            return (self.__forward_arg__ == other.__forward_arg__ and
+                    self.__forward_value__ == other.__forward_value__)
         return self.__forward_arg__ == other.__forward_arg__
 
     def __hash__(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -486,7 +486,7 @@ Literal = _SpecialForm('Literal', doc=
     """)
 
 
-class ForwardRef(_Final, _Immutable, _root=True):
+class ForwardRef(_Final, _root=True):
     """Internal wrapper to hold a forward reference."""
 
     __slots__ = ('__forward_arg__', '__forward_code__',

--- a/Misc/NEWS.d/next/Library/2019-09-06-17-40-34.bpo-37953.db5FQq.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-06-17-40-34.bpo-37953.db5FQq.rst
@@ -1,1 +1,2 @@
-Forward references in the typing module now have improved __hash__ and __eq__ methods.
+In :mod:`typing`, improved the ``__hash__`` and ``__eq__`` methods for
+:class:`ForwardReferences`.

--- a/Misc/NEWS.d/next/Library/2019-09-06-17-40-34.bpo-37953.db5FQq.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-06-17-40-34.bpo-37953.db5FQq.rst
@@ -1,3 +1,1 @@
-Forward references in the typing module now have different hash and eq methods. References will now compare equal properly if only one of them has been evaluated and the other hasn't. Hash values are now consistent across the lifetime of a forward reference. 
-
-There is a slight chance this will break existing code, but this has been judged to be unlikely. If two references have the same hash, this now does not mean they are equal, although if two references are equal they will have the same hash.
+Forward references in the typing module now have improved __hash__ and __eq__ methods.

--- a/Misc/NEWS.d/next/Library/2019-09-06-17-40-34.bpo-37953.db5FQq.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-06-17-40-34.bpo-37953.db5FQq.rst
@@ -1,0 +1,3 @@
+Forward references in the typing module now have different hash and eq methods. References will now compare equal properly if only one of them has been evaluated and the other hasn't. Hash values are now consistent across the lifetime of a forward reference. 
+
+There is a slight chance this will break existing code, but this has been judged to be unlikely. If two references have the same hash, this now does not mean they are equal, although if two references are equal they will have the same hash.


### PR DESCRIPTION
Ideally if we stick a ForwardRef in a dictionary we would like to reliably be able to get it out again.

<!-- issue-number: [bpo-37953](https://bugs.python.org/issue37953) -->
https://bugs.python.org/issue37953
<!-- /issue-number -->
