### PR TITLE
bpo-38209: Simplify dataclasses.InitVar by using __class_getitem__().

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -199,11 +199,7 @@ _POST_INIT_NAME = '__post_init__'
 # https://bugs.python.org/issue33453 for details.
 _MODULE_IDENTIFIER_RE = re.compile(r'^(?:\s*(\w+)\s*\.)?\s*(\w+)')
 
-class _InitVarMeta(type):
-    def __getitem__(self, params):
-        return InitVar(params)
-
-class InitVar(metaclass=_InitVarMeta):
+class InitVar:
     __slots__ = ('type', )
 
     def __init__(self, type):
@@ -211,6 +207,9 @@ class InitVar(metaclass=_InitVarMeta):
 
     def __repr__(self):
         return f'dataclasses.InitVar[{self.type.__name__}]'
+
+    def __class_getitem__(cls, type):
+        return InitVar(type)
 
 
 # Instances of Field are only ever created from within this module,


### PR DESCRIPTION


<!-- issue-number: [bpo-38209](https://bugs.python.org/issue38209) -->
https://bugs.python.org/issue38209
<!-- /issue-number -->
