### PR TITLE
bpo-38115: fix invalid lnotab after optimization

### DIFF
--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -40,6 +40,20 @@ class TestTranforms(BytecodeTestCase):
                 self.fail(f'{instr.opname} at {instr.offset} '
                           f'jumps to {tgt.opname} at {tgt.offset}')
 
+    def check_lnotab(self, code):
+        "Check that the lnotab byte offsets are sensible."
+        code = dis._get_code_object(code)
+        lnotab = list(dis.findlinestarts(code))
+        # Don't bother checking if the line info is sensible, because
+        # most of the line info we can get at comes from lnotab.
+        min_bytecode = min(t[0] for t in lnotab)
+        max_bytecode = max(t[0] for t in lnotab)
+        self.assertGreaterEqual(min_bytecode, 0)
+        self.assertLess(max_bytecode, len(code.co_code))
+        # This could conceivably test more (and probably should, as there
+        # aren't very many tests of lnotab), if peepholer wasn't scheduled
+        # to be replaced anyway.
+
     def test_unot(self):
         # UNARY_NOT POP_JUMP_IF_FALSE  -->  POP_JUMP_IF_TRUE'
         def unot(x):
@@ -48,6 +62,7 @@ class TestTranforms(BytecodeTestCase):
         self.assertNotInBytecode(unot, 'UNARY_NOT')
         self.assertNotInBytecode(unot, 'POP_JUMP_IF_FALSE')
         self.assertInBytecode(unot, 'POP_JUMP_IF_TRUE')
+        self.check_lnotab(unot)
 
     def test_elim_inversion_of_is_or_in(self):
         for line, cmp_op in (
@@ -58,6 +73,7 @@ class TestTranforms(BytecodeTestCase):
             ):
             code = compile(line, '', 'single')
             self.assertInBytecode(code, 'COMPARE_OP', cmp_op)
+            self.check_lnotab(code)
 
     def test_global_as_constant(self):
         # LOAD_GLOBAL None/True/False  -->  LOAD_CONST None/True/False
@@ -75,6 +91,7 @@ class TestTranforms(BytecodeTestCase):
         for func, elem in ((f, None), (g, True), (h, False)):
             self.assertNotInBytecode(func, 'LOAD_GLOBAL')
             self.assertInBytecode(func, 'LOAD_CONST', elem)
+            self.check_lnotab(func)
 
         def f():
             'Adding a docstring made this test fail in Py2.5.0'
@@ -82,6 +99,7 @@ class TestTranforms(BytecodeTestCase):
 
         self.assertNotInBytecode(f, 'LOAD_GLOBAL')
         self.assertInBytecode(f, 'LOAD_CONST', None)
+        self.check_lnotab(f)
 
     def test_while_one(self):
         # Skip over:  LOAD_CONST trueconst  POP_JUMP_IF_FALSE xx
@@ -93,6 +111,7 @@ class TestTranforms(BytecodeTestCase):
             self.assertNotInBytecode(f, elem)
         for elem in ('JUMP_ABSOLUTE',):
             self.assertInBytecode(f, elem)
+        self.check_lnotab(f)
 
     def test_pack_unpack(self):
         for line, elem in (
@@ -104,6 +123,7 @@ class TestTranforms(BytecodeTestCase):
             self.assertInBytecode(code, elem)
             self.assertNotInBytecode(code, 'BUILD_TUPLE')
             self.assertNotInBytecode(code, 'UNPACK_TUPLE')
+            self.check_lnotab(code)
 
     def test_folding_of_tuples_of_constants(self):
         for line, elem in (
@@ -116,6 +136,7 @@ class TestTranforms(BytecodeTestCase):
             code = compile(line,'','single')
             self.assertInBytecode(code, 'LOAD_CONST', elem)
             self.assertNotInBytecode(code, 'BUILD_TUPLE')
+            self.check_lnotab(code)
 
         # Long tuples should be folded too.
         code = compile(repr(tuple(range(10000))),'','single')
@@ -124,6 +145,7 @@ class TestTranforms(BytecodeTestCase):
         load_consts = [instr for instr in dis.get_instructions(code)
                               if instr.opname == 'LOAD_CONST']
         self.assertEqual(len(load_consts), 2)
+        self.check_lnotab(code)
 
         # Bug 1053819:  Tuple of constants misidentified when presented with:
         # . . . opcode_with_arg 100   unary_opcode   BUILD_TUPLE 1  . . .
@@ -141,6 +163,7 @@ class TestTranforms(BytecodeTestCase):
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
             ],)
