### PR TITLE
bpo-38657: Clarify numeric padding behaviour in string formatting

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -416,7 +416,7 @@ error.
    Added the ``'_'`` option (see also :pep:`515`).
 
 *width* is a decimal integer defining the minimum total field width,
-including any signs. If not specified, then the field width will be
+including any prefixes, separators, and other formatting characters. If not specified, then the field width will be
 determined by the content.
 
 When no explicit alignment is given, preceding the *width* field by a zero

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -416,8 +416,8 @@ error.
    Added the ``'_'`` option (see also :pep:`515`).
 
 *width* is a decimal integer defining the minimum total field width,
-including any prefixes, separators, and other formatting characters. If not specified, then the field width will be
-determined by the content.
+including any prefixes, separators, and other formatting characters.
+If not specified, then the field width will be determined by the content.
 
 When no explicit alignment is given, preceding the *width* field by a zero
 (``'0'``) character enables

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -415,8 +415,9 @@ error.
 .. versionchanged:: 3.6
    Added the ``'_'`` option (see also :pep:`515`).
 
-*width* is a decimal integer defining the minimum field width.  If not
-specified, then the field width will be determined by the content.
+*width* is a decimal integer defining the minimum total field width,
+including any signs. If not specified, then the field width will be
+determined by the content.
 
 When no explicit alignment is given, preceding the *width* field by a zero
 (``'0'``) character enables

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -416,8 +416,8 @@ error.
    Added the ``'_'`` option (see also :pep:`515`).
 
 *width* is a decimal integer defining the minimum total field width,
-including any prefixes, separators, and other formatting characters.
-If not specified, then the field width will be determined by the content.
+including any prefixes, separators, and other formatting characters. If not specified, then the field width will be
+determined by the content.
 
 When no explicit alignment is given, preceding the *width* field by a zero
 (``'0'``) character enables

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -529,7 +529,7 @@ calc_number_widths(NumberFieldWidths *spec, Py_ssize_t n_prefix,
     /* min_width can go negative, that's okay. format->width == -1 means
        we don't care. */
     if (format->fill_char == '0' && format->align == '=')
-        spec->n_min_width = format->width - n_non_digit_non_padding;
+        spec->n_min_width = format->width + n_non_digit_non_padding;
     else
         spec->n_min_width = 0;
 

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -529,7 +529,7 @@ calc_number_widths(NumberFieldWidths *spec, Py_ssize_t n_prefix,
     /* min_width can go negative, that's okay. format->width == -1 means
        we don't care. */
     if (format->fill_char == '0' && format->align == '=')
-        spec->n_min_width = format->width + n_non_digit_non_padding;
+        spec->n_min_width = format->width - n_non_digit_non_padding;
     else
         spec->n_min_width = 0;
 


### PR DESCRIPTION
Make the definition of the width more explicit that it includes any
extra signs added by other options.

<!-- issue-number: [bpo-38657](https://bugs.python.org/issue38657) -->
https://bugs.python.org/issue38657
<!-- /issue-number -->


Automerge-Triggered-By: @Mariatta