### PR TITLE
 bpo-38041: Refine IDLE Shell restart lines. 

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,9 +3,9 @@ Released on 2019-10-20?
 ======================================
 
 
-bpo-38401: Shell restart lines now fill the window width and always
-start with '='.  Filenames still wrap if long relative to the width,
-but there is no longer a trailing space that can wrap by itself.
+bpo-38401: Shell restart lines now fill the window width, always start
+with '=', and avoid wrapping unnecessarily. The line will still wrap
+if the included file name is long relative to the width.
 
 bpo-37092: Add mousewheel scrolling for IDLE module, path, and stack
 browsers.  Patch by George Zhang.

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,10 @@ Released on 2019-10-20?
 ======================================
 
 
+bpo-38401: Shell restart lines now fill the window width and always
+start with '='.  Filenames still wrap if long relative to the width,
+but there is no longer a trailing space that can wrap by itself.
+
 bpo-37092: Add mousewheel scrolling for IDLE module, path, and stack
 browsers.  Patch by George Zhang.
 

--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -9,7 +9,7 @@ from tkinter import Tk
 
 class FunctionTest(unittest.TestCase):
     # Test stand-alone module level non-gui functions.
-    def test_restart_line(self):
+    def test_restart_line_wide(self):
         eq = self.assertEqual
         for file, mul, extra in (('', 22, ''), ('finame', 21, '=')):
             width = 60
@@ -19,6 +19,13 @@ class FunctionTest(unittest.TestCase):
                 line = pyshell.restart_line(width, file)
                 eq(len(line), width + 1)  # +1 for '\n'
                 eq(line, f"\n{bar+extra} RESTART: {file} {bar}")
+
+    def test_restart_line_narrow(self):
+        expect, taglen = "\n= RESTART: Shell", 16  # Don't count '\n'.
+        for width in (taglen-1, taglen, taglen+1):
+            with self.subTest(width=width):
+                self.assertEqual(pyshell.restart_line(width, ''), expect)
+        self.assertEqual(pyshell.restart_line(taglen+2, ''), expect+' =')
 
 
 class PyShellFileListTest(unittest.TestCase):

--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -10,10 +10,15 @@ from tkinter import Tk
 class FunctionTest(unittest.TestCase):
     # Test stand-alone module level non-gui functions.
     def test_restart_line(self):
-        self.assertEqual(pyshell.restart_line(80, ''),
-                         f"\n{31*'='} RESTART: Shell {31*'='}")
-        self.assertEqual(pyshell.restart_line(80, 'finame'),
-                         f"\n{30*'='} RESTART: finame {30*'='}")
+        eq = self.assertEqual
+        for file, mul, extra in (('', 22, ''), ('finame', 21, '=')):
+            width = 60
+            bar = mul * '='
+            with self.subTest(file=file, bar=bar):
+                file = file if file else 'Shell'
+                line = pyshell.restart_line(width, file)
+                eq(len(line), width + 1)  # +1 for '\n'
+                eq(line, f"\n{bar+extra} RESTART: {file} {bar}")
 
 
 class PyShellFileListTest(unittest.TestCase):

--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -7,6 +7,15 @@ from test.support import requires
 from tkinter import Tk
 
 
+class FunctionTest(unittest.TestCase):
+    # Test stand-alone module level non-gui functions.
+    def test_restart_line(self):
+        self.assertEqual(pyshell.restart_line(80, ''),
+                         f"\n{31*'='} RESTART: Shell {31*'='}")
+        self.assertEqual(pyshell.restart_line(80, 'finame'),
+                         f"\n{30*'='} RESTART: finame {30*'='}")
+
+
 class PyShellFileListTest(unittest.TestCase):
 
     @classmethod

--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -18,11 +18,11 @@ class FunctionTest(unittest.TestCase):
             with self.subTest(file=file, bar=bar):
                 file = file or 'Shell'
                 line = pyshell.restart_line(width, file)
-                eq(len(line), width + 1)  # +1 for '\n'
-                eq(line, f"\n{bar+extra} RESTART: {file} {bar}")
+                eq(len(line), width)
+                eq(line, f"{bar+extra} RESTART: {file} {bar}")
 
     def test_restart_line_narrow(self):
-        expect, taglen = "\n= RESTART: Shell", 16  # Don't count '\n'.
+        expect, taglen = "= RESTART: Shell", 16
         for width in (taglen-1, taglen, taglen+1):
             with self.subTest(width=width):
                 self.assertEqual(pyshell.restart_line(width, ''), expect)

--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -16,7 +16,7 @@ class FunctionTest(unittest.TestCase):
             width = 60
             bar = mul * '='
             with self.subTest(file=file, bar=bar):
-                file = file if file else 'Shell'
+                file = file or 'Shell'
                 line = pyshell.restart_line(width, file)
                 eq(len(line), width + 1)  # +1 for '\n'
                 eq(line, f"\n{bar+extra} RESTART: {file} {bar}")

--- a/Lib/idlelib/idle_test/test_pyshell.py
+++ b/Lib/idlelib/idle_test/test_pyshell.py
@@ -9,6 +9,7 @@ from tkinter import Tk
 
 class FunctionTest(unittest.TestCase):
     # Test stand-alone module level non-gui functions.
+
     def test_restart_line_wide(self):
         eq = self.assertEqual
         for file, mul, extra in (('', 22, ''), ('finame', 21, '=')):

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -387,10 +387,15 @@ class MyRPCClient(rpc.RPCClient):
         "Override the base class - just re-raise EOFError"
         raise EOFError
 
