### PR TITLE
bpo-26868: Fix example usage of PyModule_AddObject.

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -419,6 +419,21 @@ state:
    be used from the module's initialization function.  This steals a reference to
    *value*.  Return ``-1`` on error, ``0`` on success.
 
+   .. note::
+
+      Unlike other functions which steal references, ``PyModule_AddObject`` only
+      decrements the reference count of *value* **on success**.
+
+      This means you must check this function's return value and
+      :c:func:`Py_DECREF` *value* manually on error. Example usage::
+
+         Py_INCREF(spam);
+         if (PyModule_AddObject(module, "spam", spam)) {
+             Py_DECREF(module);
+             Py_DECREF(spam);
+             return NULL;
+         }
+
 .. c:function:: int PyModule_AddIntConstant(PyObject *module, const char *name, long value)
 
    Add an integer constant to *module* as *name*.  This convenience function can be

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -421,10 +421,10 @@ state:
 
    .. note::
 
-      Unlike other functions which steal references, ``PyModule_AddObject`` only
+      Unlike other functions that steal references, ``PyModule_AddObject`` only
       decrements the reference count of *value* **on success**.
 
-      This means you must check this function's return value and
+      This means that its return value must be checked, and calling code must
       :c:func:`Py_DECREF` *value* manually on error. Example usage::
 
          Py_INCREF(spam);

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -417,18 +417,18 @@ state:
 
    Add an object to *module* as *name*.  This is a convenience function which can
    be used from the module's initialization function.  This steals a reference to
-   *value*.  Return ``-1`` on error, ``0`` on success.
+   *value* on success.  Return ``-1`` on error, ``0`` on success.
 
    .. note::
 
-      Unlike other functions that steal references, ``PyModule_AddObject`` only
+      Unlike other functions that steal references, ``PyModule_AddObject()`` only
       decrements the reference count of *value* **on success**.
 
       This means that its return value must be checked, and calling code must
       :c:func:`Py_DECREF` *value* manually on error. Example usage::
 
          Py_INCREF(spam);
