### PR TITLE
bpo-36076: Add SNI support to ssl.get_server_certificate.

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -1475,7 +1475,7 @@ def get_server_certificate(addr, ssl_version=PROTOCOL_TLS, ca_certs=None):
                                      cert_reqs=cert_reqs,
                                      cafile=ca_certs)
     with  create_connection(addr) as sock:
-        with context.wrap_socket(sock) as sslsock:
+        with context.wrap_socket(sock, server_hostname=host) as sslsock:
             dercert = sslsock.getpeercert(True)
     return DER_cert_to_PEM_cert(dercert)
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1803,6 +1803,7 @@ Michael Urman
 Hector Urtubia
 Elizabeth Uselton
 Lukas Vacek
+Juho Vähä-Herttua
 Ville Vainio
 Yann Vaginay
 Andi Vajda

--- a/Misc/NEWS.d/next/Library/2019-10-16-17-21-53.bpo-36076.FGeQQT.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-16-17-21-53.bpo-36076.FGeQQT.rst
@@ -1,0 +1,1 @@
+Added SNI support to :func:`ssl.get_server_certificate`.


### PR DESCRIPTION
Many servers in the cloud environment require SNI to be used during the
SSL/TLS handshake, therefore it is not possible to fetch their certificates
using the ssl.get_server_certificate interface.

This change adds an additional optional hostname argument that can be used to
set the SNI. Note that it is intentionally a separate argument instead of
using the host part of the addr tuple, because one might want to explicitly
fetch the default certificate or fetch a certificate from a specific IP
address with the specified SNI hostname. A separate argument also works better
for backwards compatibility.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36076](https://bugs.python.org/issue36076) -->
https://bugs.python.org/issue36076
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran