### PR TITLE
bpo-38721: Add support for import hooks in modulefinder

### DIFF
--- a/Lib/modulefinder.py
+++ b/Lib/modulefinder.py
@@ -445,15 +445,16 @@ class ModuleFinder:
         for finder in sys.meta_path:
             with _ImportLockContext():
                 if finder is importlib.machinery.PathFinder and path is None:
-                    return finder.find_spec(name, self.path)
-                try:
-                    find_spec = finder.find_spec
-                except AttributeError:
-                    spec = _find_spec_legacy(finder, name, path)
-                    if spec is None:
-                        continue
+                    spec = finder.find_spec(name, self.path)
                 else:
-                    spec = find_spec(name, path, None)
+                    try:
+                        find_spec = finder.find_spec
+                    except AttributeError:
+                        spec = _find_spec_legacy(finder, name, path)
+                        if spec is None:
+                            continue
+                    else:
+                        spec = find_spec(name, path, None)
             if spec is not None:
                 # The parent import may have already imported this module.
                 if not is_reload and name in sys.modules:

--- a/Lib/test/test_modulefinder.py
+++ b/Lib/test/test_modulefinder.py
@@ -1,10 +1,11 @@
 import os
 import errno
-import importlib.machinery
 import py_compile
 import shutil
 import unittest
 import tempfile
+import sys
+from importlib.machinery import SOURCE_SUFFIXES, BYTECODE_SUFFIXES, ModuleSpec
 
 from test import support
 
@@ -13,7 +14,7 @@ import modulefinder
 TEST_DIR = tempfile.mkdtemp()
 TEST_PATH = [TEST_DIR, os.path.dirname(tempfile.__file__)]
 
-# Each test description is a list of 5 items:
+# Test descriptions will be a list of 5 items:
 #
 # 1. a module name that will be imported by modulefinder
 # 2. a list of module names that modulefinder is required to find
@@ -27,6 +28,65 @@ TEST_PATH = [TEST_DIR, os.path.dirname(tempfile.__file__)]
 # removed after the tests again.
 # Modulefinder searches in a path that contains TEST_DIR, plus
 # the standard Lib directory.
+
+def open_file(path):
+    dirname = os.path.dirname(path)
+    try:
+        os.makedirs(dirname)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+    return open(path, "w")
+
+
+def create_package(source):
+    ofi = None
+    try:
+        for line in source.splitlines():
+            if line.startswith(" ") or line.startswith("\t"):
+                ofi.write(line.strip() + "\n")
+            else:
+                if ofi:
+                    ofi.close()
+                ofi = open_file(os.path.join(TEST_DIR, line.strip()))
+    finally:
+        if ofi:
+            ofi.close()
+
+
+def _do_test(test_case, info, report=False, debug=0, replace_paths=[]):
+    import_this, modules, missing, maybe_missing, source = info
+    if source is not None:
+        create_package(source)
+    try:
+        mf = modulefinder.ModuleFinder(path=TEST_PATH, debug=debug,
+                                       replace_paths=replace_paths)
+        mf.import_hook(import_this)
+        if report:
+            mf.report()
+##          # This wouldn't work in general when executed several times:
+##          opath = sys.path[:]
+##          sys.path = TEST_PATH
+##          try:
+##              __import__(import_this)
+##          except:
+##              import traceback; traceback.print_exc()
+##          sys.path = opath
+##          return
+        modules = sorted(set(modules))
+        found = sorted(mf.modules)
+        # check if we found what we expected, not more, not less
+        test_case.assertEqual(found, modules)
+
+        # check for missing and maybe missing modules
+        bad, maybe = mf.any_missing_maybe()
+        test_case.assertEqual(bad, missing)
+        test_case.assertEqual(maybe, maybe_missing)
+    finally:
+        if source is not None:
+            shutil.rmtree(TEST_DIR)
+
+
 
 maybe_test = [
     "a.module",
@@ -246,108 +306,97 @@ b/c.py
 """]
 
 
-def open_file(path):
-    dirname = os.path.dirname(path)
-    try:
-        os.makedirs(dirname)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
-    return open(path, "w")
+second_dir = os.path.join(TEST_DIR, "second_dir")
+third_dir = os.path.join(TEST_DIR, "third_dir")
+modulefinder.AddPackagePath("extended_package", second_dir)
+modulefinder.AddPackagePath("extended_package", third_dir)
+
+namespace_package_test = [
+    "a",
+    ["a", "extended_package", "extended_package.b",
+     "extended_package.b.c", "extended_package.b.e",
+     "extended_package.b.f", "extended_package.d"],
+    ["extended_package.b.arglebargle", "extended_package.b.b"], [],
+    """\
+a.py
+                                import extended_package.b.c
+                                import extended_package.b.e
+extended_package/__init__.py
+extended_package/b/c.py
+                                import extended_package.b.arglebargle
+extended_package/d.py
+second_dir/b/e.py
+                                from . import f
+                                from .. import d
+third_dir/b/f.py
+                                import extended_package.b.b
+"""]
+
+namespace_package_test_2 = [
+    "a",
+    ["a", "extended_package", "extended_package.b",
+     "extended_package.b.c"],
+    ["extended_package.b.a"], [],
+    """\
+a.py
+                                # Should load from second_dir, since it's
+                                # earlier on the path
+                                import extended_package.b.c
+extended_package/__init__.py
+second_dir/b/c.py
+                                import extended_package.b.a
+third_dir/b/c.py
+"""]
 
 
-def create_package(source):
-    ofi = None
-    try:
-        for line in source.splitlines():
-            if line.startswith(" ") or line.startswith("\t"):
-                ofi.write(line.strip() + "\n")
-            else:
-                if ofi:
-                    ofi.close()
-                ofi = open_file(os.path.join(TEST_DIR, line.strip()))
-    finally:
-        if ofi:
-            ofi.close()
-
-
-class ModuleFinderTest(unittest.TestCase):
-    def _do_test(self, info, report=False, debug=0, replace_paths=[]):
-        import_this, modules, missing, maybe_missing, source = info
-        create_package(source)
-        try:
-            mf = modulefinder.ModuleFinder(path=TEST_PATH, debug=debug,
-                                           replace_paths=replace_paths)
-            mf.import_hook(import_this)
-            if report:
-                mf.report()
-##                # This wouldn't work in general when executed several times:
-##                opath = sys.path[:]
-##                sys.path = TEST_PATH
-##                try:
-##                    __import__(import_this)
-##                except:
-##                    import traceback; traceback.print_exc()
-##                sys.path = opath
-##                return
-            modules = sorted(set(modules))
-            found = sorted(mf.modules)
-            # check if we found what we expected, not more, not less
-            self.assertEqual(found, modules)
-
-            # check for missing and maybe missing modules
-            bad, maybe = mf.any_missing_maybe()
-            self.assertEqual(bad, missing)
-            self.assertEqual(maybe, maybe_missing)
-        finally:
-            shutil.rmtree(TEST_DIR)
+class BasicTests(unittest.TestCase):
 
     def test_package(self):
-        self._do_test(package_test)
+        _do_test(self, package_test)
 
     def test_maybe(self):
-        self._do_test(maybe_test)
+        _do_test(self, maybe_test)
 
     def test_maybe_new(self):
-        self._do_test(maybe_test_new)
+        _do_test(self, maybe_test_new)
 
     def test_absolute_imports(self):
-        self._do_test(absolute_import_test)
+        _do_test(self, absolute_import_test)
 
     def test_relative_imports(self):
-        self._do_test(relative_import_test)
+        _do_test(self, relative_import_test)
 
     def test_relative_imports_2(self):
-        self._do_test(relative_import_test_2)
+        _do_test(self, relative_import_test_2)
 
     def test_relative_imports_3(self):
-        self._do_test(relative_import_test_3)
+        _do_test(self, relative_import_test_3)
 
     def test_relative_imports_4(self):
-        self._do_test(relative_import_test_4)
+        _do_test(self, relative_import_test_4)
 
     def test_syntax_error(self):
-        self._do_test(syntax_error_test)
+        _do_test(self, syntax_error_test)
 
     def test_same_name_as_bad(self):
-        self._do_test(same_name_as_bad_test)
+        _do_test(self, same_name_as_bad_test)
 
     def test_bytecode(self):
         base_path = os.path.join(TEST_DIR, 'a')
-        source_path = base_path + importlib.machinery.SOURCE_SUFFIXES[0]
-        bytecode_path = base_path + importlib.machinery.BYTECODE_SUFFIXES[0]
+        source_path = base_path + SOURCE_SUFFIXES[0]
+        bytecode_path = base_path + BYTECODE_SUFFIXES[0]
         with open_file(source_path) as file:
             file.write('testing_modulefinder = True\n')
         py_compile.compile(source_path, cfile=bytecode_path)
         os.remove(source_path)
-        self._do_test(bytecode_test)
+        _do_test(self, bytecode_test)
 
     def test_replace_paths(self):
         old_path = os.path.join(TEST_DIR, 'a', 'module.py')
         new_path = os.path.join(TEST_DIR, 'a', 'spam.py')
         with support.captured_stdout() as output:
-            self._do_test(maybe_test, debug=2,
-                          replace_paths=[(old_path, new_path)])
+            _do_test(self, maybe_test, debug=2,
+                     replace_paths=[(old_path, new_path)])
         output = output.getvalue()
         expected = "co_filename %r changed to %r" % (old_path, new_path)
         self.assertIn(expected, output)
@@ -363,7 +412,128 @@ a.py
                                 import b
 b.py
 """ % list(range(2**16))]  # 2**16 constants
