### PR TITLE
bpo-38336: Remove the __set__ method restriction on data descriptors for attribute lookup precedence

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1714,9 +1714,9 @@ define :meth:`__get__`, then accessing the attribute will return the descriptor
 object itself unless there is a value in the object's instance dictionary.  If
 the descriptor defines :meth:`__set__` and/or :meth:`__delete__`, it is a data
 descriptor; if it defines neither, it is a non-data descriptor.  Normally, data
-descriptors define both :meth:`__get__` and :meth:`__set__`, while non-data
+descriptors define both :meth:`__get__` and :meth:`__set__` (and/or :meth:`__delete__`), while non-data
 descriptors have just the :meth:`__get__` method.  Data descriptors with
-:meth:`__get__` defined always override a redefinition in an
+:meth:`__get__` and :meth:`__set__` (and/or :meth:`__delete__`) defined always override a redefinition in an
 instance dictionary.  In contrast, non-data descriptors can be overridden by
 instances.
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1716,7 +1716,7 @@ the descriptor defines :meth:`__set__` and/or :meth:`__delete__`, it is a data
 descriptor; if it defines neither, it is a non-data descriptor.  Normally, data
 descriptors define both :meth:`__get__` and :meth:`__set__`, while non-data
 descriptors have just the :meth:`__get__` method.  Data descriptors with
-:meth:`__set__` and :meth:`__get__` defined always override a redefinition in an
+:meth:`__get__` defined always override a redefinition in an
 instance dictionary.  In contrast, non-data descriptors can be overridden by
 instances.
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1714,7 +1714,7 @@ define :meth:`__get__`, then accessing the attribute will return the descriptor
 object itself unless there is a value in the object's instance dictionary.  If
 the descriptor defines :meth:`__set__` and/or :meth:`__delete__`, it is a data
 descriptor; if it defines neither, it is a non-data descriptor.  Normally, data
-descriptors define both :meth:`__get__` and :meth:`__set__` (and/or :meth:`__delete__`), while non-data
+descriptors define both :meth:`__get__` and :meth:`__set__`, while non-data
 descriptors have just the :meth:`__get__` method.  Data descriptors with
 :meth:`__get__` and :meth:`__set__` (and/or :meth:`__delete__`) defined always override a redefinition in an
 instance dictionary.  In contrast, non-data descriptors can be overridden by


### PR DESCRIPTION
The [language documentation](https://docs.python.org/3/reference/datamodel.html#invoking-descriptors) states:

> Data descriptors with \_\_set\_\_() and \_\_get\_\_() defined always override a redefinition in an instance dictionary. In contrast, non-data descriptors can be overridden by instances.

This override is not limited to data descriptors defining `__set__()` (and `__get__()`). It is also true for data descriptors defining `__delete__()` (and `__get__()`) and data descriptors defining both `__set__()` and `__delete__()` (and `__get__()`).

In other words, _any_ data descriptors (objects defining either `__set__()` or `__delete__()` or both) defining `__get__()` override an attribute redefinition in an instance dictionary.

<!-- issue-number: [bpo-38336](https://bugs.python.org/issue38336) -->
https://bugs.python.org/issue38336
<!-- /issue-number -->
