### PR TITLE
bpo-36763: PyConfig_Read() handles PySys_AddXOption()

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -43,6 +43,8 @@ extern PyStatus _PySys_Create(
     PyThreadState *tstate,
     PyObject **sysmod_p);
 extern PyStatus _PySys_SetPreliminaryStderr(PyObject *sysdict);
+extern PyStatus _PySys_ReadPreinitWarnOptions(PyConfig *config);
+extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_InitMain(
     _PyRuntimeState *runtime,
     PyThreadState *tstate);

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -902,6 +902,23 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                                api=API_PYTHON,
                                modify_path_cb=modify_path)
 
+    def test_init_sys_add(self):
+        config = {
+            'faulthandler': 1,
+            'xoptions': [
+                'config_xoption',
+                'cmdline_xoption',
+                'sysadd_xoption',
+                'faulthandler',
+            ],
+            'warnoptions': [
+                'ignore:::config_warnoption',
+                'ignore:::cmdline_warnoption',
+                'ignore:::sysadd_warnoption',
+            ],
+        }
+        self.check_all_configs("test_init_sys_add", config, api=API_PYTHON)
+
     def test_init_run_main(self):
         code = ('import _testinternalcapi, json; '
                 'print(json.dumps(_testinternalcapi.get_configs()))')

--- a/Misc/NEWS.d/next/C API/2019-08-23-18-45-11.bpo-36763.q3Kh8Z.rst
+++ b/Misc/NEWS.d/next/C API/2019-08-23-18-45-11.bpo-36763.q3Kh8Z.rst
@@ -1,0 +1,2 @@
+Options added by ``PySys_AddXOption()`` are now handled the same way than
+``PyConfig.xoptions`` and command line ``-X`` options.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1375,6 +1375,54 @@ fail:
 }
 
 
+static int test_init_sys_add(void)
+{
+    PySys_AddXOption(L"sysadd_xoption");
+    PySys_AddXOption(L"faulthandler");
+    PySys_AddWarnOption(L"ignore:::sysadd_warnoption");
+
+    PyConfig config;
+    PyStatus status;
+    status = PyConfig_InitPythonConfig(&config);
+    if (PyStatus_Exception(status)) {
+        goto fail;
+    }
+
+    wchar_t* argv[] = {
+        L"python3",
+        L"-W",
+        L"ignore:::cmdline_warnoption",
+        L"-X",
+        L"cmdline_xoption",
+    };
+    config_set_argv(&config, Py_ARRAY_LENGTH(argv), argv);
+    config.parse_argv = 1;
+
+    status = PyWideStringList_Append(&config.xoptions,
+                                     L"config_xoption");
+    if (PyStatus_Exception(status)) {
+        goto fail;
+    }
+
+    status = PyWideStringList_Append(&config.warnoptions,
+                                     L"ignore:::config_warnoption");
+    if (PyStatus_Exception(status)) {
+        goto fail;
+    }
+
+    config_set_program_name(&config);
+    init_from_config_clear(&config);
+
+    dump_config();
+    Py_Finalize();
+    return 0;
+
+fail:
+    PyConfig_Clear(&config);
+    Py_ExitStatusException(status);
+}
+
+
 static void configure_init_main(PyConfig *config)
 {
     wchar_t* argv[] = {
@@ -1510,6 +1558,7 @@ static struct TestCase TestCases[] = {
     {"test_init_read_set", test_init_read_set},
     {"test_init_run_main", test_init_run_main},
     {"test_init_main", test_init_main},
+    {"test_init_sys_add", test_init_sys_add},
     {"test_run_main", test_run_main},
     {"test_open_code_hook", test_open_code_hook},
     {"test_audit", test_audit},


### PR DESCRIPTION
PyConfig_Read() is now responsible to handle early calls to
PySys_AddXOption() and PySys_AddWarnOption().

Options added by PySys_AddXOption() are now handled the same way than
PyConfig.xoptions and command line -X options.

For example, PySys_AddXOption(L"faulthandler") enables faulthandler
as expected.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
