### PR TITLE
gh-83067: add option to zipfile.writestr to open permissions

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -318,6 +318,14 @@ class AbstractTestsWithSourceFile:
         self.assertEqual(b_info.compress_type, self.compression)
         self.assertEqual(b_info._compresslevel, 2)
 
+    def test_writestr_permission(self):
+        zipfp = zipfile.ZipFile(TESTFN2, "w")
+        zipfp.writestr("b.txt", "hello world", file_perm=0o755)
+        b_info = zipfp.getinfo('b.txt')
+        perm = oct(b_info.external_attr >> 16)
+        assert perm == '0o755'
+
+
     def test_read_return_size(self):
         # Issue #9837: ZipExtFile.read() shouldn't return more bytes
         # than requested.

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1751,12 +1751,14 @@ class ZipFile:
                 shutil.copyfileobj(src, dest, 1024*8)
 
     def writestr(self, zinfo_or_arcname, data,
-                 compress_type=None, compresslevel=None):
+                 compress_type=None, compresslevel=None,
+                 file_perm=0o600):
         """Write a file into the archive.  The contents is 'data', which
         may be either a 'str' or a 'bytes' instance; if it is a 'str',
         it is encoded as UTF-8 first.
         'zinfo_or_arcname' is either a ZipInfo instance or
-        the name of the file in the archive."""
+        the name of the file in the archive. Default permission is set to 600
+        (rw-------) but can be specified with file_perm."""
         if isinstance(data, str):
             data = data.encode("utf-8")
         if not isinstance(zinfo_or_arcname, ZipInfo):
@@ -1768,7 +1770,7 @@ class ZipFile:
                 zinfo.external_attr = 0o40775 << 16   # drwxrwxr-x
                 zinfo.external_attr |= 0x10           # MS-DOS directory flag
             else:
-                zinfo.external_attr = 0o600 << 16     # ?rw-------
+                zinfo.external_attr = file_perm << 16     # ?rw-------
         else:
             zinfo = zinfo_or_arcname
 

--- a/Misc/NEWS.d/next/Library/2019-11-22-15-31-12.bpo-38886.yLQRPS.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-22-15-31-12.bpo-38886.yLQRPS.rst
@@ -1,0 +1,2 @@
+add option to zipfile.writestr to open permissions: new optional argument
+to allow user to choose permission of written file


### PR DESCRIPTION
when writing files inside zip archive, permissions default of 600 can be too restrictive.
This PR adds an optional argument to allow to choose the desired permission

<!-- issue-number: [bpo-38886](https://bugs.python.org/issue38886) -->
https://bugs.python.org/issue38886
<!-- /issue-number -->

<!-- gh-issue-number: gh-83067 -->
* Issue: gh-83067
<!-- /gh-issue-number -->
