### PR TITLE
bpo-36338: urllib.urlparse rejects invalid IPv6 addresses

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-10-15-19-06-10.bpo-33342.OI3ROU.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-15-19-06-10.bpo-33342.OI3ROU.rst
@@ -1,0 +1,2 @@
+Fix :func:`urllib.parse.urlparse` for IPv6 address when user or password
+contains "[" or "]" character.

--- a/Misc/NEWS.d/next/Security/2019-10-14-15-42-18.bpo-36338.Vxqtz6.rst
+++ b/Misc/NEWS.d/next/Security/2019-10-14-15-42-18.bpo-36338.Vxqtz6.rst
@@ -1,0 +1,2 @@
+The :mod:`urllib.urlparse` module now rejects invalid IPv6 addresses and
+invalid port numbers when parsing an URL.


### PR DESCRIPTION
The urllib.urlparse module now rejects invalid IPv6 addresses and
invalid port numbers when parsing an URL.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36338](https://bugs.python.org/issue36338) -->
https://bugs.python.org/issue36338
<!-- /issue-number -->
