### PR TITLE
bpo-38470: compileall tests: Use a shorter path on Windows

### DIFF
--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -51,7 +51,14 @@ class CompileallTestsBase:
 
         # Create a long path, 10 directories at a time.
         # It will be 100 directories deep, or shorter if the OS limits it.
-        for i in range(10):
+        MAX_ITERATIONS = 10
+
+        # Workaround: use a shorter path on Windows.
+        # see: https://bugs.python.org/issue38470
+        if sys.platform == "win32":
+            MAX_ITERATIONS = 2
+
+        for i in range(MAX_ITERATIONS):
             longer_path = os.path.join(
                 long_path, *(f"dir_{i}_{j}" for j in range(10))
             )
@@ -91,7 +98,7 @@ class CompileallTestsBase:
         # directories is 160 characters long, leaving something for the
         # root (self.directory) as well.
         # Tests assume long_path contains at least 10 directories.
-        if i < 2:
+        if i < 1:
             raise ValueError(f'"Long path" is too short: {long_path}')
 
         self.source_path_long = long_source


### PR DESCRIPTION
I'd like to test compileall with a really deeply nested path everywhere, but I cannot reproduce the issue occuring on Windows.
This limits the maximum path depth to 20 on Windows. That's enough to test the compileall functionality.

cc @frenzymadness 

<!-- issue-number: [bpo-38470](https://bugs.python.org/issue38470) -->
https://bugs.python.org/issue38470
<!-- /issue-number -->
