### PR TITLE
Be more specific about the `.so` gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 *.iml
 *.o
 *.a
-*.so*
+*.so
+*.so.*
 *.dylib
 *.dll
 *.orig


### PR DESCRIPTION
In #15823 the pattern was changed from `libpython*.so*` to `*.so*` which
matches a bit too greedily for some packagers.  For instance this trips up
`debian/README.source`.  A more specific pattern fixes this issue.
