### PR TITLE
bpo-37025: AddRefActCtx() shouldn't be checked for failure

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-10-04-03-46-36.bpo-37025.tLheEe.rst
+++ b/Misc/NEWS.d/next/Windows/2019-10-04-03-46-36.bpo-37025.tLheEe.rst
@@ -1,0 +1,2 @@
+``AddRefActCtx()`` was needlessly being checked for failure in
+``PC/dl_nt.c``.

--- a/PC/dl_nt.c
+++ b/PC/dl_nt.c
@@ -41,8 +41,8 @@ const char *PyWin_DLLVersionString = dllVersionBuffer;
 typedef BOOL (WINAPI * PFN_GETCURRENTACTCTX)(HANDLE *);
 typedef BOOL (WINAPI * PFN_ACTIVATEACTCTX)(HANDLE, ULONG_PTR *);
 typedef BOOL (WINAPI * PFN_DEACTIVATEACTCTX)(DWORD, ULONG_PTR);
-typedef BOOL (WINAPI * PFN_ADDREFACTCTX)(HANDLE);
-typedef BOOL (WINAPI * PFN_RELEASEACTCTX)(HANDLE);
+typedef void (WINAPI * PFN_ADDREFACTCTX)(HANDLE);
+typedef void (WINAPI * PFN_RELEASEACTCTX)(HANDLE);
 
 // locals and function pointers for this activation context magic.
 static HANDLE PyWin_DLLhActivationContext = NULL; // one day it might be public
@@ -103,9 +103,14 @@ BOOL    WINAPI  DllMain (HANDLE hInst,
             // and capture our activation context for use when loading extensions.
             _LoadActCtxPointers();
             if (pfnGetCurrentActCtx && pfnAddRefActCtx)
-                if ((*pfnGetCurrentActCtx)(&PyWin_DLLhActivationContext))
-                    if (!(*pfnAddRefActCtx)(PyWin_DLLhActivationContext))
-                        OutputDebugString("Python failed to load the default activation context\n");
+                if ((*pfnGetCurrentActCtx)(&PyWin_DLLhActivationContext)) {
+                    (*pfnAddRefActCtx)(PyWin_DLLhActivationContext);
+                }
+                else {
+                    OutputDebugString("Python failed to load the default "
+                                      "activation context\n");
+                    return FALSE;
+                }
 #endif
             break;
 


### PR DESCRIPTION
AddRefActCtx() does not return a value.

<!-- issue-number: [bpo-37025](https://bugs.python.org/issue37025) -->
https://bugs.python.org/issue37025
<!-- /issue-number -->
