### PR TITLE
bpo-38807: Add os.PathLike to exception message raised by _check_arg_types

### DIFF
--- a/Lib/genericpath.py
+++ b/Lib/genericpath.py
@@ -149,7 +149,7 @@ def _check_arg_types(funcname, *args):
         elif isinstance(s, bytes):
             hasbytes = True
         else:
-            raise TypeError('%s() argument must be str, bytes or os.PathLike object, not %r' %
-                            (funcname, s.__class__.__name__)) from None
+            raise TypeError(f'{funcname}() argument must be str, bytes, or '
+                            f'os.PathLike object, not {s.__class__.__name__}') from None
     if hasstr and hasbytes:
         raise TypeError("Can't mix strings and bytes in path components") from None

--- a/Lib/genericpath.py
+++ b/Lib/genericpath.py
@@ -150,6 +150,6 @@ def _check_arg_types(funcname, *args):
             hasbytes = True
         else:
             raise TypeError(f'{funcname}() argument must be str, bytes, or '
-                            f'os.PathLike object, not {s.__class__.__name__}') from None
+                            f'os.PathLike object, not {s.__class__.__name__!r}') from None
     if hasstr and hasbytes:
         raise TypeError("Can't mix strings and bytes in path components") from None

--- a/Lib/genericpath.py
+++ b/Lib/genericpath.py
@@ -149,7 +149,7 @@ def _check_arg_types(funcname, *args):
         elif isinstance(s, bytes):
             hasbytes = True
         else:
-            raise TypeError('%s() argument must be str or bytes, not %r' %
+            raise TypeError('%s() argument must be str, bytes or os.PathLike object, not %r' %
                             (funcname, s.__class__.__name__)) from None
     if hasstr and hasbytes:
         raise TypeError("Can't mix strings and bytes in path components") from None

--- a/Misc/NEWS.d/next/Library/2019-11-15-09-30-29.bpo-38807.PsmRog.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-15-09-30-29.bpo-38807.PsmRog.rst
@@ -1,0 +1,1 @@
+Update :exc:`TypeError` messages for :meth:`os.path.join` to include :class:`os.PathLike` objects as acceptable input types.


### PR DESCRIPTION
`os.PathLike` objects can be passed to `os.path.join`, however this is not reflected in the `TypeError` raised by `_check_arg_types` when passing an invalid type:

`TypeError: join() argument must be str or bytes, not 'NoneType'`

<!-- issue-number: [bpo-38807](https://bugs.python.org/issue38807) -->
https://bugs.python.org/issue38807
<!-- /issue-number -->
