### PR TITLE
gh-61842: Add hotkeys to resize IDLE's font

### DIFF
--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -576,6 +576,10 @@ class IdleConf:
         """
         return ('<<'+virtualEvent+'>>') in self.GetCoreKeys()
 
+    def GetFontSizes(self):
+        return ('7', '8', '9', '10', '11', '12', '13', '14',
+                '16', '18', '20', '22', '25', '29', '34', '40')
+
 # TODO make keyBindins a file or class attribute used for test above
 # and copied in function below.
 

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -619,9 +619,7 @@ class FontPage(Frame):
         except ValueError:
             pass
         # Set font size dropdown.
-        self.sizelist.SetMenu(('7', '8', '9', '10', '11', '12', '13', '14',
-                               '16', '18', '20', '22', '25', '29', '34', '40'),
-                              font_size)
+        self.sizelist.SetMenu(idleConf.GetFontSizes(), font_size)
         # Set font weight.
         self.font_bold.set(font_bold)
         self.set_samples()

--- a/Misc/NEWS.d/next/IDLE/2019-11-11-16-26-54.bpo-17642.m6VW2z.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-11-11-16-26-54.bpo-17642.m6VW2z.rst
@@ -1,0 +1,1 @@
+Add hotkeys to resize the font of IDLE's shell and editor windows.


### PR DESCRIPTION
The implementation is based on the font-resizing code in turtledemo.
Changing the font size with the hotkeys or the mouse wheel will not
modify the config setting.

<!-- issue-number: [bpo-17642](https://bugs.python.org/issue17642) -->
https://bugs.python.org/issue17642
<!-- /issue-number -->


<!-- gh-issue-number: gh-61842 -->
* Issue: gh-61842
<!-- /gh-issue-number -->
