### PR TITLE
bpo-38696: Fix usage example of HTTPStatus

### DIFF
--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -38,7 +38,7 @@ associated messages through the :class:`http.HTTPStatus` enum:
       <HTTPStatus.OK: 200>
       >>> HTTPStatus.OK == 200
       True
-      >>> http.HTTPStatus.OK.value
+      >>> HTTPStatus.OK.value
       200
       >>> HTTPStatus.OK.phrase
       'OK'


### PR DESCRIPTION
As pointed out in the bpo issue, this particular line is syntactically invalid for the import statement given.

<!-- issue-number: [bpo-38696](https://bugs.python.org/issue38696) -->
https://bugs.python.org/issue38696
<!-- /issue-number -->
