### PR TITLE
[3.8] Doc: Fix link to window.getch in curses documentation (GH-16132)

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -1283,7 +1283,7 @@ The :mod:`curses` module defines the following data members:
 
 .. data:: ERR
 
-   Some curses routines  that  return  an integer, such as  :func:`getch`, return
+   Some curses routines  that  return  an integer, such as :meth:`~window.getch`, return
    :const:`ERR` upon failure.
 
 


### PR DESCRIPTION
(cherry picked from commit a26ace19bddea2d7a999a6de8286b3f27b132f35)

Co-authored-by: Anthony Sottile <asottile@umich.edu>

Automerge-Triggered-By: @matrixise