### PR TITLE
bpo-38738: Fix formatting of True and False.

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -263,8 +263,8 @@ StreamWriter
 
    .. method:: can_write_eof()
 
-      Return *True* if the underlying transport supports
-      the :meth:`write_eof` method, *False* otherwise.
+      Return ``True`` if the underlying transport supports
+      the :meth:`write_eof` method, ``False`` otherwise.
 
    .. method:: write_eof()
 

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -386,8 +386,8 @@ Module-level decorators, classes, and functions
 
 .. function:: is_dataclass(class_or_instance)
 
-   Returns ``True`` if its parameter is a dataclass or an instance of one,
-   otherwise returns ``False``.
+   Return ``True`` if its parameter is a dataclass or an instance of one,
+   otherwise return ``False``.
 
    If you need to know if a class is an instance of a dataclass (and
    not a dataclass itself), then add a further check for ``not

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -153,7 +153,7 @@ Module-level decorators, classes, and functions
      method of the superclass will be used (if the superclass is
      :class:`object`, this means it will fall back to id-based hashing).
 
-   - ``frozen``: If true (the default is False), assigning to fields will
+   - ``frozen``: If true (the default is ``False``), assigning to fields will
      generate an exception.  This emulates read-only frozen instances.  If
      :meth:`__setattr__` or :meth:`__delattr__` is defined in the class, then
      :exc:`TypeError` is raised.  See the discussion below.
@@ -386,8 +386,8 @@ Module-level decorators, classes, and functions
 
 .. function:: is_dataclass(class_or_instance)
 
-   Returns True if its parameter is a dataclass or an instance of one,
-   otherwise returns False.
+   Returns ``True`` if its parameter is a dataclass or an instance of one,
+   otherwise returns ``False``.
 
    If you need to know if a class is an instance of a dataclass (and
    not a dataclass itself), then add a further check for ``not

--- a/Doc/library/dialog.rst
+++ b/Doc/library/dialog.rst
@@ -73,7 +73,7 @@ listed below:
 
  | *defaultextension* - default extension to append to file (save dialogs)
 
- | *multiple* - when True, selection of multiple items is allowed
+ | *multiple* - when true, selection of multiple items is allowed
 
 
 **Static factory functions**

--- a/Doc/library/dialog.rst
+++ b/Doc/library/dialog.rst
@@ -73,7 +73,7 @@ listed below:
 
  | *defaultextension* - default extension to append to file (save dialogs)
 
- | *multiple* - when ``True``, selection of multiple items is allowed
+ | *multiple* - when true, selection of multiple items is allowed
 
 
 **Static factory functions**

--- a/Doc/library/dialog.rst
+++ b/Doc/library/dialog.rst
@@ -73,7 +73,7 @@ listed below:
 
  | *defaultextension* - default extension to append to file (save dialogs)
 
- | *multiple* - when true, selection of multiple items is allowed
+ | *multiple* - when ``True``, selection of multiple items is allowed
 
 
 **Static factory functions**

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -338,14 +338,14 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
 
 .. function:: IS_LINE_JUNK(line)
 
-   Return true for ignorable lines.  The line *line* is ignorable if *line* is
+   Return ``True`` for ignorable lines.  The line *line* is ignorable if *line* is
    blank or contains a single ``'#'``, otherwise it is not ignorable.  Used as a
    default for parameter *linejunk* in :func:`ndiff` in older versions.
 
 
 .. function:: IS_CHARACTER_JUNK(ch)
 
-   Return true for ignorable characters.  The character *ch* is ignorable if *ch*
+   Return ``True`` for ignorable characters.  The character *ch* is ignorable if *ch*
    is a space or tab, otherwise it is not ignorable.  Used as a default for
    parameter *charjunk* in :func:`ndiff`.
 
@@ -370,7 +370,7 @@ The :class:`SequenceMatcher` class has this constructor:
    Optional argument *isjunk* must be ``None`` (the default) or a one-argument
    function that takes a sequence element and returns true if and only if the
    element is "junk" and should be ignored. Passing ``None`` for *isjunk* is
-   equivalent to passing ``lambda x: 0``; in other words, no elements are ignored.
+   equivalent to passing ``lambda x: False``; in other words, no elements are ignored.
    For example, pass::
 
       lambda x: x in " \t"

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -1529,7 +1529,7 @@ OutputChecker objects
 
    A class used to check the whether the actual output from a doctest example
    matches the expected output.  :class:`OutputChecker` defines two methods:
-   :meth:`check_output`, which compares a given pair of outputs, and returns true
+   :meth:`check_output`, which compares a given pair of outputs, and returns ``True``
    if they match; and :meth:`output_difference`, which returns a string describing
    the differences between two outputs.
 

--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -308,7 +308,7 @@ Here are the methods of the :class:`Message` class:
 
    .. method:: __contains__(name)
 
-      Return true if the message object has a field named *name*. Matching is
+      Return ``True`` if the message object has a field named *name*. Matching is
       done case-insensitively and *name* should not include the trailing colon.
       Used for the ``in`` operator, e.g.::
 

--- a/Doc/library/email.errors.rst
+++ b/Doc/library/email.errors.rst
@@ -99,7 +99,7 @@ All defect classes are subclassed from :class:`email.errors.MessageDefect`.
 * :class:`MultipartInvariantViolationDefect` -- A message claimed to be a
   :mimetype:`multipart`, but no subparts were found.  Note that when a message
   has this defect, its :meth:`~email.message.Message.is_multipart` method may
-  return false even though its content type claims to be :mimetype:`multipart`.
+  return ``False`` even though its content type claims to be :mimetype:`multipart`.
 
 * :class:`InvalidBase64PaddingDefect` -- When decoding a block of base64
   encoded bytes, the padding was not correct.  Enough padding is added to

--- a/Doc/library/email.message.rst
+++ b/Doc/library/email.message.rst
@@ -178,7 +178,7 @@ message objects.
 
    .. method:: __contains__(name)
 
-      Return true if the message object has a field named *name*. Matching is
+      Return ``True`` if the message object has a field named *name*. Matching is
       done without regard to case and *name* does not include the trailing
       colon.  Used for the ``in`` operator.  For example::
 

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -109,14 +109,14 @@ if there is no active state, :exc:`RuntimeError` is raised.
 
 .. function:: isfirstline()
 
-   Returns ``True`` if the line just read is the first line of its file, otherwise
-   returns ``False``.
+   Return ``True`` if the line just read is the first line of its file, otherwise
+   return ``False``.
 
 
 .. function:: isstdin()
 
-   Returns ``True`` if the last line was read from ``sys.stdin``, otherwise returns
-   false.
+   Return ``True`` if the last line was read from ``sys.stdin``, otherwise return
+   ``False``.
 
 
 .. function:: nextfile()

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -109,13 +109,13 @@ if there is no active state, :exc:`RuntimeError` is raised.
 
 .. function:: isfirstline()
 
-   Returns true if the line just read is the first line of its file, otherwise
-   returns false.
+   Returns ``True`` if the line just read is the first line of its file, otherwise
+   returns ``False``.
 
 
 .. function:: isstdin()
 
-   Returns true if the last line was read from ``sys.stdin``, otherwise returns
+   Returns ``True`` if the last line was read from ``sys.stdin``, otherwise returns
    false.
 
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -181,8 +181,8 @@ are always available.  They are listed here in alphabetical order.
 .. function:: callable(object)
 
    Return :const:`True` if the *object* argument appears callable,
-   :const:`False` if not.  If this returns true, it is still possible that a
-   call fails, but if it is false, calling *object* will never succeed.
+   :const:`False` if not.  If this returns ``True``, it is still possible that a
+   call fails, but if it is ``False``, calling *object* will never succeed.
    Note that classes are callable (calling a class returns a new instance);
    instances are callable if their class has a :meth:`__call__` method.
 
@@ -840,19 +840,19 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: isinstance(object, classinfo)
 
-   Return true if the *object* argument is an instance of the *classinfo*
+   Return ``True`` if the *object* argument is an instance of the *classinfo*
    argument, or of a (direct, indirect or :term:`virtual <abstract base
    class>`) subclass thereof.  If *object* is not
-   an object of the given type, the function always returns false.
+   an object of the given type, the function always returns ``False``.
    If *classinfo* is a tuple of type objects (or recursively, other such
-   tuples), return true if *object* is an instance of any of the types.
+   tuples), return ``True`` if *object* is an instance of any of the types.
    If *classinfo* is not a type or tuple of types and such tuples,
    a :exc:`TypeError` exception is raised.
 
 
 .. function:: issubclass(class, classinfo)
 
