### PR TITLE
bpo-37903: IDLE: Shell sidebar with prompts

### DIFF
--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -120,12 +120,10 @@ class ColorDelegator(Delegator):
             "BUILTIN": idleConf.GetHighlight(theme, "builtin"),
             "STRING": idleConf.GetHighlight(theme, "string"),
             "DEFINITION": idleConf.GetHighlight(theme, "definition"),
-            "SYNC": {'background':None,'foreground':None},
-            "TODO": {'background':None,'foreground':None},
+            "SYNC": {'background': None, 'foreground': None},
+            "TODO": {'background': None, 'foreground': None},
             "ERROR": idleConf.GetHighlight(theme, "error"),
-            # The following is used by ReplaceDialog:
-            "hit": idleConf.GetHighlight(theme, "hit"),
-            }
+        }
 
         if DEBUG: print('tagdefs',self.tagdefs)
 

--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -123,6 +123,11 @@ class ColorDelegator(Delegator):
             "SYNC": {'background': None, 'foreground': None},
             "TODO": {'background': None, 'foreground': None},
             "ERROR": idleConf.GetHighlight(theme, "error"),
+            # "hit" is used by ReplaceDialog to mark matches. It shouldn't be changed by Colorizer, but
+            # that currently isn't technically possible. This should be moved elsewhere in the future
+            # when fixing the "hit" tag's visibility, or when the replace dialog is replaced with a
+            # non-modal alternative.
+            "hit": idleConf.GetHighlight(theme, "hit"),
         }
 
         if DEBUG: print('tagdefs',self.tagdefs)

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -233,7 +233,7 @@ class ConfigDialog(Toplevel):
         """
         win_instances = self.parent.instance_dict.keys()
         for instance in win_instances:
-            instance.ResetColorizer()
+            instance.update_colors()
             instance.ResetFont()
             instance.set_notabs_indentwidth()
             instance.ApplyKeybindings()

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1322,8 +1322,6 @@ class EditorWindow(object):
         # Debug prompt is multilined....
         ncharsdeleted = 0
         while 1:
-            if chars == self.prompt_last_line:  # '' unless PyShell
-                break
             chars = chars[:-1]
             ncharsdeleted = ncharsdeleted + 1
             have = len(chars.expandtabs(tabwidth))
@@ -1402,7 +1400,7 @@ class EditorWindow(object):
 
             # Strip whitespace before insert point unless it's in the prompt.
             i = 0
-            while line and line[-1] in " \t" and line != self.prompt_last_line:
+            while line and line[-1] in " \t":
                 line = line[:-1]
                 i += 1
             if i:

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -782,9 +782,7 @@ class EditorWindow(object):
             self.color = self.ColorDelegator()
         # can add more colorizers here...
         if self.color:
-            self.per.removefilter(self.undo)
-            self.per.insertfilter(self.color)
-            self.per.insertfilter(self.undo)
+            self.per.insertfilterafter(filter=self.color, after=self.undo)
 
     def _rmcolorizer(self):
         if not self.color:

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -807,10 +807,6 @@ class EditorWindow(object):
         """
         EditorWindow.color_config(self.text)
 
-        tag_colors = self.get_tag_colors()
-        for tag, tag_colors_config in tag_colors.items():
-            self.text.tag_configure(tag, **tag_colors_config)
-
         self.ResetColorizer()
 
         if self.code_context is not None:
@@ -818,13 +814,6 @@ class EditorWindow(object):
 
         if self.line_numbers is not None:
             self.line_numbers.update_colors()
-
-    def get_tag_colors(self):
-        theme = idleConf.CurrentTheme()
-        return {
-            # The following is used by ReplaceDialog:
-            "hit": idleConf.GetHighlight(theme, "hit"),
-        }
 
     IDENTCHARS = string.ascii_letters + string.digits + "_"
 

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -68,6 +68,7 @@ class EditorWindow(object):
 
     allow_code_context = True
     allow_line_numbers = True
+    user_input_insert_tags = None
 
     def __init__(self, flist=None, filename=None, key=None, root=None):
         # Delay import: runscript imports pyshell imports EditorWindow.
@@ -1331,7 +1332,7 @@ class EditorWindow(object):
         text.undo_block_start()
         text.delete("insert-%dc" % ncharsdeleted, "insert")
         if have < want:
-            text.insert("insert", ' ' * (want - have))
+            text.insert("insert", ' ' * (want - have), self.user_input_insert_tags)
         text.undo_block_stop()
         return "break"
 
@@ -1364,7 +1365,7 @@ class EditorWindow(object):
                     effective = len(prefix.expandtabs(self.tabwidth))
                     n = self.indentwidth
                     pad = ' ' * (n - effective % n)
-                text.insert("insert", pad)
+                text.insert("insert", pad, self.user_input_insert_tags)
             text.see("insert")
             return "break"
         finally:
@@ -1395,7 +1396,7 @@ class EditorWindow(object):
             if i == n:
                 # The cursor is in or at leading indentation in a continuation
                 # line; just inject an empty line at the start.
-                text.insert("insert linestart", '\n')
+                text.insert("insert linestart", '\n', self.user_input_insert_tags)
                 return "break"
             indent = line[:i]
 
@@ -1412,7 +1413,7 @@ class EditorWindow(object):
                 text.delete("insert")
 
             # Insert new line.
-            text.insert("insert", '\n')
+            text.insert("insert", '\n', self.user_input_insert_tags)
 
             # Adjust indentation for continuations and block open/close.
             # First need to find the last statement.
@@ -1448,7 +1449,7 @@ class EditorWindow(object):
                 elif c == pyparse.C_STRING_NEXT_LINES:
                     # Inside a string which started before this line;
                     # just mimic the current indent.
-                    text.insert("insert", indent)
+                    text.insert("insert", indent, self.user_input_insert_tags)
                 elif c == pyparse.C_BRACKET:
                     # Line up with the first (if any) element of the
                     # last open bracket structure; else indent one
@@ -1462,7 +1463,7 @@ class EditorWindow(object):
                     # beyond leftmost =; else to beyond first chunk of
                     # non-whitespace on initial line.
                     if y.get_num_lines_in_stmt() > 1:
-                        text.insert("insert", indent)
+                        text.insert("insert", indent, self.user_input_insert_tags)
                     else:
                         self.reindent_to(y.compute_backslash_indent())
                 else:
