### PR TITLE
bpo-38054: enhance pdb.set_trace() to run when the specified condition is true

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -128,12 +128,13 @@ slightly different way:
    is entered.
 
 
-.. function:: set_trace(*, header=None)
+.. function:: set_trace(*, header=None, trigger=True)
 
    Enter the debugger at the calling stack frame.  This is useful to hard-code
    a breakpoint at a given point in a program, even if the code is not
-   otherwise being debugged (e.g. when an assertion fails).  If given,
-   *header* is printed to the console just before debugging begins.
+   otherwise being debugged (e.g. when an assertion fails).  If given, *header*
+   is printed to the console just before debugging begins, and *trigger* allows
+   to programmatically enable or disable the command at runtime.
 
    .. versionchanged:: 3.7
       The keyword-only argument *header*.

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1600,7 +1600,9 @@ def runctx(statement, globals, locals):
 def runcall(*args, **kwds):
     return Pdb().runcall(*args, **kwds)
 
-def set_trace(*, header=None):
+def set_trace(*, header=None, trigger=True):
+    if not trigger:
+        return
     pdb = Pdb()
     if header is not None:
         pdb.message(header)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1399,6 +1399,16 @@ class PdbTestCase(unittest.TestCase):
             pdb.set_trace(header=header)
         self.assertEqual(stdout.getvalue(), header + '\n')
 
+    def test_trigger(self):
+        stdout = StringIO()
+        with ExitStack() as resources:
+            resources.enter_context(patch('sys.stdout', stdout))
+            resources.enter_context(patch.object(pdb.Pdb, 'set_trace'))
+            pdb.set_trace(header="unspecified")
+            pdb.set_trace(header="trigger set to True", trigger=True)
+            pdb.set_trace(header="trigger set to False", trigger=False)
+        self.assertEqual(stdout.getvalue(), "unspecified\ntrigger set to True\n")
+
     def test_run_module(self):
         script = """print("SUCCESS")"""
         commands = """

--- a/Misc/NEWS.d/next/Library/2019-09-08-12-54-51.bpo-38054.FbItzM.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-08-12-54-51.bpo-38054.FbItzM.rst
@@ -1,0 +1,2 @@
+A key-word argument *trigger* is added to the pdb.set_trace() command. If
+specified, allows to execute the command only when the condition is true.


### PR DESCRIPTION
* Added a new key-word argument *trigger* to `pdb.set_trace()` method. If specified, `set_trace()` will execute only when the condition is true.
* Added a unit test for the *trigger* kwarg
* Updated documentation

<!-- issue-number: [bpo-38054](https://bugs.python.org/issue38054) -->
https://bugs.python.org/issue38054
<!-- /issue-number -->
