### PR TITLE
bpo-36046: posix_spawn() doesn't support uid/gid

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1681,7 +1681,10 @@ class Popen(object):
                     and (p2cread == -1 or p2cread > 2)
                     and (c2pwrite == -1 or c2pwrite > 2)
                     and (errwrite == -1 or errwrite > 2)
-                    and not start_new_session):
+                    and not start_new_session
+                    and gid is None
+                    and gids is None
+                    and uid is None):
                 self._posix_spawn(args, executable, env, restore_signals,
                                   p2cread, p2cwrite,
                                   c2pread, c2pwrite,


### PR DESCRIPTION
* subprocess.Popen now longer uses posix_spawn() if uid, gid or gids
  are set.
* test_subprocess: add "nobody" and "nfsnobody" group names for
  test_group().
* test_subprocess: test_user() and test_group() are now also tested
  with close_fds=False.

<!-- issue-number: [bpo-36046](https://bugs.python.org/issue36046) -->
https://bugs.python.org/issue36046
<!-- /issue-number -->
