### PR TITLE
bpo-38100: Spelling error in unittest.mock code

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1988,9 +1988,9 @@ def _set_return_value(mock, method, name):
         method.return_value = fixed
         return
 
-    return_calulator = _calculate_return_value.get(name)
-    if return_calulator is not None:
-        return_value = return_calulator(mock)
+    return_calculator = _calculate_return_value.get(name)
+    if return_calculator is not None:
+        return_value = return_calculator(mock)
         method.return_value = return_value
         return
 


### PR DESCRIPTION
Spelling error in unittest.mock code

Spelling correction in the unittest.mock library, "return_calulator" replaced with "return_calculator" in the `_set_return_value` method in `Lib/unittest/mock.py`.

<!-- issue-number: [bpo-38100](https://bugs.python.org/issue38100) -->
https://bugs.python.org/issue38100
<!-- /issue-number -->
