### PR TITLE
[3.7] bpo-38449: Revert "bpo-22347: Update mimetypes.guess_type to allow oper parsing of URLs (GH-15685)" (GH-16724)

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -114,8 +114,7 @@ class MimeTypes:
         but non-standard types.
         """
         url = os.fspath(url)
-        p = urllib.parse.urlparse(url)
-        scheme, url = p.scheme, p.path
+        scheme, url = urllib.parse.splittype(url)
         if scheme == 'data':
             # syntax of data URLs:
             # dataurl   := "data:" [ mediatype ] [ ";base64" ] "," data

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -50,14 +50,6 @@ class MimeTypesTestCase(unittest.TestCase):
         eq(self.db.guess_type('foo.xul', strict=False), ('text/xul', None))
         eq(self.db.guess_extension('image/jpg', strict=False), '.jpg')
 
-    def test_url(self):
-        result = self.db.guess_type('http://host.html')
-        msg = 'URL only has a host name, not a file'
-        self.assertSequenceEqual(result, (None, None), msg)
-        result = self.db.guess_type('http://example.com/host.html')
-        msg = 'Should be text/html'
-        self.assertSequenceEqual(result, ('text/html', None), msg)
-
     def test_guess_all_types(self):
         eq = self.assertEqual
         unless = self.assertTrue

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -746,7 +746,7 @@ class HandlerTests(unittest.TestCase):
              ["foo", "bar"], "", None),
             ("ftp://localhost/baz.gif;type=a",
              "localhost", ftplib.FTP_PORT, "", "", "A",
-             [], "baz.gif", "image/gif"),
+             [], "baz.gif", None),  # XXX really this should guess image/gif
             ]:
             req = Request(url)
             req.timeout = None

--- a/Misc/NEWS.d/next/Library/2019-10-12-08-57-34.bpo-38449.9TWMlz.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-12-08-57-34.bpo-38449.9TWMlz.rst
@@ -1,0 +1,2 @@
+Revert GH-15522, which introduces a regression in
+:meth:`mimetypes.guess_type` due to improper handling of filenames as urls.


### PR DESCRIPTION
Reverts GH-15687 which caused the issue.

<!-- issue-number: [bpo-22347](https://bugs.python.org/issue22347) -->
https://bugs.python.org/issue22347
<!-- /issue-number -->
https://bugs.python.org/issue38449

Automerge-Triggered-By: @maxking