### PR TITLE
bpo-38811: Check for presence of os.link method in pathlib (v2)

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -418,7 +418,12 @@ class _NormalAccessor(_Accessor):
 
     unlink = os.unlink
 
-    link_to = os.link
+    if hasattr(os, "link"):
+        link_to = os.link
+    else:
+        @staticmethod
+        def link_to(self, target):
+            raise NotImplementedError("os.link() not available on this system")
 
     rmdir = os.rmdir
 

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1759,6 +1759,7 @@ class _BasePathTest(object):
         self.assertFileNotFound(p.stat)
         self.assertFileNotFound(p.unlink)
 
+    @unittest.skipUnless(hasattr(os, "link"), "os.link() is not present")
     def test_link_to(self):
         P = self.cls(BASE)
         p = P / 'fileA'
@@ -1777,6 +1778,15 @@ class _BasePathTest(object):
         q.link_to(r)
         self.assertEqual(os.stat(r).st_size, size)
         self.assertTrue(q.stat)
+
+    @unittest.skipIf(hasattr(os, "link"), "os.link() is present")
+    def test_link_to_not_implemented(self):
+        P = self.cls(BASE)
+        p = P / 'fileA'
+        # linking to another path.
+        q = P / 'dirA' / 'fileAA'
+        with self.assertRaises(NotImplementedError):
+            p.link_to(q)
 
     def test_rename(self):
         P = self.cls(BASE)

--- a/Misc/NEWS.d/next/Library/2019-11-15-18-06-04.bpo-38811.AmdQ6M.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-15-18-06-04.bpo-38811.AmdQ6M.rst
@@ -1,0 +1,1 @@
+Fix an unhandled exception in :mod:`pathlib` when :meth:`os.link` is missing. Patch by Toke Høiland-Jørgensen.


### PR DESCRIPTION
This is a do-over of #17170, with a symlink test that hopefully doesn't crash on Windows.

Commit 6b5b013 ("[bpo-26978](https://bugs.python.org/issue26978): Implement pathlib.Path.link_to (Using
os.link) (GH-12990)") introduced a new link_to method in pathlib. However,
this makes pathlib crash when the 'os' module is missing a 'link' method.

Fix this by checking for the presence of the 'link' method on pathlib
module import, and if it's not present, turn it into a runtime error like
those emitted when there is no lchmod() or symlink().

Also, add a test for the NotImplemented error raised by the corresponding symlink_to method.

<!-- issue-number: [bpo-38811](https://bugs.python.org/issue38811) -->
https://bugs.python.org/issue38811
<!-- /issue-number -->
