### PR TITLE
No-BPO: Remove unused import in hmac.py

### DIFF
--- a/Lib/hmac.py
+++ b/Lib/hmac.py
@@ -4,7 +4,6 @@ Implements the HMAC algorithm as described by RFC 2104.
 """
 
 import warnings as _warnings
-from _operator import _compare_digest as compare_digest
 try:
     import _hashlib as _hashopenssl
 except ImportError:


### PR DESCRIPTION
Simple one line change to remove an unused import in hmac.py