### PR TITLE
bpo-38422: Clarify docstrings of pathlib suffix(es)

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -795,7 +795,11 @@ class PurePath(object):
 
     @property
     def suffix(self):
-        """The final component's last suffix, if any."""
+        """
+        The final component's last suffix, if any.
+
+        This includes the leading period. For example: '.txt'
+        """
         name = self.name
         i = name.rfind('.')
         if 0 < i < len(name) - 1:
@@ -805,7 +809,11 @@ class PurePath(object):
 
     @property
     def suffixes(self):
-        """A list of the final component's suffixes, if any."""
+        """
+        A list of the final component's suffixes, if any.
+
+        These include the leading periods. For example: ['.tar', '.gz']
+        """
         name = self.name
         if name.endswith('.'):
             return []

--- a/Misc/NEWS.d/next/Library/2019-10-09-18-16-51.bpo-38422.aiM5bq.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-09-18-16-51.bpo-38422.aiM5bq.rst
@@ -1,0 +1,1 @@
+Clarify docstrings of pathlib suffix(es)


### PR DESCRIPTION
Whenever I use `path.suffix` I have to check again whether it includes the dot or not. I decided to add it to the docstring so I won't have to keep checking. 

<!-- issue-number: [bpo-38422](https://bugs.python.org/issue38422) -->
https://bugs.python.org/issue38422
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou