### PR TITLE
bpo-38210: Fix compiler warning in dictobject.c

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -4186,7 +4186,6 @@ _PyDictView_Intersect(PyObject* self, PyObject *other)
     Py_ssize_t len_self;
     int rv;
     int (*dict_contains)(_PyDictViewObject *, PyObject *);
-    PyObject *tmp;
 
     /* Python interpreter swaps parameters when dict view
        is on right side of & */


### PR DESCRIPTION
The "tmp" variable is no longer used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38210](https://bugs.python.org/issue38210) -->
https://bugs.python.org/issue38210
<!-- /issue-number -->
