### PR TITLE
bpo-9495: argparse unittest tracebacks are confusing if an error is raised when not expected

### DIFF
--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -105,7 +105,8 @@ def stderr_to_parser_error(parse_args, *args, **kwargs):
             code = sys.exc_info()[1].code
             stdout = sys.stdout.getvalue()
             stderr = sys.stderr.getvalue()
-            raise ArgumentParserError("SystemExit", stdout, stderr, code)
+            raise ArgumentParserError(
+                "SystemExit", stdout, stderr, code) from None
     finally:
         sys.stdout = old_stdout
         sys.stderr = old_stderr

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -306,6 +306,7 @@ Gilles Civario
 Chris Clark
 Diana Clarke
 Laurie Clark-Michalek
+Alexander Clarkson
 Mike Clarkson
 Andrew Clegg
 Brad Clements


### PR DESCRIPTION
Hi,

This is my first contribution to CPython - fixing the issue at https://bugs.python.org/issue9495

@brandtbucher 

<!-- issue-number: [bpo-9495](https://bugs.python.org/issue9495) -->
https://bugs.python.org/issue9495
<!-- /issue-number -->
