### PR TITLE
bpo-26103: Update the description of isdatadescriptor in inspect.rst

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -427,7 +427,7 @@ attributes:
 
    Return true if the object is a data descriptor.
 
-   Data descriptors have both a :attr:`~object.__get__` and a :attr:`~object.__set__` method.
+   Data descriptors have a :attr:`~object.__set__` or a :attr:`~object.__delete__` method.
    Examples are properties (defined in Python), getsets, and members.  The
    latter two are defined in C and there are more specific tests available for
    those types, which is robust across Python implementations.  Typically, data


### PR DESCRIPTION
This is a complement to that PR #1959 . That PR may have forgotten to update the `inspect.rst` file.

<!-- issue-number: [bpo-26103](https://bugs.python.org/issue26103) -->
https://bugs.python.org/issue26103
<!-- /issue-number -->
