### PR TITLE
bpo-38279: use of easier to understand syntax 

### DIFF
--- a/Doc/includes/mp_workers.py
+++ b/Doc/includes/mp_workers.py
@@ -8,7 +8,8 @@ from multiprocessing import Process, Queue, current_process, freeze_support
 #
 
 def worker(input, output):
-    for func, args in iter(input.get, 'STOP'):
+    while True:
+        func,args=input.get()
         result = calculate(func, args)
         output.put(result)
 
@@ -51,8 +52,11 @@ def test():
         task_queue.put(task)
 
     # Start worker processes
+    processes=[]
     for i in range(NUMBER_OF_PROCESSES):
-        Process(target=worker, args=(task_queue, done_queue)).start()
+        p=Process(target=worker, args=(task_queue, done_queue))
+        p.start()
+        processes.append(p)
 
     # Get and print results
     print('Unordered results:')
@@ -68,8 +72,9 @@ def test():
         print('\t', done_queue.get())
 
     # Tell child processes to stop
-    for i in range(NUMBER_OF_PROCESSES):
-        task_queue.put('STOP')
+    for p in processes:
+        p.terminate()
+        #task_queue.put('STOP')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The suggested changes mostly deal with my troubles to understand how long a process "lives" in code, how and when they stop.

The first change is putting the processes in a list, after creating and starting them in separate lines. Should be easier to read.

It was unclear to me, why iter(input.get,"stop") and putting "stop" to the task queue would stop a process. Also after reading up on iter(), it should pass "stop" anyway when input.get() wouldn't work. After removing the last "stop" putting loop, it didn't do that though. So I don't get how that works. Since it's an example I don't think it's too much to ask for it to be obvious. Or more "obvious" anway.

So I replaced that for ... iter(...) with a while that just gets stuff basically the same way, and terminates processes explicitly.

This is safe, as far as I understand it, because the for i in range(len(tasks2)) done_queue.get() will always wait until all tasks are done, because of the defaults for queue.get().



<!-- issue-number: [bpo-38279](https://bugs.python.org/issue38279) -->
https://bugs.python.org/issue38279
<!-- /issue-number -->
