### PR TITLE
Correct Roman-numeral example in Unicode HOWTO.

### DIFF
--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -57,14 +57,14 @@ their corresponding code points:
    ...
    007B    '{'; LEFT CURLY BRACKET
    ...
-   2167    'Ⅶ': ROMAN NUMERAL SEVEN
-   2168    'Ⅸ': ROMAN NUMERAL NINE
+   2167    'Ⅷ'; ROMAN NUMERAL EIGHT
+   2168    'Ⅸ'; ROMAN NUMERAL NINE
    ...
-   265E    '♞': BLACK CHESS KNIGHT
-   265F    '♟': BLACK CHESS PAWN
+   265E    '♞'; BLACK CHESS KNIGHT
+   265F    '♟'; BLACK CHESS PAWN
    ...
-   1F600   '😀': GRINNING FACE
-   1F609   '😉': WINKING FACE
+   1F600   '😀'; GRINNING FACE
+   1F609   '😉'; WINKING FACE
    ...
 
 Strictly, these definitions imply that it's meaningless to say 'this is


### PR DESCRIPTION
We had the character Ⅶ aka U+2166 ROMAN NUMERAL SEVEN, but the
code point given is 2167 and it's next to 2168.  Adjust so the
code point, character, and name all agree.  (This follows up on
77df9a157, which made the name match the character.)

We also had a mixture of `;` and `:` for a delimiter.
It doesn't really matter which, but it's good to be consistent.
The actual Unicode database files use `;`, so go with that.
