### PR TITLE
bpo-38854: Adjust ``inspect.getsource`` to properly extract source for decorated functions

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -899,6 +899,7 @@ class BlockFinder:
         self.indecorator = False
         self.decoratorhasargs = False
         self.last = 1
+        self.decoratorparens = []
 
     def tokeneater(self, type, token, srowcol, erowcol, line):
         if not self.started and not self.indecorator:
@@ -913,11 +914,18 @@ class BlockFinder:
             self.passline = True    # skip to the end of the line
         elif token == "(":
             if self.indecorator:
+                self.decoratorparens.append(token)
                 self.decoratorhasargs = True
         elif token == ")":
             if self.indecorator:
-                self.indecorator = False
-                self.decoratorhasargs = False
+                if self.decoratorparens:
+                    if self.decoratorparens[-1] == "(":
+                        self.decoratorparens = self.decoratorparens[:-1]
+                    if not self.decoratorparens:
+                        self.indecorator = False
+                        self.decoratorhasargs = False
+                else:
+                    self.decoratorparens.append(token)
         elif type == tokenize.NEWLINE:
             self.passline = False   # stop skipping when a NEWLINE is seen
             self.last = srowcol[0]

--- a/Lib/test/inspect_fodder.py
+++ b/Lib/test/inspect_fodder.py
@@ -1,7 +1,7 @@
 # line 1
 'A module docstring.'
 
-import sys, inspect
+import sys, collections, functools, inspect
 # line 5
 
 # line 7
@@ -91,3 +91,32 @@ class Callable:
 
 custom_method = Callable().as_method_of(42)
 del Callable
+
+
+def decorator(*args):
+    def inner(func):
+        @functools.wraps(func)
+        def wrapper():
+            pass
+        return wrapper
+    return inner
+
+
+@decorator(dict(), 24)
+@decorator(dict(), 1)
+@decorator(dict(), collections.defaultdict(lambda: 1))
+@decorator("string containing )", "other string ()")
+@decorator(
+    (()),
+    collections.defaultdict(lambda: 1),
+    [(i, j) for i, j in enumerate(range(5))],
+)
+def decorated():
+    local_var = 2
+    return local_var + 42
+
+
+@decorator()
+def other_decorated():
+    local_var = 2
+    return local_var + 42

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -419,8 +419,11 @@ class TestRetrievingSourceCode(GetSourceBase):
 
     def test_getfunctions(self):
         functions = inspect.getmembers(mod, inspect.isfunction)
-        self.assertEqual(functions, [('eggs', mod.eggs),
+        self.assertEqual(functions, [('decorated', mod.decorated),
+                                     ('decorator', mod.decorator),
+                                     ('eggs', mod.eggs),
                                      ('lobbest', mod.lobbest),
+                                     ('other_decorated', mod.other_decorated),
                                      ('spam', mod.spam)])
 
     @unittest.skipIf(sys.flags.optimize >= 2,
@@ -493,6 +496,8 @@ class TestRetrievingSourceCode(GetSourceBase):
         self.assertSourceEqual(git.abuse, 29, 39)
         self.assertSourceEqual(mod.StupidGit, 21, 51)
         self.assertSourceEqual(mod.lobbest, 75, 76)
+        self.assertSourceEqual(mod.decorated, 105, 116)
+        self.assertSourceEqual(mod.other_decorated, 119, 122)
 
     def test_getsourcefile(self):
         self.assertEqual(normcase(inspect.getsourcefile(mod.spam)), modfile)

--- a/Misc/NEWS.d/next/Library/2019-11-25-09-37-50.bpo-38854.o-4kLU.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-25-09-37-50.bpo-38854.o-4kLU.rst
@@ -1,0 +1,3 @@
+Properly extract source with ``inspect.getsource`` for decorated functions.
+
+Patch by Claudiu Popa


### PR DESCRIPTION
When the arguments to a decorator call contain additional parentheses
from scalar values such as tuples or additional function calls,
``inspect.BlockFinder`` is misinterpreting the closing paren as the closing
paren of the decorator call itself, leading to a clipped result of the extracted
source of a function.
Instead of assuming the closing paren closes the decorator call itself, we keep
track of all the parentheses in a new stack, making sure to unset the decorator
context once we consumed all of them.

https://bugs.python.org/issue38854

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38854](https://bugs.python.org/issue38854) -->
<!-- /issue-number -->
