### PR TITLE
fix GROWTH_RATE comments bug

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -414,7 +414,7 @@ dictkeys_set_index(PyDictKeysObject *keys, Py_ssize_t i, Py_ssize_t ix)
 
 /* GROWTH_RATE. Growth rate upon hitting maximum load.
  * Currently set to used*3.
- * This means that dicts double in size when growing without deletions,
+ * This means that dicts three times in size when growing without deletions,
  * but have more head room when the number of deletions is on a par with the
  * number of insertions.  See also bpo-17563 and bpo-33205.
  *


### PR DESCRIPTION
It also exists in  3.7/3.6/3.3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
