### PR TITLE
[2.7] bpo-36502: Update link to UAX GH-44, the Unicode doc on the UCD (GH-15301)

### DIFF
--- a/Doc/library/unicodedata.rst
+++ b/Doc/library/unicodedata.rst
@@ -20,7 +20,7 @@ based on the :file:`UnicodeData.txt` file version 5.2.0 which is publicly
 available from ftp://ftp.unicode.org/.
 
 The module uses the same names and symbols as defined by the UnicodeData File
-Format 5.2.0 (see http://www.unicode.org/reports/tr44/tr44-4.html).
+Format 5.2.0 (see https://www.unicode.org/reports/tr44/).
 It defines the following functions:
 
 


### PR DESCRIPTION
The link we have points to the version from Unicode 6.0.0, dated 2010.
There have been numerous updates to it since then:
  https://www.unicode.org/reports/tr44/GH-Modifications

Change the link to one that points to the current version. Also, use HTTPS..
(cherry picked from commit 64c6ac74e254d31f93fcc74bf02b3daa7d3e3f25)

Co-authored-by: Greg Price <gnprice@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36502](https://bugs.python.org/issue36502) -->
https://bugs.python.org/issue36502
<!-- /issue-number -->
