### PR TITLE
bpo-37951: Lift subprocess's fork() restriction (GH-15544)

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -483,6 +483,12 @@ functions.
       The *start_new_session* parameter can take the place of a previously
       common use of *preexec_fn* to call os.setsid() in the child.
 
+   .. versionchanged:: 3.8
+
+      The *preexec_fn* parameter is no longer supported in subinterpreters.
+      The new restriction may affect applications that are deployed in
+      mod_wsgi, uWSGI, and other environments.
+
    If *close_fds* is true, all file descriptors except :const:`0`, :const:`1` and
    :const:`2` will be closed before the child process is executed.  Otherwise
    when *close_fds* is false, file descriptors obey their inheritable flag

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -486,8 +486,9 @@ functions.
    .. versionchanged:: 3.8
 
       The *preexec_fn* parameter is no longer supported in subinterpreters.
-      The new restriction may affect applications that are deployed in
-      mod_wsgi, uWSGI, and other environments.
+      The use of the parameter in a subinterpreter raises
+      :exc:`RuntimeError`. The new restriction may affect applications that
+      are deployed in mod_wsgi, uWSGI, and other embedded environments.
 
    If *close_fds* is true, all file descriptors except :const:`0`, :const:`1` and
    :const:`2` will be closed before the child process is executed.  Otherwise

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1531,6 +1531,11 @@ Changes in the Python API
   non-zero :attr:`~Popen.returncode`.
   (Contributed by Joannah Nanjekye and Victor Stinner in :issue:`35537`.)
 
+* The *preexec_fn* argument of * :class:`subprocess.Popen` is no longer
+  compatible with subinterpreters.
+  (Contributed by Eric Snow in :issue:`34651`, modified by Christian Heimes
+  in :issue:`37951`.)
+
 * The :meth:`imap.IMAP4.logout` method no longer ignores silently arbitrary
   exceptions.
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1532,7 +1532,8 @@ Changes in the Python API
   (Contributed by Joannah Nanjekye and Victor Stinner in :issue:`35537`.)
 
 * The *preexec_fn* argument of * :class:`subprocess.Popen` is no longer
-  compatible with subinterpreters.
+  compatible with subinterpreters. The use of the parameter in a
+  subinterpreter now raises :exc:`RuntimeError`.
   (Contributed by Eric Snow in :issue:`34651`, modified by Christian Heimes
   in :issue:`37951`.)
 

--- a/Misc/NEWS.d/next/Library/2019-08-27-10-03-48.bpo-37951.MfRQgL.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-27-10-03-48.bpo-37951.MfRQgL.rst
@@ -1,0 +1,2 @@
+Most features of the subprocess module now work again in subinterpreters.
+Only *preexec_fn* is restricted in subinterpreters.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -583,8 +583,9 @@ subprocess_fork_exec(PyObject* self, PyObject *args)
             &restore_signals, &call_setsid, &preexec_fn))
         return NULL;
 
-    if (_PyInterpreterState_Get() != PyInterpreterState_Main()) {
-        PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
+    if ((preexec_fn != Py_None) &&
+            (_PyInterpreterState_Get() != PyInterpreterState_Main())) {
+        PyErr_SetString(PyExc_RuntimeError, "preexec_fn not supported for subinterpreters");
         return NULL;
     }
 

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -585,7 +585,8 @@ subprocess_fork_exec(PyObject* self, PyObject *args)
 
     if ((preexec_fn != Py_None) &&
             (_PyInterpreterState_Get() != PyInterpreterState_Main())) {
-        PyErr_SetString(PyExc_RuntimeError, "preexec_fn not supported for subinterpreters");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "preexec_fn not supported within subinterpreters");
         return NULL;
     }
 


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-37951](https://bugs.python.org/issue37951) -->
https://bugs.python.org/issue37951
<!-- /issue-number -->
