### PR TITLE
bpo-22273: Removed temporary test skipping on PPC platforms.

### DIFF
--- a/Lib/ctypes/test/test_structures.py
+++ b/Lib/ctypes/test/test_structures.py
@@ -6,6 +6,9 @@ from struct import calcsize
 import _ctypes_test
 from test import support
 
+# The following definition is meant to be used from time to time to assist
+# temporarily disabling tests on specific architectures while investigations
+# are in progress, to keep buildbots happy.
 MACHINE = platform.machine()
 
 class SubclassesTest(unittest.TestCase):
@@ -480,8 +483,6 @@ class StructureTestCase(unittest.TestCase):
         self.assertEqual(s.first, got.first)
         self.assertEqual(s.second, got.second)
 
-    @unittest.skipIf(MACHINE.startswith('ppc'),
-                     'Test temporarily disabled on this architecture')
     def test_array_in_struct(self):
         # See bpo-22273
 


### PR DESCRIPTION


<!-- issue-number: [bpo-22273](https://bugs.python.org/issue22273) -->
https://bugs.python.org/issue22273
<!-- /issue-number -->
