### PR TITLE
bpo-23878: Remove the key parameter of _Py_FindEnvConfigValue()

### DIFF
--- a/Include/internal/pycore_pathconfig.h
+++ b/Include/internal/pycore_pathconfig.h
@@ -51,7 +51,6 @@ extern int _PyPathConfig_ComputeSysPath0(
     PyObject **path0);
 extern int _Py_FindEnvConfigValue(
     FILE *env_file,
-    const wchar_t *key,
     wchar_t *value,
     size_t value_size);
 

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -986,7 +986,7 @@ calculate_read_pyenv(PyCalculatePath *calculate)
     }
 
     /* Look for a 'home' variable and set argv0_path to it, if found */
-    if (_Py_FindEnvConfigValue(env_file, L"home", tmpbuffer, buflen)) {
+    if (_Py_FindEnvConfigValue(env_file, tmpbuffer, buflen)) {
         if (safe_wcscpy(calculate->argv0_path, tmpbuffer,
                         Py_ARRAY_LENGTH(calculate->argv0_path)) < 0) {
             return PATHLEN_ERR();

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -742,7 +742,7 @@ calculate_pyvenv_file(PyCalculatePath *calculate)
 
     /* Look for a 'home' variable and set argv0_path to it, if found */
     wchar_t tmpbuffer[MAXPATHLEN+1];
-    if (_Py_FindEnvConfigValue(env_file, L"home", tmpbuffer, MAXPATHLEN)) {
+    if (_Py_FindEnvConfigValue(env_file, tmpbuffer, MAXPATHLEN)) {
         wcscpy_s(calculate->argv0_path, MAXPATHLEN+1, tmpbuffer);
     }
     fclose(env_file);

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -734,8 +734,7 @@ _PyPathConfig_ComputeSysPath0(const PyWideStringList *argv, PyObject **path0_p)
 /* Search for a prefix value in an environment file (pyvenv.cfg).
    If found, copy it into the provided buffer. */
 int
-_Py_FindEnvConfigValue(FILE *env_file, const wchar_t *key,
-                       wchar_t *value, size_t value_size)
+_Py_FindEnvConfigValue(FILE *env_file, wchar_t *value, size_t value_size)
 {
     int result = 0; /* meaning not found */
     char buffer[MAXPATHLEN * 2 + 1];  /* allow extra for key, '=', etc. */
@@ -763,7 +762,7 @@ _Py_FindEnvConfigValue(FILE *env_file, const wchar_t *key,
         if (tmpbuffer) {
             wchar_t * state;
             wchar_t * tok = WCSTOK(tmpbuffer, L" \t\r\n", &state);
-            if ((tok != NULL) && !wcscmp(tok, key)) {
+            if ((tok != NULL) && !wcscmp(tok, L"home")) {
                 tok = WCSTOK(NULL, L" \t", &state);
                 if ((tok != NULL) && !wcscmp(tok, L"=")) {
                     tok = WCSTOK(NULL, L"\r\n", &state);


### PR DESCRIPTION
Suggested by @vstinner in GH-15424.

<!-- issue-number: [bpo-23878](https://bugs.python.org/issue23878) -->
https://bugs.python.org/issue23878
<!-- /issue-number -->
