### PR TITLE
[typo] fix dupe in datetime.fromisoformat docs

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -997,8 +997,6 @@ Other constructors, all class methods:
      as the inverse operation of :meth:`datetime.isoformat`. A more full-featured
      ISO 8601 parser, ``dateutil.parser.isoparse`` is available in the third-party package
      `dateutil <https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse>`__.
-     This does not support parsing arbitrary ISO 8601 strings - it is only intended
-     as the inverse operation of :meth:`datetime.isoformat`.
 
    Examples::
 


### PR DESCRIPTION
Fixes a nearly word for word duplication of a sentence that appears
earlier in the caution section of datetime.datetime.fromisoformat in
Doc/Library/datetime.rst.

No issue created as it's a trivial change.

Automerge-Triggered-By: @pganssle