### PR TITLE
Improve clarity of try-return-finally-return

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -388,17 +388,17 @@ example::
      File "<stdin>", line 2, in <module>
    KeyboardInterrupt
 
-A *finally clause* is always executed before leaving the :keyword:`try`
-statement, whether an exception has occurred or not. When an exception has
-occurred in the :keyword:`!try` clause and has not been handled by an
-:keyword:`except` clause (or it has occurred in an :keyword:`!except` or
-:keyword:`!else` clause), it is re-raised after the :keyword:`!finally` clause has
-been executed.  The :keyword:`!finally` clause is also executed penultimately
-when the :keyword:`!try` statement is left via a :keyword:`break`,
-:keyword:`continue` or :keyword:`return` statement (thus a :keyword:`return`
-in a :keyword:`finally` clause will execute before and instead of a
-:keyword:`return` statement in a :keyword:`try` clause). For
-example::
+If a :keyword:`finally` clause is present, the :keyword:`finally` clause will execute as the last task before the :keyword:`try` statement completes. The :keyword:`finally` clause runs whether or not the :keyword:try statement produces an exception. The following points discuss more complex cases when an exception occurs:
+
+* If an exception occurs during execution of the :keyword:`!try` clause, the exception may be handled by an :keyword:`except` clause. In all cases, the exception is re-raised after the :keyword:`!finally` clause has been executed.
+
+* An exception could occur during execution of an :keyword:`!except` or :keyword:`!else` clause. Again, the exception is re-raised after the :keyword:`!finally` clause has been executed.
+
+* If the :keyword:`!try` statement reaches a :keyword:`break`, :keyword:`continue` or :keyword:`return` statement, the :keyword:`finally` clause will execute just prior to the :keyword:`break`, :keyword:`continue` or :keyword:`return` statement's execution.
+
+* If a :keyword:`finally` clause includes a :keyword:`return` statement, the :keyword:`finally` clause's :keyword:`return` statement will execute before, and instead of, the :keyword:`return` statement in a :keyword:`try` clause. 
+
+Forexample::
 
    >>> def bool_return(): -> bool:
    ...     try:

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -392,7 +392,7 @@ A *finally clause* is always executed before leaving the :keyword:`try`
 statement, whether an exception has occurred or not. When an exception has
 occurred in the :keyword:`!try` clause and has not been handled by an
 :keyword:`except` clause (or it has occurred in an :keyword:`!except` or
-:keyword:`!else` clause), it is re-raised after the :keyword:`finally` clause has
+:keyword:`!else` clause), it is re-raised after the :keyword:`!finally` clause has
 been executed.  The :keyword:`!finally` clause is also executed penultimately
 when the :keyword:`!try` statement is left via a :keyword:`break`,
 :keyword:`continue` or :keyword:`return` statement (thus a :keyword:`return`

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -396,7 +396,7 @@ If a :keyword:`finally` clause is present, the :keyword:`finally` clause will ex
 
 * If the :keyword:`!try` statement reaches a :keyword:`break`, :keyword:`continue` or :keyword:`return` statement, the :keyword:`finally` clause will execute just prior to the :keyword:`break`, :keyword:`continue` or :keyword:`return` statement's execution.
 
-* If a :keyword:`finally` clause includes a :keyword:`return` statement, the :keyword:`finally` clause's :keyword:`return` statement will execute before, and instead of, the :keyword:`return` statement in a :keyword:`try` clause. 
+* If a :keyword:`finally` clause includes a :keyword:`return` statement, the :keyword:`finally` clause's :keyword:`return` statement will execute before, and instead of, the :keyword:`return` statement in a :keyword:`try` clause.
 
 Forexample::
 

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -388,7 +388,7 @@ example::
      File "<stdin>", line 2, in <module>
    KeyboardInterrupt
 
-If a :keyword:`finally` clause is present, the :keyword:`finally` clause will execute as the last task before the :keyword:`try` statement completes. The :keyword:`finally` clause runs whether or not the :keyword:try statement produces an exception. The following points discuss more complex cases when an exception occurs:
+If a :keyword:`finally` clause is present, the :keyword:`finally` clause will execute as the last task before the :keyword:`try` statement completes. The :keyword:`finally` clause runs whether or not the :keyword:`try` statement produces an exception. The following points discuss more complex cases when an exception occurs:
 
 * If an exception occurs during execution of the :keyword:`!try` clause, the exception may be handled by an :keyword:`except` clause. In all cases, the exception is re-raised after the :keyword:`!finally` clause has been executed.
 

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -397,7 +397,18 @@ been executed.  The :keyword:`!finally` clause is also executed penultimately
 when the :keyword:`!try` statement is left via a :keyword:`break`,
 :keyword:`continue` or :keyword:`return` statement (thus a :keyword:`return`
 in a :keyword:`finally` clause will execute before and instead of a
-:keyword:`return` statement in a :keyword:`try` clause).
+:keyword:`return` statement in a :keyword:`try` clause). For
+example::
+
+   >>> def bool_return(): -> bool:
+   ...     try:
+   ...         return True
+   ...     finally:
+   ...         return False
+   ...
+   >>> bool_return()
+   False
+
 A more complicated example::
 
    >>> def divide(x, y):

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -393,10 +393,12 @@ statement, whether an exception has occurred or not. When an exception has
 occurred in the :keyword:`!try` clause and has not been handled by an
 :keyword:`except` clause (or it has occurred in an :keyword:`!except` or
 :keyword:`!else` clause), it is re-raised after the :keyword:`finally` clause has
-been executed.  The :keyword:`!finally` clause is also executed "on the way out"
-when any other clause of the :keyword:`!try` statement is left via a
-:keyword:`break`, :keyword:`continue` or :keyword:`return` statement.  A more
-complicated example::
+been executed.  The :keyword:`!finally` clause is also executed penultimately
+when the :keyword:`!try` statement is left via a :keyword:`break`,
+:keyword:`continue` or :keyword:`return` statement (thus a :keyword:`return`
+in a :keyword:`finally` clause will execute before and instead of a 
+:keyword:`return` statement in a :keyword:`try` clause).  
+A more complicated example::
 
    >>> def divide(x, y):
    ...     try:

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -396,8 +396,8 @@ occurred in the :keyword:`!try` clause and has not been handled by an
 been executed.  The :keyword:`!finally` clause is also executed penultimately
 when the :keyword:`!try` statement is left via a :keyword:`break`,
 :keyword:`continue` or :keyword:`return` statement (thus a :keyword:`return`
-in a :keyword:`finally` clause will execute before and instead of a 
-:keyword:`return` statement in a :keyword:`try` clause).  
+in a :keyword:`finally` clause will execute before and instead of a
+:keyword:`return` statement in a :keyword:`try` clause).
 A more complicated example::
 
    >>> def divide(x, y):

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -398,7 +398,7 @@ If a :keyword:`finally` clause is present, the :keyword:`finally` clause will ex
 
 * If a :keyword:`finally` clause includes a :keyword:`return` statement, the :keyword:`finally` clause's :keyword:`return` statement will execute before, and instead of, the :keyword:`return` statement in a :keyword:`try` clause.
 
-Forexample::
+For example::
 
    >>> def bool_return(): -> bool:
    ...     try:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -58,6 +58,7 @@ Jon Anglin
 Michele Angrisano
 Ankur Ankan
 Heidi Annexstad
+David Antonini
 Ramchandra Apte
 Éric Araujo
 Alexandru Ardelean


### PR DESCRIPTION
Clarify execution of try-return-finally-return case.
Per discussion https://discuss.python.org/t/pep-601-forbid-return-break-continue-breaking-out-of-finally
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
