### PR TITLE
remove unnecessary quantifier in regex in __format__ for ip_address.py

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -639,7 +639,7 @@ class _BaseAddress(_IPAddressBase):
         # From here on down, support for 'bnXx'
 
         import re
-        fmt_re = '^(?P<alternate>#?)(?P<grouping>_?)(?P<fmt_base>[xbnX]){1}$'
+        fmt_re = '^(?P<alternate>#?)(?P<grouping>_?)(?P<fmt_base>[xbnX])$'
         m = re.match(fmt_re, fmt)
         if not m:
             return super().__format__(fmt)


### PR DESCRIPTION
This is very  small re factor and a very straight forward change. There is no need to create an issue for this or add an entry in the news since no behavior change is happening.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
