### PR TITLE
bpo-38334: Fix seeking bug for encrypted zipfiles

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-10-02-00-32-22.bpo-38334.g3VGs3.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-02-00-32-22.bpo-38334.g3VGs3.rst
@@ -1,0 +1,1 @@
+Fix seeking on an encrypted :class:`zipfile.ZipExtFile` where seeking backwards would cause the crc keys to go out of sync resulting in bad data to be read after the seek. This refactors the :func:`zipfile._ZipDecrypter` function into a class :class:`zipfile.CRCZipDecrypter`.


### PR DESCRIPTION
This resolves an issue where seeking on an encrypted `zipfile` would cause the crc keys to go out of sync resulting in bad data to be read after the seek.

<!-- issue-number: [bpo-38334](https://bugs.python.org/issue38334) -->
https://bugs.python.org/issue38334
<!-- /issue-number -->
