### PR TITLE
bpo-37834: Prevent shutil.rmtree exception

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -544,7 +544,7 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
                          ignore_dangling_symlinks=ignore_dangling_symlinks,
                          dirs_exist_ok=dirs_exist_ok)
 
-if hasattr(stat, 'FILE_ATTRIBUTE_REPARSE_POINT'):
+if hasattr(os.stat_result, 'st_file_attributes'):
     # Special handling for directory junctions to make them behave like
     # symlinks for shutil.rmtree, since in general they do not appear as
     # regular links.

--- a/Misc/NEWS.d/next/Library/2019-08-29-16-41-36.bpo-37834.FThnsh.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-29-16-41-36.bpo-37834.FThnsh.rst
@@ -1,0 +1,2 @@
+Prevent shutil.rmtree exception when built on non-Windows system without fd
+system call support, like older versions of macOS.


### PR DESCRIPTION
when built on non-Windows system without fd system call support,
like older versions of macOS.


<!-- issue-number: [bpo-37834](https://bugs.python.org/issue37834) -->
https://bugs.python.org/issue37834
<!-- /issue-number -->
