### PR TITLE
bpo-37731: Reorder includes in xmltok.c to avoid redefinition of _POSIX_C_SOURCE

### DIFF
--- a/Modules/expat/xmltok.c
+++ b/Modules/expat/xmltok.c
@@ -30,6 +30,14 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#ifdef _WIN32
+#  include "winconfig.h"
+#else
+#  ifdef HAVE_EXPAT_CONFIG_H
+#    include <expat_config.h>
+#  endif
+#endif /* ndef _WIN32 */
+
 #include <stddef.h>
 #include <string.h> /* memcpy */
 
@@ -41,14 +49,6 @@
 #else
 #  include <stdbool.h>
 #endif
-
-#ifdef _WIN32
-#  include "winconfig.h"
-#else
-#  ifdef HAVE_EXPAT_CONFIG_H
-#    include <expat_config.h>
-#  endif
-#endif /* ndef _WIN32 */
 
 #include "expat_external.h"
 #include "internal.h"


### PR DESCRIPTION
<!-- issue-number: [bpo-37731](https://bugs.python.org/issue37731) -->
https://bugs.python.org/issue37731
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal