### PR TITLE
Ignore .pytest_cache/.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ TAGS
 gmon.out
 .coverage
 .mypy_cache/
+.pytest_cache/
 
 *.exe
 !Lib/distutils/command/*.exe


### PR DESCRIPTION
Keeps my plugin from sneaking JSON files into commits.
