### PR TITLE
bpo-38066: Hide internal Stream methods

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -1133,9 +1133,9 @@ class _BaseStreamProtocol(FlowControlMixin, protocols.Protocol):
         stream = self._stream
         if stream is not None:
             if exc is None:
-                stream.feed_eof()
+                stream._feed_eof()
             else:
-                stream.set_exception(exc)
+                stream._set_exception(exc)
         if not self._closed.done():
             if exc is None:
                 self._closed.set_result(None)
@@ -1147,12 +1147,12 @@ class _BaseStreamProtocol(FlowControlMixin, protocols.Protocol):
     def data_received(self, data):
         stream = self._stream
         if stream is not None:
-            stream.feed_data(data)
+            stream._feed_data(data)
 
     def eof_received(self):
         stream = self._stream
         if stream is not None:
-            stream.feed_eof()
+            stream._feed_eof()
         if self._over_ssl:
             # Prevent a warning in SSLProtocol.eof_received:
             # "returning true from eof_received()
@@ -1219,7 +1219,7 @@ class _StreamProtocol(_BaseStreamProtocol):
         stream = self._stream
         if stream is None:
             return
-        stream.set_transport(transport)
+        stream._set_transport(transport)
         stream._protocol = self
 
     def connection_lost(self, exc):
@@ -1449,7 +1449,7 @@ class Stream:
     def exception(self):
         return self._exception
 
-    def set_exception(self, exc):
+    def _set_exception(self, exc):
         self._exception = exc
 
         waiter = self._waiter
@@ -1466,7 +1466,7 @@ class Stream:
             if not waiter.cancelled():
                 waiter.set_result(None)
 
-    def set_transport(self, transport):
+    def _set_transport(self, transport):
         if transport is self._transport:
             return
         assert self._transport is None, 'Transport already set'
@@ -1477,7 +1477,7 @@ class Stream:
             self._paused = False
             self._transport.resume_reading()
 
-    def feed_eof(self):
+    def _feed_eof(self):
         self._eof = True
         self._wakeup_waiter()
 
@@ -1485,7 +1485,7 @@ class Stream:
         """Return True if the buffer is empty and 'feed_eof' was called."""
         return self._eof and not self._buffer
 
-    def feed_data(self, data):
+    def _feed_data(self, data):
         _ensure_can_read(self._mode)
         assert not self._eof, 'feed_data after feed_eof'
 

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -1454,6 +1454,14 @@ class Stream:
     def exception(self):
         return self._exception
 
+    def set_exception(self, exc):
+        warnings.warn("Stream.set_exception() is deprecated "
+                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "it is an internal API",
+                      DeprecationWarning,
+                      stacklevel=2)
+        self._set_exception(exc)
+
     def _set_exception(self, exc):
         self._exception = exc
 

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -1351,6 +1351,11 @@ class Stream:
 
     @property
     def transport(self):
+        warnings.warn("Stream.transport attribute is deprecated "
+                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "it is an internal API",
+                      DeprecationWarning,
+                      stacklevel=2)
         return self._transport
 
     def write(self, data):
@@ -1366,7 +1371,7 @@ class Stream:
     def _fast_drain(self):
         # The helper tries to use fast-path to return already existing
         # complete future object if underlying transport is not paused
-        #and actual waiting for writing resume is not needed
+        # and actual waiting for writing resume is not needed
         exc = self.exception()
         if exc is not None:
             fut = self._loop.create_future()
@@ -1466,6 +1471,14 @@ class Stream:
             if not waiter.cancelled():
                 waiter.set_result(None)
 
+    def set_transport(self, transport):
+        warnings.warn("Stream.set_transport() is deprecated "
+                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "it is an internal API",
+                      DeprecationWarning,
+                      stacklevel=2)
+        self._set_transport(transport)
+
     def _set_transport(self, transport):
         if transport is self._transport:
             return
@@ -1477,6 +1490,14 @@ class Stream:
             self._paused = False
             self._transport.resume_reading()
 
+    def feed_eof(self):
+        warnings.warn("Stream.feed_eof() is deprecated "
+                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "it is an internal API",
+                      DeprecationWarning,
+                      stacklevel=2)
+        self._feed_eof()
+
     def _feed_eof(self):
         self._eof = True
         self._wakeup_waiter()
@@ -1484,6 +1505,14 @@ class Stream:
     def at_eof(self):
         """Return True if the buffer is empty and 'feed_eof' was called."""
         return self._eof and not self._buffer
