### PR TITLE
bpo-38218: Corrected syntax for return annotation

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -400,7 +400,7 @@ If a :keyword:`finally` clause is present, the :keyword:`finally` clause will ex
 
 For example::
 
-   >>> def bool_return(): -> bool:
+   >>> def bool_return():
    ...     try:
    ...         return True
    ...     finally:


### PR DESCRIPTION
Signed-off-by: Jason Plurad <pluradj@us.ibm.com>


<!-- issue-number: [bpo-38218](https://bugs.python.org/issue38218) -->
https://bugs.python.org/issue38218
<!-- /issue-number -->
