### PR TITLE
bpo-38527: fix configure script for Solaris

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-03-28-10-43-09.bpo-38527.fqCRgD.rst
+++ b/Misc/NEWS.d/next/Build/2020-03-28-10-43-09.bpo-38527.fqCRgD.rst
@@ -1,0 +1,1 @@
+Fix configure check for "float word ordering". The check did not always use the correct "grep" command.

--- a/Misc/NEWS.d/next/Build/2020-03-28-10-43-09.bpo-38527.fqCRgD.rst
+++ b/Misc/NEWS.d/next/Build/2020-03-28-10-43-09.bpo-38527.fqCRgD.rst
@@ -1,1 +1,2 @@
-Fix configure check for "float word ordering". The check did not always use the correct "grep" command.
+Fix configure check on Solaris for "float word ordering": sometimes, the correct "grep" command was not being used.
+Patch by Arnon Yaari.

--- a/configure
+++ b/configure
@@ -14281,10 +14281,10 @@ _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
 
 
-if grep noonsees conftest.$ac_objext >/dev/null ; then
+if $GREP noonsees conftest.$ac_objext >/dev/null ; then
   ax_cv_c_float_words_bigendian=yes
 fi
-if grep seesnoon conftest.$ac_objext >/dev/null ; then
+if $GREP seesnoon conftest.$ac_objext >/dev/null ; then
   if test "$ax_cv_c_float_words_bigendian" = unknown; then
     ax_cv_c_float_words_bigendian=no
   else

--- a/m4/ax_c_float_words_bigendian.m4
+++ b/m4/ax_c_float_words_bigendian.m4
@@ -49,10 +49,10 @@ double d = 909042349670368103374704789055050114762116927356156320147971208440534
 
 ]])], [
 
-if grep noonsees conftest.$ac_objext >/dev/null ; then
+if $GREP noonsees conftest.$ac_objext >/dev/null ; then
   ax_cv_c_float_words_bigendian=yes
 fi
-if grep seesnoon conftest.$ac_objext >/dev/null ; then
+if $GREP seesnoon conftest.$ac_objext >/dev/null ; then
   if test "$ax_cv_c_float_words_bigendian" = unknown; then
     ax_cv_c_float_words_bigendian=no
   else


### PR DESCRIPTION
On Solaris, the regular "grep" command may be an old version that fails to search a binary file. We need to use the correct command (ggrep, in our case), which is found by the configure script earlier.

<!-- issue-number: [bpo-38527](https://bugs.python.org/issue38527) -->
https://bugs.python.org/issue38527
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal