### PR TITLE
bpo-32972: Document IsolatedAsyncioTestCase of unittest module

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1486,8 +1486,85 @@ Test cases
       .. versionadded:: 3.8
 
 
+.. class:: async_case.IsolatedAsyncioTestCase(methodName='runTest')
+
+   This class provides an API similar to :class:`TestCase` and also accepts
+   coroutines as test functions.
+
+   .. versionadded:: 3.8
+
+   .. coroutinemethod:: asyncSetUp()
+
+      Method called to prepare the test fixture. This is called after :meth:`setUp`.
+      This is called immediately before calling the test method; other than
+      :exc:`AssertionError` or :exc:`SkipTest`, any exception raised by this method
+      will be considered an error rather than a test failure. The default implementation
+      does nothing.
+
+   .. coroutinemethod:: asyncTearDown()
+
+      Method called immediately after the test method has been called and the
+      result recorded.  This is called before :meth:`tearDown`. This is called even if
+      the test method raised an exception, so the implementation in subclasses may need
+      to be particularly careful about checking internal state.  Any exception, other than
+      :exc:`AssertionError` or :exc:`SkipTest`, raised by this method will be
+      considered an additional error rather than a test failure (thus increasing
+      the total number of reported errors). This method will only be called if
+      the :meth:`asyncSetUp` succeeds, regardless of the outcome of the test method.
+      The default implementation does nothing.
+
+   .. method:: addAsyncCleanup(function, /, *args, **kwargs)
+
+      This method accepts a coroutine that can be used as a cleanup function.
+
+   .. method:: run(result=None)
+
+      Sets up a new event loop to run the test, collecting the result into
+      the :class:`TestResult` object passed as *result*.  If *result* is
+      omitted or ``None``, a temporary result object is created (by calling
+      the :meth:`defaultTestResult` method) and used. The result object is
+      returned to :meth:`run`'s caller. At the end of the test all the tasks
+      in the event loop are cancelled.
 
 
+   An example illustrating the order::
+
+      from unittest.async_case import IsolatedAsyncioTestCase
+
+      events = []
+
+      class Test(IsolatedAsyncioTestCase):
+
+          def setUp(self):
+              self._sync_connection = ExpensiveSyncConnection()
+	      events.append("setUp")
+
+          async def asyncSetUp(self):
+              self._async_connection = await ExpensiveAsyncConnection()
+	      events.append("asyncSetUp")
+
+          async def test_response(self):
+	      response = await self._async_connection.get("https://example.com")
+	      self.assertEqual(response.status_code, 200)
+	      self.addAsyncCleanup(self.on_cleanup)
+
+              response = self._sync_connection.get("https://example.com")
+	      self.assertEqual(response.status_code, 200)
+
+          def tearDown(self):
+              self._sync_connection.close()
+	      events.append("tearDown")
+
+          async def asyncTearDown(self):
+              await self._async_connection.close()
+	      events.append("asyncTearDown")
+
+	  async def on_cleanup(self):
+	      events.append("cleanup")
+
+      test = Test("test_response")
+      test.run()
+      assert events == ["setUp", "asyncSetUp", "asyncTearDown", "tearDown", "cleanup"]
 
 
 .. class:: FunctionTestCase(testFunc, setUp=None, tearDown=None, description=None)

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1486,7 +1486,7 @@ Test cases
       .. versionadded:: 3.8
 
 
-.. class:: async_case.IsolatedAsyncioTestCase(methodName='runTest')
+.. class:: IsolatedAsyncioTestCase(methodName='runTest')
 
    This class provides an API similar to :class:`TestCase` and also accepts
    coroutines as test functions.
@@ -1529,7 +1529,7 @@ Test cases
 
    An example illustrating the order::
 
-      from unittest.async_case import IsolatedAsyncioTestCase
+      from unittest import IsolatedAsyncioTestCase
 
       events = []
 

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1555,7 +1555,7 @@ Test cases
 
           def tearDown(self):
               self._sync_connection.close()
-	      events.append("tearDown")
+              events.append("tearDown")
 
           async def asyncTearDown(self):
               await self._async_connection.close()

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1542,16 +1542,14 @@ Test cases
               events.append("setUp")
 
           async def asyncSetUp(self):
-              self._async_connection = await ExpensiveAsyncConnection()
+              self._async_connection = await AsyncConnection()
               events.append("asyncSetUp")
 
           async def test_response(self):
+              events.append("test_response")
               response = await self._async_connection.get("https://example.com")
               self.assertEqual(response.status_code, 200)
               self.addAsyncCleanup(self.on_cleanup)
-
-              response = self._sync_connection.get("https://example.com")
-              self.assertEqual(response.status_code, 200)
 
           def tearDown(self):
               self._sync_connection.close()
@@ -1564,9 +1562,10 @@ Test cases
           async def on_cleanup(self):
               events.append("cleanup")
 
