### PR TITLE
bpo-38018: increase code coverage for multiprocessing.shared_memory

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3719,6 +3719,30 @@ class _TestSharedMemory(BaseTestCase):
         self.assertLess(same_sms.size, 20*sms.size)  # Size was ignored.
         same_sms.close()
 
+        # Creating Shared Memory Segment with -ve size
+        with self.assertRaises(ValueError):
+            shared_memory.SharedMemory(create=True, size=-2)
+
+        # Attaching Shared Memory Segment without a name
+        with self.assertRaises(ValueError):
+            shared_memory.SharedMemory(create=False)
+
+        # Test if shared memory segment is created properly,
+        # when _make_filename returns an existing shared memory segment name
+        with unittest.mock.patch(
+            'multiprocessing.shared_memory._make_filename') as mock_make_filename:
+
+            names = ['test01_fn', 'test02_fn']
+            mock_make_filename.side_effect = names
+            shm1 = shared_memory.SharedMemory(create=True, size=1)
+            self.addCleanup(shm1.unlink)
+            self.assertEqual(shm1.name, names[0])
+
+            mock_make_filename.side_effect = names
+            shm2 = shared_memory.SharedMemory(create=True, size=1)
+            self.addCleanup(shm2.unlink)
+            self.assertEqual(shm2.name, names[1])
+
         if shared_memory._USE_POSIX:
             # Posix Shared Memory can only be unlinked once.  Here we
             # test an implementation detail that is not observed across

--- a/Misc/NEWS.d/next/Tests/2019-09-03-19-33-10.bpo-38018.zTrMu7.rst
+++ b/Misc/NEWS.d/next/Tests/2019-09-03-19-33-10.bpo-38018.zTrMu7.rst
@@ -1,0 +1,1 @@
+increase code coverage for multiprocessing.shared_memory

--- a/Misc/NEWS.d/next/Tests/2019-09-03-19-33-10.bpo-38018.zTrMu7.rst
+++ b/Misc/NEWS.d/next/Tests/2019-09-03-19-33-10.bpo-38018.zTrMu7.rst
@@ -1,1 +1,1 @@
-increase code coverage for multiprocessing.shared_memory
+Increase code coverage for multiprocessing.shared_memory.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38018](https://bugs.python.org/issue38018) -->
https://bugs.python.org/issue38018
<!-- /issue-number -->
