### PR TITLE
bpo-38395: Fix ownership in weakref.proxy methods

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -391,6 +391,23 @@ class ReferencesTestCase(TestBase):
         lyst = List()
         self.assertEqual(bool(weakref.proxy(lyst)), bool(lyst))
 
+    def test_proxy_iter(self):
+        # Test fails with a debug build of the interpreter
+        # (see bpo-38395).
+
+        obj = None
+
+        class MyObj:
+            def __iter__(self):
+                nonlocal obj
+                del obj
+                return NotImplemented
+
+        obj = MyObj()
+        p = weakref.proxy(obj)
+        with self.assertRaises(TypeError):
+            "blech" in p
+
     def test_getweakrefcount(self):
         o = C()
         ref1 = weakref.ref(o)

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -406,6 +406,9 @@ class ReferencesTestCase(TestBase):
         obj = MyObj()
         p = weakref.proxy(obj)
         with self.assertRaises(TypeError):
+            # "blech" in p calls MyObj.__iter__ through the proxy,
+            # without keeping a reference to the real object, so it
+            # can be killed in the middle of the call
             "blech" in p
 
     def test_getweakrefcount(self):

--- a/Misc/NEWS.d/next/C API/2019-10-08-01-23-24.bpo-38395.MJ6Ey9.rst
+++ b/Misc/NEWS.d/next/C API/2019-10-08-01-23-24.bpo-38395.MJ6Ey9.rst
@@ -1,0 +1,3 @@
+Fix a crash in :class:`weakref.proxy` objects due to incorrect lifetime
+management when calling some associated methods that may delete the last
+reference to object being referenced by the proxy. Patch by Pablo Galindo.

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -166,7 +166,10 @@ weakref_repr(PyWeakReference *self)
     if (PyWeakref_GET_OBJECT(self) == Py_None)
         return PyUnicode_FromFormat("<weakref at %p; dead>", self);
 
-    if (_PyObject_LookupAttrId(PyWeakref_GET_OBJECT(self), &PyId___name__, &name) < 0) {
+    PyObect* obj = PyWeakref_GET_OBJECT(self);
+    Py_INCREF(obj);
+    if (_PyObject_LookupAttrId(obj, &PyId___name__, &name) < 0) {
+        Py_DECREF(obj);
         return NULL;
     }
     if (name == NULL || !PyUnicode_Check(name)) {
@@ -174,16 +177,17 @@ weakref_repr(PyWeakReference *self)
             "<weakref at %p; to '%s' at %p>",
             self,
             Py_TYPE(PyWeakref_GET_OBJECT(self))->tp_name,
-            PyWeakref_GET_OBJECT(self));
+            obj);
     }
     else {
         repr = PyUnicode_FromFormat(
             "<weakref at %p; to '%s' at %p (%U)>",
             self,
             Py_TYPE(PyWeakref_GET_OBJECT(self))->tp_name,
-            PyWeakref_GET_OBJECT(self),
+            obj,
             name);
     }
+    Py_DECREF(obj);
     Py_XDECREF(name);
     return repr;
 }

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -481,7 +481,11 @@ proxy_setattr(PyWeakReference *proxy, PyObject *name, PyObject *value)
 {
     if (!proxy_checkref(proxy))
         return -1;
-    return PyObject_SetAttr(PyWeakref_GET_OBJECT(proxy), name, value);
+    PyObject *obj = PyWeakref_GET_OBJECT(proxy);
+    Py_INCREF(obj);
+    int res = PyObject_SetAttr(obj, name, value);
+    Py_DECREF(obj);
+    return res;
 }
 
 static PyObject *
@@ -553,9 +557,13 @@ proxy_contains(PyWeakReference *proxy, PyObject *value)
 {
     if (!proxy_checkref(proxy))
         return -1;
-    return PySequence_Contains(PyWeakref_GET_OBJECT(proxy), value);
-}
 
+    PyObject *obj = PyWeakref_GET_OBJECT(proxy);
+    Py_INCREF(obj);
+    int res = PySequence_Contains(obj, value);
+    Py_DECREF(obj);
+    return res;
+}
 
 /* mapping slots */
 
