### PR TITLE
bpo-38161: Removes _AwaitEvent from AsyncMock.

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -246,7 +246,6 @@ def _setup_async_mock(mock):
     mock.await_count = 0
     mock.await_args = None
     mock.await_args_list = _CallList()
-    mock.awaited = _AwaitEvent(mock)
 
     # Mock is not configured yet so the attributes are set
     # to a function and then the corresponding mock helper function
@@ -2133,7 +2132,6 @@ class MagicProxy(object):
 
 
 class AsyncMockMixin(Base):
-    awaited = _delegating_property('awaited')
     await_count = _delegating_property('await_count')
     await_args = _delegating_property('await_args')
     await_args_list = _delegating_property('await_args_list')
@@ -2147,7 +2145,6 @@ class AsyncMockMixin(Base):
         # It is set through __dict__ because when spec_set is True, this
         # attribute is likely undefined.
         self.__dict__['_is_coroutine'] = asyncio.coroutines._is_coroutine
-        self.__dict__['_mock_awaited'] = _AwaitEvent(self)
         self.__dict__['_mock_await_count'] = 0
         self.__dict__['_mock_await_args'] = None
         self.__dict__['_mock_await_args_list'] = _CallList()
@@ -2176,7 +2173,6 @@ class AsyncMockMixin(Base):
                 self.await_count += 1
                 self.await_args = _call
                 self.await_args_list.append(_call)
-                await self.awaited._notify()
 
         return await proxy()
 
@@ -2907,35 +2903,3 @@ class _AsyncIterator:
         except StopIteration:
             pass
         raise StopAsyncIteration
-
-
-class _AwaitEvent:
-    def __init__(self, mock):
-        self._mock = mock
-        self._condition = None
-
-    async def _notify(self):
-        condition = self._get_condition()
-        try:
-            await condition.acquire()
-            condition.notify_all()
-        finally:
-            condition.release()
-
-    def _get_condition(self):
-        """
-        Creation of condition is delayed, to minimize the chance of using the
-        wrong loop.
-        A user may create a mock with _AwaitEvent before selecting the
-        execution loop.  Requiring a user to delay creation is error-prone and
-        inflexible. Instead, condition is created when user actually starts to
-        use the mock.
-        """
-        # No synchronization is needed:
-        #   - asyncio is thread unsafe
-        #   - there are no awaits here, method will be executed without
-        #   switching asyncio context.
-        if self._condition is None:
-            self._condition = asyncio.Condition()
-
-        return self._condition

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -4,7 +4,7 @@ import re
 import unittest
 
 from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock,
-                           create_autospec, _AwaitEvent, sentinel, _CallList)
+                           create_autospec, sentinel, _CallList)
 
 
 def tearDownModule():
@@ -178,7 +178,6 @@ class AsyncAutospecTest(unittest.TestCase):
         self.assertEqual(spec.await_count, 0)
         self.assertIsNone(spec.await_args)
         self.assertEqual(spec.await_args_list, [])
-        self.assertIsInstance(spec.awaited, _AwaitEvent)
         spec.assert_not_awaited()
 
         asyncio.run(main())
@@ -212,7 +211,6 @@ class AsyncAutospecTest(unittest.TestCase):
                 self.assertEqual(mock_method.await_count, 0)
                 self.assertEqual(mock_method.await_args_list, [])
                 self.assertIsNone(mock_method.await_args)
-                self.assertIsInstance(mock_method.awaited, _AwaitEvent)
                 mock_method.assert_not_awaited()
 
                 await awaitable

--- a/Misc/NEWS.d/next/Library/2019-09-27-16-31-28.bpo-38161.zehai1.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-27-16-31-28.bpo-38161.zehai1.rst
@@ -1,0 +1,1 @@
+Removes _AwaitEvent from AsyncMock.


### PR DESCRIPTION
This is something we can add back in as a feature in the future, but for now I want to take it out. With the release of 3.8 coming up I don't think this is thought out well enough- I don't like the name, I'm struggling to document it, its not tested, and I'm not sure if it's worth getting stuck with an attribute we may have to make significant changes to in the future. 

If someone really wants it in now that's fine, just make a PR adding all those things in for me :) 



<!-- issue-number: [bpo-38161](https://bugs.python.org/issue38161) -->
https://bugs.python.org/issue38161
<!-- /issue-number -->
