### PR TITLE
bpo-38304: PyConfig_InitPythonConfig() cannot fail anymore

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -343,12 +343,12 @@ PyConfig
 
    Structure methods:
 
-   .. c:function:: PyStatus PyConfig_InitPythonConfig(PyConfig *config)
+   .. c:function:: void PyConfig_InitPythonConfig(PyConfig *config)
 
       Initialize configuration with :ref:`Python Configuration
       <init-python-config>`.
 
-   .. c:function:: PyStatus PyConfig_InitIsolatedConfig(PyConfig *config)
+   .. c:function:: void PyConfig_InitIsolatedConfig(PyConfig *config)
 
       Initialize configuration with :ref:`Isolated Configuration
       <init-isolated-conf>`.
@@ -724,12 +724,9 @@ Example setting the program name::
     void init_python(void)
     {
         PyStatus status;
-        PyConfig config;
 
-        status = PyConfig_InitPythonConfig(&config);
-        if (PyStatus_Exception(status)) {
-            goto fail;
-        }
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
 
         /* Set the program name. Implicitly preinitialize Python. */
         status = PyConfig_SetString(&config, &config.program_name,
@@ -756,12 +753,9 @@ configuration, and then override some parameters::
     PyStatus init_python(const char *program_name)
     {
         PyStatus status;
-        PyConfig config;
 
-        status = PyConfig_InitPythonConfig(&config);
-        if (PyStatus_Exception(status)) {
-            goto done;
-        }
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
 
         /* Set the program name before reading the configuraton
            (decode byte string from the locale encoding).
@@ -843,13 +837,9 @@ Example of customized Python always running in isolated mode::
     int main(int argc, char **argv)
     {
         PyStatus status;
+
         PyConfig config;
-
-        status = PyConfig_InitPythonConfig(&config);
-        if (PyStatus_Exception(status)) {
-            goto fail;
-        }
-
+        PyConfig_InitPythonConfig(&config);
         config.isolated = 1;
 
         /* Decode command line arguments.
@@ -1034,14 +1024,9 @@ phases::
     void init_python(void)
     {
         PyStatus status;
+
         PyConfig config;
-
-        status = PyConfig_InitPythonConfig(&config);
-        if (PyStatus_Exception(status)) {
-            PyConfig_Clear(&config);
-            Py_ExitStatusException(status);
-        }
-
+        PyConfig_InitPythonConfig(&config);
         config._init_main = 0;
 
         /* ... customize 'config' configuration ... */

--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -404,8 +404,8 @@ typedef struct {
     int _init_main;
 } PyConfig;
 
-PyAPI_FUNC(PyStatus) PyConfig_InitPythonConfig(PyConfig *config);
-PyAPI_FUNC(PyStatus) PyConfig_InitIsolatedConfig(PyConfig *config);
+PyAPI_FUNC(void) PyConfig_InitPythonConfig(PyConfig *config);
+PyAPI_FUNC(void) PyConfig_InitIsolatedConfig(PyConfig *config);
 PyAPI_FUNC(void) PyConfig_Clear(PyConfig *);
 PyAPI_FUNC(PyStatus) PyConfig_SetString(
     PyConfig *config,

--- a/Include/internal/pycore_initconfig.h
+++ b/Include/internal/pycore_initconfig.h
@@ -144,7 +144,7 @@ typedef enum {
     _PyConfig_INIT_ISOLATED = 3
 } _PyConfigInitEnum;
 
-PyAPI_FUNC(PyStatus) _PyConfig_InitCompatConfig(PyConfig *config);
+PyAPI_FUNC(void) _PyConfig_InitCompatConfig(PyConfig *config);
 extern PyStatus _PyConfig_Copy(
     PyConfig *config,
     const PyConfig *config2);

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -61,11 +61,7 @@ pymain_init(const _PyArgv *args)
     }
 
     PyConfig config;
-
-    status = PyConfig_InitPythonConfig(&config);
-    if (_PyStatus_EXCEPTION(status)) {
-        goto done;
-    }
+    PyConfig_InitPythonConfig(&config);
 
     /* pass NULL as the config: config is read from command line arguments,
        environment variables, configuration files */

--- a/PC/python_uwp.cpp
+++ b/PC/python_uwp.cpp
@@ -193,10 +193,7 @@ wmain(int argc, wchar_t **argv)
         }
     }
 
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        goto fail_without_config;
-    }
+    PyConfig_InitPythonConfig(&config);
 
     status = PyConfig_SetArgv(&config, argc, argv);
     if (PyStatus_Exception(status)) {

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -76,17 +76,12 @@ main(int argc, char *argv[])
     }
     text[text_size] = '\0';
 
-    PyStatus status;
     PyConfig config;
-
-    status = PyConfig_InitIsolatedConfig(&config);
-    if (PyStatus_Exception(status)) {
-        PyConfig_Clear(&config);
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitIsolatedConfig(&config);
 
     config.site_import = 0;
 
+    PyStatus status;
     status = PyConfig_SetString(&config, &config.program_name,
                                 L"./_freeze_importlib");
     if (PyStatus_Exception(status)) {

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -394,11 +394,7 @@ static int check_init_compat_config(int preinit)
     }
 
     PyConfig config;
-
-    status = _PyConfig_InitCompatConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
+    _PyConfig_InitCompatConfig(&config);
 
     config_set_program_name(&config);
     init_from_config_clear(&config);
@@ -488,11 +484,8 @@ static int test_init_from_config(void)
     }
 
     PyConfig config;
+    _PyConfig_InitCompatConfig(&config);
 
-    status = _PyConfig_InitCompatConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
     config.install_signal_handlers = 0;
 
     /* FIXME: test use_environment */
@@ -621,14 +614,8 @@ static int test_init_from_config(void)
 
 static int check_init_parse_argv(int parse_argv)
 {
-    PyStatus status;
-
     PyConfig config;
-
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitPythonConfig(&config);
 
     config.parse_argv = parse_argv;
 
@@ -705,16 +692,10 @@ static int test_init_compat_env(void)
 
 static int test_init_python_env(void)
 {
-    PyStatus status;
-
     set_all_env_vars();
 
     PyConfig config;
-
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitPythonConfig(&config);
 
     config_set_program_name(&config);
     init_from_config_clear(&config);
@@ -760,15 +741,9 @@ static int test_init_env_dev_mode_alloc(void)
 
 static int test_init_isolated_flag(void)
 {
-    PyStatus status;
-
     /* Test PyConfig.isolated=1 */
     PyConfig config;
-
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitPythonConfig(&config);
 
     Py_IsolatedFlag = 0;
     config.isolated = 1;
@@ -797,11 +772,8 @@ static int test_preinit_isolated1(void)
     }
 
     PyConfig config;
+    _PyConfig_InitCompatConfig(&config);
 
-    status = _PyConfig_InitCompatConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
     config_set_program_name(&config);
     set_all_env_vars();
     init_from_config_clear(&config);
@@ -827,11 +799,7 @@ static int test_preinit_isolated2(void)
 
     /* Test PyConfig.isolated=1 */
     PyConfig config;
-
-    status = _PyConfig_InitCompatConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
+    _PyConfig_InitCompatConfig(&config);
 
     Py_IsolatedFlag = 0;
     config.isolated = 1;
@@ -867,12 +835,7 @@ static int test_preinit_dont_parse_argv(void)
     }
 
     PyConfig config;
-
-    status = PyConfig_InitIsolatedConfig(&config);
-    if (PyStatus_Exception(status)) {
-        PyConfig_Clear(&config);
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitIsolatedConfig(&config);
 
     config.isolated = 0;
 
@@ -890,14 +853,8 @@ static int test_preinit_dont_parse_argv(void)
 
 static int test_preinit_parse_argv(void)
 {
-    PyStatus status;
     PyConfig config;
-
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        PyConfig_Clear(&config);
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitPythonConfig(&config);
 
     /* Pre-initialize implicitly using argv: make sure that -X dev
        is used to configure the allocation in preinitialization */
@@ -962,12 +919,8 @@ static int check_preinit_isolated_config(int preinit)
     }
 
     PyConfig config;
+    PyConfig_InitIsolatedConfig(&config);
 
-    status = PyConfig_InitIsolatedConfig(&config);
-    if (PyStatus_Exception(status)) {
-        PyConfig_Clear(&config);
-        Py_ExitStatusException(status);
-    }
     config_set_program_name(&config);
     init_from_config_clear(&config);
 
@@ -995,8 +948,6 @@ static int test_init_isolated_config(void)
 
 static int check_init_python_config(int preinit)
 {
-    PyStatus status;
-
     /* global configuration variables must be ignored */
     set_all_global_config_variables();
     Py_IsolatedFlag = 1;
@@ -1014,18 +965,15 @@ static int check_init_python_config(int preinit)
         PyPreConfig preconfig;
         PyPreConfig_InitPythonConfig(&preconfig);
 
-        status = Py_PreInitialize(&preconfig);
+        PyStatus status = Py_PreInitialize(&preconfig);
         if (PyStatus_Exception(status)) {
             Py_ExitStatusException(status);
         }
     }
 
     PyConfig config;
+    PyConfig_InitPythonConfig(&config);
 
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
     config_set_program_name(&config);
     init_from_config_clear(&config);
 
@@ -1062,11 +1010,8 @@ static int test_init_dont_configure_locale(void)
     }
 
     PyConfig config;
+    PyConfig_InitPythonConfig(&config);
 
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
     config_set_program_name(&config);
     init_from_config_clear(&config);
 
@@ -1078,13 +1023,9 @@ static int test_init_dont_configure_locale(void)
 
 static int test_init_dev_mode(void)
 {
-    PyStatus status;
     PyConfig config;
+    PyConfig_InitPythonConfig(&config);
 
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
     putenv("PYTHONFAULTHANDLER=");
     putenv("PYTHONMALLOC=");
     config.dev_mode = 1;
@@ -1302,13 +1243,9 @@ static int test_audit_run_file(void)
 
 static int run_audit_run_test(int argc, wchar_t **argv, void *test)
 {
-    PyStatus status;
     PyConfig config;
+    PyConfig_InitPythonConfig(&config);
 
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
     config.argv.length = argc;
     config.argv.items = argv;
     config.parse_argv = 1;
@@ -1320,7 +1257,7 @@ static int run_audit_run_test(int argc, wchar_t **argv, void *test)
 
     PySys_AddAuditHook(_audit_hook_run, test);
 
-    status = Py_InitializeFromConfig(&config);
+    PyStatus status = Py_InitializeFromConfig(&config);
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
     }
@@ -1353,11 +1290,7 @@ static int test_init_read_set(void)
 {
     PyStatus status;
     PyConfig config;
-
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitPythonConfig(&config);
 
     status = PyConfig_SetBytesString(&config, &config.program_name,
                                      "./init_read_set");
@@ -1402,12 +1335,7 @@ static int test_init_sys_add(void)
     PySys_AddWarnOption(L"ignore:::sysadd_warnoption");
 
     PyConfig config;
-
-    PyStatus status;
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        goto fail;
-    }
+    PyConfig_InitPythonConfig(&config);
 
     wchar_t* argv[] = {
         L"python3",
@@ -1419,6 +1347,7 @@ static int test_init_sys_add(void)
     config_set_argv(&config, Py_ARRAY_LENGTH(argv), argv);
     config.parse_argv = 1;
 
+    PyStatus status;
     status = PyWideStringList_Append(&config.xoptions,
                                      L"config_xoption");
     if (PyStatus_Exception(status)) {
@@ -1494,11 +1423,8 @@ static int test_init_setpath_config(void)
     putenv("TESTPATH=");
 
     PyConfig config;
+    PyConfig_InitPythonConfig(&config);
 
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
     config_set_string(&config, &config.program_name, L"conf_program_name");
     config_set_string(&config, &config.executable, L"conf_executable");
     init_from_config_clear(&config);
@@ -1534,24 +1460,20 @@ static int test_init_setpythonhome(void)
 
 static int test_init_warnoptions(void)
 {
-    PyStatus status;
     putenv("PYTHONWARNINGS=ignore:::env1,ignore:::env2");
 
     PySys_AddWarnOption(L"ignore:::PySys_AddWarnOption1");
     PySys_AddWarnOption(L"ignore:::PySys_AddWarnOption2");
 
     PyConfig config;
-
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitPythonConfig(&config);
 
     config.dev_mode = 1;
     config.bytes_warning = 1;
 
     config_set_program_name(&config);
 
+    PyStatus status;
     status = PyWideStringList_Append(&config.warnoptions,
                                      L"ignore:::PyConfig_BeforeRead");
     if (PyStatus_Exception(status)) {
@@ -1606,13 +1528,9 @@ static void configure_init_main(PyConfig *config)
 
 static int test_init_run_main(void)
 {
-    PyStatus status;
     PyConfig config;
+    PyConfig_InitPythonConfig(&config);
 
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
     configure_init_main(&config);
     init_from_config_clear(&config);
 
@@ -1622,13 +1540,9 @@ static int test_init_run_main(void)
 
 static int test_init_main(void)
 {
-    PyStatus status;
     PyConfig config;
+    PyConfig_InitPythonConfig(&config);
 
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        Py_ExitStatusException(status);
-    }
     configure_init_main(&config);
     config._init_main = 0;
     init_from_config_clear(&config);
@@ -1642,7 +1556,7 @@ static int test_init_main(void)
         exit(1);
     }
 
-    status = _Py_InitializeMain();
+    PyStatus status = _Py_InitializeMain();
     if (PyStatus_Exception(status)) {
         Py_ExitStatusException(status);
     }
@@ -1653,14 +1567,8 @@ static int test_init_main(void)
 
 static int test_run_main(void)
 {
-    PyStatus status;
     PyConfig config;
-
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        PyConfig_Clear(&config);
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitPythonConfig(&config);
 
     wchar_t *argv[] = {L"python3", L"-c",
                        (L"import sys; "

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -40,11 +40,7 @@ Py_FrozenMain(int argc, char **argv)
     }
 
     PyConfig config;
-    status = PyConfig_InitPythonConfig(&config);
-    if (PyStatus_Exception(status)) {
-        PyConfig_Clear(&config);
-        Py_ExitStatusException(status);
-    }
+    PyConfig_InitPythonConfig(&config);
     config.pathconfig_warnings = 0;   /* Suppress errors from getpath.c */
 
     if ((p = Py_GETENV("PYTHONINSPECT")) && *p != '\0')

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -569,7 +569,7 @@ PyConfig_Clear(PyConfig *config)
 }
 
 
-PyStatus
+void
 _PyConfig_InitCompatConfig(PyConfig *config)
 {
     memset(config, 0, sizeof(*config));
@@ -603,17 +603,13 @@ _PyConfig_InitCompatConfig(PyConfig *config)
 #ifdef MS_WINDOWS
     config->legacy_windows_stdio = -1;
 #endif
-    return _PyStatus_OK();
 }
 
 
-static PyStatus
+static void
 config_init_defaults(PyConfig *config)
 {
-    PyStatus status = _PyConfig_InitCompatConfig(config);
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
+    _PyConfig_InitCompatConfig(config);
 
     config->isolated = 0;
     config->use_environment = 1;
@@ -632,35 +628,24 @@ config_init_defaults(PyConfig *config)
 #ifdef MS_WINDOWS
     config->legacy_windows_stdio = 0;
 #endif
-    return _PyStatus_OK();
 }
 
 
-PyStatus
+void
 PyConfig_InitPythonConfig(PyConfig *config)
 {
-    PyStatus status = config_init_defaults(config);
-    if (_PyStatus_EXCEPTION(status)) {
-        _PyStatus_UPDATE_FUNC(status);
-        return status;
-    }
+    config_init_defaults(config);
 
     config->_config_init = (int)_PyConfig_INIT_PYTHON;
     config->configure_c_stdio = 1;
     config->parse_argv = 1;
-
-    return _PyStatus_OK();
 }
 
 
-PyStatus
+void
 PyConfig_InitIsolatedConfig(PyConfig *config)
 {
-    PyStatus status = config_init_defaults(config);
-    if (_PyStatus_EXCEPTION(status)) {
-        _PyStatus_UPDATE_FUNC(status);
-        return status;
-    }
+    config_init_defaults(config);
 
     config->_config_init = (int)_PyConfig_INIT_ISOLATED;
     config->isolated = 1;
@@ -675,8 +660,6 @@ PyConfig_InitIsolatedConfig(PyConfig *config)
 #ifdef MS_WINDOWS
     config->legacy_windows_stdio = 0;
 #endif
-
-    return _PyStatus_OK();
 }
 
 

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -432,16 +432,11 @@ _PyConfig_InitPathConfig(PyConfig *config)
 static PyStatus
 pathconfig_global_read(_PyPathConfig *pathconfig)
 {
-    PyStatus status;
     PyConfig config;
-
-    status = _PyConfig_InitCompatConfig(&config);
-    if (_PyStatus_EXCEPTION(status)) {
-        goto done;
-    }
+    _PyConfig_InitCompatConfig(&config);
 
     /* Call _PyConfig_InitPathConfig() */
-    status = PyConfig_Read(&config);
+    PyStatus status = PyConfig_Read(&config);
     if (_PyStatus_EXCEPTION(status)) {
         goto done;
     }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -847,11 +847,7 @@ pyinit_core(_PyRuntimeState *runtime,
     }
 
     PyConfig config;
-
-    status = _PyConfig_InitCompatConfig(&config);
-    if (_PyStatus_EXCEPTION(status)) {
-        goto done;
-    }
+    _PyConfig_InitCompatConfig(&config);
 
     status = _PyConfig_Copy(&config, src_config);
     if (_PyStatus_EXCEPTION(status)) {
@@ -1073,11 +1069,7 @@ Py_InitializeEx(int install_sigs)
     }
 
     PyConfig config;
-
-    status = _PyConfig_InitCompatConfig(&config);
-    if (_PyStatus_EXCEPTION(status)) {
-        Py_ExitStatusException(status);
-    }
+    _PyConfig_InitCompatConfig(&config);
 
     config.install_signal_handlers = install_sigs;
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -205,14 +205,7 @@ PyInterpreterState_New(void)
     memset(interp, 0, sizeof(*interp));
     interp->id_refcount = -1;
 
-    PyStatus status = PyConfig_InitPythonConfig(&interp->config);
-    if (_PyStatus_EXCEPTION(status)) {
-        /* Don't report status to caller: PyConfig_InitPythonConfig()
-           can only fail with a memory allocation error. */
-        PyConfig_Clear(&interp->config);
-        PyMem_RawFree(interp);
-        return NULL;
-    }
+    PyConfig_InitPythonConfig(&interp->config);
 
     interp->eval_frame = _PyEval_EvalFrameDefault;
 #ifdef HAVE_DLOPEN


### PR DESCRIPTION
PyConfig_InitPythonConfig() and PyConfig_InitIsolatedConfig() no
longer return PyStatus: they cannot fail anymore.

<!-- issue-number: [bpo-38304](https://bugs.python.org/issue38304) -->
https://bugs.python.org/issue38304
<!-- /issue-number -->