@@ -564,7 +572,12 @@ proxy_length(PyWeakReference *proxy)
 {
     if (!proxy_checkref(proxy))
         return -1;
-    return PyObject_Length(PyWeakref_GET_OBJECT(proxy));
+
+    PyObject *obj = PyWeakref_GET_OBJECT(proxy);
+    Py_INCREF(obj);
+    Py_ssize_t res = PyObject_Length(obj);
+    Py_DECREF(obj);
+    return res;
 }
 
 WRAP_BINARY(proxy_getitem, PyObject_GetItem)
@@ -572,13 +585,19 @@ WRAP_BINARY(proxy_getitem, PyObject_GetItem)
 static int
 proxy_setitem(PyWeakReference *proxy, PyObject *key, PyObject *value)
 {
+    int res = 0;
     if (!proxy_checkref(proxy))
         return -1;
 
-    if (value == NULL)
-        return PyObject_DelItem(PyWeakref_GET_OBJECT(proxy), key);
-    else
-        return PyObject_SetItem(PyWeakref_GET_OBJECT(proxy), key, value);
+    PyObject *obj = PyWeakref_GET_OBJECT(proxy);
+    Py_INCREF(obj);
+    if (value == NULL) {
+        res = PyObject_DelItem(obj, key);
+    } else {
+        res = PyObject_SetItem(obj, key, value);
+    }
+    Py_DECREF(obj);
+    return res;
 }
 
 /* iterator slots */
@@ -588,7 +607,11 @@ proxy_iter(PyWeakReference *proxy)
 {
     if (!proxy_checkref(proxy))
         return NULL;
-    return PyObject_GetIter(PyWeakref_GET_OBJECT(proxy));
+    PyObject *obj = PyWeakref_GET_OBJECT(proxy);
+    Py_INCREF(obj);
+    PyObject* res = PyObject_GetIter(obj);
+    Py_DECREF(obj);
+    return res;
 }
 
 static PyObject *
@@ -596,7 +619,12 @@ proxy_iternext(PyWeakReference *proxy)
 {
     if (!proxy_checkref(proxy))
         return NULL;
-    return PyIter_Next(PyWeakref_GET_OBJECT(proxy));
+
+    PyObject *obj = PyWeakref_GET_OBJECT(proxy);
+    Py_INCREF(obj);
+    PyObject* res = PyIter_Next(obj);
+    Py_DECREF(obj);
+    return res;
 }
 
 

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -166,7 +166,7 @@ weakref_repr(PyWeakReference *self)
     if (PyWeakref_GET_OBJECT(self) == Py_None)
         return PyUnicode_FromFormat("<weakref at %p; dead>", self);
 
-    PyObect* obj = PyWeakref_GET_OBJECT(self);
+    PyObject* obj = PyWeakref_GET_OBJECT(self);
     Py_INCREF(obj);
     if (_PyObject_LookupAttrId(obj, &PyId___name__, &name) < 0) {
         Py_DECREF(obj);
@@ -217,10 +217,10 @@ weakref_richcompare(PyWeakReference* self, PyWeakReference* other, int op)
     PyObject* obj = PyWeakref_GET_OBJECT(self);
     PyObject* other_obj = PyWeakref_GET_OBJECT(other);
     Py_INCREF(obj);
-    Py_INCREF(other);
+    Py_INCREF(other_obj);
     PyObject* res = PyObject_RichCompare(obj, other_obj, op);
     Py_DECREF(obj);
-    Py_DECREF(other);
+    Py_DECREF(other_obj);
     return res;
 }
 


### PR DESCRIPTION
The implementation of weakref.proxy's methods call back into the Python
API using a borrowed references of the weakly referenced object
(acquired via PyWeakref_GET_OBJECT). This API call may delete the last
reference to the object (either directly or via GC), leaving a dangling
pointer, which can be subsequently dereferenced.

To fix this, claim temporarily ownership of the referenced object when
calling the appropiate method. Some functions because at the moment they
do not need to access the borrowed referent, but to protect against
future changes to these functions, ownership needs to be fixed in
all potentially affected methids.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38395](https://bugs.python.org/issue38395) -->
https://bugs.python.org/issue38395
<!-- /issue-number -->
