### PR TITLE
bpo-38152: Fix refleak in the finalizer of AST type

### DIFF
--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -638,9 +638,13 @@ static void
 ast_dealloc(AST_object *self)
 {
     /* bpo-31095: UnTrack is needed before calling any callbacks */
+    PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
     Py_CLEAR(self->dict);
-    Py_TYPE(self)->tp_free(self);
+    freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+    assert(free_func != NULL);
+    free_func(self);
+    Py_DECREF(tp);
 }
 
 static int

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1130,9 +1130,13 @@ static void
 ast_dealloc(AST_object *self)
 {
     /* bpo-31095: UnTrack is needed before calling any callbacks */
+    PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
     Py_CLEAR(self->dict);
-    Py_TYPE(self)->tp_free(self);
+    freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+    assert(free_func != NULL);
+    free_func(self);
+    Py_DECREF(tp);
 }
 
 static int


### PR DESCRIPTION
The `AST_object` was leaking its reference to the `AST` type. This change properly decreases the reference to the type at deallocation time. Also, this modifies `tp_free` to use `PyType_GetSlot` to make `PyTypeObject` opaque.

<!-- issue-number: [bpo-38152](https://bugs.python.org/issue38152) -->
https://bugs.python.org/issue38152
<!-- /issue-number -->
