### PR TITLE
bpo-38167 Allow for 4K O_DIRECT reads.

### DIFF
--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1016,7 +1016,7 @@ _buffered_readinto_generic(buffered *self, Py_buffer *buffer, char readinto1)
          written += n, remaining -= n) {
         /* If remaining bytes is larger than internal buffer size, copy
          * directly into caller's buffer. */
-        if (remaining > self->buffer_size) {
+        if (remaining >= self->buffer_size) {
             n = _bufferedreader_raw_read(self, (char *) buffer->buf + written,
                                          remaining);
         }


### PR DESCRIPTION
O_DIRECT reads would fail if given a 4K buffer due to being compared to
the default buffer length of 4K.

The following bug describes the test: https://bugs.python.org/issue38167

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
