### PR TITLE
bpo-38112: Compileall improvements

### DIFF
--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -57,7 +57,7 @@ compile Python sources.
 
    Remove (``-s``) or append (``-p``) the given prefix of paths
    recorded in the ``.pyc`` files.
-   Raises :exc:`ValueError` if combined with ``-d``.
+   Cannot be combined with ``-d``.
 
 .. cmdoption:: -x regex
 
@@ -126,7 +126,7 @@ compile Python sources.
 
 .. versionchanged:: 3.9
    Added the ``-s``, ``-p``, ``-e`` options.
-   Raised the default default recursion limit from 10 to
+   Raised the default recursion limit from 10 to
    :py:func:`sys.getrecursionlimit()`.
    Added the possibility to specify the ``-o`` option multiple times.
 

--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -52,6 +52,13 @@ compile Python sources.
    cases where the source file does not exist at the time the byte-code file is
    executed.
 
+.. cmdoption:: -s strip_prefix
+.. cmdoption:: -p prepend_prefix
+
+   Remove (``-s``) or append (``-p``) the given prefix of paths
+   recorded in the ``.pyc`` files.
+   Raises :exc:`ValueError` if combined with ``-d``.
+
 .. cmdoption:: -x regex
 
    regex is used to search the full path to each file considered for
@@ -96,6 +103,16 @@ compile Python sources.
    variable is not set, and ``checked-hash`` if the ``SOURCE_DATE_EPOCH``
    environment variable is set.
 
+.. cmdoption:: -o level
+
+   Compile with the given optimization level. May be used multiple times
+   to compile for multiple levels at a time (for example,
+   ``compileall -o 1 -o 2``).
+
+.. cmdoption:: -e dir
+
+   Ignore symlinks pointing outside the given directory.
+
 .. versionchanged:: 3.2
    Added the ``-i``, ``-b`` and ``-h`` options.
 
@@ -106,6 +123,12 @@ compile Python sources.
 
 .. versionchanged:: 3.7
    Added the ``--invalidation-mode`` option.
+
+.. versionchanged:: 3.9
+   Added the ``-s``, ``-p``, ``-e`` options.
+   Raised the default default recursion limit from 10 to
+   :py:func:`sys.getrecursionlimit()`.
+   Added the possibility to specify the ``-o`` option multiple times.
 
 
 There is no command-line option to control the optimization level used by the
@@ -120,7 +143,7 @@ runtime.
 Public functions
 ----------------
 
-.. function:: compile_dir(dir, maxlevels=10, ddir=None, force=False, rx=None, quiet=0, legacy=False, optimize=-1, workers=1, invalidation_mode=None)
+.. function:: compile_dir(dir, maxlevels=sys.getrecursionlimit(), ddir=None, force=False, rx=None, quiet=0, legacy=False, optimize=-1, workers=1, invalidation_mode=None, stripdir=None, prependdir=None, limit_sl_dest=None)
 
    Recursively descend the directory tree named by *dir*, compiling all :file:`.py`
    files along the way. Return a true value if all the files compiled successfully,
@@ -166,6 +189,10 @@ Public functions
    :class:`py_compile.PycInvalidationMode` enum and controls how the generated
    pycs are invalidated at runtime.
 
+   The *stripdir*, *prependdir* and *limit_sl_dest* arguments correspond to
+   the ``-s``, ``-p`` and ``-e`` options described above.
+   They may be specified as ``str``, ``bytes`` or :py:class:`os.PathLike`.
+
    .. versionchanged:: 3.2
       Added the *legacy* and *optimize* parameter.
 
@@ -190,6 +217,9 @@ Public functions
 
    .. versionchanged:: 3.8
       Setting *workers* to 0 now chooses the optimal number of cores.
+
+   .. versionchanged:: 3.9
+      Added *stripdir*, *prependdir* and *limit_sl_dest* arguments.
 
 .. function:: compile_file(fullname, ddir=None, force=False, rx=None, quiet=0, legacy=False, optimize=-1, invalidation_mode=None)
 
@@ -223,6 +253,10 @@ Public functions
    :class:`py_compile.PycInvalidationMode` enum and controls how the generated
    pycs are invalidated at runtime.
 
