### PR TITLE
bpo-38622: Ensure ctypes audit events pass tuples as a single argument

### DIFF
--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1631,7 +1631,7 @@ addressof(PyObject *self, PyObject *obj)
                         "invalid type");
         return NULL;
     }
-    if (PySys_Audit("ctypes.addressof", "O", obj) < 0) {
+    if (PySys_Audit("ctypes.addressof", "(O)", obj) < 0) {
         return NULL;
     }
     return PyLong_FromVoidPtr(((CDataObject *)obj)->b_ptr);
@@ -1651,7 +1651,7 @@ My_PyObj_FromPtr(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O&:PyObj_FromPtr", converter, &ob)) {
         return NULL;
     }
-    if (PySys_Audit("ctypes.PyObj_FromPtr", "O", ob) < 0) {
+    if (PySys_Audit("ctypes.PyObj_FromPtr", "(O)", ob) < 0) {
         return NULL;
     }
     Py_INCREF(ob);


### PR DESCRIPTION
This only impacts PyObj_FromPtr - if the object is a tuple, `PySys_Audit(... "O", ob)` will treat it as the full set of arguments (as we do elsewhere in this file deliberately). But in this case, we want it to be passed as the sole argument of the event.

To repro on CPython: `_ctypes.PyObj_FromPtr(id(a_tuple))`

`addressof` _shouldn't_ suffer the same thing, but it won't hurt to be sure. The other uses in this file are correct.

<!-- issue-number: [bpo-38622](https://bugs.python.org/issue38622) -->
https://bugs.python.org/issue38622
<!-- /issue-number -->
