### PR TITLE
[WIP/RFC] multiprocessing: proxy: keep _manager after forking

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -874,7 +874,6 @@ class BaseProxy(object):
             del tls.connection
 
     def _after_fork(self):
-        self._manager = None
         try:
             self._incref()
         except Exception as e:


### PR DESCRIPTION
Fixes iterating over dicts:

    import multiprocessing as mp

    def run(d):
        for k in d:
            print(k)

    manager = mp.Manager()

    d = manager.dict({1: 2, 3: 4})

    process = mp.Process(target=run, args=(d,))
    process.start()
    process.join()

With this fix:

    _callmethod __iter__ #PROXY (('__next__', 'send', 'throw', 'close'), Token(typeid='Iterator', address='/tmp/pymp-wfn3r3nd/listener-ze4ow_dl', id='7f12414ca130'))
    _callmethod __next__ #RETURN 1
    1
    _callmethod __next__ #RETURN 3
    3
    _callmethod __next__ #ERROR

Without:

    _callmethod __iter__ #PROXY (('__next__', 'send', 'throw', 'close'), Token(typeid='Iterator', address='/tmp/pymp-uppzhf9p/listener-mvmwwxma', id='7f5b7b42da90'))
    Process Process-2:
    Traceback (most recent call last):
      File "…/pyenv/3.8.0/lib/python3.8/multiprocessing/process.py", line 313, in _bootstrap
        self.run()
      File "…/pyenv/3.8.0/lib/python3.8/multiprocessing/process.py", line 108, in run
        self._target(*self._args, **self._kwargs)
      File "t-mp.py", line 5, in run
        for k in d:
      File "<string>", line 2, in __iter__
      File "…/pyenv/3.8.0/lib/python3.8/multiprocessing/managers.py", line 842, in _callmethod
        proxytype = self._manager._registry[token.typeid][-1]
    AttributeError: 'NoneType' object has no attribute '_registry'

The line is from when multiprocessing was added in e711cafab1, so I am
probably missing something here?  This PR is meant to get tests run with
it, and of course for any feedback already.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
