### PR TITLE
bpo-37972: unittest.mock._Call now passes on __getitem__ to the __getattr__ chaining so that call() can be subscriptable

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2428,6 +2428,12 @@ class _Call(tuple):
         return _Call(name=name, parent=self, from_kall=False)
 
 
+    def __getattribute__(self, attr):
+        if attr == '__getitem__':
+            raise AttributeError
+        return tuple.__getattribute__(self, attr)
+
+
     def count(self, /, *args, **kwargs):
         return self.__getattr__('count')(*args, **kwargs)
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2429,7 +2429,7 @@ class _Call(tuple):
 
 
     def __getattribute__(self, attr):
-        if attr == '__getitem__':
+        if attr not in tuple.__getattribute__(self, '__dict__'):
             raise AttributeError
         return tuple.__getattribute__(self, attr)
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2429,7 +2429,7 @@ class _Call(tuple):
 
 
     def __getattribute__(self, attr):
-        if attr not in tuple.__getattribute__(self, '__dict__'):
+        if attr in tuple.__dict__:
             raise AttributeError
         return tuple.__getattribute__(self, attr)
 

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -334,12 +334,24 @@ class CallTest(unittest.TestCase):
         self.assertEqual(_Call((('bar', 'barz'),),)[0], '')
         self.assertEqual(_Call((('bar', 'barz'), {'hello': 'world'}),)[0], '')
 
-    def test_subscriptable_call(self):
+    def test_dunder_call(self):
         m = MagicMock()
         m().foo()['bar']()
         self.assertEqual(
             m.mock_calls,
             [call(), call().foo(), call().foo().__getitem__('bar'), call().foo().__getitem__()()]
+        )
+        m = MagicMock()
+        m().foo()['bar'] = 1
+        self.assertEqual(
+            m.mock_calls,
+            [call(), call().foo(), call().foo().__setitem__('bar', 1)]
+        )
+        m = MagicMock()
+        iter(m().foo())
+        self.assertEqual(
+            m.mock_calls,
+            [call(), call().foo(), call().foo().__iter__()]
         )
 
 

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -334,6 +334,14 @@ class CallTest(unittest.TestCase):
         self.assertEqual(_Call((('bar', 'barz'),),)[0], '')
         self.assertEqual(_Call((('bar', 'barz'), {'hello': 'world'}),)[0], '')
 
+    def test_subscriptable_call(self):
+        m = MagicMock()
+        m().foo()['bar']()
+        self.assertEqual(
+            m.mock_calls,
+            [call(), call().foo(), call().foo().__getitem__('bar'), call().foo().__getitem__()()]
+        )
+
 
 class SpecSignatureTest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2019-08-28-21-40-12.bpo-37972.kP-n4L.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-28-21-40-12.bpo-37972.kP-n4L.rst
@@ -1,0 +1,3 @@
+Subscripts to the `unittest.mock.call` objects now receive the same chaining mechanism as any other custom attributes, so that the following no longer raises a `TypeError`:
+
+    call().foo().__getitem__('bar')

--- a/Misc/NEWS.d/next/Library/2019-08-28-21-40-12.bpo-37972.kP-n4L.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-28-21-40-12.bpo-37972.kP-n4L.rst
@@ -1,3 +1,5 @@
-Subscripts to the `unittest.mock.call` objects now receive the same chaining mechanism as any other custom attributes, so that the following no longer raises a `TypeError`:
+Subscripts to the `unittest.mock.call` objects now receive the same chaining mechanism as any other custom attributes, so that the following usage no longer raises a `TypeError`:
 
     call().foo().__getitem__('bar')
+
+Patch by blhsing


### PR DESCRIPTION
As reported on StackOverflow:
https://stackoverflow.com/questions/57636747/how-to-perform-assert-has-calls-for-a-getitem-call

The following code:

```
from unittest.mock import MagicMock, call
mm = MagicMock()
mm().foo()['bar']
print(mm.mock_calls)
```
would output:

`[call(), call().foo(), call().foo().__getitem__('bar')]`

But trying to use that list with:

`mm.assert_has_calls([call(), call().foo(), call().foo().__getitem__('bar')])`

would result in:

`TypeError: tuple indices must be integers or slices, not str`

This fix now makes `unittest.mock._Call.__getattribute__` raise an `AttributeError` when the given attribute name is `'__getitem__'` so that `__getitem__` can get the same chaining mechanism provided by the `__getattr__` method.

<!-- issue-number: [bpo-37972](https://bugs.python.org/issue37972) -->
https://bugs.python.org/issue37972
<!-- /issue-number -->
