### PR TITLE
bpo-34679: Add conditional to BaseProactorEventLoop init

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -12,6 +12,7 @@ import socket
 import warnings
 import signal
 import collections
+import threading
 
 from . import base_events
 from . import constants
@@ -627,7 +628,8 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         proactor.set_loop(self)
         self._make_self_pipe()
         self_no = self._csock.fileno()
-        signal.set_wakeup_fd(self_no)
+        if threading.current_thread() is threading.main_thread():
+            signal.set_wakeup_fd(self_no)
 
     def _make_socket_transport(self, sock, protocol, waiter=None,
                                extra=None, server=None):


### PR DESCRIPTION
Adds a conditional to BaseProactorEventLoop.\_\_init\_\_() to only call set_wakeup_fd() if the current thread is the main thread. Fixes asyncio Windows (this error only occurs on Windows) ValueError (see bpo issue comments).


<!-- issue-number: [bpo-34679](https://bugs.python.org/issue34679) -->
https://bugs.python.org/issue34679
<!-- /issue-number -->
