### PR TITLE
bpo-27873: Update docstring for multiprocessing.Pool.map

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2168,8 +2168,11 @@ with the :class:`Pool` class.
 
    .. method:: map(func, iterable[, chunksize])
 
-      A parallel equivalent of the :func:`map` built-in function (it supports only
-      one *iterable* argument though).  It blocks until the result is ready.
+      A parallel equivalent of the built-in function :func:`map`. It blocks
+      until the result is ready.
+
+      Unlike :func:`map`, this method supports only one *iterable* argument.
+      For functions that require multiple arguments, see :meth:`starmap`.
 
       This method chops the iterable into a number of chunks which it submits to
       the process pool as separate tasks.  The (approximate) size of these


### PR DESCRIPTION
Co-authored-by: naught101 .

This PR is transfered from https://bugs.python.org/issue27873

<!-- issue-number: [bpo-27873](https://bugs.python.org/issue27873) -->
https://bugs.python.org/issue27873
<!-- /issue-number -->
