### PR TITLE
bpo-38294: Add list of no-longer-escaped chars to re.escape documentation

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -939,8 +939,8 @@ form.
       [abcdefghijklmnopqrstuvwxyz0123456789!\#\$%\&'\*\+\-\.\^_`\|\~:]+
 
       >>> operators = ['+', '-', '*', '/', '**']
-      >>> print('|'.join(map(re.escape, sorted(operators, reverse=True))))
-      /|\-|\+|\*\*|\*
+      >>> print(' '.join(map(re.escape, operators)))
+      \+ \- \* / \*\*
 
    This function must not be used for the replacement string in :func:`sub`
    and :func:`subn`, only backslashes should be escaped.  For example::
@@ -955,7 +955,9 @@ form.
 
    .. versionchanged:: 3.7
       Only characters that can have special meaning in a regular expression
-      are escaped.
+      are escaped. As a result, ``'!'``, ``'"'``, ``'%'``, ``"'"``, ``','``,
+      ``'/'``, ``':'``, ``';'``, ``'<'``, ``'='``, ``'>'``, ``'@'``, and
+      ``"`"`` are no longer escaped.
 
 
 .. function:: purge()

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -938,9 +938,8 @@ form.
       >>> print('[%s]+' % re.escape(legal_chars))
       [abcdefghijklmnopqrstuvwxyz0123456789!\#\$%\&'\*\+\-\.\^_`\|\~:]+
 
-      >>> operators = ['+', '-', '*', '/', '**']
-      >>> print(' '.join(map(re.escape, operators)))
-      \+ \- \* / \*\*
+      >>> print(' '.join(map(re.escape, string.punctuation)))
+      ! " \# \$ % \& ' \( \) \* \+ , \- \. / : ; < = > \? @ \[ \\ \] \^ _ ` \{ \| \} \~
 
    This function must not be used for the replacement string in :func:`sub`
    and :func:`subn`, only backslashes should be escaped.  For example::

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -931,8 +931,8 @@ form.
    This is useful if you want to match an arbitrary literal string that may
    have regular expression metacharacters in it.  For example::
 
-      >>> print(re.escape('python.exe'))
-      python\.exe
+      >>> print(re.escape('http://www.python.org'))
+      http://www\.python\.org
 
       >>> legal_chars = string.ascii_lowercase + string.digits + "!#$%&'*+-.^_`|~:"
       >>> print('[%s]+' % re.escape(legal_chars))

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -938,8 +938,9 @@ form.
       >>> print('[%s]+' % re.escape(legal_chars))
       [abcdefghijklmnopqrstuvwxyz0123456789!\#\$%\&'\*\+\-\.\^_`\|\~:]+
 
-      >>> print(' '.join(map(re.escape, string.punctuation)))
-      ! " \# \$ % \& ' \( \) \* \+ , \- \. / : ; < = > \? @ \[ \\ \] \^ _ ` \{ \| \} \~
+      >>> operators = ['+', '-', '*', '/', '**']
+      >>> print('|'.join(map(re.escape, sorted(operators, reverse=True))))
+      /|\-|\+|\*\*|\*
 
    This function must not be used for the replacement string in :func:`sub`
    and :func:`subn`, only backslashes should be escaped.  For example::

--- a/Doc/tools/susp-ignored.csv
+++ b/Doc/tools/susp-ignored.csv
@@ -356,3 +356,4 @@ whatsnew/changelog,,::,default::BytesWarning
 whatsnew/changelog,,::,default::DeprecationWarning
 library/importlib.metadata,,:main,"EntryPoint(name='wheel', value='wheel.cli:main', group='console_scripts')"
 library/importlib.metadata,,`,loading the metadata for packages for the indicated ``context``.
+library/re,,`,"`"

--- a/Misc/NEWS.d/next/Documentation/2019-09-27-23-37-41.bpo-38294.go_jFf.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-09-27-23-37-41.bpo-38294.go_jFf.rst
@@ -1,0 +1,1 @@
+Add list of no-longer-escaped chars to re.escape documentation


### PR DESCRIPTION
The changes in behavior from 3.6 to 3.7 caused some minor issues with code that still needs to run on 2.7 while it is being migrated to 3.7. 

Since "/" is usually a common delimiter for regexes, we assumed it'd be escaped, as it was up to 3.6, but since that's no longer the case, it'd be nice to emphasise the difference a little bit more than the current documentation does. As it is, it's easy to miss this specific character.

<!-- issue-number: [bpo-38294](https://bugs.python.org/issue38294) -->
https://bugs.python.org/issue38294
<!-- /issue-number -->
