### PR TITLE
bpo-38405: Make nested subclasses of typing.NamedTuple pickleable.

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1593,7 +1593,7 @@ _prohibited = ('__new__', '__init__', '__slots__', '__getnewargs__',
                '_fields', '_field_defaults', '_field_types',
                '_make', '_replace', '_asdict', '_source')
 
-_special = ('__module__', '__name__', '__qualname__', '__annotations__')
+_special = ('__module__', '__name__', '__annotations__')
 
 
 class NamedTupleMeta(type):

--- a/Misc/NEWS.d/next/Library/2019-10-08-11-18-40.bpo-38405.0-7e7s.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-08-11-18-40.bpo-38405.0-7e7s.rst
@@ -1,0 +1,1 @@
+Nested subclasses of :class:`typing.NamedTuple` are now pickleable.


### PR DESCRIPTION


<!-- issue-number: [bpo-38405](https://bugs.python.org/issue38405) -->
https://bugs.python.org/issue38405
<!-- /issue-number -->
