### PR TITLE
bpo-37224: Fix test__xxsubinterpreters failure and GIL handling in interp_destroy()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-20-08-37-29.bpo-38154.UnJXLK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-20-08-37-29.bpo-38154.UnJXLK.rst
@@ -1,0 +1,1 @@
+Improve GIL handling in ``interp_destroy()``.

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2054,7 +2054,7 @@ interp_destroy(PyObject *self, PyObject *args, PyObject *kwds)
     if (_ensure_not_running(interp) < 0) {
         return NULL;
     }
-    // Ensure current thread has the GIL (bpo-38154)
+    // Safely ensure current thread has the GIL (bpo-38154)
     PyThreadState *current_tstate = PyGILState_GetThisThreadState();
     if (!_Py_IsFinalizing() && !PyGILState_Check()){
         PyEval_RestoreThread(current_tstate);

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2054,6 +2054,7 @@ interp_destroy(PyObject *self, PyObject *args, PyObject *kwds)
     if (_ensure_not_running(interp) < 0) {
         return NULL;
     }
+
     // Safely ensure current thread has the GIL (bpo-38154)
     PyThreadState *current_tstate = PyGILState_GetThisThreadState();
     if (!_Py_IsFinalizing() && !PyGILState_Check()){

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2054,7 +2054,11 @@ interp_destroy(PyObject *self, PyObject *args, PyObject *kwds)
     if (_ensure_not_running(interp) < 0) {
         return NULL;
     }
-
+    // Ensure current thread has the GIL (bpo-38154)
+    PyThreadState *current_tstate = PyGILState_GetThisThreadState();
+    if (!_Py_IsFinalizing() && !PyGILState_Check()){
+        PyEval_RestoreThread(current_tstate);
+    }
     // Destroy the interpreter.
     //PyInterpreterState_Delete(interp);
     PyThreadState *tstate = PyInterpreterState_ThreadHead(interp);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

This is primarily targeted at addressing the BuildBot (AMD64 FreeBSD) failure for ``test__xxsubinterpreters``:

```
FAIL: test_still_running (test.test__xxsubinterpreters.DestroyTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/home/buildbot/python/3.x.koobs-freebsd-current/build/Lib/test/test__xxsubinterpreters.py", line 765, in test_still_running
    interpreters.destroy(interp)
AssertionError: RuntimeError not raised
```

I suspect the failure is occurring when multiple threads are attempting to destroy the same sub-interpreter. To fix this issue, the appropriate solution seems to be ensuring that the current thread attempting to end the sub-interpreter is able to do so without interruption. 

From my understanding, this can be accomplished by ensuring the current thread has acquired the GIL. To ensure it is done safely, ``PyEval_RestoreThread`` is called only when the thread is not finalizing and has not already acquired the GIL.

Note: This is my first attempt at fixing an issue involving sub-interpreters, and my first fix within the C-API. My main areas of experience thus far have been in the documentation and in exclusively Python code changes. If I have made any mistakes or misunderstandings, I would greatly appreciate it if they could be explained in detail.

<!-- issue-number: [bpo-38154](https://bugs.python.org/issue38154) -->
https://bugs.python.org/issue38154
<!-- /issue-number -->
