### PR TITLE
[3.8] bpo-38449: Revert "bpo-22347: Update mimetypes.guess_type to allow oper parsing of URLs (GH-15685)" (GH-16724)

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -114,8 +114,7 @@ class MimeTypes:
         but non-standard types.
         """
         url = os.fspath(url)
-        p = urllib.parse.urlparse(url)
-        scheme, url = p.scheme, p.path
+        scheme, url = urllib.parse._splittype(url)
         if scheme == 'data':
             # syntax of data URLs:
             # dataurl   := "data:" [ mediatype ] [ ";base64" ] "," data

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -51,14 +51,6 @@ class MimeTypesTestCase(unittest.TestCase):
         eq(self.db.guess_type('foo.xul', strict=False), ('text/xul', None))
         eq(self.db.guess_extension('image/jpg', strict=False), '.jpg')
 
-    def test_url(self):
-        result = self.db.guess_type('http://host.html')
-        msg = 'URL only has a host name, not a file'
-        self.assertSequenceEqual(result, (None, None), msg)
-        result = self.db.guess_type('http://example.com/host.html')
-        msg = 'Should be text/html'
-        self.assertSequenceEqual(result, ('text/html', None), msg)
-
     def test_guess_all_types(self):
         eq = self.assertEqual
         unless = self.assertTrue

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -744,7 +744,7 @@ class HandlerTests(unittest.TestCase):
              ["foo", "bar"], "", None),
             ("ftp://localhost/baz.gif;type=a",
              "localhost", ftplib.FTP_PORT, "", "", "A",
-             [], "baz.gif", "image/gif"),
+             [], "baz.gif", None),  # XXX really this should guess image/gif
             ]:
             req = Request(url)
             req.timeout = None

--- a/Misc/NEWS.d/next/Library/2019-10-11-18-49-00.bpo-38449.9TWMlz.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-11-18-49-00.bpo-38449.9TWMlz.rst
@@ -1,0 +1,2 @@
+Revert GH-15522, which introduces a regression in
+:meth:`mimetypes.guess_type` due to improper handling of filenames as urls.


### PR DESCRIPTION
This reverts GH-15685 in 3.8 branch.

The reason for revert is a regression caused by the change in 3.8.0rc1, see [bpo-38449](https://bugs.python.org/issue38449) for more details.

https://bugs.python.org/issue38449
(cherry picked from commit 19a3d873005e5730eeabdc394c961e93f2ec02f0)

Co-authored-by: Abhilash Raj <maxking@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38449](https://bugs.python.org/issue38449) -->
https://bugs.python.org/issue38449
<!-- /issue-number -->
