### PR TITLE
bpo-38236: Fix init_dump_ascii_wstr()

### DIFF
--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2547,6 +2547,7 @@ init_dump_ascii_wstr(const wchar_t *str)
 {
     if (str == NULL) {
         PySys_WriteStderr("(not set)");
+        return;
     }
 
     PySys_WriteStderr("'");


### PR DESCRIPTION
Add missing "return;" (to not dereference NULL pointer).

<!-- issue-number: [bpo-38236](https://bugs.python.org/issue38236) -->
https://bugs.python.org/issue38236
<!-- /issue-number -->
