### PR TITLE
bpo-38615: Add timeout parameter for IMAP4 and IMAP4_SSL constructor

### DIFF
--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -30,12 +30,14 @@ Three classes are provided by the :mod:`imaplib` module, :class:`IMAP4` is the
 base class:
 
 
-.. class:: IMAP4(host='', port=IMAP4_PORT)
+.. class:: IMAP4(host='', port=IMAP4_PORT[, timeout])
 
    This class implements the actual IMAP4 protocol.  The connection is created and
    protocol version (IMAP4 or IMAP4rev1) is determined when the instance is
    initialized. If *host* is not specified, ``''`` (the local host) is used. If
-   *port* is omitted, the standard IMAP4 port (143) is used.
+   *port* is omitted, the standard IMAP4 port (143) is used. The optional *timeout*
+   parameter specifies a timeout in seconds for the connection attempt
+   (if not specified, the global default timeout setting will be used).
 
    The :class:`IMAP4` class supports the :keyword:`with` statement.  When used
    like this, the IMAP4 ``LOGOUT`` command is issued automatically when the
@@ -49,6 +51,9 @@ base class:
 
    .. versionchanged:: 3.5
       Support for the :keyword:`with` statement was added.
+
+   .. versionchanged:: 3.9
+      The optional *timeout* parameter was added.
 
 Three exceptions are defined as attributes of the :class:`IMAP4` class:
 
