### PR TITLE
bpo-33936: Don't call obsolete init methods with OpenSSL 1.1.0+

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-09-14-10-34-00.bpo-33936.8wCI_n.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-14-10-34-00.bpo-33936.8wCI_n.rst
@@ -1,0 +1,2 @@
+_hashlib no longer calls obsolete OpenSSL initialization function with
+OpenSSL 1.1.0+.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -1129,7 +1129,7 @@ PyInit__hashlib(void)
 {
     PyObject *m, *openssl_md_meth_names;
 
-#ifndef OPENSSL_VERSION_1_1
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
     /* Load all digest algorithms and initialize cpuid */
     OPENSSL_add_all_algorithms_noconf();
     ERR_load_crypto_strings();


### PR DESCRIPTION
``OPENSSL_VERSION_1_1`` was never defined in ``_hashopenssl.c``. 

<!-- issue-number: [bpo-33936](https://bugs.python.org/issue33936) -->
https://bugs.python.org/issue33936
<!-- /issue-number -->


Automerge-Triggered-By: @tiran