-         if (PyModule_AddObject(module, "spam", spam)) {
+         if (PyModule_AddObject(module, "spam", spam) < 0) {
              Py_DECREF(module);
              Py_DECREF(spam);
              return NULL;

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -209,7 +209,7 @@ usually declare a static object variable at the beginning of your file::
    static PyObject *SpamError;
 
 and initialize it in your module's initialization function (:c:func:`PyInit_spam`)
-with an exception object (leaving out the error checking for now)::
+with an exception object::
 
    PyMODINIT_FUNC
    PyInit_spam(void)
@@ -221,9 +221,10 @@ with an exception object (leaving out the error checking for now)::
            return NULL;
 
        SpamError = PyErr_NewException("spam.error", NULL, NULL);
-       Py_INCREF(SpamError);
+       Py_XINCREF(SpamError);
        if (PyModule_AddObject(m, "error", SpamError)) {
-           Py_DECREF(SpamError);
+           Py_XDECREF(SpamError);
+           Py_CLEAR(SpamError);
            Py_DECREF(m);
            return NULL;
        }
@@ -1266,13 +1267,8 @@ function must take care of initializing the C API pointer array::
        /* Create a Capsule containing the API pointer array's address */
        c_api_object = PyCapsule_New((void *)PySpam_API, "spam._C_API", NULL);
 
-       if (c_api_object == NULL) {
-           Py_DECREF(m);
-           return NULL;
-       }
-
        if (PyModule_AddObject(m, "_C_API", c_api_object)) {
-           Py_DECREF(c_api_object);
+           Py_XDECREF(c_api_object);
            Py_DECREF(m);
            return NULL;
        }

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -222,7 +222,7 @@ with an exception object::
 
        SpamError = PyErr_NewException("spam.error", NULL, NULL);
        Py_XINCREF(SpamError);
-       if (PyModule_AddObject(m, "error", SpamError)) {
+       if (PyModule_AddObject(m, "error", SpamError) < 0) {
            Py_XDECREF(SpamError);
            Py_CLEAR(SpamError);
            Py_DECREF(m);
@@ -1267,7 +1267,7 @@ function must take care of initializing the C API pointer array::
        /* Create a Capsule containing the API pointer array's address */
        c_api_object = PyCapsule_New((void *)PySpam_API, "spam._C_API", NULL);
 
-       if (PyModule_AddObject(m, "_C_API", c_api_object)) {
+       if (PyModule_AddObject(m, "_C_API", c_api_object) < 0) {
            Py_XDECREF(c_api_object);
            Py_DECREF(m);
            return NULL;

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -227,6 +227,7 @@ with an exception object (leaving out the error checking for now)::
            Py_DECREF(m);
            return NULL;
        }
+
        return m;
    }
 

--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -180,7 +180,7 @@ to the appropriate default values, including :attr:`ob_type` that we initially
 set to *NULL*. ::
 
    Py_INCREF(&CustomType);
-   if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+   if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
        Py_DECREF(&CustomType);
        PY_DECREF(m);
        return NULL;
@@ -869,7 +869,7 @@ function::
            return NULL;
 
        Py_INCREF(&SubListType);
-       if (PyModule_AddObject(m, "SubList", (PyObject *) &SubListType)) {
+       if (PyModule_AddObject(m, "SubList", (PyObject *) &SubListType) < 0) {
            Py_DECREF(&SubListType);
            Py_DECREF(m);
            return NULL;

--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -179,7 +179,12 @@ This initializes the :class:`Custom` type, filling in a number of members
 to the appropriate default values, including :attr:`ob_type` that we initially
 set to *NULL*. ::
 
-   PyModule_AddObject(m, "Custom", (PyObject *) &CustomType);
+   Py_INCREF(&CustomType);
+   if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+       Py_DECREF(&CustomType);
+       PY_DECREF(m);
+       return NULL;
+   }
 
 This adds the type to the module dictionary.  This allows us to create
 :class:`Custom` instances by calling the :class:`Custom` class:
@@ -864,7 +869,12 @@ function::
            return NULL;
 
        Py_INCREF(&SubListType);
-       PyModule_AddObject(m, "SubList", (PyObject *) &SubListType);
+       if (PyModule_AddObject(m, "SubList", (PyObject *) &SubListType)) {
+           Py_DECREF(&SubListType);
+           Py_DECREF(m);
+           return NULL;
+       }
+
        return m;
    }
 

--- a/Doc/includes/custom.c
+++ b/Doc/includes/custom.c
@@ -35,6 +35,11 @@ PyInit_custom(void)
         return NULL;
 
     Py_INCREF(&CustomType);
-    PyModule_AddObject(m, "Custom", (PyObject *) &CustomType);
+    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+        Py_DECREF(&CustomType);
+        PY_DECREF(m);
+        return NULL;
+    }
+
     return m;
 }

--- a/Doc/includes/custom.c
+++ b/Doc/includes/custom.c
@@ -35,7 +35,7 @@ PyInit_custom(void)
         return NULL;
 
     Py_INCREF(&CustomType);
-    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
         Py_DECREF(&CustomType);
         PY_DECREF(m);
         return NULL;

--- a/Doc/includes/custom2.c
+++ b/Doc/includes/custom2.c
@@ -128,6 +128,11 @@ PyInit_custom2(void)
         return NULL;
 
     Py_INCREF(&CustomType);
-    PyModule_AddObject(m, "Custom", (PyObject *) &CustomType);
+    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+        Py_DECREF(&CustomType);
+        Py_DECREF(m);
+        return NULL;
+    }
+
     return m;
 }

--- a/Doc/includes/custom2.c
+++ b/Doc/includes/custom2.c
@@ -128,7 +128,7 @@ PyInit_custom2(void)
         return NULL;
 
     Py_INCREF(&CustomType);
-    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
         Py_DECREF(&CustomType);
         Py_DECREF(m);
         return NULL;

