### PR TITLE
bpo-38167 Allow for 4K O_DIRECT reads.

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -227,6 +227,41 @@ class FileTests(unittest.TestCase):
         self.fdopen_helper('r')
         self.fdopen_helper('r', 100)
 
+    @unittest.skipUnless(hasattr(os, 'O_DIRECT'), 'test needs os.O_DIRECT')
+    def test_odirect_readinto(self):
+        fname = support.TESTFN
+        create_file(fname, bytearray(mmap.PAGESIZE*2))
+        self.addCleanup(support.unlink, fname)
+
+        # Test one page readinto
+        fd = os.open(fname, os.O_DIRECT|os.O_RDONLY)
+        f = os.fdopen(fd, 'rb')
+        m = mmap.mmap(-1, mmap.PAGESIZE)
+        f.readinto(m)
+        f.close()
+
+        # Test two page readinto
+        fd = os.open(fname, os.O_DIRECT|os.O_RDONLY)
+        f = os.fdopen(fd, 'rb')
+        m = mmap.mmap(-1, mmap.PAGESIZE * 2)
+        f.readinto(m)
+        f.close()
+
+        # Test two page readinto1
+        fd = os.open(fname, os.O_DIRECT|os.O_RDONLY)
+        f = os.fdopen(fd, 'rb')
+        m = mmap.mmap(-1, mmap.PAGESIZE * 2)
+        f.readinto1(m)
+        f.close()
+
+        # Test illegal page size.
+        fd = os.open(fname, os.O_DIRECT|os.O_RDONLY)
+        f = os.fdopen(fd, 'rb')
+        m = mmap.mmap(-1, mmap.PAGESIZE - 1)
+        with self.assertRaises(OSError):
+            f.readinto(m)
+        f.close()
+
     def test_replace(self):
         TESTFN2 = support.TESTFN + ".2"
         self.addCleanup(support.unlink, support.TESTFN)

--- a/Misc/NEWS.d/next/Library/2019-09-13-16-56-56.bpo-38167.52trQr.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-13-16-56-56.bpo-38167.52trQr.rst
@@ -1,0 +1,1 @@
+Fixed bug with O_DIRECT reads into 4K mmap buffer.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1016,7 +1016,7 @@ _buffered_readinto_generic(buffered *self, Py_buffer *buffer, char readinto1)
          written += n, remaining -= n) {
         /* If remaining bytes is larger than internal buffer size, copy
          * directly into caller's buffer. */
-        if (remaining > self->buffer_size) {
+        if (remaining >= self->buffer_size) {
             n = _bufferedreader_raw_read(self, (char *) buffer->buf + written,
                                          remaining);
         }


### PR DESCRIPTION
O_DIRECT reads would fail if given a 4K buffer due to being compared to
the default buffer length of 4K.

https://bugs.python.org/issue38167

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38167](https://bugs.python.org/issue38167) -->
https://bugs.python.org/issue38167
<!-- /issue-number -->