+
+    def feed_data(self, data):
+        warnings.warn("Stream.feed_data() is deprecated "
+                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "it is an internal API",
+                      DeprecationWarning,
+                      stacklevel=2)
+        self._feed_data(data)
 
     def _feed_data(self, data):
         _ensure_can_read(self._mode)

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -1352,7 +1352,7 @@ class Stream:
     @property
     def transport(self):
         warnings.warn("Stream.transport attribute is deprecated "
-                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "since Python 3.8 and is scheduled for removal in 3.10; "
                       "it is an internal API",
                       DeprecationWarning,
                       stacklevel=2)
@@ -1456,7 +1456,7 @@ class Stream:
 
     def set_exception(self, exc):
         warnings.warn("Stream.set_exception() is deprecated "
-                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "since Python 3.8 and is scheduled for removal in 3.10; "
                       "it is an internal API",
                       DeprecationWarning,
                       stacklevel=2)
@@ -1481,7 +1481,7 @@ class Stream:
 
     def set_transport(self, transport):
         warnings.warn("Stream.set_transport() is deprecated "
-                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "since Python 3.8 and is scheduled for removal in 3.10; "
                       "it is an internal API",
                       DeprecationWarning,
                       stacklevel=2)
@@ -1500,7 +1500,7 @@ class Stream:
 
     def feed_eof(self):
         warnings.warn("Stream.feed_eof() is deprecated "
-                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "since Python 3.8 and is scheduled for removal in 3.10; "
                       "it is an internal API",
                       DeprecationWarning,
                       stacklevel=2)
@@ -1516,7 +1516,7 @@ class Stream:
 
     def feed_data(self, data):
         warnings.warn("Stream.feed_data() is deprecated "
-                      "since Python 3.8, and scheduled for removal in 3.10; "
+                      "since Python 3.8 and is scheduled for removal in 3.10; "
                       "it is an internal API",
                       DeprecationWarning,
                       stacklevel=2)

--- a/Lib/asyncio/subprocess.py
+++ b/Lib/asyncio/subprocess.py
@@ -50,7 +50,7 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
                                          limit=self._limit,
                                          loop=self._loop,
                                          _asyncio_internal=True)
-            self.stdout.set_transport(stdout_transport)
+            self.stdout._set_transport(stdout_transport)
             self._pipe_fds.append(1)
 
         stderr_transport = transport.get_pipe_transport(2)
@@ -61,7 +61,7 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
                                          limit=self._limit,
                                          loop=self._loop,
                                          _asyncio_internal=True)
-            self.stderr.set_transport(stderr_transport)
+            self.stderr._set_transport(stderr_transport)
             self._pipe_fds.append(2)
 
         stdin_transport = transport.get_pipe_transport(0)
@@ -80,7 +80,7 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
         else:
             reader = None
         if reader is not None:
-            reader.feed_data(data)
+            reader._feed_data(data)
 
     def pipe_connection_lost(self, fd, exc):
         if fd == 0:
@@ -101,9 +101,9 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
             reader = None
         if reader is not None:
             if exc is None:
-                reader.feed_eof()
+                reader._feed_eof()
             else:
-                reader.set_exception(exc)
+                reader._set_exception(exc)
 
         if fd in self._pipe_fds:
             self._pipe_fds.remove(fd)

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -96,8 +96,8 @@ class StreamReaderTests(BaseTest):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(DATA)
-        stream.feed_eof()
+        stream._feed_data(DATA)
+        stream._feed_eof()
 
         async def reader():
             data = []

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -1806,6 +1806,9 @@ os.close(fd)
         with self.assertWarns(DeprecationWarning):
             stream.feed_eof()
 
+        with self.assertWarns(DeprecationWarning):
+            stream.set_exception(ConnectionResetError("test"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -1785,6 +1785,27 @@ os.close(fd)
                                     "by asyncio internals only"):
             asyncio.Stream(asyncio.StreamMode.READWRITE)
 
+    def test_deprecated_methods(self):
+        async def f():
+            return asyncio.Stream(mode=asyncio.StreamMode.READWRITE,
+                                  _asyncio_internal=True)
+
+        stream = self.loop.run_until_complete(f())
+
+        tr = mock.Mock()
+
+        with self.assertWarns(DeprecationWarning):
+            stream.set_transport(tr)
+
+        with self.assertWarns(DeprecationWarning):
+            stream.transport is tr
+
+        with self.assertWarns(DeprecationWarning):
+            stream.feed_data(b'data')
+
+        with self.assertWarns(DeprecationWarning):
+            stream.feed_eof()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -165,7 +165,7 @@ class StreamTests(test_utils.TestCase):
                                 loop=self.loop,
                                 _asyncio_internal=True)
 
