### PR TITLE
bpo-38321: Fix PyCStructUnionType_update_stgdict() warning

### DIFF
--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -701,7 +701,7 @@ PyCStructUnionType_update_stgdict(PyObject *type, PyObject *fields, int isStruct
                 assert(actual_type_index <= MAX_ELEMENTS);
             }
             else {
-                int length = dict->length;
+                Py_ssize_t length = dict->length;
                 StgDictObject *edict;
 
                 edict = PyType_stgdict(dict->proto);


### PR DESCRIPTION
[bpo-22273](https://bugs.python.org/issue22273), [bpo-38321](https://bugs.python.org/issue38321): Fix following warning:

    modules\_ctypes\stgdict.c(704):
    warning C4244: 'initializing': conversion from 'Py_ssize_t' to
    'int', possible loss of data

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38321](https://bugs.python.org/issue38321) -->
https://bugs.python.org/issue38321
<!-- /issue-number -->
