### PR TITLE
Fix definition of multiple ']' in header

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -563,7 +563,7 @@ class RawConfigParser(MutableMapping):
     # Regular expressions for parsing section headers and options
     _SECT_TMPL = r"""
         \[                                 # [
-        (?P<header>[^]]+)                  # very permissive!
+        (?P<header>.*)                     # very permissive!
         \]                                 # ]
         """
     _OPT_TMPL = r"""

--- a/Misc/NEWS.d/next/Library/2019-11-08-06-08-42.bpo-38741.pShzDL.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-08-06-08-42.bpo-38741.pShzDL.rst
@@ -1,0 +1,3 @@
+in example header is "[i love [python] lang]"
+parse as "i love [python", only up to the first character ']'.
+now saving works correctly, but reading does not


### PR DESCRIPTION
Fix definition of multiple ']' in header in configparser

in old version in example header is "[i love [python] lang]"
parse as "i love [python", only up to the first character ']'.

once fixed, multiple ']' can be used and this will not cause the header to be clipped. 
now saving works correctly, but reading does not