### PR TITLE
bpo-38168: Fix possible refleaks in setint() of mmapmodule.c

### DIFF
--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1468,7 +1468,8 @@ static void
 setint(PyObject *d, const char *name, long value)
 {
     PyObject *o = PyLong_FromLong(value);
-    if (o && PyDict_SetItemString(d, name, o) == 0) {
+    if (o) {
+        PyDict_SetItemString(d, name, o);
         Py_DECREF(o);
     }
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-38168](https://bugs.python.org/issue38168) -->
https://bugs.python.org/issue38168
<!-- /issue-number -->
