### PR TITLE
[2.7] bpo-32758: Warn that compile() can crash when compiling to an AST object (GH-6043)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -248,6 +248,12 @@ section.
       character.  This is to facilitate detection of incomplete and complete
       statements in the :mod:`code` module.
 
+   .. warning::
+
+      It is possible to crash the Python interpreter with a
+      sufficiently large/complex string when compiling to an AST
+      object due to stack depth limitations in Python's AST compiler.
+
    .. versionchanged:: 2.3
       The *flags* and *dont_inherit* arguments were added.
 


### PR DESCRIPTION
(cherry picked from commit f7a6ff6fcab32a53f262ba3f8a072c27afc330d7)

Co-authored-by: Brett Cannon <brettcannon@users.noreply.github.com>

<!-- issue-number: [bpo-32758](https://bugs.python.org/issue32758) -->
https://bugs.python.org/issue32758
<!-- /issue-number -->
