### PR TITLE
bpo-38353: Simplify calculate_pybuilddir()

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -657,11 +657,6 @@ calculate_pybuilddir(const wchar_t *argv0_path,
         return _PyStatus_NO_MEMORY();
     }
 
-    if (!isfile(filename)) {
-        PyMem_RawFree(filename);
-        return _PyStatus_OK();
-    }
-
     FILE *fp = _Py_wfopen(filename, L"rb");
     PyMem_RawFree(filename);
     if (fp == NULL) {


### PR DESCRIPTION
Calling _Py_wfopen() is enough to check if filename is an existing
file or not. There is no need to check first isfile().

<!-- issue-number: [bpo-38353](https://bugs.python.org/issue38353) -->
https://bugs.python.org/issue38353
<!-- /issue-number -->
