### PR TITLE
bpo-38371: Tkinter: deprecate the split() method.

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -191,6 +191,11 @@ Deprecated
   the module will restrict its seeds to :const:`None`, :class:`int`,
   :class:`float`, :class:`str`, :class:`bytes`, and :class:`bytearray`.
 
+* Deprecated the ``split()`` method of :class:`_tkinter.TkappType` in
+  favour of the ``splitlist()`` method which has more consistent and
+  predicable behavior.
+  (Contributed by Serhiy Storchaka in :issue:`38371`.)
+
 
 Removed
 =======

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import sys
 import os
+import warnings
 from test import support
 
 # Skip this test if the _tkinter module wasn't built.
@@ -573,9 +574,12 @@ class TclTest(unittest.TestCase):
     def test_split(self):
         split = self.interp.tk.split
         call = self.interp.tk.call
-        self.assertRaises(TypeError, split)
-        self.assertRaises(TypeError, split, 'a', 'b')
-        self.assertRaises(TypeError, split, 2)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'\bsplit\b.*\bsplitlist\b',
+                                    DeprecationWarning)
+            self.assertRaises(TypeError, split)
+            self.assertRaises(TypeError, split, 'a', 'b')
+            self.assertRaises(TypeError, split, 2)
         testcases = [
             ('2', '2'),
             ('', ''),
@@ -617,7 +621,8 @@ class TclTest(unittest.TestCase):
                     expected),
             ]
         for arg, res in testcases:
-            self.assertEqual(split(arg), res, msg=arg)
+            with self.assertWarns(DeprecationWarning):
+                self.assertEqual(split(arg), res, msg=arg)
 
     def test_splitdict(self):
         splitdict = tkinter._splitdict

--- a/Misc/NEWS.d/next/Library/2019-10-04-18-39-59.bpo-38371.S6Klvm.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-04-18-39-59.bpo-38371.S6Klvm.rst
@@ -1,0 +1,3 @@
+Deprecated the ``split()`` method in :class:`_tkinter.TkappType` in favour
+of the ``splitlist()`` method which has more consistent and predicable
+behavior.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -2304,6 +2304,12 @@ _tkinter_tkapp_split(TkappObject *self, PyObject *arg)
     PyObject *v;
     char *list;
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+            "split() is deprecated; consider using splitlist() instead", 1))
+    {
+        return NULL;
+    }
+
     if (PyTclObject_Check(arg)) {
         Tcl_Obj *value = ((PyTclObject*)arg)->value;
         int objc;


### PR DESCRIPTION


<!-- issue-number: [bpo-38371](https://bugs.python.org/issue38371) -->
https://bugs.python.org/issue38371
<!-- /issue-number -->
