### PR TITLE
bpo-25457: Remove sorting bug in json._iterencode_dict

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -350,7 +350,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             item_separator = _item_separator
         first = True
         if _sort_keys:
-            items = sorted(dct.items())
+            items = sorted(dct.items(), key=lambda k: str(k[0]))
         else:
             items = dct.items()
         for key, value in items:

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -350,7 +350,10 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             item_separator = _item_separator
         first = True
         if _sort_keys:
-            items = sorted(dct.items(), key=lambda k: str(k[0]))
+            try:
+                items = sorted(dct.items())
+            except(TypeError):
+                items = sorted(dct.items(), key=lambda kv: str(kv[0]))
         else:
             items = dct.items()
         for key, value in items:


### PR DESCRIPTION
Remove int / str keys sorting error due to dict with integers and strings keys
(TypeError: '<' not supported between instances of 'int' and 'str')
Using str() for each key could slow significantly the treatment !

nb : I don't want to put more than 10 mins on this little issue, the process seems heavy to me to pull it in the right way

<!-- issue-number: [bpo-38046](https://bugs.python.org/issue38046) -->
https://bugs.python.org/issue38046
<!-- /issue-number -->
