### PR TITLE
bpo-37979: Add alternative to fromisoformat in documentation

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -857,7 +857,9 @@ Other constructors, all class methods:
   .. caution::
 
     This does not support parsing arbitrary ISO 8601 strings - it is only intended
-    as the inverse operation of :meth:`datetime.isoformat`.
+    as the inverse operation of :meth:`datetime.isoformat`. A more full-featured
+    ISO 8601 parser, ``dateutil.parser.isoparse`` is available in the third-party package
+    `dateutil <https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse>`_.
 
   .. versionadded:: 3.7
 

--- a/Misc/NEWS.d/next/Documentation/2019-08-29-10-40-05.bpo-37979.TAUx_E.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-08-29-10-40-05.bpo-37979.TAUx_E.rst
@@ -1,0 +1,2 @@
+Added a link to dateutil.parser.isoparse in the datetime.fromisoformat
+documentation. Patch by Paul Ganssle


### PR DESCRIPTION
Adds a link to `dateutil.parser.isoparse` in the documentation.

It would be nice to set up intersphinx for things like this, but I think we can leave that for a separate PR.

CC: @pitrou 

[bpo-37979](https://bugs.python.org/issue37979)

<!-- issue-number: [bpo-37979](https://bugs.python.org/issue37979) -->
https://bugs.python.org/issue37979
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou