### PR TITLE
bpo-38471: Fix _ProactorDatagramTransport close() behaviour

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -47,14 +47,6 @@
 This article explains the new features in Python 3.8, compared to 3.7.
 For full details, see the :ref:`changelog <changelog>`.
 
-Prerelease users should be aware that this document is currently in
-draft form. It will be updated as Python 3.8 moves towards release, so
-it's worth checking back even after reading earlier versions. Some
-notable items not yet covered are:
-
-* :pep:`578` - Runtime audit hooks for potentially sensitive operations
-* ``python -m asyncio`` runs a natively async REPL
-
 .. testsetup::
 
    from datetime import date
@@ -285,6 +277,18 @@ calculations can be shown::
   theta=30  cos(radians(theta))=0.866
 
 (Contributed by Eric V. Smith and Larry Hastings in :issue:`36817`.)
+
+
+PEP 578: Python Runtime Audit Hooks
+-----------------------------------
+
+The PEP adds an Audit Hook and Verified Open Hook. Both are available from
+Python and native code, allowing applications and frameworks written in pure
+Python code to take advantage of extra notifications, while also allowing
+embedders or system administrators to deploy builds of Python where auditing is
+always enabled.
+
+See :pep:`578` for full details.
 
 
 PEP 587: Python Initialization Configuration
@@ -583,6 +587,23 @@ The :func:`ast.parse` function has some new flags:
 
 asyncio
 -------
+
+Running ``python -m asyncio`` launches a natively async REPL.  This allows rapid
+experimentation with code that has a top-level :keyword:`await`.  There is no
+longer a need to directly call ``asyncio.run()`` which would spawn a new event
+loop on every invocation:
+
+.. code-block:: none
+
+    $ python -m asyncio
+    asyncio REPL 3.8.0
+    Use "await" directly instead of "asyncio.run()".
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> import asyncio
+    >>> await asyncio.sleep(10, result='hello')
+    hello
+
+(Contributed by Yury Selivanov in :issue:`37028`.)
 
 On Windows, the default event loop is now :class:`~asyncio.ProactorEventLoop`.
 (Contributed by Victor Stinner in :issue:`34687`.)

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -503,9 +503,6 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport):
 
     def _loop_writing(self, fut=None):
         try:
-            if self._conn_lost:
-                return
-
             assert fut is self._write_fut
             self._write_fut = None
             if fut:

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1068,7 +1068,7 @@ def change_cwd(path, quiet=False):
     """
     saved_dir = os.getcwd()
     try:
-        os.chdir(path)
+        os.chdir(os.path.realpath(path))
     except OSError as exc:
         if not quiet:
             raise

--- a/Misc/NEWS.d/next/Windows/2019-10-14-18-06-58.bpo-38471.tfehj1.rst
+++ b/Misc/NEWS.d/next/Windows/2019-10-14-18-06-58.bpo-38471.tfehj1.rst
@@ -1,0 +1,1 @@
+Fix _ProactorDatagramTransport close() behaviour

--- a/Misc/NEWS.d/next/Windows/2019-10-14-18-06-58.bpo-38471.tfehj1.rst
+++ b/Misc/NEWS.d/next/Windows/2019-10-14-18-06-58.bpo-38471.tfehj1.rst
@@ -1,1 +1,1 @@
-Fix _ProactorDatagramTransport close() behaviour
+Fix _ProactorDatagramTransport close() when buffer is not empty behaviour


### PR DESCRIPTION
Fixes an issue where if the _ProactorDatagramTransport close method is called while there is data in the write buffer, the data is not sent and connection_lost is not called. Behaviour now matches _SelectorDatagramTransport.

<!-- issue-number: [bpo-38471](https://bugs.python.org/issue38471) -->
https://bugs.python.org/issue38471
<!-- /issue-number -->
