### PR TITLE
bpo-37953: Fix deprecation warnings in test_typing

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2379,8 +2379,8 @@ class ForwardRefTests(BaseTestCase):
         self.assertEqual(List[c1], List[c1_gth])
         self.assertNotEqual(List[c1], List[C])
         self.assertNotEqual(List[c1_gth], List[C])
-        self.assertEquals(Union[c1, c1_gth], Union[c1])
-        self.assertEquals(Union[c1, c1_gth, int], Union[c1, int])
+        self.assertEqual(Union[c1, c1_gth], Union[c1])
+        self.assertEqual(Union[c1, c1_gth, int], Union[c1, int])
 
     def test_forward_equality_hash(self):
         c1 = typing.ForwardRef('int')


### PR DESCRIPTION
self.assertEquals() is deprecated.

```
./python -We -m test test_typing
Run tests sequentially
0:00:00 load avg: 0.23 [1/1] test_typing
test test_typing failed -- Traceback (most recent call last):
  File "/home/lubuntu2/cpython/Lib/test/test_typing.py", line 2382, in test_forward_equality_gth
    self.assertEquals(Union[c1, c1_gth], Union[c1])
  File "/home/lubuntu2/cpython/Lib/unittest/case.py", line 1390, in deprecated_func
    warnings.warn(
DeprecationWarning: Please use assertEqual instead.

test_typing failed

== Tests result: FAILURE ==

1 test failed:
    test_typing

Total duration: 140 ms
Tests result: FAILURE
```


<!-- issue-number: [bpo-37953](https://bugs.python.org/issue37953) -->
https://bugs.python.org/issue37953
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum