### PR TITLE
bpo-38038: Remove urllib.parse._splittype from xmlrpc.client.

### DIFF
--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -1424,9 +1424,8 @@ class ServerProxy:
         p = urllib.parse.urlparse(uri)
         if p.scheme not in ("http", "https"):
             raise OSError("unsupported XML-RPC protocol")
-        self.__host, self.__handler = p.netloc, p.path
-        if not self.__handler:
-            self.__handler = "/RPC2"
+        self.__host = p.netloc
+        self.__handler = p.path or "/RPC2"
 
         if transport is None:
             if p.scheme == "https":

--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -1220,9 +1220,7 @@ class Transport:
         if isinstance(host, tuple):
             host, x509 = host
 
-        p = urllib.parse.urlparse(host)
-        user, delim, host = p.path.rpartition('@')
-        auth = user if delim else None
+        auth, host = urllib.parse._splituser(host)
 
         if auth:
             auth = urllib.parse.unquote_to_bytes(auth)

--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -1220,7 +1220,9 @@ class Transport:
         if isinstance(host, tuple):
             host, x509 = host
 
-        auth, host = urllib.parse._splituser(host)
+        p = urllib.parse.urlparse(host)
+        user, delim, host = p.path.rpartition('@')
+        auth = user if delim else None
 
         if auth:
             auth = urllib.parse.unquote_to_bytes(auth)
@@ -1421,15 +1423,15 @@ class ServerProxy:
         # establish a "logical" server connection
 
         # get the url
-        type, uri = urllib.parse._splittype(uri)
-        if type not in ("http", "https"):
+        p = urllib.parse.urlparse(uri)
+        if p.scheme not in ("http", "https"):
             raise OSError("unsupported XML-RPC protocol")
-        self.__host, self.__handler = urllib.parse._splithost(uri)
+        self.__host, self.__handler = p.netloc, p.path
         if not self.__handler:
             self.__handler = "/RPC2"
 
         if transport is None:
-            if type == "https":
+            if p.scheme == "https":
                 handler = SafeTransport
                 extra_kwargs = {"context": context}
             else:

--- a/Misc/NEWS.d/next/Library/2019-09-05-23-21-33.bpo-38038.--6YvP.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-05-23-21-33.bpo-38038.--6YvP.rst
@@ -1,2 +1,0 @@
-Remove urllib.parse._splittype from :meth:`__init__` of 
-:class:`xmlrpc.client.ServerProxy`. Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Library/2019-09-05-23-21-33.bpo-38038.--6YvP.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-05-23-21-33.bpo-38038.--6YvP.rst
@@ -1,2 +1,2 @@
-Remove urllib.parse._splituser and urllib.parse._splittype from
-xmlrpc.client. Patch by Dong-hee Na.
+Remove urllib.parse._splittype from :meth:`__init__` of 
+:class:`xmlrpc.client.ServerProxy`. Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Library/2019-09-05-23-21-33.bpo-38038.--6YvP.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-05-23-21-33.bpo-38038.--6YvP.rst
@@ -1,0 +1,2 @@
+Remove urllib.parse._splituser and urllib.parse._splittype from
+xmlrpc.client. Patch by Dong-hee Na.


### PR DESCRIPTION


<!-- issue-number: [bpo-38038](https://bugs.python.org/issue38038) -->
https://bugs.python.org/issue38038
<!-- /issue-number -->
