### PR TITLE
bpo-38835: Don't use PyFPE_START_PROTECT and PyFPE_END_PROTECT

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-18-16-37-49.bpo-38835.-U4se1.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-18-16-37-49.bpo-38835.-U4se1.rst
@@ -1,0 +1,2 @@
+The ``PyFPE_START_PROTECT()`` and ``PyFPE_END_PROTECT()`` macros are empty:
+they have been doing nothing for the last year, so stop using them.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -2166,11 +2166,9 @@ _tkinter_tkapp_exprdouble_impl(TkappObject *self, const char *s)
 
     CHECK_STRING_LENGTH(s);
     CHECK_TCL_APPARTMENT;
-    PyFPE_START_PROTECT("Tkapp_ExprDouble", return 0)
     ENTER_TCL
     retval = Tcl_ExprDouble(Tkapp_Interp(self), s, &v);
     ENTER_OVERLAP
-    PyFPE_END_PROTECT(retval)
     if (retval == TCL_ERROR)
         res = Tkinter_Error(self);
     else

--- a/Modules/clinic/cmathmodule.c.h
+++ b/Modules/clinic/cmathmodule.c.h
@@ -26,9 +26,8 @@ cmath_acos(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_acos_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -69,9 +68,8 @@ cmath_acosh(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_acosh_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -112,9 +110,8 @@ cmath_asin(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_asin_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -155,9 +152,8 @@ cmath_asinh(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_asinh_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -198,9 +194,8 @@ cmath_atan(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_atan_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -241,9 +236,8 @@ cmath_atanh(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_atanh_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -284,9 +278,8 @@ cmath_cos(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_cos_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -327,9 +320,8 @@ cmath_cosh(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_cosh_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -370,9 +362,8 @@ cmath_exp(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_exp_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -413,9 +404,8 @@ cmath_log10(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_log10_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -456,9 +446,8 @@ cmath_sin(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_sin_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -499,9 +488,8 @@ cmath_sinh(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_sinh_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -542,9 +530,8 @@ cmath_sqrt(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_sqrt_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -585,9 +572,8 @@ cmath_tan(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_tan_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -628,9 +614,8 @@ cmath_tanh(PyObject *module, PyObject *arg)
         goto exit;
     }
     /* modifications for z */
-    errno = 0; PyFPE_START_PROTECT("complex function", goto exit);
+    errno = 0;
     _return_value = cmath_tanh_impl(module, z);
-    PyFPE_END_PROTECT(_return_value);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ValueError, "math domain error");
         goto exit;
@@ -968,4 +953,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3edc4484b10ae752 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=353347db2e808e0d input=a9049054013a1b77]*/

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -17,7 +17,7 @@ module cmath
 /*[python input]
 class Py_complex_protected_converter(Py_complex_converter):
     def modify(self):
-        return 'errno = 0; PyFPE_START_PROTECT("complex function", goto exit);'
+        return 'errno = 0;'
 
 
 class Py_complex_protected_return_converter(CReturnConverter):
@@ -26,7 +26,6 @@ class Py_complex_protected_return_converter(CReturnConverter):
     def render(self, function, data):
         self.declare(data)
         data.return_conversion.append("""
-PyFPE_END_PROTECT(_return_value);
 if (errno == EDOM) {
     PyErr_SetString(PyExc_ValueError, "math domain error");
     goto exit;
@@ -40,7 +39,7 @@ else {
 }
 """.strip())
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=345daa075b1028e7]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=8b27adb674c08321]*/
 
 #if (FLT_RADIX != 2 && FLT_RADIX != 16)
 #error "Modules/cmathmodule.c expects FLT_RADIX to be 2 or 16"
@@ -960,7 +959,6 @@ cmath_log_impl(PyObject *module, Py_complex x, PyObject *y_obj)
     Py_complex y;
 
     errno = 0;
-    PyFPE_START_PROTECT("complex function", return 0)
     x = c_log(x);
     if (y_obj != NULL) {
         y = PyComplex_AsCComplex(y_obj);
@@ -970,7 +968,6 @@ cmath_log_impl(PyObject *module, Py_complex x, PyObject *y_obj)
         y = c_log(y);
         x = _Py_c_quot(x, y);
     }
-    PyFPE_END_PROTECT(x)
     if (errno != 0)
         return math_error();
     return PyComplex_FromCComplex(x);
@@ -1008,9 +1005,7 @@ cmath_phase_impl(PyObject *module, Py_complex z)
     double phi;
 
     errno = 0;
-    PyFPE_START_PROTECT("arg function", return 0)
     phi = c_atan2(z);
-    PyFPE_END_PROTECT(phi)
     if (errno != 0)
         return math_error();
     else
@@ -1035,10 +1030,8 @@ cmath_polar_impl(PyObject *module, Py_complex z)
     double r, phi;
 
     errno = 0;
-    PyFPE_START_PROTECT("polar function", return 0)
     phi = c_atan2(z); /* should not cause any exception */
     r = _Py_c_abs(z); /* sets errno to ERANGE on overflow */
-    PyFPE_END_PROTECT(r)
     if (errno != 0)
         return math_error();
     else
@@ -1074,7 +1067,6 @@ cmath_rect_impl(PyObject *module, double r, double phi)
 {
     Py_complex z;
     errno = 0;
-    PyFPE_START_PROTECT("rect function", return 0)
 
     /* deal with special values */
     if (!Py_IS_FINITE(r) || !Py_IS_FINITE(phi)) {
@@ -1116,7 +1108,6 @@ cmath_rect_impl(PyObject *module, double r, double phi)
         errno = 0;
     }
 
-    PyFPE_END_PROTECT(z)
     if (errno != 0)
         return math_error();
     else

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -936,9 +936,7 @@ math_1_to_whatever(PyObject *arg, double (*func) (double),
     if (x == -1.0 && PyErr_Occurred())
         return NULL;
     errno = 0;
-    PyFPE_START_PROTECT("in math_1", return 0);
     r = (*func)(x);
-    PyFPE_END_PROTECT(r);
     if (Py_IS_NAN(r) && !Py_IS_NAN(x)) {
         PyErr_SetString(PyExc_ValueError,
                         "math domain error"); /* invalid arg */
@@ -972,9 +970,7 @@ math_1a(PyObject *arg, double (*func) (double))
     if (x == -1.0 && PyErr_Occurred())
         return NULL;
     errno = 0;
-    PyFPE_START_PROTECT("in math_1a", return 0);
     r = (*func)(x);
-    PyFPE_END_PROTECT(r);
     if (errno && is_error(r))
         return NULL;
     return PyFloat_FromDouble(r);
@@ -1025,9 +1021,7 @@ math_2(PyObject *const *args, Py_ssize_t nargs,
     if ((x == -1.0 || y == -1.0) && PyErr_Occurred())
         return NULL;
     errno = 0;
-    PyFPE_START_PROTECT("in math_2", return 0);
     r = (*func)(x, y);
-    PyFPE_END_PROTECT(r);
     if (Py_IS_NAN(r)) {
         if (!Py_IS_NAN(x) && !Py_IS_NAN(y))
             errno = EDOM;
@@ -1340,8 +1334,6 @@ math_fsum(PyObject *module, PyObject *seq)
     if (iter == NULL)
         return NULL;
 
-    PyFPE_START_PROTECT("fsum", Py_DECREF(iter); return NULL)
-
     for(;;) {           /* for x in iterable */
         assert(0 <= n && n <= m);
         assert((m == NUM_PARTIALS && p == ps) ||
@@ -1436,7 +1428,6 @@ math_fsum(PyObject *module, PyObject *seq)
     sum = PyFloat_FromDouble(hi);
 
   _fsum_error:
-    PyFPE_END_PROTECT(hi)
     Py_DECREF(iter);
     if (p != ps)
         PyMem_Free(p);
@@ -2111,9 +2102,7 @@ math_frexp_impl(PyObject *module, double x)
         i = 0;
     }
     else {
-        PyFPE_START_PROTECT("in math_frexp", return 0);
         x = frexp(x, &i);
-        PyFPE_END_PROTECT(x);
     }
     return Py_BuildValue("(di)", x, i);
 }
@@ -2168,9 +2157,7 @@ math_ldexp_impl(PyObject *module, double x, PyObject *i)
         errno = 0;
     } else {
         errno = 0;
-        PyFPE_START_PROTECT("in math_ldexp", return 0);
         r = ldexp(x, (int)exp);
-        PyFPE_END_PROTECT(r);
         if (Py_IS_INFINITY(r))
             errno = ERANGE;
     }
@@ -2207,9 +2194,7 @@ math_modf_impl(PyObject *module, double x)
     }
 
     errno = 0;
-    PyFPE_START_PROTECT("in math_modf", return 0);
     x = modf(x, &y);
-    PyFPE_END_PROTECT(x);
     return Py_BuildValue("(dd)", x, y);
 }
 
@@ -2356,9 +2341,7 @@ math_fmod_impl(PyObject *module, double x, double y)
     if (Py_IS_INFINITY(y) && Py_IS_FINITE(x))
         return PyFloat_FromDouble(x);
     errno = 0;
-    PyFPE_START_PROTECT("in math_fmod", return 0);
     r = fmod(x, y);
-    PyFPE_END_PROTECT(r);
     if (Py_IS_NAN(r)) {
         if (!Py_IS_NAN(x) && !Py_IS_NAN(y))
             errno = EDOM;
@@ -2646,9 +2629,7 @@ math_pow_impl(PyObject *module, double x, double y)
     else {
         /* let libm handle finite**finite */
         errno = 0;
-        PyFPE_START_PROTECT("in math_pow", return 0);
         r = pow(x, y);
-        PyFPE_END_PROTECT(r);
         /* a NaN result should arise only from (-ve)**(finite
            non-integer); in this case we want to raise ValueError. */
         if (!Py_IS_FINITE(r)) {

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -466,9 +466,7 @@ complex_add(PyObject *v, PyObject *w)
     Py_complex a, b;
     TO_COMPLEX(v, a);
     TO_COMPLEX(w, b);
-    PyFPE_START_PROTECT("complex_add", return 0)
     result = _Py_c_sum(a, b);
-    PyFPE_END_PROTECT(result)
     return PyComplex_FromCComplex(result);
 }
 
@@ -479,9 +477,7 @@ complex_sub(PyObject *v, PyObject *w)
     Py_complex a, b;
     TO_COMPLEX(v, a);
     TO_COMPLEX(w, b);
-    PyFPE_START_PROTECT("complex_sub", return 0)
     result = _Py_c_diff(a, b);
-    PyFPE_END_PROTECT(result)
     return PyComplex_FromCComplex(result);
 }
 
@@ -492,9 +488,7 @@ complex_mul(PyObject *v, PyObject *w)
     Py_complex a, b;
     TO_COMPLEX(v, a);
     TO_COMPLEX(w, b);
-    PyFPE_START_PROTECT("complex_mul", return 0)
     result = _Py_c_prod(a, b);
-    PyFPE_END_PROTECT(result)
     return PyComplex_FromCComplex(result);
 }
 
@@ -505,10 +499,8 @@ complex_div(PyObject *v, PyObject *w)
     Py_complex a, b;
     TO_COMPLEX(v, a);
     TO_COMPLEX(w, b);
-    PyFPE_START_PROTECT("complex_div", return 0)
     errno = 0;
     quot = _Py_c_quot(a, b);
-    PyFPE_END_PROTECT(quot)
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ZeroDivisionError, "complex division by zero");
         return NULL;
@@ -547,7 +539,6 @@ complex_pow(PyObject *v, PyObject *w, PyObject *z)
         PyErr_SetString(PyExc_ValueError, "complex modulo");
         return NULL;
     }
-    PyFPE_START_PROTECT("complex_pow", return 0)
     errno = 0;
     exponent = b;
     int_exponent = (long)exponent.real;
@@ -556,7 +547,6 @@ complex_pow(PyObject *v, PyObject *w, PyObject *z)
     else
         p = _Py_c_pow(a, exponent);
 
-    PyFPE_END_PROTECT(p)
     Py_ADJUST_ERANGE2(p.real, p.imag);
     if (errno == EDOM) {
         PyErr_SetString(PyExc_ZeroDivisionError,
@@ -604,9 +594,7 @@ complex_abs(PyComplexObject *v)
 {
     double result;
 
-    PyFPE_START_PROTECT("complex_abs", return 0)
     result = _Py_c_abs(v->cval);
-    PyFPE_END_PROTECT(result)
 
     if (errno == ERANGE) {
         PyErr_SetString(PyExc_OverflowError,

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -506,7 +506,6 @@ float_richcompare(PyObject *v, PyObject *w, int op)
         goto Unimplemented;
 
  Compare:
-    PyFPE_START_PROTECT("richcompare", return NULL)
     switch (op) {
     case Py_EQ:
         r = i == j;
@@ -527,7 +526,6 @@ float_richcompare(PyObject *v, PyObject *w, int op)
         r = i > j;
         break;
     }
-    PyFPE_END_PROTECT(r)
     return PyBool_FromLong(r);
 
  Unimplemented:
@@ -546,9 +544,7 @@ float_add(PyObject *v, PyObject *w)
     double a,b;
     CONVERT_TO_DOUBLE(v, a);
     CONVERT_TO_DOUBLE(w, b);
-    PyFPE_START_PROTECT("add", return 0)
     a = a + b;
-    PyFPE_END_PROTECT(a)
     return PyFloat_FromDouble(a);
 }
 
@@ -558,9 +554,7 @@ float_sub(PyObject *v, PyObject *w)
     double a,b;
     CONVERT_TO_DOUBLE(v, a);
     CONVERT_TO_DOUBLE(w, b);
-    PyFPE_START_PROTECT("subtract", return 0)
     a = a - b;
-    PyFPE_END_PROTECT(a)
     return PyFloat_FromDouble(a);
 }
 
@@ -570,9 +564,7 @@ float_mul(PyObject *v, PyObject *w)
     double a,b;
     CONVERT_TO_DOUBLE(v, a);
     CONVERT_TO_DOUBLE(w, b);
-    PyFPE_START_PROTECT("multiply", return 0)
     a = a * b;
-    PyFPE_END_PROTECT(a)
     return PyFloat_FromDouble(a);
 }
 
@@ -587,9 +579,7 @@ float_div(PyObject *v, PyObject *w)
                         "float division by zero");
         return NULL;
     }
-    PyFPE_START_PROTECT("divide", return 0)
     a = a / b;
-    PyFPE_END_PROTECT(a)
     return PyFloat_FromDouble(a);
 }
 
@@ -605,7 +595,6 @@ float_rem(PyObject *v, PyObject *w)
                         "float modulo");
         return NULL;
     }
-    PyFPE_START_PROTECT("modulo", return 0)
     mod = fmod(vx, wx);
     if (mod) {
         /* ensure the remainder has the same sign as the denominator */
@@ -619,7 +608,6 @@ float_rem(PyObject *v, PyObject *w)
            it has the same sign as the denominator. */
         mod = copysign(0.0, wx);
     }
-    PyFPE_END_PROTECT(mod)
     return PyFloat_FromDouble(mod);
 }
 
@@ -634,7 +622,6 @@ float_divmod(PyObject *v, PyObject *w)
         PyErr_SetString(PyExc_ZeroDivisionError, "float divmod()");
         return NULL;
     }
-    PyFPE_START_PROTECT("divmod", return 0)
     mod = fmod(vx, wx);
     /* fmod is typically exact, so vx-mod is *mathematically* an
        exact multiple of wx.  But this is fp arithmetic, and fp
@@ -666,7 +653,6 @@ float_divmod(PyObject *v, PyObject *w)
         /* div is zero - get the same sign as the true quotient */
         floordiv = copysign(0.0, vx / wx); /* zero w/ sign of vx/wx */
     }
-    PyFPE_END_PROTECT(floordiv)
     return Py_BuildValue("(dd)", floordiv, mod);
 }
 
@@ -793,9 +779,7 @@ float_pow(PyObject *v, PyObject *w, PyObject *z)
      * the platform pow to step in and do the rest.
      */
     errno = 0;
-    PyFPE_START_PROTECT("pow", return NULL)
     ix = pow(iv, iw);
-    PyFPE_END_PROTECT(ix)
     Py_ADJUST_ERANGE1(ix);
     if (negate_result)
         ix = -ix;
@@ -849,9 +833,7 @@ float_is_integer_impl(PyObject *self)
     if (!Py_IS_FINITE(x))
         Py_RETURN_FALSE;
     errno = 0;
-    PyFPE_START_PROTECT("is_integer", return NULL)
     o = (floor(x) == x) ? Py_True : Py_False;
-    PyFPE_END_PROTECT(x)
     if (errno != 0) {
         PyErr_SetFromErrno(errno == ERANGE ? PyExc_OverflowError :
                              PyExc_ValueError);
@@ -1567,9 +1549,7 @@ float_as_integer_ratio_impl(PyObject *self)
         return NULL;
     }
 
-    PyFPE_START_PROTECT("as_integer_ratio", goto error);
     float_part = frexp(self_double, &exponent);        /* self_double == float_part * 2**exponent exactly */
-    PyFPE_END_PROTECT(float_part);
 
     for (i=0; i<300 && float_part != floor(float_part) ; i++) {
         float_part *= 2.0;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2385,9 +2385,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
                 return PyFloat_FromDouble(f_result);
             }
             if (PyFloat_CheckExact(item)) {
-                PyFPE_START_PROTECT("add", Py_DECREF(item); Py_DECREF(iter); return 0)
                 f_result += PyFloat_AS_DOUBLE(item);
-                PyFPE_END_PROTECT(f_result)
                 Py_DECREF(item);
                 continue;
             }
@@ -2396,9 +2394,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
                 int overflow;
                 value = PyLong_AsLongAndOverflow(item, &overflow);
                 if (!overflow) {
-                    PyFPE_START_PROTECT("add", Py_DECREF(item); Py_DECREF(iter); return 0)
                     f_result += (double)value;
-                    PyFPE_END_PROTECT(f_result)
                     Py_DECREF(item);
                     continue;
                 }

--- a/Python/pystrtod.c
+++ b/Python/pystrtod.c
@@ -342,9 +342,7 @@ PyOS_string_to_double(const char *s,
     char *fail_pos;
 
     errno = 0;
-    PyFPE_START_PROTECT("PyOS_string_to_double", return -1.0)
     x = _PyOS_ascii_strtod(s, &fail_pos);
-    PyFPE_END_PROTECT(x)
 
     if (errno == ENOMEM) {
         PyErr_NoMemory();


### PR DESCRIPTION
PyFPE_START_PROTECT() and PyFPE_END_PROTECT() macros are empty: they
do nothing for one year (since commit
735ae8d139a673b30b321dc10acfd3d14f0d633b), stop using them.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38835](https://bugs.python.org/issue38835) -->
https://bugs.python.org/issue38835
<!-- /issue-number -->
