### PR TITLE
bpo-35448: check_exist parameter for ConfigParser.read

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -971,7 +971,7 @@ ConfigParser Objects
       *section* is :const:`None` or an empty string, DEFAULT is assumed.
 
 
-   .. method:: read(filenames, encoding=None)
+   .. method:: read(filenames, encoding=None, check_exist=False)
 
       Attempt to read and parse an iterable of filenames, returning a list of
       filenames which were successfully parsed.
@@ -985,16 +985,16 @@ ConfigParser Objects
       directory), and all existing configuration files in the iterable will be
       read.
 
-      If none of the named files exist, the :class:`ConfigParser`
-      instance will contain an empty dataset.  An application which requires
-      initial values to be loaded from a file should load the required file or
-      files using :meth:`read_file` before calling :meth:`read` for any
-      optional files::
+      If none of the named files exist and *check_exist* is False, the
+      :class:`ConfigParser` instance will contain an empty dataset. An
+      application which requires a field to be loaded should set *check_exist*
+      to ``True``. If *check_exist* is active, it will raise a
+      :exc:`FileNotFoundError` whenever it couldn't find the file::
 
          import configparser, os
 
          config = configparser.ConfigParser()
-         config.read_file(open('defaults.cfg'))
+         config.read('defaults.cfg', check_exist=True)
          config.read(['site.cfg', os.path.expanduser('~/.myapp.cfg')],
                      encoding='cp1250')
 
@@ -1008,6 +1008,8 @@ ConfigParser Objects
       .. versionadded:: 3.7
          The *filenames* parameter accepts a :class:`bytes` object.
 
+      .. versionadded:: 3.9
+         The *check_exist* parameter.
 
    .. method:: read_file(f, source=None)
 

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -676,7 +676,7 @@ class RawConfigParser(MutableMapping):
         opts.update(self._defaults)
         return list(opts.keys())
 
-    def read(self, filenames, encoding=None):
+    def read(self, filenames, encoding=None, check_exist=False):
         """Read and parse a filename or an iterable of filenames.
 
         Files that cannot be opened are silently ignored; this is
@@ -695,6 +695,11 @@ class RawConfigParser(MutableMapping):
             try:
                 with open(filename, encoding=encoding) as fp:
                     self._read(fp, filename)
+            except FileNotFoundError:
+                if check_exist:
+                    raise
+                else:
+                    continue
             except OSError:
                 continue
             if isinstance(filename, os.PathLike):

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -757,6 +757,13 @@ boolean {0[0]} NO
         parsed_files = cf.read([file1_bytestring, b'nonexistent-file'])
         self.assertEqual(parsed_files, [file1_bytestring])
 
+    def test_read_non_existent_file(self):
+        cf = self.newconfig()
+        parsed_files = cf.read('nonexistent-file')
+        self.assertEqual(parsed_files, [])
+        with self.assertRaises(FileNotFoundError):
+            cf.read('nonexistent-file', check_exist=True)
+
     # shared by subclasses
     def get_interpolation_config(self):
         return self.fromstring(

--- a/Misc/NEWS.d/next/Library/2019-10-25-06-41-28.bpo-35448.0iMH63.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-25-06-41-28.bpo-35448.0iMH63.rst
@@ -1,0 +1,2 @@
+A check_exist parameter for ConfigParser's read method which raises a
+FileNotFoundError when it couldn't find the given file.


### PR DESCRIPTION


<!-- issue-number: [bpo-35448](https://bugs.python.org/issue35448) -->
https://bugs.python.org/issue35448
<!-- /issue-number -->
