### PR TITLE
bpo-38858: new_interpreter() reuses pycore_init_builtins()

### DIFF
--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -3045,8 +3045,6 @@ Py_XINCREF:PyObject*:o:+1:if o is not NULL
 
 _PyImport_Fini:void:::
 
-_PyImport_Init:void:::
-
 _PyObject_New:PyObject*::+1:
 _PyObject_New:PyTypeObject*:type:0:
 

--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -44,7 +44,6 @@ extern PyStatus _PySys_SetPreliminaryStderr(PyObject *sysdict);
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_InitMain(PyThreadState *tstate);
-extern PyStatus _PyImport_Init(PyThreadState *tstate);
 extern PyStatus _PyExc_Init(void);
 extern PyStatus _PyErr_Init(void);
 extern PyStatus _PyBuiltins_AddExceptions(PyObject * bltinmod);

--- a/Python/import.c
+++ b/Python/import.c
@@ -49,17 +49,6 @@ module _imp
 /* Initialize things */
 
 PyStatus
-_PyImport_Init(PyThreadState *tstate)
-{
-    PyInterpreterState *interp = tstate->interp;
-    interp->builtins_copy = PyDict_Copy(interp->builtins);
-    if (interp->builtins_copy == NULL) {
-        return _PyStatus_ERR("Can't backup builtins dict");
-    }
-    return _PyStatus_OK();
-}
-
-PyStatus
 _PyImportHooks_Init(PyThreadState *tstate)
 {
     PyObject *v, *path_hooks = NULL;


### PR DESCRIPTION
new_interpreter() now calls _PyBuiltin_Init() to create the builtins
module and calls _PyImport_FixupBuiltin(), rather than using
_PyImport_FindBuiltin(tstate, "builtins").

pycore_init_builtins() is now responsible to initialize
intepr->builtins_copy: inline _PyImport_Init() and remove this
function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38858](https://bugs.python.org/issue38858) -->
https://bugs.python.org/issue38858
<!-- /issue-number -->
