### PR TITLE
bpo-34679: Restore instantiation Windows IOCP event loop from non-main thread

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -11,6 +11,7 @@ import os
 import socket
 import warnings
 import signal
+import threading
 import collections
 
 from . import base_events
@@ -627,7 +628,9 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         proactor.set_loop(self)
         self._make_self_pipe()
         self_no = self._csock.fileno()
-        signal.set_wakeup_fd(self_no)
+        if threading.current_thread() is threading.main_thread():
+            # wakeup fd can be installed from main thread only
+            signal.set_wakeup_fd(self_no)
 
     def _make_socket_transport(self, sock, protocol, waiter=None,
                                extra=None, server=None):

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -629,7 +629,7 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         self._make_self_pipe()
         self_no = self._csock.fileno()
         if threading.current_thread() is threading.main_thread():
-            # wakeup fd can be installed from main thread only
+            # wakeup fd can only be installed to a file descriptor from the main thread
             signal.set_wakeup_fd(self_no)
 
     def _make_socket_transport(self, sock, protocol, waiter=None,

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -59,6 +59,25 @@ class ProactorLoopCtrlC(test_utils.TestCase):
         thread.join()
 
 
+class ProactorMultithreading(test_utils.TestCase):
+    def test_run_from_nonmain_thread(self):
+        finished = False
+
+        async def coro():
+            await asyncio.sleep(0)
+
+        def func():
+            nonlocal finished
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(coro())
+            finished = True
+
+        thread = threading.Thread(target=func)
+        thread.start()
+        thread.join()
+        self.assertTrue(finished)
+
+
 class ProactorTests(test_utils.TestCase):
 
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2019-08-25-18-07-48.bpo-34679.HECzL7.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-25-18-07-48.bpo-34679.HECzL7.rst
@@ -1,1 +1,1 @@
-Restore instantiation Windows IOCP event loop from non-main thread.
+Restores instantiation of Windows IOCP event loops from the non-main thread.

--- a/Misc/NEWS.d/next/Library/2019-08-25-18-07-48.bpo-34679.HECzL7.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-25-18-07-48.bpo-34679.HECzL7.rst
@@ -1,0 +1,1 @@
+Restore instantiation Windows IOCP event loop from non-main thread.


### PR DESCRIPTION

<!-- issue-number: [bpo-34769](https://bugs.python.org/issue34769) -->
https://bugs.python.org/issue34679
<!-- /issue-number -->
