### PR TITLE
bpo-38353: Fix compiler warning in internal headers

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -9,10 +9,10 @@ extern "C" {
 #endif
 
 /* Forward declarations */
-typedef struct pyruntimestate _PyRuntimeState;
+struct pyruntimestate;
 struct _ceval_runtime_state;
 
-PyAPI_FUNC(void) _Py_FinishPendingCalls(_PyRuntimeState *runtime);
+PyAPI_FUNC(void) _Py_FinishPendingCalls(struct pyruntimestate *runtime);
 PyAPI_FUNC(void) _PyEval_Initialize(struct _ceval_runtime_state *);
 PyAPI_FUNC(void) _PyEval_FiniThreads(
     struct _ceval_runtime_state *ceval);
@@ -26,7 +26,7 @@ PyAPI_FUNC(int) _PyEval_AddPendingCall(
 PyAPI_FUNC(void) _PyEval_SignalAsyncExc(
     struct _ceval_runtime_state *ceval);
 PyAPI_FUNC(void) _PyEval_ReInitThreads(
-    _PyRuntimeState *runtime);
+    struct pyruntimestate *runtime);
 PyAPI_FUNC(void) _PyEval_SetCoroutineOriginTrackingDepth(
     PyThreadState *tstate,
     int new_depth);

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -9,8 +9,8 @@ extern "C" {
 #endif
 
 /* Forward declarations */
-typedef struct _PyArgv _PyArgv;
-typedef struct pyruntimestate _PyRuntimeState;
+struct _PyArgv;
+struct pyruntimestate;
 
 /* True if the main interpreter thread exited due to an unhandled
  * KeyboardInterrupt exception, suggesting the user pressed ^C. */
@@ -38,14 +38,14 @@ extern PyStatus _PyFaulthandler_Init(int enable);
 extern int _PyTraceMalloc_Init(int enable);
 extern PyObject * _PyBuiltin_Init(PyThreadState *tstate);
 extern PyStatus _PySys_Create(
-    _PyRuntimeState *runtime,
+    struct pyruntimestate *runtime,
     PyThreadState *tstate,
     PyObject **sysmod_p);
 extern PyStatus _PySys_SetPreliminaryStderr(PyObject *sysdict);
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_InitMain(
-    _PyRuntimeState *runtime,
+    struct pyruntimestate *runtime,
     PyThreadState *tstate);
 extern PyStatus _PyImport_Init(PyThreadState *tstate);
 extern PyStatus _PyExc_Init(void);
@@ -78,7 +78,7 @@ extern void PyOS_FiniInterrupts(void);
 extern void _PyExc_Fini(void);
 extern void _PyImport_Fini(void);
 extern void _PyImport_Fini2(void);
-extern void _PyGC_Fini(_PyRuntimeState *runtime);
+extern void _PyGC_Fini(struct pyruntimestate *runtime);
 extern void _PyType_Fini(void);
 extern void _Py_HashRandomization_Fini(void);
 extern void _PyUnicode_Fini(void);
@@ -89,18 +89,18 @@ extern void _PyTraceMalloc_Fini(void);
 extern void _PyWarnings_Fini(PyInterpreterState *interp);
 
 extern void _PyGILState_Init(
-    _PyRuntimeState *runtime,
+    struct pyruntimestate *runtime,
     PyThreadState *tstate);
-extern void _PyGILState_Fini(_PyRuntimeState *runtime);
+extern void _PyGILState_Fini(struct pyruntimestate *runtime);
 
-PyAPI_FUNC(void) _PyGC_DumpShutdownStats(_PyRuntimeState *runtime);
+PyAPI_FUNC(void) _PyGC_DumpShutdownStats(struct pyruntimestate *runtime);
 
 PyAPI_FUNC(PyStatus) _Py_PreInitializeFromPyArgv(
     const PyPreConfig *src_config,
-    const _PyArgv *args);
+    const struct _PyArgv *args);
 PyAPI_FUNC(PyStatus) _Py_PreInitializeFromConfig(
     const PyConfig *config,
-    const _PyArgv *args);
+    const struct _PyArgv *args);
 
 
 PyAPI_FUNC(int) _Py_HandleSystemExit(int *exitcode_p);
@@ -111,7 +111,7 @@ PyAPI_FUNC(void) _PyErr_Print(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyErr_Display(PyObject *file, PyObject *exception,
                                 PyObject *value, PyObject *tb);
 
-PyAPI_FUNC(void) _PyThreadState_DeleteCurrent(_PyRuntimeState *runtime);
+PyAPI_FUNC(void) _PyThreadState_DeleteCurrent(struct pyruntimestate *runtime);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /* Forward declaration */
-typedef struct _is PyInterpreterState;
+struct _is;
 
 /* Write the Python traceback into the file 'fd'. For example:
 
@@ -57,7 +57,7 @@ PyAPI_FUNC(void) _Py_DumpTraceback(
 
 PyAPI_FUNC(const char*) _Py_DumpTracebackThreads(
     int fd,
-    PyInterpreterState *interp,
+    struct _is *interp,
     PyThreadState *current_tstate);
 
 /* Write a Unicode object into the file descriptor fd. Encode the string to


### PR DESCRIPTION
Replace "_PyRuntimeState" with "struct pyruntimestate" to avoid
a warning on typedef re-definition.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38353](https://bugs.python.org/issue38353) -->
https://bugs.python.org/issue38353
<!-- /issue-number -->
