### PR TITLE
bpo-38785: Prevent asyncio from crashing 

### DIFF
--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -115,7 +115,10 @@ class Future:
 
     def get_loop(self):
         """Return the event loop the Future is bound to."""
-        return self._loop
+        loop = self._loop
+        if loop is None:
+            raise RuntimeError("Future object is not initialized.")
+        return loop
 
     def cancel(self):
         """Cancel the future and schedule callbacks.

--- a/Misc/NEWS.d/next/Library/2019-11-13-16-17-43.bpo-38785.NEOEfk.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-13-16-17-43.bpo-38785.NEOEfk.rst
@@ -1,0 +1,2 @@
+Prevent asyncio from crashing if parent ``__init__`` is not called from a
+constructor of object derived from ``asyncio.Future``.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1091,6 +1091,7 @@ static PyObject *
 _asyncio_Future_get_loop_impl(FutureObj *self)
 /*[clinic end generated code: output=119b6ea0c9816c3f input=cba48c2136c79d1f]*/
 {
+    ENSURE_FUTURE_ALIVE(self)
     Py_INCREF(self->fut_loop);
     return self->fut_loop;
 }


### PR DESCRIPTION
if parent `__init__` is not called from a constructor of object derived from `asyncio.Future`


<!-- issue-number: [bpo-38785](https://bugs.python.org/issue38785) -->
https://bugs.python.org/issue38785
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov