### PR TITLE
bpo-38421: Update email.utils documentation

### DIFF
--- a/Doc/library/email.utils.rst
+++ b/Doc/library/email.utils.rst
@@ -117,8 +117,8 @@ of the new API.
    a 10-tuple; the first 9 elements make up a tuple that can be passed directly to
    :func:`time.mktime`, and the tenth is the offset of the date's timezone from UTC
    (which is the official term for Greenwich Mean Time) [#]_.  If the input string
-   has no timezone, the last element of the tuple returned is ``None``.  Note that
-   indexes 6, 7, and 8 of the result tuple are not usable.
+   has no timezone, the last element of the tuple returned is ``0``, which represents 
+   UTC. Note that indexes 6, 7, and 8 of the result tuple are not usable.
 
 
 .. function:: parsedate_to_datetime(date)

--- a/Doc/library/email.utils.rst
+++ b/Doc/library/email.utils.rst
@@ -117,7 +117,7 @@ of the new API.
    a 10-tuple; the first 9 elements make up a tuple that can be passed directly to
    :func:`time.mktime`, and the tenth is the offset of the date's timezone from UTC
    (which is the official term for Greenwich Mean Time) [#]_.  If the input string
-   has no timezone, the last element of the tuple returned is ``0``, which represents 
+   has no timezone, the last element of the tuple returned is ``0``, which represents
    UTC. Note that indexes 6, 7, and 8 of the result tuple are not usable.
 
 


### PR DESCRIPTION
Updates documentation around email.utils.parsedate_tz().

Currently, the documentation specifies that when a string without a is timezone passed to parsedate_tz(), the last tuple is returned as ```None```.

This is no longer true since Python 3.3

<!-- issue-number: [bpo-38421](https://bugs.python.org/issue38421) -->
https://bugs.python.org/issue38421
<!-- /issue-number -->


Automerge-Triggered-By: @encukou