### PR TITLE
bpo-38234: Fix test_embed.test_init_setpath_config() on FreeBSD

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -15,6 +15,7 @@ import textwrap
 
 
 MS_WINDOWS = (os.name == 'nt')
+MACOS = (sys.platform == 'darwin')
 
 PYMEM_ALLOCATOR_NOT_SET = 0
 PYMEM_ALLOCATOR_DEBUG = 2
@@ -1011,7 +1012,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             executable = self.test_exe
         else:
             program_name = 'python3'
-            executable = shutil.which(program_name) or ''
+            if MACOS:
+                executable = self.test_exe
+            else:
+                executable = shutil.which(program_name) or ''
         config.update({
             'program_name': program_name,
             'base_executable': executable,
@@ -1054,13 +1058,8 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'executable': 'conf_executable',
         }
         env = {'TESTPATH': os.path.pathsep.join(paths)}
-        # Py_SetPath() preinitialized Python using the compat API,
-        # so we need preconfig_api=API_COMPAT.
         self.check_all_configs("test_init_setpath_config", config,
-                               api=API_PYTHON,
-                               preconfig_api=API_COMPAT,
-                               env=env,
-                               ignore_stderr=True)
+                               api=API_PYTHON, env=env, ignore_stderr=True)
 
     def module_search_paths(self, prefix=None, exec_prefix=None):
         config = self._get_expected_config()

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1448,6 +1448,17 @@ static int test_init_setpath(void)
 
 static int test_init_setpath_config(void)
 {
+    PyStatus status;
+    PyPreConfig preconfig;
+    PyPreConfig_InitPythonConfig(&preconfig);
+
+    /* Explicitly preinitializes with Python preconfiguration to avoid
+      Py_SetPath() implicit preinitialization with compat preconfiguration. */
+    status = Py_PreInitialize(&preconfig);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
+
     char *env = getenv("TESTPATH");
     if (!env) {
         fprintf(stderr, "missing TESTPATH env var\n");
@@ -1462,7 +1473,6 @@ static int test_init_setpath_config(void)
     PyMem_RawFree(path);
     putenv("TESTPATH=");
 
-    PyStatus status;
     PyConfig config;
 
     status = PyConfig_InitPythonConfig(&config);


### PR DESCRIPTION
Explicitly preinitializes with a Python preconfiguration to avoid
Py_SetPath() implicit preinitialization with a compat
preconfiguration.

Fix also test_init_setpath() and test_init_setpythonhome() on macOS:
use self.test_exe as the executable (and base_executable), rather
than shutil.which('python3').

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38234](https://bugs.python.org/issue38234) -->
https://bugs.python.org/issue38234
<!-- /issue-number -->
