### PR TITLE
[3.8] bpo-37206: Unrepresentable default values no longer represented as None. (GH-13933)

### DIFF
--- a/Lib/test/clinic.test
+++ b/Lib/test/clinic.test
@@ -92,7 +92,7 @@ test_objects_converter
 [clinic start generated code]*/
 
 PyDoc_STRVAR(test_objects_converter__doc__,
-"test_objects_converter($module, a, b=None, /)\n"
+"test_objects_converter($module, a, b=<unrepresentable>, /)\n"
 "--\n"
 "\n");
 
@@ -126,7 +126,7 @@ exit:
 
 static PyObject *
 test_objects_converter_impl(PyObject *module, PyObject *a, PyObject *b)
-/*[clinic end generated code: output=58009c0e42b4834e input=4cbb3d9edd2a36f3]*/
+/*[clinic end generated code: output=0e461f38d3b2bd08 input=4cbb3d9edd2a36f3]*/
 
 
 /*[clinic input]
@@ -1718,8 +1718,8 @@ test_str_converter
 [clinic start generated code]*/
 
 PyDoc_STRVAR(test_str_converter__doc__,
-"test_str_converter($module, a=None, b=\'ab\', c=\'cd\', d=\'cef\', e=\'gh\',\n"
-"                   f=\'ij\', g=\'kl\', h=\'mn\', /)\n"
+"test_str_converter($module, a=<unrepresentable>, b=\'ab\', c=\'cd\',\n"
+"                   d=\'cef\', e=\'gh\', f=\'ij\', g=\'kl\', h=\'mn\', /)\n"
 "--\n"
 "\n");
 
@@ -1765,7 +1765,7 @@ test_str_converter_impl(PyObject *module, const char *a, const char *b,
                         const char *f, Py_ssize_clean_t f_length,
                         const char *g, Py_ssize_clean_t g_length,
                         const char *h, Py_ssize_clean_t h_length)
