### PR TITLE
bpo-36670, regrtest: Fix WindowsLoadTracker() for partial line

### DIFF
--- a/Lib/test/libregrtest/win_utils.py
+++ b/Lib/test/libregrtest/win_utils.py
@@ -32,6 +32,7 @@ class WindowsLoadTracker():
     def __init__(self):
         self.load = 0.0
         self.counter_name = ''
+        self._buffer = b''
         self.popen = None
         self.start()
 
@@ -100,7 +101,9 @@ class WindowsLoadTracker():
         if res != 0:
             return
 
-        output = overlapped.getbuffer()
+        # self._buffer stores an incomplete line
+        output = self._buffer + overlapped.getbuffer()
+        output, _, self._buffer = output.rpartition(b'\n')
         return output.decode('oem', 'replace')
 
     def getloadavg(self):


### PR DESCRIPTION
WindowsLoadTracker.read_output() now uses a short buffer for
incomplete line.

<!-- issue-number: [bpo-36670](https://bugs.python.org/issue36670) -->
https://bugs.python.org/issue36670
<!-- /issue-number -->
