### PR TITLE
gh-82924: configure: on darwin add CoreFoundation to flags before checking for gettext

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2839,6 +2839,11 @@ void *x = uuid_enc_be
 # pthread (first!) on Linux
 AC_SEARCH_LIBS(sem_init, pthread rt posix4)
 
+if test $ac_sys_system = Darwin
+then
+  LIBS="$LIBS -framework CoreFoundation"
+fi
+
 # check if we need libintl for locale functions
 AC_CHECK_LIB(intl, textdomain,
 	[AC_DEFINE(WITH_LIBINTL, 1,
@@ -5167,11 +5172,6 @@ AC_CHECK_FILE(/dev/ptc, [], [])
 if test "x$ac_cv_file__dev_ptc" = xyes; then
   AC_DEFINE(HAVE_DEV_PTC, 1,
   [Define to 1 if you have the /dev/ptc device file.])
-fi
-
-if test $ac_sys_system = Darwin
-then
-	LIBS="$LIBS -framework CoreFoundation"
 fi
 
 AC_CACHE_CHECK([for %zd printf() format support], ac_cv_have_size_t_format, [dnl


### PR DESCRIPTION
macOS needs to link to CoreFoundation for gettext to work. We reorder the autoconf tests so CoreFoundation is added to LIBS earlier and the -lintl test does not fail (which would exclude it from the final set of flags).

Btw. the whole test seems fishy: if compilation fails it does not mean -lintl is not needed, for this we would need to test a gettext function without -lintl. Basically two tests (with and without -lintl) are needed to properly diagnose the situation. The test in question had been written in 2009 as a fix for the https://bugs.python.org/issue6154 bug report.

This may be an issue only with non-Framework builds (since Homebrew manages to build a framework-based Python on macOS without any special shenigans) but I had not tested it.

<!-- issue-number: [bpo-38743](https://bugs.python.org/issue38743) -->
https://bugs.python.org/issue38743
<!-- /issue-number -->


<!-- gh-issue-number: gh-82924 -->
* Issue: gh-82924
<!-- /gh-issue-number -->
