### PR TITLE
bpo-38310: Predict BUILD_MAP_UNPACK_WITH_CALL -> CALL_FUNCTION_EX.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-09-28-22-54-25.bpo-38310.YDTbEo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-09-28-22-54-25.bpo-38310.YDTbEo.rst
@@ -1,0 +1,1 @@
+Predict ``BUILD_MAP_UNPACK_WITH_CALL`` -> ``CALL_FUNCTION_EX`` opcode pairs in the main interpreter loop. Patch by Brandt Bucher.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2943,6 +2943,7 @@ main_loop:
             while (oparg--)
                 Py_DECREF(POP());
             PUSH(sum);
+            PREDICT(CALL_FUNCTION_EX);
             DISPATCH();
         }
 
@@ -3522,6 +3523,7 @@ main_loop:
         }
 
         case TARGET(CALL_FUNCTION_EX): {
+            PREDICTED(CALL_FUNCTION_EX);
             PyObject *func, *callargs, *kwargs = NULL, *result;
             if (oparg & 0x01) {
                 kwargs = POP();


### PR DESCRIPTION
This patch adds ~~four~~ one new opcode prediction:

`BUILD_MAP_UNPACK_WITH_CALL` -> `CALL_FUNCTION_EX`:
 - Emitted whenever more than one map of `**kwargs` is unpacked into a call.
 - Pair **always** occurs together.

~~`LOAD_BUILD_CLASS` -> `LOAD_CONST`:~~
 - Emitted whenever a class is defined *without* the use of cell vars.
 - In my analysis, occurs ~93% of the time.

~~`LOAD_BUILD_CLASS` -> `LOAD_CLOSURE`:~~
 - Emitted whenever a class is defined *with* the use of cell vars.
 - Occurs the other ~7% of the time

~~`LOAD_ASSERTION_ERROR` -> `RAISE_VARARGS`:~~
 - Emitted whenever the one-argument form of `assert` is used.
 - Occurs ~91% of the time.

<!-- issue-number: [bpo-38310](https://bugs.python.org/issue38310) -->
https://bugs.python.org/issue38310
<!-- /issue-number -->
