### PR TITLE
bpo-38614: Increase asyncio test_communicate() timeout

### DIFF
--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -143,7 +143,7 @@ class SubprocessMixin:
             return proc.returncode, stdout
 
         task = run(b'some data')
-        task = asyncio.wait_for(task, 60.0)
+        task = asyncio.wait_for(task, support.LONG_TIMEOUT)
         exitcode, stdout = self.loop.run_until_complete(task)
         self.assertEqual(exitcode, 0)
         self.assertEqual(stdout, b'some data')

--- a/Misc/NEWS.d/next/Tests/2019-10-30-15-12-32.bpo-38614.M6UnLB.rst
+++ b/Misc/NEWS.d/next/Tests/2019-10-30-15-12-32.bpo-38614.M6UnLB.rst
@@ -1,0 +1,2 @@
+Fix test_communicate() of test_asyncio.test_subprocess: use
+``support.LONG_TIMEOUT`` (5 minutes), instead of just 1 minute.


### PR DESCRIPTION
Fix test_communicate() of test_asyncio.test_subprocess: use
support.LONG_TIMEOUT (5 minutes), instead of 1 minute.

<!-- issue-number: [bpo-38614](https://bugs.python.org/issue38614) -->
https://bugs.python.org/issue38614
<!-- /issue-number -->