-        stream.feed_data(b'')
+        stream._feed_data(b'')
         self.assertEqual(b'', stream._buffer)
 
     def test_feed_nonempty_data(self):
@@ -173,7 +173,7 @@ class StreamTests(test_utils.TestCase):
                                 loop=self.loop,
                                 _asyncio_internal=True)
 
-        stream.feed_data(self.DATA)
+        stream._feed_data(self.DATA)
         self.assertEqual(self.DATA, stream._buffer)
 
     def test_read_zero(self):
@@ -181,7 +181,7 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(self.DATA)
+        stream._feed_data(self.DATA)
 
         data = self.loop.run_until_complete(stream.read(0))
         self.assertEqual(b'', data)
@@ -195,7 +195,7 @@ class StreamTests(test_utils.TestCase):
         read_task = asyncio.Task(stream.read(30), loop=self.loop)
 
         def cb():
-            stream.feed_data(self.DATA)
+            stream._feed_data(self.DATA)
         self.loop.call_soon(cb)
 
         data = self.loop.run_until_complete(read_task)
@@ -207,8 +207,8 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'line1')
-        stream.feed_data(b'line2')
+        stream._feed_data(b'line1')
+        stream._feed_data(b'line2')
 
         data = self.loop.run_until_complete(stream.read(5))
 
@@ -223,7 +223,7 @@ class StreamTests(test_utils.TestCase):
         read_task = asyncio.Task(stream.read(1024), loop=self.loop)
 
         def cb():
-            stream.feed_eof()
+            stream._feed_eof()
         self.loop.call_soon(cb)
 
         data = self.loop.run_until_complete(read_task)
@@ -238,9 +238,9 @@ class StreamTests(test_utils.TestCase):
         read_task = asyncio.Task(stream.read(-1), loop=self.loop)
 
         def cb():
-            stream.feed_data(b'chunk1\n')
-            stream.feed_data(b'chunk2')
-            stream.feed_eof()
+            stream._feed_data(b'chunk1\n')
+            stream._feed_data(b'chunk2')
+            stream._feed_eof()
         self.loop.call_soon(cb)
 
         data = self.loop.run_until_complete(read_task)
@@ -252,12 +252,12 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'line\n')
+        stream._feed_data(b'line\n')
 
         data = self.loop.run_until_complete(stream.read(2))
         self.assertEqual(b'li', data)
 
-        stream.set_exception(ValueError())
+        stream._set_exception(ValueError())
         self.assertRaises(
             ValueError, self.loop.run_until_complete, stream.read(2))
 
@@ -276,7 +276,7 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 limit=3, loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'chunk')
+        stream._feed_data(b'chunk')
         data = self.loop.run_until_complete(stream.read(5))
         self.assertEqual(b'chunk', data)
         self.assertEqual(b'', stream._buffer)
@@ -287,13 +287,13 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'chunk1 ')
+        stream._feed_data(b'chunk1 ')
         read_task = asyncio.Task(stream.readline(), loop=self.loop)
 
         def cb():
-            stream.feed_data(b'chunk2 ')
-            stream.feed_data(b'chunk3 ')
-            stream.feed_data(b'\n chunk4')
+            stream._feed_data(b'chunk2 ')
+            stream._feed_data(b'chunk3 ')
+            stream._feed_data(b'\n chunk4')
         self.loop.call_soon(cb)
 
         line = self.loop.run_until_complete(read_task)
@@ -307,8 +307,8 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 limit=3, loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'li')
-        stream.feed_data(b'ne1\nline2\n')
+        stream._feed_data(b'li')
+        stream._feed_data(b'ne1\nline2\n')
 
         self.assertRaises(
             ValueError, self.loop.run_until_complete, stream.readline())
@@ -318,9 +318,9 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 limit=3, loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'li')
-        stream.feed_data(b'ne1')
-        stream.feed_data(b'li')
+        stream._feed_data(b'li')
+        stream._feed_data(b'ne1')
+        stream._feed_data(b'li')
 
         self.assertRaises(
             ValueError, self.loop.run_until_complete, stream.readline())
