### PR TITLE
[2.7] Workaround Path.glob() issue when creating nuget package

### DIFF
--- a/Tools/nuget/make_zip.py
+++ b/Tools/nuget/make_zip.py
@@ -103,7 +103,7 @@ FULL_LAYOUT = [
     ('Lib/', 'Lib', '**/*', include_in_lib),
     ('libs/', 'PCBuild/$arch', '*.lib', include_in_libs),
     ('Tools/', 'Tools', '**/*', include_in_tools),
-    ('/', '', 'LICENSE', None),
+    ('/', '', 'LICENSE*', None),
 ]
 
 EMBED_LAYOUT = [


### PR DESCRIPTION
Because of issue 31202, the LICENSE file was copying as license, which caused an upload error to nuget.org because it uses case sensitive comparisons. This works around the issue.