### PR TITLE
bpo-37933: do not segfault canceling never started faulthandler dump

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -819,12 +819,12 @@ class FaultHandlerTests(unittest.TestCase):
 
     def test_cancel_later_no_dump(self):
         code = dedent("""
-        import faulthandler
-        faulthandler.cancel_dump_traceback_later()
+            import faulthandler
+            faulthandler.cancel_dump_traceback_later()
         """)
         output, exitcode = self.get_output(code)
         self.assertEqual(output, [])
-        self.assertEqual(exitcode, 0x00000000)
+        self.assertEqual(exitcode, 0)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -817,6 +817,9 @@ class FaultHandlerTests(unittest.TestCase):
         self.assertEqual(output, [])
         self.assertEqual(exitcode, 0xC0000005)
 
+    def test_cancel_later_no_dump(self):
+        faulthandler.cancel_dump_traceback_later()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -819,7 +819,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     def test_cancel_later_without_dump_traceback_later(self):
         # bpo-37933: Calling cancel_dump_traceback_later()
-        # without dump_traceback_later() must not segfault
+        # without dump_traceback_later() must not segfault.
         code = dedent("""
             import faulthandler
             faulthandler.cancel_dump_traceback_later()

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -819,7 +819,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     def test_cancel_later_without_dump_traceback_later(self):
         # bpo-37933: Calling cancel_dump_traceback_later()
-        # without dump_traceback_later() must not gfaust
+        # without dump_traceback_later() must not segfaust
         code = dedent("""
             import faulthandler
             faulthandler.cancel_dump_traceback_later()

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -819,7 +819,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     def test_cancel_later_without_dump_traceback_later(self):
         # bpo-37933: Calling cancel_dump_traceback_later()
-        # without dump_traceback_later() must not segfaust
+        # without dump_traceback_later() must not segfault
         code = dedent("""
             import faulthandler
             faulthandler.cancel_dump_traceback_later()

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -817,7 +817,9 @@ class FaultHandlerTests(unittest.TestCase):
         self.assertEqual(output, [])
         self.assertEqual(exitcode, 0xC0000005)
 
-    def test_cancel_later_no_dump(self):
+    def test_cancel_later_without_dump_traceback_later(self):
+        # bpo-37933: Calling cancel_dump_traceback_later()
+        # without dump_traceback_later() must not gfaust
         code = dedent("""
             import faulthandler
             faulthandler.cancel_dump_traceback_later()

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -818,7 +818,13 @@ class FaultHandlerTests(unittest.TestCase):
         self.assertEqual(exitcode, 0xC0000005)
 
     def test_cancel_later_no_dump(self):
+        code = dedent("""
+        import faulthandler
         faulthandler.cancel_dump_traceback_later()
+        """)
+        output, exitcode = self.get_output(code)
+        self.assertEqual(output, [])
+        self.assertEqual(exitcode, 0x00000000)
 
 
 if __name__ == "__main__":

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -631,6 +631,11 @@ faulthandler_thread(void *unused)
 static void
 cancel_dump_traceback_later(void)
 {
+    /* If not scheduled, nothing to cancel */
+    if (!thread.cancel_event) {
+        return;
+    }
+
     /* Notify cancellation */
     PyThread_release_lock(thread.cancel_event);
 


### PR DESCRIPTION
If there is no lock, do not try to release it.

The issue is that https://github.com/python/cpython/pull/15358 deferred creating the lock until `faulthandler_dump_traceback_later` is called.  This now short-circuits if there is no lock (as we are sure there is nothing to cancel!).

<!-- issue-number: [bpo-37933](https://bugs.python.org/issue37933) -->
https://bugs.python.org/issue37933
<!-- /issue-number -->
