### PR TITLE
bpo-38823: Clean up refleak in fcntl initialization.

### DIFF
--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -668,8 +668,10 @@ PyInit_fcntl(void)
         return NULL;
 
     /* Add some symbolic constants to the module */
-    if (all_ins(m) < 0)
+    if (all_ins(m) < 0) {
+        Py_DECREF(m);
         return NULL;
+    }
 
     return m;
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-38823](https://bugs.python.org/issue38823) -->
https://bugs.python.org/issue38823
<!-- /issue-number -->
