### PR TITLE
bpo-38243: Escape the server_title of DocXMLRPCServer when rendering

### DIFF
--- a/Lib/test/test_docxmlrpc.py
+++ b/Lib/test/test_docxmlrpc.py
@@ -194,13 +194,14 @@ class DocXMLRPCHTTPGETServer(unittest.TestCase):
             response.read())
 
     def test_server_title_escape(self):
+        # bpo-38243: Ensure that the server title and documentation
+        # are escaped for HTML.
         self.serv.set_server_title('test_title<script>')
         self.serv.set_server_documentation('test_documentation<script>')
         self.assertEqual('test_title<script>', self.serv.server_title)
         self.assertEqual('test_documentation<script>',
                 self.serv.server_documentation)
 
-        # bpo-38243
         generated = self.serv.generate_html_documentation()
         title = re.search(r'<title>(.+?)</title>', generated).group()
         documentation = re.search(r'<p><tt>(.+?)</tt></p>', generated).group()

--- a/Lib/test/test_docxmlrpc.py
+++ b/Lib/test/test_docxmlrpc.py
@@ -193,14 +193,6 @@ class DocXMLRPCHTTPGETServer(unittest.TestCase):
              b'method_annotation</strong></a>(x: bytes)</dt></dl>'),
             response.read())
 
-
-class XMLRPCDocGeneratorTest(unittest.TestCase):
-    def setUp(self):
-        self.serv = DocXMLRPCServer(("localhost", 0), logRequests=False)
-
-    def tearDown(self):
-        self.serv.server_close()
-
     def test_server_title_escape(self):
         self.serv.set_server_title('test_title<script>')
         self.serv.set_server_documentation('test_documentation<script>')

--- a/Lib/test/test_docxmlrpc.py
+++ b/Lib/test/test_docxmlrpc.py
@@ -1,5 +1,6 @@
 from xmlrpc.server import DocXMLRPCServer
 import http.client
+import re
 import sys
 import threading
 import unittest
@@ -191,6 +192,28 @@ class DocXMLRPCHTTPGETServer(unittest.TestCase):
              b'<dl><dt><a name="-method_annotation"><strong>'
              b'method_annotation</strong></a>(x: bytes)</dt></dl>'),
             response.read())
+
+
+class XMLRPCDocGeneratorTest(unittest.TestCase):
+    def setUp(self):
+        self.serv = DocXMLRPCServer(("localhost", 0), logRequests=False)
+
+    def tearDown(self):
+        self.serv.server_close()
+
+    def test_server_title_escape(self):
+        self.serv.set_server_title('test_title<script>')
+        self.serv.set_server_documentation('test_documentation<script>')
+        self.assertEqual('test_title<script>', self.serv.server_title)
+        self.assertEqual('test_documentation<script>',
+                self.serv.server_documentation)
+
+        # bpo-38243
+        generated = self.serv.generate_html_documentation()
+        title = re.search(r'<title>(.+?)</title>', generated).group()
+        documentation = re.search(r'<p><tt>(.+?)</tt></p>', generated).group()
+        self.assertEqual('<title>Python: test_title&lt;script&gt;</title>', title)
+        self.assertEqual('<p><tt>test_documentation&lt;script&gt;</tt></p>', documentation)
 
 
 if __name__ == '__main__':

--- a/Lib/xmlrpc/server.py
+++ b/Lib/xmlrpc/server.py
@@ -108,6 +108,7 @@ from xmlrpc.client import Fault, dumps, loads, gzip_encode, gzip_decode
 from http.server import BaseHTTPRequestHandler
 from functools import partial
 from inspect import signature
+import html
 import http.server
 import socketserver
 import sys
@@ -894,7 +895,7 @@ class XMLRPCDocGenerator:
                                 methods
                             )
 
-        return documenter.page(self.server_title, documentation)
+        return documenter.page(html.escape(self.server_title), documentation)
 
 class DocXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
     """XML-RPC and documentation request handler class.

--- a/Misc/NEWS.d/next/Security/2019-09-25-13-21-09.bpo-38243.1pfz24.rst
+++ b/Misc/NEWS.d/next/Security/2019-09-25-13-21-09.bpo-38243.1pfz24.rst
@@ -1,2 +1,2 @@
-Escape the server_title of :class:`DocXMLRPCServer` when rendering the
-document page. (Contributed by Dong-hee Na in :issue:`38243`.)
+Escape the server title of :class:`DocXMLRPCServer` when rendering the
+document page as HTML. (Contributed by Dong-hee Na in :issue:`38243`.)

--- a/Misc/NEWS.d/next/Security/2019-09-25-13-21-09.bpo-38243.1pfz24.rst
+++ b/Misc/NEWS.d/next/Security/2019-09-25-13-21-09.bpo-38243.1pfz24.rst
@@ -1,2 +1,3 @@
-Escape the server title of :class:`DocXMLRPCServer` when rendering the
-document page as HTML. (Contributed by Dong-hee Na in :issue:`38243`.)
+Escape the server title of :class:`xmlrpc.server.DocXMLRPCServer`
+when rendering the document page as HTML.
+(Contributed by Dong-hee Na in :issue:`38243`.)

--- a/Misc/NEWS.d/next/Security/2019-09-25-13-21-09.bpo-38243.1pfz24.rst
+++ b/Misc/NEWS.d/next/Security/2019-09-25-13-21-09.bpo-38243.1pfz24.rst
@@ -1,0 +1,2 @@
+Escape the server_title of :class:`DocXMLRPCServer` when rendering the
+document page. (Contributed by Dong-hee Na in :issue:`38243`.)


### PR DESCRIPTION
Escape the server_title of DocXMLRPCServer when rendering,
The title will only be escaped when the server_title should be rendered.

<!-- issue-number: [bpo-38243](https://bugs.python.org/issue38243) -->
https://bugs.python.org/issue38243
<!-- /issue-number -->
