### PR TITLE
bpo-35379: When exiting IDLE, catch any AttributeError

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -2,6 +2,13 @@ What's New in IDLE 3.8.0 (since 3.7.0)
 Released on 2019-10-20?
 ======================================
 
+bpo-35379: When exiting IDLE, catch any AttributeError.  One happens
+when EditorWindow.close is called twice.  Printing a traceback, when
+IDLE is run from a terminal, is useless and annoying.
+
+bpo-38183: To avoid test issues, test_idle ignores the user config
+directory.  It no longer tries to create or access .idlerc or any files
+within.  Users must run IDLE to discover problems with saving settings.
 
 bpo-38077: IDLE no longer adds 'argv' to the user namespace when
 initializing it.  This bug only affected 3.7.4 and 3.8.0b2 to 3.8.0b4.

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1061,10 +1061,13 @@ class EditorWindow(object):
             return self.io.maybesave()
 
     def close(self):
-        reply = self.maybesave()
-        if str(reply) != "cancel":
-            self._close()
-        return reply
+        try:
+            reply = self.maybesave()
+            if str(reply) != "cancel":
+                self._close()
+            return reply
+        except AttributeError:  # bpo-35379: close called twice
+            pass
 
     def _close(self):
         if self.io.filename:

--- a/Misc/NEWS.d/next/IDLE/2019-09-17-01-28-56.bpo-35379.yAECDr.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-09-17-01-28-56.bpo-35379.yAECDr.rst
@@ -1,0 +1,3 @@
+When exiting IDLE, catch any AttributeError.  One happens when
+EditorWindow.close is called twice.  Printing a traceback, when IDLE is run
+from a terminal, is useless and annoying.


### PR DESCRIPTION
One happens when EditorWindow.close is called twice.
Printing a traceback, when IDLE is run from a terminal,
is useless and annoying.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35379](https://bugs.python.org/issue35379) -->
https://bugs.python.org/issue35379
<!-- /issue-number -->