+   The *stripdir*, *prependdir* and *limit_sl_dest* arguments correspond to
+   the ``-s``, ``-p`` and ``-e`` options described above.
+   They may be specified as ``str``, ``bytes`` or :py:class:`os.PathLike`.
+
    .. versionadded:: 3.2
 
    .. versionchanged:: 3.5
@@ -237,6 +271,9 @@ Public functions
 
    .. versionchanged:: 3.7.2
       The *invalidation_mode* parameter's default value is updated to None.
+
+   .. versionchanged:: 3.9
+      Added *stripdir*, *prependdir* and *limit_sl_dest* arguments.
 
 .. function:: compile_path(skip_curdir=True, maxlevels=0, force=False, quiet=0, legacy=False, optimize=-1, invalidation_mode=None)
 

--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -22,7 +22,7 @@ RECURSION_LIMIT = sys.getrecursionlimit()
 
 __all__ = ["compile_dir","compile_file","compile_path"]
 
-def _walk_dir(dir, ddir=None, maxlevels=RECURSION_LIMIT, quiet=0):
+def _walk_dir(dir, maxlevels=RECURSION_LIMIT, quiet=0):
     if quiet < 2 and isinstance(dir, os.PathLike):
         dir = os.fspath(dir)
     if not quiet:
@@ -38,16 +38,12 @@ def _walk_dir(dir, ddir=None, maxlevels=RECURSION_LIMIT, quiet=0):
         if name == '__pycache__':
             continue
         fullname = os.path.join(dir, name)
-        if ddir is not None:
-            dfile = os.path.join(ddir, name)
-        else:
-            dfile = None
         if not os.path.isdir(fullname):
             yield fullname
         elif (maxlevels > 0 and name != os.curdir and name != os.pardir and
               os.path.isdir(fullname) and not os.path.islink(fullname)):
