### PR TITLE
bpo-36546: No longer have a need to make "data" positional only

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -615,7 +615,7 @@ def multimode(data):
 # position is that fewer options make for easier choices and that
 # external packages can be used for anything more advanced.
 
-def quantiles(data, /, *, n=4, method='exclusive'):
+def quantiles(data, *, n=4, method='exclusive'):
     """Divide *data* into *n* continuous intervals with equal probability.
 
     Returns a list of (n - 1) cut points separating the intervals.


### PR DESCRIPTION
With the *inv_cdf()* hook removed, the first argument is alway *data* and never a distribution.  So, we can make the signature the same as the other statistics functions.

<!-- issue-number: [bpo-36546](https://bugs.python.org/issue36546) -->
https://bugs.python.org/issue36546
<!-- /issue-number -->
