### PR TITLE
bpo-38244: [Documentation] Fix unreliable link to sever in ftplib.rst

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -22,7 +22,7 @@ as mirroring other FTP servers.  It is also used by the module
 Here's a sample session using the :mod:`ftplib` module::
 
    >>> from ftplib import FTP
-   >>> ftp = FTP('ftp.us.debian.org')     # connect to host, default port
+   >>> ftp = FTP('ftp.us.debian.org')  # connect to host, default port
    >>> ftp.login()                     # user anonymous, passwd anonymous@
    '230 Login successful.'
    >>> ftp.cwd('debian')               # change into "debian" directory

--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -22,7 +22,7 @@ as mirroring other FTP servers.  It is also used by the module
 Here's a sample session using the :mod:`ftplib` module::
 
    >>> from ftplib import FTP
-   >>> ftp = FTP('ftp.debian.org')     # connect to host, default port
+   >>> ftp = FTP('ftp.us.debian.org')     # connect to host, default port
    >>> ftp.login()                     # user anonymous, passwd anonymous@
    '230 Login successful.'
    >>> ftp.cwd('debian')               # change into "debian" directory


### PR DESCRIPTION
* The link to `ftp.debian.org` is unreliable due to a failed redirect. Instead the main URL to `ftp.us.debian.org` is preferred

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38244](https://bugs.python.org/issue38244) -->
https://bugs.python.org/issue38244
<!-- /issue-number -->
