### PR TITLE
Fix or remove dead assignments identified by scan-build

### DIFF
--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2489,7 +2489,6 @@ delta_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         int x_is_odd;
         PyObject *temp;
 
-        whole_us = round(leftover_us);
         if (fabs(whole_us - leftover_us) == 0.5) {
             /* We're exactly halfway between two integers.  In order
              * to do round-half-to-even, we must determine whether x

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -1002,7 +1002,6 @@ pattern_subx(PatternObject* self, PyObject* ptemplate, PyObject* string,
         int literal;
         view.buf = NULL;
         ptr = getstring(ptemplate, &n, &isbytes, &charsize, &view);
-        b = charsize;
         if (ptr) {
             if (charsize == 1)
                 literal = memchr(ptr, '\\', n) == NULL;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4176,7 +4176,6 @@ _ssl__SSLContext_load_verify_locations_impl(PySSLContext *self,
         r = SSL_CTX_load_verify_locations(self->ctx, cafile_buf, capath_buf);
         PySSL_END_ALLOW_THREADS
         if (r != 1) {
-            ok = 0;
             if (errno != 0) {
                 ERR_clear_error();
                 PyErr_SetFromErrno(PyExc_OSError);

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -221,8 +221,9 @@ _sharedexception_bind(PyObject *exctype, PyObject *exc, PyObject *tb)
     if (err->name == NULL) {
         if (PyErr_ExceptionMatches(PyExc_MemoryError)) {
             failure = "out of memory copying exception type name";
+        } else {
+            failure = "unable to encode and copy exception type name";
         }
-        failure = "unable to encode and copy exception type name";
         goto finally;
     }
 
@@ -237,8 +238,9 @@ _sharedexception_bind(PyObject *exctype, PyObject *exc, PyObject *tb)
         if (err->msg == NULL) {
             if (PyErr_ExceptionMatches(PyExc_MemoryError)) {
                 failure = "out of memory copying exception message";
+            } else {
+                failure = "unable to encode and copy exception message";
             }
-            failure = "unable to encode and copy exception message";
             goto finally;
         }
     }

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1639,7 +1639,6 @@ idna_converter(PyObject *obj, struct maybe_idna *data)
         return 1;
     }
     data->obj = NULL;
-    len = -1;
     if (PyBytes_Check(obj)) {
         data->buf = PyBytes_AsString(obj);
         len = PyBytes_Size(obj);

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -265,7 +265,7 @@ config_init_module_search_paths(PyConfig *config, _PyPathConfig *pathconfig)
 
     const wchar_t *sys_path = pathconfig->module_search_path;
     const wchar_t delim = DELIM;
-    const wchar_t *p = sys_path;
+    const wchar_t *p;
     while (1) {
         p = wcschr(sys_path, delim);
         if (p == NULL) {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -680,7 +680,6 @@ pyinit_config(_PyRuntimeState *runtime,
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
-    config = &tstate->interp->config;
     *tstate_p = tstate;
 
     status = pycore_init_types();


### PR DESCRIPTION
[scan-build](https://clang-analyzer.llvm.org/scan-build.html) identified several variable assignments that are overwritten before they can be used. To make the code easier to understand and to ensure that it is fully optimized, let's fix or get rid of these dead assignments.