### PR TITLE
bpo-38311: Avoid sqlite3_enable_shared_cache deprecation warning when building with the macOS system SQLite3

### DIFF
--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -131,7 +131,7 @@ PyDoc_STRVAR(module_complete_doc,
 \n\
 Checks if a string contains a complete SQL statement. Non-standard.");
 
-#ifdef HAVE_SHARED_CACHE
+#if defined(HAVE_SHARED_CACHE) && !defined(__APPLE__)
 static PyObject* module_enable_shared_cache(PyObject* self, PyObject* args, PyObject*
         kwargs)
 {


### PR DESCRIPTION
sqlite shared cached is disabled since the 10.7 release (2011).



<!-- issue-number: [bpo-38311](https://bugs.python.org/issue38311) -->
https://bugs.python.org/issue38311
<!-- /issue-number -->
