### PR TITLE
bpo-15088 : Remove PyGen_NeedsFinalizing()

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -219,6 +219,10 @@ Removed
   standard :class:`bytes` objects are always used.
   (Contributed by Jon Janzen in :issue:`36409`.)
 
+* The C function ``PyGen_NeedsFinalizing`` has been removed. It was documented
+  and not used anywhere in the source code.
+  (Contributed by Joannah Nanjekye in :issue:`15088`)
+
 
 Porting to Python 3.9
 =====================

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -219,11 +219,6 @@ Removed
   standard :class:`bytes` objects are always used.
   (Contributed by Jon Janzen in :issue:`36409`.)
 
-* The C function ``PyGen_NeedsFinalizing`` has been removed. It was not
-  documented, tested or even used anywhere in the code base after
-  after :pep:`442` implementation made it useless.
-  (Contributed by Joannah Nanjekye in :issue:`15088`)
-
 
 Porting to Python 3.9
 =====================

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -219,7 +219,7 @@ Removed
   standard :class:`bytes` objects are always used.
   (Contributed by Jon Janzen in :issue:`36409`.)
 
-* The C function ``PyGen_NeedsFinalizing`` has been removed. It was documented
+* The C function ``PyGen_NeedsFinalizing`` has been removed. It was not documented
   and not used anywhere in the source code.
   (Contributed by Joannah Nanjekye in :issue:`15088`)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -219,8 +219,9 @@ Removed
   standard :class:`bytes` objects are always used.
   (Contributed by Jon Janzen in :issue:`36409`.)
 
-* The C function ``PyGen_NeedsFinalizing`` has been removed. It was not documented
-  and not used anywhere in the source code.
+* The C function ``PyGen_NeedsFinalizing`` has been deprecated. It was not
+  documented anor even used wnywhere in the codebase. It will therefore be
+  removed in the next release.
   (Contributed by Joannah Nanjekye in :issue:`15088`)
 
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -222,6 +222,11 @@ Removed
 * ``PyThreadState_DeleteCurrent()`` has been removed. It was not documented.
   (Contributed by Joannah Nanjekye in :issue:`37878`.)
 
+* The C function ``PyGen_NeedsFinalizing`` has been removed. It was not
+  documented, tested or even used anywhere in the code base after
+  after :pep:`442` implementation which made it useless.
+  (Contributed by Joannah Nanjekye in :issue:`15088`)
+
 
 Porting to Python 3.9
 =====================

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -223,8 +223,8 @@ Removed
   (Contributed by Joannah Nanjekye in :issue:`37878`.)
 
 * The C function ``PyGen_NeedsFinalizing`` has been removed. It was not
-  documented, tested or even used anywhere in the code base after
-  after :pep:`442` implementation which made it useless.
+  documented, tested or used anywhere within CPython after the implementation
+  of :pep:`442`. Patch by Joannah Nanjekye.
   (Contributed by Joannah Nanjekye in :issue:`15088`)
 
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -219,9 +219,9 @@ Removed
   standard :class:`bytes` objects are always used.
   (Contributed by Jon Janzen in :issue:`36409`.)
 
-* The C function ``PyGen_NeedsFinalizing`` has been deprecated. It was not
-  documented anor even used wnywhere in the codebase. It will therefore be
-  removed in the next release.
+* The C function ``PyGen_NeedsFinalizing`` has been removed. It was not
+  documented, tested or even used anywhere in the code base after
+  after :pep:`442` implementation made it useless.
   (Contributed by Joannah Nanjekye in :issue:`15088`)
 
 

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -43,7 +43,7 @@ PyAPI_DATA(PyTypeObject) PyGen_Type;
 PyAPI_FUNC(PyObject *) PyGen_New(struct _frame *);
 PyAPI_FUNC(PyObject *) PyGen_NewWithQualName(struct _frame *,
     PyObject *name, PyObject *qualname);
-PyAPI_FUNC(int) PyGen_NeedsFinalizing(PyGenObject *);
+PyAPI_FUNC(int) _PyGen_NeedsFinalizing(PyGenObject *);
 PyAPI_FUNC(int) _PyGen_SetStopIterationValue(PyObject *);
 PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
 PyAPI_FUNC(PyObject *) _PyGen_Send(PyGenObject *, PyObject *);

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -43,7 +43,6 @@ PyAPI_DATA(PyTypeObject) PyGen_Type;
 PyAPI_FUNC(PyObject *) PyGen_New(struct _frame *);
 PyAPI_FUNC(PyObject *) PyGen_NewWithQualName(struct _frame *,
     PyObject *name, PyObject *qualname);
-Py_DEPRECATED(3.9) PyAPI_FUNC(int) PyGen_NeedsFinalizing(PyGenObject *);
 PyAPI_FUNC(int) _PyGen_SetStopIterationValue(PyObject *);
 PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
 PyAPI_FUNC(PyObject *) _PyGen_Send(PyGenObject *, PyObject *);

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -43,7 +43,7 @@ PyAPI_DATA(PyTypeObject) PyGen_Type;
 PyAPI_FUNC(PyObject *) PyGen_New(struct _frame *);
 PyAPI_FUNC(PyObject *) PyGen_NewWithQualName(struct _frame *,
     PyObject *name, PyObject *qualname);
-PyAPI_FUNC(int) _PyGen_NeedsFinalizing(PyGenObject *);
+Py_DEPRECATED(3.9) PyAPI_FUNC(int) PyGen_NeedsFinalizing(PyGenObject *);
 PyAPI_FUNC(int) _PyGen_SetStopIterationValue(PyObject *);
 PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
 PyAPI_FUNC(PyObject *) _PyGen_Send(PyGenObject *, PyObject *);

--- a/Misc/NEWS.d/next/C API/2019-09-05-14-17-21.bpo-15088.plt8Em.rst
+++ b/Misc/NEWS.d/next/C API/2019-09-05-14-17-21.bpo-15088.plt8Em.rst
@@ -1,0 +1,1 @@
+Remove undocumented and unused `PyGen_NeedsFinalizing()`.

--- a/Misc/NEWS.d/next/C API/2019-09-05-14-17-21.bpo-15088.plt8Em.rst
+++ b/Misc/NEWS.d/next/C API/2019-09-05-14-17-21.bpo-15088.plt8Em.rst
@@ -1,1 +1,4 @@
-Remove undocumented and unused `PyGen_NeedsFinalizing()`.
+The C function ``PyGen_NeedsFinalizing`` has been deprecated. It was not
+documented anor even used wnywhere in the codebase. It will therefore be
+removed in the next release.
+(Patch by Joannah Nanjekye)

--- a/Misc/NEWS.d/next/C API/2019-09-05-14-17-21.bpo-15088.plt8Em.rst
+++ b/Misc/NEWS.d/next/C API/2019-09-05-14-17-21.bpo-15088.plt8Em.rst
@@ -1,4 +1,4 @@
 The C function ``PyGen_NeedsFinalizing`` has been removed. It was not
-documented, tested or even used anywhere in the code base after
-PEP 442 implementation made it useless.
+documented, tested or used anywhere within CPython after the implementation
+of :pep:`442`. Patch by Joannah Nanjekye.
 (Patch by Joannah Nanjekye)

--- a/Misc/NEWS.d/next/C API/2019-09-05-14-17-21.bpo-15088.plt8Em.rst
+++ b/Misc/NEWS.d/next/C API/2019-09-05-14-17-21.bpo-15088.plt8Em.rst
@@ -1,4 +1,4 @@
-The C function ``PyGen_NeedsFinalizing`` has been deprecated. It was not
-documented anor even used wnywhere in the codebase. It will therefore be
-removed in the next release.
+The C function ``PyGen_NeedsFinalizing`` has been removed. It was not
+documented, tested or even used anywhere in the code base after
+PEP 442 implementation made it useless.
 (Patch by Joannah Nanjekye)

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -819,22 +819,6 @@ PyGen_New(PyFrameObject *f)
     return gen_new_with_qualname(&PyGen_Type, f, NULL, NULL);
 }
 
-int
-PyGen_NeedsFinalizing(PyGenObject *gen)
-{
-    PyFrameObject *f = gen->gi_frame;
-
-    if (f == NULL || f->f_stacktop == NULL)
-        return 0; /* no frame or empty blockstack == no finalization */
-
-    /* Any (exception-handling) block type requires cleanup. */
-    if (f->f_iblock > 0)
-        return 1;
-
-    /* No blocks, it's safe to skip finalization. */
-    return 0;
-}
-
 /* Coroutine Object */
 
 typedef struct {

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -820,7 +820,7 @@ PyGen_New(PyFrameObject *f)
 }
 
 int
-_PyGen_NeedsFinalizing(PyGenObject *gen)
+PyGen_NeedsFinalizing(PyGenObject *gen)
 {
     PyFrameObject *f = gen->gi_frame;
 

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -820,7 +820,7 @@ PyGen_New(PyFrameObject *f)
 }
 
 int
-PyGen_NeedsFinalizing(PyGenObject *gen)
+_PyGen_NeedsFinalizing(PyGenObject *gen)
 {
     PyFrameObject *f = gen->gi_frame;
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3227,11 +3227,6 @@ main_loop:
         }
 
         case TARGET(SETUP_FINALLY): {
-            /* NOTE: If you add any new block-setup opcodes that
-               are not try/except/finally handlers, you may need
-               to update the PyGen_NeedsFinalizing() function.
-               */
-
             PyFrame_BlockSetup(f, SETUP_FINALLY, INSTR_OFFSET() + oparg,
                                STACK_LEVEL());
             DISPATCH();

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3229,7 +3229,7 @@ main_loop:
         case TARGET(SETUP_FINALLY): {
             /* NOTE: If you add any new block-setup opcodes that
                are not try/except/finally handlers, you may need
-               to update the PyGen_NeedsFinalizing() function.
+               to update the _PyGen_NeedsFinalizing() function.
                */
 
             PyFrame_BlockSetup(f, SETUP_FINALLY, INSTR_OFFSET() + oparg,

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3229,7 +3229,7 @@ main_loop:
         case TARGET(SETUP_FINALLY): {
             /* NOTE: If you add any new block-setup opcodes that
                are not try/except/finally handlers, you may need
-               to update the _PyGen_NeedsFinalizing() function.
+               to update the PyGen_NeedsFinalizing() function.
                */
 
             PyFrame_BlockSetup(f, SETUP_FINALLY, INSTR_OFFSET() + oparg,


### PR DESCRIPTION
I made `PyGen_NeedsFinalizing()` internal instead of deleting the logic all together much as the function is not called anywhere in the codebase. Should I have done the later? @vstinner @pitrou 

Edit: We decided to remove it all together.

<!-- issue-number: [bpo-15088](https://bugs.python.org/issue15088) -->
https://bugs.python.org/issue15088
<!-- /issue-number -->
