### PR TITLE
some website requests User-Agent field in headers

### DIFF
--- a/Lib/urllib/robotparser.py
+++ b/Lib/urllib/robotparser.py
@@ -25,13 +25,14 @@ class RobotFileParser:
 
     """
 
-    def __init__(self, url=''):
+    def __init__(self, url='', headers={}):
         self.entries = []
         self.default_entry = None
         self.disallow_all = False
         self.allow_all = False
         self.set_url(url)
         self.last_checked = 0
+        self.headers = headers
 
     def mtime(self):
         """Returns the time the robots.txt file was last fetched.
@@ -58,7 +59,10 @@ class RobotFileParser:
     def read(self):
         """Reads the robots.txt URL and feeds it to the parser."""
         try:
-            f = urllib.request.urlopen(self.url)
+            req = urllib.request.Request(self.url)
+            for k in self.headers.keys():
+                req.add_header(k, self.headers[k])
+            f = urllib.request.urlopen(req)
         except urllib.error.HTTPError as err:
             if err.code in (401, 403):
                 self.disallow_all = True


### PR DESCRIPTION
I found some website like "sony.co.jp" requests User-Agent field in headers when I try to fetch their robots.txt. Unless they returns 403 Forbidden status code and RobotTextParser fails to read robots.txt.  Currently there is no way to specify headers so I propose add headers arguments in constructor.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
