### PR TITLE
bpo-38332: catch KeyError from unknown cte in encoded-word

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1057,7 +1057,7 @@ def get_encoded_word(value):
     value = ''.join(remainder)
     try:
         text, charset, lang, defects = _ew.decode('=?' + tok + '?=')
-    except ValueError:
+    except (ValueError, KeyError):
         raise _InvalidEwError(
             "encoded word format invalid: '{}'".format(ew.cte))
     ew.charset = charset

--- a/Lib/test/test_email/test__encoded_words.py
+++ b/Lib/test/test_email/test__encoded_words.py
@@ -58,6 +58,8 @@ class TestDecode(TestEmailBase):
             _ew.decode('=?')
         with self.assertRaises(ValueError):
             _ew.decode('')
+        with self.assertRaises(KeyError):
+            _ew.decode('=?utf-8?X?somevalue?=')
 
     def _test(self, source, result, charset='us-ascii', lang='', defects=[]):
         res, char, l, d = _ew.decode(source)

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -89,6 +89,10 @@ class TestParser(TestParserMixin, TestEmailBase):
         with self.assertRaises(errors.HeaderParseError):
             parser.get_encoded_word('=?abc?=')
 
+    def test_get_encoded_word_invalid_cte(self):
+        with self.assertRaises(errors.HeaderParseError):
+            parser.get_encoded_word('=?utf-8?X?somevalue?=')
+
     def test_get_encoded_word_valid_ew(self):
         self._test_get_x(parser.get_encoded_word,
                          '=?us-ascii?q?this_is_a_test?=  bird',
@@ -396,6 +400,14 @@ class TestParser(TestParserMixin, TestEmailBase):
             '=?utf-8?q?=somevalue?=',
             '=?utf-8?q?=somevalue?=',
             '=?utf-8?q?=somevalue?=',
+            [],
+            '')
+
+    def test_get_unstructured_invalid_ew_cte(self):
+        self._test_get_x(self._get_unst,
+            '=?utf-8?X?=somevalue?=',
+            '=?utf-8?X?=somevalue?=',
+            '=?utf-8?X?=somevalue?=',
             [],
             '')
 

--- a/Misc/NEWS.d/next/Library/2019-10-05-02-07-52.bpo-38332.hwrPN7.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-05-02-07-52.bpo-38332.hwrPN7.rst
@@ -1,0 +1,3 @@
+Prevent :exc:`KeyError` thrown by :func:`_encoded_words.decode` when given
+an encoded-word with invalid content-type encoding from propagating all the
+way to :func:`email.message.get`.


### PR DESCRIPTION
Given an encoded-word with an invalid content-transfer-encoding (something other than `b` or `q`, for instance: `=?utf-8?X?somevalue?=`), `_encoded_words.decode()` throws a `KeyError` which propagates all the way down to `email.message.get()`.

Fix is to explicitly catch the `KeyError` in `get_encoded_word` and raise `InvalidEwError` which then causes `get_unstructured` to return the value unchanged.

If accepted, this should be backported to 3.5 through to 3.8

* https://bugs.python.org/issue38332

<!-- issue-number: [bpo-38332](https://bugs.python.org/issue38332) -->
https://bugs.python.org/issue38332
<!-- /issue-number -->


Automerge-Triggered-By: @maxking