### PR TITLE
bpo-38138: Fix memory leak introduced by interned strings

### DIFF
--- a/Python/ast.c
+++ b/Python/ast.c
@@ -630,6 +630,7 @@ new_identifier(const char *n, struct compiling *c)
         PyObject *args[2] = {form, id};
         id2 = _PyObject_FastCall(c->c_normalize, args, 2);
         Py_DECREF(id);
+        Py_DECREF(form);
         if (!id2)
             return NULL;
         if (!PyUnicode_Check(id2)) {


### PR DESCRIPTION
Interned string needs to be decref'd


<!-- issue-number: [bpo-38138](https://bugs.python.org/issue38138) -->
https://bugs.python.org/issue38138
<!-- /issue-number -->


Automerge-Triggered-By: @matrixise