### PR TITLE
[2.7] bpo-38117: Updated OpenSSL to 1.0.2t in macOS installer for 2.7.x.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -213,9 +213,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.0.2s",
-              url="https://www.openssl.org/source/openssl-1.0.2s.tar.gz",
-              checksum='98ec4e085962689b91d25e1dcdfc14a2',
+              name="OpenSSL 1.0.2t",
+              url="https://www.openssl.org/source/openssl-1.0.2t.tar.gz",
+              checksum='ef66581b80f06eae42f5268bc0b50c6d',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2019-09-15-21-45-15.bpo-38117._U9F2r.rst
+++ b/Misc/NEWS.d/next/macOS/2019-09-15-21-45-15.bpo-38117._U9F2r.rst
@@ -1,0 +1,1 @@
+Updated OpenSSL to 1.0.2t in macOS installer for 2.7.x.


### PR DESCRIPTION


<!-- issue-number: [bpo-38117](https://bugs.python.org/issue38117) -->
https://bugs.python.org/issue38117
<!-- /issue-number -->
