### PR TITLE
bpo-38431: fix dataclasses.InitVar.__repr__

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -210,7 +210,12 @@ class InitVar(metaclass=_InitVarMeta):
         self.type = type
 
     def __repr__(self):
-        return f'dataclasses.InitVar[{self.type.__name__}]'
+        try:
+            type_name = self.type.__name__
+        except AttributeError:
+            # typing objects, e.g. Union
+            type_name = repr(self.type)
+        return f'dataclasses.InitVar[{type_name}]'
 
 
 # Instances of Field are only ever created from within this module,

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2883,6 +2883,11 @@ class TestStringAnnotations(unittest.TestCase):
                 # x is not an InitVar, so there will be a member x.
                 self.assertEqual(C(10).x, 10)
 
+    def test_initvar_repr(self):
+        self.assertEqual(repr(InitVar[str]), 'dataclasses.InitVar[str]')
+        self.assertEqual(repr(InitVar[Optional[str]]),
+                         'dataclasses.InitVar[typing.Union[str, NoneType]]')
+
     def test_classvar_module_level_import(self):
         from test import dataclass_module_1
         from test import dataclass_module_1_str

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -320,6 +320,7 @@ Benjamin Collar
 Jeffery Collins
 Robert Collins
 Paul Colomiets
+Samuel Colvin
 Christophe Combelles
 Geremy Condra
 Denver Coneybeare

--- a/Misc/NEWS.d/next/Library/2019-10-10-16-53-00.bpo-38431.d5wzNp.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-10-16-53-00.bpo-38431.d5wzNp.rst
@@ -1,0 +1,2 @@
+Fix ``__repr__`` method for ``dataclasses.InitVar`` to work with typing
+objects.


### PR DESCRIPTION
see https://bugs.python.org/issue38431 and the original bug https://github.com/samuelcolvin/pydantic/issues/886

<!-- issue-number: [bpo-38431](https://bugs.python.org/issue38431) -->
https://bugs.python.org/issue38431
<!-- /issue-number -->