@@ -337,14 +337,14 @@ class StreamTests(test_utils.TestCase):
                                 _asyncio_internal=True)
         self.assertFalse(stream.at_eof())
 
-        stream.feed_data(b'some data\n')
+        stream._feed_data(b'some data\n')
         self.assertFalse(stream.at_eof())
 
         self.loop.run_until_complete(stream.readline())
         self.assertFalse(stream.at_eof())
 
-        stream.feed_data(b'some data\n')
-        stream.feed_eof()
+        stream._feed_data(b'some data\n')
+        stream._feed_eof()
         self.loop.run_until_complete(stream.readline())
         self.assertTrue(stream.at_eof())
 
@@ -356,10 +356,10 @@ class StreamTests(test_utils.TestCase):
                                 limit=7, loop=self.loop,
                                 _asyncio_internal=True)
         def cb():
-            stream.feed_data(b'chunk1')
-            stream.feed_data(b'chunk2')
-            stream.feed_data(b'chunk3\n')
-            stream.feed_eof()
+            stream._feed_data(b'chunk1')
+            stream._feed_data(b'chunk2')
+            stream._feed_data(b'chunk3\n')
+            stream._feed_eof()
         self.loop.call_soon(cb)
 
         self.assertRaises(
@@ -372,10 +372,10 @@ class StreamTests(test_utils.TestCase):
                                 limit=7, loop=self.loop,
                                 _asyncio_internal=True)
         def cb():
-            stream.feed_data(b'chunk1')
-            stream.feed_data(b'chunk2\n')
-            stream.feed_data(b'chunk3\n')
-            stream.feed_eof()
+            stream._feed_data(b'chunk1')
+            stream._feed_data(b'chunk2\n')
+            stream._feed_data(b'chunk3\n')
+            stream._feed_eof()
         self.loop.call_soon(cb)
 
         self.assertRaises(
@@ -386,17 +386,17 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 limit=7, loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'1234567\n')
+        stream._feed_data(b'1234567\n')
         line = self.loop.run_until_complete(stream.readline())
         self.assertEqual(b'1234567\n', line)
         self.assertEqual(b'', stream._buffer)
 
-        stream.feed_data(b'12345678\n')
+        stream._feed_data(b'12345678\n')
         with self.assertRaises(ValueError) as cm:
             self.loop.run_until_complete(stream.readline())
         self.assertEqual(b'', stream._buffer)
 
-        stream.feed_data(b'12345678')
+        stream._feed_data(b'12345678')
         with self.assertRaises(ValueError) as cm:
             self.loop.run_until_complete(stream.readline())
         self.assertEqual(b'', stream._buffer)
@@ -407,8 +407,8 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(self.DATA[:6])
-        stream.feed_data(self.DATA[6:])
+        stream._feed_data(self.DATA[:6])
+        stream._feed_data(self.DATA[6:])
 
         line = self.loop.run_until_complete(stream.readline())
 
@@ -419,8 +419,8 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'some data')
-        stream.feed_eof()
+        stream._feed_data(b'some data')
+        stream._feed_eof()
 
         line = self.loop.run_until_complete(stream.readline())
         self.assertEqual(b'some data', line)
@@ -429,7 +429,7 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_eof()
+        stream._feed_eof()
 
         line = self.loop.run_until_complete(stream.readline())
         self.assertEqual(b'', line)
@@ -438,7 +438,7 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(self.DATA)
+        stream._feed_data(self.DATA)
 
         self.loop.run_until_complete(stream.readline())
 
@@ -451,12 +451,12 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'line\n')
+        stream._feed_data(b'line\n')
 
         data = self.loop.run_until_complete(stream.readline())
         self.assertEqual(b'line\n', data)
 
-        stream.set_exception(ValueError())
+        stream._set_exception(ValueError())
         self.assertRaises(
             ValueError, self.loop.run_until_complete, stream.readline())
         self.assertEqual(b'', stream._buffer)
@@ -473,17 +473,17 @@ class StreamTests(test_utils.TestCase):
                                 loop=self.loop,
                                 _asyncio_internal=True)
 
-        stream.feed_data(b'lineAAA')
+        stream._feed_data(b'lineAAA')
         data = self.loop.run_until_complete(stream.readuntil(separator=b'AAA'))
         self.assertEqual(b'lineAAA', data)
         self.assertEqual(b'', stream._buffer)
 
