### PR TITLE
bpo-36205: Fix the rusage implementation of time.process_time()

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-08-27-03-53-26.bpo-36205.AfkGRl.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-27-03-53-26.bpo-36205.AfkGRl.rst
@@ -1,0 +1,1 @@
+Fix the rusage implementation of time.process_time() to correctly report the sum of the system and user CPU time.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1208,7 +1208,7 @@ _PyTime_GetProcessTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
             return -1;
         }
 
-        _PyTime_t total = utime + utime;
+        _PyTime_t total = utime + stime;
         *tp = total;
         return 0;
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-36205](https://bugs.python.org/issue36205) -->
https://bugs.python.org/issue36205
<!-- /issue-number -->
