### PR TITLE
bpo-36871: Handle spec errors in assert_has_calls

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -936,12 +936,12 @@ class NonCallableMock(Base):
         if not any_order:
             if expected not in all_calls:
                 if cause is None:
-                  problem = 'Calls not found.'
+                    problem = 'Calls not found.'
                 else:
-                  problem = ('Error processing expected calls.\n'
-                             'Errors: {}').format(
-                                 [e if isinstance(e, Exception) else None
-                                  for e in expected])
+                    problem = ('Error processing expected calls.\n'
+                               'Errors: {}').format(
+                                   [e if isinstance(e, Exception) else None
+                                    for e in expected])
                 raise AssertionError(
                     f'{problem}\n'
                     f'Expected: {_CallList(calls)}\n'
@@ -2227,12 +2227,12 @@ class AsyncMockMixin(Base):
         if not any_order:
             if expected not in all_awaits:
                 if cause is None:
-                  problem = 'Awaits not found.'
+                    problem = 'Awaits not found.'
                 else:
-                  problem = ('Error processing expected awaits.\n'
-                             'Errors: {}').format(
-                                 [e if isinstance(e, Exception) else None
-                                  for e in expected])
+                    problem = ('Error processing expected awaits.\n'
+                               'Errors: {}').format(
+                                   [e if isinstance(e, Exception) else None
+                                    for e in expected])
                 raise AssertionError(
                     f'{problem}\n'
                     f'Expected: {_CallList(calls)}\n'

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -935,9 +935,17 @@ class NonCallableMock(Base):
         all_calls = _CallList(self._call_matcher(c) for c in self.mock_calls)
         if not any_order:
             if expected not in all_calls:
+                if cause is None:
+                  problem = 'Calls not found.'
+                else:
+                  problem = ('Error processing expected calls.\n'
+                             'Errors: {}').format(
+                                 [e if isinstance(e, Exception) else None
+                                  for e in expected])
                 raise AssertionError(
-                    'Calls not found.\nExpected: %r%s'
-                    % (_CallList(calls), self._calls_repr(prefix="Actual"))
+                    f'{problem}\n'
+                    f'Expected: {_CallList(calls)}\n'
+                    f'Actual: {self._calls_repr(prefix="Actual")}'
                 ) from cause
             return
 
@@ -2218,8 +2226,16 @@ class AsyncMockMixin(Base):
         all_awaits = _CallList(self._call_matcher(c) for c in self.await_args_list)
         if not any_order:
             if expected not in all_awaits:
+                if cause is None:
+                  problem = 'Awaits not found.'
+                else:
+                  problem = ('Error processing expected awaits.\n'
+                             'Errors: {}').format(
+                                 [e if isinstance(e, Exception) else None
+                                  for e in expected])
                 raise AssertionError(
-                    f'Awaits not found.\nExpected: {_CallList(calls)}\n'
+                    f'{problem}\n'
+                    f'Expected: {_CallList(calls)}\n'
                     f'Actual: {self.await_args_list}'
                 ) from cause
             return

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2214,7 +2214,7 @@ class AsyncMockMixin(Base):
         they must all appear in :attr:`await_args_list`.
         """
         expected = [self._call_matcher(c) for c in calls]
-        cause = expected if isinstance(expected, Exception) else None
+        cause = next((e for e in expected if isinstance(e, Exception)), None)
         all_awaits = _CallList(self._call_matcher(c) for c in self.await_args_list)
         if not any_order:
             if expected not in all_awaits:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -931,7 +931,7 @@ class NonCallableMock(Base):
         If `any_order` is True then the calls can be in any order, but
         they must all appear in `mock_calls`."""
         expected = [self._call_matcher(c) for c in calls]
-        cause = expected if isinstance(expected, Exception) else None
+        cause = next((e for e in expected if isinstance(e, Exception)), None)
         all_calls = _CallList(self._call_matcher(c) for c in self.mock_calls)
         if not any_order:
             if expected not in all_calls:

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import re
 import unittest
 
 from unittest.mock import (call, AsyncMock, patch, MagicMock, create_autospec,
@@ -637,6 +638,18 @@ class AsyncMockAssert(unittest.TestCase):
         async def f(): pass
 
         mock = AsyncMock(spec=f)
-        with self.assertRaises(AssertionError) as cm:
-            mock.assert_has_awaits([call('wrong')])
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                re.escape('Awaits not found.\nExpected:')) as cm:
+            mock.assert_has_awaits([call()])
+        self.assertIsNone(cm.exception.__cause__)
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                re.escape('Error processing expected awaits.\n'
+                          "Errors: [None, TypeError('too many positional "
+                          "arguments')]\n"
+                          'Expected:')) as cm:
+            mock.assert_has_awaits([call(), call('wrong')])
         self.assertIsInstance(cm.exception.__cause__, TypeError)

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -632,3 +632,11 @@ class AsyncMockAssert(unittest.TestCase):
         asyncio.run(self._runnable_test())
         with self.assertRaises(AssertionError):
             self.mock.assert_not_awaited()
+
+    def test_assert_has_awaits_not_matching_spec_error(self):
+        async def f(): pass
+
+        mock = AsyncMock(spec=f)
+        with self.assertRaises(AssertionError) as cm:
+            mock.assert_has_awaits([call('wrong')])
+        self.assertIsInstance(cm.exception.__cause__, TypeError)

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1426,6 +1426,13 @@ class MockTest(unittest.TestCase):
             mock.assert_has_calls(calls[:-1])
         mock.assert_has_calls(calls[:-1], any_order=True)
 
+    def test_assert_has_calls_not_matching_spec_error(self):
+        def f(): pass
+
+        mock = Mock(spec=f)
+        with self.assertRaises(AssertionError) as cm:
+            mock.assert_has_calls([call('wrong')])
+        self.assertIsInstance(cm.exception.__cause__, TypeError)
 
     def test_assert_any_call(self):
         mock = Mock()

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1430,8 +1430,20 @@ class MockTest(unittest.TestCase):
         def f(): pass
 
         mock = Mock(spec=f)
-        with self.assertRaises(AssertionError) as cm:
-            mock.assert_has_calls([call('wrong')])
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                re.escape('Calls not found.\nExpected:')) as cm:
+            mock.assert_has_calls([call()])
+        self.assertIsNone(cm.exception.__cause__)
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                re.escape('Error processing expected calls.\n'
+                          "Errors: [None, TypeError('too many positional "
+                          "arguments')]\n"
+                          'Expected:')) as cm:
+            mock.assert_has_calls([call(), call('wrong')])
         self.assertIsInstance(cm.exception.__cause__, TypeError)
 
     def test_assert_any_call(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-24-18-45-46.bpo-36871.p47knk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-24-18-45-46.bpo-36871.p47knk.rst
@@ -1,1 +1,3 @@
-Improve error handling for the assert_has_calls and assert_has_awaits methods of mocks. Fixed a bug where any errors encountered while binding the expected calls to the mock's spec were silently swallowed, leading to misleading error output.
+Improve error handling for the assert_has_calls and assert_has_awaits methods of
+mocks. Fixed a bug where any errors encountered while binding the expected calls
+to the mock's spec were silently swallowed, leading to misleading error output.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-24-18-45-46.bpo-36871.p47knk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-24-18-45-46.bpo-36871.p47knk.rst
@@ -1,0 +1,1 @@
+Improve error handling for the assert_has_calls and assert_has_awaits methods of mocks. Fixed a bug where any errors encountered while binding the expected calls to the mock's spec were silently swallowed, leading to misleading error output.


### PR DESCRIPTION
The fix in PR #13261 handled the underlying issue about the spec for specific methods not being applied correctly, but it didn't fix the issue that was causing the misleading error message.

The code currently grabs a list of responses from _call_matcher (which may include exceptions). But it doesn't reach inside the list when checking if the result is an exception. This results in a misleading error message when one of the provided calls does not match the spec.

<!-- issue-number: [bpo-36871](https://bugs.python.org/issue36871) -->
https://bugs.python.org/issue36871
<!-- /issue-number -->


Automerge-Triggered-By: @gpshead