### PR TITLE
bpo-7982: Modify captured_output to allow diferent encodings

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -645,8 +645,8 @@ The :mod:`test.support` module defines the following functions:
 
 
 .. function:: captured_stdin()
-              captured_stdout()
-              captured_stderr()
+              captured_stdout(encoding=None)
+              captured_stderr(encoding=None)
 
    A context managers that temporarily replaces the named stream with
    :class:`io.StringIO` object.
@@ -659,6 +659,13 @@ The :mod:`test.support` module defines the following functions:
       assert stdout.getvalue() == "hello\n"
       assert stderr.getvalue() == "error\n"
 
+   You can use the *encoding* keyword-only parameter to simulate different
+   encodings for output streams::
+
+      with captured_stdout(encoding="ascii") as stdout:
+          print("hello")
+      assert stdout.getvalue() == b"hello\n"
+
    Example use with input stream::
 
       with captured_stdin() as stdin:
@@ -668,6 +675,9 @@ The :mod:`test.support` module defines the following functions:
           captured = input()
       self.assertEqual(captured, "hello")
 
+   .. versionchanged:: 3.8
+      Added *encoding* keyword-only parameters to :func:`captured_stdout` and
+      :func:`captured_stderr`.
 
 .. function:: temp_dir(path=None, quiet=False)
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1579,10 +1579,9 @@ def transient_internet(resource_name, *, timeout=30.0, errnos=()):
     finally:
         socket.setdefaulttimeout(old_timeout)
 
-import io
-class StringIOWrapper(io.StringIO):
+class StringIOWrapper:
+    # also allows for TextIOWrapper-like functions
     def __init__(self, stream, encoding):
-        super().__init__()
         self.stream = stream
         self._encoding = encoding
 
@@ -1592,11 +1591,24 @@ class StringIOWrapper(io.StringIO):
     def seek(self, s):
         return self.stream.seek(s)
 
+    def read(self):
+        return self.stream.read()
+
+    def readlines(self):
+        return self.stream.readlines()
+
+    def readline(self, size=None):
+        return self.stream.readline(size)
+
+    def detach(self):
+        return self.stream.detatch
+
     def getvalue(self):
         if self._encoding is not None:
             return self.stream.getvalue().encode(self._encoding)
         return self.stream.getvalue()
 
+import io
 @contextlib.contextmanager
 def captured_output(stream_name, *, encoding=None):
     """Return a context manager used by captured_stdout/stdin/stderr

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1603,6 +1603,9 @@ class StringIOWrapper:
     def detach(self):
         return self.stream.detatch
 
+    def __iter__(self):
+        return self.stream
+
     def getvalue(self):
         if self._encoding is not None:
             return self.stream.getvalue().encode(self._encoding)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1586,6 +1586,12 @@ class StringIOWrapper(io.StringIO):
         self.stream = stream
         self._encoding = encoding
 
+    def write(self, s):
+        self.stream.write(s)
+
+    def seek(self, s):
+        return self.stream.seek(s)
+
     def getvalue(self):
         if self._encoding is not None:
             return self.stream.getvalue().encode(self._encoding)
@@ -1596,10 +1602,10 @@ def captured_output(stream_name, *, encoding=None):
     """Return a context manager used by captured_stdout/stdin/stderr
     that temporarily replaces the sys stream *stream_name* with a StringIO."""
     orig_stdout = getattr(sys, stream_name)
-    wrapper = StringIOWrapper(io.StringIO, encoding)
-    setattr(sys, stream_name,  wrapper)
+
+    setattr(sys, stream_name, io.StringIO())
     try:
-        yield getattr(sys, stream_name)
+        yield StringIOWrapper(getattr(sys, stream_name), encoding)
     finally:
         setattr(sys, stream_name, orig_stdout)
 

--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -204,9 +204,9 @@ class AbstractSourceEncodingTest:
 class BytesSourceEncodingTest(AbstractSourceEncodingTest, unittest.TestCase):
 
     def check_script_output(self, src, expected):
-        with captured_stdout() as stdout:
+        with captured_stdout(encoding='latin1') as stdout:
             exec(src)
-        out = stdout.getvalue().encode('latin1')
+        out = stdout.getvalue()
         self.assertEqual(out.rstrip(), expected)
 
 

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -306,17 +306,21 @@ class TestSupport(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), "hello\n")
 
     def test_capture_stdout_encoding(self):
-        with support.captured_stdout(encoding='cp1252') as stdout:
-            print("Montr\xe9al\n")
-        self.assertEqual(stdout.getvalue(), "Montr\xe9al\n")
-     
+        with support.captured_stdout(encoding="cp1252") as stdout:
+            print("Montréal")
+        self.assertEqual(stdout.getvalue(), b'Montr\xe9al\n')
+
+        with support.captured_stdout(encoding="utf-8") as stdout:
+            print("Montréal")
+        self.assertEqual(stdout.getvalue(), b'Montr\xc3\xa9al\n')
+
     def test_captured_stderr(self):
         with support.captured_stderr() as stderr:
             print("hello", file=sys.stderr)
         self.assertEqual(stderr.getvalue(), "hello\n")
 
     def test_captured_stdin(self):
-        with support.captured_stdin() as stdin: 
+        with support.captured_stdin() as stdin:
             stdin.write('hello\n')
             stdin.seek(0)
             # call test code that consumes from sys.stdin

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -305,13 +305,18 @@ class TestSupport(unittest.TestCase):
             print("hello")
         self.assertEqual(stdout.getvalue(), "hello\n")
 
+    def test_capture_stdout_encoding(self):
+        with support.captured_stdout(encoding='cp1252') as stdout:
+            print("Montr\xe9al\n")
+        self.assertEqual(stdout.getvalue(), "Montr\xe9al\n")
+     
     def test_captured_stderr(self):
         with support.captured_stderr() as stderr:
             print("hello", file=sys.stderr)
         self.assertEqual(stderr.getvalue(), "hello\n")
 
     def test_captured_stdin(self):
-        with support.captured_stdin() as stdin:
+        with support.captured_stdin() as stdin: 
             stdin.write('hello\n')
             stdin.seek(0)
             # call test code that consumes from sys.stdin

--- a/Misc/NEWS.d/next/Tests/2020-01-23-01-14-52.bpo-7982.1wUc0h.rst
+++ b/Misc/NEWS.d/next/Tests/2020-01-23-01-14-52.bpo-7982.1wUc0h.rst
@@ -1,0 +1,1 @@
+Adds an encoding option to the captured_output (captured_stdout, captured_stdin, captured_stderr) functions that makes writing test cases involving encodings easier.


### PR DESCRIPTION
This allows for different types of encodings to be used when writing test cases. 

I added a test case for this new feature, and I also modified a few existing test cases I found that would utilize this
<!-- issue-number: [bpo-7982](https://bugs.python.org/issue7982) -->
https://bugs.python.org/issue7982
<!-- /issue-number -->
