### PR TITLE
bpo-38088: Fixes distutils not finding vcruntime140.dll with only v142 toolset installed

### DIFF
--- a/Lib/distutils/_msvccompiler.py
+++ b/Lib/distutils/_msvccompiler.py
@@ -107,7 +107,7 @@ def _find_vcvarsall(plat_spec):
 
     if best_dir:
         vcredist = os.path.join(best_dir, "..", "..", "redist", "MSVC", "**",
-            vcruntime_plat, "Microsoft.VC141.CRT", "vcruntime140.dll")
+            vcruntime_plat, "Microsoft.VC14*.CRT", "vcruntime140.dll")
         try:
             import glob
             vcruntime = glob.glob(vcredist, recursive=True)[-1]

--- a/Misc/NEWS.d/next/Windows/2019-09-10-14-17-25.bpo-38088.FOvWSM.rst
+++ b/Misc/NEWS.d/next/Windows/2019-09-10-14-17-25.bpo-38088.FOvWSM.rst
@@ -1,0 +1,2 @@
+Fixes distutils not finding vcruntime140.dll with only the v142 toolset
+installed.


### PR DESCRIPTION


<!-- issue-number: [bpo-38088](https://bugs.python.org/issue38088) -->
https://bugs.python.org/issue38088
<!-- /issue-number -->
