### PR TITLE
Clarify argument types in datetime docs.

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -401,7 +401,7 @@ systems.
 
 .. class:: date(year, month, day)
 
-   All arguments are required.  Arguments may be integers, in the following
+   All arguments are required.  Arguments must be integers in the following
    ranges:
 
    * ``MINYEAR <= year <= MAXYEAR``
@@ -714,7 +714,7 @@ Constructor:
 .. class:: datetime(year, month, day, hour=0, minute=0, second=0, microsecond=0, tzinfo=None, *, fold=0)
 
    The year, month and day arguments are required.  *tzinfo* may be ``None``, or an
-   instance of a :class:`tzinfo` subclass.  The remaining arguments may be integers,
+   instance of a :class:`tzinfo` subclass.  The remaining arguments must be integers
    in the following ranges:
 
    * ``MINYEAR <= year <= MAXYEAR``,
@@ -1439,7 +1439,7 @@ day, and subject to adjustment via a :class:`tzinfo` object.
 .. class:: time(hour=0, minute=0, second=0, microsecond=0, tzinfo=None, *, fold=0)
 
    All arguments are optional.  *tzinfo* may be ``None``, or an instance of a
-   :class:`tzinfo` subclass.  The remaining arguments may be integers, in the
+   :class:`tzinfo` subclass.  The remaining arguments must be integers in the
    following ranges:
 
    * ``0 <= hour < 24``,


### PR DESCRIPTION
"Arguments may be integers... " could be misunderstand as they also
could be strings.

New wording makes it clear that arguments have to be integers.

modified:   Doc/library/datetime.rst



Automerge-Triggered-By: @pganssle