### PR TITLE
bpo-38791: Add readline history environment variable

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -145,10 +145,10 @@ On systems that support :mod:`readline`, this module will also import and
 configure the :mod:`rlcompleter` module, if Python is started in
 :ref:`interactive mode <tut-interactive>` and without the :option:`-S` option.
 The default behavior is enable tab-completion and to use
-:file:`~/.python_history` as the history save file.  To disable it, delete (or
-override) the :data:`sys.__interactivehook__` attribute in your
-:mod:`sitecustomize` or :mod:`usercustomize` module or your
-:envvar:`PYTHONSTARTUP` file.
+:envvar:`PYTHONHISTFILE` (or :file:`~/.python_history`, if the former does not
+exist) as the history save file.  To disable it, delete (or override) the
+:data:`sys.__interactivehook__` attribute in your :mod:`sitecustomize` or
+:mod:`usercustomize` module or your :envvar:`PYTHONSTARTUP` file.
 
 .. versionchanged:: 3.4
    Activation of rlcompleter and history was made automatic.

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -515,6 +515,12 @@ before the command-line switches other than -E or -I.  It is customary that
 command-line switches override environmental variables where there is a
 conflict.
 
+.. envvar:: PYTHONHISTFILE
+
+   If this is the name of a file, and :mod:`readline` is enabled, it will be
+   used as the history save file.  The default is :file:`~/.python_history`.
+
+
 .. envvar:: PYTHONHOME
 
    Change the location of the standard Python libraries.  By default, the

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -434,8 +434,11 @@ def enablerlcompleter():
             # each interpreter exit when readline was already configured
             # through a PYTHONSTARTUP hook, see:
             # http://bugs.python.org/issue5845#msg198636
-            history = os.path.join(os.path.expanduser('~'),
-                                   '.python_history')
+            history = os.environ.get('PYTHONHISTFILE')
+            if not history or not os.path.isfile(history):
+                history = os.path.join(os.path.expanduser('~'),
+                                       '.python_history')
+
             try:
                 readline.read_history_file(history)
             except OSError:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
If PYTHONHISTFILE refers to a file, use it instead of ~/.python_history when running interactively. This is similar to how bash does it.

<!-- issue-number: [bpo-38791](https://bugs.python.org/issue38791) -->
https://bugs.python.org/issue38791
<!-- /issue-number -->
