### PR TITLE
bpo-38176: Fix missing dec ref

### DIFF
--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -572,6 +572,7 @@ static int
 _random_clear(PyObject *module)
 {
     Py_CLEAR(_randomstate(module)->Random_Type);
+    Py_CLEAR(_randomstate(module)->Long___abs__);
     return 0;
 }
 


### PR DESCRIPTION
Fixes missing dec ref when cleaning up random module

<!-- issue-number: [bpo-38176](https://bugs.python.org/issue38176) -->
https://bugs.python.org/issue38176
<!-- /issue-number -->


Automerge-Triggered-By: @DinoV