### PR TITLE
bpo-38018: fix test for multiprocessing.shared_memory

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3732,16 +3732,21 @@ class _TestSharedMemory(BaseTestCase):
         with unittest.mock.patch(
             'multiprocessing.shared_memory._make_filename') as mock_make_filename:
 
+            NAME_PREFIX = shared_memory._SHM_NAME_PREFIX
             names = ['test01_fn', 'test02_fn']
+            # Prepend NAME_PREFIX which can be '/psm_' or 'wnsm_', necessary
+            # because some POSIX compliant systems require name to start with /
+            names = [NAME_PREFIX + name for name in names]
+
             mock_make_filename.side_effect = names
             shm1 = shared_memory.SharedMemory(create=True, size=1)
             self.addCleanup(shm1.unlink)
-            self.assertEqual(shm1.name, names[0])
+            self.assertEqual(shm1._name, names[0])
 
             mock_make_filename.side_effect = names
             shm2 = shared_memory.SharedMemory(create=True, size=1)
             self.addCleanup(shm2.unlink)
-            self.assertEqual(shm2.name, names[1])
+            self.assertEqual(shm2._name, names[1])
 
         if shared_memory._USE_POSIX:
             # Posix Shared Memory can only be unlinked once.  Here we


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38018](https://bugs.python.org/issue38018) -->
https://bugs.python.org/issue38018
<!-- /issue-number -->