-        stream.feed_data(b'lineAAA')
+        stream._feed_data(b'lineAAA')
         data = self.loop.run_until_complete(stream.readuntil(b'AAA'))
         self.assertEqual(b'lineAAA', data)
         self.assertEqual(b'', stream._buffer)
 
-        stream.feed_data(b'lineAAAxxx')
+        stream._feed_data(b'lineAAAxxx')
         data = self.loop.run_until_complete(stream.readuntil(b'AAA'))
         self.assertEqual(b'lineAAA', data)
         self.assertEqual(b'xxx', stream._buffer)
@@ -493,34 +493,34 @@ class StreamTests(test_utils.TestCase):
                                 loop=self.loop,
                                 _asyncio_internal=True)
 
-        stream.feed_data(b'QWEaa')
-        stream.feed_data(b'XYaa')
-        stream.feed_data(b'a')
+        stream._feed_data(b'QWEaa')
+        stream._feed_data(b'XYaa')
+        stream._feed_data(b'a')
         data = self.loop.run_until_complete(stream.readuntil(b'aaa'))
         self.assertEqual(b'QWEaaXYaaa', data)
         self.assertEqual(b'', stream._buffer)
 
-        stream.feed_data(b'QWEaa')
-        stream.feed_data(b'XYa')
-        stream.feed_data(b'aa')
+        stream._feed_data(b'QWEaa')
+        stream._feed_data(b'XYa')
+        stream._feed_data(b'aa')
         data = self.loop.run_until_complete(stream.readuntil(b'aaa'))
         self.assertEqual(b'QWEaaXYaaa', data)
         self.assertEqual(b'', stream._buffer)
 
-        stream.feed_data(b'aaa')
+        stream._feed_data(b'aaa')
         data = self.loop.run_until_complete(stream.readuntil(b'aaa'))
         self.assertEqual(b'aaa', data)
         self.assertEqual(b'', stream._buffer)
 
-        stream.feed_data(b'Xaaa')
+        stream._feed_data(b'Xaaa')
         data = self.loop.run_until_complete(stream.readuntil(b'aaa'))
         self.assertEqual(b'Xaaa', data)
         self.assertEqual(b'', stream._buffer)
 
-        stream.feed_data(b'XXX')
-        stream.feed_data(b'a')
-        stream.feed_data(b'a')
-        stream.feed_data(b'a')
+        stream._feed_data(b'XXX')
+        stream._feed_data(b'a')
+        stream._feed_data(b'a')
+        stream._feed_data(b'a')
         data = self.loop.run_until_complete(stream.readuntil(b'aaa'))
         self.assertEqual(b'XXXaaa', data)
         self.assertEqual(b'', stream._buffer)
@@ -529,8 +529,8 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'some dataAA')
-        stream.feed_eof()
+        stream._feed_data(b'some dataAA')
+        stream._feed_eof()
 
         with self.assertRaises(asyncio.IncompleteReadError) as cm:
             self.loop.run_until_complete(stream.readuntil(b'AAA'))
@@ -542,7 +542,7 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop, limit=3,
                                 _asyncio_internal=True)
-        stream.feed_data(b'some dataAA')
+        stream._feed_data(b'some dataAA')
 
         with self.assertRaisesRegex(asyncio.LimitOverrunError,
                                     'not found') as cm:
@@ -550,7 +550,7 @@ class StreamTests(test_utils.TestCase):
 
         self.assertEqual(b'some dataAA', stream._buffer)
 
-        stream.feed_data(b'A')
+        stream._feed_data(b'A')
         with self.assertRaisesRegex(asyncio.LimitOverrunError,
                                     'is found') as cm:
             self.loop.run_until_complete(stream.readuntil(b'AAA'))
@@ -562,7 +562,7 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(self.DATA)
+        stream._feed_data(self.DATA)
 
         data = self.loop.run_until_complete(stream.readexactly(0))
         self.assertEqual(b'', data)
@@ -582,9 +582,9 @@ class StreamTests(test_utils.TestCase):
         read_task = asyncio.Task(stream.readexactly(n), loop=self.loop)
 
         def cb():
-            stream.feed_data(self.DATA)
-            stream.feed_data(self.DATA)
-            stream.feed_data(self.DATA)
+            stream._feed_data(self.DATA)
+            stream._feed_data(self.DATA)
+            stream._feed_data(self.DATA)
         self.loop.call_soon(cb)
 
         data = self.loop.run_until_complete(read_task)
