### PR TITLE
bpo-38823: Clean up _statistics initialization.

### DIFF
--- a/Modules/_statisticsmodule.c
+++ b/Modules/_statisticsmodule.c
@@ -144,7 +144,5 @@ static struct PyModuleDef statisticsmodule = {
 PyMODINIT_FUNC
 PyInit__statistics(void)
 {
-    PyObject *m = PyModule_Create(&statisticsmodule);
-    if (!m) return NULL;
-    return m;
+    return PyModule_Create(&statisticsmodule);
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-38823](https://bugs.python.org/issue38823) -->
https://bugs.python.org/issue38823
<!-- /issue-number -->
