### PR TITLE
[3.8] bpo-37064: Skip test_tools.test_pathfix if installed (GH-15705)

### DIFF
--- a/Lib/test/test_tools/test_pathfix.py
+++ b/Lib/test/test_tools/test_pathfix.py
@@ -3,7 +3,11 @@ import subprocess
 import sys
 import unittest
 from test import support
-from test.test_tools import import_tool, scriptsdir
+from test.test_tools import import_tool, scriptsdir, skip_if_missing
+
+
+# need Tools/script/ directory: skip if run on Python installed on the system
+skip_if_missing()
 
 
 class TestPathfixFunctional(unittest.TestCase):


### PR DESCRIPTION
If Python is installed, skip test_tools.test_pathfix test because
Tools/scripts/pathfix.py script is not installed.

(cherry picked from commit 3f43ceff186da09978d0aff257bb18b8ac7611f7)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37064](https://bugs.python.org/issue37064) -->
https://bugs.python.org/issue37064
<!-- /issue-number -->
