### PR TITLE
Doc: add list(dict) in stdtypes library

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4234,6 +4234,10 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
    These are the operations that dictionaries support (and therefore, custom
    mapping types should support too):
 
+   .. describe:: list(d)
+
+      Return a list of all the keys used in the dictionary *d*.
+
    .. describe:: len(d)
 
       Return the number of items in the dictionary *d*.


### PR DESCRIPTION
Doc about list(dict) was missing in stdtypes library.

Maybe we must add something in Dictionary view objects section, too.
But, I'm not sure.