### PR TITLE
bpo-38392: Only declare visit_validate() if Py_DEBUG is defined

### DIFF
--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -162,7 +162,7 @@ PyAPI_FUNC(int) _PyMem_SetDefaultAllocator(
    - PYMEM_DEADBYTE dead (newly freed) memory
    - PYMEM_FORBIDDENBYTE: untouchable bytes at each end of a block
 
-   Byte patterns 0xCB, 0xBB and 0xFB have been replaced with 0xCD, 0xDD and
+   Byte patterns 0xCB, 0xDB and 0xFB have been replaced with 0xCD, 0xDD and
    0xFD to use the same values than Windows CRT debug malloc() and free().
    If modified, _PyMem_IsPtrFreed() should be updated as well. */
 #define PYMEM_CLEANBYTE      0xCD

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1921,6 +1921,8 @@ _PyGC_Dump(PyGC_Head *g)
     _PyObject_Dump(FROM_GC(g));
 }
 
+
+#ifdef Py_DEBUG
 static int
 visit_validate(PyObject *op, void *parent_raw)
 {
@@ -1931,6 +1933,7 @@ visit_validate(PyObject *op, void *parent_raw)
     }
     return 0;
 }
+#endif
 
 
 /* extension modules might be compiled with GC support so these


### PR DESCRIPTION
[bpo-38392](https://bugs.python.org/issue38392), [bpo-38426](https://bugs.python.org/issue38426): Fix a compiler warning in gcmodule.c.

Fix also a typo in PYMEM_DEADBYTE macro comment.

<!-- issue-number: [bpo-38392](https://bugs.python.org/issue38392) -->
https://bugs.python.org/issue38392
<!-- /issue-number -->
