### PR TITLE
bpo-38525: Fix segfault when using reverse iterators of empty dict literals

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1154,6 +1154,19 @@ class DictTest(unittest.TestCase):
             values = list(it) + [drop]
             self.assertEqual(sorted(values), sorted(data.values()))
 
+    def test_reverseiterator_empty_dict(self):
+        # Check bpo-38525
+
+        the_dict = {}
+        self.assertEqual(list(reversed(the_dict)), list())
+        self.assertEqual(list(reversed(the_dict.values())), list())
+        self.assertEqual(list(reversed(the_dict.keys())), list())
+
+        the_dict = dict()
+        self.assertEqual(list(reversed(the_dict)), list())
+        self.assertEqual(list(reversed(the_dict.values())), list())
+        self.assertEqual(list(reversed(the_dict.keys())), list())
+
     def test_instance_dict_getattr_str_subclass(self):
         class Foo:
             def __init__(self, msg):

--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-19-15-58-26.bpo-38525.rmOpTg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-19-15-58-26.bpo-38525.rmOpTg.rst
@@ -1,0 +1,2 @@
+Fix a segmentation fault when using reverse iterators of empty ``dict``
+objects that were created as empty dict literals. Patch by Pablo Galindo.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3826,7 +3826,7 @@ dictreviter_iternext(dictiterobject *di)
     PyObject *key, *value, *result;
 
     if (d->ma_values) {
-        if (i < 0) {
+        if (i < 0 || i >= d->ma_used) {
             goto fail;
         }
         key = DK_ENTRIES(k)[i].me_key;


### PR DESCRIPTION
This was a consequence of

```
commit f2a186712bfe726d54723eba37d80c7f0303a50b
Author: Inada Naoki <songofacandy@gmail.com>
Date:   Tue Mar 12 17:25:44 2019 +0900

    [bpo-30040](https://bugs.python.org/issue30040): new empty dict uses key-sharing dict (GH-1080)
    
    Sizeof new empty dict becomes 72 bytes from 240 bytes (amd64).
    It is same size to empty dict created by dict.clear().
```

and

```
commit 6531bf6309c8fda1954060a0fb5ea930b1efb656
Author: Rémi Lapeyre <remi.lapeyre@henki.fr>
Date:   Tue Nov 6 01:38:54 2018 +0100

    [bpo-33462](https://bugs.python.org/issue33462): Add __reversed__ to dict and dict views (GH-6827)
```
together.

<!-- issue-number: [bpo-38525](https://bugs.python.org/issue38525) -->
https://bugs.python.org/issue38525
<!-- /issue-number -->
