### PR TITLE
bpo-38903: Remove #if block that is not used on parsetok.c

### DIFF
--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -207,24 +207,6 @@ PyParser_ParseFileFlagsEx(FILE *fp, const char *filename,
     return n;
 }
 
-#ifdef PY_PARSER_REQUIRES_FUTURE_KEYWORD
-#if 0
-static const char with_msg[] =
-"%s:%d: Warning: 'with' will become a reserved keyword in Python 2.6\n";
-
-static const char as_msg[] =
-"%s:%d: Warning: 'as' will become a reserved keyword in Python 2.6\n";
-
-static void
-warn(const char *msg, const char *filename, int lineno)
-{
-    if (filename == NULL)
-        filename = "<string>";
-    PySys_WriteStderr(msg, filename, lineno);
-}
-#endif
-#endif
-
 /* Parse input coming from the given tokenizer structure.
    Return error code. */
 


### PR DESCRIPTION
On parsetok.c we can see a #if that has not effect on compilation

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38903](https://bugs.python.org/issue38903) -->
https://bugs.python.org/issue38903
<!-- /issue-number -->
