### PR TITLE
bpo-38524: add note about the implicit and explicit calling of __set_name__

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1657,6 +1657,18 @@ class' :attr:`~object.__dict__`.
 
    .. versionadded:: 3.6
 
+   .. note::
+
+      ``__set_name__`` is only called implicitly as part of the ``type`` constructor, so
+      it will need to be called explicitly with the appropriate parameters when a
+      descriptor is added to a class after initial creation::
+
+         descr = custom_descriptor()
+         cls.attr = descr
+         descr.__set_name__(cls, 'attr')
+
+      See :ref:`class-object-creation` for more details.
+
 
 The attribute :attr:`__objclass__` is interpreted by the :mod:`inspect` module
 as specifying the class where this object was defined (setting this
@@ -2001,16 +2013,6 @@ invoked after creating the class object:
   being defined and the assigned name of that particular descriptor;
 * finally, the :meth:`~object.__init_subclass__` hook is called on the
   immediate parent of the new class in its method resolution order.
-
-.. note::
-
-   ``__set_name__`` is only called implicitly as part of the ``type`` constructor, so
-   it will need to be called explicitly with the appropriate parameters when a
-   descriptor is added to a class after initial creation::
-
-      descr = custom_descriptor()
-      cls.attr = descr
-      descr.__set_name__(cls, 'attr')
 
 After the class object is created, it is passed to the class decorators
 included in the class definition (if any) and the resulting object is bound

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1655,8 +1655,6 @@ class' :attr:`~object.__dict__`.
    Called at the time the owning class *owner* is created. The
    descriptor has been assigned to *name*.
 
-   .. versionadded:: 3.6
-
    .. note::
 
       ``__set_name__`` is only called implicitly as part of the ``type`` constructor, so
@@ -1669,6 +1667,7 @@ class' :attr:`~object.__dict__`.
 
       See :ref:`class-object-creation` for more details.
 
+   .. versionadded:: 3.6
 
 The attribute :attr:`__objclass__` is interpreted by the :mod:`inspect` module
 as specifying the class where this object was defined (setting this

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2002,6 +2002,16 @@ invoked after creating the class object:
 * finally, the :meth:`~object.__init_subclass__` hook is called on the
   immediate parent of the new class in its method resolution order.
 
+.. note::
+
+   ``__set_name__`` is only called implicitly as part of the ``type`` constructor, so
+   it will need to be called explicitly with the appropriate parameters when a
+   descriptor is added to a class after initial creation::
+
+      descr = custom_descriptor()
+      cls.attr = descr
+      descr.__set_name__(cls, 'attr')
+
 After the class object is created, it is passed to the class decorators
 included in the class definition (if any) and the resulting object is bound
 in the local namespace as the defined class.


### PR DESCRIPTION
As described in the corresponding issue a note about the implicit and explicit calling of `__set_name__` should be added to the documentation.

@taleinat I cannot explicitly request your review. However, I mention you here as you said you'd be happy to review it. Let me know if I missed something.

<!-- issue-number: [bpo-38524](https://bugs.python.org/issue38524) -->
https://bugs.python.org/issue38524
<!-- /issue-number -->
