### PR TITLE
bpo-38436: Improved performance for list addition.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-10-19-20-24.bpo-38436.LfVbc-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-10-19-20-24.bpo-38436.LfVbc-.rst
@@ -1,0 +1,1 @@
+Improved the performance of repeated/literal :class:`list` addition.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1551,6 +1551,11 @@ main_loop:
                 sum = unicode_concatenate(tstate, left, right, f, next_instr);
                 /* unicode_concatenate consumed the ref to left */
             }
+            else if (PyList_CheckExact(left) && PyList_CheckExact(right)
+                     && Py_REFCNT(left) == 1) {
+                sum = PySequence_InPlaceConcat(left, right);
+                Py_DECREF(left);
+            }
             else {
                 sum = PyNumber_Add(left, right);
                 Py_DECREF(left);


### PR DESCRIPTION
This PR adds a fast path for `BINARY_ADD` instructions involving two lists, where the left list has a refcount of exactly 1.

In this case, we instead do a `PySequence_InPlaceConcat` operation. This has the affect of avoiding quadratic complexity for list summations, by keeping only one intermediate result and extending it in-place.

For (potentially large) lists:

```py
a + b + c + d ...
```

Currently executed as:

```py
tmp = a + b
tmp = tmp + c
tmp = tmp + d
...
```

With this change:

```py
tmp = a + b
tmp += c
tmp += d
...
```

~Here are the `pyperformance` results (optimizations enabled):~

**EDIT: there are better measurements in the BPO discussion.**

This is related to my earlier work in [bpo-36229](https://bugs.python.org/issue36229), however this is a much less invasive change that's limited to `ceval.c`, where our knowledge of context is much better. 

<!-- issue-number: [bpo-38436](https://bugs.python.org/issue38436) -->
https://bugs.python.org/issue38436
<!-- /issue-number -->
