### PR TITLE
bpo-38187: Fix a refleak in Tools/c-analyzer.

### DIFF
--- a/Lib/test/test_tools/test_c_analyzer/test_c_analyzer_common/__init__.py
+++ b/Lib/test/test_tools/test_c_analyzer/test_c_analyzer_common/__init__.py
@@ -1,0 +1,6 @@
+import os.path
+from test.support import load_package_tests
+
+
+def load_tests(*args):
+    return load_package_tests(os.path.dirname(__file__), *args)

--- a/Lib/test/test_tools/test_c_analyzer/test_c_analyzer_common/test_known.py
+++ b/Lib/test/test_tools/test_c_analyzer/test_c_analyzer_common/test_known.py
@@ -15,9 +15,6 @@ class FromFileTests(unittest.TestCase):
 
     _return_read_tsv = ()
 
-    def tearDown(self):
-        Variable._isglobal.instances.clear()
-
     @property
     def calls(self):
         try:

--- a/Lib/test/test_tools/test_c_analyzer/test_c_globals/__init__.py
+++ b/Lib/test/test_tools/test_c_analyzer/test_c_globals/__init__.py
@@ -1,0 +1,6 @@
+import os.path
+from test.support import load_package_tests
+
+
+def load_tests(*args):
+    return load_package_tests(os.path.dirname(__file__), *args)

--- a/Lib/test/test_tools/test_c_analyzer/test_c_globals/test_find.py
+++ b/Lib/test/test_tools/test_c_analyzer/test_c_globals/test_find.py
@@ -64,7 +64,9 @@ class StaticsFromBinaryTests(_Base):
                                          **self.kwargs))
 
         self.assertEqual(found, [
+            info.Variable.from_parts('dir1/spam.c', None, 'var1', 'int'),
             info.Variable.from_parts('dir1/spam.c', None, 'var2', 'static int'),
+            info.Variable.from_parts('dir1/spam.c', None, 'var3', 'char *'),
             info.Variable.from_parts('dir1/eggs.c', None, 'var1', 'static int'),
             info.Variable.from_parts('dir1/eggs.c', 'func1', 'var2', 'static char *'),
             ])
@@ -299,7 +301,7 @@ class StaticsTest(_Base):
             info.Variable.from_parts('src1/spam.c', None, 'var1', 'static const char *'),
             info.Variable.from_parts('src1/spam.c', None, 'var1b', 'const char *'),
             info.Variable.from_parts('src1/spam.c', 'ham', 'initialized', 'static int'),
-            info.Variable.from_parts('src1/spam.c', 'ham', 'result', 'int'),
+            info.Variable.from_parts('src1/spam.c', 'ham', 'result', 'int'),  # skipped
             info.Variable.from_parts('src1/spam.c', None, 'var2', 'static PyObject *'),
             info.Variable.from_parts('src1/eggs.c', 'tofu', 'ready', 'static int'),
             info.Variable.from_parts('src1/spam.c', None, 'freelist', 'static (PyTupleObject *)[10]'),
@@ -318,6 +320,7 @@ class StaticsTest(_Base):
 
         self.assertEqual(found, [
             info.Variable.from_parts('src1/spam.c', None, 'var1', 'static const char *'),
+            info.Variable.from_parts('src1/spam.c', None, 'var1b', 'const char *'),
             info.Variable.from_parts('src1/spam.c', 'ham', 'initialized', 'static int'),
             info.Variable.from_parts('src1/spam.c', None, 'var2', 'static PyObject *'),
             info.Variable.from_parts('src1/eggs.c', 'tofu', 'ready', 'static int'),

--- a/Lib/test/test_tools/test_c_analyzer/test_c_parser/__init__.py
+++ b/Lib/test/test_tools/test_c_analyzer/test_c_parser/__init__.py
@@ -1,0 +1,6 @@
+import os.path
+from test.support import load_package_tests
+
+
+def load_tests(*args):
+    return load_package_tests(os.path.dirname(__file__), *args)

--- a/Lib/test/test_tools/test_c_analyzer/test_c_symbols/__init__.py
+++ b/Lib/test/test_tools/test_c_analyzer/test_c_symbols/__init__.py
@@ -1,0 +1,6 @@
+import os.path
+from test.support import load_package_tests
+
+
+def load_tests(*args):
+    return load_package_tests(os.path.dirname(__file__), *args)

--- a/Tools/c-analyzer/c_analyzer_common/_generate.py
+++ b/Tools/c-analyzer/c_analyzer_common/_generate.py
@@ -262,7 +262,7 @@ def _known(symbol):
                 raise
     if symbol.name not in decl:
         decl = decl + symbol.name
-    return Variable(varid, decl)
+    return Variable(varid, 'static', decl)
 
 
 def known_row(varid, decl):
@@ -291,7 +291,7 @@ def known_rows(symbols, *,
             except KeyError:
                 found = _find_match(symbol, cache, filenames)
                 if found is None:
-                    found = Variable(symbol.id, UNKNOWN)
+                    found = Variable(symbol.id, UNKNOWN, UNKNOWN)
             yield _as_known(found.id, found.vartype)
     else:
         raise NotImplementedError  # XXX incorporate KNOWN

--- a/Tools/c-analyzer/c_analyzer_common/util.py
+++ b/Tools/c-analyzer/c_analyzer_common/util.py
@@ -82,6 +82,13 @@ class Slot:
         self.default = default
         self.readonly = readonly
 
+        # The instance cache is not inherently tied to the normal
+        # lifetime of the instances.  So must do something in order to
+        # avoid keeping the instances alive by holding a reference here.
+        # Ideally we would use weakref.WeakValueDictionary to do this.
+        # However, most builtin types do not support weakrefs.  So
+        # instead we monkey-patch __del__ on the attached class to clear
+        # the instance.
         self.instances = {}
         self.name = None
 
@@ -89,6 +96,12 @@ class Slot:
         if self.name is not None:
             raise TypeError('already used')
         self.name = name
+        try:
+            slotnames = cls.__slot_names__
+        except AttributeError:
+            slotnames = cls.__slot_names__ = []
+        slotnames.append(name)
+        self._ensure___del__(cls, slotnames)
 
     def __get__(self, obj, cls):
         if obj is None:  # called on the class
@@ -116,6 +129,22 @@ class Slot:
         if self.readonly:
             raise AttributeError(f'{self.name} is readonly')
         self.instances[id(obj)] = self.default
+
+    def _ensure___del__(self, cls, slotnames):  # See the comment in __init__().
+        try:
+            old___del__ = cls.__del__
+        except AttributeError:
+            old___del__ = (lambda s: None)
+        else:
+            if getattr(old___del__, '_slotted', False):
+                return
+
+        def __del__(_self):
+            for name in slotnames:
+                delattr(_self, name)
+            old___del__(_self)
+        __del__._slotted = True
+        cls.__del__ = __del__
 
     def set(self, obj, value):
         """Update the cached value for an object.

--- a/Tools/c-analyzer/c_analyzer_common/util.py
+++ b/Tools/c-analyzer/c_analyzer_common/util.py
@@ -128,7 +128,7 @@ class Slot:
     def __delete__(self, obj):
         if self.readonly:
             raise AttributeError(f'{self.name} is readonly')
-        self.instances[id(obj)] = self.default
+        self.instances[id(obj)] = self.default  # XXX refleak?
 
     def _ensure___del__(self, cls, slotnames):  # See the comment in __init__().
         try:

--- a/Tools/c-analyzer/c_parser/info.py
+++ b/Tools/c-analyzer/c_parser/info.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import re
 
 from c_analyzer_common import info, util
 from c_analyzer_common.util import classonly, _NTBase
@@ -15,28 +16,53 @@ def normalize_vartype(vartype):
     return str(vartype)
 
 
+def extract_storage(decl, *, isfunc=False):
+    """Return (storage, vartype) based on the given declaration.
+
+    The default storage is "implicit" or "local".
+    """
+    if decl == info.UNKNOWN:
+        return decl, decl
+    if decl.startswith('static '):
+        return 'static', decl
+        #return 'static', decl.partition(' ')[2].strip()
+    elif decl.startswith('extern '):
+        return 'extern', decl
+        #return 'extern', decl.partition(' ')[2].strip()
+    elif re.match('.*\b(static|extern)\b', decl):
+        raise NotImplementedError
+    elif isfunc:
+        return 'local', decl
+    else:
+        return 'implicit', decl
+
+
 class Variable(_NTBase,
-               namedtuple('Variable', 'id vartype')):
+               namedtuple('Variable', 'id storage vartype')):
     """Information about a single variable declaration."""
 
     __slots__ = ()
-    _isglobal = util.Slot()
 
-    def __del__(self):
-        del self._isglobal
+    STORAGE = (
+            'static',
+            'extern',
+            'implicit',
+            'local',
+            )
 
     @classonly
-    def from_parts(cls, filename, funcname, name, vartype, isglobal=False):
+    def from_parts(cls, filename, funcname, name, decl, storage=None):
+        if storage is None:
+            storage, decl = extract_storage(decl, isfunc=funcname)
         id = info.ID(filename, funcname, name)
-        self = cls(id, vartype)
-        if isglobal:
-            self._isglobal = True
+        self = cls(id, storage, decl)
         return self
 
-    def __new__(cls, id, vartype):
+    def __new__(cls, id, storage, vartype):
         self = super().__new__(
                 cls,
                 id=info.ID.from_raw(id),
+                storage=str(storage) if storage else None,
                 vartype=normalize_vartype(vartype) if vartype else None,
                 )
         return self
@@ -63,18 +89,17 @@ class Variable(_NTBase,
         """Fail if the object is invalid (i.e. init with bad data)."""
         self._validate_id()
 
+        if self.storage is None or self.storage == info.UNKNOWN:
+            raise TypeError('missing storage')
+        elif self.storage not in self.STORAGE:
+            raise ValueError(f'unsupported storage {self.storage:r}')
+
         if self.vartype is None or self.vartype == info.UNKNOWN:
             raise TypeError('missing vartype')
 
     @property
     def isglobal(self):
-        try:
-            return self._isglobal
-        except AttributeError:
-            # XXX Include extern variables.
-            # XXX Ignore functions.
-            self._isglobal = ('static' in self.vartype.split())
-            return self._isglobal
+        return self.storage != 'local'
 
     @property
     def isconst(self):

--- a/Tools/c-analyzer/c_parser/naive.py
+++ b/Tools/c-analyzer/c_parser/naive.py
@@ -163,7 +163,7 @@ def find_variables(varids, filenames=None, *,
             srcfiles = [varid.filename]
         else:
             if not filenames:
-                yield Variable(varid, UNKNOWN)
+                yield Variable(varid, UNKNOWN, UNKNOWN)
                 continue
             srcfiles = filenames
         for filename in srcfiles:
@@ -177,4 +177,4 @@ def find_variables(varids, filenames=None, *,
                 used.add(found)
                 break
         else:
-            yield Variable(varid, UNKNOWN)
+            yield Variable(varid, UNKNOWN, UNKNOWN)

--- a/Tools/c-analyzer/c_symbols/resolve.py
+++ b/Tools/c-analyzer/c_symbols/resolve.py
@@ -68,14 +68,11 @@ def find_in_source(symbol, dirnames, *,
     if symbol.funcname and symbol.funcname != UNKNOWN:
         raise NotImplementedError
 
-    (filename, funcname, vartype
+    (filename, funcname, decl
      ) = _find_symbol(symbol.name, filenames, _perfilecache)
     if filename == UNKNOWN:
         return None
-    return info.Variable(
-            id=(filename, funcname, symbol.name),
-            vartype=vartype,
-            )
+    return info.Variable.from_parts(filename, funcname, symbol.name, decl)
 
 
 def get_resolver(knownvars=None, dirnames=None, *,
@@ -144,6 +141,7 @@ def symbols_to_variables(symbols, *,
             #raise NotImplementedError(symbol)
             resolved = info.Variable(
                     id=symbol.id,
+                    storage=UNKNOWN,
                     vartype=UNKNOWN,
                     )
         yield resolved


### PR DESCRIPTION
The "Slot" helper (descriptor) is leaking references due to its caching mechanism.  The PR includes a partial fix to Slot, but also adds Variable.storage to replace the problematic use of Slot.

<!-- issue-number: [bpo-38187](https://bugs.python.org/issue38187) -->
https://bugs.python.org/issue38187
<!-- /issue-number -->
