### PR TITLE
Clarify, for BaseHTTPRequestHandler, that path includes query

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -99,6 +99,10 @@ provides three different variants:
    .. attribute:: path
 
       Contains the request path.
+      If a query is present (a part that starts with ``?``),
+      then that is also included in this attribute.
+      Thus using the terminology of :rfc:`3986`,
+      ``path`` here includes the ``hier-part`` and the ``query``.
 
    .. attribute:: request_version
 


### PR DESCRIPTION
A minor improvement to the documentation for BaseHTTPRequestHandler in the `http.server` library.
Pointing that the `path` attribute also includes the `query` part, when present.