### PR TITLE
bpo-20806: os.times document points to wrong section of non-Linux manual

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3879,9 +3879,9 @@ written in Python, such as a mail server's external command delivery program.
    :attr:`children_system`, and :attr:`elapsed` in that order.
 
    See the Unix manual page
-   :manpage:`times(2)` and :manpage:`times(3)` manual page on Unix or `the MSDN
-   <https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/
-   nf-processthreadsapi-getprocesstimes>`_ on Windows.
+   :manpage:`times(2)` and :manpage:`times(3)` manual page on Unix or `the GetProcessTimes MSDN
+   <https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocesstimes>`
+   _ on Windows.
    On Windows, only :attr:`user` and :attr:`system` are known; the other
    attributes are zero.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3879,7 +3879,7 @@ written in Python, such as a mail server's external command delivery program.
    :attr:`children_system`, and :attr:`elapsed` in that order.
 
    See the Unix manual page
-   :manpage:`times(2)` or the corresponding Windows Platform API documentation.
+   :manpage:`times(3p)` or the corresponding Windows Platform API documentation.
    On Windows, only :attr:`user` and :attr:`system` are known; the other
    attributes are zero.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3879,7 +3879,9 @@ written in Python, such as a mail server's external command delivery program.
    :attr:`children_system`, and :attr:`elapsed` in that order.
 
    See the Unix manual page
-   :manpage:`times(3p)` or the corresponding Windows Platform API documentation.
+   :manpage:`times(2)` and :manpage:`times(3)` manual page on Unix or `the MSDN
+   <https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/
+   nf-processthreadsapi-getprocesstimes>`_ on Windows.
    On Windows, only :attr:`user` and :attr:`system` are known; the other
    attributes are zero.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3880,7 +3880,7 @@ written in Python, such as a mail server's external command delivery program.
 
    See the Unix manual page
    :manpage:`times(2)` and :manpage:`times(3)` manual page on Unix or `the GetProcessTimes MSDN
-   <https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocesstimes>`
+   <https://docs.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocesstimes>`
    _ on Windows.
    On Windows, only :attr:`user` and :attr:`system` are known; the other
    attributes are zero.


### PR DESCRIPTION
Change reference from `times(2)` to `times(3p)` .

<!-- issue-number: [bpo-20806](https://bugs.python.org/issue20806) -->
https://bugs.python.org/issue20806
<!-- /issue-number -->
