### PR TITLE
bpo-38383: undefined behavior in tailmatch() of bytes_methods.c

### DIFF
--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -743,7 +743,7 @@ tailmatch(const char *str, Py_ssize_t len, PyObject *substr,
 
     if (direction < 0) {
         /* startswith */
-        if (start + slen > len)
+        if (start > len - slen)
             goto notfound;
     } else {
         /* endswith */


### PR DESCRIPTION


<!-- issue-number: [bpo-38383](https://bugs.python.org/issue38383) -->
https://bugs.python.org/issue38383
<!-- /issue-number -->
