### PR TITLE
bpo-37531: regrtest ignores output on timeout

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1153,7 +1153,6 @@ class ArgsTestCase(BaseTestCase):
                                   env_changed=[testname],
                                   fail_env_changed=True)
 
-    @unittest.skipIf(True, 'bpo-37531, bpo-38207: test hangs randomly')
     def test_multiprocessing_timeout(self):
         code = textwrap.dedent(r"""
             import time

--- a/Misc/NEWS.d/next/Tests/2019-10-08-16-42-05.bpo-37531.7v-_Ca.rst
+++ b/Misc/NEWS.d/next/Tests/2019-10-08-16-42-05.bpo-37531.7v-_Ca.rst
@@ -1,0 +1,5 @@
+On timeout, regrtest no longer attempts to call ``popen.communicate()``
+again: it can hang until all child processes using stdout and stderr pipes
+completes. Kill the worker process and ignores its output. Change also the
+faulthandler timeout of the main process from 1 minute to 5 minutes, for Python
+slowest buildbots.


### PR DESCRIPTION
[bpo-37531](https://bugs.python.org/issue37531), [bpo-38207](https://bugs.python.org/issue38207): On timeout, regrtest no longer attempts to call
`popen.communicate() again: on Windows, it can hang until all child
processes using stdout and stderr pipes completes. Kill the worker
process and ignores its output.

Reenable test_regrtest.test_multiprocessing_timeout().

[bpo-37531](https://bugs.python.org/issue37531): Change also the faulthandler timeout of the main process
from 1 minute to 5 minutes, for Python slowest buildbots.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37531](https://bugs.python.org/issue37531) -->
https://bugs.python.org/issue37531
<!-- /issue-number -->
