### PR TITLE
bpo-38304: Add PyConfig.struct_size

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -194,17 +194,24 @@ PyPreConfig
    * Configure the LC_CTYPE locale
    * Set the UTF-8 mode
 
+   The :c:member:`struct_size` field must be explicitly initialized to
+   ``sizeof(PyPreConfig)``.
+
    Function to initialize a preconfiguration:
 
-   .. c:function:: void PyPreConfig_InitIsolatedConfig(PyPreConfig *preconfig)
+   .. c:function:: PyStatus PyPreConfig_InitIsolatedConfig(PyPreConfig *preconfig)
 
       Initialize the preconfiguration with :ref:`Python Configuration
       <init-python-config>`.
 
-   .. c:function:: void PyPreConfig_InitPythonConfig(PyPreConfig *preconfig)
+   .. c:function:: PyStatus PyPreConfig_InitPythonConfig(PyPreConfig *preconfig)
 
       Initialize the preconfiguration with :ref:`Isolated Configuration
       <init-isolated-conf>`.
+
+   The caller of these functions is responsible to handle exceptions (error or
+   exit) using :c:func:`PyStatus_Exception` and
+   :c:func:`Py_ExitStatusException`.
 
    Structure fields:
 
@@ -267,6 +274,13 @@ PyPreConfig
       same way the regular Python parses command line arguments: see
       :ref:`Command Line Arguments <using-on-cmdline>`.
 
+   .. c:member:: size_t struct_size
+
+      Size of the structure in bytes: must be initialized to
+      ``sizeof(PyPreConfig)``.
+
+      Field used for API and ABI compatibility.
+
    .. c:member:: int use_environment
 
       See :c:member:`PyConfig.use_environment`.
@@ -316,12 +330,18 @@ the preinitialization.
 
 Example using the preinitialization to enable the UTF-8 Mode::
 
+    PyStatus status;
     PyPreConfig preconfig;
-    PyPreConfig_InitPythonConfig(&preconfig);
+    preconfig.struct_size = sizeof(PyPreConfig);
+
+    status = PyPreConfig_InitPythonConfig(&preconfig);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
 
     preconfig.utf8_mode = 1;
 
-    PyStatus status = Py_PreInitialize(&preconfig);
+    status = Py_PreInitialize(&preconfig);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
     }
@@ -339,6 +359,9 @@ PyConfig
 .. c:type:: PyConfig
 
    Structure containing most parameters to configure Python.
+
+   The :c:member:`struct_size` field must be explicitly initialized to
+   ``sizeof(PyConfig)``.
 
    Structure methods:
 
@@ -656,6 +679,13 @@ PyConfig
       Encoding and encoding errors of :data:`sys.stdin`, :data:`sys.stdout` and
       :data:`sys.stderr`.
 
+   .. c:member:: size_t struct_size
+
+      Size of the structure in bytes: must be initialized to
+      ``sizeof(PyConfig)``.
+
+      Field used for API and ABI compatibility.
+
    .. c:member:: int tracemalloc
 
       If non-zero, call :func:`tracemalloc.start` at startup.