@@ -1473,7 +1474,7 @@ class EditorWindow(object):
             # indentation of initial line of closest preceding
             # interesting statement.
             indent = y.get_base_indent_string()
-            text.insert("insert", indent)
+            text.insert("insert", indent, self.user_input_insert_tags)
             if y.is_block_opener():
                 self.smart_indent_event(event)
             elif indent and y.is_block_closer():
@@ -1520,7 +1521,7 @@ class EditorWindow(object):
         if text.compare("insert linestart", "!=", "insert"):
             text.delete("insert linestart", "insert")
         if column:
-            text.insert("insert", self._make_blanks(column))
+            text.insert("insert", self._make_blanks(column), self.user_input_insert_tags)
         text.undo_block_stop()
 
     # Guess indentwidth from text content.

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -60,7 +60,6 @@ class EditorWindow(object):
     from idlelib.sidebar import LineNumbers
     from idlelib.format import FormatParagraph, FormatRegion, Indents, Rstrip
     from idlelib.parenmatch import ParenMatch
-    from idlelib.squeezer import Squeezer
     from idlelib.zoomheight import ZoomHeight
 
     filesystemencoding = sys.getfilesystemencoding()  # for file names

--- a/Lib/idlelib/history.py
+++ b/Lib/idlelib/history.py
@@ -74,13 +74,13 @@ class History:
                 else:
                     if self.text.get("iomark", "end-1c") != prefix:
                         self.text.delete("iomark", "end-1c")
-                        self.text.insert("iomark", prefix)
+                        self.text.insert("iomark", prefix, "stdin")
                     pointer = prefix = None
                 break
             item = self.history[pointer]
             if item[:nprefix] == prefix and len(item) > nprefix:
                 self.text.delete("iomark", "end-1c")
-                self.text.insert("iomark", item)
+                self.text.insert("iomark", item, "stdin")
                 break
         self.text.see("insert")
         self.text.tag_remove("sel", "1.0", "end")

--- a/Lib/idlelib/idle_test/test_editor.py
+++ b/Lib/idlelib/idle_test/test_editor.py
@@ -167,7 +167,6 @@ class IndentAndNewlineTest(unittest.TestCase):
                           '2.end'),
                  )
 
-        w.prompt_last_line = ''
         for test in tests:
             with self.subTest(label=test.label):
                 insert(text, test.text)
@@ -181,13 +180,6 @@ class IndentAndNewlineTest(unittest.TestCase):
         nl(None)
         # Deletes selected text before adding new line.
         eq(get('1.0', 'end'), '  def f1(self, a,\n         \n    return a + b\n')
-
-        # Preserves the whitespace in shell prompt.
-        w.prompt_last_line = '>>> '
-        insert(text, '>>> \t\ta =')
-        text.mark_set('insert', '1.5')
-        nl(None)
-        eq(get('1.0', 'end'), '>>> \na =\n')
 
 
 class RMenuTest(unittest.TestCase):

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -1,4 +1,4 @@
-"""Test sidebar, coverage 96%"""
+"""Test sidebar, coverage 93%"""
 from textwrap import dedent
 import sys
 

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -1,4 +1,4 @@
-"""Test sidebar, coverage 93%"""
+"""Test sidebar, coverage 96%"""
 from textwrap import dedent
 import sys
 

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -378,7 +378,7 @@ class LineNumbersTest(unittest.TestCase):
         assert_colors_are_equal(orig_colors)
 
 
-class TestShellSidebar(unittest.TestCase):
+class ShellSidebarTest(unittest.TestCase):
     root: tk.Tk = None
     shell: PyShell = None
 

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -162,7 +162,7 @@ class LineNumbersTest(unittest.TestCase):
         self.assert_sidebar_n_lines(3)
         self.assert_state_disabled()
 
-        # Note: deleting up to "2.end" doesn't delete the final newline.
+        # Deleting up to "2.end" doesn't delete the final newline.
         self.text.delete('2.0', '2.end')
         self.assert_text_equals('fbarfoo\n\n\n')
         self.assert_sidebar_n_lines(3)
@@ -173,7 +173,7 @@ class LineNumbersTest(unittest.TestCase):
         self.assert_sidebar_n_lines(1)
         self.assert_state_disabled()
 
-        # Note: Text widgets always keep a single '\n' character at the end.
+        # Text widgets always keep a single '\n' character at the end.
         self.text.delete('1.0', 'end')
         self.assert_text_equals('\n')
         self.assert_sidebar_n_lines(1)
@@ -242,7 +242,7 @@ class LineNumbersTest(unittest.TestCase):
         self.assert_sidebar_n_lines(4)
         self.assertEqual(get_width(), 1)
 
-        # Note: Text widgets always keep a single '\n' character at the end.
+        # Text widgets always keep a single '\n' character at the end.
         self.text.delete('1.0', 'end -1c')
         self.assert_sidebar_n_lines(1)
         self.assertEqual(get_width(), 1)
@@ -495,7 +495,7 @@ class TestShellSidebar(unittest.TestCase):
         self.assert_sidebar_lines_end_with(['>>>', '   ', '>>>'])
 
     def test_multi_line_command(self):
