### PR TITLE
bpo-38319: Fix shutil._fastcopy_sendfile(): set sendfile() max block size

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -135,8 +135,8 @@ def _fastcopy_sendfile(fsrc, fdst):
     # should not make any difference, also in case the file content
     # changes while being copied.
     try:
-        blocksize = max(os.fstat(infd).st_size, 2 ** 23)  # min 8MB
-        blocksize = min(blocksize, 2 ** 30)  # max 1GB
+        blocksize = max(os.fstat(infd).st_size, 2 ** 23)  # min 8MiB
+        blocksize = min(blocksize, 2 ** 30)  # max 1GiB
     except OSError:
         blocksize = 2 ** 27  # 128MB
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -136,8 +136,8 @@ def _fastcopy_sendfile(fsrc, fdst):
     # changes while being copied.
     try:
         blocksize = max(os.fstat(infd).st_size, 2 ** 23)  # min 8MB
-        blocksize = min(blocksize, 2 ** 31 - 2)  # max 2GB
-    except Exception:
+        blocksize = min(blocksize, 2 ** 30)  # max 1GB
+    except OSError:
         blocksize = 2 ** 27  # 128MB
 
     offset = 0

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -136,7 +136,8 @@ def _fastcopy_sendfile(fsrc, fdst):
     # changes while being copied.
     try:
         blocksize = max(os.fstat(infd).st_size, 2 ** 23)  # min 8MiB
-        blocksize = min(blocksize, 2 ** 30)  # max 1GiB
+        if sys.maxsize < 2 ** 32:  # 32-bit architecture
+            blocksize = min(blocksize, 2 ** 30)  # max 1GiB
     except OSError:
         blocksize = 2 ** 27  # 128MB
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -136,6 +136,7 @@ def _fastcopy_sendfile(fsrc, fdst):
     # changes while being copied.
     try:
         blocksize = max(os.fstat(infd).st_size, 2 ** 23)  # min 8MB
+        blocksize = min(blocksize, 2 ** 31 - 2)  # max 2GB
     except Exception:
         blocksize = 2 ** 27  # 128MB
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -136,10 +136,12 @@ def _fastcopy_sendfile(fsrc, fdst):
     # changes while being copied.
     try:
         blocksize = max(os.fstat(infd).st_size, 2 ** 23)  # min 8MiB
-        if sys.maxsize < 2 ** 32:  # 32-bit architecture
-            blocksize = min(blocksize, 2 ** 30)  # max 1GiB
     except OSError:
-        blocksize = 2 ** 27  # 128MB
+        blocksize = 2 ** 27  # 128MiB
+    # On 32-bit architectures truncate to 1GiB to avoid OverflowError,
+    # see bpo-38319.
+    if sys.maxsize < 2 ** 32:
+        blocksize = min(blocksize, 2 ** 30)
 
     offset = 0
     while True:

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -357,6 +357,7 @@ class socket(_socket.socket):
             if not fsize:
                 return 0  # empty file
             blocksize = fsize if not count else count
+            blocksize = min(blocksize, 2 ** 31 - 2)  # max 2GB
 
             timeout = self.gettimeout()
             if timeout == 0:

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -356,8 +356,7 @@ class socket(_socket.socket):
                 raise _GiveupOnSendfile(err)  # not a regular file
             if not fsize:
                 return 0  # empty file
-            blocksize = fsize if not count else count
-            blocksize = min(blocksize, 2 ** 30)  # max 1GB
+            blocksize = min(count or fsize, 2 ** 30)  # max 1GiB
 
             timeout = self.gettimeout()
             if timeout == 0:

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -357,7 +357,7 @@ class socket(_socket.socket):
             if not fsize:
                 return 0  # empty file
             blocksize = fsize if not count else count
-            blocksize = min(blocksize, 2 ** 31 - 2)  # max 2GB
+            blocksize = min(blocksize, 2 ** 30)  # max 1GB
 
             timeout = self.gettimeout()
             if timeout == 0:

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -356,8 +356,8 @@ class socket(_socket.socket):
                 raise _GiveupOnSendfile(err)  # not a regular file
             if not fsize:
                 return 0  # empty file
-            blocksize = min(count or fsize, 2 ** 30)  # max 1GiB
-
+            # Truncate to 1GiB to avoid OverflowError, see bpo-38319.
+            blocksize = min(count or fsize, 2 ** 30)
             timeout = self.gettimeout()
             if timeout == 0:
                 raise ValueError("non-blocking sockets are not supported")

--- a/Misc/NEWS.d/next/Library/2019-09-30-22-06-33.bpo-38319.5QjiDa.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-30-22-06-33.bpo-38319.5QjiDa.rst
@@ -1,2 +1,2 @@
-sendfile() (used by socket and shutil modules) was raising OverflowError for
-files >= 2GiB on 32-bit systems.
+sendfile() used in socket and shutil modules was raising OverflowError for
+files >= 2GiB on 32-bit architectures.  (patch by Giampaolo Rodola)

--- a/Misc/NEWS.d/next/Library/2019-09-30-22-06-33.bpo-38319.5QjiDa.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-30-22-06-33.bpo-38319.5QjiDa.rst
@@ -1,0 +1,2 @@
+sendfile() (used by socket and shutil modules) was raising OverflowError for
+files > 2GB on 32-bit systems.

--- a/Misc/NEWS.d/next/Library/2019-09-30-22-06-33.bpo-38319.5QjiDa.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-30-22-06-33.bpo-38319.5QjiDa.rst
@@ -1,2 +1,2 @@
 sendfile() (used by socket and shutil modules) was raising OverflowError for
-files > 2GB on 32-bit systems.
+files >= 2GiB on 32-bit systems.


### PR DESCRIPTION
An attempt to fix:
https://bugs.python.org/issue38319

<!-- issue-number: [bpo-38319](https://bugs.python.org/issue38319) -->
https://bugs.python.org/issue38319
<!-- /issue-number -->
