### PR TITLE
bpo-38686: fix HTTP Digest handling in request.py

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1136,7 +1136,7 @@ class AbstractDigestAuthHandler:
         A2 = "%s:%s" % (req.get_method(),
                         # XXX selector: what about proxies and full urls
                         req.selector)
-        if qop == 'auth':
+        if 'auth' in qop.split(','):
             if nonce == self.last_nonce:
                 self.nonce_count += 1
             else:
@@ -1144,7 +1144,7 @@ class AbstractDigestAuthHandler:
                 self.last_nonce = nonce
             ncvalue = '%08x' % self.nonce_count
             cnonce = self.get_cnonce(nonce)
-            noncebit = "%s:%s:%s:%s:%s" % (nonce, ncvalue, cnonce, qop, H(A2))
+            noncebit = "%s:%s:%s:%s:%s" % (nonce, ncvalue, cnonce, 'auth', H(A2))
             respdig = KD(H(A1), noncebit)
         elif qop is None:
             respdig = KD(H(A1), "%s:%s" % (nonce, H(A2)))

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1137,7 +1137,7 @@ class AbstractDigestAuthHandler:
                         # XXX selector: what about proxies and full urls
                         req.selector)
         # NOTE: As per  RFC 2617, when server sends "auth,auth-int", the client could use either `auth`
-        #     or `auth-int` to the response back. we use `auth` to send the response back. 
+        #     or `auth-int` to the response back. we use `auth` to send the response back.
         if 'auth' in qop.split(','):
             if nonce == self.last_nonce:
                 self.nonce_count += 1

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1136,6 +1136,8 @@ class AbstractDigestAuthHandler:
         A2 = "%s:%s" % (req.get_method(),
                         # XXX selector: what about proxies and full urls
                         req.selector)
+        # NOTE: As per  RFC 2617, when server sends "auth,auth-int", the client could use either `auth`
+        #     or `auth-int` to the response back. we use `auth` to send the response back. 
         if 'auth' in qop.split(','):
             if nonce == self.last_nonce:
                 self.nonce_count += 1

--- a/Misc/NEWS.d/next/Library/2019-11-06-15-26-15.bpo-38686.HNFBce.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-06-15-26-15.bpo-38686.HNFBce.rst
@@ -1,0 +1,1 @@
+Added support for multiple ``qop`` values in :class:`urllib.request.AbstractDigestAuthHandler`.


### PR DESCRIPTION
There is a bug triggered when server replies to a request with `WWW-Authenticate: Digest` where `qop="auth,auth-int"` rather than mere `qop="auth"`. Having both `auth` and `auth-int` is legitimate according to the `qop-options` rule in §3.2.1 of https://www.ietf.org/rfc/rfc2617.txt:
>      qop-options       = "qop" "=" <"> 1#qop-value <">
>      qop-value         = "auth" | "auth-int" | token
> **qop-options**: [...] If present, it is a quoted string **of one or more** tokens indicating the "quality of protection" values supported by the server.  The value `"auth"` indicates authentication; the value `"auth-int"` indicates authentication with integrity protection

This is description confirmed by the definition of the [_n_]`#`[_m_]_rule_ extended-BNF pattern defined in §2.1 of https://www.ietf.org/rfc/rfc2616.txt as 'a comma-separated list of _rule_ with at least _n_ and at most _m_ items'.

When this reply is parsed by `get_authorization`, request.py only tests for identity with `'auth'`, failing to recognize it as one of the supported modes the server announced, and claims that `"qop 'auth,auth-int' is not supported"`.


<!-- issue-number: [bpo-38686](https://bugs.python.org/issue38686) -->
https://bugs.python.org/issue38686
<!-- /issue-number -->
