### PR TITLE
bpo-38145: Fix short option d for bdist_dumb

### DIFF
--- a/Lib/distutils/command/bdist_dumb.py
+++ b/Lib/distutils/command/bdist_dumb.py
@@ -16,7 +16,7 @@ class bdist_dumb(Command):
 
     description = "create a \"dumb\" built distribution"
 
-    user_options = [('bdist-dir=', 'd',
+    user_options = [('bdist-dir=', 'b',
                      "temporary directory for creating the distribution"),
                     ('plat-name=', 'p',
                      "platform name to embed in generated filenames "

--- a/Misc/NEWS.d/next/Library/2019-10-08-13-43-23.bpo-38145.6_0d_w.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-08-13-43-23.bpo-38145.6_0d_w.rst
@@ -1,0 +1,1 @@
+In the 'distutils' command 'bdist_dumb', the short option 'd' was used for both the 'bdist-dir' and 'dist-dir' options. The short for the 'bdist-dir' option is now 'b'.


### PR DESCRIPTION
In the 'distutils' command 'bdist_dumb', the short option 'd' is used
for both the 'bdist-dir' and 'dist-dir' options.

The bdist-dir option appeared first on 2000-05-13 in commit: ba0506b3492a13f5c8cec7598bf2b5f9735ac7b2

The dist-dir option appeared then on 2000-07-05 in commit: c4eb84accb1ac1e09ea78bc3af81acdbe9499fb8

There appears to have been no version released between these two
commits, so most likely the global behaviour of the command has
stayed consistent.

The short option d actually triggers the dist-dir option, not the
bdist-dir option.

It is therefore safe to change the short option for bdist-dir. A
choice consistent with other similar distutils commands is 'b'.

<!-- issue-number: [bpo-38145](https://bugs.python.org/issue38145) -->
https://bugs.python.org/issue38145
<!-- /issue-number -->
