### PR TITLE
bpo-38495: Updated functions.rst: Clearer *sep* and *end* defaults explanation 

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1307,9 +1307,10 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: print(*objects, sep=' ', end='\\n', file=sys.stdout, flush=False)
 
-   Print *objects* to the text stream *file*, separated by *sep* and followed
-   by *end*.  *sep*, *end*, *file* and *flush*, if present, must be given as keyword
-   arguments.
+   Print *objects* to the text stream *file* (the standard output by default),
+   separated by *sep* (a space by default) and followed by *end* 
+   (a newline by default).
+   *sep*, *end*, *file* and *flush*, if present, must be given as keyword arguments.
 
    All non-keyword arguments are converted to strings like :func:`str` does and
    written to the stream, separated by *sep* and followed by *end*.  Both *sep*

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1308,7 +1308,7 @@ are always available.  They are listed here in alphabetical order.
 .. function:: print(*objects, sep=' ', end='\\n', file=sys.stdout, flush=False)
 
    Print *objects* to the text stream *file* (the standard output by default),
-   separated by *sep* (a space by default) and followed by *end* 
+   separated by *sep* (a space by default) and followed by *end*
    (a newline by default).
    *sep*, *end*, *file* and *flush*, if present, must be given as keyword arguments.
 


### PR DESCRIPTION
<!-- issue-number: [bpo-38495](https://bugs.python.org/issue38495) -->
https://bugs.python.org/issue38495
<!-- /issue-number -->
