### PR TITLE
bpo-38778: Document that os.fork is not allowed in subinterpreters

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3499,6 +3499,10 @@ written in Python, such as a mail server's external command delivery program.
    master end of the pseudo-terminal.  For a more portable approach, use the
    :mod:`pty` module.  If an error occurs :exc:`OSError` is raised.
 
+   .. versionchanged:: 3.8
+      Calling ``forkpty()`` in a subinterpreter is no longer supported
+      (:exc:`RuntimeError` is raised).
+
    .. availability:: some flavors of Unix.
 
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3480,6 +3480,11 @@ written in Python, such as a mail server's external command delivery program.
    Note that some platforms including FreeBSD <= 6.3 and Cygwin have
    known issues when using fork() from a thread.
 
+   .. note::
+
+      Calling fork() in a subinterpreter is not supported (:exc:`RuntimeError`
+      is raised).
+
    .. warning::
 
       See :mod:`ssl` for applications that use the SSL module with fork().

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3478,10 +3478,10 @@ written in Python, such as a mail server's external command delivery program.
    parent.  If an error occurs :exc:`OSError` is raised.
 
    Note that some platforms including FreeBSD <= 6.3 and Cygwin have
-   known issues when using fork() from a thread.
+   known issues when using ``fork()`` from a thread.
 
    .. versionchanged:: 3.8
-      Calling fork() in a subinterpreter is no longer supported
+      Calling ``fork()`` in a subinterpreter is no longer supported
       (:exc:`RuntimeError` is raised).
 
    .. warning::

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3480,10 +3480,9 @@ written in Python, such as a mail server's external command delivery program.
    Note that some platforms including FreeBSD <= 6.3 and Cygwin have
    known issues when using fork() from a thread.
 
-   .. note::
-
-      Calling fork() in a subinterpreter is not supported (:exc:`RuntimeError`
-      is raised).
+   .. versionchanged:: 3.8
+      Calling fork() in a subinterpreter is no longer supported
+      (:exc:`RuntimeError` is raised).
 
    .. warning::
 

--- a/Misc/NEWS.d/next/Documentation/2019-11-12-15-31-09.bpo-38778.PHhTlv.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-11-12-15-31-09.bpo-38778.PHhTlv.rst
@@ -1,0 +1,1 @@
+Document the fact that `RuntimeError` is raised if `os.fork()` is called in a subinterpreter.

--- a/Misc/NEWS.d/next/Documentation/2019-11-12-15-31-09.bpo-38778.PHhTlv.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-11-12-15-31-09.bpo-38778.PHhTlv.rst
@@ -1,1 +1,1 @@
-Document the fact that `RuntimeError` is raised if `os.fork()` is called in a subinterpreter.
+Document the fact that :exc:`RuntimeError` is raised if :meth:`os.fork` is called in a subinterpreter.


### PR DESCRIPTION
Small docs update for [bpo-34651](https://bugs.python.org/issue34651).

Other references to fork (e.g. the PyOS.*Fork functions or discussions of fork() when embedding Python) point back to os.fork, so I don't think any other updates are needed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38778](https://bugs.python.org/issue38778) -->
https://bugs.python.org/issue38778
<!-- /issue-number -->


Automerge-Triggered-By: @ericsnowcurrently