### PR TITLE
closes bpo-38124: Fix bounds check in PyState_AddModule.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-12-00-14-01.bpo-38124.n6E0H7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-12-00-14-01.bpo-38124.n6E0H7.rst
@@ -1,0 +1,2 @@
+Fix an off-by-one error in PyState_AddModule that could cause out-of-bounds
+memory access.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -684,7 +684,7 @@ _PyState_AddModule(PyObject* module, struct PyModuleDef* def)
         if (!state->modules_by_index)
             return -1;
     }
-    while(PyList_GET_SIZE(state->modules_by_index) <= def->m_base.m_index)
+    while (PyList_GET_SIZE(state->modules_by_index) <= def->m_base.m_index)
         if (PyList_Append(state->modules_by_index, Py_None) < 0)
             return -1;
     Py_INCREF(module);
@@ -702,13 +702,11 @@ PyState_AddModule(PyObject* module, struct PyModuleDef* def)
         return -1;
     }
     index = def->m_base.m_index;
-    if (state->modules_by_index) {
-        if(PyList_GET_SIZE(state->modules_by_index) >= index) {
-            if(module == PyList_GET_ITEM(state->modules_by_index, index)) {
-                Py_FatalError("PyState_AddModule: Module already added!");
-                return -1;
-            }
-        }
+    if (state->modules_by_index &&
+        index < PyList_GET_SIZE(state->modules_by_index) &&
+        module == PyList_GET_ITEM(state->modules_by_index, index)) {
+        Py_FatalError("PyState_AddModule: Module already added!");
+        return -1;
     }
     return _PyState_AddModule(module, def);
 }


### PR DESCRIPTION
The >=, checking whether a module index was in already in the module-by-index list, needed to be strict.

Also, fold nested ifs into one and fix some bad spacing.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38124](https://bugs.python.org/issue38124) -->
https://bugs.python.org/issue38124
<!-- /issue-number -->
