### PR TITLE
bpo-38059: Using sys.exit() over exit() in inspect.py

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3118,7 +3118,7 @@ def _main():
                                                     type(exc).__name__,
                                                     exc)
         print(msg, file=sys.stderr)
-        exit(2)
+        sys.exit(2)
 
     if has_attrs:
         parts = attrs.split(".")
@@ -3128,7 +3128,7 @@ def _main():
 
     if module.__name__ in sys.builtin_module_names:
         print("Can't get info for builtin modules.", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
 
     if args.details:
         print('Target: {}'.format(target))

--- a/Misc/NEWS.d/next/Library/2019-09-08-11-36-50.bpo-38059.8SA6co.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-08-11-36-50.bpo-38059.8SA6co.rst
@@ -1,0 +1,1 @@
+inspect.py now uses sys.exit() instead of exit()


### PR DESCRIPTION
Constants added by the site module like exit() "should not be used in programs"
https://docs.python.org/3/library/constants.html#exit


<!-- issue-number: [bpo-38059](https://bugs.python.org/issue38059) -->
https://bugs.python.org/issue38059
<!-- /issue-number -->
