### PR TITLE
bpo-27218 : improve tracing performance with f_trace set to Py_None

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-09-15-13-33-16.bpo-27218.Hhphpd.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-15-13-33-16.bpo-27218.Hhphpd.rst
@@ -1,0 +1,3 @@
+Set `f_trace` to `Py_None` to improve performance. Setting `f_trace` to `Py_None` in ``trace_trampoline()`` when the trace function
+returns `Py_None` provides a way to avoid the costly calls to ``maybe_call_line_trace()`` that are made for each line in this scope
+even though the trace function is not called.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -929,6 +929,9 @@ trace_trampoline(PyObject *self, PyFrameObject *frame,
     if (callback == NULL)
         return 0;
     result = call_trampoline(callback, frame, what, arg);
+    if (result == Py_None) {
+        Py_XSETREF(frame->f_trace, NULL);
+    }
     if (result == NULL) {
         PyEval_SetTrace(NULL, NULL);
         Py_CLEAR(frame->f_trace);


### PR DESCRIPTION
I am not adding a new test as I think this test :

```
def test_set_and_retrieve_none(self):
        sys.settrace(None)
        assert sys.gettrace() is None

```
Works for this case too. No ?

<!-- issue-number: [bpo-27218](https://bugs.python.org/issue27218) -->
https://bugs.python.org/issue27218
<!-- /issue-number -->
