### PR TITLE
bpo-38163: Child mocks detect their type as sync or async

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -865,7 +865,7 @@ object::
     True
 
   The result of ``mock()`` is an async function which will have the outcome
-  of ``side_effect`` or ``return_value``:
+  of ``side_effect`` or ``return_value`` after it has been awaited:
 
   - if ``side_effect`` is a function, the async function will return the
     result of that function,
@@ -889,6 +889,32 @@ object::
     <MagicMock spec='function' id='...'>
     >>> mock()  # doctest: +SKIP
     <coroutine object AsyncMockMixin._mock_call at ...>
+
+
+  Setting the *spec* of a :class:`Mock`, :class:`MagicMock`, or :class:`AsyncMock`
+  to a class with asynchronous and synchronous functions will automatically
+  detect the synchronous functions and set them as :class:`MagicMock` (if the
+  parent mock is :class:`AsyncMock` or :class:`MagicMock`) or :class:`Mock` (if
+  the parent mock is :class:`Mock`). All asynchronous functions will be
+  :class:`AsyncMock`.
+
+  >>> class ExampleClass:
+  ...     def sync_foo():
+  ...         pass
+  ...     async def async_foo():
+  ...         pass
+  ...
+  >>> a_mock = AsyncMock(ExampleClass)
+  >>> a_mock.sync_foo
+  <MagicMock name='a_mock.sync_foo' id='...'>
+  >>> a_mock.async_foo
+  <AsyncMock name='a_mock.async_foo' id='...'>
+  >>> mock = Mock(ExampleClass)
+  >>> mock.sync_foo
+  <Mock name='mock.sync_foo' id='...'>
+  >>> mock.async_foo
+  <AsyncMock name='mock.async_foo' id='...'>
+
 
   .. method:: assert_awaited()
 

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -906,14 +906,14 @@ object::
   ...
   >>> a_mock = AsyncMock(ExampleClass)
   >>> a_mock.sync_foo
-  <MagicMock name='a_mock.sync_foo' id='...'>
+  <MagicMock name='a_mock.sync_foo' id='4404894528'>
   >>> a_mock.async_foo
-  <AsyncMock name='a_mock.async_foo' id='...'>
+  <AsyncMock name='a_mock.async_foo' id='4404894688'>
   >>> mock = Mock(ExampleClass)
   >>> mock.sync_foo
-  <Mock name='mock.sync_foo' id='...'>
+  <Mock name='mock.sync_foo' id='4405092912'>
   >>> mock.async_foo
-  <AsyncMock name='mock.async_foo' id='...'>
+  <AsyncMock name='mock.async_foo' id='4405092592'>
 
 
   .. method:: assert_awaited()

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -906,14 +906,14 @@ object::
   ...
   >>> a_mock = AsyncMock(ExampleClass)
   >>> a_mock.sync_foo
-  <MagicMock name='a_mock.sync_foo' id='4404894528'>
+  <MagicMock name='mock.sync_foo' id='...'>
   >>> a_mock.async_foo
-  <AsyncMock name='a_mock.async_foo' id='4404894688'>
+  <AsyncMock name='mock.async_foo' id='...'>
   >>> mock = Mock(ExampleClass)
   >>> mock.sync_foo
-  <Mock name='mock.sync_foo' id='4405092912'>
+  <Mock name='mock.sync_foo' id='...'>
   >>> mock.async_foo
-  <AsyncMock name='mock.async_foo' id='4405092592'>
+  <AsyncMock name='mock.async_foo' id='...'>
 
 
   .. method:: assert_awaited()

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -993,8 +993,9 @@ class NonCallableMock(Base):
             # Any asynchronous magic becomes an AsyncMock
             klass = AsyncMock
         elif issubclass(_type, AsyncMockMixin):
-            if _new_name in _all_sync_magics:
-                # Any synchronous magic becomes a MagicMock
+            if (_new_name in _all_sync_magics or
+                    self._mock_methods and _new_name in self._mock_methods):
+                # Any synchronous method on AsyncMock becomes a MagicMock
                 klass = MagicMock
             else:
                 klass = AsyncMock

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -4,7 +4,7 @@ import re
 import unittest
 
 from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock, Mock,
-                           create_autospec, _AwaitEvent, sentinel, _CallList)
+                           create_autospec, sentinel, _CallList)
 
 
 def tearDownModule():

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -396,7 +396,7 @@ class AsyncArguments(unittest.TestCase):
                 RuntimeError('coroutine raised StopIteration')
             )
 
-class AsyncMagicTypes(unittest.TestCase):
+class AsyncMagicMethods(unittest.TestCase):
     def test_async_magic_methods_return_async_mocks(self):
         m_mock = MagicMock()
         self.assertIsInstance(m_mock.__aenter__, AsyncMock)

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -3,7 +3,7 @@ import inspect
 import re
 import unittest
 
-from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock,
+from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock, Mock,
                            create_autospec, _AwaitEvent, sentinel, _CallList)
 
 
@@ -234,33 +234,50 @@ class AsyncAutospecTest(unittest.TestCase):
 
 
 class AsyncSpecTest(unittest.TestCase):
