### PR TITLE
bpo-37283: Ensure command-line and unattend.xml setting override previously detected states in Windows installer

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-09-09-12-22-23.bpo-37283.8NvOkU.rst
+++ b/Misc/NEWS.d/next/Windows/2019-09-09-12-22-23.bpo-37283.8NvOkU.rst
@@ -1,0 +1,2 @@
+Ensure command-line and unattend.xml setting override previously detected
+states in Windows installer.

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -71,11 +71,10 @@
     <Variable Name="Include_tools" Value="1" bal:Overridable="yes" />
     <Variable Name="Include_tcltk" Value="1" bal:Overridable="yes" />
     <Variable Name="Include_pip" Value="1" bal:Overridable="yes" />
+    <Variable Name="Include_launcher" Value="-1" bal:Overridable="yes" />
     <?if "$(var.PyTestExt)"="" ?>
-    <Variable Name="Include_launcher" Value="1" bal:Overridable="yes" />
     <Variable Name="Include_launcherState" Value="enabled" bal:Overridable="yes" />
     <?else ?>
-    <Variable Name="Include_launcher" Value="0" />
     <Variable Name="Include_launcherState" Value="disable" />
     <?endif ?>
     <Variable Name="Include_symbols" Value="0" bal:Overridable="yes" />


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37283](https://bugs.python.org/issue37283) -->
https://bugs.python.org/issue37283
<!-- /issue-number -->
