### PR TITLE
bpo-38466: fix threading.excepthook doc that talks about "object" instead of "thread"

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -62,8 +62,8 @@ This module defines the following functions:
    should be cleared explicitly to break the reference cycle when the
    exception is no longer needed.
 
-   Storing *object* using a custom hook can resurrect it if it is set to an
-   object which is being finalized. Avoid storing *object* after the custom
+   Storing *thread* using a custom hook can resurrect it if it is set to an
+   object which is being finalized. Avoid storing *thread* after the custom
    hook completes to avoid resurrecting objects.
 
    .. seealso::


### PR DESCRIPTION
Changed mentions of *object* in [`threading.excepthook` docs](https://docs.python.org/3.8/library/threading.html#threading.excepthook) to *thread* - *args* parameter has *thread* attribute, but not *object*.

<!-- issue-number: [bpo-38466](https://bugs.python.org/issue38466) -->
https://bugs.python.org/issue38466
<!-- /issue-number -->
