### PR TITLE
[3.8] bpo-38148: Add slots to asyncio transports (GH-16077)

### DIFF
--- a/Lib/asyncio/transports.py
+++ b/Lib/asyncio/transports.py
@@ -9,6 +9,8 @@ __all__ = (
 class BaseTransport:
     """Base class for transports."""
 
+    __slots__ = ('_extra',)
+
     def __init__(self, extra=None):
         if extra is None:
             extra = {}
@@ -44,6 +46,8 @@ class BaseTransport:
 class ReadTransport(BaseTransport):
     """Interface for read-only transports."""
 
+    __slots__ = ()
+
     def is_reading(self):
         """Return True if the transport is receiving."""
         raise NotImplementedError
@@ -67,6 +71,8 @@ class ReadTransport(BaseTransport):
 
 class WriteTransport(BaseTransport):
     """Interface for write-only transports."""
+
+    __slots__ = ()
 
     def set_write_buffer_limits(self, high=None, low=None):
         """Set the high- and low-water limits for write flow control.
@@ -154,9 +160,13 @@ class Transport(ReadTransport, WriteTransport):
     except writelines(), which calls write() in a loop.
     """
 
+    __slots__ = ()
+
 
 class DatagramTransport(BaseTransport):
     """Interface for datagram (UDP) transports."""
+
+    __slots__ = ()
 
     def sendto(self, data, addr=None):
         """Send data to the transport.
@@ -179,6 +189,8 @@ class DatagramTransport(BaseTransport):
 
 
 class SubprocessTransport(BaseTransport):
+
+    __slots__ = ()
 
     def get_pid(self):
         """Get subprocess id."""
@@ -246,6 +258,8 @@ class _FlowControlMixin(Transport):
     get_write_buffer_size(), and their protocol's pause_writing() and
     resume_writing() may be called.
     """
+
+    __slots__ = ('_loop', '_protocol_paused', '_high_water', '_low_water')
 
     def __init__(self, extra=None, loop=None):
         super().__init__(extra)

--- a/Lib/test/test_asyncio/test_transports.py
+++ b/Lib/test/test_asyncio/test_transports.py
@@ -22,14 +22,19 @@ class TransportTests(unittest.TestCase):
         self.assertIs(default, transport.get_extra_info('unknown', default))
 
     def test_writelines(self):
-        transport = asyncio.Transport()
-        transport.write = mock.Mock()
+        writer = mock.Mock()
+
+        class MyTransport(asyncio.Transport):
+            def write(self, data):
+                writer(data)
+
+        transport = MyTransport()
 
         transport.writelines([b'line1',
                               bytearray(b'line2'),
                               memoryview(b'line3')])
-        self.assertEqual(1, transport.write.call_count)
-        transport.write.assert_called_with(b'line1line2line3')
+        self.assertEqual(1, writer.call_count)
+        writer.assert_called_with(b'line1line2line3')
 
     def test_not_implemented(self):
         transport = asyncio.Transport()

--- a/Misc/NEWS.d/next/Library/2019-09-13-08-55-43.bpo-38148.Lnww6D.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-13-08-55-43.bpo-38148.Lnww6D.rst
@@ -1,0 +1,1 @@
+Add slots to :mod:`asyncio` transport classes, which can reduce memory usage.


### PR DESCRIPTION
* [bpo-38148](https://bugs.python.org/issue38148): Add slots to asyncio transports

* Update Misc/NEWS.d/next/Library/2019-09-13-08-55-43.[bpo-38148](https://bugs.python.org/issue38148).Lnww6D.rst

Co-Authored-By: Kyle Stanley <aeros167@gmail.com>
(cherry picked from commit 9eb35ab0d71a6bd680e84fa0f828cb634e72b681)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38148](https://bugs.python.org/issue38148) -->
https://bugs.python.org/issue38148
<!-- /issue-number -->
