### PR TITLE
bpo-37340: Remove PyMethod_ClearFreeList() and PyCFunction_ClearFreeList()

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -217,6 +217,7 @@ Build and C API Changes
   ``PyThreadState.recursion_depth`` field. Remove ``_Py_CheckRecursionLimit``
   from the stable ABI.
   (Contributed by Victor Stinner in :issue:`38644`.)
+
 * Add a new public :c:func:`PyObject_CallNoArgs` function to the C API, which
   calls a callable Python object without any arguments. It is the most efficient
   way to call a callable Python object without any argument.
@@ -229,6 +230,10 @@ Build and C API Changes
 * Exclude ``PyFPE_START_PROTECT()`` and ``PyFPE_END_PROTECT()`` macros of
   ``pyfpe.h`` from ``Py_LIMITED_API`` (stable API).
   (Contributed by Victor Stinner in :issue:`38835`.)
+
+* Remove ``PyMethod_ClearFreeList()`` and ``PyCFunction_ClearFreeList()``
+  functions: the free lists of bound method objects have been removed.
+  (Contributed by Inada Naoki and Victor Stinner in :issue:`37340`.)
 
 
 Deprecated

--- a/Include/classobject.h
+++ b/Include/classobject.h
@@ -33,8 +33,6 @@ PyAPI_FUNC(PyObject *) PyMethod_Self(PyObject *);
 #define PyMethod_GET_SELF(meth) \
         (((PyMethodObject *)meth) -> im_self)
 
-PyAPI_FUNC(int) PyMethod_ClearFreeList(void);
-
 typedef struct {
     PyObject_HEAD
     PyObject *func;

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -59,9 +59,7 @@ extern PyStatus _PyGC_Init(PyThreadState *tstate);
 
 /* Various internal finalizers */
 
-extern void _PyMethod_Fini(void);
 extern void _PyFrame_Fini(void);
-extern void _PyCFunction_Fini(void);
 extern void _PyDict_Fini(void);
 extern void _PyTuple_Fini(void);
 extern void _PyList_Fini(void);

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -97,8 +97,6 @@ typedef struct {
 } PyCFunctionObject;
 #endif
 
-PyAPI_FUNC(int) PyCFunction_ClearFreeList(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C API/2019-11-20-11-08-06.bpo-37340.JBQJMS.rst
+++ b/Misc/NEWS.d/next/C API/2019-11-20-11-08-06.bpo-37340.JBQJMS.rst
@@ -1,0 +1,2 @@
+Remove ``PyMethod_ClearFreeList()`` and ``PyCFunction_ClearFreeList()``
+functions: the free lists of bound method objects have been removed.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1029,9 +1029,7 @@ delete_garbage(PyThreadState *tstate, GCState *gcstate,
 static void
 clear_freelists(void)
 {
-    (void)PyMethod_ClearFreeList();
     (void)PyFrame_ClearFreeList();
-    (void)PyCFunction_ClearFreeList();
     (void)PyTuple_ClearFreeList();
     (void)PyUnicode_ClearFreeList();
     (void)PyFloat_ClearFreeList();

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -371,20 +371,6 @@ PyTypeObject PyMethod_Type = {
     method_new,                                 /* tp_new */
 };
 
-/* Clear out the free list */
-
-int
-PyMethod_ClearFreeList(void)
-{
-    return 0;
-}
-
-void
-_PyMethod_Fini(void)
-{
-    (void)PyMethod_ClearFreeList();
-}
-
 /* ------------------------------------------------------------------------
  * instance method
  */

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -313,21 +313,6 @@ PyTypeObject PyCFunction_Type = {
     0,                                          /* tp_dict */
 };
 
-/* Clear out the free list */
-
-int
-PyCFunction_ClearFreeList(void)
-{
-    return 0;
-}
-
-void
-_PyCFunction_Fini(void)
-{
-    (void)PyCFunction_ClearFreeList();
-}
-
-
 /* Vectorcall functions for each of the PyCFunction calling conventions,
  * except for METH_VARARGS (possibly combined with METH_KEYWORDS) which
  * doesn't use vectorcall.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1173,9 +1173,7 @@ finalize_interp_types(PyThreadState *tstate, int is_main_interp)
 {
     if (is_main_interp) {
         /* Sundry finalizers */
-        _PyMethod_Fini();
         _PyFrame_Fini();
-        _PyCFunction_Fini();
         _PyTuple_Fini();
         _PyList_Fini();
         _PySet_Fini();


### PR DESCRIPTION
Remove PyMethod_ClearFreeList() and PyCFunction_ClearFreeList()
functions: the free list of bound method objects and the free list of
C functions have been removed.
    
Remove also _PyMethod_Fini() and _PyCFunction_Fini() functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37340](https://bugs.python.org/issue37340) -->
https://bugs.python.org/issue37340
<!-- /issue-number -->
