### PR TITLE
bpo-8425: Set inplace difference fash path for large complement sets

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-29-01-55-38.bpo-8425.FTq4A8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-29-01-55-38.bpo-8425.FTq4A8.rst
@@ -1,0 +1,3 @@
+Optimize set difference_update for the case when the other set is much
+larger than the base set.  (Suggested by Evgeny Kapun with code contributed
+by Michele Orrù).


### PR DESCRIPTION


<!-- issue-number: [bpo-8425](https://bugs.python.org/issue8425) -->
https://bugs.python.org/issue8425
<!-- /issue-number -->
