### PR TITLE
bpo-38688: Consume iterator and create list of entries to prevent infinite loop

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -442,7 +442,7 @@ def ignore_patterns(*patterns):
 def _copytree(entries, src, dst, symlinks, ignore, copy_function,
               ignore_dangling_symlinks, dirs_exist_ok=False):
     if ignore is not None:
-        ignored_names = ignore(src, set(os.listdir(src)))
+        ignored_names = ignore(src, {x.name for x in entries})
     else:
         ignored_names = set()
 
@@ -543,11 +543,12 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
 
     """
     sys.audit("shutil.copytree", src, dst)
-    with os.scandir(src) as entries:
-        return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
-                         ignore=ignore, copy_function=copy_function,
-                         ignore_dangling_symlinks=ignore_dangling_symlinks,
-                         dirs_exist_ok=dirs_exist_ok)
+    with os.scandir(src) as itr:
+        entries = list(itr)
+    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
+                     ignore=ignore, copy_function=copy_function,
+                     ignore_dangling_symlinks=ignore_dangling_symlinks,
+                     dirs_exist_ok=dirs_exist_ok)
 
 if hasattr(os.stat_result, 'st_file_attributes'):
     # Special handling for directory junctions to make them behave like

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -727,6 +727,17 @@ class TestCopyTree(BaseTest, unittest.TestCase):
         rv = shutil.copytree(src_dir, dst_dir)
         self.assertEqual(['foo'], os.listdir(rv))
 
+    def test_copytree_subdirectory(self):
+        # copytree where dst is a subdirectory of src, see Issue 38688
+        base_dir = self.mkdtemp()
+        self.addCleanup(shutil.rmtree, base_dir, ignore_errors=True)
+        src_dir = os.path.join(base_dir, "t", "pg")
+        dst_dir = os.path.join(src_dir, "somevendor", "1.0")
+        os.makedirs(src_dir)
+        src = os.path.join(src_dir, 'pol')
+        write_file(src, 'pol')
+        rv = shutil.copytree(src_dir, dst_dir)
+        self.assertEqual(['pol'], os.listdir(rv))
 
 class TestCopy(BaseTest, unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2019-11-22-10-45-03.bpo-38668.iKx23z.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-22-10-45-03.bpo-38668.iKx23z.rst
@@ -1,0 +1,5 @@
+Calling func:`shutil.copytree` to copy a directory tree from one directory
+to another subdirectory resulted in an endless loop and a RecursionError. A
+fix was added to consume an iterator and create the list of the entries to
+be copied, avoiding the recursion for newly created directories. Patch by
+Bruno P. Kinoshita.


### PR DESCRIPTION
Hi,

Reverted part of `33695` due to the regression reported in [`38688`](https://bugs.python.org/issue38688). Text below is a copy-paste from my comment in the bugs.python.org issue.

It looks to me that the iterator returned by with `os.scandir(...)` is including the newly created `dst` directory. See the call for `os.makedirs(dst, exist_ok=dirs_exist_ok)`, just before the iterator is open:

https://github.com/python/cpython/blob/e27449da92b13730a5e11182f329d5da98a5e05b/Lib/shutil.py#L449-L453

This results in the function finding an extra directory, and repeating the steps for this folder and its subfolder recursively. This only happens because in the example reported in the issue, `dst` is a subdirectory of `src`.

The [bpo-33695](https://bugs.python.org/issue33695) commit had more changes, so I've reverted just this block of the `copytree` as a tentative fix, and added a unit test.

--

Here's a simplified version of what's going on:

```
import os
import shutil

# create dirs and files
shutil.rmtree('/tmp/test/', True)
os.makedirs('/tmp/test')
with open('/tmp/test/foo', 'w+') as f:
  f.write('foo')

# now we have /tmp/test/foo, let's simulate what happens in copytree on master

with os.scandir('/tmp/test') as entries:
  # up to this point, /tmp/test/foo is the only entry
  os.makedirs('/tmp/test/1/2/3/', exist_ok=True) # <---- when the iterator starts below in `f in entries`, it will find 1 too
  # now 1 will have been added too
  for f in entries:
    print(f)
```

My first PR here. Let me know if I forgot anything. Happy to update the PR as necessary :+1: 

Bruno

<!-- issue-number: [bpo-38688](https://bugs.python.org/issue38688) -->
https://bugs.python.org/issue38688
<!-- /issue-number -->
