### PR TITLE
[3.7] bpo-35998: Fix test_asyncio.test_start_tls_server_1() (GH-16815)

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-10-16-01-36-15.bpo-35998.G305Bf.rst
+++ b/Misc/NEWS.d/next/Tests/2019-10-16-01-36-15.bpo-35998.G305Bf.rst
@@ -1,0 +1,5 @@
+Fix a race condition in test_asyncio.test_start_tls_server_1(). Previously,
+there was a race condition between the test main() function which replaces the
+protocol and the test ServerProto protocol which sends ANSWER once it gets
+HELLO. Now, only the test main() function is responsible to send data,
+ServerProto no longer sends data.


### PR DESCRIPTION
main() is now responsible to send the ANSWER, rather than
ServerProto. main() now waits until it got the HELLO before sending
the ANSWER over the new transport.

Previously, there was a race condition between main() replacing the
protocol and the protocol sending the ANSWER once it gets the HELLO.

TLSv1.3 was disabled for the test: reenable it.

(cherry picked from commit fab4ef2df0857ab0c97f3058ac5ec3280c4eb891)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35998](https://bugs.python.org/issue35998) -->
https://bugs.python.org/issue35998
<!-- /issue-number -->
