### PR TITLE
Fix minor typos in What's New in Python 3.8.

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -759,7 +759,7 @@ numbers::
     >>> math.prod(likelihoods, start=prior)
     0.126
 
-(Contributed by Pablo Galindo in :issue:`35606`)
+(Contributed by Pablo Galindo in :issue:`35606`.)
 
 Added new function :func:`math.isqrt` for computing integer square roots.
 (Contributed by Mark Dickinson in :issue:`36887`.)
@@ -859,12 +859,12 @@ pickle
 Reduction methods can now include a 6th item in the tuple they return. This
 item should specify a custom state-setting method that's called instead of the
 regular ``__setstate__`` method.
-(Contributed by Pierre Glaser and Olivier Grisel in :issue:`35900`)
+(Contributed by Pierre Glaser and Olivier Grisel in :issue:`35900`.)
 
 :mod:`pickle` extensions subclassing the C-optimized :class:`~pickle.Pickler`
 can now override the pickling logic of functions and classes by defining the
 special :meth:`~pickle.Pickler.reducer_override` method.
-(Contributed by Pierre Glaser and Olivier Grisel in :issue:`35900`)
+(Contributed by Pierre Glaser and Olivier Grisel in :issue:`35900`.)
 
 
 plistlib
@@ -1217,7 +1217,7 @@ Optimizations
 
 * Removed one ``Py_ssize_t`` member from ``PyGC_Head``.  All GC tracked
   objects (e.g. tuple, list, dict) size is reduced 4 or 8 bytes.
-  (Contributed by Inada Naoki in :issue:`33597`)
+  (Contributed by Inada Naoki in :issue:`33597`.)
 
 * :class:`uuid.UUID` now uses ``__slots__`` to reduce its memory footprint.
 


### PR DESCRIPTION
Added periods at the end of the sentences.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
