### PR TITLE
bpo-37802: Fix a compiler warning in longobject.c

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -383,7 +383,7 @@ PyLong_FromLong(long ival)
 #define PYLONG_FROM_UINT(INT_TYPE, ival) \
     do { \
         if (IS_SMALL_UINT(ival)) { \
-            return get_small_int((ival)); \
+            return get_small_int((sdigit)(ival)); \
         } \
         /* Count the number of Python digits. */ \
         Py_ssize_t ndigits = 0; \


### PR DESCRIPTION
[bpo-37802](https://bugs.python.org/issue37802), [bpo-38321](https://bugs.python.org/issue38321): Fix the following warnings:

    longobject.c(420): warning C4244: 'function': conversion from
    'unsigned __int64' to 'sdigit', possible loss of data

    longobject.c(428): warning C4267: 'function': conversion from
    'size_t' to 'sdigit', possible loss of data

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37802](https://bugs.python.org/issue37802) -->
https://bugs.python.org/issue37802
<!-- /issue-number -->
