### PR TITLE
[3.5] bpo-37461: Fix infinite loop in parsing of specially crafted email headers (GH-14794)

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2769,6 +2769,9 @@ def get_parameter(value):
         while value:
             if value[0] in WSP:
                 token, value = get_fws(value)
+            elif value[0] == '"':
+                token = ValueTerminal('"', 'DQUOTE')
+                value = value[1:]
             else:
                 token, value = get_qcontent(value)
             v.append(token)

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2563,6 +2563,13 @@ class Test_parse_mime_parameters(TestParserMixin, TestEmailBase):
             # Defects are apparent missing *0*, and two 'out of sequence'.
             [errors.InvalidHeaderDefect]*3),
 
+        # bpo-37461: Check that we don't go into an infinite loop.
+        'extra_dquote': (
+            'r*="\'a\'\\"',
+            ' r="\\""',
+            'r*=\'a\'"',
+            [('r', '"')],
+            [errors.InvalidHeaderDefect]*2),
     }
 
 @parameterize

--- a/Misc/NEWS.d/next/Security/2019-07-16-08-11-00.bpo-37461.1Ahz7O.rst
+++ b/Misc/NEWS.d/next/Security/2019-07-16-08-11-00.bpo-37461.1Ahz7O.rst
@@ -1,0 +1,2 @@
+Fix an inifite loop when parsing specially crafted email headers. Patch by
+Abhilash Raj.

--- a/Misc/NEWS.d/next/Security/2019-07-16-08-11-00.bpo-37461.1Ahz7O.rst
+++ b/Misc/NEWS.d/next/Security/2019-07-16-08-11-00.bpo-37461.1Ahz7O.rst
@@ -1,2 +1,2 @@
-Fix an inifite loop when parsing specially crafted email headers. Patch by
+Fix an infinite loop when parsing specially crafted email headers. Patch by
 Abhilash Raj.


### PR DESCRIPTION

* [bpo-37461](https://bugs.python.org/issue37461): Fix infinite loop in parsing of specially crafted email headers.

Some crafted email header would cause the get_parameter method to run in an
infinite loop causing a DoS attack surface when parsing those headers. This
patch fixes that by making sure the DQUOTE character is handled to prevent
going into an infinite loop.
(cherry picked from commit a4a994bd3e619cbaff97610a1cee8ffa87c672f5)

Co-authored-by: Abhilash Raj <maxking@users.noreply.github.com>

<!-- issue-number: [bpo-37461](https://bugs.python.org/issue37461) -->
https://bugs.python.org/issue37461
<!-- /issue-number -->
