### PR TITLE
[2.7] bpo-38540: Fix possible leak in PyArg_Parse for "es#" and "et#". (GH-16869).

### DIFF
--- a/Misc/NEWS.d/next/C API/2019-10-21-09-24-03.bpo-38540.314N_T.rst
+++ b/Misc/NEWS.d/next/C API/2019-10-21-09-24-03.bpo-38540.314N_T.rst
@@ -1,0 +1,3 @@
+Fixed possible leak in :c:func:`PyArg_Parse` and similar functions for
+format units ``"es#"`` and ``"et#"`` when the macro
+:c:macro:`PY_SSIZE_T_CLEAN` is not defined.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1156,7 +1156,19 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
             memcpy(*buffer,
                    PyString_AS_STRING(s),
                    size + 1);
-            STORE_SIZE(size);
+
+            if (flags & FLAG_SIZE_T) {
+                *q2 = size;
+            }
+            else {
+                if (INT_MAX < size) {
+                    Py_DECREF(s);
+                    PyErr_SetString(PyExc_OverflowError,
+                                    "size does not fit in an int");
+                    return converterr("", arg, msgbuf, bufsize);
+                }
+                *q = (int)size;
+            }
         } else {
             /* Using a 0-terminated buffer:
 


### PR DESCRIPTION
(cherry picked from commit 5bc6a7c06eda20ba131ecba6752be0506d310181)


<!-- issue-number: [bpo-38540](https://bugs.python.org/issue38540) -->
https://bugs.python.org/issue38540
<!-- /issue-number -->
