### PR TITLE
bpo-38839: Fix some unused functions in tests

### DIFF
--- a/Lib/distutils/tests/support.py
+++ b/Lib/distutils/tests/support.py
@@ -39,8 +39,6 @@ class LoggingSilencer(object):
         self.logs.append((level, msg, args))
 
     def get_logs(self, *levels):
-        def _format(msg, args):
-            return msg % args
         return [msg % args for level, msg, args
                 in self.logs if level in levels]
 

--- a/Lib/test/test_asynchat.py
+++ b/Lib/test/test_asynchat.py
@@ -73,14 +73,14 @@ class echo_client(asynchat.async_chat):
         self.set_terminator(terminator)
         self.buffer = b""
 
-        def handle_connect(self):
-            pass
+    def handle_connect(self):
+        pass
 
-        if sys.platform == 'darwin':
-            # select.poll returns a select.POLLHUP at the end of the tests
-            # on darwin, so just ignore it
-            def handle_expt(self):
-                pass
+    if sys.platform == 'darwin':
+        # select.poll returns a select.POLLHUP at the end of the tests
+        # on darwin, so just ignore it
+        def handle_expt(self):
+            pass
 
     def collect_incoming_data(self, data):
         self.buffer += data

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -969,8 +969,6 @@ class TestBufferProtocol(unittest.TestCase):
             m.tobytes()  # Releasing mm didn't release m
 
     def verify_getbuf(self, orig_ex, ex, req, sliced=False):
-        def simple_fmt(ex):
-            return ex.format == '' or ex.format == 'B'
         def match(req, flag):
             return ((req&flag) == flag)
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -765,6 +765,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(hash('spam'), hash(b'spam'))
         hash((0,1,2,3))
         def f(): pass
+        hash(f)
         self.assertRaises(TypeError, hash, [])
         self.assertRaises(TypeError, hash, {})
         # Bug 1536021: Allow hash to return long objects

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -241,7 +241,7 @@ class CodeTest(unittest.TestCase):
         def func2():
             y = 2
             return y
-        code2 = func.__code__
+        code2 = func2.__code__
 
         for attr, value in (
             ("co_argcount", 0),

--- a/Lib/test/test_importlib/import_/test_relative_imports.py
+++ b/Lib/test/test_importlib/import_/test_relative_imports.py
@@ -133,6 +133,7 @@ class RelativeImports:
             self.assertEqual(module.__name__, 'pkg')
             self.assertTrue(hasattr(module, 'subpkg2'))
             self.assertEqual(module.subpkg2.attr, 'pkg.subpkg2.__init__')
+        self.relative_import_test(create, globals_, callback)
 
     def test_deep_import(self):
         # [deep import]

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -335,6 +335,7 @@ class AsyncSpecSetTest(unittest.TestCase):
         @patch.object(AsyncClass, 'async_method', spec_set=True)
         def test_async(async_method):
             self.assertIsInstance(async_method, AsyncMock)
+        test_async()
 
     def test_is_async_AsyncMock(self):
         mock = AsyncMock(spec_set=AsyncClass.async_method)

--- a/Misc/NEWS.d/next/Tests/2019-11-18-22-10-55.bpo-38839.di6tXv.rst
+++ b/Misc/NEWS.d/next/Tests/2019-11-18-22-10-55.bpo-38839.di6tXv.rst
@@ -1,1 +1,1 @@
-Fix some unused functions in tests
+Fix some unused functions in tests. Patch by Adam Johnson.

--- a/Misc/NEWS.d/next/Tests/2019-11-18-22-10-55.bpo-38839.di6tXv.rst
+++ b/Misc/NEWS.d/next/Tests/2019-11-18-22-10-55.bpo-38839.di6tXv.rst
@@ -1,0 +1,1 @@
+Fix some unused functions in tests

--- a/Tools/ccbench/ccbench.py
+++ b/Tools/ccbench/ccbench.py
@@ -84,13 +84,6 @@ def task_regex():
     pat = re.compile(r'^(\s*def\s)|(.*(?<!\w)lambda(:|\s))|^(\s*@)', re.MULTILINE)
     with open(__file__, "r") as f:
         arg = f.read(2000)
-
-    def findall(s):
-        t = time.time()
-        try:
-            return pat.findall(s)
-        finally:
-            print(time.time() - t)
     return pat.findall, (arg, )
 
 def task_sort():


### PR DESCRIPTION
Whilst developing https://github.com/PyCQA/pyflakes/pull/485 I ran it against the CPython code base and found these examples of unused functions that I think need fixing.

<!-- issue-number: [bpo-38839](https://bugs.python.org/issue38839) -->
https://bugs.python.org/issue38839
<!-- /issue-number -->
