### PR TITLE
[3.8] bpo-38234: Fix Windows _PyPathConfig_Calculate()

### DIFF
--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -692,9 +692,10 @@ error:
 
 
 static PyStatus
-calculate_init(PyCalculatePath *calculate, const PyConfig *config)
+calculate_init(PyCalculatePath *calculate, _PyPathConfig *pathconfig,
+               const PyConfig *config)
 {
-    calculate->home = config->home;
+    calculate->home = pathconfig->home;
     calculate->path_env = _wgetenv(L"PATH");
 
     calculate->dll_path = _Py_GetDLLPath();
@@ -1068,7 +1069,7 @@ _PyPathConfig_Calculate(_PyPathConfig *pathconfig, const PyConfig *config)
     PyCalculatePath calculate;
     memset(&calculate, 0, sizeof(calculate));
 
-    status = calculate_init(&calculate, config);
+    status = calculate_init(&calculate, pathconfig, config);
     if (_PyStatus_EXCEPTION(status)) {
         goto done;
     }


### PR DESCRIPTION
On Windows, _PyPathConfig.home is now preferred over PyConfig.home.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38234](https://bugs.python.org/issue38234) -->
https://bugs.python.org/issue38234
<!-- /issue-number -->
