### PR TITLE
bpo-38723: Pdb._runscript should use io.open_code() instead of open()

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -68,6 +68,7 @@ Debugger commands
 # commands and is appended to __doc__ after the class has been defined.
 
 import os
+import io
 import re
 import sys
 import cmd
@@ -1565,7 +1566,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self._wait_for_mainpyfile = True
         self.mainpyfile = self.canonic(filename)
         self._user_requested_quit = False
-        with open(filename, "rb") as fp:
+        with io.open_code(filename) as fp:
             statement = "exec(compile(%r, %r, 'exec'))" % \
                         (fp.read(), self.mainpyfile)
         self.run(statement)

--- a/Misc/NEWS.d/next/Library/2019-11-12-15-46-28.bpo-38723.gcdMFn.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-12-15-46-28.bpo-38723.gcdMFn.rst
@@ -1,0 +1,1 @@
+pdb now uses io.open_code

--- a/Misc/NEWS.d/next/Library/2019-11-12-15-46-28.bpo-38723.gcdMFn.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-12-15-46-28.bpo-38723.gcdMFn.rst
@@ -1,1 +1,1 @@
-pdb now uses io.open_code
+:mod:`pdb` now uses :meth:`io.open_code` to trigger auditing events.


### PR DESCRIPTION
From the io.open_code documentation:
This function should be used when the intent is to treat
the contents as executable code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38723](https://bugs.python.org/issue38723) -->
https://bugs.python.org/issue38723
<!-- /issue-number -->
