### PR TITLE
[3.8] bpo-38191: Use positional-only parameters in TypedDict().

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3653,16 +3653,10 @@ class TypedDictTests(BaseTestCase):
             TypedDict()
         with self.assertRaises(TypeError):
             TypedDict('Emp', [('name', str)], None)
-
-        with self.assertWarns(DeprecationWarning):
-            Emp = TypedDict(_typename='Emp', name=str, id=int)
-        self.assertEqual(Emp.__name__, 'Emp')
-        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
-
-        with self.assertWarns(DeprecationWarning):
-            Emp = TypedDict('Emp', _fields={'name': str, 'id': int})
-        self.assertEqual(Emp.__name__, 'Emp')
-        self.assertEqual(Emp.__annotations__, {'name': str, 'id': int})
+        with self.assertRaises(TypeError):
+            TypedDict(_typename='Emp', name=str, id=int)
+        with self.assertRaises(TypeError):
+            TypedDict('Emp', _fields={'name': str, 'id': int})
 
     def test_typeddict_errors(self):
         Emp = TypedDict('Emp', {'name': str, 'id': int})

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1691,43 +1691,11 @@ class NamedTuple(metaclass=NamedTupleMeta):
     __new__.__text_signature__ = '($cls, typename, fields=None, /, **kwargs)'
 
 
-def _dict_new(*args, **kwargs):
-    if not args:
-        raise TypeError('TypedDict.__new__(): not enough arguments')
-    cls, *args = args  # allow the "cls" keyword be passed
+def _dict_new(cls, /, *args, **kwargs):
     return dict(*args, **kwargs)
-_dict_new.__text_signature__ = '($cls, _typename, _fields=None, /, **kwargs)'
 
 
-def _typeddict_new(*args, total=True, **kwargs):
-    if not args:
-        raise TypeError('TypedDict.__new__(): not enough arguments')
-    cls, *args = args  # allow the "cls" keyword be passed
-    if args:
-        typename, *args = args # allow the "_typename" keyword be passed
-    elif '_typename' in kwargs:
-        typename = kwargs.pop('_typename')
-        import warnings
-        warnings.warn("Passing '_typename' as keyword argument is deprecated",
-                      DeprecationWarning, stacklevel=2)
-    else:
-        raise TypeError("TypedDict.__new__() missing 1 required positional "
-                        "argument: '_typename'")
-    if args:
-        try:
-            fields, = args # allow the "_fields" keyword be passed
-        except ValueError:
-            raise TypeError(f'TypedDict.__new__() takes from 2 to 3 '
-                            f'positional arguments but {len(args) + 2} '
-                            f'were given') from None
-    elif '_fields' in kwargs and len(kwargs) == 1:
-        fields = kwargs.pop('_fields')
-        import warnings
-        warnings.warn("Passing '_fields' as keyword argument is deprecated",
-                      DeprecationWarning, stacklevel=2)
-    else:
-        fields = None
-
+def _typeddict_new(cls, typename, fields=None, /, *, total=True, **kwargs):
     if fields is None:
         fields = kwargs
     elif kwargs:
@@ -1742,7 +1710,6 @@ def _typeddict_new(*args, total=True, **kwargs):
         pass
 
     return _TypedDictMeta(typename, (), ns)
-_typeddict_new.__text_signature__ = '($cls, _typename, _fields=None, /, *, total=True, **kwargs)'
 
 
 def _check_fails(cls, other):


### PR DESCRIPTION
Since TypedDict is added in 3.8, I think it is better to get rid of deprecations.

<!-- issue-number: [bpo-38191](https://bugs.python.org/issue38191) -->
https://bugs.python.org/issue38191
<!-- /issue-number -->
