### PR TITLE
bpo-36670: fixed encoding issue with libregrtest on win systems

### DIFF
--- a/Lib/test/libregrtest/win_utils.py
+++ b/Lib/test/libregrtest/win_utils.py
@@ -59,7 +59,7 @@ class WindowsLoadTracker():
         self.p = subprocess.Popen(command, stdout=command_stdout, cwd=support.SAVEDCWD)
 
         # Close our copy of the write end of the pipe
-        os.close(command_stdout)
+        # os.close(command_stdout)
 
     def close(self):
         if self.p is None:
@@ -79,7 +79,7 @@ class WindowsLoadTracker():
         if res != 0:
             return
 
-        return overlapped.getbuffer().decode()
+        return overlapped.getbuffer().decode(encoding='oem', errors='ignore')
 
     def getloadavg(self):
         typeperf_output = self.read_output()

--- a/Misc/NEWS.d/next/Tests/2019-09-28-09-59-16.bpo-36670.g9nzfJ.rst
+++ b/Misc/NEWS.d/next/Tests/2019-09-28-09-59-16.bpo-36670.g9nzfJ.rst
@@ -1,0 +1,2 @@
+fixed encoding issues with test execution on non english systems these
+systems will return default load 0.0


### PR DESCRIPTION
alternative solution to [PR 15488](https://github.com/python/cpython/pull/15488) - fixing encoding issue with libregrtest on win systems (non english), load of default 0.0 is returned

Was not easily able to write early (instantiation) raise, instead adding of the encoding works fine.
I am unsure about the closing of the write end of the pipe (l. 62) -> tests fail if the pipe is closed, so I uncommented it.

<!-- issue-number: [bpo-36670](https://bugs.python.org/issue36670) -->
https://bugs.python.org/issue36670
<!-- /issue-number -->
