### PR TITLE
bpo-34344 Fixed AbstractEventLoopPolicy.get_event_loop docstrings

### DIFF
--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -631,6 +631,7 @@ class BaseDefaultEventLoopPolicy(AbstractEventLoopPolicy):
 
     def get_event_loop(self):
         """Get the event loop for the current context.
+
            Returns an instance of EventLoop or raises an exception.
         """
         if (self._local._loop is None and

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -631,7 +631,7 @@ class BaseDefaultEventLoopPolicy(AbstractEventLoopPolicy):
 
     def get_event_loop(self):
         """Get the event loop for the current context.
-           Returns an instance of EventLoop or raises an exception.
+        Returns an instance of EventLoop or raises an exception.
         """
         if (self._local._loop is None and
                 not self._local._set_called and

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -577,10 +577,13 @@ class AbstractEventLoopPolicy:
     """Abstract policy for accessing the event loop."""
 
     def get_event_loop(self):
+        """Get the event loop for the current context.
 
-        """ Get the event loop for the current context.
-            Returns an instance of EventLoop or raises an exception.
-       """
+        Returns an event loop object implementing the BaseEventLoop interface,
+        or raises an exception in case no event loop has been set for the
+        current context and the current policy does not specify to create one.
+
+        It should never return None."""
         raise NotImplementedError
 
     def set_event_loop(self, loop):
@@ -627,9 +630,8 @@ class BaseDefaultEventLoopPolicy(AbstractEventLoopPolicy):
         self._local = self._Local()
 
     def get_event_loop(self):
-        """Get the event loop.
-
-        This may be None or an instance of EventLoop.
+        """Get the event loop for the current context.
+           Returns an instance of EventLoop or raises an exception.
         """
         if (self._local._loop is None and
                 not self._local._set_called and

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -577,13 +577,10 @@ class AbstractEventLoopPolicy:
     """Abstract policy for accessing the event loop."""
 
     def get_event_loop(self):
-        """Get the event loop for the current context.
 
-        Returns an event loop object implementing the BaseEventLoop interface,
-        or raises an exception in case no event loop has been set for the
-        current context and the current policy does not specify to create one.
-
-        It should never return None."""
+        """ Get the event loop for the current context.
+            Returns an instance of EventLoop or raises an exception.
+       """
         raise NotImplementedError
 
     def set_event_loop(self, loop):

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -348,8 +348,6 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         The maximum amount of data to be received at once is specified by
         nbytes.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         try:
@@ -388,8 +386,6 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         The received data is written into *buf* (a writable buffer).
         The return value is the number of bytes written.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         try:
@@ -429,8 +425,6 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         raised, and there is no way to determine how much data, if any, was
         successfully processed by the receiving end of the connection.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         try:
@@ -478,8 +472,6 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
 
         This method is a coroutine.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
 
@@ -541,8 +533,6 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         object usable to send and receive data on the connection, and address
         is the address bound to the socket on the other end of the connection.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         fut = self.create_future()

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -348,6 +348,8 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         The maximum amount of data to be received at once is specified by
         nbytes.
         """
+        if isinstance(sock, ssl.SSLSocket):
+            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         try:
@@ -386,6 +388,8 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         The received data is written into *buf* (a writable buffer).
         The return value is the number of bytes written.
         """
+        if isinstance(sock, ssl.SSLSocket):
+            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         try:
@@ -425,6 +429,8 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         raised, and there is no way to determine how much data, if any, was
         successfully processed by the receiving end of the connection.
         """
+        if isinstance(sock, ssl.SSLSocket):
+            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         try:
@@ -472,6 +478,8 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
 
         This method is a coroutine.
         """
+        if isinstance(sock, ssl.SSLSocket):
+            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
 
@@ -533,6 +541,8 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         object usable to send and receive data on the connection, and address
         is the address bound to the socket on the other end of the connection.
         """
+        if isinstance(sock, ssl.SSLSocket):
+            warnings.warn("Socket cannot be of type SSLSocket instance", DeprecationWarning, source=self)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         fut = self.create_future()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# [bpo-34344](https://bugs.python.org/issue34344) Fixed AbstractEventLoopPolicy.get_event_loop docstrings

# [3.7] [bpo-34344](https://bugs.python.org/issue34344) Fixed AbstractEventLoopPolicy.get_event_loop docstrings (GH-16463)
# [3.8] [bpo-34344](https://bugs.python.org/issue34344) Fixed AbstractEventLoopPolicy.get_event_loop docstrings (GH-16463)

-->


<!-- issue-number: [bpo-34344](https://bugs.python.org/issue34344) -->
https://bugs.python.org/issue34344
<!-- /issue-number -->
