### PR TITLE
[3.7] Update badges in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,21 +1,17 @@
 This is Python version 3.7.5 release candidate+
 ===============================================
 
-.. image:: https://travis-ci.org/python/cpython.svg?branch=master
+.. image:: https://travis-ci.org/python/cpython.svg?branch=3.7
    :alt: CPython build status on Travis CI
-   :target: https://travis-ci.org/python/cpython
-
-.. image:: https://ci.appveyor.com/api/projects/status/4mew1a93xdkbf5ua/branch/master?svg=true
-   :alt: CPython build status on Appveyor
-   :target: https://ci.appveyor.com/project/python/cpython/branch/master
+   :target: https://travis-ci.org/python/cpython/branches
 
 .. image:: https://dev.azure.com/python/cpython/_apis/build/status/Azure%20Pipelines%20CI?branchName=3.7
    :alt: CPython build status on Azure Pipelines
    :target: https://dev.azure.com/python/cpython/_build/latest?definitionId=4&branchName=3.7
 
-.. image:: https://codecov.io/gh/python/cpython/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/python/cpython/branch/3.7/graph/badge.svg
    :alt: CPython code coverage on Codecov
-   :target: https://codecov.io/gh/python/cpython
+   :target: https://codecov.io/gh/python/cpython/branch/3.7
 
 Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Python Software Foundation.  All


### PR DESCRIPTION
We no longer use AppVeyor in 3.x, and others were still pointed at master.