### PR TITLE
[3.8] bpo-3832: Fix compiler warnings

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2664,7 +2664,6 @@ task_step_impl(TaskObj *task, PyObject *exc)
         /* Some other exception; pop it and call Task.set_exception() */
         PyErr_Fetch(&et, &ev, &tb);
 
-set_exception:
         assert(et);
         if (!ev || !PyObject_TypeCheck(ev, (PyTypeObject *) et)) {
             PyErr_NormalizeException(&et, &ev, &tb);

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -701,7 +701,7 @@ PyCStructUnionType_update_stgdict(PyObject *type, PyObject *fields, int isStruct
                 assert(actual_type_index <= MAX_ELEMENTS);
             }
             else {
-                int length = dict->length;
+                Py_ssize_t length = dict->length;
                 StgDictObject *edict;
 
                 edict = PyType_stgdict(dict->proto);


### PR DESCRIPTION
* [bpo-38321](https://bugs.python.org/issue38321): Fix _asynciomodule.c compiler warning (GH-16493)
* [bpo-38321](https://bugs.python.org/issue38321): Fix PyCStructUnionType_update_stgdict() warning (GH-16492)


<!-- issue-number: [bpo-3832](https://bugs.python.org/issue3832) -->
https://bugs.python.org/issue3832
<!-- /issue-number -->
