### PR TITLE
bpo-37759:  Show output from var_access_benchmark

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -2152,6 +2152,55 @@ CPython bytecode changes
 Demos and Tools
 ---------------
 
-* Added a benchmark script for timing various ways to access variables:
-  ``Tools/scripts/var_access_benchmark.py``.
-  (Contributed by Raymond Hettinger in :issue:`35884`.)
+Added a benchmark script for timing various ways to access variables:
+``Tools/scripts/var_access_benchmark.py``.
+(Contributed by Raymond Hettinger in :issue:`35884`.)
+
+Here's a summary of performance improvements since Python 3.3:
+
+.. code-block:: none
+
+    Python version                       3.3     3.4     3.5     3.6     3.7     3.8
+    --------------                       ---     ---     ---     ---     ---     ---
+
+    Variable and attribute read access:
+        read_local                       4.0     7.1     7.1     5.4     5.1     3.9
+        read_nonlocal                    5.3     7.1     8.1     5.8     5.4     4.4
+        read_global                     13.3    15.5    19.0    14.3    13.6     7.6
+        read_builtin                    20.0    21.1    21.6    18.5    19.0     7.5
+        read_classvar_from_class        20.5    25.6    26.5    20.7    19.5    18.4
+        read_classvar_from_instance     18.5    22.8    23.5    18.8    17.1    16.4
+        read_instancevar                26.8    32.4    33.1    28.0    26.3    25.4
+        read_instancevar_slots          23.7    27.8    31.3    20.8    20.8    20.2
+        read_namedtuple                 68.5    73.8    57.5    45.0    46.8    18.4
+        read_boundmethod                29.8    37.6    37.9    29.6    26.9    27.7
+
+    Variable and attribute write access:
+        write_local                      4.6     8.7     9.3     5.5     5.3     4.3
+        write_nonlocal                   7.3    10.5    11.1     5.6     5.5     4.7
+        write_global                    15.9    19.7    21.2    18.0    18.0    15.8
+        write_classvar                  81.9    92.9    96.0   104.6   102.1    39.2
+        write_instancevar               36.4    44.6    45.8    40.0    38.9    35.5
+        write_instancevar_slots         28.7    35.6    36.1    27.3    26.6    25.7
+
+    Data structure read access:
+        read_list                       19.2    24.2    24.5    20.8    20.8    19.0
+        read_deque                      19.9    24.7    25.5    20.2    20.6    19.8
+        read_dict                       19.7    24.3    25.7    22.3    23.0    21.0
+        read_strdict                    17.9    22.6    24.3    19.5    21.2    18.9
+
+    Data structure write access:
+        write_list                      21.2    27.1    28.5    22.5    21.6    20.0
+        write_deque                     23.8    28.7    30.1    22.7    21.8    23.5
+        write_dict                      25.9    31.4    33.3    29.3    29.2    24.7
+        write_strdict                   22.9    28.4    29.9    27.5    25.2    23.1
+
+    Stack (or queue) operations:
+        list_append_pop                144.2    93.4   112.7    75.4    74.2    50.8
+        deque_append_pop                30.4    43.5    57.0    49.4    49.2    42.5
+        deque_append_popleft            30.8    43.7    57.3    49.7    49.7    42.8
+
+    Timing loop:
+        loop_overhead                    0.3     0.5     0.6     0.4     0.3     0.3
+
+    (Measured from the macOS 64-bit builds found at python.org)


### PR DESCRIPTION


<!-- issue-number: [bpo-37759](https://bugs.python.org/issue37759) -->
https://bugs.python.org/issue37759
<!-- /issue-number -->
