### PR TITLE
bpo-38387: Formally document PyDoc_STRVAR and PyDoc_STR macros

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -174,6 +174,17 @@ complete listing.
    .. versionchanged:: 3.8
       MSVC support was added.
 
+.. c:macro:: PyDoc_STRVAR(name, str)
+
+   A shortcut for ``static const char name[] = str``, commonly used
+   to initialize a module, function, class, or method docstring.
+
+   Example::
+
+      PyDoc_STRVAR(module_doc, "This is the module's docstring.");
+
+   .. versionchanged:: 3.8
+      This macro previously inserted ``static char name[]``.
 
 .. _api-objects:
 

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -177,10 +177,10 @@ complete listing.
 .. c:macro:: PyDoc_STRVAR(name, str)
 
    Creates a variable with name ``name`` that can be used in docstrings.
+   If Python is built without docstrings, the value will be empty.
 
-   Use the :c:macro:`PyDoc_STRVAR` or :c:macro:`PyDoc_STR` macros for
-   docstrings to support building Python without docstrings,
-   as specified in :pep:`7`.
+   Use :c:macro:`PyDoc_STRVAR` for docstrings to support building
+   Python without docstrings, as specified in :pep:`7`.
 
    Example::
 
@@ -191,6 +191,22 @@ complete listing.
           {"pop", (PyCFunction)deque_pop, METH_NOARGS, pop_doc},
           // ...
       }
+
+.. c:macro:: PyDoc_STR(str)
+
+   Creates a docstring for the given input string or an empty string
+   if docstrings are disabled.
+
+   Use :c:macro:`PyDoc_STR` in specifying docstrings to support
+   building Python without docstrings, as specified in :pep:`7`.
+
+   Example::
+
+      static PyMethodDef pysqlite_row_methods[] = {
+          {"keys", (PyCFunction)pysqlite_row_keys, METH_NOARGS,
+              PyDoc_STR("Returns the keys of the row.")},
+          {NULL, NULL}
+      };
 
 .. _api-objects:
 

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -176,15 +176,21 @@ complete listing.
 
 .. c:macro:: PyDoc_STRVAR(name, str)
 
-   A shortcut for ``static const char name[] = str``, commonly used
-   to initialize a module, function, class, or method docstring.
+   Creates a variable with name ``name`` that can be used in docstrings.
+
+   Use the :c:macro:`PyDoc_STRVAR` or :c:macro:`PyDoc_STR` macros for
+   docstrings to support building Python without docstrings,
+   as specified in :pep:`7`.
 
    Example::
 
-      PyDoc_STRVAR(module_doc, "This is the module's docstring.");
+      PyDoc_STRVAR(pop_doc, "Remove and return the rightmost element.");
 
-   .. versionchanged:: 3.8
-      This macro previously inserted ``static char name[]``.
+      static PyMethodDef deque_methods[] = {
+          // ...
+          {"pop", (PyCFunction)deque_pop, METH_NOARGS, pop_doc},
+          // ...
+      }
 
 .. _api-objects:
 

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -153,7 +153,7 @@ or request "multi-phase initialization" by returning the definition struct itsel
    .. c:member:: const char *m_doc
 
       Docstring for the module; usually a docstring variable created with
-      :c:func:`PyDoc_STRVAR` is used.
+      :c:macro:`PyDoc_STRVAR` is used.
 
    .. c:member:: Py_ssize_t m_size
 

--- a/Misc/NEWS.d/next/Documentation/2019-10-06-23-44-15.bpo-38387.fZoq0S.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-10-06-23-44-15.bpo-38387.fZoq0S.rst
@@ -1,1 +1,1 @@
-Document PyDoc_STRVAR macro in the C-API reference.
+Document :c:macro:`PyDoc_STRVAR` macro in the C-API reference.

--- a/Misc/NEWS.d/next/Documentation/2019-10-06-23-44-15.bpo-38387.fZoq0S.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-10-06-23-44-15.bpo-38387.fZoq0S.rst
@@ -1,0 +1,1 @@
+Document PyDoc_STRVAR macro in the C-API reference.


### PR DESCRIPTION
Adds a short description of `PyDoc_STRVAR` and `PyDoc_STR` to "Useful macros" section of C-API docs.

Currently, there is [one lone mention](https://docs.python.org/3/c-api/module.html?highlight=pydoc_strvar#c.PyModuleDef) in the C-API reference, despite the fact that `PyDoc_STRVAR` is ubiquitous to `Modules/`.

Additionally, this properly uses `c:macro` within `c-api/module.html` to link.

<!-- issue-number: [bpo-38387](https://bugs.python.org/issue38387) -->
https://bugs.python.org/issue38387
<!-- /issue-number -->
