### PR TITLE
Make PyXXX_Fini() functions private

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -62,18 +62,19 @@ extern PyStatus _PyImportZip_Init(PyThreadState *tstate);
 
 /* Various internal finalizers */
 
-extern void PyMethod_Fini(void);
-extern void PyFrame_Fini(void);
-extern void PyCFunction_Fini(void);
-extern void PyDict_Fini(void);
-extern void PyTuple_Fini(void);
-extern void PyList_Fini(void);
-extern void PySet_Fini(void);
-extern void PyBytes_Fini(void);
-extern void PyFloat_Fini(void);
+extern void _PyMethod_Fini(void);
+extern void _PyFrame_Fini(void);
+extern void _PyCFunction_Fini(void);
+extern void _PyDict_Fini(void);
+extern void _PyTuple_Fini(void);
+extern void _PyList_Fini(void);
+extern void _PySet_Fini(void);
+extern void _PyBytes_Fini(void);
+extern void _PyFloat_Fini(void);
+extern void _PySlice_Fini(void);
+extern void _PyAsyncGen_Fini(void);
+
 extern void PyOS_FiniInterrupts(void);
-extern void PySlice_Fini(void);
-extern void PyAsyncGen_Fini(void);
 
 extern void _PyExc_Fini(void);
 extern void _PyImport_Fini(void);
@@ -82,7 +83,7 @@ extern void _PyGC_Fini(_PyRuntimeState *runtime);
 extern void _PyType_Fini(void);
 extern void _Py_HashRandomization_Fini(void);
 extern void _PyUnicode_Fini(void);
-extern void PyLong_Fini(void);
+extern void _PyLong_Fini(void);
 extern void _PyFaulthandler_Fini(void);
 extern void _PyHash_Fini(void);
 extern int _PyTraceMalloc_Fini(void);

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3047,7 +3047,7 @@ error:
 }
 
 void
-PyBytes_Fini(void)
+_PyBytes_Fini(void)
 {
     int i;
     for (i = 0; i < UCHAR_MAX + 1; i++)

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -375,7 +375,7 @@ PyMethod_ClearFreeList(void)
 }
 
 void
-PyMethod_Fini(void)
+_PyMethod_Fini(void)
 {
     (void)PyMethod_ClearFreeList();
 }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -282,7 +282,7 @@ _PyDict_DebugMallocStats(FILE *out)
 
 
 void
-PyDict_Fini(void)
+_PyDict_Fini(void)
 {
     PyDict_ClearFreeList();
 }

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -2031,7 +2031,7 @@ PyFloat_ClearFreeList(void)
 }
 
 void
-PyFloat_Fini(void)
+_PyFloat_Fini(void)
 {
     (void)PyFloat_ClearFreeList();
 }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -997,7 +997,7 @@ PyFrame_ClearFreeList(void)
 }
 
 void
-PyFrame_Fini(void)
+_PyFrame_Fini(void)
 {
     (void)PyFrame_ClearFreeList();
 }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1463,7 +1463,7 @@ PyAsyncGen_ClearFreeLists(void)
 }
 
 void
-PyAsyncGen_Fini(void)
+_PyAsyncGen_Fini(void)
 {
     PyAsyncGen_ClearFreeLists();
 }

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -138,7 +138,7 @@ PyList_ClearFreeList(void)
 }
 
 void
-PyList_Fini(void)
+_PyList_Fini(void)
 {
     PyList_ClearFreeList();
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5869,7 +5869,7 @@ _PyLong_Init(void)
 }
 
 void
-PyLong_Fini(void)
+_PyLong_Fini(void)
 {
     /* Integers are currently statically allocated. Py_DECREF is not
        needed, but Python must forget about the reference or multiple

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -319,7 +319,7 @@ PyCFunction_ClearFreeList(void)
 }
 
 void
-PyCFunction_Fini(void)
+_PyCFunction_Fini(void)
 {
     (void)PyCFunction_ClearFreeList();
 }

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2318,7 +2318,7 @@ PySet_ClearFreeList(void)
 }
 
 void
-PySet_Fini(void)
+_PySet_Fini(void)
 {
     Py_CLEAR(emptyfrozenset);
 }

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -100,7 +100,8 @@ PyObject _Py_EllipsisObject = {
  * created and then deleted again
  */
 static PySliceObject *slice_cache = NULL;
-void PySlice_Fini(void)
+
+void _PySlice_Fini(void)
 {
     PySliceObject *obj = slice_cache;
     if (obj != NULL) {

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -989,7 +989,7 @@ PyTuple_ClearFreeList(void)
 }
 
 void
-PyTuple_Fini(void)
+_PyTuple_Fini(void)
 {
 #if PyTuple_MAXSAVESIZE > 0
     /* empty tuples are used all over the place and applications may

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1307,22 +1307,22 @@ Py_FinalizeEx(void)
     _PyExc_Fini();
 
     /* Sundry finalizers */
-    PyMethod_Fini();
-    PyFrame_Fini();
-    PyCFunction_Fini();
-    PyTuple_Fini();
-    PyList_Fini();
-    PySet_Fini();
-    PyBytes_Fini();
-    PyLong_Fini();
-    PyFloat_Fini();
-    PyDict_Fini();
-    PySlice_Fini();
+    _PyMethod_Fini();
+    _PyFrame_Fini();
+    _PyCFunction_Fini();
+    _PyTuple_Fini();
+    _PyList_Fini();
+    _PySet_Fini();
+    _PyBytes_Fini();
+    _PyLong_Fini();
+    _PyFloat_Fini();
+    _PyDict_Fini();
+    _PySlice_Fini();
     _PyGC_Fini(runtime);
     _PyWarnings_Fini(interp);
     _Py_HashRandomization_Fini();
     _PyArg_Fini();
-    PyAsyncGen_Fini();
+    _PyAsyncGen_Fini();
     _PyContext_Fini();
 
     /* Cleanup Unicode implementation */


### PR DESCRIPTION
For example, rename PyTuple_Fini() to _PyTuple_Fini().

These functions are only declared in the internal C API.