### PR TITLE
bpo-38841: Skip asyncio test_create_datagram_endpoint_existing_sock_unix

### DIFF
--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1700,7 +1700,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.loop.run_until_complete(protocol.done)
         self.assertEqual('CLOSED', protocol.state)
 
-    @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), 'No UNIX Sockets')
+    @support.skip_unless_bind_unix_socket
     def test_create_datagram_endpoint_existing_sock_unix(self):
         with test_utils.unix_socket_path() as path:
             sock = socket.socket(socket.AF_UNIX, type=socket.SOCK_DGRAM)

--- a/Misc/NEWS.d/next/Tests/2019-11-20-16-08-19.bpo-38841.5F5Lbw.rst
+++ b/Misc/NEWS.d/next/Tests/2019-11-20-16-08-19.bpo-38841.5F5Lbw.rst
@@ -1,0 +1,2 @@
+Skip asyncio test_create_datagram_endpoint_existing_sock_unix on platforms
+lacking a functional bind() for named unix domain sockets.


### PR DESCRIPTION
on platforms lacking a functional bind() for named unix domain sockets


<!-- issue-number: [bpo-38841](https://bugs.python.org/issue38841) -->
https://bugs.python.org/issue38841
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov