### PR TITLE
bpo-38113: Update the Python-ast.c generator to PEP384

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-11-14-10-02.bpo-38113.yZXC3P.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-11-14-10-02.bpo-38113.yZXC3P.rst
@@ -1,0 +1,1 @@
+ast module updated to PEP-384 and all statics removed

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -78,14 +78,18 @@ class EmitVisitor(asdl.VisitorBase):
     def __init__(self, file):
         self.file = file
         self.identifiers = set()
+        self.singletons = set()
+        self.types = set()
         super(EmitVisitor, self).__init__()
 
     def emit_identifier(self, name):
-        name = str(name)
-        if name in self.identifiers:
-            return
-        self.emit("_Py_IDENTIFIER(%s);" % name, 0)
-        self.identifiers.add(name)
+        self.identifiers.add(str(name))
+
+    def emit_singleton(self, name):
+        self.singletons.add(str(name))
+
+    def emit_type(self, name):
+        self.types.add(str(name))
 
     def emit(self, s, depth, reflow=True):
         # XXX reflow long lines?
@@ -391,9 +395,8 @@ class Obj2ModVisitor(PickleVisitor):
     def simpleSum(self, sum, name):
         self.funcHeader(name)
         for t in sum.types:
-            line = ("isinstance = PyObject_IsInstance(obj, "
-                    "(PyObject *)%s_type);")
-            self.emit(line % (t.name,), 1)
+            self.emit("isinstance = PyObject_IsInstance(obj, "
+                      f"astmodulestate_global->{t.name}_type);", 1)
             self.emit("if (isinstance == -1) {", 1)
             self.emit("return 1;", 2)
             self.emit("}", 1)
@@ -409,6 +412,7 @@ class Obj2ModVisitor(PickleVisitor):
     def complexSum(self, sum, name):
         self.funcHeader(name)
         self.emit("PyObject *tmp = NULL;", 1)
+        self.emit("PyObject *tp;", 1)
         for a in sum.attributes:
             self.visitAttributeDeclaration(a, name, sum=sum)
         self.emit("", 0)
@@ -420,8 +424,8 @@ class Obj2ModVisitor(PickleVisitor):
         for a in sum.attributes:
             self.visitField(a, name, sum=sum, depth=1)
         for t in sum.types:
-            line = "isinstance = PyObject_IsInstance(obj, (PyObject*)%s_type);"
-            self.emit(line % (t.name,), 1)
+            self.emit(f"tp = astmodulestate_global->{t.name}_type;", 1)
+            self.emit("isinstance = PyObject_IsInstance(obj, tp);", 1)
             self.emit("if (isinstance == -1) {", 1)
             self.emit("return 1;", 2)
             self.emit("}", 1)
@@ -497,7 +501,7 @@ class Obj2ModVisitor(PickleVisitor):
 
     def visitField(self, field, name, sum=None, prod=None, depth=0):
         ctype = get_c_type(field.type)
-        self.emit("if (_PyObject_LookupAttrId(obj, &PyId_%s, &tmp) < 0) {" % field.name, depth)
+        self.emit(f"if (_PyObject_LookupAttr(obj, astmodulestate_global->{field.name}, &tmp) < 0) {{", depth)
         self.emit("return 1;", depth+1)
         self.emit("}", depth)
         if not field.opt:
@@ -523,9 +527,8 @@ class Obj2ModVisitor(PickleVisitor):
             self.emit("Py_ssize_t len;", depth+1)
             self.emit("Py_ssize_t i;", depth+1)
             self.emit("if (!PyList_Check(tmp)) {", depth+1)