-      test = Test("test_response")
-      test.run()
-      assert events == ["setUp", "asyncSetUp", "asyncTearDown", "tearDown", "cleanup"]
+      if __name__ == "__main__":
+          unittest.main()
+
+   After running the test ``events`` would contain ``["setUp", "asyncSetUp", "test_response", "asyncTearDown", "tearDown", "cleanup"]``
 
 
 .. class:: FunctionTestCase(testFunc, setUp=None, tearDown=None, description=None)

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1538,7 +1538,6 @@ Test cases
 
 
           def setUp(self):
-              self._sync_connection = ExpensiveSyncConnection()
               events.append("setUp")
 
           async def asyncSetUp(self):
@@ -1552,7 +1551,6 @@ Test cases
               self.addAsyncCleanup(self.on_cleanup)
 
           def tearDown(self):
-              self._sync_connection.close()
               events.append("tearDown")
 
           async def asyncTearDown(self):

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1533,23 +1533,25 @@ Test cases
 
       events = []
 
+
       class Test(IsolatedAsyncioTestCase):
+
 
           def setUp(self):
               self._sync_connection = ExpensiveSyncConnection()
-	      events.append("setUp")
+              events.append("setUp")
 
           async def asyncSetUp(self):
               self._async_connection = await ExpensiveAsyncConnection()
-	      events.append("asyncSetUp")
+              events.append("asyncSetUp")
 
           async def test_response(self):
-	      response = await self._async_connection.get("https://example.com")
-	      self.assertEqual(response.status_code, 200)
-	      self.addAsyncCleanup(self.on_cleanup)
+              response = await self._async_connection.get("https://example.com")
+              self.assertEqual(response.status_code, 200)
+              self.addAsyncCleanup(self.on_cleanup)
 
               response = self._sync_connection.get("https://example.com")
-	      self.assertEqual(response.status_code, 200)
+              self.assertEqual(response.status_code, 200)
 
           def tearDown(self):
               self._sync_connection.close()
@@ -1557,10 +1559,10 @@ Test cases
 
           async def asyncTearDown(self):
               await self._async_connection.close()
-	      events.append("asyncTearDown")
+              events.append("asyncTearDown")
 
-	  async def on_cleanup(self):
-	      events.append("cleanup")
+          async def on_cleanup(self):
+              events.append("cleanup")
 
       test = Test("test_response")
       test.run()

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1111,6 +1111,32 @@ unittest
 * Several mock assert functions now also print a list of actual calls upon
   failure. (Contributed by Petter Strandmark in :issue:`35047`.)
 
+* :mod:`unittest` module gained support for coroutines to be used as test cases
+  with :class:`unittest.IsolatedAsyncioTestCase`.
+  (Contributed by Andrew Svetlov in :issue:`32972`.)
+
+  Example::
+
+    import unittest
+
+
+    class TestRequest(unittest.IsolatedAsyncioTestCase):
+
+        async def asyncSetUp(self):
+            self.connection = await ExpensiveConnection()
+
+        async def test_get(self):
+            response = await self.connection.get("https://example.com")
+            self.assertEqual(response.status_code, 200)
+
+        async def asyncTearDown(self):
+            await self.connection.close()
+
+
+    if __name__ == "__main__":
+        unittest.main()
+
+
 venv
 ----
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1123,7 +1123,7 @@ unittest
     class TestRequest(unittest.IsolatedAsyncioTestCase):
 
         async def asyncSetUp(self):
-            self.connection = await ExpensiveConnection()
+            self.connection = await AsyncConnection()
 
         async def test_get(self):
             response = await self.connection.get("https://example.com")

--- a/Misc/NEWS.d/3.8.0b1.rst
+++ b/Misc/NEWS.d/3.8.0b1.rst
@@ -808,7 +808,7 @@ detect classes that can be passed to `hex()`, `oct()` and `bin()`.
 .. nonce: LoeUNh
 .. section: Library
 
-Implement ``unittest.AsyncTestCase`` to help testing asyncio-based code.
+Implement ``unittest.async_case.IsolatedAsyncioTestCase`` to help testing asyncio-based code.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0b1.rst
+++ b/Misc/NEWS.d/3.8.0b1.rst
@@ -808,7 +808,7 @@ detect classes that can be passed to `hex()`, `oct()` and `bin()`.
 .. nonce: LoeUNh
 .. section: Library
 
-Implement ``unittest.async_case.IsolatedAsyncioTestCase`` to help testing asyncio-based code.
+Implement ``unittest.IsolatedAsyncioTestCase`` to help testing asyncio-based code.
 
 ..
 


### PR DESCRIPTION
* Document `unittest.IsolatedAsyncioTestCase` API
* Add a simple example with respect to order of evaluation of setup and teardown calls.

<!-- issue-number: [bpo-32972](https://bugs.python.org/issue32972) -->
https://bugs.python.org/issue32972
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov