### PR TITLE
bpo-37960: Silence only necessary errors in repr() of buffered and text streams.

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -409,7 +409,7 @@ class IOBase(metaclass=abc.ABCMeta):
         """Destructor.  Calls close()."""
         try:
             closed = self.closed
-        except Exception:
+        except AttributeError:
             # If getting closed fails, then the object is probably
             # in an unusable state, so ignore.
             return
@@ -867,7 +867,7 @@ class _BufferedIOMixin(BufferedIOBase):
         clsname = self.__class__.__qualname__
         try:
             name = self.name
-        except Exception:
+        except AttributeError:
             return "<{}.{}>".format(modname, clsname)
         else:
             return "<{}.{} name={!r}>".format(modname, clsname, name)
@@ -2083,13 +2083,13 @@ class TextIOWrapper(TextIOBase):
                                  self.__class__.__qualname__)
         try:
             name = self.name
-        except Exception:
+        except AttributeError:
             pass
         else:
             result += " name={0!r}".format(name)
         try:
             mode = self.mode
-        except Exception:
+        except AttributeError:
             pass
         else:
             result += " mode={0!r}".format(mode)

--- a/Misc/NEWS.d/next/Library/2019-08-27-10-52-13.bpo-37960.CTY7Lw.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-27-10-52-13.bpo-37960.CTY7Lw.rst
@@ -1,0 +1,2 @@
+``repr()`` of buffered and text streams now silences only expected
+exceptions when get the value of "name" and "mode" attributes.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1378,12 +1378,14 @@ buffered_repr(buffered *self)
 {
     PyObject *nameobj, *res;
 
-    nameobj = _PyObject_GetAttrId((PyObject *) self, &PyId_name);
-    if (nameobj == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_Exception))
-            PyErr_Clear();
-        else
+    if (_PyObject_LookupAttrId((PyObject *) self, &PyId_name, &nameobj) < 0) {
+        if (!PyErr_ExceptionMatches(PyExc_ValueError)) {
             return NULL;
+        }
+        /* Ignore ValueError raised if the underlying stream was detached */
+        PyErr_Clear();
+    }
+    if (nameobj == NULL) {
         res = PyUnicode_FromFormat("<%s>", Py_TYPE(self)->tp_name);
     }
     else {

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2899,14 +2899,14 @@ textiowrapper_repr(textio *self)
         }
         goto error;
     }
-    nameobj = _PyObject_GetAttrId((PyObject *) self, &PyId_name);
-    if (nameobj == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_Exception))
-            PyErr_Clear();
-        else
+    if (_PyObject_LookupAttrId((PyObject *) self, &PyId_name, &nameobj) < 0) {
+        if (!PyErr_ExceptionMatches(PyExc_ValueError)) {
             goto error;
+        }
+        /* Ignore ValueError raised if the underlying stream was detached */
+        PyErr_Clear();
     }
-    else {
+    if (nameobj != NULL) {
         s = PyUnicode_FromFormat(" name=%R", nameobj);
         Py_DECREF(nameobj);
         if (s == NULL)
@@ -2915,14 +2915,10 @@ textiowrapper_repr(textio *self)
         if (res == NULL)
             goto error;
     }
-    modeobj = _PyObject_GetAttrId((PyObject *) self, &PyId_mode);
-    if (modeobj == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_Exception))
-            PyErr_Clear();
-        else
-            goto error;
+    if (_PyObject_LookupAttrId((PyObject *) self, &PyId_mode, &modeobj) < 0) {
+        goto error;
     }
-    else {
+    if (modeobj != NULL) {
         s = PyUnicode_FromFormat(" mode=%R", modeobj);
         Py_DECREF(modeobj);
         if (s == NULL)


### PR DESCRIPTION


<!-- issue-number: [bpo-37960](https://bugs.python.org/issue37960) -->
https://bugs.python.org/issue37960
<!-- /issue-number -->
