### PR TITLE
bpo-38492: Remove pythonw.exe dependency on the Microsoft C++ runtime

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-10-16-09-49-09.bpo-38492.Te1LxC.rst
+++ b/Misc/NEWS.d/next/Windows/2019-10-16-09-49-09.bpo-38492.Te1LxC.rst
@@ -1,0 +1,1 @@
+Remove ``pythonw.exe`` dependency on the Microsoft C++ runtime.

--- a/PCbuild/pythonw_uwp.vcxproj
+++ b/PCbuild/pythonw_uwp.vcxproj
@@ -65,6 +65,15 @@
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="$(Configuration) != 'Debug'">
+    <ClCompile>
+      <RuntimeLibrary>Multithreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>ucrt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>libucrt;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="..\PC\pyconw.ico" />
   </ItemGroup>


### PR DESCRIPTION


<!-- issue-number: [bpo-38492](https://bugs.python.org/issue38492) -->
https://bugs.python.org/issue38492
<!-- /issue-number -->
