### PR TITLE
bpo-38034: Fix typo in logging.handlers.rst

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1067,7 +1067,7 @@ possible, while any potentially slow operations (such as sending an email via
    versions - to always pass each message to each handler.
 
    .. versionchanged:: 3.5
-      The ``respect_handler_levels`` argument was added.
+      The ``respect_handler_level`` argument was added.
 
    .. method:: dequeue(block)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-38034](https://bugs.python.org/issue38034) -->
https://bugs.python.org/issue38034
<!-- /issue-number -->
