### PR TITLE
bpo-38382: Fix premature return on ZeroDivisionError in statistics.harmonic_mean

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -282,14 +282,6 @@ def _find_rteq(a, l, x):
     raise ValueError
 
 
-def _fail_neg(values, errmsg='negative value'):
-    """Iterate over values, failing if any are less than zero."""
-    for x in values:
-        if x < 0:
-            raise StatisticsError(errmsg)
-        yield x
-
-
 # === Measures of central tendency (averages) ===
 
 def mean(data):
@@ -402,8 +394,10 @@ def harmonic_mean(data):
             return x
         else:
             raise TypeError('unsupported type')
+    if any(x < 0 for x in data):
+        raise StatisticsError(errmsg)
     try:
-        T, total, count = _sum(1/x for x in _fail_neg(data, errmsg))
+        T, total, count = _sum(1/x for x in data)
     except ZeroDivisionError:
         return 0
     assert count == n

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -1005,34 +1005,6 @@ class ConvertTest(unittest.TestCase):
             self.assertTrue(_nan_equal(x, nan))
 
 
-class FailNegTest(unittest.TestCase):
-    """Test _fail_neg private function."""
-
-    def test_pass_through(self):
-        # Test that values are passed through unchanged.
-        values = [1, 2.0, Fraction(3), Decimal(4)]
-        new = list(statistics._fail_neg(values))
-        self.assertEqual(values, new)
-
-    def test_negatives_raise(self):
-        # Test that negatives raise an exception.
-        for x in [1, 2.0, Fraction(3), Decimal(4)]:
-            seq = [-x]
-            it = statistics._fail_neg(seq)
-            self.assertRaises(statistics.StatisticsError, next, it)
-
-    def test_error_msg(self):
-        # Test that a given error message is used.
-        msg = "badness #%d" % random.randint(10000, 99999)
-        try:
-            next(statistics._fail_neg([-1], msg))
-        except statistics.StatisticsError as e:
-            errmsg = e.args[0]
-        else:
-            self.fail("expected exception, but it didn't happen")
-        self.assertEqual(errmsg, msg)
-
-
 # === Tests for public functions ===
 
 class UnivariateCommonMixin:
@@ -1472,7 +1444,7 @@ class TestHarmonicMean(NumericTestCase, AverageMixin, UnivariateTypeMixin):
     def test_negative_error(self):
         # Test that harmonic mean raises when given a negative value.
         exc = statistics.StatisticsError
-        for values in ([-1], [1, -2, 3]):
+        for values in ([-1], [1, -2, 3], [0, -1, 3]):
             with self.subTest(values=values):
                 self.assertRaises(exc, self.func, values)
 

--- a/Misc/NEWS.d/next/Library/2019-10-06-01-27-05.bpo-38382.lX3DJp.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-06-01-27-05.bpo-38382.lX3DJp.rst
@@ -1,0 +1,3 @@
+Fix premature return on ZeroDivisionError in statistics.harmonic_mean that
+caused the function to return 0 instead of raising an error with negative
+values or with values with invalid types.


### PR DESCRIPTION
* Check for any negative values before attempting to compute the harmonic mean.
* The private function _fail_neg is no longer used, so remove it.


<!-- issue-number: [bpo-38382](https://bugs.python.org/issue38382) -->
https://bugs.python.org/issue38382
<!-- /issue-number -->
