### PR TITLE
bpo-38136: Updates await_count and call_count to be different things

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -514,21 +514,6 @@ the *new_callable* argument to :func:`patch`.
             >>> mock.call_count
             2
 
-        For :class:`AsyncMock` the :attr:`call_count` is only iterated if the function
-        has been awaited:
-
-            >>> mock = AsyncMock()
-            >>> mock()  # doctest: +SKIP
-            <coroutine object AsyncMockMixin._mock_call at ...>
-            >>> mock.call_count
-            0
-            >>> async def main():
-            ...     await mock()
-            ...
-            >>> asyncio.run(main())
-            >>> mock.call_count
-            1
-
     .. attribute:: return_value
 
         Set this to configure the value returned by calling the mock:

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -892,19 +892,22 @@ object::
 
   .. method:: assert_awaited()
 
-      Assert that the mock was awaited at least once.
+      Assert that the mock was awaited at least once. Note that this is separate
+      from the object having been called, the ``await`` keyword must be used:
 
           >>> mock = AsyncMock()
-          >>> async def main():
-          ...     await mock()
+          >>> async def main(coroutine_mock):
+          ...     await coroutine_mock
           ...
-          >>> asyncio.run(main())
+          >>> coroutine_mock = mock()
+          >>> mock.called
+          True
           >>> mock.assert_awaited()
-          >>> mock_2 = AsyncMock()
-          >>> mock_2.assert_awaited()
           Traceback (most recent call last):
           ...
           AssertionError: Expected mock to have been awaited.
+          >>> asyncio.run(main(coroutine_mock))
+          >>> mock.assert_awaited()
 
   .. method:: assert_awaited_once()
 
@@ -989,14 +992,15 @@ object::
         ...     await mock(*args, **kwargs)
         ...
         >>> calls = [call("foo"), call("bar")]
-        >>> mock.assert_has_calls(calls)
+        >>> mock.assert_has_awaits(calls)
         Traceback (most recent call last):
         ...
-        AssertionError: Calls not found.
+        AssertionError: Awaits not found.
         Expected: [call('foo'), call('bar')]
+        Actual: []
         >>> asyncio.run(main('foo'))
         >>> asyncio.run(main('bar'))
-        >>> mock.assert_has_calls(calls)
+        >>> mock.assert_has_awaits(calls)
 
   .. method:: assert_not_awaited()
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1069,8 +1069,9 @@ class CallableMixin(Base):
         self.called = True
         self.call_count += 1
 
-    def _execute_mock_call(self, /, *args, **kwargs):
         # handle call_args
+        # needs to be set here so assertions on call arguments pass before
+        # execution in the case of awaited calls
         _call = _Call((args, kwargs), two=True)
         self.call_args = _call
         self.call_args_list.append(_call)
@@ -1109,6 +1110,10 @@ class CallableMixin(Base):
 
             # follow the parental chain:
             _new_parent = _new_parent._mock_new_parent
+
+    def _execute_mock_call(self, /, *args, **kwargs):
+        # seperate from _increment_mock_call so that awaited functions are
+        # executed seperately from their call
 
         effect = self.side_effect
         if effect is not None:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1058,13 +1058,18 @@ class CallableMixin(Base):
         # can't use self in-case a function / method we are mocking uses self
         # in the signature
         self._mock_check_sig(*args, **kwargs)
+        self._increment_mock_call(*args, **kwargs)
         return self._mock_call(*args, **kwargs)
 
 
     def _mock_call(self, /, *args, **kwargs):
+        return self._execute_mock_call(*args, **kwargs)
+
+    def _increment_mock_call(self, /, *args, **kwargs):
         self.called = True
         self.call_count += 1
 
+    def _execute_mock_call(self, /, *args, **kwargs):
         # handle call_args
         _call = _Call((args, kwargs), two=True)
         self.call_args = _call

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -633,8 +633,8 @@ class AsyncMockAssert(unittest.TestCase):
             # Will raise a warning because never awaited
             self.mock('foo')
             self.mock('baz')
-        kalls_args = ([call(), call('foo'), call('baz')])
-        self.assertEqual(self.mock.mock_calls, kalls_args)
+        mock_kalls = ([call(), call('foo'), call('baz')])
+        self.assertEqual(self.mock.mock_calls, mock_kalls)
 
     def test_assert_has_mock_calls_on_async_mock_with_spec(self):
         a_class_mock = AsyncMock(AsyncClass)
@@ -648,19 +648,14 @@ class AsyncMockAssert(unittest.TestCase):
         with self.assertWarns(RuntimeWarning):
             # Will raise a warning because never awaited
             a_class_mock.async_method(1, 2, 3, a=4, b=5)
