### PR TITLE
bpo-34679: ProactorEventLoop only uses set_wakeup_fd() in main thread

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -627,10 +627,9 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         self._accept_futures = {}   # socket file descriptor => Future
         proactor.set_loop(self)
         self._make_self_pipe()
-        self_no = self._csock.fileno()
         if threading.current_thread() is threading.main_thread():
             # wakeup fd can only be installed to a file descriptor from the main thread
-            signal.set_wakeup_fd(self_no)
+            signal.set_wakeup_fd(self._csock.fileno())
 
     def _make_socket_transport(self, sock, protocol, waiter=None,
                                extra=None, server=None):
@@ -676,7 +675,8 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         if self.is_closed():
             return
 
-        signal.set_wakeup_fd(-1)
+        if threading.current_thread() is threading.main_thread():
+            signal.set_wakeup_fd(-1)
         # Call these methods before closing the event loop (before calling
         # BaseEventLoop.close), because they can schedule callbacks with
         # call_soon(), which is forbidden when the event loop is closed.

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -69,6 +69,8 @@ class ProactorMultithreading(test_utils.TestCase):
             nonlocal finished
             loop = asyncio.new_event_loop()
             loop.run_until_complete(coro())
+            # close() must not call signal.set_wakeup_fd()
+            loop.close()
             finished = True
 
         thread = threading.Thread(target=func)

--- a/Misc/NEWS.d/next/Library/2019-10-23-16-25-12.bpo-34679.Bnw8o3.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-23-16-25-12.bpo-34679.Bnw8o3.rst
@@ -1,0 +1,2 @@
+asynci.ProactorEventLoop.close() now only calls signal.set_wakeup_fd() in the
+main thread.


### PR DESCRIPTION
[bpo-34679](https://bugs.python.org/issue34679), [bpo-38563](https://bugs.python.org/issue38563): asyncio.ProactorEventLoop.close() now only calls
signal.set_wakeup_fd() in the main thread.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34679](https://bugs.python.org/issue34679) -->
https://bugs.python.org/issue34679
<!-- /issue-number -->
