### PR TITLE
Remove strict-aliasing rules errors on gcc 4.8.5

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1133,7 +1133,7 @@ insert_to_emptydict(PyDictObject *mp, PyObject *key, Py_hash_t hash,
     MAINTAIN_TRACKING(mp, key, value);
 
     size_t hashpos = (size_t)hash & (PyDict_MINSIZE-1);
-    PyDictKeyEntry *ep = &DK_ENTRIES(mp->ma_keys)[0];
+    PyDictKeyEntry *ep = DK_ENTRIES(mp->ma_keys);
     dictkeys_set_index(mp->ma_keys, hashpos, 0);
     ep->me_key = key;
     ep->me_hash = hash;


### PR DESCRIPTION
Remove below error on 
CentOS Linux release 7.6.1810
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-36)

````bash
Objects/dictobject.c:1136:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
     PyDictKeyEntry *ep = &DK_ENTRIES(mp->ma_keys)[0];
````