-/*[clinic end generated code: output=8415d82c56154307 input=8afe9da8185cd38c]*/
+/*[clinic end generated code: output=ad868ad94a488e32 input=8afe9da8185cd38c]*/
 
 
 /*[clinic input]

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -2273,8 +2273,8 @@ class TestSignatureObject(unittest.TestCase):
         test_callable(d.dump)
 
         # static method
-        test_callable(str.maketrans)
-        test_callable('abc'.maketrans)
+        test_callable(bytes.maketrans)
+        test_callable(b'abc'.maketrans)
 
         # class method
         test_callable(dict.fromkeys)

--- a/Misc/NEWS.d/next/Library/2019-06-09-22-25-03.bpo-37206.2WBg4q.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-09-22-25-03.bpo-37206.2WBg4q.rst
@@ -1,0 +1,2 @@
+Default values which cannot be represented as Python objects no longer
+improperly represented as ``None`` in function signatures.

--- a/Modules/_codecsmodule.c
+++ b/Modules/_codecsmodule.c
@@ -171,14 +171,14 @@ PyObject *codec_tuple(PyObject *decoded,
 /*[clinic input]
 _codecs.escape_decode
     data: Py_buffer(accept={str, buffer})
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_escape_decode_impl(PyObject *module, Py_buffer *data,
                            const char *errors)
-/*[clinic end generated code: output=505200ba8056979a input=0018edfd99db714d]*/
+/*[clinic end generated code: output=505200ba8056979a input=77298a561c90bd82]*/
 {
     PyObject *decoded = PyBytes_DecodeEscape(data->buf, data->len,
                                              errors, 0, NULL);
@@ -188,14 +188,14 @@ _codecs_escape_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.escape_encode
     data: object(subclass_of='&PyBytes_Type')
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_escape_encode_impl(PyObject *module, PyObject *data,
                            const char *errors)
-/*[clinic end generated code: output=4af1d477834bab34 input=da9ded00992f32f2]*/
+/*[clinic end generated code: output=4af1d477834bab34 input=8f4b144799a94245]*/
 {
     Py_ssize_t size;
     Py_ssize_t newsize;
@@ -252,7 +252,7 @@ _codecs_escape_encode_impl(PyObject *module, PyObject *data,
 /*[clinic input]
 _codecs.utf_7_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -260,7 +260,7 @@ _codecs.utf_7_decode
 static PyObject *
 _codecs_utf_7_decode_impl(PyObject *module, Py_buffer *data,
                           const char *errors, int final)
-/*[clinic end generated code: output=0cd3a944a32a4089 input=2d94a5a1f170c8ae]*/
+/*[clinic end generated code: output=0cd3a944a32a4089 input=22c395d357815d26]*/
 {
     Py_ssize_t consumed = data->len;
     PyObject *decoded = PyUnicode_DecodeUTF7Stateful(data->buf, data->len,
@@ -272,7 +272,7 @@ _codecs_utf_7_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_8_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -280,7 +280,7 @@ _codecs.utf_8_decode
 static PyObject *
 _codecs_utf_8_decode_impl(PyObject *module, Py_buffer *data,
                           const char *errors, int final)
-/*[clinic end generated code: output=10f74dec8d9bb8bf input=1ea6c21492e8bcbe]*/
+/*[clinic end generated code: output=10f74dec8d9bb8bf input=f611b3867352ba59]*/
 {
     Py_ssize_t consumed = data->len;
     PyObject *decoded = PyUnicode_DecodeUTF8Stateful(data->buf, data->len,
@@ -292,7 +292,7 @@ _codecs_utf_8_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_16_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -300,7 +300,7 @@ _codecs.utf_16_decode
 static PyObject *
 _codecs_utf_16_decode_impl(PyObject *module, Py_buffer *data,
                            const char *errors, int final)
-/*[clinic end generated code: output=783b442abcbcc2d0 input=2ba128c28ea0bb40]*/
+/*[clinic end generated code: output=783b442abcbcc2d0 input=191d360bd7309180]*/
 {
     int byteorder = 0;
     /* This is overwritten unless final is true. */
@@ -314,7 +314,7 @@ _codecs_utf_16_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_16_le_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -322,7 +322,7 @@ _codecs.utf_16_le_decode
 static PyObject *
 _codecs_utf_16_le_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final)
-/*[clinic end generated code: output=899b9e6364379dcd input=43aeb8b0461cace5]*/
+/*[clinic end generated code: output=899b9e6364379dcd input=c6904fdc27fb4724]*/
 {
     int byteorder = -1;
     /* This is overwritten unless final is true. */
@@ -336,7 +336,7 @@ _codecs_utf_16_le_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_16_be_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -344,7 +344,7 @@ _codecs.utf_16_be_decode
 static PyObject *
 _codecs_utf_16_be_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final)
-/*[clinic end generated code: output=49f6465ea07669c8 input=339e554c804f34b2]*/
+/*[clinic end generated code: output=49f6465ea07669c8 input=e49012400974649b]*/
 {
     int byteorder = 1;
     /* This is overwritten unless final is true. */
@@ -365,7 +365,7 @@ _codecs_utf_16_be_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_16_ex_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     byteorder: int = 0
     final: bool(accept={int}) = False
     /
@@ -374,7 +374,7 @@ _codecs.utf_16_ex_decode
 static PyObject *
 _codecs_utf_16_ex_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int byteorder, int final)
-/*[clinic end generated code: output=0f385f251ecc1988 input=3201aeddb9636889]*/
+/*[clinic end generated code: output=0f385f251ecc1988 input=5a9c19f2e6b6cf0e]*/
 {
     /* This is overwritten unless final is true. */
     Py_ssize_t consumed = data->len;
@@ -390,7 +390,7 @@ _codecs_utf_16_ex_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_32_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -398,7 +398,7 @@ _codecs.utf_32_decode
 static PyObject *
 _codecs_utf_32_decode_impl(PyObject *module, Py_buffer *data,
                            const char *errors, int final)
-/*[clinic end generated code: output=2fc961807f7b145f input=155a5c673a4e2514]*/
+/*[clinic end generated code: output=2fc961807f7b145f input=fd7193965627eb58]*/
 {
     int byteorder = 0;
     /* This is overwritten unless final is true. */
@@ -412,7 +412,7 @@ _codecs_utf_32_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_32_le_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -420,7 +420,7 @@ _codecs.utf_32_le_decode
 static PyObject *
 _codecs_utf_32_le_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final)
-/*[clinic end generated code: output=ec8f46b67a94f3e6 input=7baf061069e92d3b]*/
+/*[clinic end generated code: output=ec8f46b67a94f3e6 input=9078ec70acfe7613]*/
 {
     int byteorder = -1;
     /* This is overwritten unless final is true. */
@@ -434,7 +434,7 @@ _codecs_utf_32_le_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_32_be_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -442,7 +442,7 @@ _codecs.utf_32_be_decode
 static PyObject *
 _codecs_utf_32_be_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final)
-/*[clinic end generated code: output=ff82bae862c92c4e input=b182026300dae595]*/
+/*[clinic end generated code: output=ff82bae862c92c4e input=f1ae1bbbb86648ff]*/
 {
     int byteorder = 1;
     /* This is overwritten unless final is true. */
@@ -463,7 +463,7 @@ _codecs_utf_32_be_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_32_ex_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     byteorder: int = 0
     final: bool(accept={int}) = False
     /
@@ -472,7 +472,7 @@ _codecs.utf_32_ex_decode
 static PyObject *
 _codecs_utf_32_ex_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int byteorder, int final)
-/*[clinic end generated code: output=6bfb177dceaf4848 input=7b9c2cb819fb237a]*/
+/*[clinic end generated code: output=6bfb177dceaf4848 input=e46a73bc859d0bd0]*/
 {
     Py_ssize_t consumed = data->len;
     PyObject *decoded = PyUnicode_DecodeUTF32Stateful(data->buf, data->len,
@@ -486,14 +486,14 @@ _codecs_utf_32_ex_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.unicode_escape_decode
     data: Py_buffer(accept={str, buffer})
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_unicode_escape_decode_impl(PyObject *module, Py_buffer *data,
                                    const char *errors)
-/*[clinic end generated code: output=3ca3c917176b82ab input=49fd27d06813a7f5]*/
+/*[clinic end generated code: output=3ca3c917176b82ab input=8328081a3a569bd6]*/
 {
     PyObject *decoded = PyUnicode_DecodeUnicodeEscape(data->buf, data->len,
                                                       errors);
@@ -503,14 +503,14 @@ _codecs_unicode_escape_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.raw_unicode_escape_decode
     data: Py_buffer(accept={str, buffer})
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_raw_unicode_escape_decode_impl(PyObject *module, Py_buffer *data,
                                        const char *errors)
-/*[clinic end generated code: output=c98eeb56028070a6 input=770903a211434ebc]*/
+/*[clinic end generated code: output=c98eeb56028070a6 input=d2f5159ce3b3392f]*/
 {
     PyObject *decoded = PyUnicode_DecodeRawUnicodeEscape(data->buf, data->len,
                                                          errors);
@@ -520,14 +520,14 @@ _codecs_raw_unicode_escape_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.latin_1_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_latin_1_decode_impl(PyObject *module, Py_buffer *data,
                             const char *errors)
-/*[clinic end generated code: output=07f3dfa3f72c7d8f input=5cad0f1759c618ec]*/
+/*[clinic end generated code: output=07f3dfa3f72c7d8f input=76ca58fd6dcd08c7]*/
 {
     PyObject *decoded = PyUnicode_DecodeLatin1(data->buf, data->len, errors);
     return codec_tuple(decoded, data->len);
@@ -536,14 +536,14 @@ _codecs_latin_1_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.ascii_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_ascii_decode_impl(PyObject *module, Py_buffer *data,
                           const char *errors)
-/*[clinic end generated code: output=2627d72058d42429 input=ad1106f64037bd16]*/
+/*[clinic end generated code: output=2627d72058d42429 input=e428a267a04b4481]*/
 {
     PyObject *decoded = PyUnicode_DecodeASCII(data->buf, data->len, errors);
     return codec_tuple(decoded, data->len);
@@ -552,15 +552,15 @@ _codecs_ascii_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.charmap_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
-    mapping: object = NULL
+    errors: str(accept={str, NoneType}) = None
+    mapping: object = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_charmap_decode_impl(PyObject *module, Py_buffer *data,
                             const char *errors, PyObject *mapping)
-/*[clinic end generated code: output=2c335b09778cf895 input=19712ca35c5a80e2]*/
+/*[clinic end generated code: output=2c335b09778cf895 input=15b69df43458eb40]*/
 {
     PyObject *decoded;
 
@@ -576,7 +576,7 @@ _codecs_charmap_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.mbcs_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -584,7 +584,7 @@ _codecs.mbcs_decode
 static PyObject *
 _codecs_mbcs_decode_impl(PyObject *module, Py_buffer *data,
                          const char *errors, int final)
-/*[clinic end generated code: output=39b65b8598938c4b input=b5f2fe568f311297]*/
+/*[clinic end generated code: output=39b65b8598938c4b input=1c1d50f08fa53789]*/
 {
     Py_ssize_t consumed = data->len;
     PyObject *decoded = PyUnicode_DecodeMBCSStateful(data->buf, data->len,
@@ -595,7 +595,7 @@ _codecs_mbcs_decode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.oem_decode
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -603,7 +603,7 @@ _codecs.oem_decode
 static PyObject *
 _codecs_oem_decode_impl(PyObject *module, Py_buffer *data,
                         const char *errors, int final)
-/*[clinic end generated code: output=da1617612f3fcad8 input=278709bcfd374a9c]*/
+/*[clinic end generated code: output=da1617612f3fcad8 input=81b67cba811022e5]*/
 {
     Py_ssize_t consumed = data->len;
     PyObject *decoded = PyUnicode_DecodeCodePageStateful(CP_OEMCP,
@@ -615,7 +615,7 @@ _codecs_oem_decode_impl(PyObject *module, Py_buffer *data,
 _codecs.code_page_decode
     codepage: int
     data: Py_buffer
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     final: bool(accept={int}) = False
     /
 [clinic start generated code]*/
@@ -623,7 +623,7 @@ _codecs.code_page_decode
 static PyObject *
 _codecs_code_page_decode_impl(PyObject *module, int codepage,
                               Py_buffer *data, const char *errors, int final)
-/*[clinic end generated code: output=53008ea967da3fff input=51f6169021c68dd5]*/
+/*[clinic end generated code: output=53008ea967da3fff input=c5f58d036cb63575]*/
 {
     Py_ssize_t consumed = data->len;
     PyObject *decoded = PyUnicode_DecodeCodePageStateful(codepage,
@@ -640,14 +640,14 @@ _codecs_code_page_decode_impl(PyObject *module, int codepage,
 /*[clinic input]
 _codecs.readbuffer_encode
     data: Py_buffer(accept={str, buffer})
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_readbuffer_encode_impl(PyObject *module, Py_buffer *data,
                                const char *errors)
-/*[clinic end generated code: output=c645ea7cdb3d6e86 input=b7c322b89d4ab923]*/
+/*[clinic end generated code: output=c645ea7cdb3d6e86 input=aa10cfdf252455c5]*/
 {
     PyObject *result = PyBytes_FromStringAndSize(data->buf, data->len);
     return codec_tuple(result, data->len);
@@ -656,14 +656,14 @@ _codecs_readbuffer_encode_impl(PyObject *module, Py_buffer *data,
 /*[clinic input]
 _codecs.utf_7_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_utf_7_encode_impl(PyObject *module, PyObject *str,
                           const char *errors)
-/*[clinic end generated code: output=0feda21ffc921bc8 input=d1a47579e79cbe15]*/
+/*[clinic end generated code: output=0feda21ffc921bc8 input=2546dbbb3fa53114]*/
 {
     return codec_tuple(_PyUnicode_EncodeUTF7(str, 0, 0, errors),
                        PyUnicode_GET_LENGTH(str));
@@ -672,14 +672,14 @@ _codecs_utf_7_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.utf_8_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_utf_8_encode_impl(PyObject *module, PyObject *str,
                           const char *errors)
-/*[clinic end generated code: output=02bf47332b9c796c input=42e3ba73c4392eef]*/
+/*[clinic end generated code: output=02bf47332b9c796c input=a3e71ae01c3f93f3]*/
 {
     return codec_tuple(_PyUnicode_AsUTF8String(str, errors),
                        PyUnicode_GET_LENGTH(str));
@@ -695,7 +695,7 @@ _codecs_utf_8_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.utf_16_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     byteorder: int = 0
     /
 [clinic start generated code]*/
@@ -703,7 +703,7 @@ _codecs.utf_16_encode
 static PyObject *
 _codecs_utf_16_encode_impl(PyObject *module, PyObject *str,
                            const char *errors, int byteorder)
-/*[clinic end generated code: output=c654e13efa2e64e4 input=ff46416b04edb944]*/
+/*[clinic end generated code: output=c654e13efa2e64e4 input=68cdc2eb8338555d]*/
 {
     return codec_tuple(_PyUnicode_EncodeUTF16(str, errors, byteorder),
                        PyUnicode_GET_LENGTH(str));
@@ -712,14 +712,14 @@ _codecs_utf_16_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.utf_16_le_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_utf_16_le_encode_impl(PyObject *module, PyObject *str,
                               const char *errors)
-/*[clinic end generated code: output=431b01e55f2d4995 input=cb385455ea8f2fe0]*/
+/*[clinic end generated code: output=431b01e55f2d4995 input=83d042706eed6798]*/
 {
     return codec_tuple(_PyUnicode_EncodeUTF16(str, errors, -1),
                        PyUnicode_GET_LENGTH(str));
@@ -728,14 +728,14 @@ _codecs_utf_16_le_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.utf_16_be_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_utf_16_be_encode_impl(PyObject *module, PyObject *str,
                               const char *errors)
-/*[clinic end generated code: output=96886a6fd54dcae3 input=9119997066bdaefd]*/
+/*[clinic end generated code: output=96886a6fd54dcae3 input=6f1e9e623b03071b]*/
 {
     return codec_tuple(_PyUnicode_EncodeUTF16(str, errors, +1),
                        PyUnicode_GET_LENGTH(str));
@@ -751,7 +751,7 @@ _codecs_utf_16_be_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.utf_32_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     byteorder: int = 0
     /
 [clinic start generated code]*/
@@ -759,7 +759,7 @@ _codecs.utf_32_encode
 static PyObject *
 _codecs_utf_32_encode_impl(PyObject *module, PyObject *str,
                            const char *errors, int byteorder)
-/*[clinic end generated code: output=5c760da0c09a8b83 input=c5e77da82fbe5c2a]*/
+/*[clinic end generated code: output=5c760da0c09a8b83 input=8ec4c64d983bc52b]*/
 {
     return codec_tuple(_PyUnicode_EncodeUTF32(str, errors, byteorder),
                        PyUnicode_GET_LENGTH(str));
@@ -768,14 +768,14 @@ _codecs_utf_32_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.utf_32_le_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_utf_32_le_encode_impl(PyObject *module, PyObject *str,
                               const char *errors)
-/*[clinic end generated code: output=b65cd176de8e36d6 input=9993b25fe0877848]*/
+/*[clinic end generated code: output=b65cd176de8e36d6 input=f0918d41de3eb1b1]*/
 {
     return codec_tuple(_PyUnicode_EncodeUTF32(str, errors, -1),
                        PyUnicode_GET_LENGTH(str));
@@ -784,14 +784,14 @@ _codecs_utf_32_le_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.utf_32_be_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_utf_32_be_encode_impl(PyObject *module, PyObject *str,
                               const char *errors)
-/*[clinic end generated code: output=1d9e71a9358709e9 input=d3e0ccaa02920431]*/
+/*[clinic end generated code: output=1d9e71a9358709e9 input=967a99a95748b557]*/
 {
     return codec_tuple(_PyUnicode_EncodeUTF32(str, errors, +1),
                        PyUnicode_GET_LENGTH(str));
@@ -800,14 +800,14 @@ _codecs_utf_32_be_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.unicode_escape_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_unicode_escape_encode_impl(PyObject *module, PyObject *str,
                                    const char *errors)
-/*[clinic end generated code: output=66271b30bc4f7a3c input=65d9eefca65b455a]*/
+/*[clinic end generated code: output=66271b30bc4f7a3c input=8c4de07597054e33]*/
 {
     return codec_tuple(PyUnicode_AsUnicodeEscapeString(str),
                        PyUnicode_GET_LENGTH(str));
@@ -816,14 +816,14 @@ _codecs_unicode_escape_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.raw_unicode_escape_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_raw_unicode_escape_encode_impl(PyObject *module, PyObject *str,
                                        const char *errors)
-/*[clinic end generated code: output=a66a806ed01c830a input=5aa33e4a133391ab]*/
+/*[clinic end generated code: output=a66a806ed01c830a input=4aa6f280d78e4574]*/
 {
     return codec_tuple(PyUnicode_AsRawUnicodeEscapeString(str),
                        PyUnicode_GET_LENGTH(str));
@@ -832,14 +832,14 @@ _codecs_raw_unicode_escape_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.latin_1_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_latin_1_encode_impl(PyObject *module, PyObject *str,
                             const char *errors)
-/*[clinic end generated code: output=2c28c83a27884e08 input=30b11c9e49a65150]*/
+/*[clinic end generated code: output=2c28c83a27884e08 input=ec3ef74bf85c5c5d]*/
 {
     return codec_tuple(_PyUnicode_AsLatin1String(str, errors),
                        PyUnicode_GET_LENGTH(str));
@@ -848,14 +848,14 @@ _codecs_latin_1_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.ascii_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_ascii_encode_impl(PyObject *module, PyObject *str,
                           const char *errors)
-/*[clinic end generated code: output=b5e035182d33befc input=843a1d268e6dfa8e]*/
+/*[clinic end generated code: output=b5e035182d33befc input=93e6e602838bd3de]*/
 {
     return codec_tuple(_PyUnicode_AsASCIIString(str, errors),
                        PyUnicode_GET_LENGTH(str));
@@ -864,15 +864,15 @@ _codecs_ascii_encode_impl(PyObject *module, PyObject *str,
 /*[clinic input]
 _codecs.charmap_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
-    mapping: object = NULL
+    errors: str(accept={str, NoneType}) = None
+    mapping: object = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_charmap_encode_impl(PyObject *module, PyObject *str,
                             const char *errors, PyObject *mapping)
-/*[clinic end generated code: output=047476f48495a9e9 input=0752cde07a6d6d00]*/
+/*[clinic end generated code: output=047476f48495a9e9 input=2a98feae73dadce8]*/
 {
     if (mapping == Py_None)
         mapping = NULL;
@@ -899,13 +899,13 @@ _codecs_charmap_build_impl(PyObject *module, PyObject *map)
 /*[clinic input]
 _codecs.mbcs_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_mbcs_encode_impl(PyObject *module, PyObject *str, const char *errors)
-/*[clinic end generated code: output=76e2e170c966c080 input=de471e0815947553]*/
+/*[clinic end generated code: output=76e2e170c966c080 input=2e932fc289ea5a5b]*/
 {
     return codec_tuple(PyUnicode_EncodeCodePage(CP_ACP, str, errors),
                        PyUnicode_GET_LENGTH(str));
@@ -914,13 +914,13 @@ _codecs_mbcs_encode_impl(PyObject *module, PyObject *str, const char *errors)
 /*[clinic input]
 _codecs.oem_encode
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_oem_encode_impl(PyObject *module, PyObject *str, const char *errors)
-/*[clinic end generated code: output=65d5982c737de649 input=3fc5f0028aad3cda]*/
+/*[clinic end generated code: output=65d5982c737de649 input=9eac86dc21eb14f2]*/
 {
     return codec_tuple(PyUnicode_EncodeCodePage(CP_OEMCP, str, errors),
         PyUnicode_GET_LENGTH(str));
@@ -930,14 +930,14 @@ _codecs_oem_encode_impl(PyObject *module, PyObject *str, const char *errors)
 _codecs.code_page_encode
     code_page: int
     str: unicode
-    errors: str(accept={str, NoneType}) = NULL
+    errors: str(accept={str, NoneType}) = None
     /
 [clinic start generated code]*/
 
 static PyObject *
 _codecs_code_page_encode_impl(PyObject *module, int code_page, PyObject *str,
                               const char *errors)
-/*[clinic end generated code: output=45673f6085657a9e input=786421ae617d680b]*/
+/*[clinic end generated code: output=45673f6085657a9e input=7d18a33bc8cd0f94]*/
 {
     return codec_tuple(PyUnicode_EncodeCodePage(code_page, str, errors),
                        PyUnicode_GET_LENGTH(str));

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3202,7 +3202,7 @@ _curses_initscr_impl(PyObject *module)
 /*[clinic input]
 _curses.setupterm
 
-    term: str(accept={str, NoneType}) = NULL
+    term: str(accept={str, NoneType}) = None
         Terminal name.
         If omitted, the value of the TERM environment variable will be used.
     fd: int = -1
@@ -3214,7 +3214,7 @@ Initialize the terminal.
 
 static PyObject *
 _curses_setupterm_impl(PyObject *module, const char *term, int fd)
-/*[clinic end generated code: output=4584e587350f2848 input=8ac5f78ec6268be3]*/
+/*[clinic end generated code: output=4584e587350f2848 input=4511472766af0c12]*/
 {
     int err;
 

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -2465,10 +2465,10 @@ treebuilder_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 /*[clinic input]
 _elementtree.TreeBuilder.__init__
 
-    element_factory: object = NULL
+    element_factory: object = None
     *
-    comment_factory: object = NULL
-    pi_factory: object = NULL
+    comment_factory: object = None
+    pi_factory: object = None
     insert_comments: bool = False
     insert_pis: bool = False
 
@@ -2480,16 +2480,16 @@ _elementtree_TreeBuilder___init___impl(TreeBuilderObject *self,
                                        PyObject *comment_factory,
                                        PyObject *pi_factory,
                                        int insert_comments, int insert_pis)
-/*[clinic end generated code: output=8571d4dcadfdf952 input=1f967b5c245e0a71]*/
+/*[clinic end generated code: output=8571d4dcadfdf952 input=ae98a94df20b5cc3]*/
 {
-    if (element_factory && element_factory != Py_None) {
+    if (element_factory != Py_None) {
         Py_INCREF(element_factory);
         Py_XSETREF(self->element_factory, element_factory);
     } else {
         Py_CLEAR(self->element_factory);
     }
 
-    if (!comment_factory || comment_factory == Py_None) {
+    if (comment_factory == Py_None) {
         elementtreestate *st = ET_STATE_GLOBAL;
         comment_factory = st->comment_factory;
     }
@@ -2502,7 +2502,7 @@ _elementtree_TreeBuilder___init___impl(TreeBuilderObject *self,
         self->insert_comments = 0;
     }
 
-    if (!pi_factory || pi_factory == Py_None) {
+    if (pi_factory == Py_None) {
         elementtreestate *st = ET_STATE_GLOBAL;
         pi_factory = st->pi_factory;
     }
@@ -3708,14 +3708,14 @@ _elementtree.XMLParser.__init__
 
     *
     target: object = NULL
-    encoding: str(accept={str, NoneType}) = NULL
+    encoding: str(accept={str, NoneType}) = None
 
 [clinic start generated code]*/
 
 static int
 _elementtree_XMLParser___init___impl(XMLParserObject *self, PyObject *target,
                                      const char *encoding)
-/*[clinic end generated code: output=3ae45ec6cdf344e4 input=96288fcba916cfce]*/
+/*[clinic end generated code: output=3ae45ec6cdf344e4 input=53e35a829ae043e8]*/
 {
     self->entity = PyDict_New();
     if (!self->entity)

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -448,7 +448,7 @@ EVPnew(const EVP_MD *digest,
 _hashlib.new as EVP_new
 
     name as name_obj: object
-    string as data_obj: object(py_default="b''") = NULL
+    string as data_obj: object(c_default="NULL") = b''
 
 Return a new hash object using the named algorithm.
 
@@ -460,7 +460,7 @@ The MD5 and SHA1 algorithms are always supported.
 
 static PyObject *
 EVP_new_impl(PyObject *module, PyObject *name_obj, PyObject *data_obj)
-/*[clinic end generated code: output=9e7cf664e04b0226 input=1c46e40e0fec91f3]*/
+/*[clinic end generated code: output=9e7cf664e04b0226 input=7eb79bf30058bd02]*/
 {
     Py_buffer view = { 0 };
     PyObject *ret_obj;

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -103,9 +103,9 @@ _io.open
     file: object
     mode: str = "r"
     buffering: int = -1
-    encoding: str(accept={str, NoneType}) = NULL
-    errors: str(accept={str, NoneType}) = NULL
-    newline: str(accept={str, NoneType}) = NULL
+    encoding: str(accept={str, NoneType}) = None
+    errors: str(accept={str, NoneType}) = None
+    newline: str(accept={str, NoneType}) = None
     closefd: bool(accept={int}) = True
     opener: object = None
 
@@ -233,7 +233,7 @@ static PyObject *
 _io_open_impl(PyObject *module, PyObject *file, const char *mode,
               int buffering, const char *encoding, const char *errors,
               const char *newline, int closefd, PyObject *opener)
-/*[clinic end generated code: output=aefafc4ce2b46dc0 input=03da2940c8a65871]*/
+/*[clinic end generated code: output=aefafc4ce2b46dc0 input=7295902222e6b311]*/
 {
     unsigned i;
 

--- a/Modules/_io/clinic/fileio.c.h
+++ b/Modules/_io/clinic/fileio.c.h
@@ -408,7 +408,7 @@ static PyObject *
 _io_FileIO_truncate(fileio *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *posobj = NULL;
+    PyObject *posobj = Py_None;
 
     if (!_PyArg_CheckPositional("truncate", nargs, 0, 1)) {
         goto exit;
@@ -447,4 +447,4 @@ _io_FileIO_isatty(fileio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO_FILEIO_TRUNCATE_METHODDEF
     #define _IO_FILEIO_TRUNCATE_METHODDEF
 #endif /* !defined(_IO_FILEIO_TRUNCATE_METHODDEF) */
-/*[clinic end generated code: output=a7e9cca3613660fb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e7682d0a3264d284 input=a9049054013a1b77]*/

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -979,7 +979,7 @@ _io_FileIO_tell_impl(fileio *self)
 #ifdef HAVE_FTRUNCATE
 /*[clinic input]
 _io.FileIO.truncate
-    size as posobj: object = NULL
+    size as posobj: object = None
     /
 
 Truncate the file to at most size bytes and return the truncated size.
@@ -990,7 +990,7 @@ The current file position is changed to the value of size.
 
 static PyObject *
 _io_FileIO_truncate_impl(fileio *self, PyObject *posobj)
-/*[clinic end generated code: output=e49ca7a916c176fa input=9026af44686b7318]*/
+/*[clinic end generated code: output=e49ca7a916c176fa input=b0ac133939823875]*/
 {
     Py_off_t pos;
     int ret;
@@ -1002,7 +1002,7 @@ _io_FileIO_truncate_impl(fileio *self, PyObject *posobj)
     if (!self->writable)
         return err_mode("writing");
 
-    if (posobj == Py_None || posobj == NULL) {
+    if (posobj == Py_None) {
         /* Get the current position. */
         posobj = portable_lseek(self, NULL, 1);
         if (posobj == NULL)

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -991,9 +991,9 @@ _textiowrapper_fix_encoder_state(textio *self)
 /*[clinic input]
 _io.TextIOWrapper.__init__
     buffer: object
-    encoding: str(accept={str, NoneType}) = NULL
+    encoding: str(accept={str, NoneType}) = None
     errors: object = None
-    newline: str(accept={str, NoneType}) = NULL
+    newline: str(accept={str, NoneType}) = None
     line_buffering: bool(accept={int}) = False
     write_through: bool(accept={int}) = False
 
@@ -1032,7 +1032,7 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
                                 const char *encoding, PyObject *errors,
                                 const char *newline, int line_buffering,
                                 int write_through)
-/*[clinic end generated code: output=72267c0c01032ed2 input=1c5dd5d78bfcc675]*/
+/*[clinic end generated code: output=72267c0c01032ed2 input=77d8696d1a1f460b]*/
 {
     PyObject *raw, *codec_info = NULL;
     _PyIO_State *state = NULL;

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1142,7 +1142,7 @@ _Pickler_SetProtocol(PicklerObject *self, PyObject *protocol, int fix_imports)
 {
     long proto;
 
-    if (protocol == NULL || protocol == Py_None) {
+    if (protocol == Py_None) {
         proto = DEFAULT_PROTOCOL;
     }
     else {
@@ -4640,9 +4640,9 @@ Pickler_clear(PicklerObject *self)
 _pickle.Pickler.__init__
 
   file: object
-  protocol: object = NULL
+  protocol: object = None
   fix_imports: bool = True
-  buffer_callback: object = NULL
+  buffer_callback: object = None
 
 This takes a binary file for writing a pickle data stream.
 
@@ -4680,7 +4680,7 @@ static int
 _pickle_Pickler___init___impl(PicklerObject *self, PyObject *file,
                               PyObject *protocol, int fix_imports,
                               PyObject *buffer_callback)
-/*[clinic end generated code: output=0abedc50590d259b input=9a43a1c50ab91652]*/
+/*[clinic end generated code: output=0abedc50590d259b input=bb886e00443a7811]*/
 {
     _Py_IDENTIFIER(persistent_id);
     _Py_IDENTIFIER(dispatch_table);
@@ -7202,7 +7202,7 @@ _pickle.Unpickler.__init__
   fix_imports: bool = True
   encoding: str = 'ASCII'
   errors: str = 'strict'
-  buffers: object = NULL
+  buffers: object(c_default="NULL") = ()
 
 This takes a binary file for reading a pickle data stream.
 
@@ -7230,7 +7230,7 @@ static int
 _pickle_Unpickler___init___impl(UnpicklerObject *self, PyObject *file,
                                 int fix_imports, const char *encoding,
                                 const char *errors, PyObject *buffers)
-/*[clinic end generated code: output=09f0192649ea3f85 input=da4b62d9edb68700]*/
+/*[clinic end generated code: output=09f0192649ea3f85 input=ca4c1faea9553121]*/
 {
     _Py_IDENTIFIER(persistent_load);
 
@@ -7622,10 +7622,10 @@ _pickle.dump
 
   obj: object
   file: object
-  protocol: object = NULL
+  protocol: object = None
   *
   fix_imports: bool = True
-  buffer_callback: object = NULL
+  buffer_callback: object = None
 
 Write a pickled representation of obj to the open file object file.
 
@@ -7660,7 +7660,7 @@ static PyObject *
 _pickle_dump_impl(PyObject *module, PyObject *obj, PyObject *file,
                   PyObject *protocol, int fix_imports,
                   PyObject *buffer_callback)
-/*[clinic end generated code: output=706186dba996490c input=2f035f02cc0f9547]*/
+/*[clinic end generated code: output=706186dba996490c input=cfdcaf573ed6e46c]*/
 {
     PicklerObject *pickler = _Pickler_New();
 
@@ -7695,10 +7695,10 @@ _pickle_dump_impl(PyObject *module, PyObject *obj, PyObject *file,
 _pickle.dumps
 
   obj: object
-  protocol: object = NULL
+  protocol: object = None
   *
   fix_imports: bool = True
-  buffer_callback: object = NULL
+  buffer_callback: object = None
 
 Return the pickled representation of the object as a bytes object.
 
@@ -7724,7 +7724,7 @@ into *file* as part of the pickle stream.  It is an error if
 static PyObject *
 _pickle_dumps_impl(PyObject *module, PyObject *obj, PyObject *protocol,
                    int fix_imports, PyObject *buffer_callback)
-/*[clinic end generated code: output=fbab0093a5580fdf input=001f167df711b9f1]*/
+/*[clinic end generated code: output=fbab0093a5580fdf input=9f334d535ff7194f]*/
 {
     PyObject *result;
     PicklerObject *pickler = _Pickler_New();
@@ -7759,7 +7759,7 @@ _pickle.load
   fix_imports: bool = True
   encoding: str = 'ASCII'
   errors: str = 'strict'
-  buffers: object = NULL
+  buffers: object(c_default="NULL") = ()
 
 Read and return an object from the pickle data stored in a file.
 
@@ -7790,7 +7790,7 @@ static PyObject *
 _pickle_load_impl(PyObject *module, PyObject *file, int fix_imports,
                   const char *encoding, const char *errors,
                   PyObject *buffers)
-/*[clinic end generated code: output=250452d141c23e76 input=29fae982fe778156]*/
+/*[clinic end generated code: output=250452d141c23e76 input=46c7c31c92f4f371]*/
 {
     PyObject *result;
     UnpicklerObject *unpickler = _Unpickler_New();
@@ -7827,7 +7827,7 @@ _pickle.loads
   fix_imports: bool = True
   encoding: str = 'ASCII'
   errors: str = 'strict'
-  buffers: object = NULL
+  buffers: object(c_default="NULL") = ()
 
 Read and return an object from the given pickle data.
 
@@ -7849,7 +7849,7 @@ static PyObject *
 _pickle_loads_impl(PyObject *module, PyObject *data, int fix_imports,
                    const char *encoding, const char *errors,
                    PyObject *buffers)
-/*[clinic end generated code: output=82ac1e6b588e6d02 input=c6004393f8276867]*/
+/*[clinic end generated code: output=82ac1e6b588e6d02 input=9c2ab6a0960185ea]*/
 {
     PyObject *result;
     UnpicklerObject *unpickler = _Unpickler_New();

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3883,15 +3883,15 @@ error:
 /*[clinic input]
 _ssl._SSLContext.load_cert_chain
     certfile: object
-    keyfile: object = NULL
-    password: object = NULL
+    keyfile: object = None
+    password: object = None
 
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLContext_load_cert_chain_impl(PySSLContext *self, PyObject *certfile,
                                       PyObject *keyfile, PyObject *password)
-/*[clinic end generated code: output=9480bc1c380e2095 input=7cf9ac673cbee6fc]*/
+/*[clinic end generated code: output=9480bc1c380e2095 input=30bc7e967ea01a58]*/
 {
     PyObject *certfile_bytes = NULL, *keyfile_bytes = NULL;
     pem_password_cb *orig_passwd_cb = SSL_CTX_get_default_passwd_cb(self->ctx);
@@ -3917,7 +3917,7 @@ _ssl__SSLContext_load_cert_chain_impl(PySSLContext *self, PyObject *certfile,
         }
         goto error;
     }
-    if (password && password != Py_None) {
+    if (password != Py_None) {
         if (PyCallable_Check(password)) {
             pw_info.callable = password;
         } else if (!_pwinfo_set(&pw_info, password,
@@ -4075,9 +4075,9 @@ _add_ca_certs(PySSLContext *self, void *data, Py_ssize_t len,
 
 /*[clinic input]
 _ssl._SSLContext.load_verify_locations
-    cafile: object = NULL
-    capath: object = NULL
-    cadata: object = NULL
+    cafile: object = None
+    capath: object = None
+    cadata: object = None
 
 [clinic start generated code]*/
 
@@ -4086,7 +4086,7 @@ _ssl__SSLContext_load_verify_locations_impl(PySSLContext *self,
                                             PyObject *cafile,
                                             PyObject *capath,
                                             PyObject *cadata)
-/*[clinic end generated code: output=454c7e41230ca551 input=997f1fb3a784ef88]*/
+/*[clinic end generated code: output=454c7e41230ca551 input=42ecfe258233e194]*/
 {
     PyObject *cafile_bytes = NULL, *capath_bytes = NULL;
     const char *cafile_buf = NULL, *capath_buf = NULL;

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3121,8 +3121,8 @@ _tkinter__flatten(PyObject *module, PyObject *item)
 /*[clinic input]
 _tkinter.create
 
-    screenName: str(accept={str, NoneType}) = NULL
-    baseName: str = NULL
+    screenName: str(accept={str, NoneType}) = None
+    baseName: str = ""
     className: str = "Tk"
     interactive: bool(accept={int}) = False
     wantobjects: bool(accept={int}) = False
@@ -3130,7 +3130,7 @@ _tkinter.create
         if false, then Tk_Init() doesn't get called
     sync: bool(accept={int}) = False
         if true, then pass -sync to wish
-    use: str(accept={str, NoneType}) = NULL
+    use: str(accept={str, NoneType}) = None
         if not None, then pass -use to wish
     /
 
@@ -3141,7 +3141,7 @@ _tkinter_create_impl(PyObject *module, const char *screenName,
                      const char *baseName, const char *className,
                      int interactive, int wantobjects, int wantTk, int sync,
                      const char *use)
-/*[clinic end generated code: output=e3315607648e6bb4 input=431907c134c80085]*/
+/*[clinic end generated code: output=e3315607648e6bb4 input=da9b17ee7358d862]*/
 {
     /* XXX baseName is not used anymore;
      * try getting rid of it. */

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -548,7 +548,7 @@ errorexit:
 _multibytecodec.MultibyteCodec.encode
 
   input: object
-  errors: str(accept={str, NoneType}) = NULL
+  errors: str(accept={str, NoneType}) = None
 
 Return an encoded string version of `input'.
 
@@ -562,7 +562,7 @@ static PyObject *
 _multibytecodec_MultibyteCodec_encode_impl(MultibyteCodecObject *self,
                                            PyObject *input,
                                            const char *errors)
-/*[clinic end generated code: output=7b26652045ba56a9 input=05f6ced3c8dd0582]*/
+/*[clinic end generated code: output=7b26652045ba56a9 input=606d0e128a577bae]*/
 {
     MultibyteCodec_State state;
     PyObject *errorcb, *r, *ucvt;
@@ -617,7 +617,7 @@ errorexit:
 _multibytecodec.MultibyteCodec.decode
 
   input: Py_buffer
-  errors: str(accept={str, NoneType}) = NULL
+  errors: str(accept={str, NoneType}) = None
 
 Decodes 'input'.
 
@@ -631,7 +631,7 @@ static PyObject *
 _multibytecodec_MultibyteCodec_decode_impl(MultibyteCodecObject *self,
                                            Py_buffer *input,
                                            const char *errors)
-/*[clinic end generated code: output=ff419f65bad6cc77 input=a7d45f87f75e5e02]*/
+/*[clinic end generated code: output=ff419f65bad6cc77 input=e0c78fc7ab190def]*/
 {
     MultibyteCodec_State state;
     MultibyteDecodeBuffer buf;

--- a/Modules/clinic/_asynciomodule.c.h
+++ b/Modules/clinic/_asynciomodule.c.h
@@ -119,7 +119,7 @@ PyDoc_STRVAR(_asyncio_Future_set_exception__doc__,
     {"set_exception", (PyCFunction)_asyncio_Future_set_exception, METH_O, _asyncio_Future_set_exception__doc__},
 
 PyDoc_STRVAR(_asyncio_Future_add_done_callback__doc__,
-"add_done_callback($self, fn, /, *, context=None)\n"
+"add_done_callback($self, fn, /, *, context=<unrepresentable>)\n"
 "--\n"
 "\n"
 "Add a callback to be run when the future becomes done.\n"
@@ -832,4 +832,4 @@ _asyncio__leave_task(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=51c50219f6a0863a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=585ba1f8de5b4103 input=a9049054013a1b77]*/

--- a/Modules/clinic/_codecsmodule.c.h
+++ b/Modules/clinic/_codecsmodule.c.h
@@ -1434,7 +1434,7 @@ _codecs_charmap_decode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
-    PyObject *mapping = NULL;
+    PyObject *mapping = Py_None;
 
     if (!_PyArg_CheckPositional("charmap_decode", nargs, 1, 3)) {
         goto exit;
@@ -2542,7 +2542,7 @@ _codecs_charmap_encode(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-    PyObject *mapping = NULL;
+    PyObject *mapping = Py_None;
 
     if (!_PyArg_CheckPositional("charmap_encode", nargs, 1, 3)) {
         goto exit;
@@ -2922,4 +2922,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=59726a305e4ec24a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=51b42d170889524c input=a9049054013a1b77]*/

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -650,9 +650,9 @@ _elementtree_TreeBuilder___init__(PyObject *self, PyObject *args, PyObject *kwar
     PyObject * const *fastargs;
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t noptargs = nargs + (kwargs ? PyDict_GET_SIZE(kwargs) : 0) - 0;
-    PyObject *element_factory = NULL;
-    PyObject *comment_factory = NULL;
-    PyObject *pi_factory = NULL;
+    PyObject *element_factory = Py_None;
+    PyObject *comment_factory = Py_None;
+    PyObject *pi_factory = Py_None;
     int insert_comments = 0;
     int insert_pis = 0;
 
@@ -969,4 +969,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=50e0b1954c5f9e0f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1443ed7bb9f9e03e input=a9049054013a1b77]*/

--- a/Modules/clinic/_pickle.c.h
+++ b/Modules/clinic/_pickle.c.h
@@ -112,9 +112,9 @@ _pickle_Pickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t noptargs = nargs + (kwargs ? PyDict_GET_SIZE(kwargs) : 0) - 1;
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     fastargs = _PyArg_UnpackKeywords(_PyTuple_CAST(args)->ob_item, nargs, kwargs, NULL, &_parser, 1, 4, 0, argsbuf);
     if (!fastargs) {
@@ -292,7 +292,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_Unpickler___init____doc__,
 "Unpickler(file, *, fix_imports=True, encoding=\'ASCII\', errors=\'strict\',\n"
-"          buffers=None)\n"
+"          buffers=())\n"
 "--\n"
 "\n"
 "This takes a binary file for reading a pickle data stream.\n"
@@ -502,9 +502,9 @@ _pickle_dump(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
     PyObject *obj;
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 2, 3, 0, argsbuf);
     if (!args) {
@@ -582,9 +582,9 @@ _pickle_dumps(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
     PyObject *argsbuf[4];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *obj;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 2, 0, argsbuf);
     if (!args) {
@@ -623,7 +623,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_load__doc__,
 "load($module, /, file, *, fix_imports=True, encoding=\'ASCII\',\n"
-"     errors=\'strict\', buffers=None)\n"
+"     errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the pickle data stored in a file.\n"
@@ -735,7 +735,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_loads__doc__,
 "loads($module, /, data, *, fix_imports=True, encoding=\'ASCII\',\n"
-"      errors=\'strict\', buffers=None)\n"
+"      errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the given pickle data.\n"
@@ -835,4 +835,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=17f6a76ebd94325d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=de075ec48d4ee0e1 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -571,8 +571,8 @@ _ssl__SSLContext_load_cert_chain(PySSLContext *self, PyObject *const *args, Py_s
     PyObject *argsbuf[3];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *certfile;
-    PyObject *keyfile = NULL;
-    PyObject *password = NULL;
+    PyObject *keyfile = Py_None;
+    PyObject *password = Py_None;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 3, 0, argsbuf);
     if (!args) {
@@ -618,9 +618,9 @@ _ssl__SSLContext_load_verify_locations(PySSLContext *self, PyObject *const *args
     static _PyArg_Parser _parser = {NULL, _keywords, "load_verify_locations", 0};
     PyObject *argsbuf[3];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
-    PyObject *cafile = NULL;
-    PyObject *capath = NULL;
-    PyObject *cadata = NULL;
+    PyObject *cafile = Py_None;
+    PyObject *capath = Py_None;
+    PyObject *cadata = Py_None;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 0, 3, 0, argsbuf);
     if (!args) {
@@ -1482,4 +1482,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=aa4947067c3fef2d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a4aeb3f92a091c64 input=a9049054013a1b77]*/

--- a/Modules/clinic/_tkinter.c.h
+++ b/Modules/clinic/_tkinter.c.h
@@ -674,7 +674,7 @@ PyDoc_STRVAR(_tkinter__flatten__doc__,
     {"_flatten", (PyCFunction)_tkinter__flatten, METH_O, _tkinter__flatten__doc__},
 
 PyDoc_STRVAR(_tkinter_create__doc__,
-"create($module, screenName=None, baseName=None, className=\'Tk\',\n"
+"create($module, screenName=None, baseName=\'\', className=\'Tk\',\n"
 "       interactive=False, wantobjects=False, wantTk=True, sync=False,\n"
 "       use=None, /)\n"
 "--\n"
@@ -702,7 +702,7 @@ _tkinter_create(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *screenName = NULL;
-    const char *baseName = NULL;
+    const char *baseName = "";
     const char *className = "Tk";
     int interactive = 0;
     int wantobjects = 0;
@@ -912,4 +912,4 @@ exit:
 #ifndef _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
     #define _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
 #endif /* !defined(_TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF) */
-/*[clinic end generated code: output=da0115c470aac1c0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=492b8b833fe54bc9 input=a9049054013a1b77]*/

--- a/Modules/clinic/binascii.c.h
+++ b/Modules/clinic/binascii.c.h
@@ -432,7 +432,7 @@ exit:
 }
 
 PyDoc_STRVAR(binascii_b2a_hex__doc__,
-"b2a_hex($module, /, data, sep=None, bytes_per_sep=1)\n"
+"b2a_hex($module, /, data, sep=<unrepresentable>, bytes_per_sep=1)\n"
 "--\n"
 "\n"
 "Hexadecimal representation of binary data.\n"
@@ -515,7 +515,7 @@ exit:
 }
 
 PyDoc_STRVAR(binascii_hexlify__doc__,
-"hexlify($module, /, data, sep=None, bytes_per_sep=1)\n"
+"hexlify($module, /, data, sep=<unrepresentable>, bytes_per_sep=1)\n"
 "--\n"
 "\n"
 "Hexadecimal representation of binary data.\n"
@@ -801,4 +801,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=e13bd02ac40496f0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ec26d03c2007eaac input=a9049054013a1b77]*/

--- a/Modules/clinic/cmathmodule.c.h
+++ b/Modules/clinic/cmathmodule.c.h
@@ -648,10 +648,10 @@ exit:
 }
 
 PyDoc_STRVAR(cmath_log__doc__,
-"log($module, x, y_obj=None, /)\n"
+"log($module, z, base=<unrepresentable>, /)\n"
 "--\n"
 "\n"
-"The logarithm of z to the given base.\n"
+"log(z[, base]) -> the logarithm of z to the given base.\n"
 "\n"
 "If the base not specified, returns the natural logarithm (base e) of z.");
 
@@ -968,4 +968,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3ab228947d1709cc input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3edc4484b10ae752 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1971,8 +1971,8 @@ os_uname(PyObject *module, PyObject *Py_UNUSED(ignored))
 #endif /* defined(HAVE_UNAME) */
 
 PyDoc_STRVAR(os_utime__doc__,
-"utime($module, /, path, times=None, *, ns=None, dir_fd=None,\n"
-"      follow_symlinks=True)\n"
+"utime($module, /, path, times=None, *, ns=<unrepresentable>,\n"
+"      dir_fd=None, follow_symlinks=True)\n"
 "--\n"
 "\n"
 "Set the access and modified time of path.\n"
@@ -2015,7 +2015,7 @@ os_utime(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kw
     PyObject *argsbuf[5];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     path_t path = PATH_T_INITIALIZE("utime", "path", 0, PATH_UTIME_HAVE_FD);
-    PyObject *times = NULL;
+    PyObject *times = Py_None;
     PyObject *ns = NULL;
     int dir_fd = DEFAULT_DIR_FD;
     int follow_symlinks = 1;
@@ -2208,8 +2208,8 @@ exit:
 
 PyDoc_STRVAR(os_posix_spawn__doc__,
 "posix_spawn($module, path, argv, env, /, *, file_actions=(),\n"
-"            setpgroup=None, resetids=False, setsid=False,\n"
-"            setsigmask=(), setsigdef=(), scheduler=None)\n"
+"            setpgroup=<unrepresentable>, resetids=False, setsid=False,\n"
+"            setsigmask=(), setsigdef=(), scheduler=<unrepresentable>)\n"
 "--\n"
 "\n"
 "Execute the program specified by path in a new process.\n"
@@ -2345,8 +2345,8 @@ exit:
 
 PyDoc_STRVAR(os_posix_spawnp__doc__,
 "posix_spawnp($module, path, argv, env, /, *, file_actions=(),\n"
-"             setpgroup=None, resetids=False, setsid=False,\n"
-"             setsigmask=(), setsigdef=(), scheduler=None)\n"
+"             setpgroup=<unrepresentable>, resetids=False, setsid=False,\n"
+"             setsigmask=(), setsigdef=(), scheduler=<unrepresentable>)\n"
 "--\n"
 "\n"
 "Execute the program specified by path in a new process.\n"
@@ -2598,8 +2598,9 @@ exit:
 #if defined(HAVE_FORK)
 
 PyDoc_STRVAR(os_register_at_fork__doc__,
-"register_at_fork($module, /, *, before=None, after_in_child=None,\n"
-"                 after_in_parent=None)\n"
+"register_at_fork($module, /, *, before=<unrepresentable>,\n"
+"                 after_in_child=<unrepresentable>,\n"
+"                 after_in_parent=<unrepresentable>)\n"
 "--\n"
 "\n"
 "Register callables to be called when forking a new process.\n"
@@ -6854,10 +6855,8 @@ os_abort(PyObject *module, PyObject *Py_UNUSED(ignored))
 #if defined(MS_WINDOWS)
 
 PyDoc_STRVAR(os_startfile__doc__,
-"startfile($module, /, filepath, operation=None)\n"
+"startfile($module, /, filepath, operation=<unrepresentable>)\n"
 "--\n"
-"\n"
-"startfile(filepath [, operation])\n"
 "\n"
 "Start a file with its associated application.\n"
 "\n"
@@ -8724,4 +8723,4 @@ exit:
 #ifndef OS__REMOVE_DLL_DIRECTORY_METHODDEF
     #define OS__REMOVE_DLL_DIRECTORY_METHODDEF
 #endif /* !defined(OS__REMOVE_DLL_DIRECTORY_METHODDEF) */
-/*[clinic end generated code: output=ba6bac1702f55dbb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1ded1fbc8fd37b27 input=a9049054013a1b77]*/

--- a/Modules/clinic/pyexpat.c.h
+++ b/Modules/clinic/pyexpat.c.h
@@ -133,7 +133,8 @@ pyexpat_xmlparser_GetInputContext(xmlparseobject *self, PyObject *Py_UNUSED(igno
 }
 
 PyDoc_STRVAR(pyexpat_xmlparser_ExternalEntityParserCreate__doc__,
-"ExternalEntityParserCreate($self, context, encoding=None, /)\n"
+"ExternalEntityParserCreate($self, context, encoding=<unrepresentable>,\n"
+"                           /)\n"
 "--\n"
 "\n"
 "Create a parser for parsing an external entity based on the information passed to the ExternalEntityRefHandler.");
@@ -280,7 +281,7 @@ exit:
 
 PyDoc_STRVAR(pyexpat_ParserCreate__doc__,
 "ParserCreate($module, /, encoding=None, namespace_separator=None,\n"
-"             intern=None)\n"
+"             intern=<unrepresentable>)\n"
 "--\n"
 "\n"
 "Return a new XML parser object.");
@@ -401,4 +402,4 @@ exit:
 #ifndef PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
     #define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
 #endif /* !defined(PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF) */
-/*[clinic end generated code: output=133a4105d508ebec input=a9049054013a1b77]*/
+/*[clinic end generated code: output=68ce25024280af41 input=a9049054013a1b77]*/

--- a/Modules/clinic/unicodedata.c.h
+++ b/Modules/clinic/unicodedata.c.h
@@ -3,7 +3,7 @@ preserve
 [clinic start generated code]*/
 
 PyDoc_STRVAR(unicodedata_UCD_decimal__doc__,
-"decimal($self, chr, default=None, /)\n"
+"decimal($self, chr, default=<unrepresentable>, /)\n"
 "--\n"
 "\n"
 "Converts a Unicode character into its equivalent decimal value.\n"
@@ -53,7 +53,7 @@ exit:
 }
 
 PyDoc_STRVAR(unicodedata_UCD_digit__doc__,
-"digit($self, chr, default=None, /)\n"
+"digit($self, chr, default=<unrepresentable>, /)\n"
 "--\n"
 "\n"
 "Converts a Unicode character into its equivalent digit value.\n"
@@ -102,7 +102,7 @@ exit:
 }
 
 PyDoc_STRVAR(unicodedata_UCD_numeric__doc__,
-"numeric($self, chr, default=None, /)\n"
+"numeric($self, chr, default=<unrepresentable>, /)\n"
 "--\n"
 "\n"
 "Converts a Unicode character into its equivalent numeric value.\n"
@@ -481,7 +481,7 @@ exit:
 }
 
 PyDoc_STRVAR(unicodedata_UCD_name__doc__,
-"name($self, chr, default=None, /)\n"
+"name($self, chr, default=<unrepresentable>, /)\n"
 "--\n"
 "\n"
 "Returns the name assigned to the character chr as a string.\n"
@@ -559,4 +559,4 @@ unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3238f76814fb48d1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=10c23477dbe8a202 input=a9049054013a1b77]*/

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -944,18 +944,18 @@ cmath_tanh_impl(PyObject *module, Py_complex z)
 /*[clinic input]
 cmath.log
 
-    x: Py_complex
-    y_obj: object = NULL
+    z as x: Py_complex
+    base as y_obj: object = NULL
     /
 
-The logarithm of z to the given base.
+log(z[, base]) -> the logarithm of z to the given base.
 
 If the base not specified, returns the natural logarithm (base e) of z.
 [clinic start generated code]*/
 
 static PyObject *
 cmath_log_impl(PyObject *module, Py_complex x, PyObject *y_obj)
-/*[clinic end generated code: output=4effdb7d258e0d94 input=ee0e823a7c6e68ea]*/
+/*[clinic end generated code: output=4effdb7d258e0d94 input=230ed3a71ecd000a]*/
 {
     Py_complex y;
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4739,7 +4739,7 @@ exit:
 os.utime
 
     path: path_t(allow_fd='PATH_UTIME_HAVE_FD')
-    times: object = NULL
+    times: object = None
     *
     ns: object = NULL
     dir_fd: dir_fd(requires='futimensat') = None
@@ -4776,7 +4776,7 @@ dir_fd and follow_symlinks may not be available on your platform.
 static PyObject *
 os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
               int dir_fd, int follow_symlinks)
-/*[clinic end generated code: output=cfcac69d027b82cf input=081cdc54ca685385]*/
+/*[clinic end generated code: output=cfcac69d027b82cf input=2fbd62a2f228f8f4]*/
 {
 #ifdef MS_WINDOWS
     HANDLE hFile;
@@ -4789,14 +4789,14 @@ os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
 
     memset(&utime, 0, sizeof(utime_t));
 
-    if (times && (times != Py_None) && ns) {
+    if (times != Py_None && ns) {
         PyErr_SetString(PyExc_ValueError,
                      "utime: you may specify either 'times'"
                      " or 'ns' but not both");
         return NULL;
     }
 
-    if (times && (times != Py_None)) {
+    if (times != Py_None) {
         time_t a_sec, m_sec;
         long a_nsec, m_nsec;
         if (!PyTuple_CheckExact(times) || (PyTuple_Size(times) != 2)) {
@@ -11576,8 +11576,6 @@ os.startfile
     filepath: path_t
     operation: Py_UNICODE = NULL
 
-startfile(filepath [, operation])
-
 Start a file with its associated application.
 
 When "operation" is not specified or "open", this acts like
@@ -11599,7 +11597,7 @@ the underlying Win32 ShellExecute function doesn't work if it is.
 static PyObject *
 os_startfile_impl(PyObject *module, path_t *filepath,
                   const Py_UNICODE *operation)
-/*[clinic end generated code: output=66dc311c94d50797 input=63950bf2986380d0]*/
+/*[clinic end generated code: output=66dc311c94d50797 input=c940888a5390f039]*/
 {
     HINSTANCE rc;
 

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1503,8 +1503,8 @@ static PyTypeObject Xmlparsetype = {
 /*[clinic input]
 pyexpat.ParserCreate
 
-    encoding: str(accept={str, NoneType}) = NULL
-    namespace_separator: str(accept={str, NoneType}) = NULL
+    encoding: str(accept={str, NoneType}) = None
+    namespace_separator: str(accept={str, NoneType}) = None
     intern: object = NULL
 
 Return a new XML parser object.
@@ -1513,7 +1513,7 @@ Return a new XML parser object.
 static PyObject *
 pyexpat_ParserCreate_impl(PyObject *module, const char *encoding,
                           const char *namespace_separator, PyObject *intern)
-/*[clinic end generated code: output=295c0cf01ab1146c input=23d29704acad385d]*/
+/*[clinic end generated code: output=295c0cf01ab1146c input=e8da8e8d7122cb5d]*/
 {
     PyObject *result;
     int intern_decref = 0;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2004,7 +2004,7 @@ do_strip(PyBytesObject *self, int striptype)
 Py_LOCAL_INLINE(PyObject *)
 do_argstrip(PyBytesObject *self, int striptype, PyObject *bytes)
 {
-    if (bytes != NULL && bytes != Py_None) {
+    if (bytes != Py_None) {
         return do_xstrip(self, striptype, bytes);
     }
     return do_strip(self, striptype);

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -868,7 +868,7 @@ exit:
 }
 
 PyDoc_STRVAR(bytearray_hex__doc__,
-"hex($self, /, sep=None, bytes_per_sep=1)\n"
+"hex($self, /, sep=<unrepresentable>, bytes_per_sep=1)\n"
 "--\n"
 "\n"
 "Create a str of hexadecimal numbers from a bytearray object.\n"
@@ -1011,4 +1011,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=09df354d3374dfb2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=508dce79cf2dffcc input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -688,7 +688,7 @@ exit:
 }
 
 PyDoc_STRVAR(bytes_hex__doc__,
-"hex($self, /, sep=None, bytes_per_sep=1)\n"
+"hex($self, /, sep=<unrepresentable>, bytes_per_sep=1)\n"
 "--\n"
 "\n"
 "Create a str of hexadecimal numbers from a bytes object.\n"
@@ -755,4 +755,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=dbed3c3ff6faa382 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ca60dfccf8d51e88 input=a9049054013a1b77]*/

--- a/Objects/clinic/floatobject.c.h
+++ b/Objects/clinic/floatobject.c.h
@@ -56,7 +56,7 @@ static PyObject *
 float___round__(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *o_ndigits = NULL;
+    PyObject *o_ndigits = Py_None;
 
     if (!_PyArg_CheckPositional("__round__", nargs, 0, 1)) {
         goto exit;
@@ -351,4 +351,4 @@ float___format__(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=cc8098eb73f1a64c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1676433b9f04fbc9 input=a9049054013a1b77]*/

--- a/Objects/clinic/memoryobject.c.h
+++ b/Objects/clinic/memoryobject.c.h
@@ -3,7 +3,7 @@ preserve
 [clinic start generated code]*/
 
 PyDoc_STRVAR(memoryview_hex__doc__,
-"hex($self, /, sep=None, bytes_per_sep=1)\n"
+"hex($self, /, sep=<unrepresentable>, bytes_per_sep=1)\n"
 "--\n"
 "\n"
 "Return the data in the buffer as a str of hexadecimal numbers.\n"
@@ -71,4 +71,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5e44e2bcf01057b5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ee265a73f68b0077 input=a9049054013a1b77]*/

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -630,7 +630,7 @@ static PyObject *
 unicode_lstrip(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *chars = NULL;
+    PyObject *chars = Py_None;
 
     if (!_PyArg_CheckPositional("lstrip", nargs, 0, 1)) {
         goto exit;
@@ -664,7 +664,7 @@ static PyObject *
 unicode_rstrip(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *chars = NULL;
+    PyObject *chars = Py_None;
 
     if (!_PyArg_CheckPositional("rstrip", nargs, 0, 1)) {
         goto exit;
@@ -1045,7 +1045,7 @@ unicode_swapcase(PyObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(unicode_maketrans__doc__,
-"maketrans(x, y=None, z=None, /)\n"
+"maketrans(x, y=<unrepresentable>, z=<unrepresentable>, /)\n"
 "--\n"
 "\n"
 "Return a translation table usable for str.translate().\n"
@@ -1232,4 +1232,4 @@ unicode_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return unicode_sizeof_impl(self);
 }
-/*[clinic end generated code: output=d9a6ee45ddd0ccfd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5e15747f78f18329 input=a9049054013a1b77]*/

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1042,7 +1042,7 @@ double_round(double x, int ndigits) {
 /*[clinic input]
 float.__round__
 
-    ndigits as o_ndigits: object = NULL
+    ndigits as o_ndigits: object = None
     /
 
 Return the Integral closest to x, rounding half toward even.
@@ -1052,13 +1052,13 @@ When an argument is passed, work like built-in round(x, ndigits).
 
 static PyObject *
 float___round___impl(PyObject *self, PyObject *o_ndigits)
-/*[clinic end generated code: output=374c36aaa0f13980 input=1ca2316b510293b8]*/
+/*[clinic end generated code: output=374c36aaa0f13980 input=fc0fe25924fbc9ed]*/
 {
     double x, rounded;
     Py_ssize_t ndigits;
 
     x = PyFloat_AsDouble(self);
-    if (o_ndigits == NULL || o_ndigits == Py_None) {
+    if (o_ndigits == Py_None) {
         /* single-argument round or with None ndigits:
          * round to nearest integer */
         rounded = round(x);

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -107,12 +107,12 @@ class structseq "PyStructSequence *" "NULL"
 @classmethod
 structseq.__new__ as structseq_new
     sequence as arg: object
-    dict: object = NULL
+    dict: object(c_default="NULL") = {}
 [clinic start generated code]*/
 
 static PyObject *
 structseq_new_impl(PyTypeObject *type, PyObject *arg, PyObject *dict)
-/*[clinic end generated code: output=baa082e788b171da input=9b44810243907377]*/
+/*[clinic end generated code: output=baa082e788b171da input=90532511101aa3fb]*/
 {
     PyObject *ob;
     PyStructSequence *res = NULL;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12455,7 +12455,7 @@ do_strip(PyObject *self, int striptype)
 static PyObject *
 do_argstrip(PyObject *self, int striptype, PyObject *sep)
 {
-    if (sep != NULL && sep != Py_None) {
+    if (sep != Py_None) {
         if (PyUnicode_Check(sep))
             return _PyUnicode_XStrip(self, striptype, sep);
         else {
@@ -12492,7 +12492,7 @@ unicode_strip_impl(PyObject *self, PyObject *chars)
 /*[clinic input]
 str.lstrip as unicode_lstrip
 
-    chars: object = NULL
+    chars: object = None
     /
 
 Return a copy of the string with leading whitespace removed.
@@ -12502,7 +12502,7 @@ If chars is given and not None, remove characters in chars instead.
 
 static PyObject *
 unicode_lstrip_impl(PyObject *self, PyObject *chars)
-/*[clinic end generated code: output=3b43683251f79ca7 input=9e56f3c45f5ff4c3]*/
+/*[clinic end generated code: output=3b43683251f79ca7 input=529f9f3834448671]*/
 {
     return do_argstrip(self, LEFTSTRIP, chars);
 }
@@ -12511,7 +12511,7 @@ unicode_lstrip_impl(PyObject *self, PyObject *chars)
 /*[clinic input]
 str.rstrip as unicode_rstrip
 
-    chars: object = NULL
+    chars: object = None
     /
 
 Return a copy of the string with trailing whitespace removed.
@@ -12521,7 +12521,7 @@ If chars is given and not None, remove characters in chars instead.
 
 static PyObject *
 unicode_rstrip_impl(PyObject *self, PyObject *chars)
-/*[clinic end generated code: output=4a59230017cc3b7a input=ac89d0219cb411ee]*/
+/*[clinic end generated code: output=4a59230017cc3b7a input=62566c627916557f]*/
 {
     return do_argstrip(self, RIGHTSTRIP, chars);
 }

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2147,7 +2147,7 @@ builtin_repr(PyObject *module, PyObject *obj)
 round as builtin_round
 
     number: object
-    ndigits: object = NULL
+    ndigits: object = None
 
 Round a number to a given precision in decimal digits.
 
@@ -2157,7 +2157,7 @@ the return value has the same type as the number.  ndigits may be negative.
 
 static PyObject *
 builtin_round_impl(PyObject *module, PyObject *number, PyObject *ndigits)
-/*[clinic end generated code: output=ff0d9dd176c02ede input=854bc3a217530c3d]*/
+/*[clinic end generated code: output=ff0d9dd176c02ede input=275678471d7aca15]*/
 {
     PyObject *round, *result;
 
@@ -2175,7 +2175,7 @@ builtin_round_impl(PyObject *module, PyObject *number, PyObject *ndigits)
         return NULL;
     }
 
-    if (ndigits == NULL || ndigits == Py_None)
+    if (ndigits == Py_None)
         result = _PyObject_CallNoArg(round);
     else
         result = PyObject_CallFunctionObjArgs(round, ndigits, NULL);

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -719,7 +719,7 @@ builtin_round(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *number;
-    PyObject *ndigits = NULL;
+    PyObject *ndigits = Py_None;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 2, 0, argsbuf);
     if (!args) {
@@ -849,4 +849,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=1927f3c9abd00c35 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4e118c2cd2cd98f3 input=a9049054013a1b77]*/

--- a/Python/clinic/context.c.h
+++ b/Python/clinic/context.c.h
@@ -115,7 +115,7 @@ _contextvars_Context_copy(PyContext *self, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(_contextvars_ContextVar_get__doc__,
-"get($self, default=None, /)\n"
+"get($self, default=<unrepresentable>, /)\n"
 "--\n"
 "\n"
 "Return a value for the context variable for the current context.\n"
@@ -177,4 +177,4 @@ PyDoc_STRVAR(_contextvars_ContextVar_reset__doc__,
 
 #define _CONTEXTVARS_CONTEXTVAR_RESET_METHODDEF    \
     {"reset", (PyCFunction)_contextvars_ContextVar_reset, METH_O, _contextvars_ContextVar_reset__doc__},
-/*[clinic end generated code: output=a86b66e1516c25d4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f2e42f34e358e179 input=a9049054013a1b77]*/

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -300,7 +300,7 @@ exit:
 #if defined(HAVE_DYNAMIC_LOADING)
 
 PyDoc_STRVAR(_imp_create_dynamic__doc__,
-"create_dynamic($module, spec, file=None, /)\n"
+"create_dynamic($module, spec, file=<unrepresentable>, /)\n"
 "--\n"
 "\n"
 "Create an extension module.");
@@ -454,4 +454,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=ff06f7cf4b73eb76 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3dc495e9c64d944e input=a9049054013a1b77]*/

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -135,7 +135,7 @@ static PyObject *
 sys_exit(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *status = NULL;
+    PyObject *status = Py_None;
 
     if (!_PyArg_CheckPositional("exit", nargs, 0, 1)) {
         goto exit;
@@ -1088,4 +1088,4 @@ sys_getandroidapilevel(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=092edc868de055a6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=273f9cec8bfcab91 input=a9049054013a1b77]*/

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -705,7 +705,7 @@ sys_unraisablehook(PyObject *module, PyObject *unraisable)
 /*[clinic input]
 sys.exit
 
-    status: object = NULL
+    status: object = None
     /
 
 Exit the interpreter by raising SystemExit(status).
@@ -718,7 +718,7 @@ exit status will be one (i.e., failure).
 
 static PyObject *
 sys_exit_impl(PyObject *module, PyObject *status)
-/*[clinic end generated code: output=13870986c1ab2ec0 input=a737351f86685e9c]*/
+/*[clinic end generated code: output=13870986c1ab2ec0 input=b86ca9497baa94f2]*/
 {
     /* Raise SystemExit so callers may catch it or clean up. */
     PyErr_SetObject(PyExc_SystemExit, status);

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -43,9 +43,6 @@ NoneType = type(None)
 
 version = '1'
 
-_empty = inspect._empty
-_void = inspect._void
-
 NoneType = type(None)
 
 class Unspecified:
@@ -2175,7 +2172,7 @@ class Function:
     def __init__(self, parameters=None, *, name,
                  module, cls=None, c_basename=None,
                  full_name=None,
-                 return_converter, return_annotation=_empty,
+                 return_converter, return_annotation=inspect.Signature.empty,
                  docstring=None, kind=CALLABLE, coexist=False,
                  docstring_only=False):
         self.parameters = parameters or collections.OrderedDict()
@@ -2253,8 +2250,8 @@ class Parameter:
     Mutable duck type of inspect.Parameter.
     """
 
-    def __init__(self, name, kind, *, default=_empty,
-                 function, converter, annotation=_empty,
+    def __init__(self, name, kind, *, default=inspect.Parameter.empty,
+                 function, converter, annotation=inspect.Parameter.empty,
                  docstring=None, group=0):
         self.name = name
         self.kind = kind
@@ -3230,6 +3227,8 @@ class str_converter(CConverter):
             self.type = 'char *'
             # sorry, clinic can't support preallocated buffers
             # for es# and et#
+            self.c_default = "NULL"
+        if NoneType in accept and self.c_default == "Py_None":
             self.c_default = "NULL"
 
     def cleanup(self):
@@ -4433,7 +4432,7 @@ class DSLParser:
                 # mild hack: explicitly support NULL as a default value
                 if isinstance(expr, ast.Name) and expr.id == 'NULL':
                     value = NULL
-                    py_default = 'None'
+                    py_default = '<unrepresentable>'
                     c_default = "NULL"
                 elif (isinstance(expr, ast.BinOp) or
                     (isinstance(expr, ast.UnaryOp) and


### PR DESCRIPTION
In ArgumentClinic, value "NULL" should now be used only for unrepresentable default values
(like in the optional third parameter of getattr). "None" should be used if None is accepted
as argument and passing None has the same effect as not passing the argument at all.
(cherry picked from commit 279f44678c8b84a183f9eeb85e0b086228154497)


<!-- issue-number: [bpo-37206](https://bugs.python.org/issue37206) -->
https://bugs.python.org/issue37206
<!-- /issue-number -->
