### PR TITLE
[3.8] Slightly improve plistlib test coverage. (GH-17025)

### DIFF
--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -188,8 +188,8 @@ The following classes are available:
    Wraps an :class:`int`.  This is used when reading or writing NSKeyedArchiver
    encoded data, which contains UID (see PList manual).
 
-   It has one attribute, :attr:`data` which can be used to retrieve the int value
-   of the UID.  :attr:`data` must be in the range `0 <= data <= 2**64`.
+   It has one attribute, :attr:`data`, which can be used to retrieve the int value
+   of the UID.  :attr:`data` must be in the range `0 <= data < 2**64`.
 
    .. versionadded:: 3.8
 

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -505,6 +505,26 @@ class TestPlistlib(unittest.TestCase):
                 pl2 = plistlib.loads(data)
                 self.assertEqual(dict(pl), dict(pl2))
 
+    def test_dump_invalid_format(self):
+        with self.assertRaises(ValueError):
+            plistlib.dumps({}, fmt="blah")
+
+    def test_load_invalid_file(self):
+        with self.assertRaises(plistlib.InvalidFileException):
+            plistlib.loads(b"these are not plist file contents")
+
+    def test_modified_uid_negative(self):
+        neg_uid = UID(1)
+        neg_uid.data = -1  # dodge the negative check in the constructor
+        with self.assertRaises(ValueError):
+            plistlib.dumps(neg_uid, fmt=plistlib.FMT_BINARY)
+
+    def test_modified_uid_huge(self):
+        huge_uid = UID(1)
+        huge_uid.data = 2 ** 64  # dodge the size check in the constructor
+        with self.assertRaises(OverflowError):
+            plistlib.dumps(huge_uid, fmt=plistlib.FMT_BINARY)
+
 
 class TestBinaryPlistlib(unittest.TestCase):
 
@@ -748,9 +768,5 @@ class MiscTestCase(unittest.TestCase):
         support.check__all__(self, plistlib, blacklist=blacklist)
 
 
-def test_main():
-    support.run_unittest(TestPlistlib, TestPlistlibDeprecated, TestKeyedArchive, MiscTestCase)
-
-
 if __name__ == '__main__':
-    test_main()
+    unittest.main()


### PR DESCRIPTION
* Add missing test class (mistake in GH-4455)

* Increase coverage with 4 more test cases

* Rename neg_uid to huge_uid in test_modified_uid_huge

* Replace test_main() with unittest.main()

* Update plistlib docs.
(cherry picked from commit d0d9f7cfa36bafa4e1d9e73eb08835180d376df1)

Co-authored-by: Jon Janzen <jjjonjanzen@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
