### PR TITLE
bpo-38026: fix inspect.getattr_static

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1558,7 +1558,7 @@ def _shadowed_dict(klass):
         except KeyError:
             pass
         else:
-            if not (isinstance(class_dict, types.GetSetDescriptorType) and
+            if not (type(class_dict) is types.GetSetDescriptorType and
                     class_dict.__name__ == "__dict__" and
                     class_dict.__objclass__ is entry):
                 return class_dict
@@ -1580,7 +1580,7 @@ def getattr_static(obj, attr, default=_sentinel):
         klass = type(obj)
         dict_attr = _shadowed_dict(klass)
         if (dict_attr is _sentinel or
-            isinstance(dict_attr, types.MemberDescriptorType)):
+            type(dict_attr) is types.MemberDescriptorType):
             instance_result = _check_instance(obj, attr)
     else:
         klass = obj

--- a/Misc/NEWS.d/next/Library/2019-09-04-20-34-14.bpo-38026.0LLRX-.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-04-20-34-14.bpo-38026.0LLRX-.rst
@@ -1,0 +1,2 @@
+Fixed :func:`inspect.getattr_static` used ``isinstance`` while it should
+avoid dynamic lookup.


### PR DESCRIPTION
It should avoid dynamic lookup including `isinstance`.

This is a regression caused by #5351.

<!-- issue-number: [bpo-38026](https://bugs.python.org/issue38026) -->
https://bugs.python.org/issue38026
<!-- /issue-number -->
