### PR TITLE
bpo-36946:Fix possible signed integer overflow when handling slices

### DIFF
--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -150,6 +150,10 @@ class ListTest(list_tests.CommonTest):
             a[:] = data
             self.assertEqual(list(it), [])
 
+    def test_step_overflow(self):
+        a = [0, 1, 2, 3, 4]
+        self.assertEqual(a[3::sys.maxsize], [3])
+
     def test_no_comdat_folding(self):
         # Issue 8847: In the PGO build, the MSVC linker's COMDAT folding
         # optimization causes failures in code that relies on distinct

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -152,6 +152,7 @@ class ListTest(list_tests.CommonTest):
 
     def test_step_overflow(self):
         a = [0, 1, 2, 3, 4]
+        a[1::sys.maxsize] = [0]
         self.assertEqual(a[3::sys.maxsize], [3])
 
     def test_no_comdat_folding(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-02-16-17-42.bpo-36946._lAuSR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-02-16-17-42.bpo-36946._lAuSR.rst
@@ -1,0 +1,1 @@
+A complement to fix possible signed integer overflow when handling slices.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-02-16-17-42.bpo-36946._lAuSR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-02-16-17-42.bpo-36946._lAuSR.rst
@@ -1,1 +1,1 @@
-A complement to fix possible signed integer overflow when handling slices.
+Fix possible signed integer overflow when handling slices. Patch by hongweipeng.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5154,7 +5154,8 @@ Pointer_subscript(PyObject *myself, PyObject *item)
         PyObject *np;
         StgDictObject *stgdict, *itemdict;
         PyObject *proto;
-        Py_ssize_t i, len, cur;
+        Py_ssize_t i, len;
+        size_t cur;
 
         /* Since pointers have no length, and we want to apply
            different semantics to negative indices than normal

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2789,7 +2789,8 @@ list_subscript(PyListObject* self, PyObject* item)
         return list_item(self, i);
     }
     else if (PySlice_Check(item)) {
-        Py_ssize_t start, stop, step, slicelength, cur, i;
+        Py_ssize_t start, stop, step, slicelength, i;
+        size_t cur;
         PyObject* result;
         PyObject* it;
         PyObject **src, **dest;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2926,7 +2926,8 @@ list_ass_subscript(PyListObject* self, PyObject* item, PyObject* value)
             /* assign slice */
             PyObject *ins, *seq;
             PyObject **garbage, **seqitems, **selfitems;
-            Py_ssize_t cur, i;
+            Py_ssize_t i;
+            size_t cur;
 
             /* protect against a[::-1] = a */
             if (self == (PyListObject*)value) {


### PR DESCRIPTION
This is a complement to that PR #13375 .

<!-- issue-number: [bpo-36946](https://bugs.python.org/issue36946) -->
https://bugs.python.org/issue36946
<!-- /issue-number -->
