### PR TITLE
[2.7] bpo-37445: Include FORMAT_MESSAGE_IGNORE_INSERTS in FormatMessageW() calls (GH-14462)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-06-28-18-10-29.bpo-37445.LsdYO6.rst
+++ b/Misc/NEWS.d/next/Windows/2019-06-28-18-10-29.bpo-37445.LsdYO6.rst
@@ -1,0 +1,2 @@
+Include the ``FORMAT_MESSAGE_IGNORE_INSERTS`` flag in ``FormatMessageW()``
+calls.

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -242,7 +242,9 @@ static TCHAR *FormatError(DWORD code)
 {
     TCHAR *lpMsgBuf;
     DWORD n;
-    n = FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+    n = FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                      FORMAT_MESSAGE_FROM_SYSTEM |
+                      FORMAT_MESSAGE_IGNORE_INSERTS,
                       NULL,
                       code,
                       MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), /* Default language */

--- a/PC/bdist_wininst/install.c
+++ b/PC/bdist_wininst/install.c
@@ -895,7 +895,8 @@ static BOOL SystemError(int error, char *msg)
         LPVOID lpMsgBuf;
         FormatMessage(
             FORMAT_MESSAGE_ALLOCATE_BUFFER |
-            FORMAT_MESSAGE_FROM_SYSTEM,
+            FORMAT_MESSAGE_FROM_SYSTEM |
+            FORMAT_MESSAGE_IGNORE_INSERTS,
             NULL,
             error,
             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),


### PR DESCRIPTION
If FormatMessageW() is passed the FORMAT_MESSAGE_FROM_SYSTEM flag
without FORMAT_MESSAGE_IGNORE_INSERTS, it will fail if there are
insert sequences in the message definition.
(cherry picked from commit a656365)

<!-- issue-number: [bpo-37445](https://bugs.python.org/issue37445) -->
https://bugs.python.org/issue37445
<!-- /issue-number -->
