### PR TITLE
bpo-13743: Add some documentation strings to xml.dom.minidom

### DIFF
--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -718,6 +718,14 @@ class Element(Node):
         Node.unlink(self)
 
     def getAttribute(self, attname):
+        """Returns the value of the specified attribute.
+
+        Returns the value of the element's attribute named attname as
+        a string. An empty string is returned if the element does not
+        have such an attribute. Note that an empty string may also be
+        returned as an explicitly given attribute value, use the
+        hasAttribute method to distinguish these two cases.
+        """
         if self._attrs is None:
             return ""
         try:
@@ -828,6 +836,11 @@ class Element(Node):
     removeAttributeNodeNS = removeAttributeNode
 
     def hasAttribute(self, name):
+        """Checks whether the element has an attribute with the specified name.
+
+        Returns True if the element has an attribute with the specified name.
+        Otherwise, returns False.
+        """
         if self._attrs is None:
             return False
         return name in self._attrs
@@ -838,6 +851,11 @@ class Element(Node):
         return (namespaceURI, localName) in self._attrsNS
 
     def getElementsByTagName(self, name):
+        """Returns all descendant elements with the given tag name.
+
+        Returns the list of all descendant elements (not direct children
+        only) with the specified tag name.
+        """
         return _get_elements_by_tagName_helper(self, name, NodeList())
 
     def getElementsByTagNameNS(self, namespaceURI, localName):
@@ -848,6 +866,11 @@ class Element(Node):
         return "<DOM Element: %s at %#x>" % (self.tagName, id(self))
 
     def writexml(self, writer, indent="", addindent="", newl=""):
+        """Write an XML element to a file-like object
+
+        Write the element to the writer object that must provide
+        a write method (e.g. a file or StringIO object).
+        """
         # indent = current indentation
         # addindent = indentation to add to higher levels
         # newl = newline string

--- a/Misc/NEWS.d/next/Documentation/2019-09-25-23-20-55.bpo-13743.5ToLDy.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-09-25-23-20-55.bpo-13743.5ToLDy.rst
@@ -1,0 +1,1 @@
+Some methods within xml.dom.minidom.Element class are now better documented.


### PR DESCRIPTION
Add  documentation strings to some methods of the `xml.dom.minidom.Element` class. It would be possibly better to be able to know some small but  important features of these methods directly from `pydoc`. The `Element.getAttribute` method returns an empty string both if there  is no such attribute and if an empty string is an explicitly given attribute value. It never returns None. The `Element.getElementsByTagName` method returns all descendants, not direct children only.

<!-- issue-number: [bpo-13743](https://bugs.python.org/issue13743) -->
https://bugs.python.org/issue13743
<!-- /issue-number -->
