### PR TITLE
Docs: Add asyncio source code links

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1,10 +1,15 @@
 .. currentmodule:: asyncio
 
+.. _asyncio-event-loop:
 
 ==========
 Event Loop
 ==========
 
+**Source code:** :source:`Lib/asyncio/events.py`,
+:source:`Lib/asyncio/base_events.py`
+
+------------------------------------
 
 .. rubric:: Preface
 
@@ -80,8 +85,6 @@ This documentation page contains the following sections:
 * The `Examples`_ section showcases how to work with some event
   loop APIs.
 
-
-.. _asyncio-event-loop:
 
 Event Loop Methods
 ==================

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1,6 +1,5 @@
 .. currentmodule:: asyncio
 
-.. _asyncio-event-loop:
 
 ==========
 Event Loop
@@ -85,6 +84,8 @@ This documentation page contains the following sections:
 * The `Examples`_ section showcases how to work with some event
   loop APIs.
 
+
+.. _asyncio-event-loop:
 
 Event Loop Methods
 ==================

--- a/Doc/library/asyncio-exceptions.rst
+++ b/Doc/library/asyncio-exceptions.rst
@@ -7,6 +7,9 @@
 Exceptions
 ==========
 
+**Source code:** :source:`Lib/asyncio/exceptions.py`
+
+----------------------------------------------------
 
 .. exception:: TimeoutError
 

--- a/Doc/library/asyncio-future.rst
+++ b/Doc/library/asyncio-future.rst
@@ -7,6 +7,11 @@
 Futures
 =======
 
+**Source code:** :source:`Lib/asyncio/futures.py`,
+:source:`Lib/asyncio/base_futures.py`
+
+-------------------------------------
+
 *Future* objects are used to bridge **low-level callback-based code**
 with high-level async/await code.
 

--- a/Doc/library/asyncio-platforms.rst
+++ b/Doc/library/asyncio-platforms.rst
@@ -23,6 +23,12 @@ All Platforms
 Windows
 =======
 
+**Source code:** :source:`Lib/asyncio/proactor_events.py`,
+:source:`Lib/asyncio/windows_events.py`,
+:source:`Lib/asyncio/windows_utils.py`
+
+--------------------------------------
+
 .. versionchanged:: 3.8
 
    On Windows, :class:`ProactorEventLoop` is now the default event loop.

--- a/Doc/library/asyncio-protocol.rst
+++ b/Doc/library/asyncio-protocol.rst
@@ -69,6 +69,10 @@ This documentation page contains the following sections:
 Transports
 ==========
 
+**Source code:** :source:`Lib/asyncio/transports.py`
+
+----------------------------------------------------
+
 Transports are classes provided by :mod:`asyncio` in order to abstract
 various kinds of communication channels.
 
@@ -430,6 +434,10 @@ Subprocess Transports
 
 Protocols
 =========
+
+**Source code:** :source:`Lib/asyncio/protocols.py`
+
+---------------------------------------------------
 
 asyncio provides a set of abstract base classes that should be used
 to implement network protocols.  Those classes are meant to be used

--- a/Doc/library/asyncio-queue.rst
+++ b/Doc/library/asyncio-queue.rst
@@ -6,6 +6,10 @@
 Queues
 ======
 
+**Source code:** :source:`Lib/asyncio/queues.py`
+
+------------------------------------------------
+
 asyncio queues are designed to be similar to classes of the
 :mod:`queue` module.  Although asyncio queues are not thread-safe,
 they are designed to be used specifically in async/await code.

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -6,6 +6,10 @@
 Streams
 =======
 
+**Source code:** :source:`Lib/asyncio/streams.py`
+
+-------------------------------------------------
+
 Streams are high-level async/await-ready primitives to work with
 network connections.  Streams allow sending and receiving data without
 using callbacks or low-level protocols and transports.

--- a/Doc/library/asyncio-subprocess.rst
+++ b/Doc/library/asyncio-subprocess.rst
@@ -6,6 +6,11 @@
 Subprocesses
 ============
 
+**Source code:** :source:`Lib/asyncio/subprocess.py`,
+:source:`Lib/asyncio/base_subprocess.py`
+
+----------------------------------------
+
 This section describes high-level async/await asyncio APIs to
 create and manage subprocesses.
 

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -6,6 +6,10 @@
 Synchronization Primitives
 ==========================
 
+**Source code:** :source:`Lib/asyncio/locks.py`
+
+-----------------------------------------------
+
 asyncio synchronization primitives are designed to be similar to
 those of the :mod:`threading` module with two important caveats:
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -210,10 +210,6 @@ is :meth:`loop.run_in_executor`.
 Running an asyncio Program
 ==========================
 
