### PR TITLE
bpo-38821: Fix crash in argparse when using gettext

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2148,10 +2148,11 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 OPTIONAL: _('expected at most one argument'),
                 ONE_OR_MORE: _('expected at least one argument'),
             }
-            default = ngettext('expected %s argument',
+            msg = nargs_errors.get(action.nargs)
+            if msg is None:
+                msg = ngettext('expected %s argument',
                                'expected %s arguments',
                                action.nargs) % action.nargs
-            msg = nargs_errors.get(action.nargs, default)
             raise ArgumentError(action, msg)
 
         # return the number of arguments matched

--- a/Misc/NEWS.d/next/Library/2019-11-16-23-26-25.bpo-38821.-albNN.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-16-23-26-25.bpo-38821.-albNN.rst
@@ -1,0 +1,1 @@
+Fix crash in argparse when using gettext.

--- a/Misc/NEWS.d/next/Library/2019-11-16-23-26-25.bpo-38821.-albNN.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-16-23-26-25.bpo-38821.-albNN.rst
@@ -1,1 +1,1 @@
-Fix crash in argparse when using gettext.
+Fix unhandled exceptions in :mod:`argparse` when internationalizing some error messages.

--- a/Misc/NEWS.d/next/Library/2019-11-16-23-26-25.bpo-38821.-albNN.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-16-23-26-25.bpo-38821.-albNN.rst
@@ -1,1 +1,1 @@
-Fix unhandled exceptions in :mod:`argparse` when internationalizing some error messages.
+Fix unhandled exceptions in :mod:`argparse` when internationalizing error messages for arguments with ``nargs`` set to special (non-integer) values.  Patch by Federico Bond.


### PR DESCRIPTION


<!-- issue-number: [bpo-38821](https://bugs.python.org/issue38821) -->
https://bugs.python.org/issue38821
<!-- /issue-number -->
