### PR TITLE
closes bpo-37965: Fix compiler warning of distutils CCompiler.test_function.

### DIFF
--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -781,8 +781,9 @@ class CCompiler:
             for incl in includes:
                 f.write("""#include "%s"\n""" % incl)
             f.write("""\
-main (int argc, char **argv) {
+int main (int argc, char **argv) {
     %s();
+    return 0;
 }
 """ % funcname)
         finally:

--- a/Misc/NEWS.d/next/Library/2019-08-28-14-04-18.bpo-37965.7xGE-C.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-28-14-04-18.bpo-37965.7xGE-C.rst
@@ -1,0 +1,1 @@
+Fix compiler warning of distutils.ccompiler.CCompiler.has_function

--- a/Misc/NEWS.d/next/Library/2019-08-28-14-04-18.bpo-37965.7xGE-C.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-28-14-04-18.bpo-37965.7xGE-C.rst
@@ -1,1 +1,1 @@
-Fix compiler warning of distutils.ccompiler.CCompiler.has_function
+Fix C compiler warning caused by distutils.ccompiler.CCompiler.has_function.


### PR DESCRIPTION
https://bugs.python.org/issue37965

<!-- issue-number: [bpo-37965](https://bugs.python.org/issue37965) -->
https://bugs.python.org/issue37965
<!-- /issue-number -->


Automerge-Triggered-By: @benjaminp