### PR TITLE
bpo-38415 @asynccontextmanager as decorators like @contextmanager

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -191,6 +191,14 @@ class _AsyncGeneratorContextManager(
 ):
     """Helper for @asynccontextmanager decorator."""
 
+    def __call__(self, func):
+        @wraps(func)
+        async def inner(*args, **kwds):
+            async with self.__class__(self.func, self.args, self.kwds):
+                return await func(*args, **kwds)
+
+        return inner
+
     async def __aenter__(self):
         # do not keep args and kwds alive unnecessarily
         # they are only needed for recreation, which is not possible anymore

--- a/Misc/NEWS.d/next/Library/2019-10-08-14-08-59.bpo-38415.N1bUw6.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-08-14-08-59.bpo-38415.N1bUw6.rst
@@ -1,0 +1,3 @@
+Added missing behavior to :func:`contextlib.asynccontextmanager` to match
+:func:`contextlib.contextmanager` so decorated functions can themselves be
+decorators.


### PR DESCRIPTION
I assumed at that an asynccontextmanager would some time be available in the stdlib when we first got async generators.  Before it had been released I cooked up an internal version at facebook whiched mapped all the features of @contextmanager but as an async variant.   This one feature seems to be missing from the stdlib.  

I would like to stop using my version and just use the stdlib version, can we get this feature parity with contextmanager? 

```
@asynccontextmanager
async def our_context(...):
     ...
     yield
     ...

@our_context(...)
async def some_function(...):
   # we are inside the context of our_context now
    ...

@our_context(...)
async def some_other_function(...):
   ...
```
<!-- issue-number: [bpo-38415](https://bugs.python.org/issue38415) -->
https://bugs.python.org/issue38415
<!-- /issue-number -->
