### PR TITLE
bpo-38390: Fix a compile warning in dictobject.c

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4186,7 +4186,6 @@ _PyDictView_Intersect(PyObject* self, PyObject *other)
     Py_ssize_t len_self;
     int rv;
     int (*dict_contains)(_PyDictViewObject *, PyObject *);
-    PyObject *tmp;
 
     /* Python interpreter swaps parameters when dict view
        is on right side of & */


### PR DESCRIPTION


<!-- issue-number: [bpo-38390](https://bugs.python.org/issue38390) -->
https://bugs.python.org/issue38390
<!-- /issue-number -->
