### PR TITLE
bpo-37954: Fix reference leak in the symtable

### DIFF
--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -999,7 +999,9 @@ symtable_lookup(struct symtable *st, PyObject *name)
     PyObject *mangled = _Py_Mangle(st->st_private, name);
     if (!mangled)
         return 0;
-    return _PyST_GetSymbol(st->st_cur, mangled);
+    long ret = _PyST_GetSymbol(st->st_cur, mangled);
+    Py_DECREF(mangled);
+    return ret;
 }
 
 static int


### PR DESCRIPTION


<!-- issue-number: [bpo-37954](https://bugs.python.org/issue37954) -->
https://bugs.python.org/issue37954
<!-- /issue-number -->
