### PR TITLE
bpo-38468 : Refactor python-config

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
+++ b/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
@@ -1,2 +1,2 @@
-Use `getvar` for all still existing `sysconfig.get_config_var()` calls .
+Use `getvar` for all still existing `sysconfig.get_config_var()` calls.
 Patch by Joannah Nanjekye

--- a/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
+++ b/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
@@ -1,0 +1,2 @@
+Use `getvar` for all still existing `sysconfig.get_config_var()` calls .
+Patch by Joannah Nanjekye

--- a/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
+++ b/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
@@ -1,3 +1,4 @@
 Use `getvar` for all still existing `sysconfig.get_config_var()` calls.
 The affected file is `Python3.9-config.in`.
-Patch by Joannah Nanjekye
+Misc/python-config.in now uses `getvar` for all still existing `sysconfig.get_config_var()` calls.
+Patch by Joannah Nanjekye 

--- a/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
+++ b/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
@@ -1,2 +1,3 @@
 Use `getvar` for all still existing `sysconfig.get_config_var()` calls.
+The affected file is `Python3.9-config.in`.
 Patch by Joannah Nanjekye

--- a/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
+++ b/Misc/NEWS.d/next/Build/2019-10-13-16-18-24.bpo-38468.buCO84.rst
@@ -1,4 +1,2 @@
-Use `getvar` for all still existing `sysconfig.get_config_var()` calls.
-The affected file is `Python3.9-config.in`.
-Misc/python-config.in now uses `getvar` for all still existing `sysconfig.get_config_var()` calls.
-Patch by Joannah Nanjekye 
+Misc/python-config.in now uses `getvar()` for all still existing `sysconfig.get_config_var()` calls.
+Patch by Joannah Nanjekye.

--- a/Misc/python-config.in
+++ b/Misc/python-config.in
@@ -35,10 +35,10 @@ if '--help' in opt_flags:
 
 for opt in opt_flags:
     if opt == '--prefix':
-        print(sysconfig.get_config_var('prefix'))
+        print(getvar('prefix'))
 
     elif opt == '--exec-prefix':
-        print(sysconfig.get_config_var('exec_prefix'))
+        print(getvar('exec_prefix'))
 
     elif opt in ('--includes', '--cflags'):
         flags = ['-I' + sysconfig.get_path('include'),
@@ -65,10 +65,10 @@ for opt in opt_flags:
         print(' '.join(libs))
 
     elif opt == '--extension-suffix':
-        print(sysconfig.get_config_var('EXT_SUFFIX'))
+        print(getvar('EXT_SUFFIX'))
 
     elif opt == '--abiflags':
         print(sys.abiflags)
 
     elif opt == '--configdir':
-        print(sysconfig.get_config_var('LIBPL'))
+        print(getvar('LIBPL'))

--- a/Misc/python-config.in
+++ b/Misc/python-config.in
@@ -25,8 +25,8 @@ except getopt.error:
 if not opts:
     exit_with_usage()
 
-pyver = sysconfig.get_config_var('VERSION')
 getvar = sysconfig.get_config_var
+pyver = getvar('VERSION')
 
 opt_flags = [flag for (flag, val) in opts]
 


### PR DESCRIPTION
Use `getvar ` for all still existing `sysconfig.get_config_var()` calls .

<!-- issue-number: [bpo-38468](https://bugs.python.org/issue38468) -->
https://bugs.python.org/issue38468
<!-- /issue-number -->
