### PR TITLE
bpo-38677: Fix arraymodule error handling in module initialization

### DIFF
--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3044,7 +3044,9 @@ array_modexec(PyObject *m)
         return -1;
     }
     Py_INCREF((PyObject *)&Arraytype);
-    if (PyModule_AddObject(m, "array", (PyObject *)&Arraytype) < 0)
+    if (PyModule_AddObject(m, "array", (PyObject *)&Arraytype) < 0) {
+        Py_DECREF((PyObject *)&Arraytype);
+        Py_CLEAR(m);
       return -1;
 
     for (descr=descriptors; descr->typecode != '\0'; descr++) {

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3040,9 +3040,11 @@ array_modexec(PyObject *m)
     Py_TYPE(&PyArrayIter_Type) = &PyType_Type;
 
     Py_INCREF((PyObject *)&Arraytype);
-    PyModule_AddObject(m, "ArrayType", (PyObject *)&Arraytype);
+    if (PyModule_AddObject(m, "ArrayType", (PyObject *)&Arraytype) < 0)
+      return -1;
     Py_INCREF((PyObject *)&Arraytype);
-    PyModule_AddObject(m, "array", (PyObject *)&Arraytype);
+    if (PyModule_AddObject(m, "array", (PyObject *)&Arraytype) < 0)
+      return -1;
 
     for (descr=descriptors; descr->typecode != '\0'; descr++) {
         size++;
@@ -3053,13 +3055,11 @@ array_modexec(PyObject *m)
         *p++ = (char)descr->typecode;
     }
     typecodes = PyUnicode_DecodeASCII(buffer, p - buffer, NULL);
+    assert(typecodes != NULL);
 
-    PyModule_AddObject(m, "typecodes", typecodes);
+    if (PyModule_AddObject(m, "typecodes", typecodes) < 0)
+      return -1;
 
-    if (PyErr_Occurred()) {
-        Py_DECREF(m);
-        m = NULL;
-    }
     return 0;
 }
 

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3040,13 +3040,13 @@ array_modexec(PyObject *m)
     Py_TYPE(&PyArrayIter_Type) = &PyType_Type;
 
     Py_INCREF((PyObject *)&Arraytype);
-    if (PyModule_AddObject(m, "ArrayType", (PyObject *)&Arraytype) < 0)
+    if (PyModule_AddObject(m, "ArrayType", (PyObject *)&Arraytype) < 0) {
+        Py_DECREF((PyObject *)&Arraytype);
         return -1;
     }
     Py_INCREF((PyObject *)&Arraytype);
     if (PyModule_AddObject(m, "array", (PyObject *)&Arraytype) < 0) {
         Py_DECREF((PyObject *)&Arraytype);
-        Py_CLEAR(m);
         return -1;
     }
 
@@ -3061,7 +3061,8 @@ array_modexec(PyObject *m)
     typecodes = PyUnicode_DecodeASCII(buffer, p - buffer, NULL);
     assert(typecodes != NULL);
 
-    if (PyModule_AddObject(m, "typecodes", typecodes) < 0)
+    if (PyModule_AddObject(m, "typecodes", typecodes) < 0) {
+        Py_DECREF(typecodes);
         return -1;
     }
 

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3059,8 +3059,9 @@ array_modexec(PyObject *m)
         *p++ = (char)descr->typecode;
     }
     typecodes = PyUnicode_DecodeASCII(buffer, p - buffer, NULL);
-    assert(typecodes != NULL);
-
+    if (typecodes == NULL) {
+        return -1;
+    }
     if (PyModule_AddObject(m, "typecodes", typecodes) < 0) {
         Py_DECREF(typecodes);
         return -1;

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3041,7 +3041,8 @@ array_modexec(PyObject *m)
 
     Py_INCREF((PyObject *)&Arraytype);
     if (PyModule_AddObject(m, "ArrayType", (PyObject *)&Arraytype) < 0)
-      return -1;
+        return -1;
+    }
     Py_INCREF((PyObject *)&Arraytype);
     if (PyModule_AddObject(m, "array", (PyObject *)&Arraytype) < 0)
       return -1;

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3047,7 +3047,8 @@ array_modexec(PyObject *m)
     if (PyModule_AddObject(m, "array", (PyObject *)&Arraytype) < 0) {
         Py_DECREF((PyObject *)&Arraytype);
         Py_CLEAR(m);
-      return -1;
+        return -1;
+    }
 
     for (descr=descriptors; descr->typecode != '\0'; descr++) {
         size++;

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3059,11 +3059,8 @@ array_modexec(PyObject *m)
         *p++ = (char)descr->typecode;
     }
     typecodes = PyUnicode_DecodeASCII(buffer, p - buffer, NULL);
-    if (typecodes == NULL) {
-        return -1;
-    }
     if (PyModule_AddObject(m, "typecodes", typecodes) < 0) {
-        Py_DECREF(typecodes);
+        Py_XDECREF(typecodes);
         return -1;
     }
 

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3061,7 +3061,8 @@ array_modexec(PyObject *m)
     assert(typecodes != NULL);
 
     if (PyModule_AddObject(m, "typecodes", typecodes) < 0)
-      return -1;
+        return -1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
<!-- issue-number: [bpo-38677](https://bugs.python.org/issue38677) -->
https://bugs.python.org/issue38677
<!-- /issue-number -->
