### PR TITLE
bpo-38187: Fix reference leak in test_tools

### DIFF
--- a/Lib/test/test_tools/test_c_analyzer/test_c_analyzer_common/test_known.py
+++ b/Lib/test/test_tools/test_c_analyzer/test_c_analyzer_common/test_known.py
@@ -15,6 +15,9 @@ class FromFileTests(unittest.TestCase):
 
     _return_read_tsv = ()
 
+    def tearDown(self):
+        Variable._isglobal.instances.clear()
+
     @property
     def calls(self):
         try:

--- a/Tools/c-analyzer/c_parser/info.py
+++ b/Tools/c-analyzer/c_parser/info.py
@@ -22,6 +22,9 @@ class Variable(_NTBase,
     __slots__ = ()
     _isglobal = util.Slot()
 
+    def __del__(self):
+        del self._isglobal
+
     @classonly
     def from_parts(cls, filename, funcname, name, vartype, isglobal=False):
         id = info.ID(filename, funcname, name)


### PR DESCRIPTION
This PR fixes the reference leak in test_tools (there is still a problem with some tests when running -R). The problem is that the `Variable` class in `Tools/c-analyzer/c_parser/info.py` has a descriptor that stores state in the class-level. Therefore when running the tests multiple times, the state is leaked as there and never released.

Probably this needs a better architecture so we don't need to remember to call `Variable._isglobal.instances.clear()` after the tests that use Variable, but for now it fixes the leak.

<!-- issue-number: [bpo-38187](https://bugs.python.org/issue38187) -->
https://bugs.python.org/issue38187
<!-- /issue-number -->

This one was tricky to find.
