### PR TITLE
bpo-38684: haslib: fix build when Blake2 not enabled in OpenSSL

### DIFF
--- a/Misc/NEWS.d/next/Build/2019-11-04-14-30-37.bpo-38684.aed593.rst
+++ b/Misc/NEWS.d/next/Build/2019-11-04-14-30-37.bpo-38684.aed593.rst
@@ -1,0 +1,1 @@
+Fix _hashlib build when Blake2 is disabled, but OpenSSL supports it.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -42,7 +42,7 @@
 #define PY_OPENSSL_HAS_SHAKE 1
 #endif
 
-#ifdef NID_blake2b512
+#if defined(NID_blake2b512) && !defined(OPENSSL_NO_BLAKE2)
 #define PY_OPENSSL_HAS_BLAKE2 1
 #endif
 


### PR DESCRIPTION
This was caught via OpenWrt's build, when upgrading to 3.8.
By default, Blake2 is not enabled in OpenWrt's OpenSSL.
Not sure if this is an issue in OpenSSL or Python or both.

After digging through the _hashopenssl.c, it seems that the check for
Blake2 being enabled/present in OpenSSL is not consistent with how OpenSSL
does it.

I guess this issue happens when Blake2 is present, but not enabled.
While the previous code was checking whether it is present.

Error is:
```
Modules/_hashopenssl.c:220:22: error: implicit declaration of function 'EVP_blake2s256'; did you mean 'SN_blake2s256'? [-Werror=implicit-function-declaration]
             digest = EVP_blake2s256();
                      ^~~~~~~~~~~~~~
                      SN_blake2s256
Modules/_hashopenssl.c:220:20: warning: assignment to 'const EVP_MD *' {aka 'const struct evp_md_st *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
             digest = EVP_blake2s256();
Modules/_hashopenssl.c:223:22: error: implicit declaration of function 'EVP_blake2b512'; did you mean 'LN_blake2b512'? [-Werror=implicit-function-declaration]
             digest = EVP_blake2b512();
                      ^~~~~~~~~~~~~~
Modules/_hashopenssl.c:223:20: warning: assignment to 'const EVP_MD *' {aka 'const struct evp_md_st *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
             digest = EVP_blake2b512();
                    ^
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>

<!-- issue-number: [bpo-38684](https://bugs.python.org/issue38684) -->
https://bugs.python.org/issue38684
<!-- /issue-number -->
