### PR TITLE
bpo-38169: Increase code coverage for SharedMemory and ShareableList

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3705,6 +3705,18 @@ class _TestSharedMemory(BaseTestCase):
         self.assertGreaterEqual(sms.size, 512)
         self.assertGreaterEqual(len(sms.buf), sms.size)
 
+        # Verify __repr__
+        self.assertIn(sms.name, str(sms))
+        self.assertIn(str(sms.size), str(sms))
+
+        # Test pickling
+        sms.buf[0:6] = b'pickle'
+        pickled_sms = pickle.dumps(sms)
+        sms2 = pickle.loads(pickled_sms)
+        self.assertEqual(sms.name, sms2.name)
+        self.assertEqual(sms.size, sms2.size)
+        self.assertEqual(bytes(sms.buf[0:6]), bytes(sms2.buf[0:6]), b'pickle')
+
         # Modify contents of shared memory segment through memoryview.
         sms.buf[0] = 42
         self.assertEqual(sms.buf[0], 42)
@@ -3909,6 +3921,23 @@ class _TestSharedMemory(BaseTestCase):
             ['howdy', b'HoWdY', -273.154, 100, None, True, 42]
         )
         self.addCleanup(sl.shm.unlink)
+
+        # Verify __repr__
+        self.assertIn(sl.shm.name, str(sl))
+        self.assertIn(str(list(sl)), str(sl))
+
+        # Index Out of Range (get)
+        with self.assertRaises(IndexError):
+            sl[7]
+
+        # Index Out of Range (set)
+        with self.assertRaises(IndexError):
+            sl[7] = 2
+
+        # Assign value without format change (str -> str)
+        current_format = sl._get_packing_format(0)
+        sl[0] = 'howdy'
+        self.assertEqual(current_format, sl._get_packing_format(0))
 
         # Verify attributes are readable.
         self.assertEqual(sl.format, '8s8sdqxxxxxx?xxxxxxxx?q')

--- a/Misc/NEWS.d/next/Tests/2019-09-14-13-20-27.bpo-38169.hurq4B.rst
+++ b/Misc/NEWS.d/next/Tests/2019-09-14-13-20-27.bpo-38169.hurq4B.rst
@@ -1,0 +1,1 @@
+Increase code coverage for SharedMemory and ShareableList


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Increase Code Coverage, and add check in SharedMemory when user wants to create shm with size 0, to throw ValueError.

<!-- issue-number: [bpo-38169](https://bugs.python.org/issue38169) -->
https://bugs.python.org/issue38169
<!-- /issue-number -->
