### PR TITLE
bpo-38875: test_capi: trashcan tests require cpu resource

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -351,9 +351,11 @@ class CAPITest(unittest.TestCase):
         for i in range(1000):
             L = MyList((L,))
 
+    @support.requires_resource('cpu')
     def test_trashcan_python_class1(self):
         self.do_test_trashcan_python_class(list)
 
+    @support.requires_resource('cpu')
     def test_trashcan_python_class2(self):
         from _testcapi import MyList
         self.do_test_trashcan_python_class(MyList)

--- a/Misc/NEWS.d/next/Tests/2019-11-21-09-11-06.bpo-38875.wSZJal.rst
+++ b/Misc/NEWS.d/next/Tests/2019-11-21-09-11-06.bpo-38875.wSZJal.rst
@@ -1,0 +1,1 @@
+test_capi: trashcan tests now require the test "cpu" resource.


### PR DESCRIPTION
test_capi: trashcan tests now require the test "cpu" resource.

<!-- issue-number: [bpo-38875](https://bugs.python.org/issue38875) -->
https://bugs.python.org/issue38875
<!-- /issue-number -->
