### PR TITLE
bpo-36710: Add PyInterpreterState.runtime field

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -38,15 +38,12 @@ extern PyStatus _PyFaulthandler_Init(int enable);
 extern int _PyTraceMalloc_Init(int enable);
 extern PyObject * _PyBuiltin_Init(PyThreadState *tstate);
 extern PyStatus _PySys_Create(
-    struct pyruntimestate *runtime,
     PyThreadState *tstate,
     PyObject **sysmod_p);
 extern PyStatus _PySys_SetPreliminaryStderr(PyObject *sysdict);
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
-extern int _PySys_InitMain(
-    struct pyruntimestate *runtime,
-    PyThreadState *tstate);
+extern int _PySys_InitMain(PyThreadState *tstate);
 extern PyStatus _PyImport_Init(PyThreadState *tstate);
 extern PyStatus _PyExc_Init(void);
 extern PyStatus _PyErr_Init(void);
@@ -57,7 +54,7 @@ extern PyStatus _Py_HashRandomization_Init(const PyConfig *);
 
 extern PyStatus _PyTypes_Init(void);
 extern PyStatus _PyImportZip_Init(PyThreadState *tstate);
-extern PyStatus _PyGC_Init(struct pyruntimestate *runtime);
+extern PyStatus _PyGC_Init(PyThreadState *tstate);
 
 
 /* Various internal finalizers */
@@ -89,9 +86,7 @@ extern void _PyHash_Fini(void);
 extern void _PyTraceMalloc_Fini(void);
 extern void _PyWarnings_Fini(PyInterpreterState *interp);
 
-extern void _PyGILState_Init(
-    struct pyruntimestate *runtime,
-    PyThreadState *tstate);
+extern void _PyGILState_Init(PyThreadState *tstate);
 extern void _PyGILState_Fini(struct pyruntimestate *runtime);
 
 PyAPI_FUNC(void) _PyGC_DumpShutdownStats(struct pyruntimestate *runtime);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -62,6 +62,11 @@ struct _is {
     struct _is *next;
     struct _ts *tstate_head;
 
+    /* Reference to the _PyRuntime global variable. This field exists
+       to not have to pass runtime in addition to tstate to a function.
+       Get runtime from tstate: tstate->interp->runtime. */
+    struct pyruntimestate *runtime;
+
     int64_t id;
     int64_t id_refcount;
     int requires_idref;
@@ -301,7 +306,6 @@ PyAPI_FUNC(void) _PyRuntime_Finalize(void);
 /* Other */
 
 PyAPI_FUNC(void) _PyThreadState_Init(
-    _PyRuntimeState *runtime,
     PyThreadState *tstate);
 PyAPI_FUNC(void) _PyThreadState_DeleteExcept(
     _PyRuntimeState *runtime,

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1007,7 +1007,7 @@ t_bootstrap(void *boot_raw)
     runtime = boot->runtime;
     tstate = boot->tstate;
     tstate->thread_id = PyThread_get_thread_ident();
-    _PyThreadState_Init(runtime, tstate);
+    _PyThreadState_Init(tstate);
     PyEval_AcquireThread(tstate);
     tstate->interp->num_threads++;
     res = PyObject_Call(boot->func, boot->args, boot->keyw);

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -154,9 +154,9 @@ _PyGC_InitializeRuntime(struct _gc_runtime_state *state)
 
 
 PyStatus
-_PyGC_Init(_PyRuntimeState *runtime)
+_PyGC_Init(PyThreadState *tstate)
 {
-    struct _gc_runtime_state *state = &runtime->gc;
+    struct _gc_runtime_state *state = &tstate->interp->runtime->gc;
     if (state->garbage == NULL) {
         state->garbage = PyList_New(0);
         if (state->garbage == NULL) {


### PR DESCRIPTION
Add PyInterpreterState.runtime field: reference to the _PyRuntime
global variable. This field exists to not have to pass runtime in
addition to tstate to a function.  Get runtime from tstate:
tstate->interp->runtime.

Remove "_PyRuntimeState *runtime" parameter from functions already
taking a "PyThreadState *tstate" parameter.

_PyGC_Init() first parameter becomes "PyThreadState *tstate".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36710](https://bugs.python.org/issue36710) -->
https://bugs.python.org/issue36710
<!-- /issue-number -->
