### PR TITLE
bpo-36356: Fix memory leak in _asynciomodule.c during "setup.py build_ext"

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3250,7 +3250,8 @@ module_init(void)
     }
     if (module_initialized != 0) {
         return 0;
-    } else {
+    } 
+    else {
         module_initialized = 1;
     }
 

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -33,6 +33,7 @@ static PyObject *asyncio_task_repr_info_func;
 static PyObject *asyncio_InvalidStateError;
 static PyObject *asyncio_CancelledError;
 static PyObject *context_kwname;
+static int module_initialized;
 
 static PyObject *cached_running_holder;
 static volatile uint64_t cached_running_holder_tsid;
@@ -3247,10 +3248,13 @@ module_init(void)
     if (asyncio_mod == NULL) {
         goto fail;
     }
-
-    if (current_tasks == NULL) {
-        current_tasks = PyDict_New();
+    if (module_initialized != 0) {
+        return 0;
+    } else {
+        module_initialized = 1;
     }
+
+    current_tasks = PyDict_New();
     if (current_tasks == NULL) {
         goto fail;
     }
@@ -3261,9 +3265,7 @@ module_init(void)
     }
 
 
-    if (context_kwname == NULL) {
-        context_kwname = Py_BuildValue("(s)", "context");
-    }
+    context_kwname = Py_BuildValue("(s)", "context");
     if (context_kwname == NULL) {
         goto fail;
     }

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3248,7 +3248,9 @@ module_init(void)
         goto fail;
     }
 
-    current_tasks = PyDict_New();
+    if (current_tasks == NULL) {
+        current_tasks = PyDict_New();
+    }
     if (current_tasks == NULL) {
         goto fail;
     }
@@ -3259,7 +3261,9 @@ module_init(void)
     }
 
 
-    context_kwname = Py_BuildValue("(s)", "context");
+    if (context_kwname == NULL) {
+        context_kwname = Py_BuildValue("(s)", "context");
+    }
     if (context_kwname == NULL) {
         goto fail;
     }


### PR DESCRIPTION
The module seems to be imported twice during the build process which causes a leak. Since these objects are intended to be global for the life of the import, retain them during the second import.

The double import seems to be an artifact of the build system, and not indicative of normal use.

Multiple PRs for BPO-36356 were largely grouped under a single NEWS entry, should this continue to be skipped, or should a new note be added for the 3.9 branch?


<!-- issue-number: [bpo-36356](https://bugs.python.org/issue36356) -->
https://bugs.python.org/issue36356
<!-- /issue-number -->
