### PR TITLE
bpo-38210: Remove intersection operation with empty set

### DIFF
--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -158,17 +158,6 @@ class DictSetTest(unittest.TestCase):
         self.assertTrue(de.keys().isdisjoint(de.keys()))
         self.assertTrue(de.keys().isdisjoint([1]))
 
-    def test_keys_set_operations_with_iterator(self):
-        origin = {1: 2, 3: 4}
-        self.assertEqual((origin.keys() & iter([1, 2])), {1})
-        self.assertEqual((origin.keys() | iter([1, 2])), {1, 2, 3})
-        self.assertEqual((origin.keys() ^ iter([1, 2])), {2, 3})
-
-        items = origin.items()
-        self.assertEqual((items & iter([(1, 2)])), {(1, 2)})
-        self.assertEqual((items ^ iter([(1, 2)])), {(3, 4)})
-        self.assertEqual((items | iter([(1, 2)])), {(1, 2), (3, 4)})
-
     def test_items_set_operations(self):
         d1 = {'a': 1, 'b': 2}
         d2 = {'a': 2, 'b': 2}
@@ -224,6 +213,16 @@ class DictSetTest(unittest.TestCase):
         self.assertTrue(de.items().isdisjoint([]))
         self.assertTrue(de.items().isdisjoint(de.items()))
         self.assertTrue(de.items().isdisjoint([1]))
+
+    def test_set_operations_with_iterator(self):
+        origin = {1: 2, 3: 4}
+        self.assertEqual((origin.keys() | iter([1, 2])), {1, 2, 3})
+        self.assertEqual((origin.keys() ^ iter([1, 2])), {2, 3})
+
+        items = origin.items()
+        self.assertEqual((items & iter([(1, 2)])), {(1, 2)})
+        self.assertEqual((items ^ iter([(1, 2)])), {(3, 4)})
+        self.assertEqual((items | iter([(1, 2)])), {(1, 2), (3, 4)})
 
     def test_recursive_repr(self):
         d = {}

--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -216,14 +216,14 @@ class DictSetTest(unittest.TestCase):
 
     def test_set_operations_with_iterator(self):
         origin = {1: 2, 3: 4}
-        self.assertEqual((origin.keys() & iter([1, 2])), {1})
-        self.assertEqual((origin.keys() | iter([1, 2])), {1, 2, 3})
-        self.assertEqual((origin.keys() ^ iter([1, 2])), {2, 3})
+        self.assertEqual(origin.keys() & iter([1, 2]), {1})
+        self.assertEqual(origin.keys() | iter([1, 2]), {1, 2, 3})
+        self.assertEqual(origin.keys() ^ iter([1, 2]), {2, 3})
 
         items = origin.items()
-        self.assertEqual((items & iter([(1, 2)])), {(1, 2)})
-        self.assertEqual((items ^ iter([(1, 2)])), {(3, 4)})
-        self.assertEqual((items | iter([(1, 2)])), {(1, 2), (3, 4)})
+        self.assertEqual(items & iter([(1, 2)]), {(1, 2)})
+        self.assertEqual(items ^ iter([(1, 2)]), {(3, 4)})
+        self.assertEqual(items | iter([(1, 2)]), {(1, 2), (3, 4)})
 
     def test_recursive_repr(self):
         d = {}

--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -164,6 +164,11 @@ class DictSetTest(unittest.TestCase):
         self.assertEqual((origin.keys() | iter([1, 2])), {1, 2, 3})
         self.assertEqual((origin.keys() ^ iter([1, 2])), {2, 3})
 
+        items = origin.items()
+        self.assertEqual((items & iter([(1, 2)])), {(1, 2)})
+        self.assertEqual((items ^ iter([(1, 2)])), {(3, 4)})
+        self.assertEqual((items | iter([(1, 2)])), {(1, 2), (3, 4)})
+
     def test_items_set_operations(self):
         d1 = {'a': 1, 'b': 2}
         d2 = {'a': 2, 'b': 2}

--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -216,6 +216,7 @@ class DictSetTest(unittest.TestCase):
 
     def test_set_operations_with_iterator(self):
         origin = {1: 2, 3: 4}
+        self.assertEqual((origin.keys() & iter([1, 2])), {1})
         self.assertEqual((origin.keys() | iter([1, 2])), {1, 2, 3})
         self.assertEqual((origin.keys() ^ iter([1, 2])), {2, 3})
 

--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -158,6 +158,12 @@ class DictSetTest(unittest.TestCase):
         self.assertTrue(de.keys().isdisjoint(de.keys()))
         self.assertTrue(de.keys().isdisjoint([1]))
 
+    def test_keys_set_operations_with_iterator(self):
+        origin = {1: 2, 3: 4}
+        self.assertEqual((origin.keys() & iter([1, 2])), {1})
+        self.assertEqual((origin.keys() | iter([1, 2])), {1, 2, 3})
+        self.assertEqual((origin.keys() ^ iter([1, 2])), {2, 3})
+
     def test_items_set_operations(self):
         d1 = {'a': 1, 'b': 2}
         d2 = {'a': 2, 'b': 2}

--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-06-15-01-57.bpo-38210.Xgc6F_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-06-15-01-57.bpo-38210.Xgc6F_.rst
@@ -1,0 +1,2 @@
+Remove unecessary intersection and update set operation in dictview with
+empty set. (Contributed by Dong-hee Na in :issue:`38210`.)

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4225,14 +4225,6 @@ _PyDictView_Intersect(PyObject* self, PyObject *other)
 
     it = PyObject_GetIter(other);
 
-    _Py_IDENTIFIER(intersection_update);
-    tmp = _PyObject_CallMethodIdOneArg(result, &PyId_intersection_update, other);
-    if (tmp == NULL) {
-        Py_DECREF(result);
-        return NULL;
-    }
-    Py_DECREF(tmp);
-
     if (PyDictKeys_Check(self)) {
         dict_contains = dictkeys_contains;
     }


### PR DESCRIPTION
There was an unnecessary logic with the empty set.
The logic can be represented by blow code in pure python

```python

result = set() # result = PySet_New(NULL);
it = iter(other)
result.intersection_update(other) 
# result will be empty set and iterator is fully consumed.
# so this logic should be removed
```

<!-- issue-number: [bpo-38210](https://bugs.python.org/issue38210) -->
https://bugs.python.org/issue38210
<!-- /issue-number -->
