### PR TITLE
bpo-38396: dump(node) instead of repr(node) on ast.literal_eval

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -63,7 +63,7 @@ def literal_eval(node_or_string):
         if isinstance(node, Constant):
             if type(node.value) in (int, float, complex):
                 return node.value
-        raise ValueError('malformed node or string: ' + repr(node))
+        raise ValueError('malformed node or string: ' + dump(node))
     def _convert_signed_num(node):
         if isinstance(node, UnaryOp) and isinstance(node.op, (UAdd, USub)):
             operand = _convert_num(node.operand)

--- a/Misc/NEWS.d/next/Library/2019-10-07-18-56-55.bpo-38396.CRjoAy.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-07-18-56-55.bpo-38396.CRjoAy.rst
@@ -1,0 +1,1 @@
+When raising ValueError use dump instead of repr on ast.literal_eval.


### PR DESCRIPTION


<!-- issue-number: [bpo-38396](https://bugs.python.org/issue38396) -->
https://bugs.python.org/issue38396
<!-- /issue-number -->
