### PR TITLE
bpo-38532: Add missing decrefs in PyCFuncPtr_FromDll()

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3508,10 +3508,12 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (PySys_Audit("ctypes.dlsym",
                     ((uintptr_t)name & ~0xFFFF) ? "Os" : "On",
                     dll, name) < 0) {
+        Py_DECREF(ftuple);
         return NULL;
     }
 #else
     if (PySys_Audit("ctypes.dlsym", "Os", dll, name) < 0) {
+        Py_DECREF(ftuple);
         return NULL;
     }
 #endif


### PR DESCRIPTION


<!-- issue-number: [bpo-38532](https://bugs.python.org/issue38532) -->
https://bugs.python.org/issue38532
<!-- /issue-number -->
