### PR TITLE
bpo-38473: Handle autospecced functions and methods used with attach_mock

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -824,10 +824,7 @@ class NonCallableMock(Base):
                 # not used.
                 child = _extract_mock(child)
                 children = child._mock_children
-                try:
-                    sig = child._spec_signature
-                except AttributeError:
-                    sig = None
+                sig = child._spec_signature
 
         return sig
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -819,9 +819,7 @@ class NonCallableMock(Base):
             else:
                 # If an autospecced object is attached using attach_mock the
                 # child would be a function with mock object as attribute from
-                # which signature has to be derived. If there is no signature
-                # attribute then fallback to None to ensure old signature is
-                # not used.
+                # which signature has to be derived.
                 child = _extract_mock(child)
                 children = child._mock_children
                 sig = child._spec_signature

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -817,13 +817,13 @@ class NonCallableMock(Base):
             if child is None or isinstance(child, _SpecState):
                 break
             else:
-                children = child._mock_children
                 # If an autospecced object is attached using attach_mock the
                 # child would be a function with mock object as attribute from
                 # which signature has to be derived. If there is no signature
                 # attribute then fallback to None to ensure old signature is
                 # not used.
                 child = _extract_mock(child)
+                children = child._mock_children
                 try:
                     sig = child._spec_signature
                 except AttributeError:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -818,7 +818,16 @@ class NonCallableMock(Base):
                 break
             else:
                 children = child._mock_children
-                sig = child._spec_signature
+                # If an autospecced object is attached using attach_mock the
+                # child would be a function with mock object as attribute from
+                # which signature has to be derived. If there is no signature
+                # attribute then fallback to None to ensure old signature is
+                # not used.
+                child = _extract_mock(child)
+                try:
+                    sig = child._spec_signature
+                except AttributeError:
+                    sig = None
 
         return sig
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1922,6 +1922,15 @@ class MockTest(unittest.TestCase):
             self.assertEqual(mock_func.mock._extract_mock_name(), 'mock.child')
 
 
+    def test_attach_mock_patch_autospec_method(self):
+        with mock.patch(f'{__name__}.Something.meth', autospec=True) as mocked:
+            manager = Mock()
+            manager.attach_mock(mocked, 'attach_meth')
+            obj = Something()
+            obj.meth(1, 2, 3, d=4)
+            manager.assert_has_calls([call.attach_meth(mock.ANY, 1, 2, 3, d=4)])
+
+
     def test_attribute_deletion(self):
         for mock in (Mock(), MagicMock(), NonCallableMagicMock(),
                      NonCallableMock()):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1922,13 +1922,23 @@ class MockTest(unittest.TestCase):
             self.assertEqual(mock_func.mock._extract_mock_name(), 'mock.child')
 
 
-    def test_attach_mock_patch_autospec_method(self):
+    def test_attach_mock_patch_autospec(self):
         with mock.patch(f'{__name__}.Something.meth', autospec=True) as mocked:
             manager = Mock()
             manager.attach_mock(mocked, 'attach_meth')
             obj = Something()
             obj.meth(1, 2, 3, d=4)
             manager.assert_has_calls([call.attach_meth(mock.ANY, 1, 2, 3, d=4)])
+            obj.meth.assert_has_calls([call(mock.ANY, 1, 2, 3, d=4)])
+            mocked.assert_has_calls([call(mock.ANY, 1, 2, 3, d=4)])
+
+        with mock.patch(f'{__name__}.something', autospec=True) as mocked:
+            manager = Mock()
+            manager.attach_mock(mocked, 'attach_func')
+            something(1)
+            manager.assert_has_calls([call.attach_func(1)])
+            something.assert_has_calls([call(1)])
+            mocked.assert_has_calls([call(1)])
 
 
     def test_attribute_deletion(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1922,7 +1922,7 @@ class MockTest(unittest.TestCase):
             self.assertEqual(mock_func.mock._extract_mock_name(), 'mock.child')
 
 
-    def test_attach_mock_patch_autospec(self):
+    def test_attach_mock_patch_autospec_signature(self):
         with mock.patch(f'{__name__}.Something.meth', autospec=True) as mocked:
             manager = Mock()
             manager.attach_mock(mocked, 'attach_meth')
@@ -1939,6 +1939,16 @@ class MockTest(unittest.TestCase):
             manager.assert_has_calls([call.attach_func(1)])
             something.assert_has_calls([call(1)])
             mocked.assert_has_calls([call(1)])
+
+        with mock.patch(f'{__name__}.Something', autospec=True) as mocked:
+            manager = Mock()
+            manager.attach_mock(mocked, 'attach_obj')
+            obj = Something()
+            obj.meth(1, 2, 3, d=4)
+            manager.assert_has_calls([call.attach_obj(),
+                                      call.attach_obj().meth(1, 2, 3, d=4)])
+            obj.meth.assert_has_calls([call(1, 2, 3, d=4)])
+            mocked.assert_has_calls([call(), call().meth(1, 2, 3, d=4)])
 
 
     def test_attribute_deletion(self):

--- a/Misc/NEWS.d/next/Library/2019-10-14-21-14-55.bpo-38473.uXpVld.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-14-21-14-55.bpo-38473.uXpVld.rst
@@ -1,0 +1,2 @@
+Use signature from inner mock for autospecced methods attached with
+:func:`unittest.mock.attach_mock`. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
Extract signature from the inner mock object for methods/functions autospecced and attached to a mock object using `attach_mock`.

<!-- issue-number: [bpo-38473](https://bugs.python.org/issue38473) -->
https://bugs.python.org/issue38473
<!-- /issue-number -->
