### PR TITLE
bpo-38431: Support non-class types in InitVar.

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -206,7 +206,10 @@ class InitVar:
         self.type = type
 
     def __repr__(self):
-        return f'dataclasses.InitVar[{self.type.__name__}]'
+        if isinstance(self.type, type):
+            return f'dataclasses.InitVar[{self.type.__name__}]'
+        else:
+            return f'dataclasses.InitVar[{self.type!r}]'
 
     def __class_getitem__(cls, type):
         return InitVar(type)

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1103,6 +1103,12 @@ class TestCase(unittest.TestCase):
         # Make sure the repr is correct.
         self.assertEqual(repr(InitVar[int]), 'dataclasses.InitVar[int]')
 
+    def test_init_var_non_class(self):
+        self.assertEqual(InitVar[List[int]].type, List[int])
+
+        # Make sure the repr is correct.
+        self.assertEqual(repr(InitVar[List[int]]), 'dataclasses.InitVar[typing.List[int]]')
+
     def test_init_var_inheritance(self):
         # Note that this deliberately tests that a dataclass need not
         #  have a __post_init__ function if it has an InitVar field.

--- a/Misc/NEWS.d/next/Library/2019-10-10-19-02-49.bpo-38431.rtlDVB.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-10-19-02-49.bpo-38431.rtlDVB.rst
@@ -1,0 +1,2 @@
+:class:`dataclasses.InitVar` now supports non-class types, like
+``List[int]``.


### PR DESCRIPTION


<!-- issue-number: [bpo-38431](https://bugs.python.org/issue38431) -->
https://bugs.python.org/issue38431
<!-- /issue-number -->
