### PR TITLE
bpo-37754: make shared_memory's unix implementation consistent with W…

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-08-24-20-43-40.bpo-37754.KAvVkE.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-24-20-43-40.bpo-37754.KAvVkE.rst
@@ -1,0 +1,1 @@
+make shared_memory's unix implementation consistent with Windows


### PR DESCRIPTION
…indows

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

For instance:
Let's say a three processes P1, P2 and P3 are trying to communicate using shared memory.
 --> P1 creates the shared memory block, and waits for P2 and P3 to access it.
 --> P2 starts and attaches this shared memory segment, writes some data to it and exits.
 --> Now in case of Unix, shm_unlink is called as soon as P2 exits.
 --> Now, P3 starts and tries to attach the shared memory segment.
 --> P3 will not be able to attach the shared memory segment in Unix, because shm_unlink has been called on that segment.
 --> Whereas, P3 will be able to attach to the shared memory segment in Windows

This Pull request fixes the above issue by using advisory locking on shared memory files to make unix's shared memory consistent with windows, as suggested in the issue thread.


<!-- issue-number: [bpo-37754](https://bugs.python.org/issue37754) -->
https://bugs.python.org/issue37754
<!-- /issue-number -->
