### PR TITLE
bpo-38835: Exclude PyFPE macros from the stable API

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -219,6 +219,10 @@ Build and C API Changes
   and refers to a constant string.
   (Contributed by Serhiy Storchaka in :issue:`38650`.)
 
+* Exclude ``PyFPE_START_PROTECT()`` and ``PyFPE_END_PROTECT()`` macros of
+  ``pyfpe.h`` from ``Py_LIMITED_API`` (stable API).
+  (Contributed by Victor Stinner in :issue:`38835`.)
+
 
 Deprecated
 ==========

--- a/Include/pyfpe.h
+++ b/Include/pyfpe.h
@@ -1,5 +1,7 @@
 #ifndef Py_PYFPE_H
 #define Py_PYFPE_H
+/* Header excluded from the stable API */
+#ifndef Py_LIMITED_API
 
 /* These macros used to do something when Python was built with --with-fpectl,
  * but support for that was dropped in 3.7. We continue to define them though,
@@ -9,4 +11,5 @@
 #define PyFPE_START_PROTECT(err_string, leave_stmt)
 #define PyFPE_END_PROTECT(v)
 
+#endif /* !defined(Py_LIMITED_API) */
 #endif /* !Py_PYFPE_H */

--- a/Misc/NEWS.d/next/C API/2019-11-18-15-38-23.bpo-38835.II8Szd.rst
+++ b/Misc/NEWS.d/next/C API/2019-11-18-15-38-23.bpo-38835.II8Szd.rst
@@ -1,0 +1,2 @@
+Exclude ``PyFPE_START_PROTECT()`` and ``PyFPE_END_PROTECT()`` macros of
+``pyfpe.h`` from ``Py_LIMITED_API`` (stable API).


### PR DESCRIPTION
Exclude PyFPE_START_PROTECT() and PyFPE_END_PROTECT() macros of
pyfpe.h from Py_LIMITED_API (stable API).

<!-- issue-number: [bpo-38835](https://bugs.python.org/issue38835) -->
https://bugs.python.org/issue38835
<!-- /issue-number -->