@@ -595,7 +595,7 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 limit=3, loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'chunk')
+        stream._feed_data(b'chunk')
         data = self.loop.run_until_complete(stream.readexactly(5))
         self.assertEqual(b'chunk', data)
         self.assertEqual(b'', stream._buffer)
@@ -609,8 +609,8 @@ class StreamTests(test_utils.TestCase):
         read_task = asyncio.Task(stream.readexactly(n), loop=self.loop)
 
         def cb():
-            stream.feed_data(self.DATA)
-            stream.feed_eof()
+            stream._feed_data(self.DATA)
+            stream._feed_eof()
         self.loop.call_soon(cb)
 
         with self.assertRaises(asyncio.IncompleteReadError) as cm:
@@ -625,12 +625,12 @@ class StreamTests(test_utils.TestCase):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'line\n')
+        stream._feed_data(b'line\n')
 
         data = self.loop.run_until_complete(stream.readexactly(2))
         self.assertEqual(b'li', data)
 
-        stream.set_exception(ValueError())
+        stream._set_exception(ValueError())
         self.assertRaises(
             ValueError, self.loop.run_until_complete, stream.readexactly(2))
 
@@ -641,7 +641,7 @@ class StreamTests(test_utils.TestCase):
         self.assertIsNone(stream.exception())
 
         exc = ValueError()
-        stream.set_exception(exc)
+        stream._set_exception(exc)
         self.assertIs(stream.exception(), exc)
 
     def test_exception_waiter(self):
@@ -650,7 +650,7 @@ class StreamTests(test_utils.TestCase):
                                 _asyncio_internal=True)
 
         async def set_err():
-            stream.set_exception(ValueError())
+            stream._set_exception(ValueError())
 
         t1 = asyncio.Task(stream.readline(), loop=self.loop)
         t2 = asyncio.Task(set_err(), loop=self.loop)
@@ -669,7 +669,7 @@ class StreamTests(test_utils.TestCase):
         t.cancel()
         test_utils.run_briefly(self.loop)
         # The following line fails if set_exception() isn't careful.
-        stream.set_exception(RuntimeError('message'))
+        stream._set_exception(RuntimeError('message'))
         test_utils.run_briefly(self.loop)
         self.assertIs(stream._waiter, None)
 
@@ -993,14 +993,14 @@ os.close(fd)
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_eof()
+        stream._feed_eof()
         self.assertEqual("<Stream mode=StreamMode.READ eof>", repr(stream))
 
     def test___repr__data(self):
         stream = asyncio.Stream(mode=asyncio.StreamMode.READ,
                                 loop=self.loop,
                                 _asyncio_internal=True)
-        stream.feed_data(b'data')
+        stream._feed_data(b'data')
         self.assertEqual("<Stream mode=StreamMode.READ 4 bytes>", repr(stream))
 
     def test___repr__exception(self):
@@ -1008,7 +1008,7 @@ os.close(fd)
                                 loop=self.loop,
                                 _asyncio_internal=True)
         exc = RuntimeError()
-        stream.set_exception(exc)
+        stream._set_exception(exc)
         self.assertEqual("<Stream mode=StreamMode.READ exception=RuntimeError()>",
                          repr(stream))
 
@@ -1260,7 +1260,7 @@ os.close(fd)
             stream = asyncio.Stream(mode=asyncio.StreamMode.WRITE,
                                     _asyncio_internal=True)
             with self.assertRaisesRegex(RuntimeError, "The stream is write-only"):
-                stream.feed_data(b'data')
+                stream._feed_data(b'data')
             with self.assertRaisesRegex(RuntimeError, "The stream is write-only"):
                 await stream.readline()
             with self.assertRaisesRegex(RuntimeError, "The stream is write-only"):

--- a/Misc/NEWS.d/next/Library/2019-09-09-14-39-47.bpo-38066.l9mWv-.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-09-14-39-47.bpo-38066.l9mWv-.rst
@@ -1,0 +1,2 @@
+Hide internal asyncio.Stream methods: feed_eof(), feed_data(),
+set_exception() and set_transport().


### PR DESCRIPTION
feed_eof(), feed_data(), set_exception(), and set_transport() are prefixed with underscore now.

<!-- issue-number: [bpo-38066](https://bugs.python.org/issue38066) -->
https://bugs.python.org/issue38066
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov