### PR TITLE
bpo-27145:small_ints[x] could be returned in long_add and long_sub

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -961,9 +961,10 @@ class LongTest(unittest.TestCase):
         a = 2 ** SHIFT
         b = 2 ** SHIFT - 1
         c = 2 ** SHIFT + 1
+        d = -a
+        self.assertIsNot(a + b, 2 ** (SHIFT + 1) - 1)
         self.assertIs(a - b, 1)
-        self.assertIs(c + (-a), 1)
-        self.assertIs(a // a, 1)
+        self.assertIs(c + d, 1)
 
     def test_small_ints(self):
         for i in range(-5, 257):

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -956,6 +956,15 @@ class LongTest(unittest.TestCase):
         self.assertEqual(huge >> (sys.maxsize + 1), (1 << 499) + 5)
         self.assertEqual(huge >> (sys.maxsize + 1000), 0)
 
+    @support.cpython_only
+    def test_small_ints_in_huge_calculation(self):
+        a = 2 ** SHIFT
+        b = 2 ** SHIFT - 1
+        c = 2 ** SHIFT + 1
+        self.assertIs(a - b, 1)
+        self.assertIs(c + (-a), 1)
+        self.assertIs(a // a, 1)
+
     def test_small_ints(self):
         for i in range(-5, 257):
             self.assertIs(i, i + 0)

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -958,13 +958,11 @@ class LongTest(unittest.TestCase):
 
     @support.cpython_only
     def test_small_ints_in_huge_calculation(self):
-        a = 2 ** SHIFT
-        b = 2 ** SHIFT - 1
-        c = 2 ** SHIFT + 1
-        d = -a
-        self.assertIsNot(a + b, 2 ** (SHIFT + 1) - 1)
-        self.assertIs(a - b, 1)
-        self.assertIs(c + d, 1)
+        a = 2 ** 100
+        b = -a + 1
+        c = a + 1
+        self.assertIs(a + b, 1)
+        self.assertIs(c - a, 1)
 
     def test_small_ints(self):
         for i in range(-5, 257):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-06-16-40-12.bpo-27145.njuCXU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-06-16-40-12.bpo-27145.njuCXU.rst
@@ -1,1 +1,1 @@
-small_ints[x] could be returned in long_add and long_sub. Patch by hongweipeng.
+int + int and int - int operators can now return small integer singletons. Patch by hongweipeng.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-06-16-40-12.bpo-27145.njuCXU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-06-16-40-12.bpo-27145.njuCXU.rst
@@ -1,0 +1,1 @@
+small_ints[x] could be returned in long_add and long_sub. Patch by hongweipeng.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3295,8 +3295,9 @@ long_sub(PyLongObject *a, PyLongObject *b)
         return PyLong_FromLong(MEDIUM_VALUE(a) - MEDIUM_VALUE(b));
     }
     if (Py_SIZE(a) < 0) {
-        if (Py_SIZE(b) < 0)
+        if (Py_SIZE(b) < 0) {
             z = x_sub(b, a);
+        }
         else {
             z = x_add(a, b);
             if (z != NULL) {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3281,7 +3281,7 @@ long_add(PyLongObject *a, PyLongObject *b)
         else
             z = x_add(a, b);
     }
-    return (PyObject *)z;
+    return (PyObject *)maybe_small_long(z);
 }
 
 static PyObject *
@@ -3310,7 +3310,7 @@ long_sub(PyLongObject *a, PyLongObject *b)
         else
             z = x_sub(a, b);
     }
-    return (PyObject *)z;
+    return (PyObject *)maybe_small_long(z);
 }
 
 /* Grade school multiplication, ignoring the signs.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3216,10 +3216,10 @@ x_sub(PyLongObject *a, PyLongObject *b)
     else if (size_a == size_b) {
         /* Find highest digit where a and b differ: */
         i = size_a;
