### PR TITLE
[3.8] Fix typo (inifite -> infinite)

### DIFF
--- a/Misc/NEWS.d/3.8.0b3.rst
+++ b/Misc/NEWS.d/3.8.0b3.rst
@@ -4,7 +4,7 @@
 .. release date: 2019-07-29
 .. section: Security
 
-Fix an inifite loop when parsing specially crafted email headers. Patch by
+Fix an infinite loop when parsing specially crafted email headers. Patch by
 Abhilash Raj.
 
 ..


### PR DESCRIPTION
The same typo exists in the changelogs of 3.6 and 3.7.

Automerge-Triggered-By: @Mariatta