### PR TITLE
bpo-17258: use sha256 instead of md5 within multiprocessing.connection

### DIFF
--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -42,6 +42,10 @@ BUFSIZE = 8192
 # A very generous timeout when it comes to local connections...
 CONNECTION_TIMEOUT = 20.
 
+# The hmac module implicitly defaults to using MD5.
+# Support using a stronger algorithm for the challenge/response code:
+HMAC_DIGEST_NAME='sha256'
+
 _mmap_counter = itertools.count()
 
 default_family = 'AF_INET'
@@ -735,7 +739,7 @@ def deliver_challenge(connection, authkey):
             "Authkey must be bytes, not {0!s}".format(type(authkey)))
     message = os.urandom(MESSAGE_LENGTH)
     connection.send_bytes(CHALLENGE + message)
-    digest = hmac.new(authkey, message, 'md5').digest()
+    digest = hmac.new(authkey, message, HMAC_DIGEST_NAME).digest()
     response = connection.recv_bytes(256)        # reject large message
     if response == digest:
         connection.send_bytes(WELCOME)
@@ -751,7 +755,7 @@ def answer_challenge(connection, authkey):
     message = connection.recv_bytes(256)         # reject large message
     assert message[:len(CHALLENGE)] == CHALLENGE, 'message = %r' % message
     message = message[len(CHALLENGE):]
-    digest = hmac.new(authkey, message, 'md5').digest()
+    digest = hmac.new(authkey, message, HMAC_DIGEST_NAME).digest()
     connection.send_bytes(digest)
     response = connection.recv_bytes(256)        # reject large message
     if response != WELCOME:

--- a/Misc/NEWS.d/next/Library/2019-09-18-18-11-20.bpo-17258.-dzbBz.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-18-18-11-20.bpo-17258.-dzbBz.rst
@@ -1,0 +1,2 @@
+Within multiprocessing.connection, use sha256 instead of md5 for
+deliver_challenge() and answer_challenge().


### PR DESCRIPTION
Within multiprocessing.connection, deliver_challenge() and
answer_challenge() use hmac for a challenge/response, however
hmac implicitly defaults to using MD5, which fails under FIPS
mode. Hardcode the digest value to sha256.

This PR is adapted from the patch provided at [bpo-17258](https://bugs.python.org/issue17258) and pulled from https://github.com/encukou/cpython/commit/b819ca654873ea36144ce1cb6f8c422a6d2f5d7d

<!-- issue-number: [bpo-17258](https://bugs.python.org/issue17258) -->
https://bugs.python.org/issue17258
<!-- /issue-number -->