-        # note: block statements are not indented because IDLE auto-indents
+        # Block statements are not indented because IDLE auto-indents.
         self.do_input(dedent('''\
             if True:
             print(1)

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -436,13 +436,13 @@ class TestShellSidebar(unittest.TestCase):
         texts.sort(key=lambda text: canvas.bbox(text)[1])
         return [canvas.itemcget(text, 'text') for text in texts]
 
-    def assertSidebarLinesEndWith(self, expected_lines):
+    def assert_sidebar_lines_end_with(self, expected_lines):
         self.assertEqual(
             self.get_sidebar_lines()[-len(expected_lines):],
             expected_lines,
         )
 
-    def getShellLineYCoords(self):
+    def get_shell_line_y_coords(self):
         text = self.shell.text
         y_coords = []
         index = text.index("@0,0")
@@ -454,19 +454,19 @@ class TestShellSidebar(unittest.TestCase):
             index = text.index(f"{index} +1line")
         return y_coords
 
-    def getSidebarLineYCoords(self):
+    def get_sidebar_line_y_coords(self):
         canvas = self.shell.shell_sidebar.canvas
         texts = list(canvas.find(tk.ALL))
         texts.sort(key=lambda text: canvas.bbox(text)[1])
         return [canvas.bbox(text)[1] for text in texts]
 
-    def assertSidebarLinesSynced(self):
+    def assert_sidebar_lines_synced(self):
         self.assertEqual(
-            self.getSidebarLineYCoords(),
-            self.getShellLineYCoords(),
+            self.get_sidebar_line_y_coords(),
+            self.get_shell_line_y_coords(),
         )
 
-    def doInput(self, input):
+    def do_input(self, input):
         shell = self.shell
         text = shell.text
         for line_index, line in enumerate(input.split('\n')):
@@ -478,30 +478,30 @@ class TestShellSidebar(unittest.TestCase):
         sleep(0.1)
         self.root.update()
 
-    def testInitialState(self):
+    def test_initial_state(self):
         sidebar_lines = self.get_sidebar_lines()
         self.assertEqual(
             sidebar_lines,
             ['   '] * (len(sidebar_lines) - 1) + ['>>>'],
         )
-        self.assertSidebarLinesSynced()
+        self.assert_sidebar_lines_synced()
 
-    def testSingleEmptyInput(self):
-        self.doInput('\n')
-        self.assertSidebarLinesEndWith(['>>>', '>>>'])
+    def test_single_empty_input(self):
+        self.do_input('\n')
+        self.assert_sidebar_lines_end_with(['>>>', '>>>'])
 
-    def testSingleLineCommand(self):
-        self.doInput('1\n')
-        self.assertSidebarLinesEndWith(['>>>', '   ', '>>>'])
+    def test_single_line_command(self):
+        self.do_input('1\n')
+        self.assert_sidebar_lines_end_with(['>>>', '   ', '>>>'])
 
-    def testMultiLineCommand(self):
+    def test_multi_line_command(self):
         # note: block statements are not indented because IDLE auto-indents
-        self.doInput(dedent('''\
+        self.do_input(dedent('''\
             if True:
             print(1)
 
             '''))
-        self.assertSidebarLinesEndWith([
+        self.assert_sidebar_lines_end_with([
             '>>>',
             '...',
             '...',
@@ -510,32 +510,32 @@ class TestShellSidebar(unittest.TestCase):
             '>>>',
         ])
 
-    def testSingleLongLineWraps(self):
-        self.doInput('1' * 200 + '\n')
-        self.assertSidebarLinesEndWith(['>>>', '   ', '>>>'])
-        self.assertSidebarLinesSynced()
+    def test_single_long_line_wraps(self):
+        self.do_input('1' * 200 + '\n')
+        self.assert_sidebar_lines_end_with(['>>>', '   ', '>>>'])
+        self.assert_sidebar_lines_synced()
 
-    def testSqueezeSingleLineCommand(self):
+    def test_squeeze_single_line_command(self):
         root = self.root
         shell = self.shell
         text = shell.text
 
-        self.doInput('1\n')
-        self.assertSidebarLinesEndWith(['>>>', '   ', '>>>'])
+        self.do_input('1\n')
+        self.assert_sidebar_lines_end_with(['>>>', '   ', '>>>'])
 
         line = int(shell.text.index('insert -1line').split('.')[0])
         text.mark_set('insert', f"{line}.0")
         text.event_generate('<<squeeze-current-text>>')
         sleep(0.1)
         root.update()
-        self.assertSidebarLinesEndWith(['>>>', '   ', '>>>'])
-        self.assertSidebarLinesSynced()
+        self.assert_sidebar_lines_end_with(['>>>', '   ', '>>>'])
+        self.assert_sidebar_lines_synced()
 
         shell.squeezer.expandingbuttons[0].expand()
         sleep(0.1)
         root.update()
-        self.assertSidebarLinesEndWith(['>>>', '   ', '>>>'])
-        self.assertSidebarLinesSynced()
+        self.assert_sidebar_lines_end_with(['>>>', '   ', '>>>'])
+        self.assert_sidebar_lines_synced()
 
 
 if __name__ == '__main__':

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -389,6 +389,7 @@ class TestShellSidebar(unittest.TestCase):
         idlelib.pyshell.use_subprocess = True
 
         cls.root = root = tk.Tk()
+        root.withdraw()
 
         fix_scaling(root)
         fixwordbreaks(root)

--- a/Lib/idlelib/idle_test/test_squeezer.py
+++ b/Lib/idlelib/idle_test/test_squeezer.py
@@ -7,13 +7,12 @@ from unittest.mock import Mock, NonCallableMagicMock, patch, sentinel, ANY
 from test.support import requires
 
 from idlelib.config import idleConf
+from idlelib.percolator import Percolator
 from idlelib.squeezer import count_lines_with_wrapping, ExpandingButton, \
     Squeezer
 from idlelib import macosx
 from idlelib.textview import view_text
 from idlelib.tooltip import Hovertip
-from idlelib.pyshell import PyShell
-
 
 SENTINEL_VALUE = sentinel.SENTINEL_VALUE
 
@@ -205,8 +204,8 @@ class SqueezerTest(unittest.TestCase):
         self.assertEqual(text_widget.get('1.0', 'end'), '\n')
         self.assertEqual(len(squeezer.expandingbuttons), 1)
 
-    def test_squeeze_current_text_event(self):
-        """Test the squeeze_current_text event."""
+    def test_squeeze_current_text(self):
+        """Test the squeeze_current_text method."""
         # Squeezing text should work for both stdout and stderr.
         for tag_name in ["stdout", "stderr"]:
             editwin = self.make_mock_editor_window(with_text_widget=True)
@@ -222,7 +221,7 @@ class SqueezerTest(unittest.TestCase):
             self.assertEqual(len(squeezer.expandingbuttons), 0)
 
             # Test squeezing the current text.
-            retval = squeezer.squeeze_current_text_event(event=Mock())
+            retval = squeezer.squeeze_current_text()
             self.assertEqual(retval, "break")
             self.assertEqual(text_widget.get('1.0', 'end'), '\n\n')
             self.assertEqual(len(squeezer.expandingbuttons), 1)
@@ -230,11 +229,11 @@ class SqueezerTest(unittest.TestCase):
 
             # Test that expanding the squeezed text works and afterwards
             # the Text widget contains the original text.
-            squeezer.expandingbuttons[0].expand(event=Mock())
+            squeezer.expandingbuttons[0].expand()
             self.assertEqual(text_widget.get('1.0', 'end'), 'SOME\nTEXT\n\n')
             self.assertEqual(len(squeezer.expandingbuttons), 0)
 
-    def test_squeeze_current_text_event_no_allowed_tags(self):
+    def test_squeeze_current_text_no_allowed_tags(self):
         """Test that the event doesn't squeeze text without a relevant tag."""
         editwin = self.make_mock_editor_window(with_text_widget=True)
         text_widget = editwin.text
@@ -249,7 +248,7 @@ class SqueezerTest(unittest.TestCase):
         self.assertEqual(len(squeezer.expandingbuttons), 0)
 
         # Test squeezing the current text.
-        retval = squeezer.squeeze_current_text_event(event=Mock())
+        retval = squeezer.squeeze_current_text()
         self.assertEqual(retval, "break")
         self.assertEqual(text_widget.get('1.0', 'end'), 'SOME\nTEXT\n\n')
         self.assertEqual(len(squeezer.expandingbuttons), 0)
@@ -264,13 +263,13 @@ class SqueezerTest(unittest.TestCase):
         # Prepare some text in the Text widget and squeeze it.
         text_widget.insert("1.0", "SOME\nTEXT\n", "stdout")
         text_widget.mark_set("insert", "1.0")
-        squeezer.squeeze_current_text_event(event=Mock())
+        squeezer.squeeze_current_text()
         self.assertEqual(len(squeezer.expandingbuttons), 1)
 
         # Test squeezing the current text.
         text_widget.insert("1.0", "MORE\nSTUFF\n", "stdout")
         text_widget.mark_set("insert", "1.0")
-        retval = squeezer.squeeze_current_text_event(event=Mock())
+        retval = squeezer.squeeze_current_text()
         self.assertEqual(retval, "break")
         self.assertEqual(text_widget.get('1.0', 'end'), '\n\n\n')
         self.assertEqual(len(squeezer.expandingbuttons), 2)
@@ -311,6 +310,7 @@ class ExpandingButtonTest(unittest.TestCase):
         root = get_test_tk_root(self)
         squeezer = Mock()
         squeezer.editwin.text = Text(root)
+        squeezer.editwin.per = Percolator(squeezer.editwin.text)
 
         # Set default values for the configuration settings.
         squeezer.auto_squeeze_min_lines = 50
@@ -352,13 +352,8 @@ class ExpandingButtonTest(unittest.TestCase):
 
         # Insert the button into the text widget
         # (this is normally done by the Squeezer class).
-        text_widget = expandingbutton.text
+        text_widget = squeezer.editwin.text
         text_widget.window_create("1.0", window=expandingbutton)
-
-        # Set base_text to the text widget, so that changes are actually
-        # made to it (by ExpandingButton) and we can inspect these
-        # changes afterwards.
-        expandingbutton.base_text = expandingbutton.text
 
         # trigger the expand event
         retval = expandingbutton.expand(event=Mock())
@@ -389,11 +384,6 @@ class ExpandingButtonTest(unittest.TestCase):
         # (this is normally done by the Squeezer class).
         text_widget = expandingbutton.text
         text_widget.window_create("1.0", window=expandingbutton)
-
-        # Set base_text to the text widget, so that changes are actually
-        # made to it (by ExpandingButton) and we can inspect these
-        # changes afterwards.
-        expandingbutton.base_text = expandingbutton.text
 
         # Patch the message box module to always return False.
         with patch('idlelib.squeezer.tkMessageBox') as mock_msgbox:

--- a/Lib/idlelib/percolator.py
+++ b/Lib/idlelib/percolator.py
@@ -38,6 +38,21 @@ class Percolator:
         filter.setdelegate(self.top)
         self.top = filter
 
+    def insertfilterafter(self, filter, after):
+        assert isinstance(filter, Delegator)
+        assert isinstance(after, Delegator)
+        assert filter.delegate is None
+
+        f = self.top
+        f.resetcache()
+        while f is not after:
+            assert f is not self.bottom
+            f = f.delegate
+            f.resetcache()
+
+        filter.setdelegate(f.delegate)
+        f.setdelegate(filter)
+
     def removefilter(self, filter):
         # XXX Perhaps should only support popfilter()?
         assert isinstance(filter, Delegator)

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -970,6 +970,7 @@ class PyShell(OutputWindow):
         # During __init__, update_colors() is called before the sidebar is created.
         if self.shell_sidebar is not None:
             self.shell_sidebar.update_colors()
+
     def replace_event(self, event):
         replace.replace(self.text, insert_tags="stdin")
         return "break"

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -54,6 +54,7 @@ from idlelib import debugger_r
 from idlelib.editor import EditorWindow, fixwordbreaks
 from idlelib.filelist import FileList
 from idlelib.outwin import OutputWindow
+from idlelib import replace
 from idlelib import rpc
 from idlelib.run import idle_formatwarning, StdInputFile, StdOutputFile
 from idlelib.undo import UndoDelegator
@@ -968,6 +969,10 @@ class PyShell(OutputWindow):
         # During __init__, update_colors() is called before the sidebar is created.
         if self.shell_sidebar is not None:
             self.shell_sidebar.update_colors()
+
+    def replace_event(self, event):
+        replace.replace(self.text, insert_tags="stdin")
+        return "break"
 
     def get_standard_extension_names(self):
         return idleConf.GetExtensions(shell_only=True)

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -940,7 +940,6 @@ class PyShell(OutputWindow):
         self.pollinterval = 50  # millisec
 
         self.shell_sidebar = self.ShellSidebar(self)
-        self.shell_sidebar.show_sidebar()
 
         # Insert UserInputTaggingDelegator at the top of the percolator,
         # but make calls to text.insert() skip it.  This causes only insert

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -335,25 +335,10 @@ class PyShellFileList(FileList):
 
 class ModifiedColorDelegator(ColorDelegator):
     "Extend base class: colorizer for the shell window itself"
-
-    def __init__(self):
-        ColorDelegator.__init__(self)
-        self.LoadTagDefs()
-
     def recolorize_main(self):
         self.tag_remove("TODO", "1.0", "iomark")
         self.tag_add("SYNC", "1.0", "iomark")
         ColorDelegator.recolorize_main(self)
-
-    def LoadTagDefs(self):
-        ColorDelegator.LoadTagDefs(self)
-        theme = idleConf.CurrentTheme()
-        self.tagdefs.update({
-            "stdin": {'background':None,'foreground':None},
-            "stdout": idleConf.GetHighlight(theme, "stdout"),
-            "stderr": idleConf.GetHighlight(theme, "stderr"),
-            "console": idleConf.GetHighlight(theme, "console"),
-        })
 
     def removecolors(self):
         # Don't remove shell color tags before "iomark"
@@ -932,6 +917,18 @@ class PyShell(OutputWindow):
 
         self.shell_sidebar = self.ShellSidebar(self)
         self.shell_sidebar.show_sidebar()
+
+    def get_tag_colors(self):
+        tag_colors = super().get_tag_colors()
+
+        theme = idleConf.CurrentTheme()
+        tag_colors.update({
+            "stdin": {'background': None, 'foreground': None},
+            "stdout": idleConf.GetHighlight(theme, "stdout"),
+            "stderr": idleConf.GetHighlight(theme, "stderr"),
+            "console": idleConf.GetHighlight(theme, "console"),
+        })
+        return tag_colors
 
     def get_standard_extension_names(self):
         return idleConf.GetExtensions(shell_only=True)

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -840,6 +840,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
 
 
 class PyShell(OutputWindow):
+    from idlelib.squeezer import Squeezer
 
     shell_title = "Python " + python_version() + " Shell"
 
@@ -905,9 +906,9 @@ class PyShell(OutputWindow):
         if use_subprocess:
             text.bind("<<view-restart>>", self.view_restart_mark)
             text.bind("<<restart-shell>>", self.restart_shell)
-        squeezer = self.Squeezer(self)
+        self.squeezer = self.Squeezer(self)
         text.bind("<<squeeze-current-text>>",
-                  squeezer.squeeze_current_text_event)
+                  self.squeeze_current_text_event)
 
         self.save_stdout = sys.stdout
         self.save_stderr = sys.stderr
@@ -1388,6 +1389,13 @@ class PyShell(OutputWindow):
         if self.text.compare('insert','<','iomark'):
             return 'disabled'
         return super().rmenu_check_paste()
+
+    def squeeze_current_text_event(self, event=None):
+        self.squeezer.squeeze_current_text()
+        self.shell_sidebar.update_sidebar()
+
+    def on_squeezed_expand(self, index, text, tags):
+        self.shell_sidebar.update_sidebar()
 
 
 def fix_x11_paste(root):

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -863,6 +863,7 @@ class PyShell(OutputWindow):
     ]
 
     allow_line_numbers = False
+    user_input_insert_tags = "stdin"
 
     # New classes
     from idlelib.history import History
@@ -1284,7 +1285,7 @@ class PyShell(OutputWindow):
             if prefix.rstrip().endswith(':'):
                 self.newline_and_indent_event(event)
                 prefix = self.text.get("insert linestart", "insert")
-            self.text.insert("insert", lines[0].strip(), "stdin")
+            self.text.insert("insert", lines[0].strip(), self.user_input_insert_tags)
             if len(lines) > 1:
                 orig_base_indent = re.search(r'^([ \t]*)', lines[0]).group(0)
                 new_base_indent  = re.search(r'^([ \t]*)', prefix).group(0)
@@ -1292,8 +1293,7 @@ class PyShell(OutputWindow):
                     if line.startswith(orig_base_indent):
                         # replace orig base indentation with new indentation
                         line = new_base_indent + line[len(orig_base_indent):]
-                    self.text.insert('insert', '\n'+line.rstrip(), "stdin")
-            self.shell_sidebar.update_sidebar()
+                    self.text.insert('insert', '\n'+line.rstrip(), self.user_input_insert_tags)
         finally:
             self.text.see("insert")
             self.text.undo_block_stop()

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -1324,6 +1324,7 @@ class PyShell(OutputWindow):
         self.text.tag_add("console", "iomark-1c")
         self.console.write(prompt)
 
+        self.shell_sidebar.update_sidebar()
         self.text.mark_set("insert", "end-1c")
         self.set_line_and_column()
         self.io.reset_undo()

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -1265,7 +1265,6 @@ class PyShell(OutputWindow):
             if prefix.rstrip().endswith(':'):
                 self.newline_and_indent_event(event)
                 prefix = self.text.get("insert linestart", "insert")
-            first_line = self.getlineno("insert")
             self.text.insert("insert", lines[0].strip(), "stdin")
             if len(lines) > 1:
                 orig_base_indent = re.search(r'^([ \t]*)', lines[0]).group(0)

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -879,6 +879,8 @@ class PyShell(OutputWindow):
             root.withdraw()
             flist = PyShellFileList(root)
 
+        self.shell_sidebar = None  # initialized below
+
         OutputWindow.__init__(self, flist, None, None)
 
         self.usetabs = True
@@ -956,10 +958,16 @@ class PyShell(OutputWindow):
         return tag_colors
 
     def ResetFont(self):
+        super().ResetFont()
         # Update the sidebar widget, since its width affects
         # the width of the text widget.
         self.shell_sidebar.update_font()
-        super().ResetFont()
+
+    def update_colors(self):
+        super().update_colors()
+        # During __init__, update_colors() is called before the sidebar is created.
+        if self.shell_sidebar is not None:
+            self.shell_sidebar.update_colors()
 
     def get_standard_extension_names(self):
         return idleConf.GetExtensions(shell_only=True)

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -948,18 +948,6 @@ class PyShell(OutputWindow):
         self.text.insert = self.per.top.insert
         self.per.insertfilter(UserInputTaggingDelegator())
 
-    def get_tag_colors(self):
-        tag_colors = super().get_tag_colors()
-
-        theme = idleConf.CurrentTheme()
-        tag_colors.update({
-            "stdin": {'background': None, 'foreground': None},
-            "stdout": idleConf.GetHighlight(theme, "stdout"),
-            "stderr": idleConf.GetHighlight(theme, "stderr"),
-            "console": idleConf.GetHighlight(theme, "console"),
-        })
-        return tag_colors
-
     def ResetFont(self):
         super().ResetFont()
         # Update the sidebar widget, since its width affects
@@ -968,10 +956,20 @@ class PyShell(OutputWindow):
 
     def update_colors(self):
         super().update_colors()
+
+        theme = idleConf.CurrentTheme()
+        tag_colors = {
+          "stdin": {'background': None, 'foreground': None},
+          "stdout": idleConf.GetHighlight(theme, "stdout"),
+          "stderr": idleConf.GetHighlight(theme, "stderr"),
+          "console": idleConf.GetHighlight(theme, "console"),
+        }
+        for tag, tag_colors_config in tag_colors.items():
+            self.text.tag_configure(tag, **tag_colors_config)
+
         # During __init__, update_colors() is called before the sidebar is created.
         if self.shell_sidebar is not None:
             self.shell_sidebar.update_colors()
-
     def replace_event(self, event):
         replace.replace(self.text, insert_tags="stdin")
         return "break"

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -955,6 +955,12 @@ class PyShell(OutputWindow):
         })
         return tag_colors
 
