### PR TITLE
bpo-37531: regrtest now catchs ProcessLookupError

### DIFF
--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -152,6 +152,11 @@ class TestWorkerProcess(threading.Thread):
         print(f"Kill {self}", file=sys.stderr, flush=True)
         try:
             popen.kill()
+        except ProcessLookupError:
+            # Process completed, the TestWorkerProcess thread read its exit
+            # status, but Popen.send_signal() read the returncode just before
+            # Popen.wait() set returncode.
+            pass
         except OSError as exc:
             print_warning(f"Failed to kill {self}: {exc!r}")
 


### PR DESCRIPTION
Fix a warning on a race condition on TestWorkerProcess.kill(): ignore
silently ProcessLookupError rather than logging an useless warning.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37531](https://bugs.python.org/issue37531) -->
https://bugs.python.org/issue37531
<!-- /issue-number -->
