### PR TITLE
bpo-22377: Fixes documentation for %Z in datetime

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2362,7 +2362,7 @@ requires, and these work on all platforms with a standard C implementation.
 |           | string if the object is        | +063415,               |       |
 |           | naive).                        | -030712.345216         |       |
 +-----------+--------------------------------+------------------------+-------+
-| ``%Z``    | Time zone name (empty string   | (empty), UTC, EST, CST |       |
+| ``%Z``    | Time zone name (empty string   | (empty), UTC, GMT      | \(6)  |
 |           | if the object is naive).       |                        |       |
 +-----------+--------------------------------+------------------------+-------+
 | ``%j``    | Day of the year as a           | 001, 002, ..., 366     | \(9)  |
@@ -2536,6 +2536,14 @@ Notes:
       If :meth:`tzname` returns ``None``, ``%Z`` is replaced by an empty
       string. Otherwise ``%Z`` is replaced by the returned value, which must
       be a string.
+
+      Note that :meth:`strptime` only accepts certain values for ``%Z``:
+
+      1. the hard-coded values ``UTC`` and ``GMT``
+      2. any value in ``time.tzname`` for your machine's locale
+
+      So someone living in Japan may have ``JST``, ``UTC``, and ``GMT`` as valid
+      values, but probably not ``EST``.
 
    .. versionchanged:: 3.2
       When the ``%z`` directive is provided to the :meth:`strptime` method, an

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2533,17 +2533,18 @@ Notes:
       In addition, providing ``'Z'`` is identical to ``'+00:00'``.
 
    ``%Z``
-      If :meth:`tzname` returns ``None``, ``%Z`` is replaced by an empty
-      string. Otherwise ``%Z`` is replaced by the returned value, which must
-      be a string. It will return a ``ValueError`` for any invalid strings.
+      In :meth:`strftime`, ``%Z`` is replaced by an empty string if
+      :meth:`tzname` returns ``None``; otherwise ``%Z`` is replaced by the
+      returned value, which must be a string.
 
-      Note that :meth:`strptime` only accepts certain values for ``%Z``:
+      :meth:`strptime` only accepts certain values for ``%Z``:
 
-      1. the hard-coded values ``UTC`` and ``GMT``
-      2. any value in ``time.tzname`` for your machine's locale
+      1. any value in ``time.tzname`` for your machine's locale
+      2. the hard-coded values ``UTC`` and ``GMT``
 
-      So someone living in Japan may have ``JST``, ``UTC``, and ``GMT`` as valid
-      values, but probably not ``EST``.
+      So someone living in Japan may have ``JST``, ``UTC``, and ``GMT`` as
+      valid values, but probably not ``EST``. It will raise ``ValueError`` for
+      invalid values.
 
    .. versionchanged:: 3.2
       When the ``%z`` directive is provided to the :meth:`strptime` method, an

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2535,7 +2535,7 @@ Notes:
    ``%Z``
       If :meth:`tzname` returns ``None``, ``%Z`` is replaced by an empty
       string. Otherwise ``%Z`` is replaced by the returned value, which must
-      be a string.
+      be a string. It will return a ``ValueError`` for any invalid strings.
 
       Note that :meth:`strptime` only accepts certain values for ``%Z``:
 

--- a/Misc/NEWS.d/next/Documentation/2019-10-01-10-53-46.bpo-22377.5ni-iC.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-10-01-10-53-46.bpo-22377.5ni-iC.rst
@@ -1,0 +1,1 @@
+Improves ``%Z`` in datetime documentation.

--- a/Misc/NEWS.d/next/Documentation/2019-10-01-10-53-46.bpo-22377.5ni-iC.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-10-01-10-53-46.bpo-22377.5ni-iC.rst
@@ -1,1 +1,2 @@
-Improves ``%Z`` in datetime documentation.
+Improves documentation of the values that :meth:`datetime.datetime.strptime` accepts for ``%Z``.
+Patch by Karl Dubost.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

This fixes the issue discussed in https://bugs.python.org/issue22377
and fixes it according to the comments made by Paul Ganssle @pganssle

* It clarifies which values are acceptable in the table
* It extends the note with a clearer information on the valid values

<!-- issue-number: [bpo-22377](https://bugs.python.org/issue22377) -->
https://bugs.python.org/issue22377
<!-- /issue-number -->


Automerge-Triggered-By: @pganssle