### PR TITLE
bpo-37064: Skip test_tools.test_pathfix if installed

### DIFF
--- a/Lib/test/test_tools/test_pathfix.py
+++ b/Lib/test/test_tools/test_pathfix.py
@@ -3,7 +3,11 @@ import subprocess
 import sys
 import unittest
 from test import support
-from test.test_tools import import_tool, scriptsdir
+from test.test_tools import import_tool, scriptsdir, skip_if_missing
+
+
+# need Tools/script/ directory: skip if run on Python installed on the system
+skip_if_missing()
 
 
 class TestPathfixFunctional(unittest.TestCase):


### PR DESCRIPTION
If Python is installed, skip test_tools.test_pathfix test because
Tools/scripts/pathfix.py script is not installed.

<!-- issue-number: [bpo-37064](https://bugs.python.org/issue37064) -->
https://bugs.python.org/issue37064
<!-- /issue-number -->
