### PR TITLE
Fix funny typo in  Doc/bugs.

### DIFF
--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -80,7 +80,7 @@ taken on the bug.
       Article which goes into some detail about how to create a useful bug report.
       This describes what kind of information is useful and why it is useful.
 
-   `Bug Writing Guidelines <https://developer.mozilla.org/en-US/docs/Mozilla/QA/Bug_writing_guidelines>`_
+   `Bug Report Writing Guidelines <https://developer.mozilla.org/en-US/docs/Mozilla/QA/Bug_writing_guidelines>`_
       Information about writing a good bug report.  Some of this is specific to the
       Mozilla project, but describes general good practices.
 


### PR DESCRIPTION
Fix typo in description of link to mozilla bug report writing guidelines.

Though the URL is misleading, we're indeed trying to write bug _reports_, not to add bugs.

Automerge-Triggered-By: @ned-deily