### PR TITLE
bpo-38077: IDLE no longer adds 'argv' to the user namespace

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,9 @@ Released on 2019-10-20?
 ======================================
 
 
+bpo-38077: IDLE no longer adds 'argv' to the user namespace when
+initializing it.  This bug only affected 3.7.4 and 3.8.0b2 to 3.8.0b4.
+
 bpo-38401: Shell restart lines now fill the window width, always start
 with '=', and avoid wrapping unnecessarily. The line will still wrap
 if the included file name is long relative to the width.

--- a/Lib/idlelib/runscript.py
+++ b/Lib/idlelib/runscript.py
@@ -164,7 +164,7 @@ class ScriptBinding:
                 _sys.argv = argv
             import os as _os
             _os.chdir({dirname!r})
-            del _sys, _basename, _os
+            del _sys, argv, _basename, _os
             \n""")
         interp.prepend_syspath(filename)
         # XXX KBK 03Jul04 When run w/o subprocess, runtime warnings still

--- a/Misc/NEWS.d/next/IDLE/2019-09-09-22-08-36.bpo-38077.Mzpfe2.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-09-09-22-08-36.bpo-38077.Mzpfe2.rst
@@ -1,0 +1,2 @@
+IDLE no longer adds 'argv' to the user namespace when initializing it.  This
+bug only affected 3.7.4 and 3.8.0b2 to 3.8.0b4.


### PR DESCRIPTION
This regression first appeared in 3.7.4 and 3.8.0b2.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38077](https://bugs.python.org/issue38077) -->
https://bugs.python.org/issue38077
<!-- /issue-number -->