-            yield from _walk_dir(fullname, ddir=dfile,
-                                 maxlevels=maxlevels - 1, quiet=quiet)
+            yield from _walk_dir(fullname, maxlevels=maxlevels - 1,
+                                 quiet=quiet)
 
 def compile_dir(dir, maxlevels=RECURSION_LIMIT, ddir=None, force=False,
                 rx=None, quiet=0, legacy=False, optimize=-1, workers=1,
@@ -78,8 +74,7 @@ def compile_dir(dir, maxlevels=RECURSION_LIMIT, ddir=None, force=False,
             from concurrent.futures import ProcessPoolExecutor
         except ImportError:
             workers = 1
-    files = _walk_dir(dir, quiet=quiet, maxlevels=maxlevels,
-                      ddir=ddir)
+    files = _walk_dir(dir, quiet=quiet, maxlevels=maxlevels)
     success = True
     if workers != 1 and ProcessPoolExecutor is not None:
         # If workers == 0, let ProcessPoolExecutor choose

--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -18,9 +18,11 @@ import struct
 
 from functools import partial
 
+RECURSION_LIMIT = sys.getrecursionlimit()
+
 __all__ = ["compile_dir","compile_file","compile_path"]
 
-def _walk_dir(dir, ddir=None, maxlevels=10, quiet=0):
+def _walk_dir(dir, ddir=None, maxlevels=RECURSION_LIMIT, quiet=0):
     if quiet < 2 and isinstance(dir, os.PathLike):
         dir = os.fspath(dir)
     if not quiet:
@@ -47,15 +49,15 @@ def _walk_dir(dir, ddir=None, maxlevels=10, quiet=0):
             yield from _walk_dir(fullname, ddir=dfile,
                                  maxlevels=maxlevels - 1, quiet=quiet)
 
-def compile_dir(dir, maxlevels=10, ddir=None, force=False, rx=None,
-                quiet=0, legacy=False, optimize=-1, workers=1,
+def compile_dir(dir, maxlevels=RECURSION_LIMIT, ddir=None, force=False,
+                rx=None, quiet=0, legacy=False, optimize=-1, workers=1,
                 invalidation_mode=None):
     """Byte-compile all modules in the given directory tree.
 
     Arguments (only dir is required):
 
     dir:       the directory to byte-compile
-    maxlevels: maximum recursion level (default 10)
+    maxlevels: maximum recursion level (default `sys.getrecursionlimit()`)
     ddir:      the directory that will be prepended to the path to the
                file as it is compiled into each byte-code file.
     force:     if True, force compilation, even if timestamps are up-to-date
@@ -225,7 +227,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Utilities to support installing Python libraries.')
     parser.add_argument('-l', action='store_const', const=0,
-                        default=10, dest='maxlevels',
+                        default=RECURSION_LIMIT, dest='maxlevels',
                         help="don't recurse into subdirectories")
     parser.add_argument('-r', type=int, dest='recursion',
                         help=('control the maximum recursion level. '

--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -364,6 +364,11 @@ def main():
     if args.opt_levels is None:
         args.opt_levels = [-1]
 
+    if args.ddir is not None and (
+        args.stripdir is not None or args.prependdir is not None
+    ):
+        parser.error("-d cannot be used in combination with -s or -p")
+
     # if flist is provided then load it
     if args.flist:
         try:

--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -17,6 +17,7 @@ import py_compile
 import struct
 
 from functools import partial
+from pathlib import Path
 
 RECURSION_LIMIT = sys.getrecursionlimit()
 
@@ -48,7 +49,7 @@ def _walk_dir(dir, maxlevels=RECURSION_LIMIT, quiet=0):
 def compile_dir(dir, maxlevels=RECURSION_LIMIT, ddir=None, force=False,
                 rx=None, quiet=0, legacy=False, optimize=-1, workers=1,
                 invalidation_mode=None, stripdir=None,
-                prependdir=None):
+                prependdir=None, limit_sl_dest=None):
     """Byte-compile all modules in the given directory tree.
 
     Arguments (only dir is required):
@@ -69,6 +70,8 @@ def compile_dir(dir, maxlevels=RECURSION_LIMIT, ddir=None, force=False,
     stripdir:  part of path to left-strip from source file path
     prependdir: path to prepend to beggining of original file path, applied
                after stripdir
+    limit_sl_dest: ignore symlinks if they are pointing outside of
+                   the defined path
     """
     ProcessPoolExecutor = None
     if workers < 0:
@@ -93,20 +96,23 @@ def compile_dir(dir, maxlevels=RECURSION_LIMIT, ddir=None, force=False,
                                            optimize=optimize,
                                            invalidation_mode=invalidation_mode,
                                            stripdir=stripdir,
-                                           prependdir=prependdir),
+                                           prependdir=prependdir,
+                                           limit_sl_dest=limit_sl_dest),
                                    files)
             success = min(results, default=True)
     else:
         for file in files:
             if not compile_file(file, ddir, force, rx, quiet,
                                 legacy, optimize, invalidation_mode,
-                                stripdir=stripdir, prependdir=prependdir):
+                                stripdir=stripdir, prependdir=prependdir,
+                                limit_sl_dest=limit_sl_dest):
                 success = False
     return success
 
 def compile_file(fullname, ddir=None, force=False, rx=None, quiet=0,
                  legacy=False, optimize=-1,
-                 invalidation_mode=None, stripdir=None, prependdir=None):
+                 invalidation_mode=None, stripdir=None, prependdir=None,
+                 limit_sl_dest=None):
     """Byte-compile one file.
 
     Arguments (only fullname is required):
@@ -125,6 +131,8 @@ def compile_file(fullname, ddir=None, force=False, rx=None, quiet=0,
     stripdir:  part of path to left-strip from source file path
     prependdir: path to prepend to beggining of original file path, applied
                after stripdir
+    limit_sl_dest: ignore symlinks if they are pointing outside of
+                   the defined path.
     """
 
     if ddir is not None and (stripdir is not None or prependdir is not None):
@@ -164,6 +172,10 @@ def compile_file(fullname, ddir=None, force=False, rx=None, quiet=0,
     if rx is not None:
         mo = rx.search(fullname)
         if mo:
+            return success
+
+    if limit_sl_dest is not None and os.path.islink(fullname):
+        if Path(limit_sl_dest).resolve() not in Path(fullname).resolve().parents:
             return success
 
     opt_cfiles = {}
@@ -331,6 +343,8 @@ def main():
                         help=('Optimization levels to run compilation with.'
                               'Default is -1 which uses optimization level of'
                               'Python interpreter itself (specified by -O).'))
+    parser.add_argument('-e', metavar='DIR', dest='limit_sl_dest',
+                        help='Ignore symlinks pointing outsite of the DIR')
 
     args = parser.parse_args()
     compile_dests = args.compile_dest
@@ -339,6 +353,8 @@ def main():
         import re
         args.rx = re.compile(args.rx)
 
+    if args.limit_sl_dest == "":
+        args.limit_sl_dest = None
 
     if args.recursion is not None:
         maxlevels = args.recursion
@@ -375,7 +391,8 @@ def main():
                                         invalidation_mode=invalidation_mode,
                                         stripdir=args.stripdir,
                                         prependdir=args.prependdir,
-                                        optimize=args.opt_levels):
+                                        optimize=args.opt_levels,
+                                        limit_sl_dest=args.limit_sl_dest):
                         success = False
                 else:
                     if not compile_dir(dest, maxlevels, args.ddir,
@@ -384,7 +401,8 @@ def main():
                                        invalidation_mode=invalidation_mode,
                                        stripdir=args.stripdir,
                                        prependdir=args.prependdir,
-                                       optimize=args.opt_levels):
+                                       optimize=args.opt_levels,
+                                       limit_sl_dest=args.limit_sl_dest):
                         success = False
             return success
         else:

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -41,6 +41,16 @@ class CompileallTestsBase:
         os.mkdir(self.subdirectory)
         self.source_path3 = os.path.join(self.subdirectory, '_test3.py')
         shutil.copyfile(self.source_path, self.source_path3)
+        many_directories = [str(number) for number in range(1, 100)]
+        self.long_path = os.path.join(self.directory,
+                                      "long",
+                                      *many_directories)
+        os.makedirs(self.long_path)
+        self.source_path_long = os.path.join(self.long_path, '_test4.py')
+        shutil.copyfile(self.source_path, self.source_path_long)
+        self.bc_path_long = importlib.util.cache_from_source(
+            self.source_path_long
+        )
 
     def tearDown(self):
         shutil.rmtree(self.directory)
@@ -193,6 +203,15 @@ class CompileallTestsBase:
     def test_compile_missing_multiprocessing(self, compile_file_mock):
         compileall.compile_dir(self.directory, quiet=True, workers=5)
         self.assertTrue(compile_file_mock.called)
+
+    def text_compile_dir_maxlevels(self):
+        # Test the actual impact of maxlevels attr
+        compileall.compile_dir(os.path.join(self.directory, "long"),
+                               maxlevels=10, quiet=True)
+        self.assertFalse(os.path.isfile(self.bc_path_long))
+        compileall.compile_dir(os.path.join(self.directory, "long"),
+                               maxlevels=110, quiet=True)
+        self.assertTrue(os.path.isfile(self.bc_path_long))
 
 
 class CompileallTestsWithSourceEpoch(CompileallTestsBase,

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -563,6 +563,20 @@ class CommandLineTestsBase:
         self.assertCompiled(spamfn)
         self.assertCompiled(eggfn)
 
+    @support.skip_unless_symlink
+    def test_symlink_loop(self):
+        # Currently, compileall ignores symlinks to directories.
+        # If that limitation is ever lifted, it should protect against
+        # recursion in symlink loops.
+        pkg = os.path.join(self.pkgdir, 'spam')
+        script_helper.make_pkg(pkg)
+        os.symlink('.', os.path.join(pkg, 'evil'))
+        os.symlink('.', os.path.join(pkg, 'evil2'))
+        self.assertRunOK('-q', self.pkgdir)
+        self.assertCompiled(os.path.join(
+            self.pkgdir, 'spam', 'evil', 'evil2', '__init__.py'
+        ))
+
     def test_quiet(self):
         noisy = self.assertRunOK(self.pkgdir)
         quiet = self.assertRunOK('-q', self.pkgdir)

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -296,6 +296,31 @@ class CompileallTestsBase:
                 except Exception:
                     pass
 
+    @support.skip_unless_symlink
+    def test_ignore_symlink_destination(self):
+        # Create folders for allowed files, symlinks and prohibited area
+        allowed_path = os.path.join(self.directory, "test", "dir", "allowed")
+        symlinks_path = os.path.join(self.directory, "test", "dir", "symlinks")
+        prohibited_path = os.path.join(self.directory, "test", "dir", "prohibited")
+        os.makedirs(allowed_path)
+        os.makedirs(symlinks_path)
+        os.makedirs(prohibited_path)
+
+        # Create scripts and symlinks and remember their byte-compiled versions
+        allowed_script = script_helper.make_script(allowed_path, "test_allowed", "a = 0")
+        prohibited_script = script_helper.make_script(prohibited_path, "test_prohibited", "a = 0")
+        allowed_symlink = os.path.join(symlinks_path, "test_allowed.py")
+        prohibited_symlink = os.path.join(symlinks_path, "test_prohibited.py")
+        os.symlink(allowed_script, allowed_symlink)
+        os.symlink(prohibited_script, prohibited_symlink)
+        allowed_bc = importlib.util.cache_from_source(allowed_symlink)
+        prohibited_bc = importlib.util.cache_from_source(prohibited_symlink)
+
+        compileall.compile_dir(symlinks_path, quiet=True, limit_sl_dest=allowed_path)
+
+        self.assertTrue(os.path.isfile(allowed_bc))
+        self.assertFalse(os.path.isfile(prohibited_bc))
+
 
 class CompileallTestsWithSourceEpoch(CompileallTestsBase,
                                      unittest.TestCase,
@@ -721,6 +746,31 @@ class CommandLineTestsBase:
                     os.unlink(bc[opt_level])
                 except Exception:
                     pass
+
+    @support.skip_unless_symlink
+    def test_ignore_symlink_destination(self):
+        # Create folders for allowed files, symlinks and prohibited area
+        allowed_path = os.path.join(self.directory, "test", "dir", "allowed")
+        symlinks_path = os.path.join(self.directory, "test", "dir", "symlinks")
+        prohibited_path = os.path.join(self.directory, "test", "dir", "prohibited")
+        os.makedirs(allowed_path)
+        os.makedirs(symlinks_path)
+        os.makedirs(prohibited_path)
+
+        # Create scripts and symlinks and remember their byte-compiled versions
+        allowed_script = script_helper.make_script(allowed_path, "test_allowed", "a = 0")
+        prohibited_script = script_helper.make_script(prohibited_path, "test_prohibited", "a = 0")
+        allowed_symlink = os.path.join(symlinks_path, "test_allowed.py")
+        prohibited_symlink = os.path.join(symlinks_path, "test_prohibited.py")
+        os.symlink(allowed_script, allowed_symlink)
+        os.symlink(prohibited_script, prohibited_symlink)
+        allowed_bc = importlib.util.cache_from_source(allowed_symlink)
+        prohibited_bc = importlib.util.cache_from_source(prohibited_symlink)
+
+        self.assertRunOK(symlinks_path, "-e", allowed_path)
+
+        self.assertTrue(os.path.isfile(allowed_bc))
+        self.assertFalse(os.path.isfile(prohibited_bc))
 
 
 class CommandLineTestsWithSourceEpoch(CommandLineTestsBase,

--- a/Misc/NEWS.d/next/Library/2019-09-24-10-55-01.bpo-38112.2EinX9.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-24-10-55-01.bpo-38112.2EinX9.rst
@@ -1,0 +1,3 @@
+:mod:`compileall` has a higher default recursion limit and new command-line
+arguments for path manipulation, symlinks handling, and multiple
+optimization levels.


### PR DESCRIPTION
Improvements of compileall module (released as compileall2 on [PyPI](https://pypi.org/project/compileall2/)|[GitHub](https://github.com/fedora-python/compileall2)) which makes the module better for Linux distributions where some manipulation with a baked path into a byte-compiled file is necessary. This patchset contains tests but needs to add documentation.

<!-- issue-number: [bpo-38112](https://bugs.python.org/issue38112) -->
https://bugs.python.org/issue38112
<!-- /issue-number -->
