### PR TITLE
bpo-38418: Fixes audit event for os.system to be named 'os.system'

### DIFF
--- a/Misc/NEWS.d/next/Security/2019-10-08-19-29-55.bpo-38418.QL7s0-.rst
+++ b/Misc/NEWS.d/next/Security/2019-10-08-19-29-55.bpo-38418.QL7s0-.rst
@@ -1,0 +1,1 @@
+Fixes audit event for :func:`os.system` to be named ``os.system``.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4324,7 +4324,7 @@ os_system_impl(PyObject *module, const Py_UNICODE *command)
 {
     long result;
 
-    if (PySys_Audit("system", "(u)", command) < 0) {
+    if (PySys_Audit("os.system", "(u)", command) < 0) {
         return -1;
     }
 
@@ -4351,7 +4351,7 @@ os_system_impl(PyObject *module, PyObject *command)
     long result;
     const char *bytes = PyBytes_AsString(command);
 
-    if (PySys_Audit("system", "(O)", command) < 0) {
+    if (PySys_Audit("os.system", "(O)", command) < 0) {
         return -1;
     }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-38418](https://bugs.python.org/issue38418) -->
https://bugs.python.org/issue38418
<!-- /issue-number -->


Automerge-Triggered-By: @zooba