### PR TITLE
bpo-38863: Fix a bug of is_cgi() in http.server

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1013,7 +1013,7 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
 
         """
         collapsed_path = _url_collapse_path(self.path)
-        dir_sep = collapsed_path.find('/', 1)
+        dir_sep = collapsed_path.rfind('/', 1)
         head, tail = collapsed_path[:dir_sep], collapsed_path[dir_sep+1:]
         if head in self.cgi_directories:
             self.cgi_info = head, tail


### PR DESCRIPTION
is_cgi() function of http.server library does not correctly separate
given path for cgi script into a directory and a file part. is_cgi() in
CGIHTTPRequestHandler class separates given path into (dir, rest) then
checks if dir is in cgi_directories. However, it divides based on the
first seen '/', multi-level directories like /sub/dir/cgi-bin/hello.py
is divided into head=/sub, rest=dir/cgi-bin/hello.py then check whether
'/sub' exists in cgi_directories = [..., '/sub/dir/cgi-bin'].
If the function divides by last seen '/', it works correctly as
head=/sub/dir/cgi-bin, rest=hello.py

Signed-off-by: Siwon Kang <kkangshawn@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38863](https://bugs.python.org/issue38863) -->
https://bugs.python.org/issue38863
<!-- /issue-number -->