-def restart_line(width, filename):
-    tag = f"= RESTART: {filename if filename else 'Shell'} ="
-    div, mod = divmod((width -len(tag)), 2)
-    return f"\n{(div+mod)*'='}{tag}{div*'='}"
+def restart_line(width, filename):  # See bpo-38141.
+    if filename == '':
+        filename = 'Shell'
+    tag = f"= RESTART: {filename} ="
+    if width >= 13 + len(filename):  # The length of tag.
+        div, mod = divmod((width -len(tag)), 2)
+        return f"\n{(div+mod)*'='}{tag}{div*'='}"
+    else:
+        return '\n' + tag[:-2]  # Remove ' ='.
 
 
 class ModifiedInterpreter(InteractiveInterpreter):

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -391,7 +391,7 @@ def restart_line(width, filename):  # See bpo-38141.
     if filename == '':
         filename = 'Shell'
     tag = f"= RESTART: {filename} ="
-    if width >= 13 + len(filename):  # The length of tag.
+    if width >= len(tag):
         div, mod = divmod((width -len(tag)), 2)
         return f"\n{(div+mod)*'='}{tag}{div*'='}"
     else:

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -388,14 +388,17 @@ class MyRPCClient(rpc.RPCClient):
         raise EOFError
 
 def restart_line(width, filename):  # See bpo-38141.
-    if filename == '':
-        filename = 'Shell'
-    tag = f"= RESTART: {filename} ="
+    """Return width long restart line formatted with filename.
+
+    Fill line with balanced '='s, with any extras and at least one at
+    the beginning.  Do not end with a trailing space.
+    """
+    tag = f"= RESTART: {filename or 'Shell'} ="
     if width >= len(tag):
         div, mod = divmod((width -len(tag)), 2)
-        return f"\n{(div+mod)*'='}{tag}{div*'='}"
+        return f"{(div+mod)*'='}{tag}{div*'='}"
     else:
-        return '\n' + tag[:-2]  # Remove ' ='.
+        return tag[:-2]  # Remove ' ='.
 
 
 class ModifiedInterpreter(InteractiveInterpreter):
@@ -501,6 +504,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
         console.stop_readline()
         # annotate restart in shell window and mark it
         console.text.delete("iomark", "end-1c")
+        console.write('\n')
         console.write(restart_line(console.width, filename))
         console.text.mark_set("restart", "end-1c")
         console.text.mark_gravity("restart", "left")

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -389,8 +389,9 @@ class MyRPCClient(rpc.RPCClient):
 
 def restart_line(width, filename):
     tag = 'RESTART: ' + (filename if filename else 'Shell')
-    halfbar = ((width -len(tag) - 4) // 2) * '='
-    return "\n{0} {1} {0}".format(halfbar, tag)
+    print(tag, len(tag))
+    div, mod = divmod((width -len(tag) - 2), 2)
+    return f"\n{(div+mod)*'='} {tag} {div*'='}"
 
 
 class ModifiedInterpreter(InteractiveInterpreter):

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -387,6 +387,11 @@ class MyRPCClient(rpc.RPCClient):
         "Override the base class - just re-raise EOFError"
         raise EOFError
 
+def restart_line(width, filename):
+    tag = 'RESTART: ' + (filename if filename else 'Shell')
+    halfbar = ((width -len(tag) - 4) // 2) * '='
+    return "\n{0} {1} {0}".format(halfbar, tag)
+
 
 class ModifiedInterpreter(InteractiveInterpreter):
 
@@ -491,9 +496,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
         console.stop_readline()
         # annotate restart in shell window and mark it
         console.text.delete("iomark", "end-1c")
-        tag = 'RESTART: ' + (filename if filename else 'Shell')
-        halfbar = ((int(console.width) -len(tag) - 4) // 2) * '='
-        console.write("\n{0} {1} {0}".format(halfbar, tag))
+        console.write(restart_line(console.width, filename))
         console.text.mark_set("restart", "end-1c")
         console.text.mark_gravity("restart", "left")
         if not filename:

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -388,10 +388,9 @@ class MyRPCClient(rpc.RPCClient):
         raise EOFError
 
 def restart_line(width, filename):
-    tag = 'RESTART: ' + (filename if filename else 'Shell')
-    print(tag, len(tag))
-    div, mod = divmod((width -len(tag) - 2), 2)
-    return f"\n{(div+mod)*'='} {tag} {div*'='}"
+    tag = f"= RESTART: {filename if filename else 'Shell'} ="
+    div, mod = divmod((width -len(tag)), 2)
+    return f"\n{(div+mod)*'='}{tag}{div*'='}"
 
 
 class ModifiedInterpreter(InteractiveInterpreter):

--- a/Misc/NEWS.d/next/IDLE/2019-09-05-23-12-13.bpo-38041.nxmGGK.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-09-05-23-12-13.bpo-38041.nxmGGK.rst
@@ -1,3 +1,3 @@
-IDLE Shell restart lines now fill the window width and always start with
-'='.  Filenames still wrap if long relative to the width, but there is
-no longer a trailing space that can wrap by itself.
+Shell restart lines now fill the window width, always start with '=',
+and avoid wrapping unnecessarily. The line will still wrap if the
+included file name is long relative to the width.

--- a/Misc/NEWS.d/next/IDLE/2019-09-05-23-12-13.bpo-38041.nxmGGK.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-09-05-23-12-13.bpo-38041.nxmGGK.rst
@@ -1,0 +1,3 @@
+IDLE Shell restart lines now fill the window width and always start with
+'='.  Filenames still wrap if long relative to the width, but there is
+no longer a trailing space that can wrap by itself.


### PR DESCRIPTION
Restart lines now always start with '=' and never end with ' ' and fill the width of the window unless that would require ending with ' ', which could be wrapped by itself and possible confusing the user.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38041](https://bugs.python.org/issue38041) -->
https://bugs.python.org/issue38041
<!-- /issue-number -->
