### PR TITLE
[3.8] Fix _PyTime_MIN/MAX values (GH-15384)

### DIFF
--- a/Include/pytime.h
+++ b/Include/pytime.h
@@ -17,8 +17,8 @@ extern "C" {
    store a duration, and so indirectly a date (related to another date, like
    UNIX epoch). */
 typedef int64_t _PyTime_t;
-#define _PyTime_MIN PY_LLONG_MIN
-#define _PyTime_MAX PY_LLONG_MAX
+#define _PyTime_MIN INT64_MIN
+#define _PyTime_MAX INT64_MAX
 
 typedef enum {
     /* Round towards minus infinity (-inf).


### PR DESCRIPTION
_PyTime_t type is defined as int64_t, and so min/max are INT64_MIN/INT64_MAX,
not PY_LLONG_MIN/PY_LLONG_MAX.

(cherry picked from commit 8e76c456226438f2e4931ce7baf05ac8faae34a1)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
