### PR TITLE
bpo-38866: Remove asyncore from test_pyclbr.py

### DIFF
--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -247,7 +247,7 @@ class ReadmoduleTests(TestCase):
         # not a package.
         #
         # Issue #14798.
-        self.assertRaises(ImportError, pyclbr.readmodule_ex, 'foo.bar')
+        self.assertRaises(ImportError, pyclbr.readmodule_ex, 'asyncio.foo')
 
     def test_module_has_no_spec(self):
         module_name = "doesnotexist"

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -247,7 +247,7 @@ class ReadmoduleTests(TestCase):
         # not a package.
         #
         # Issue #14798.
-        self.assertRaises(ImportError, pyclbr.readmodule_ex, 'asyncore.foo')
+        self.assertRaises(ImportError, pyclbr.readmodule_ex, 'foo.bar')
 
     def test_module_has_no_spec(self):
         module_name = "doesnotexist"


### PR DESCRIPTION
This change (trivially) removes the mention of `asyncore` from Lib/test/test_pyclbr.py as part of [issue 28533](https://bugs.python.org/issue28533), as it is not required for this test. 

<!-- issue-number: [bpo-38866](https://bugs.python.org/issue38866) -->
https://bugs.python.org/issue38866
<!-- /issue-number -->
