### PR TITLE
bpo-38623: Add note about site module (site-packages)

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -198,6 +198,12 @@ named :file:`spam.py` in a list of directories given by the variable
    script is calculated after the symlink is followed. In other words the
    directory containing the symlink is **not** added to the module search path.
 
+.. note::
+   The :mod:`site` module is responsible for appending site-specific paths to
+   the module search path. It also provides a way to get a list of all
+   site-specific paths, which can be global and per user site-packages
+   directories (:pep:`370`), from the command line via ``python -m site``.
+
 After initialization, Python programs can modify :data:`sys.path`.  The
 directory containing the script being run is placed at the beginning of the
 search path, ahead of the standard library path. This means that scripts in that

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -191,17 +191,13 @@ named :file:`spam.py` in a list of directories given by the variable
   file is specified).
 * :envvar:`PYTHONPATH` (a list of directory names, with the same syntax as the
   shell variable :envvar:`PATH`).
-* The installation-dependent default.
+* The installation-dependent default (by convention including a
+  ``site-packages`` directory, handled by the :mod:`site` module).
 
 .. note::
    On file systems which support symlinks, the directory containing the input
    script is calculated after the symlink is followed. In other words the
    directory containing the symlink is **not** added to the module search path.
-
-.. note::
-   The :mod:`site` module is responsible for appending site-specific paths to
-   the module search path. It also provides a command line interface to print
-   a list of all module search paths (e.g. ``python -m site``).
 
 After initialization, Python programs can modify :data:`sys.path`.  The
 directory containing the script being run is placed at the beginning of the

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -200,9 +200,8 @@ named :file:`spam.py` in a list of directories given by the variable
 
 .. note::
    The :mod:`site` module is responsible for appending site-specific paths to
-   the module search path. It also provides a way to get a list of all
-   site-specific paths, which can be global and per user site-packages
-   directories (:pep:`370`), from the command line via ``python -m site``.
+   the module search path. It also provides a command line interface to print
+   a list of all module search paths (e.g. ``python -m site``).
 
 After initialization, Python programs can modify :data:`sys.path`.  The
 directory containing the script being run is placed at the beginning of the


### PR DESCRIPTION
Adds a information about "site-packages" in a concise way.

## Background

A popular question on StackOverflow is, "[How do I find the location of my Python site-packages directory?](https://stackoverflow.com/questions/122327/how-do-i-find-the-location-of-my-python-site-packages-directory/46071447)"

While this may hint at a deeper problem that needs to be solved, [a user suggested](https://stackoverflow.com/questions/122327/how-do-i-find-the-location-of-my-python-site-packages-directory/46071447#comment103247041_46071447) the accepted answer to be added to Python's official documentation.

<!-- issue-number: [bpo-38623](https://bugs.python.org/issue38623) -->
https://bugs.python.org/issue38623
<!-- /issue-number -->
