### PR TITLE
bpo-29986: Delete tip to raise TypeError from tp_richcompare.

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1311,12 +1311,6 @@ and :c:type:`PyType_Type` effectively act as defaults.)
    ``Py_NotImplemented``, if another error occurred it must return *NULL* and
    set an exception condition.
 
-   .. note::
-
-      If you want to implement a type for which only a limited set of
-      comparisons makes sense (e.g. ``==`` and ``!=``, but not ``<`` and
-      friends), directly raise :exc:`TypeError` in the rich comparison function.
-
    The following constants are defined to be used as the third argument for
    :c:member:`~PyTypeObject.tp_richcompare` and for :c:func:`PyObject_RichCompare`:
 


### PR DESCRIPTION
This is just a rebase of https://github.com/python/cpython/pull/987 on top of master, so it can be merged.

<!-- issue-number: [bpo-29986](https://bugs.python.org/issue29986) -->
https://bugs.python.org/issue29986
<!-- /issue-number -->