+    def ResetFont(self):
+        # Update the sidebar widget, since its width affects
+        # the width of the text widget.
+        self.shell_sidebar.update_font()
+        super().ResetFont()
+
     def get_standard_extension_names(self):
         return idleConf.GetExtensions(shell_only=True)
 

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -858,6 +858,7 @@ class PyShell(OutputWindow):
 
     # New classes
     from idlelib.history import History
+    from idlelib.sidebar import ShellSidebar
 
     def __init__(self, flist=None):
         if use_subprocess:
@@ -925,6 +926,9 @@ class PyShell(OutputWindow):
         self.history = self.History(self.text)
         #
         self.pollinterval = 50  # millisec
+
+        self.shell_sidebar = self.ShellSidebar(self)
+        self.shell_sidebar.show_sidebar()
 
     def get_standard_extension_names(self):
         return idleConf.GetExtensions(shell_only=True)

--- a/Lib/idlelib/replace.py
+++ b/Lib/idlelib/replace.py
@@ -11,7 +11,7 @@ from idlelib.searchbase import SearchDialogBase
 from idlelib import searchengine
 
 
-def replace(text):
+def replace(text, insert_tags=None):
     """Create or reuse a singleton ReplaceDialog instance.
 
     The singleton dialog saves user entries and preferences
@@ -25,7 +25,7 @@ def replace(text):
     if not hasattr(engine, "_replacedialog"):
         engine._replacedialog = ReplaceDialog(root, engine)
     dialog = engine._replacedialog
-    dialog.open(text)
+    dialog.open(text, insert_tags=insert_tags)
 
 
 class ReplaceDialog(SearchDialogBase):
@@ -49,8 +49,9 @@ class ReplaceDialog(SearchDialogBase):
         """
         super().__init__(root, engine)
         self.replvar = StringVar(root)
