### PR TITLE
bpo-38282: Correctly manage the Bluetooth L2CAP socket structure in FreeBSD

### DIFF
--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -235,7 +235,12 @@ typedef union sock_addr {
     struct sockaddr_in6 in6;
     struct sockaddr_storage storage;
 #endif
-#ifdef HAVE_BLUETOOTH_BLUETOOTH_H
+#if defined(HAVE_BLUETOOTH_H) && defined(__FreeBSD__)
+    struct sockaddr_l2cap bt_l2;
+    struct sockaddr_rfcomm bt_rc;
+    struct sockaddr_sco bt_sco;
+    struct sockaddr_hci bt_hci;
+#elif defined(HAVE_BLUETOOTH_BLUETOOTH_H)
     struct sockaddr_l2 bt_l2;
     struct sockaddr_rc bt_rc;
     struct sockaddr_sco bt_sco;


### PR DESCRIPTION
Example description:

https://man.cx/ng_btsocket(4)


<!-- issue-number: [bpo-38282](https://bugs.python.org/issue38282) -->
https://bugs.python.org/issue38282
<!-- /issue-number -->
