### PR TITLE
Typo fix - empy should be empty

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1751,7 +1751,7 @@ compiler_body(struct compiler *c, asdl_seq *stmts)
     /* Set current line number to the line number of first statement.
        This way line number for SETUP_ANNOTATIONS will always
        coincide with the line number of first "real" statement in module.
-       If body is empy, then lineno will be set later in assemble. */
+       If body is empty, then lineno will be set later in assemble. */
     if (c->u->u_scope_type == COMPILER_SCOPE_MODULE &&
         !c->u->u_lineno && asdl_seq_LEN(stmts)) {
         st = (stmt_ty)asdl_seq_GET(stmts, 0);


### PR DESCRIPTION
- empy should be empty in a block level comment
- Typo fix in file Python/compile.c