### PR TITLE
bpo-28556: Remove another mention of metaclass of Generic in typing docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -231,8 +231,8 @@ A user-defined class can be defined as a generic class.
 single type parameter ``T`` . This also makes ``T`` valid as a type within the
 class body.
 
-The :class:`Generic` base class uses a metaclass that defines
-:meth:`__getitem__` so that ``LoggedVar[t]`` is valid as a type::
+The :class:`Generic` base class defines :meth:`__class_getitem__` so that
+``LoggedVar[t]`` is valid as a type::
 
    from typing import Iterable
 


### PR DESCRIPTION
Metaclass was removed in Python 3.7 (there is already a `versionchanged` item about this).

<!-- issue-number: [bpo-28556](https://bugs.python.org/issue28556) -->
https://bugs.python.org/issue28556
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum