### PR TITLE
bpo-38431: fix dataclasses.InitVar.__repr__

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -206,10 +206,10 @@ class InitVar:
         self.type = type
 
     def __repr__(self):
-        try:
+        if isinstance(self.type, type):
             type_name = self.type.__name__
-        except AttributeError:
-            # typing objects, e.g. Union
+        else:
+            # typing objects, e.g. List[int]
             type_name = repr(self.type)
         return f'dataclasses.InitVar[{type_name}]'
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -206,7 +206,12 @@ class InitVar:
         self.type = type
 
     def __repr__(self):
-        return f'dataclasses.InitVar[{self.type.__name__}]'
+        try:
+            type_name = self.type.__name__
+        except AttributeError:
+            # typing objects, e.g. Union
+            type_name = repr(self.type)
+        return f'dataclasses.InitVar[{type_name}]'
 
     def __class_getitem__(cls, type):
         return InitVar(type)

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2883,6 +2883,11 @@ class TestStringAnnotations(unittest.TestCase):
                 # x is not an InitVar, so there will be a member x.
                 self.assertEqual(C(10).x, 10)
 
+    def test_initvar_repr(self):
+        self.assertEqual(repr(InitVar[str]), 'dataclasses.InitVar[str]')
+        self.assertEqual(repr(InitVar[Optional[str]]),
+                         'dataclasses.InitVar[typing.Union[str, NoneType]]')
+
     def test_classvar_module_level_import(self):
         from test import dataclass_module_1
         from test import dataclass_module_1_str

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1102,6 +1102,8 @@ class TestCase(unittest.TestCase):
 
         # Make sure the repr is correct.
         self.assertEqual(repr(InitVar[int]), 'dataclasses.InitVar[int]')
+        self.assertEqual(repr(InitVar[List[int]]),
+                         'dataclasses.InitVar[typing.List[int]]')
 
     def test_init_var_inheritance(self):
         # Note that this deliberately tests that a dataclass need not
@@ -2882,11 +2884,6 @@ class TestStringAnnotations(unittest.TestCase):
 
                 # x is not an InitVar, so there will be a member x.
                 self.assertEqual(C(10).x, 10)
-
-    def test_initvar_repr(self):
-        self.assertEqual(repr(InitVar[str]), 'dataclasses.InitVar[str]')
-        self.assertEqual(repr(InitVar[Optional[str]]),
-                         'dataclasses.InitVar[typing.Union[str, NoneType]]')
 
     def test_classvar_module_level_import(self):
         from test import dataclass_module_1

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -321,6 +321,7 @@ Benjamin Collar
 Jeffery Collins
 Robert Collins
 Paul Colomiets
+Samuel Colvin
 Christophe Combelles
 Geremy Condra
 Denver Coneybeare

--- a/Misc/NEWS.d/next/Library/2019-10-10-16-53-00.bpo-38431.d5wzNp.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-10-16-53-00.bpo-38431.d5wzNp.rst
@@ -1,1 +1,2 @@
-Fix ``__repr__`` method for :class:`dataclasses.InitVar` to support typing objects.
+Fix ``__repr__`` method for :class:`dataclasses.InitVar` to support typing objects,
+patched by: Samuel Colvin.

--- a/Misc/NEWS.d/next/Library/2019-10-10-16-53-00.bpo-38431.d5wzNp.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-10-16-53-00.bpo-38431.d5wzNp.rst
@@ -1,0 +1,1 @@
+Fix ``__repr__`` method for :class:`dataclasses.InitVar` to support typing objects.

--- a/Misc/NEWS.d/next/Library/2019-10-10-16-53-00.bpo-38431.d5wzNp.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-10-16-53-00.bpo-38431.d5wzNp.rst
@@ -1,2 +1,1 @@
-Fix ``__repr__`` method for :class:`dataclasses.InitVar` to support typing objects,
-patched by: Samuel Colvin.
+Fix ``__repr__`` method for :class:`dataclasses.InitVar` to support typing objects, patch by Samuel Colvin.


### PR DESCRIPTION
new version of #16700 based off master.

See original bug https://github.com/samuelcolvin/pydantic/issues/886

<!-- issue-number: [bpo-38431](https://bugs.python.org/issue38431) -->
https://bugs.python.org/issue38431
<!-- /issue-number -->
