### PR TITLE
bpo-38328: Speed up the creation time of constant set literals.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-10-22-00-55-25.bpo-38328.pW0jsL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-10-22-00-55-25.bpo-38328.pW0jsL.rst
@@ -1,0 +1,1 @@
+Sped up the creation time of constant :class:`set` literals. Patch by Brandt Bucher.


### PR DESCRIPTION
This is basically the same patch as #16498, except for sets. It's nearly identical, except that it adds a new argument to `fold_tuple_on_constants` to create a `frozenset` instead.

This one can probably be merged first, since the other PR is waiting for a list overallocation issue to be resolved.

<!-- issue-number: [bpo-38328](https://bugs.python.org/issue38328) -->
https://bugs.python.org/issue38328
<!-- /issue-number -->
