### PR TITLE
bpo-38465: Convert the type of ob_exports in PyByteArrayObject to Py_ssize_t

### DIFF
--- a/Include/bytearrayobject.h
+++ b/Include/bytearrayobject.h
@@ -22,11 +22,10 @@ extern "C" {
 #ifndef Py_LIMITED_API
 typedef struct {
     PyObject_VAR_HEAD
-    Py_ssize_t ob_alloc; /* How many bytes allocated in ob_bytes */
-    char *ob_bytes;      /* Physical backing buffer */
-    char *ob_start;      /* Logical start inside ob_bytes */
-    /* XXX(nnorwitz): should ob_exports be Py_ssize_t? */
-    int ob_exports;      /* How many buffer exports */
+    Py_ssize_t ob_alloc;   /* How many bytes allocated in ob_bytes */
+    char *ob_bytes;        /* Physical backing buffer */
+    char *ob_start;        /* Logical start inside ob_bytes */
+    Py_ssize_t ob_exports; /* How many buffer exports */
 } PyByteArrayObject;
 #endif
 

--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-19-12-44-13.bpo-38465.V1L8c4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-19-12-44-13.bpo-38465.V1L8c4.rst
@@ -1,0 +1,1 @@
+:class:`bytearray`, :class:`~array.array` and :class:`~mmap.mmap` objects allow now to export more than 2**31 buffers at a time.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -43,7 +43,7 @@ typedef struct arrayobject {
     Py_ssize_t allocated;
     const struct arraydescr *ob_descr;
     PyObject *weakreflist; /* List of weak references */
-    int ob_exports;  /* Number of exported buffers */
+    Py_ssize_t ob_exports;  /* Number of exported buffers */
 } arrayobject;
 
 static PyTypeObject Arraytype;

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -97,7 +97,7 @@ typedef struct {
 #else
     off_t       offset;
 #endif
-    int     exports;
+    Py_ssize_t  exports;
 
 #ifdef MS_WINDOWS
     HANDLE      map_handle;


### PR DESCRIPTION


<!-- issue-number: [bpo-38465](https://bugs.python.org/issue38465) -->
https://bugs.python.org/issue38465
<!-- /issue-number -->
