### PR TITLE
[2.7] bpo-38168: Fix a possbile refleak in setint() of mmapmodule.c (GH-16136)

### DIFF
--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1436,7 +1436,8 @@ static void
 setint(PyObject *d, const char *name, long value)
 {
     PyObject *o = PyInt_FromLong(value);
-    if (o && PyDict_SetItemString(d, name, o) == 0) {
+    if (o) {
+        PyDict_SetItemString(d, name, o);
         Py_DECREF(o);
     }
 }


### PR DESCRIPTION
(cherry picked from commit 56a4514)

Co-authored-by: Hai Shi shihai1992@gmail.com

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38168](https://bugs.python.org/issue38168) -->
https://bugs.python.org/issue38168
<!-- /issue-number -->
