### PR TITLE
bpo-38334: Fix seeking backward on an encrypted zipfile.ZipExtFile.

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-10-27-00-08-49.bpo-38334.pfLLmc.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-27-00-08-49.bpo-38334.pfLLmc.rst
@@ -1,0 +1,1 @@
+Fixed seeking backward on an encrypted :class:`zipfile.ZipExtFile`.


### PR DESCRIPTION
Test by Daniel Hillier.


<!-- issue-number: [bpo-38334](https://bugs.python.org/issue38334) -->
https://bugs.python.org/issue38334
<!-- /issue-number -->
