### PR TITLE
bpo-31722: Update codecs.IncrementalDecoder to use __subclasshook__

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4177,6 +4177,9 @@ class MiscIOTest(unittest.TestCase):
         proc = assert_python_failure('-X', 'dev', '-c', code)
         self.assertEqual(proc.rc, 10, proc)
 
+    def test_subclass_of_codecs_incremental_decoder(self):
+        self.assertTrue(self.io.IncrementalNewlineDecoder,
+                        codecs.IncrementalDecoder)
 
 class CMiscIOTest(MiscIOTest):
     io = io

--- a/Misc/NEWS.d/next/Library/2019-10-09-02-57-03.bpo-31722.r1mkRa.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-09-02-57-03.bpo-31722.r1mkRa.rst
@@ -1,0 +1,2 @@
+Fix :class:`io.IncrementalNewlineDecoder` to be subclass of :class:`codecs.IncrementalDecoder`.
+(Contributed by Dong-hee Na in :issue:`31722`.)

--- a/Misc/NEWS.d/next/Library/2019-10-09-02-57-03.bpo-31722.r1mkRa.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-09-02-57-03.bpo-31722.r1mkRa.rst
@@ -1,2 +1,2 @@
-Fix :class:`io.IncrementalNewlineDecoder` to be subclass of :class:`codecs.IncrementalDecoder`.
+Update :class:`codecs.IncrementalDecoder` to use :meth:`__subclasshook__` method.
 (Contributed by Dong-hee Na in :issue:`31722`.)


### PR DESCRIPTION
I 've updated to codecs.IncrementalDecoder to be able to get True from below code snippets.

```python
>>> issubclass(_pyio.IncrementalNewlineDecoder, codecs.IncrementalDecoder)
True
>>> issubclass(_io.IncrementalNewlineDecoder, codecs.IncrementalDecoder)
True
>>> issubclass(io.IncrementalNewlineDecoder, codecs.IncrementalDecoder)
True
>>> class A(_io.IncrementalNewlineDecoder):
...     pass
...
>>> class B(_pyio.IncrementalNewlineDecoder):
...     pass
...
>>> issubclass(A, codecs.IncrementalDecoder)
True
>>> issubclass(B, codecs.IncrementalDecoder)
True
```

<!-- issue-number: [bpo-31722](https://bugs.python.org/issue31722) -->
https://bugs.python.org/issue31722
<!-- /issue-number -->
