### PR TITLE
bpo-34790: Implement deprecation of passing coroutines to asyncio.wait()

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -216,6 +216,9 @@ Deprecated
   predicable behavior.
   (Contributed by Serhiy Storchaka in :issue:`38371`.)
 
+* The explicit passing of coroutine objects to :func:`asyncio.wait` has been
+  deprecated and will be removed in version 3.11.
+  (Contributed by Yury Selivanov and Kyle Stanley in :issue:`34790`.)
 
 Removed
 =======

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -421,6 +421,11 @@ async def wait(fs, *, loop=None, timeout=None, return_when=ALL_COMPLETED):
                       "and scheduled for removal in Python 3.10.",
                       DeprecationWarning, stacklevel=2)
 
+    if any(coroutines.iscoroutine(f) for f in set(fs)):
+        warnings.warn("Passing coroutines objects to asyncio.wait() is "
+                      "deprecated since Python 3.8, and scheduled for removal "
+                      "in Python 3.11", DeprecationWarning)
+
     fs = {ensure_future(f, loop=loop) for f in set(fs)}
 
     return await _wait(fs, timeout, return_when, loop)

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -422,9 +422,10 @@ async def wait(fs, *, loop=None, timeout=None, return_when=ALL_COMPLETED):
                       DeprecationWarning, stacklevel=2)
 
     if any(coroutines.iscoroutine(f) for f in set(fs)):
-        warnings.warn("Passing coroutines objects to asyncio.wait() is "
-                      "deprecated since Python 3.8, and scheduled for removal "
-                      "in Python 3.11", DeprecationWarning)
+        warnings.warn("The explicit passing of coroutine objects to "
+                      "asyncio.wait() is deprecated since Python 3.8, and "
+                      "scheduled for removal in Python 3.11.",
+                      DeprecationWarning, stacklevel=2)
 
     fs = {ensure_future(f, loop=loop) for f in set(fs)}
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -979,12 +979,12 @@ class BaseTaskTests:
             def coro(s):
                 return s
         c = coro('test')
-
-        task =self.new_task(
+        task = self.new_task(
             self.loop,
             asyncio.wait([c, c, coro('spam')]))
 
-        done, pending = self.loop.run_until_complete(task)
+        with self.assertWarns(DeprecationWarning):
+            done, pending = self.loop.run_until_complete(task)
 
         self.assertFalse(pending)
         self.assertEqual(set(f.result() for f in done), {'test', 'spam'})
@@ -1346,7 +1346,9 @@ class BaseTaskTests:
             futs = list(asyncio.as_completed(fs, loop=loop))
         self.assertEqual(len(futs), 2)
         waiter = asyncio.wait(futs)
-        done, pending = loop.run_until_complete(waiter)
+        # Deprecation from passing coros in futs to asyncio.wait()
+        with self.assertWarns(DeprecationWarning):
+            done, pending = loop.run_until_complete(waiter)
         self.assertEqual(set(f.result() for f in done), {'a', 'b'})
 
     def test_as_completed_duplicate_coroutines(self):
@@ -1751,7 +1753,8 @@ class BaseTaskTests:
 
         async def outer():
             nonlocal proof
-            d, p = await asyncio.wait([inner()])
+            with self.assertWarns(DeprecationWarning):
+                d, p = await asyncio.wait([inner()])
             proof += 100
 
         f = asyncio.ensure_future(outer(), loop=self.loop)

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3307,6 +3307,19 @@ class WaitTests(test_utils.TestCase):
             self.loop.run_until_complete(
                 asyncio.wait_for(coroutine_function(), 0.01, loop=self.loop))
 
+    def test_coro_is_deprecated_in_wait(self):
+        # Remove test when passing coros to asyncio.wait() is removed in 3.11
+        # Test with coro as first arg
+        with self.assertWarns(DeprecationWarning):
+            self.loop.run_until_complete(
+                asyncio.wait([coroutine_function()]))
+
+        # Test with coro as second arg
+        task = self.loop.create_task(coroutine_function())
+        with self.assertWarns(DeprecationWarning):
+            self.loop.run_until_complete(
+                asyncio.wait([task, coroutine_function()]))
+
 
 class CompatibilityTests(test_utils.TestCase):
     # Tests for checking a bridge between old-styled coroutines

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3312,12 +3312,10 @@ class WaitTests(test_utils.TestCase):
 
     def test_coro_is_deprecated_in_wait(self):
         # Remove test when passing coros to asyncio.wait() is removed in 3.11
-        # Test with coro as first arg
         with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(
                 asyncio.wait([coroutine_function()]))
 
-        # Test with coro as second arg
         task = self.loop.create_task(coroutine_function())
         with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

/cc @1st1 @asvetlov 

<!-- issue-number: [bpo-34790](https://bugs.python.org/issue34790) -->
https://bugs.python.org/issue34790
<!-- /issue-number -->
