### PR TITLE
bpo-36763: Make Py_BytesMain() public

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -15,8 +15,6 @@ extern "C" {
  * KeyboardInterrupt exception, suggesting the user pressed ^C. */
 PyAPI_DATA(int) _Py_UnhandledKeyboardInterrupt;
 
-PyAPI_FUNC(int) Py_BytesMain(int argc, char **argv);
-
 extern int _Py_SetFileSystemEncoding(
     const char *encoding,
     const char *errors);

--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -32,6 +32,8 @@ PyAPI_FUNC(void) _Py_NO_RETURN Py_Exit(int);
 /* Bootstrap __main__ (defined in Modules/main.c) */
 PyAPI_FUNC(int) Py_Main(int argc, wchar_t **argv);
 
+PyAPI_FUNC(int) Py_BytesMain(int argc, char **argv);
+
 /* In pathconfig.c */
 PyAPI_FUNC(void) Py_SetProgramName(const wchar_t *);
 PyAPI_FUNC(wchar_t *) Py_GetProgramName(void);


### PR DESCRIPTION
Declare Py_BytesMain() in Include/pylifecycle.h, rather in
Include/internal/pycore_pylifecycle.h.

<!-- issue-number: [bpo-36763](https://bugs.python.org/issue36763) -->
https://bugs.python.org/issue36763
<!-- /issue-number -->
