### PR TITLE
bpo-38565: expose typed filed for lru_cache().cache_info()

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -111,7 +111,7 @@ The :mod:`functools` module defines the following functions:
    To help measure the effectiveness of the cache and tune the *maxsize*
    parameter, the wrapped function is instrumented with a :func:`cache_info`
    function that returns a :term:`named tuple` showing *hits*, *misses*,
-   *maxsize* and *currsize*.  In a multi-threaded environment, the hits
+   *maxsize*,  *currsize* and *typed*.  In a multi-threaded environment, the hits
    and misses are approximate.
 
    The decorator also provides a :func:`cache_clear` function for clearing or

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -417,7 +417,7 @@ def _unwrap_partial(func):
 ### LRU Cache function decorator
 ################################################################################
 
-_CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+_CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize", "typed"])
 
 class _HashedSeq(list):
     """ This class guarantees that hash() will be called no more than once
@@ -611,7 +611,7 @@ def _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo):
     def cache_info():
         """Report cache statistics"""
         with lock:
-            return _CacheInfo(hits, misses, maxsize, cache_len())
+            return _CacheInfo(hits, misses, maxsize, cache_len(), typed)
 
     def cache_clear():
         """Clear the cache and cache statistics"""

--- a/Misc/NEWS.d/next/Library/2019-10-24-06-54-02.bpo-38565.F6BcgP.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-24-06-54-02.bpo-38565.F6BcgP.rst
@@ -1,0 +1,1 @@
+expose typed filed for lru_cache().cache_info()

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1248,13 +1248,13 @@ static PyObject *
 lru_cache_cache_info(lru_cache_object *self, PyObject *unused)
 {
     if (self->maxsize == -1) {
-        return PyObject_CallFunction(self->cache_info_type, "nnOn",
+        return PyObject_CallFunction(self->cache_info_type, "nnOnn",
                                      self->hits, self->misses, Py_None,
-                                     PyDict_GET_SIZE(self->cache));
+                                     PyDict_GET_SIZE(self->cache), self->typed);
     }
-    return PyObject_CallFunction(self->cache_info_type, "nnnn",
+    return PyObject_CallFunction(self->cache_info_type, "nnnnn",
                                  self->hits, self->misses, self->maxsize,
-                                 PyDict_GET_SIZE(self->cache));
+                                 PyDict_GET_SIZE(self->cache), self->typed);
 }
 
 static PyObject *


### PR DESCRIPTION
https://bugs.python.org/issue38565

expose typed filed for lru_cache().cache_info()

<!-- issue-number: [bpo-38565](https://bugs.python.org/issue38565) -->
https://bugs.python.org/issue38565
<!-- /issue-number -->
