### PR TITLE
bpo-37383: Updates docs to reflect AsyncMock call_count after await.

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -519,7 +519,7 @@ the *new_callable* argument to :func:`patch`.
 
             >>> mock = AsyncMock()
             >>> mock()  # doctest: +SKIP
-            >>> <coroutine object AsyncMockMixin._mock_call at ...>
+            <coroutine object AsyncMockMixin._mock_call at ...>
             >>> mock.call_count
             0
             >>> async def main():

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -523,7 +523,8 @@ the *new_callable* argument to :func:`patch`.
             >>> mock.call_count
             0
             >>> async def main():
-            >>>    await mock()
+            ...     await mock()
+            ...
             >>> asyncio.run(main())
             >>> mock.call_count
             1

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -518,7 +518,8 @@ the *new_callable* argument to :func:`patch`.
         has been awaited:
 
             >>> mock = AsyncMock()
-            >>> mock()
+            >>> mock()  # doctest: +SKIP
+            >>> <coroutine object AsyncMockMixin._mock_call at ...>
             >>> mock.call_count
             0
             >>> async def main():

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -514,6 +514,18 @@ the *new_callable* argument to :func:`patch`.
             >>> mock.call_count
             2
 
+        For :class:`AsyncMock` the :attr:`call_count` is only iterated if the function
+        has been awaited:
+
+            >>> mock = AsyncMock()
+            >>> mock()
+            >>> mock.call_count
+            0
+            >>> async def main():
+            >>>    await mock()
+            >>> asyncio.run(main())
+            >>> mock.call_count
+            1
 
     .. attribute:: return_value
 


### PR DESCRIPTION
Updates documentation to make it more clear that call_count is not updated _unless_ the AsyncMock has been awaited.



<!-- issue-number: [[bpo-351428](https://bugs.python.org/issue351428)](https://bugs.python.org/issue37383) -->
https://bugs.python.org/issue37383
<!-- /issue-number -->
