### PR TITLE
bpo-2986: Allow disabling difflib's automatic junk heuristic

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -837,7 +837,7 @@ class Differ:
         Compare two sequences of lines; generate the resulting delta.
     """
 
-    def __init__(self, linejunk=None, charjunk=None):
+    def __init__(self, linejunk=None, charjunk=None, autojunk=True):
         """
         Construct a text differencer, with optional filters.
 
@@ -859,6 +859,7 @@ class Differ:
 
         self.linejunk = linejunk
         self.charjunk = charjunk
+        self.autojunk = autojunk
 
     def compare(self, a, b):
         r"""
@@ -886,7 +887,7 @@ class Differ:
         + emu
         """
 
-        cruncher = SequenceMatcher(self.linejunk, a, b)
+        cruncher = SequenceMatcher(self.linejunk, a, b, self.autojunk)
         for tag, alo, ahi, blo, bhi in cruncher.get_opcodes():
             if tag == 'replace':
                 g = self._fancy_replace(a, alo, ahi, b, blo, bhi)
@@ -1330,7 +1331,7 @@ def diff_bytes(dfunc, a, b, fromfile=b'', tofile=b'',
     for line in lines:
         yield line.encode('ascii', 'surrogateescape')
 
-def ndiff(a, b, linejunk=None, charjunk=IS_CHARACTER_JUNK):
+def ndiff(a, b, linejunk=None, charjunk=IS_CHARACTER_JUNK, autojunk=True):
     r"""
     Compare `a` and `b` (lists of strings); return a `Differ`-style delta.
 
@@ -1365,7 +1366,7 @@ def ndiff(a, b, linejunk=None, charjunk=IS_CHARACTER_JUNK):
     + tree
     + emu
     """
-    return Differ(linejunk, charjunk).compare(a, b)
+    return Differ(linejunk, charjunk, autojunk).compare(a, b)
 
 def _mdiff(fromlines, tolines, context=None, linejunk=None,
            charjunk=IS_CHARACTER_JUNK):


### PR DESCRIPTION
```
[bpo-2986](https://bugs.python.org/issue2986): Allow disabling difflib's automatic junk heuristic
```

Added parameter for `autojunk` to the `Differ` class and the `ndiff` method to allow disabling the automatic junk heuristic.

I am using difflib extensively as part of a current project. We are working across a large amount of text, and for our purposes quality is preferred over speed. We have examples of where the diff algorithm fails (fails meaning treats the majority of our input as one large deletion / addition) with autojunking enabled and does not without, meaning we are required to set this parameter to false for our purposes.

This parameter is not accessible to us from the API provided by difflib currently. To resolve this we have copied this out and modified it in a similar way to this PR.

The issue we are facing plus the suggestion to allow this parameter to be configured it mentioned by others in [bpo-2986](https://bugs.python.org/issue2986).

Thanks, Liam

<!-- issue-number: [bpo-2986](https://bugs.python.org/issue2986) -->
https://bugs.python.org/issue2986
<!-- /issue-number -->
