### PR TITLE
bpo-38896: Remove PyUnicode_ClearFreeList() function

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -197,11 +197,6 @@ access internal read-only data of Unicode objects:
    .. versionadded:: 3.3
 
 
-.. c:function:: int PyUnicode_ClearFreeList()
-
-   Clear the free list. Return the total number of freed items.
-
-
 .. c:function:: Py_ssize_t PyUnicode_GET_SIZE(PyObject *o)
 
    Return the size of the deprecated :c:type:`Py_UNICODE` representation, in

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -235,6 +235,10 @@ Build and C API Changes
   functions: the free lists of bound method objects have been removed.
   (Contributed by Inada Naoki and Victor Stinner in :issue:`37340`.)
 
+* Remove ``PyUnicode_ClearFreeList()`` function: the Unicode free list has been
+  removed in Python 3.3.
+  (Contributed by Victor Stinner in :issue:`38896`.)
+
 
 Deprecated
 ==========

--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -328,17 +328,6 @@ PyAPI_FUNC(wchar_t*) PyUnicode_AsWideCharString(
 
 PyAPI_FUNC(PyObject*) PyUnicode_FromOrdinal(int ordinal);
 
-/* --- Free-list management ----------------------------------------------- */
-
-/* Clear the free list used by the Unicode implementation.
-
-   This can be used to release memory used for objects on the free
-   list back to the Python memory allocator.
-
-*/
-
-PyAPI_FUNC(int) PyUnicode_ClearFreeList(void);
-
 /* === Builtin Codecs =====================================================
 
    Many of these APIs take two arguments encoding and errors. These

--- a/Misc/NEWS.d/next/C API/2019-11-22-19-43-43.bpo-38896.6wvNMJ.rst
+++ b/Misc/NEWS.d/next/C API/2019-11-22-19-43-43.bpo-38896.6wvNMJ.rst
@@ -1,0 +1,2 @@
+Remove ``PyUnicode_ClearFreeList()`` function: the Unicode free list has
+been removed in Python 3.3.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1031,7 +1031,6 @@ clear_freelists(void)
 {
     (void)PyFrame_ClearFreeList();
     (void)PyTuple_ClearFreeList();
-    (void)PyUnicode_ClearFreeList();
     (void)PyFloat_ClearFreeList();
     (void)PyList_ClearFreeList();
     (void)PyDict_ClearFreeList();

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15332,14 +15332,6 @@ _PyUnicode_Init(void)
     return _PyStatus_OK();
 }
 
-/* Finalize the Unicode implementation */
-
-int
-PyUnicode_ClearFreeList(void)
-{
-    return 0;
-}
-
 
 void
 PyUnicode_InternInPlace(PyObject **p)
@@ -15951,7 +15943,6 @@ _PyUnicode_Fini(PyThreadState *tstate)
             Py_CLEAR(unicode_latin1[i]);
         }
         _PyUnicode_ClearStaticStrings();
-        (void)PyUnicode_ClearFreeList();
     }
 
     PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();

--- a/PC/python3.def
+++ b/PC/python3.def
@@ -649,7 +649,6 @@ EXPORTS
   PyUnicode_AsWideChar=python39.PyUnicode_AsWideChar
   PyUnicode_AsWideCharString=python39.PyUnicode_AsWideCharString
   PyUnicode_BuildEncodingMap=python39.PyUnicode_BuildEncodingMap
-  PyUnicode_ClearFreeList=python39.PyUnicode_ClearFreeList
   PyUnicode_Compare=python39.PyUnicode_Compare
   PyUnicode_CompareWithASCIIString=python39.PyUnicode_CompareWithASCIIString
   PyUnicode_Concat=python39.PyUnicode_Concat


### PR DESCRIPTION
Remove PyUnicode_ClearFreeList() function: the Unicode free list has
been removed in Python 3.3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38896](https://bugs.python.org/issue38896) -->
https://bugs.python.org/issue38896
<!-- /issue-number -->
