### PR TITLE
bpo-37937: Mention frame.f_trace in sys.settrace docs

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1306,8 +1306,9 @@ always available.
    trace function. This is also required for activating the trace function on
    the current frame, which :func:`settrace` doesn't do. If you do this, you
    must also call :func:`settrace` with the same tracing function for it to
-   work. For more information on code and frame objects, refer to
-   :ref:`types`.
+   affect called functions.
+   
+   For more information on code and frame objects, refer to :ref:`types`.
 
    .. audit-event:: sys.settrace "" sys.settrace
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1300,7 +1300,14 @@ always available.
    Note that as an exception is propagated down the chain of callers, an
    ``'exception'`` event is generated at each level.
 
-   For more information on code and frame objects, refer to :ref:`types`.
+   For more fine-grained usage, it's possible to set a trace function by
+   assigning ``frame.f_trace = tracefunc`` explicitly, rather than relying on
+   it being set indirectly via the return value from an already installed
+   trace function. This is also required for activating the trace function on
+   the current frame, which :func:`settrace` doesn't do. If you do this, you
+   must also call :func:`settrace` with the same tracing function for it to
+   work. For more information on code and frame objects, refer to
+   :ref:`types`.
 
    .. audit-event:: sys.settrace "" sys.settrace
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1310,7 +1310,7 @@ always available.
    but it doesn't need to be the same tracing function (e.g. it could be a
    low overhead tracing function that simply returns ``None`` to disable
    itself immediately on each frame).
-   
+
    For more information on code and frame objects, refer to :ref:`types`.
 
    .. audit-event:: sys.settrace "" sys.settrace

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1304,9 +1304,12 @@ always available.
    assigning ``frame.f_trace = tracefunc`` explicitly, rather than relying on
    it being set indirectly via the return value from an already installed
    trace function. This is also required for activating the trace function on
-   the current frame, which :func:`settrace` doesn't do. If you do this, you
-   must also call :func:`settrace` with the same tracing function for it to
-   affect called functions.
+   the current frame, which :func:`settrace` doesn't do. Note that in order
+   for this to work, a global tracing function must have been installed
+   with :func:`settrace` in order to enable the runtime tracing machinery,
+   but it doesn't need to be the same tracing function (e.g. it could be a
+   low overhead tracing function that simply returns ``None`` to disable
+   itself immediately on each frame).
    
    For more information on code and frame objects, refer to :ref:`types`.
 

--- a/Misc/NEWS.d/next/Documentation/2019-08-24-12-59-06.bpo-37937.F7fHbt.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-08-24-12-59-06.bpo-37937.F7fHbt.rst
@@ -1,0 +1,1 @@
+Mention ``frame.f_trace`` in :func:`sys.settrace` docs.


### PR DESCRIPTION
After I released `PySnooper`, @alexmojaki added the awesome optimization of using `f_trace` instead of `sys.settrace`. He needed to explain to me how it works, because I couldn't find any documentation of `f_trace` online. So I figured I'd add it to Python's documentation.

<!-- issue-number: [bpo-37937](https://bugs.python.org/issue37937) -->
https://bugs.python.org/issue37937
<!-- /issue-number -->
