### PR TITLE
bpo-38648: Remove double tp_free slot in Python-ast.c

### DIFF
--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -751,7 +751,6 @@ static PyType_Slot AST_type_slots[] = {
     {Py_tp_init, ast_type_init},
     {Py_tp_alloc, PyType_GenericAlloc},
     {Py_tp_new, PyType_GenericNew},
-    {Py_tp_free, PyType_GenericNew},
     {Py_tp_free, PyObject_GC_Del},
     {0, 0},
 };

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -1244,7 +1244,6 @@ static PyType_Slot AST_type_slots[] = {
     {Py_tp_init, ast_type_init},
     {Py_tp_alloc, PyType_GenericAlloc},
     {Py_tp_new, PyType_GenericNew},
-    {Py_tp_free, PyType_GenericNew},
     {Py_tp_free, PyObject_GC_Del},
     {0, 0},
 };


### PR DESCRIPTION
This looks like a typo due to copy-paste.

<!-- issue-number: [bpo-38648](https://bugs.python.org/issue38648) -->
https://bugs.python.org/issue38648
<!-- /issue-number -->
