### PR TITLE
[2.7] bpo-38330 Only set content-length when transfer-encoding is not present

### DIFF
--- a/Lib/httplib.py
+++ b/Lib/httplib.py
@@ -1091,7 +1091,8 @@ class HTTPConnection:
 
         self.putrequest(method, url, **skips)
 
-        if 'content-length' not in header_names:
+        if 'content-length' not in header_names and \
+           'transfer-encoding' not in header_names:
             self._set_content_length(body, method)
         for hdr, value in headers.iteritems():
             self.putheader(hdr, value)


### PR DESCRIPTION
RFC 7230 3.3.2 states "A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field."

>>> import httplib
>>> http = httplib.HTTPSConnection('google.com')
>>> http.set_debuglevel(1)
>>> http.request("POST", '/', None, {'Content-Type': 'text/plain','Transfer-Encoding': 'chunked'})
send: 'POST / HTTP/1.1\r\nHost: google.com\r\nAccept-Encoding: identity\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n'

Includes both content-length and transfer-encoding.  With this change:

>>> import httplib
>>> http = httplib.HTTPSConnection('google.com')
>>> http.set_debuglevel(1)
>>> http.request("POST", '/', None, {'Content-Type': 'text/plain','Transfer-Encoding': 'chunked'})
send: 'POST / HTTP/1.1\r\nHost: google.com\r\nAccept-Encoding: identity\r\nTransfer-Encoding: chunked\r\nContent-Type: text/plain\r\n\r\n'

Includes only transfer-encoding.

<!-- issue-number: [bpo-38330](https://bugs.python.org/issue38330) -->
https://bugs.python.org/issue38330
<!-- /issue-number -->
