### PR TITLE
bpo-38534: Replace wrong KB number references

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1970,7 +1970,7 @@ Changes in the Python API
   resolution. If your application relies on these mechanisms, you should check
   for :func:`~os.add_dll_directory` and if it exists, use it to add your DLLs
   directory while loading your library. Note that Windows 7 users will need to
-  ensure that Windows Update KB2533625 has been installed (this is also verified
+  ensure that Windows Update KB2533623 has been installed (this is also verified
   by the installer).
   (Contributed by Steve Dower in :issue:`36085`.)
 

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -3013,8 +3013,8 @@ private:
             } else if (IsWindowsVersionOrGreater(6, 1, 1)) {
                 HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
                 if (hKernel32 && !GetProcAddress(hKernel32, "AddDllDirectory")) {
-                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows Server 2008 R2 without KB2533625");
-                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "KB2533625 update is required to continue.");
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows Server 2008 R2 without KB2533623");
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "KB2533623 update is required to continue.");
                     /* The "MissingSP1" error also specifies updates are required */
                     LocGetString(_wixLoc, L"#(loc.FailureWS2K8R2MissingSP1)", &pLocString);
                 } else {
@@ -3044,8 +3044,8 @@ private:
             } else if (IsWindows7SP1OrGreater()) {
                 HMODULE hKernel32 = GetModuleHandleW(L"kernel32");
                 if (hKernel32 && !GetProcAddress(hKernel32, "AddDllDirectory")) {
-                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows 7 SP1 without KB2533625");
-                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "KB2533625 update is required to continue.");
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows 7 SP1 without KB2533623");
+                    BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "KB2533623 update is required to continue.");
                     /* The "MissingSP1" error also specifies updates are required */
                     LocGetString(_wixLoc, L"#(loc.FailureWin7MissingSP1)", &pLocString);
                 } else {


### PR DESCRIPTION
This is my first contribution to CPython.

I'm fixing the issue from:
https://bugs.python.org/issue38534

<!-- issue-number: [bpo-38534](https://bugs.python.org/issue38534) -->
https://bugs.python.org/issue38534
<!-- /issue-number -->
