### PR TITLE
bpo-38114: Do not include pip.ini in Nuget package

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-09-11-15-24-04.bpo-38114.cc0E5E.rst
+++ b/Misc/NEWS.d/next/Windows/2019-09-11-15-24-04.bpo-38114.cc0E5E.rst
@@ -1,0 +1,1 @@
+The ``pip.ini`` is no longer included in the Nuget package.

--- a/PC/layout/support/options.py
+++ b/PC/layout/support/options.py
@@ -17,6 +17,7 @@ def public(f):
 OPTIONS = {
     "stable": {"help": "stable ABI stub"},
     "pip": {"help": "pip"},
+    "pip-user": {"help": "pip.ini file for default --user"},
     "distutils": {"help": "distutils"},
     "tcltk": {"help": "Tcl, Tk and tkinter"},
     "idle": {"help": "Idle"},
@@ -42,6 +43,7 @@ PRESETS = {
         "options": [
             "stable",
             "pip",
+            "pip-user",
             "distutils",
             "tcltk",
             "idle",

--- a/PC/layout/support/pip.py
+++ b/PC/layout/support/pip.py
@@ -33,11 +33,12 @@ def get_pip_layout(ns):
         pkg_root = "packages/{}" if ns.zip_lib else "Lib/site-packages/{}"
         for dest, src in rglob(pip_dir, "**/*"):
             yield pkg_root.format(dest), src
-        content = "\n".join(
-            "[{}]\nuser=yes".format(n)
-            for n in ["install", "uninstall", "freeze", "list"]
-        )
-        yield "pip.ini", ("pip.ini", content.encode())
+        if ns.include_pip_user:
+            content = "\n".join(
+                "[{}]\nuser=yes".format(n)
+                for n in ["install", "uninstall", "freeze", "list"]
+            )
+            yield "pip.ini", ("pip.ini", content.encode())
 
 
 def extract_pip_files(ns):


### PR DESCRIPTION


<!-- issue-number: [bpo-38114](https://bugs.python.org/issue38114) -->
https://bugs.python.org/issue38114
<!-- /issue-number -->
