### PR TITLE
bpo-38616: Using Py_XDECREF to replace Py_DECREF in PyAST_FromNodeObject()

### DIFF
--- a/Python/ast.c
+++ b/Python/ast.c
@@ -937,9 +937,7 @@ PyAST_FromNodeObject(const node *n, PyCompilerFlags *flags,
             goto out;
     }
  out:
-    if (c.c_normalize) {
-        Py_DECREF(c.c_normalize);
-    }
+    Py_XDECREF(c.c_normalize);
     return res;
 }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-38616](https://bugs.python.org/issue38616) -->
https://bugs.python.org/issue38616
<!-- /issue-number -->
