### PR TITLE
bpo-38341: Add SMTPNotSupportedError in the exports of smtplib

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -54,7 +54,7 @@ import datetime
 import sys
 from email.base64mime import body_encode as encode_base64
 
-__all__ = ["SMTPException", "SMTPServerDisconnected", "SMTPResponseException",
+__all__ = ["SMTPException", "SMTPNotSupportedError", "SMTPServerDisconnected", "SMTPResponseException",
            "SMTPSenderRefused", "SMTPRecipientsRefused", "SMTPDataError",
            "SMTPConnectError", "SMTPHeloError", "SMTPAuthenticationError",
            "quoteaddr", "quotedata", "SMTP"]

--- a/Misc/NEWS.d/next/Library/2019-10-01-21-06-18.bpo-38341.uqwgU_.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-01-21-06-18.bpo-38341.uqwgU_.rst
@@ -1,0 +1,1 @@
+Add SMTPNotSupportedError in the smtplib exported names.

--- a/Misc/NEWS.d/next/Library/2019-10-01-21-06-18.bpo-38341.uqwgU_.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-01-21-06-18.bpo-38341.uqwgU_.rst
@@ -1,1 +1,1 @@
-Add SMTPNotSupportedError in the smtplib exported names.
+Add :exc:`smtplib.SMTPNotSupportedError` to the :mod:`smtplib` exported names.


### PR DESCRIPTION
Pretty simple add in the __all__ variable, the missing exception SMTPNotSupportedError

<!-- issue-number: [bpo-38341](https://bugs.python.org/issue38341) -->
https://bugs.python.org/issue38341
<!-- /issue-number -->