-        kalls_args_kwargs = [call(), call(1, 2, 3, a=4, b=5)]
-        self.assertEqual(a_class_mock.async_method.mock_calls, kalls_args_kwargs)
-        self.assertEqual(
-            a_class_mock.mock_calls,
-            [
-                call.async_method(),
-                call.async_method(1, 2, 3, a=4, b=5)
-            ]
-        )
+        method_kalls = [call(), call(1, 2, 3, a=4, b=5)]
+        mock_kalls = [call.async_method(), call.async_method(1, 2, 3, a=4, b=5)]
+        self.assertEqual(a_class_mock.async_method.mock_calls, method_kalls)
+        self.assertEqual(a_class_mock.mock_calls, mock_kalls)
 
     def test_async_method_calls_recorded(self):
         with self.assertWarns(RuntimeWarning):
-            # Will raise a warning because never awaited
+            # Will raise warnings because never awaited
             self.mock.something(3, fish=None)
             self.mock.something_else.something(6, cake=sentinel.Cake)
 
@@ -684,7 +679,7 @@ class AsyncMockAssert(unittest.TestCase):
 
         assert_attrs(self.mock)
         with self.assertWarns(RuntimeWarning):
-            # Will raise a warning because never awaited
+            # Will raise warnings because never awaited
             self.mock()
             self.mock(1, 2)
             self.mock(a=3)
@@ -694,7 +689,7 @@ class AsyncMockAssert(unittest.TestCase):
 
         a_mock = AsyncMock(AsyncClass)
         with self.assertWarns(RuntimeWarning):
-            # Will raise a warning because never awaited
+            # Will raise warnings because never awaited
             a_mock.async_method()
             a_mock.async_method(1, a=3)
 

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -3,7 +3,7 @@ import inspect
 import unittest
 
 from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock,
-                            create_autospec, _AwaitEvent, sentinel)
+                           create_autospec, _AwaitEvent, sentinel)
 
 
 def tearDownModule():

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -3,7 +3,7 @@ import inspect
 import unittest
 
 from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock,
-                           create_autospec, _AwaitEvent, sentinel)
+                           create_autospec, _AwaitEvent, sentinel, _CallList)
 
 
 def tearDownModule():
@@ -529,10 +529,7 @@ class AsyncMockAssert(unittest.TestCase):
         self.mock = AsyncMock()
 
     async def _runnable_test(self, *args, **kwargs):
-        if not args and not kwargs:
-            await self.mock()
-        else:
-            await self.mock(*args, **kwargs)
+        await self.mock(*args, **kwargs)
 
     async def _await_coroutine(self, coroutine):
         return await coroutine
@@ -548,6 +545,8 @@ class AsyncMockAssert(unittest.TestCase):
         mock.async_method.assert_called_once_with()
         with self.assertRaises(AssertionError):
             mock.assert_awaited()
+        with self.assertRaises(AssertionError):
+            mock.async_method.assert_awaited()
 
     def test_assert_called_then_awaited(self):
         mock = AsyncMock(AsyncClass)
@@ -561,6 +560,7 @@ class AsyncMockAssert(unittest.TestCase):
         asyncio.run(self._await_coroutine(mock_coroutine))
         # Assert we haven't re-called the function
         mock.async_method.assert_called_once()
+        mock.async_method.assert_awaited()
         mock.async_method.assert_awaited_once()
         mock.async_method.assert_awaited_once_with()
 
@@ -579,10 +579,14 @@ class AsyncMockAssert(unittest.TestCase):
         mock = AsyncMock(AsyncClass)
         coroutine = mock.async_method()
         with self.assertWarns(RuntimeWarning):
-            # Will raise a warning because never awaited
+            # The first call will be awaited so no warning there
+            # But this call will never get awaited, so it will warn here
             mock.async_method()
+        with self.assertRaises(AssertionError):
+            mock.async_method.assert_awaited()
         mock.async_method.assert_called()
         asyncio.run(self._await_coroutine(coroutine))
+        mock.async_method.assert_awaited()
         mock.async_method.assert_awaited_once()
 
     def test_assert_called_once_and_awaited_twice(self):
@@ -610,76 +614,92 @@ class AsyncMockAssert(unittest.TestCase):
             self.mock.assert_called()
 
     def test_assert_has_calls_not_awaits(self):
-        kalls = [call('NormalFoo')]
+        kalls = [call('foo')]
         with self.assertWarns(RuntimeWarning):
-            self.mock('NormalFoo')
+            # Will raise a warning because never awaited
+            self.mock('foo')
         self.mock.assert_has_calls(kalls)
         with self.assertRaises(AssertionError):
             self.mock.assert_has_awaits(kalls)
 
