### PR TITLE
bpo-35784: Include optional kwargs in hashlib.new() documentation

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -99,7 +99,7 @@ More condensed:
    >>> hashlib.sha224(b"Nobody inspects the spammish repetition").hexdigest()
    'a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2'
 
-.. function:: new(name[, data])
+.. function:: new(name[, data, **kwargs])
 
    Is a generic constructor that takes the string *name* of the desired
    algorithm as its first parameter.  It also exists to allow access to the
@@ -107,12 +107,21 @@ More condensed:
    library may offer.  The named constructors are much faster than :func:`new`
    and should be preferred.
 
+   Optionally provide an initial chunk of *data* to hash and additional
+   keyword arguments that are specific to the selected hashing algorithm.
+
 Using :func:`new` with an algorithm provided by OpenSSL:
 
    >>> h = hashlib.new('ripemd160')
    >>> h.update(b"Nobody inspects the spammish repetition")
    >>> h.hexdigest()
    'cc4a5ce1b3df48aec5d22d1f16b894a0b894eccc'
+
+Using :func:`new` with an initial data chunk and some keyword arguments:
+
+   >>> h = hashlib.new('blake2s', data=b'top secret', salt=b'foo', digest_size=16)
+   >>> h.hexdigest()
+   'a6a80726652c81c0195b108d6aa07bce'
 
 Hashlib provides the following constant attributes:
 

--- a/Lib/hashlib.py
+++ b/Lib/hashlib.py
@@ -129,16 +129,17 @@ def __get_openssl_constructor(name):
 
 
 def __py_new(name, data=b'', **kwargs):
-    """new(name, data=b'', **kwargs) - Return a new hashing object using the
-    named algorithm; optionally initialized with data (which must be
-    a bytes-like object).
+    """Return a new hashing object using the named algorithm; optionally
+    initialized with data (which must be a bytes-like object) and keyword
+    arguments specific to the named algorithm.
     """
     return __get_builtin_constructor(name)(data, **kwargs)
 
 
 def __hash_new(name, data=b'', **kwargs):
-    """new(name, data=b'') - Return a new hashing object using the named algorithm;
-    optionally initialized with data (which must be a bytes-like object).
+    """Return a new hashing object using the named algorithm; optionally
+    initialized with data (which must be a bytes-like object) and keyword
+    arguments specific to the named algorithm.
     """
     if name in {'blake2b', 'blake2s'}:
         # Prefer our blake2 implementation.

--- a/Misc/NEWS.d/next/Documentation/2019-09-10-22-22-23.bpo-35784.je_3Kp.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-09-10-22-22-23.bpo-35784.je_3Kp.rst
@@ -1,0 +1,1 @@
+Updating documentation for hashlib.new() to include mention of optional keyword arguments.


### PR DESCRIPTION
Updating documentation for hashlib.new(), including Doc/library/hashlib.rst and the docstring in Lib/hashlib.py. 

https://bugs.python.org/issue35784
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35784](https://bugs.python.org/issue35784) -->
https://bugs.python.org/issue35784
<!-- /issue-number -->
