### PR TITLE
bpo-38225: allow external code to easily mark a function as a coroutine

### DIFF
--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -158,7 +158,7 @@ def coroutine(func):
 
 
 # A marker for iscoroutinefunction.
-_is_coroutine = object()
+_is_coroutine = True
 
 
 def iscoroutinefunction(func):


### PR DESCRIPTION
<!-- issue-number: [bpo-38225](https://bugs.python.org/issue38225) -->
https://bugs.python.org/issue38225
<!-- /issue-number -->
