### PR TITLE
[3.8] bpo-36670, regrtest: Fix WindowsLoadTracker() for partial line (GH-16550)

### DIFF
--- a/Lib/test/libregrtest/win_utils.py
+++ b/Lib/test/libregrtest/win_utils.py
@@ -32,6 +32,7 @@ class WindowsLoadTracker():
     def __init__(self):
         self.load = 0.0
         self.counter_name = ''
+        self._buffer = b''
         self.popen = None
         self.start()
 
@@ -100,7 +101,9 @@ class WindowsLoadTracker():
         if res != 0:
             return
 
-        output = overlapped.getbuffer()
+        # self._buffer stores an incomplete line
+        output = self._buffer + overlapped.getbuffer()
+        output, _, self._buffer = output.rpartition(b'\n')
         return output.decode('oem', 'replace')
 
     def getloadavg(self):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36670](https://bugs.python.org/issue36670) -->
https://bugs.python.org/issue36670
<!-- /issue-number -->
