### PR TITLE
bpo-39464: Allow translating argument error messages 

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -746,7 +746,7 @@ class ArgumentError(Exception):
         if self.argument_name is None:
             format = '%(message)s'
         else:
-            format = 'argument %(argument_name)s: %(message)s'
+            format = _('argument %(argument_name)s: %(message)s')
         return format % dict(message=self.message,
                              argument_name=self.argument_name)
 


### PR DESCRIPTION
Argument error messages display the untranslatable text 'argument ', which should be translatable to other languages, just like it's possible to do with the rest of the constructed error message.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39464](https://bugs.python.org/issue39464) -->
https://bugs.python.org/issue39464
<!-- /issue-number -->
