### PR TITLE
bpo-38818: PyInterpreterState.eval_frame now pass tstate

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -214,7 +214,9 @@ Build and C API Changes
   calls a callable Python object without any arguments. It is the most efficient
   way to call a callable Python object without any argument.
   (Contributed by Victor Stinner in :issue:`37194`.)
-
+* ``PyInterpreterState.eval_frame`` (:pep:`523`) now requires a new mandatory
+  *tstate* parameter (``PyThreadState*``).
+  (Contributed by Victor Stinner in :issue:`38818`.)
 
 
 Deprecated

--- a/Include/cpython/ceval.h
+++ b/Include/cpython/ceval.h
@@ -21,7 +21,10 @@ PyAPI_FUNC(PyObject *) _PyEval_GetBuiltinId(_Py_Identifier *);
    flag was set, else return 0. */
 PyAPI_FUNC(int) PyEval_MergeCompilerFlags(PyCompilerFlags *cf);
 
-PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(struct _frame *f, int exc);
+PyAPI_FUNC(PyObject *) _PyEval_EvalFrameDefault(
+    PyThreadState *tstate,
+    struct _frame *f,
+    int exc);
 
 PyAPI_FUNC(void) _PyEval_SetSwitchInterval(unsigned long microseconds);
 PyAPI_FUNC(unsigned long) _PyEval_GetSwitchInterval(void);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -40,7 +40,7 @@ void _PyEval_Fini(void);
 static inline PyObject*
 _PyEval_EvalFrame(PyThreadState *tstate, struct _frame *f, int throwflag)
 {
-    return tstate->interp->eval_frame(f, throwflag);
+    return tstate->interp->eval_frame(tstate, f, throwflag);
 }
 
 extern PyObject *_PyEval_EvalCode(

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -54,7 +54,7 @@ struct _ceval_runtime_state {
 
 /* interpreter state */
 
-typedef PyObject* (*_PyFrameEvalFunction)(struct _frame *, int);
+typedef PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, struct _frame *, int);
 
 // The PyInterpreterState typedef is in Include/pystate.h.
 struct _is {

--- a/Misc/NEWS.d/next/C API/2019-11-16-01-12-32.bpo-38818.bUyp8O.rst
+++ b/Misc/NEWS.d/next/C API/2019-11-16-01-12-32.bpo-38818.bUyp8O.rst
@@ -1,0 +1,2 @@
+``PyInterpreterState.eval_frame`` (:pep:`523`) now requires a new mandatory
+*tstate* parameter (``PyThreadState*``).

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -740,7 +740,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 }
 
 PyObject* _Py_HOT_FUNCTION
-_PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
+_PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
 {
 #ifdef DXPAIRS
     int lastopcode = 0;
@@ -752,7 +752,6 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
     PyObject **fastlocals, **freevars;
     PyObject *retval = NULL;            /* Return value */
     _PyRuntimeState * const runtime = &_PyRuntime;
-    PyThreadState * const tstate = _PyRuntimeState_GetThreadState(runtime);
     struct _ceval_runtime_state * const ceval = &runtime->ceval;
     _Py_atomic_int * const eval_breaker = &ceval->eval_breaker;
     PyCodeObject *co;


### PR DESCRIPTION
PyInterpreterState.eval_frame (PEP 523) now requires a new mandatory
tstate parameter (PyThreadState*).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38818](https://bugs.python.org/issue38818) -->
https://bugs.python.org/issue38818
<!-- /issue-number -->
