### PR TITLE
bpo-38215: Do not import modules in star-import when __all__ is not defined.

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -811,9 +811,14 @@ of strings which are names defined or imported by that module.  The names
 given in ``__all__`` are all considered public and are required to exist.  If
 ``__all__`` is not defined, the set of public names includes all names found
 in the module's namespace which do not begin with an underscore character
-(``'_'``).  ``__all__`` should contain the entire public API. It is intended
-to avoid accidentally exporting items that are not part of the API (such as
-library modules which were imported and used within the module).
+(``'_'``) and corresponding values are not modules (such as library modules
+which were imported and used within the module).  ``__all__`` should contain
+the entire public API.  It is intended to avoid accidentally exporting items
+that are not part of the API.
+
+.. versionchanged:: 3.9
+   Modules from the module's namespace are not included in *public names*
+   if ``__all__`` is not defined.
 
 The wild card form of import --- ``from module import *`` --- is only allowed at
 the module level.  Attempting to use it in class or function definitions will

--- a/Lib/test/test_pkg.py
+++ b/Lib/test/test_pkg.py
@@ -99,7 +99,7 @@ class TestPkg(unittest.TestCase):
     def test_2(self):
         hier = [
          ("t2", None),
-         ("t2 __init__.py", "'doc for t2'"),
+         ("t2 __init__.py", "'doc for t2'\nbar = 1\n_baz = 2"),
          ("t2 sub", None),
          ("t2 sub __init__.py", ""),
          ("t2 sub subsub", None),
@@ -118,7 +118,7 @@ class TestPkg(unittest.TestCase):
         s = """
             import t2
             from t2 import *
-            self.assertEqual(dir(), ['self', 'sub', 't2'])
+            self.assertEqual(dir(), ['bar', 'self', 't2'])
             """
         self.run_code(s)
 
@@ -139,7 +139,7 @@ class TestPkg(unittest.TestCase):
 
         s = """
             from t2 import *
-            self.assertEqual(dir(), ['self', 'sub'])
+            self.assertEqual(dir(), ['bar', 'self'])
             """
         self.run_code(s)
 
@@ -183,7 +183,7 @@ class TestPkg(unittest.TestCase):
     def test_5(self):
         hier = [
         ("t5", None),
-        ("t5 __init__.py", "import t5.foo"),
+        ("t5 __init__.py", "import t5.foo\nbar = 1\n_baz = 2"),
         ("t5 string.py", "spam = 1"),
         ("t5 foo.py",
          "from . import string; assert string.spam == 1"),
@@ -193,7 +193,7 @@ class TestPkg(unittest.TestCase):
         import t5
         s = """
             from t5 import *
-            self.assertEqual(dir(), ['foo', 'self', 'string', 't5'])
+            self.assertEqual(dir(), ['bar', 'self'])
             """
         self.run_code(s)
 
@@ -201,7 +201,7 @@ class TestPkg(unittest.TestCase):
         self.assertEqual(fixdir(dir(t5)),
                          ['__cached__', '__doc__', '__file__', '__loader__',
                           '__name__', '__package__', '__path__', '__spec__',
-                          'foo', 'string', 't5'])
+                          '_baz', 'bar', 'foo', 'string', 't5'])
         self.assertEqual(fixdir(dir(t5.foo)),
                          ['__cached__', '__doc__', '__file__', '__loader__',
                           '__name__', '__package__', '__spec__', 'string'])

--- a/Lib/xml/parsers/expat.py
+++ b/Lib/xml/parsers/expat.py
@@ -2,6 +2,7 @@
 import sys
 
 from pyexpat import *
+from pyexpat import model, errors
 
 # provide pyexpat submodules as xml.parsers.expat submodules
 sys.modules['xml.parsers.expat.model'] = model

--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-18-18-59-59.bpo-38215.Zn0q3l.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-18-18-59-59.bpo-38215.Zn0q3l.rst
@@ -1,0 +1,2 @@
+Modules from the module's namespace no longer included in *public names* if
+``__all__`` is not defined.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5332,6 +5332,8 @@ import_all_from(PyThreadState *tstate, PyObject *locals, PyObject *v)
         value = PyObject_GetAttr(v, name);
         if (value == NULL)
             err = -1;
+        else if (skip_leading_underscores && PyModule_Check(value))
+            err = 0;  /* skip modules if no __all__ */
         else if (PyDict_CheckExact(locals))
             err = PyDict_SetItem(locals, name, value);
         else


### PR DESCRIPTION


<!-- issue-number: [bpo-38215](https://bugs.python.org/issue38215) -->
https://bugs.python.org/issue38215
<!-- /issue-number -->
