### PR TITLE
bpo-38692: Skip test_posix.test_pidfd_open() on EPERM

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1476,6 +1476,8 @@ class PosixTester(unittest.TestCase):
             os.pidfd_open(-1)
         if cm.exception.errno == errno.ENOSYS:
             self.skipTest("system does not support pidfd_open")
+        if isinstance(cm.exception, PermissionError):
+            self.skipTest(f"pidfd_open syscall blocked: {cm.exception!r}")
         self.assertEqual(cm.exception.errno, errno.EINVAL)
         os.close(os.pidfd_open(os.getpid(), 0))
 

--- a/Misc/NEWS.d/next/Tests/2019-11-20-15-42-06.bpo-38692.aqAvyF.rst
+++ b/Misc/NEWS.d/next/Tests/2019-11-20-15-42-06.bpo-38692.aqAvyF.rst
@@ -1,0 +1,3 @@
+Skip the test_posix.test_pidfd_open() test if ``os.pidfd_open()`` fails with a
+:exc:`PermissionError`. This situation can happen in a Linux sandbox using a
+syscall whitelist which doesn't allow the ``pidfd_open()`` syscall yet.


### PR DESCRIPTION
Skip test_posix.test_pidfd_open() test if os.pidfd_open() fails with
a PermissionError. It can happen in a Linux sandbox using a whitelist
of syscalls which doesn't allow pidfd_open syscall yet.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38692](https://bugs.python.org/issue38692) -->
https://bugs.python.org/issue38692
<!-- /issue-number -->
