### PR TITLE
bpo-38554: Fix a possible assertion failure in test_descr

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -769,7 +769,6 @@ type_set_bases(PyTypeObject *type, PyObject *new_bases, void *context)
         goto bail;
     if (mro_hierarchy(type, temp) < 0)
         goto undo;
-    Py_DECREF(temp);
 
     /* Take no action in case if type->tp_bases has been replaced
        through reentrance.  */
@@ -782,10 +781,12 @@ type_set_bases(PyTypeObject *type, PyObject *new_bases, void *context)
         /* for now, sod that: just remove from all old_bases,
            add to all new_bases */
         remove_all_subclasses(type, old_bases);
-        res = add_all_subclasses(type, new_bases);
+        if (add_all_subclasses(type, new_bases) < 0) {
+            goto undo;
+        }
         update_all_slots(type);
     }
-
+    Py_DECREF(temp);
     Py_DECREF(old_bases);
     Py_DECREF(old_base);
 


### PR DESCRIPTION
update_all_slots() was being called immediately after
add_all_subclasses().  This would cause an assertion failure
in update_all_slots() if an exception occurred during
add_all_subclasses().

<!-- issue-number: [bpo-38554](https://bugs.python.org/issue38554) -->
https://bugs.python.org/issue38554
<!-- /issue-number -->
