### PR TITLE
bpo-38337: Change getattr to inspect.getattr_static

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -347,7 +347,10 @@ def getmembers(object, predicate=None):
         # like calling their __get__ (see bug #1785), so fall back to
         # looking in the __dict__.
         try:
-            value = getattr_static(object, key)
+            if isinstance(getattr_static(object, key), property):
+                value = getattr_static(object, key)
+            else:
+                value = getattr(object, key)
             # handle the duplicate key
             if key in processed:
                 raise AttributeError

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -347,7 +347,7 @@ def getmembers(object, predicate=None):
         # like calling their __get__ (see bug #1785), so fall back to
         # looking in the __dict__.
         try:
-            value = getattr(object, key)
+            value = getattr_static(object, key)
             # handle the duplicate key
             if key in processed:
                 raise AttributeError

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1204,7 +1204,11 @@ class TestClassesAndFunctions(unittest.TestCase):
         foobar = Foo(42)
         try:
             members = inspect.getmembers(foobar)
+            property_member = ('bar', inspect.getattr_static(foobar, 'bar'))
+            self.assertIn(property_member, members)
             class_members = inspect.getmembers(Foo)
+            property_class_member = ('bar', inspect.getattr_static(Foo, 'bar'))
+            self.assertIn(property_member, class_members)
         except NotImplementedError:
             self.fail('getmembers() called property!')
 

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1191,6 +1191,23 @@ class TestClassesAndFunctions(unittest.TestCase):
         self.assertIn(('f', b.f), inspect.getmembers(b))
         self.assertIn(('f', b.f), inspect.getmembers(b, inspect.ismethod))
 
+    def test_getmembers_static(self):
+        class Foo:
+            def __init__(bar):
+                self._bar = bar
+
+            @property
+            def bar(self):
+                # This property should not be called by getmembers
+                raise NotImplementedError
+            
+        foobar = Foo(42)
+        try:
+            members = inspect.getmembers(foobar)
+            class_members = inspect.getmembers(Foo)
+        except NotImplementedError:
+            self.fail('getmembers() called property!')
+
     def test_getmembers_VirtualAttribute(self):
         class M(type):
             def __getattr__(cls, name):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1193,7 +1193,7 @@ class TestClassesAndFunctions(unittest.TestCase):
 
     def test_getmembers_static(self):
         class Foo:
-            def __init__(bar):
+            def __init__(self, bar):
                 self._bar = bar
 
             @property

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1200,7 +1200,7 @@ class TestClassesAndFunctions(unittest.TestCase):
             def bar(self):
                 # This property should not be called by getmembers
                 raise NotImplementedError
-            
+
         foobar = Foo(42)
         try:
             members = inspect.getmembers(foobar)

--- a/Misc/NEWS.d/next/Library/2019-10-01-12-23-37.bpo-38337.QmLSXW.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-01-12-23-37.bpo-38337.QmLSXW.rst
@@ -1,0 +1,1 @@
+Prevent ``inspect.getmembers`` to call properties. Used ``inspect.getattr_static`` instead.

--- a/Misc/NEWS.d/next/Library/2019-10-01-12-23-37.bpo-38337.QmLSXW.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-01-12-23-37.bpo-38337.QmLSXW.rst
@@ -1,1 +1,1 @@
-Prevent ``inspect.getmembers`` to call properties. Used ``inspect.getattr_static`` instead.
+Prevent :func:`inspect.getmembers` from calling descriptors.


### PR DESCRIPTION
When calling `inspect.getmembers` on a class that has a property (`@property`), the property will be called by the `getattr` call in `getmembers`.

Example:

```python
import inspect

class Example:
    def __init__(self, var):
        self._var = var
        print('__init__')

    def foo(self, bar):
        print(bar)
        print('foo')

    @property
    def var(self):
        print('Access property')
        return self._var


if __name__ == '__main__':
    ex = Example('Hello')
    print('--- getmembers from instance ---')
    print(inspect.getmembers(ex))
    print('--- getmembers from class    ---')
    print(inspect.getmembers(Example))
```

## Result:

```
__init__
--- getmembers from instance ---
Access property
[('__class__', <attribute '__class__' of 'object' objects>), ..., ('var', 'Hello')]
--- getmembers from class    ---
[('__class__', <attribute '__class__' of 'object' objects>), ..., ('var', <property object at 0x...>)]
```

## Expected (new result):

```
__init__
--- getmembers from instance ---
[('__class__', <attribute '__class__' of 'object' objects>), ..., ('var', <property object at 0x...>)]
--- getmembers from class    ---
[('__class__', <attribute '__class__' of 'object' objects>), ..., ('var', <property object at 0x...>)]
```

<!-- issue-number: [bpo-38337](https://bugs.python.org/issue38337) -->
https://bugs.python.org/issue38337
<!-- /issue-number -->
