### PR TITLE
bpo-21063: Improve module synopsis

### DIFF
--- a/Doc/distutils/apiref.rst
+++ b/Doc/distutils/apiref.rst
@@ -1699,7 +1699,7 @@ lines, and joining lines with backslashes.
 ===================================================================
 
 .. module:: distutils.cmd
-   :synopsis: Provides the abstract base class Command. This class
+   :synopsis: Provides the abstract base class :class:`~distutils.cmd.Command`. This class
               is subclassed by the modules in the distutils.command subpackage.
 
 

--- a/Doc/distutils/apiref.rst
+++ b/Doc/distutils/apiref.rst
@@ -1545,7 +1545,7 @@ Python's own build procedures.
 =================================================
 
 .. module:: distutils.text_file
-   :synopsis: provides the TextFile class, a simple interface to text files
+   :synopsis: Provides the TextFile class, a simple interface to text files
 
 
 This module provides the :class:`TextFile` class, which gives an interface  to
@@ -1684,7 +1684,7 @@ lines, and joining lines with backslashes.
 ===================================================
 
 .. module:: distutils.version
-   :synopsis: implements classes that represent module version numbers.
+   :synopsis: Implements classes that represent module version numbers.
 
 
 .. % todo
@@ -1699,7 +1699,7 @@ lines, and joining lines with backslashes.
 ===================================================================
 
 .. module:: distutils.cmd
-   :synopsis: This module provides the abstract base class Command. This class
+   :synopsis: Provides the abstract base class Command. This class
               is subclassed by the modules in the distutils.command subpackage.
 
 
@@ -1792,7 +1792,7 @@ Subclasses of :class:`Command` must define the following methods.
 ==========================================================
 
 .. module:: distutils.command
-   :synopsis: This subpackage contains one module for each standard Distutils command.
+   :synopsis: Contains one module for each standard Distutils command.
 
 
 .. % \subsubsection{Individual Distutils commands}
@@ -2039,7 +2039,7 @@ This is described in more detail in :pep:`301`.
 ===================================================================
 
 .. module:: distutils.command.check
-   :synopsis: Check the metadata of a package
+   :synopsis: Check the meta-data of a package
 
 
 The ``check`` command performs some tests on the meta-data of a package.

--- a/Doc/library/2to3.rst
+++ b/Doc/library/2to3.rst
@@ -456,7 +456,7 @@ and off individually.  They are described here in more detail.
 -------------------------------
 
 .. module:: lib2to3
-   :synopsis: the 2to3 library
+   :synopsis: The 2to3 library
 
 .. moduleauthor:: Guido van Rossum
 .. moduleauthor:: Collin Winter

--- a/Doc/library/linecache.rst
+++ b/Doc/library/linecache.rst
@@ -2,7 +2,7 @@
 ================================================
 
 .. module:: linecache
-   :synopsis: This module provides random access to individual lines from text files.
+   :synopsis: Provides random access to individual lines from text files.
 
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
 

--- a/Doc/library/statistics.rst
+++ b/Doc/library/statistics.rst
@@ -2,7 +2,7 @@
 =======================================================
 
 .. module:: statistics
-   :synopsis: mathematical statistics functions
+   :synopsis: Mathematical statistics functions
 
 .. moduleauthor:: Steven D'Aprano <steve+python@pearwood.info>
 .. sectionauthor:: Steven D'Aprano <steve+python@pearwood.info>

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -2,7 +2,7 @@
 =====================================================
 
 .. module:: zipimport
-   :synopsis: support for importing Python modules from ZIP archives.
+   :synopsis: Support for importing Python modules from ZIP archives.
 
 .. moduleauthor:: Just van Rossum <just@letterror.com>
 


### PR DESCRIPTION
Cleanup synopsis of modules in documentation.

<!-- issue-number: [bpo-21063](https://bugs.python.org/issue21063) -->
https://bugs.python.org/issue21063
<!-- /issue-number -->
