### PR TITLE
[3.7] bpo-37915: Fix comparison between tzinfo objects and timezone objects (GH-15390)

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -413,6 +413,11 @@ class TestTimeZone(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     timezone(delta)
 
+    def test_comparison_with_tzinfo(self):
+        # Constructing tzinfo objects directly should not be done by users
+        # and serves only to check the bug described in bpo-37915
+        self.assertNotEqual(timezone.utc, tzinfo())
+        self.assertNotEqual(timezone(timedelta(hours=1)), tzinfo())
 
 #############################################################################
 # Base class for testing a particular aspect of timedelta, time, date and

--- a/Misc/NEWS.d/next/Library/2019-08-22-16-13-27.bpo-37915.xyoZI5.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-22-16-13-27.bpo-37915.xyoZI5.rst
@@ -1,0 +1,3 @@
+Fix a segmentation fault that appeared when comparing instances of
+``datetime.timezone`` and ``datetime.tzinfo`` objects. Patch by Pablo
+Galindo.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -20,6 +20,8 @@
 #include "datetime.h"
 #undef Py_BUILD_CORE
 
+#define PyTimezone_Check(op) PyObject_TypeCheck(op, &PyDateTime_TimeZoneType)
+
 /*[clinic input]
 module datetime
 class datetime.datetime "PyDateTime_DateTime *" "&PyDateTime_DateTimeType"
@@ -3648,7 +3650,7 @@ timezone_richcompare(PyDateTime_TimeZone *self,
 {
     if (op != Py_EQ && op != Py_NE)
         Py_RETURN_NOTIMPLEMENTED;
-    if (!PyTZInfo_Check(other)) {
+    if (!PyTimezone_Check(other)) {
         Py_RETURN_NOTIMPLEMENTED;
     }
     return delta_richcompare(self->offset, other->offset, op);


### PR DESCRIPTION


<!-- issue-number: [bpo-37915](https://bugs.python.org/issue37915) -->
https://bugs.python.org/issue37915
<!-- /issue-number -->
