### PR TITLE
bpo-17013: Extend Mock.called to allow waiting for calls

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -493,7 +493,7 @@ the *new_callable* argument to :func:`patch`.
 
     .. attribute:: called
 
-        A boolean representing whether or not the mock object has been called:
+        A boolean-like object representing whether or not the mock object has been called:
 
             >>> mock = Mock(return_value=None)
             >>> mock.called
@@ -501,6 +501,15 @@ the *new_callable* argument to :func:`patch`.
             >>> mock()
             >>> mock.called
             True
+
+        The object gives access to methods helpful in multithreaded tests:
+
+        - :meth:`wait(/, skip=0, timeout=None)` asserts that mock is called
+          *skip* times during *timeout*
+
+        - :meth:`wait_for(predicate, /, timeout=None)` asserts that
+          *predicate* was ``True`` at least once during the timeout;
+          *predicate* receives exactly one positional argument: the mock itself
 
     .. attribute:: call_count
 

--- a/Lib/unittest/test/testmock/support.py
+++ b/Lib/unittest/test/testmock/support.py
@@ -1,3 +1,7 @@
+import concurrent.futures
+import time
+
+
 target = {'foo': 'FOO'}
 
 
@@ -14,3 +18,15 @@ class SomeClass(object):
 
 class X(object):
     pass
+
+
+def call_after_delay(func, /, *args, **kwargs):
+    time.sleep(kwargs.pop('delay'))
+    func(*args, **kwargs)
+
+
+def run_async(func, /, *args, executor=None, delay=0, **kwargs):
+    if executor is None:
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=5)
+
+    executor.submit(call_after_delay, func, *args, **kwargs, delay=delay)

--- a/Misc/NEWS.d/next/Library/2019-11-12-13-11-44.bpo-17013.C06aC9.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-12-13-11-44.bpo-17013.C06aC9.rst
@@ -1,0 +1,2 @@
+Extend :attr:`called` of :class:`Mock.called` to wait for the calls in
+multithreaded tests. Patch by Ilya Kulakov.


### PR DESCRIPTION
This implementation of [bpo-17013](https://bugs.python.org/issue17013) is alternative to #16094

Changes are based on my work for [`asynctest`](https://github.com/Martiusweb/asynctest). Specifically on [`_AwaitEvent`](https://github.com/Martiusweb/asynctest/pull/67) that was left out when related code was [ported](https://github.com/python/cpython/pull/9296) to CPython.

Key features:

- Gives meaning to the _existing_ `Mock.called` property, otherwise not much useful
- Does not require end users to do anything: change is automatically available in every Mock
- Utilizes existing semantics of python conditionals (both asyncio and threading)

Accepting this change will allow me to port `_AwaitEvent` therefore giving identical semantics to both wait-for-calls and wait-for-awaits.

I will provide necessary typing annotations for typeshed.

Considerations:
1. This approach changes type of the `Mock.called` property from `bool` to private bool-like `_CallEvent`. However, the only practical problem I could think of is if someone was checking type of `Mock.called` (e.g. via `isinstance`). That does not sound like a plausible problem: after all the property itself is seldom used with exception of conditional expressions where `_CallEvent.__bool__` and `_CallEvent.__eq__` is sufficient.
2. It probably makes sense to provide convenience methods like `wait_for_call`, but I would like to hear the opinion of the reviewers.

CC: @vstinner @tirkarthi @mariocj89


<!-- issue-number: [bpo-17013](https://bugs.python.org/issue17013) -->
https://bugs.python.org/issue17013
<!-- /issue-number -->
