### PR TITLE
bpo-37587: _json: use _PyUnicodeWriter when scanning string

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-08-29-18-48-48.bpo-37587.N7TGTC.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-29-18-48-48.bpo-37587.N7TGTC.rst
@@ -1,2 +1,2 @@
-``_json.scanstring`` is now up to 4x faster when there are many backslash
+``_json.scanstring`` is now up to 3x faster when there are many backslash
 escaped characters in the JSON string.

--- a/Misc/NEWS.d/next/Library/2019-08-29-18-48-48.bpo-37587.N7TGTC.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-29-18-48-48.bpo-37587.N7TGTC.rst
@@ -1,2 +1,2 @@
-Use ``_PyUnicodeWriter`` instead of list of unicode chunks in
-``_json.scanstring``. Decoding long non-ASCII string is up to 4x faster.
+``_json.scanstring`` is now up to 4x faster when there are many backslash
+escaped characters in the JSON string.

--- a/Misc/NEWS.d/next/Library/2019-08-29-18-48-48.bpo-37587.N7TGTC.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-29-18-48-48.bpo-37587.N7TGTC.rst
@@ -1,0 +1,2 @@
+Use ``_PyUnicodeWriter`` instead of list of unicode chunks in
+``_json.scanstring``. Decoding long non-ASCII string is up to 4x faster.


### PR DESCRIPTION
```
$ ./python -m pyperf compare_to before.json patched.json
short-ascii: Mean +- std dev: [before] 23.4 ms +- 0.3 ms -> [patched] 23.8 ms +- 0.1 ms: 1.02x slower (+2%)
long-no-ascii: Mean +- std dev: [before] 47.1 us +- 0.2 us -> [patched] 14.1 us +- 0.2 us: 3.34x faster (-70%)
```

<!-- issue-number: [bpo-37587](https://bugs.python.org/issue37587) -->
https://bugs.python.org/issue37587
<!-- /issue-number -->