@@ -78,7 +83,7 @@ There's also a subclass for secure connections:
 
 
 .. class:: IMAP4_SSL(host='', port=IMAP4_SSL_PORT, keyfile=None, \
-                     certfile=None, ssl_context=None)
+                     certfile=None, ssl_context=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT)
 
    This is a subclass derived from :class:`IMAP4` that connects over an SSL
    encrypted socket (to use this class you need a socket module that was compiled
@@ -96,7 +101,7 @@ There's also a subclass for secure connections:
    if *keyfile*/*certfile* is provided along with *ssl_context*.
 
    .. versionchanged:: 3.3
-      *ssl_context* parameter added.
+      *ssl_context* parameter was added.
 
    .. versionchanged:: 3.4
       The class now supports hostname check with
@@ -110,6 +115,8 @@ There's also a subclass for secure connections:
        :func:`ssl.create_default_context` select the system's trusted CA
        certificates for you.
 
+   .. versionchanged:: 3.9
+      The optional *timeout* parameter was added.
 
 The second subclass allows for connections created by a child process:
 
@@ -353,7 +360,7 @@ An :class:`IMAP4` instance has the following methods:
    Send ``NOOP`` to server.
 
 
-.. method:: IMAP4.open(host, port)
+.. method:: IMAP4.open(host, port, timeout)
 
    Opens socket to *port* at *host*.  This method is implicitly called by
    the :class:`IMAP4` constructor.  The connection objects established by this
@@ -363,6 +370,8 @@ An :class:`IMAP4` instance has the following methods:
 
    .. audit-event:: imaplib.open self,host,port imaplib.IMAP4.open
 
+   .. versionchanged:: 3.9
+      The *timeout* parameter was added.
 
 .. method:: IMAP4.partial(message_num, message_part, start, length)
 

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -369,10 +369,11 @@ An :class:`IMAP4` instance has the following methods:
    Opens socket to *port* at *host*.  This method is implicitly called by
    the :class:`IMAP4` constructor.  The connection objects established by this
    method will be used in the :meth:`IMAP4.read`, :meth:`IMAP4.readline`,
-   :meth:`IMAP4.send`, and :meth:`IMAP4.shutdown` methods.  You may override
-   this method. The optional *timeout* parameter specifies a timeout in seconds
+   :meth:`IMAP4.send`, and :meth:`IMAP4.shutdown` methods.
+   The optional *timeout* parameter specifies a timeout in seconds
    for the connection attempt. If timeout is not given or is None,
    the global default socket timeout is used.
+   You may override this method.
 
    .. audit-event:: imaplib.open self,host,port imaplib.IMAP4.open
 

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -30,14 +30,14 @@ Three classes are provided by the :mod:`imaplib` module, :class:`IMAP4` is the
 base class:
 
 
-.. class:: IMAP4(host='', port=IMAP4_PORT[, timeout])
+.. class:: IMAP4(host='', port=IMAP4_PORT[, timeout=None])
 
    This class implements the actual IMAP4 protocol.  The connection is created and
    protocol version (IMAP4 or IMAP4rev1) is determined when the instance is
    initialized. If *host* is not specified, ``''`` (the local host) is used. If
    *port* is omitted, the standard IMAP4 port (143) is used. The optional *timeout*
-   parameter specifies a timeout in seconds for the connection attempt
-   (if not specified, the global default timeout setting will be used).
+   parameter specifies a timeout in seconds for the connection attempt.
+   If timeout is not given or is None, the global default socket timeout is used.
 
    The :class:`IMAP4` class supports the :keyword:`with` statement.  When used
    like this, the IMAP4 ``LOGOUT`` command is issued automatically when the
@@ -83,7 +83,7 @@ There's also a subclass for secure connections:
 
 
 .. class:: IMAP4_SSL(host='', port=IMAP4_SSL_PORT, keyfile=None, \
-                     certfile=None, ssl_context=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT)
+                     certfile=None, ssl_context=None, timeout=None)
 
    This is a subclass derived from :class:`IMAP4` that connects over an SSL
    encrypted socket (to use this class you need a socket module that was compiled
@@ -99,6 +99,10 @@ There's also a subclass for secure connections:
    the SSL connection.  Note that the *keyfile*/*certfile* parameters are
    mutually exclusive with *ssl_context*, a :class:`ValueError` is raised
    if *keyfile*/*certfile* is provided along with *ssl_context*.
+
+   The optional *timeout* parameter specifies a timeout in seconds for the
+   connection attempt. If timeout is not given or is None, the global default
+   socket timeout is used.
 
    .. versionchanged:: 3.3
       *ssl_context* parameter was added.
@@ -360,13 +364,15 @@ An :class:`IMAP4` instance has the following methods:
    Send ``NOOP`` to server.
 
 
-.. method:: IMAP4.open(host, port, timeout)
+.. method:: IMAP4.open(host, port, timeout=None)
 
    Opens socket to *port* at *host*.  This method is implicitly called by
    the :class:`IMAP4` constructor.  The connection objects established by this
    method will be used in the :meth:`IMAP4.read`, :meth:`IMAP4.readline`,
    :meth:`IMAP4.send`, and :meth:`IMAP4.shutdown` methods.  You may override
-   this method.
+   this method. The optional *timeout* parameter specifies a timeout in seconds
+   for the connection attempt. If timeout is not given or is None,
+   the global default socket timeout is used.
 
    .. audit-event:: imaplib.open self,host,port imaplib.IMAP4.open
 

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -369,7 +369,9 @@ An :class:`IMAP4` instance has the following methods:
    Opens socket to *port* at *host*. The optional *timeout* parameter
    specifies a timeout in seconds for the connection attempt.
    If timeout is not given or is None, the global default socket timeout
-   is used. This method is implicitly called by the :class:`IMAP4` constructor.
+   is used. Also note that if the *timeout* parameter is set to be zero,
+   it will raise a :class:`ValueError` to reject creating a non-blocking socket.
+   This method is implicitly called by the :class:`IMAP4` constructor.
    The connection objects established by this method will be used in
    the :meth:`IMAP4.read`, :meth:`IMAP4.readline`, :meth:`IMAP4.send`,
    and :meth:`IMAP4.shutdown` methods. You may override this method.

--- a/Doc/library/imaplib.rst
+++ b/Doc/library/imaplib.rst
@@ -30,7 +30,7 @@ Three classes are provided by the :mod:`imaplib` module, :class:`IMAP4` is the
 base class:
 
 
-.. class:: IMAP4(host='', port=IMAP4_PORT[, timeout=None])
+.. class:: IMAP4(host='', port=IMAP4_PORT, timeout=None)
 
    This class implements the actual IMAP4 protocol.  The connection is created and
    protocol version (IMAP4 or IMAP4rev1) is determined when the instance is
@@ -366,14 +366,13 @@ An :class:`IMAP4` instance has the following methods:
 
 .. method:: IMAP4.open(host, port, timeout=None)
 
-   Opens socket to *port* at *host*.  This method is implicitly called by
-   the :class:`IMAP4` constructor.  The connection objects established by this
-   method will be used in the :meth:`IMAP4.read`, :meth:`IMAP4.readline`,
-   :meth:`IMAP4.send`, and :meth:`IMAP4.shutdown` methods.
-   The optional *timeout* parameter specifies a timeout in seconds
-   for the connection attempt. If timeout is not given or is None,
-   the global default socket timeout is used.
-   You may override this method.
+   Opens socket to *port* at *host*. The optional *timeout* parameter
+   specifies a timeout in seconds for the connection attempt.
+   If timeout is not given or is None, the global default socket timeout
+   is used. This method is implicitly called by the :class:`IMAP4` constructor.
+   The connection objects established by this method will be used in
+   the :meth:`IMAP4.read`, :meth:`IMAP4.readline`, :meth:`IMAP4.send`,
+   and :meth:`IMAP4.shutdown` methods. You may override this method.
 
    .. audit-event:: imaplib.open self,host,port imaplib.IMAP4.open
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -172,6 +172,9 @@ imaplib
 
 :class:`~imaplib.IMAP4` and :class:`~imaplib.IMAP4_SSL` now have
 an optional *timeout* parameter for their constructors.
+Also, the :meth:`~imaplib.IMAP4.open` method now has an optional *timeout* parameter
+with this change. The overridden methods of :class:`~imaplib.IMAP4_SSL` and
+:class:`~imaplib.IMAP4_stream` were applied to this change.
 (Contributed by Dong-hee Na in :issue:`38615`.)
 
 os

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -167,6 +167,13 @@ When the garbage collector makes a collection in which some objects resurrect
 been executed), do not block the collection of all objects that are still
 unreachable. (Contributed by Pablo Galindo and Tim Peters in :issue:`38379`.)
 
+imaplib
+-------
+
+The :class:`~imaplib.IMAP4` and :class:`~imaplib.IMAP4_SSL` now has
+optional *timeout* parameter for constructor.
+(Contributed by Dong-hee Na in :issue:`38615`.)
+
 os
 --
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -170,8 +170,8 @@ unreachable. (Contributed by Pablo Galindo and Tim Peters in :issue:`38379`.)
 imaplib
 -------
 
-The :class:`~imaplib.IMAP4` and :class:`~imaplib.IMAP4_SSL` now has
-optional *timeout* parameter for constructor.
+:class:`~imaplib.IMAP4` and :class:`~imaplib.IMAP4_SSL` now have
+an optional *timeout* parameter for their constructors.
 (Contributed by Dong-hee Na in :issue:`38615`.)
 
 os

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -139,7 +139,7 @@ class IMAP4:
 
             host - host's name (default: localhost);
             port - port number (default: standard IMAP4 port).
-            timeout - socket timeout (default: None))
+            timeout - socket timeout (default: None)
                       If timeout is not given or is None,
                       the global default socket timeout is used
 

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -184,8 +184,7 @@ class IMAP4:
     class abort(error): pass        # Service errors - close and retry
     class readonly(abort): pass     # Mailbox status changed to READ-ONLY
 
-    def __init__(self, host='', port=IMAP4_PORT,
-                 timeout=None):
+    def __init__(self, host='', port=IMAP4_PORT, timeout=None):
         self.debug = Debug
         self.state = 'LOGOUT'
         self.literal = None             # A literal argument to a command
@@ -1308,8 +1307,7 @@ if HAVE_SSL:
             return self.ssl_context.wrap_socket(sock,
                                                 server_hostname=self.host)
 
-        def open(self, host='', port=IMAP4_SSL_PORT,
-                timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+        def open(self, host='', port=IMAP4_SSL_PORT, timeout=None):
             """Setup connection to remote server on "host:port".
                 (default: localhost:standard IMAP4 SSL port).
             This connection will be used by the routines:

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -292,7 +292,7 @@ class IMAP4:
         # (which is used by socket.create_connection()) expects None
         # as a default value for host.
         if timeout is not None and not timeout:
-            raise ValueError('A non-blocking socket is not supported')
+            raise ValueError('Non-blocking socket (timeout=0) is not supported')
         host = None if not self.host else self.host
         sys.audit("imaplib.open", self, self.host, self.port)
         address = (host, self.port)

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -140,6 +140,8 @@ class IMAP4:
             host - host's name (default: localhost);
             port - port number (default: standard IMAP4 port).
             timeout - socket timeout (default: None))
+                      If timeout is not given or is None,
+                      the global default socket timeout is used
 
     All IMAP4rev1 commands are supported by methods of the same
     name (in lower-case).
@@ -1274,7 +1276,8 @@ if HAVE_SSL:
                               and private key (default: None)
                 Note: if ssl_context is provided, then parameters keyfile or
                 certfile should not be set otherwise ValueError is raised.
-                timeout - socket timeout (default: None)
+                timeout - socket timeout (default: None) If timeout is not given or is None,
+                          the global default socket timeout is used
 
         for more documentation see the docstring of the parent class IMAP4.
         """

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -291,12 +291,16 @@ class IMAP4:
         # Default value of IMAP4.host is '', but socket.getaddrinfo()
         # (which is used by socket.create_connection()) expects None
         # as a default value for host.
+        if timeout is not None and not timeout:
+            raise ValueError('A non-blocking socket is not supported')
         host = None if not self.host else self.host
         sys.audit("imaplib.open", self, self.host, self.port)
-        timeout = socket._GLOBAL_DEFAULT_TIMEOUT if timeout is None else timeout
-        return socket.create_connection((host, self.port), timeout)
+        address = (host, self.port)
+        if timeout is not None:
+            return socket.create_connection(address, timeout)
+        return socket.create_connection(address)
 
-    def open(self, host = '', port = IMAP4_PORT, timeout = None):
+    def open(self, host='', port=IMAP4_PORT, timeout=None):
         """Setup connection to remote server on "host:port"
             (default: localhost:standard IMAP4 port).
         This connection will be used by the routines:
@@ -1335,7 +1339,7 @@ class IMAP4_stream(IMAP4):
         IMAP4.__init__(self)
 
 
-    def open(self, host = None, port = None):
+    def open(self, host=None, port=None, timeout=None):
         """Setup a stream connection.
         This connection will be used by the routines:
             read, readline, send, shutdown.

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -135,11 +135,11 @@ class IMAP4:
 
     r"""IMAP4 client class.
 
-    Instantiate with: IMAP4([host[, port[, timeout]]])
+    Instantiate with: IMAP4([host[, port[, timeout=None]]])
 
             host - host's name (default: localhost);
             port - port number (default: standard IMAP4 port).
-            timeout - socket timeout (default: socket._GLOBAL_DEFAULT_TIMEOUT))
+            timeout - socket timeout (default: None))
 
     All IMAP4rev1 commands are supported by methods of the same
     name (in lower-case).
@@ -183,7 +183,7 @@ class IMAP4:
     class readonly(abort): pass     # Mailbox status changed to READ-ONLY
 
     def __init__(self, host='', port=IMAP4_PORT,
-                 timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+                 timeout=None):
         self.debug = Debug
         self.state = 'LOGOUT'
         self.literal = None             # A literal argument to a command
@@ -292,10 +292,10 @@ class IMAP4:
         # as a default value for host.
         host = None if not self.host else self.host
         sys.audit("imaplib.open", self, self.host, self.port)
+        timeout = socket._GLOBAL_DEFAULT_TIMEOUT if timeout is None else timeout
         return socket.create_connection((host, self.port), timeout)
 
-    def open(self, host = '', port = IMAP4_PORT,
-            timeout = socket._GLOBAL_DEFAULT_TIMEOUT):
+    def open(self, host = '', port = IMAP4_PORT, timeout = None):
         """Setup connection to remote server on "host:port"
             (default: localhost:standard IMAP4 port).
         This connection will be used by the routines:
@@ -1264,7 +1264,7 @@ if HAVE_SSL:
 
         """IMAP4 client class over SSL connection
 
-        Instantiate with: IMAP4_SSL([host[, port[, keyfile[, certfile[, ssl_context[, timeout]]]]]])
+        Instantiate with: IMAP4_SSL([host[, port[, keyfile[, certfile[, ssl_context[, timeout=None]]]]]])
 
                 host - host's name (default: localhost);
                 port - port number (default: standard IMAP4 SSL port);
@@ -1274,14 +1274,14 @@ if HAVE_SSL:
                               and private key (default: None)
                 Note: if ssl_context is provided, then parameters keyfile or
                 certfile should not be set otherwise ValueError is raised.
-                timeout - socket timeout (default: socket._GLOBAL_DEFAULT_TIMEOUT)
+                timeout - socket timeout (default: None)
 
         for more documentation see the docstring of the parent class IMAP4.
         """
 
 
         def __init__(self, host='', port=IMAP4_SSL_PORT, keyfile=None,
-                     certfile=None, ssl_context=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+                     certfile=None, ssl_context=None, timeout=None):
             if ssl_context is not None and keyfile is not None:
                 raise ValueError("ssl_context and keyfile arguments are mutually "
                                  "exclusive")

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -440,6 +440,18 @@ class NewIMAPTestsMixin():
         with self.imap_class(*server.server_address):
             pass
 
+    def test_imaplib_timeout_test(self):
+        _, server = self._setup(SimpleIMAPHandler)
+        client = self.imap_class("localhost", server.server_address[1], timeout=10.0)
+        self.assertEqual(client.sock.timeout, 10.0)
+        client.shutdown()
+        client = self.imap_class("localhost", server.server_address[1], timeout=None)
+        self.assertEqual(client.sock.timeout, None)
+        client.shutdown()
+        client = self.imap_class("localhost", server.server_address[1], timeout=socket._GLOBAL_DEFAULT_TIMEOUT)
+        self.assertEqual(client.sock.timeout, None)
+        client.shutdown()
+
     def test_with_statement(self):
         _, server = self._setup(SimpleIMAPHandler, connect=False)
         with self.imap_class(*server.server_address) as imap:

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -442,13 +442,14 @@ class NewIMAPTestsMixin():
 
     def test_imaplib_timeout_test(self):
         _, server = self._setup(SimpleIMAPHandler)
-        client = self.imap_class("localhost", server.server_address[1], timeout=10.0)
+        addr = server.server_address[1]
+        client = self.imap_class("localhost", addr, timeout=10.0)
         self.assertEqual(client.sock.timeout, 10.0)
         client.shutdown()
-        client = self.imap_class("localhost", server.server_address[1], timeout=None)
+        client = self.imap_class("localhost", addr, timeout=None)
         self.assertEqual(client.sock.timeout, None)
         client.shutdown()
-        client = self.imap_class("localhost", server.server_address[1], timeout=socket._GLOBAL_DEFAULT_TIMEOUT)
+        client = self.imap_class("localhost", addr, timeout=socket._GLOBAL_DEFAULT_TIMEOUT)
         self.assertEqual(client.sock.timeout, None)
         client.shutdown()
 

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -443,11 +443,11 @@ class NewIMAPTestsMixin():
     def test_imaplib_timeout_test(self):
         _, server = self._setup(SimpleIMAPHandler)
         addr = server.server_address[1]
-        client = self.imap_class("localhost", addr, timeout=support.LOOPBACK_TIMEOUT)
-        self.assertEqual(client.sock.timeout, support.LOOPBACK_TIMEOUT)
-        client.shutdown()
         client = self.imap_class("localhost", addr, timeout=None)
         self.assertEqual(client.sock.timeout, None)
+        client.shutdown()
+        client = self.imap_class("localhost", addr, timeout=support.LOOPBACK_TIMEOUT)
+        self.assertEqual(client.sock.timeout, support.LOOPBACK_TIMEOUT)
         client.shutdown()
         with self.assertRaises(ValueError):
             client = self.imap_class("localhost", addr, timeout=0)

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -453,6 +453,17 @@ class NewIMAPTestsMixin():
         self.assertEqual(client.sock.timeout, None)
         client.shutdown()
 
+    def test_imaplib_timeout_functionality_test(self):
+        class TimeoutHandler(SimpleIMAPHandler):
+            def handle(self):
+                time.sleep(1)
+                SimpleIMAPHandler.handle(self)
+
+        _, server = self._setup(TimeoutHandler)
+        addr = server.server_address[1]
+        with self.assertRaises(socket.timeout):
+            client = self.imap_class("localhost", addr, timeout=0.1)
+
     def test_with_statement(self):
         _, server = self._setup(SimpleIMAPHandler, connect=False)
         with self.imap_class(*server.server_address) as imap:

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -443,15 +443,14 @@ class NewIMAPTestsMixin():
     def test_imaplib_timeout_test(self):
         _, server = self._setup(SimpleIMAPHandler)
         addr = server.server_address[1]
-        client = self.imap_class("localhost", addr, timeout=10.0)
-        self.assertEqual(client.sock.timeout, 10.0)
+        client = self.imap_class("localhost", addr, timeout=support.LOOPBACK_TIMEOUT)
+        self.assertEqual(client.sock.timeout, support.LOOPBACK_TIMEOUT)
         client.shutdown()
         client = self.imap_class("localhost", addr, timeout=None)
         self.assertEqual(client.sock.timeout, None)
         client.shutdown()
-        client = self.imap_class("localhost", addr, timeout=socket._GLOBAL_DEFAULT_TIMEOUT)
-        self.assertEqual(client.sock.timeout, None)
-        client.shutdown()
+        with self.assertRaises(ValueError):
+            client = self.imap_class("localhost", addr, timeout=0)
 
     def test_imaplib_timeout_functionality_test(self):
         class TimeoutHandler(SimpleIMAPHandler):
@@ -462,7 +461,7 @@ class NewIMAPTestsMixin():
         _, server = self._setup(TimeoutHandler)
         addr = server.server_address[1]
         with self.assertRaises(socket.timeout):
-            client = self.imap_class("localhost", addr, timeout=0.1)
+            client = self.imap_class("localhost", addr, timeout=0.001)
 
     def test_with_statement(self):
         _, server = self._setup(SimpleIMAPHandler, connect=False)

--- a/Misc/NEWS.d/next/Library/2019-11-17-17-32-35.bpo-38615.OVyaNX.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-17-17-32-35.bpo-38615.OVyaNX.rst
@@ -1,0 +1,2 @@
+The :class:`~imaplib.IMAP4` and :class:`~imaplib.IMAP4_SSL` now has optional
+*timeout* parameter for constructor. Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Library/2019-11-17-17-32-35.bpo-38615.OVyaNX.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-17-17-32-35.bpo-38615.OVyaNX.rst
@@ -1,2 +1,2 @@
-The :class:`~imaplib.IMAP4` and :class:`~imaplib.IMAP4_SSL` now has optional
-*timeout* parameter for constructor. Patch by Dong-hee Na.
+:class:`~imaplib.IMAP4` and :class:`~imaplib.IMAP4_SSL` now have an 
+optional *timeout* parameter for their constructors. Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Library/2019-11-17-17-32-35.bpo-38615.OVyaNX.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-17-17-32-35.bpo-38615.OVyaNX.rst
@@ -1,2 +1,5 @@
 :class:`~imaplib.IMAP4` and :class:`~imaplib.IMAP4_SSL` now have an 
-optional *timeout* parameter for their constructors. Patch by Dong-hee Na.
+optional *timeout* parameter for their constructors. 
+Also, the :meth:`~imaplib.IMAP4.open` method now has an optional *timeout* parameter
+with this change. The overridden methods of :class:`~imaplib.IMAP4_SSL` and
+:class:`~imaplib.IMAP4_stream` were applied to this change. Patch by Dong-hee Na.


### PR DESCRIPTION


<!-- issue-number: [bpo-38615](https://bugs.python.org/issue38615) -->
https://bugs.python.org/issue38615
<!-- /issue-number -->
