### PR TITLE
bpo-15999: Always pass bool instead of int to socket.setblocking().

### DIFF
--- a/Doc/howto/sockets.rst
+++ b/Doc/howto/sockets.rst
@@ -317,7 +317,7 @@ know about the mechanics of using sockets. You'll still use the same calls, in
 much the same ways. It's just that, if you do it right, your app will be almost
 inside-out.
 
-In Python, you use ``socket.setblocking(0)`` to make it non-blocking. In C, it's
+In Python, you use ``socket.setblocking(False)`` to make it non-blocking. In C, it's
 more complex, (for one thing, you'll need to choose between the BSD flavor
 ``O_NONBLOCK`` and the almost indistinguishable Posix flavor ``O_NDELAY``, which
 is completely different from ``TCP_NODELAY``), but it's the exact same idea. You

--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -228,7 +228,7 @@ class dispatcher:
         if sock:
             # Set to nonblocking just to make sure for cases where we
             # get a socket from a blocking source.
-            sock.setblocking(0)
+            sock.setblocking(False)
             self.set_socket(sock, map)
             self.connected = True
             # The constructor no longer requires that the socket
@@ -280,7 +280,7 @@ class dispatcher:
     def create_socket(self, family=socket.AF_INET, type=socket.SOCK_STREAM):
         self.family_and_type = family, type
         sock = socket.socket(family, type)
-        sock.setblocking(0)
+        sock.setblocking(False)
         self.set_socket(sock)
 
     def set_socket(self, sock, map=None):

--- a/Lib/test/test_asyncio/functional.py
+++ b/Lib/test/test_asyncio/functional.py
@@ -225,7 +225,7 @@ class TestThreadedServer(SocketThread):
     def run(self):
         try:
             with self._sock:
-                self._sock.setblocking(0)
+                self._sock.setblocking(False)
                 self._run()
         finally:
             self._s1.close()

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4597,7 +4597,7 @@ class NonBlockingTCPTests(ThreadedTCPSocketTest):
 
     def testAccept(self):
         # Testing non-blocking accept
-        self.serv.setblocking(0)
+        self.serv.setblocking(False)
 
         # connect() didn't start: non-blocking accept() fails
         start_time = time.monotonic()
@@ -4628,7 +4628,7 @@ class NonBlockingTCPTests(ThreadedTCPSocketTest):
         # Testing non-blocking recv
         conn, addr = self.serv.accept()
         self.addCleanup(conn.close)
-        conn.setblocking(0)
+        conn.setblocking(False)
 
         # the server didn't send data yet: non-blocking recv() fails
         with self.assertRaises(BlockingIOError):
@@ -5698,15 +5698,15 @@ class NonblockConstantTest(unittest.TestCase):
         with socket.socket(socket.AF_INET,
                            socket.SOCK_STREAM | socket.SOCK_NONBLOCK) as s:
             self.checkNonblock(s)
-            s.setblocking(1)
+            s.setblocking(True)
             self.checkNonblock(s, nonblock=False)
-            s.setblocking(0)
+            s.setblocking(False)
             self.checkNonblock(s)
             s.settimeout(None)
             self.checkNonblock(s, nonblock=False)
             s.settimeout(2.0)
             self.checkNonblock(s, timeout=2.0)
-            s.setblocking(1)
+            s.setblocking(True)
             self.checkNonblock(s, nonblock=False)
         # defaulttimeout
         t = socket.getdefaulttimeout()

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2209,7 +2209,7 @@ class ThreadedEchoServer(threading.Thread):
             self.running = False
             self.sock = connsock
             self.addr = addr
-            self.sock.setblocking(1)
+            self.sock.setblocking(True)
             self.sslconn = None
             threading.Thread.__init__(self)
             self.daemon = True
@@ -3255,7 +3255,7 @@ class ThreadedTests(unittest.TestCase):
         wrapped = False
         with server:
             s = socket.socket()
-            s.setblocking(1)
+            s.setblocking(True)
             s.connect((HOST, server.port))
             if support.verbose:
                 sys.stdout.write("\n")

--- a/Lib/test/test_timeout.py
+++ b/Lib/test/test_timeout.py
@@ -79,24 +79,24 @@ class CreationTestCase(unittest.TestCase):
     def testTimeoutThenBlocking(self):
         # Test settimeout() followed by setblocking()
         self.sock.settimeout(10)
-        self.sock.setblocking(1)
+        self.sock.setblocking(True)
         self.assertEqual(self.sock.gettimeout(), None)
-        self.sock.setblocking(0)
+        self.sock.setblocking(False)
         self.assertEqual(self.sock.gettimeout(), 0.0)
 
         self.sock.settimeout(10)
-        self.sock.setblocking(0)
+        self.sock.setblocking(False)
         self.assertEqual(self.sock.gettimeout(), 0.0)
-        self.sock.setblocking(1)
+        self.sock.setblocking(True)
         self.assertEqual(self.sock.gettimeout(), None)
 
     def testBlockingThenTimeout(self):
         # Test setblocking() followed by settimeout()
-        self.sock.setblocking(0)
+        self.sock.setblocking(False)
         self.sock.settimeout(1)
         self.assertEqual(self.sock.gettimeout(), 1)
 
-        self.sock.setblocking(1)
+        self.sock.setblocking(True)
         self.sock.settimeout(1)
         self.assertEqual(self.sock.gettimeout(), 1)
 

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -146,7 +146,7 @@ recvfrom_into(buffer[, nbytes, [, flags])\n\
 sendall(data[, flags]) -- send all data\n\
 send(data[, flags]) -- send data, may not send all of it\n\
 sendto(data[, flags], addr) -- send data to a given address\n\
-setblocking(0 | 1) -- set or clear the blocking I/O flag\n\
+setblocking(bool) -- set or clear the blocking I/O flag\n\
 getblocking() -- return True if socket is blocking, False if non-blocking\n\
 setsockopt(level, optname, value[, optlen]) -- set socket options\n\
 settimeout(None | float) -- set or clear the timeout\n\


### PR DESCRIPTION


<!-- issue-number: [bpo-15999](https://bugs.python.org/issue15999) -->
https://bugs.python.org/issue15999
<!-- /issue-number -->
