### PR TITLE
Improve message for openssl lookup

### DIFF
--- a/configure
+++ b/configure
@@ -17207,8 +17207,8 @@ fi
     if ! $found; then
         OPENSSL_INCLUDES=
         for ssldir in $ssldirs; do
-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for openssl/ssl.h in $ssldir" >&5
-$as_echo_n "checking for openssl/ssl.h in $ssldir... " >&6; }
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for include/openssl/ssl.h in $ssldir" >&5
+$as_echo_n "checking for include/openssl/ssl.h in $ssldir... " >&6; }
             if test -f "$ssldir/include/openssl/ssl.h"; then
                 OPENSSL_INCLUDES="-I$ssldir/include"
                 OPENSSL_LDFLAGS="-L$ssldir/lib"


### PR DESCRIPTION
This is a re-open from #15082 , in which one of my reviewers suggested it go on `master`. It is a cosmetic change on the display message, so I don't think any issue number is needed.

Rationale for the change:
> I was trying to test the pre-release 3.8b3, and since I have multiple installation of OpenSSL, having this improved message with more specific on which type of OpenSSL header would be needed, will definitely make my hunt go easier.

It is still my first PR to Python, so kindly let me know if anything else that I can improve.
