### PR TITLE
bpo-38361: syslog: fixed making default "ident" from sys.argv[0]

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-10-04-09-49-56.bpo-38361.LM4u4T.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-04-09-49-56.bpo-38361.LM4u4T.rst
@@ -1,0 +1,1 @@
+Fixed an issue where ``ident`` could include a leading path separator when :func:`syslog.openlog` was called without arguments.

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -99,7 +99,7 @@ syslog_get_argv(void)
     if (slash == -2)
         return NULL;
     if (slash != -1) {
-        return PyUnicode_Substring(scriptobj, slash, scriptlen);
+        return PyUnicode_Substring(scriptobj, slash + 1, scriptlen);
     } else {
         Py_INCREF(scriptobj);
         return(scriptobj);


### PR DESCRIPTION
The default value of "ident" parameter should be sys.argv[0] with leading path
components stripped, but it contained the last slash, i.e. '/program' instead
of 'program'.

BPO issue: https://bugs.python.org/issue38361

<!-- issue-number: [bpo-38361](https://bugs.python.org/issue38361) -->
https://bugs.python.org/issue38361
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum