### PR TITLE
bpo-37251: Removes __code__ check from _is_async_obj.

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -46,10 +46,9 @@ FILTER_DIR = True
 _safe_super = super
 
 def _is_async_obj(obj):
-    if getattr(obj, '__code__', None):
-        return asyncio.iscoroutinefunction(obj) or inspect.isawaitable(obj)
-    else:
+    if _is_instance_mock(obj) and not isinstance(obj, AsyncMock):
         return False
+    return asyncio.iscoroutinefunction(obj) or inspect.isawaitable(obj)
 
 
 def _is_async_func(func):

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -18,6 +18,10 @@ class AsyncClass:
     def normal_method(self):
         pass
 
+class AwaitableClass:
+    def __await__(self):
+        yield
+
 async def async_func():
     pass
 
@@ -159,6 +163,10 @@ class AsyncAutospecTest(unittest.TestCase):
     def test_create_autospec_instance(self):
         with self.assertRaises(RuntimeError):
             create_autospec(async_func, instance=True)
+
+    def test_create_autospec_awaitable_class(self):
+        awaitable_mock = create_autospec(spec=AwaitableClass())
+        self.assertIsInstance(create_autospec(awaitable_mock), AsyncMock)
 
     def test_create_autospec(self):
         spec = create_autospec(async_func_args)
@@ -320,6 +328,13 @@ class AsyncSpecSetTest(unittest.TestCase):
         self.assertIsInstance(mock.async_method, AsyncMock)
         self.assertIsInstance(mock.normal_method, MagicMock)
         self.assertIsInstance(mock, MagicMock)
+
+    def test_magicmock_lambda_spec(self):
+        mock_obj = MagicMock()
+        mock_obj.mock_func = MagicMock(spec=lambda x: x)
+
+        with patch.object(mock_obj, "mock_func") as cm:
+            self.assertIsInstance(cm, MagicMock)
 
 
 class AsyncArguments(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2019-09-10-10-59-50.bpo-37251.8zn2o3.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-10-10-59-50.bpo-37251.8zn2o3.rst
@@ -1,3 +1,3 @@
-Removes `__code__` check in AsyncMock's `_is_async_obj` that incorrectly
+Remove `__code__` check in AsyncMock that incorrectly
 evaluated function specs as async objects but failed to evaluate classes
 with `__await__` but no `__code__` attribute defined as async objects.

--- a/Misc/NEWS.d/next/Library/2019-09-10-10-59-50.bpo-37251.8zn2o3.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-10-10-59-50.bpo-37251.8zn2o3.rst
@@ -1,3 +1,3 @@
 Removes `__code__` check in AsyncMock's `_is_async_obj` that incorrectly
 evaluated function specs as async objects but failed to evaluate classes
-with `__await__` and but no `__code__` attribute defined as async objects.
+with `__await__` but no `__code__` attribute defined as async objects.

--- a/Misc/NEWS.d/next/Library/2019-09-10-10-59-50.bpo-37251.8zn2o3.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-10-10-59-50.bpo-37251.8zn2o3.rst
@@ -1,0 +1,3 @@
+Removes `__code__` check in AsyncMock's `_is_async_obj` that incorrectly
+evaluated function specs as async objects but failed to evaluate classes
+with `__await__` and but no `__code__` attribute defined as async objects.


### PR DESCRIPTION
It should be possible that an awaitable object does not have a `__code__`, so technically checking for the `__code__` attribute in `_is_async_obj` is incorrect. This faulty code check is also why things like: `mock.MagicMock(spec=lambda x: x)` evaluate to True, even though they are not asynchronous.



<!-- issue-number: [bpo-37251](https://bugs.python.org/issue37251) -->
https://bugs.python.org/issue37251
<!-- /issue-number -->
