### PR TITLE
bpo-37982: add a `--minify` flag to json.tool

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -1,4 +1,4 @@
-r"""Command-line tool to validate and pretty-print JSON
+r"""Command-line tool to validate, minify, and pretty-print JSON.
 
 Usage::
 
@@ -18,7 +18,7 @@ import sys
 def main():
     prog = 'python -m json.tool'
     description = ('A simple command line interface for json module '
-                   'to validate and pretty-print JSON objects.')
+                   'to validate, minify, and pretty-print JSON objects.')
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('infile', nargs='?', type=argparse.FileType(),
                         help='a JSON file to be validated or pretty-printed',
@@ -30,12 +30,19 @@ def main():
                         help='sort the output of dictionaries alphabetically by key')
     parser.add_argument('--json-lines', action='store_true', default=False,
                         help='parse input using the jsonlines format')
+    parser.add_argument('--minify', action='store_true', default=False,
+                        help='output a compact (minified) representation')
     options = parser.parse_args()
 
     infile = options.infile
     outfile = options.outfile
     sort_keys = options.sort_keys
     json_lines = options.json_lines
+    if options.minify:
+        indent = None
+        separators = (',', ':')
+    else:
+        indent, separators = 4, None
     with infile, outfile:
         try:
             if json_lines:
@@ -43,8 +50,10 @@ def main():
             else:
                 objs = (json.load(infile), )
             for obj in objs:
-                json.dump(obj, outfile, sort_keys=sort_keys, indent=4)
-                outfile.write('\n')
+                json.dump(obj, outfile, sort_keys=sort_keys,
+                          indent=indent, separators=separators)
+                if not options.minify:
+                    outfile.write('\n')
         except ValueError as e:
             raise SystemExit(e)
 

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -82,6 +82,8 @@ class TestTool(unittest.TestCase):
     }
     """)
 
+    minify_expect = """[["blorpie"],["whoops"],[],"d-shtaeou","d-nthiouh","i-vhbjkhnth",{"nifty":87},{"field":"yes","morefield":false}]"""
+
     def test_stdin_stdout(self):
         args = sys.executable, '-m', 'json.tool'
         with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
@@ -133,4 +135,11 @@ class TestTool(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(out.splitlines(),
                          self.expect_without_sort_keys.encode().splitlines())
+        self.assertEqual(err, b'')
+
+    def test_minify_flag(self):
+        infile = self._create_infile()
+        rc, out, err = assert_python_ok('-m', 'json.tool', '--minify', '--sort-keys', infile)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, self.minify_expect.encode())
         self.assertEqual(err, b'')

--- a/Misc/NEWS.d/next/Library/2019-08-29-15-31-13.bpo-37982.NA1aDV.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-29-15-31-13.bpo-37982.NA1aDV.rst
@@ -1,0 +1,1 @@
+Add a --minify command-line argument to json.tool for minifying JSON.


### PR DESCRIPTION
Adds a corresponding test; passes `./python.exe -m unittest Lib.test.test_json.test_tool`


<!-- issue-number: [bpo-37982](https://bugs.python.org/issue37982) -->
https://bugs.python.org/issue37982
<!-- /issue-number -->
