### PR TITLE
bpo-38592 Add pt-br switcher to Python Docs website

### DIFF
--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -23,6 +23,7 @@
       'fr': 'French',
       'ja': 'Japanese',
       'ko': 'Korean',
+      'pt-br': 'Brazilian Portuguese',
       'zh-cn': 'Simplified Chinese',
   };
 

--- a/Misc/NEWS.d/next/Documentation/2019-10-26-13-19-07.bpo-38592.Y96BYO.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-10-26-13-19-07.bpo-38592.Y96BYO.rst
@@ -1,0 +1,1 @@
+Add Brazilian Portuguese to the language switcher at Python Documentation website.


### PR DESCRIPTION
Olá people!

I discussed with Julien about adding pt-br to the language switcher at the Python Docs website. Since we have around 20% translated, we thought it would be a good idea :)

I’m opening this PR from Python Brasil 2019 and we’re really happy about it.

<!-- issue-number: [bpo-38592](https://bugs.python.org/issue38592) -->
https://bugs.python.org/issue38592
<!-- /issue-number -->
