### PR TITLE
bpo-38823: Clean up refleak in _tracemalloc initialization.

### DIFF
--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -1657,7 +1657,7 @@ PyInit__tracemalloc(void)
         return NULL;
 
     if (tracemalloc_init() < 0) {
-        PY_DECREF(m);
+        Py_DECREF(m);
         return NULL;
     }
 

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -1656,8 +1656,10 @@ PyInit__tracemalloc(void)
     if (m == NULL)
         return NULL;
 
-    if (tracemalloc_init() < 0)
+    if (tracemalloc_init() < 0) {
+        PY_DECREF(m);
         return NULL;
+    }
 
     return m;
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-38823](https://bugs.python.org/issue38823) -->
https://bugs.python.org/issue38823
<!-- /issue-number -->