+        self.insert_tags = None
 
-    def open(self, text):
+    def open(self, text, insert_tags=None):
         """Make dialog visible on top of others and ready to use.
 
         Also, highlight the currently selected text and set the
@@ -72,6 +73,7 @@ class ReplaceDialog(SearchDialogBase):
         last = last or first
         self.show_hit(first, last)
         self.ok = True
+        self.insert_tags = insert_tags
 
     def create_entries(self):
         "Create base and additional label and text entry widgets."
@@ -177,7 +179,7 @@ class ReplaceDialog(SearchDialogBase):
                 if first != last:
                     text.delete(first, last)
                 if new:
-                    text.insert(first, new)
+                    text.insert(first, new, self.insert_tags)
             col = i + len(new)
             ok = False
         text.undo_block_stop()
@@ -231,7 +233,7 @@ class ReplaceDialog(SearchDialogBase):
         if m.group():
             text.delete(first, last)
         if new:
-            text.insert(first, new)
+            text.insert(first, new, self.insert_tags)
         text.undo_block_stop()
         self.show_hit(first, text.index("insert"))
         self.ok = False
@@ -264,6 +266,7 @@ class ReplaceDialog(SearchDialogBase):
         "Close the dialog and remove hit tags."
         SearchDialogBase.close(self, event)
         self.text.tag_remove("hit", "1.0", "end")
+        self.insert_tags = None
 
 
 def _replace_dialog(parent):  # htest #

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -12,12 +12,12 @@ from idlelib.delegator import Delegator
 
 
 def get_lineno(text, index):
-    """Utility to get the line number of an index in a Tk text widget."""
+    """Return the line number of an index in a Tk text widget."""
     return int(float(text.index(index)))
 
 
 def get_end_linenumber(text):
-    """Utility to get the last line's number in a Tk text widget."""
+    """Return the number of the last line in a Tk text widget."""
     return get_lineno(text, 'end-1c')
 
 

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -391,23 +391,6 @@ class WrappedLineHeightChangeDelegator(Delegator):
 
         self.callback()
 
