### PR TITLE
bpo-38631: Avoid Py_FatalError() in _multibytecodec init

### DIFF
--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -2085,7 +2085,6 @@ PyInit__multibytecodec(void)
     }
 
     if (PyErr_Occurred()) {
-        Py_FatalError("can't initialize the _multibytecodec module");
         Py_DECREF(m);
         m = NULL;
     }


### PR DESCRIPTION
If an exception is raised and PyInit__multibytecodec() returns NULL,
Python reports properly the exception to the user. There is no need
to crash Python with Py_FatalError().

<!-- issue-number: [bpo-38631](https://bugs.python.org/issue38631) -->
https://bugs.python.org/issue38631
<!-- /issue-number -->
