### PR TITLE
bpo-38644: Add _PyEval_EvalFrame() with tstate

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -11,6 +11,9 @@ extern "C" {
 /* Forward declarations */
 struct pyruntimestate;
 struct _ceval_runtime_state;
+struct _frame;
+
+#include "pycore_pystate.h"   /* PyInterpreterState.eval_frame */
 
 PyAPI_FUNC(void) _Py_FinishPendingCalls(struct pyruntimestate *runtime);
 PyAPI_FUNC(void) _PyEval_Initialize(struct _ceval_runtime_state *);
@@ -33,6 +36,12 @@ PyAPI_FUNC(void) _PyEval_SetCoroutineOriginTrackingDepth(
 
 /* Private function */
 void _PyEval_Fini(void);
+
+static inline PyObject*
+_PyEval_EvalFrame(PyThreadState *tstate, struct _frame *f, int throwflag)
+{
+    return tstate->interp->eval_frame(f, throwflag);
+}
 
 #ifdef __cplusplus
 }

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_ceval.h"   /* _PyEval_EvalFrame() */
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"
@@ -303,7 +304,7 @@ function_code_fastcall(PyCodeObject *co, PyObject *const *args, Py_ssize_t nargs
         Py_INCREF(*args);
         fastlocals[i] = *args++;
     }
-    PyObject *result = PyEval_EvalFrameEx(f, 0);
+    PyObject *result = _PyEval_EvalFrame(tstate, f, 0);
 
     if (Py_REFCNT(f) > 1) {
         Py_DECREF(f);

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1,6 +1,7 @@
 /* Generator object implementation */
 
 #include "Python.h"
+#include "pycore_ceval.h"   /* _PyEval_EvalFrame() */
 #include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "frameobject.h"
@@ -219,7 +220,7 @@ gen_send_ex(PyGenObject *gen, PyObject *arg, int exc, int closing)
     gen->gi_running = 1;
     gen->gi_exc_state.previous_item = tstate->exc_info;
     tstate->exc_info = &gen->gi_exc_state;
-    result = PyEval_EvalFrameEx(f, exc);
+    result = _PyEval_EvalFrame(tstate, f, exc);
     tstate->exc_info = gen->gi_exc_state.previous_item;
     gen->gi_exc_state.previous_item = NULL;
     gen->gi_running = 0;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -722,18 +722,20 @@ PyEval_EvalCode(PyObject *co, PyObject *globals, PyObject *locals)
 /* Interpreter main loop */
 
 PyObject *
-PyEval_EvalFrame(PyFrameObject *f) {
+PyEval_EvalFrame(PyFrameObject *f)
+{
     /* This is for backward compatibility with extension modules that
        used this API; core interpreter code should call
        PyEval_EvalFrameEx() */
-    return PyEval_EvalFrameEx(f, 0);
+    PyThreadState *tstate = _PyThreadState_GET();
+    return _PyEval_EvalFrame(tstate, f, 0);
 }
 
 PyObject *
 PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 {
-    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
-    return interp->eval_frame(f, throwflag);
+    PyThreadState *tstate = _PyThreadState_GET();
+    return _PyEval_EvalFrame(tstate, f, throwflag);
 }
 
 PyObject* _Py_HOT_FUNCTION
@@ -4295,7 +4297,7 @@ _PyEval_EvalCodeWithName(PyObject *_co, PyObject *globals, PyObject *locals,
         return gen;
     }
 
-    retval = PyEval_EvalFrameEx(f,0);
+    retval = _PyEval_EvalFrame(tstate, f, 0);
 
 fail: /* Jump here from prelude on failure */
 


### PR DESCRIPTION
Add _PyEval_EvalFrame() static inline function to get eval_frame from
tstate->interp.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38644](https://bugs.python.org/issue38644) -->
https://bugs.python.org/issue38644
<!-- /issue-number -->
