### PR TITLE
Doc: Use walrus operator in example.

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -516,10 +516,7 @@ Here is an example session that uses the ``GET`` method::
    >>> # The following example demonstrates reading data in chunks.
    >>> conn.request("GET", "/")
    >>> r1 = conn.getresponse()
-   >>> while True:
-   ...     chunk = r1.read(200)  # 200 bytes
-   ...     if not chunk:
-   ...          break
+   >>> while chunk := r1.read(200):
    ...     print(repr(chunk))
    b'<!doctype html>\n<!--[if"...
    ...


### PR DESCRIPTION
As proposed in https://github.com/python/cpython/pull/11441#pullrequestreview-286725473, but I did in two steps so the first could be backported to 3.7 where the example was not working, and this second step for the 3.8 doc with the walrus. 

Automerge-Triggered-By: @matrixise