### PR TITLE
bpo-37936: Remove some .gitignore rules that were intended locally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,8 @@
-# added for local development
-.buildaix/
-Modules/python.exp
-buildaix/
-installp/
-.gitignore
-
 # Two-trick pony for OSX and other case insensitive file systems:
 # Ignore ./python binary on Unix but still look into ./Python/ directory.
 /python
 !/Python/
+
 *.cover
 *.iml
 *.o


### PR DESCRIPTION
These appeared in commit c5ae169e1.  The comment on them, as well as
the presence among them of a rule for the .gitignore file itself,
indicate that the author intended these lines to remain only in their
own local working tree -- not to get committed even to their own repo,
let alone merged upstream.

They did nevertheless get committed, because it turns out that Git
takes no notice of what .gitignore says about files that it's already
tracking... for example, this .gitignore file itself.

Give effect to these lines' original intention, by deleting them. :-)

Git tip, for reference: the `.git/info/exclude` file is a handy way
to do exactly what these lines were originally intended to do.  A
related handy file is `~/.config/git/ignore`.  See gitignore(5),
aka `git help ignore`, for details.


<!-- issue-number: [bpo-37936](https://bugs.python.org/issue37936) -->
https://bugs.python.org/issue37936
<!-- /issue-number -->


Automerge-Triggered-By: @zware