### PR TITLE
bpo-38550: call OPENSSL_init_crypto for openssl >= 1.1.0

### DIFF
--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -1153,6 +1153,8 @@ PyInit__hashlib(void)
     /* Load all digest algorithms and initialize cpuid */
     OPENSSL_add_all_algorithms_noconf();
     ERR_load_crypto_strings();
+#else
+    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS|OPENSSL_INIT_ADD_ALL_DIGESTS, NULL);
 #endif
 
     m = PyState_FindModule(&_hashlibmodule);


### PR DESCRIPTION
This call is necessary to enable all available algorithms in the
hashlib module.

To test, compare hashlib.algorithms_available with/without this patch.

Signed-off-by: Mike Gilbert <floppym@gentoo.org>

<!-- issue-number: [bpo-38550](https://bugs.python.org/issue38550) -->
https://bugs.python.org/issue38550
<!-- /issue-number -->
