### PR TITLE
bpo-37228: Fix loop.create_datagram_endpoint()'s usage of SO_REUSEADDR

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -476,7 +476,7 @@ Opening network connections
    .. note::
       The parameter *reuse_address* is no longer supported, as using
       :py:data:`~sockets.SO_REUSEADDR` poses a significant security concern for
-      UDP. Explicitly passing `reuse_address=True` will raise an exception.
+      UDP. Explicitly passing ``reuse_address=True`` will raise an exception.
       For supported platforms, *reuse_port* can be used instead for similar
       functionality.
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -477,8 +477,16 @@ Opening network connections
       The parameter *reuse_address* is no longer supported, as using
       :py:data:`~sockets.SO_REUSEADDR` poses a significant security concern for
       UDP. Explicitly passing ``reuse_address=True`` will raise an exception.
-      For supported platforms, *reuse_port* can be used instead for similar
-      functionality.
+
+      When multiple processes with differing UIDs assign sockets to an
+      indentical UDP socket address with ``SO_REUSEADDR``, incoming packets can
+      become randomly distributed among the sockets.
+
+      For supported platforms, *reuse_port* can be used as a replacement for
+      similar functionality. With *reuse_port*,
+      :py:data:`~sockets.SO_REUSEPORT` is used instead, which specifically
+      prevents processes with differing UIDs from assigning sockets to the same
+      socket address.
 
    Create a datagram connection.
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -537,7 +537,7 @@ Opening network connections
       The *family*, *proto*, *flags*, *reuse_address*, *reuse_port,
       *allow_broadcast*, and *sock* parameters were added.
 
-   .. versionchanged:: 3.5.10
+   .. versionchanged:: 3.8.1
       The *reuse_address* parameter is no longer supported due to security
       concerns.
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -473,6 +473,13 @@ Opening network connections
                         reuse_address=None, reuse_port=None, \
                         allow_broadcast=None, sock=None)
 
+   .. note::
+      The parameter *reuse_address* is no longer supported, as using
+      :py:data:`~sockets.SO_REUSEADDR` poses a significant security concern for
+      UDP. Explicitly passing `reuse_address=True` will raise an exception.
+      For supported platforms, *reuse_port* can be used instead for similar
+      functionality.
+
    Create a datagram connection.
 
    The socket family can be either :py:data:`~socket.AF_INET`,
@@ -501,11 +508,6 @@ Opening network connections
      resolution. If given, these should all be integers from the
      corresponding :mod:`socket` module constants.
 
-   * *reuse_address* tells the kernel to reuse a local socket in
-     ``TIME_WAIT`` state, without waiting for its natural timeout to
-     expire. If not specified will automatically be set to ``True`` on
-     Unix.
-
    * *reuse_port* tells the kernel to allow this endpoint to be bound to the
      same port as other existing endpoints are bound to, so long as they all
      set this flag when being created. This option is not supported on Windows
@@ -526,6 +528,10 @@ Opening network connections
    .. versionchanged:: 3.4.4
       The *family*, *proto*, *flags*, *reuse_address*, *reuse_port,
       *allow_broadcast*, and *sock* parameters were added.
