### PR TITLE
bpo-38786: Add parsing of https links to pydoc

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -585,7 +585,7 @@ class HTMLDoc(Doc):
         escape = escape or self.escape
         results = []
         here = 0
-        pattern = re.compile(r'\b((http|ftp)://\S+[\w/]|'
+        pattern = re.compile(r'\b((http|https|ftp)://\S+[\w/]|'
                                 r'RFC[- ]?(\d+)|'
                                 r'PEP[- ]?(\d+)|'
                                 r'(self\.)?(\w+))')

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1311,6 +1311,17 @@ foo
             'async <a name="-an_async_generator"><strong>an_async_generator',
             html)
 
+    def test_html_for_https_links(self):
+        def a_fn_with_https_link():
+            """a link https://localhost/"""
+            pass
+
+        html = pydoc.HTMLDoc().document(a_fn_with_https_link)
+        self.assertIn(
+            '<a href="https://localhost/">https://localhost/</a>',
+            html
+        )
+
 class PydocServerTest(unittest.TestCase):
     """Tests for pydoc._start_server"""
 

--- a/Lib/xmlrpc/server.py
+++ b/Lib/xmlrpc/server.py
@@ -732,7 +732,7 @@ class ServerHTMLDoc(pydoc.HTMLDoc):
         # hyperlinking of arbitrary strings being used as method
         # names. Only methods with names consisting of word characters
         # and '.'s are hyperlinked.
-        pattern = re.compile(r'\b((http|ftp)://\S+[\w/]|'
+        pattern = re.compile(r'\b((http|https|ftp)://\S+[\w/]|'
                                 r'RFC[- ]?(\d+)|'
                                 r'PEP[- ]?(\d+)|'
                                 r'(self\.)?((?:\w|\.)+))\b')

--- a/Misc/NEWS.d/next/Library/2019-11-13-16-49-03.bpo-38786.gNOwKh.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-13-16-49-03.bpo-38786.gNOwKh.rst
@@ -1,0 +1,1 @@
+pydoc now recognizes and parses HTTPS URLs. Patch by python273.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

previous PR: #2975 (force pushed to my branch, seems like can't reopen)

<!-- issue-number: [bpo-38786](https://bugs.python.org/issue38786) -->
https://bugs.python.org/issue38786
<!-- /issue-number -->
