### PR TITLE
bpo-38275: Fix test_ssl issue caused by GH-16386

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -190,11 +190,13 @@ def has_tls_version(version):
     # be compiled in but disabled by a policy or config option.
     ctx = ssl.SSLContext()
     if (
+            hasattr(ctx, 'minimum_version') and
             ctx.minimum_version != ssl.TLSVersion.MINIMUM_SUPPORTED and
             version < ctx.minimum_version
     ):
         return False
     if (
+        hasattr(ctx, 'maximum_version') and
         ctx.maximum_version != ssl.TLSVersion.MAXIMUM_SUPPORTED and
         version > ctx.maximum_version
     ):


### PR DESCRIPTION
Check presence of SSLContext.minimum_version to make tests pass with
old versions of OpenSSL.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-38275](https://bugs.python.org/issue38275) -->
https://bugs.python.org/issue38275
<!-- /issue-number -->