+
+   .. versionchanged:: 3.5.10
+      The *reuse_address* parameter is no longer supported due to security
+      concerns.
 
    .. versionchanged:: 3.8
       Added support for Windows.

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1309,9 +1309,9 @@ class BaseEventLoop(events.AbstractEventLoop):
             if reuse_address:
                 # bpo-37228
                 raise ValueError("Passing `reuse_address=True` is no "
-                                   "longer supported, as the usage of "
-                                   "SO_REUSEPORT in UDP poses a significant "
-                                   "security concern.")
+                                 "longer supported, as the usage of "
+                                 "SO_REUSEPORT in UDP poses a significant "
+                                 "security concern.")
 
             for ((family, proto),
                  (local_address, remote_address)) in addr_pairs_info:

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1243,7 +1243,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                     f'A UDP Socket was expected, got {sock!r}')
             if (local_addr or remote_addr or
                     family or proto or flags or
-                    reuse_address or reuse_port or allow_broadcast):
+                    reuse_port or allow_broadcast):
                 # show the problematic kwargs in exception msg
                 opts = dict(local_addr=local_addr, remote_addr=remote_addr,
                             family=family, proto=proto, flags=flags,

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1306,8 +1306,12 @@ class BaseEventLoop(events.AbstractEventLoop):
 
             exceptions = []
 
-            if reuse_address is None:
-                reuse_address = os.name == 'posix' and sys.platform != 'cygwin'
+            if reuse_address:
+                # bpo-37228
+                raise RuntimeError("Passing `reuse_address=True` is no "
+                                   "longer supported, as the usage of "
+                                   "SO_REUSEPORT in UDP poses a significant "
+                                   "security concern.")
 
             for ((family, proto),
                  (local_address, remote_address)) in addr_pairs_info:
@@ -1316,9 +1320,6 @@ class BaseEventLoop(events.AbstractEventLoop):
                 try:
                     sock = socket.socket(
                         family=family, type=socket.SOCK_DGRAM, proto=proto)
-                    if reuse_address:
-                        sock.setsockopt(
-                            socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                     if reuse_port:
                         _set_reuseport(sock)
                     if allow_broadcast:

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1308,7 +1308,7 @@ class BaseEventLoop(events.AbstractEventLoop):
 
             if reuse_address:
                 # bpo-37228
-                raise RuntimeError("Passing `reuse_address=True` is no "
+                raise ValueError("Passing `reuse_address=True` is no "
                                    "longer supported, as the usage of "
                                    "SO_REUSEPORT in UDP poses a significant "
                                    "security concern.")

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1739,10 +1739,6 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.assertRaises(ValueError, self.loop.run_until_complete, fut)
 
         fut = self.loop.create_datagram_endpoint(
-            MyDatagramProto, reuse_address=True, sock=FakeSock())
-        self.assertRaises(ValueError, self.loop.run_until_complete, fut)
-
-        fut = self.loop.create_datagram_endpoint(
             MyDatagramProto, reuse_port=True, sock=FakeSock())
         self.assertRaises(ValueError, self.loop.run_until_complete, fut)
 
@@ -1807,6 +1803,17 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             reuse_address=True)
 
         with self.assertRaises(ValueError):
+            self.loop.run_until_complete(coro)
+
+    def test_create_datagram_endpoint_reuse_address_warning(self):
+        # bpo-37228: Deprecate *reuse_address* parameter
+
+        coro = self.loop.create_datagram_endpoint(
+            lambda: MyDatagramProto(create_future=True, loop=self.loop),
+            local_addr=('127.0.0.1', 0),
+            reuse_address=False)
+
+        with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(coro)
 
     @patch_socket

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1752,7 +1752,6 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
 
     def test_create_datagram_endpoint_sockopts(self):
         # Socket options should not be applied unless asked for.
-        # SO_REUSEADDR defaults to on for UNIX.
         # SO_REUSEPORT is not available on all platforms.
 
         coro = self.loop.create_datagram_endpoint(
@@ -1761,18 +1760,8 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         transport, protocol = self.loop.run_until_complete(coro)
         sock = transport.get_extra_info('socket')
 
-        reuse_address_default_on = (
-            os.name == 'posix' and sys.platform != 'cygwin')
         reuseport_supported = hasattr(socket, 'SO_REUSEPORT')
 
-        if reuse_address_default_on:
-            self.assertTrue(
-                sock.getsockopt(
-                    socket.SOL_SOCKET, socket.SO_REUSEADDR))
-        else:
-            self.assertFalse(
-                sock.getsockopt(
-                    socket.SOL_SOCKET, socket.SO_REUSEADDR))
         if reuseport_supported:
             self.assertFalse(
                 sock.getsockopt(
@@ -1788,13 +1777,12 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         coro = self.loop.create_datagram_endpoint(
             lambda: MyDatagramProto(create_future=True, loop=self.loop),
             local_addr=('127.0.0.1', 0),
-            reuse_address=True,
             reuse_port=reuseport_supported,
             allow_broadcast=True)
         transport, protocol = self.loop.run_until_complete(coro)
         sock = transport.get_extra_info('socket')
 
-        self.assertTrue(
+        self.assertFalse(
             sock.getsockopt(
                 socket.SOL_SOCKET, socket.SO_REUSEADDR))
         if reuseport_supported:
@@ -1808,6 +1796,18 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         transport.close()
         self.loop.run_until_complete(protocol.done)
         self.assertEqual('CLOSED', protocol.state)
+
+    def test_create_datagram_endpoint_reuse_address_error(self):
+        # bpo-37228: Ensure that explicit passing of `reuse_address=True`
+        # raises an error, as it is not safe to use SO_REUSEADDR when using UDP
+
+        coro = self.loop.create_datagram_endpoint(
+            lambda: MyDatagramProto(create_future=True, loop=self.loop),
+            local_addr=('127.0.0.1', 0),
+            reuse_address=True)
+
+        with self.assertRaises(RuntimeError):
+            self.loop.run_until_complete(coro)
 
     @patch_socket
     def test_create_datagram_endpoint_nosoreuseport(self, m_socket):

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1806,7 +1806,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             local_addr=('127.0.0.1', 0),
             reuse_address=True)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             self.loop.run_until_complete(coro)
 
     @patch_socket

--- a/Misc/NEWS.d/next/Security/2019-11-21-21-36-54.bpo-37228.yBZnFG.rst
+++ b/Misc/NEWS.d/next/Security/2019-11-21-21-36-54.bpo-37228.yBZnFG.rst
@@ -1,3 +1,4 @@
 Due to significant security concerns, the *reuse_address* parameter of
 :meth:`asyncio.loop.create_datagram_endpoint` is no longer supported. This is
-due to the behavior of ``SO_REUSEADDR`` in UDP.
+because of the behavior of ``SO_REUSEADDR`` in UDP. For more details, see the
+documentation for ``loop.create_datagram_endpoint()``.

--- a/Misc/NEWS.d/next/Security/2019-11-21-21-36-54.bpo-37228.yBZnFG.rst
+++ b/Misc/NEWS.d/next/Security/2019-11-21-21-36-54.bpo-37228.yBZnFG.rst
@@ -1,3 +1,3 @@
 Due to significant security concerns, the *reuse_address* parameter of
 :meth:`asyncio.loop.create_datagram_endpoint` is no longer supported. This is
-due to the behavior of `SO_REUSEADDR` in UDP.
+due to the behavior of ``SO_REUSEADDR`` in UDP.

--- a/Misc/NEWS.d/next/Security/2019-11-21-21-36-54.bpo-37228.yBZnFG.rst
+++ b/Misc/NEWS.d/next/Security/2019-11-21-21-36-54.bpo-37228.yBZnFG.rst
@@ -1,0 +1,3 @@
+Due to significant security concerns, the *reuse_address* parameter of
+:meth:`asyncio.loop.create_datagram_endpoint` is no longer supported. This is
+due to the behavior of `SO_REUSEADDR` in UDP.

--- a/Misc/NEWS.d/next/Security/2019-11-21-21-36-54.bpo-37228.yBZnFG.rst
+++ b/Misc/NEWS.d/next/Security/2019-11-21-21-36-54.bpo-37228.yBZnFG.rst
@@ -2,3 +2,5 @@ Due to significant security concerns, the *reuse_address* parameter of
 :meth:`asyncio.loop.create_datagram_endpoint` is no longer supported. This is
 because of the behavior of ``SO_REUSEADDR`` in UDP. For more details, see the
 documentation for ``loop.create_datagram_endpoint()``.
+(Contributed by Kyle Stanley, Antoine Pitrou, and Yury Selivanov in
+:issue:`37228`.)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Edit: This PR has been revised based on @pitrou's proposal, due to Windows compatibility concerns.

<!-- issue-number: [bpo-37228](https://bugs.python.org/issue37228) -->
https://bugs.python.org/issue37228
<!-- /issue-number -->
