### PR TITLE
[3.7] Revert "bpo-37785: Fix xgettext warning in argparse (GH-15161)"

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1207,9 +1207,8 @@ class FileType(object):
             return open(string, self._mode, self._bufsize, self._encoding,
                         self._errors)
         except OSError as e:
-            args = {'filename': string, 'error': e}
-            message = _("can't open '%(filename)s': %(error)s")
-            raise ArgumentTypeError(message % args)
+            message = _("can't open '%s': %s")
+            raise ArgumentTypeError(message % (string, e))
 
     def __repr__(self):
         args = self._mode, self._bufsize

--- a/Misc/NEWS.d/next/Library/2019-08-07-14-49-22.bpo-37785.y7OlT8.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-07-14-49-22.bpo-37785.y7OlT8.rst
@@ -1,1 +1,0 @@
-Fix xgettext warnings in :mod:`argparse`.


### PR DESCRIPTION
This reverts commit b50eff65906f8e9b4597cb0128ea1729341346fc because
it's an incompatible change that would have broken the existing
translations.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37785](https://bugs.python.org/issue37785) -->
https://bugs.python.org/issue37785
<!-- /issue-number -->
