### PR TITLE
bpo-15243: Specify __prepare__ should be a classmethod

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1927,7 +1927,8 @@ Preparing the class namespace
 Once the appropriate metaclass has been identified, then the class namespace
 is prepared. If the metaclass has a ``__prepare__`` attribute, it is called
 as ``namespace = metaclass.__prepare__(name, bases, **kwds)`` (where the
-additional keyword arguments, if any, come from the class definition).
+additional keyword arguments, if any, come from the class definition). The
+``__prepare__`` method should be implemented as a :func:`classmethod`.
 
 If the metaclass has no ``__prepare__`` attribute, then the class namespace
 is initialised as an empty ordered mapping.


### PR DESCRIPTION
Hi,

This is an updated patch for the issue https://bugs.python.org/issue15243 - specifying that __prepare__ should be a classmethod.

@brandtbucher 

<!-- issue-number: [bpo-15243](https://bugs.python.org/issue15243) -->
https://bugs.python.org/issue15243
<!-- /issue-number -->
