### PR TITLE
Reuse identifier of PREDICT macros as PREDICT_ID

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -923,21 +923,23 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
 
 */
 
+#define PREDICT_ID(op)          PRED_##op
+
 #if defined(DYNAMIC_EXECUTION_PROFILE) || USE_COMPUTED_GOTOS
-#define PREDICT(op)             if (0) goto PRED_##op
+#define PREDICT(op)             if (0) goto PREDICT_ID(op)
 #else
 #define PREDICT(op) \
-    do{ \
+    do { \
         _Py_CODEUNIT word = *next_instr; \
         opcode = _Py_OPCODE(word); \
         if (opcode == op){ \
             oparg = _Py_OPARG(word); \
             next_instr++; \
-            goto PRED_##op; \
+            goto PREDICT_ID(op); \
         } \
     } while(0)
 #endif
-#define PREDICTED(op)           PRED_##op:
+#define PREDICTED(op)           PREDICT_ID(op):
 
 
 /* Stack manipulation macros */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -932,7 +932,7 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
     do { \
         _Py_CODEUNIT word = *next_instr; \
         opcode = _Py_OPCODE(word); \
-        if (opcode == op){ \
+        if (opcode == op) { \
             oparg = _Py_OPARG(word); \
             next_instr++; \
             goto PREDICT_ID(op); \


### PR DESCRIPTION
_Trivial change_

In function `_PyEval_EvalFrameDefault`, macros `PREDICT` and `PREDICTED` use the same identifier creation scheme, which may be shared between them, reducing code repetition, and do ensure that the same identifier is generated.