### PR TITLE
bpo-38108: Makes mock objects inherit from Base

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2033,7 +2033,7 @@ class MagicMixin(Base):
         self._mock_set_magics()  # fix magic broken by upper level init
 
 
-    def _mock_set_magics(self, async_magics=False):
+    def _mock_set_magics(self):
         orig_magics = _magics | _async_method_magics
         these_magics = orig_magics
 
@@ -2071,9 +2071,9 @@ class NonCallableMagicMock(MagicMixin, NonCallableMock):
 
 class AsyncMagicMixin(MagicMixin):
     def __init__(self, /, *args, **kw):
-        self._mock_set_magics(async_magics=True)  # make magic work for kwargs in init
+        self._mock_set_magics()  # make magic work for kwargs in init
         _safe_super(AsyncMagicMixin, self).__init__(*args, **kw)
-        self._mock_set_magics(async_magics=True)  # fix magic broken by upper level init
+        self._mock_set_magics()  # fix magic broken by upper level init
 
 class MagicMock(MagicMixin, Mock):
     """

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -409,7 +409,7 @@ class NonCallableMock(Base):
             if spec_arg and _is_async_obj(spec_arg):
                 bases = (AsyncMockMixin, cls)
         new = type(cls.__name__, bases, {'__doc__': cls.__doc__})
-        instance = object.__new__(new)
+        instance = _safe_super(NonCallableMock, cls).__new__(new)
         return instance
 
 
@@ -2024,7 +2024,7 @@ def _set_return_value(mock, method, name):
 
 
 
-class MagicMixin(object):
+class MagicMixin(Base):
     def __init__(self, /, *args, **kw):
         self._mock_set_magics()  # make magic work for kwargs in init
         _safe_super(MagicMixin, self).__init__(*args, **kw)
@@ -2066,7 +2066,7 @@ class NonCallableMagicMock(MagicMixin, NonCallableMock):
         self._mock_set_magics()
 
 
-class AsyncMagicMixin:
+class AsyncMagicMixin(MagicMixin):
     def __init__(self, /, *args, **kw):
         self._mock_set_async_magics()  # make magic work for kwargs in init
         _safe_super(AsyncMagicMixin, self).__init__(*args, **kw)
@@ -2092,7 +2092,7 @@ class AsyncMagicMixin:
             setattr(_type, entry, MagicProxy(entry, self))
 
 
-class MagicMock(MagicMixin, AsyncMagicMixin, Mock):
+class MagicMock(AsyncMagicMixin, Mock):
     """
     MagicMock is a subclass of Mock with default implementations
     of most of the magic methods. You can use MagicMock without having to
@@ -2114,7 +2114,7 @@ class MagicMock(MagicMixin, AsyncMagicMixin, Mock):
 
 
 
-class MagicProxy(object):
+class MagicProxy(Base):
     def __init__(self, name, parent):
         self.name = name
         self.parent = parent

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -379,6 +379,43 @@ class AsyncArguments(unittest.TestCase):
                 RuntimeError('coroutine raised StopIteration')
             )
 
+class AsyncMagicMethods(unittest.TestCase):
+    def test_async_magic_methods_return_async_mocks(self):
+        m_mock = MagicMock()
+        self.assertIsInstance(m_mock.__aenter__, AsyncMock)
+        self.assertIsInstance(m_mock.__aexit__, AsyncMock)
+        self.assertIsInstance(m_mock.__anext__, AsyncMock)
+        # __aiter__ is actually a synchronous object
+        # so should return a MagicMock
+        self.assertIsInstance(m_mock.__aiter__, MagicMock)
+
+    def test_sync_magic_methods_return_magic_mocks(self):
+        a_mock = AsyncMock()
+        self.assertIsInstance(a_mock.__enter__, MagicMock)
+        self.assertIsInstance(a_mock.__exit__, MagicMock)
+        self.assertIsInstance(a_mock.__next__, MagicMock)
+        self.assertIsInstance(a_mock.__len__, MagicMock)
+
+    def test_magicmock_has_async_magic_methods(self):
+        m_mock = MagicMock()
+        self.assertTrue(hasattr(m_mock, "__aenter__"))
+        self.assertTrue(hasattr(m_mock, "__aexit__"))
+        self.assertTrue(hasattr(m_mock, "__anext__"))
+
+    def test_asyncmock_has_sync_magic_methods(self):
+        a_mock = AsyncMock()
+        self.assertTrue(hasattr(a_mock, "__enter__"))
+        self.assertTrue(hasattr(a_mock, "__exit__"))
+        self.assertTrue(hasattr(a_mock, "__next__"))
+        self.assertTrue(hasattr(a_mock, "__len__"))
+
+    def test_magic_methods_are_async_functions(self):
+        m_mock = MagicMock()
+        self.assertIsInstance(m_mock.__aenter__, AsyncMock)
+        self.assertIsInstance(m_mock.__aexit__, AsyncMock)
+        # AsyncMocks are also coroutine functions
+        self.assertTrue(asyncio.iscoroutinefunction(m_mock.__aenter__))
+        self.assertTrue(asyncio.iscoroutinefunction(m_mock.__aexit__))
 
 class AsyncContextManagerTest(unittest.TestCase):
 
@@ -405,43 +442,6 @@ class AsyncContextManagerTest(unittest.TestCase):
             async with self.session.post('https://python.org') as response:
                 val = await response.json()
                 return val