-    def replace(self, index1, index2, chars, *args):
-        is_single_line = (
-            '\n' not in chars and
-            get_lineno(self, index1) == get_lineno(self, index2)
-        )
-        if is_single_line:
-            before_displaylines = get_displaylines(self, index1)
-
-        self.delegate.replace(index1, index2, chars, *args)
-
-        if is_single_line:
-            after_displaylines = get_displaylines(self, index1)
-            if after_displaylines == before_displaylines:
-                return  # no need to update the sidebar
-
-        self.callback()
-
     def delete(self, index1, index2=None):
         if index2 is None:
             index2 = index1 + "+1c"

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -371,7 +371,7 @@ class WrappedLineHeightChangeDelegator(Delegator):
     def __init__(self, callback):
         """
         callback - Callable, will be called when an insert, delete or replace
-                   action on the text widget requires updating the shell
+                   action on the text widget may require updating the shell
                    sidebar.
         """
         Delegator.__init__(self)
@@ -419,7 +419,6 @@ class WrappedLineHeightChangeDelegator(Delegator):
 
         if is_single_line:
             after_displaylines = get_displaylines(self, index1)
-            print("displaylines", before_displaylines, after_displaylines)
             if after_displaylines == before_displaylines:
                 return  # no need to update the sidebar
 

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -379,12 +379,12 @@ class WrappedLineHeightChangeDelegator(Delegator):
 
     def insert(self, index, chars, tags=None):
         is_single_line = '\n' not in chars
-        if not is_single_line:
+        if is_single_line:
             before_displaylines = get_displaylines(self, index)
 
         self.delegate.insert(index, chars, tags)
 
-        if not is_single_line:
+        if is_single_line:
             after_displaylines = get_displaylines(self, index)
             if after_displaylines == before_displaylines:
                 return  # no need to update the sidebar
