### PR TITLE
bpo-38545: Support updatable cached values

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -27,6 +27,11 @@ The :mod:`functools` module defines the following functions:
    to :func:`property`, with the addition of caching. Useful for expensive
    computed properties of instances that are otherwise effectively immutable.
 
+   The cached attribute can be updated and cleared by setting the
+   ``updatable`` attribute of the decorated method to ``True``. The usual
+   attribute syntax is used for updating (``instance.prop = value`` and
+   ``del instance.prop``).
+
    Example::
 
        class DataSet:
@@ -41,7 +46,12 @@ The :mod:`functools` module defines the following functions:
            def variance(self):
                return statistics.variance(self._data)
 
+           variance.updatable = True
+
    .. versionadded:: 3.8
+
+   .. versionchanged:: 3.9
+      Support updatable cached values
 
    .. note::
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1212,6 +1212,7 @@ Grant Olson
 Koray Oner
 Piet van Oostrum
 Tomas Oppelstrup
+Laurie Opperman
 Jason Orendorff
 Bastien Orivel
 orlnub123

--- a/Misc/NEWS.d/next/Library/2019-10-21-11-16-50.bpo-38545.-PZtv5.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-21-11-16-50.bpo-38545.-PZtv5.rst
@@ -1,0 +1,1 @@
+``functools.cached_property`` instances now have the ``updatable`` attribute, which allows for cached value's setting/update and clearing via attribute assignment and deletion respectively.


### PR DESCRIPTION
`functools.cached_property` instances now have the `updatable` attribute, which allows for cached value's setting/update and clearing via attribute assignment and deletion respectively.

Note that this PR uses option (b) from the original Python bug.

<!-- issue-number: [bpo-38545](https://bugs.python.org/issue38545) -->
https://bugs.python.org/issue38545
<!-- /issue-number -->
