### PR TITLE
bpo-35771: IDLE: Fix and optimize flaky tool-tip hover delay tests

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,9 @@ Released on 2019-10-20?
 ======================================
 
 
+bpo-35771: To avoid occasional spurious test_idle failures on slower
+machines, increase the ``hover_delay`` in test_tooltip.
+
 bpo-37824: Properly handle user input warnings in IDLE shell.
 Cease turning SyntaxWarnings into SyntaxErrors.
 

--- a/Lib/idlelib/idle_test/test_tooltip.py
+++ b/Lib/idlelib/idle_test/test_tooltip.py
@@ -1,26 +1,30 @@
+from functools import wraps
 from idlelib.tooltip import TooltipBase, Hovertip
 from test.support import requires
-requires('gui')
-
-from functools import wraps
 import time
 from tkinter import Button, Tk, Toplevel
 import unittest
+
+
+requires('gui')
 
 
 def setUpModule():
     global root
     root = Tk()
 
+
 def root_update():
     global root
     root.update()
+
 
 def tearDownModule():
     global root
     root.update_idletasks()
     root.destroy()
     del root
+
 
 def add_call_counting(func):
     @wraps(func)

--- a/Lib/idlelib/idle_test/test_tooltip.py
+++ b/Lib/idlelib/idle_test/test_tooltip.py
@@ -108,7 +108,7 @@ class HovertipTest(unittest.TestCase):
         # Run multiple tests requiring an actual delay simultaneously.
 
         # Test #1: A hover tip with a non-zero delay appears after the delay.
-        tooltip1 = Hovertip(self.button, 'ToolTip text', hover_delay=50)
+        tooltip1 = Hovertip(self.button, 'ToolTip text', hover_delay=100)
         self.addCleanup(tooltip1.hidetip)
         tooltip1.showtip = add_call_counting(tooltip1.showtip)
         root_update()
@@ -120,7 +120,7 @@ class HovertipTest(unittest.TestCase):
         # Test #2: A hover tip with a non-zero delay doesn't appear when
         # the mouse stops hovering over the base widget before the delay
         # expires.
-        tooltip2 = Hovertip(self.button, 'ToolTip text', hover_delay=50)
+        tooltip2 = Hovertip(self.button, 'ToolTip text', hover_delay=100)
         self.addCleanup(tooltip2.hidetip)
         tooltip2.showtip = add_call_counting(tooltip2.showtip)
         root_update()
@@ -129,7 +129,7 @@ class HovertipTest(unittest.TestCase):
         self.button.event_generate('<Leave>', x=0, y=0)
         root_update()
 
-        time.sleep(0.1)
+        time.sleep(0.15)
         root_update()
 
         # Test #1 assertions.

--- a/Lib/idlelib/idle_test/test_tooltip.py
+++ b/Lib/idlelib/idle_test/test_tooltip.py
@@ -65,22 +65,25 @@ class HovertipTest(unittest.TestCase):
     def setUp(self):
         self.top, self.button = _make_top_and_button(self)
 
+    def is_tipwindow_shown(self, tooltip):
+        return tooltip.tipwindow and tooltip.tipwindow.winfo_viewable()
+
     def test_showtip(self):
         tooltip = Hovertip(self.button, 'ToolTip text')
         self.addCleanup(tooltip.hidetip)
