### PR TITLE
bpo-38127: PyObject_IsSubclass() should be checked for failure

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1168,7 +1168,11 @@ PyCPointerType_from_param(PyObject *type, PyObject *value)
         */
         StgDictObject *v = PyObject_stgdict(value);
         assert(v); /* Cannot be NULL for pointer or array objects */
-        if (PyObject_IsSubclass(v->proto, typedict->proto)) {
+        int ret = PyObject_IsSubclass(v->proto, typedict->proto);
+        if (ret < 0) {
+            return NULL;
+        }
+        if (ret) {
             Py_INCREF(value);
             return value;
         }


### PR DESCRIPTION
An exception may occur during a PyObject_IsSubclass() call.


<!-- issue-number: [bpo-38127](https://bugs.python.org/issue38127) -->
https://bugs.python.org/issue38127
<!-- /issue-number -->
