### PR TITLE
bpo-38589: Fixes HTML Help shortcut when Windows is not installed to C drive

### DIFF
--- a/Misc/NEWS.d/next/Windows/2019-10-28-10-48-16.bpo-38589.V69Q1a.rst
+++ b/Misc/NEWS.d/next/Windows/2019-10-28-10-48-16.bpo-38589.V69Q1a.rst
@@ -1,0 +1,1 @@
+Fixes HTML Help shortcut when Windows is not installed to C drive

--- a/Tools/msi/doc/doc.wxs
+++ b/Tools/msi/doc/doc.wxs
@@ -8,7 +8,7 @@
         <PropertyRef Id="REGISTRYKEY" />
         
         <Property Id="HHExe" Value="C:\Windows\hh.exe" />
-        <CustomAction Id="SetHHExe" Property="HHCExe" Value='[WindowsFolder]\hh.exe' Execute="immediate" />
+        <CustomAction Id="SetHHExe" Property="HHExe" Value='[WindowsFolder]\hh.exe' Execute="immediate" />
         <InstallExecuteSequence>
             <Custom Action="SetHHExe" Before="CostFinalize">1</Custom>
         </InstallExecuteSequence>


### PR DESCRIPTION


<!-- issue-number: [bpo-38589](https://bugs.python.org/issue38589) -->
https://bugs.python.org/issue38589
<!-- /issue-number -->
