### PR TITLE
bpo-38353: Fix typos in calculate_argv0_path_framework()

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -1126,7 +1126,7 @@ calculate_argv0_path_framework(PyCalculatePath *calculate, _PyPathConfig *pathco
     }
 
     reduce(parent);
-    wchar_t *lib_python = joinpath2(path, calculate->lib_python);
+    wchar_t *lib_python = joinpath2(parent, calculate->lib_python);
     PyMem_RawFree(parent);
 
     if (lib_python == NULL) {
@@ -1144,7 +1144,7 @@ calculate_argv0_path_framework(PyCalculatePath *calculate, _PyPathConfig *pathco
     if (!module) {
         /* We are in the build directory so use the name of the
            executable - we know that the absolute path is passed */
-        PyMem_RawFree(*calculate->argv0_path);
+        PyMem_RawFree(calculate->argv0_path);
         calculate->argv0_path = _PyMem_RawWcsdup(pathconfig->program_full_path);
         if (calculate->argv0_path == NULL) {
             status = _PyStatus_NO_MEMORY();
@@ -1156,8 +1156,8 @@ calculate_argv0_path_framework(PyCalculatePath *calculate, _PyPathConfig *pathco
     }
 
     /* Use the location of the library as argv0_path */
-    PyMem_RawFree(*calculate->argv0_path);
-    calculate->argv0_path = wbuf
+    PyMem_RawFree(calculate->argv0_path);
+    calculate->argv0_path = wbuf;
     return _PyStatus_OK();
 
 done:


### PR DESCRIPTION
[bpo-38353](https://bugs.python.org/issue38353), [bpo-38429](https://bugs.python.org/issue38429): Fix typos introduced by commit
c02b41b1fb115c87693530ea6a480b2e15460424 in
calculate_argv0_path_framework() of getpath.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38353](https://bugs.python.org/issue38353) -->
https://bugs.python.org/issue38353
<!-- /issue-number -->
