### PR TITLE
bpo-38281: Using mode "write" when initializing gzip.GzipFile if there's "+" in the mode string

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -180,13 +180,7 @@ class GzipFile(_compression.BaseStream):
         if mode is None:
             mode = getattr(fileobj, 'mode', 'rb')
 
-        if mode.startswith('r'):
-            self.mode = READ
-            raw = _GzipReader(fileobj)
-            self._buffer = io.BufferedReader(raw)
-            self.name = filename
-
-        elif mode.startswith(('w', 'a', 'x')):
+        if mode.startswith(('w', 'a', 'x')) or '+' in mode:
             self.mode = WRITE
             self._init_write(filename)
             self.compress = zlib.compressobj(compresslevel,
@@ -195,6 +189,11 @@ class GzipFile(_compression.BaseStream):
                                              zlib.DEF_MEM_LEVEL,
                                              0)
             self._write_mtime = mtime
+        elif mode.startswith('r'):
+            self.mode = READ
+            raw = _GzipReader(fileobj)
+            self._buffer = io.BufferedReader(raw)
+            self.name = filename
         else:
             raise ValueError("Invalid mode: {!r}".format(mode))
 

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -461,11 +461,11 @@ class TestGzip(BaseTest):
                 self.assertEqual(g.mode, gzip.WRITE)
             with self.assertRaises(ValueError):
                 gzip.GzipFile(fileobj=f, mode='z')
-        for mode in "rb", "r+b":
+        for mode in "rb", "r":
             with open(self.filename, mode) as f:
                 with gzip.GzipFile(fileobj=f) as g:
                     self.assertEqual(g.mode, gzip.READ)
-        for mode in "wb", "ab", "xb":
+        for mode in "wb", "ab", "xb", "rb+":
             if "x" in mode:
                 support.unlink(self.filename)
             with open(self.filename, mode) as f:


### PR DESCRIPTION
https://bugs.python.org/issue38281

<!-- issue-number: [bpo-38281](https://bugs.python.org/issue38281) -->
https://bugs.python.org/issue38281
<!-- /issue-number -->
