### PR TITLE
bpo-38471 Fix _ProactorDatagramTransport close() behaviour

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -503,9 +503,6 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport):
 
     def _loop_writing(self, fut=None):
         try:
-            if self._conn_lost:
-                return
-
             assert fut is self._write_fut
             self._write_fut = None
             if fut:

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -632,6 +632,25 @@ class ProactorDatagramTransportTests(test_utils.TestCase):
         self.sock.close.assert_called_with()
         self.protocol.connection_lost.assert_called_with(None)
 
+    def test_loop_close_with_write_buffer(self):
+        data1 = b'data1'
+        data2 = b'data2'
+        transport = self.datagram_transport()
+        transport.sendto(data1, ('0.0.0.0', 1234))
+        self.proactor.sendto.assert_called_with(
+            self.sock, data1, addr=('0.0.0.0', 1234))
+        self.proactor.sendto.reset_mock()
+        transport.sendto(data2, ('0.0.0.0', 1234))
+        self.proactor.sendto.assert_not_called()
+        transport.close()
+        self.assertIsNotNone(transport._write_fut)
+        transport._loop_writing(transport._write_fut)
+        self.proactor.sendto.assert_called_with(
+            self.sock, data2, addr=('0.0.0.0', 1234))
+        transport._loop_writing(transport._write_fut)
+        test_utils.run_briefly(self.loop)
+        self.protocol.connection_lost.assert_called_with(None)
+
     def test__loop_writing_exception(self):
         err = self.proactor.sendto.side_effect = RuntimeError()
 

--- a/Misc/NEWS.d/next/Windows/2019-10-20-13-36-25.bpo-38471.tfehj1.rst
+++ b/Misc/NEWS.d/next/Windows/2019-10-20-13-36-25.bpo-38471.tfehj1.rst
@@ -1,0 +1,1 @@
+Fix behaviour for _ProactorDatagramTransport close() when buffer is not empty


### PR DESCRIPTION
Fixes an issue where if the _ProactorDatagramTransport close method is called while there is data in the write buffer, the data is not sent and connection_lost is not called. Behaviour now matches _SelectorDatagramTransport.

https://bugs.python.org/issue38471

Re-create of pull request #16779


<!-- issue-number: [bpo-38471](https://bugs.python.org/issue38471) -->
https://bugs.python.org/issue38471
<!-- /issue-number -->
