### PR TITLE
[3.8] bpo-37990: fix gc stats (GH-15626)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-08-31-09-22-33.bpo-37990.WDY2f-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-08-31-09-22-33.bpo-37990.WDY2f-.rst
@@ -1,0 +1,2 @@
+Fix elapsed time in gc stats was not printed correctly.  This bug was
+a regression in 3.8b4.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1115,8 +1115,9 @@ collect(struct _gc_runtime_state *state, int generation,
     }
     if (state->debug & DEBUG_STATS) {
         double d = _PyTime_AsSecondsDouble(_PyTime_GetMonotonicClock() - t1);
-        PySys_FormatStderr(
-            "gc: done, %zd unreachable, %zd uncollectable, %.4fs elapsed\n",
+        PySys_WriteStderr(
+            "gc: done, %" PY_FORMAT_SIZE_T "d unreachable, "
+            "%" PY_FORMAT_SIZE_T "d uncollectable, %.4fs elapsed\n",
             n+m, n, d);
     }
 


### PR DESCRIPTION
(cherry picked from commit 013e52f)


<!-- issue-number: [bpo-37990](https://bugs.python.org/issue37990) -->
https://bugs.python.org/issue37990
<!-- /issue-number -->
