### PR TITLE
bpo-38716: stop rotating handlers from setting inherited namer and rotator to None

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -58,8 +58,10 @@ class BaseRotatingHandler(logging.FileHandler):
         self.mode = mode
         self.encoding = encoding
         self.errors = errors
-        self.namer = None
-        self.rotator = None
+        if not hasattr(self, 'namer'):
+            self.namer = None
+        if not hasattr(self, 'rotator'):
+            self.rotator = None
 
     def emit(self, record):
         """

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -48,6 +48,9 @@ class BaseRotatingHandler(logging.FileHandler):
     Not meant to be instantiated directly.  Instead, use RotatingFileHandler
     or TimedRotatingFileHandler.
     """
+    namer = None
+    rotator = None
+
     def __init__(self, filename, mode, encoding=None, delay=False, errors=None):
         """
         Use the specified filename for streamed logging
@@ -58,10 +61,6 @@ class BaseRotatingHandler(logging.FileHandler):
         self.mode = mode
         self.encoding = encoding
         self.errors = errors
-        if not hasattr(self, 'namer'):
-            self.namer = None
-        if not hasattr(self, 'rotator'):
-            self.rotator = None
 
     def emit(self, record):
         """

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5030,6 +5030,25 @@ class RotatingFileHandlerTest(BaseFileTest):
         self.assertFalse(os.path.exists(namer(self.fn + ".3")))
         rh.close()
 
+    def test_namer_rotator_inheritance(self):
+        class HandlerWithNamerAndRotator(logging.handlers.RotatingFileHandler):
+            def namer(self, name):
+                return name + ".test"
+
+            def rotator(self, source, dest):
+                if os.path.exists(source):
+                    os.rename(source, dest + ".rotated")
+
+        rh = HandlerWithNamerAndRotator(
+            self.fn, backupCount=2, maxBytes=1)
+        self.assertEqual(rh.namer(self.fn), self.fn + ".test")
+        rh.emit(self.next_rec())
+        self.assertLogFile(self.fn)
+        rh.emit(self.next_rec())
+        self.assertLogFile(rh.namer(self.fn + ".1") + ".rotated")
+        self.assertFalse(os.path.exists(rh.namer(self.fn + ".1")))
+        rh.close()
+
     @support.requires_zlib
     def test_rotator(self):
         def namer(name):

--- a/Misc/NEWS.d/next/Library/2019-11-06-15-58-07.bpo-38716.R3uMLT.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-06-15-58-07.bpo-38716.R3uMLT.rst
@@ -1,0 +1,1 @@
+logging: change rotating handlers namer and rotator to class level attributes. this stops init from setting them to None in the case where a subclass creates them as methods

--- a/Misc/NEWS.d/next/Library/2019-11-06-15-58-07.bpo-38716.R3uMLT.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-06-15-58-07.bpo-38716.R3uMLT.rst
@@ -1,1 +1,1 @@
-logging: change rotating handlers namer and rotator to class level attributes. this stops init from setting them to None in the case where a subclass creates them as methods
+logging: change RotatingHandler namer and rotator to class-level attributes. This stops __init__ from setting them to None in the case where a subclass defines them with eponymous methods.


### PR DESCRIPTION


<!-- issue-number: [bpo-38716](https://bugs.python.org/issue38716) -->
https://bugs.python.org/issue38716
<!-- /issue-number -->
