### PR TITLE
Add missing asyncio changes from 3.8 whatsnew

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -597,26 +597,32 @@ asyncio
 
 :func:`asyncio.run` has graduated from the provisional to stable API. This
 function can be used to execute a :term:`coroutine` and return the result while
-automatically managing the event loop. For example:
+automatically managing the event loop. For example::
 
-    >>> import asyncio
-    >>> async def main():
-    ...     await asyncio.sleep(0)
-    ...     return 42
-    >>> asyncio.run(main())
-    42
+    import asyncio
 
-This is *roughly* equivalent to:
+    async def main():
+        await asyncio.sleep(0)
+        return 42
 
-    >>> async def main():
-    ...     await asyncio.sleep(0)
-    ...     return 42
-    >>> loop = asyncio.new_event_loop()
-    >>> asyncio.set_event_loop(loop)
-    >>> loop.run_until_complete(main())
-    42
-    >>> asyncio.set_event_loop(None)
-    >>> loop.close()
+    asyncio.run(main())
+
+This is *roughly* equivalent to::
+
+    import asyncio
+
+    async def main():
+        await asyncio.sleep(0)
+        return 42
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(main())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
 
 The actual implementation is significantly more complex. Thus,
 :func:`asyncio.run` should be the preferred way of running asyncio programs.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1633,7 +1633,7 @@ Deprecated
 
 * Passing an object that is not an instance of
   :class:`concurrent.futures.ThreadPoolExecutor` to
-  :meth:`asyncio.loop.set_default_executor` is
+  :meth:`loop.set_default_executor() <asyncio.loop.set_default_executor>` is
   deprecated and will be prohibited in Python 3.9.
   (Contributed by Elvis Pranskevichus in :issue:`34075`.)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -668,6 +668,7 @@ Added support for
 parameters have been added: *happy_eyeballs_delay* and *interleave*. The Happy
 Eyeballs algorithm improves responsiveness in applications that support IPv4
 and IPv6 by attempting to simultaneously connect using both.
+(Contributed by twisteroid ambassador in :issue:`33530`.)
 
 
 builtins

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -616,7 +616,7 @@ This is *roughly* equivalent to:
     42
     >>> asyncio.set_event_loop(None)
     >>> loop.close()
-    
+
 The actual implementation is significantly more complex. Thus,
 :func:`asyncio.run` should be the preferred way of running asyncio programs.
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -616,6 +616,9 @@ This is *roughly* equivalent to:
     42
     >>> asyncio.set_event_loop(None)
     >>> loop.close()
+    
+The actual implementation is significantly more complex. Thus,
+:func:`asyncio.run` should be the preferred way of running asyncio programs.
 
 (Contributed by Yury Selivanov in :issue:`32314`.)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -640,6 +640,10 @@ loop on every invocation:
 
 (Contributed by Yury Selivanov in :issue:`37028`.)
 
+The exception :class:`asyncio.CancelledError` now inherits from
+:class:`BaseException` rather than :class:`Exception`.
+(Contributed by Yury Selivanov in :issue:`32528`.)
+
 On Windows, the default event loop is now :class:`~asyncio.ProactorEventLoop`.
 (Contributed by Victor Stinner in :issue:`34687`.)
 
@@ -1935,8 +1939,8 @@ Changes in the Python API
   (Contributed by Anthony Sottile in :issue:`36264`.)
 
 * The exception :class:`asyncio.CancelledError` now inherits from
-  :class:`BaseException` rather than a :class:`Exception`.
-  (Contributed by Yury Selivanov in :issue:`13528`.)
+  :class:`BaseException` rather than :class:`Exception`.
+  (Contributed by Yury Selivanov in :issue:`32528`.)
 
 * The function :func:`asyncio.wait_for` now correctly waits for cancellation
   when using an instance of :class:`asyncio.Task`. Previously, upon reaching

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -599,6 +599,7 @@ asyncio
 function can be used to execute a :term:`coroutine` and return the result while
 automatically managing the event loop. For example:
 
+    >>> import asyncio
     >>> async def main():
     ...     await asyncio.sleep(0)
     ...     return 42

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -595,6 +595,30 @@ The :func:`ast.parse` function has some new flags:
 asyncio
 -------
 
+:func:`asyncio.run` has graduated from the provisional to stable API. This
+function can be used to execute a :term:`coroutine` and return the result while
+automatically managing the event loop. For example:
+
+    >>> async def main():
+    ...     await asyncio.sleep(0)
+    ...     return 42
+    >>> asyncio.run(main())
+    42
+
+This is *roughly* equivalent to:
+
+    >>> async def main():
+    ...     await asyncio.sleep(0)
+    ...     return 42
+    >>> loop = asyncio.new_event_loop()
+    >>> asyncio.set_event_loop(loop)
+    >>> loop.run_until_complete(main())
+    42
+    >>> asyncio.set_event_loop(None)
+    >>> loop.close()
+
+(Contributed by Yury Selivanov in :issue:`32314`.)
+
 Running ``python -m asyncio`` launches a natively async REPL.  This allows rapid
 experimentation with code that has a top-level :keyword:`await`.  There is no
 longer a need to directly call ``asyncio.run()`` which would spawn a new event
@@ -621,6 +645,25 @@ On Windows, the default event loop is now :class:`~asyncio.ProactorEventLoop`.
 :class:`~asyncio.ProactorEventLoop` can now be interrupted by
 :exc:`KeyboardInterrupt` ("CTRL+C").
 (Contributed by Vladimir Matveev in :issue:`23057`.)
+
+Added :meth:`asyncio.Task.get_coro` for getting the wrapped coroutine
+within an :class:`asyncio.Task`.
+(Contributed by Alex Grönholm in :issue:`36999`.)
+
+Asyncio tasks can now be named, either by passing the ``name`` keyword
+argument to :func:`asyncio.create_task` or
+the :meth:`~asyncio.loop.create_task` event loop method, or by
+calling the :meth:`~asyncio.Task.set_name` method on the task object. The
+task name is visible in the ``repr()`` output of :class:`asyncio.Task` and
+can also be retrieved using the :meth:`~asyncio.Task.get_name` method.
+(Contributed by Alex Grönholm in :issue:`34270`.)
+
+Added support for
+`Happy Eyeballs <https://en.wikipedia.org/wiki/Happy_Eyeballs>`_ to
+:func:`asyncio.loop.create_connection`. To specify the behavior, two new
+parameters have been added: *happy_eyeballs_delay* and *interleave*. The Happy
+Eyeballs algorithm improves responsiveness in applications that support IPv4
+and IPv6 by attempting to simultaneously connect using both.
 
 
 builtins
@@ -1575,7 +1618,7 @@ Deprecated
 
 * Passing an object that is not an instance of
   :class:`concurrent.futures.ThreadPoolExecutor` to
-  :meth:`asyncio.loop.set_default_executor()` is
+  :meth:`asyncio.loop.set_default_executor` is
   deprecated and will be prohibited in Python 3.9.
   (Contributed by Elvis Pranskevichus in :issue:`34075`.)
 
@@ -1607,6 +1650,19 @@ Deprecated
   removed in version 3.10.  Instead of ``@asyncio.coroutine``, use
   :keyword:`async def` instead.
   (Contributed by Andrew Svetlov in :issue:`36921`.)
+
+* In :mod:`asyncio`, the explicit passing of a *loop* argument has been
+  deprecated and will be removed in version 3.10 for the following:
+  :func:`asyncio.sleep`, :func:`asyncio.gather`, :func:`asyncio.shield`,
+  :func:`asyncio.wait_for`, :func:`asyncio.wait`, :func:`asyncio.as_completed`,
+  :class:`asyncio.Task`, :class:`asyncio.Lock`, :class:`asyncio.Event`,
+  :class:`asyncio.Condition`, :class:`asyncio.Semaphore`,
+  :class:`asyncio.BoundedSemaphore`, :class:`asyncio.Queue`,
+  :func:`asyncio.create_subprocess_exec`, and
+  :func:`asyncio.create_subprocess_shell`.
+
+* The explicit passing of coroutine objects to :func:`asyncio.wait` has been
+  deprecated and will be removed in version 3.10.
 
 * The following functions and methods are deprecated in the :mod:`gettext`
   module: :func:`~gettext.lgettext`, :func:`~gettext.ldgettext`,
@@ -1852,13 +1908,6 @@ Changes in the Python API
   you adjust (possibly including adding accessor functions to the
   public API).  (See :issue:`35886`.)
 
-* Asyncio tasks can now be named, either by passing the ``name`` keyword
-  argument to :func:`asyncio.create_task` or
-  the :meth:`~asyncio.loop.create_task` event loop method, or by
-  calling the :meth:`~asyncio.Task.set_name` method on the task object. The
-  task name is visible in the ``repr()`` output of :class:`asyncio.Task` and
-  can also be retrieved using the :meth:`~asyncio.Task.get_name` method.
-
 * The :meth:`mmap.flush() <mmap.mmap.flush>` method now returns ``None`` on
   success and raises an exception on error under all platforms.  Previously,
   its behavior was platform-dependent: a nonzero value was returned on success;
@@ -1883,6 +1932,17 @@ Changes in the Python API
 * The exception :class:`asyncio.CancelledError` now inherits from
   :class:`BaseException` rather than a :class:`Exception`.
   (Contributed by Yury Selivanov in :issue:`13528`.)
+
+* The function :func:`asyncio.wait_for` now correctly waits for cancellation
+  when using an instance of :class:`asyncio.Task`. Previously, upon reaching
+  *timeout*, it was cancelled and immediately returned.
+  (Contributed by Elvis Pranskevichus in :issue:`32751`.)
+
+* The function :func:`asyncio.BaseTransport.get_extra_info` now returns a safe
+  to use socket object when 'socket' is passed to the *name* parameter.
+  (Contributed by Yury Selivanov in :issue:`37027`.)
+
+* :class:`asyncio.BufferedProtocol` has graduated to the stable API.
 
 .. _bpo-36085-whatsnew:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

The motivation for this PR was from a request by @1st1 to look for and add missing important changes from the 3.8 whatsnew document.

This includes:

Graduation of `asyncio.run()` to the stable API and example of its usage. An example is featured because there wasn't one when it was provisionally added in 3.7 and it's a major change to the high-level API of asyncio.

Addition of `asyncio.Task.get_coro()`.

Support for Happy Eyeballs algorithm in `asyncio.loop.create_connection()`.

Deprecation of passing an explicit *loop* to several functions and class constructors.

Deprecation of passing coroutine objects to `asyncio.wait()`.

Change to `asyncio.wait_for()` to correctly wait for cancellation of asyncio tasks.

Change to `asyncio.BaseTransport.get_extra_info()` to return a safe to use socket object.  

Graduation of `asyncio.BufferedReader` to the stable API.

I also moved the ability to name asyncio tasks from "Porting to Python 3.8 > Changes in the Python API" to "Improved Modules > asyncio". This is because the change does not affect the process of upgrading to Python 3.8 and should be in the "Improved Modules > asyncio" section since it's a new feature addition to a commonly used component of asyncio. Also because it added a new method, `asyncio.Task.get_name()`. 

I believe this includes all of the missing significant user-facing changes made to asyncio in version 3.8. Let me know if I missed anything @1st1 and @asvetlov.