### PR TITLE
bpo-38282: Rewrite getsockaddrarg() helper function

### DIFF
--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -261,6 +261,9 @@ typedef union sock_addr {
 #ifdef AF_VSOCK
     struct sockaddr_vm vm;
 #endif
+#ifdef HAVE_LINUX_TIPC_H
+    struct sockaddr_tipc tipc;
+#endif
 } sock_addr_t;
 
 /* The object holding a socket.  It holds some extra information,


### PR DESCRIPTION
Rewrite getsockaddrarg() helper function of socketmodule.c (_socket
module) to prevent a false alarm when compiling codde using GCC with
_FORTIFY_SOURCE=2. Pass a pointer of the sock_addr_t union, rather
than passing a pointer to a sockaddr structure.

Add "struct sockaddr_tipc tipc;" to the sock_addr_t union.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38282](https://bugs.python.org/issue38282) -->
https://bugs.python.org/issue38282
<!-- /issue-number -->
