### PR TITLE
bpo-38707: Fix for multiprocessing.Process MainThread.native_id

### DIFF
--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -301,6 +301,8 @@ class BaseProcess(object):
             _current_process = self
             _parent_process = _ParentProcess(
                 self._parent_name, self._parent_pid, parent_sentinel)
+            if threading._HAVE_THREAD_NATIVE_ID:
+                threading.main_thread()._set_native_id()
             try:
                 util._finalizer_registry.clear()
                 util._run_after_forkers()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -374,8 +374,9 @@ class _TestProcess(BaseTestCase):
             p.start()
 
             child_mainthread_native_id = q.get()
-            self.assertNotEqual(current_mainthread_native_id, child_mainthread_native_id)
             close_queue(q)
+
+            self.assertNotEqual(current_mainthread_native_id, child_mainthread_native_id)
 
         @classmethod
         def _test_process_thread_attributes(cls, q):

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -361,6 +361,24 @@ class _TestProcess(BaseTestCase):
         self.assertNotIn(p, self.active_children())
         close_queue(q)
 
+    if threading._HAVE_THREAD_NATIVE_ID:
+        def test_process_thread_attributes(self):
+            current_mainthread_native_id = threading.main_thread().native_id
+
+            q = self.Queue(1)
+            p = self.Process(target=self._test_process_thread_attributes, args=(q,))
+            p.daemon = True
+            p.start()
+
+            child_mainthread_native_id = q.get()
+            self.assertNotEqual(current_mainthread_native_id, child_mainthread_native_id)
+            close_queue(q)
+
+        @classmethod
+        def _test_process_thread_attributes(cls, q):
+            mainthread_native_id = threading.main_thread().native_id
+            q.put(mainthread_native_id)
+
     @classmethod
     def _sleep_some(cls):
         time.sleep(100)

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -370,10 +370,10 @@ class _TestProcess(BaseTestCase):
 
         q = self.Queue(1)
         p = self.Process(target=self._test_process_mainthread_native_id, args=(q,))
-        p.daemon = True
         p.start()
 
         child_mainthread_native_id = q.get()
+        p.join()
         close_queue(q)
 
         self.assertNotEqual(current_mainthread_native_id, child_mainthread_native_id)

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -361,27 +361,27 @@ class _TestProcess(BaseTestCase):
         self.assertNotIn(p, self.active_children())
         close_queue(q)
 
-    if threading._HAVE_THREAD_NATIVE_ID:
-        def test_process_thread_attributes(self):
-            if self.TYPE == 'threads':
-                self.skipTest('test not appropriate for {}'.format(self.TYPE))
+    @unittest.skipUnless(threading._HAVE_THREAD_NATIVE_ID, "needs native_id")
+    def test_process_mainthread_native_id(self):
+        if self.TYPE == 'threads':
+            self.skipTest('test not appropriate for {}'.format(self.TYPE))
 
-            current_mainthread_native_id = threading.main_thread().native_id
+        current_mainthread_native_id = threading.main_thread().native_id
 
-            q = self.Queue(1)
-            p = self.Process(target=self._test_process_thread_attributes, args=(q,))
-            p.daemon = True
-            p.start()
+        q = self.Queue(1)
+        p = self.Process(target=self._test_process_mainthread_native_id, args=(q,))
+        p.daemon = True
+        p.start()
 
-            child_mainthread_native_id = q.get()
-            close_queue(q)
+        child_mainthread_native_id = q.get()
+        close_queue(q)
 
-            self.assertNotEqual(current_mainthread_native_id, child_mainthread_native_id)
+        self.assertNotEqual(current_mainthread_native_id, child_mainthread_native_id)
 
-        @classmethod
-        def _test_process_thread_attributes(cls, q):
-            mainthread_native_id = threading.main_thread().native_id
-            q.put(mainthread_native_id)
+    @classmethod
+    def _test_process_mainthread_native_id(cls, q):
+        mainthread_native_id = threading.main_thread().native_id
+        q.put(mainthread_native_id)
 
     @classmethod
     def _sleep_some(cls):

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -363,6 +363,9 @@ class _TestProcess(BaseTestCase):
 
     if threading._HAVE_THREAD_NATIVE_ID:
         def test_process_thread_attributes(self):
+            if self.TYPE == 'threads':
+                self.skipTest('test not appropriate for {}'.format(self.TYPE))
+
             current_mainthread_native_id = threading.main_thread().native_id
 
             q = self.Queue(1)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-08-00-36-10.bpo-38707.SZL036.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-08-00-36-10.bpo-38707.SZL036.rst
@@ -1,0 +1,1 @@
+`multiprocessing.Process` objects now retain their correct `MainThread.native_id` attribute

--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-08-00-36-10.bpo-38707.SZL036.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-08-00-36-10.bpo-38707.SZL036.rst
@@ -1,1 +1,1 @@
-:class:`multiprocessing.Process` objects now retain their correct ``MainThread.native_id`` attribute.
+``MainThread.native_id`` is now correctly reset in child processes spawned using :class:`multiprocessing.Process`, instead of retaining the parent's value.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-08-00-36-10.bpo-38707.SZL036.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-08-00-36-10.bpo-38707.SZL036.rst
@@ -1,1 +1,1 @@
-`multiprocessing.Process` objects now retain their correct `MainThread.native_id` attribute
+:class:`multiprocessing.Process` objects now retain their correct ``MainThread.native_id`` attribute.


### PR DESCRIPTION
This PR implements a fix for `multiprocessing.Process` objects; the error occurs when Processes are created using either `fork` or `forkserver` as the `start_method`.

In these instances, the `MainThread` of the newly created `Process` object retains all attributes from its parent's `MainThread` object, including the `native_id` attribute. The resulting behavior is such that the new process' `MainThread` captures an incorrect/outdated `native_id` (the parent's instead of its own). 

This change forces the Process object to update its `native_id` attribute during the bootstrap process.

cc @vstinner

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38707](https://bugs.python.org/issue38707) -->
https://bugs.python.org/issue38707
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou