### PR TITLE
bpo-38852: Set thread stack size to 8 Mb for debug builds on android platforms

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-22-09-55-21.bpo-38852.y7oPEa.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-22-09-55-21.bpo-38852.y7oPEa.rst
@@ -1,0 +1,1 @@
+Set the thread stack size to 8 Mb for debug builds on android platforms.

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -51,6 +51,12 @@
 #undef  THREAD_STACK_SIZE
 #define THREAD_STACK_SIZE       0x200000
 #endif
+#if defined(__ANDROID__) && defined(THREAD_STACK_SIZE) && THREAD_STACK_SIZE == 0
+#   ifdef Py_DEBUG
+#   undef  THREAD_STACK_SIZE
+#   define THREAD_STACK_SIZE    0x800000
+#   endif
+#endif
 /* for safety, ensure a viable minimum stacksize */
 #define THREAD_STACK_MIN        0x8000  /* 32 KiB */
 #else  /* !_POSIX_THREAD_ATTR_STACKSIZE */

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -51,6 +51,10 @@
 #undef  THREAD_STACK_SIZE
 #define THREAD_STACK_SIZE       0x200000
 #endif
+/* bpo-38852: test_threading.test_recursion_limit() checks that 1000 recursive
+   Python calls (default recursion limit) doesn't crash, but raise a regular
+   RecursionError exception. In debug mode, Python function calls allocates
+   more memory on the stack, so use a stack of 8 MiB. */
 #if defined(__ANDROID__) && defined(THREAD_STACK_SIZE) && THREAD_STACK_SIZE == 0
 #   ifdef Py_DEBUG
 #   undef  THREAD_STACK_SIZE


### PR DESCRIPTION


<!-- issue-number: [bpo-38852](https://bugs.python.org/issue38852) -->
https://bugs.python.org/issue38852
<!-- /issue-number -->
