### PR TITLE
bpo-38159: Clarify documentation of PyState_AddModule

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -487,9 +487,11 @@ since multiple such modules can be created from a single definition.
 
    Python calls ``PyState_AddModule`` automatically after importing a module,
    so it is unnecessary (but harmless) to call it from module initialization
-   code. An explicit call is needed only if the module's own init code subsequently calls ``PyState_FindModule``.
+   code. An explicit call is needed only if the module's own init code
+   subsequently calls ``PyState_FindModule``.
    The function is mainly intended for implementing alternative import
-   mechanisms (either by calling it directly, or by referring to its implementation for details of the required state updates).
+   mechanisms (either by calling it directly, or by referring to its
+   implementation for details of the required state updates).
 
    Return 0 on success or -1 on failure.
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -487,9 +487,9 @@ since multiple such modules can be created from a single definition.
 
    Python calls ``PyState_AddModule`` automatically after importing a module,
    so it is unnecessary (but harmless) to call it from module initialization
-   code, unless that code itself needs the module to be registered.
+   code. An explicit call is needed only if the module's own init code subsequently calls ``PyState_FindModule``.
    The function is mainly intended for implementing alternative import
-   mechanisms.
+   mechanisms (either by calling it directly, or by referring to its implementation for details of the required state updates).
 
    Return 0 on success or -1 on failure.
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -485,10 +485,17 @@ since multiple such modules can be created from a single definition.
 
    Only effective on modules created using single-phase initialization.
 
+   The function is intended for implementing alternative import mechanisms.
+   Python calls PyState_AddModule automatically when importing a module; it
+   is generally not necessary to call it at module initialization time.
+
+   Return 0 on success or -1 on failure.
+
    .. versionadded:: 3.3
 
 .. c:function:: int PyState_RemoveModule(PyModuleDef *def)
 
    Removes the module object created from *def* from the interpreter state.
+   Return 0 on success or -1 on failure.
 
    .. versionadded:: 3.3

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -485,9 +485,11 @@ since multiple such modules can be created from a single definition.
 
    Only effective on modules created using single-phase initialization.
 
-   The function is intended for implementing alternative import mechanisms.
-   Python calls PyState_AddModule automatically when importing a module; it
-   is generally not necessary to call it at module initialization time.
+   Python calls ``PyState_AddModule`` automatically after importing a module,
+   so it is unnecessary (but harmless) to call it from module initialization
+   code, unless that code itself needs the module to be registered.
+   The function is mainly intended for implementing alternative import
+   mechanisms.
 
    Return 0 on success or -1 on failure.
 


### PR DESCRIPTION
This was never intented to be called manually from PyInit_*.

Also, clarify PyState_RemoveModule return value.


<!-- issue-number: [bpo-38159](https://bugs.python.org/issue38159) -->
https://bugs.python.org/issue38159
<!-- /issue-number -->


Automerge-Triggered-By: @encukou

Automerge-Triggered-By: @encukou