--- a/Doc/includes/custom3.c
+++ b/Doc/includes/custom3.c
@@ -179,6 +179,11 @@ PyInit_custom3(void)
         return NULL;
 
     Py_INCREF(&CustomType);
-    PyModule_AddObject(m, "Custom", (PyObject *) &CustomType);
+    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+        Py_DECREF(&CustomType);
+        Py_DECREF(m);
+        return NULL;
+    }
+
     return m;
 }

--- a/Doc/includes/custom3.c
+++ b/Doc/includes/custom3.c
@@ -179,7 +179,7 @@ PyInit_custom3(void)
         return NULL;
 
     Py_INCREF(&CustomType);
-    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
         Py_DECREF(&CustomType);
         Py_DECREF(m);
         return NULL;

--- a/Doc/includes/custom4.c
+++ b/Doc/includes/custom4.c
@@ -193,7 +193,7 @@ PyInit_custom4(void)
         return NULL;
 
     Py_INCREF(&CustomType);
-    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
         Py_DECREF(&CustomType);
         Py_DECREF(m);
         return NULL;

--- a/Doc/includes/custom4.c
+++ b/Doc/includes/custom4.c
@@ -193,6 +193,11 @@ PyInit_custom4(void)
         return NULL;
 
     Py_INCREF(&CustomType);
-    PyModule_AddObject(m, "Custom", (PyObject *) &CustomType);
+    if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType)) {
+        Py_DECREF(&CustomType);
+        Py_DECREF(m);
+        return NULL;
+    }
+
     return m;
 }

--- a/Doc/includes/sublist.c
+++ b/Doc/includes/sublist.c
@@ -59,6 +59,11 @@ PyInit_sublist(void)
         return NULL;
 
     Py_INCREF(&SubListType);
-    PyModule_AddObject(m, "SubList", (PyObject *) &SubListType);
+    if ((m, "SubList", (PyObject *) &SubListType)) {
+        Py_DECREF(&SubListType);
+        Py_DECREF(m);
+        return NULL;
+    }
+
     return m;
 }

--- a/Doc/includes/sublist.c
+++ b/Doc/includes/sublist.c
@@ -59,7 +59,7 @@ PyInit_sublist(void)
         return NULL;
 
     Py_INCREF(&SubListType);
-    if ((m, "SubList", (PyObject *) &SubListType)) {
+    if (PyModule_AddObject(m, "SubList", (PyObject *) &SubListType)) {
         Py_DECREF(&SubListType);
         Py_DECREF(m);
         return NULL;

--- a/Doc/includes/sublist.c
+++ b/Doc/includes/sublist.c
@@ -59,7 +59,7 @@ PyInit_sublist(void)
         return NULL;
 
     Py_INCREF(&SubListType);
-    if (PyModule_AddObject(m, "SubList", (PyObject *) &SubListType)) {
+    if (PyModule_AddObject(m, "SubList", (PyObject *) &SubListType) < 0) {
         Py_DECREF(&SubListType);
         Py_DECREF(m);
         return NULL;

--- a/Misc/NEWS.d/next/Documentation/2019-09-07-15-55-46.bpo-26868.Raw0Gd.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-09-07-15-55-46.bpo-26868.Raw0Gd.rst
@@ -1,0 +1,1 @@
+Fix example usage of :c:func:`PyModule_AddObject` to properly handle errors.


### PR DESCRIPTION
Unlike other APIs that steal references, `PyModule_AddObject` only does it on success. However, most calls throughout the codebase don't manually `Py_DECREF` on failure as required by the implementation, which leads contributors to believe that it is not necessary. This PR fixes example usage and adds a note on this behavior *in the documentation only*.

There are over 200 bad calls throughout the codebase that are not addressed by this patch. Because there are so many bugs, fixing them all will likely require more care and likely several PRs (or a possible deprecation period and behavior change... it appears incorrect usage is actually more common than correct usage). I'm willing to do the work, but some direction on this would be nice.

<!-- issue-number: [bpo-26868](https://bugs.python.org/issue26868) -->
https://bugs.python.org/issue26868
<!-- /issue-number -->
