### PR TITLE
bpo-32592: Set Windows 8 as the minimum required version for API support

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-09-11-14-51-56.bpo-32592.jvQMD9.rst
+++ b/Misc/NEWS.d/next/Windows/2019-09-11-14-51-56.bpo-32592.jvQMD9.rst
@@ -1,0 +1,1 @@
+Set Windows 8 as the minimum required version for API support

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12204,8 +12204,6 @@ os_cpu_count_impl(PyObject *module)
 {
     int ncpu = 0;
 #ifdef MS_WINDOWS
-    /* Declare prototype here to avoid pulling in all of the Win7 APIs in 3.8 */
-    DWORD WINAPI GetActiveProcessorCount(WORD group);
     ncpu = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
 #elif defined(__hpux)
     ncpu = mpctl(MPC_GETNUMSPUS, NULL, NULL);

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -135,9 +135,9 @@ WIN32 is still required for the locale module.
 #endif /* MS_WIN64 */
 
 /* set the version macros for the windows headers */
-/* Python 3.5+ requires Windows Vista or greater */
-#define Py_WINVER 0x0600 /* _WIN32_WINNT_VISTA */
-#define Py_NTDDI NTDDI_VISTA
+/* Python 3.9+ requires Windows 8 or greater */
+#define Py_WINVER 0x0602 /* _WIN32_WINNT_WIN8 */
+#define Py_NTDDI NTDDI_WIN8
 
 /* We only set these values when building Python - we don't want to force
    these values on extensions, as that will affect the prototypes and


### PR DESCRIPTION


<!-- issue-number: [bpo-32592](https://bugs.python.org/issue32592) -->
https://bugs.python.org/issue32592
<!-- /issue-number -->
