### PR TITLE
bpo-36670, regrtest: Fix WindowsLoadTracker sampling rate

### DIFF
--- a/Lib/test/libregrtest/win_utils.py
+++ b/Lib/test/libregrtest/win_utils.py
@@ -10,11 +10,11 @@ from test.libregrtest.utils import print_warning
 
 # Max size of asynchronous reads
 BUFSIZE = 8192
-# Exponential damping factor (see below)
+# Seconds per measurement
+SAMPLING_INTERVAL = 5
+# Exponential damping factor for a sampling interval of 5 seconds (see below)
 LOAD_FACTOR_1 = 0.9200444146293232478931553241
 
-# Seconds per measurement
-SAMPLING_INTERVAL = 1
 # Windows registry subkey of HKEY_LOCAL_MACHINE where the counter names
 # of typeperf are registered
 COUNTER_REGISTRY_KEY = (r"SOFTWARE\Microsoft\Windows NT\CurrentVersion"


### PR DESCRIPTION
regrtest WindowsLoadTracker: the LOAD_FACTOR_1 constant has been
computed for a sampling rate of 5 seconds.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36670](https://bugs.python.org/issue36670) -->
https://bugs.python.org/issue36670
<!-- /issue-number -->
