### PR TITLE
gh-58572: Fix behavior when '--' as argument to option in argparse

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1959,6 +1959,9 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             for action, arg_count in zip(positionals, arg_counts):
                 args = arg_strings[start_index: start_index + arg_count]
                 start_index += arg_count
+                if action.nargs not in [PARSER, REMAINDER]:
+                    if '--' in args:
+                        args.remove('--')
                 take_action(action, args)
 
             # slice off the Positionals that we just parsed and return the
@@ -2352,13 +2355,6 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     # Value conversion methods
     # ========================
     def _get_values(self, action, arg_strings):
-        # for everything but PARSER, REMAINDER args, strip out first '--'
-        if action.nargs not in [PARSER, REMAINDER]:
-            try:
-                arg_strings.remove('--')
-            except ValueError:
-                pass
-
         # optional argument produces a default when not present
         if not arg_strings and action.nargs == OPTIONAL:
             if action.option_strings:

--- a/Misc/NEWS.d/next/Library/2019-09-06-06-16-35.bpo-14364.eEtNMR.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-06-06-16-35.bpo-14364.eEtNMR.rst
@@ -1,0 +1,1 @@
+Fix behavior of argparse when '--' as argument to option.

--- a/Misc/NEWS.d/next/Library/2019-09-06-06-16-35.bpo-14364.eEtNMR.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-06-06-16-35.bpo-14364.eEtNMR.rst
@@ -1,1 +1,2 @@
-Fix behavior of argparse when '--' as argument to option.
+'--' should be treated as other characters when '--' is
+a part of argument.


### PR DESCRIPTION
Co-Authored-by: paul j3

<!-- issue-number: [bpo-14364](https://bugs.python.org/issue14364) -->
https://bugs.python.org/issue14364
<!-- /issue-number -->


<!-- gh-issue-number: gh-58572 -->
* Issue: gh-58572
<!-- /gh-issue-number -->
