### PR TITLE
[3.8] bpo-38830: Correct slot signature in Qt example. (GH-17220)

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -2949,7 +2949,7 @@ refer to the comments in the code snippet for more detailed information.
         # The functions below update the UI and run in the main thread because
         # that's where the slots are set up
 
-        @Slot(str)
+        @Slot(str, logging.LogRecord)
         def update_status(self, status, record):
             color = self.COLORS.get(record.levelno, 'black')
             s = '<pre><font color="%s">%s</font></pre>' % (color, status)


### PR DESCRIPTION
(cherry picked from commit 5383956583bb758f3828513bcdd011871f24a0e8)

<!-- issue-number: [bpo-38830](https://bugs.python.org/issue38830) -->
https://bugs.python.org/issue38830
<!-- /issue-number -->
