### PR TITLE
bpo-38216, bpo-36274: Allow subclasses to override validation and encoding behavior

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1172,15 +1172,20 @@ class HTTPConnection:
             # For HTTP/1.0, the server will assume "not chunked"
             pass
 
+
+    # The encoding URLs are constrained to before hitting the wire.
+    _prepare_path_encoding = 'ascii'
+
     def _prepare_path(self, url):
         """Validate a url for putrequest and return encoded bytes."""
         # Prevent CVE-2019-9740.
-        if match := _contains_disallowed_url_pchar_re.search(url):
+        match = _contains_disallowed_url_pchar_re.search(url)
+        if match:
             raise InvalidURL(f"URL can't contain control characters. {url!r} "
                              f"(found at least {match.group()!r})")
 
-        # Require ASCII characters only
-        return url.encode('ascii')
+        # Require a specific character set (normally ASCII).
+        return url.encode(self._prepare_path_encoding)
 
     def putheader(self, header, *values):
         """Send a request header line to the server.

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1094,7 +1094,6 @@ class HTTPConnection:
             self._http_vsn_str.encode('ascii')
         ))
 
-        # Non-ASCII characters should have been eliminated earlier
         self._output(request)
 
         if self._http_vsn == 11:

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1173,8 +1173,9 @@ class HTTPConnection:
             pass
 
 
-    # The encoding URLs are constrained to before hitting the wire.
-    _prepare_path_encoding = 'ascii'
+    def _encode_prepared_path(self, str_url):
+        # ASCII also helps prevent CVE-2019-9740.
+        return str_url.encode('ascii')
 
     def _prepare_path(self, url):
         """Validate a url for putrequest and return encoded bytes."""
@@ -1184,8 +1185,7 @@ class HTTPConnection:
             raise InvalidURL(f"URL can't contain control characters. {url!r} "
                              f"(found at least {match.group()!r})")
 
-        # Require a specific character set (normally ASCII).
-        return url.encode(self._prepare_path_encoding)
+        return self._encode_prepared_path(url)
 
     def putheader(self, header, *values):
         """Send a request header line to the server.

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1089,10 +1089,7 @@ class HTTPConnection:
         self._method = method
         if not url:
             url = '/'
-        # Prevent CVE-2019-9740.
-        if match := _contains_disallowed_url_pchar_re.search(url):
-            raise InvalidURL(f"URL can't contain control characters. {url!r} "
-                             f"(found at least {match.group()!r})")
+        self._validate_url(url)
         request = '%s %s %s' % (method, url, self._http_vsn_str)
 
         # Non-ASCII characters should have been eliminated earlier
@@ -1173,6 +1170,13 @@ class HTTPConnection:
         else:
             # For HTTP/1.0, the server will assume "not chunked"
             pass
+
+    def _validate_url(self, url):
+        """Validate a url for putrequest"""
+        # Prevent CVE-2019-9740.
+        if match := _contains_disallowed_url_pchar_re.search(url):
+            raise InvalidURL(f"URL can't contain control characters. {url!r} "
+                             f"(found at least {match.group()!r})")
 
     def putheader(self, header, *values):
         """Send a request header line to the server.

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -1175,15 +1175,7 @@ class BasicTest(TestCase):
         (bpo-36274).
         """
         class UnsafeHTTPConnection(client.HTTPConnection):
-            def _prepare_path(self, url):
-                # Prevent CVE-2019-9740.
-                if match := client._contains_disallowed_url_pchar_re.search(
-                        url):
-                    raise InvalidURL(
-                        f"URL can't contain control characters. {url!r} "
-                        f"(found at least {match.group()!r})")
-
-                return url.encode('utf-8')
+            _prepare_path_encoding = 'utf-8'
 
         conn = UnsafeHTTPConnection('example.com')
         conn.sock = FakeSocket('')

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -1175,7 +1175,8 @@ class BasicTest(TestCase):
         (bpo-36274).
         """
         class UnsafeHTTPConnection(client.HTTPConnection):
-            _prepare_path_encoding = 'utf-8'
+            def _encode_prepared_path(self, str_url):
+                return str_url.encode('utf-8')
 
         conn = UnsafeHTTPConnection('example.com')
         conn.sock = FakeSocket('')

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -1209,7 +1209,7 @@ class BasicTest(TestCase):
 
         conn = UnsafeHTTPConnection('example.com')
         conn.sock = FakeSocket('')
-        conn.putrequest('GET', InvalidObject())
+        conn.putrequest('GET', InvalidObject(), skip_host=True)
 
 
 class ExtendedReadTest(TestCase):

--- a/Misc/NEWS.d/next/Library/2019-09-27-15-24-45.bpo-38216.-7yvZR.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-27-15-24-45.bpo-38216.-7yvZR.rst
@@ -1,0 +1,4 @@
+Allow the rare code that wants to send invalid http requests from the
+`http.client` library a way to do so.  The fixes for bpo-30458 led to
+breakage for some projects that were relying on this ability to test their
+own behavior in the face of bad requests.


### PR DESCRIPTION
This patch introduces a new semi-private hook for subclasses to override the validation and encoding behavior in `http.client.HTTPConnection.putrequest`, allowing select clients to customize the behavior and implement invalid requests as was possible prior to the patch in [bpo-30458](https://bugs.python.org/issue30458) (for control characters) and prior to Python 3.0 (for encoding).

<!-- issue-number: [bpo-38216](https://bugs.python.org/issue38216) -->
https://bugs.python.org/issue38216
<!-- /issue-number -->
