### PR TITLE
[2.7] bpo-38243: Escape the server title of DocXMLRPCServer

### DIFF
--- a/Lib/DocXMLRPCServer.py
+++ b/Lib/DocXMLRPCServer.py
@@ -20,6 +20,17 @@ from SimpleXMLRPCServer import (SimpleXMLRPCServer,
             CGIXMLRPCRequestHandler,
             resolve_dotted_attribute)
 
+
+def _html_escape_quote(s, quote=True):
+    s = s.replace("&", "&amp;") # Must be done first!
+    s = s.replace("<", "&lt;")
+    s = s.replace(">", "&gt;")
+    if quote:
+        s = s.replace('"', "&quot;")
+        s = s.replace('\'', "&#x27;")
+    return s
+
+
 class ServerHTMLDoc(pydoc.HTMLDoc):
     """Class used to generate pydoc HTML document for a server"""
 
@@ -210,14 +221,7 @@ class XMLRPCDocGenerator:
                                 methods
                             )
 
-        escape_table = {
-            "&": "&amp;",
-            '"': "&quot;",
-            "'": "&#x27;",
-            ">": "&gt;",
-            "<": "&lt;",
-        }
-        title = ''.join(escape_table.get(c, c) for c in self.server_title)
+        title = _html_escape_quote(self.server_title)
         return documenter.page(title, documentation)
 
 class DocXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):

--- a/Lib/DocXMLRPCServer.py
+++ b/Lib/DocXMLRPCServer.py
@@ -210,7 +210,15 @@ class XMLRPCDocGenerator:
                                 methods
                             )
 
-        return documenter.page(self.server_title, documentation)
+        escape_table = {
+            "&": "&amp;",
+            '"': "&quot;",
+            "'": "&#x27;",
+            ">": "&gt;",
+            "<": "&lt;",
+        }
+        title = ''.join(escape_table.get(c, c) for c in self.server_title)
+        return documenter.page(title, documentation)
 
 class DocXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
     """XML-RPC and documentation request handler class.

--- a/Lib/DocXMLRPCServer.py
+++ b/Lib/DocXMLRPCServer.py
@@ -21,13 +21,12 @@ from SimpleXMLRPCServer import (SimpleXMLRPCServer,
             resolve_dotted_attribute)
 
 
-def _html_escape_quote(s, quote=True):
+def _html_escape_quote(s):
     s = s.replace("&", "&amp;") # Must be done first!
     s = s.replace("<", "&lt;")
     s = s.replace(">", "&gt;")
-    if quote:
-        s = s.replace('"', "&quot;")
-        s = s.replace('\'', "&#x27;")
+    s = s.replace('"', "&quot;")
+    s = s.replace('\'', "&#x27;")
     return s
 
 

--- a/Lib/test/test_docxmlrpc.py
+++ b/Lib/test/test_docxmlrpc.py
@@ -1,5 +1,6 @@
 from DocXMLRPCServer import DocXMLRPCServer
 import httplib
+import re
 import sys
 from test import test_support
 threading = test_support.import_module('threading')
@@ -175,6 +176,25 @@ class DocXMLRPCHTTPGETServer(unittest.TestCase):
 
         self.assertIn("""Try&nbsp;self.<strong>add</strong>,&nbsp;too.""",
                       response.read())
+
+    def test_server_title_escape(self):
+        """Test that the server title and documentation
+        are escaped for HTML.
+        """
+        self.serv.set_server_title('test_title<script>')
+        self.serv.set_server_documentation('test_documentation<script>')
+        self.assertEqual('test_title<script>', self.serv.server_title)
+        self.assertEqual('test_documentation<script>',
+                self.serv.server_documentation)
+
+        generated = self.serv.generate_html_documentation()
+        title = re.search(r'<title>(.+?)</title>', generated).group()
+        documentation = re.search(r'<p><tt>(.+?)</tt></p>', generated).group()
+        self.assertEqual('<title>Python: test_title&lt;script&gt;</title>',
+                title)
+        self.assertEqual('<p><tt>test_documentation&lt;script&gt;</tt></p>',
+                documentation)
+
 
 def test_main():
     test_support.run_unittest(DocXMLRPCHTTPGETServer)

--- a/Misc/NEWS.d/next/Security/2019-09-25-13-21-09.bpo-38243.1pfz24.rst
+++ b/Misc/NEWS.d/next/Security/2019-09-25-13-21-09.bpo-38243.1pfz24.rst
@@ -1,0 +1,3 @@
+Escape the server title of :class:`DocXMLRPCServer.DocXMLRPCServer`
+when rendering the document page as HTML.
+(Contributed by Dong-hee Na in :issue:`38243`.)


### PR DESCRIPTION


<!-- issue-number: [bpo-38243](https://bugs.python.org/issue38243) -->
https://bugs.python.org/issue38243
<!-- /issue-number -->
