### PR TITLE
bpo-38899: virtual environment activation for fish should use `source`

### DIFF
--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -104,7 +104,7 @@ directory containing the virtual environment):
 +=============+=================+=========================================+
 | POSIX       | bash/zsh        | $ source <venv>/bin/activate            |
 +-------------+-----------------+-----------------------------------------+
-|             | fish            | $ . <venv>/bin/activate.fish            |
+|             | fish            | $ source <venv>/bin/activate.fish       |
 +-------------+-----------------+-----------------------------------------+
 |             | csh/tcsh        | $ source <venv>/bin/activate.csh        |
 +-------------+-----------------+-----------------------------------------+

--- a/Lib/venv/scripts/posix/activate.fish
+++ b/Lib/venv/scripts/posix/activate.fish
@@ -1,5 +1,5 @@
-# This file must be used with ". bin/activate.fish" *from fish* (http://fishshell.org);
-# you cannot run it directly.
+# This file must be used with "source <venv>/bin/activate.fish" *from fish*
+# (http://fishshell.org); you cannot run it directly.
 
 function deactivate  -d "Exit virtualenv and return to normal shell environment"
     # reset old environment variables

--- a/Misc/NEWS.d/next/Documentation/2019-11-22-15-57-29.bpo-38899.4aYPW2.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-11-22-15-57-29.bpo-38899.4aYPW2.rst
@@ -1,0 +1,3 @@
+Update documentation to state that to activate virtual environments under
+fish one should use `source`, not `.` as documented at
+https://fishshell.com/docs/current/commands.html#source.


### PR DESCRIPTION
The previously documented use of `.` is considered deprecated (https://fishshell.com/docs/current/commands.html#source).

<!-- issue-number: [bpo-38899](https://bugs.python.org/issue38899) -->
https://bugs.python.org/issue38899
<!-- /issue-number -->


Automerge-Triggered-By: @brettcannon