### PR TITLE
[3.7] bpo-38100: Fix spelling error in unittest.mock code

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1876,10 +1876,10 @@ def _set_return_value(mock, method, name):
         method.return_value = fixed
         return
 
-    return_calulator = _calculate_return_value.get(name)
-    if return_calulator is not None:
+    return_calculator = _calculate_return_value.get(name)
+    if return_calculator is not None:
         try:
-            return_value = return_calulator(mock)
+            return_value = return_calculator(mock)
         except AttributeError:
             # XXXX why do we return AttributeError here?
             #      set it as a side_effect instead?


### PR DESCRIPTION


<!-- issue-number: [bpo-38100](https://bugs.python.org/issue38100) -->
https://bugs.python.org/issue38100
<!-- /issue-number -->


Automerge-Triggered-By: @matrixise