### PR TITLE
bpo-38118: Ignore Valgrind false alarm in PyUnicode_Decode()

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2019-10-08-15-07-52.bpo-38118.pIZD6H.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2019-10-08-15-07-52.bpo-38118.pIZD6H.rst
@@ -1,0 +1,2 @@
+Update Valgrind suppression file to ignore a false alarm in
+:c:func:`PyUnicode_Decode` when using GCC builtin strcmp().

--- a/Misc/valgrind-python.supp
+++ b/Misc/valgrind-python.supp
@@ -283,6 +283,17 @@
    fun:rl_initialize
 }
 
+# Valgrind emits "Conditional jump or move depends on uninitialised value(s)"
+# false alarms on GCC builtin strcmp() function. The GCC code is correct.
+#
+# Valgrind bug: https://bugs.kde.org/show_bug.cgi?id=264936
+{
+   bpo-38118: Valgrind emits false alarm on GCC builtin strcmp()
+   Memcheck:Cond
+   fun:PyUnicode_Decode
+}
+
+
 ###
 ### These occur from somewhere within the SSL, when running
 ###  test_socket_sll.  They are too general to leave on by default.


### PR DESCRIPTION
Valgrind emits "Conditional jump or move depends on uninitialised
value(s)" false alarms on GCC builtin strcmp() function. The GCC code
is correct.

Valgrind bug: https://bugs.kde.org/show_bug.cgi?id=264936

<!-- issue-number: [bpo-38118](https://bugs.python.org/issue38118) -->
https://bugs.python.org/issue38118
<!-- /issue-number -->
