### PR TITLE
bpo-36634: Fixes activate.bat when existing values contain double quotes

### DIFF
--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -10,36 +10,24 @@ if defined _OLD_CODEPAGE (
 
 set VIRTUAL_ENV=__VENV_DIR__
 
-if not defined PROMPT (
-    set PROMPT=$P$G
-)
+if not defined PROMPT set PROMPT=$P$G
 
-if defined _OLD_VIRTUAL_PROMPT (
-    set PROMPT=%_OLD_VIRTUAL_PROMPT%
-)
-
-if defined _OLD_VIRTUAL_PYTHONHOME (
-    set PYTHONHOME=%_OLD_VIRTUAL_PYTHONHOME%
-)
+if defined _OLD_VIRTUAL_PROMPT set PROMPT=%_OLD_VIRTUAL_PROMPT%
+if defined _OLD_VIRTUAL_PYTHONHOME set PYTHONHOME=%_OLD_VIRTUAL_PYTHONHOME%
 
 set _OLD_VIRTUAL_PROMPT=%PROMPT%
 set PROMPT=__VENV_PROMPT__%PROMPT%
 
-if defined PYTHONHOME (
-    set _OLD_VIRTUAL_PYTHONHOME=%PYTHONHOME%
-    set PYTHONHOME=
-)
+if defined PYTHONHOME set _OLD_VIRTUAL_PYTHONHOME=%PYTHONHOME%
+set PYTHONHOME=
 
-if defined _OLD_VIRTUAL_PATH (
-    set PATH=%_OLD_VIRTUAL_PATH%
-) else (
-    set _OLD_VIRTUAL_PATH=%PATH%
-)
+if defined _OLD_VIRTUAL_PATH set PATH=%_OLD_VIRTUAL_PATH%
+else set _OLD_VIRTUAL_PATH=%PATH%
 
 set PATH=%VIRTUAL_ENV%\__VENV_BIN_NAME__;%PATH%
 
 :END
 if defined _OLD_CODEPAGE (
     "%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE% > nul
-    set "_OLD_CODEPAGE="
+    set _OLD_CODEPAGE=
 )

--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -2,41 +2,41 @@
 
 rem This file is UTF-8 encoded, so we need to update the current code page while executing it
 for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\System32\chcp.com"') do (
-    set "_OLD_CODEPAGE=%%a"
+    set _OLD_CODEPAGE=%%a
 )
 if defined _OLD_CODEPAGE (
     "%SystemRoot%\System32\chcp.com" 65001 > nul
 )
 
-set "VIRTUAL_ENV=__VENV_DIR__"
+set VIRTUAL_ENV=__VENV_DIR__
 
 if not defined PROMPT (
-    set "PROMPT=$P$G"
+    set PROMPT=$P$G
 )
 
 if defined _OLD_VIRTUAL_PROMPT (
-    set "PROMPT=%_OLD_VIRTUAL_PROMPT%"
+    set PROMPT=%_OLD_VIRTUAL_PROMPT%
 )
 
 if defined _OLD_VIRTUAL_PYTHONHOME (
-    set "PYTHONHOME=%_OLD_VIRTUAL_PYTHONHOME%"
+    set PYTHONHOME=%_OLD_VIRTUAL_PYTHONHOME%
 )
 
-set "_OLD_VIRTUAL_PROMPT=%PROMPT%"
-set "PROMPT=__VENV_PROMPT__%PROMPT%"
+set _OLD_VIRTUAL_PROMPT=%PROMPT%
+set PROMPT=__VENV_PROMPT__%PROMPT%
 
 if defined PYTHONHOME (
-    set "_OLD_VIRTUAL_PYTHONHOME=%PYTHONHOME%"
+    set _OLD_VIRTUAL_PYTHONHOME=%PYTHONHOME%
     set PYTHONHOME=
 )
 
 if defined _OLD_VIRTUAL_PATH (
-    set "PATH=%_OLD_VIRTUAL_PATH%"
+    set PATH=%_OLD_VIRTUAL_PATH%
 ) else (
-    set "_OLD_VIRTUAL_PATH=%PATH%"
+    set _OLD_VIRTUAL_PATH=%PATH%
 )
 
-set "PATH=%VIRTUAL_ENV%\__VENV_BIN_NAME__;%PATH%"
+set PATH=%VIRTUAL_ENV%\__VENV_BIN_NAME__;%PATH%
 
 :END
 if defined _OLD_CODEPAGE (

--- a/Misc/NEWS.d/next/Windows/2019-09-11-12-34-31.bpo-36634.xLaGgb.rst
+++ b/Misc/NEWS.d/next/Windows/2019-09-11-12-34-31.bpo-36634.xLaGgb.rst
@@ -1,0 +1,2 @@
+venv activate.bat now works when the existing variables contain double quote
+characters.


### PR DESCRIPTION


<!-- issue-number: [bpo-36634](https://bugs.python.org/issue36634) -->
https://bugs.python.org/issue36634
<!-- /issue-number -->