@@ -430,7 +430,7 @@ class ShellSidebar:
         if d.delegate is not self.text:
             while d.delegate is not self.editwin.per.bottom:
                 d = d.delegate
-        self.editwin.per.insertfilterafter(change_delegator, d)
+        self.editwin.per.insertfilterafter(change_delegator, after=d)
 
         self.text['yscrollcommand'] = self.yscroll_event
 

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -64,9 +64,7 @@ def temp_enable_text_widget(text):
 
 
 class BaseSideBar:
-    """
-    The base class for extensions which require a sidebar.
-    """
+    """A base class for sidebars using Text."""
     def __init__(self, editwin):
         self.editwin = editwin
         self.parent = editwin.text_frame
@@ -142,14 +140,11 @@ class BaseSideBar:
 
 
 class EndLineDelegator(Delegator):
-    """Generate callbacks with the current end line number after
-       insert or delete operations"""
+    """Generate callbacks with the current end line number.
+
+    The provided callback is called after every insert and delete.
+    """
     def __init__(self, changed_callback):
-        """
-        changed_callback - Callable, will be called after insert
-                           or delete operations with the current
-                           end line number.
-        """
         Delegator.__init__(self)
         self.changed_callback = changed_callback
 

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -429,11 +429,10 @@ class ShellSidebar:
             if lineinfo is None:
                 break
             y = lineinfo[1]
