### PR TITLE
bpo-38823: Clean up refleaks in faulthandler initialization.

### DIFF
--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1359,9 +1359,11 @@ PyInit_faulthandler(void)
 
     return m;
 
+#ifdef MS_WINDOWS
 error:
     Py_DECREF(m);
     return NULL;
+#endif
 }
 
 static int

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1334,22 +1334,32 @@ PyInit_faulthandler(void)
 #ifdef MS_WINDOWS
     /* RaiseException() codes (prefixed by an underscore) */
     if (PyModule_AddIntConstant(m, "_EXCEPTION_ACCESS_VIOLATION",
-                                EXCEPTION_ACCESS_VIOLATION))
+                                EXCEPTION_ACCESS_VIOLATION)) {
+        Py_DECREF(m);
         return NULL;
+    }
     if (PyModule_AddIntConstant(m, "_EXCEPTION_INT_DIVIDE_BY_ZERO",
-                                EXCEPTION_INT_DIVIDE_BY_ZERO))
+                                EXCEPTION_INT_DIVIDE_BY_ZERO)) {
+        Py_DECREF(m);
         return NULL;
+    }
     if (PyModule_AddIntConstant(m, "_EXCEPTION_STACK_OVERFLOW",
-                                EXCEPTION_STACK_OVERFLOW))
+                                EXCEPTION_STACK_OVERFLOW)) {
+        Py_DECREF(m);
         return NULL;
+    }
 
     /* RaiseException() flags (prefixed by an underscore) */
     if (PyModule_AddIntConstant(m, "_EXCEPTION_NONCONTINUABLE",
-                                EXCEPTION_NONCONTINUABLE))
+                                EXCEPTION_NONCONTINUABLE)) {
+        Py_DECREF(m);
         return NULL;
+    }
     if (PyModule_AddIntConstant(m, "_EXCEPTION_NONCONTINUABLE_EXCEPTION",
-                                EXCEPTION_NONCONTINUABLE_EXCEPTION))
+                                EXCEPTION_NONCONTINUABLE_EXCEPTION)) {
+        Py_DECREF(m);
         return NULL;
+    }
 #endif
 
     return m;

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1335,34 +1335,33 @@ PyInit_faulthandler(void)
     /* RaiseException() codes (prefixed by an underscore) */
     if (PyModule_AddIntConstant(m, "_EXCEPTION_ACCESS_VIOLATION",
                                 EXCEPTION_ACCESS_VIOLATION)) {
-        Py_DECREF(m);
-        return NULL;
+        goto error;
     }
     if (PyModule_AddIntConstant(m, "_EXCEPTION_INT_DIVIDE_BY_ZERO",
                                 EXCEPTION_INT_DIVIDE_BY_ZERO)) {
-        Py_DECREF(m);
-        return NULL;
+        goto error;
     }
     if (PyModule_AddIntConstant(m, "_EXCEPTION_STACK_OVERFLOW",
                                 EXCEPTION_STACK_OVERFLOW)) {
-        Py_DECREF(m);
-        return NULL;
+        goto error;
     }
 
     /* RaiseException() flags (prefixed by an underscore) */
     if (PyModule_AddIntConstant(m, "_EXCEPTION_NONCONTINUABLE",
                                 EXCEPTION_NONCONTINUABLE)) {
-        Py_DECREF(m);
-        return NULL;
+        goto error;
     }
     if (PyModule_AddIntConstant(m, "_EXCEPTION_NONCONTINUABLE_EXCEPTION",
                                 EXCEPTION_NONCONTINUABLE_EXCEPTION)) {
-        Py_DECREF(m);
-        return NULL;
+        goto error;
     }
 #endif
 
     return m;
+
+error:
+    Py_DECREF(m);
+    return NULL;
 }
 
 static int


### PR DESCRIPTION


<!-- issue-number: [bpo-38823](https://bugs.python.org/issue38823) -->
https://bugs.python.org/issue38823
<!-- /issue-number -->
