### PR TITLE
bpo-22273: Disabled tests while investigating buildbot failures on ARM7L/PPC64.

### DIFF
--- a/Lib/ctypes/test/test_structures.py
+++ b/Lib/ctypes/test/test_structures.py
@@ -1,9 +1,12 @@
+import platform
 import unittest
 from ctypes import *
 from ctypes.test import need_symbol
 from struct import calcsize
 import _ctypes_test
 from test import support
+
+MACHINE = platform.machine()
 
 class SubclassesTest(unittest.TestCase):
     def test_subclass(self):
@@ -477,6 +480,8 @@ class StructureTestCase(unittest.TestCase):
         self.assertEqual(s.first, got.first)
         self.assertEqual(s.second, got.second)
 
+    @unittest.skipIf(MACHINE in ('armv7l', 'ppc64'),
+                     'Test temporarily disabled on this architecture')
     def test_array_in_struct(self):
         # See bpo-22273
 

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -652,7 +652,7 @@ PyCStructUnionType_update_stgdict(PyObject *type, PyObject *fields, int isStruct
 
 #define MAX_ELEMENTS 16
 
-    if (arrays_seen && (size <= 16)) {
+    if (arrays_seen && (size <= MAX_ELEMENTS)) {
         /*
          * See bpo-22273. Arrays are normally treated as pointers, which is
          * fine when an array name is being passed as parameter, but not when


### PR DESCRIPTION


<!-- issue-number: [bpo-22273](https://bugs.python.org/issue22273) -->
https://bugs.python.org/issue22273
<!-- /issue-number -->
