### PR TITLE
bpo-36876: Skip test_check_c_globals for now.

### DIFF
--- a/Lib/test/test_check_c_globals.py
+++ b/Lib/test/test_check_c_globals.py
@@ -9,7 +9,9 @@ with test.test_tools.imports_under_tool('c-analyzer'):
 class ActualChecks(unittest.TestCase):
 
     # XXX Also run the check in "make check".
-    @unittest.expectedFailure
+    #@unittest.expectedFailure
+    # Failing on one of the buildbots (see https://bugs.python.org/issue36876).
+    @unittest.skip('activate this once all the globals have been resolved')
     def test_check_c_globals(self):
         try:
             main('check', {})


### PR DESCRIPTION
The test is [failing on one of the buildbots](https://buildbot.python.org/all/#/builders/141/builds/2443).  The test is currently an expected failure (and will be for a while), so it's okay to simply skip the test for now.

<!-- issue-number: [bpo-36876](https://bugs.python.org/issue36876) -->
https://bugs.python.org/issue36876
<!-- /issue-number -->
