### PR TITLE
Update the URL for the requests package

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -20,7 +20,7 @@ HTTPS protocols.  It is normally not used directly --- the module
 
 .. seealso::
 
-    The `Requests package <https://requests.kennethreitz.org/>`_
+    The `Requests package <https://requests.readthedocs.io/en/master/>`_
     is recommended for a higher-level HTTP client interface.
 
 .. note::

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -20,7 +20,7 @@ HTTPS protocols.  It is normally not used directly --- the module
 
 .. seealso::
 
-    The `Requests package <http://docs.python-requests.org/>`_
+    The `Requests package <https://requests.kennethreitz.org/>`_
     is recommended for a higher-level HTTP client interface.
 
 .. note::

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -18,7 +18,7 @@ authentication, redirections, cookies and more.
 
 .. seealso::
 
-    The `Requests package <http://docs.python-requests.org/>`_
+    The `Requests package <https://requests.readthedocs.io/en/master/>`_
     is recommended for a higher-level HTTP client interface.
 
 


### PR DESCRIPTION
Change the url from docs.python-requests.org to requests.readthedocs.io

Automerge-Triggered-By: @Mariatta