### PR TITLE
bpo-38158: Removing non-existant member "doc" from PyType_Spec documentation

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -142,10 +142,6 @@ The following functions and structs are used to create
 
       Name of the type, used to set :c:member:`PyTypeObject.tp_name`.
 
-   .. c:member:: const char* PyType_Spec.doc
-
-      Type docstring, used to set :c:member:`PyTypeObject.tp_doc`.
-
    .. c:member:: int PyType_Spec.basicsize
    .. c:member:: int PyType_Spec.itemsize
 


### PR DESCRIPTION
Just removing a couple lines.

<!-- issue-number: [bpo-38158](https://bugs.python.org/issue38158) -->
https://bugs.python.org/issue38158
<!-- /issue-number -->
