### PR TITLE
Revert "remove a strange non-ASCII character in _iomodule.c (GH-17239)"

### DIFF
--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -503,7 +503,7 @@ _io_open_code_impl(PyObject *module, PyObject *path)
 {
     return PyFile_OpenCodeObject(path);
 }
-
+
 /*
  * Private helpers for the io module.
  */


### PR DESCRIPTION
This reverts commit bcc1cc5c, which removed an intentionally placed "form feed" character.