### PR TITLE
bpo-38112: compileall: Skip long path path on Windows if the path can't be created

### DIFF
--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -72,9 +72,13 @@ class CompileallTestsBase:
                 # is too long") is raised for long paths
                 if sys.platform == "win32":
                     break
+                else:
+                    raise
             except OSError as exc:
                 if exc.errno == errno.ENAMETOOLONG:
                     break
+                else:
+                    raise
 
             # Remove the __pycache__
             shutil.rmtree(os.path.dirname(longer_cache))


### PR DESCRIPTION
This avoids the buildbot failure on Windows:
```
FileNotFoundError: [WinError 206] The filename or extension is too long: 'd:\\temp\\tmp5r3z438t\\long\\1\\2\\3\\4\\5\\6\\7\\8\\9\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\20\\21\\22\\23\\24\\25\\26\\27\\28\\29\\30\\31\\32\\33\\34\\35\\36\\37\\38\\39\\40\\41\\42\\43\\44\\45\\46\\47\\48\\49\\50\\51\\52\\53\\54\\55\\56\\57\\58\\59\\60\\61\\62\\63\\64\\65\\66\\67\\68\\69\\70\\71\\72\\73\\74\\75\\76\\77\\78'
```
This creates a path that's long but avoids OS restrictions.

<!-- issue-number: [bpo-38112](https://bugs.python.org/issue38112) -->
https://bugs.python.org/issue38112
<!-- /issue-number -->


Automerge-Triggered-By: @encukou