-            is_prompt = "console" in text_tagnames(f"{index} linestart -1c")
-            is_input = "stdin" in text_tagnames(f"{index} lineend -1c")
+            prev_newline_tagnames = text_tagnames(f"{index} linestart -1c")
             prompt = (
-                '>>>' if is_prompt else
-                '...' if is_input else
+                '>>>' if "console" in prev_newline_tagnames else
+                '...' if "stdin" in prev_newline_tagnames else
                 '   '
             )
             canvas.create_text(2, y, anchor=tk.NW, text=prompt,

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -478,6 +478,7 @@ class ShellSidebar:
 
     def update_sidebar(self):
         text = self.text
+        text_tagnames = text.tag_names
         canvas = self.canvas
 
         canvas.delete(tk.ALL)
@@ -488,10 +489,11 @@ class ShellSidebar:
             if lineinfo is None:
                 break
             y = lineinfo[1]
-            lineno = self.editwin.getlineno(index)
+            is_prompt = "console" in text_tagnames(f"{index} linestart -1c")
+            is_input = "stdin" in text_tagnames(f"{index} lineend -1c")
             prompt = (
-                '>>>' if lineno in self.editwin.prompt_lines else
-                '...' if lineno in self.editwin.input_lines else
+                '>>>' if is_prompt else
+                '...' if is_input else
                 '   '
             )
             canvas.create_text(2, y, anchor=tk.NW, text=prompt,

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -463,9 +463,10 @@ class ShellSidebar:
 
     def update_colors(self):
         """Update the sidebar text colors, usually after config changes."""
-        colors = idleConf.GetHighlight(idleConf.CurrentTheme(), 'linenumber')
-        self._update_colors(foreground=colors['foreground'],
-                            background=colors['background'])
+        linenumbers_colors = idleConf.GetHighlight(idleConf.CurrentTheme(), 'linenumber')
+        prompt_colors = idleConf.GetHighlight(idleConf.CurrentTheme(), 'console')
+        self._update_colors(foreground=prompt_colors['foreground'],
+                            background=linenumbers_colors['background'])
 
     def _update_colors(self, foreground, background):
         self.colors = (foreground, background)

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -182,14 +182,8 @@ class LineNumbers(BaseSideBar):
         end_line_delegator = EndLineDelegator(self.update_sidebar_text)
         # Insert the delegator after the undo delegator, so that line numbers
         # are properly updated after undo and redo actions.
-        end_line_delegator.setdelegate(self.editwin.undo.delegate)
-        self.editwin.undo.setdelegate(end_line_delegator)
-        # Reset the delegator caches of the delegators "above" the
-        # end line delegator we just inserted.
-        delegator = self.editwin.per.top
-        while delegator is not end_line_delegator:
-            delegator.resetcache()
-            delegator = delegator.delegate
+        self.editwin.per.insertfilterafter(filter=end_line_delegator,
+                                           after=self.editwin.undo)
 
     def bind_events(self):
         # Ensure focus is always redirected to the main editor text widget.
@@ -450,16 +444,11 @@ class ShellSidebar:
 
         # Insert the TextChangeDelegator after the last delegator, so that
         # the sidebar reflects final changes to the text widget contents.
-        delegator = self.editwin.per.top
-        if delegator.delegate != self.text:
-            while delegator.delegate != self.editwin.per.bottom:
-                # Reset the delegator caches of the delegators "above" the
-                # TextChangeDelegator we will insert.
-                delegator.resetcache()
-                delegator = delegator.delegate
-        last_delegator = delegator
-        change_delegator.setdelegate(last_delegator.delegate)
-        last_delegator.setdelegate(change_delegator)
+        d = self.editwin.per.top
+        if d.delegate is not self.text:
+            while d.delegate is not self.editwin.per.bottom:
+                d = d.delegate
+        self.editwin.per.insertfilterafter(change_delegator, d)
 
         self.text['yscrollcommand'] = self.yscroll_event
 

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -391,21 +391,9 @@ class ShellSidebar:
 
         self.update_font()
         self.update_colors()
-
-    def show_sidebar(self):
-        if not self.is_shown:
-            self.update_sidebar()
-            # _padx, pady = get_widget_padding(self.text)
-            self.canvas.grid(row=1, column=0, sticky=tk.NSEW,
-                             # padx=2, pady=pady)
-                             padx=2, pady=0)
-            self.is_shown = True
-
-    def hide_sidebar(self):
-        if self.is_shown:
-            self.canvas.grid_forget()
-            self.canvas.delete(tk.ALL)
-            self.is_shown = False
+        self.update_sidebar()
+        self.canvas.grid(row=1, column=0, sticky=tk.NSEW, padx=2, pady=0)
+        self.is_shown = True
 
     def change_callback(self):
         if self.is_shown:

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -325,48 +325,6 @@ class LineNumbers(BaseSideBar):
         self.prev_end = end
 
 
-# class ShellSidebar(LineNumbers):
-#     """Show shell prompts in a sidebar."""
-#     def __init__(self, editwin):
-#         super().__init__(editwin)
-#         self.sidebar_text.delete('1.0', 'end-1c')
-#         self.sidebar_text.config(width=3)
-#         self.sidebar_text.tag_config('linenumber', justify=tk.LEFT)
-#
-#     def update_sidebar_text(self, end):
-#         """
-#         Perform the following action:
-#         Each line sidebar_text contains the linenumber for that line
-#         Synchronize with editwin.text so that both sidebar_text and
-#         editwin.text contain the same number of lines"""
-#         if end == self.prev_end:
-#             return
-#
-#         with temp_enable_text_widget(self.sidebar_text):
-#             # if end > self.prev_end:
-#             #     new_text = '\n'.join(itertools.chain(
-#             #         [''],
-#             #         itertools.repeat('...', end - self.prev_end),
-#             #     ))
-#             #     self.sidebar_text.insert(f'end -1c', new_text, 'linenumber')
-#             # elif self.prev_end > self.editwin.getlineno("iomark"):
-#             #     self.sidebar_text.delete(f'{end+1}.0 -1c', 'end -1c')
-#             # else:
-#                 import sys
-#                 for i in range(1, self.editwin.getlineno('end')):
-#                     print(i, self.text.tag_names(f'{i}.0'), file=sys.stderr)
-#                 new_text = '\n'.join(itertools.chain(
-#                     # [''],
-#                     ('>>>' if 'console' in self.text.tag_names(f'{line}.0') else '---'
-#                      # for line in range(self.prev_end + 1, end + 1)),
-#                      for line in range(1, end + 1)),
-#                 ))
-#                 self.sidebar_text.delete('1.0', 'end-1c')
-#                 self.sidebar_text.insert(f'end -1c', new_text, 'linenumber')
-#
-#         self.prev_end = end
-
-
 class WrappedLineHeightChangeDelegator(Delegator):
     def __init__(self, callback):
         """

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -494,6 +494,30 @@ class ShellSidebar:
         # the line numbers.
         self.canvas.bind('<MouseWheel>', self.redirect_mousewheel_event)
 
+        # Redirect mouse button events to the main editor text widget,
+        # except for the left mouse button (1).
+        #
+        # Note: X-11 sends Button-4 and Button-5 events for the scroll wheel.
+        def bind_mouse_event(event_name, target_event_name):
+            handler = functools.partial(self.redirect_mousebutton_event,
+                                        event_name=target_event_name)
+            self.canvas.bind(event_name, handler)
+
+        for button in [2, 3, 4, 5]:
+            for event_name in (f'<Button-{button}>',
+                               f'<ButtonRelease-{button}>',
+                               f'<B{button}-Motion>',
+                               ):
+                bind_mouse_event(event_name, target_event_name=event_name)
+
+            # Convert double- and triple-click events to normal click events,
+            # since event_generate() doesn't allow generating such events.
+            for event_name in (f'<Double-Button-{button}>',
+                               f'<Triple-Button-{button}>',
+                               ):
+                bind_mouse_event(event_name,
+                                 target_event_name=f'<Button-{button}>')
+
 
 def _linenumbers_drag_scrolling(parent):  # htest #
     from idlelib.idle_test.test_sidebar import Dummy_editwin

--- a/Lib/idlelib/squeezer.py
+++ b/Lib/idlelib/squeezer.py
@@ -160,8 +160,10 @@ class ExpandingButton(tk.Button):
             if not confirm:
                 return "break"
 
-        self.base_text.insert(self.text.index(self), self.s, self.tags)
+        index = self.text.index(self)
+        self.base_text.insert(index, self.s, self.tags)
         self.base_text.delete(self)
+        self.editwin.on_squeezed_expand(index, self.s, self.tags)
         self.squeezer.expandingbuttons.remove(self)
 
     def copy(self, event=None):
@@ -285,7 +287,7 @@ class Squeezer:
         """
         return count_lines_with_wrapping(s, self.editwin.width)
 
-    def squeeze_current_text_event(self, event):
+    def squeeze_current_text(self):
         """squeeze-current-text event handler
 
         Squeeze the block of text inside which contains the "insert" cursor.

--- a/Lib/idlelib/squeezer.py
+++ b/Lib/idlelib/squeezer.py
@@ -288,11 +288,9 @@ class Squeezer:
         return count_lines_with_wrapping(s, self.editwin.width)
 
     def squeeze_current_text(self):
-        """squeeze-current-text event handler
+        """Squeeze the text block where the insertion cursor is.
 
-        Squeeze the block of text inside which contains the "insert" cursor.
-
-        If the insert cursor is not in a squeezable block of text, give the
+        If the cursor is not in a squeezable block of text, give the
         user a small warning and do nothing.
         """
         # Set tag_name to the first valid tag found on the "insert" cursor.

--- a/Misc/NEWS.d/next/IDLE/2019-08-24-23-49-36.bpo-37903.4xjast.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-08-24-23-49-36.bpo-37903.4xjast.rst
@@ -1,0 +1,1 @@
+IDLE's shell now shows prompts in a separate side-bar.


### PR DESCRIPTION
This is a working implementation of a sidebar for IDLE's shell, removing the prompts from the main text widget (except for special prompts such as the one used by the debugger.) It works very well in my testing.

__Please give this a try and let me know what you think!__

Currently known to be missing:
1. handling of left mouse button clicks/drags on the sidebar

Notes on the implementation:
* I mostly made each change in a separate commit to make reviewing easier.
* This does *not* use the same base-class as the editor line-numbers sidebar, because it uses a canvas widget rather than a text widget. This is needed due to the shell soft-wrapping lines, causing lines to have varied height. Also, Squeezer inserts buttons into the shell's text window, and those lines have a different height as well.
* This includes quite a bit of work to get the "stdin" tag applied consistently to user input, which was rather broken but not relied on for anything. (Actually, this fixes the "recall" functionality in some edge cases.)
* Removing prompts from the text widget made knowing where each statement started impossible, but the sidebar needs to know this. This PR adds the "console" tag to the newline before each statement to overcome this.
* Removing prompts has other side effects which needed to be addressed. For example, successive statements without output now create a single long range of input tagged "stdin", which required some changes to the `recall()` method.

<!-- issue-number: [bpo-37903](https://bugs.python.org/issue37903) -->
https://bugs.python.org/issue37903
<!-- /issue-number -->
