### PR TITLE
gh-82784: Inherit docstrings in dynamically generated subclasses if possible

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -697,6 +697,12 @@ def indentsize(line):
     return len(expline) - len(expline.lstrip())
 
 def _findclass(func):
+    try:
+        idx = func.__code__.co_freevars.index('__class__')
+    except ValueError:
+        pass
+    else:
+        return func.__closure__[0].cell_contents
     cls = sys.modules.get(func.__module__)
     if cls is None:
         return None

--- a/Lib/test/test_inspect/inspect_fodder.py
+++ b/Lib/test/test_inspect/inspect_fodder.py
@@ -118,3 +118,15 @@ class WhichComments:
 # a closing parenthesis with the opening paren being in another line
 (
 ); after_closing = lambda: 1
+
+def gen_subclass(abuse_msg):
+
+    class subclass(StupidGit):
+        def abuse(self, a, b, c):
+            print(abuse_msg)
+            super().abuse(a, b, c)
+
+    return subclass
+
+DynamicSubclass = gen_subclass("some message")
+del gen_subclass

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -629,7 +629,8 @@ class TestRetrievingSourceCode(GetSourceBase):
     def test_getclasses(self):
         classes = inspect.getmembers(mod, inspect.isclass)
         self.assertEqual(classes,
-                         [('FesteringGob', mod.FesteringGob),
+                         [('DynamicSubclass', mod.DynamicSubclass),
+                          ('FesteringGob', mod.FesteringGob),
                           ('MalodorousPervert', mod.MalodorousPervert),
                           ('ParrotDroppings', mod.ParrotDroppings),
                           ('StupidGit', mod.StupidGit),
@@ -649,7 +650,8 @@ class TestRetrievingSourceCode(GetSourceBase):
                                                     mod.ParrotDroppings))
                              ]
                             ],
-                            (mod.WhichComments, (object,),)
+                            (mod.WhichComments, (object,),),
+                            (mod.DynamicSubclass, (mod.StupidGit,)),
                            ]
                           ])
         tree = inspect.getclasstree([cls[1] for cls in classes], True)
@@ -662,7 +664,8 @@ class TestRetrievingSourceCode(GetSourceBase):
                                                     mod.ParrotDroppings))
                              ]
                             ],
-                            (mod.WhichComments, (object,),)
+                            (mod.WhichComments, (object,),),
+                            (mod.DynamicSubclass, (mod.StupidGit,)),
                            ]
                           ])
 
@@ -697,6 +700,10 @@ class TestRetrievingSourceCode(GetSourceBase):
                          'Another\n\ndocstring\n\ncontaining\n\ntabs')
         self.assertEqual(inspect.getdoc(mod.FesteringGob.contradiction),
                          'The automatic gainsaying.')
+        self.assertEqual(inspect.getdoc(mod.DynamicSubclass.abuse),
+                         'Another\n\ndocstring\n\ncontaining\n\ntabs')
+        self.assertEqual(inspect.getdoc(mod.DynamicSubclass().abuse),
+                         'Another\n\ndocstring\n\ncontaining\n\ntabs')
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")

--- a/Misc/NEWS.d/next/Library/2019-11-24-21-58-04.bpo-38603.2RMn1t.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-24-21-58-04.bpo-38603.2RMn1t.rst
@@ -1,0 +1,3 @@
+`inspect.getdoc` now correctly inherits docstrings in dynamically generated
+subclasses for methods that rely on `super()` (as the owning class can be
+retrieved by inspecting the `__class__` cell).


### PR DESCRIPTION
Currently, `inspect.getdoc()` fails to inherit docstrings in dynamically
generated subclasses, such as
```
class Base:
    def method(self): "some docstring"

def make_subclass():
    class subclass(Base):
        def method(self): return super().method()
    return subclass

subclass = make_subclass()
inspect.getdoc(subclass.method)  # => returns None
```
because `inspect._findclass()` tries to find the base
class by parsing `subclass.method.__qualname__` which is
`"make_subclass.<locals>.subclass.method"` and chokes over
`.<locals>.`.

In the case where the method does rely on `super()`, there is another
way we can go back to the "owning" class of the method: by looking up
the contents of the `__class__` cell (which is set up to make 0-arg
super()).  This approach is implemented by this PR.

Perhaps a `__class__` cell could even be set up (in a separate patch)
for *all* methods defined in dynamically created subclasses (i.e. whose
`__qualname__` includes `.<locals>.`), to help with introspection?

<!-- issue-number: [bpo-38603](https://bugs.python.org/issue38603) -->
https://bugs.python.org/issue38603
<!-- /issue-number -->

<!-- gh-issue-number: gh-82784 -->
* Issue: gh-82784
<!-- /gh-issue-number -->
