### PR TITLE
bpo-36871: Avoid duplicated 'Actual:' in assertion message

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -939,8 +939,8 @@ class NonCallableMock(Base):
                                     for e in expected])
                 raise AssertionError(
                     f'{problem}\n'
-                    f'Expected: {_CallList(calls)}\n'
-                    f'Actual: {self._calls_repr(prefix="Actual")}'
+                    f'Expected: {_CallList(calls)}'
+                    f'{self._calls_repr(prefix="Actual").rstrip(".")}'
                 ) from cause
             return
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1436,23 +1436,30 @@ class MockTest(unittest.TestCase):
         mock.assert_has_calls(calls[:-1], any_order=True)
 
     def test_assert_has_calls_not_matching_spec_error(self):
-        def f(): pass
+        def f(x=None): pass
 
         mock = Mock(spec=f)
+        mock(1)
 
         with self.assertRaisesRegex(
                 AssertionError,
-                re.escape('Calls not found.\nExpected:')) as cm:
+                '^{}$'.format(
+                    re.escape('Calls not found.\n'
+                              'Expected: [call()]\n'
+                              'Actual: [call(1)]'))) as cm:
             mock.assert_has_calls([call()])
         self.assertIsNone(cm.exception.__cause__)
 
+
         with self.assertRaisesRegex(
                 AssertionError,
-                re.escape('Error processing expected calls.\n'
-                          "Errors: [None, TypeError('too many positional "
-                          "arguments')]\n"
-                          'Expected:')) as cm:
-            mock.assert_has_calls([call(), call('wrong')])
+                '^{}$'.format(
+                    re.escape(
+                        'Error processing expected calls.\n'
+                        "Errors: [None, TypeError('too many positional arguments')]\n"
+                        "Expected: [call(), call(1, 2)]\n"
+                        'Actual: [call(1)]'))) as cm:
+            mock.assert_has_calls([call(), call(1, 2)])
         self.assertIsInstance(cm.exception.__cause__, TypeError)
 
     def test_assert_any_call(self):


### PR DESCRIPTION
Fixes an issue caught after merge of PR #16005.

Tightened test assertions to check the entire assertion message.

(Also removing a trailing period for consistency. If that's too finicky, I could leave that out.)

<!-- issue-number: [bpo-36871](https://bugs.python.org/issue36871) -->
https://bugs.python.org/issue36871
<!-- /issue-number -->
