### PR TITLE
Remove some unused defines in multiprocessing.h

### DIFF
--- a/Modules/_multiprocessing/multiprocessing.h
+++ b/Modules/_multiprocessing/multiprocessing.h
@@ -27,14 +27,6 @@
 #    include <semaphore.h>
      typedef sem_t *SEM_HANDLE;
 #  endif
-#  define HANDLE int
-#  define SOCKET int
-#  define BOOL int
-#  define UINT32 uint32_t
-#  define INT32 int32_t
-#  define TRUE 1
-#  define FALSE 0
-#  define INVALID_HANDLE_VALUE (-1)
 #endif
 
 /*

--- a/Modules/_multiprocessing/multiprocessing.h
+++ b/Modules/_multiprocessing/multiprocessing.h
@@ -64,8 +64,6 @@
 #  define T_HANDLE T_POINTER
 #  define F_SEM_HANDLE F_HANDLE
 #  define T_SEM_HANDLE T_HANDLE
-#  define F_DWORD "k"
-#  define T_DWORD T_ULONG
 #else
 #  define F_HANDLE "i"
 #  define T_HANDLE T_INT


### PR DESCRIPTION
It looks like they are unused since 87cf220972c9cb400ddcd577962883dcc5dca51a.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
