### PR TITLE
bpo-38376: Fix build error when enabling assertions but not Py_DEBUG.

### DIFF
--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -1032,14 +1032,10 @@ PyAPI_FUNC(int) PyUnicode_IsIdentifier(PyObject *s);
 
 /* === Characters Type APIs =============================================== */
 
-#if defined(Py_DEBUG) && !defined(Py_LIMITED_API)
+#if (defined(Py_DEBUG) || !defined(NDEBUG)) && !defined(Py_LIMITED_API)
 PyAPI_FUNC(int) _PyUnicode_CheckConsistency(
     PyObject *op,
     int check_content);
-#elif !defined(NDEBUG)
-/* For asserts that call _PyUnicode_CheckConsistency(), which would
- * otherwise be a problem when building with asserts but without Py_DEBUG. */
-#define _PyUnicode_CheckConsistency(op, check_content) PyUnicode_Check(op)
 #endif
 
 #ifndef Py_LIMITED_API


### PR DESCRIPTION
_PyUnicode_CheckConsistency is now defined even without Py_DEBUG set, so get rid of the #define hack that was there to deal with calls in assert statements not explicitly guarded by Py_DEBUG.



<!-- issue-number: [bpo-38376](https://bugs.python.org/issue38376) -->
https://bugs.python.org/issue38376
<!-- /issue-number -->
