### PR TITLE
bpo-38584: fix a bug in argparse with whitespace-only help messages

### DIFF
--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4792,6 +4792,15 @@ class TestOptionalsHelpVersionActions(TestCase):
             self.assertPrintHelpExit(parser, format % '--help')
             self.assertRaises(AttributeError, getattr, parser, 'format_version')
 
+    def test_whitespace_help(self):
+        for formatter_class in (argparse.ArgumentDefaultsHelpFormatter, argparse.HelpFormatter,
+                                argparse.MetavarTypeHelpFormatter,
+                                argparse.RawDescriptionHelpFormatter, argparse.RawTextHelpFormatter):
+            parser = argparse.ArgumentParser(formatter_class=formatter_class)
+            parser.add_argument('--foo', action='store_true', help=' ')
+            parser.add_argument('bar', type=float, help=' ')
+            parser.format_help()  # does not raise any error
+
 
 # ======================
 # str() and repr() tests

--- a/Misc/NEWS.d/next/Library/2020-11-01-12-27-34.bpo-38584.S6K8sF.rst
+++ b/Misc/NEWS.d/next/Library/2020-11-01-12-27-34.bpo-38584.S6K8sF.rst
@@ -1,0 +1,1 @@
+Fix a minor bug in argparse with whitespace-only argument help messages


### PR DESCRIPTION
_cf._ https://bugs.python.org/issue38584

Tested under Windows with:

    .\python -m test -v -m test_whitespace_help test_argparse


<!-- issue-number: [bpo-38584](https://bugs.python.org/issue38584) -->
https://bugs.python.org/issue38584
<!-- /issue-number -->
