### PR TITLE
[doc] Mention actual regular expressions cache size

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -632,7 +632,7 @@ form.
 
    .. note::
 
-      The compiled versions of the most recent patterns passed to
+      The compiled versions of the 512 most recent patterns passed to
       :func:`re.compile` and the module-level matching functions are cached, so
       programs that use only a few regular expressions at a time needn't worry
       about compiling regular expressions.


### PR DESCRIPTION
I believe its quite useful to know the actual cache size. Prior to researching, I though it would be on the 10/20 regular expressions myself.