### PR TITLE
bpo-38922: Raise code.__new__ audit event when code object replace() is called

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-26-12-20-34.bpo-38922.i6ja-i.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-26-12-20-34.bpo-38922.i6ja-i.rst
@@ -1,0 +1,2 @@
+Calling ``replace`` on a code object now raises the ``code.__new__`` audit
+event.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -641,6 +641,13 @@ code_replace_impl(PyCodeObject *self, int co_argcount,
 
 #undef CHECK_INT_ARG
 
+    if (PySys_Audit("code.__new__", "OOOiiiiii",
+                    co_code, co_filename, co_name, co_argcount,
+                    co_posonlyargcount, co_kwonlyargcount, co_nlocals,
+                    co_stacksize, co_flags) < 0) {
+        return NULL;
+    }
+
     return (PyObject *)PyCode_NewWithPosOnlyArgs(
         co_argcount, co_posonlyargcount, co_kwonlyargcount, co_nlocals,
         co_stacksize, co_flags, (PyObject*)co_code, co_consts, co_names,


### PR DESCRIPTION


<!-- issue-number: [bpo-38922](https://bugs.python.org/issue38922) -->
https://bugs.python.org/issue38922
<!-- /issue-number -->
