### PR TITLE
bpo-38109: Add missing constants to Lib/stat.py

### DIFF
--- a/Lib/stat.py
+++ b/Lib/stat.py
@@ -40,6 +40,10 @@ S_IFREG  = 0o100000  # regular file
 S_IFIFO  = 0o010000  # fifo (named pipe)
 S_IFLNK  = 0o120000  # symbolic link
 S_IFSOCK = 0o140000  # socket file
+# Fallbacks for uncommon platform-specific constants
+S_IFDOOR = 0
+S_IFPORT = 0
+S_IFWHT = 0
 
 # Functions to test for each file type
 
@@ -70,6 +74,18 @@ def S_ISLNK(mode):
 def S_ISSOCK(mode):
     """Return True if mode is from a socket."""
     return S_IFMT(mode) == S_IFSOCK
+
+def S_ISDOOR(mode):
+    """Return True if mode is from a door."""
+    return False
+
+def S_ISPORT(mode):
+    """Return True if mode is from an event port."""
+    return False
+
+def S_ISWHT(mode):
+    """Return True if mode is from a whiteout."""
+    return False
 
 # Names for permission bits
 

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -16,10 +16,10 @@ class TestFilemode:
                   'UF_IMMUTABLE', 'UF_NODUMP', 'UF_NOUNLINK', 'UF_OPAQUE'}
 
     formats = {'S_IFBLK', 'S_IFCHR', 'S_IFDIR', 'S_IFIFO', 'S_IFLNK',
-               'S_IFREG', 'S_IFSOCK'}
+               'S_IFREG', 'S_IFSOCK', 'S_IFDOOR', 'S_IFPORT', 'S_IFWHT'}
 
     format_funcs = {'S_ISBLK', 'S_ISCHR', 'S_ISDIR', 'S_ISFIFO', 'S_ISLNK',
-                    'S_ISREG', 'S_ISSOCK'}
+                    'S_ISREG', 'S_ISSOCK', 'S_ISDOOR', 'S_ISPORT', 'S_ISWHT'}
 
     stat_struct = {
         'ST_MODE': 0,
@@ -230,10 +230,6 @@ class TestFilemode:
 
 class TestFilemodeCStat(TestFilemode, unittest.TestCase):
     statmod = c_stat
-
-    formats = TestFilemode.formats | {'S_IFDOOR', 'S_IFPORT', 'S_IFWHT'}
-    format_funcs = TestFilemode.format_funcs | {'S_ISDOOR', 'S_ISPORT',
-                                                'S_ISWHT'}
 
 
 class TestFilemodePyStat(TestFilemode, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2019-10-10-00-25-28.bpo-38109.9w-IGF.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-10-00-25-28.bpo-38109.9w-IGF.rst
@@ -1,0 +1,3 @@
+Add missing :data:`stat.S_IFDOOR`, :data:`stat.S_IFPORT`, :data:`stat.S_IFWHT`,
+:func:`stat.S_ISDOOR`, :func:`stat.S_ISPORT`, and :func:`stat.S_ISWHT` values to
+the Python implementation of :mod:`stat`.


### PR DESCRIPTION
Lib/stat.py was missing the constants S_IFDOOR, S_IFPORT, S_IFWHT as well as the related S_IS... functions. This is a port of https://bitbucket.org/pypy/pypy/commits/f245f35c61eb.


<!-- issue-number: [bpo-38109](https://bugs.python.org/issue38109) -->
https://bugs.python.org/issue38109
<!-- /issue-number -->
