### PR TITLE
[2.7] bpo-38301: In Solaris family, we must be sure to use '-D_REENTRANT' (GH-16446)

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-09-28-02-37-11.bpo-38301.123456.rst
+++ b/Misc/NEWS.d/next/Build/2019-09-28-02-37-11.bpo-38301.123456.rst
@@ -1,0 +1,2 @@
+In Solaris family, we must be sure to use ``-D_REENTRANT``.
+Patch by Jesús Cea Avión.

--- a/configure
+++ b/configure
@@ -9602,6 +9602,9 @@ then
 
     posix_threads=yes
     THREADOBJ="Python/thread.o"
+    if test "$ac_sys_system" = "SunOS"; then
+        CFLAGS="$CFLAGS -D_REENTRANT"
+    fi
 elif test "$ac_cv_kpthread" = "yes"
 then
     CC="$CC -Kpthread"

--- a/configure.ac
+++ b/configure.ac
@@ -2625,6 +2625,9 @@ then
     AC_DEFINE(_REENTRANT)
     posix_threads=yes
     THREADOBJ="Python/thread.o"    
+    if test "$ac_sys_system" = "SunOS"; then
+        CFLAGS="$CFLAGS -D_REENTRANT"
+    fi
 elif test "$ac_cv_kpthread" = "yes"
 then
     CC="$CC -Kpthread"


### PR DESCRIPTION
(cherry picked from commit 52d1b86bde2b772a76919c76991c326384954bf1)

Co-authored-by: Jesús Cea <jcea@jcea.es>


<!-- issue-number: [bpo-38301](https://bugs.python.org/issue38301) -->
https://bugs.python.org/issue38301
<!-- /issue-number -->
