### PR TITLE
bpo-36321: Fix misspelled attribute name in namedtuple()

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -425,8 +425,6 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
         '__slots__': (),
         '_fields': field_names,
         '_field_defaults': field_defaults,
-        # alternate spelling for backward compatibility
-        '_fields_defaults': field_defaults,
         '__new__': __new__,
         '_make': _make,
         '_replace': _replace,

--- a/Misc/NEWS.d/next/Library/2019-10-19-21-41-20.bpo-36321.CFlxfy.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-19-21-41-20.bpo-36321.CFlxfy.rst
@@ -1,0 +1,2 @@
+Remove misspelled attribute.  The 3.8 changelog noted that this would be
+removed in 3.9.


### PR DESCRIPTION


<!-- issue-number: [bpo-36321](https://bugs.python.org/issue36321) -->
https://bugs.python.org/issue36321
<!-- /issue-number -->
