### PR TITLE
[3.7] bpo-34293: Fix PDF documentation paper size (GH-8585)

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -12,7 +12,11 @@ PAPER        =
 SOURCES      =
 DISTVERSION  = $(shell $(PYTHON) tools/extensions/patchlevel.py)
 
-ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees -D latex_elements.papersize=$(PAPER) \
+# Internal variables.
+PAPEROPT_a4     = -D latex_elements.papersize=a4paper
+PAPEROPT_letter = -D latex_elements.papersize=letterpaper
+
+ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees $(PAPEROPT_$(PAPER)) \
                 $(SPHINXOPTS) . build/$(BUILDER) $(SOURCES)
 
 .PHONY: help build html htmlhelp latex text changes linkcheck \

--- a/Misc/NEWS.d/next/Documentation/2018-07-31-15-38-26.bpo-34293.yHupAL.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-07-31-15-38-26.bpo-34293.yHupAL.rst
@@ -1,0 +1,1 @@
+Fix the Doc/Makefile regarding PAPER environment variable and PDF builds


### PR DESCRIPTION
The "A4" pdfs were previously the wrong size due to a change in the options in Sphinx 1.5.

See also sphinx-doc/sphinxGH-5235.
(cherry picked from commit b5381f669718aa19690f42f3b8bd88f03045b9d2)

Authored-by: Jean-François B <jfbu@free.fr>


<!-- issue-number: [bpo-34293](https://bugs.python.org/issue34293) -->
https://bugs.python.org/issue34293
<!-- /issue-number -->
