### PR TITLE
 [3.7] bpo-12144: Handle cookies with expires attribute in CookieJar.make_cookies (GH-13921)

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -1590,6 +1590,7 @@ class CookieJar:
         headers = response.info()
         rfc2965_hdrs = headers.get_all("Set-Cookie2", [])
         ns_hdrs = headers.get_all("Set-Cookie", [])
+        self._policy._now = self._now = int(time.time())
 
         rfc2965 = self._policy.rfc2965
         netscape = self._policy.netscape
@@ -1669,8 +1670,6 @@ class CookieJar:
         _debug("extract_cookies: %s", response.info())
         self._cookies_lock.acquire()
         try:
-            self._policy._now = self._now = int(time.time())
-
             for cookie in self.make_cookies(response, request):
                 if self._policy.set_ok(cookie, request):
                     _debug(" setting cookie: %s", cookie)

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -6,6 +6,7 @@ import test.support
 import time
 import unittest
 import urllib.request
+import warnings
 
 from http.cookiejar import (time2isoz, http2time, iso2time, time2netscape,
      parse_ns_headers, join_header_words, split_header_words, Cookie,
@@ -561,13 +562,14 @@ class CookieTests(unittest.TestCase):
         c = CookieJar()
         future = time2netscape(time.time()+3600)
 
-        with test.support.check_no_warnings(self):
+        with warnings.catch_warnings(record=True) as warns:
             headers = [f"Set-Cookie: FOO=BAR; path=/; expires={future}"]
             req = urllib.request.Request("http://www.coyote.com/")
             res = FakeResponse(headers, "http://www.coyote.com/")
             cookies = c.make_cookies(res, req)
             self.assertEqual(len(cookies), 1)
             self.assertEqual(time2netscape(cookies[0].expires), future)
+            self.assertEqual(len(warns), 0)
 
         interact_netscape(c, "http://www.acme.com/", 'spam="bar"; expires=%s' %
                           future)

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -560,6 +560,15 @@ class CookieTests(unittest.TestCase):
         # if expires is in future, keep cookie...
         c = CookieJar()
         future = time2netscape(time.time()+3600)
+
+        with test.support.check_no_warnings(self):
+            headers = [f"Set-Cookie: FOO=BAR; path=/; expires={future}"]
+            req = urllib.request.Request("http://www.coyote.com/")
+            res = FakeResponse(headers, "http://www.coyote.com/")
+            cookies = c.make_cookies(res, req)
+            self.assertEqual(len(cookies), 1)
+            self.assertEqual(time2netscape(cookies[0].expires), future)
+
         interact_netscape(c, "http://www.acme.com/", 'spam="bar"; expires=%s' %
                           future)
         self.assertEqual(len(c), 1)

--- a/Misc/NEWS.d/next/Library/2019-06-08-23-26-58.bpo-12144.Z7mz-q.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-08-23-26-58.bpo-12144.Z7mz-q.rst
@@ -1,0 +1,2 @@
+Ensure cookies with ``expires`` attribute are handled in
+:meth:`CookieJar.make_cookies`.


### PR DESCRIPTION
Handle time comparison for cookies with expires attribute when CookieJar.make_cookies is called.

Co-authored-by: Demian Brecht demianbrecht@gmail.com

bugs.python.org/issue12144

Automerge-Triggered-By: @asvetlov
(cherry picked from commit bb41147)

Co-authored-by: Xtreak tir.karthi@gmail.com

bugs.python.org/issue12144

<!-- issue-number: [bpo-12144](https://bugs.python.org/issue12144) -->
https://bugs.python.org/issue12144
<!-- /issue-number -->
