### PR TITLE
bpo-38478: Correctly handle keyword argument with same name as positional-only parameter

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2960,7 +2960,7 @@ class Signature:
                         arguments[param.name] = tuple(values)
                         break
 
-                    if param.name in kwargs:
+                    if param.name in kwargs and param.kind != _POSITIONAL_ONLY:
                         raise TypeError(
                             'multiple values for argument {arg!r}'.format(
                                 arg=param.name)) from None

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3573,6 +3573,16 @@ class TestSignatureBind(unittest.TestCase):
         iterator = iter(range(5))
         self.assertEqual(self.call(setcomp_func, iterator), {0, 1, 4, 9, 16})
 
+    def test_signature_bind_posonly_kwargs(self):
+        def foo(bar, /, **kwargs):
+            return bar, kwargs.get(bar)
+
+        sig = inspect.signature(foo)
+        result = sig.bind("pos-only", bar="keyword")
+
+        self.assertEqual(result.kwargs, {"bar": "keyword"})
+        self.assertIn(("bar", "pos-only"), result.arguments.items())
+
 
 class TestBoundArguments(unittest.TestCase):
     def test_signature_bound_arguments_unhashable(self):

--- a/Misc/NEWS.d/next/Library/2019-10-15-11-37-57.bpo-38478.A87OPO.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-15-11-37-57.bpo-38478.A87OPO.rst
@@ -1,0 +1,3 @@
+Fixed a bug in :meth:`inspect.signature.bind` that was causing it to fail
+when handling a keyword argument with same name as positional-only parameter.
+Patch by Pablo Galindo.


### PR DESCRIPTION


<!-- issue-number: [bpo-38478](https://bugs.python.org/issue38478) -->
https://bugs.python.org/issue38478
<!-- /issue-number -->
