### PR TITLE
bpo-38586: setting logging.Handler .name property in fileConfig

### DIFF
--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -143,6 +143,7 @@ def _install_handlers(cp, formatters):
         kwargs = section.get("kwargs", '{}')
         kwargs = eval(kwargs, vars(logging))
         h = klass(*args, **kwargs)
+        h.name = hand
         if "level" in section:
             level = section["level"]
             h.setLevel(level)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1591,6 +1591,30 @@ class ConfigFileTest(BaseTest):
         self.apply_config(self.disable_test, disable_existing_loggers=False)
         self.assertFalse(logger.disabled)
 
+    def test_config_set_handler_names(self):
+        test_config = """
+            [loggers]
+            keys=root
+
+            [handlers]
+            keys=hand1
+
+            [formatters]
+            keys=form1
+
+            [logger_root]
+            handlers=hand1
+
+            [handler_hand1]
+            class=StreamHandler
+            formatter=form1
+
+            [formatter_form1]
+            format=%(levelname)s ++ %(message)s
+            """
+        self.apply_config(test_config)
+        self.assertEquals(logging.getLogger().handlers[0].name, 'hand1')
+
     def test_defaults_do_no_interpolation(self):
         """bpo-33802 defaults should not get interpolated"""
         ini = textwrap.dedent("""

--- a/Misc/NEWS.d/next/Library/2019-10-24-17-26-39.bpo-38586.cyq5nr.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-24-17-26-39.bpo-38586.cyq5nr.rst
@@ -1,0 +1,1 @@
+Now :func:`~logging.config.fileConfig` correcty sets the .name of handlers loaded.


### PR DESCRIPTION
_cf._ https://bugs.python.org/issue38586

Tested under Windows with:

    .\python -m test -v -m test_config_set_handler_names test_logging

<!-- issue-number: [bpo-38586](https://bugs.python.org/issue38586) -->
https://bugs.python.org/issue38586
<!-- /issue-number -->