-    def test_spec_as_async_positional_magicmock(self):
-        mock = MagicMock(async_func)
-        self.assertIsInstance(mock, MagicMock)
-        m = mock()
-        self.assertTrue(inspect.isawaitable(m))
-        asyncio.run(m)
+    def test_spec_normal_methods_on_class(self):
+        def inner_test(mock_type):
+            mock = mock_type(AsyncClass)
+            self.assertIsInstance(mock.async_method, AsyncMock)
+            self.assertIsInstance(mock.normal_method, MagicMock)
 
-    def test_spec_as_async_kw_magicmock(self):
-        mock = MagicMock(spec=async_func)
-        self.assertIsInstance(mock, MagicMock)
-        m = mock()
-        self.assertTrue(inspect.isawaitable(m))
-        asyncio.run(m)
+        for mock_type in [AsyncMock, MagicMock]:
+            with self.subTest(f"test method types with {mock_type}"):
+                inner_test(mock_type)
 
-    def test_spec_as_async_kw_AsyncMock(self):
-        mock = AsyncMock(spec=async_func)
-        self.assertIsInstance(mock, AsyncMock)
-        m = mock()
-        self.assertTrue(inspect.isawaitable(m))
-        asyncio.run(m)
+    def test_spec_normal_methods_on_class_with_mock(self):
+        mock = Mock(AsyncClass)
+        self.assertIsInstance(mock.async_method, AsyncMock)
+        self.assertIsInstance(mock.normal_method, Mock)
 
-    def test_spec_as_async_positional_AsyncMock(self):
-        mock = AsyncMock(async_func)
-        self.assertIsInstance(mock, AsyncMock)
-        m = mock()
-        self.assertTrue(inspect.isawaitable(m))
-        asyncio.run(m)
+    def test_spec_mock_type_kw(self):
+        def inner_test(mock_type):
+            async_mock = mock_type(spec=async_func)
+            self.assertIsInstance(async_mock, mock_type)
+            with self.assertWarns(RuntimeWarning):
+                # Will raise a warning because never awaited
+                self.assertTrue(inspect.isawaitable(async_mock()))
+
+            sync_mock = mock_type(spec=normal_func)
+            self.assertIsInstance(sync_mock, mock_type)
+
+        for mock_type in [AsyncMock, MagicMock, Mock]:
+            with self.subTest(f"test spec kwarg with {mock_type}"):
+                inner_test(mock_type)
+
+    def test_spec_mock_type_positional(self):
+        def inner_test(mock_type):
+            async_mock = mock_type(async_func)
+            self.assertIsInstance(async_mock, mock_type)
+            with self.assertWarns(RuntimeWarning):
+                # Will raise a warning because never awaited
+                self.assertTrue(inspect.isawaitable(async_mock()))
+
+            sync_mock = mock_type(normal_func)
+            self.assertIsInstance(sync_mock, mock_type)
+
+        for mock_type in [AsyncMock, MagicMock, Mock]:
+            with self.subTest(f"test spec positional with {mock_type}"):
+                inner_test(mock_type)
 
     def test_spec_as_normal_kw_AsyncMock(self):
         mock = AsyncMock(spec=normal_func)
@@ -379,7 +396,7 @@ class AsyncArguments(unittest.TestCase):
                 RuntimeError('coroutine raised StopIteration')
             )
 
-class AsyncMagicMethods(unittest.TestCase):
+class AsyncMagicTypes(unittest.TestCase):
     def test_async_magic_methods_return_async_mocks(self):
         m_mock = MagicMock()
         self.assertIsInstance(m_mock.__aenter__, AsyncMock)

--- a/Misc/NEWS.d/next/Library/2019-09-28-20-16-40.bpo-38163.x51-vK.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-28-20-16-40.bpo-38163.x51-vK.rst
@@ -1,0 +1,4 @@
+Child mocks will now detect their type as either synchronous or
+asynchronous, asynchronous child mocks will be AsyncMocks and synchronous
+child mocks will be either MagicMock or Mock (depending on their parent
+type).


### PR DESCRIPTION
This should be the last diff to get the child mocks detecting their type as either synchronous or asynchronous and returning AsyncMock or MagicMock (or Mock) depending on their type. 

The main goal is for classes that have a mix of asynchronous and synchronous methods to auto-detect whether they should be AsyncMock or a synchronous mocks. Example:

```
  >>> class ExampleClass:
  ...     def sync_foo():
  ...         pass
  ...     async def async_foo():
  ...         pass
  ...
  >>> a_mock = AsyncMock(ExampleClass)
  >>> a_mock.sync_foo
  <MagicMock name='a_mock.sync_foo' id='...'>
  >>> a_mock.async_foo
  <AsyncMock name='a_mock.async_foo' id='...'>
  >>> mock = Mock(ExampleClass)
  >>> mock.sync_foo
  <Mock name='mock.sync_foo' id='...'>
  >>> mock.async_foo
  <AsyncMock name='mock.async_foo' id='...'>
```

This defies Mock's typical functionality where all child mocks follow the type of their parent mock, but after some discussion I believe the auto-detection is more important to the typical user than a consistency with current Mock style. 


<!-- issue-number: [bpo-38163](https://bugs.python.org/issue38163) -->
https://bugs.python.org/issue38163
<!-- /issue-number -->
