### PR TITLE
Typo fix - inferface should be interface

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1305,7 +1305,7 @@ _PyErr_WarnUnawaitedCoroutine(PyObject *coro)
 }
 
 PyDoc_STRVAR(warn_explicit_doc,
-"Low-level inferface to warnings functionality.");
+"Low-level interface to warnings functionality.");
 
 static PyMethodDef warnings_functions[] = {
     WARNINGS_WARN_METHODDEF


### PR DESCRIPTION
- Typo fix in file Python/_warnings.c
- inferface should be interface