### PR TITLE
[WIP] gh-82987: bdb: stop_here: always stop at calling frame

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -201,8 +201,8 @@ class Bdb:
 
     def stop_here(self, frame):
         "Return True if frame is below the starting frame in the stack."
-        # (CT) stopframe may now also be None, see dispatch_call.
-        # (CT) the former test for None is therefore removed from here.
+        if self.stopframe is None:
+            return True
         if self.skip and \
                self.is_skipped_module(frame.f_globals.get('__name__')):
             return False

--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -201,7 +201,9 @@ class Bdb:
 
     def stop_here(self, frame):
         "Return True if frame is below the starting frame in the stack."
-        if self.stopframe is None:
+        if (self.stopframe is None
+                and self.returnframe is None
+                and self.stoplineno == 0):  # TEST: via set_step
             return True
         if self.skip and \
                self.is_skipped_module(frame.f_globals.get('__name__')):


### PR DESCRIPTION
The following will not stop for debugging:

    python3.8 -c 'import pdb; pdb.Pdb(skip=["*"]).set_trace()'

The example is contrived, the real case would be to have some "noisy"
module being excluded in general, but when you add an explicit
"set_trace()" in there it should still stop there, and not on some upper
frame.

This was changed a long time already in
https://github.com/python/cpython/commit/313a7513b0c5771042d850d70782a2448d1cdcb7
(Python 2.3), but it is not really clear.
/cc @ctismer 

This PR is meant to see how reverting that part goes.

<!-- issue-number: [bpo-38806](https://bugs.python.org/issue38806) -->
https://bugs.python.org/issue38806
<!-- /issue-number -->

<!-- gh-issue-number: gh-82987 -->
* Issue: gh-82987
<!-- /gh-issue-number -->
