### PR TITLE
[2.7] bpo-37025: AddRefActCtx() shouldn't be checked for failure

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-10-04-03-46-36.bpo-37025.tLheEe.rst
+++ b/Misc/NEWS.d/next/Windows/2019-10-04-03-46-36.bpo-37025.tLheEe.rst
@@ -1,0 +1,2 @@
+``AddRefActCtx()`` was needlessly being checked for failure in
+``PC/dl_nt.c``.


### PR DESCRIPTION
AddRefActCtx() does not return a value.

<!-- issue-number: [bpo-37025](https://bugs.python.org/issue37025) -->
https://bugs.python.org/issue37025
<!-- /issue-number -->
