### PR TITLE
[2.7] bpo-32758: warn that a couple ast functions can crash the interpreter (GH-5960)

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -129,6 +129,11 @@ and classes for traversing abstract syntax trees:
    Parse the source into an AST node.  Equivalent to ``compile(source,
    filename, mode, ast.PyCF_ONLY_AST)``.
 
+   .. warning::
+      It is possible to crash the Python interpreter with a
+      sufficiently large/complex string due to stack depth limitations
+      in Python's AST compiler.
+
 
 .. function:: literal_eval(node_or_string)
 
@@ -141,6 +146,11 @@ and classes for traversing abstract syntax trees:
    untrusted sources without the need to parse the values oneself.  It is not
    capable of evaluating arbitrarily complex expressions, for example involving
    operators or indexing.
+
+   .. warning::
+      It is possible to crash the Python interpreter with a
+      sufficiently large/complex string due to stack depth limitations
+      in Python's AST compiler.
 
 
 .. function:: get_docstring(node, clean=True)


### PR DESCRIPTION


<!-- issue-number: [bpo-32758](https://bugs.python.org/issue32758) -->
https://bugs.python.org/issue32758
<!-- /issue-number -->
