### PR TITLE
bpo-38356: Fix ThreadedChildWatcher thread leak in test_asyncio

### DIFF
--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1270,7 +1270,7 @@ class ThreadedChildWatcher(AbstractChildWatcher):
 
     def _join_threads(self):
         threads = [thread for thread in list(self._threads.values())
-                            if thread.is_alive()]
+                   if thread.is_alive()]
         for thread in threads:
             thread.join()
 
@@ -1282,7 +1282,7 @@ class ThreadedChildWatcher(AbstractChildWatcher):
 
     def __del__(self, _warn=warnings.warn):
         threads = [thread for thread in list(self._threads.values())
-                            if thread.is_alive()]
+                   if thread.is_alive()]
         if threads:
             _warn(f"{self.__class__} has registered but not finished child processes",
                   ResourceWarning,

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1270,8 +1270,7 @@ class ThreadedChildWatcher(AbstractChildWatcher):
 
     def _join_threads(self):
         threads = [thread for thread in list(self._threads.values())
-                   if thread.is_alive()]
-
+                            if thread.is_alive()]
         for thread in threads:
             thread.join()
 
@@ -1283,7 +1282,7 @@ class ThreadedChildWatcher(AbstractChildWatcher):
 
     def __del__(self, _warn=warnings.warn):
         threads = [thread for thread in list(self._threads.values())
-                   if thread.is_alive()]
+                            if thread.is_alive()]
         if threads:
             _warn(f"{self.__class__} has registered but not finished child processes",
                   ResourceWarning,

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1270,7 +1270,7 @@ class ThreadedChildWatcher(AbstractChildWatcher):
 
     def _join_threads(self):
         threads = [thread for thread in list(self._threads.values())
-                   if thread.is_alive()]
+                   if thread.is_alive() and not thread.daemon]
         for thread in threads:
             thread.join()
 

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1266,7 +1266,14 @@ class ThreadedChildWatcher(AbstractChildWatcher):
         return True
 
     def close(self):
-        pass
+        self._join_threads()
+
+    def _join_threads(self):
+        threads = [thread for thread in list(self._threads.values())
+                   if thread.is_alive()]
+
+        for thread in threads:
+            thread.join()
 
     def __enter__(self):
         return self

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -1269,6 +1269,7 @@ class ThreadedChildWatcher(AbstractChildWatcher):
         self._join_threads()
 
     def _join_threads(self):
+        """Internal: Join all non-daemon threads"""
         threads = [thread for thread in list(self._threads.values())
                    if thread.is_alive() and not thread.daemon]
         for thread in threads:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Motivation for this PR (comment from @vstinner in bpo issue):
```
Warning seen o AMD64 Ubuntu Shared 3.x buildbot:
https://buildbot.python.org/all/#/builders/141/builds/2593

test_devnull_output (test.test_a=syncio.test_subprocess.SubprocessThreadedWatcherTests) ...
Warning -- threading_cleanup() failed to cleanup 1 threads (count: 1, dangling: 2)
```
The following implementation details for the new method are TBD:

1) Public vs private

2) Inclusion in `close()`

3) Name

4) Coroutine vs subroutine method

5) *timeout* parameter

If it's a private method, 3, 4, and 5 are significantly less important.

I started with the most minimal implementation that fixes the dangling threads without modifying the regression tests, which I think is particularly important. I typically try to avoid directly modifying existing tests as much as possible unless it's necessary to do so. However, I am open to changing any part of this.

<!-- issue-number: [bpo-38356](https://bugs.python.org/issue38356) -->
https://bugs.python.org/issue38356
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov