### PR TITLE
[3.7] bpo-38540: Revert a warning if PY_SSIZE_T_CLEAN is not defined.

### DIFF
--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1176,19 +1176,7 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
                trailing 0-byte
 
             */
-            int *q = NULL; Py_ssize_t *q2 = NULL;
-            if (flags & FLAG_SIZE_T) {
-                q2 = va_arg(*p_va, Py_ssize_t*);
-            }
-            else {
-                if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                            "PY_SSIZE_T_CLEAN will be required for '#' formats", 1))
-                {
-                    Py_DECREF(s);
-                    return NULL;
-                }
-                q = va_arg(*p_va, int*);
-            }
+            FETCH_SIZE;
 
             format++;
             if (q == NULL && q2 == NULL) {


### PR DESCRIPTION


<!-- issue-number: [bpo-38540](https://bugs.python.org/issue38540) -->
https://bugs.python.org/issue38540
<!-- /issue-number -->
