### PR TITLE
bpo-38304: Fix PyConfig usage in python_uwp.cpp

### DIFF
--- a/PC/python_uwp.cpp
+++ b/PC/python_uwp.cpp
@@ -167,7 +167,10 @@ wmain(int argc, wchar_t **argv)
     PyStatus status;
 
     PyPreConfig preconfig;
+    preconfig.struct_size = sizeof(PyPreConfig);
+
     PyConfig config;
+    config.struct_size = sizeof(PyConfig);
 
     const wchar_t *moduleName = NULL;
     const wchar_t *p = wcsrchr(argv[0], L'\\');
@@ -186,7 +189,10 @@ wmain(int argc, wchar_t **argv)
         }
     }
 
-    PyPreConfig_InitPythonConfig(&preconfig);
+    status = PyPreConfig_InitPythonConfig(&preconfig);
+    if (PyStatus_Exception(status)) {
+        goto fail_without_config;
+    }
     if (!moduleName) {
         status = Py_PreInitializeFromArgs(&preconfig, argc, argv);
         if (PyStatus_Exception(status)) {


### PR DESCRIPTION
* Set PyPreConfig.struct_size and PyConfig.struct_size as required by
  the API.
* PyPreConfig_InitPythonConfig() can now fail: check PyStatus result.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38304](https://bugs.python.org/issue38304) -->
https://bugs.python.org/issue38304
<!-- /issue-number -->
