### PR TITLE
[3.7] bpo-33095: Add reference to isolated mode in -m and script option (GH-7764)

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -100,6 +100,11 @@ source.
    first element will be set to ``"-m"``). As with the :option:`-c` option,
    the current directory will be added to the start of :data:`sys.path`.
 
+   :option:`-I` option can  be used to run the script in isolated mode where
+   :data:`sys.path` contains neither the current directory nor the user's
+   site-packages directory. All :envvar:`PYTHON*` environment variables are
+   ignored, too.
+
    Many standard library modules contain code that is invoked on their execution
    as a script.  An example is the :mod:`timeit` module::
 
@@ -119,6 +124,7 @@ source.
    .. versionchanged:: 3.4
       namespace packages are also supported
 
+.. _cmdarg-dash:
 
 .. describe:: -
 
@@ -129,6 +135,8 @@ source.
    ``"-"`` and the current directory will be added to the start of
    :data:`sys.path`.
 
+
+.. _cmdarg-script:
 
 .. describe:: <script>
 
@@ -147,6 +155,11 @@ source.
    If the script name refers to a directory or zipfile, the script name is
    added to the start of :data:`sys.path` and the ``__main__.py`` file in
    that location is executed as the :mod:`__main__` module.
+
+   :option:`-I` option can  be used to run the script in isolated mode where
+   :data:`sys.path` contains neither the script's directory nor the user's
+   site-packages directory. All :envvar:`PYTHON*` environment variables are
+   ignored, too.
 
    .. seealso::
       :func:`runpy.run_path`


### PR DESCRIPTION

Attempt to make isolated mode easier to discover via additional inline documentation.

Co-Authored-By: Julien Palard <julien@palard.fr>.
(cherry picked from commit bdd6945d4dbd1fe6a7fcff95f7d6908db7d791a1)

Co-authored-by: Xtreak <tir.karthi@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-33095](https://bugs.python.org/issue33095) -->
https://bugs.python.org/issue33095
<!-- /issue-number -->
