### PR TITLE
Revert "bpo-38811: Check for presence of os.link method in pathlib"

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -418,12 +418,7 @@ class _NormalAccessor(_Accessor):
 
     unlink = os.unlink
 
-    if hasattr(os, "link"):
-        link_to = os.link
-    else:
-        @staticmethod
-        def link_to(self, target):
-            raise NotImplementedError("os.link() not available on this system")
+    link_to = os.link
 
     rmdir = os.rmdir
 
@@ -435,7 +430,6 @@ class _NormalAccessor(_Accessor):
         if supports_symlinks:
             symlink = os.symlink
         else:
-            @staticmethod
             def symlink(a, b, target_is_directory):
                 raise NotImplementedError("symlink() not available on this system")
     else:

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1759,7 +1759,6 @@ class _BasePathTest(object):
         self.assertFileNotFound(p.stat)
         self.assertFileNotFound(p.unlink)
 
-    @unittest.skipUnless(hasattr(os, "link"), "os.link() is not present")
     def test_link_to(self):
         P = self.cls(BASE)
         p = P / 'fileA'
@@ -1778,15 +1777,6 @@ class _BasePathTest(object):
         q.link_to(r)
         self.assertEqual(os.stat(r).st_size, size)
         self.assertTrue(q.stat)
-
-    @unittest.skipIf(hasattr(os, "link"), "os.link() is present")
-    def test_link_to_not_implemented(self):
-        P = self.cls(BASE)
-        p = P / 'fileA'
-        # linking to another path.
-        q = P / 'dirA' / 'fileAA'
-        with self.assertRaises(NotImplementedError):
-            p.link_to(q)
 
     def test_rename(self):
         P = self.cls(BASE)
@@ -2020,15 +2010,6 @@ class _BasePathTest(object):
         self.assertNotEqual(link.lstat(), target.stat())
         self.assertTrue(link.is_dir())
         self.assertTrue(list(link.iterdir()))
-
-    @unittest.skipIf(support.can_symlink(), "symlink support is present")
-    def test_symlink_to_not_implemented(self):
-        P = self.cls(BASE)
-        target = P / 'fileA'
-        # Symlinking a path target.
-        link = P / 'dirA' / 'linkAA'
-        with self.assertRaises(NotImplementedError):
-            link.symlink_to(target)
 
     def test_is_dir(self):
         P = self.cls(BASE)

--- a/Misc/NEWS.d/next/Library/2019-11-15-18-06-04.bpo-38811.AmdQ6M.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-15-18-06-04.bpo-38811.AmdQ6M.rst
@@ -1,1 +1,0 @@
-Fix an unhandled exception in :mod:`pathlib` when :meth:`os.link` is missing. Patch by Toke Høiland-Jørgensen.


### PR DESCRIPTION
Reverts python/cpython#17170

<!-- issue-number: [bpo-38811](https://bugs.python.org/issue38811) -->
https://bugs.python.org/issue38811
<!-- /issue-number -->