-    def test_assert_has_mock_calls_on_async_mock(self):
-        mock = AsyncMock()
+    def test_assert_has_mock_calls_on_async_mock_no_spec(self):
         with self.assertWarns(RuntimeWarning):
-            mock()
+            # Will raise a warning because never awaited
+            self.mock()
         kalls_empty = [('', (), {})]
-        self.assertEqual(mock.mock_calls, kalls_empty)
+        self.assertEqual(self.mock.mock_calls, kalls_empty)
 
-        kalls_args = ([call('NormalFoo'), call('baz')])
         with self.assertWarns(RuntimeWarning):
-            self.mock('NormalFoo')
+            # Will raise a warning because never awaited
+            self.mock('foo')
             self.mock('baz')
+        kalls_args = ([call(), call('foo'), call('baz')])
         self.assertEqual(self.mock.mock_calls, kalls_args)
 
-        a_mock = AsyncMock(AsyncClass)
+    def test_assert_has_mock_calls_on_async_mock_with_spec(self):
+        a_class_mock = AsyncMock(AsyncClass)
         with self.assertWarns(RuntimeWarning):
-            a_mock.async_method()
-        self.assertEqual(a_mock.async_method.mock_calls, kalls_empty)
-        self.assertEqual(a_mock.mock_calls, [call.async_method()])
+            # Will raise a warning because never awaited
+            a_class_mock.async_method()
+        kalls_empty = [('', (), {})]
+        self.assertEqual(a_class_mock.async_method.mock_calls, kalls_empty)
+        self.assertEqual(a_class_mock.mock_calls, [call.async_method()])
 
-        kalls_args_kwargs = [call(), call(1, 2, 3, a=4, b=5)]
         with self.assertWarns(RuntimeWarning):
-            a_mock.async_method(1, 2, 3, a=4, b=5)
-        self.assertEqual(a_mock.async_method.mock_calls, kalls_args_kwargs)
+            # Will raise a warning because never awaited
+            a_class_mock.async_method(1, 2, 3, a=4, b=5)
+        kalls_args_kwargs = [call(), call(1, 2, 3, a=4, b=5)]
+        self.assertEqual(a_class_mock.async_method.mock_calls, kalls_args_kwargs)
+        self.assertEqual(
+            a_class_mock.mock_calls,
+            [
+                call.async_method(),
+                call.async_method(1, 2, 3, a=4, b=5)
+            ]
+        )
 
     def test_async_method_calls_recorded(self):
         with self.assertWarns(RuntimeWarning):
+            # Will raise a warning because never awaited
             self.mock.something(3, fish=None)
             self.mock.something_else.something(6, cake=sentinel.Cake)
 
-        self.assertEqual(self.mock.something_else.method_calls,
-                        [("something", (6,), {'cake': sentinel.Cake})],
-                        "method calls not recorded correctly")
         self.assertEqual(self.mock.method_calls, [
             ("something", (3,), {'fish': None}),
             ("something_else.something", (6,), {'cake': sentinel.Cake})
         ],
             "method calls not recorded correctly")
+        self.assertEqual(self.mock.something_else.method_calls,
+                         [("something", (6,), {'cake': sentinel.Cake})],
+                         "method calls not recorded correctly")
 
     def test_async_arg_lists(self):
         def assert_attrs(mock):
-            names = 'call_args_list', 'method_calls', 'mock_calls'
+            names = ('call_args_list', 'method_calls', 'mock_calls')
             for name in names:
                 attr = getattr(mock, name)
                 self.assertIsInstance(attr, _CallList)
                 self.assertIsInstance(attr, list)
                 self.assertEqual(attr, [])
 
-            assert_attrs(self.mock)
+        assert_attrs(self.mock)
+        with self.assertWarns(RuntimeWarning):
+            # Will raise a warning because never awaited
+            self.mock()
+            self.mock(1, 2)
+            self.mock(a=3)
 
-            with self.assertWarns(RuntimeWarning):
-                self.mock()
-                self.mock(1, 2)
-                self.mock(a=3)
+        self.mock.reset_mock()
+        assert_attrs(self.mock)
 
-                self.mock.reset_mock()
-                assert_attrs(self.mock)
+        a_mock = AsyncMock(AsyncClass)
+        with self.assertWarns(RuntimeWarning):
+            # Will raise a warning because never awaited
+            a_mock.async_method()
+            a_mock.async_method(1, a=3)
 
-                a_mock = AsyncMock(AsyncClass)
-                a_mock.async_method()
-                a_mock.async_method(1, a=3)
-
-                a_mock.reset_mock()
-                assert_attrs(a_mock)
+        a_mock.reset_mock()
+        assert_attrs(a_mock)
 
     def test_assert_awaited(self):
         with self.assertRaises(AssertionError):
