### PR TITLE
bpo-38353: Fix compiler warning in pycore_initconfig.h

### DIFF
--- a/Include/internal/pycore_initconfig.h
+++ b/Include/internal/pycore_initconfig.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /* Forward declaration */
-typedef struct pyruntimestate _PyRuntimeState;
+struct pyruntimestate;
 
 /* --- PyStatus ----------------------------------------------- */
 
@@ -151,7 +151,7 @@ extern PyStatus _PyConfig_Copy(
     const PyConfig *config2);
 extern PyStatus _PyConfig_InitPathConfig(PyConfig *config);
 extern void _PyConfig_Write(const PyConfig *config,
-    _PyRuntimeState *runtime);
+    struct pyruntimestate *runtime);
 extern PyStatus _PyConfig_SetPyArgv(
     PyConfig *config,
     const _PyArgv *args);


### PR DESCRIPTION
Use "_PyRuntimeState" with "struct pyruntimestate" to avoid a warning
on typedef re-definition.

<!-- issue-number: [bpo-38353](https://bugs.python.org/issue38353) -->
https://bugs.python.org/issue38353
<!-- /issue-number -->