-        self._do_test(extended_opargs_test)
+        _do_test(self, extended_opargs_test)
+
+    def test_namespace_package(self):
+        _do_test(self, namespace_package_test)
+
+    def test_namespace_package_2(self):
+        _do_test(self, namespace_package_test_2)
+
+
+class BasicLoader:
+    def create_module(self, spec):
+        return
+
+    def exec_module(self, module):
+        raise RuntimeError("This method should not be run.")
+    
+    def get_code(self, name):
+        return compile(modules[name], "<string>", "exec")
+
+
+modules = {"a": "import b\nimport b.c",
+           "b": "from . import d",
+           "b.c": "from . import e",
+           "b.d": "import f"}
+
+
+class BasicFinder:
+    def __init__(self, loader_class):
+        self.loader_class = loader_class
+
+    def find_spec(self, name, path, target=None):
+        if name not in modules:
+            return None
+        return ModuleSpec(name, self.loader_class(), is_package=(name == "b"))
+        
+
+basic_test = ["a", ["a", "b", "b.c", "b.d"], ["b.e", "f"], [], None]
+
+
+class BaseImportHookCase(unittest.TestCase):
+    def setUp(self):
+        self.real_finders = sys.meta_path
+    
+    def tearDown(self):
+        sys.meta_path = self.real_finders
+
+class HookTests(BaseImportHookCase):
+    def test_normal_hooks(self):
+        # This produces virtually the same results as
+        # any of the default SourceLoaders served by
+        # PathFinder using FileFinder.
+
+        sys.meta_path = [BasicFinder(BasicLoader)]
+        _do_test(self, basic_test)
+
+    def test_deprecated_hooks(self):
+        # As above, but with the deprecated APIs instead.
+
+        class Loader:
+            def load_module(self, name):
+                raise RuntimeError("This method cannot be run either, "
+                                   "since it will execute the module.")
+
+            def is_package(self, name):
+                # We can't stick this information in the spec,
+                # since we aren't creating a spec.
+                # modulefinder should accept information
+                # in this form, but it is more likely that older loaders
+                # will not provide this function.
+                # Nothing we can do about that.
+                return name == "b"
+            
+            def get_code(self, name):
+                return compile(modules[name], "<string>", "exec")
+
+        class Finder:
+            def find_module(self, name, path=None):
+                if name not in modules:
+                    return None
+                return Loader()
+
+        sys.meta_path = [Finder()]
+        _do_test(self, basic_test)
+
+    def test_create_module(self):
+        class Module:
+            pass
+        
+        class Loader(BasicLoader):
+            def create_module(self, spec):
+                self.module = Module()
+                return self.module
+
+            def get_code(self, name):
+                assert sys.modules[name] is self.module
+                return super().get_code(name)
+
+        sys.meta_path = [BasicFinder(Loader)]
+        _do_test(self, basic_test)
+
+
+class NoneFinder:
+    def __init__(self, attr):
+        self.attr = attr
+
+    def find_spec(self, name, path, target=None):
+        spec = ModuleSpec(name, BasicLoader(), is_package=(name == "b"))
+        if name == "b":
+            setattr(spec, self.attr, None)
+        return spec
+
+
+class NoneTests(BaseImportHookCase):
+    def test_loader_None(self):        
+        sys.meta_path = [NoneFinder("loader")]
+        _do_test(self, ["a", ["a", "b", "b.c"], ["b.e"], [], None])
+
+    def test_name_None(self):
+        sys.meta_path = [NoneFinder("name")]
+        _do_test(self, ["a", ["a"], ["b", "b.c"], [], None])
+
+    # Other attributes are usually None anyway
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2019-11-21-19-57-27.bpo-38721.7yv8dT.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-21-19-57-27.bpo-38721.7yv8dT.rst
@@ -1,0 +1,1 @@
+Added support for import hooks in modulefinder.


### PR DESCRIPTION
Adds support for import hooks, including those using the deprecated api.

It's a bit difficult to determine which parts of this module are considered a public API - the documentation is a little incomplete, and the regression tests even more so. I have ensured that anything covered on [the documentation](https://docs.python.org/3/library/modulefinder.html) remains backward compatible, as well as the load_file and import_hook functions. Almost everything else has been changed massively.

As noted in my bug report, it is impossible to be compatible with every possible setup and still allow finders and loaders to import things for their own use. I have opted to assume this kind of dynamic importing doesn't happen.

<!-- issue-number: [bpo-38721](https://bugs.python.org/issue38721) -->
https://bugs.python.org/issue38721
<!-- /issue-number -->
