### PR TITLE
bpo-38140: Document offsets in PyMemberDef

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -348,7 +348,7 @@ Accessing attributes of extension types
 
    .. _pymemberdef-offsets:
 
-   For heap classes (created using :c:func:`PyType_FromSpec` or similar),
+   Heap allocated types (created using :c:func:`PyType_FromSpec` or similar),
    ``PyMemberDef`` may contain defintitions for the special members
    ``__dictoffset__`` and ``__weaklistoffset__``, corresponding to
    :c:member:`~PyTypeObject.tp_dictoffset` and

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -346,6 +346,19 @@ Accessing attributes of extension types
    Only :c:macro:`T_OBJECT` and :c:macro:`T_OBJECT_EX`
    members can be deleted.  (They are set to *NULL*).
 
+   .. _pymemberdef-offsets:
+
+   For heap classes (created using :c:func:`PyType_FromSpec` or similar),
+   ``PyMemberDef`` may contain defintitions for the special members
+   ``__dictoffset__`` and ``__weaklistoffset__``, corresponding to
+   :c:member:`~PyTypeObject.tp_dictoffset` and
+   :c:member:`~PyTypeObject.tp_weaklistoffset` in type objects.
+   These must be defined with ``T_PYSSIZET`` and ``READONLY``, for example::
+
+      static PyMemberDef spam_type_members[] = {
+          {"__dictoffset__", T_PYSSIZET, offsetof(Spam_object, dict), READONLY},
+          {NULL}  /* Sentinel */
+      };
 
 .. c:type:: PyGetSetDef
 

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -188,7 +188,10 @@ The following functions and structs are used to create
       * :c:member:`~PyTypeObject.tp_subclasses`
       * :c:member:`~PyTypeObject.tp_weaklist`
       * :c:member:`~PyTypeObject.tp_vectorcall`
-      * :c:member:`~PyTypeObject.tp_print`
+      * :c:member:`~PyTypeObject.tp_weaklistoffset`
+        (see :ref:`PyMemberDef <pymemberdef-offsets>`)
+      * :c:member:`~PyTypeObject.tp_dictoffset`
+        (see :ref:`PyMemberDef <pymemberdef-offsets>`)
       * :c:member:`~PyBufferProcs.bf_getbuffer`
       * :c:member:`~PyBufferProcs.bf_releasebuffer`
 


### PR DESCRIPTION
Add docs for commit 3368f3c6ae4140a0883e19350e672fd09c9db616

<!-- issue-number: [bpo-38140](https://bugs.python.org/issue38140) -->
https://bugs.python.org/issue38140
<!-- /issue-number -->
