### PR TITLE
bpo-3530: Use fix_missing_locations when node transformer adds nodes

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -300,7 +300,7 @@ and classes for traversing abstract syntax trees:
       class RewriteName(NodeTransformer):
 
           def visit_Name(self, node):
-              return copy_location(Subscript(
+              return Subscript(
                   value=Name(id='data', ctx=Load()),
                   slice=Index(value=Constant(value=node.id)),
                   ctx=node.ctx
@@ -313,6 +313,11 @@ and classes for traversing abstract syntax trees:
    For nodes that were part of a collection of statements (that applies to all
    statement nodes), the visitor may also return a list of nodes rather than
    just a single node.
+
+   If :class:`NodeTransformer` introduces new nodes (that weren't part of
+   original tree) without giving them location information (such as
+   :attr:`lineno`), :func:`fix_missing_locations` should be called with
+   new tree to apply location information for compiler.
 
    Usually you use the transformer like this::
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -317,7 +317,7 @@ and classes for traversing abstract syntax trees:
    If :class:`NodeTransformer` introduces new nodes (that weren't part of
    original tree) without giving them location information (such as
    :attr:`lineno`), :func:`fix_missing_locations` should be called with
-   new tree to apply location information for compiler.
+   the new sub-tree to recalculate the location information.
 
    Usually you use the transformer like this::
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -317,7 +317,10 @@ and classes for traversing abstract syntax trees:
    If :class:`NodeTransformer` introduces new nodes (that weren't part of
    original tree) without giving them location information (such as
    :attr:`lineno`), :func:`fix_missing_locations` should be called with
-   the new sub-tree to recalculate the location information.
+   the new sub-tree to recalculate the location information::
+
+      tree = ast.parse('foo', mode='eval')
+      new_tree = fix_missing_locations(RewriteName().visit(tree))
 
    Usually you use the transformer like this::
 

--- a/Misc/NEWS.d/next/Documentation/2019-11-17-11-53-10.bpo-3530.8zFUMc.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-11-17-11-53-10.bpo-3530.8zFUMc.rst
@@ -1,0 +1,2 @@
+In ast doc, fix misleading NodeTransformer example and add
+fix_missing_locations advice.

--- a/Misc/NEWS.d/next/Documentation/2019-11-17-11-53-10.bpo-3530.8zFUMc.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-11-17-11-53-10.bpo-3530.8zFUMc.rst
@@ -1,2 +1,2 @@
-in the :mod:`ast` module documentation, fix a misleading ``NodeTransformer`` example and add
+In the :mod:`ast` module documentation, fix a misleading ``NodeTransformer`` example and add
 advice on when to use the ``fix_missing_locations`` function.

--- a/Misc/NEWS.d/next/Documentation/2019-11-17-11-53-10.bpo-3530.8zFUMc.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-11-17-11-53-10.bpo-3530.8zFUMc.rst
@@ -1,2 +1,2 @@
-In :mod:`ast` doc, fix misleading ``NodeTransformer`` example and add
-``fix_missing_locations`` advice.
+in the :mod:`ast` module documentation, fix a misleading ``NodeTransformer`` example and add
+advice on when to use the ``fix_missing_locations`` function.

--- a/Misc/NEWS.d/next/Documentation/2019-11-17-11-53-10.bpo-3530.8zFUMc.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-11-17-11-53-10.bpo-3530.8zFUMc.rst
@@ -1,2 +1,2 @@
-In ast doc, fix misleading NodeTransformer example and add
-fix_missing_locations advice.
+In :mod:`ast` doc, fix misleading ``NodeTransformer`` example and add
+``fix_missing_locations`` advice.


### PR DESCRIPTION
Remove misleading (inadequate) suggestion from example.

<!-- issue-number: [bpo-3530](https://bugs.python.org/issue3530) -->
https://bugs.python.org/issue3530
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal