### PR TITLE
bpo-38823: Add a private _PyModule_StealObject API.

### DIFF
--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -134,6 +134,7 @@ void _PyArg_Fini(void);
 #endif   /* Py_LIMITED_API */
 
 PyAPI_FUNC(int) PyModule_AddObject(PyObject *, const char *, PyObject *);
+PyAPI_FUNC(int) _PyModule_StealObject(PyObject *, const char *, PyObject *);
 PyAPI_FUNC(int) PyModule_AddIntConstant(PyObject *, const char *, long);
 PyAPI_FUNC(int) PyModule_AddStringConstant(PyObject *, const char *, const char *);
 #define PyModule_AddIntMacro(m, c) PyModule_AddIntConstant(m, #c, c)

--- a/Misc/NEWS.d/next/C API/2019-11-20-18-47-48.bpo-38823.x1nghH.rst
+++ b/Misc/NEWS.d/next/C API/2019-11-20-18-47-48.bpo-38823.x1nghH.rst
@@ -1,0 +1,3 @@
+Add a new private ``_PyModule_StealObject`` API. It is identical to :c:func:`PyModule_AddObject`, but steals a reference to the added object on both success *and* failure.
+
+Patch by Brandt Bucher.

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -755,11 +755,20 @@ PyInit__bz2(void)
         return NULL;
 
     Py_INCREF(&BZ2Compressor_Type);
-    PyModule_AddObject(m, "BZ2Compressor", (PyObject *)&BZ2Compressor_Type);
+    if (_PyModule_StealObject(m, "BZ2Compressor",
+                            (PyObject *)&BZ2Compressor_Type) < 0) {
+        goto fail;
+    }
 
     Py_INCREF(&BZ2Decompressor_Type);
-    PyModule_AddObject(m, "BZ2Decompressor",
-                       (PyObject *)&BZ2Decompressor_Type);
+    if (_PyModule_StealObject(m, "BZ2Decompressor",
+                            (PyObject *)&BZ2Decompressor_Type) < 0) {
+        goto fail;
+    }
 
     return m;
+
+fail:
+    Py_DECREF(m);
+    return NULL;
 }

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2539,34 +2539,55 @@ PyInit__collections(void)
     if (m == NULL)
         return NULL;
 
-    if (PyType_Ready(&deque_type) < 0)
-        return NULL;
+    if (PyType_Ready(&deque_type) < 0) {
+        goto fail;
+    }
     Py_INCREF(&deque_type);
-    PyModule_AddObject(m, "deque", (PyObject *)&deque_type);
+    if (_PyModule_StealObject(m, "deque", (PyObject *)&deque_type) < 0) {
+        goto fail;
+    }
 
     defdict_type.tp_base = &PyDict_Type;
-    if (PyType_Ready(&defdict_type) < 0)
-        return NULL;
+    if (PyType_Ready(&defdict_type) < 0) {
+        goto fail;
+    }
     Py_INCREF(&defdict_type);
-    PyModule_AddObject(m, "defaultdict", (PyObject *)&defdict_type);
+    if (_PyModule_StealObject(m, "defaultdict", (PyObject *)&defdict_type) < 0) {
+        goto fail;
+    }
 
     Py_INCREF(&PyODict_Type);
-    PyModule_AddObject(m, "OrderedDict", (PyObject *)&PyODict_Type);
+    if (_PyModule_StealObject(m, "OrderedDict", (PyObject *)&PyODict_Type) < 0) {
+        goto fail;
+    }
 
-    if (PyType_Ready(&dequeiter_type) < 0)
-        return NULL;
+    if (PyType_Ready(&dequeiter_type) < 0) {
+        goto fail;
+    }
     Py_INCREF(&dequeiter_type);
-    PyModule_AddObject(m, "_deque_iterator", (PyObject *)&dequeiter_type);
+    if (_PyModule_StealObject(m, "_deque_iterator", (PyObject *)&dequeiter_type) < 0) {
+        goto fail;
+    }
 
-    if (PyType_Ready(&dequereviter_type) < 0)
-        return NULL;
+    if (PyType_Ready(&dequereviter_type) < 0) {
+        goto fail;
+    }
     Py_INCREF(&dequereviter_type);
-    PyModule_AddObject(m, "_deque_reverse_iterator", (PyObject *)&dequereviter_type);
+    if (_PyModule_StealObject(m, "_deque_reverse_iterator", (PyObject *)&dequereviter_type) < 0) {
+        goto fail;
+    }
 
-    if (PyType_Ready(&tuplegetter_type) < 0)
-        return NULL;
+    if (PyType_Ready(&tuplegetter_type) < 0) {
+        goto fail;
+    }
     Py_INCREF(&tuplegetter_type);
-    PyModule_AddObject(m, "_tuplegetter", (PyObject *)&tuplegetter_type);
+    if (_PyModule_StealObject(m, "_tuplegetter", (PyObject *)&tuplegetter_type) < 0) {
+        goto fail;
+    }
 
     return m;
+
+fail:
+    Py_DECREF(m);
+    return NULL;
 }

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1457,7 +1457,10 @@ PyInit__functools(void)
         }
         name = _PyType_Name(typelist[i]);
         Py_INCREF(typelist[i]);
-        PyModule_AddObject(m, name, (PyObject *)typelist[i]);
+        if (_PyModule_StealObject(m, name, (PyObject *)typelist[i]) < 0) {
+            Py_DECREF(m);
+            return NULL;
+        }
     }
     return m;
 }

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -1120,6 +1120,9 @@ PyInit__msi(void)
     MSIError = PyErr_NewException ("_msi.MSIError", NULL, NULL);
     if (!MSIError)
         return NULL;
-    PyModule_AddObject(m, "MSIError", MSIError);
+    if (_PyModule_StealObject(m, "MSIError", MSIError) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
     return m;
 }

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1353,17 +1353,17 @@ _PyWarnings_Init(void)
     }
 
     Py_INCREF(st->filters);
-    if (PyModule_AddObject(m, "filters", st->filters) < 0) {
+    if (_PyModule_StealObject(m, "filters", st->filters) < 0) {
         goto error;
     }
 
     Py_INCREF(st->once_registry);
-    if (PyModule_AddObject(m, "_onceregistry", st->once_registry) < 0) {
+    if (_PyModule_StealObject(m, "_onceregistry", st->once_registry) < 0) {
         goto error;
     }
 
     Py_INCREF(st->default_action);
-    if (PyModule_AddObject(m, "_defaultaction", st->default_action) < 0) {
+    if (_PyModule_StealObject(m, "_defaultaction", st->default_action) < 0) {
         goto error;
     }
 

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -655,6 +655,19 @@ PyModule_AddObject(PyObject *m, const char *name, PyObject *o)
     return 0;
 }
 
+/* Like PyModule_AddObject, but steals o on success AND failure.
+   This is probably what you want! */
+
+int
+_PyModule_StealObject(PyObject *m, const char *name, PyObject *o)
+{
+    if (PyModule_AddObject(m, name, o) < 0) {
+        Py_XDECREF(o);
+        return -1;
+    }
+    return 0;
+}
+
 int
 PyModule_AddIntConstant(PyObject *m, const char *name, long value)
 {


### PR DESCRIPTION
This will be helpful for the refactoring I'm doing in [bpo-38823](https://bugs.python.org/issue38823), and keep the diffs small. It's also just nice to have around, since it (not `PyModule_AddObject`) is actually what we want in most cases.

<!-- issue-number: [bpo-38823](https://bugs.python.org/issue38823) -->
https://bugs.python.org/issue38823
<!-- /issue-number -->
