### PR TITLE
bpo-37955: mock.patch incorrect reference to Mock

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1369,7 +1369,7 @@ patch
     "as"; very useful if :func:`patch` is creating a mock object for you.
 
     :func:`patch` takes arbitrary keyword arguments. These will be passed to
-    :class:`AsyncMock` if the patched object is asynchronous, to 
+    :class:`AsyncMock` if the patched object is asynchronous, to
     :class:`MagicMock` otherwise or to *new_callable* if specified.
 
     ``patch.dict(...)``, ``patch.multiple(...)`` and ``patch.object(...)`` are

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1369,8 +1369,8 @@ patch
     "as"; very useful if :func:`patch` is creating a mock object for you.
 
     :func:`patch` takes arbitrary keyword arguments. These will be passed to
-    to construct a :class:`AsyncMock` if the patched object is an async function,
-    to :class:`MagicMock` otherwise or to *new_callable* if specified.
+    :class:`AsyncMock` if the patched object is an async function, to 
+    :class:`MagicMock` otherwise or to *new_callable* if specified.
 
     ``patch.dict(...)``, ``patch.multiple(...)`` and ``patch.object(...)`` are
     available for alternate use-cases.

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1369,7 +1369,7 @@ patch
     "as"; very useful if :func:`patch` is creating a mock object for you.
 
     :func:`patch` takes arbitrary keyword arguments. These will be passed to
-    :class:`AsyncMock` if the patched object is an async function, to 
+    :class:`AsyncMock` if the patched object is asynchronous, to 
     :class:`MagicMock` otherwise or to *new_callable* if specified.
 
     ``patch.dict(...)``, ``patch.multiple(...)`` and ``patch.object(...)`` are

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1369,7 +1369,8 @@ patch
     "as"; very useful if :func:`patch` is creating a mock object for you.
 
     :func:`patch` takes arbitrary keyword arguments. These will be passed to
-    the :class:`MagicMock` (or *new_callable*) on construction.
+    to construct a :class:`AsyncMock` if the patched object is an async function,
+    to :class:`MagicMock` otherwise or to *new_callable* if specified.
 
     ``patch.dict(...)``, ``patch.multiple(...)`` and ``patch.object(...)`` are
     available for alternate use-cases.

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1369,7 +1369,7 @@ patch
     "as"; very useful if :func:`patch` is creating a mock object for you.
 
     :func:`patch` takes arbitrary keyword arguments. These will be passed to
-    the :class:`Mock` (or *new_callable*) on construction.
+    the :class:`MagicMock` (or *new_callable*) on construction.
 
     ``patch.dict(...)``, ``patch.multiple(...)`` and ``patch.object(...)`` are
     available for alternate use-cases.

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1651,8 +1651,8 @@ def patch(
     "as"; very useful if `patch` is creating a mock object for you.
 
     `patch` takes arbitrary keyword arguments. These will be passed to
-    to construct a `AsyncMock` if the patched object is an async function,
-    to `MagicMock` otherwise or to `new_callable` if specified.
+    `AsyncMock` if the patched object is an async function, to `MagicMock`
+    otherwise or to `new_callable` if specified.
 
     `patch.dict(...)`, `patch.multiple(...)` and `patch.object(...)` are
     available for alternate use-cases.

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1651,7 +1651,8 @@ def patch(
     "as"; very useful if `patch` is creating a mock object for you.
 
     `patch` takes arbitrary keyword arguments. These will be passed to
-    the `MagicMock` (or `new_callable`) on construction.
+    to construct a `AsyncMock` if the patched object is an async function,
+    to `MagicMock` otherwise or to `new_callable` if specified.
 
     `patch.dict(...)`, `patch.multiple(...)` and `patch.object(...)` are
     available for alternate use-cases.

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1651,7 +1651,7 @@ def patch(
     "as"; very useful if `patch` is creating a mock object for you.
 
     `patch` takes arbitrary keyword arguments. These will be passed to
-    `AsyncMock` if the patched object is an async function, to `MagicMock`
+    `AsyncMock` if the patched object is asynchronous, to `MagicMock`
     otherwise or to `new_callable` if specified.
 
     `patch.dict(...)`, `patch.multiple(...)` and `patch.object(...)` are

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1651,7 +1651,7 @@ def patch(
     "as"; very useful if `patch` is creating a mock object for you.
 
     `patch` takes arbitrary keyword arguments. These will be passed to
-    the `Mock` (or `new_callable`) on construction.
+    the `MagicMock` (or `new_callable`) on construction.
 
     `patch.dict(...)`, `patch.multiple(...)` and `patch.object(...)` are
     available for alternate use-cases.


### PR DESCRIPTION
mock.patch mentions that keyword arguments are passed
to Mock when it passes to MagicMock by default.

This PR fixes that.


<!-- issue-number: [bpo-37955](https://bugs.python.org/issue37955) -->
https://bugs.python.org/issue37955
<!-- /issue-number -->
