### PR TITLE
Slightly improve plistlib test coverage

### DIFF
--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -133,7 +133,7 @@ The following classes are available:
    encoded data, which contains UID (see PList manual).
 
    It has one attribute, :attr:`data`, which can be used to retrieve the int value
-   of the UID.  :attr:`data` must be in the range `0 <= data <= 2**64`.
+   of the UID.  :attr:`data` must be in the range `0 <= data < 2**64`.
 
    .. versionadded:: 3.8
 

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -503,6 +503,26 @@ class TestPlistlib(unittest.TestCase):
                 pl2 = plistlib.loads(data)
                 self.assertEqual(dict(pl), dict(pl2))
 
+    def test_dump_invalid_format(self):
+        with self.assertRaises(ValueError):
+            plistlib.dumps({}, fmt="blah")
+
+    def test_load_invalid_file(self):
+        with self.assertRaises(plistlib.InvalidFileException):
+            plistlib.loads(b"these are not plist file contents")
+
+    def test_modified_uid_negative(self):
+        neg_uid = UID(1)
+        neg_uid.data = -1  # dodge the negative check in the constructor
+        with self.assertRaises(ValueError):
+            plistlib.dumps(neg_uid, fmt=plistlib.FMT_BINARY)
+
+    def test_modified_uid_huge(self):
+        neg_uid = UID(1)
+        neg_uid.data = 2 ** 64  # dodge the size check in the constructor
+        with self.assertRaises(OverflowError):
+            plistlib.dumps(neg_uid, fmt=plistlib.FMT_BINARY)
+
 
 class TestBinaryPlistlib(unittest.TestCase):
 

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -656,7 +656,7 @@ class MiscTestCase(unittest.TestCase):
 
 
 def test_main():
-    support.run_unittest(TestPlistlib, TestKeyedArchive, MiscTestCase)
+    support.run_unittest(TestPlistlib, TestBinaryPlistlib, TestKeyedArchive, MiscTestCase)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -675,9 +675,5 @@ class MiscTestCase(unittest.TestCase):
         support.check__all__(self, plistlib, blacklist=blacklist)
 
 
-def test_main():
-    support.run_unittest(TestPlistlib, TestBinaryPlistlib, TestKeyedArchive, MiscTestCase)
-
-
 if __name__ == '__main__':
-    test_main()
+    unittest.main()

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -518,10 +518,10 @@ class TestPlistlib(unittest.TestCase):
             plistlib.dumps(neg_uid, fmt=plistlib.FMT_BINARY)
 
     def test_modified_uid_huge(self):
-        neg_uid = UID(1)
-        neg_uid.data = 2 ** 64  # dodge the size check in the constructor
+        huge_uid = UID(1)
+        huge_uid.data = 2 ** 64  # dodge the size check in the constructor
         with self.assertRaises(OverflowError):
-            plistlib.dumps(neg_uid, fmt=plistlib.FMT_BINARY)
+            plistlib.dumps(huge_uid, fmt=plistlib.FMT_BINARY)
 
 
 class TestBinaryPlistlib(unittest.TestCase):


### PR DESCRIPTION
* Re-enable `TestBinaryPlistlib` (Accidentally dropped in GH-4455)
* Add 4 test cases to increase coverage slightly

I don't think this warrants a b.p.o issue, but I'm happy to create one if necessary