+        self.check_lnotab(crater)
 
     def test_folding_of_lists_of_constants(self):
         for line, elem in (
@@ -153,6 +176,7 @@ class TestTranforms(BytecodeTestCase):
             code = compile(line, '', 'single')
             self.assertInBytecode(code, 'LOAD_CONST', elem)
             self.assertNotInBytecode(code, 'BUILD_LIST')
+            self.check_lnotab(code)
 
     def test_folding_of_sets_of_constants(self):
         for line, elem in (
@@ -166,6 +190,7 @@ class TestTranforms(BytecodeTestCase):
             code = compile(line, '', 'single')
             self.assertNotInBytecode(code, 'BUILD_SET')
             self.assertInBytecode(code, 'LOAD_CONST', elem)
+            self.check_lnotab(code)
 
         # Ensure that the resulting code actually works:
         def f(a):
@@ -176,9 +201,11 @@ class TestTranforms(BytecodeTestCase):
 
         self.assertTrue(f(3))
         self.assertTrue(not f(4))
+        self.check_lnotab(f)
 
         self.assertTrue(not g(3))
         self.assertTrue(g(4))
+        self.check_lnotab(g)
 
 
     def test_folding_of_binops_on_constants(self):
@@ -203,41 +230,50 @@ class TestTranforms(BytecodeTestCase):
             self.assertInBytecode(code, 'LOAD_CONST', elem)
             for instr in dis.get_instructions(code):
                 self.assertFalse(instr.opname.startswith('BINARY_'))
+            self.check_lnotab(code)
 
         # Verify that unfoldables are skipped
         code = compile('a=2+"b"', '', 'single')
         self.assertInBytecode(code, 'LOAD_CONST', 2)
         self.assertInBytecode(code, 'LOAD_CONST', 'b')
+        self.check_lnotab(code)
 
         # Verify that large sequences do not result from folding
         code = compile('a="x"*10000', '', 'single')
         self.assertInBytecode(code, 'LOAD_CONST', 10000)
         self.assertNotIn("x"*10000, code.co_consts)
+        self.check_lnotab(code)
         code = compile('a=1<<1000', '', 'single')
         self.assertInBytecode(code, 'LOAD_CONST', 1000)
         self.assertNotIn(1<<1000, code.co_consts)
+        self.check_lnotab(code)
         code = compile('a=2**1000', '', 'single')
         self.assertInBytecode(code, 'LOAD_CONST', 1000)
         self.assertNotIn(2**1000, code.co_consts)
+        self.check_lnotab(code)
 
     def test_binary_subscr_on_unicode(self):
         # valid code get optimized
         code = compile('"foo"[0]', '', 'single')
         self.assertInBytecode(code, 'LOAD_CONST', 'f')
         self.assertNotInBytecode(code, 'BINARY_SUBSCR')
+        self.check_lnotab(code)
         code = compile('"\u0061\uffff"[1]', '', 'single')
         self.assertInBytecode(code, 'LOAD_CONST', '\uffff')
         self.assertNotInBytecode(code,'BINARY_SUBSCR')
+        self.check_lnotab(code)
 
         # With PEP 393, non-BMP char get optimized
         code = compile('"\U00012345"[0]', '', 'single')
         self.assertInBytecode(code, 'LOAD_CONST', '\U00012345')
         self.assertNotInBytecode(code, 'BINARY_SUBSCR')
+        self.check_lnotab(code)
 
         # invalid code doesn't get optimized
         # out of range
         code = compile('"fuu"[10]', '', 'single')
         self.assertInBytecode(code, 'BINARY_SUBSCR')
+        self.check_lnotab(code)
 
     def test_folding_of_unaryops_on_constants(self):
         for line, elem in (
@@ -252,13 +288,15 @@ class TestTranforms(BytecodeTestCase):
             self.assertInBytecode(code, 'LOAD_CONST', elem)
             for instr in dis.get_instructions(code):
                 self.assertFalse(instr.opname.startswith('UNARY_'))
+            self.check_lnotab(code)
 
         # Check that -0.0 works after marshaling
         def negzero():
             return -(1.0-1.0)
 
-        for instr in dis.get_instructions(code):
+        for instr in dis.get_instructions(negzero):
             self.assertFalse(instr.opname.startswith('UNARY_'))
+        self.check_lnotab(negzero)
 
         # Verify that unfoldables are skipped
         for line, elem, opname in (
@@ -268,6 +306,7 @@ class TestTranforms(BytecodeTestCase):
             code = compile(line, '', 'single')
             self.assertInBytecode(code, 'LOAD_CONST', elem)
             self.assertInBytecode(code, opname)
+            self.check_lnotab(code)
 
     def test_elim_extra_return(self):
         # RETURN LOAD_CONST None RETURN  -->  RETURN
@@ -277,6 +316,7 @@ class TestTranforms(BytecodeTestCase):
         returns = [instr for instr in dis.get_instructions(f)
                           if instr.opname == 'RETURN_VALUE']
         self.assertEqual(len(returns), 1)
+        self.check_lnotab(f)
 
     def test_elim_jump_to_return(self):
         # JUMP_FORWARD to RETURN -->  RETURN
@@ -290,6 +330,7 @@ class TestTranforms(BytecodeTestCase):
         returns = [instr for instr in dis.get_instructions(f)
                           if instr.opname == 'RETURN_VALUE']
         self.assertEqual(len(returns), 2)
+        self.check_lnotab(f)
 
     def test_elim_jump_to_uncond_jump(self):
         # POP_JUMP_IF_FALSE to JUMP_FORWARD --> POP_JUMP_IF_FALSE to non-jump
@@ -302,6 +343,7 @@ class TestTranforms(BytecodeTestCase):
             else:
                 baz()
         self.check_jump_targets(f)
+        self.check_lnotab(f)
 
     def test_elim_jump_to_uncond_jump2(self):
         # POP_JUMP_IF_FALSE to JUMP_ABSOLUTE --> POP_JUMP_IF_FALSE to non-jump
@@ -312,6 +354,7 @@ class TestTranforms(BytecodeTestCase):
                     or d):
                     a = foo()
         self.check_jump_targets(f)
+        self.check_lnotab(f)
 
     def test_elim_jump_to_uncond_jump3(self):
         # Intentionally use two-line expressions to test issue37213.
@@ -320,18 +363,21 @@ class TestTranforms(BytecodeTestCase):
             return ((a and b)
                     and c)
         self.check_jump_targets(f)
+        self.check_lnotab(f)
         self.assertEqual(count_instr_recursively(f, 'JUMP_IF_FALSE_OR_POP'), 2)
         # JUMP_IF_TRUE_OR_POP to JUMP_IF_TRUE_OR_POP --> JUMP_IF_TRUE_OR_POP to non-jump
         def f(a, b, c):
             return ((a or b)
                     or c)
         self.check_jump_targets(f)
+        self.check_lnotab(f)
         self.assertEqual(count_instr_recursively(f, 'JUMP_IF_TRUE_OR_POP'), 2)
         # JUMP_IF_FALSE_OR_POP to JUMP_IF_TRUE_OR_POP --> POP_JUMP_IF_FALSE to non-jump
         def f(a, b, c):
             return ((a and b)
                     or c)
         self.check_jump_targets(f)
+        self.check_lnotab(f)
         self.assertNotInBytecode(f, 'JUMP_IF_FALSE_OR_POP')
         self.assertInBytecode(f, 'JUMP_IF_TRUE_OR_POP')
         self.assertInBytecode(f, 'POP_JUMP_IF_FALSE')
@@ -340,6 +386,7 @@ class TestTranforms(BytecodeTestCase):
             return ((a or b)
                     and c)
         self.check_jump_targets(f)
+        self.check_lnotab(f)
         self.assertNotInBytecode(f, 'JUMP_IF_TRUE_OR_POP')
         self.assertInBytecode(f, 'JUMP_IF_FALSE_OR_POP')
         self.assertInBytecode(f, 'POP_JUMP_IF_TRUE')
@@ -360,6 +407,7 @@ class TestTranforms(BytecodeTestCase):
         returns = [instr for instr in dis.get_instructions(f)
                           if instr.opname == 'RETURN_VALUE']
         self.assertLessEqual(len(returns), 6)
+        self.check_lnotab(f)
 
     def test_elim_jump_after_return2(self):
         # Eliminate dead code: jumps immediately after returns can't be reached
@@ -374,6 +422,7 @@ class TestTranforms(BytecodeTestCase):
         returns = [instr for instr in dis.get_instructions(f)
                           if instr.opname == 'RETURN_VALUE']
         self.assertLessEqual(len(returns), 2)
+        self.check_lnotab(f)
 
     def test_make_function_doesnt_bail(self):
         def f():
@@ -381,6 +430,7 @@ class TestTranforms(BytecodeTestCase):
                 pass
             return g
         self.assertNotInBytecode(f, 'BINARY_ADD')
+        self.check_lnotab(f)
 
     def test_constant_folding(self):
         # Issue #11244: aggressive constant folding.
@@ -401,17 +451,20 @@ class TestTranforms(BytecodeTestCase):
                 self.assertFalse(instr.opname.startswith('UNARY_'))
                 self.assertFalse(instr.opname.startswith('BINARY_'))
                 self.assertFalse(instr.opname.startswith('BUILD_'))
+            self.check_lnotab(code)
 
     def test_in_literal_list(self):
         def containtest():
             return x in [a, b]
         self.assertEqual(count_instr_recursively(containtest, 'BUILD_LIST'), 0)
+        self.check_lnotab(containtest)
 
     def test_iterate_literal_list(self):
         def forloop():
             for x in [a, b]:
                 pass
         self.assertEqual(count_instr_recursively(forloop, 'BUILD_LIST'), 0)
+        self.check_lnotab(forloop)
 
     def test_condition_with_binop_with_bools(self):
         def f():
@@ -419,6 +472,7 @@ class TestTranforms(BytecodeTestCase):
                 return 1
             return 0
         self.assertEqual(f(), 1)
+        self.check_lnotab(f)
 
     def test_if_with_if_expression(self):
         # Check bpo-37289
@@ -427,6 +481,19 @@ class TestTranforms(BytecodeTestCase):
                 return True
             return False
         self.assertTrue(f(True))
+        self.check_lnotab(f)
+
+    def test_trailing_nops(self):
+        # Check the lnotab of a function that even after trivial
+        # optimization has trailing nops, which the lnotab adjustment has to
+        # handle properly (bpo-38115).
+        def f(x):
+            while 1:
+                return 3
+            while 1:
+                return 5
+            return 6
+        self.check_lnotab(f)
 
 
 class TestBuglets(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-11-14-50-48.bpo-38115.cVUqj0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-11-14-50-48.bpo-38115.cVUqj0.rst
@@ -1,0 +1,1 @@
+Fix a bug in the bytecode optimizer that could (rarely) generate invalid bytecode offsets in the code object's line number information.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-11-15-41-11.bpo-38115-_Yhg1s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-11-15-41-11.bpo-38115-_Yhg1s.rst
@@ -1,2 +1,0 @@
-Fix a bug in the bytecode optimizer that could (rarely) generate invalid
-bytecode offsets in the code object's line number information.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-11-15-41-11.bpo-38115-_Yhg1s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-11-15-41-11.bpo-38115-_Yhg1s.rst
@@ -1,0 +1,2 @@
+Fix a bug in the bytecode optimizer that could (rarely) generate invalid
+bytecode offsets in the code object's line number information.

--- a/Python/peephole.c
+++ b/Python/peephole.c
@@ -474,7 +474,7 @@ PyCode_Optimize(PyObject *code, PyObject* consts, PyObject *names,
      * NOP (in case the NOP is a jump target), but positions past the end
      * should point at the end, instead. This (currently) doesn't matter for
      * jump targets, but it matters for lnotab. */
-    while (blocks[--i] > (codelen - nops - 1)) {
+    while (i-- > 0 && blocks[i] > (codelen - nops - 1)) {
         blocks[i] = (codelen - nops - 1);
     }
 

--- a/Python/peephole.c
+++ b/Python/peephole.c
@@ -474,7 +474,7 @@ PyCode_Optimize(PyObject *code, PyObject* consts, PyObject *names,
      * NOP (in case the NOP is a jump target), but positions past the end
      * should point at the end, instead. This (currently) doesn't matter for
      * jump targets, but it matters for lnotab. */
-    while (i-- > 0 && blocks[i] > (codelen - nops - 1)) {
+    for (i = codelen-1; i >= 0 && blocks[i] > (codelen - nops - 1); i--) {
         blocks[i] = (codelen - nops - 1);
     }
 
@@ -517,7 +517,7 @@ PyCode_Optimize(PyObject *code, PyObject* consts, PyObject *names,
         h += ilen;
     }
     assert(h + (Py_ssize_t)nops == codelen);
-    assert(blocks[codelen - 1] < h);
+    assert(codelen == 0 || blocks[codelen - 1] < h);
 
     /* Fixup lnotab. This modifies the lnotab bytes object in-place, so it
      * has to happen last. */


### PR DESCRIPTION
Fix [bpo-38115](https://bugs.python.org/issue38115), a bug in the peephole optimizer that caused lnotab to have invalid bytecode offsets when the optimizer got rid of the last line(s) of a function. Also fix a bug where the optimizer bails out of optimization but leaves the lnotab modified. This is a very old bug, but before 3.8 the optimizer is more likely to successfully optimize away the last line of a function.

These don't change the *bytecode* that's generated, but they do change the *code objects* (the co_lnotab attribute), so though they theoretically affect Python 3.7 and earlier, we shouldn't backport this beyond 3.8. (Also, if you want to verify this manually, don't forget to touch the .py file or delete the .pyc file... not that I'm speaking of personal experience or anything.)

<!-- issue-number: [bpo-38115](https://bugs.python.org/issue38115) -->
https://bugs.python.org/issue38115
<!-- /issue-number -->
