### PR TITLE
bpo-37947: Adjust correctly the recursion level in symtable for named expressions

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-26-04-09-57.bpo-37947.mzAQtB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-26-04-09-57.bpo-37947.mzAQtB.rst
@@ -1,0 +1,2 @@
+Adjust correctly the recursion level in the symtable generation for named
+expressions. Patch by Pablo Galindo.

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1508,6 +1508,7 @@ symtable_handle_namedexpr(struct symtable *st, expr_ty e)
     }
     VISIT(st, expr, e->v.NamedExpr.value);
     VISIT(st, expr, e->v.NamedExpr.target);
+    VISIT_QUIT(st, 1);
 }
 
 static int
@@ -1520,7 +1521,8 @@ symtable_visit_expr(struct symtable *st, expr_ty e)
     }
     switch (e->kind) {
     case NamedExpr_kind:
-        symtable_handle_namedexpr(st, e);
+        if(!symtable_handle_namedexpr(st, e))
+            VISIT_QUIT(st, 0);
         break;
     case BoolOp_kind:
         VISIT_SEQ(st, expr, e->v.BoolOp.values);


### PR DESCRIPTION
<!-- issue-number: [bpo-37947](https://bugs.python.org/issue37947) -->
https://bugs.python.org/issue37947
<!-- /issue-number -->