### PR TITLE
bpo-37828: Fix default mock_name in unittest.mock.assert_called error

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -868,7 +868,7 @@ class NonCallableMock(Base):
         """
         if self.call_count == 0:
             msg = ("Expected '%s' to have been called." %
-                   self._mock_name or 'mock')
+                   (self._mock_name or 'mock'))
             raise AssertionError(msg)
 
     def assert_called_once(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -397,9 +397,10 @@ class MockTest(unittest.TestCase):
 
 
     def test_assert_called_exception_message(self):
-        with self.assertRaisesRegex(AssertionError, "Expected 'mock' to have been called"):
+        msg = "Expected '{0}' to have been called"
+        with self.assertRaisesRegex(AssertionError, msg.format('mock')):
             Mock().assert_called()
-        with self.assertRaisesRegex(AssertionError, "Expected 'test_name' to have been called"):
+        with self.assertRaisesRegex(AssertionError, msg.format('test_name')):
             Mock(name="test_name").assert_called()
 
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -396,6 +396,13 @@ class MockTest(unittest.TestCase):
         _check(mock)
 
 
+    def test_assert_called_exception_message():
+        with self.assertRaisesRegexp(AssertionError, "Expected 'mock' to have been called"):
+            Mock().assert_called()
+        with self.assertRaisesRegexp(AssertionError, "Expected 'test_name' to have been called"):
+            Mock(name="test_name").assert_called()
+
+
     def test_assert_called_once_with(self):
         mock = Mock()
         mock()

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -396,10 +396,10 @@ class MockTest(unittest.TestCase):
         _check(mock)
 
 
-    def test_assert_called_exception_message():
-        with self.assertRaisesRegexp(AssertionError, "Expected 'mock' to have been called"):
+    def test_assert_called_exception_message(self):
+        with self.assertRaisesRegex(AssertionError, "Expected 'mock' to have been called"):
             Mock().assert_called()
-        with self.assertRaisesRegexp(AssertionError, "Expected 'test_name' to have been called"):
+        with self.assertRaisesRegex(AssertionError, "Expected 'test_name' to have been called"):
             Mock(name="test_name").assert_called()
 
 

--- a/Misc/NEWS.d/next/Library/2019-09-15-21-31-18.bpo-37828.gLLDX7.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-15-21-31-18.bpo-37828.gLLDX7.rst
@@ -1,1 +1,2 @@
-Properly report the mock name in :meth:`unittest.mock.assert_called` error
+Fix default mock name in :meth:`unittest.mock.Mock.assert_called` exceptions.
+Patch by Abraham Toriz Cruz.

--- a/Misc/NEWS.d/next/Library/2019-09-15-21-31-18.bpo-37828.gLLDX7.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-15-21-31-18.bpo-37828.gLLDX7.rst
@@ -1,0 +1,1 @@
+Properly report the mock name in :meth:`unittest.mock.assert_called` error


### PR DESCRIPTION
I used parenthesis to change precedence so the correct message is displayed. This is my very fist contribution to python (:

<!-- issue-number: [bpo-37828](https://bugs.python.org/issue37828) -->
https://bugs.python.org/issue37828
<!-- /issue-number -->
