### PR TITLE
bpo-38255: Replace "method" with "attribute" in the description of super()

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1594,7 +1594,7 @@ are always available.  They are listed here in alphabetical order.
 .. function:: super([type[, object-or-type]])
 
    Return a proxy object that delegates attribute access to a parent or sibling
-   class of *type*.  This is useful for accessing inherited methods that have
+   class of *type*.  This is commonly used for accessing inherited methods that have
    been overridden in a class.
 
    The *object-or-type* determines the :term:`method resolution order`

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1593,8 +1593,8 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: super([type[, object-or-type]])
 
-   Return a proxy object that delegates method calls to a parent or sibling
-   class of *type*.  This is useful for accessing inherited methods that have
+   Return a proxy object that delegates attribute accesses to a parent or sibling
+   class of *type*.  This is useful for accessing inherited attributes that have
    been overridden in a class.
 
    The *object-or-type* determines the :term:`method resolution order`

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1594,7 +1594,7 @@ are always available.  They are listed here in alphabetical order.
 .. function:: super([type[, object-or-type]])
 
    Return a proxy object that delegates attribute access to a parent or sibling
-   class of *type*.  This is useful for accessing inherited methods (or data attributes) that have
+   class of *type*.  This is useful for accessing inherited methods that have
    been overridden in a class.
 
    The *object-or-type* determines the :term:`method resolution order`

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1594,7 +1594,7 @@ are always available.  They are listed here in alphabetical order.
 .. function:: super([type[, object-or-type]])
 
    Return a proxy object that delegates attribute access to a parent or sibling
-   class of *type*.  This is useful for accessing inherited attributes that have
+   class of *type*.  This is useful for accessing inherited methods (or data attributes) that have
    been overridden in a class.
 
    The *object-or-type* determines the :term:`method resolution order`

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1593,7 +1593,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: super([type[, object-or-type]])
 
-   Return a proxy object that delegates attribute accesses to a parent or sibling
+   Return a proxy object that delegates attribute access to a parent or sibling
    class of *type*.  This is useful for accessing inherited attributes that have
    been overridden in a class.
 


### PR DESCRIPTION
This PR will make the following change to the [_Built-in Functions_ chapter](https://docs.python.org/3.8/library/functions.html#super) of the library documentation:

- replace the word "method" with the more general word "attribute" in the description of `super()`, since `super()` is not restricted to method access but can also do data attribute access:

```
>>> class A:
...     x = True
... 
>>> class B(A):
...     x = False
... 
>>> B().x
False
>>> super(B, B()).x
True
```

<!-- issue-number: [bpo-38255](https://bugs.python.org/issue38255) -->
https://bugs.python.org/issue38255
<!-- /issue-number -->