### PR TITLE
[2.7] bpo-34521: Fix FD transfer in multiprocessing on FreeBSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-08-23-14-47-09.bpo-34521.Y2BYu5.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-23-14-47-09.bpo-34521.Y2BYu5.rst
@@ -1,0 +1,2 @@
+Fix file descriptors transfer in multiprocessing on FreeBSD: use
+``CMSG_SPACE()`` rather than ``CMSG_LEN()``; see :rfc:`3542`.

--- a/Modules/_multiprocessing/multiprocessing.c
+++ b/Modules/_multiprocessing/multiprocessing.c
@@ -167,7 +167,7 @@ multiprocessing_recvfd(PyObject *self, PyObject *args)
     cmsg = CMSG_FIRSTHDR(&msg);
     cmsg->cmsg_level = SOL_SOCKET;
     cmsg->cmsg_type = SCM_RIGHTS;
-    cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+    cmsg->cmsg_len = CMSG_SPACE(sizeof(int));
     msg.msg_controllen = cmsg->cmsg_len;
 
     Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
Fix file descriptors transfer in multiprocessing on FreeBSD: use
CMSG_SPACE() rather than CMSG_LEN(); see RFC 3542.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34521](https://bugs.python.org/issue34521) -->
https://bugs.python.org/issue34521
<!-- /issue-number -->