-        while (--i > 0 && a->ob_digit[i] == b->ob_digit[i])
+        while (--i >= 0 && a->ob_digit[i] == b->ob_digit[i])
             ;
-        if (i == 0)
-            return (PyLongObject *)PyLong_FromLong((sdigit)a->ob_digit[0] - (sdigit)b->ob_digit[0]);
+        if (i < 0)
+            return (PyLongObject *)PyLong_FromLong(0);
         if (a->ob_digit[i] < b->ob_digit[i]) {
             sign = -1;
             { PyLongObject *temp = a; a = b; b = temp; }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3247,7 +3247,7 @@ x_sub(PyLongObject *a, PyLongObject *b)
     if (sign < 0) {
         Py_SIZE(z) = -Py_SIZE(z);
     }
-    return long_normalize(z);
+    return maybe_small_long(long_normalize(z));
 }
 
 static PyObject *
@@ -3281,7 +3281,7 @@ long_add(PyLongObject *a, PyLongObject *b)
         else
             z = x_add(a, b);
     }
-    return (PyObject *)maybe_small_long(z);
+    return (PyObject *)z;
 }
 
 static PyObject *
@@ -3296,12 +3296,13 @@ long_sub(PyLongObject *a, PyLongObject *b)
     }
     if (Py_SIZE(a) < 0) {
         if (Py_SIZE(b) < 0)
-            z = x_sub(a, b);
-        else
+            z = x_sub(b, a);
+        else {
             z = x_add(a, b);
-        if (z != NULL) {
-            assert(Py_SIZE(z) == 0 || Py_REFCNT(z) == 1);
-            Py_SIZE(z) = -(Py_SIZE(z));
+            if (z != NULL) {
+                assert(Py_SIZE(z) == 0 || Py_REFCNT(z) == 1);
+                Py_SIZE(z) = -(Py_SIZE(z));
+            }
         }
     }
     else {
@@ -3310,7 +3311,7 @@ long_sub(PyLongObject *a, PyLongObject *b)
         else
             z = x_sub(a, b);
     }
-    return (PyObject *)maybe_small_long(z);
+    return (PyObject *)z;
 }
 
 /* Grade school multiplication, ignoring the signs.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3216,10 +3216,8 @@ x_sub(PyLongObject *a, PyLongObject *b)
     else if (size_a == size_b) {
         /* Find highest digit where a and b differ: */
         i = size_a;
-        while (--i >= 0 && a->ob_digit[i] == b->ob_digit[i])
+        while (--i > 0 && a->ob_digit[i] == b->ob_digit[i])
             ;
-        if (i < 0)
-            return (PyLongObject *)PyLong_FromLong(0);
         if (i == 0)
             return (PyLongObject *)PyLong_FromLong((sdigit)a->ob_digit[0] - (sdigit)b->ob_digit[0]);
         if (a->ob_digit[i] < b->ob_digit[i]) {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3220,6 +3220,8 @@ x_sub(PyLongObject *a, PyLongObject *b)
             ;
         if (i < 0)
             return (PyLongObject *)PyLong_FromLong(0);
+        if (i == 0)
+            return (PyLongObject *)PyLong_FromLong((sdigit)a->ob_digit[0] - (sdigit)b->ob_digit[0]);
         if (a->ob_digit[i] < b->ob_digit[i]) {
             sign = -1;
             { PyLongObject *temp = a; a = b; b = temp; }


### PR DESCRIPTION
Master branch:
```
>>> a = 2 ** 30
>>> b = 2 ** 30 - 1
>>> id(a - b)
140649692469056
>>> id(1)
9865760
```
This PR:
```
>>> a = 2 ** 30
>>> b = 2 ** 30 - 1
>>> id(a - b)
9865760
>>> id(1)
9865760
```

<!-- issue-number: [bpo-27145](https://bugs.python.org/issue27145) -->
https://bugs.python.org/issue27145
<!-- /issue-number -->
