### PR TITLE
bpo-36670: fixed encoding issue with libregrtest on win systems

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-08-25-10-38-53.bpo-36670._OSseG.rst
+++ b/Misc/NEWS.d/next/Tests/2019-08-25-10-38-53.bpo-36670._OSseG.rst
@@ -1,0 +1,2 @@
+regrtest: fixed typeperf encoding for cpu usage evaluation on win 10, lookup
+of correct typeperf key in winreg removed closing of the stdout pipe


### PR DESCRIPTION
detailed: fixed decoding of typeperf in regrtest for win environments, added lookup for locations dependent typeperf key

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36670](https://bugs.python.org/issue36670) -->
https://bugs.python.org/issue36670
<!-- /issue-number -->
