### PR TITLE
bpo-38409: Grammatically correct help documentation of str.strip()

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2019-10-10-01-00-29.bpo-38409.UQgQk1.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-10-10-01-00-29.bpo-38409.UQgQk1.rst
@@ -1,1 +1,0 @@
-Grammatically corrected help(str.strip) documentation. Patch by Hansraj Das

--- a/Misc/NEWS.d/next/Documentation/2019-10-10-01-00-29.bpo-38409.UQgQk1.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-10-10-01-00-29.bpo-38409.UQgQk1.rst
@@ -1,0 +1,1 @@
+Grammatically corrected help(str.strip) documentation. Patch by Hansraj Das

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -582,7 +582,7 @@ PyDoc_STRVAR(unicode_strip__doc__,
 "strip($self, chars=None, /)\n"
 "--\n"
 "\n"
-"Return a copy of the string with leading and trailing whitespace remove.\n"
+"Return a copy of the string with leading and trailing whitespace removed.\n"
 "\n"
 "If chars is given and not None, remove characters in chars instead.");
 

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -1232,4 +1232,4 @@ unicode_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return unicode_sizeof_impl(self);
 }
-/*[clinic end generated code: output=5e15747f78f18329 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e4ed33400979c7e8 input=a9049054013a1b77]*/

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12551,7 +12551,7 @@ If chars is given and not None, remove characters in chars instead.
 
 static PyObject *
 unicode_strip_impl(PyObject *self, PyObject *chars)
-/*[clinic end generated code: output=ca19018454345d57 input=eefe24a1059c352b]*/
+/*[clinic end generated code: output=ca19018454345d57 input=385289c6f423b954]*/
 {
     return do_argstrip(self, BOTHSTRIP, chars);
 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12544,7 +12544,7 @@ str.strip as unicode_strip
     chars: object = None
     /
 
-Return a copy of the string with leading and trailing whitespace remove.
+Return a copy of the string with leading and trailing whitespace removed.
 
 If chars is given and not None, remove characters in chars instead.
 [clinic start generated code]*/


### PR DESCRIPTION
* `remove` should be `removed` as done for lstrip and rstrip help docs

strip help doc in python2 was correct but it was updated in python3:
python2.7
```
strip(...)
    S.strip([chars]) -> string or unicode

    Return a copy of the string S with leading and trailing
    whitespace removed.
    If chars is given and not None, remove characters in chars instead.
    If chars is unicode, S will be converted to unicode before stripping
```
python3.7
```
strip(self, chars=None, /)
    Return a copy of the string with leading and trailing whitespace remove.

    If chars is given and not None, remove characters in chars instead.
```
<!-- issue-number: [bpo-38409](https://bugs.python.org/issue38409) -->
https://bugs.python.org/issue38409
<!-- /issue-number -->