### PR TITLE
bpo-37474: Don't call fedisableexcept() on FreeBSD

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-01-12-46-30.bpo-37474.cB3se1.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-01-12-46-30.bpo-37474.cB3se1.rst
@@ -1,0 +1,3 @@
+On FreeBSD, Python no longer calls ``fedisableexcept()`` at startup to
+control the floating point control mode. The call became useless since
+FreeBSD 6: it became the default mode.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -6,10 +6,6 @@
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 
-#ifdef __FreeBSD__
-#  include <fenv.h>     /* fedisableexcept() */
-#endif
-
 /* Includes for exit_sigint() */
 #include <stdio.h>      /* perror() */
 #ifdef HAVE_SIGNAL_H
@@ -42,15 +38,6 @@ pymain_init(const _PyArgv *args)
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
-
-    /* 754 requires that FP exceptions run in "no stop" mode by default,
-     * and until C vendors implement C99's ways to control FP exceptions,
-     * Python requires non-stop mode.  Alas, some platforms enable FP
-     * exceptions by default.  Here we disable them.
-     */
-#ifdef __FreeBSD__
-    fedisableexcept(FE_OVERFLOW);
-#endif
 
     PyPreConfig preconfig;
     PyPreConfig_InitPythonConfig(&preconfig);


### PR DESCRIPTION
On FreeBSD, Python no longer calls fedisableexcept() at startup to
control the floating point control mode. The call became useless
since FreeBSD 6: it became the default mode.

<!-- issue-number: [bpo-37474](https://bugs.python.org/issue37474) -->
https://bugs.python.org/issue37474
<!-- /issue-number -->
