### PR TITLE
bpo-38069: Convert _posixsubprocess to PEP-384

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-09-14-46-05.bpo-38069.cn8XLv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-09-14-46-05.bpo-38069.cn8XLv.rst
@@ -1,0 +1,1 @@
+Make _posixsubprocess PEP-384 compatible


### PR DESCRIPTION
Summary:
Eliminate uses of `_Py_IDENTIFIER` from `_posixsubprocess`, replacing them with interned strings.

Also tries to find an existing version of the module, which will allow subinterpreters.


<!-- issue-number: [bpo-38069](https://bugs.python.org/issue38069) -->
https://bugs.python.org/issue38069
<!-- /issue-number -->


Automerge-Triggered-By: @tiran