-
-    def test_async_magic_methods_return_async_mocks(self):
-        cm_mock = MagicMock()
-        self.assertIsInstance(cm_mock.__aenter__, AsyncMock)
-        self.assertIsInstance(cm_mock.__aexit__, AsyncMock)
-        self.assertIsInstance(cm_mock.__anext__, AsyncMock)
-        # __aiter__ is actually a synchronous object
-        # so should return a MagicMock
-        self.assertIsInstance(cm_mock.__aiter__, MagicMock)
-
-    def test_sync_magic_methods_return_magic_mocks(self):
-        am_mock = AsyncMock()
-        self.assertIsInstance(am_mock.__enter__, MagicMock)
-        self.assertIsInstance(am_mock.__exit__, MagicMock)
-        self.assertIsInstance(am_mock.__next__, MagicMock)
-        self.assertIsInstance(am_mock.__len__, MagicMock)
-
-    def test_magicmock_has_async_magic_methods(self):
-        cm = MagicMock(name='magic_cm')
-        self.assertTrue(hasattr(cm, "__aenter__"))
-        self.assertTrue(hasattr(cm, "__aexit__"))
-        self.assertTrue(hasattr(cm, "__anext__"))
-
-    def test_asyncmock_has_sync_magic_methods(self):
-        am = AsyncMock(name='async_cm')
-        self.assertTrue(hasattr(am, "__enter__"))
-        self.assertTrue(hasattr(am, "__exit__"))
-        self.assertTrue(hasattr(am, "__next__"))
-        self.assertTrue(hasattr(am, "__len__"))
-
-    def test_magic_methods_are_async_functions(self):
-        cm = MagicMock(name='magic_cm')
-        self.assertIsInstance(cm.__aenter__, AsyncMock)
-        self.assertIsInstance(cm.__aexit__, AsyncMock)
-        # AsyncMocks are also coroutine functions
-        self.assertTrue(asyncio.iscoroutinefunction(cm.__aenter__))
-        self.assertTrue(asyncio.iscoroutinefunction(cm.__aexit__))
 
     def test_set_return_value_of_aenter(self):
         def inner_test(mock_type):

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -406,15 +406,34 @@ class AsyncContextManagerTest(unittest.TestCase):
                 val = await response.json()
                 return val
 
-    def test_async_magic_methods_are_async_mocks_with_magicmock(self):
-        cm_mock = MagicMock(self.WithAsyncContextManager())
+    def test_async_magic_methods_return_async_mocks(self):
+        cm_mock = MagicMock()
         self.assertIsInstance(cm_mock.__aenter__, AsyncMock)
         self.assertIsInstance(cm_mock.__aexit__, AsyncMock)
+        self.assertIsInstance(cm_mock.__anext__, AsyncMock)
+        # __aiter__ is actually a synchronous object
+        # so should return a MagicMock
+        self.assertIsInstance(cm_mock.__aiter__, MagicMock)
+
+    def test_sync_magic_methods_return_magic_mocks(self):
+        am_mock = AsyncMock()
+        self.assertIsInstance(am_mock.__enter__, MagicMock)
+        self.assertIsInstance(am_mock.__exit__, MagicMock)
+        self.assertIsInstance(am_mock.__next__, MagicMock)
+        self.assertIsInstance(am_mock.__len__, MagicMock)
 
     def test_magicmock_has_async_magic_methods(self):
         cm = MagicMock(name='magic_cm')
         self.assertTrue(hasattr(cm, "__aenter__"))
         self.assertTrue(hasattr(cm, "__aexit__"))
+        self.assertTrue(hasattr(cm, "__anext__"))
+
+    def test_asyncmock_has_sync_magic_methods(self):
+        am = AsyncMock(name='async_cm')
+        self.assertTrue(hasattr(am, "__enter__"))
+        self.assertTrue(hasattr(am, "__exit__"))
+        self.assertTrue(hasattr(am, "__next__"))
+        self.assertTrue(hasattr(am, "__len__"))
 
     def test_magic_methods_are_async_functions(self):
         cm = MagicMock(name='magic_cm')

--- a/Lib/unittest/test/testmock/testmagicmethods.py
+++ b/Lib/unittest/test/testmock/testmagicmethods.py
@@ -271,9 +271,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(mock == mock, True)
         self.assertEqual(mock != mock, False)
 
-
-    # This should be fixed with issue38163
-    @unittest.expectedFailure
     def test_asyncmock_defaults(self):
         mock = AsyncMock()
         self.assertEqual(int(mock), 1)

--- a/Misc/NEWS.d/next/Library/2019-09-25-21-37-02.bpo-38108.Jr9HU6.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-25-21-37-02.bpo-38108.Jr9HU6.rst
@@ -1,0 +1,2 @@
+Any synchronous magic methods on an AsyncMock now return a MagicMock. Any
+asynchronous magic methods on a MagicMock now return an AsyncMock.


### PR DESCRIPTION
Updates the few Mock classes that do not inherit from Base to properly inherit from base. Updates the super() calls that should go with them as well.

That was all I planned on doing with this diff, but the changes to get AsyncMock inheritance working right with subclasses was so linked with this diff I merged it into one to prevent temporary breaking changes. 

<!-- issue-number: [bpo-38108](https://bugs.python.org/issue38108) -->
https://bugs.python.org/issue38108
<!-- /issue-number -->
