### PR TITLE
bpo-37995: Add an option to ast.dump() to produce a multiline output.

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -330,9 +330,13 @@ and classes for traversing abstract syntax trees:
    *include_attributes* can be set to true.
 
    If *indent* is a non-negative integer or string, then the tree will be
-   pretty-printed with that indent level.
+   pretty-printed with that indent level.  An indent level
+   of 0, negative, or ``""`` will only insert newlines.  ``None`` (the default)
+   selects the single line representation. Using a positive integer indent
+   indents that many spaces per level.  If *indent* is a string (such as ``"\t"``),
+   that string is used to indent each level.
 
-   .. versionchange:: 3.9
+   .. versionchanged:: 3.9
       Added the *indent* option.
 
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -319,7 +319,7 @@ and classes for traversing abstract syntax trees:
       node = YourTransformer().visit(node)
 
 
-.. function:: dump(node, annotate_fields=True, include_attributes=False)
+.. function:: dump(node, annotate_fields=True, include_attributes=False, *, indent=None)
 
    Return a formatted dump of the tree in *node*.  This is mainly useful for
    debugging purposes.  If *annotate_fields* is true (by default),
@@ -328,6 +328,13 @@ and classes for traversing abstract syntax trees:
    omitting unambiguous field names.  Attributes such as line
    numbers and column offsets are not dumped by default.  If this is wanted,
    *include_attributes* can be set to true.
+
+   If *indent* is a non-negative integer or string, then the tree will be
+   pretty-printed with that indent level.
+
+   .. versionchange:: 3.9
+      Added the *indent* option.
+
 
 .. seealso::
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -109,6 +109,14 @@ New Modules
 Improved Modules
 ================
 
+ast
+---
+
+Added the *indent* option to :func:`~ast.dump` which allows it to produce a
+multiline indented output.
+(Contributed by Serhiy Storchaka in :issue:`37995`.)
+
+
 threading
 ---------
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -96,7 +96,7 @@ def literal_eval(node_or_string):
     return _convert(node_or_string)
 
 
-def dump(node, annotate_fields=True, include_attributes=False, indent=None):
+def dump(node, annotate_fields=True, include_attributes=False, *, indent=None):
     """
     Return a formatted dump of the tree in node.  This is mainly useful for
     debugging purposes.  If annotate_fields is true (by default),

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -106,7 +106,7 @@ def dump(node, annotate_fields=True, include_attributes=False, indent=None):
     numbers and column offsets are not dumped by default.  If this is wanted,
     include_attributes can be set to true.  If indent is a non-negative
     integer or string, then the tree will be pretty-printed with that indent
-    level.
+    level. None (the default) selects the single line representation.
     """
     def _format(node, level=0):
         if indent is not None:

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -652,16 +652,10 @@ Module(
    body=[
       Expr(
          value=Call(
-            func=Name(
-               id='spam',
-               ctx=Load()),
+            func=Name(id='spam', ctx=Load()),
             args=[
-               Name(
-                  id='eggs',
-                  ctx=Load()),
-               Constant(
-                  value='and cheese',
-                  kind=None)],
+               Name(id='eggs', ctx=Load()),
+               Constant(value='and cheese', kind=None)],
             keywords=[]))],
    type_ignores=[])""")
         self.assertEqual(ast.dump(node, annotate_fields=False, indent='\t'), """\
@@ -669,16 +663,10 @@ Module(
 \t[
 \t\tExpr(
 \t\t\tCall(
-\t\t\t\tName(
-\t\t\t\t\t'spam',
-\t\t\t\t\tLoad()),
+\t\t\t\tName('spam', Load()),
 \t\t\t\t[
-\t\t\t\t\tName(
-\t\t\t\t\t\t'eggs',
-\t\t\t\t\t\tLoad()),
-\t\t\t\t\tConstant(
-\t\t\t\t\t\t'and cheese',
-\t\t\t\t\t\tNone)],
+\t\t\t\t\tName('eggs', Load()),
+\t\t\t\t\tConstant('and cheese', None)],
 \t\t\t\t[]))],
 \t[])""")
         self.assertEqual(ast.dump(node, include_attributes=True, indent=3), """\

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -645,6 +645,80 @@ class ASTHelpers_Test(unittest.TestCase):
             "lineno=1, col_offset=0, end_lineno=1, end_col_offset=24)], type_ignores=[])"
         )
 
+    def test_dump_indent(self):
+        node = ast.parse('spam(eggs, "and cheese")')
+        self.assertEqual(ast.dump(node, indent=3), """\
+Module(
+   body=[
+      Expr(
+         value=Call(
+            func=Name(
+               id='spam',
+               ctx=Load()),
+            args=[
+               Name(
+                  id='eggs',
+                  ctx=Load()),
+               Constant(
+                  value='and cheese',
+                  kind=None)],
+            keywords=[]))],
+   type_ignores=[])""")
+        self.assertEqual(ast.dump(node, annotate_fields=False, indent='\t'), """\
+Module(
+\t[
+\t\tExpr(
+\t\t\tCall(
+\t\t\t\tName(
+\t\t\t\t\t'spam',
+\t\t\t\t\tLoad()),
+\t\t\t\t[
+\t\t\t\t\tName(
+\t\t\t\t\t\t'eggs',
+\t\t\t\t\t\tLoad()),
+\t\t\t\t\tConstant(
+\t\t\t\t\t\t'and cheese',
+\t\t\t\t\t\tNone)],
+\t\t\t\t[]))],
+\t[])""")
+        self.assertEqual(ast.dump(node, include_attributes=True, indent=3), """\
+Module(
+   body=[
+      Expr(
+         value=Call(
+            func=Name(
+               id='spam',
+               ctx=Load(),
+               lineno=1,
+               col_offset=0,
+               end_lineno=1,
+               end_col_offset=4),
+            args=[
+               Name(
+                  id='eggs',
+                  ctx=Load(),
+                  lineno=1,
+                  col_offset=5,
+                  end_lineno=1,
+                  end_col_offset=9),
+               Constant(
+                  value='and cheese',
+                  kind=None,
+                  lineno=1,
+                  col_offset=11,
+                  end_lineno=1,
+                  end_col_offset=23)],
+            keywords=[],
+            lineno=1,
+            col_offset=0,
+            end_lineno=1,
+            end_col_offset=24),
+         lineno=1,
+         col_offset=0,
+         end_lineno=1,
+         end_col_offset=24)],
+   type_ignores=[])""")
+
     def test_dump_incomplete(self):
         node = ast.Raise(lineno=3, col_offset=4)
         self.assertEqual(ast.dump(node),

--- a/Misc/NEWS.d/next/Library/2019-08-31-13-36-09.bpo-37995.rS8HzT.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-31-13-36-09.bpo-37995.rS8HzT.rst
@@ -1,0 +1,2 @@
+Added the *indent* option to :func:`ast.dump` which allows it to produce a
+multiline indented output.


### PR DESCRIPTION


<!-- issue-number: [bpo-37995](https://bugs.python.org/issue37995) -->
https://bugs.python.org/issue37995
<!-- /issue-number -->
