### PR TITLE
bpo-38517: Support partial functions & partialmethod's in functools.cached_property

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -911,9 +911,9 @@ _NOT_FOUND = object()
 
 
 class cached_property:
-    def __init__(self, func):
+    def __init__(self, func, name=None):
         self.func = func
-        self.attrname = None
+        self.attrname = name
         self.__doc__ = func.__doc__
         self.lock = RLock()
 
@@ -946,7 +946,10 @@ class cached_property:
                 # check if another thread filled cache while we awaited lock
                 val = cache.get(self.attrname, _NOT_FOUND)
                 if val is _NOT_FOUND:
-                    val = self.func(instance)
+                    if callable(self.func):
+                        val = self.func(instance)
+                    else:
+                        val = self.func.func(instance, *self.func.args, **self.func.keywords)
                     try:
                         cache[self.attrname] = val
                     except TypeError:

--- a/Misc/NEWS.d/next/Library/2019-10-18-16-57-52.bpo-38517.PBwbZj.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-18-16-57-52.bpo-38517.PBwbZj.rst
@@ -1,0 +1,2 @@
+Add support for partial functions and partialmethod's to
+functools.cached_property


### PR DESCRIPTION
Currently, the cached_property decorator does not support partial functions and partialmethod's.

This is needed so we can dynamically create cached attributes in a class like this:

This PR adds a `name` parameter to specify the name of the function.

Use case:

```
import os
from functools import cached_property, partialmethod

class ProcNet:
    def __new__(cls, *args, **kwargs):
        for proto in ('icmp', 'icmp6', 'raw', 'raw6', 'tcp', 'tcp6', 'udp', 'udp6', 'udplite', 'udplite6'):
            setattr(cls, proto, cached_property(partialmethod(cls._proto, proto), name=proto))
        return super().__new__(cls, *args, **kwargs)

    def _proto(self, proto):
        """
        Get /proc/net/{icmp,icmp6,raw,raw6,tcp,tcp6,udp,udp6,udplite,udplite6}
        """
        with open(os.path.join("/proc/net", proto)) as file:
            return file.read()

net = ProcNet()
print(net.tcp)
```


<!-- issue-number: [bpo-38517](https://bugs.python.org/issue38517) -->
https://bugs.python.org/issue38517
<!-- /issue-number -->
