### PR TITLE
bpo-38425: Remove ‘res’ may be used uninitialized warning

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-10-14-04-26.bpo-38425.xB59iJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-10-14-04-26.bpo-38425.xB59iJ.rst
@@ -1,2 +1,0 @@
-Remove ‘res’ may be used uninitialized warning. (Contributed by Dong-hee Na
-in :issue:`38425`.)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-10-14-04-26.bpo-38425.xB59iJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-10-14-04-26.bpo-38425.xB59iJ.rst
@@ -1,0 +1,2 @@
+Remove ‘res’ may be used uninitialized warning. (Contributed by Dong-hee Na
+in :issue:`38425`.)

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1197,7 +1197,7 @@ PyObject* PyAST_mod2obj(mod_ty t)
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
-    mod_ty res;
+    mod_ty res = NULL;
     PyObject *req_type[3];
     const char * const req_name[] = {"Module", "Expression", "Interactive"};
     int isinstance;

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1197,7 +1197,6 @@ PyObject* PyAST_mod2obj(mod_ty t)
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
-    mod_ty res = NULL;
     PyObject *req_type[3];
     const char * const req_name[] = {"Module", "Expression", "Interactive"};
     int isinstance;
@@ -1223,6 +1222,8 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
                      req_name[mode], _PyType_Name(Py_TYPE(ast)));
         return NULL;
     }
+
+    mod_ty res = NULL;
     if (obj2ast_mod(ast, &res, arena) != 0)
         return NULL;
     else

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -10250,7 +10250,7 @@ PyObject* PyAST_mod2obj(mod_ty t)
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
-    mod_ty res;
+    mod_ty res = NULL;
     PyObject *req_type[3];
     const char * const req_name[] = {"Module", "Expression", "Interactive"};
     int isinstance;

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -10250,7 +10250,6 @@ PyObject* PyAST_mod2obj(mod_ty t)
 /* mode is 0 for "exec", 1 for "eval" and 2 for "single" input */
 mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
 {
-    mod_ty res = NULL;
     PyObject *req_type[3];
     const char * const req_name[] = {"Module", "Expression", "Interactive"};
     int isinstance;
@@ -10276,6 +10275,8 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
                      req_name[mode], _PyType_Name(Py_TYPE(ast)));
         return NULL;
     }
+
+    mod_ty res = NULL;
     if (obj2ast_mod(ast, &res, arena) != 0)
         return NULL;
     else


### PR DESCRIPTION
I' ve noticed this warning on this environment.

```
Python/Python-ast.c: In function ‘PyAST_obj2mod’:
Python/Python-ast.c:10253:12: warning: ‘res’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```
CentOS Linux release 7.6.1810
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-36)

<!-- issue-number: [bpo-38425](https://bugs.python.org/issue38425) -->
https://bugs.python.org/issue38425
<!-- /issue-number -->