-**Source code:** :source:`Lib/asyncio/runners.py`
-
--------------------------------------------------
-
 .. function:: run(coro, \*, debug=False)
 
     Execute the :term:`coroutine` *coro* and return the result.
@@ -243,6 +239,10 @@ Running an asyncio Program
 
     .. versionchanged:: 3.9
        Updated to use :meth:`loop.shutdown_default_executor`.
+
+.. note::
+   The source code for ``asyncio.run()`` can be found in
+   :source:`Lib/asyncio/runners.py`.
 
 Creating Tasks
 ==============

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -247,11 +247,6 @@ Running an asyncio Program
 Creating Tasks
 ==============
 
-**Source code:** :source:`Lib/asyncio/tasks.py`,
-:source:`Lib/asyncio/base_tasks.py`
-
------------------------------------
-
 .. function:: create_task(coro, \*, name=None)
 
    Wrap the *coro* :ref:`coroutine <coroutine>` into a :class:`Task`

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -18,9 +18,9 @@ and Tasks.
 Coroutines
 ==========
 
-Coroutines declared with async/await syntax is the preferred way of
-writing asyncio applications.  For example, the following snippet
-of code (requires Python 3.7+) prints "hello", waits 1 second,
+:term:`Coroutines <coroutine>` declared with the async/await syntax is the
+preferred way of writing asyncio applications.  For example, the following
+snippet of code (requires Python 3.7+) prints "hello", waits 1 second,
 and then prints "world"::
 
     >>> import asyncio
@@ -210,6 +210,10 @@ is :meth:`loop.run_in_executor`.
 Running an asyncio Program
 ==========================
 
+**Source code:** :source:`Lib/asyncio/runners.py`
+
+-------------------------------------------------
+
 .. function:: run(coro, \*, debug=False)
 
     Execute the :term:`coroutine` *coro* and return the result.
@@ -242,6 +246,11 @@ Running an asyncio Program
 
 Creating Tasks
 ==============
+
+**Source code:** :source:`Lib/asyncio/tasks.py`,
+:source:`Lib/asyncio/base_tasks.py`
+
+-----------------------------------
 
 .. function:: create_task(coro, \*, name=None)
 

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -240,9 +240,9 @@ Running an asyncio Program
     .. versionchanged:: 3.9
        Updated to use :meth:`loop.shutdown_default_executor`.
 
-.. note::
-   The source code for ``asyncio.run()`` can be found in
-   :source:`Lib/asyncio/runners.py`.
+    .. note::
+       The source code for ``asyncio.run()`` can be found in
+       :source:`Lib/asyncio/runners.py`.
 
 Creating Tasks
 ==============

--- a/Doc/library/asyncio.rst
+++ b/Doc/library/asyncio.rst
@@ -4,6 +4,8 @@
 .. module:: asyncio
    :synopsis: Asynchronous I/O.
 
+-------------------------------
+
 .. sidebar:: Hello World!
 
    ::
@@ -90,4 +92,5 @@ Additionally, there are **low-level** APIs for
    asyncio-llapi-index.rst
    asyncio-dev.rst
 
-.. note:: The source code for asyncio can be found in :source:`Lib/asyncio/`.
+.. note::
+   The source code for asyncio can be found in :source:`Lib/asyncio/`.

--- a/Doc/library/asyncio.rst
+++ b/Doc/library/asyncio.rst
@@ -4,7 +4,9 @@
 .. module:: asyncio
    :synopsis: Asynchronous I/O.
 
---------------
+**Source code:** :source:`Lib/asyncio/`
+
+---------------------------------------
 
 .. sidebar:: Hello World!
 

--- a/Doc/library/asyncio.rst
+++ b/Doc/library/asyncio.rst
@@ -4,10 +4,6 @@
 .. module:: asyncio
    :synopsis: Asynchronous I/O.
 
-**Source code:** :source:`Lib/asyncio/`
-
----------------------------------------
-
 .. sidebar:: Hello World!
 
    ::
@@ -93,3 +89,5 @@ Additionally, there are **low-level** APIs for
    asyncio-api-index.rst
    asyncio-llapi-index.rst
    asyncio-dev.rst
+
+.. note:: The source code for asyncio can be found in :source:`Lib/asyncio/`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Many of the other stdlib modules link to the source code in the documentation pages. Asyncio currently does not. 

This PR adds source code links to the documentation pages for asyncio. It also fixes the location of a reference point in `asyncio-eventloop.rst` (which fixes a link in `asyncio.rst`), adds a Sphinx term (link to glossary) for "coroutine" in `asyncio-task.rst`, and fixes a minor grammar typo.
