### PR TITLE
bpo-35696: Remove unnecessary operation in long_compare()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-15-01-30-06.bpo-35696.1iK_1H.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-15-01-30-06.bpo-35696.1iK_1H.rst
@@ -1,1 +1,1 @@
-Slightly improve perfomance of long_compare. Patch by hongweipeng.
+Slightly improve perfomance of ``long_compare()``. Patch by hongweipeng and Sergey Fedoseev.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-15-01-30-06.bpo-35696.1iK_1H.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-15-01-30-06.bpo-35696.1iK_1H.rst
@@ -1,1 +1,0 @@
-Slightly improve perfomance of ``long_compare()``. Patch by hongweipeng and Sergey Fedoseev.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-15-01-30-06.bpo-35696.1iK_1H.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-15-01-30-06.bpo-35696.1iK_1H.rst
@@ -1,0 +1,1 @@
+Slightly improve perfomance of long_compare. Patch by hongweipeng.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3041,8 +3041,9 @@ long_compare(PyLongObject *a, PyLongObject *b)
         while (--i > 0 && a->ob_digit[i] == b->ob_digit[i])
             ;
         sign = (sdigit)a->ob_digit[i] - (sdigit)b->ob_digit[i];
-        if (Py_SIZE(a) < 0)
+        if (Py_SIZE(a) < 0) {
             sign = -sign;
+        }
     }
     return sign;
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3038,17 +3038,13 @@ long_compare(PyLongObject *a, PyLongObject *b)
     }
     else {
         Py_ssize_t i = Py_ABS(Py_SIZE(a));
-        while (--i >= 0 && a->ob_digit[i] == b->ob_digit[i])
+        while (--i > 0 && a->ob_digit[i] == b->ob_digit[i])
             ;
-        if (i < 0)
-            sign = 0;
-        else {
-            sign = (sdigit)a->ob_digit[i] - (sdigit)b->ob_digit[i];
-            if (Py_SIZE(a) < 0)
-                sign = -sign;
-        }
+        sign = (sdigit)a->ob_digit[i] - (sdigit)b->ob_digit[i];
+        if (Py_SIZE(a) < 0)
+            sign = -sign;
     }
-    return sign < 0 ? -1 : sign > 0 ? 1 : 0;
+    return sign;
 }
 
 static PyObject *

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3028,11 +3028,15 @@ PyLong_AsDouble(PyObject *v)
 
 /* Methods */
 
+/* if a < b, return a negative number
+   if a == b, return 0
+   if a > b, return a positive number */
+
 static Py_ssize_t
 long_compare(PyLongObject *a, PyLongObject *b)
 {
     Py_ssize_t sign = Py_SIZE(a) - Py_SIZE(b);
-    if (!sign) {
+    if (sign == 0) {
         Py_ssize_t i = Py_ABS(Py_SIZE(a));
         sdigit diff = 0;
         while (--i >= 0) {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3035,8 +3035,12 @@ long_compare(PyLongObject *a, PyLongObject *b)
     if (!sign) {
         Py_ssize_t i = Py_ABS(Py_SIZE(a));
         sdigit diff = 0;
-        while (--i >= 0 && !(diff = (sdigit) a->ob_digit[i] - (sdigit) b->ob_digit[i]))
-            ;
+        while (--i >= 0) {
+            diff = (sdigit) a->ob_digit[i] - (sdigit) b->ob_digit[i];
+            if (diff) {
+                break;
+            }
+        }
         sign = Py_SIZE(a) < 0 ? -diff : diff;
     }
     return sign;


### PR DESCRIPTION
```
$ ./python -m pyperf timeit -s "a = 100; b = 99" "a == b" --compare-to=../cpython-master/python --duplicate=1000
/home/weapon/workspace/cpython-master/python: ..................... 13.0 ns +- 0.3 ns
/home/weapon/workspace/cpython/python: ..................... 12.7 ns +- 0.1 ns

Mean +- std dev: [/home/weapon/workspace/cpython-master/python] 13.0 ns +- 0.3 ns -> [/home/weapon/workspace/cpython/python] 12.7 ns +- 0.1 ns: 1.02x faster (-2%)

$ ./python -m pyperf timeit -s "a = 2 ** 100 + 1; b = 2 ** 100" "a == b" --compare-to=../cpython-master/python --duplicate=1000
/home/weapon/workspace/cpython-master/python: ..................... 14.1 ns +- 0.2 ns
/home/weapon/workspace/cpython/python: ..................... 13.6 ns +- 0.1 ns

Mean +- std dev: [/home/weapon/workspace/cpython-master/python] 14.1 ns +- 0.2 ns -> [/home/weapon/workspace/cpython/python] 13.6 ns +- 0.1 ns: 1.04x faster (-4%)
```
![long_compare](https://user-images.githubusercontent.com/7546325/64911805-0fe15e80-d759-11e9-8b02-d0c12be9b8fe.png)


<!-- issue-number: [bpo-35696](https://bugs.python.org/issue35696) -->
https://bugs.python.org/issue35696
<!-- /issue-number -->
