### PR TITLE
bpo-37531: Skip test_regrtest.test_multiprocessing_timeout() on Windows

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1154,6 +1154,8 @@ class ArgsTestCase(BaseTestCase):
                                   env_changed=[testname],
                                   fail_env_changed=True)
 
+    @unittest.skipIf(sys.platform == 'win32',
+                     'bpo-37531, bpo-38207: test hangs randomly on Windows')
     def test_multiprocessing_timeout(self):
         code = textwrap.dedent(r"""
             import time


### PR DESCRIPTION
It is a known and tracked bug: disable the test until it's fixed.

<!-- issue-number: [bpo-37531](https://bugs.python.org/issue37531) -->
https://bugs.python.org/issue37531
<!-- /issue-number -->
