### PR TITLE
bpo-38631: Avoid Py_FatalError() in float.__getformat__()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-18-17-10-20.bpo-38631.tRHaAk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-18-17-10-20.bpo-38631.tRHaAk.rst
@@ -1,0 +1,2 @@
+Replace ``Py_FatalError()`` call with a regular :exc:`RuntimeError`
+exception in :meth:`float.__getformat__`.

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1726,7 +1726,8 @@ float___getformat___impl(PyTypeObject *type, const char *typestr)
     case ieee_big_endian_format:
         return PyUnicode_FromString("IEEE, big-endian");
     default:
-        Py_FatalError("insane float_format or double_format");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "insane float_format or double_format");
         return NULL;
     }
 }


### PR DESCRIPTION
Replace Py_FatalError() with a regular RuntimeError exception in
`float.__getformat__()`.

<!-- issue-number: [bpo-38631](https://bugs.python.org/issue38631) -->
https://bugs.python.org/issue38631
<!-- /issue-number -->
