### PR TITLE
bpo-38013: make async_generator_athrow object tolerant to throwing exceptions

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1125,6 +1125,27 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         res = self.loop.run_until_complete(run())
         self.assertEqual(res, [i * 2 for i in range(1, 10)])
 
+    def test_asyncgen_nonstarted_hooks_are_cancellable(self):
+        messages = []
+
+        def exception_handler(loop, context):
+            messages.append(context)
+
+        async def async_iterate():
+            yield 1
+            yield 2
+
+        async def main():
+            loop = asyncio.get_running_loop()
+            loop.set_exception_handler(exception_handler)
+
+            async for i in async_iterate():
+                break
+
+        asyncio.run(main())
+
+        self.assertEqual([], messages)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1126,6 +1126,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         self.assertEqual(res, [i * 2 for i in range(1, 10)])
 
     def test_asyncgen_nonstarted_hooks_are_cancellable(self):
+        # See https://bugs.python.org/issue38013
         messages = []
 
         def exception_handler(loop, context):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-12-19-50-01.bpo-38013.I7btD0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-12-19-50-01.bpo-38013.I7btD0.rst
@@ -1,0 +1,3 @@
+Allow to call ``async_generator_athrow().throw(...)`` even for non-started
+async generator helper. It fixes annoying warning at the end of
+:func:`asyncio.run` call.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1884,11 +1884,6 @@ async_gen_athrow_throw(PyAsyncGenAThrow *o, PyObject *args)
 {
     PyObject *retval;
 
-    if (o->agt_state == AWAITABLE_STATE_INIT) {
-        PyErr_SetString(PyExc_RuntimeError, NON_INIT_CORO_MSG);
-        return NULL;
-    }
-
     if (o->agt_state == AWAITABLE_STATE_CLOSED) {
         PyErr_SetNone(PyExc_StopIteration);
         return NULL;


### PR DESCRIPTION
Even when the helper is not started yet.

This behavior follows conventional generator one.
There is no reason for `async_generator_athrow` to handle `gen.throw()` differently.


<!-- issue-number: [bpo-38013](https://bugs.python.org/issue38013) -->
https://bugs.python.org/issue38013
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov