### PR TITLE
bpo-38089: Move Azure Pipelines to latest VM versions and make macOS tests optional

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -12,7 +12,7 @@ jobs:
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   steps:
   - template: ./prebuild-checks.yml
@@ -24,7 +24,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   steps:
   - template: ./docs-steps.yml
@@ -42,7 +42,7 @@ jobs:
     testRunPlatform: macos
 
   pool:
-    vmImage: macos-latest
+    vmImage: macos-10.14
 
   steps:
   - template: ./macos-steps.yml
@@ -54,7 +54,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   variables:
     testRunTitle: '$(build.sourceBranchName)-linux'
@@ -80,7 +80,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   container: manylinux1
 
@@ -111,7 +111,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
@@ -131,7 +131,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: windows-latest
+    vmImage: windows-2019
 
   strategy:
     matrix:

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -12,7 +12,7 @@ jobs:
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   steps:
   - template: ./prebuild-checks.yml
@@ -24,7 +24,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   steps:
   - template: ./docs-steps.yml
@@ -42,7 +42,7 @@ jobs:
     testRunPlatform: macos
 
   pool:
-    vmImage: xcode9-macos10.13
+    vmImage: macos-latest
 
   steps:
   - template: ./macos-steps.yml
@@ -54,7 +54,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   variables:
     testRunTitle: '$(build.sourceBranchName)-linux'
@@ -80,7 +80,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   container: manylinux1
 
@@ -111,7 +111,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
@@ -131,7 +131,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-latest
 
   strategy:
     matrix:

--- a/.azure-pipelines/macos-steps.yml
+++ b/.azure-pipelines/macos-steps.yml
@@ -14,6 +14,8 @@ steps:
 
 - script: make buildbottest TESTOPTS="-j4 -uall,-cpu --junit-xml=$(build.binariesDirectory)/test-results.xml"
   displayName: 'Tests'
+  continueOnError: true
+  timeoutInMinutes: 30
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -12,7 +12,7 @@ jobs:
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   steps:
   - template: ./prebuild-checks.yml
@@ -24,7 +24,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   steps:
   - template: ./docs-steps.yml
@@ -40,7 +40,7 @@ jobs:
     testRunPlatform: macos
 
   pool:
-    vmImage: xcode9-macos10.13
+    vmImage: macos-latest
 
   steps:
   - template: ./macos-steps.yml
@@ -54,7 +54,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   variables:
     testRunTitle: '$(system.pullRequest.TargetBranch)-linux'
@@ -80,7 +80,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   container: manylinux1
 
@@ -111,7 +111,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
@@ -131,7 +131,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-latest
 
   strategy:
     matrix:

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -12,7 +12,7 @@ jobs:
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   steps:
   - template: ./prebuild-checks.yml
@@ -24,7 +24,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['docs.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   steps:
   - template: ./docs-steps.yml
@@ -40,7 +40,7 @@ jobs:
     testRunPlatform: macos
 
   pool:
-    vmImage: macos-latest
+    vmImage: macos-10.14
 
   steps:
   - template: ./macos-steps.yml
@@ -54,7 +54,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   variables:
     testRunTitle: '$(system.pullRequest.TargetBranch)-linux'
@@ -80,7 +80,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   container: manylinux1
 
@@ -111,7 +111,7 @@ jobs:
     )
 
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-16.04
 
   variables:
     testRunTitle: '$(Build.SourceBranchName)-linux-coverage'
@@ -131,7 +131,7 @@ jobs:
   condition: and(succeeded(), eq(dependencies.Prebuild.outputs['tests.run'], 'true'))
 
   pool:
-    vmImage: windows-latest
+    vmImage: windows-2019
 
   strategy:
     matrix:

--- a/Misc/NEWS.d/next/macOS/2019-09-10-14-24-35.bpo-38089.eedgyD.rst
+++ b/Misc/NEWS.d/next/macOS/2019-09-10-14-24-35.bpo-38089.eedgyD.rst
@@ -1,0 +1,1 @@
+Move Azure Pipelines to latest VM versions and make macOS tests optional


### PR DESCRIPTION


<!-- issue-number: [bpo-38089](https://bugs.python.org/issue38089) -->
https://bugs.python.org/issue38089
<!-- /issue-number -->
