### PR TITLE
bpo-37702: Fix SSL's certificate-store leak on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-07-29-16-49-31.bpo-37702.Lj2f5e.rst
+++ b/Misc/NEWS.d/next/Windows/2019-07-29-16-49-31.bpo-37702.Lj2f5e.rst
@@ -1,0 +1,2 @@
+Fix memory leak on Windows in creating an SSLContext object or
+running urllib.request.urlopen('https://...').

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5581,6 +5581,7 @@ ssl_collect_certificates(const char *store_name)
             if (result) {
                 ++storesAdded;
             }
+            CertCloseStore(hSystemStore, 0);  /* flag must be 0 */
         }
     }
     if (storesAdded == 0) {


### PR DESCRIPTION
ssl_collect_certificates function in _ssl.c has a memory leak.
Calling CertOpenStore() and CertAddStoreToCollection(), a store's refcount gets incremented by 2.
But CertCloseStore() is called only once and the refcount leaves 1.

Even after this fix, CertEnumCertificatesInStore() can be called successfully.

Closing each store with CERT_CLOSE_STORE_CHECK_FLAG helped me to confirm the above.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37702](https://bugs.python.org/issue37702) -->
https://bugs.python.org/issue37702
<!-- /issue-number -->