-        self.assertFalse(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertFalse(self.is_tipwindow_shown(tooltip))
         tooltip.showtip()
-        self.assertTrue(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertTrue(self.is_tipwindow_shown(tooltip))
 
     def test_showtip_twice(self):
         tooltip = Hovertip(self.button, 'ToolTip text')
         self.addCleanup(tooltip.hidetip)
-        self.assertFalse(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertFalse(self.is_tipwindow_shown(tooltip))
         tooltip.showtip()
-        self.assertTrue(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertTrue(self.is_tipwindow_shown(tooltip))
         orig_tipwindow = tooltip.tipwindow
         tooltip.showtip()
-        self.assertTrue(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertTrue(self.is_tipwindow_shown(tooltip))
         self.assertIs(tooltip.tipwindow, orig_tipwindow)
 
     def test_hidetip(self):
@@ -88,17 +91,17 @@ class HovertipTest(unittest.TestCase):
         self.addCleanup(tooltip.hidetip)
         tooltip.showtip()
         tooltip.hidetip()
-        self.assertFalse(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertFalse(self.is_tipwindow_shown(tooltip))
 
     def test_showtip_on_mouse_enter_no_delay(self):
         tooltip = Hovertip(self.button, 'ToolTip text', hover_delay=None)
         self.addCleanup(tooltip.hidetip)
         tooltip.showtip = add_call_counting(tooltip.showtip)
         root_update()
-        self.assertFalse(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertFalse(self.is_tipwindow_shown(tooltip))
         self.button.event_generate('<Enter>', x=0, y=0)
         root_update()
-        self.assertTrue(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertTrue(self.is_tipwindow_shown(tooltip))
         self.assertGreater(len(tooltip.showtip.call_args_list), 0)
 
     def test_showtip_on_mouse_enter_hover_delay(self):
@@ -106,13 +109,13 @@ class HovertipTest(unittest.TestCase):
         self.addCleanup(tooltip.hidetip)
         tooltip.showtip = add_call_counting(tooltip.showtip)
         root_update()
-        self.assertFalse(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertFalse(self.is_tipwindow_shown(tooltip))
         self.button.event_generate('<Enter>', x=0, y=0)
         root_update()
-        self.assertFalse(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertFalse(self.is_tipwindow_shown(tooltip))
         time.sleep(0.1)
         root_update()
-        self.assertTrue(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertTrue(self.is_tipwindow_shown(tooltip))
         self.assertGreater(len(tooltip.showtip.call_args_list), 0)
 
     def test_hidetip_on_mouse_leave(self):
@@ -124,7 +127,7 @@ class HovertipTest(unittest.TestCase):
         root_update()
         self.button.event_generate('<Leave>', x=0, y=0)
         root_update()
-        self.assertFalse(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertFalse(self.is_tipwindow_shown(tooltip))
         self.assertGreater(len(tooltip.showtip.call_args_list), 0)
 
     def test_dont_show_on_mouse_leave_before_delay(self):
@@ -138,7 +141,7 @@ class HovertipTest(unittest.TestCase):
         root_update()
         time.sleep(0.1)
         root_update()
-        self.assertFalse(tooltip.tipwindow and tooltip.tipwindow.winfo_viewable())
+        self.assertFalse(self.is_tipwindow_shown(tooltip))
         self.assertEqual(tooltip.showtip.call_args_list, [])
 
 

--- a/Lib/idlelib/idle_test/test_tooltip.py
+++ b/Lib/idlelib/idle_test/test_tooltip.py
@@ -1,23 +1,23 @@
-from functools import wraps
+"""Test tooltip, coverage 100%.
+
+Coverage is 100% after excluding 6 lines with "# pragma: no cover".
+They involve TclErrors that either should or should not happen in a
+particular situation, and which are 'pass'ed if they do.
+"""
+
 from idlelib.tooltip import TooltipBase, Hovertip
 from test.support import requires
+requires('gui')
+
+from functools import wraps
 import time
 from tkinter import Button, Tk, Toplevel
 import unittest
 
 
-requires('gui')
-
-
 def setUpModule():
     global root
     root = Tk()
-
-
-def root_update():
-    global root
-    root.update()
-
 
 def tearDownModule():
     global root
@@ -101,10 +101,10 @@ class HovertipTest(unittest.TestCase):
         tooltip = Hovertip(self.button, 'ToolTip text', hover_delay=None)
         self.addCleanup(tooltip.hidetip)
         tooltip.showtip = add_call_counting(tooltip.showtip)
-        root_update()
+        root.update()
         self.assertFalse(self.is_tipwindow_shown(tooltip))
         self.button.event_generate('<Enter>', x=0, y=0)
-        root_update()
+        root.update()
         self.assertTrue(self.is_tipwindow_shown(tooltip))
         self.assertGreater(len(tooltip.showtip.call_args_list), 0)
 
@@ -115,10 +115,10 @@ class HovertipTest(unittest.TestCase):
         tooltip1 = Hovertip(self.button, 'ToolTip text', hover_delay=100)
         self.addCleanup(tooltip1.hidetip)
         tooltip1.showtip = add_call_counting(tooltip1.showtip)
-        root_update()
+        root.update()
         self.assertFalse(self.is_tipwindow_shown(tooltip1))
         self.button.event_generate('<Enter>', x=0, y=0)
-        root_update()
+        root.update()
         self.assertFalse(self.is_tipwindow_shown(tooltip1))
 
         # Test #2: A hover tip with a non-zero delay doesn't appear when
@@ -127,14 +127,14 @@ class HovertipTest(unittest.TestCase):
         tooltip2 = Hovertip(self.button, 'ToolTip text', hover_delay=100)
         self.addCleanup(tooltip2.hidetip)
         tooltip2.showtip = add_call_counting(tooltip2.showtip)
-        root_update()
+        root.update()
         self.button.event_generate('<Enter>', x=0, y=0)
-        root_update()
+        root.update()
         self.button.event_generate('<Leave>', x=0, y=0)
-        root_update()
+        root.update()
 
         time.sleep(0.15)
-        root_update()
+        root.update()
 
         # Test #1 assertions.
         self.assertTrue(self.is_tipwindow_shown(tooltip1))
@@ -148,11 +148,11 @@ class HovertipTest(unittest.TestCase):
         tooltip = Hovertip(self.button, 'ToolTip text', hover_delay=None)
         self.addCleanup(tooltip.hidetip)
         tooltip.showtip = add_call_counting(tooltip.showtip)
-        root_update()
+        root.update()
         self.button.event_generate('<Enter>', x=0, y=0)
-        root_update()
+        root.update()
         self.button.event_generate('<Leave>', x=0, y=0)
-        root_update()
+        root.update()
         self.assertFalse(self.is_tipwindow_shown(tooltip))
         self.assertGreater(len(tooltip.showtip.call_args_list), 0)
 

--- a/Lib/idlelib/tooltip.py
+++ b/Lib/idlelib/tooltip.py
@@ -75,7 +75,7 @@ class TooltipBase(object):
         if tw:
             try:
                 tw.destroy()
-            except TclError:
+            except TclError:  # pragma: no cover
                 pass
 
 
@@ -103,8 +103,8 @@ class OnHoverTooltipBase(TooltipBase):
     def __del__(self):
         try:
             self.anchor_widget.unbind("<Enter>", self._id1)
-            self.anchor_widget.unbind("<Leave>", self._id2)
-            self.anchor_widget.unbind("<Button>", self._id3)
+            self.anchor_widget.unbind("<Leave>", self._id2)  # pragma: no cover
+            self.anchor_widget.unbind("<Button>", self._id3) # pragma: no cover
         except TclError:
             pass
         super(OnHoverTooltipBase, self).__del__()
@@ -137,7 +137,7 @@ class OnHoverTooltipBase(TooltipBase):
         """hide the tooltip"""
         try:
             self.unschedule()
-        except TclError:
+        except TclError:  # pragma: no cover
             pass
         super(OnHoverTooltipBase, self).hidetip()
 

--- a/Misc/NEWS.d/next/IDLE/2019-09-01-10-22-55.bpo-35771.tdbmbP.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-09-01-10-22-55.bpo-35771.tdbmbP.rst
@@ -1,2 +1,2 @@
-Increase the ``hover_delay`` in IDLE's test_tooltip, and run both tests
-waiting for a delay to expire simultaneously, to reduce total run time.
+To avoid occasional spurious test_idle failures on slower machines, 
+increase the ``hover_delay`` in test_tooltip.

--- a/Misc/NEWS.d/next/IDLE/2019-09-01-10-22-55.bpo-35771.tdbmbP.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-09-01-10-22-55.bpo-35771.tdbmbP.rst
@@ -1,0 +1,2 @@
+Increase the ``hover_delay`` in IDLE's test_tooltip, and run both tests
+waiting for a delay to expire simultaneously, to reduce total run time.


### PR DESCRIPTION
A 50ms delay will often causes failures on slower machines.

This PR is an alternative to PR GH-14926. In this PR, both of the tests with a delay have been merged into one, to avoid multiple `time.sleep()` calls, reducing the overall run time.

For reference, the total run time for `test_idle` on my machine is about 7.5 seconds. 0.15 seconds, which is the delay time added by these tests, is 2% of that.

<!-- issue-number: [bpo-35771](https://bugs.python.org/issue35771) -->
https://bugs.python.org/issue35771
<!-- /issue-number -->
