### PR TITLE
bpo-38047: don't add multi-arch paths if cross compiling.

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-09-06-19-40-21.bpo-38047.S0PTLV.rst
+++ b/Misc/NEWS.d/next/Build/2019-09-06-19-40-21.bpo-38047.S0PTLV.rst
@@ -1,0 +1,1 @@
+multi-arch headers and libs will not be added when cross compiling.

--- a/setup.py
+++ b/setup.py
@@ -651,10 +651,10 @@ class PyBuildExt(build_ext):
         if not CROSS_COMPILING:
             add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
             add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
+            self.add_multiarch_paths()
         # only change this for cross builds for 3.3, issues on Mageia
         if CROSS_COMPILING:
             self.add_cross_compiling_paths()
-        self.add_multiarch_paths()
         self.add_ldflags_cppflags()
 
     def init_inc_lib_dirs(self):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

This breaks cross compiling because unexpected host header paths are added.

<!-- issue-number: [bpo-38047](https://bugs.python.org/issue38047) -->
https://bugs.python.org/issue38047
<!-- /issue-number -->