-   Return true if *class* is a subclass (direct, indirect or :term:`virtual
+   Return ``True`` if *class* is a subclass (direct, indirect or :term:`virtual
    <abstract base class>`) of *classinfo*.  A
    class is considered a subclass of itself. *classinfo* may be a tuple of class
    objects, in which case every entry in *classinfo* will be checked. In any other

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -35,7 +35,7 @@ The :mod:`gc` module provides the following functions:
 
 .. function:: isenabled()
 
-   Returns true if automatic collection is enabled.
+   Returns ``True`` if automatic collection is enabled.
 
 
 .. function:: collect(generation=2)

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -35,7 +35,7 @@ The :mod:`gc` module provides the following functions:
 
 .. function:: isenabled()
 
-   Returns ``True`` if automatic collection is enabled.
+   Return ``True`` if automatic collection is enabled.
 
 
 .. function:: collect(generation=2)

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -82,8 +82,8 @@ library that Python uses on your platform. On most platforms the
 
 .. versionchanged:: 3.9
    All hashlib constructors take a keyword-only argument *usedforsecurity*
-   with default value *True*. A false value allows the use of insecure and
-   blocked hashing algorithms in restricted environments. *False* indicates
+   with default value ``True``. A false value allows the use of insecure and
+   blocked hashing algorithms in restricted environments. ``False`` indicates
    that the hashing algorithm is not used in a security context, e.g. as a
    non-cryptographic one-way compression function.
 

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -378,7 +378,7 @@ methods:
 
 .. method:: CookiePolicy.domain_return_ok(domain, request)
 
-   Return false if cookies should not be returned, given cookie domain.
+   Return ``False`` if cookies should not be returned, given cookie domain.
 
    This method is an optimization.  It removes the need for checking every cookie
    with a particular domain (which might involve reading many files).  Returning
@@ -402,7 +402,7 @@ methods:
 
 .. method:: CookiePolicy.path_return_ok(path, request)
 
-   Return false if cookies should not be returned, given cookie path.
+   Return ``False`` if cookies should not be returned, given cookie path.
 
    See the documentation for :meth:`domain_return_ok`.
 
@@ -711,7 +711,7 @@ accessed using the following methods:
 
 .. method:: Cookie.has_nonstandard_attr(name)
 
-   Return true if cookie has the named cookie-attribute.
+   Return ``True`` if cookie has the named cookie-attribute.
 
 
 .. method:: Cookie.get_nonstandard_attr(name, default=None)

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1168,7 +1168,7 @@ find and load modules.
 
    .. method:: is_package(fullname)
 
-      Return true if :attr:`path` appears to be for a package.
+      Return ``True`` if :attr:`path` appears to be for a package.
 
    .. method:: path_stats(path)
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -277,55 +277,55 @@ attributes:
 
 .. function:: ismodule(object)
 
-   Return true if the object is a module.
+   Return ``True`` if the object is a module.
 
 
 .. function:: isclass(object)
 
-   Return true if the object is a class, whether built-in or created in Python
+   Return ``True`` if the object is a class, whether built-in or created in Python
    code.
 
 
 .. function:: ismethod(object)
 
-   Return true if the object is a bound method written in Python.
+   Return ``True`` if the object is a bound method written in Python.
 
 
 .. function:: isfunction(object)
 
-   Return true if the object is a Python function, which includes functions
+   Return ``True`` if the object is a Python function, which includes functions
    created by a :term:`lambda` expression.
 
 
 .. function:: isgeneratorfunction(object)
 
-   Return true if the object is a Python generator function.
+   Return ``True`` if the object is a Python generator function.
 
    .. versionchanged:: 3.8
-      Functions wrapped in :func:`functools.partial` now return true if the
+      Functions wrapped in :func:`functools.partial` now return ``True`` if the
       wrapped function is a Python generator function.
 
 
 .. function:: isgenerator(object)
 
-   Return true if the object is a generator.
+   Return ``True`` if the object is a generator.
 
 
 .. function:: iscoroutinefunction(object)
 
-   Return true if the object is a :term:`coroutine function`
+   Return ``True`` if the object is a :term:`coroutine function`
    (a function defined with an :keyword:`async def` syntax).
 
    .. versionadded:: 3.5
 
    .. versionchanged:: 3.8
-      Functions wrapped in :func:`functools.partial` now return true if the
+      Functions wrapped in :func:`functools.partial` now return ``True`` if the
       wrapped function is a :term:`coroutine function`.
 
 
 .. function:: iscoroutine(object)
 
-   Return true if the object is a :term:`coroutine` created by an
+   Return ``True`` if the object is a :term:`coroutine` created by an
    :keyword:`async def` function.
 
    .. versionadded:: 3.5
@@ -333,7 +333,7 @@ attributes:
 
 .. function:: isawaitable(object)
 
-   Return true if the object can be used in :keyword:`await` expression.
+   Return ``True`` if the object can be used in :keyword:`await` expression.
 
    Can also be used to distinguish generator-based coroutines from regular
    generators::
@@ -352,7 +352,7 @@ attributes:
 
 .. function:: isasyncgenfunction(object)
 
-   Return true if the object is an :term:`asynchronous generator` function,
+   Return ``True`` if the object is an :term:`asynchronous generator` function,
    for example::
 
     >>> async def agen():
@@ -364,50 +364,50 @@ attributes:
    .. versionadded:: 3.6
 
    .. versionchanged:: 3.8
-      Functions wrapped in :func:`functools.partial` now return true if the
+      Functions wrapped in :func:`functools.partial` now return ``True`` if the
       wrapped function is a :term:`asynchronous generator` function.
 
 
 .. function:: isasyncgen(object)
 
-   Return true if the object is an :term:`asynchronous generator iterator`
+   Return ``True`` if the object is an :term:`asynchronous generator iterator`
    created by an :term:`asynchronous generator` function.
 
    .. versionadded:: 3.6
 
 .. function:: istraceback(object)
 
-   Return true if the object is a traceback.
+   Return ``True`` if the object is a traceback.
 
 
 .. function:: isframe(object)
 
-   Return true if the object is a frame.
+   Return ``True`` if the object is a frame.
 
 
 .. function:: iscode(object)
 
-   Return true if the object is a code.
+   Return ``True`` if the object is a code.
 
 
 .. function:: isbuiltin(object)
 
-   Return true if the object is a built-in function or a bound built-in method.
+   Return ``True`` if the object is a built-in function or a bound built-in method.
 
 
 .. function:: isroutine(object)
 
-   Return true if the object is a user-defined or built-in function or method.
+   Return ``True`` if the object is a user-defined or built-in function or method.
 
 
 .. function:: isabstract(object)
 
-   Return true if the object is an abstract base class.
+   Return ``True`` if the object is an abstract base class.
 
 
 .. function:: ismethoddescriptor(object)
 
-   Return true if the object is a method descriptor, but not if
+   Return ``True`` if the object is a method descriptor, but not if
    :func:`ismethod`, :func:`isclass`, :func:`isfunction` or :func:`isbuiltin`
    are true.
 
@@ -418,14 +418,14 @@ attributes:
    sensible, and :attr:`__doc__` often is.
 
    Methods implemented via descriptors that also pass one of the other tests
-   return false from the :func:`ismethoddescriptor` test, simply because the
+   return ``False`` from the :func:`ismethoddescriptor` test, simply because the
    other tests promise more -- you can, e.g., count on having the
    :attr:`__func__` attribute (etc) when an object passes :func:`ismethod`.
 
 
 .. function:: isdatadescriptor(object)
 
-   Return true if the object is a data descriptor.
+   Return ``True`` if the object is a data descriptor.
 
    Data descriptors have both a :attr:`~object.__get__` and a :attr:`~object.__set__` method.
    Examples are properties (defined in Python), getsets, and members.  The
@@ -438,7 +438,7 @@ attributes:
 
 .. function:: isgetsetdescriptor(object)
 
-   Return true if the object is a getset descriptor.
+   Return ``True`` if the object is a getset descriptor.
 
    .. impl-detail::
 
@@ -449,7 +449,7 @@ attributes:
 
 .. function:: ismemberdescriptor(object)
 
-   Return true if the object is a member descriptor.
+   Return ``True`` if the object is a member descriptor.
 
    .. impl-detail::
 

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -557,7 +557,7 @@ dictionaries.
 
    .. method:: subnet_of(other)
 
-      Returns ``True`` if this network is a subnet of *other*.
+      Return ``True`` if this network is a subnet of *other*.
 
         >>> a = ip_network('192.168.1.0/24')
         >>> b = ip_network('192.168.1.128/30')
@@ -568,7 +568,7 @@ dictionaries.
 
    .. method:: supernet_of(other)
 
-      Returns ``True`` if this network is a supernet of *other*.
+      Return ``True`` if this network is a supernet of *other*.
 
         >>> a = ip_network('192.168.1.0/24')
         >>> b = ip_network('192.168.1.128/30')

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -557,7 +557,7 @@ dictionaries.
 
    .. method:: subnet_of(other)
 
-      Returns *True* if this network is a subnet of *other*.
+      Returns ``True`` if this network is a subnet of *other*.
 
         >>> a = ip_network('192.168.1.0/24')
         >>> b = ip_network('192.168.1.128/30')
@@ -568,7 +568,7 @@ dictionaries.
 
    .. method:: supernet_of(other)
 
-      Returns *True* if this network is a supernet of *other*.
+      Returns ``True`` if this network is a supernet of *other*.
 
         >>> a = ip_network('192.168.1.0/24')
         >>> b = ip_network('192.168.1.128/30')

--- a/Doc/library/keyword.rst
+++ b/Doc/library/keyword.rst
@@ -13,7 +13,7 @@ This module allows a Python program to determine if a string is a keyword.
 
 .. function:: iskeyword(s)
 
-   Return true if *s* is a Python keyword.
+   Return ``True`` if *s* is a Python keyword.
 
 
 .. data:: kwlist

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -867,8 +867,8 @@ should, then :meth:`flush` is expected to do the flushing.
 
    .. method:: emit(record)
 
-      Appends the record to the buffer. If :meth:`shouldFlush` returns true,
-      calls :meth:`flush` to process the buffer.
+      Append the record to the buffer. If :meth:`shouldFlush` returns true,
+      call :meth:`flush` to process the buffer.
 
 
    .. method:: flush()
@@ -879,7 +879,7 @@ should, then :meth:`flush` is expected to do the flushing.
 
    .. method:: shouldFlush(record)
 
-      Returns ``True`` if the buffer is up to capacity. This method can be
+      Return ``True`` if the buffer is up to capacity. This method can be
       overridden to implement custom flushing strategies.
 
 

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -879,7 +879,7 @@ should, then :meth:`flush` is expected to do the flushing.
 
    .. method:: shouldFlush(record)
 
-      Returns true if the buffer is up to capacity. This method can be
+      Returns ``True`` if the buffer is up to capacity. This method can be
       overridden to implement custom flushing strategies.
 
 

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -294,7 +294,7 @@ is the module's name in the Python package namespace.
 
    .. method:: Logger.filter(record)
 
-      Applies this logger's filters to the record and returns ``True`` if the
+      Apply this logger's filters to the record and return ``True`` if the
       record is to be processed. The filters are consulted in turn, until one of
       them returns a false value. If none of them return a false value, the record
       will be processed (passed to handlers). If one returns a false value, no
@@ -447,7 +447,7 @@ subclasses. However, the :meth:`__init__` method in subclasses needs to call
 
    .. method:: Handler.filter(record)
 
-      Applies this handler's filters to the record and returns ``True`` if the
+      Apply this handler's filters to the record and return ``True`` if the
       record is to be processed. The filters are consulted in turn, until one of
       them returns a false value. If none of them return a false value, the record
       will be emitted. If one returns a false value, the handler will not emit the

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -294,7 +294,7 @@ is the module's name in the Python package namespace.
 
    .. method:: Logger.filter(record)
 
-      Applies this logger's filters to the record and returns a true value if the
+      Applies this logger's filters to the record and returns ``True`` if the
       record is to be processed. The filters are consulted in turn, until one of
       them returns a false value. If none of them return a false value, the record
       will be processed (passed to handlers). If one returns a false value, no
@@ -447,7 +447,7 @@ subclasses. However, the :meth:`__init__` method in subclasses needs to call
 
    .. method:: Handler.filter(record)
 
-      Applies this handler's filters to the record and returns a true value if the
+      Applies this handler's filters to the record and returns ``True`` if the
       record is to be processed. The filters are consulted in turn, until one of
       them returns a false value. If none of them return a false value, the record
       will be emitted. If one returns a false value, the handler will not emit the

--- a/Doc/library/lzma.rst
+++ b/Doc/library/lzma.rst
@@ -313,7 +313,7 @@ Miscellaneous
 
 .. function:: is_check_supported(check)
 
-   Returns true if the given integrity check is supported on this system.
+   Returns ``True`` if the given integrity check is supported on this system.
 
    :const:`CHECK_NONE` and :const:`CHECK_CRC32` are always supported.
    :const:`CHECK_CRC64` and :const:`CHECK_SHA256` may be unavailable if you are

--- a/Doc/library/lzma.rst
+++ b/Doc/library/lzma.rst
@@ -313,7 +313,7 @@ Miscellaneous
 
 .. function:: is_check_supported(check)
 
-   Returns ``True`` if the given integrity check is supported on this system.
+   Return ``True`` if the given integrity check is supported on this system.
 
    :const:`CHECK_NONE` and :const:`CHECK_CRC32` are always supported.
    :const:`CHECK_CRC64` and :const:`CHECK_SHA256` may be unavailable if you are

--- a/Doc/library/msvcrt.rst
+++ b/Doc/library/msvcrt.rst
@@ -92,7 +92,7 @@ Console I/O
 
 .. function:: kbhit()
 
-   Return true if a keypress is waiting to be read.
+   Return ``True`` if a keypress is waiting to be read.
 
 
 .. function:: getch()

--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -928,10 +928,10 @@ The canonical way to create an :class:`Option` instance is with the
       store a constant value
 
    ``"store_true"``
-      store a true value
+      store ``True``
 
    ``"store_false"``
-      store a false value
+      store ``False``
 
    ``"append"``
       append this option's argument to a list
@@ -1135,12 +1135,12 @@ must specify for any option using that action.
 
 * ``"store_true"`` [relevant: :attr:`~Option.dest`]
 
-  A special case of ``"store_const"`` that stores a true value to
+  A special case of ``"store_const"`` that stores ``True`` to
   :attr:`~Option.dest`.
 
 * ``"store_false"`` [relevant: :attr:`~Option.dest`]
 
-  Like ``"store_true"``, but stores a false value.
+  Like ``"store_true"``, but stores ``False``.
 
   Example::
 
@@ -1396,7 +1396,7 @@ provides several methods to help you out:
 
 .. method:: OptionParser.has_option(opt_str)
 
-   Return true if the OptionParser has an option with option string *opt_str*
+   Return ``True`` if the OptionParser has an option with option string *opt_str*
    (e.g., ``-q`` or ``--verbose``).
 
 .. method:: OptionParser.remove_option(opt_str)

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -148,7 +148,7 @@ process and user.
    versa).
 
    :data:`environb` is only available if :data:`supports_bytes_environ` is
-   True.
+   ``True``.
 
    .. versionadded:: 3.2
 
@@ -236,7 +236,7 @@ process and user.
    *default* if it doesn't. *key*, *default* and the result are bytes.
 
    :func:`getenvb` is only available if :data:`supports_bytes_environ`
-   is True.
+   is ``True``.
 
    .. availability:: most flavors of Unix.
 

--- a/Doc/library/parser.rst
+++ b/Doc/library/parser.rst
@@ -234,8 +234,8 @@ determine if an ST was created from source code via :func:`expr` or
 
    .. index:: builtin: compile
 
-   When *st* represents an ``'eval'`` form, this function returns true, otherwise
-   it returns false.  This is useful, since code objects normally cannot be queried
+   When *st* represents an ``'eval'`` form, this function returns ``True``, otherwise
+   it returns ``False``.  This is useful, since code objects normally cannot be queried
    for this information using existing built-in functions.  Note that the code
    objects created by :func:`compilest` cannot be queried like this either, and
    are identical to those created by the built-in :func:`compile` function.

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -226,8 +226,8 @@ Windows Platform
 
 .. function:: win32_is_iot()
 
-   Returns True if the windows edition returned by win32_edition is recognized
-   as an IoT edition.
+   Returns ``True`` if the Windows edition returned by :func:`win32_edition`
+   is recognized as an IoT edition.
 
    .. versionadded:: 3.8
 

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -226,7 +226,7 @@ Windows Platform
 
 .. function:: win32_is_iot()
 
-   Returns ``True`` if the Windows edition returned by :func:`win32_edition`
+   Return ``True`` if the Windows edition returned by :func:`win32_edition`
    is recognized as an IoT edition.
 
    .. versionadded:: 3.8

--- a/Doc/library/sched.rst
+++ b/Doc/library/sched.rst
@@ -104,7 +104,7 @@ Scheduler Objects
 
 .. method:: scheduler.empty()
 
-   Return true if the event queue is empty.
+   Return ``True`` if the event queue is empty.
 
 
 .. method:: scheduler.run(blocking=True)

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1658,7 +1658,7 @@ to speed up repeated connections from the same clients.
    return the agreed-upon protocol.
 
    This method will raise :exc:`NotImplementedError` if :data:`HAS_ALPN` is
-   False.
+   ``False``.
 
    OpenSSL 1.1.0 to 1.1.0e will abort the handshake and raise :exc:`SSLError`
    when both sides support ALPN but cannot agree on a protocol. 1.1.0f+
@@ -1677,7 +1677,7 @@ to speed up repeated connections from the same clients.
    return the agreed-upon protocol.
 
    This method will raise :exc:`NotImplementedError` if :data:`HAS_NPN` is
-   False.
+   ``False``.
 
    .. versionadded:: 3.3
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1669,16 +1669,16 @@ expression support in the :mod:`re` module).
 
 .. method:: str.isalnum()
 
-   Return true if all characters in the string are alphanumeric and there is at
-   least one character, false otherwise.  A character ``c`` is alphanumeric if one
+   Return ``True`` if all characters in the string are alphanumeric and there is at
+   least one character, ``False`` otherwise.  A character ``c`` is alphanumeric if one
    of the following returns ``True``: ``c.isalpha()``, ``c.isdecimal()``,
    ``c.isdigit()``, or ``c.isnumeric()``.
 
 
 .. method:: str.isalpha()
 
-   Return true if all characters in the string are alphabetic and there is at least
-   one character, false otherwise.  Alphabetic characters are those characters defined
+   Return ``True`` if all characters in the string are alphabetic and there is at least
+   one character, ``False`` otherwise.  Alphabetic characters are those characters defined
    in the Unicode character database as "Letter", i.e., those with general category
    property being one of "Lm", "Lt", "Lu", "Ll", or "Lo".  Note that this is different
    from the "Alphabetic" property defined in the Unicode Standard.
@@ -1686,8 +1686,8 @@ expression support in the :mod:`re` module).
 
 .. method:: str.isascii()
 
-   Return true if the string is empty or all characters in the string are ASCII,
-   false otherwise.
+   Return ``True`` if the string is empty or all characters in the string are ASCII,
+   ``False`` otherwise.
    ASCII characters have code points in the range U+0000-U+007F.
 
    .. versionadded:: 3.7
@@ -1695,8 +1695,8 @@ expression support in the :mod:`re` module).
 
 .. method:: str.isdecimal()
 
-   Return true if all characters in the string are decimal
-   characters and there is at least one character, false
+   Return ``True`` if all characters in the string are decimal
+   characters and there is at least one character, ``False``
    otherwise. Decimal characters are those that can be used to form
    numbers in base 10, e.g. U+0660, ARABIC-INDIC DIGIT
    ZERO.  Formally a decimal character is a character in the Unicode
@@ -1705,8 +1705,8 @@ expression support in the :mod:`re` module).
 
 .. method:: str.isdigit()
 
-   Return true if all characters in the string are digits and there is at least one
-   character, false otherwise.  Digits include decimal characters and digits that need
+   Return ``True`` if all characters in the string are digits and there is at least one
+   character, ``False`` otherwise.  Digits include decimal characters and digits that need
    special handling, such as the compatibility superscript digits.
    This covers digits which cannot be used to form numbers in base 10,
    like the Kharosthi numbers.  Formally, a digit is a character that has the
@@ -1715,7 +1715,7 @@ expression support in the :mod:`re` module).
 
 .. method:: str.isidentifier()
 
-   Return true if the string is a valid identifier according to the language
+   Return ``True`` if the string is a valid identifier according to the language
    definition, section :ref:`identifiers`.
 
    Call :func:`keyword.iskeyword` to test whether string ``s`` is a reserved
@@ -1734,14 +1734,14 @@ expression support in the :mod:`re` module).
 
 .. method:: str.islower()
 
-   Return true if all cased characters [4]_ in the string are lowercase and
-   there is at least one cased character, false otherwise.
+   Return ``True`` if all cased characters [4]_ in the string are lowercase and
+   there is at least one cased character, ``False`` otherwise.
 
 
 .. method:: str.isnumeric()
 
-   Return true if all characters in the string are numeric
-   characters, and there is at least one character, false
+   Return ``True`` if all characters in the string are numeric
+   characters, and there is at least one character, ``False``
    otherwise. Numeric characters include digit characters, and all characters
    that have the Unicode numeric value property, e.g. U+2155,
    VULGAR FRACTION ONE FIFTH.  Formally, numeric characters are those with the property
@@ -1750,8 +1750,8 @@ expression support in the :mod:`re` module).
 
 .. method:: str.isprintable()
 
-   Return true if all characters in the string are printable or the string is
-   empty, false otherwise.  Nonprintable characters are those characters defined
+   Return ``True`` if all characters in the string are printable or the string is
+   empty, ``False`` otherwise.  Nonprintable characters are those characters defined
    in the Unicode character database as "Other" or "Separator", excepting the
    ASCII space (0x20) which is considered printable.  (Note that printable
    characters in this context are those which should not be escaped when
@@ -1761,8 +1761,8 @@ expression support in the :mod:`re` module).
 
 .. method:: str.isspace()
 
-   Return true if there are only whitespace characters in the string and there is
-   at least one character, false otherwise.
+   Return ``True`` if there are only whitespace characters in the string and there is
+   at least one character, ``False`` otherwise.
 
    A character is *whitespace* if in the Unicode character database
    (see :mod:`unicodedata`), either its general category is ``Zs``
@@ -1772,15 +1772,15 @@ expression support in the :mod:`re` module).
 
 .. method:: str.istitle()
 
-   Return true if the string is a titlecased string and there is at least one
+   Return ``True`` if the string is a titlecased string and there is at least one
    character, for example uppercase characters may only follow uncased characters
-   and lowercase characters only cased ones.  Return false otherwise.
+   and lowercase characters only cased ones.  Return ``False`` otherwise.
 
 
 .. method:: str.isupper()
 
-   Return true if all cased characters [4]_ in the string are uppercase and
-   there is at least one cased character, false otherwise.
+   Return ``True`` if all cased characters [4]_ in the string are uppercase and
+   there is at least one cased character, ``False`` otherwise.
 
       >>> 'BANANA'.isupper()
       True
@@ -3010,8 +3010,8 @@ place, and instead produce new objects.
 .. method:: bytes.isalnum()
             bytearray.isalnum()
 
-   Return true if all bytes in the sequence are alphabetical ASCII characters
-   or ASCII decimal digits and the sequence is not empty, false otherwise.
+   Return ``True`` if all bytes in the sequence are alphabetical ASCII characters
+   or ASCII decimal digits and the sequence is not empty, ``False`` otherwise.
    Alphabetic ASCII characters are those byte values in the sequence
    ``b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'``. ASCII decimal
    digits are those byte values in the sequence ``b'0123456789'``.
@@ -3027,8 +3027,8 @@ place, and instead produce new objects.
 .. method:: bytes.isalpha()
             bytearray.isalpha()
 
-   Return true if all bytes in the sequence are alphabetic ASCII characters
-   and the sequence is not empty, false otherwise.  Alphabetic ASCII
+   Return ``True`` if all bytes in the sequence are alphabetic ASCII characters
+   and the sequence is not empty, ``False`` otherwise.  Alphabetic ASCII
    characters are those byte values in the sequence
    ``b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'``.
 
@@ -3043,8 +3043,8 @@ place, and instead produce new objects.
 .. method:: bytes.isascii()
             bytearray.isascii()
 
-   Return true if the sequence is empty or all bytes in the sequence are ASCII,
-   false otherwise.
+   Return ``True`` if the sequence is empty or all bytes in the sequence are ASCII,
+   ``False`` otherwise.
    ASCII bytes are in the range 0-0x7F.
 
    .. versionadded:: 3.7
@@ -3053,8 +3053,8 @@ place, and instead produce new objects.
 .. method:: bytes.isdigit()
             bytearray.isdigit()
 
-   Return true if all bytes in the sequence are ASCII decimal digits
-   and the sequence is not empty, false otherwise. ASCII decimal digits are
+   Return ``True`` if all bytes in the sequence are ASCII decimal digits
+   and the sequence is not empty, ``False`` otherwise. ASCII decimal digits are
    those byte values in the sequence ``b'0123456789'``.
 
    For example::
@@ -3068,8 +3068,8 @@ place, and instead produce new objects.
 .. method:: bytes.islower()
             bytearray.islower()
 
-   Return true if there is at least one lowercase ASCII character
-   in the sequence and no uppercase ASCII characters, false otherwise.
+   Return ``True`` if there is at least one lowercase ASCII character
+   in the sequence and no uppercase ASCII characters, ``False`` otherwise.
 
    For example::
 
@@ -3086,8 +3086,8 @@ place, and instead produce new objects.
 .. method:: bytes.isspace()
             bytearray.isspace()
 
-   Return true if all bytes in the sequence are ASCII whitespace and the
-   sequence is not empty, false otherwise.  ASCII whitespace characters are
+   Return ``True`` if all bytes in the sequence are ASCII whitespace and the
+   sequence is not empty, ``False`` otherwise.  ASCII whitespace characters are
    those byte values in the sequence ``b' \t\n\r\x0b\f'`` (space, tab, newline,
    carriage return, vertical tab, form feed).
 
@@ -3095,8 +3095,8 @@ place, and instead produce new objects.
 .. method:: bytes.istitle()
             bytearray.istitle()
 
-   Return true if the sequence is ASCII titlecase and the sequence is not
-   empty, false otherwise. See :meth:`bytes.title` for more details on the
+   Return ``True`` if the sequence is ASCII titlecase and the sequence is not
+   empty, ``False`` otherwise. See :meth:`bytes.title` for more details on the
    definition of "titlecase".
 
    For example::
@@ -3110,8 +3110,8 @@ place, and instead produce new objects.
 .. method:: bytes.isupper()
             bytearray.isupper()
 
-   Return true if there is at least one uppercase alphabetic ASCII character
-   in the sequence and no lowercase ASCII characters, false otherwise.
+   Return ``True`` if there is at least one uppercase alphabetic ASCII character
+   in the sequence and no lowercase ASCII characters, ``False`` otherwise.
 
    For example::
 

--- a/Doc/library/stringprep.rst
+++ b/Doc/library/stringprep.rst
@@ -34,7 +34,7 @@ itself was generated using the ``mkstringprep.py`` utility.
 As a result, these tables are exposed as functions, not as data structures.
 There are two kinds of tables in the RFC: sets and mappings. For a set,
 :mod:`stringprep` provides the "characteristic function", i.e. a function that
-returns true if the parameter is part of the set. For mappings, it provides the
+returns ``True`` if the parameter is part of the set. For mappings, it provides the
 mapping function: given the key, it returns the associated value. Below is a
 list of all functions available in the module.
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1414,7 +1414,7 @@ always available.
      On Windows, UTF-8 is used for the console device.  Non-character
      devices such as disk files and pipes use the system locale
      encoding (i.e. the ANSI codepage).  Non-console character
-     devices such as NUL (i.e. where isatty() returns True) use the
+     devices such as NUL (i.e. where ``isatty()`` returns ``True``) use the
      value of the console input and output codepages at startup,
      respectively for stdin and stdout/stderr. This defaults to the
      system locale encoding if the process is not initially attached

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -543,15 +543,15 @@ Reentrant locks also support the :ref:`context management protocol <with-locks>`
       There is no return value in this case.
 
       When invoked with the *blocking* argument set to true, do the same thing as when
-      called without arguments, and return true.
+      called without arguments, and return ``True``.
 
       When invoked with the *blocking* argument set to false, do not block.  If a call
-      without an argument would block, return false immediately; otherwise, do the
-      same thing as when called without arguments, and return true.
+      without an argument would block, return ``False`` immediately; otherwise, do the
+      same thing as when called without arguments, and return ``True``.
 
       When invoked with the floating-point *timeout* argument set to a positive
       value, block for at most the number of seconds specified by *timeout*
-      and as long as the lock cannot be acquired.  Return true if the lock has
+      and as long as the lock cannot be acquired.  Return ``True`` if the lock has
       been acquired, false if the timeout has elapsed.
 
       .. versionchanged:: 3.2
@@ -784,20 +784,20 @@ Semaphores also support the :ref:`context management protocol <with-locks>`.
       When invoked without arguments:
 
       * If the internal counter is larger than zero on entry, decrement it by
-        one and return true immediately.
+        one and return ``True`` immediately.
       * If the internal counter is zero on entry, block until awoken by a call to
         :meth:`~Semaphore.release`.  Once awoken (and the counter is greater
-        than 0), decrement the counter by 1 and return true.  Exactly one
+        than 0), decrement the counter by 1 and return ``True``.  Exactly one
         thread will be awoken by each call to :meth:`~Semaphore.release`.  The
         order in which threads are awoken should not be relied on.
 
       When invoked with *blocking* set to false, do not block.  If a call
-      without an argument would block, return false immediately; otherwise, do
-      the same thing as when called without arguments, and return true.
+      without an argument would block, return ``False`` immediately; otherwise, do
+      the same thing as when called without arguments, and return ``True``.
 
       When invoked with a *timeout* other than ``None``, it will block for at
       most *timeout* seconds.  If acquire does not complete successfully in
-      that interval, return false.  Return true otherwise.
+      that interval, return ``False``.  Return ``True`` otherwise.
 
       .. versionchanged:: 3.2
          The *timeout* parameter is new.
@@ -877,7 +877,7 @@ method.  The :meth:`~Event.wait` method blocks until the flag is true.
 
    .. method:: is_set()
 
-      Return true if and only if the internal flag is true.
+      Return ``True`` if and only if the internal flag is true.
 
    .. method:: set()
 
@@ -901,7 +901,7 @@ method.  The :meth:`~Event.wait` method blocks until the flag is true.
       floating point number specifying a timeout for the operation in seconds
       (or fractions thereof).
 
-      This method returns true if and only if the internal flag has been set to
+      This method returns ``True`` if and only if the internal flag has been set to
       true, either before the wait call or after the wait starts, so it will
       always return ``True`` except if a timeout is given and the operation
       times out.

--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -871,8 +871,8 @@ widget commands.
    |        | remaining values are assumed empty. If there are more values  |
    |        | than columns, the extra values are ignored.                   |
    +--------+---------------------------------------------------------------+
-   | open   | True/False value indicating whether the item's children should|
-   |        | be displayed or hidden.                                       |
+   | open   | ``True``/``False`` value indicating whether the item's        |
+   |        | children should be displayed or hidden.                       |
    +--------+---------------------------------------------------------------+
    | tags   | A list of tags associated with this item.                     |
    +--------+---------------------------------------------------------------+
@@ -997,7 +997,7 @@ ttk.Treeview
          The minimum width of the column in pixels. The treeview widget will
          not make the column any smaller than specified by this option when
          the widget is resized or the user drags a column.
-      * stretch: True/False
+      * stretch: ``True``/``False``
          Specifies whether the column's width should be adjusted when
          the widget is resized.
       * width: width

--- a/Doc/library/token.rst
+++ b/Doc/library/token.rst
@@ -29,17 +29,17 @@ functions.  The functions mirror definitions in the Python C header files.
 
 .. function:: ISTERMINAL(x)
 
-   Return true for terminal token values.
+   Return ``True`` for terminal token values.
 
 
 .. function:: ISNONTERMINAL(x)
 
-   Return true for non-terminal token values.
+   Return ``True`` for non-terminal token values.
 
 
 .. function:: ISEOF(x)
 
-   Return true if *x* is the marker indicating the end of input.
+   Return ``True`` if *x* is the marker indicating the end of input.
 
 
 The token constants are:

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1006,11 +1006,11 @@ object::
       Assert the mock has been awaited with the specified calls.
       The :attr:`await_args_list` list is checked for the awaits.
 
-      If *any_order* is False (the default) then the awaits must be
+      If *any_order* is false (the default) then the awaits must be
       sequential. There can be extra calls before or after the
       specified awaits.
 
-      If *any_order* is True then the awaits can be in any order, but
+      If *any_order* is true then the awaits can be in any order, but
       they must all appear in :attr:`await_args_list`.
 
         >>> mock = AsyncMock()
@@ -2085,20 +2085,20 @@ to change the default.
 
 Methods and their defaults:
 
-* ``__lt__``: NotImplemented
-* ``__gt__``: NotImplemented
-* ``__le__``: NotImplemented
-* ``__ge__``: NotImplemented
-* ``__int__``: 1
-* ``__contains__``: False
-* ``__len__``: 0
-* ``__iter__``: iter([])
-* ``__exit__``: False
-* ``__aexit__``: False
-* ``__complex__``: 1j
-* ``__float__``: 1.0
-* ``__bool__``: True
-* ``__index__``: 1
+* ``__lt__``: ``NotImplemented``
+* ``__gt__``: ``NotImplemented``
+* ``__le__``: ``NotImplemented``
+* ``__ge__``: ``NotImplemented``
+* ``__int__``: ``1``
+* ``__contains__``: ``False``
+* ``__len__``: ``0``
+* ``__iter__``: ``iter([])``
+* ``__exit__``: ``False``
+* ``__aexit__``: ``False``
+* ``__complex__``: ``1j``
+* ``__float__``: ``1.0``
+* ``__bool__``: ``True``
+* ``__index__``: ``1``
 * ``__hash__``: default hash for the mock
 * ``__str__``: default str for the mock
 * ``__sizeof__``: default sizeof for the mock

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -360,7 +360,7 @@ the *new_callable* argument to :func:`patch`.
         assert the mock has been called with the specified calls.
         The :attr:`mock_calls` list is checked for the calls.
 
-        If *any_order* is false (the default) then the calls must be
+        If *any_order* is false then the calls must be
         sequential. There can be extra calls before or after the
         specified calls.
 
@@ -1006,7 +1006,7 @@ object::
       Assert the mock has been awaited with the specified calls.
       The :attr:`await_args_list` list is checked for the awaits.
 
-      If *any_order* is false (the default) then the awaits must be
+      If *any_order* is false then the awaits must be
       sequential. There can be extra calls before or after the
       specified awaits.
 

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -281,9 +281,9 @@ subclass which installs setuptools and pip into a created virtual environment::
         This builder installs setuptools and pip so that you can pip or
         easy_install other packages into the created virtual environment.
 
-        :param nodist: If True, setuptools and pip are not installed into the
+        :param nodist: If true, setuptools and pip are not installed into the
                        created virtual environment.
-        :param nopip: If True, pip is not installed into the created
+        :param nopip: If true, pip is not installed into the created
                       virtual environment.
         :param progress: If setuptools or pip are installed, the progress of the
                          installation can be monitored by passing a progress

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -144,7 +144,7 @@ also provides these miscellaneous utilities:
 
 .. function:: is_hop_by_hop(header_name)
 
-   Return true if 'header_name' is an HTTP/1.1 "Hop-by-Hop" header, as defined by
+   Return ``True`` if 'header_name' is an HTTP/1.1 "Hop-by-Hop" header, as defined by
    :rfc:`2616`.
 
 

--- a/Doc/library/xml.dom.rst
+++ b/Doc/library/xml.dom.rst
@@ -335,17 +335,17 @@ All of the components of an XML document are subclasses of :class:`Node`.
 
 .. method:: Node.hasAttributes()
 
-   Returns ``True`` if the node has any attributes.
+   Return ``True`` if the node has any attributes.
 
 
 .. method:: Node.hasChildNodes()
 
-   Returns ``True`` if the node has any child nodes.
+   Return ``True`` if the node has any child nodes.
 
 
 .. method:: Node.isSameNode(other)
 
-   Returns ``True`` if *other* refers to the same node as this node. This is especially
+   Return ``True`` if *other* refers to the same node as this node. This is especially
    useful for DOM implementations which use any sort of proxy architecture (because
    more than one object can refer to the same node).
 
@@ -604,12 +604,12 @@ of that class.
 
 .. method:: Element.hasAttribute(name)
 
-   Returns ``True`` if the element has an attribute named by *name*.
+   Return ``True`` if the element has an attribute named by *name*.
 
 
 .. method:: Element.hasAttributeNS(namespaceURI, localName)
 
-   Returns ``True`` if the element has an attribute named by *namespaceURI* and
+   Return ``True`` if the element has an attribute named by *namespaceURI* and
    *localName*.
 
 

--- a/Doc/library/xml.dom.rst
+++ b/Doc/library/xml.dom.rst
@@ -210,7 +210,7 @@ DOM Level 2 added the ability to create new :class:`Document` and
 
 .. method:: DOMImplementation.hasFeature(feature, version)
 
-   Return true if the feature identified by the pair of strings *feature* and
+   Return ``True`` if the feature identified by the pair of strings *feature* and
    *version* is implemented.
 
 
@@ -335,17 +335,17 @@ All of the components of an XML document are subclasses of :class:`Node`.
 
 .. method:: Node.hasAttributes()
 
-   Returns true if the node has any attributes.
+   Returns ``True`` if the node has any attributes.
 
 
 .. method:: Node.hasChildNodes()
 
-   Returns true if the node has any child nodes.
+   Returns ``True`` if the node has any child nodes.
 
 
 .. method:: Node.isSameNode(other)
 
-   Returns true if *other* refers to the same node as this node. This is especially
+   Returns ``True`` if *other* refers to the same node as this node. This is especially
    useful for DOM implementations which use any sort of proxy architecture (because
    more than one object can refer to the same node).
 
@@ -604,12 +604,12 @@ of that class.
 
 .. method:: Element.hasAttribute(name)
 
-   Returns true if the element has an attribute named by *name*.
+   Returns ``True`` if the element has an attribute named by *name*.
 
 
 .. method:: Element.hasAttributeNS(namespaceURI, localName)
 
-   Returns true if the element has an attribute named by *namespaceURI* and
+   Returns ``True`` if the element has an attribute named by *namespaceURI* and
    *localName*.
 
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -587,7 +587,7 @@ Functions
 .. function:: iselement(element)
 
    Checks if an object appears to be a valid element object.  *element* is an
-   element instance.  Returns a true value if this is an element object.
+   element instance.  Returns ``True`` if this is an element object.
 
 
 .. function:: iterparse(source, events=None, parser=None)

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -586,8 +586,8 @@ Functions
 
 .. function:: iselement(element)
 
-   Checks if an object appears to be a valid element object.  *element* is an
-   element instance.  Returns ``True`` if this is an element object.
+   Check if an object appears to be a valid element object.  *element* is an
+   element instance.  Return ``True`` if this is an element object.
 
 
 .. function:: iterparse(source, events=None, parser=None)

--- a/Doc/tools/susp-ignored.csv
+++ b/Doc/tools/susp-ignored.csv
@@ -240,9 +240,9 @@ library/urllib.request,,:password,"""joe:password@python.org"""
 library/urllib.parse,,:scheme,<URL:scheme://host/path>
 library/urllib.parse,,:scheme,URL:scheme://host/path
 library/uuid,,:uuid,urn:uuid:12345678-1234-5678-1234-567812345678
-library/venv,,:param,":param nodist: If True, setuptools and pip are not installed into the"
+library/venv,,:param,":param nodist: If true, setuptools and pip are not installed into the"
 library/venv,,:param,":param progress: If setuptools or pip are installed, the progress of the"
-library/venv,,:param,":param nopip: If True, pip is not installed into the created"
+library/venv,,:param,":param nopip: If true, pip is not installed into the created"
 library/venv,,:param,:param context: The information for the virtual environment
 library/xmlrpc.client,,:nil,ex:nil
 library/xmlrpc.client,,:pass,http://user:pass@host:port/path

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -924,7 +924,7 @@ logging
 -------
 
 Added a *force* keyword argument to :func:`logging.basicConfig()`
-When set to *True*, any existing handlers attached
+When set to true, any existing handlers attached
 to the root logger are removed and closed before carrying out the
 configuration specified by the other arguments.
 
@@ -1051,7 +1051,7 @@ environment variable and does not use :envvar:`HOME`, which is not normally set
 for regular user accounts.
 (Contributed by Anthony Sottile in :issue:`36264`.)
 
-:func:`~os.path.isdir` on Windows no longer returns true for a link to a
+:func:`~os.path.isdir` on Windows no longer returns ``True`` for a link to a
 non-existent directory.
 
 :func:`~os.path.realpath` on Windows now resolves reparse points, including
@@ -1100,12 +1100,12 @@ pprint
 
 The :mod:`pprint` module added a *sort_dicts* parameter to several functions.
 By default, those functions continue to sort dictionaries before rendering or
-printing.  However, if *sort_dicts* is set to *False*, the dictionaries retain
+printing.  However, if *sort_dicts* is set to false, the dictionaries retain
 the order that keys were inserted.  This can be useful for comparison to JSON
 inputs during debugging.
 
 In addition, there is a convenience new function, :func:`pprint.pp` that is
-like :func:`pprint.pprint` but with *sort_dicts* defaulting to *False*::
+like :func:`pprint.pprint` but with *sort_dicts* defaulting to ``False``::
 
     >>> from pprint import pprint, pp
     >>> d = dict(source='input.txt', operation='filter', destination='output.txt')

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1074,7 +1074,7 @@ import re
 
 def IS_LINE_JUNK(line, pat=re.compile(r"\s*(?:#\s*)?$").match):
     r"""
-    Return 1 for ignorable line: iff `line` is blank or contains a single '#'.
+    Return True for ignorable line: iff `line` is blank or contains a single '#'.
 
     Examples:
 
@@ -1090,7 +1090,7 @@ def IS_LINE_JUNK(line, pat=re.compile(r"\s*(?:#\s*)?$").match):
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):
     r"""
-    Return 1 for ignorable character: iff `ch` is a space or tab.
+    Return True for ignorable character: iff `ch` is a space or tab.
 
     Examples:
 

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -1053,7 +1053,7 @@ class Misc:
         return self.tk.call('winfo', 'class', self._w)
 
     def winfo_colormapfull(self):
-        """Return true if at the last color request the colormap was full."""
+        """Return True if at the last color request the colormap was full."""
         return self.tk.getboolean(
             self.tk.call('winfo', 'colormapfull', self._w))
 
@@ -3226,7 +3226,7 @@ class Listbox(Widget, XView, YView):
     select_clear = selection_clear
 
     def selection_includes(self, index):
-        """Return 1 if INDEX is part of the selection."""
+        """Return True if INDEX is part of the selection."""
         return self.tk.getboolean(self.tk.call(
             self._w, 'selection', 'includes', index))
 


### PR DESCRIPTION
* "Return true/false" is replaced with "Return ``` ``True``/``False`` ```"
  if the function actually returns a bool.
* Fixed formatting of some True and False literals (now in monospace).
* Replaced "True/False" with "true/false" if it can be not only bool.
* Replaced some 1/0 with True/False if it corresponds the code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38738](https://bugs.python.org/issue38738) -->
https://bugs.python.org/issue38738
<!-- /issue-number -->
