### PR TITLE
bpo-38483: Add support for venv.ini

### DIFF
--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -133,17 +133,23 @@ detail (typically a script or shell function will be used).
    PowerShell activation scripts installed under POSIX for PowerShell Core
    support.
 
-The venv module supports a Running Command file (commandparser ini format) within
-a users home directory (``~/.venvrc``) to overload CLI defaults. This allows
-any CLI argument mention above to me overloaded by default.
-- Please replace '-' chars with '_' to match cli args.
-Example Usage:
+The venv module supports an ini config file in the following locations:
 
-[venv]
-upgrade_deps = true
+* ``$HOME/.venv.ini`` on Linux/Unix (+ Darwin/Mac OSX) platforms
+* ``%APPDATA%\Python\venv\venv.ini'`` on Windows platforms
+
+to overload CLI defaults. This allows any CLI argument mentioned above
+to be overloaded by default.
+
+* Please replace '-' chars with '_' to match cli args.
+
+Example ``venv.ini``:
+
+    [venv]
+    upgrade_deps = true
 
 This would result in ``--upgrade-deps`` to defualt to True.
-Please use ``--help`` to test ``~/.venvrc``
+Please use ``--help`` to test ``venv.ini`` applied defaults
 
 .. versionadded:: 3.9
-   Add support for ~/.venvrc to overload CLI argument defaults
+   Add support for venv.ini to overload CLI argument defaults

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -135,21 +135,30 @@ detail (typically a script or shell function will be used).
 
 The venv module supports an ini config file in the following locations:
 
-* ``$HOME/.venv.ini`` on Linux/Unix (+ Darwin/Mac OSX) platforms
-* ``%APPDATA%\Python\venv\venv.ini'`` on Windows platforms
+* ``$HOME/.config/python/venv.ini`` on Linux/Unix (+ Darwin/Mac OSX) platforms
+* ``%APPDATA%\Python\venv.ini'`` on Windows platforms
 
-to overload CLI defaults. This allows any CLI argument mentioned above
-to be overloaded by default.
+This config allows a user to alter the CLI option defaults set in the venv module.
+The config only alters the default and if specified on the command line it
+will obtain that value.
 
 * Please replace '-' chars with '_' to match cli args.
 
 Example ``venv.ini``:
 
     [venv]
-    upgrade_deps = true
+    upgrade_deps = True
 
-This would result in ``--upgrade-deps`` to defualt to True.
+This would result in ``--upgrade-deps`` to default to True.
 Please use ``--help`` to test ``venv.ini`` applied defaults
 
+If a non valid key is set in ``venv.ini`` it will be silently ignored.
+Example:
+
+    [venv]
+    guido_retired = True
+
+will result in no changes to defaults to occur
+
 .. versionadded:: 3.9
-   Add support for venv.ini to overload CLI argument defaults
+   Add support for venv.ini to supply CLI argument defaults

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -132,3 +132,18 @@ detail (typically a script or shell function will be used).
 .. versionadded:: 3.8
    PowerShell activation scripts installed under POSIX for PowerShell Core
    support.
+
+The venv module supports a Running Command file (commandparser ini format) within
+a users home directory (``~/.venvrc``) to overload CLI defaults. This allows
+any CLI argument mention above to me overloaded by default.
+- Please replace '-' chars with '_' to match cli args.
+Example Usage:
+
+[venv]
+upgrade_deps = true
+
+This would result in ``--upgrade-deps`` to defualt to True.
+Please use ``--help`` to test ``~/.venvrc``
+
+.. versionadded:: 3.9
+   Add support for ~/.venvrc to overload CLI argument defaults

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -384,29 +384,29 @@ class BasicTest(BaseTest):
 class CliTest(BaseTest):
     """ Test various CLI related functions """
 
-    BAD_VENVRC = "|not_venv_or_ini|\nkey = value\n"
-    GOOD_VENVRC = "[venv]\nupgrade_deps = TrUe"  # case on purpose for test
+    BAD_VENV_INI = "|not_venv_or_ini|\nkey = value\n"
+    GOOD_VENV_INI = "[venv]\nupgrade_deps = TrUe"  # case on purpose for test
 
     def test_get_default_args(self):
         # Use env_dir as it gets cleaned up
         defaults = venv.CliDefaults()
-        venvrc_path = os.path.join(self.env_dir, "venvrc")
+        venv_ini_path = os.path.join(self.env_dir, "venv.ini")
 
         # Test we handle no config existing
-        # - Not using homedir incase user has a .venvrc
-        self.assertEqual(venv.get_default_args(venvrc_path), defaults)
+        # - Not using homedir incase user has a venv.ini
+        self.assertEqual(venv.get_default_args(venv_ini_path), defaults)
 
         # Write out bad RC file + ensure we throw exception
-        with open(venvrc_path, "w") as vfp:
-            vfp.write(self.BAD_VENVRC)
+        with open(venv_ini_path, "w") as vfp:
+            vfp.write(self.BAD_VENV_INI)
         with self.assertRaises(configparser.MissingSectionHeaderError):
-            venv.get_default_args(venvrc_path)
+            venv.get_default_args(venv_ini_path)
 
         # Write out good RC file and expect upgrade_deps == True
         expected = venv.CliDefaults(upgrade_deps=True)
-        with open(venvrc_path, "w") as vfp:
-            vfp.write(self.GOOD_VENVRC)
-        self.assertEqual(venv.get_default_args(venvrc_path), expected)
+        with open(venv_ini_path, "w") as vfp:
+            vfp.write(self.GOOD_VENV_INI)
+        self.assertEqual(venv.get_default_args(venv_ini_path), expected)
 
 
 @requireVenvCreate

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -381,10 +381,12 @@ class BasicTest(BaseTest):
         self.assertEqual(err, "".encode())
 
     def test_get_default_args_errors(self):
-        bad_bool = "[venv]\nupgrade_deps = Try\n"
+        bad_bool = "[DEFAULT]\nupgrade_deps = Try\n"
         bad_format_venv_ini = "|not_venv_or_ini|\nkey = value\n"
-        bad_duplicate_keys = "[venv]\nupgrade_deps = True\nupgrade_deps = True\n"
-        no_valid_options = "[venv]\nguido_retired = True\n"
+        bad_duplicate_keys = (
+            "[DEFAULT]\nupgrade_deps = True\nupgrade_deps = True\n"
+        )
+        no_valid_options = "[DEFAULT]\nguido_retired = True\n"
         defaults = venv.Defaults()
 
         with tempfile.TemporaryDirectory() as conf_dir:
@@ -413,7 +415,8 @@ class BasicTest(BaseTest):
     def test_get_default_args_success(self):
         # Add the random key to show we ignore it
         good_venv_ini = (
-            "[venv]\nprompt = CooperVenv\nrandom = None\nupgrade_deps = TrUe\n"
+            "[DEFAULT]\nprompt = CooperVenv\nrandom = None\n"
+            + "upgrade_deps = TrUe\n"
         )
 
         with tempfile.TemporaryDirectory() as conf_dir:

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -448,16 +448,16 @@ def get_default_args(venv_ini_path=VENV_INI_DEFAULT_PATH):
 
     cp = configparser.ConfigParser()
     cp.read(venv_ini_path)
-    if not cp.has_section("venv"):
+    if not cp.has_section("DEFAULT"):
         return defaults
 
     read_kwargs = {}
-    for name, value in cp.items("venv"):
+    for name, value in cp.items("DEFAULT"):
         if name not in Defaults._fields:
             continue
 
         if name in bool_keys:
-            read_kwargs[name] = cp["venv"].getboolean(name)
+            read_kwargs[name] = cp["DEFAULT"].getboolean(name)
         else:
             read_kwargs[name] = value
 

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -15,6 +15,9 @@ import types
 from typing import NamedTuple, Optional
 
 CORE_VENV_DEPS = ('pip', 'setuptools')
+VENV_INI_DEFAULT = '~/.venv.ini'
+if sys.platform == "win32":
+    VENV_INI_DEFAULT = os.path.expandvars(r'%APPDATA%\Python\venv\venv.ini')
 logger = logging.getLogger(__name__)
 
 
@@ -422,15 +425,15 @@ def create(env_dir, system_site_packages=False, clear=False,
     builder.create(env_dir)
 
 
-def get_default_args(rc_file='~/.venvrc'):
-    """ Check if a .venvrc exists in a user's home directory
-        + override defaults if it exists. Use `--help` to test rc file """
-    venvrc_path = os.path.expanduser(rc_file)
-    if not os.path.exists(venvrc_path):
+def get_default_args(venv_ini_default=VENV_INI_DEFAULT):
+    """ Check if a venv.ini exists in the platform location
+        + override defaults if it exists. Use `--help` to test ini config """
+    venvini_path = os.path.expanduser(venv_ini_default)
+    if not os.path.exists(venvini_path):
         return CliDefaults()
 
     cp = configparser.ConfigParser()
-    cp.read(venvrc_path)
+    cp.read(venvini_path)
     if not cp.has_section("venv"):
         return CliDefaults()
 

--- a/Misc/NEWS.d/next/Library/2019-10-15-13-03-59.bpo-34556.K2XyWH.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-15-13-03-59.bpo-34556.K2XyWH.rst
@@ -1,1 +1,1 @@
-Add ``venv.ini`` support to venv module to overload CLI argument defaults. Patch by Cooper Ry Lees
+Add ``venv.ini`` support to venv module to supply CLI argument defaults. Patch by Cooper Ry Lees

--- a/Misc/NEWS.d/next/Library/2019-10-15-13-03-59.bpo-34556.K2XyWH.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-15-13-03-59.bpo-34556.K2XyWH.rst
@@ -1,1 +1,1 @@
-Add ``~/.venvrc`` support to venv module to overload CLI argument defaults. Patch by Cooper Ry Lees
+Add ``venv.ini`` support to venv module to overload CLI argument defaults. Patch by Cooper Ry Lees

--- a/Misc/NEWS.d/next/Library/2019-10-15-13-03-59.bpo-34556.K2XyWH.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-15-13-03-59.bpo-34556.K2XyWH.rst
@@ -1,0 +1,1 @@
+Add ``~/.venvrc`` support to venv module to overload CLI argument defaults. Patch by Cooper Ry Lees


### PR DESCRIPTION
- Add argparse.ArgumentDefaultsHelpFormatter so user can see overloads
- Add new CliDefaults NamedTuple with defaults
- Check for ~/.venvrc + parse if exists
- Check args, if true or false bool otherwise string
- Overload by creating NamedTuple passing kwargs
- Update docs

Test:
- Run `./python.exe -m venv --help`
- Add unit tests for new function


<!-- issue-number: [bpo-38483](https://bugs.python.org/issue38483) -->
https://bugs.python.org/issue38483
<!-- /issue-number -->
