### PR TITLE
WIP: bpo-38247: list(str.split(ch))

### DIFF
--- a/Objects/stringlib/split.h
+++ b/Objects/stringlib/split.h
@@ -112,16 +112,35 @@ STRINGLIB(split_char)(PyObject* str_obj,
         return NULL;
 
     i = j = 0;
-    while ((j < str_len) && (maxcount-- > 0)) {
+    while (i < str_len && str[i] == ch){
+        i++;
+        j++;
+    }
+    if(i<str_len){
+        j++;
+        while(j<str_len){
+            if(str[j-1]==ch && str[j-1]!=ch){
+                i=j;
+            }
+            if(str[j]==ch && str[j-1]!=ch){
+                SPLIT_ADD(str, i, j);
+            }
+            j++;
+        }
+    }
+    if(str[str_len-1]!=ch){
+        SPLIT_ADD(str, i, j);
+    }
+    /*while ((j < str_len) && (maxcount-- > 0)) {
         for(; j < str_len; j++) {
-            /* I found that using memchr makes no difference */
+            // I found that using memchr makes no difference 
             if (str[j] == ch) {
                 SPLIT_ADD(str, i, j);
                 i = j = j + 1;
                 break;
             }
         }
-    }
+    } */
 #ifndef STRINGLIB_MUTABLE
     if (count == 0 && STRINGLIB_CHECK_EXACT(str_obj)) {
         /* ch not in str_obj, so just use str_obj as list[0] */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# list(string.split(char))

It should be in the following format:

```
[bpo-15902](https://bugs.python.org/issue15902): Changed the loop so that empty elements aren't added when the characters are repeated 
I have been annoyed by the fact that at multiple where we print list(str.split(ch)) we get empty elements in place of repeated characters (ch).

Example:

####
>>> print(list("Hello World How Are You?".split(" ")))
['Hello', 'World', 'How', 'Are', 'You?']
>>> print(list("Hello World       How Are      You?".split(" ")))
['Hello', 'World', '', '', '', '', '', '', 'How', 'Are', '', '', '', '', '', 'You?']
####

So can it be fixed so that  it gives:

####
>>> print(list("Hello World How Are You?".split(" ")))
['Hello', 'World', 'How', 'Are', 'You?']
>>> print(list("Hello World       How Are      You?".split(" ")))
['Hello', 'World', 'How', 'Are', 'You?']
####
```

Where: [bpo-15902](https://bugs.python.org/issue15902) refers to the issue number in the https://bugs.python.org.

```
[X.Y] <title from the original PR> (GH-16324)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-16324 refers to the PR number from `master`.

-->