@@ -718,6 +748,7 @@ Example setting the program name::
     {
         PyStatus status;
         PyConfig config;
+        config.struct_size = sizeof(PyConfig);
 
         status = PyConfig_InitPythonConfig(&config);
         if (PyStatus_Exception(status)) {
@@ -750,6 +781,7 @@ configuration, and then override some parameters::
     {
         PyStatus status;
         PyConfig config;
+        config.struct_size = sizeof(PyConfig);
 
         status = PyConfig_InitPythonConfig(&config);
         if (PyStatus_Exception(status)) {
@@ -835,8 +867,9 @@ Example of customized Python always running in isolated mode::
 
     int main(int argc, char **argv)
     {
-        PyConfig config;
         PyStatus status;
+        PyConfig config;
+        config.struct_size = sizeof(PyConfig);
 
         status = PyConfig_InitPythonConfig(&config);
         if (PyStatus_Exception(status)) {
@@ -1028,6 +1061,7 @@ phases::
     {
         PyStatus status;
         PyConfig config;
+        config.struct_size = sizeof(PyConfig);
 
         status = PyConfig_InitPythonConfig(&config);
         if (PyStatus_Exception(status)) {

--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -45,8 +45,10 @@ PyAPI_FUNC(PyStatus) PyWideStringList_Insert(PyWideStringList *list,
 /* --- PyPreConfig ----------------------------------------------- */
 
 typedef struct {
-    int _config_version;  /* Internal configuration version,
-                             used for ABI compatibility */
+    /* Size of the structure in bytes: must be initialized to
+       sizeof(PyPreConfig). Field used for API and ABI compatibility. */
+    size_t struct_size;
+
     int _config_init;     /* _PyConfigInitEnum value */
 
     /* Parse Py_PreInitializeFromBytesArgs() arguments?
@@ -122,15 +124,17 @@ typedef struct {
     int allocator;
 } PyPreConfig;
 
-PyAPI_FUNC(void) PyPreConfig_InitPythonConfig(PyPreConfig *config);
-PyAPI_FUNC(void) PyPreConfig_InitIsolatedConfig(PyPreConfig *config);
+PyAPI_FUNC(PyStatus) PyPreConfig_InitPythonConfig(PyPreConfig *config);
+PyAPI_FUNC(PyStatus) PyPreConfig_InitIsolatedConfig(PyPreConfig *config);
 
 
 /* --- PyConfig ---------------------------------------------- */
 
 typedef struct {
-    int _config_version;  /* Internal configuration version,
-                             used for ABI compatibility */
+    /* Size of the structure in bytes: must be initialized to
+       sizeof(PyConfig). Field used for API and ABI compatibility. */
+    size_t struct_size;
+
     int _config_init;     /* _PyConfigInitEnum value */
 
     int isolated;         /* Isolated mode? see PyPreConfig.isolated */
@@ -403,7 +407,6 @@ typedef struct {
 
     /* If equal to 0, stop Python initialization before the "main" phase */
     int _init_main;
-
 } PyConfig;
 
 PyAPI_FUNC(PyStatus) PyConfig_InitPythonConfig(PyConfig *config);

--- a/Include/internal/pycore_initconfig.h
+++ b/Include/internal/pycore_initconfig.h
@@ -40,6 +40,8 @@ extern "C" {
     (err._type == _PyStatus_TYPE_EXIT)
 #define _PyStatus_EXCEPTION(err) \
     (err._type != _PyStatus_TYPE_OK)
+#define _PyStatus_UPDATE_FUNC(err) \
+    do { err.func = _PyStatus_GET_FUNC(); } while (0)
 
 /* --- PyWideStringList ------------------------------------------------ */
 
@@ -118,11 +120,11 @@ extern PyStatus _PyPreCmdline_Read(_PyPreCmdline *cmdline,
 
 /* --- PyPreConfig ----------------------------------------------- */
 
-PyAPI_FUNC(void) _PyPreConfig_InitCompatConfig(PyPreConfig *preconfig);
-extern void _PyPreConfig_InitFromConfig(
+PyAPI_FUNC(PyStatus) _PyPreConfig_InitCompatConfig(PyPreConfig *preconfig);
+extern PyStatus _PyPreConfig_InitFromConfig(
     PyPreConfig *preconfig,
     const PyConfig *config);
-extern void _PyPreConfig_InitFromPreConfig(
+extern PyStatus _PyPreConfig_InitFromPreConfig(
     PyPreConfig *preconfig,
     const PyPreConfig *config2);
 extern PyObject* _PyPreConfig_AsDict(const PyPreConfig *preconfig);
@@ -135,8 +137,6 @@ extern PyStatus _PyPreConfig_Write(const PyPreConfig *preconfig);
 
 /* --- PyConfig ---------------------------------------------- */
 
-#define _Py_CONFIG_VERSION 1
-
 typedef enum {
     /* Py_Initialize() API: backward compatibility with Python 3.6 and 3.7 */
     _PyConfig_INIT_COMPAT = 1,
@@ -144,7 +144,7 @@ typedef enum {
     _PyConfig_INIT_ISOLATED = 3
 } _PyConfigInitEnum;
 
-PyAPI_FUNC(void) _PyConfig_InitCompatConfig(PyConfig *config);
+PyAPI_FUNC(PyStatus) _PyConfig_InitCompatConfig(PyConfig *config);
 extern PyStatus _PyConfig_Copy(
     PyConfig *config,
     const PyConfig *config2);

--- a/Misc/NEWS.d/next/C API/2019-09-28-03-43-27.bpo-38304.RqHAwd.rst
+++ b/Misc/NEWS.d/next/C API/2019-09-28-03-43-27.bpo-38304.RqHAwd.rst
@@ -1,0 +1,3 @@
+Add a new ``struct_size`` field to :c:type:`PyPreConfig` and :c:type:`PyConfig`
+structures to allow to modify these structures in the future without breaking
+the backward compatibility.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -53,13 +53,20 @@ pymain_init(const _PyArgv *args)
 #endif
 
     PyPreConfig preconfig;
-    PyPreConfig_InitPythonConfig(&preconfig);
+    preconfig.struct_size = sizeof(PyPreConfig);
+
+    status = PyPreConfig_InitPythonConfig(&preconfig);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     status = _Py_PreInitializeFromPyArgv(&preconfig, args);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
     status = PyConfig_InitPythonConfig(&config);
     if (_PyStatus_EXCEPTION(status)) {
         goto done;

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -78,6 +78,7 @@ main(int argc, char *argv[])
 
     PyStatus status;
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
 
     status = PyConfig_InitIsolatedConfig(&config);
     if (PyStatus_Exception(status)) {

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -385,7 +385,12 @@ static int check_init_compat_config(int preinit)
 
     if (preinit) {
         PyPreConfig preconfig;
-        _PyPreConfig_InitCompatConfig(&preconfig);
+        preconfig.struct_size = sizeof(PyPreConfig);
+
+        status = _PyPreConfig_InitCompatConfig(&preconfig);
+        if (PyStatus_Exception(status)) {
+            Py_ExitStatusException(status);
+        }
 
         status = Py_PreInitialize(&preconfig);
         if (PyStatus_Exception(status)) {
@@ -394,7 +399,13 @@ static int check_init_compat_config(int preinit)
     }
 
     PyConfig config;
-    _PyConfig_InitCompatConfig(&config);
+    config.struct_size = sizeof(PyConfig);
+
+    status = _PyConfig_InitCompatConfig(&config);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
+
     config_set_program_name(&config);
     init_from_config_clear(&config);
 
@@ -470,7 +481,12 @@ static int test_init_from_config(void)
     PyStatus status;
 
     PyPreConfig preconfig;
-    _PyPreConfig_InitCompatConfig(&preconfig);
+    preconfig.struct_size = sizeof(PyPreConfig);
+
+    status = _PyPreConfig_InitCompatConfig(&preconfig);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
 
     putenv("PYTHONMALLOC=malloc_debug");
     preconfig.allocator = PYMEM_ALLOCATOR_MALLOC;
@@ -485,7 +501,12 @@ static int test_init_from_config(void)
     }
 
     PyConfig config;
-    _PyConfig_InitCompatConfig(&config);
+    config.struct_size = sizeof(PyConfig);
+
+    status = _PyConfig_InitCompatConfig(&config);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
     config.install_signal_handlers = 0;
 
     /* FIXME: test use_environment */
@@ -617,6 +638,8 @@ static int check_init_parse_argv(int parse_argv)
     PyStatus status;
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
@@ -702,6 +725,8 @@ static int test_init_python_env(void)
     set_all_env_vars();
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
@@ -755,6 +780,8 @@ static int test_init_isolated_flag(void)
 
     /* Test PyConfig.isolated=1 */
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
@@ -779,7 +806,13 @@ static int test_preinit_isolated1(void)
     PyStatus status;
 
     PyPreConfig preconfig;
-    _PyPreConfig_InitCompatConfig(&preconfig);
+    preconfig.struct_size = sizeof(PyPreConfig);
+
+    status = _PyPreConfig_InitCompatConfig(&preconfig);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
+
     preconfig.isolated = 1;
 
     status = Py_PreInitialize(&preconfig);
@@ -788,7 +821,12 @@ static int test_preinit_isolated1(void)
     }
 
     PyConfig config;
-    _PyConfig_InitCompatConfig(&config);
+    config.struct_size = sizeof(PyConfig);
+
+    status = _PyConfig_InitCompatConfig(&config);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
     config_set_program_name(&config);
     set_all_env_vars();
     init_from_config_clear(&config);
@@ -805,7 +843,13 @@ static int test_preinit_isolated2(void)
     PyStatus status;
 
     PyPreConfig preconfig;
-    _PyPreConfig_InitCompatConfig(&preconfig);
+    preconfig.struct_size = sizeof(PyPreConfig);
+
+    status = _PyPreConfig_InitCompatConfig(&preconfig);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
+
     preconfig.isolated = 0;
 
     status = Py_PreInitialize(&preconfig);
@@ -815,7 +859,11 @@ static int test_preinit_isolated2(void)
 
     /* Test PyConfig.isolated=1 */
     PyConfig config;
-    _PyConfig_InitCompatConfig(&config);
+    config.struct_size = sizeof(PyConfig);
+    status = _PyConfig_InitCompatConfig(&config);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
 
     Py_IsolatedFlag = 0;
     config.isolated = 1;
@@ -835,7 +883,12 @@ static int test_preinit_dont_parse_argv(void)
     PyStatus status;
 
     PyPreConfig preconfig;
-    PyPreConfig_InitIsolatedConfig(&preconfig);
+    preconfig.struct_size = sizeof(PyPreConfig);
+
+    status = PyPreConfig_InitIsolatedConfig(&preconfig);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
 
     preconfig.isolated = 0;
 
@@ -852,6 +905,7 @@ static int test_preinit_dont_parse_argv(void)
     }
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
 
     status = PyConfig_InitIsolatedConfig(&config);
     if (PyStatus_Exception(status)) {
@@ -877,6 +931,7 @@ static int test_preinit_parse_argv(void)
 {
     PyStatus status;
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
 
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
@@ -934,7 +989,12 @@ static int check_preinit_isolated_config(int preinit)
 
     if (preinit) {
         PyPreConfig preconfig;
-        PyPreConfig_InitIsolatedConfig(&preconfig);
+        preconfig.struct_size = sizeof(PyPreConfig);
+
+        status = PyPreConfig_InitIsolatedConfig(&preconfig);
+        if (PyStatus_Exception(status)) {
+            Py_ExitStatusException(status);
+        }
 
         status = Py_PreInitialize(&preconfig);
         if (PyStatus_Exception(status)) {
@@ -947,6 +1007,8 @@ static int check_preinit_isolated_config(int preinit)
     }
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitIsolatedConfig(&config);
     if (PyStatus_Exception(status)) {
         PyConfig_Clear(&config);
@@ -996,7 +1058,12 @@ static int check_init_python_config(int preinit)
 
     if (preinit) {
         PyPreConfig preconfig;
-        PyPreConfig_InitPythonConfig(&preconfig);
+        preconfig.struct_size = sizeof(PyPreConfig);
+
+        status = PyPreConfig_InitPythonConfig(&preconfig);
+        if (PyStatus_Exception(status)) {
+            Py_ExitStatusException(status);
+        }
 
         status = Py_PreInitialize(&preconfig);
         if (PyStatus_Exception(status)) {
@@ -1005,6 +1072,8 @@ static int check_init_python_config(int preinit)
     }
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
@@ -1035,7 +1104,13 @@ static int test_init_dont_configure_locale(void)
     PyStatus status;
 
     PyPreConfig preconfig;
-    PyPreConfig_InitPythonConfig(&preconfig);
+    preconfig.struct_size = sizeof(PyPreConfig);
+
+    status = PyPreConfig_InitPythonConfig(&preconfig);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
+
     preconfig.configure_locale = 0;
     preconfig.coerce_c_locale = 1;
     preconfig.coerce_c_locale_warn = 1;
@@ -1046,6 +1121,8 @@ static int test_init_dont_configure_locale(void)
     }
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
@@ -1063,6 +1140,8 @@ static int test_init_dev_mode(void)
 {
     PyStatus status;
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
@@ -1286,6 +1365,8 @@ static int run_audit_run_test(int argc, wchar_t **argv, void *test)
 {
     PyStatus status;
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
@@ -1334,6 +1415,8 @@ static int test_init_read_set(void)
 {
     PyStatus status;
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
@@ -1382,6 +1465,8 @@ static int test_init_sys_add(void)
     PySys_AddWarnOption(L"ignore:::sysadd_warnoption");
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     PyStatus status;
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
@@ -1450,7 +1535,12 @@ static int test_init_setpath_config(void)
 {
     PyStatus status;
     PyPreConfig preconfig;
-    PyPreConfig_InitPythonConfig(&preconfig);
+    preconfig.struct_size = sizeof(PyPreConfig);
+
+    status = PyPreConfig_InitPythonConfig(&preconfig);
+    if (PyStatus_Exception(status)) {
+        Py_ExitStatusException(status);
+    }
 
     /* Explicitly preinitializes with Python preconfiguration to avoid
       Py_SetPath() implicit preinitialization with compat preconfiguration. */
@@ -1474,6 +1564,7 @@ static int test_init_setpath_config(void)
     putenv("TESTPATH=");
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
 
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
@@ -1531,6 +1622,8 @@ static int test_init_run_main(void)
 {
     PyStatus status;
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
+
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
@@ -1546,6 +1639,7 @@ static int test_init_main(void)
 {
     PyStatus status;
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
 
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
@@ -1577,6 +1671,7 @@ static int test_run_main(void)
 {
     PyStatus status;
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
 
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -40,6 +40,7 @@ Py_FrozenMain(int argc, char **argv)
     }
 
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
     status = PyConfig_InitPythonConfig(&config);
     if (PyStatus_Exception(status)) {
         PyConfig_Clear(&config);

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -434,7 +434,12 @@ pathconfig_global_read(_PyPathConfig *pathconfig)
 {
     PyStatus status;
     PyConfig config;
-    _PyConfig_InitCompatConfig(&config);
+    config.struct_size = sizeof(PyConfig);
+
+    status = _PyConfig_InitCompatConfig(&config);
+    if (_PyStatus_EXCEPTION(status)) {
+        goto done;
+    }
 
     /* Call _PyConfig_InitPathConfig() */
     status = PyConfig_Read(&config);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -735,7 +735,12 @@ _Py_PreInitializeFromPyArgv(const PyPreConfig *src_config, const _PyArgv *args)
     runtime->preinitializing = 1;
 
     PyPreConfig config;
-    _PyPreConfig_InitFromPreConfig(&config, src_config);
+    config.struct_size = sizeof(PyPreConfig);
+
+    status = _PyPreConfig_InitFromPreConfig(&config, src_config);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
 
     status = _PyPreConfig_Read(&config, args);
     if (_PyStatus_EXCEPTION(status)) {
@@ -794,7 +799,12 @@ _Py_PreInitializeFromConfig(const PyConfig *config,
     }
 
     PyPreConfig preconfig;
-    _PyPreConfig_InitFromConfig(&preconfig, config);
+    preconfig.struct_size = sizeof(PyPreConfig);
+
+    status = _PyPreConfig_InitFromConfig(&preconfig, config);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
 
     if (!config->parse_argv) {
         return Py_PreInitialize(&preconfig);
@@ -842,7 +852,12 @@ pyinit_core(_PyRuntimeState *runtime,
     }
 
     PyConfig config;
-    _PyConfig_InitCompatConfig(&config);
+    config.struct_size = sizeof(PyConfig);
+
+    status = _PyConfig_InitCompatConfig(&config);
+    if (_PyStatus_EXCEPTION(status)) {
+        goto done;
+    }
 
     status = _PyConfig_Copy(&config, src_config);
     if (_PyStatus_EXCEPTION(status)) {
@@ -1064,7 +1079,13 @@ Py_InitializeEx(int install_sigs)
     }
 
     PyConfig config;
-    _PyConfig_InitCompatConfig(&config);
+    config.struct_size = sizeof(PyConfig);
+
+    status = _PyConfig_InitCompatConfig(&config);
+    if (_PyStatus_EXCEPTION(status)) {
+        Py_ExitStatusException(status);
+    }
+
     config.install_signal_handlers = install_sigs;
 
     status = Py_InitializeFromConfig(&config);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -60,7 +60,12 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
 
     _PyGC_Initialize(&runtime->gc);
     _PyEval_Initialize(&runtime->ceval);
-    PyPreConfig_InitPythonConfig(&runtime->preconfig);
+
+    runtime->preconfig.struct_size = sizeof(PyPreConfig);
+    PyStatus status = PyPreConfig_InitPythonConfig(&runtime->preconfig);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
 
     runtime->gilstate.check_enabled = 1;
 
@@ -204,6 +209,7 @@ PyInterpreterState_New(void)
     memset(interp, 0, sizeof(*interp));
     interp->id_refcount = -1;
 
+    interp->config.struct_size = sizeof(PyConfig);
     PyStatus status = PyConfig_InitPythonConfig(&interp->config);
     if (_PyStatus_EXCEPTION(status)) {
         /* Don't report status to caller: PyConfig_InitPythonConfig()


### PR DESCRIPTION
Add a new struct_size field to PyPreConfig and PyConfig structures to
allow to modify these structures in the future without breaking the
backward compatibility.

* Replace private _config_version field with public struct_size field
  in PyPreConfig and PyConfig.
* Public PyPreConfig_InitIsolatedConfig() and
  PyPreConfig_InitPythonConfig()
  return type becomes PyStatus, instead of void.
* Internal _PyConfig_InitCompatConfig(),
  _PyPreConfig_InitCompatConfig(), _PyPreConfig_InitFromConfig(),
  _PyPreConfig_InitFromPreConfig() return type becomes PyStatus,
  instead of void.
* Remove _Py_CONFIG_VERSION
* Update the Initialization Configuration documentation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38304](https://bugs.python.org/issue38304) -->
https://bugs.python.org/issue38304
<!-- /issue-number -->
