### PR TITLE
bpo-33387: Correct release version to 3.9 for new bytecodes

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -710,7 +710,7 @@ iterations of the loop.
 
     Re-raises the exception currently on top of the stack.
 
-    .. versionadded:: 3.8
+    .. versionadded:: 3.9
 
 
 .. opcode:: WITH_EXCEPT_START
@@ -720,7 +720,7 @@ iterations of the loop.
     Used to implement the call ``context_manager.__exit__(*exc_info())`` when an exception
     has occurred in a :keyword:`with` statement.
 
-    .. versionadded:: 3.8
+    .. versionadded:: 3.9
 
 
 .. opcode:: LOAD_ASSERTION_ERROR


### PR DESCRIPTION


<!-- issue-number: [bpo-33387](https://bugs.python.org/issue33387) -->
https://bugs.python.org/issue33387
<!-- /issue-number -->
