### PR TITLE
 bpo-26510: Add versionchanged for required arg of add_subparsers

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1636,7 +1636,7 @@ Sub-commands
      stored; by default ``None`` and no value is stored
 
    * required_ - Whether or not a subcommand must be provided, by default
-     ``False``.
+     ``False``. (added in 3.7)
 
    * help_ - help for sub-parser group in help output, by default ``None``
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1792,6 +1792,9 @@ Sub-commands
      >>> parser.parse_args(['2', 'frobble'])
      Namespace(subparser_name='2', y='frobble')
 
+   .. versionadded:: 3.7
+      The *required* keyword argument.
+
 
 FileType objects
 ^^^^^^^^^^^^^^^^

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1636,7 +1636,7 @@ Sub-commands
      stored; by default ``None`` and no value is stored
 
    * required_ - Whether or not a subcommand must be provided, by default
-     ``False``. (added in 3.7)
+     ``False`` (added in 3.7)
 
    * help_ - help for sub-parser group in help output, by default ``None``
 
@@ -1792,8 +1792,8 @@ Sub-commands
      >>> parser.parse_args(['2', 'frobble'])
      Namespace(subparser_name='2', y='frobble')
 
-   .. versionadded:: 3.7
-      The *required* keyword argument.
+   .. versionchanged:: 3.7
+      New *required* keyword argument.
 
 
 FileType objects

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2401,8 +2401,8 @@ Changes in the Python API
   instead of a :class:`bytes` instance.
   (Contributed by Victor Stinner in :issue:`21071`.)
 
-* :meth:`ArgumentParser.add_subparsers() <argparse.ArgumentParser.add_subparsers>`
-  has a new ``required`` parameter that defaults to ``False``.
+* :mod:`argparse` subparsers can now be made mandatory by passing ``required=True``
+  to :meth:`ArgumentParser.add_subparsers() <argparse.ArgumentParser.add_subparsers>`.
   (Contributed by Anthony Sottile in :issue:`26510`.)
 
 * :meth:`ast.literal_eval()` is now stricter.  Addition and subtraction of

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2401,6 +2401,10 @@ Changes in the Python API
   instead of a :class:`bytes` instance.
   (Contributed by Victor Stinner in :issue:`21071`.)
 
+* :meth:`ArgumentParser.add_subparsers() <argparse.ArgumentParser.add_subparsers>`
+  has a new ``required`` parameter that defaults to ``False``.
+  (Contributed by Anthony Sottile in :issue:`26510`.)
+
 * :meth:`ast.literal_eval()` is now stricter.  Addition and subtraction of
   arbitrary numbers are no longer allowed.
   (Contributed by Serhiy Storchaka in :issue:`31778`.)


### PR DESCRIPTION
The `required` argument to `argparse.add_subparsers` was added in #3027. This PR specifies the earliest version of Python where it is available.

<!-- issue-number: [bpo-26510](https://bugs.python.org/issue26510) -->
https://bugs.python.org/issue26510
<!-- /issue-number -->


Automerge-Triggered-By: @merwok