### PR TITLE
bpo-13214: raise EOFError in Lib/cmd.py

### DIFF
--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -125,7 +125,7 @@ class Cmd:
                         try:
                             line = input(self.prompt)
                         except EOFError:
-                            line = 'EOF'
+                            raise
                     else:
                         self.stdout.write(self.prompt)
                         self.stdout.flush()


### PR DESCRIPTION
The current behavior of the cmd module is to return the string 'EOF'
when the program receives an EOF (e.g. when you press ctrl + d,
or when the end of a file is reached). When you're writing some kind of
REPL, you often want to exit when when you get an EOF (for example,
python's REPL exits when you press ctrl + d). The way to
achieve that functionality here is to create a function
called `do_EOF` in your subclass of `cmd.Cmd`, and call `exit()`
If you want some other behavior when you get an EOF, you can put
that in `do_EOF` instead.

This is problematic for two main reasons:

1. `EOF` shows up as an undocumented command when you type `help`. It's
not that big of a deal, but it's definitely not ideal (and perhaps
confusing).
2. If you type `EOF` into the terminal, it will call your `do_EOF`
function. If your `do_EOF` function exits, typing `do_EOF` will exit the
program. Seems rather silly.

I propose the cmd class NOT catch the EOFError. That will eliminate both
of the above problems.

See also https://bugs.python.org/issue13214 and https://github.com/python/cpython/pull/13536


<!-- issue-number: [bpo-13214](https://bugs.python.org/issue13214) -->
https://bugs.python.org/issue13214
<!-- /issue-number -->
