### PR TITLE
bpo-38519: Internal include files missing on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-10-28-05-01-29.bpo-38519.dCkY66.rst
+++ b/Misc/NEWS.d/next/Windows/2019-10-28-05-01-29.bpo-38519.dCkY66.rst
@@ -1,0 +1,2 @@
+Restores the internal C headers that were missing from the nuget.org and
+Microsoft Store packages.

--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -216,12 +216,7 @@ def get_layout(ns):
 
     if ns.include_dev:
 
-        def _c(d):
-            if d.is_dir():
-                return d.name != "internal"
-            return True
-
-        for dest, src in rglob(ns.source / "Include", "**/*.h", _c):
+        for dest, src in rglob(ns.source / "Include", "**/*.h"):
             yield "include/{}".format(dest), src
         src = ns.source / "PC" / "pyconfig.h"
         yield "include/pyconfig.h", src


### PR DESCRIPTION


<!-- issue-number: [bpo-38519](https://bugs.python.org/issue38519) -->
https://bugs.python.org/issue38519
<!-- /issue-number -->
