### PR TITLE
[3.7] bpo-38117: Update bundled Windows OpenSSL to 1.1.1d (GH-16184)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-09-16-14-07-11.bpo-38117.hJVf0C.rst
+++ b/Misc/NEWS.d/next/Windows/2019-09-16-14-07-11.bpo-38117.hJVf0C.rst
@@ -1,0 +1,1 @@
+Update bundled OpenSSL to 1.1.1d

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -49,7 +49,7 @@ echo.Fetching external libraries...
 
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.6
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1c
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1d
 set libraries=%libraries%                                       sqlite-3.28.0.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.9.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.9.0
@@ -72,7 +72,7 @@ for %%e in (%libraries%) do (
 echo.Fetching external binaries...
 
 set binaries=
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1c
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1d
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -49,8 +49,8 @@
     <sqlite3Dir>$(ExternalsDir)sqlite-3.28.0.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.1c\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1c\$(ArchName)\</opensslOutDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.1d\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1d\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>


### PR DESCRIPTION


<!-- issue-number: [bpo-38117](https://bugs.python.org/issue38117) -->
https://bugs.python.org/issue38117
<!-- /issue-number -->
