### PR TITLE
bpo-38526: Fix zipfile.Path method name to be the correct one

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -494,7 +494,7 @@ Path objects are traversable using the ``/`` operator.
    Invoke :meth:`ZipFile.open` on the current path. Accepts
    the same arguments as :meth:`ZipFile.open`.
 
-.. method:: Path.listdir()
+.. method:: Path.iterdir()
 
    Enumerate the children of the current directory.
 


### PR DESCRIPTION
Super minor one, fixes a correct method name in documentation. `zipfile.Path.listdir` does not actually exist, but there is `zipfile.Path.iterdir` which seems to be what was originally intentioned.

https://bugs.python.org/issue38526

<!-- issue-number: [bpo-38526](https://bugs.python.org/issue38526) -->
https://bugs.python.org/issue38526
<!-- /issue-number -->
