### PR TITLE
[3.7] bpo-38347: find pathfix for Python scripts whose name contain a '-' (GH-16536)

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2019-10-02-09-48-42.bpo-38347.2Tq5D1.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2019-10-02-09-48-42.bpo-38347.2Tq5D1.rst
@@ -1,0 +1,1 @@
+pathfix.py: Assume all files that end on '.py' are Python scripts when working recursively.

--- a/Tools/scripts/pathfix.py
+++ b/Tools/scripts/pathfix.py
@@ -70,9 +70,9 @@ def main():
             if fix(arg): bad = 1
     sys.exit(bad)
 
-ispythonprog = re.compile(r'^[a-zA-Z0-9_]+\.py$')
+
 def ispython(name):
-    return bool(ispythonprog.match(name))
+    return name.endswith('.py')
 
 def recursedown(dirname):
     dbg('recursedown(%r)\n' % (dirname,))


### PR DESCRIPTION
 pathfix.py: Assume all files that end on '.py' are Python scripts when working recursively.

(cherry picked from commit 2b7dc40b2af6578181808ba73c1533fc114e55df)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38347](https://bugs.python.org/issue38347) -->
https://bugs.python.org/issue38347
<!-- /issue-number -->
