### PR TITLE
bpo-29275: Remove Y2K reference from time module docs

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -43,16 +43,13 @@ An explanation of some terminology and conventions is in order.
 
 .. index::
    single: Year 2000
+   single: 2-digit years
    single: Y2K
 
-.. _time-y2kissues:
-
-* **Year 2000 (Y2K) issues**: Python depends on the platform's C library, which
-  generally doesn't have year 2000 issues, since all dates and times are
-  represented internally as seconds since the epoch.  Function :func:`strptime`
-  can parse 2-digit years when given ``%y`` format code.  When 2-digit years are
-  parsed, they are converted according to the POSIX and ISO C standards: values
-  69--99 are mapped to 1969--1999, and values 0--68 are mapped to 2000--2068.
+* Function :func:`strptime` can parse 2-digit years when given ``%y`` format
+  code. When 2-digit years are parsed, they are converted according to the POSIX
+  and ISO C standards: values 69--99 are mapped to 1969--1999, and values 0--68
+  are mapped to 2000--2068.
 
 .. index::
    single: UTC

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -42,9 +42,7 @@ An explanation of some terminology and conventions is in order.
   library; for 32-bit systems, it is typically in 2038.
 
 .. index::
-   single: Year 2000
    single: 2-digit years
-   single: Y2K
 
 * Function :func:`strptime` can parse 2-digit years when given ``%y`` format
   code. When 2-digit years are parsed, they are converted according to the POSIX


### PR DESCRIPTION
The Y2K reference is no longer needed as it only points out that Python's use of C standard functions doesn't generally suffer from Y2K issues; the point regarding conventions for conversion of 2-digit years in :func:`strptime` is still valid.

Some advice on what indexes to add/remove would be appreciated alongside review.

<!-- issue-number: [bpo-29275](https://bugs.python.org/issue29275) -->
https://bugs.python.org/issue29275
<!-- /issue-number -->
