### PR TITLE
Revert "bpo-34410: Raise a RuntimeError when tee iterator is consumed from different threads."

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -643,8 +643,7 @@ loops that truncate the stream.
 
    Once :func:`tee` has made a split, the original *iterable* should not be
    used anywhere else; otherwise, the *iterable* could get advanced without
-   the tee objects being informed. the :func:`tee` iterator can not be consumed
-   from different threads, even if an underlying iterator is thread-safe.
+   the tee objects being informed.
 
    This itertool may require significant auxiliary storage (depending on how
    much temporary data needs to be stored). In general, if one iterator uses

--- a/Misc/NEWS.d/next/Library/2019-08-29-10-26-57.bpo-34410.ttCIpm.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-29-10-26-57.bpo-34410.ttCIpm.rst
@@ -1,2 +1,0 @@
-Raise a RuntimeError when itertools.tee() iterator is consumed from different
-threads. Patch by hongweipeng.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -452,7 +452,6 @@ typedef struct {
     teedataobject *dataobj;
     int index;                  /* 0 <= index <= LINKCELLS */
     PyObject *weakreflist;
-    unsigned long thread_id;
 } teeobject;
 
 static PyTypeObject teedataobject_type;
@@ -681,11 +680,6 @@ tee_next(teeobject *to)
 {
     PyObject *value, *link;
 
-    if (to->thread_id != PyThread_get_thread_ident()) {
-        PyErr_SetString(PyExc_RuntimeError,
-            "tee() iterator can not be consumed from different threads.");
-        return NULL;
-    }
     if (to->index >= LINKCELLS) {
         link = teedataobject_jumplink(to->dataobj);
         if (link == NULL)
@@ -719,7 +713,6 @@ tee_copy(teeobject *to, PyObject *Py_UNUSED(ignored))
     newto->dataobj = to->dataobj;
     newto->index = to->index;
     newto->weakreflist = NULL;
-    newto->thread_id = to->thread_id;
     PyObject_GC_Track(newto);
     return (PyObject *)newto;
 }
@@ -752,7 +745,6 @@ tee_fromiterable(PyObject *iterable)
 
     to->index = 0;
     to->weakreflist = NULL;
-    to->thread_id = PyThread_get_thread_ident();
     PyObject_GC_Track(to);
 done:
     Py_XDECREF(it);


### PR DESCRIPTION
Reverts python/cpython#15567

<!-- issue-number: [bpo-34410](https://bugs.python.org/issue34410) -->
https://bugs.python.org/issue34410
<!-- /issue-number -->
