### PR TITLE
[2.7] bpo-34155: Dont parse domains containing @ (GH-13079)

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -336,7 +336,12 @@ class AddrlistClass:
         aslist.append('@')
         self.pos += 1
         self.gotonext()
-        return EMPTYSTRING.join(aslist) + self.getdomain()
+        domain = self.getdomain()
+        if not domain:
+            # Invalid domain, return an empty address instead of returning a
+            # local part to denote failed parsing.
+            return EMPTYSTRING
+        return EMPTYSTRING.join(aslist) + domain
 
     def getdomain(self):
         """Get the complete domain name from an address."""
@@ -351,6 +356,10 @@ class AddrlistClass:
             elif self.field[self.pos] == '.':
                 self.pos += 1
                 sdlist.append('.')
+            elif self.field[self.pos] == '@':
+                # bpo-34155: Don't parse domains with two `@` like
+                # `a@malicious.org@important.com`.
+                return EMPTYSTRING
             elif self.field[self.pos] in self.atomends:
                 break
             else:

--- a/Lib/email/test/test_email.py
+++ b/Lib/email/test/test_email.py
@@ -2306,6 +2306,20 @@ class TestMiscellaneous(TestEmailBase):
         self.assertEqual(Utils.parseaddr('<>'), ('', ''))
         self.assertEqual(Utils.formataddr(Utils.parseaddr('<>')), '')
 
+    def test_parseaddr_multiple_domains(self):
+        self.assertEqual(
+            Utils.parseaddr('a@b@c'),
+            ('', '')
+        )
+        self.assertEqual(
+            Utils.parseaddr('a@b.c@c'),
+            ('', '')
+        )
+        self.assertEqual(
+            Utils.parseaddr('a@172.17.0.1@c'),
+            ('', '')
+        )
+
     def test_noquote_dump(self):
         self.assertEqual(
             Utils.formataddr(('A Silly Person', 'person@dom.ain')),

--- a/Misc/NEWS.d/next/Security/2019-05-04-13-33-37.bpo-34155.MJll68.rst
+++ b/Misc/NEWS.d/next/Security/2019-05-04-13-33-37.bpo-34155.MJll68.rst
@@ -1,0 +1,1 @@
+Fix parsing of invalid email addresses with more than one ``@`` (e.g. a@b@c.com.) to not return the part before 2nd ``@`` as valid email address. Patch by maxking & jpic.


### PR DESCRIPTION
This change skips parsing of email addresses where domains include a "@" character, which can be maliciously used since the local part is returned as a complete address. 

(cherry picked from commit 8cb65d1381b027f0b09ee36bfed7f35bb4dec9a9)

Excludes changes to Lib/email/_header_value_parser.py, which did not
exist in 2.7.

Co-authored-by: jpic <jpic@users.noreply.github.com>

<!-- issue-number: [bpo-34155](https://bugs.python.org/issue34155) -->
https://bugs.python.org/issue34155
<!-- /issue-number -->


Automerge-Triggered-By: @maxking