### PR TITLE
bpo-37635: Update arg name for seek() in IO tutorial

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -412,11 +412,11 @@ or a bytes object (in binary mode) -- before writing them::
 represented as number of bytes from the beginning of the file when in binary mode and
 an opaque number when in text mode.
 
-To change the file object's position, use ``f.seek(offset, from_what)``.  The position is computed
+To change the file object's position, use ``f.seek(offset, whence)``.  The position is computed
 from adding *offset* to a reference point; the reference point is selected by
-the *from_what* argument.  A *from_what* value of 0 measures from the beginning
+the *whence* argument.  A *whence* value of 0 measures from the beginning
 of the file, 1 uses the current file position, and 2 uses the end of the file as
-the reference point.  *from_what* can be omitted and defaults to 0, using the
+the reference point.  *whence* can be omitted and defaults to 0, using the
 beginning of the file as the reference point. ::
 
    >>> f = open('workfile', 'rb+')


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Typically, the second positional argument for ``seek()`` is *whence*. That is the POSIX standard name (http://man7.org/linux/man-pages/man3/lseek.3p.html) and the name listed in the documentation for ``io`` module (https://docs.python.org/3/library/io.html#io.IOBase.seek). 

The tutorial for IO is the only location where the second positional argument for ``seek()`` is referred to as *from_what*. I suspect this was created at an early point in Python's history, and was never updated (as this section predates the GitHub repository):

```
$ git grep "from_what"
Doc/tutorial/inputoutput.rst:To change the file object's position, use ``f.seek(offset, from_what)``.  The position is computed
Doc/tutorial/inputoutput.rst:the *from_what* argument.  A *from_what* value of 0 measures from the beginning
Doc/tutorial/inputoutput.rst:the reference point.  *from_what* can be omitted and defaults to 0, using the
```

For consistency, I am suggesting that the tutorial be updated to use the same argument name as the IO documentation and POSIX standard for ``seek()``, particularly since this is the only location where *from_what* is being used.

Note: In the POSIX standard, *whence* is technically the third positional argument, but the first argument *fildes* (file descriptor) is implicit in Python.

<!-- issue-number: [bpo-37635](https://bugs.python.org/issue37635) -->
https://bugs.python.org/issue37635
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou