### PR TITLE
bpo-38120: Fix DeprecationWarning in test_random for invalid type of arguments to random.seed

### DIFF
--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -42,10 +42,16 @@ class TestBasicOps:
             def __hash__(self):
                 return -1729
         for arg in [None, 0, 0, 1, 1, -1, -1, 10**20, -(10**20),
-                    3.14, 1+2j, 'a', tuple('abc'), MySeed()]:
+                    3.14, 'a']:
             self.gen.seed(arg)
+
+        for arg in [1+2j, tuple('abc'), MySeed()]:
+            with self.assertWarns(DeprecationWarning):
+                self.gen.seed(arg)
+
         for arg in [list(range(3)), dict(one=1)]:
-            self.assertRaises(TypeError, self.gen.seed, arg)
+            with self.assertWarns(DeprecationWarning):
+                self.assertRaises(TypeError, self.gen.seed, arg)
         self.assertRaises(TypeError, self.gen.seed, 1, 2, 3, 4)
         self.assertRaises(TypeError, type(self.gen), [])
 

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -41,7 +41,7 @@ class TestBasicOps:
         class MySeed(object):
             def __hash__(self):
                 return -1729
-        for arg in [None, 0, 0, 1, 1, -1, -1, 10**20, -(10**20),
+        for arg in [None, 0, 1, -1, 10**20, -(10**20),
                     3.14, 'a']:
             self.gen.seed(arg)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-38120](https://bugs.python.org/issue38120) -->
https://bugs.python.org/issue38120
<!-- /issue-number -->
