### PR TITLE
Fix spelling of patching in wave.py

### DIFF
--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -53,7 +53,7 @@ This returns an instance of a class with the following public methods:
                       -- set all parameters at once
       tell()          -- return current position in output file
       writeframesraw(data)
-                      -- write audio frames without pathing up the
+                      -- write audio frames without patching up the
                          file header
       writeframes(data)
                       -- write audio frames and patch up the file header


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
This PR fixes the spelling of the word patching in the wave module.
`pathing` -> `patching`