@@ -725,20 +745,20 @@ class AsyncMockAssert(unittest.TestCase):
 
     def test_assert_any_wait(self):
         with self.assertRaises(AssertionError):
-            self.mock.assert_any_await('NormalFoo')
+            self.mock.assert_any_await('foo')
+
+        asyncio.run(self._runnable_test('baz'))
+        with self.assertRaises(AssertionError):
+            self.mock.assert_any_await('foo')
 
         asyncio.run(self._runnable_test('foo'))
-        with self.assertRaises(AssertionError):
-            self.mock.assert_any_await('NormalFoo')
-
-        asyncio.run(self._runnable_test('NormalFoo'))
-        self.mock.assert_any_await('NormalFoo')
+        self.mock.assert_any_await('foo')
 
         asyncio.run(self._runnable_test('SomethingElse'))
-        self.mock.assert_any_await('NormalFoo')
+        self.mock.assert_any_await('foo')
 
     def test_assert_has_awaits_no_order(self):
-        calls = [call('NormalFoo'), call('baz')]
+        calls = [call('foo'), call('baz')]
 
         with self.assertRaises(AssertionError) as cm:
             self.mock.assert_has_awaits(calls)
@@ -748,7 +768,7 @@ class AsyncMockAssert(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.mock.assert_has_awaits(calls)
 
-        asyncio.run(self._runnable_test('NormalFoo'))
+        asyncio.run(self._runnable_test('foo'))
         with self.assertRaises(AssertionError):
             self.mock.assert_has_awaits(calls)
 
@@ -783,7 +803,7 @@ class AsyncMockAssert(unittest.TestCase):
         mock_with_spec.assert_any_await(ANY, 1)
 
     def test_assert_has_awaits_ordered(self):
-        calls = [call('NormalFoo'), call('baz')]
+        calls = [call('foo'), call('baz')]
         with self.assertRaises(AssertionError):
             self.mock.assert_has_awaits(calls, any_order=True)
 
@@ -791,11 +811,11 @@ class AsyncMockAssert(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.mock.assert_has_awaits(calls, any_order=True)
 
-        asyncio.run(self._runnable_test('foo'))
+        asyncio.run(self._runnable_test('bamf'))
         with self.assertRaises(AssertionError):
             self.mock.assert_has_awaits(calls, any_order=True)
 
-        asyncio.run(self._runnable_test('NormalFoo'))
+        asyncio.run(self._runnable_test('foo'))
         self.mock.assert_has_awaits(calls, any_order=True)
 
         asyncio.run(self._runnable_test('qux'))

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -2,8 +2,8 @@ import asyncio
 import inspect
 import unittest
 
-from unittest.mock import (call, AsyncMock, patch, MagicMock, create_autospec,
-                           _AwaitEvent, sentinel)
+from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock,
+                            create_autospec, _AwaitEvent, sentinel)
 
 
 def tearDownModule():

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -2018,7 +2018,7 @@ class MockTest(unittest.TestCase):
             )
 
             mocks = [
-                Mock, MagicMock, NonCallableMock, NonCallableMagicMock
+                Mock, MagicMock, NonCallableMock, NonCallableMagicMock, AsyncMock
             ]
 
             for mock in mocks:

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -842,6 +842,7 @@ class MockTest(unittest.TestCase):
     def test_setting_call(self):
         mock = Mock()
         def __call__(self, a):
+            self._increment_mock_call(a)
             return self._mock_call(a)
 
         type(mock).__call__ = __call__

--- a/Misc/NEWS.d/next/Library/2019-09-16-09-54-42.bpo-38136.MdI-Zb.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-16-09-54-42.bpo-38136.MdI-Zb.rst
@@ -1,0 +1,3 @@
+Changes AsyncMock call count and await count to be two different counters.
+Now await count only counts when a coroutine has been awaited, not when it
+has been called, and vice-versa.

--- a/Misc/NEWS.d/next/Library/2019-09-16-09-54-42.bpo-38136.MdI-Zb.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-16-09-54-42.bpo-38136.MdI-Zb.rst
@@ -1,3 +1,3 @@
 Changes AsyncMock call count and await count to be two different counters.
 Now await count only counts when a coroutine has been awaited, not when it
-has been called, and vice-versa.
+has been called, and vice-versa. Update the documentation around this.


### PR DESCRIPTION
After a lot of discussion we have decided that "calls" and "awaits" should be counted as two different things. 

To accomplish this I separated the call counting from the actual execution of the call, that way they are counted at two different times. For synchronous calls the increment and execute calls happen one immediately after another, but for asynchronous calls the increment count for call count happens first, and then only after `await` is called does the call execute and increment the await counters.

<!-- issue-number: [bpo-38136](https://bugs.python.org/issue38136) -->
https://bugs.python.org/issue38136
<!-- /issue-number -->