-            self.emit("PyErr_Format(PyExc_TypeError, \"%s field \\\"%s\\\" must "
-                      "be a list, not a %%.200s\", tmp->ob_type->tp_name);" %
-                      (name, field.name),
+            self.emit(f"PyErr_Format(PyExc_TypeError, \"{name} field \\\"{field.name}\\\" must "
+                      "be a list, not a %.200s\", _PyType_Name(Py_TYPE(tmp)));",
                       depth+2, reflow=False)
             self.emit("goto failed;", depth+2)
             self.emit("}", depth+1)
@@ -574,7 +577,7 @@ class MarshalPrototypeVisitor(PickleVisitor):
 class PyTypesDeclareVisitor(PickleVisitor):
 
     def visitProduct(self, prod, name):
-        self.emit("static PyTypeObject *%s_type;" % name, 0)
+        self.emit_type(f"{name}_type")
         self.emit("static PyObject* ast2obj_%s(void*);" % name, 0)
         if prod.attributes:
             for a in prod.attributes:
@@ -592,7 +595,7 @@ class PyTypesDeclareVisitor(PickleVisitor):
             self.emit("};", 0)
 
     def visitSum(self, sum, name):
-        self.emit("static PyTypeObject *%s_type;" % name, 0)
+        self.emit_type(f"{name}_type")
         if sum.attributes:
             for a in sum.attributes:
                 self.emit_identifier(a.name)
@@ -603,17 +606,13 @@ class PyTypesDeclareVisitor(PickleVisitor):
         ptype = "void*"
         if is_simple(sum):
             ptype = get_c_type(name)
-            tnames = []
             for t in sum.types:
-                tnames.append(str(t.name)+"_singleton")
-            tnames = ", *".join(tnames)
-            self.emit("static PyObject *%s;" % tnames, 0)
+                self.emit_singleton(f"{str(t.name)}_singleton")
         self.emit("static PyObject* ast2obj_%s(%s);" % (name, ptype), 0)
         for t in sum.types:
             self.visitConstructor(t, name)
 
     def visitConstructor(self, cons, name):
-        self.emit("static PyTypeObject *%s_type;" % cons.name, 0)
         if cons.fields:
             for t in cons.fields:
                 self.emit_identifier(t.name)
@@ -626,8 +625,6 @@ class PyTypesVisitor(PickleVisitor):
 
     def visitModule(self, mod):
         self.emit("""
-_Py_IDENTIFIER(_fields);
-_Py_IDENTIFIER(_attributes);
 
 typedef struct {
     PyObject_HEAD
@@ -663,7 +660,7 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields;
-    if (_PyObject_LookupAttrId((PyObject*)Py_TYPE(self), &PyId__fields, &fields) < 0) {
+    if (_PyObject_LookupAttr((PyObject*)Py_TYPE(self), astmodulestate_global->_fields, &fields) < 0) {
         goto cleanup;
     }
     if (fields) {
@@ -676,7 +673,7 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     if (numfields < PyTuple_GET_SIZE(args)) {
         PyErr_Format(PyExc_TypeError, "%.400s constructor takes at most "
                      "%zd positional argument%s",
-                     Py_TYPE(self)->tp_name,
+                     _PyType_Name(Py_TYPE(self)),
                      numfields, numfields == 1 ? "" : "s");
         res = -1;
         goto cleanup;
@@ -710,9 +707,8 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
 static PyObject *
 ast_type_reduce(PyObject *self, PyObject *unused)
 {
-    _Py_IDENTIFIER(__dict__);
     PyObject *dict;
-    if (_PyObject_LookupAttrId(self, &PyId___dict__, &dict) < 0) {
+    if (_PyObject_LookupAttr(self, astmodulestate_global->__dict__, &dict) < 0) {
         return NULL;
     }
     if (dict) {
@@ -731,54 +727,33 @@ static PyGetSetDef ast_type_getsets[] = {
     {NULL}
 };
 
-static PyTypeObject AST_type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
+static PyType_Slot AST_type_slots[] = {
+    {Py_tp_dealloc, ast_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_traverse, ast_traverse},
+    {Py_tp_clear, ast_clear},
+    {Py_tp_methods, ast_type_methods},
+    {Py_tp_getset, ast_type_getsets},
+    {Py_tp_init, ast_type_init},
+    {Py_tp_alloc, PyType_GenericAlloc},
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_free, PyType_GenericNew},
+    {Py_tp_free, PyObject_GC_Del},
+    {0, 0},
+};
+
+static PyType_Spec AST_type_spec = {
     "_ast.AST",
     sizeof(AST_object),
     0,
-    (destructor)ast_dealloc, /* tp_dealloc */
-    0,                       /* tp_vectorcall_offset */
-    0,                       /* tp_getattr */
-    0,                       /* tp_setattr */
-    0,                       /* tp_as_async */
-    0,                       /* tp_repr */
-    0,                       /* tp_as_number */
-    0,                       /* tp_as_sequence */
-    0,                       /* tp_as_mapping */
-    0,                       /* tp_hash */
-    0,                       /* tp_call */
-    0,                       /* tp_str */
-    PyObject_GenericGetAttr, /* tp_getattro */
-    PyObject_GenericSetAttr, /* tp_setattro */
-    0,                       /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /* tp_flags */
-    0,                       /* tp_doc */
-    (traverseproc)ast_traverse, /* tp_traverse */
-    (inquiry)ast_clear,      /* tp_clear */
-    0,                       /* tp_richcompare */
-    0,                       /* tp_weaklistoffset */
-    0,                       /* tp_iter */
-    0,                       /* tp_iternext */
-    ast_type_methods,        /* tp_methods */
-    0,                       /* tp_members */
-    ast_type_getsets,        /* tp_getset */
-    0,                       /* tp_base */
-    0,                       /* tp_dict */
-    0,                       /* tp_descr_get */
-    0,                       /* tp_descr_set */
-    offsetof(AST_object, dict),/* tp_dictoffset */
-    (initproc)ast_type_init, /* tp_init */
-    PyType_GenericAlloc,     /* tp_alloc */
-    PyType_GenericNew,       /* tp_new */
-    PyObject_GC_Del,         /* tp_free */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    AST_type_slots
 };
 
-
-static PyTypeObject *
-make_type(const char *type, PyTypeObject *base, const char * const *fields, int num_fields)
+static PyObject *
+make_type(const char *type, PyObject* base, const char* const* fields, int num_fields)
 {
-    _Py_IDENTIFIER(__module__);
-    _Py_IDENTIFIER(_ast);
     PyObject *fnames, *result;
     int i;
     fnames = PyTuple_New(num_fields);
@@ -793,15 +768,15 @@ make_type(const char *type, PyTypeObject *base, const char * const *fields, int 
     }
     result = PyObject_CallFunction((PyObject*)&PyType_Type, "s(O){OOOO}",
                     type, base,
-                    _PyUnicode_FromId(&PyId__fields), fnames,
-                    _PyUnicode_FromId(&PyId___module__),
-                    _PyUnicode_FromId(&PyId__ast));
+                    astmodulestate_global->_fields, fnames,
+                    astmodulestate_global->__module__,
+                    astmodulestate_global->_ast);
     Py_DECREF(fnames);
-    return (PyTypeObject*)result;
+    return result;
 }
 
 static int
-add_attributes(PyTypeObject *type, const char * const *attrs, int num_fields)
+add_attributes(PyObject *type, const char * const *attrs, int num_fields)
 {
     int i, result;
     PyObject *s, *l = PyTuple_New(num_fields);
@@ -815,7 +790,7 @@ add_attributes(PyTypeObject *type, const char * const *attrs, int num_fields)
         }
         PyTuple_SET_ITEM(l, i, s);
     }
-    result = _PyObject_SetAttrId((PyObject*)type, &PyId__attributes, l) >= 0;
+    result = PyObject_SetAttr(type, astmodulestate_global->_attributes, l) >= 0;
     Py_DECREF(l);
     return result;
 }
@@ -921,14 +896,11 @@ static int obj2ast_int(PyObject* obj, int* out, PyArena* arena)
 
 static int add_ast_fields(void)
 {
-    PyObject *empty_tuple, *d;
-    if (PyType_Ready(&AST_type) < 0)
-        return -1;
-    d = AST_type.tp_dict;
+    PyObject *empty_tuple;
     empty_tuple = PyTuple_New(0);
     if (!empty_tuple ||
-        _PyDict_SetItemId(d, &PyId__fields, empty_tuple) < 0 ||
-        _PyDict_SetItemId(d, &PyId__attributes, empty_tuple) < 0) {
+        PyObject_SetAttrString(astmodulestate_global->AST_type, "_fields", empty_tuple) < 0 ||
+        PyObject_SetAttrString(astmodulestate_global->AST_type, "_attributes", empty_tuple) < 0) {
         Py_XDECREF(empty_tuple);
         return -1;
     }
@@ -940,12 +912,22 @@ static int add_ast_fields(void)
 
         self.emit("static int init_types(void)",0)
         self.emit("{", 0)
-        self.emit("static int initialized;", 1)
-        self.emit("if (initialized) return 1;", 1)
+        self.emit("PyObject *m;", 1)
+        self.emit("if (PyState_FindModule(&_astmodule) == NULL) {", 1)
+        self.emit("m = PyModule_Create(&_astmodule);", 2)
+        self.emit("if (!m) return 0;", 2)
+        self.emit("PyState_AddModule(m, &_astmodule);", 2)
+        self.emit("}", 1)
+        self.emit("astmodulestate *state = astmodulestate_global;", 1)
+        self.emit("if (state->initialized) return 1;", 1)
+        self.emit("if (init_identifiers() < 0) return 0;", 1)
+        self.emit("state->AST_type = PyType_FromSpec(&AST_type_spec);", 1)
+        self.emit("if (!state->AST_type) return 0;", 1)
+        self.emit("((PyTypeObject*)state->AST_type)->tp_dictoffset = offsetof(AST_object, dict);", 1)
         self.emit("if (add_ast_fields() < 0) return 0;", 1)
         for dfn in mod.dfns:
             self.visit(dfn)
-        self.emit("initialized = 1;", 1)
+        self.emit("state->initialized = 1;", 1)
         self.emit("return 1;", 1);
         self.emit("}", 0)
 
@@ -954,24 +936,29 @@ static int add_ast_fields(void)
             fields = name+"_fields"
         else:
             fields = "NULL"
-        self.emit('%s_type = make_type("%s", &AST_type, %s, %d);' %
-                        (name, name, fields, len(prod.fields)), 1)
-        self.emit("if (!%s_type) return 0;" % name, 1)
+        state_name = f"state->{name}"
+        self.emit_type("AST_type")
+        self.emit(f"{state_name}_type = make_type(\"{name}\", "
+                  f"state->AST_type, {fields}, {len(prod.fields)});", 1)
+        self.emit_type(f"{name}_type")
+        self.emit(f"if (!{state_name}_type) return 0;", 1)
         if prod.attributes:
-            self.emit("if (!add_attributes(%s_type, %s_attributes, %d)) return 0;" %
-                            (name, name, len(prod.attributes)), 1)
+            self.emit(f"if (!add_attributes({state_name}_type, {name}_attributes, "
+                      f"{len(prod.attributes)})) return 0;", 1)
         else:
-            self.emit("if (!add_attributes(%s_type, NULL, 0)) return 0;" % name, 1)
+            self.emit(f"if (!add_attributes({state_name}_type, NULL, 0)) return 0;", 1)
 
     def visitSum(self, sum, name):
-        self.emit('%s_type = make_type("%s", &AST_type, NULL, 0);' %
-                  (name, name), 1)
-        self.emit("if (!%s_type) return 0;" % name, 1)
+        state_name = f"state->{name}"
+        self.emit(f"{state_name}_type = make_type(\"{name}\", "
+                  "state->AST_type, NULL, 0);", 1)
+        self.emit_type(f"{name}_type")
+        self.emit(f"if (!{state_name}_type) return 0;", 1)
         if sum.attributes:
-            self.emit("if (!add_attributes(%s_type, %s_attributes, %d)) return 0;" %
-                            (name, name, len(sum.attributes)), 1)
+            self.emit(f"if (!add_attributes({state_name}_type, "
+                      f"{name}_attributes, {len(sum.attributes)})) return 0;", 1)
         else:
-            self.emit("if (!add_attributes(%s_type, NULL, 0)) return 0;" % name, 1)
+            self.emit(f"if (!add_attributes({state_name}_type, NULL, 0)) return 0;", 1)
         simple = is_simple(sum)
         for t in sum.types:
             self.visitConstructor(t, name, simple)
@@ -981,30 +968,30 @@ static int add_ast_fields(void)
             fields = cons.name+"_fields"
         else:
             fields = "NULL"
-        self.emit('%s_type = make_type("%s", %s_type, %s, %d);' %
-                            (cons.name, cons.name, name, fields, len(cons.fields)), 1)
-        self.emit("if (!%s_type) return 0;" % cons.name, 1)
+        state_name = f"state->{name}"
+        cons_state_name = f"state->{cons.name}"
+        self.emit(f"{cons_state_name}_type = make_type(\"{cons.name}\", "
+                  f"{state_name}_type, {fields}, {len(cons.fields)});", 1)
+        self.emit_type(f"{cons.name}_type")
+        self.emit(f"if (!{cons_state_name}_type) return 0;", 1)
         if simple:
-            self.emit("%s_singleton = PyType_GenericNew(%s_type, NULL, NULL);" %
-                             (cons.name, cons.name), 1)
-            self.emit("if (!%s_singleton) return 0;" % cons.name, 1)
+            self.emit(f"{cons_state_name}_singleton = PyType_GenericNew("
+                      f"(PyTypeObject *){cons_state_name}_type, NULL, NULL);", 1)
+            self.emit(f"if (!{cons_state_name}_singleton) return 0;", 1)
 
 
 class ASTModuleVisitor(PickleVisitor):
 
     def visitModule(self, mod):
-        self.emit("static struct PyModuleDef _astmodule = {", 0)
-        self.emit('  PyModuleDef_HEAD_INIT, "_ast"', 0)
-        self.emit("};", 0)
         self.emit("PyMODINIT_FUNC", 0)
         self.emit("PyInit__ast(void)", 0)
         self.emit("{", 0)
-        self.emit("PyObject *m, *d;", 1)
+        self.emit("PyObject *m;", 1)
         self.emit("if (!init_types()) return NULL;", 1)
-        self.emit('m = PyModule_Create(&_astmodule);', 1)
+        self.emit('m = PyState_FindModule(&_astmodule);', 1)
         self.emit("if (!m) return NULL;", 1)
-        self.emit("d = PyModule_GetDict(m);", 1)
-        self.emit('if (PyDict_SetItemString(d, "AST", (PyObject*)&AST_type) < 0) return NULL;', 1)
+        self.emit('Py_INCREF(astmodulestate(m)->AST_type);', 1)
+        self.emit('if (PyModule_AddObject(m, "AST", astmodulestate_global->AST_type) < 0) return NULL;', 1)
         self.emit('if (PyModule_AddIntMacro(m, PyCF_ALLOW_TOP_LEVEL_AWAIT) < 0)', 1)
         self.emit("return NULL;", 2)
         self.emit('if (PyModule_AddIntMacro(m, PyCF_ONLY_AST) < 0)', 1)
@@ -1028,7 +1015,9 @@ class ASTModuleVisitor(PickleVisitor):
         self.addObj(cons.name)
 
     def addObj(self, name):
-        self.emit('if (PyDict_SetItemString(d, "%s", (PyObject*)%s_type) < 0) return NULL;' % (name, name), 1)
+        self.emit(f"if (PyModule_AddObject(m, \"{name}\", "
+                  f"astmodulestate_global->{name}_type) < 0) return NULL;", 1)
+        self.emit(f"Py_INCREF(astmodulestate(m)->{name}_type);", 1)
 
 
 _SPECIALIZED_SEQUENCES = ('stmt', 'expr')
@@ -1066,6 +1055,7 @@ class ObjVisitor(PickleVisitor):
         self.emit("{", 0)
         self.emit("%s o = (%s)_o;" % (ctype, ctype), 1)
         self.emit("PyObject *result = NULL, *value = NULL;", 1)
+        self.emit("PyTypeObject *tp;", 1)
         self.emit('if (!o) {', 1)
         self.emit("Py_RETURN_NONE;", 2)
         self.emit("}", 1)
@@ -1093,7 +1083,7 @@ class ObjVisitor(PickleVisitor):
         for a in sum.attributes:
             self.emit("value = ast2obj_%s(o->%s);" % (a.type, a.name), 1)
             self.emit("if (!value) goto failed;", 1)
-            self.emit('if (_PyObject_SetAttrId(result, &PyId_%s, value) < 0)' % a.name, 1)
+            self.emit(f"if (PyObject_SetAttr(result, astmodulestate_global->{a.name}, value) < 0)", 1)
             self.emit('goto failed;', 2)
             self.emit('Py_DECREF(value);', 1)
         self.func_end()
@@ -1104,8 +1094,8 @@ class ObjVisitor(PickleVisitor):
         self.emit("switch(o) {", 1)
         for t in sum.types:
             self.emit("case %s:" % t.name, 2)
-            self.emit("Py_INCREF(%s_singleton);" % t.name, 3)
-            self.emit("return %s_singleton;" % t.name, 3)
+            self.emit(f"Py_INCREF(astmodulestate_global->{t.name}_singleton);", 3)
+            self.emit(f"return astmodulestate_global->{t.name}_singleton;", 3)
         self.emit("default:", 2)
         self.emit('/* should never happen, but just in case ... */', 3)
         code = "PyErr_Format(PyExc_SystemError, \"unknown %s found\");" % name
@@ -1116,21 +1106,23 @@ class ObjVisitor(PickleVisitor):
 
     def visitProduct(self, prod, name):
         self.func_begin(name)
-        self.emit("result = PyType_GenericNew(%s_type, NULL, NULL);" % name, 1);
+        self.emit(f"tp = (PyTypeObject *)astmodulestate_global->{name}_type;", 1)
+        self.emit("result = PyType_GenericNew(tp, NULL, NULL);", 1);
         self.emit("if (!result) return NULL;", 1)
         for field in prod.fields:
             self.visitField(field, name, 1, True)
         for a in prod.attributes:
             self.emit("value = ast2obj_%s(o->%s);" % (a.type, a.name), 1)
             self.emit("if (!value) goto failed;", 1)
-            self.emit('if (_PyObject_SetAttrId(result, &PyId_%s, value) < 0)' % a.name, 1)
+            self.emit(f"if (PyObject_SetAttr(result, astmodulestate_global->{a.name}, value) < 0)", 1)
             self.emit('goto failed;', 2)
             self.emit('Py_DECREF(value);', 1)
         self.func_end()
 
     def visitConstructor(self, cons, enum, name):
         self.emit("case %s_kind:" % cons.name, 1)
-        self.emit("result = PyType_GenericNew(%s_type, NULL, NULL);" % cons.name, 2);
+        self.emit(f"tp = (PyTypeObject *)astmodulestate_global->{cons.name}_type;", 2)
+        self.emit("result = PyType_GenericNew(tp, NULL, NULL);", 2);
         self.emit("if (!result) goto failed;", 2)
         for f in cons.fields:
             self.visitField(f, cons.name, 2, False)
@@ -1145,7 +1137,7 @@ class ObjVisitor(PickleVisitor):
             value = "o->v.%s.%s" % (name, field.name)
         self.set(field, value, depth)
         emit("if (!value) goto failed;", 0)
-        emit('if (_PyObject_SetAttrId(result, &PyId_%s, value) == -1)' % field.name, 0)
+        emit(f"if (PyObject_SetAttr(result, astmodulestate_global->{field.name}, value) == -1)", 0)
         emit("goto failed;", 1)
         emit("Py_DECREF(value);", 0)
 
@@ -1205,9 +1197,9 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
         return NULL;
     }
 
-    req_type[0] = (PyObject*)Module_type;
-    req_type[1] = (PyObject*)Expression_type;
-    req_type[2] = (PyObject*)Interactive_type;
+    req_type[0] = astmodulestate_global->Module_type;
+    req_type[1] = astmodulestate_global->Expression_type;
+    req_type[2] = astmodulestate_global->Interactive_type;
 
     assert(0 <= mode && mode <= 2);
 
@@ -1219,7 +1211,7 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
         return NULL;
     if (!isinstance) {
         PyErr_Format(PyExc_TypeError, "expected %s node, got %.400s",
-                     req_name[mode], Py_TYPE(ast)->tp_name);
+                     req_name[mode], _PyType_Name(Py_TYPE(ast)));
         return NULL;
     }
     if (obj2ast_mod(ast, &res, arena) != 0)
@@ -1232,7 +1224,7 @@ int PyAST_Check(PyObject* obj)
 {
     if (!init_types())
         return -1;
-    return PyObject_IsInstance(obj, (PyObject*)&AST_type);
+    return PyObject_IsInstance(obj, astmodulestate_global->AST_type);
 }
 """
 
@@ -1244,6 +1236,86 @@ class ChainOfVisitors:
         for v in self.visitors:
             v.visit(object)
             v.emit("", 0)
+
+
+def generate_module_def(f, mod):
+    # Gather all the data needed for ModuleSpec
+    visitor_list = set()
+    with open(os.devnull, "w") as devnull:
+        visitor = PyTypesDeclareVisitor(devnull)
+        visitor.visit(mod)
+        visitor_list.add(visitor)
+        visitor = PyTypesVisitor(devnull)
+        visitor.visit(mod)
+        visitor_list.add(visitor)
+
+    state_strings = set(["__dict__", "_attributes", "_fields", "__module__", "_ast"])
+    module_state = set(["__dict__", "_attributes", "_fields", "__module__", "_ast"])
+    for visitor in visitor_list:
+          for identifier in visitor.identifiers:
+              module_state.add(identifier)
+              state_strings.add(identifier)
+          for singleton in visitor.singletons:
+              module_state.add(singleton)
+          for tp in visitor.types:
+              module_state.add(tp)
+    state_strings = sorted(state_strings)
+    module_state = sorted(module_state)
+    f.write('typedef struct {\n')
+    f.write('    int initialized;\n')
+    for s in module_state:
+          f.write('    PyObject *' + s + ';\n')
+    f.write('} astmodulestate;\n\n')
+    f.write("""
+#define astmodulestate(o) ((astmodulestate *)PyModule_GetState(o))
+
+static int astmodule_clear(PyObject *module)
+{
+""")
+    for s in module_state:
+        f.write("    Py_CLEAR(astmodulestate(module)->" + s + ');\n')
+    f.write("""
+    return 0;
+}
+
+static int astmodule_traverse(PyObject *module, visitproc visit, void* arg)
+{
+""")
+    for s in module_state:
+        f.write("    Py_VISIT(astmodulestate(module)->" + s + ');\n')
+    f.write("""
+    return 0;
+}
+
+static void astmodule_free(void* module) {
+    astmodule_clear((PyObject*)module);
+}
+
+static struct PyModuleDef _astmodule = {
+    PyModuleDef_HEAD_INIT,
+    "_ast",
+    NULL,
+    sizeof(astmodulestate),
+    NULL,
+    NULL,
+    astmodule_traverse,
+    astmodule_clear,
+    astmodule_free,
+};
+
+#define astmodulestate_global ((astmodulestate *)PyModule_GetState(PyState_FindModule(&_astmodule)))
+
+""")
+    f.write('static int init_identifiers(void)\n')
+    f.write('{\n')
+    f.write('    astmodulestate *state = astmodulestate_global;\n')
+    for identifier in state_strings:
+        f.write('    if ((state->' + identifier)
+        f.write(' = PyUnicode_InternFromString("')
+        f.write(identifier + '")) == NULL) return 0;\n')
+    f.write('    return 1;\n')
+    f.write('};\n\n')
+
 
 common_msg = "/* File automatically generated by %s. */\n\n"
 
@@ -1295,7 +1367,9 @@ def main(srcfile, dump_module=False):
             f.write('#include "Python.h"\n')
             f.write('#include "%s-ast.h"\n' % mod.name)
             f.write('\n')
-            f.write("static PyTypeObject AST_type;\n")
+
+            generate_module_def(f, mod)
+
             v = ChainOfVisitors(
                 PyTypesDeclareVisitor(f),
                 PyTypesVisitor(f),

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1252,19 +1252,19 @@ def generate_module_def(f, mod):
     state_strings = set(["__dict__", "_attributes", "_fields", "__module__", "_ast"])
     module_state = set(["__dict__", "_attributes", "_fields", "__module__", "_ast"])
     for visitor in visitor_list:
-          for identifier in visitor.identifiers:
-              module_state.add(identifier)
-              state_strings.add(identifier)
-          for singleton in visitor.singletons:
-              module_state.add(singleton)
-          for tp in visitor.types:
-              module_state.add(tp)
+        for identifier in visitor.identifiers:
+            module_state.add(identifier)
+            state_strings.add(identifier)
+        for singleton in visitor.singletons:
+            module_state.add(singleton)
+        for tp in visitor.types:
+            module_state.add(tp)
     state_strings = sorted(state_strings)
     module_state = sorted(module_state)
     f.write('typedef struct {\n')
     f.write('    int initialized;\n')
     for s in module_state:
-          f.write('    PyObject *' + s + ';\n')
+        f.write('    PyObject *' + s + ';\n')
     f.write('} astmodulestate;\n\n')
     f.write("""
 #define astmodulestate(o) ((astmodulestate *)PyModule_GetState(o))

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -5,40 +5,810 @@
 #include "Python.h"
 #include "Python-ast.h"
 
-static PyTypeObject AST_type;
-static PyTypeObject *mod_type;
+typedef struct {
+    int initialized;
+    PyObject *AST_type;
+    PyObject *Add_singleton;
+    PyObject *Add_type;
+    PyObject *And_singleton;
+    PyObject *And_type;
+    PyObject *AnnAssign_type;
+    PyObject *Assert_type;
+    PyObject *Assign_type;
+    PyObject *AsyncFor_type;
+    PyObject *AsyncFunctionDef_type;
+    PyObject *AsyncWith_type;
+    PyObject *Attribute_type;
+    PyObject *AugAssign_type;
+    PyObject *AugLoad_singleton;
+    PyObject *AugLoad_type;
+    PyObject *AugStore_singleton;
+    PyObject *AugStore_type;
+    PyObject *Await_type;
+    PyObject *BinOp_type;
+    PyObject *BitAnd_singleton;
+    PyObject *BitAnd_type;
+    PyObject *BitOr_singleton;
+    PyObject *BitOr_type;
+    PyObject *BitXor_singleton;
+    PyObject *BitXor_type;
+    PyObject *BoolOp_type;
+    PyObject *Break_type;
+    PyObject *Call_type;
+    PyObject *ClassDef_type;
+    PyObject *Compare_type;
+    PyObject *Constant_type;
+    PyObject *Continue_type;
+    PyObject *Del_singleton;
+    PyObject *Del_type;
+    PyObject *Delete_type;
+    PyObject *DictComp_type;
+    PyObject *Dict_type;
+    PyObject *Div_singleton;
+    PyObject *Div_type;
+    PyObject *Eq_singleton;
+    PyObject *Eq_type;
+    PyObject *ExceptHandler_type;
+    PyObject *Expr_type;
+    PyObject *Expression_type;
+    PyObject *ExtSlice_type;
+    PyObject *FloorDiv_singleton;
+    PyObject *FloorDiv_type;
+    PyObject *For_type;
+    PyObject *FormattedValue_type;
+    PyObject *FunctionDef_type;
+    PyObject *FunctionType_type;
+    PyObject *GeneratorExp_type;
+    PyObject *Global_type;
+    PyObject *GtE_singleton;
+    PyObject *GtE_type;
+    PyObject *Gt_singleton;
+    PyObject *Gt_type;
+    PyObject *IfExp_type;
+    PyObject *If_type;
+    PyObject *ImportFrom_type;
+    PyObject *Import_type;
+    PyObject *In_singleton;
+    PyObject *In_type;
+    PyObject *Index_type;
+    PyObject *Interactive_type;
+    PyObject *Invert_singleton;
+    PyObject *Invert_type;
+    PyObject *IsNot_singleton;
+    PyObject *IsNot_type;
+    PyObject *Is_singleton;
+    PyObject *Is_type;
+    PyObject *JoinedStr_type;
+    PyObject *LShift_singleton;
+    PyObject *LShift_type;
+    PyObject *Lambda_type;
+    PyObject *ListComp_type;
+    PyObject *List_type;
+    PyObject *Load_singleton;
+    PyObject *Load_type;
+    PyObject *LtE_singleton;
+    PyObject *LtE_type;
+    PyObject *Lt_singleton;
+    PyObject *Lt_type;
+    PyObject *MatMult_singleton;
+    PyObject *MatMult_type;
+    PyObject *Mod_singleton;
+    PyObject *Mod_type;
+    PyObject *Module_type;
+    PyObject *Mult_singleton;
+    PyObject *Mult_type;
+    PyObject *Name_type;
+    PyObject *NamedExpr_type;
+    PyObject *Nonlocal_type;
+    PyObject *NotEq_singleton;
+    PyObject *NotEq_type;
+    PyObject *NotIn_singleton;
+    PyObject *NotIn_type;
+    PyObject *Not_singleton;
+    PyObject *Not_type;
+    PyObject *Or_singleton;
+    PyObject *Or_type;
+    PyObject *Param_singleton;
+    PyObject *Param_type;
+    PyObject *Pass_type;
+    PyObject *Pow_singleton;
+    PyObject *Pow_type;
+    PyObject *RShift_singleton;
+    PyObject *RShift_type;
+    PyObject *Raise_type;
+    PyObject *Return_type;
+    PyObject *SetComp_type;
+    PyObject *Set_type;
+    PyObject *Slice_type;
+    PyObject *Starred_type;
+    PyObject *Store_singleton;
+    PyObject *Store_type;
+    PyObject *Sub_singleton;
+    PyObject *Sub_type;
+    PyObject *Subscript_type;
+    PyObject *Suite_type;
+    PyObject *Try_type;
+    PyObject *Tuple_type;
+    PyObject *TypeIgnore_type;
+    PyObject *UAdd_singleton;
+    PyObject *UAdd_type;
+    PyObject *USub_singleton;
+    PyObject *USub_type;
+    PyObject *UnaryOp_type;
+    PyObject *While_type;
+    PyObject *With_type;
+    PyObject *YieldFrom_type;
+    PyObject *Yield_type;
+    PyObject *__dict__;
+    PyObject *__module__;
+    PyObject *_ast;
+    PyObject *_attributes;
+    PyObject *_fields;
+    PyObject *alias_type;
+    PyObject *annotation;
+    PyObject *arg;
+    PyObject *arg_type;
+    PyObject *args;
+    PyObject *argtypes;
+    PyObject *arguments_type;
+    PyObject *asname;
+    PyObject *attr;
+    PyObject *bases;
+    PyObject *body;
+    PyObject *boolop_type;
+    PyObject *cause;
+    PyObject *cmpop_type;
+    PyObject *col_offset;
+    PyObject *comparators;
+    PyObject *comprehension_type;
+    PyObject *context_expr;
+    PyObject *conversion;
+    PyObject *ctx;
+    PyObject *decorator_list;
+    PyObject *defaults;
+    PyObject *dims;
+    PyObject *elt;
+    PyObject *elts;
+    PyObject *end_col_offset;
+    PyObject *end_lineno;
+    PyObject *exc;
+    PyObject *excepthandler_type;
+    PyObject *expr_context_type;
+    PyObject *expr_type;
+    PyObject *finalbody;
+    PyObject *format_spec;
+    PyObject *func;
+    PyObject *generators;
+    PyObject *handlers;
+    PyObject *id;
+    PyObject *ifs;
+    PyObject *is_async;
+    PyObject *items;
+    PyObject *iter;
+    PyObject *key;
+    PyObject *keys;
+    PyObject *keyword_type;
+    PyObject *keywords;
+    PyObject *kind;
+    PyObject *kw_defaults;
+    PyObject *kwarg;
+    PyObject *kwonlyargs;
+    PyObject *left;
+    PyObject *level;
+    PyObject *lineno;
+    PyObject *lower;
+    PyObject *mod_type;
+    PyObject *module;
+    PyObject *msg;
+    PyObject *name;
+    PyObject *names;
+    PyObject *op;
+    PyObject *operand;
+    PyObject *operator_type;
+    PyObject *ops;
+    PyObject *optional_vars;
+    PyObject *orelse;
+    PyObject *posonlyargs;
+    PyObject *returns;
+    PyObject *right;
+    PyObject *simple;
+    PyObject *slice;
+    PyObject *slice_type;
+    PyObject *step;
+    PyObject *stmt_type;
+    PyObject *tag;
+    PyObject *target;
+    PyObject *targets;
+    PyObject *test;
+    PyObject *type;
+    PyObject *type_comment;
+    PyObject *type_ignore_type;
+    PyObject *type_ignores;
+    PyObject *unaryop_type;
+    PyObject *upper;
+    PyObject *value;
+    PyObject *values;
+    PyObject *vararg;
+    PyObject *withitem_type;
+} astmodulestate;
+
+
+#define astmodulestate(o) ((astmodulestate *)PyModule_GetState(o))
+
+static int astmodule_clear(PyObject *module)
+{
+    Py_CLEAR(astmodulestate(module)->AST_type);
+    Py_CLEAR(astmodulestate(module)->Add_singleton);
+    Py_CLEAR(astmodulestate(module)->Add_type);
+    Py_CLEAR(astmodulestate(module)->And_singleton);
+    Py_CLEAR(astmodulestate(module)->And_type);
+    Py_CLEAR(astmodulestate(module)->AnnAssign_type);
+    Py_CLEAR(astmodulestate(module)->Assert_type);
+    Py_CLEAR(astmodulestate(module)->Assign_type);
+    Py_CLEAR(astmodulestate(module)->AsyncFor_type);
+    Py_CLEAR(astmodulestate(module)->AsyncFunctionDef_type);
+    Py_CLEAR(astmodulestate(module)->AsyncWith_type);
+    Py_CLEAR(astmodulestate(module)->Attribute_type);
+    Py_CLEAR(astmodulestate(module)->AugAssign_type);
+    Py_CLEAR(astmodulestate(module)->AugLoad_singleton);
+    Py_CLEAR(astmodulestate(module)->AugLoad_type);
+    Py_CLEAR(astmodulestate(module)->AugStore_singleton);
+    Py_CLEAR(astmodulestate(module)->AugStore_type);
+    Py_CLEAR(astmodulestate(module)->Await_type);
+    Py_CLEAR(astmodulestate(module)->BinOp_type);
+    Py_CLEAR(astmodulestate(module)->BitAnd_singleton);
+    Py_CLEAR(astmodulestate(module)->BitAnd_type);
+    Py_CLEAR(astmodulestate(module)->BitOr_singleton);
+    Py_CLEAR(astmodulestate(module)->BitOr_type);
+    Py_CLEAR(astmodulestate(module)->BitXor_singleton);
+    Py_CLEAR(astmodulestate(module)->BitXor_type);
+    Py_CLEAR(astmodulestate(module)->BoolOp_type);
+    Py_CLEAR(astmodulestate(module)->Break_type);
+    Py_CLEAR(astmodulestate(module)->Call_type);
+    Py_CLEAR(astmodulestate(module)->ClassDef_type);
+    Py_CLEAR(astmodulestate(module)->Compare_type);
+    Py_CLEAR(astmodulestate(module)->Constant_type);
+    Py_CLEAR(astmodulestate(module)->Continue_type);
+    Py_CLEAR(astmodulestate(module)->Del_singleton);
+    Py_CLEAR(astmodulestate(module)->Del_type);
+    Py_CLEAR(astmodulestate(module)->Delete_type);
+    Py_CLEAR(astmodulestate(module)->DictComp_type);
+    Py_CLEAR(astmodulestate(module)->Dict_type);
+    Py_CLEAR(astmodulestate(module)->Div_singleton);
+    Py_CLEAR(astmodulestate(module)->Div_type);
+    Py_CLEAR(astmodulestate(module)->Eq_singleton);
+    Py_CLEAR(astmodulestate(module)->Eq_type);
+    Py_CLEAR(astmodulestate(module)->ExceptHandler_type);
+    Py_CLEAR(astmodulestate(module)->Expr_type);
+    Py_CLEAR(astmodulestate(module)->Expression_type);
+    Py_CLEAR(astmodulestate(module)->ExtSlice_type);
+    Py_CLEAR(astmodulestate(module)->FloorDiv_singleton);
+    Py_CLEAR(astmodulestate(module)->FloorDiv_type);
+    Py_CLEAR(astmodulestate(module)->For_type);
+    Py_CLEAR(astmodulestate(module)->FormattedValue_type);
+    Py_CLEAR(astmodulestate(module)->FunctionDef_type);
+    Py_CLEAR(astmodulestate(module)->FunctionType_type);
+    Py_CLEAR(astmodulestate(module)->GeneratorExp_type);
+    Py_CLEAR(astmodulestate(module)->Global_type);
+    Py_CLEAR(astmodulestate(module)->GtE_singleton);
+    Py_CLEAR(astmodulestate(module)->GtE_type);
+    Py_CLEAR(astmodulestate(module)->Gt_singleton);
+    Py_CLEAR(astmodulestate(module)->Gt_type);
+    Py_CLEAR(astmodulestate(module)->IfExp_type);
+    Py_CLEAR(astmodulestate(module)->If_type);
+    Py_CLEAR(astmodulestate(module)->ImportFrom_type);
+    Py_CLEAR(astmodulestate(module)->Import_type);
+    Py_CLEAR(astmodulestate(module)->In_singleton);
+    Py_CLEAR(astmodulestate(module)->In_type);
+    Py_CLEAR(astmodulestate(module)->Index_type);
+    Py_CLEAR(astmodulestate(module)->Interactive_type);
+    Py_CLEAR(astmodulestate(module)->Invert_singleton);
+    Py_CLEAR(astmodulestate(module)->Invert_type);
+    Py_CLEAR(astmodulestate(module)->IsNot_singleton);
+    Py_CLEAR(astmodulestate(module)->IsNot_type);
+    Py_CLEAR(astmodulestate(module)->Is_singleton);
+    Py_CLEAR(astmodulestate(module)->Is_type);
+    Py_CLEAR(astmodulestate(module)->JoinedStr_type);
+    Py_CLEAR(astmodulestate(module)->LShift_singleton);
+    Py_CLEAR(astmodulestate(module)->LShift_type);
+    Py_CLEAR(astmodulestate(module)->Lambda_type);
+    Py_CLEAR(astmodulestate(module)->ListComp_type);
+    Py_CLEAR(astmodulestate(module)->List_type);
+    Py_CLEAR(astmodulestate(module)->Load_singleton);
+    Py_CLEAR(astmodulestate(module)->Load_type);
+    Py_CLEAR(astmodulestate(module)->LtE_singleton);
+    Py_CLEAR(astmodulestate(module)->LtE_type);
+    Py_CLEAR(astmodulestate(module)->Lt_singleton);
+    Py_CLEAR(astmodulestate(module)->Lt_type);
+    Py_CLEAR(astmodulestate(module)->MatMult_singleton);
+    Py_CLEAR(astmodulestate(module)->MatMult_type);
+    Py_CLEAR(astmodulestate(module)->Mod_singleton);
+    Py_CLEAR(astmodulestate(module)->Mod_type);
+    Py_CLEAR(astmodulestate(module)->Module_type);
+    Py_CLEAR(astmodulestate(module)->Mult_singleton);
+    Py_CLEAR(astmodulestate(module)->Mult_type);
+    Py_CLEAR(astmodulestate(module)->Name_type);
+    Py_CLEAR(astmodulestate(module)->NamedExpr_type);
+    Py_CLEAR(astmodulestate(module)->Nonlocal_type);
+    Py_CLEAR(astmodulestate(module)->NotEq_singleton);
+    Py_CLEAR(astmodulestate(module)->NotEq_type);
+    Py_CLEAR(astmodulestate(module)->NotIn_singleton);
+    Py_CLEAR(astmodulestate(module)->NotIn_type);
+    Py_CLEAR(astmodulestate(module)->Not_singleton);
+    Py_CLEAR(astmodulestate(module)->Not_type);
+    Py_CLEAR(astmodulestate(module)->Or_singleton);
+    Py_CLEAR(astmodulestate(module)->Or_type);
+    Py_CLEAR(astmodulestate(module)->Param_singleton);
+    Py_CLEAR(astmodulestate(module)->Param_type);
+    Py_CLEAR(astmodulestate(module)->Pass_type);
+    Py_CLEAR(astmodulestate(module)->Pow_singleton);
+    Py_CLEAR(astmodulestate(module)->Pow_type);
+    Py_CLEAR(astmodulestate(module)->RShift_singleton);
+    Py_CLEAR(astmodulestate(module)->RShift_type);
+    Py_CLEAR(astmodulestate(module)->Raise_type);
+    Py_CLEAR(astmodulestate(module)->Return_type);
+    Py_CLEAR(astmodulestate(module)->SetComp_type);
+    Py_CLEAR(astmodulestate(module)->Set_type);
+    Py_CLEAR(astmodulestate(module)->Slice_type);
+    Py_CLEAR(astmodulestate(module)->Starred_type);
+    Py_CLEAR(astmodulestate(module)->Store_singleton);
+    Py_CLEAR(astmodulestate(module)->Store_type);
+    Py_CLEAR(astmodulestate(module)->Sub_singleton);
+    Py_CLEAR(astmodulestate(module)->Sub_type);
+    Py_CLEAR(astmodulestate(module)->Subscript_type);
+    Py_CLEAR(astmodulestate(module)->Suite_type);
+    Py_CLEAR(astmodulestate(module)->Try_type);
+    Py_CLEAR(astmodulestate(module)->Tuple_type);
+    Py_CLEAR(astmodulestate(module)->TypeIgnore_type);
+    Py_CLEAR(astmodulestate(module)->UAdd_singleton);
+    Py_CLEAR(astmodulestate(module)->UAdd_type);
+    Py_CLEAR(astmodulestate(module)->USub_singleton);
+    Py_CLEAR(astmodulestate(module)->USub_type);
+    Py_CLEAR(astmodulestate(module)->UnaryOp_type);
+    Py_CLEAR(astmodulestate(module)->While_type);
+    Py_CLEAR(astmodulestate(module)->With_type);
+    Py_CLEAR(astmodulestate(module)->YieldFrom_type);
+    Py_CLEAR(astmodulestate(module)->Yield_type);
+    Py_CLEAR(astmodulestate(module)->__dict__);
+    Py_CLEAR(astmodulestate(module)->__module__);
+    Py_CLEAR(astmodulestate(module)->_ast);
+    Py_CLEAR(astmodulestate(module)->_attributes);
+    Py_CLEAR(astmodulestate(module)->_fields);
+    Py_CLEAR(astmodulestate(module)->alias_type);
+    Py_CLEAR(astmodulestate(module)->annotation);
+    Py_CLEAR(astmodulestate(module)->arg);
+    Py_CLEAR(astmodulestate(module)->arg_type);
+    Py_CLEAR(astmodulestate(module)->args);
+    Py_CLEAR(astmodulestate(module)->argtypes);
+    Py_CLEAR(astmodulestate(module)->arguments_type);
+    Py_CLEAR(astmodulestate(module)->asname);
+    Py_CLEAR(astmodulestate(module)->attr);
+    Py_CLEAR(astmodulestate(module)->bases);
+    Py_CLEAR(astmodulestate(module)->body);
+    Py_CLEAR(astmodulestate(module)->boolop_type);
+    Py_CLEAR(astmodulestate(module)->cause);
+    Py_CLEAR(astmodulestate(module)->cmpop_type);
+    Py_CLEAR(astmodulestate(module)->col_offset);
+    Py_CLEAR(astmodulestate(module)->comparators);
+    Py_CLEAR(astmodulestate(module)->comprehension_type);
+    Py_CLEAR(astmodulestate(module)->context_expr);
+    Py_CLEAR(astmodulestate(module)->conversion);
+    Py_CLEAR(astmodulestate(module)->ctx);
+    Py_CLEAR(astmodulestate(module)->decorator_list);
+    Py_CLEAR(astmodulestate(module)->defaults);
+    Py_CLEAR(astmodulestate(module)->dims);
+    Py_CLEAR(astmodulestate(module)->elt);
+    Py_CLEAR(astmodulestate(module)->elts);
+    Py_CLEAR(astmodulestate(module)->end_col_offset);
+    Py_CLEAR(astmodulestate(module)->end_lineno);
+    Py_CLEAR(astmodulestate(module)->exc);
+    Py_CLEAR(astmodulestate(module)->excepthandler_type);
+    Py_CLEAR(astmodulestate(module)->expr_context_type);
+    Py_CLEAR(astmodulestate(module)->expr_type);
+    Py_CLEAR(astmodulestate(module)->finalbody);
+    Py_CLEAR(astmodulestate(module)->format_spec);
+    Py_CLEAR(astmodulestate(module)->func);
+    Py_CLEAR(astmodulestate(module)->generators);
+    Py_CLEAR(astmodulestate(module)->handlers);
+    Py_CLEAR(astmodulestate(module)->id);
+    Py_CLEAR(astmodulestate(module)->ifs);
+    Py_CLEAR(astmodulestate(module)->is_async);
+    Py_CLEAR(astmodulestate(module)->items);
+    Py_CLEAR(astmodulestate(module)->iter);
+    Py_CLEAR(astmodulestate(module)->key);
+    Py_CLEAR(astmodulestate(module)->keys);
+    Py_CLEAR(astmodulestate(module)->keyword_type);
+    Py_CLEAR(astmodulestate(module)->keywords);
+    Py_CLEAR(astmodulestate(module)->kind);
+    Py_CLEAR(astmodulestate(module)->kw_defaults);
+    Py_CLEAR(astmodulestate(module)->kwarg);
+    Py_CLEAR(astmodulestate(module)->kwonlyargs);
+    Py_CLEAR(astmodulestate(module)->left);
+    Py_CLEAR(astmodulestate(module)->level);
+    Py_CLEAR(astmodulestate(module)->lineno);
+    Py_CLEAR(astmodulestate(module)->lower);
+    Py_CLEAR(astmodulestate(module)->mod_type);
+    Py_CLEAR(astmodulestate(module)->module);
+    Py_CLEAR(astmodulestate(module)->msg);
+    Py_CLEAR(astmodulestate(module)->name);
+    Py_CLEAR(astmodulestate(module)->names);
+    Py_CLEAR(astmodulestate(module)->op);
+    Py_CLEAR(astmodulestate(module)->operand);
+    Py_CLEAR(astmodulestate(module)->operator_type);
+    Py_CLEAR(astmodulestate(module)->ops);
+    Py_CLEAR(astmodulestate(module)->optional_vars);
+    Py_CLEAR(astmodulestate(module)->orelse);
+    Py_CLEAR(astmodulestate(module)->posonlyargs);
+    Py_CLEAR(astmodulestate(module)->returns);
+    Py_CLEAR(astmodulestate(module)->right);
+    Py_CLEAR(astmodulestate(module)->simple);
+    Py_CLEAR(astmodulestate(module)->slice);
+    Py_CLEAR(astmodulestate(module)->slice_type);
+    Py_CLEAR(astmodulestate(module)->step);
+    Py_CLEAR(astmodulestate(module)->stmt_type);
+    Py_CLEAR(astmodulestate(module)->tag);
+    Py_CLEAR(astmodulestate(module)->target);
+    Py_CLEAR(astmodulestate(module)->targets);
+    Py_CLEAR(astmodulestate(module)->test);
+    Py_CLEAR(astmodulestate(module)->type);
+    Py_CLEAR(astmodulestate(module)->type_comment);
+    Py_CLEAR(astmodulestate(module)->type_ignore_type);
+    Py_CLEAR(astmodulestate(module)->type_ignores);
+    Py_CLEAR(astmodulestate(module)->unaryop_type);
+    Py_CLEAR(astmodulestate(module)->upper);
+    Py_CLEAR(astmodulestate(module)->value);
+    Py_CLEAR(astmodulestate(module)->values);
+    Py_CLEAR(astmodulestate(module)->vararg);
+    Py_CLEAR(astmodulestate(module)->withitem_type);
+
+    return 0;
+}
+
+static int astmodule_traverse(PyObject *module, visitproc visit, void* arg)
+{
+    Py_VISIT(astmodulestate(module)->AST_type);
+    Py_VISIT(astmodulestate(module)->Add_singleton);
+    Py_VISIT(astmodulestate(module)->Add_type);
+    Py_VISIT(astmodulestate(module)->And_singleton);
+    Py_VISIT(astmodulestate(module)->And_type);
+    Py_VISIT(astmodulestate(module)->AnnAssign_type);
+    Py_VISIT(astmodulestate(module)->Assert_type);
+    Py_VISIT(astmodulestate(module)->Assign_type);
+    Py_VISIT(astmodulestate(module)->AsyncFor_type);
+    Py_VISIT(astmodulestate(module)->AsyncFunctionDef_type);
+    Py_VISIT(astmodulestate(module)->AsyncWith_type);
+    Py_VISIT(astmodulestate(module)->Attribute_type);
+    Py_VISIT(astmodulestate(module)->AugAssign_type);
+    Py_VISIT(astmodulestate(module)->AugLoad_singleton);
+    Py_VISIT(astmodulestate(module)->AugLoad_type);
+    Py_VISIT(astmodulestate(module)->AugStore_singleton);
+    Py_VISIT(astmodulestate(module)->AugStore_type);
+    Py_VISIT(astmodulestate(module)->Await_type);
+    Py_VISIT(astmodulestate(module)->BinOp_type);
+    Py_VISIT(astmodulestate(module)->BitAnd_singleton);
+    Py_VISIT(astmodulestate(module)->BitAnd_type);
+    Py_VISIT(astmodulestate(module)->BitOr_singleton);
+    Py_VISIT(astmodulestate(module)->BitOr_type);
+    Py_VISIT(astmodulestate(module)->BitXor_singleton);
+    Py_VISIT(astmodulestate(module)->BitXor_type);
+    Py_VISIT(astmodulestate(module)->BoolOp_type);
+    Py_VISIT(astmodulestate(module)->Break_type);
+    Py_VISIT(astmodulestate(module)->Call_type);
+    Py_VISIT(astmodulestate(module)->ClassDef_type);
+    Py_VISIT(astmodulestate(module)->Compare_type);
+    Py_VISIT(astmodulestate(module)->Constant_type);
+    Py_VISIT(astmodulestate(module)->Continue_type);
+    Py_VISIT(astmodulestate(module)->Del_singleton);
+    Py_VISIT(astmodulestate(module)->Del_type);
+    Py_VISIT(astmodulestate(module)->Delete_type);
+    Py_VISIT(astmodulestate(module)->DictComp_type);
+    Py_VISIT(astmodulestate(module)->Dict_type);
+    Py_VISIT(astmodulestate(module)->Div_singleton);
+    Py_VISIT(astmodulestate(module)->Div_type);
+    Py_VISIT(astmodulestate(module)->Eq_singleton);
+    Py_VISIT(astmodulestate(module)->Eq_type);
+    Py_VISIT(astmodulestate(module)->ExceptHandler_type);
+    Py_VISIT(astmodulestate(module)->Expr_type);
+    Py_VISIT(astmodulestate(module)->Expression_type);
+    Py_VISIT(astmodulestate(module)->ExtSlice_type);
+    Py_VISIT(astmodulestate(module)->FloorDiv_singleton);
+    Py_VISIT(astmodulestate(module)->FloorDiv_type);
+    Py_VISIT(astmodulestate(module)->For_type);
+    Py_VISIT(astmodulestate(module)->FormattedValue_type);
+    Py_VISIT(astmodulestate(module)->FunctionDef_type);
+    Py_VISIT(astmodulestate(module)->FunctionType_type);
+    Py_VISIT(astmodulestate(module)->GeneratorExp_type);
+    Py_VISIT(astmodulestate(module)->Global_type);
+    Py_VISIT(astmodulestate(module)->GtE_singleton);
+    Py_VISIT(astmodulestate(module)->GtE_type);
+    Py_VISIT(astmodulestate(module)->Gt_singleton);
+    Py_VISIT(astmodulestate(module)->Gt_type);
+    Py_VISIT(astmodulestate(module)->IfExp_type);
+    Py_VISIT(astmodulestate(module)->If_type);
+    Py_VISIT(astmodulestate(module)->ImportFrom_type);
+    Py_VISIT(astmodulestate(module)->Import_type);
+    Py_VISIT(astmodulestate(module)->In_singleton);
+    Py_VISIT(astmodulestate(module)->In_type);
+    Py_VISIT(astmodulestate(module)->Index_type);
+    Py_VISIT(astmodulestate(module)->Interactive_type);
+    Py_VISIT(astmodulestate(module)->Invert_singleton);
+    Py_VISIT(astmodulestate(module)->Invert_type);
+    Py_VISIT(astmodulestate(module)->IsNot_singleton);
+    Py_VISIT(astmodulestate(module)->IsNot_type);
+    Py_VISIT(astmodulestate(module)->Is_singleton);
+    Py_VISIT(astmodulestate(module)->Is_type);
+    Py_VISIT(astmodulestate(module)->JoinedStr_type);
+    Py_VISIT(astmodulestate(module)->LShift_singleton);
+    Py_VISIT(astmodulestate(module)->LShift_type);
+    Py_VISIT(astmodulestate(module)->Lambda_type);
+    Py_VISIT(astmodulestate(module)->ListComp_type);
+    Py_VISIT(astmodulestate(module)->List_type);
+    Py_VISIT(astmodulestate(module)->Load_singleton);
+    Py_VISIT(astmodulestate(module)->Load_type);
+    Py_VISIT(astmodulestate(module)->LtE_singleton);
+    Py_VISIT(astmodulestate(module)->LtE_type);
+    Py_VISIT(astmodulestate(module)->Lt_singleton);
+    Py_VISIT(astmodulestate(module)->Lt_type);
+    Py_VISIT(astmodulestate(module)->MatMult_singleton);
+    Py_VISIT(astmodulestate(module)->MatMult_type);
+    Py_VISIT(astmodulestate(module)->Mod_singleton);
+    Py_VISIT(astmodulestate(module)->Mod_type);
+    Py_VISIT(astmodulestate(module)->Module_type);
+    Py_VISIT(astmodulestate(module)->Mult_singleton);
+    Py_VISIT(astmodulestate(module)->Mult_type);
+    Py_VISIT(astmodulestate(module)->Name_type);
+    Py_VISIT(astmodulestate(module)->NamedExpr_type);
+    Py_VISIT(astmodulestate(module)->Nonlocal_type);
+    Py_VISIT(astmodulestate(module)->NotEq_singleton);
+    Py_VISIT(astmodulestate(module)->NotEq_type);
+    Py_VISIT(astmodulestate(module)->NotIn_singleton);
+    Py_VISIT(astmodulestate(module)->NotIn_type);
+    Py_VISIT(astmodulestate(module)->Not_singleton);
+    Py_VISIT(astmodulestate(module)->Not_type);
+    Py_VISIT(astmodulestate(module)->Or_singleton);
+    Py_VISIT(astmodulestate(module)->Or_type);
+    Py_VISIT(astmodulestate(module)->Param_singleton);
+    Py_VISIT(astmodulestate(module)->Param_type);
+    Py_VISIT(astmodulestate(module)->Pass_type);
+    Py_VISIT(astmodulestate(module)->Pow_singleton);
+    Py_VISIT(astmodulestate(module)->Pow_type);
+    Py_VISIT(astmodulestate(module)->RShift_singleton);
+    Py_VISIT(astmodulestate(module)->RShift_type);
+    Py_VISIT(astmodulestate(module)->Raise_type);
+    Py_VISIT(astmodulestate(module)->Return_type);
+    Py_VISIT(astmodulestate(module)->SetComp_type);
+    Py_VISIT(astmodulestate(module)->Set_type);
+    Py_VISIT(astmodulestate(module)->Slice_type);
+    Py_VISIT(astmodulestate(module)->Starred_type);
+    Py_VISIT(astmodulestate(module)->Store_singleton);
+    Py_VISIT(astmodulestate(module)->Store_type);
+    Py_VISIT(astmodulestate(module)->Sub_singleton);
+    Py_VISIT(astmodulestate(module)->Sub_type);
+    Py_VISIT(astmodulestate(module)->Subscript_type);
+    Py_VISIT(astmodulestate(module)->Suite_type);
+    Py_VISIT(astmodulestate(module)->Try_type);
+    Py_VISIT(astmodulestate(module)->Tuple_type);
+    Py_VISIT(astmodulestate(module)->TypeIgnore_type);
+    Py_VISIT(astmodulestate(module)->UAdd_singleton);
+    Py_VISIT(astmodulestate(module)->UAdd_type);
+    Py_VISIT(astmodulestate(module)->USub_singleton);
+    Py_VISIT(astmodulestate(module)->USub_type);
+    Py_VISIT(astmodulestate(module)->UnaryOp_type);
+    Py_VISIT(astmodulestate(module)->While_type);
+    Py_VISIT(astmodulestate(module)->With_type);
+    Py_VISIT(astmodulestate(module)->YieldFrom_type);
+    Py_VISIT(astmodulestate(module)->Yield_type);
+    Py_VISIT(astmodulestate(module)->__dict__);
+    Py_VISIT(astmodulestate(module)->__module__);
+    Py_VISIT(astmodulestate(module)->_ast);
+    Py_VISIT(astmodulestate(module)->_attributes);
+    Py_VISIT(astmodulestate(module)->_fields);
+    Py_VISIT(astmodulestate(module)->alias_type);
+    Py_VISIT(astmodulestate(module)->annotation);
+    Py_VISIT(astmodulestate(module)->arg);
+    Py_VISIT(astmodulestate(module)->arg_type);
+    Py_VISIT(astmodulestate(module)->args);
+    Py_VISIT(astmodulestate(module)->argtypes);
+    Py_VISIT(astmodulestate(module)->arguments_type);
+    Py_VISIT(astmodulestate(module)->asname);
+    Py_VISIT(astmodulestate(module)->attr);
+    Py_VISIT(astmodulestate(module)->bases);
+    Py_VISIT(astmodulestate(module)->body);
+    Py_VISIT(astmodulestate(module)->boolop_type);
+    Py_VISIT(astmodulestate(module)->cause);
+    Py_VISIT(astmodulestate(module)->cmpop_type);
+    Py_VISIT(astmodulestate(module)->col_offset);
+    Py_VISIT(astmodulestate(module)->comparators);
+    Py_VISIT(astmodulestate(module)->comprehension_type);
+    Py_VISIT(astmodulestate(module)->context_expr);
+    Py_VISIT(astmodulestate(module)->conversion);
+    Py_VISIT(astmodulestate(module)->ctx);
+    Py_VISIT(astmodulestate(module)->decorator_list);
+    Py_VISIT(astmodulestate(module)->defaults);
+    Py_VISIT(astmodulestate(module)->dims);
+    Py_VISIT(astmodulestate(module)->elt);
+    Py_VISIT(astmodulestate(module)->elts);
+    Py_VISIT(astmodulestate(module)->end_col_offset);
+    Py_VISIT(astmodulestate(module)->end_lineno);
+    Py_VISIT(astmodulestate(module)->exc);
+    Py_VISIT(astmodulestate(module)->excepthandler_type);
+    Py_VISIT(astmodulestate(module)->expr_context_type);
+    Py_VISIT(astmodulestate(module)->expr_type);
+    Py_VISIT(astmodulestate(module)->finalbody);
+    Py_VISIT(astmodulestate(module)->format_spec);
+    Py_VISIT(astmodulestate(module)->func);
+    Py_VISIT(astmodulestate(module)->generators);
+    Py_VISIT(astmodulestate(module)->handlers);
+    Py_VISIT(astmodulestate(module)->id);
+    Py_VISIT(astmodulestate(module)->ifs);
+    Py_VISIT(astmodulestate(module)->is_async);
+    Py_VISIT(astmodulestate(module)->items);
+    Py_VISIT(astmodulestate(module)->iter);
+    Py_VISIT(astmodulestate(module)->key);
+    Py_VISIT(astmodulestate(module)->keys);
+    Py_VISIT(astmodulestate(module)->keyword_type);
+    Py_VISIT(astmodulestate(module)->keywords);
+    Py_VISIT(astmodulestate(module)->kind);
+    Py_VISIT(astmodulestate(module)->kw_defaults);
+    Py_VISIT(astmodulestate(module)->kwarg);
+    Py_VISIT(astmodulestate(module)->kwonlyargs);
+    Py_VISIT(astmodulestate(module)->left);
+    Py_VISIT(astmodulestate(module)->level);
+    Py_VISIT(astmodulestate(module)->lineno);
+    Py_VISIT(astmodulestate(module)->lower);
+    Py_VISIT(astmodulestate(module)->mod_type);
+    Py_VISIT(astmodulestate(module)->module);
+    Py_VISIT(astmodulestate(module)->msg);
+    Py_VISIT(astmodulestate(module)->name);
+    Py_VISIT(astmodulestate(module)->names);
+    Py_VISIT(astmodulestate(module)->op);
+    Py_VISIT(astmodulestate(module)->operand);
+    Py_VISIT(astmodulestate(module)->operator_type);
+    Py_VISIT(astmodulestate(module)->ops);
+    Py_VISIT(astmodulestate(module)->optional_vars);
+    Py_VISIT(astmodulestate(module)->orelse);
+    Py_VISIT(astmodulestate(module)->posonlyargs);
+    Py_VISIT(astmodulestate(module)->returns);
+    Py_VISIT(astmodulestate(module)->right);
+    Py_VISIT(astmodulestate(module)->simple);
+    Py_VISIT(astmodulestate(module)->slice);
+    Py_VISIT(astmodulestate(module)->slice_type);
+    Py_VISIT(astmodulestate(module)->step);
+    Py_VISIT(astmodulestate(module)->stmt_type);
+    Py_VISIT(astmodulestate(module)->tag);
+    Py_VISIT(astmodulestate(module)->target);
+    Py_VISIT(astmodulestate(module)->targets);
+    Py_VISIT(astmodulestate(module)->test);
+    Py_VISIT(astmodulestate(module)->type);
+    Py_VISIT(astmodulestate(module)->type_comment);
+    Py_VISIT(astmodulestate(module)->type_ignore_type);
+    Py_VISIT(astmodulestate(module)->type_ignores);
+    Py_VISIT(astmodulestate(module)->unaryop_type);
+    Py_VISIT(astmodulestate(module)->upper);
+    Py_VISIT(astmodulestate(module)->value);
+    Py_VISIT(astmodulestate(module)->values);
+    Py_VISIT(astmodulestate(module)->vararg);
+    Py_VISIT(astmodulestate(module)->withitem_type);
+
+    return 0;
+}
+
+static void astmodule_free(void* module) {
+    astmodule_clear((PyObject*)module);
+}
+
+static struct PyModuleDef _astmodule = {
+    PyModuleDef_HEAD_INIT,
+    "_ast",
+    NULL,
+    sizeof(astmodulestate),
+    NULL,
+    NULL,
+    astmodule_traverse,
+    astmodule_clear,
+    astmodule_free,
+};
+
+#define astmodulestate_global ((astmodulestate *)PyModule_GetState(PyState_FindModule(&_astmodule)))
+
+static int init_identifiers(void)
+{
+    astmodulestate *state = astmodulestate_global;
+    if ((state->__dict__ = PyUnicode_InternFromString("__dict__")) == NULL) return 0;
+    if ((state->__module__ = PyUnicode_InternFromString("__module__")) == NULL) return 0;
+    if ((state->_ast = PyUnicode_InternFromString("_ast")) == NULL) return 0;
+    if ((state->_attributes = PyUnicode_InternFromString("_attributes")) == NULL) return 0;
+    if ((state->_fields = PyUnicode_InternFromString("_fields")) == NULL) return 0;
+    if ((state->annotation = PyUnicode_InternFromString("annotation")) == NULL) return 0;
+    if ((state->arg = PyUnicode_InternFromString("arg")) == NULL) return 0;
+    if ((state->args = PyUnicode_InternFromString("args")) == NULL) return 0;
+    if ((state->argtypes = PyUnicode_InternFromString("argtypes")) == NULL) return 0;
+    if ((state->asname = PyUnicode_InternFromString("asname")) == NULL) return 0;
+    if ((state->attr = PyUnicode_InternFromString("attr")) == NULL) return 0;
+    if ((state->bases = PyUnicode_InternFromString("bases")) == NULL) return 0;
+    if ((state->body = PyUnicode_InternFromString("body")) == NULL) return 0;
+    if ((state->cause = PyUnicode_InternFromString("cause")) == NULL) return 0;
+    if ((state->col_offset = PyUnicode_InternFromString("col_offset")) == NULL) return 0;
+    if ((state->comparators = PyUnicode_InternFromString("comparators")) == NULL) return 0;
+    if ((state->context_expr = PyUnicode_InternFromString("context_expr")) == NULL) return 0;
+    if ((state->conversion = PyUnicode_InternFromString("conversion")) == NULL) return 0;
+    if ((state->ctx = PyUnicode_InternFromString("ctx")) == NULL) return 0;
+    if ((state->decorator_list = PyUnicode_InternFromString("decorator_list")) == NULL) return 0;
+    if ((state->defaults = PyUnicode_InternFromString("defaults")) == NULL) return 0;
+    if ((state->dims = PyUnicode_InternFromString("dims")) == NULL) return 0;
+    if ((state->elt = PyUnicode_InternFromString("elt")) == NULL) return 0;
+    if ((state->elts = PyUnicode_InternFromString("elts")) == NULL) return 0;
+    if ((state->end_col_offset = PyUnicode_InternFromString("end_col_offset")) == NULL) return 0;
+    if ((state->end_lineno = PyUnicode_InternFromString("end_lineno")) == NULL) return 0;
+    if ((state->exc = PyUnicode_InternFromString("exc")) == NULL) return 0;
+    if ((state->finalbody = PyUnicode_InternFromString("finalbody")) == NULL) return 0;
+    if ((state->format_spec = PyUnicode_InternFromString("format_spec")) == NULL) return 0;
+    if ((state->func = PyUnicode_InternFromString("func")) == NULL) return 0;
+    if ((state->generators = PyUnicode_InternFromString("generators")) == NULL) return 0;
+    if ((state->handlers = PyUnicode_InternFromString("handlers")) == NULL) return 0;
+    if ((state->id = PyUnicode_InternFromString("id")) == NULL) return 0;
+    if ((state->ifs = PyUnicode_InternFromString("ifs")) == NULL) return 0;
+    if ((state->is_async = PyUnicode_InternFromString("is_async")) == NULL) return 0;
+    if ((state->items = PyUnicode_InternFromString("items")) == NULL) return 0;
+    if ((state->iter = PyUnicode_InternFromString("iter")) == NULL) return 0;
+    if ((state->key = PyUnicode_InternFromString("key")) == NULL) return 0;
+    if ((state->keys = PyUnicode_InternFromString("keys")) == NULL) return 0;
+    if ((state->keywords = PyUnicode_InternFromString("keywords")) == NULL) return 0;
+    if ((state->kind = PyUnicode_InternFromString("kind")) == NULL) return 0;
+    if ((state->kw_defaults = PyUnicode_InternFromString("kw_defaults")) == NULL) return 0;
+    if ((state->kwarg = PyUnicode_InternFromString("kwarg")) == NULL) return 0;
+    if ((state->kwonlyargs = PyUnicode_InternFromString("kwonlyargs")) == NULL) return 0;
+    if ((state->left = PyUnicode_InternFromString("left")) == NULL) return 0;
+    if ((state->level = PyUnicode_InternFromString("level")) == NULL) return 0;
+    if ((state->lineno = PyUnicode_InternFromString("lineno")) == NULL) return 0;
+    if ((state->lower = PyUnicode_InternFromString("lower")) == NULL) return 0;
+    if ((state->module = PyUnicode_InternFromString("module")) == NULL) return 0;
+    if ((state->msg = PyUnicode_InternFromString("msg")) == NULL) return 0;
+    if ((state->name = PyUnicode_InternFromString("name")) == NULL) return 0;
+    if ((state->names = PyUnicode_InternFromString("names")) == NULL) return 0;
+    if ((state->op = PyUnicode_InternFromString("op")) == NULL) return 0;
+    if ((state->operand = PyUnicode_InternFromString("operand")) == NULL) return 0;
+    if ((state->ops = PyUnicode_InternFromString("ops")) == NULL) return 0;
+    if ((state->optional_vars = PyUnicode_InternFromString("optional_vars")) == NULL) return 0;
+    if ((state->orelse = PyUnicode_InternFromString("orelse")) == NULL) return 0;
+    if ((state->posonlyargs = PyUnicode_InternFromString("posonlyargs")) == NULL) return 0;
+    if ((state->returns = PyUnicode_InternFromString("returns")) == NULL) return 0;
+    if ((state->right = PyUnicode_InternFromString("right")) == NULL) return 0;
+    if ((state->simple = PyUnicode_InternFromString("simple")) == NULL) return 0;
+    if ((state->slice = PyUnicode_InternFromString("slice")) == NULL) return 0;
+    if ((state->step = PyUnicode_InternFromString("step")) == NULL) return 0;
+    if ((state->tag = PyUnicode_InternFromString("tag")) == NULL) return 0;
+    if ((state->target = PyUnicode_InternFromString("target")) == NULL) return 0;
+    if ((state->targets = PyUnicode_InternFromString("targets")) == NULL) return 0;
+    if ((state->test = PyUnicode_InternFromString("test")) == NULL) return 0;
+    if ((state->type = PyUnicode_InternFromString("type")) == NULL) return 0;
+    if ((state->type_comment = PyUnicode_InternFromString("type_comment")) == NULL) return 0;
+    if ((state->type_ignores = PyUnicode_InternFromString("type_ignores")) == NULL) return 0;
+    if ((state->upper = PyUnicode_InternFromString("upper")) == NULL) return 0;
+    if ((state->value = PyUnicode_InternFromString("value")) == NULL) return 0;
+    if ((state->values = PyUnicode_InternFromString("values")) == NULL) return 0;
+    if ((state->vararg = PyUnicode_InternFromString("vararg")) == NULL) return 0;
+    return 1;
+};
+
 static PyObject* ast2obj_mod(void*);
-static PyTypeObject *Module_type;
-_Py_IDENTIFIER(body);
-_Py_IDENTIFIER(type_ignores);
 static const char * const Module_fields[]={
     "body",
     "type_ignores",
 };
-static PyTypeObject *Interactive_type;
 static const char * const Interactive_fields[]={
     "body",
 };
-static PyTypeObject *Expression_type;
 static const char * const Expression_fields[]={
     "body",
 };
-static PyTypeObject *FunctionType_type;
-_Py_IDENTIFIER(argtypes);
-_Py_IDENTIFIER(returns);
 static const char * const FunctionType_fields[]={
     "argtypes",
     "returns",
 };
-static PyTypeObject *Suite_type;
 static const char * const Suite_fields[]={
     "body",
 };
-static PyTypeObject *stmt_type;
-_Py_IDENTIFIER(lineno);
-_Py_IDENTIFIER(col_offset);
-_Py_IDENTIFIER(end_lineno);
-_Py_IDENTIFIER(end_col_offset);
 static const char * const stmt_attributes[] = {
     "lineno",
     "col_offset",
@@ -46,11 +816,6 @@ static const char * const stmt_attributes[] = {
     "end_col_offset",
 };
 static PyObject* ast2obj_stmt(void*);
-static PyTypeObject *FunctionDef_type;
-_Py_IDENTIFIER(name);
-_Py_IDENTIFIER(args);
-_Py_IDENTIFIER(decorator_list);
-_Py_IDENTIFIER(type_comment);
 static const char * const FunctionDef_fields[]={
     "name",
     "args",
@@ -59,7 +824,6 @@ static const char * const FunctionDef_fields[]={
     "returns",
     "type_comment",
 };
-static PyTypeObject *AsyncFunctionDef_type;
 static const char * const AsyncFunctionDef_fields[]={
     "name",
     "args",
@@ -68,9 +832,6 @@ static const char * const AsyncFunctionDef_fields[]={
     "returns",
     "type_comment",
 };
-static PyTypeObject *ClassDef_type;
-_Py_IDENTIFIER(bases);
-_Py_IDENTIFIER(keywords);
 static const char * const ClassDef_fields[]={
     "name",
     "bases",
@@ -78,42 +839,28 @@ static const char * const ClassDef_fields[]={
     "body",
     "decorator_list",
 };
-static PyTypeObject *Return_type;
-_Py_IDENTIFIER(value);
 static const char * const Return_fields[]={
     "value",
 };
-static PyTypeObject *Delete_type;
-_Py_IDENTIFIER(targets);
 static const char * const Delete_fields[]={
     "targets",
 };
-static PyTypeObject *Assign_type;
 static const char * const Assign_fields[]={
     "targets",
     "value",
     "type_comment",
 };
-static PyTypeObject *AugAssign_type;
-_Py_IDENTIFIER(target);
-_Py_IDENTIFIER(op);
 static const char * const AugAssign_fields[]={
     "target",
     "op",
     "value",
 };
-static PyTypeObject *AnnAssign_type;
-_Py_IDENTIFIER(annotation);
-_Py_IDENTIFIER(simple);
 static const char * const AnnAssign_fields[]={
     "target",
     "annotation",
     "value",
     "simple",
 };
-static PyTypeObject *For_type;
-_Py_IDENTIFIER(iter);
-_Py_IDENTIFIER(orelse);
 static const char * const For_fields[]={
     "target",
     "iter",
@@ -121,7 +868,6 @@ static const char * const For_fields[]={
     "orelse",
     "type_comment",
 };
-static PyTypeObject *AsyncFor_type;
 static const char * const AsyncFor_fields[]={
     "target",
     "iter",
@@ -129,83 +875,57 @@ static const char * const AsyncFor_fields[]={
     "orelse",
     "type_comment",
 };
-static PyTypeObject *While_type;
-_Py_IDENTIFIER(test);
 static const char * const While_fields[]={
     "test",
     "body",
     "orelse",
 };
-static PyTypeObject *If_type;
 static const char * const If_fields[]={
     "test",
     "body",
     "orelse",
 };
-static PyTypeObject *With_type;
-_Py_IDENTIFIER(items);
 static const char * const With_fields[]={
     "items",
     "body",
     "type_comment",
 };
-static PyTypeObject *AsyncWith_type;
 static const char * const AsyncWith_fields[]={
     "items",
     "body",
     "type_comment",
 };
-static PyTypeObject *Raise_type;
-_Py_IDENTIFIER(exc);
-_Py_IDENTIFIER(cause);
 static const char * const Raise_fields[]={
     "exc",
     "cause",
 };
-static PyTypeObject *Try_type;
-_Py_IDENTIFIER(handlers);
-_Py_IDENTIFIER(finalbody);
 static const char * const Try_fields[]={
     "body",
     "handlers",
     "orelse",
     "finalbody",
 };
-static PyTypeObject *Assert_type;
-_Py_IDENTIFIER(msg);
 static const char * const Assert_fields[]={
     "test",
     "msg",
 };
-static PyTypeObject *Import_type;
-_Py_IDENTIFIER(names);
 static const char * const Import_fields[]={
     "names",
 };
-static PyTypeObject *ImportFrom_type;
-_Py_IDENTIFIER(module);
-_Py_IDENTIFIER(level);
 static const char * const ImportFrom_fields[]={
     "module",
     "names",
     "level",
 };
-static PyTypeObject *Global_type;
 static const char * const Global_fields[]={
     "names",
 };
-static PyTypeObject *Nonlocal_type;
 static const char * const Nonlocal_fields[]={
     "names",
 };
-static PyTypeObject *Expr_type;
 static const char * const Expr_fields[]={
     "value",
 };
-static PyTypeObject *Pass_type;
-static PyTypeObject *Break_type;
-static PyTypeObject *Continue_type;
-static PyTypeObject *expr_type;
 static const char * const expr_attributes[] = {
     "lineno",
     "col_offset",
@@ -213,246 +933,137 @@ static const char * const expr_attributes[] = {
     "end_col_offset",
 };
 static PyObject* ast2obj_expr(void*);
-static PyTypeObject *BoolOp_type;
-_Py_IDENTIFIER(values);
 static const char * const BoolOp_fields[]={
     "op",
     "values",
 };
-static PyTypeObject *NamedExpr_type;
 static const char * const NamedExpr_fields[]={
     "target",
     "value",
 };
-static PyTypeObject *BinOp_type;
-_Py_IDENTIFIER(left);
-_Py_IDENTIFIER(right);
 static const char * const BinOp_fields[]={
     "left",
     "op",
     "right",
 };
-static PyTypeObject *UnaryOp_type;
-_Py_IDENTIFIER(operand);
 static const char * const UnaryOp_fields[]={
     "op",
     "operand",
 };
-static PyTypeObject *Lambda_type;
 static const char * const Lambda_fields[]={
     "args",
     "body",
 };
-static PyTypeObject *IfExp_type;
 static const char * const IfExp_fields[]={
     "test",
     "body",
     "orelse",
 };
-static PyTypeObject *Dict_type;
-_Py_IDENTIFIER(keys);
 static const char * const Dict_fields[]={
     "keys",
     "values",
 };
-static PyTypeObject *Set_type;
-_Py_IDENTIFIER(elts);
 static const char * const Set_fields[]={
     "elts",
 };
-static PyTypeObject *ListComp_type;
-_Py_IDENTIFIER(elt);
-_Py_IDENTIFIER(generators);
 static const char * const ListComp_fields[]={
     "elt",
     "generators",
 };
-static PyTypeObject *SetComp_type;
 static const char * const SetComp_fields[]={
     "elt",
     "generators",
 };
-static PyTypeObject *DictComp_type;
-_Py_IDENTIFIER(key);
 static const char * const DictComp_fields[]={
     "key",
     "value",
     "generators",
 };
-static PyTypeObject *GeneratorExp_type;
 static const char * const GeneratorExp_fields[]={
     "elt",
     "generators",
 };
-static PyTypeObject *Await_type;
 static const char * const Await_fields[]={
     "value",
 };
-static PyTypeObject *Yield_type;
 static const char * const Yield_fields[]={
     "value",
 };
-static PyTypeObject *YieldFrom_type;
 static const char * const YieldFrom_fields[]={
     "value",
 };
-static PyTypeObject *Compare_type;
-_Py_IDENTIFIER(ops);
-_Py_IDENTIFIER(comparators);
 static const char * const Compare_fields[]={
     "left",
     "ops",
     "comparators",
 };
-static PyTypeObject *Call_type;
-_Py_IDENTIFIER(func);
 static const char * const Call_fields[]={
     "func",
     "args",
     "keywords",
 };
-static PyTypeObject *FormattedValue_type;
-_Py_IDENTIFIER(conversion);
-_Py_IDENTIFIER(format_spec);
 static const char * const FormattedValue_fields[]={
     "value",
     "conversion",
     "format_spec",
 };
-static PyTypeObject *JoinedStr_type;
 static const char * const JoinedStr_fields[]={
     "values",
 };
-static PyTypeObject *Constant_type;
-_Py_IDENTIFIER(kind);
 static const char * const Constant_fields[]={
     "value",
     "kind",
 };
-static PyTypeObject *Attribute_type;
-_Py_IDENTIFIER(attr);
-_Py_IDENTIFIER(ctx);
 static const char * const Attribute_fields[]={
     "value",
     "attr",
     "ctx",
 };
-static PyTypeObject *Subscript_type;
-_Py_IDENTIFIER(slice);
 static const char * const Subscript_fields[]={
     "value",
     "slice",
     "ctx",
 };
-static PyTypeObject *Starred_type;
 static const char * const Starred_fields[]={
     "value",
     "ctx",
 };
-static PyTypeObject *Name_type;
-_Py_IDENTIFIER(id);
 static const char * const Name_fields[]={
     "id",
     "ctx",
 };
-static PyTypeObject *List_type;
 static const char * const List_fields[]={
     "elts",
     "ctx",
 };
-static PyTypeObject *Tuple_type;
 static const char * const Tuple_fields[]={
     "elts",
     "ctx",
 };
-static PyTypeObject *expr_context_type;
-static PyObject *Load_singleton, *Store_singleton, *Del_singleton,
-*AugLoad_singleton, *AugStore_singleton, *Param_singleton;
 static PyObject* ast2obj_expr_context(expr_context_ty);
-static PyTypeObject *Load_type;
-static PyTypeObject *Store_type;
-static PyTypeObject *Del_type;
-static PyTypeObject *AugLoad_type;
-static PyTypeObject *AugStore_type;
-static PyTypeObject *Param_type;
-static PyTypeObject *slice_type;
 static PyObject* ast2obj_slice(void*);
-static PyTypeObject *Slice_type;
-_Py_IDENTIFIER(lower);
-_Py_IDENTIFIER(upper);
-_Py_IDENTIFIER(step);
 static const char * const Slice_fields[]={
     "lower",
     "upper",
     "step",
 };
-static PyTypeObject *ExtSlice_type;
-_Py_IDENTIFIER(dims);
 static const char * const ExtSlice_fields[]={
     "dims",
 };
-static PyTypeObject *Index_type;
 static const char * const Index_fields[]={
     "value",
 };
-static PyTypeObject *boolop_type;
-static PyObject *And_singleton, *Or_singleton;
 static PyObject* ast2obj_boolop(boolop_ty);
-static PyTypeObject *And_type;
-static PyTypeObject *Or_type;
-static PyTypeObject *operator_type;
-static PyObject *Add_singleton, *Sub_singleton, *Mult_singleton,
-*MatMult_singleton, *Div_singleton, *Mod_singleton, *Pow_singleton,
-*LShift_singleton, *RShift_singleton, *BitOr_singleton, *BitXor_singleton,
-*BitAnd_singleton, *FloorDiv_singleton;
 static PyObject* ast2obj_operator(operator_ty);
-static PyTypeObject *Add_type;
-static PyTypeObject *Sub_type;
-static PyTypeObject *Mult_type;
-static PyTypeObject *MatMult_type;
-static PyTypeObject *Div_type;
-static PyTypeObject *Mod_type;
-static PyTypeObject *Pow_type;
-static PyTypeObject *LShift_type;
-static PyTypeObject *RShift_type;
-static PyTypeObject *BitOr_type;
-static PyTypeObject *BitXor_type;
-static PyTypeObject *BitAnd_type;
-static PyTypeObject *FloorDiv_type;
-static PyTypeObject *unaryop_type;
-static PyObject *Invert_singleton, *Not_singleton, *UAdd_singleton,
-*USub_singleton;
 static PyObject* ast2obj_unaryop(unaryop_ty);
-static PyTypeObject *Invert_type;
-static PyTypeObject *Not_type;
-static PyTypeObject *UAdd_type;
-static PyTypeObject *USub_type;
-static PyTypeObject *cmpop_type;
-static PyObject *Eq_singleton, *NotEq_singleton, *Lt_singleton, *LtE_singleton,
-*Gt_singleton, *GtE_singleton, *Is_singleton, *IsNot_singleton, *In_singleton,
-*NotIn_singleton;
 static PyObject* ast2obj_cmpop(cmpop_ty);
-static PyTypeObject *Eq_type;
-static PyTypeObject *NotEq_type;
-static PyTypeObject *Lt_type;
-static PyTypeObject *LtE_type;
-static PyTypeObject *Gt_type;
-static PyTypeObject *GtE_type;
-static PyTypeObject *Is_type;
-static PyTypeObject *IsNot_type;
-static PyTypeObject *In_type;
-static PyTypeObject *NotIn_type;
-static PyTypeObject *comprehension_type;
 static PyObject* ast2obj_comprehension(void*);
-_Py_IDENTIFIER(ifs);
-_Py_IDENTIFIER(is_async);
 static const char * const comprehension_fields[]={
     "target",
     "iter",
     "ifs",
     "is_async",
 };
-static PyTypeObject *excepthandler_type;
 static const char * const excepthandler_attributes[] = {
     "lineno",
     "col_offset",
@@ -460,21 +1071,12 @@ static const char * const excepthandler_attributes[] = {
     "end_col_offset",
 };
 static PyObject* ast2obj_excepthandler(void*);
-static PyTypeObject *ExceptHandler_type;
-_Py_IDENTIFIER(type);
 static const char * const ExceptHandler_fields[]={
     "type",
     "name",
     "body",
 };
-static PyTypeObject *arguments_type;
 static PyObject* ast2obj_arguments(void*);
-_Py_IDENTIFIER(posonlyargs);
-_Py_IDENTIFIER(vararg);
-_Py_IDENTIFIER(kwonlyargs);
-_Py_IDENTIFIER(kw_defaults);
-_Py_IDENTIFIER(kwarg);
-_Py_IDENTIFIER(defaults);
 static const char * const arguments_fields[]={
     "posonlyargs",
     "args",
@@ -484,7 +1086,6 @@ static const char * const arguments_fields[]={
     "kwarg",
     "defaults",
 };
-static PyTypeObject *arg_type;
 static PyObject* ast2obj_arg(void*);
 static const char * const arg_attributes[] = {
     "lineno",
@@ -492,45 +1093,33 @@ static const char * const arg_attributes[] = {
     "end_lineno",
     "end_col_offset",
 };
-_Py_IDENTIFIER(arg);
 static const char * const arg_fields[]={
     "arg",
     "annotation",
     "type_comment",
 };
-static PyTypeObject *keyword_type;
 static PyObject* ast2obj_keyword(void*);
 static const char * const keyword_fields[]={
     "arg",
     "value",
 };
-static PyTypeObject *alias_type;
 static PyObject* ast2obj_alias(void*);
-_Py_IDENTIFIER(asname);
 static const char * const alias_fields[]={
     "name",
     "asname",
 };
-static PyTypeObject *withitem_type;
 static PyObject* ast2obj_withitem(void*);
-_Py_IDENTIFIER(context_expr);
-_Py_IDENTIFIER(optional_vars);
 static const char * const withitem_fields[]={
     "context_expr",
     "optional_vars",
 };
-static PyTypeObject *type_ignore_type;
 static PyObject* ast2obj_type_ignore(void*);
-static PyTypeObject *TypeIgnore_type;
-_Py_IDENTIFIER(tag);
 static const char * const TypeIgnore_fields[]={
     "lineno",
     "tag",
 };
 
 
-_Py_IDENTIFIER(_fields);
-_Py_IDENTIFIER(_attributes);
 
 typedef struct {
     PyObject_HEAD
@@ -566,7 +1155,7 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields;
-    if (_PyObject_LookupAttrId((PyObject*)Py_TYPE(self), &PyId__fields, &fields) < 0) {
+    if (_PyObject_LookupAttr((PyObject*)Py_TYPE(self), astmodulestate_global->_fields, &fields) < 0) {
         goto cleanup;
     }
     if (fields) {
@@ -579,7 +1168,7 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     if (numfields < PyTuple_GET_SIZE(args)) {
         PyErr_Format(PyExc_TypeError, "%.400s constructor takes at most "
                      "%zd positional argument%s",
-                     Py_TYPE(self)->tp_name,
+                     _PyType_Name(Py_TYPE(self)),
                      numfields, numfields == 1 ? "" : "s");
         res = -1;
         goto cleanup;
@@ -613,9 +1202,8 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
 static PyObject *
 ast_type_reduce(PyObject *self, PyObject *unused)
 {
-    _Py_IDENTIFIER(__dict__);
     PyObject *dict;
-    if (_PyObject_LookupAttrId(self, &PyId___dict__, &dict) < 0) {
+    if (_PyObject_LookupAttr(self, astmodulestate_global->__dict__, &dict) < 0) {
         return NULL;
     }
     if (dict) {
@@ -634,54 +1222,33 @@ static PyGetSetDef ast_type_getsets[] = {
     {NULL}
 };
 
-static PyTypeObject AST_type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
+static PyType_Slot AST_type_slots[] = {
+    {Py_tp_dealloc, ast_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_setattro, PyObject_GenericSetAttr},
+    {Py_tp_traverse, ast_traverse},
+    {Py_tp_clear, ast_clear},
+    {Py_tp_methods, ast_type_methods},
+    {Py_tp_getset, ast_type_getsets},
+    {Py_tp_init, ast_type_init},
+    {Py_tp_alloc, PyType_GenericAlloc},
+    {Py_tp_new, PyType_GenericNew},
+    {Py_tp_free, PyType_GenericNew},
+    {Py_tp_free, PyObject_GC_Del},
+    {0, 0},
+};
+
+static PyType_Spec AST_type_spec = {
     "_ast.AST",
     sizeof(AST_object),
     0,
-    (destructor)ast_dealloc, /* tp_dealloc */
-    0,                       /* tp_vectorcall_offset */
-    0,                       /* tp_getattr */
-    0,                       /* tp_setattr */
-    0,                       /* tp_as_async */
-    0,                       /* tp_repr */
-    0,                       /* tp_as_number */
-    0,                       /* tp_as_sequence */
-    0,                       /* tp_as_mapping */
-    0,                       /* tp_hash */
-    0,                       /* tp_call */
-    0,                       /* tp_str */
-    PyObject_GenericGetAttr, /* tp_getattro */
-    PyObject_GenericSetAttr, /* tp_setattro */
-    0,                       /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /* tp_flags */
-    0,                       /* tp_doc */
-    (traverseproc)ast_traverse, /* tp_traverse */
-    (inquiry)ast_clear,      /* tp_clear */
-    0,                       /* tp_richcompare */
-    0,                       /* tp_weaklistoffset */
-    0,                       /* tp_iter */
-    0,                       /* tp_iternext */
-    ast_type_methods,        /* tp_methods */
-    0,                       /* tp_members */
-    ast_type_getsets,        /* tp_getset */
-    0,                       /* tp_base */
-    0,                       /* tp_dict */
-    0,                       /* tp_descr_get */
-    0,                       /* tp_descr_set */
-    offsetof(AST_object, dict),/* tp_dictoffset */
-    (initproc)ast_type_init, /* tp_init */
-    PyType_GenericAlloc,     /* tp_alloc */
-    PyType_GenericNew,       /* tp_new */
-    PyObject_GC_Del,         /* tp_free */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    AST_type_slots
 };
 
-
-static PyTypeObject *
-make_type(const char *type, PyTypeObject *base, const char * const *fields, int num_fields)
+static PyObject *
+make_type(const char *type, PyObject* base, const char* const* fields, int num_fields)
 {
-    _Py_IDENTIFIER(__module__);
-    _Py_IDENTIFIER(_ast);
     PyObject *fnames, *result;
     int i;
     fnames = PyTuple_New(num_fields);
@@ -696,15 +1263,15 @@ make_type(const char *type, PyTypeObject *base, const char * const *fields, int 
     }
     result = PyObject_CallFunction((PyObject*)&PyType_Type, "s(O){OOOO}",
                     type, base,
-                    _PyUnicode_FromId(&PyId__fields), fnames,
-                    _PyUnicode_FromId(&PyId___module__),
-                    _PyUnicode_FromId(&PyId__ast));
+                    astmodulestate_global->_fields, fnames,
+                    astmodulestate_global->__module__,
+                    astmodulestate_global->_ast);
     Py_DECREF(fnames);
-    return (PyTypeObject*)result;
+    return result;
 }
 
 static int
-add_attributes(PyTypeObject *type, const char * const *attrs, int num_fields)
+add_attributes(PyObject *type, const char * const *attrs, int num_fields)
 {
     int i, result;
     PyObject *s, *l = PyTuple_New(num_fields);
@@ -718,7 +1285,7 @@ add_attributes(PyTypeObject *type, const char * const *attrs, int num_fields)
         }
         PyTuple_SET_ITEM(l, i, s);
     }
-    result = _PyObject_SetAttrId((PyObject*)type, &PyId__attributes, l) >= 0;
+    result = PyObject_SetAttr(type, astmodulestate_global->_attributes, l) >= 0;
     Py_DECREF(l);
     return result;
 }
@@ -824,14 +1391,11 @@ static int obj2ast_int(PyObject* obj, int* out, PyArena* arena)
 
 static int add_ast_fields(void)
 {
-    PyObject *empty_tuple, *d;
-    if (PyType_Ready(&AST_type) < 0)
-        return -1;
-    d = AST_type.tp_dict;
+    PyObject *empty_tuple;
     empty_tuple = PyTuple_New(0);
     if (!empty_tuple ||
-        _PyDict_SetItemId(d, &PyId__fields, empty_tuple) < 0 ||
-        _PyDict_SetItemId(d, &PyId__attributes, empty_tuple) < 0) {
+        PyObject_SetAttrString(astmodulestate_global->AST_type, "_fields", empty_tuple) < 0 ||
+        PyObject_SetAttrString(astmodulestate_global->AST_type, "_attributes", empty_tuple) < 0) {
         Py_XDECREF(empty_tuple);
         return -1;
     }
@@ -842,333 +1406,427 @@ static int add_ast_fields(void)
 
 static int init_types(void)
 {
-    static int initialized;
-    if (initialized) return 1;
+    PyObject *m;
+    if (PyState_FindModule(&_astmodule) == NULL) {
+        m = PyModule_Create(&_astmodule);
+        if (!m) return 0;
+        PyState_AddModule(m, &_astmodule);
+    }
+    astmodulestate *state = astmodulestate_global;
+    if (state->initialized) return 1;
+    if (init_identifiers() < 0) return 0;
+    state->AST_type = PyType_FromSpec(&AST_type_spec);
+    if (!state->AST_type) return 0;
+    ((PyTypeObject*)state->AST_type)->tp_dictoffset = offsetof(AST_object,
+     dict);
     if (add_ast_fields() < 0) return 0;
-    mod_type = make_type("mod", &AST_type, NULL, 0);
-    if (!mod_type) return 0;
-    if (!add_attributes(mod_type, NULL, 0)) return 0;
-    Module_type = make_type("Module", mod_type, Module_fields, 2);
-    if (!Module_type) return 0;
-    Interactive_type = make_type("Interactive", mod_type, Interactive_fields,
-                                 1);
-    if (!Interactive_type) return 0;
-    Expression_type = make_type("Expression", mod_type, Expression_fields, 1);
-    if (!Expression_type) return 0;
-    FunctionType_type = make_type("FunctionType", mod_type,
-                                  FunctionType_fields, 2);
-    if (!FunctionType_type) return 0;
-    Suite_type = make_type("Suite", mod_type, Suite_fields, 1);
-    if (!Suite_type) return 0;
-    stmt_type = make_type("stmt", &AST_type, NULL, 0);
-    if (!stmt_type) return 0;
-    if (!add_attributes(stmt_type, stmt_attributes, 4)) return 0;
-    FunctionDef_type = make_type("FunctionDef", stmt_type, FunctionDef_fields,
-                                 6);
-    if (!FunctionDef_type) return 0;
-    AsyncFunctionDef_type = make_type("AsyncFunctionDef", stmt_type,
-                                      AsyncFunctionDef_fields, 6);
-    if (!AsyncFunctionDef_type) return 0;
-    ClassDef_type = make_type("ClassDef", stmt_type, ClassDef_fields, 5);
-    if (!ClassDef_type) return 0;
-    Return_type = make_type("Return", stmt_type, Return_fields, 1);
-    if (!Return_type) return 0;
-    Delete_type = make_type("Delete", stmt_type, Delete_fields, 1);
-    if (!Delete_type) return 0;
-    Assign_type = make_type("Assign", stmt_type, Assign_fields, 3);
-    if (!Assign_type) return 0;
-    AugAssign_type = make_type("AugAssign", stmt_type, AugAssign_fields, 3);
-    if (!AugAssign_type) return 0;
-    AnnAssign_type = make_type("AnnAssign", stmt_type, AnnAssign_fields, 4);
-    if (!AnnAssign_type) return 0;
-    For_type = make_type("For", stmt_type, For_fields, 5);
-    if (!For_type) return 0;
-    AsyncFor_type = make_type("AsyncFor", stmt_type, AsyncFor_fields, 5);
-    if (!AsyncFor_type) return 0;
-    While_type = make_type("While", stmt_type, While_fields, 3);
-    if (!While_type) return 0;
-    If_type = make_type("If", stmt_type, If_fields, 3);
-    if (!If_type) return 0;
-    With_type = make_type("With", stmt_type, With_fields, 3);
-    if (!With_type) return 0;
-    AsyncWith_type = make_type("AsyncWith", stmt_type, AsyncWith_fields, 3);
-    if (!AsyncWith_type) return 0;
-    Raise_type = make_type("Raise", stmt_type, Raise_fields, 2);
-    if (!Raise_type) return 0;
-    Try_type = make_type("Try", stmt_type, Try_fields, 4);
-    if (!Try_type) return 0;
-    Assert_type = make_type("Assert", stmt_type, Assert_fields, 2);
-    if (!Assert_type) return 0;
-    Import_type = make_type("Import", stmt_type, Import_fields, 1);
-    if (!Import_type) return 0;
-    ImportFrom_type = make_type("ImportFrom", stmt_type, ImportFrom_fields, 3);
-    if (!ImportFrom_type) return 0;
-    Global_type = make_type("Global", stmt_type, Global_fields, 1);
-    if (!Global_type) return 0;
-    Nonlocal_type = make_type("Nonlocal", stmt_type, Nonlocal_fields, 1);
-    if (!Nonlocal_type) return 0;
-    Expr_type = make_type("Expr", stmt_type, Expr_fields, 1);
-    if (!Expr_type) return 0;
-    Pass_type = make_type("Pass", stmt_type, NULL, 0);
-    if (!Pass_type) return 0;
-    Break_type = make_type("Break", stmt_type, NULL, 0);
-    if (!Break_type) return 0;
-    Continue_type = make_type("Continue", stmt_type, NULL, 0);
-    if (!Continue_type) return 0;
-    expr_type = make_type("expr", &AST_type, NULL, 0);
-    if (!expr_type) return 0;
-    if (!add_attributes(expr_type, expr_attributes, 4)) return 0;
-    BoolOp_type = make_type("BoolOp", expr_type, BoolOp_fields, 2);
-    if (!BoolOp_type) return 0;
-    NamedExpr_type = make_type("NamedExpr", expr_type, NamedExpr_fields, 2);
-    if (!NamedExpr_type) return 0;
-    BinOp_type = make_type("BinOp", expr_type, BinOp_fields, 3);
-    if (!BinOp_type) return 0;
-    UnaryOp_type = make_type("UnaryOp", expr_type, UnaryOp_fields, 2);
-    if (!UnaryOp_type) return 0;
-    Lambda_type = make_type("Lambda", expr_type, Lambda_fields, 2);
-    if (!Lambda_type) return 0;
-    IfExp_type = make_type("IfExp", expr_type, IfExp_fields, 3);
-    if (!IfExp_type) return 0;
-    Dict_type = make_type("Dict", expr_type, Dict_fields, 2);
-    if (!Dict_type) return 0;
-    Set_type = make_type("Set", expr_type, Set_fields, 1);
-    if (!Set_type) return 0;
-    ListComp_type = make_type("ListComp", expr_type, ListComp_fields, 2);
-    if (!ListComp_type) return 0;
-    SetComp_type = make_type("SetComp", expr_type, SetComp_fields, 2);
-    if (!SetComp_type) return 0;
-    DictComp_type = make_type("DictComp", expr_type, DictComp_fields, 3);
-    if (!DictComp_type) return 0;
-    GeneratorExp_type = make_type("GeneratorExp", expr_type,
-                                  GeneratorExp_fields, 2);
-    if (!GeneratorExp_type) return 0;
-    Await_type = make_type("Await", expr_type, Await_fields, 1);
-    if (!Await_type) return 0;
-    Yield_type = make_type("Yield", expr_type, Yield_fields, 1);
-    if (!Yield_type) return 0;
-    YieldFrom_type = make_type("YieldFrom", expr_type, YieldFrom_fields, 1);
-    if (!YieldFrom_type) return 0;
-    Compare_type = make_type("Compare", expr_type, Compare_fields, 3);
-    if (!Compare_type) return 0;
-    Call_type = make_type("Call", expr_type, Call_fields, 3);
-    if (!Call_type) return 0;
-    FormattedValue_type = make_type("FormattedValue", expr_type,
-                                    FormattedValue_fields, 3);
-    if (!FormattedValue_type) return 0;
-    JoinedStr_type = make_type("JoinedStr", expr_type, JoinedStr_fields, 1);
-    if (!JoinedStr_type) return 0;
-    Constant_type = make_type("Constant", expr_type, Constant_fields, 2);
-    if (!Constant_type) return 0;
-    Attribute_type = make_type("Attribute", expr_type, Attribute_fields, 3);
-    if (!Attribute_type) return 0;
-    Subscript_type = make_type("Subscript", expr_type, Subscript_fields, 3);
-    if (!Subscript_type) return 0;
-    Starred_type = make_type("Starred", expr_type, Starred_fields, 2);
-    if (!Starred_type) return 0;
-    Name_type = make_type("Name", expr_type, Name_fields, 2);
-    if (!Name_type) return 0;
-    List_type = make_type("List", expr_type, List_fields, 2);
-    if (!List_type) return 0;
-    Tuple_type = make_type("Tuple", expr_type, Tuple_fields, 2);
-    if (!Tuple_type) return 0;
-    expr_context_type = make_type("expr_context", &AST_type, NULL, 0);
-    if (!expr_context_type) return 0;
-    if (!add_attributes(expr_context_type, NULL, 0)) return 0;
-    Load_type = make_type("Load", expr_context_type, NULL, 0);
-    if (!Load_type) return 0;
-    Load_singleton = PyType_GenericNew(Load_type, NULL, NULL);
-    if (!Load_singleton) return 0;
-    Store_type = make_type("Store", expr_context_type, NULL, 0);
-    if (!Store_type) return 0;
-    Store_singleton = PyType_GenericNew(Store_type, NULL, NULL);
-    if (!Store_singleton) return 0;
-    Del_type = make_type("Del", expr_context_type, NULL, 0);
-    if (!Del_type) return 0;
-    Del_singleton = PyType_GenericNew(Del_type, NULL, NULL);
-    if (!Del_singleton) return 0;
-    AugLoad_type = make_type("AugLoad", expr_context_type, NULL, 0);
-    if (!AugLoad_type) return 0;
-    AugLoad_singleton = PyType_GenericNew(AugLoad_type, NULL, NULL);
-    if (!AugLoad_singleton) return 0;
-    AugStore_type = make_type("AugStore", expr_context_type, NULL, 0);
-    if (!AugStore_type) return 0;
-    AugStore_singleton = PyType_GenericNew(AugStore_type, NULL, NULL);
-    if (!AugStore_singleton) return 0;
-    Param_type = make_type("Param", expr_context_type, NULL, 0);
-    if (!Param_type) return 0;
-    Param_singleton = PyType_GenericNew(Param_type, NULL, NULL);
-    if (!Param_singleton) return 0;
-    slice_type = make_type("slice", &AST_type, NULL, 0);
-    if (!slice_type) return 0;
-    if (!add_attributes(slice_type, NULL, 0)) return 0;
-    Slice_type = make_type("Slice", slice_type, Slice_fields, 3);
-    if (!Slice_type) return 0;
-    ExtSlice_type = make_type("ExtSlice", slice_type, ExtSlice_fields, 1);
-    if (!ExtSlice_type) return 0;
-    Index_type = make_type("Index", slice_type, Index_fields, 1);
-    if (!Index_type) return 0;
-    boolop_type = make_type("boolop", &AST_type, NULL, 0);
-    if (!boolop_type) return 0;
-    if (!add_attributes(boolop_type, NULL, 0)) return 0;
-    And_type = make_type("And", boolop_type, NULL, 0);
-    if (!And_type) return 0;
-    And_singleton = PyType_GenericNew(And_type, NULL, NULL);
-    if (!And_singleton) return 0;
-    Or_type = make_type("Or", boolop_type, NULL, 0);
-    if (!Or_type) return 0;
-    Or_singleton = PyType_GenericNew(Or_type, NULL, NULL);
-    if (!Or_singleton) return 0;
-    operator_type = make_type("operator", &AST_type, NULL, 0);
-    if (!operator_type) return 0;
-    if (!add_attributes(operator_type, NULL, 0)) return 0;
-    Add_type = make_type("Add", operator_type, NULL, 0);
-    if (!Add_type) return 0;
-    Add_singleton = PyType_GenericNew(Add_type, NULL, NULL);
-    if (!Add_singleton) return 0;
-    Sub_type = make_type("Sub", operator_type, NULL, 0);
-    if (!Sub_type) return 0;
-    Sub_singleton = PyType_GenericNew(Sub_type, NULL, NULL);
-    if (!Sub_singleton) return 0;
-    Mult_type = make_type("Mult", operator_type, NULL, 0);
-    if (!Mult_type) return 0;
-    Mult_singleton = PyType_GenericNew(Mult_type, NULL, NULL);
-    if (!Mult_singleton) return 0;
-    MatMult_type = make_type("MatMult", operator_type, NULL, 0);
-    if (!MatMult_type) return 0;
-    MatMult_singleton = PyType_GenericNew(MatMult_type, NULL, NULL);
-    if (!MatMult_singleton) return 0;
-    Div_type = make_type("Div", operator_type, NULL, 0);
-    if (!Div_type) return 0;
-    Div_singleton = PyType_GenericNew(Div_type, NULL, NULL);
-    if (!Div_singleton) return 0;
-    Mod_type = make_type("Mod", operator_type, NULL, 0);
-    if (!Mod_type) return 0;
-    Mod_singleton = PyType_GenericNew(Mod_type, NULL, NULL);
-    if (!Mod_singleton) return 0;
-    Pow_type = make_type("Pow", operator_type, NULL, 0);
-    if (!Pow_type) return 0;
-    Pow_singleton = PyType_GenericNew(Pow_type, NULL, NULL);
-    if (!Pow_singleton) return 0;
-    LShift_type = make_type("LShift", operator_type, NULL, 0);
-    if (!LShift_type) return 0;
-    LShift_singleton = PyType_GenericNew(LShift_type, NULL, NULL);
-    if (!LShift_singleton) return 0;
-    RShift_type = make_type("RShift", operator_type, NULL, 0);
-    if (!RShift_type) return 0;
-    RShift_singleton = PyType_GenericNew(RShift_type, NULL, NULL);
-    if (!RShift_singleton) return 0;
-    BitOr_type = make_type("BitOr", operator_type, NULL, 0);
-    if (!BitOr_type) return 0;
-    BitOr_singleton = PyType_GenericNew(BitOr_type, NULL, NULL);
-    if (!BitOr_singleton) return 0;
-    BitXor_type = make_type("BitXor", operator_type, NULL, 0);
-    if (!BitXor_type) return 0;
-    BitXor_singleton = PyType_GenericNew(BitXor_type, NULL, NULL);
-    if (!BitXor_singleton) return 0;
-    BitAnd_type = make_type("BitAnd", operator_type, NULL, 0);
-    if (!BitAnd_type) return 0;
-    BitAnd_singleton = PyType_GenericNew(BitAnd_type, NULL, NULL);
-    if (!BitAnd_singleton) return 0;
-    FloorDiv_type = make_type("FloorDiv", operator_type, NULL, 0);
-    if (!FloorDiv_type) return 0;
-    FloorDiv_singleton = PyType_GenericNew(FloorDiv_type, NULL, NULL);
-    if (!FloorDiv_singleton) return 0;
-    unaryop_type = make_type("unaryop", &AST_type, NULL, 0);
-    if (!unaryop_type) return 0;
-    if (!add_attributes(unaryop_type, NULL, 0)) return 0;
-    Invert_type = make_type("Invert", unaryop_type, NULL, 0);
-    if (!Invert_type) return 0;
-    Invert_singleton = PyType_GenericNew(Invert_type, NULL, NULL);
-    if (!Invert_singleton) return 0;
-    Not_type = make_type("Not", unaryop_type, NULL, 0);
-    if (!Not_type) return 0;
-    Not_singleton = PyType_GenericNew(Not_type, NULL, NULL);
-    if (!Not_singleton) return 0;
-    UAdd_type = make_type("UAdd", unaryop_type, NULL, 0);
-    if (!UAdd_type) return 0;
-    UAdd_singleton = PyType_GenericNew(UAdd_type, NULL, NULL);
-    if (!UAdd_singleton) return 0;
-    USub_type = make_type("USub", unaryop_type, NULL, 0);
-    if (!USub_type) return 0;
-    USub_singleton = PyType_GenericNew(USub_type, NULL, NULL);
-    if (!USub_singleton) return 0;
-    cmpop_type = make_type("cmpop", &AST_type, NULL, 0);
-    if (!cmpop_type) return 0;
-    if (!add_attributes(cmpop_type, NULL, 0)) return 0;
-    Eq_type = make_type("Eq", cmpop_type, NULL, 0);
-    if (!Eq_type) return 0;
-    Eq_singleton = PyType_GenericNew(Eq_type, NULL, NULL);
-    if (!Eq_singleton) return 0;
-    NotEq_type = make_type("NotEq", cmpop_type, NULL, 0);
-    if (!NotEq_type) return 0;
-    NotEq_singleton = PyType_GenericNew(NotEq_type, NULL, NULL);
-    if (!NotEq_singleton) return 0;
-    Lt_type = make_type("Lt", cmpop_type, NULL, 0);
-    if (!Lt_type) return 0;
-    Lt_singleton = PyType_GenericNew(Lt_type, NULL, NULL);
-    if (!Lt_singleton) return 0;
-    LtE_type = make_type("LtE", cmpop_type, NULL, 0);
-    if (!LtE_type) return 0;
-    LtE_singleton = PyType_GenericNew(LtE_type, NULL, NULL);
-    if (!LtE_singleton) return 0;
-    Gt_type = make_type("Gt", cmpop_type, NULL, 0);
-    if (!Gt_type) return 0;
-    Gt_singleton = PyType_GenericNew(Gt_type, NULL, NULL);
-    if (!Gt_singleton) return 0;
-    GtE_type = make_type("GtE", cmpop_type, NULL, 0);
-    if (!GtE_type) return 0;
-    GtE_singleton = PyType_GenericNew(GtE_type, NULL, NULL);
-    if (!GtE_singleton) return 0;
-    Is_type = make_type("Is", cmpop_type, NULL, 0);
-    if (!Is_type) return 0;
-    Is_singleton = PyType_GenericNew(Is_type, NULL, NULL);
-    if (!Is_singleton) return 0;
-    IsNot_type = make_type("IsNot", cmpop_type, NULL, 0);
-    if (!IsNot_type) return 0;
-    IsNot_singleton = PyType_GenericNew(IsNot_type, NULL, NULL);
-    if (!IsNot_singleton) return 0;
-    In_type = make_type("In", cmpop_type, NULL, 0);
-    if (!In_type) return 0;
-    In_singleton = PyType_GenericNew(In_type, NULL, NULL);
-    if (!In_singleton) return 0;
-    NotIn_type = make_type("NotIn", cmpop_type, NULL, 0);
-    if (!NotIn_type) return 0;
-    NotIn_singleton = PyType_GenericNew(NotIn_type, NULL, NULL);
-    if (!NotIn_singleton) return 0;
-    comprehension_type = make_type("comprehension", &AST_type,
-                                   comprehension_fields, 4);
-    if (!comprehension_type) return 0;
-    if (!add_attributes(comprehension_type, NULL, 0)) return 0;
-    excepthandler_type = make_type("excepthandler", &AST_type, NULL, 0);
-    if (!excepthandler_type) return 0;
-    if (!add_attributes(excepthandler_type, excepthandler_attributes, 4))
-        return 0;
-    ExceptHandler_type = make_type("ExceptHandler", excepthandler_type,
-                                   ExceptHandler_fields, 3);
-    if (!ExceptHandler_type) return 0;
-    arguments_type = make_type("arguments", &AST_type, arguments_fields, 7);
-    if (!arguments_type) return 0;
-    if (!add_attributes(arguments_type, NULL, 0)) return 0;
-    arg_type = make_type("arg", &AST_type, arg_fields, 3);
-    if (!arg_type) return 0;
-    if (!add_attributes(arg_type, arg_attributes, 4)) return 0;
-    keyword_type = make_type("keyword", &AST_type, keyword_fields, 2);
-    if (!keyword_type) return 0;
-    if (!add_attributes(keyword_type, NULL, 0)) return 0;
-    alias_type = make_type("alias", &AST_type, alias_fields, 2);
-    if (!alias_type) return 0;
-    if (!add_attributes(alias_type, NULL, 0)) return 0;
-    withitem_type = make_type("withitem", &AST_type, withitem_fields, 2);
-    if (!withitem_type) return 0;
-    if (!add_attributes(withitem_type, NULL, 0)) return 0;
-    type_ignore_type = make_type("type_ignore", &AST_type, NULL, 0);
-    if (!type_ignore_type) return 0;
-    if (!add_attributes(type_ignore_type, NULL, 0)) return 0;
-    TypeIgnore_type = make_type("TypeIgnore", type_ignore_type,
-                                TypeIgnore_fields, 2);
-    if (!TypeIgnore_type) return 0;
-    initialized = 1;
+    state->mod_type = make_type("mod", state->AST_type, NULL, 0);
+    if (!state->mod_type) return 0;
+    if (!add_attributes(state->mod_type, NULL, 0)) return 0;
+    state->Module_type = make_type("Module", state->mod_type, Module_fields, 2);
+    if (!state->Module_type) return 0;
+    state->Interactive_type = make_type("Interactive", state->mod_type,
+                                        Interactive_fields, 1);
+    if (!state->Interactive_type) return 0;
+    state->Expression_type = make_type("Expression", state->mod_type,
+                                       Expression_fields, 1);
+    if (!state->Expression_type) return 0;
+    state->FunctionType_type = make_type("FunctionType", state->mod_type,
+                                         FunctionType_fields, 2);
+    if (!state->FunctionType_type) return 0;
+    state->Suite_type = make_type("Suite", state->mod_type, Suite_fields, 1);
+    if (!state->Suite_type) return 0;
+    state->stmt_type = make_type("stmt", state->AST_type, NULL, 0);
+    if (!state->stmt_type) return 0;
+    if (!add_attributes(state->stmt_type, stmt_attributes, 4)) return 0;
+    state->FunctionDef_type = make_type("FunctionDef", state->stmt_type,
+                                        FunctionDef_fields, 6);
+    if (!state->FunctionDef_type) return 0;
+    state->AsyncFunctionDef_type = make_type("AsyncFunctionDef",
+                                             state->stmt_type,
+                                             AsyncFunctionDef_fields, 6);
+    if (!state->AsyncFunctionDef_type) return 0;
+    state->ClassDef_type = make_type("ClassDef", state->stmt_type,
+                                     ClassDef_fields, 5);
+    if (!state->ClassDef_type) return 0;
+    state->Return_type = make_type("Return", state->stmt_type, Return_fields,
+                                   1);
+    if (!state->Return_type) return 0;
+    state->Delete_type = make_type("Delete", state->stmt_type, Delete_fields,
+                                   1);
+    if (!state->Delete_type) return 0;
+    state->Assign_type = make_type("Assign", state->stmt_type, Assign_fields,
+                                   3);
+    if (!state->Assign_type) return 0;
+    state->AugAssign_type = make_type("AugAssign", state->stmt_type,
+                                      AugAssign_fields, 3);
+    if (!state->AugAssign_type) return 0;
+    state->AnnAssign_type = make_type("AnnAssign", state->stmt_type,
+                                      AnnAssign_fields, 4);
+    if (!state->AnnAssign_type) return 0;
+    state->For_type = make_type("For", state->stmt_type, For_fields, 5);
+    if (!state->For_type) return 0;
+    state->AsyncFor_type = make_type("AsyncFor", state->stmt_type,
+                                     AsyncFor_fields, 5);
+    if (!state->AsyncFor_type) return 0;
+    state->While_type = make_type("While", state->stmt_type, While_fields, 3);
+    if (!state->While_type) return 0;
+    state->If_type = make_type("If", state->stmt_type, If_fields, 3);
+    if (!state->If_type) return 0;
+    state->With_type = make_type("With", state->stmt_type, With_fields, 3);
+    if (!state->With_type) return 0;
+    state->AsyncWith_type = make_type("AsyncWith", state->stmt_type,
+                                      AsyncWith_fields, 3);
+    if (!state->AsyncWith_type) return 0;
+    state->Raise_type = make_type("Raise", state->stmt_type, Raise_fields, 2);
+    if (!state->Raise_type) return 0;
+    state->Try_type = make_type("Try", state->stmt_type, Try_fields, 4);
+    if (!state->Try_type) return 0;
+    state->Assert_type = make_type("Assert", state->stmt_type, Assert_fields,
+                                   2);
+    if (!state->Assert_type) return 0;
+    state->Import_type = make_type("Import", state->stmt_type, Import_fields,
+                                   1);
+    if (!state->Import_type) return 0;
+    state->ImportFrom_type = make_type("ImportFrom", state->stmt_type,
+                                       ImportFrom_fields, 3);
+    if (!state->ImportFrom_type) return 0;
+    state->Global_type = make_type("Global", state->stmt_type, Global_fields,
+                                   1);
+    if (!state->Global_type) return 0;
+    state->Nonlocal_type = make_type("Nonlocal", state->stmt_type,
+                                     Nonlocal_fields, 1);
+    if (!state->Nonlocal_type) return 0;
+    state->Expr_type = make_type("Expr", state->stmt_type, Expr_fields, 1);
+    if (!state->Expr_type) return 0;
+    state->Pass_type = make_type("Pass", state->stmt_type, NULL, 0);
+    if (!state->Pass_type) return 0;
+    state->Break_type = make_type("Break", state->stmt_type, NULL, 0);
+    if (!state->Break_type) return 0;
+    state->Continue_type = make_type("Continue", state->stmt_type, NULL, 0);
+    if (!state->Continue_type) return 0;
+    state->expr_type = make_type("expr", state->AST_type, NULL, 0);
+    if (!state->expr_type) return 0;
+    if (!add_attributes(state->expr_type, expr_attributes, 4)) return 0;
+    state->BoolOp_type = make_type("BoolOp", state->expr_type, BoolOp_fields,
+                                   2);
+    if (!state->BoolOp_type) return 0;
+    state->NamedExpr_type = make_type("NamedExpr", state->expr_type,
+                                      NamedExpr_fields, 2);
+    if (!state->NamedExpr_type) return 0;
+    state->BinOp_type = make_type("BinOp", state->expr_type, BinOp_fields, 3);
+    if (!state->BinOp_type) return 0;
+    state->UnaryOp_type = make_type("UnaryOp", state->expr_type,
+                                    UnaryOp_fields, 2);
+    if (!state->UnaryOp_type) return 0;
+    state->Lambda_type = make_type("Lambda", state->expr_type, Lambda_fields,
+                                   2);
+    if (!state->Lambda_type) return 0;
+    state->IfExp_type = make_type("IfExp", state->expr_type, IfExp_fields, 3);
+    if (!state->IfExp_type) return 0;
+    state->Dict_type = make_type("Dict", state->expr_type, Dict_fields, 2);
+    if (!state->Dict_type) return 0;
+    state->Set_type = make_type("Set", state->expr_type, Set_fields, 1);
+    if (!state->Set_type) return 0;
+    state->ListComp_type = make_type("ListComp", state->expr_type,
+                                     ListComp_fields, 2);
+    if (!state->ListComp_type) return 0;
+    state->SetComp_type = make_type("SetComp", state->expr_type,
+                                    SetComp_fields, 2);
+    if (!state->SetComp_type) return 0;
+    state->DictComp_type = make_type("DictComp", state->expr_type,
+                                     DictComp_fields, 3);
+    if (!state->DictComp_type) return 0;
+    state->GeneratorExp_type = make_type("GeneratorExp", state->expr_type,
+                                         GeneratorExp_fields, 2);
+    if (!state->GeneratorExp_type) return 0;
+    state->Await_type = make_type("Await", state->expr_type, Await_fields, 1);
+    if (!state->Await_type) return 0;
+    state->Yield_type = make_type("Yield", state->expr_type, Yield_fields, 1);
+    if (!state->Yield_type) return 0;
+    state->YieldFrom_type = make_type("YieldFrom", state->expr_type,
+                                      YieldFrom_fields, 1);
+    if (!state->YieldFrom_type) return 0;
+    state->Compare_type = make_type("Compare", state->expr_type,
+                                    Compare_fields, 3);
+    if (!state->Compare_type) return 0;
+    state->Call_type = make_type("Call", state->expr_type, Call_fields, 3);
+    if (!state->Call_type) return 0;
+    state->FormattedValue_type = make_type("FormattedValue", state->expr_type,
+                                           FormattedValue_fields, 3);
+    if (!state->FormattedValue_type) return 0;
+    state->JoinedStr_type = make_type("JoinedStr", state->expr_type,
+                                      JoinedStr_fields, 1);
+    if (!state->JoinedStr_type) return 0;
+    state->Constant_type = make_type("Constant", state->expr_type,
+                                     Constant_fields, 2);
+    if (!state->Constant_type) return 0;
+    state->Attribute_type = make_type("Attribute", state->expr_type,
+                                      Attribute_fields, 3);
+    if (!state->Attribute_type) return 0;
+    state->Subscript_type = make_type("Subscript", state->expr_type,
+                                      Subscript_fields, 3);
+    if (!state->Subscript_type) return 0;
+    state->Starred_type = make_type("Starred", state->expr_type,
+                                    Starred_fields, 2);
+    if (!state->Starred_type) return 0;
+    state->Name_type = make_type("Name", state->expr_type, Name_fields, 2);
+    if (!state->Name_type) return 0;
+    state->List_type = make_type("List", state->expr_type, List_fields, 2);
+    if (!state->List_type) return 0;
+    state->Tuple_type = make_type("Tuple", state->expr_type, Tuple_fields, 2);
+    if (!state->Tuple_type) return 0;
+    state->expr_context_type = make_type("expr_context", state->AST_type, NULL,
+                                         0);
+    if (!state->expr_context_type) return 0;
+    if (!add_attributes(state->expr_context_type, NULL, 0)) return 0;
+    state->Load_type = make_type("Load", state->expr_context_type, NULL, 0);
+    if (!state->Load_type) return 0;
+    state->Load_singleton = PyType_GenericNew((PyTypeObject *)state->Load_type,
+                                              NULL, NULL);
+    if (!state->Load_singleton) return 0;
+    state->Store_type = make_type("Store", state->expr_context_type, NULL, 0);
+    if (!state->Store_type) return 0;
+    state->Store_singleton = PyType_GenericNew((PyTypeObject
+                                               *)state->Store_type, NULL, NULL);
+    if (!state->Store_singleton) return 0;
+    state->Del_type = make_type("Del", state->expr_context_type, NULL, 0);
+    if (!state->Del_type) return 0;
+    state->Del_singleton = PyType_GenericNew((PyTypeObject *)state->Del_type,
+                                             NULL, NULL);
+    if (!state->Del_singleton) return 0;
+    state->AugLoad_type = make_type("AugLoad", state->expr_context_type, NULL,
+                                    0);
+    if (!state->AugLoad_type) return 0;
+    state->AugLoad_singleton = PyType_GenericNew((PyTypeObject
+                                                 *)state->AugLoad_type, NULL,
+                                                 NULL);
+    if (!state->AugLoad_singleton) return 0;
+    state->AugStore_type = make_type("AugStore", state->expr_context_type,
+                                     NULL, 0);
+    if (!state->AugStore_type) return 0;
+    state->AugStore_singleton = PyType_GenericNew((PyTypeObject
+                                                  *)state->AugStore_type, NULL,
+                                                  NULL);
+    if (!state->AugStore_singleton) return 0;
+    state->Param_type = make_type("Param", state->expr_context_type, NULL, 0);
+    if (!state->Param_type) return 0;
+    state->Param_singleton = PyType_GenericNew((PyTypeObject
+                                               *)state->Param_type, NULL, NULL);
+    if (!state->Param_singleton) return 0;
+    state->slice_type = make_type("slice", state->AST_type, NULL, 0);
+    if (!state->slice_type) return 0;
+    if (!add_attributes(state->slice_type, NULL, 0)) return 0;
+    state->Slice_type = make_type("Slice", state->slice_type, Slice_fields, 3);
+    if (!state->Slice_type) return 0;
+    state->ExtSlice_type = make_type("ExtSlice", state->slice_type,
+                                     ExtSlice_fields, 1);
+    if (!state->ExtSlice_type) return 0;
+    state->Index_type = make_type("Index", state->slice_type, Index_fields, 1);
+    if (!state->Index_type) return 0;
+    state->boolop_type = make_type("boolop", state->AST_type, NULL, 0);
+    if (!state->boolop_type) return 0;
+    if (!add_attributes(state->boolop_type, NULL, 0)) return 0;
+    state->And_type = make_type("And", state->boolop_type, NULL, 0);
+    if (!state->And_type) return 0;
+    state->And_singleton = PyType_GenericNew((PyTypeObject *)state->And_type,
+                                             NULL, NULL);
+    if (!state->And_singleton) return 0;
+    state->Or_type = make_type("Or", state->boolop_type, NULL, 0);
+    if (!state->Or_type) return 0;
+    state->Or_singleton = PyType_GenericNew((PyTypeObject *)state->Or_type,
+                                            NULL, NULL);
+    if (!state->Or_singleton) return 0;
+    state->operator_type = make_type("operator", state->AST_type, NULL, 0);
+    if (!state->operator_type) return 0;
+    if (!add_attributes(state->operator_type, NULL, 0)) return 0;
+    state->Add_type = make_type("Add", state->operator_type, NULL, 0);
+    if (!state->Add_type) return 0;
+    state->Add_singleton = PyType_GenericNew((PyTypeObject *)state->Add_type,
+                                             NULL, NULL);
+    if (!state->Add_singleton) return 0;
+    state->Sub_type = make_type("Sub", state->operator_type, NULL, 0);
+    if (!state->Sub_type) return 0;
+    state->Sub_singleton = PyType_GenericNew((PyTypeObject *)state->Sub_type,
+                                             NULL, NULL);
+    if (!state->Sub_singleton) return 0;
+    state->Mult_type = make_type("Mult", state->operator_type, NULL, 0);
+    if (!state->Mult_type) return 0;
+    state->Mult_singleton = PyType_GenericNew((PyTypeObject *)state->Mult_type,
+                                              NULL, NULL);
+    if (!state->Mult_singleton) return 0;
+    state->MatMult_type = make_type("MatMult", state->operator_type, NULL, 0);
+    if (!state->MatMult_type) return 0;
+    state->MatMult_singleton = PyType_GenericNew((PyTypeObject
+                                                 *)state->MatMult_type, NULL,
+                                                 NULL);
+    if (!state->MatMult_singleton) return 0;
+    state->Div_type = make_type("Div", state->operator_type, NULL, 0);
+    if (!state->Div_type) return 0;
+    state->Div_singleton = PyType_GenericNew((PyTypeObject *)state->Div_type,
+                                             NULL, NULL);
+    if (!state->Div_singleton) return 0;
+    state->Mod_type = make_type("Mod", state->operator_type, NULL, 0);
+    if (!state->Mod_type) return 0;
+    state->Mod_singleton = PyType_GenericNew((PyTypeObject *)state->Mod_type,
+                                             NULL, NULL);
+    if (!state->Mod_singleton) return 0;
+    state->Pow_type = make_type("Pow", state->operator_type, NULL, 0);
+    if (!state->Pow_type) return 0;
+    state->Pow_singleton = PyType_GenericNew((PyTypeObject *)state->Pow_type,
+                                             NULL, NULL);
+    if (!state->Pow_singleton) return 0;
+    state->LShift_type = make_type("LShift", state->operator_type, NULL, 0);
+    if (!state->LShift_type) return 0;
+    state->LShift_singleton = PyType_GenericNew((PyTypeObject
+                                                *)state->LShift_type, NULL,
+                                                NULL);
+    if (!state->LShift_singleton) return 0;
+    state->RShift_type = make_type("RShift", state->operator_type, NULL, 0);
+    if (!state->RShift_type) return 0;
+    state->RShift_singleton = PyType_GenericNew((PyTypeObject
+                                                *)state->RShift_type, NULL,
+                                                NULL);
+    if (!state->RShift_singleton) return 0;
+    state->BitOr_type = make_type("BitOr", state->operator_type, NULL, 0);
+    if (!state->BitOr_type) return 0;
+    state->BitOr_singleton = PyType_GenericNew((PyTypeObject
+                                               *)state->BitOr_type, NULL, NULL);
+    if (!state->BitOr_singleton) return 0;
+    state->BitXor_type = make_type("BitXor", state->operator_type, NULL, 0);
+    if (!state->BitXor_type) return 0;
+    state->BitXor_singleton = PyType_GenericNew((PyTypeObject
+                                                *)state->BitXor_type, NULL,
+                                                NULL);
+    if (!state->BitXor_singleton) return 0;
+    state->BitAnd_type = make_type("BitAnd", state->operator_type, NULL, 0);
+    if (!state->BitAnd_type) return 0;
+    state->BitAnd_singleton = PyType_GenericNew((PyTypeObject
+                                                *)state->BitAnd_type, NULL,
+                                                NULL);
+    if (!state->BitAnd_singleton) return 0;
+    state->FloorDiv_type = make_type("FloorDiv", state->operator_type, NULL, 0);
+    if (!state->FloorDiv_type) return 0;
+    state->FloorDiv_singleton = PyType_GenericNew((PyTypeObject
+                                                  *)state->FloorDiv_type, NULL,
+                                                  NULL);
+    if (!state->FloorDiv_singleton) return 0;
+    state->unaryop_type = make_type("unaryop", state->AST_type, NULL, 0);
+    if (!state->unaryop_type) return 0;
+    if (!add_attributes(state->unaryop_type, NULL, 0)) return 0;
+    state->Invert_type = make_type("Invert", state->unaryop_type, NULL, 0);
+    if (!state->Invert_type) return 0;
+    state->Invert_singleton = PyType_GenericNew((PyTypeObject
+                                                *)state->Invert_type, NULL,
+                                                NULL);
+    if (!state->Invert_singleton) return 0;
+    state->Not_type = make_type("Not", state->unaryop_type, NULL, 0);
+    if (!state->Not_type) return 0;
+    state->Not_singleton = PyType_GenericNew((PyTypeObject *)state->Not_type,
+                                             NULL, NULL);
+    if (!state->Not_singleton) return 0;
+    state->UAdd_type = make_type("UAdd", state->unaryop_type, NULL, 0);
+    if (!state->UAdd_type) return 0;
+    state->UAdd_singleton = PyType_GenericNew((PyTypeObject *)state->UAdd_type,
+                                              NULL, NULL);
+    if (!state->UAdd_singleton) return 0;
+    state->USub_type = make_type("USub", state->unaryop_type, NULL, 0);
+    if (!state->USub_type) return 0;
+    state->USub_singleton = PyType_GenericNew((PyTypeObject *)state->USub_type,
+                                              NULL, NULL);
+    if (!state->USub_singleton) return 0;
+    state->cmpop_type = make_type("cmpop", state->AST_type, NULL, 0);
+    if (!state->cmpop_type) return 0;
+    if (!add_attributes(state->cmpop_type, NULL, 0)) return 0;
+    state->Eq_type = make_type("Eq", state->cmpop_type, NULL, 0);
+    if (!state->Eq_type) return 0;
+    state->Eq_singleton = PyType_GenericNew((PyTypeObject *)state->Eq_type,
+                                            NULL, NULL);
+    if (!state->Eq_singleton) return 0;
+    state->NotEq_type = make_type("NotEq", state->cmpop_type, NULL, 0);
+    if (!state->NotEq_type) return 0;
+    state->NotEq_singleton = PyType_GenericNew((PyTypeObject
+                                               *)state->NotEq_type, NULL, NULL);
+    if (!state->NotEq_singleton) return 0;
+    state->Lt_type = make_type("Lt", state->cmpop_type, NULL, 0);
+    if (!state->Lt_type) return 0;
+    state->Lt_singleton = PyType_GenericNew((PyTypeObject *)state->Lt_type,
+                                            NULL, NULL);
+    if (!state->Lt_singleton) return 0;
+    state->LtE_type = make_type("LtE", state->cmpop_type, NULL, 0);
+    if (!state->LtE_type) return 0;
+    state->LtE_singleton = PyType_GenericNew((PyTypeObject *)state->LtE_type,
+                                             NULL, NULL);
+    if (!state->LtE_singleton) return 0;
+    state->Gt_type = make_type("Gt", state->cmpop_type, NULL, 0);
+    if (!state->Gt_type) return 0;
+    state->Gt_singleton = PyType_GenericNew((PyTypeObject *)state->Gt_type,
+                                            NULL, NULL);
+    if (!state->Gt_singleton) return 0;
+    state->GtE_type = make_type("GtE", state->cmpop_type, NULL, 0);
+    if (!state->GtE_type) return 0;
+    state->GtE_singleton = PyType_GenericNew((PyTypeObject *)state->GtE_type,
+                                             NULL, NULL);
+    if (!state->GtE_singleton) return 0;
+    state->Is_type = make_type("Is", state->cmpop_type, NULL, 0);
+    if (!state->Is_type) return 0;
+    state->Is_singleton = PyType_GenericNew((PyTypeObject *)state->Is_type,
+                                            NULL, NULL);
+    if (!state->Is_singleton) return 0;
+    state->IsNot_type = make_type("IsNot", state->cmpop_type, NULL, 0);
+    if (!state->IsNot_type) return 0;
+    state->IsNot_singleton = PyType_GenericNew((PyTypeObject
+                                               *)state->IsNot_type, NULL, NULL);
+    if (!state->IsNot_singleton) return 0;
+    state->In_type = make_type("In", state->cmpop_type, NULL, 0);
+    if (!state->In_type) return 0;
+    state->In_singleton = PyType_GenericNew((PyTypeObject *)state->In_type,
+                                            NULL, NULL);
+    if (!state->In_singleton) return 0;
+    state->NotIn_type = make_type("NotIn", state->cmpop_type, NULL, 0);
+    if (!state->NotIn_type) return 0;
+    state->NotIn_singleton = PyType_GenericNew((PyTypeObject
+                                               *)state->NotIn_type, NULL, NULL);
+    if (!state->NotIn_singleton) return 0;
+    state->comprehension_type = make_type("comprehension", state->AST_type,
+                                          comprehension_fields, 4);
+    if (!state->comprehension_type) return 0;
+    if (!add_attributes(state->comprehension_type, NULL, 0)) return 0;
+    state->excepthandler_type = make_type("excepthandler", state->AST_type,
+                                          NULL, 0);
+    if (!state->excepthandler_type) return 0;
+    if (!add_attributes(state->excepthandler_type, excepthandler_attributes,
+        4)) return 0;
+    state->ExceptHandler_type = make_type("ExceptHandler",
+                                          state->excepthandler_type,
+                                          ExceptHandler_fields, 3);
+    if (!state->ExceptHandler_type) return 0;
+    state->arguments_type = make_type("arguments", state->AST_type,
+                                      arguments_fields, 7);
+    if (!state->arguments_type) return 0;
+    if (!add_attributes(state->arguments_type, NULL, 0)) return 0;
+    state->arg_type = make_type("arg", state->AST_type, arg_fields, 3);
+    if (!state->arg_type) return 0;
+    if (!add_attributes(state->arg_type, arg_attributes, 4)) return 0;
+    state->keyword_type = make_type("keyword", state->AST_type, keyword_fields,
+                                    2);
+    if (!state->keyword_type) return 0;
+    if (!add_attributes(state->keyword_type, NULL, 0)) return 0;
+    state->alias_type = make_type("alias", state->AST_type, alias_fields, 2);
+    if (!state->alias_type) return 0;
+    if (!add_attributes(state->alias_type, NULL, 0)) return 0;
+    state->withitem_type = make_type("withitem", state->AST_type,
+                                     withitem_fields, 2);
+    if (!state->withitem_type) return 0;
+    if (!add_attributes(state->withitem_type, NULL, 0)) return 0;
+    state->type_ignore_type = make_type("type_ignore", state->AST_type, NULL,
+                                        0);
+    if (!state->type_ignore_type) return 0;
+    if (!add_attributes(state->type_ignore_type, NULL, 0)) return 0;
+    state->TypeIgnore_type = make_type("TypeIgnore", state->type_ignore_type,
+                                       TypeIgnore_fields, 2);
+    if (!state->TypeIgnore_type) return 0;
+    state->initialized = 1;
     return 1;
 }
 
@@ -2691,63 +3349,72 @@ ast2obj_mod(void* _o)
 {
     mod_ty o = (mod_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
     switch (o->kind) {
     case Module_kind:
-        result = PyType_GenericNew(Module_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Module_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Module.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.Module.type_ignores, ast2obj_type_ignore);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_type_ignores, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->type_ignores,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Interactive_kind:
-        result = PyType_GenericNew(Interactive_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Interactive_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Interactive.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Expression_kind:
-        result = PyType_GenericNew(Expression_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Expression_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Expression.body);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case FunctionType_kind:
-        result = PyType_GenericNew(FunctionType_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->FunctionType_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.FunctionType.argtypes, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_argtypes, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->argtypes, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.FunctionType.returns);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_returns, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->returns, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Suite_kind:
-        result = PyType_GenericNew(Suite_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Suite_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Suite.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
@@ -2764,461 +3431,517 @@ ast2obj_stmt(void* _o)
 {
     stmt_ty o = (stmt_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
     switch (o->kind) {
     case FunctionDef_kind:
-        result = PyType_GenericNew(FunctionDef_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->FunctionDef_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_identifier(o->v.FunctionDef.name);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_name, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_arguments(o->v.FunctionDef.args);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_args, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.FunctionDef.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.FunctionDef.decorator_list, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_decorator_list, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->decorator_list,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.FunctionDef.returns);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_returns, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->returns, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_string(o->v.FunctionDef.type_comment);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_type_comment, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AsyncFunctionDef_kind:
-        result = PyType_GenericNew(AsyncFunctionDef_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->AsyncFunctionDef_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_identifier(o->v.AsyncFunctionDef.name);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_name, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_arguments(o->v.AsyncFunctionDef.args);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_args, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.AsyncFunctionDef.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.AsyncFunctionDef.decorator_list,
                              ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_decorator_list, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->decorator_list,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.AsyncFunctionDef.returns);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_returns, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->returns, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_string(o->v.AsyncFunctionDef.type_comment);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_type_comment, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case ClassDef_kind:
-        result = PyType_GenericNew(ClassDef_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->ClassDef_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_identifier(o->v.ClassDef.name);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_name, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.ClassDef.bases, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_bases, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->bases, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.ClassDef.keywords, ast2obj_keyword);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_keywords, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->keywords, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.ClassDef.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.ClassDef.decorator_list, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_decorator_list, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->decorator_list,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Return_kind:
-        result = PyType_GenericNew(Return_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Return_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Return.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Delete_kind:
-        result = PyType_GenericNew(Delete_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Delete_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Delete.targets, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_targets, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->targets, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Assign_kind:
-        result = PyType_GenericNew(Assign_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Assign_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Assign.targets, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_targets, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->targets, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.Assign.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_string(o->v.Assign.type_comment);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_type_comment, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AugAssign_kind:
-        result = PyType_GenericNew(AugAssign_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->AugAssign_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.AugAssign.target);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_target, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_operator(o->v.AugAssign.op);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_op, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->op, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.AugAssign.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AnnAssign_kind:
-        result = PyType_GenericNew(AnnAssign_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->AnnAssign_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.AnnAssign.target);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_target, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.AnnAssign.annotation);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_annotation, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->annotation, value)
+            == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.AnnAssign.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_int(o->v.AnnAssign.simple);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_simple, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->simple, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case For_kind:
-        result = PyType_GenericNew(For_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->For_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.For.target);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_target, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.For.iter);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_iter, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->iter, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.For.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.For.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_orelse, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_string(o->v.For.type_comment);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_type_comment, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AsyncFor_kind:
-        result = PyType_GenericNew(AsyncFor_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->AsyncFor_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.AsyncFor.target);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_target, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.AsyncFor.iter);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_iter, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->iter, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.AsyncFor.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.AsyncFor.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_orelse, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_string(o->v.AsyncFor.type_comment);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_type_comment, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case While_kind:
-        result = PyType_GenericNew(While_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->While_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.While.test);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_test, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->test, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.While.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.While.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_orelse, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case If_kind:
-        result = PyType_GenericNew(If_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->If_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.If.test);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_test, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->test, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.If.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.If.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_orelse, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case With_kind:
-        result = PyType_GenericNew(With_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->With_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.With.items, ast2obj_withitem);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_items, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->items, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.With.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_string(o->v.With.type_comment);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_type_comment, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case AsyncWith_kind:
-        result = PyType_GenericNew(AsyncWith_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->AsyncWith_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.AsyncWith.items, ast2obj_withitem);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_items, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->items, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.AsyncWith.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_string(o->v.AsyncWith.type_comment);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_type_comment, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->type_comment,
+            value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Raise_kind:
-        result = PyType_GenericNew(Raise_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Raise_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Raise.exc);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_exc, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->exc, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.Raise.cause);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_cause, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->cause, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Try_kind:
-        result = PyType_GenericNew(Try_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Try_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Try.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.Try.handlers, ast2obj_excepthandler);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_handlers, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->handlers, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.Try.orelse, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_orelse, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.Try.finalbody, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_finalbody, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->finalbody, value)
+            == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Assert_kind:
-        result = PyType_GenericNew(Assert_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Assert_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Assert.test);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_test, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->test, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.Assert.msg);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_msg, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->msg, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Import_kind:
-        result = PyType_GenericNew(Import_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Import_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Import.names, ast2obj_alias);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_names, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->names, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case ImportFrom_kind:
-        result = PyType_GenericNew(ImportFrom_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->ImportFrom_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_identifier(o->v.ImportFrom.module);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_module, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->module, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.ImportFrom.names, ast2obj_alias);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_names, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->names, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_int(o->v.ImportFrom.level);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_level, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->level, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Global_kind:
-        result = PyType_GenericNew(Global_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Global_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Global.names, ast2obj_identifier);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_names, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->names, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Nonlocal_kind:
-        result = PyType_GenericNew(Nonlocal_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Nonlocal_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Nonlocal.names, ast2obj_identifier);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_names, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->names, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Expr_kind:
-        result = PyType_GenericNew(Expr_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Expr_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Expr.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Pass_kind:
-        result = PyType_GenericNew(Pass_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Pass_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         break;
     case Break_kind:
-        result = PyType_GenericNew(Break_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Break_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         break;
     case Continue_kind:
-        result = PyType_GenericNew(Continue_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Continue_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         break;
     }
     value = ast2obj_int(o->lineno);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_lineno, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->col_offset);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_col_offset, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->end_lineno);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_end_lineno, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->end_col_offset);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_end_col_offset, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->end_col_offset, value)
+        < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -3233,223 +3956,249 @@ ast2obj_expr(void* _o)
 {
     expr_ty o = (expr_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
     switch (o->kind) {
     case BoolOp_kind:
-        result = PyType_GenericNew(BoolOp_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->BoolOp_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_boolop(o->v.BoolOp.op);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_op, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->op, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.BoolOp.values, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_values, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->values, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case NamedExpr_kind:
-        result = PyType_GenericNew(NamedExpr_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->NamedExpr_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.NamedExpr.target);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_target, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->target, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.NamedExpr.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case BinOp_kind:
-        result = PyType_GenericNew(BinOp_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->BinOp_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.BinOp.left);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_left, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->left, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_operator(o->v.BinOp.op);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_op, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->op, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.BinOp.right);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_right, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->right, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case UnaryOp_kind:
-        result = PyType_GenericNew(UnaryOp_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->UnaryOp_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_unaryop(o->v.UnaryOp.op);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_op, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->op, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.UnaryOp.operand);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_operand, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->operand, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Lambda_kind:
-        result = PyType_GenericNew(Lambda_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Lambda_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_arguments(o->v.Lambda.args);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_args, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.Lambda.body);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case IfExp_kind:
-        result = PyType_GenericNew(IfExp_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->IfExp_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.IfExp.test);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_test, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->test, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.IfExp.body);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.IfExp.orelse);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_orelse, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->orelse, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Dict_kind:
-        result = PyType_GenericNew(Dict_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Dict_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Dict.keys, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_keys, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->keys, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.Dict.values, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_values, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->values, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Set_kind:
-        result = PyType_GenericNew(Set_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Set_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Set.elts, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_elts, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->elts, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case ListComp_kind:
-        result = PyType_GenericNew(ListComp_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->ListComp_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.ListComp.elt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_elt, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.ListComp.generators, ast2obj_comprehension);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_generators, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->generators, value)
+            == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case SetComp_kind:
-        result = PyType_GenericNew(SetComp_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->SetComp_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.SetComp.elt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_elt, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.SetComp.generators, ast2obj_comprehension);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_generators, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->generators, value)
+            == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case DictComp_kind:
-        result = PyType_GenericNew(DictComp_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->DictComp_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.DictComp.key);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_key, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->key, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.DictComp.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.DictComp.generators, ast2obj_comprehension);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_generators, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->generators, value)
+            == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case GeneratorExp_kind:
-        result = PyType_GenericNew(GeneratorExp_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->GeneratorExp_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.GeneratorExp.elt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_elt, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.GeneratorExp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_generators, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->generators, value)
+            == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Await_kind:
-        result = PyType_GenericNew(Await_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Await_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Await.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Yield_kind:
-        result = PyType_GenericNew(Yield_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Yield_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Yield.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case YieldFrom_kind:
-        result = PyType_GenericNew(YieldFrom_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->YieldFrom_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.YieldFrom.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Compare_kind:
-        result = PyType_GenericNew(Compare_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Compare_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Compare.left);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_left, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->left, value) == -1)
             goto failed;
         Py_DECREF(value);
         {
@@ -3460,189 +4209,205 @@ ast2obj_expr(void* _o)
                 PyList_SET_ITEM(value, i, ast2obj_cmpop((cmpop_ty)asdl_seq_GET(o->v.Compare.ops, i)));
         }
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_ops, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->ops, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.Compare.comparators, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_comparators, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->comparators, value)
+            == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Call_kind:
-        result = PyType_GenericNew(Call_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Call_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Call.func);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_func, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->func, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.Call.args, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_args, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.Call.keywords, ast2obj_keyword);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_keywords, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->keywords, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case FormattedValue_kind:
-        result = PyType_GenericNew(FormattedValue_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->FormattedValue_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.FormattedValue.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_int(o->v.FormattedValue.conversion);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_conversion, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->conversion, value)
+            == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.FormattedValue.format_spec);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_format_spec, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->format_spec, value)
+            == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case JoinedStr_kind:
-        result = PyType_GenericNew(JoinedStr_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->JoinedStr_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.JoinedStr.values, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_values, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->values, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Constant_kind:
-        result = PyType_GenericNew(Constant_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Constant_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_constant(o->v.Constant.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_string(o->v.Constant.kind);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_kind, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->kind, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Attribute_kind:
-        result = PyType_GenericNew(Attribute_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Attribute_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Attribute.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_identifier(o->v.Attribute.attr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_attr, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->attr, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr_context(o->v.Attribute.ctx);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_ctx, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Subscript_kind:
-        result = PyType_GenericNew(Subscript_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Subscript_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Subscript.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_slice(o->v.Subscript.slice);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_slice, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->slice, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr_context(o->v.Subscript.ctx);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_ctx, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Starred_kind:
-        result = PyType_GenericNew(Starred_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Starred_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Starred.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr_context(o->v.Starred.ctx);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_ctx, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Name_kind:
-        result = PyType_GenericNew(Name_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Name_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_identifier(o->v.Name.id);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_id, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->id, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr_context(o->v.Name.ctx);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_ctx, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case List_kind:
-        result = PyType_GenericNew(List_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->List_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.List.elts, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_elts, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->elts, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr_context(o->v.List.ctx);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_ctx, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Tuple_kind:
-        result = PyType_GenericNew(Tuple_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Tuple_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.Tuple.elts, ast2obj_expr);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_elts, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->elts, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr_context(o->v.Tuple.ctx);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_ctx, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->ctx, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     }
     value = ast2obj_int(o->lineno);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_lineno, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->col_offset);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_col_offset, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->end_lineno);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_end_lineno, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->end_col_offset);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_end_col_offset, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->end_col_offset, value)
+        < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -3656,23 +4421,23 @@ PyObject* ast2obj_expr_context(expr_context_ty o)
 {
     switch(o) {
         case Load:
-            Py_INCREF(Load_singleton);
-            return Load_singleton;
+            Py_INCREF(astmodulestate_global->Load_singleton);
+            return astmodulestate_global->Load_singleton;
         case Store:
-            Py_INCREF(Store_singleton);
-            return Store_singleton;
+            Py_INCREF(astmodulestate_global->Store_singleton);
+            return astmodulestate_global->Store_singleton;
         case Del:
-            Py_INCREF(Del_singleton);
-            return Del_singleton;
+            Py_INCREF(astmodulestate_global->Del_singleton);
+            return astmodulestate_global->Del_singleton;
         case AugLoad:
-            Py_INCREF(AugLoad_singleton);
-            return AugLoad_singleton;
+            Py_INCREF(astmodulestate_global->AugLoad_singleton);
+            return astmodulestate_global->AugLoad_singleton;
         case AugStore:
-            Py_INCREF(AugStore_singleton);
-            return AugStore_singleton;
+            Py_INCREF(astmodulestate_global->AugStore_singleton);
+            return astmodulestate_global->AugStore_singleton;
         case Param:
-            Py_INCREF(Param_singleton);
-            return Param_singleton;
+            Py_INCREF(astmodulestate_global->Param_singleton);
+            return astmodulestate_global->Param_singleton;
         default:
             /* should never happen, but just in case ... */
             PyErr_Format(PyExc_SystemError, "unknown expr_context found");
@@ -3684,45 +4449,49 @@ ast2obj_slice(void* _o)
 {
     slice_ty o = (slice_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
     switch (o->kind) {
     case Slice_kind:
-        result = PyType_GenericNew(Slice_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Slice_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Slice.lower);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_lower, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->lower, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.Slice.upper);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_upper, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->upper, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_expr(o->v.Slice.step);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_step, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->step, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case ExtSlice_kind:
-        result = PyType_GenericNew(ExtSlice_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->ExtSlice_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_list(o->v.ExtSlice.dims, ast2obj_slice);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_dims, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->dims, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     case Index_kind:
-        result = PyType_GenericNew(Index_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->Index_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.Index.value);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
@@ -3738,11 +4507,11 @@ PyObject* ast2obj_boolop(boolop_ty o)
 {
     switch(o) {
         case And:
-            Py_INCREF(And_singleton);
-            return And_singleton;
+            Py_INCREF(astmodulestate_global->And_singleton);
+            return astmodulestate_global->And_singleton;
         case Or:
-            Py_INCREF(Or_singleton);
-            return Or_singleton;
+            Py_INCREF(astmodulestate_global->Or_singleton);
+            return astmodulestate_global->Or_singleton;
         default:
             /* should never happen, but just in case ... */
             PyErr_Format(PyExc_SystemError, "unknown boolop found");
@@ -3753,44 +4522,44 @@ PyObject* ast2obj_operator(operator_ty o)
 {
     switch(o) {
         case Add:
-            Py_INCREF(Add_singleton);
-            return Add_singleton;
+            Py_INCREF(astmodulestate_global->Add_singleton);
+            return astmodulestate_global->Add_singleton;
         case Sub:
-            Py_INCREF(Sub_singleton);
-            return Sub_singleton;
+            Py_INCREF(astmodulestate_global->Sub_singleton);
+            return astmodulestate_global->Sub_singleton;
         case Mult:
-            Py_INCREF(Mult_singleton);
-            return Mult_singleton;
+            Py_INCREF(astmodulestate_global->Mult_singleton);
+            return astmodulestate_global->Mult_singleton;
         case MatMult:
-            Py_INCREF(MatMult_singleton);
-            return MatMult_singleton;
+            Py_INCREF(astmodulestate_global->MatMult_singleton);
+            return astmodulestate_global->MatMult_singleton;
         case Div:
-            Py_INCREF(Div_singleton);
-            return Div_singleton;
+            Py_INCREF(astmodulestate_global->Div_singleton);
+            return astmodulestate_global->Div_singleton;
         case Mod:
-            Py_INCREF(Mod_singleton);
-            return Mod_singleton;
+            Py_INCREF(astmodulestate_global->Mod_singleton);
+            return astmodulestate_global->Mod_singleton;
         case Pow:
-            Py_INCREF(Pow_singleton);
-            return Pow_singleton;
+            Py_INCREF(astmodulestate_global->Pow_singleton);
+            return astmodulestate_global->Pow_singleton;
         case LShift:
-            Py_INCREF(LShift_singleton);
-            return LShift_singleton;
+            Py_INCREF(astmodulestate_global->LShift_singleton);
+            return astmodulestate_global->LShift_singleton;
         case RShift:
-            Py_INCREF(RShift_singleton);
-            return RShift_singleton;
+            Py_INCREF(astmodulestate_global->RShift_singleton);
+            return astmodulestate_global->RShift_singleton;
         case BitOr:
-            Py_INCREF(BitOr_singleton);
-            return BitOr_singleton;
+            Py_INCREF(astmodulestate_global->BitOr_singleton);
+            return astmodulestate_global->BitOr_singleton;
         case BitXor:
-            Py_INCREF(BitXor_singleton);
-            return BitXor_singleton;
+            Py_INCREF(astmodulestate_global->BitXor_singleton);
+            return astmodulestate_global->BitXor_singleton;
         case BitAnd:
-            Py_INCREF(BitAnd_singleton);
-            return BitAnd_singleton;
+            Py_INCREF(astmodulestate_global->BitAnd_singleton);
+            return astmodulestate_global->BitAnd_singleton;
         case FloorDiv:
-            Py_INCREF(FloorDiv_singleton);
-            return FloorDiv_singleton;
+            Py_INCREF(astmodulestate_global->FloorDiv_singleton);
+            return astmodulestate_global->FloorDiv_singleton;
         default:
             /* should never happen, but just in case ... */
             PyErr_Format(PyExc_SystemError, "unknown operator found");
@@ -3801,17 +4570,17 @@ PyObject* ast2obj_unaryop(unaryop_ty o)
 {
     switch(o) {
         case Invert:
-            Py_INCREF(Invert_singleton);
-            return Invert_singleton;
+            Py_INCREF(astmodulestate_global->Invert_singleton);
+            return astmodulestate_global->Invert_singleton;
         case Not:
-            Py_INCREF(Not_singleton);
-            return Not_singleton;
+            Py_INCREF(astmodulestate_global->Not_singleton);
+            return astmodulestate_global->Not_singleton;
         case UAdd:
-            Py_INCREF(UAdd_singleton);
-            return UAdd_singleton;
+            Py_INCREF(astmodulestate_global->UAdd_singleton);
+            return astmodulestate_global->UAdd_singleton;
         case USub:
-            Py_INCREF(USub_singleton);
-            return USub_singleton;
+            Py_INCREF(astmodulestate_global->USub_singleton);
+            return astmodulestate_global->USub_singleton;
         default:
             /* should never happen, but just in case ... */
             PyErr_Format(PyExc_SystemError, "unknown unaryop found");
@@ -3822,35 +4591,35 @@ PyObject* ast2obj_cmpop(cmpop_ty o)
 {
     switch(o) {
         case Eq:
-            Py_INCREF(Eq_singleton);
-            return Eq_singleton;
+            Py_INCREF(astmodulestate_global->Eq_singleton);
+            return astmodulestate_global->Eq_singleton;
         case NotEq:
-            Py_INCREF(NotEq_singleton);
-            return NotEq_singleton;
+            Py_INCREF(astmodulestate_global->NotEq_singleton);
+            return astmodulestate_global->NotEq_singleton;
         case Lt:
-            Py_INCREF(Lt_singleton);
-            return Lt_singleton;
+            Py_INCREF(astmodulestate_global->Lt_singleton);
+            return astmodulestate_global->Lt_singleton;
         case LtE:
-            Py_INCREF(LtE_singleton);
-            return LtE_singleton;
+            Py_INCREF(astmodulestate_global->LtE_singleton);
+            return astmodulestate_global->LtE_singleton;
         case Gt:
-            Py_INCREF(Gt_singleton);
-            return Gt_singleton;
+            Py_INCREF(astmodulestate_global->Gt_singleton);
+            return astmodulestate_global->Gt_singleton;
         case GtE:
-            Py_INCREF(GtE_singleton);
-            return GtE_singleton;
+            Py_INCREF(astmodulestate_global->GtE_singleton);
+            return astmodulestate_global->GtE_singleton;
         case Is:
-            Py_INCREF(Is_singleton);
-            return Is_singleton;
+            Py_INCREF(astmodulestate_global->Is_singleton);
+            return astmodulestate_global->Is_singleton;
         case IsNot:
-            Py_INCREF(IsNot_singleton);
-            return IsNot_singleton;
+            Py_INCREF(astmodulestate_global->IsNot_singleton);
+            return astmodulestate_global->IsNot_singleton;
         case In:
-            Py_INCREF(In_singleton);
-            return In_singleton;
+            Py_INCREF(astmodulestate_global->In_singleton);
+            return astmodulestate_global->In_singleton;
         case NotIn:
-            Py_INCREF(NotIn_singleton);
-            return NotIn_singleton;
+            Py_INCREF(astmodulestate_global->NotIn_singleton);
+            return astmodulestate_global->NotIn_singleton;
         default:
             /* should never happen, but just in case ... */
             PyErr_Format(PyExc_SystemError, "unknown cmpop found");
@@ -3862,30 +4631,32 @@ ast2obj_comprehension(void* _o)
 {
     comprehension_ty o = (comprehension_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
-    result = PyType_GenericNew(comprehension_type, NULL, NULL);
+    tp = (PyTypeObject *)astmodulestate_global->comprehension_type;
+    result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
     value = ast2obj_expr(o->target);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_target, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->target, value) == -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_expr(o->iter);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_iter, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->iter, value) == -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_list(o->ifs, ast2obj_expr);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_ifs, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->ifs, value) == -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->is_async);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_is_async, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->is_async, value) == -1)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -3900,49 +4671,52 @@ ast2obj_excepthandler(void* _o)
 {
     excepthandler_ty o = (excepthandler_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
     switch (o->kind) {
     case ExceptHandler_kind:
-        result = PyType_GenericNew(ExceptHandler_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->ExceptHandler_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_expr(o->v.ExceptHandler.type);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_type, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->type, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_identifier(o->v.ExceptHandler.name);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_name, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_list(o->v.ExceptHandler.body, ast2obj_stmt);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_body, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->body, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     }
     value = ast2obj_int(o->lineno);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_lineno, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->col_offset);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_col_offset, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->end_lineno);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_end_lineno, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->end_col_offset);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_end_col_offset, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->end_col_offset, value)
+        < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -3957,45 +4731,50 @@ ast2obj_arguments(void* _o)
 {
     arguments_ty o = (arguments_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
-    result = PyType_GenericNew(arguments_type, NULL, NULL);
+    tp = (PyTypeObject *)astmodulestate_global->arguments_type;
+    result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
     value = ast2obj_list(o->posonlyargs, ast2obj_arg);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_posonlyargs, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->posonlyargs, value) ==
+        -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_list(o->args, ast2obj_arg);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_args, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->args, value) == -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_arg(o->vararg);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_vararg, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->vararg, value) == -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_list(o->kwonlyargs, ast2obj_arg);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_kwonlyargs, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->kwonlyargs, value) ==
+        -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_list(o->kw_defaults, ast2obj_expr);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_kw_defaults, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->kw_defaults, value) ==
+        -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_arg(o->kwarg);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_kwarg, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->kwarg, value) == -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_list(o->defaults, ast2obj_expr);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_defaults, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->defaults, value) == -1)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4010,45 +4789,50 @@ ast2obj_arg(void* _o)
 {
     arg_ty o = (arg_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
-    result = PyType_GenericNew(arg_type, NULL, NULL);
+    tp = (PyTypeObject *)astmodulestate_global->arg_type;
+    result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
     value = ast2obj_identifier(o->arg);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_arg, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->arg, value) == -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_expr(o->annotation);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_annotation, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->annotation, value) ==
+        -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_string(o->type_comment);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_type_comment, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->type_comment, value) ==
+        -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->lineno);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_lineno, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->col_offset);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_col_offset, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->end_lineno);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_end_lineno, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_int(o->end_col_offset);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_end_col_offset, value) < 0)
+    if (PyObject_SetAttr(result, astmodulestate_global->end_col_offset, value)
+        < 0)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4063,20 +4847,22 @@ ast2obj_keyword(void* _o)
 {
     keyword_ty o = (keyword_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
-    result = PyType_GenericNew(keyword_type, NULL, NULL);
+    tp = (PyTypeObject *)astmodulestate_global->keyword_type;
+    result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
     value = ast2obj_identifier(o->arg);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_arg, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->arg, value) == -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_expr(o->value);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_value, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->value, value) == -1)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4091,20 +4877,22 @@ ast2obj_alias(void* _o)
 {
     alias_ty o = (alias_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
-    result = PyType_GenericNew(alias_type, NULL, NULL);
+    tp = (PyTypeObject *)astmodulestate_global->alias_type;
+    result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
     value = ast2obj_identifier(o->name);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_name, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->name, value) == -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_identifier(o->asname);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_asname, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->asname, value) == -1)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4119,20 +4907,24 @@ ast2obj_withitem(void* _o)
 {
     withitem_ty o = (withitem_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
-    result = PyType_GenericNew(withitem_type, NULL, NULL);
+    tp = (PyTypeObject *)astmodulestate_global->withitem_type;
+    result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
     value = ast2obj_expr(o->context_expr);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_context_expr, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->context_expr, value) ==
+        -1)
         goto failed;
     Py_DECREF(value);
     value = ast2obj_expr(o->optional_vars);
     if (!value) goto failed;
-    if (_PyObject_SetAttrId(result, &PyId_optional_vars, value) == -1)
+    if (PyObject_SetAttr(result, astmodulestate_global->optional_vars, value)
+        == -1)
         goto failed;
     Py_DECREF(value);
     return result;
@@ -4147,22 +4939,25 @@ ast2obj_type_ignore(void* _o)
 {
     type_ignore_ty o = (type_ignore_ty)_o;
     PyObject *result = NULL, *value = NULL;
+    PyTypeObject *tp;
     if (!o) {
         Py_RETURN_NONE;
     }
 
     switch (o->kind) {
     case TypeIgnore_kind:
-        result = PyType_GenericNew(TypeIgnore_type, NULL, NULL);
+        tp = (PyTypeObject *)astmodulestate_global->TypeIgnore_type;
+        result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
         value = ast2obj_int(o->v.TypeIgnore.lineno);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_lineno, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->lineno, value) ==
+            -1)
             goto failed;
         Py_DECREF(value);
         value = ast2obj_string(o->v.TypeIgnore.tag);
         if (!value) goto failed;
-        if (_PyObject_SetAttrId(result, &PyId_tag, value) == -1)
+        if (PyObject_SetAttr(result, astmodulestate_global->tag, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
@@ -4181,12 +4976,14 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
     int isinstance;
 
     PyObject *tmp = NULL;
+    PyObject *tp;
 
     if (obj == Py_None) {
         *out = NULL;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Module_type);
+    tp = astmodulestate_global->Module_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -4194,7 +4991,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* type_ignores;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4206,7 +5003,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Module field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Module field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4227,7 +5024,8 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_type_ignores, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_ignores,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4239,7 +5037,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Module field \"type_ignores\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Module field \"type_ignores\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4264,14 +5062,15 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Interactive_type);
+    tp = astmodulestate_global->Interactive_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         asdl_seq* body;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4283,7 +5082,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Interactive field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Interactive field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4308,14 +5107,15 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Expression_type);
+    tp = astmodulestate_global->Expression_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         expr_ty body;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4332,7 +5132,8 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)FunctionType_type);
+    tp = astmodulestate_global->FunctionType_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -4340,7 +5141,8 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         asdl_seq* argtypes;
         expr_ty returns;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_argtypes, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->argtypes, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4352,7 +5154,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "FunctionType field \"argtypes\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "FunctionType field \"argtypes\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4373,7 +5175,8 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_returns, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->returns, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4390,14 +5193,15 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Suite_type);
+    tp = astmodulestate_global->Suite_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         asdl_seq* body;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4409,7 +5213,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Suite field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Suite field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4447,6 +5251,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     int isinstance;
 
     PyObject *tmp = NULL;
+    PyObject *tp;
     int lineno;
     int col_offset;
     int end_lineno;
@@ -4456,7 +5261,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -4469,7 +5274,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_col_offset, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->col_offset, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL) {
@@ -4482,7 +5288,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_end_lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_lineno, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -4495,7 +5302,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_end_col_offset, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_col_offset, &tmp)
+        < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -4508,7 +5316,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)FunctionDef_type);
+    tp = astmodulestate_global->FunctionDef_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -4520,7 +5329,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty returns;
         string type_comment;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4533,7 +5342,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4546,7 +5355,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4558,7 +5367,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "FunctionDef field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "FunctionDef field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4579,7 +5388,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_decorator_list, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->decorator_list,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4591,7 +5401,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "FunctionDef field \"decorator_list\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "FunctionDef field \"decorator_list\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4612,7 +5422,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_returns, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->returns, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -4625,7 +5436,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_type_comment, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -4644,7 +5456,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)AsyncFunctionDef_type);
+    tp = astmodulestate_global->AsyncFunctionDef_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -4656,7 +5469,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty returns;
         string type_comment;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4669,7 +5482,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4682,7 +5495,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4694,7 +5507,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4715,7 +5528,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_decorator_list, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->decorator_list,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4727,7 +5541,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"decorator_list\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"decorator_list\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4748,7 +5562,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_returns, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->returns, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -4761,7 +5576,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_type_comment, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -4780,7 +5596,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)ClassDef_type);
+    tp = astmodulestate_global->ClassDef_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -4791,7 +5608,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* decorator_list;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4804,7 +5621,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_bases, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->bases, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4816,7 +5633,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"bases\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"bases\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4837,7 +5654,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_keywords, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->keywords, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4849,7 +5667,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"keywords\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"keywords\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4870,7 +5688,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4882,7 +5700,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4903,7 +5721,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_decorator_list, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->decorator_list,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4915,7 +5734,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"decorator_list\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"decorator_list\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4941,14 +5760,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Return_type);
+    tp = astmodulestate_global->Return_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -4966,14 +5786,16 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Delete_type);
+    tp = astmodulestate_global->Delete_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         asdl_seq* targets;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_targets, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->targets, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -4985,7 +5807,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Delete field \"targets\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Delete field \"targets\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5011,7 +5833,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Assign_type);
+    tp = astmodulestate_global->Assign_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5020,7 +5843,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty value;
         string type_comment;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_targets, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->targets, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5032,7 +5856,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Assign field \"targets\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Assign field \"targets\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5053,7 +5877,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5066,7 +5890,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_type_comment, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5084,7 +5909,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)AugAssign_type);
+    tp = astmodulestate_global->AugAssign_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5093,7 +5919,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         operator_ty op;
         expr_ty value;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5106,7 +5933,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_op, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5119,7 +5946,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5137,7 +5964,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)AnnAssign_type);
+    tp = astmodulestate_global->AnnAssign_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5147,7 +5975,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty value;
         int simple;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5160,7 +5989,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_annotation, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->annotation, &tmp)
+            < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5173,7 +6003,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5186,7 +6016,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_simple, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->simple, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5204,7 +6035,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)For_type);
+    tp = astmodulestate_global->For_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5215,7 +6047,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* orelse;
         string type_comment;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5228,7 +6061,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_iter, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->iter, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5241,7 +6074,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5253,7 +6086,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "For field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "For field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5274,7 +6107,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5286,7 +6120,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "For field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "For field \"orelse\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5307,7 +6141,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_type_comment, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5325,7 +6160,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)AsyncFor_type);
+    tp = astmodulestate_global->AsyncFor_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5336,7 +6172,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* orelse;
         string type_comment;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5349,7 +6186,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_iter, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->iter, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5362,7 +6199,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5374,7 +6211,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFor field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFor field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5395,7 +6232,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5407,7 +6245,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFor field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFor field \"orelse\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5428,7 +6266,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_type_comment, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5446,7 +6285,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)While_type);
+    tp = astmodulestate_global->While_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5455,7 +6295,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* orelse;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_test, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5468,7 +6308,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5480,7 +6320,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "While field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "While field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5501,7 +6341,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5513,7 +6354,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "While field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "While field \"orelse\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5539,7 +6380,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)If_type);
+    tp = astmodulestate_global->If_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5548,7 +6390,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* orelse;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_test, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5561,7 +6403,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5573,7 +6415,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "If field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "If field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5594,7 +6436,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5606,7 +6449,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "If field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "If field \"orelse\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5632,7 +6475,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)With_type);
+    tp = astmodulestate_global->With_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5641,7 +6485,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         string type_comment;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_items, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->items, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5653,7 +6497,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "With field \"items\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "With field \"items\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5674,7 +6518,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5686,7 +6530,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "With field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "With field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5707,7 +6551,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_type_comment, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5725,7 +6570,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)AsyncWith_type);
+    tp = astmodulestate_global->AsyncWith_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5734,7 +6580,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         string type_comment;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_items, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->items, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5746,7 +6592,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncWith field \"items\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncWith field \"items\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5767,7 +6613,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5779,7 +6625,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncWith field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncWith field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5800,7 +6646,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_type_comment, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment,
+            &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5818,7 +6665,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Raise_type);
+    tp = astmodulestate_global->Raise_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5826,7 +6674,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty exc;
         expr_ty cause;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_exc, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->exc, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5839,7 +6687,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_cause, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->cause, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -5857,7 +6705,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Try_type);
+    tp = astmodulestate_global->Try_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -5867,7 +6716,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* orelse;
         asdl_seq* finalbody;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5879,7 +6728,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5900,7 +6749,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_handlers, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->handlers, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5912,7 +6762,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"handlers\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"handlers\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5933,7 +6783,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -5945,7 +6796,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"orelse\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5966,7 +6817,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_finalbody, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->finalbody, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -5978,7 +6830,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"finalbody\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"finalbody\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6004,7 +6856,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Assert_type);
+    tp = astmodulestate_global->Assert_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6012,7 +6865,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty test;
         expr_ty msg;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_test, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6025,7 +6878,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_msg, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->msg, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6043,14 +6896,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Import_type);
+    tp = astmodulestate_global->Import_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         asdl_seq* names;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_names, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6062,7 +6916,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Import field \"names\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Import field \"names\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6088,7 +6942,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)ImportFrom_type);
+    tp = astmodulestate_global->ImportFrom_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6097,7 +6952,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* names;
         int level;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_module, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->module, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6110,7 +6966,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_names, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6122,7 +6978,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ImportFrom field \"names\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ImportFrom field \"names\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6143,7 +6999,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_level, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->level, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -6161,14 +7017,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Global_type);
+    tp = astmodulestate_global->Global_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         asdl_seq* names;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_names, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6180,7 +7037,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Global field \"names\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Global field \"names\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6206,14 +7063,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Nonlocal_type);
+    tp = astmodulestate_global->Nonlocal_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         asdl_seq* names;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_names, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->names, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6225,7 +7083,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Nonlocal field \"names\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Nonlocal field \"names\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6251,14 +7109,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Expr_type);
+    tp = astmodulestate_global->Expr_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6276,7 +7135,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Pass_type);
+    tp = astmodulestate_global->Pass_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6286,7 +7146,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Break_type);
+    tp = astmodulestate_global->Break_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6296,7 +7157,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Continue_type);
+    tp = astmodulestate_global->Continue_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6319,6 +7181,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     int isinstance;
 
     PyObject *tmp = NULL;
+    PyObject *tp;
     int lineno;
     int col_offset;
     int end_lineno;
@@ -6328,7 +7191,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -6341,7 +7204,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_col_offset, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->col_offset, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL) {
@@ -6354,7 +7218,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_end_lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_lineno, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -6367,7 +7232,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_end_col_offset, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_col_offset, &tmp)
+        < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -6380,7 +7246,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)BoolOp_type);
+    tp = astmodulestate_global->BoolOp_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6388,7 +7255,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         boolop_ty op;
         asdl_seq* values;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_op, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6401,7 +7268,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_values, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->values, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -6413,7 +7281,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "BoolOp field \"values\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "BoolOp field \"values\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6439,7 +7307,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)NamedExpr_type);
+    tp = astmodulestate_global->NamedExpr_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6447,7 +7316,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty target;
         expr_ty value;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -6460,7 +7330,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6478,7 +7348,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)BinOp_type);
+    tp = astmodulestate_global->BinOp_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6487,7 +7358,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         operator_ty op;
         expr_ty right;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_left, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->left, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6500,7 +7371,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_op, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6513,7 +7384,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_right, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->right, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6531,7 +7402,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)UnaryOp_type);
+    tp = astmodulestate_global->UnaryOp_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6539,7 +7411,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         unaryop_ty op;
         expr_ty operand;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_op, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->op, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6552,7 +7424,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_operand, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->operand, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6570,7 +7443,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Lambda_type);
+    tp = astmodulestate_global->Lambda_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6578,7 +7452,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         arguments_ty args;
         expr_ty body;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6591,7 +7465,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6609,7 +7483,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)IfExp_type);
+    tp = astmodulestate_global->IfExp_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6618,7 +7493,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty body;
         expr_ty orelse;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_test, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->test, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6631,7 +7506,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6644,7 +7519,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->orelse, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -6662,7 +7538,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Dict_type);
+    tp = astmodulestate_global->Dict_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6670,7 +7547,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* keys;
         asdl_seq* values;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_keys, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->keys, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6682,7 +7559,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Dict field \"keys\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Dict field \"keys\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6703,7 +7580,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_values, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->values, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -6715,7 +7593,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Dict field \"values\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Dict field \"values\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6741,14 +7619,15 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Set_type);
+    tp = astmodulestate_global->Set_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         asdl_seq* elts;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_elts, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->elts, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6760,7 +7639,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Set field \"elts\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Set field \"elts\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6785,7 +7664,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)ListComp_type);
+    tp = astmodulestate_global->ListComp_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6793,7 +7673,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty elt;
         asdl_seq* generators;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_elt, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->elt, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6806,7 +7686,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_generators, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->generators, &tmp)
+            < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6818,7 +7699,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ListComp field \"generators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ListComp field \"generators\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6844,7 +7725,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)SetComp_type);
+    tp = astmodulestate_global->SetComp_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6852,7 +7734,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty elt;
         asdl_seq* generators;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_elt, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->elt, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6865,7 +7747,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_generators, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->generators, &tmp)
+            < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6877,7 +7760,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "SetComp field \"generators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "SetComp field \"generators\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6903,7 +7786,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)DictComp_type);
+    tp = astmodulestate_global->DictComp_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6912,7 +7796,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty value;
         asdl_seq* generators;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_key, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->key, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6925,7 +7809,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6938,7 +7822,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_generators, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->generators, &tmp)
+            < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6950,7 +7835,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "DictComp field \"generators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "DictComp field \"generators\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6976,7 +7861,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)GeneratorExp_type);
+    tp = astmodulestate_global->GeneratorExp_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -6984,7 +7870,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty elt;
         asdl_seq* generators;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_elt, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->elt, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -6997,7 +7883,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_generators, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->generators, &tmp)
+            < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7009,7 +7896,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "GeneratorExp field \"generators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "GeneratorExp field \"generators\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7035,14 +7922,15 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Await_type);
+    tp = astmodulestate_global->Await_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7060,14 +7948,15 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Yield_type);
+    tp = astmodulestate_global->Yield_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7085,14 +7974,15 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)YieldFrom_type);
+    tp = astmodulestate_global->YieldFrom_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7110,7 +8000,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Compare_type);
+    tp = astmodulestate_global->Compare_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7119,7 +8010,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_int_seq* ops;
         asdl_seq* comparators;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_left, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->left, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7132,7 +8023,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_ops, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->ops, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7144,7 +8035,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Compare field \"ops\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Compare field \"ops\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7165,7 +8056,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_comparators, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->comparators, &tmp)
+            < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7177,7 +8069,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Compare field \"comparators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Compare field \"comparators\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7203,7 +8095,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Call_type);
+    tp = astmodulestate_global->Call_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7212,7 +8105,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* args;
         asdl_seq* keywords;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_func, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->func, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7225,7 +8118,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7237,7 +8130,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Call field \"args\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Call field \"args\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7258,7 +8151,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_keywords, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->keywords, &tmp) <
+            0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7270,7 +8164,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Call field \"keywords\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Call field \"keywords\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7296,7 +8190,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)FormattedValue_type);
+    tp = astmodulestate_global->FormattedValue_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7305,7 +8200,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         int conversion;
         expr_ty format_spec;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7318,7 +8213,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_conversion, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->conversion, &tmp)
+            < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7331,7 +8227,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_format_spec, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->format_spec, &tmp)
+            < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7349,14 +8246,16 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)JoinedStr_type);
+    tp = astmodulestate_global->JoinedStr_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         asdl_seq* values;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_values, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->values, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -7368,7 +8267,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "JoinedStr field \"values\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "JoinedStr field \"values\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7394,7 +8293,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Constant_type);
+    tp = astmodulestate_global->Constant_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7402,7 +8302,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         constant value;
         string kind;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7415,7 +8315,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_kind, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->kind, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7433,7 +8333,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Attribute_type);
+    tp = astmodulestate_global->Attribute_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7442,7 +8343,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         identifier attr;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7455,7 +8356,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_attr, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->attr, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7468,7 +8369,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7486,7 +8387,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Subscript_type);
+    tp = astmodulestate_global->Subscript_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7495,7 +8397,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         slice_ty slice;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7508,7 +8410,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_slice, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->slice, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7521,7 +8423,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7539,7 +8441,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Starred_type);
+    tp = astmodulestate_global->Starred_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7547,7 +8450,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty value;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7560,7 +8463,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7578,7 +8481,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Name_type);
+    tp = astmodulestate_global->Name_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7586,7 +8490,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         identifier id;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_id, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->id, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7599,7 +8503,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7617,7 +8521,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)List_type);
+    tp = astmodulestate_global->List_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7625,7 +8530,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* elts;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_elts, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->elts, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7637,7 +8542,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "List field \"elts\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "List field \"elts\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7658,7 +8563,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7676,7 +8581,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Tuple_type);
+    tp = astmodulestate_global->Tuple_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7684,7 +8590,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* elts;
         expr_context_ty ctx;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_elts, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->elts, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7696,7 +8602,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Tuple field \"elts\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Tuple field \"elts\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7717,7 +8623,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             }
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->ctx, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7747,7 +8653,7 @@ obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Load_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Load_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7755,7 +8661,7 @@ obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
         *out = Load;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Store_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Store_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7763,7 +8669,7 @@ obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
         *out = Store;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Del_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Del_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7771,7 +8677,7 @@ obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
         *out = Del;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)AugLoad_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->AugLoad_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7779,7 +8685,7 @@ obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
         *out = AugLoad;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)AugStore_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->AugStore_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7787,7 +8693,7 @@ obj2ast_expr_context(PyObject* obj, expr_context_ty* out, PyArena* arena)
         *out = AugStore;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Param_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Param_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7806,12 +8712,14 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
     int isinstance;
 
     PyObject *tmp = NULL;
+    PyObject *tp;
 
     if (obj == Py_None) {
         *out = NULL;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Slice_type);
+    tp = astmodulestate_global->Slice_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -7820,7 +8728,7 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
         expr_ty upper;
         expr_ty step;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_lower, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->lower, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7833,7 +8741,7 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_upper, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->upper, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7846,7 +8754,7 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_step, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->step, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -7863,14 +8771,15 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)ExtSlice_type);
+    tp = astmodulestate_global->ExtSlice_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         asdl_seq* dims;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_dims, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->dims, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7882,7 +8791,7 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ExtSlice field \"dims\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ExtSlice field \"dims\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7907,14 +8816,15 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
         if (*out == NULL) goto failed;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)Index_type);
+    tp = astmodulestate_global->Index_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
     if (isinstance) {
         expr_ty value;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -7943,7 +8853,7 @@ obj2ast_boolop(PyObject* obj, boolop_ty* out, PyArena* arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, (PyObject *)And_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->And_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7951,7 +8861,7 @@ obj2ast_boolop(PyObject* obj, boolop_ty* out, PyArena* arena)
         *out = And;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Or_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Or_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7969,7 +8879,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Add_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Add_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7977,7 +8887,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Add;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Sub_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Sub_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7985,7 +8895,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Sub;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Mult_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Mult_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -7993,7 +8903,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Mult;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)MatMult_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->MatMult_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8001,7 +8911,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = MatMult;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Div_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Div_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8009,7 +8919,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Div;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Mod_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Mod_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8017,7 +8927,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Mod;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Pow_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Pow_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8025,7 +8935,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = Pow;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)LShift_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->LShift_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8033,7 +8943,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = LShift;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)RShift_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->RShift_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8041,7 +8951,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = RShift;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)BitOr_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->BitOr_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8049,7 +8959,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = BitOr;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)BitXor_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->BitXor_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8057,7 +8967,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = BitXor;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)BitAnd_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->BitAnd_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8065,7 +8975,7 @@ obj2ast_operator(PyObject* obj, operator_ty* out, PyArena* arena)
         *out = BitAnd;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)FloorDiv_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->FloorDiv_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8083,7 +8993,7 @@ obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Invert_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Invert_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8091,7 +9001,7 @@ obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena)
         *out = Invert;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Not_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Not_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8099,7 +9009,7 @@ obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena)
         *out = Not;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)UAdd_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->UAdd_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8107,7 +9017,7 @@ obj2ast_unaryop(PyObject* obj, unaryop_ty* out, PyArena* arena)
         *out = UAdd;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)USub_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->USub_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8125,7 +9035,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
 {
     int isinstance;
 
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Eq_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Eq_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8133,7 +9043,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = Eq;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)NotEq_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->NotEq_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8141,7 +9051,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = NotEq;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Lt_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Lt_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8149,7 +9059,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = Lt;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)LtE_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->LtE_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8157,7 +9067,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = LtE;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Gt_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Gt_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8165,7 +9075,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = Gt;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)GtE_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->GtE_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8173,7 +9083,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = GtE;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)Is_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->Is_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8181,7 +9091,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = Is;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)IsNot_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->IsNot_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8189,7 +9099,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = IsNot;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)In_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->In_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8197,7 +9107,7 @@ obj2ast_cmpop(PyObject* obj, cmpop_ty* out, PyArena* arena)
         *out = In;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject *)NotIn_type);
+    isinstance = PyObject_IsInstance(obj, astmodulestate_global->NotIn_type);
     if (isinstance == -1) {
         return 1;
     }
@@ -8219,7 +9129,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
     asdl_seq* ifs;
     int is_async;
 
-    if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->target, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8232,7 +9142,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_iter, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->iter, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8245,7 +9155,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_ifs, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->ifs, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8257,7 +9167,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "comprehension field \"ifs\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "comprehension field \"ifs\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -8278,7 +9188,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_is_async, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->is_async, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8304,6 +9214,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
     int isinstance;
 
     PyObject *tmp = NULL;
+    PyObject *tp;
     int lineno;
     int col_offset;
     int end_lineno;
@@ -8313,7 +9224,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8326,7 +9237,8 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_col_offset, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->col_offset, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL) {
@@ -8339,7 +9251,8 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_end_lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_lineno, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8352,7 +9265,8 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_end_col_offset, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_col_offset, &tmp)
+        < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8365,7 +9279,8 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)ExceptHandler_type);
+    tp = astmodulestate_global->ExceptHandler_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -8374,7 +9289,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         identifier name;
         asdl_seq* body;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_type, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->type, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8387,7 +9302,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL || tmp == Py_None) {
@@ -8400,7 +9315,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->body, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8412,7 +9327,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ExceptHandler field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ExceptHandler field \"body\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -8457,7 +9372,8 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
     arg_ty kwarg;
     asdl_seq* defaults;
 
-    if (_PyObject_LookupAttrId(obj, &PyId_posonlyargs, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->posonlyargs, &tmp) <
+        0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8469,7 +9385,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"posonlyargs\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"posonlyargs\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -8490,7 +9406,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->args, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8502,7 +9418,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"args\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"args\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -8523,7 +9439,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_vararg, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->vararg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8536,7 +9452,8 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_kwonlyargs, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->kwonlyargs, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL) {
@@ -8548,7 +9465,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"kwonlyargs\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"kwonlyargs\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -8569,7 +9486,8 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_kw_defaults, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->kw_defaults, &tmp) <
+        0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8581,7 +9499,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"kw_defaults\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"kw_defaults\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -8602,7 +9520,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         }
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_kwarg, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->kwarg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8615,7 +9533,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_defaults, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->defaults, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8627,7 +9545,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"defaults\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"defaults\" must be a list, not a %.200s", _PyType_Name(Py_TYPE(tmp)));
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -8668,7 +9586,7 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     int end_lineno;
     int end_col_offset;
 
-    if (_PyObject_LookupAttrId(obj, &PyId_arg, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->arg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8681,7 +9599,8 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_annotation, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->annotation, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8694,7 +9613,8 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_type_comment, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->type_comment, &tmp) <
+        0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8707,7 +9627,7 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8720,7 +9640,8 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_col_offset, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->col_offset, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL) {
@@ -8733,7 +9654,8 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_end_lineno, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_lineno, &tmp) < 0)
+        {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8746,7 +9668,8 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_end_col_offset, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->end_col_offset, &tmp)
+        < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8774,7 +9697,7 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
     identifier arg;
     expr_ty value;
 
-    if (_PyObject_LookupAttrId(obj, &PyId_arg, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->arg, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8787,7 +9710,7 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->value, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8814,7 +9737,7 @@ obj2ast_alias(PyObject* obj, alias_ty* out, PyArena* arena)
     identifier name;
     identifier asname;
 
-    if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->name, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8827,7 +9750,7 @@ obj2ast_alias(PyObject* obj, alias_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_asname, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->asname, &tmp) < 0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8854,7 +9777,8 @@ obj2ast_withitem(PyObject* obj, withitem_ty* out, PyArena* arena)
     expr_ty context_expr;
     expr_ty optional_vars;
 
-    if (_PyObject_LookupAttrId(obj, &PyId_context_expr, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->context_expr, &tmp) <
+        0) {
         return 1;
     }
     if (tmp == NULL) {
@@ -8867,7 +9791,8 @@ obj2ast_withitem(PyObject* obj, withitem_ty* out, PyArena* arena)
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
     }
-    if (_PyObject_LookupAttrId(obj, &PyId_optional_vars, &tmp) < 0) {
+    if (_PyObject_LookupAttr(obj, astmodulestate_global->optional_vars, &tmp) <
+        0) {
         return 1;
     }
     if (tmp == NULL || tmp == Py_None) {
@@ -8893,12 +9818,14 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
     int isinstance;
 
     PyObject *tmp = NULL;
+    PyObject *tp;
 
     if (obj == Py_None) {
         *out = NULL;
         return 0;
     }
-    isinstance = PyObject_IsInstance(obj, (PyObject*)TypeIgnore_type);
+    tp = astmodulestate_global->TypeIgnore_type;
+    isinstance = PyObject_IsInstance(obj, tp);
     if (isinstance == -1) {
         return 1;
     }
@@ -8906,7 +9833,8 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
         int lineno;
         string tag;
 
-        if (_PyObject_LookupAttrId(obj, &PyId_lineno, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->lineno, &tmp) < 0)
+            {
             return 1;
         }
         if (tmp == NULL) {
@@ -8919,7 +9847,7 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        if (_PyObject_LookupAttrId(obj, &PyId_tag, &tmp) < 0) {
+        if (_PyObject_LookupAttr(obj, astmodulestate_global->tag, &tmp) < 0) {
             return 1;
         }
         if (tmp == NULL) {
@@ -8944,215 +9872,361 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
 }
 
 
-static struct PyModuleDef _astmodule = {
-  PyModuleDef_HEAD_INIT, "_ast"
-};
 PyMODINIT_FUNC
 PyInit__ast(void)
 {
-    PyObject *m, *d;
+    PyObject *m;
     if (!init_types()) return NULL;
-    m = PyModule_Create(&_astmodule);
+    m = PyState_FindModule(&_astmodule);
     if (!m) return NULL;
-    d = PyModule_GetDict(m);
-    if (PyDict_SetItemString(d, "AST", (PyObject*)&AST_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->AST_type);
+    if (PyModule_AddObject(m, "AST", astmodulestate_global->AST_type) < 0)
+        return NULL;
     if (PyModule_AddIntMacro(m, PyCF_ALLOW_TOP_LEVEL_AWAIT) < 0)
         return NULL;
     if (PyModule_AddIntMacro(m, PyCF_ONLY_AST) < 0)
         return NULL;
     if (PyModule_AddIntMacro(m, PyCF_TYPE_COMMENTS) < 0)
         return NULL;
-    if (PyDict_SetItemString(d, "mod", (PyObject*)mod_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Module", (PyObject*)Module_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Interactive", (PyObject*)Interactive_type) <
+    if (PyModule_AddObject(m, "mod", astmodulestate_global->mod_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->mod_type);
+    if (PyModule_AddObject(m, "Module", astmodulestate_global->Module_type) <
         0) return NULL;
-    if (PyDict_SetItemString(d, "Expression", (PyObject*)Expression_type) < 0)
+    Py_INCREF(astmodulestate(m)->Module_type);
+    if (PyModule_AddObject(m, "Interactive",
+        astmodulestate_global->Interactive_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->Interactive_type);
+    if (PyModule_AddObject(m, "Expression",
+        astmodulestate_global->Expression_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->Expression_type);
+    if (PyModule_AddObject(m, "FunctionType",
+        astmodulestate_global->FunctionType_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->FunctionType_type);
+    if (PyModule_AddObject(m, "Suite", astmodulestate_global->Suite_type) < 0)
         return NULL;
-    if (PyDict_SetItemString(d, "FunctionType", (PyObject*)FunctionType_type) <
-        0) return NULL;
-    if (PyDict_SetItemString(d, "Suite", (PyObject*)Suite_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "stmt", (PyObject*)stmt_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "FunctionDef", (PyObject*)FunctionDef_type) <
-        0) return NULL;
-    if (PyDict_SetItemString(d, "AsyncFunctionDef",
-        (PyObject*)AsyncFunctionDef_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "ClassDef", (PyObject*)ClassDef_type) < 0)
+    Py_INCREF(astmodulestate(m)->Suite_type);
+    if (PyModule_AddObject(m, "stmt", astmodulestate_global->stmt_type) < 0)
         return NULL;
-    if (PyDict_SetItemString(d, "Return", (PyObject*)Return_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Delete", (PyObject*)Delete_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Assign", (PyObject*)Assign_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "AugAssign", (PyObject*)AugAssign_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "AnnAssign", (PyObject*)AnnAssign_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "For", (PyObject*)For_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "AsyncFor", (PyObject*)AsyncFor_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "While", (PyObject*)While_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "If", (PyObject*)If_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "With", (PyObject*)With_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "AsyncWith", (PyObject*)AsyncWith_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Raise", (PyObject*)Raise_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Try", (PyObject*)Try_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Assert", (PyObject*)Assert_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Import", (PyObject*)Import_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "ImportFrom", (PyObject*)ImportFrom_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Global", (PyObject*)Global_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Nonlocal", (PyObject*)Nonlocal_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Expr", (PyObject*)Expr_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Pass", (PyObject*)Pass_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Break", (PyObject*)Break_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Continue", (PyObject*)Continue_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "expr", (PyObject*)expr_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "BoolOp", (PyObject*)BoolOp_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "NamedExpr", (PyObject*)NamedExpr_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "BinOp", (PyObject*)BinOp_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "UnaryOp", (PyObject*)UnaryOp_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Lambda", (PyObject*)Lambda_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "IfExp", (PyObject*)IfExp_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Dict", (PyObject*)Dict_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Set", (PyObject*)Set_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "ListComp", (PyObject*)ListComp_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "SetComp", (PyObject*)SetComp_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "DictComp", (PyObject*)DictComp_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "GeneratorExp", (PyObject*)GeneratorExp_type) <
-        0) return NULL;
-    if (PyDict_SetItemString(d, "Await", (PyObject*)Await_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Yield", (PyObject*)Yield_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "YieldFrom", (PyObject*)YieldFrom_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Compare", (PyObject*)Compare_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Call", (PyObject*)Call_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "FormattedValue",
-        (PyObject*)FormattedValue_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "JoinedStr", (PyObject*)JoinedStr_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Constant", (PyObject*)Constant_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Attribute", (PyObject*)Attribute_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Subscript", (PyObject*)Subscript_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Starred", (PyObject*)Starred_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Name", (PyObject*)Name_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "List", (PyObject*)List_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Tuple", (PyObject*)Tuple_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "expr_context", (PyObject*)expr_context_type) <
-        0) return NULL;
-    if (PyDict_SetItemString(d, "Load", (PyObject*)Load_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Store", (PyObject*)Store_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Del", (PyObject*)Del_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "AugLoad", (PyObject*)AugLoad_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "AugStore", (PyObject*)AugStore_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Param", (PyObject*)Param_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "slice", (PyObject*)slice_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Slice", (PyObject*)Slice_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "ExtSlice", (PyObject*)ExtSlice_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Index", (PyObject*)Index_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "boolop", (PyObject*)boolop_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "And", (PyObject*)And_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Or", (PyObject*)Or_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "operator", (PyObject*)operator_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "Add", (PyObject*)Add_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Sub", (PyObject*)Sub_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Mult", (PyObject*)Mult_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "MatMult", (PyObject*)MatMult_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Div", (PyObject*)Div_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Mod", (PyObject*)Mod_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Pow", (PyObject*)Pow_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "LShift", (PyObject*)LShift_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "RShift", (PyObject*)RShift_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "BitOr", (PyObject*)BitOr_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "BitXor", (PyObject*)BitXor_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "BitAnd", (PyObject*)BitAnd_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "FloorDiv", (PyObject*)FloorDiv_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "unaryop", (PyObject*)unaryop_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Invert", (PyObject*)Invert_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Not", (PyObject*)Not_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "UAdd", (PyObject*)UAdd_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "USub", (PyObject*)USub_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "cmpop", (PyObject*)cmpop_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Eq", (PyObject*)Eq_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "NotEq", (PyObject*)NotEq_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "Lt", (PyObject*)Lt_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "LtE", (PyObject*)LtE_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Gt", (PyObject*)Gt_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "GtE", (PyObject*)GtE_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "Is", (PyObject*)Is_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "IsNot", (PyObject*)IsNot_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "In", (PyObject*)In_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "NotIn", (PyObject*)NotIn_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "comprehension", (PyObject*)comprehension_type)
+    Py_INCREF(astmodulestate(m)->stmt_type);
+    if (PyModule_AddObject(m, "FunctionDef",
+        astmodulestate_global->FunctionDef_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->FunctionDef_type);
+    if (PyModule_AddObject(m, "AsyncFunctionDef",
+        astmodulestate_global->AsyncFunctionDef_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->AsyncFunctionDef_type);
+    if (PyModule_AddObject(m, "ClassDef", astmodulestate_global->ClassDef_type)
         < 0) return NULL;
-    if (PyDict_SetItemString(d, "excepthandler", (PyObject*)excepthandler_type)
-        < 0) return NULL;
-    if (PyDict_SetItemString(d, "ExceptHandler", (PyObject*)ExceptHandler_type)
-        < 0) return NULL;
-    if (PyDict_SetItemString(d, "arguments", (PyObject*)arguments_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "arg", (PyObject*)arg_type) < 0) return NULL;
-    if (PyDict_SetItemString(d, "keyword", (PyObject*)keyword_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "alias", (PyObject*)alias_type) < 0) return
-        NULL;
-    if (PyDict_SetItemString(d, "withitem", (PyObject*)withitem_type) < 0)
-        return NULL;
-    if (PyDict_SetItemString(d, "type_ignore", (PyObject*)type_ignore_type) <
+    Py_INCREF(astmodulestate(m)->ClassDef_type);
+    if (PyModule_AddObject(m, "Return", astmodulestate_global->Return_type) <
         0) return NULL;
-    if (PyDict_SetItemString(d, "TypeIgnore", (PyObject*)TypeIgnore_type) < 0)
+    Py_INCREF(astmodulestate(m)->Return_type);
+    if (PyModule_AddObject(m, "Delete", astmodulestate_global->Delete_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->Delete_type);
+    if (PyModule_AddObject(m, "Assign", astmodulestate_global->Assign_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->Assign_type);
+    if (PyModule_AddObject(m, "AugAssign",
+        astmodulestate_global->AugAssign_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->AugAssign_type);
+    if (PyModule_AddObject(m, "AnnAssign",
+        astmodulestate_global->AnnAssign_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->AnnAssign_type);
+    if (PyModule_AddObject(m, "For", astmodulestate_global->For_type) < 0)
         return NULL;
+    Py_INCREF(astmodulestate(m)->For_type);
+    if (PyModule_AddObject(m, "AsyncFor", astmodulestate_global->AsyncFor_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->AsyncFor_type);
+    if (PyModule_AddObject(m, "While", astmodulestate_global->While_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->While_type);
+    if (PyModule_AddObject(m, "If", astmodulestate_global->If_type) < 0) return
+        NULL;
+    Py_INCREF(astmodulestate(m)->If_type);
+    if (PyModule_AddObject(m, "With", astmodulestate_global->With_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->With_type);
+    if (PyModule_AddObject(m, "AsyncWith",
+        astmodulestate_global->AsyncWith_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->AsyncWith_type);
+    if (PyModule_AddObject(m, "Raise", astmodulestate_global->Raise_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Raise_type);
+    if (PyModule_AddObject(m, "Try", astmodulestate_global->Try_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Try_type);
+    if (PyModule_AddObject(m, "Assert", astmodulestate_global->Assert_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->Assert_type);
+    if (PyModule_AddObject(m, "Import", astmodulestate_global->Import_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->Import_type);
+    if (PyModule_AddObject(m, "ImportFrom",
+        astmodulestate_global->ImportFrom_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->ImportFrom_type);
+    if (PyModule_AddObject(m, "Global", astmodulestate_global->Global_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->Global_type);
+    if (PyModule_AddObject(m, "Nonlocal", astmodulestate_global->Nonlocal_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->Nonlocal_type);
+    if (PyModule_AddObject(m, "Expr", astmodulestate_global->Expr_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Expr_type);
+    if (PyModule_AddObject(m, "Pass", astmodulestate_global->Pass_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Pass_type);
+    if (PyModule_AddObject(m, "Break", astmodulestate_global->Break_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Break_type);
+    if (PyModule_AddObject(m, "Continue", astmodulestate_global->Continue_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->Continue_type);
+    if (PyModule_AddObject(m, "expr", astmodulestate_global->expr_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->expr_type);
+    if (PyModule_AddObject(m, "BoolOp", astmodulestate_global->BoolOp_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->BoolOp_type);
+    if (PyModule_AddObject(m, "NamedExpr",
+        astmodulestate_global->NamedExpr_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->NamedExpr_type);
+    if (PyModule_AddObject(m, "BinOp", astmodulestate_global->BinOp_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->BinOp_type);
+    if (PyModule_AddObject(m, "UnaryOp", astmodulestate_global->UnaryOp_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->UnaryOp_type);
+    if (PyModule_AddObject(m, "Lambda", astmodulestate_global->Lambda_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->Lambda_type);
+    if (PyModule_AddObject(m, "IfExp", astmodulestate_global->IfExp_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->IfExp_type);
+    if (PyModule_AddObject(m, "Dict", astmodulestate_global->Dict_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Dict_type);
+    if (PyModule_AddObject(m, "Set", astmodulestate_global->Set_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Set_type);
+    if (PyModule_AddObject(m, "ListComp", astmodulestate_global->ListComp_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->ListComp_type);
+    if (PyModule_AddObject(m, "SetComp", astmodulestate_global->SetComp_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->SetComp_type);
+    if (PyModule_AddObject(m, "DictComp", astmodulestate_global->DictComp_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->DictComp_type);
+    if (PyModule_AddObject(m, "GeneratorExp",
+        astmodulestate_global->GeneratorExp_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->GeneratorExp_type);
+    if (PyModule_AddObject(m, "Await", astmodulestate_global->Await_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Await_type);
+    if (PyModule_AddObject(m, "Yield", astmodulestate_global->Yield_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Yield_type);
+    if (PyModule_AddObject(m, "YieldFrom",
+        astmodulestate_global->YieldFrom_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->YieldFrom_type);
+    if (PyModule_AddObject(m, "Compare", astmodulestate_global->Compare_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->Compare_type);
+    if (PyModule_AddObject(m, "Call", astmodulestate_global->Call_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Call_type);
+    if (PyModule_AddObject(m, "FormattedValue",
+        astmodulestate_global->FormattedValue_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->FormattedValue_type);
+    if (PyModule_AddObject(m, "JoinedStr",
+        astmodulestate_global->JoinedStr_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->JoinedStr_type);
+    if (PyModule_AddObject(m, "Constant", astmodulestate_global->Constant_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->Constant_type);
+    if (PyModule_AddObject(m, "Attribute",
+        astmodulestate_global->Attribute_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->Attribute_type);
+    if (PyModule_AddObject(m, "Subscript",
+        astmodulestate_global->Subscript_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->Subscript_type);
+    if (PyModule_AddObject(m, "Starred", astmodulestate_global->Starred_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->Starred_type);
+    if (PyModule_AddObject(m, "Name", astmodulestate_global->Name_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Name_type);
+    if (PyModule_AddObject(m, "List", astmodulestate_global->List_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->List_type);
+    if (PyModule_AddObject(m, "Tuple", astmodulestate_global->Tuple_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Tuple_type);
+    if (PyModule_AddObject(m, "expr_context",
+        astmodulestate_global->expr_context_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->expr_context_type);
+    if (PyModule_AddObject(m, "Load", astmodulestate_global->Load_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Load_type);
+    if (PyModule_AddObject(m, "Store", astmodulestate_global->Store_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Store_type);
+    if (PyModule_AddObject(m, "Del", astmodulestate_global->Del_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Del_type);
+    if (PyModule_AddObject(m, "AugLoad", astmodulestate_global->AugLoad_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->AugLoad_type);
+    if (PyModule_AddObject(m, "AugStore", astmodulestate_global->AugStore_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->AugStore_type);
+    if (PyModule_AddObject(m, "Param", astmodulestate_global->Param_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Param_type);
+    if (PyModule_AddObject(m, "slice", astmodulestate_global->slice_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->slice_type);
+    if (PyModule_AddObject(m, "Slice", astmodulestate_global->Slice_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Slice_type);
+    if (PyModule_AddObject(m, "ExtSlice", astmodulestate_global->ExtSlice_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->ExtSlice_type);
+    if (PyModule_AddObject(m, "Index", astmodulestate_global->Index_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Index_type);
+    if (PyModule_AddObject(m, "boolop", astmodulestate_global->boolop_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->boolop_type);
+    if (PyModule_AddObject(m, "And", astmodulestate_global->And_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->And_type);
+    if (PyModule_AddObject(m, "Or", astmodulestate_global->Or_type) < 0) return
+        NULL;
+    Py_INCREF(astmodulestate(m)->Or_type);
+    if (PyModule_AddObject(m, "operator", astmodulestate_global->operator_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->operator_type);
+    if (PyModule_AddObject(m, "Add", astmodulestate_global->Add_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Add_type);
+    if (PyModule_AddObject(m, "Sub", astmodulestate_global->Sub_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Sub_type);
+    if (PyModule_AddObject(m, "Mult", astmodulestate_global->Mult_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Mult_type);
+    if (PyModule_AddObject(m, "MatMult", astmodulestate_global->MatMult_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->MatMult_type);
+    if (PyModule_AddObject(m, "Div", astmodulestate_global->Div_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Div_type);
+    if (PyModule_AddObject(m, "Mod", astmodulestate_global->Mod_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Mod_type);
+    if (PyModule_AddObject(m, "Pow", astmodulestate_global->Pow_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Pow_type);
+    if (PyModule_AddObject(m, "LShift", astmodulestate_global->LShift_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->LShift_type);
+    if (PyModule_AddObject(m, "RShift", astmodulestate_global->RShift_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->RShift_type);
+    if (PyModule_AddObject(m, "BitOr", astmodulestate_global->BitOr_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->BitOr_type);
+    if (PyModule_AddObject(m, "BitXor", astmodulestate_global->BitXor_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->BitXor_type);
+    if (PyModule_AddObject(m, "BitAnd", astmodulestate_global->BitAnd_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->BitAnd_type);
+    if (PyModule_AddObject(m, "FloorDiv", astmodulestate_global->FloorDiv_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->FloorDiv_type);
+    if (PyModule_AddObject(m, "unaryop", astmodulestate_global->unaryop_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->unaryop_type);
+    if (PyModule_AddObject(m, "Invert", astmodulestate_global->Invert_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->Invert_type);
+    if (PyModule_AddObject(m, "Not", astmodulestate_global->Not_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->Not_type);
+    if (PyModule_AddObject(m, "UAdd", astmodulestate_global->UAdd_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->UAdd_type);
+    if (PyModule_AddObject(m, "USub", astmodulestate_global->USub_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->USub_type);
+    if (PyModule_AddObject(m, "cmpop", astmodulestate_global->cmpop_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->cmpop_type);
+    if (PyModule_AddObject(m, "Eq", astmodulestate_global->Eq_type) < 0) return
+        NULL;
+    Py_INCREF(astmodulestate(m)->Eq_type);
+    if (PyModule_AddObject(m, "NotEq", astmodulestate_global->NotEq_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->NotEq_type);
+    if (PyModule_AddObject(m, "Lt", astmodulestate_global->Lt_type) < 0) return
+        NULL;
+    Py_INCREF(astmodulestate(m)->Lt_type);
+    if (PyModule_AddObject(m, "LtE", astmodulestate_global->LtE_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->LtE_type);
+    if (PyModule_AddObject(m, "Gt", astmodulestate_global->Gt_type) < 0) return
+        NULL;
+    Py_INCREF(astmodulestate(m)->Gt_type);
+    if (PyModule_AddObject(m, "GtE", astmodulestate_global->GtE_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->GtE_type);
+    if (PyModule_AddObject(m, "Is", astmodulestate_global->Is_type) < 0) return
+        NULL;
+    Py_INCREF(astmodulestate(m)->Is_type);
+    if (PyModule_AddObject(m, "IsNot", astmodulestate_global->IsNot_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->IsNot_type);
+    if (PyModule_AddObject(m, "In", astmodulestate_global->In_type) < 0) return
+        NULL;
+    Py_INCREF(astmodulestate(m)->In_type);
+    if (PyModule_AddObject(m, "NotIn", astmodulestate_global->NotIn_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->NotIn_type);
+    if (PyModule_AddObject(m, "comprehension",
+        astmodulestate_global->comprehension_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->comprehension_type);
+    if (PyModule_AddObject(m, "excepthandler",
+        astmodulestate_global->excepthandler_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->excepthandler_type);
+    if (PyModule_AddObject(m, "ExceptHandler",
+        astmodulestate_global->ExceptHandler_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->ExceptHandler_type);
+    if (PyModule_AddObject(m, "arguments",
+        astmodulestate_global->arguments_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->arguments_type);
+    if (PyModule_AddObject(m, "arg", astmodulestate_global->arg_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->arg_type);
+    if (PyModule_AddObject(m, "keyword", astmodulestate_global->keyword_type) <
+        0) return NULL;
+    Py_INCREF(astmodulestate(m)->keyword_type);
+    if (PyModule_AddObject(m, "alias", astmodulestate_global->alias_type) < 0)
+        return NULL;
+    Py_INCREF(astmodulestate(m)->alias_type);
+    if (PyModule_AddObject(m, "withitem", astmodulestate_global->withitem_type)
+        < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->withitem_type);
+    if (PyModule_AddObject(m, "type_ignore",
+        astmodulestate_global->type_ignore_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->type_ignore_type);
+    if (PyModule_AddObject(m, "TypeIgnore",
+        astmodulestate_global->TypeIgnore_type) < 0) return NULL;
+    Py_INCREF(astmodulestate(m)->TypeIgnore_type);
     return m;
 }
 
@@ -9176,9 +10250,9 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
         return NULL;
     }
 
-    req_type[0] = (PyObject*)Module_type;
-    req_type[1] = (PyObject*)Expression_type;
-    req_type[2] = (PyObject*)Interactive_type;
+    req_type[0] = astmodulestate_global->Module_type;
+    req_type[1] = astmodulestate_global->Expression_type;
+    req_type[2] = astmodulestate_global->Interactive_type;
 
     assert(0 <= mode && mode <= 2);
 
@@ -9190,7 +10264,7 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
         return NULL;
     if (!isinstance) {
         PyErr_Format(PyExc_TypeError, "expected %s node, got %.400s",
-                     req_name[mode], Py_TYPE(ast)->tp_name);
+                     req_name[mode], _PyType_Name(Py_TYPE(ast)));
         return NULL;
     }
     if (obj2ast_mod(ast, &res, arena) != 0)
@@ -9203,7 +10277,7 @@ int PyAST_Check(PyObject* obj)
 {
     if (!init_types())
         return -1;
-    return PyObject_IsInstance(obj, (PyObject*)&AST_type);
+    return PyObject_IsInstance(obj, astmodulestate_global->AST_type);
 }
 
 


### PR DESCRIPTION
Summary: This mostly migrates Python-ast.c to PEP384 and removes all statics from the whole file. This modifies the generator itself that generates the Python-ast.c.  It leaves in the usage of _PyObject_LookupAttr even though it's not fully PEP384 compatible (this could always be shimmed in by anyone who needs it).


<!-- issue-number: [bpo-38113](https://bugs.python.org/issue38113) -->
https://bugs.python.org/issue38113
<!-- /issue-number -->
