### PR TITLE
closes bpo-38402: Check error of primitive crypt/crypt_r.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-05-19-36-16.bpo-36161.EZuzgK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-05-19-36-16.bpo-36161.EZuzgK.rst
@@ -1,1 +1,0 @@
-Check error of primitive crypt/crypt_r

--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-05-19-36-16.bpo-36161.EZuzgK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-05-19-36-16.bpo-36161.EZuzgK.rst
@@ -1,0 +1,1 @@
+Check error of primitive crypt/crypt_r

--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-05-19-36-16.bpo-38402.EZuzgK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-05-19-36-16.bpo-38402.EZuzgK.rst
@@ -1,0 +1,1 @@
+Check the error from the system's underlying ``crypt`` or ``crypt_r``.

--- a/Modules/_cryptmodule.c
+++ b/Modules/_cryptmodule.c
@@ -42,6 +42,9 @@ crypt_crypt_impl(PyObject *module, const char *word, const char *salt)
 #else
     crypt_result = crypt(word, salt);
 #endif
+    if (crypt_result == NULL) {
+        return PyErr_SetFromErrno(PyExc_OSError);
+    }
     return Py_BuildValue("s", crypt_result);
 }
 


### PR DESCRIPTION
crypt.py has been modified to handle encryption algorithms methods not supported in different OSs.

Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38402](https://bugs.python.org/issue38402) -->
https://bugs.python.org/issue38402
<!-- /issue-number -->
