### PR TITLE
Fix typo in dictobject comment

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -39,7 +39,7 @@ Size of indices is dk_size.  Type of each index in indices is vary on dk_size:
 * int32 for 2**16 <= dk_size <= 2**31
 * int64 for 2**32 <= dk_size
 
-dk_entries is array of PyDictKeyEntry.  It's size is USABLE_FRACTION(dk_size).
+dk_entries is array of PyDictKeyEntry.  Its size is USABLE_FRACTION(dk_size).
 DK_ENTRIES(dk) can be used to get pointer to entries.
 
 NOTE: Since negative value is used for DKIX_EMPTY and DKIX_DUMMY, type of


### PR DESCRIPTION
Fixes a small typo in the dictobject comment. No`bpo` as it's a trivial fix.