### PR TITLE
 bpo-38419: fix "check-c-globals" path

### DIFF
--- a/Tools/c-analyzer/README
+++ b/Tools/c-analyzer/README
@@ -34,7 +34,7 @@ should be added for runtime state.  Instead, they should be added to
 _PyRuntimeState or one of its sub-structs.  The check-c-globals script
 should be run to ensure that no new globals have been added:
 
-  python3 Tools/c-globals/check-c-globals.py
+  python3 Tools/c-analyzer/check-c-globals.py
 
 If it reports any globals then they should be resolved.  If the globals
 are runtime state then they should be folded into _PyRuntimeState.


### PR DESCRIPTION
fix "check-c-globals" path:
`Tools/c-analyzer/check-c-globals.py` instead of `Tools/c-globals/check-c-globals.py`

<!-- issue-number: [bpo-38419](https://bugs.python.org/issue38419) -->
https://bugs.python.org/issue38419
<!-- /issue-number -->
