### PR TITLE
bpo-37926: Fix PySys_SetArgvEx(0, NULL, 0)

### DIFF
--- a/Misc/NEWS.d/next/C API/2019-08-23-11-35-55.bpo-37926.hnI5IQ.rst
+++ b/Misc/NEWS.d/next/C API/2019-08-23-11-35-55.bpo-37926.hnI5IQ.rst
@@ -1,0 +1,1 @@
+Fix a crash in ``PySys_SetArgvEx(0, NULL, 0)``.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3058,11 +3058,11 @@ make_sys_argv(int argc, wchar_t * const * argv)
 void
 PySys_SetArgvEx(int argc, wchar_t **argv, int updatepath)
 {
+    wchar_t* empty_argv[1] = {L""};
     PyThreadState *tstate = _PyThreadState_GET();
 
     if (argc < 1 || argv == NULL) {
         /* Ensure at least one (empty) argument is seen */
-        wchar_t* empty_argv[1] = {L""};
         argv = empty_argv;
         argc = 1;
     }


### PR DESCRIPTION
empty_argv is no longer static in Python 3.8, but it was declared in
a temporary scope, whereas argv kept a reference to it. Define
empty_argv in PySys_SetArgvEx() body, to ensure that it remains valid
for the whole lifetime of the PySys_SetArgvEx() call.

Previously, empty_argv memory (allocated on the stack) was reused by
make_sys_argv() code which is inlined when using gcc -O3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37926](https://bugs.python.org/issue37926) -->
https://bugs.python.org/issue37926
<!-- /issue-number -->
