### PR TITLE
Update configparser.py

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -888,9 +888,11 @@ class RawConfigParser(MutableMapping):
             return (option in self._sections[section]
                     or option in self._defaults)
 
-    def set(self, section, option, value=None):
+    def set(self, section, option, value=_UNSET):
         """Set an option."""
-        if value:
+        if value == _UNSET:
+            value = None
+        else:
             value = self._interpolation.before_set(self, section, option,
                                                    value)
         if not section or section == self.default_section:


### PR DESCRIPTION
# RawConfigParser.set does not pass non-truthy values through to Interpolation.before_set

Apologies for missing bpo-NNNN, fix seems trivial, and first pull request, don't know my way around to create a bpo number yet.

RawConfigParser.set() fix to allow non-truthy values (False, None, 0 etc) to pass through to Interpolation.before_set(). Currently default value being None leading to unexpected results. Using the established _UNSET constant to determine a value being passed to set.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
