### PR TITLE
bpo-38650: Constify PyStructSequence_UnnamedField.

### DIFF
--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -186,6 +186,9 @@ type.
 
    Special value for a field name to leave it unnamed.
 
+   versionchanged:: 3.9
+   The type was changed from ``char *``.
+
 
 .. c:function:: PyObject* PyStructSequence_New(PyTypeObject *type)
 

--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -186,8 +186,8 @@ type.
 
    Special value for a field name to leave it unnamed.
 
-   versionchanged:: 3.9
-   The type was changed from ``char *``.
+   .. versionchanged:: 3.9
+      The type was changed from ``char *``.
 
 
 .. c:function:: PyObject* PyStructSequence_New(PyTypeObject *type)

--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -182,7 +182,7 @@ type.
    +-----------+------------------+-----------------------------------------+
 
 
-.. c:var:: char* PyStructSequence_UnnamedField
+.. c:var:: const char * const PyStructSequence_UnnamedField
 
    Special value for a field name to leave it unnamed.
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -195,6 +195,9 @@ Build and C API Changes
   way to call a callable Python object without any argument.
   (Contributed by Victor Stinner in :issue:`37194`.)
 
+* The global variable :c:data:`PyStructSequence_UnnamedField` is now a constant
+  and refers to a constant string.
+  (Contributed by Serhiy Storchaka in :issue:`38650`.)
 
 
 Deprecated

--- a/Include/structseq.h
+++ b/Include/structseq.h
@@ -19,7 +19,7 @@ typedef struct PyStructSequence_Desc {
     int n_in_sequence;
 } PyStructSequence_Desc;
 
-extern char* PyStructSequence_UnnamedField;
+extern const char * const PyStructSequence_UnnamedField;
 
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(void) PyStructSequence_InitType(PyTypeObject *type,

--- a/Misc/NEWS.d/next/C API/2019-10-30-22-03-03.bpo-38650.0pi8zt.rst
+++ b/Misc/NEWS.d/next/C API/2019-10-30-22-03-03.bpo-38650.0pi8zt.rst
@@ -1,0 +1,2 @@
+The global variable :c:data:`PyStructSequence_UnnamedField` is now a
+constant and refers to a constant string.

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -18,7 +18,7 @@ static const char unnamed_fields_key[] = "n_unnamed_fields";
 
 /* Fields with this name have only a field index, not a field name.
    They are only allowed for indices < n_visible_fields. */
-char *PyStructSequence_UnnamedField = "unnamed field";
+const char * const PyStructSequence_UnnamedField = "unnamed field";
 _Py_IDENTIFIER(n_sequence_fields);
 _Py_IDENTIFIER(n_fields);
 _Py_IDENTIFIER(n_unnamed_fields);


### PR DESCRIPTION
Make it a constant and referring to a constant string.


<!-- issue-number: [bpo-38650](https://bugs.python.org/issue38650) -->
https://bugs.python.org/issue38650
<!-- /issue-number -->
