### PR TITLE
bpo-36389: Add newline to _PyObject_AssertFailed()

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2187,6 +2187,9 @@ _PyObject_AssertFailed(PyObject *obj, const char *expr, const char *msg,
         /* This might succeed or fail, but we're about to abort, so at least
            try to provide any extra info we can: */
         _PyObject_Dump(obj);
+
+        fprintf(stderr, "\n");
+        fflush(stderr);
     }
 
     Py_FatalError("_PyObject_AssertFailed");


### PR DESCRIPTION
Add a newline between the verbose object dump and the Py_FatalError()
logs for readability.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36389](https://bugs.python.org/issue36389) -->
https://bugs.python.org/issue36389
<!-- /issue-number -->
