### PR TITLE
[3.8] bpo-38137: Re-add OpenSSL 1.0.2 compat (GH-16051)

### DIFF
--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -26,6 +26,12 @@
 #include <openssl/objects.h>
 #include "openssl/err.h"
 
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+/* OpenSSL < 1.1.0 */
+#define EVP_MD_CTX_new EVP_MD_CTX_create
+#define EVP_MD_CTX_free EVP_MD_CTX_destroy
+#endif
+
 #define MUNCH_SIZE INT_MAX
 
 typedef struct {


### PR DESCRIPTION
The defines are required for OpenSSL 1.0.2 and LibreSSL.

https://bugs.python.org/issue38134

Automerge-Triggered-By: @tiran
(cherry picked from commit 9a4963b932a087b78596cca0b8394ac898faa490)

Co-authored-by: Christian Heimes <christian@python.org>

<!-- issue-number: [bpo-38137](https://bugs.python.org/issue38137) -->
https://bugs.python.org/issue38137
<!-- /issue-number -->


Automerge-Triggered-By: @matrixise