### PR TITLE
bpo-37651: Document CancelledError is now a subclass of BaseException

### DIFF
--- a/Doc/library/asyncio-exceptions.rst
+++ b/Doc/library/asyncio-exceptions.rst
@@ -25,26 +25,9 @@ Exceptions
    when asyncio Tasks are cancelled.  In almost all situations the
    exception must be re-raised.
 
-   .. important::
+   .. versionchanged:: 3.8
 
-      This exception is a subclass of :exc:`Exception`, so it can be
-      accidentally suppressed by an overly broad ``try..except`` block::
-
-        try:
-            await operation
-        except Exception:
-            # The cancellation is broken because the *except* block
-            # suppresses the CancelledError exception.
-            log.log('an error has occurred')
-
-      Instead, the following pattern should be used::
-
-        try:
-            await operation
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            log.log('an error has occurred')
+      :exc:`CancelledError` is now a subclass of :class:`BaseException`.
 
 
 .. exception:: InvalidStateError


### PR DESCRIPTION


<!-- issue-number: [bpo-37651](https://bugs.python.org/issue37651) -->
https://bugs.python.org/issue37651
<!-- /issue-number -->


Automerge-Triggered-By: @1st1