### PR TITLE
bpo-38914 Do not require email field in setup.py.

### DIFF
--- a/Doc/distutils/examples.rst
+++ b/Doc/distutils/examples.rst
@@ -255,7 +255,7 @@ Running the ``check`` command will display some warnings:
     running check
     warning: check: missing required meta-data: version, url
     warning: check: missing meta-data: either (author and author_email) or
-             (maintainer and maintainer_email) must be supplied
+             (maintainer and maintainer_email) should be supplied
 
 
 If you use the reStructuredText syntax in the ``long_description`` field and

--- a/Lib/distutils/command/check.py
+++ b/Lib/distutils/command/check.py
@@ -80,11 +80,11 @@ class check(Command):
     def check_metadata(self):
         """Ensures that all required elements of meta-data are supplied.
 
-        required fields:
-        name, version, URL.
+        Required fields:
+            name, version, URL
 
-        recommended fields:
-        (author and author_email) or (maintainer and maintainer_email)).
+        Recommended fields:
+            (author and author_email) or (maintainer and maintainer_email))
 
         Warns if any are missing.
         """

--- a/Lib/distutils/command/check.py
+++ b/Lib/distutils/command/check.py
@@ -80,8 +80,11 @@ class check(Command):
     def check_metadata(self):
         """Ensures that all required elements of meta-data are supplied.
 
-        name, version, URL, (author and author_email) or
-        (maintainer and maintainer_email)).
+        required fields:
+        name, version, URL.
+
+        recommended fields:
+        (author and author_email) or (maintainer and maintainer_email)).
 
         Warns if any are missing.
         """
@@ -97,15 +100,15 @@ class check(Command):
         if metadata.author:
             if not metadata.author_email:
                 self.warn("missing meta-data: if 'author' supplied, " +
-                          "'author_email' must be supplied too")
+                          "'author_email' should be supplied too")
         elif metadata.maintainer:
             if not metadata.maintainer_email:
                 self.warn("missing meta-data: if 'maintainer' supplied, " +
-                          "'maintainer_email' must be supplied too")
+                          "'maintainer_email' should be supplied too")
         else:
             self.warn("missing meta-data: either (author and author_email) " +
                       "or (maintainer and maintainer_email) " +
-                      "must be supplied")
+                      "should be supplied")
 
     def check_restructuredtext(self):
         """Checks if the long string fields are reST-compliant."""

--- a/Misc/NEWS.d/next/Library/2019-11-26-23-21-56.bpo-38914.8l-g-T.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-26-23-21-56.bpo-38914.8l-g-T.rst
@@ -1,0 +1,3 @@
+distutils' ``check`` command no longer strictly requires an author_email
+(maintainer_email) field when author (maintainer) is provided (Juergen
+Gmach).

--- a/Misc/NEWS.d/next/Library/2019-11-26-23-21-56.bpo-38914.8l-g-T.rst
+++ b/Misc/NEWS.d/next/Library/2019-11-26-23-21-56.bpo-38914.8l-g-T.rst
@@ -1,3 +1,5 @@
-distutils' ``check`` command no longer strictly requires an author_email
-(maintainer_email) field when author (maintainer) is provided (Juergen
-Gmach).
+Adjusted the wording of the warning issued by distutils' ``check`` command when
+the ``author`` and ``maintainer`` fields are supplied but no corresponding
+e-mail field (``author_email`` or ``maintainer_email``) is found. The wording
+now reflects the fact that these fields are suggested, but not required. Patch
+by Juergen Gmach.


### PR DESCRIPTION
When checking `setup.py` and when the `author` field was provided, but
the `author_email` field was missing, erroneously a warning message was
displayed that the `author_email` field is required.

The specs do not require the `author_email`field:
https://packaging.python.org/specifications/core-metadata/#author

The same is valid for `maintainer` and `maintainer_email`.

The warning message has been adjusted.

modified:   Doc/distutils/examples.rst
modified:   Lib/distutils/command/check.py

<!-- issue-number: [bpo-38914](https://bugs.python.org/issue38914) -->
https://bugs.python.org/issue38914
<!-- /issue-number -->


Automerge-Triggered-By: @pganssle