### PR TITLE
bpo-38698: Prevent UnboundLocalError to pop up in parse_message_id

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2113,7 +2113,8 @@ def parse_message_id(value):
     except errors.HeaderParseError:
         message_id.defects.append(errors.InvalidHeaderDefect(
             "Expected msg-id but found {!r}".format(value)))
-    message_id.append(token)
+    else:
+        message_id.append(token)
     return message_id
 
 #

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2638,6 +2638,12 @@ class TestParser(TestParserMixin, TestEmailBase):
         )
         self.assertEqual(msg_id.token_type, 'msg-id')
 
+    def test_get_msg_id_invalid_expected_msg_id_not_found(self):
+        text = "Message-Id: 935-XPB-567:0:86089:180874:0:45327:9:90305:17843586-40@example.com"
+        msg_id = parser.parse_message_id(text)
+        self.assertDefectsEqual(msg_id.all_defects,
+                                [errors.InvalidHeaderDefect])
+
     def test_get_msg_id_no_angle_start(self):
         with self.assertRaises(errors.HeaderParseError):
             parser.get_msg_id("msgwithnoankle")

--- a/Misc/NEWS.d/next/Library/2019-12-02-10-35-19.bpo-38698.WZnAPQ.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-02-10-35-19.bpo-38698.WZnAPQ.rst
@@ -1,0 +1,5 @@
+Prevent UnboundLocalError to pop up in parse_message_id
+
+parse_message_id() was improperly using a token defined inside an exception
+handler, which was raising `UnboundLocalError` on parsing an invalid value.
+Patch by Claudiu Popa.


### PR DESCRIPTION
parse_message_id() was improperly using a token defined inside an exception
handler, which was raising `UnboundLocalError` on parsing an invalid value.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-38698](https://bugs.python.org/issue38698) -->
https://bugs.python.org/issue38698
<!-- /issue-number -->


Automerge-Triggered-By: @maxking