### PR TITLE
bpo-38558: Mention `:=` in conditions tutorial.

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -676,9 +676,9 @@ to a variable.  For example, ::
    'Trondheim'
 
 Note that in Python, unlike C, assignment inside expressions must be done
-explicitly with the ``:=`` operator. This avoids a common class of problems
-encountered in C programs: typing ``=`` in an expression when ``==`` was
-intended.
+explicitly with the walrus operator ``:=``. This avoids a common class of
+problems encountered in C programs: typing ``=`` in an expression when ``==``
+was intended.
 
 
 .. _tut-comparing:

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -675,8 +675,8 @@ to a variable.  For example, ::
    >>> non_null
    'Trondheim'
 
-Note that in Python, unlike C, assignment cannot occur inside expressions. C
-programmers may grumble about this, but it avoids a common class of problems
+Note that in Python, unlike C, assignment inside expressions must be done
+explicitly with the ``:=`` operator. This avoids a common class of problems
 encountered in C programs: typing ``=`` in an expression when ``==`` was
 intended.
 


### PR DESCRIPTION
This mention about assignments is now stale with the introduction of the assignment expression operator. Adjust the wording to mention that `:=` must be used explicitly, the rest of the paragraph explaining motivation still applies.

<!-- issue-number: [bpo-38558](https://bugs.python.org/issue38558) -->
https://bugs.python.org/issue38558
<!-- /issue-number -->
