### PR TITLE
bpo-38122: minor fixes to AsyncMock spec handling

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -402,18 +402,12 @@ class NonCallableMock(Base):
         # so we can create magic methods on the
         # class without stomping on other mocks
         bases = (cls,)
-        if not issubclass(cls, AsyncMock):
+        if not issubclass(cls, AsyncMockMixin):
             # Check if spec is an async object or function
-            sig = inspect.signature(NonCallableMock.__init__)
-            bound_args = sig.bind_partial(cls, *args, **kw).arguments
-            spec_arg = [
-                arg for arg in bound_args.keys()
-                if arg.startswith('spec')
-            ]
-            if spec_arg:
-                # what if spec_set is different than spec?
-                if _is_async_obj(bound_args[spec_arg[0]]):
-                    bases = (AsyncMockMixin, cls,)
+            bound_args = _MOCK_SIG.bind_partial(cls, *args, **kw).arguments
+            spec_arg = bound_args.get('spec_set', bound_args.get('spec'))
+            if spec_arg and _is_async_obj(spec_arg):
+                bases = (AsyncMockMixin, cls)
         new = type(cls.__name__, bases, {'__doc__': cls.__doc__})
         instance = object.__new__(new)
         return instance
@@ -1018,7 +1012,7 @@ class NonCallableMock(Base):
             return ""
         return f"\n{prefix}: {safe_repr(self.mock_calls)}."
 
-
+_MOCK_SIG = inspect.signature(NonCallableMock.__init__)
 
 def _try_iter(obj):
     if obj is None:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1013,7 +1013,7 @@ class NonCallableMock(Base):
             return ""
         return f"\n{prefix}: {safe_repr(self.mock_calls)}."
 
-      
+
 _MOCK_SIG = inspect.signature(NonCallableMock.__init__)
 
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -529,6 +529,48 @@ class MockTest(unittest.TestCase):
                 )
 
 
+    def _check_autospeced_something(self, something):
+        for method_name in ['meth', 'cmeth', 'smeth']:
+            mock_method = getattr(something, method_name)
+
+            # check that the methods are callable with correct args.
+            mock_method(sentinel.a, sentinel.b, sentinel.c)
+            mock_method(sentinel.a, sentinel.b, sentinel.c, d=sentinel.d)
+            mock_method.assert_has_calls([
+                call(sentinel.a, sentinel.b, sentinel.c),
+                call(sentinel.a, sentinel.b, sentinel.c, d=sentinel.d)])
+
+            # assert that TypeError is raised if the method signature is not
+            # respected.
+            self.assertRaises(TypeError, mock_method)
+            self.assertRaises(TypeError, mock_method, sentinel.a)
+            self.assertRaises(TypeError, mock_method, a=sentinel.a)
+            self.assertRaises(TypeError, mock_method, sentinel.a, sentinel.b,
+                              sentinel.c, e=sentinel.e)
+
+        # assert that AttributeError is raised if the method does not exist.
+        self.assertRaises(AttributeError, getattr, something, 'foolish')
+
+
+    def test_mock_autospec_all_members(self):
+        for spec in [Something, Something()]:
+            mock_something = Mock(autospec=spec)
+            self._check_autospeced_something(mock_something)
+
+
+    def test_mock_spec_function(self):
+        def foo(lish):
+            pass
+
+        mock_foo = Mock(spec=foo)
+
+        mock_foo(sentinel.lish)
+        mock_foo.assert_called_once_with(sentinel.lish)
+        self.assertRaises(TypeError, mock_foo)
+        self.assertRaises(TypeError, mock_foo, sentinel.foo, sentinel.lish)
+        self.assertRaises(TypeError, mock_foo, foo=sentinel.foo)
+
+
     def test_from_spec(self):
         class Something(object):
             x = 3
@@ -1385,6 +1427,13 @@ class MockTest(unittest.TestCase):
                               mock_class.assert_has_calls,
                               [kall]
             )
+
+
+    def test_mock_add_spec_autospec_all_members(self):
+        for spec in [Something, Something()]:
+            mock_something = Mock()
+            mock_something.mock_add_spec(spec, autospec=True)
+            self._check_autospeced_something(mock_something)
 
 
     def test_assert_has_calls_nested_without_spec(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -529,48 +529,6 @@ class MockTest(unittest.TestCase):
                 )
 
 
-    def _check_autospeced_something(self, something):
-        for method_name in ['meth', 'cmeth', 'smeth']:
-            mock_method = getattr(something, method_name)
-
-            # check that the methods are callable with correct args.
-            mock_method(sentinel.a, sentinel.b, sentinel.c)
-            mock_method(sentinel.a, sentinel.b, sentinel.c, d=sentinel.d)
-            mock_method.assert_has_calls([
-                call(sentinel.a, sentinel.b, sentinel.c),
-                call(sentinel.a, sentinel.b, sentinel.c, d=sentinel.d)])
-
-            # assert that TypeError is raised if the method signature is not
-            # respected.
-            self.assertRaises(TypeError, mock_method)
-            self.assertRaises(TypeError, mock_method, sentinel.a)
-            self.assertRaises(TypeError, mock_method, a=sentinel.a)
-            self.assertRaises(TypeError, mock_method, sentinel.a, sentinel.b,
-                              sentinel.c, e=sentinel.e)
-
-        # assert that AttributeError is raised if the method does not exist.
-        self.assertRaises(AttributeError, getattr, something, 'foolish')
-
-
-    def test_mock_autospec_all_members(self):
-        for spec in [Something, Something()]:
-            mock_something = Mock(autospec=spec)
-            self._check_autospeced_something(mock_something)
-
-
-    def test_mock_spec_function(self):
-        def foo(lish):
-            pass
-
-        mock_foo = Mock(spec=foo)
-
-        mock_foo(sentinel.lish)
-        mock_foo.assert_called_once_with(sentinel.lish)
-        self.assertRaises(TypeError, mock_foo)
-        self.assertRaises(TypeError, mock_foo, sentinel.foo, sentinel.lish)
-        self.assertRaises(TypeError, mock_foo, foo=sentinel.foo)
-
-
     def test_from_spec(self):
         class Something(object):
             x = 3

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1387,13 +1387,6 @@ class MockTest(unittest.TestCase):
             )
 
 
-    def test_mock_add_spec_autospec_all_members(self):
-        for spec in [Something, Something()]:
-            mock_something = Mock()
-            mock_something.mock_add_spec(spec, autospec=True)
-            self._check_autospeced_something(mock_something)
-
-
     def test_assert_has_calls_nested_without_spec(self):
         m = MagicMock()
         m().foo().bar().baz()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Simplification of the spec handling for AsyncMock and correction for how spec_set is handled.

<!-- issue-number: [bpo-38122](https://bugs.python.org/issue38122) -->
https://bugs.python.org/issue38122
<!-- /issue-number -->
