### PR TITLE
Trivial: Show the differing module names for readlink()

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -184,7 +184,7 @@ case), and one used ``__VENV_NAME__`` instead.
 pathlib
 -------
 
-Added :meth:`pathlib.Path.readlink()` which acts similar to
+Added :meth:`pathlib.Path.readlink()` which acts similarly to
 :func:`os.readlink`.
 (Contributed by Girts Folkmanis in :issue:`30618`)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -184,8 +184,8 @@ case), and one used ``__VENV_NAME__`` instead.
 pathlib
 -------
 
-Added :meth:`~pathlib.Path.readlink()` which acts similar to
-:func:`~os.readlink`.
+Added :meth:`pathlib.Path.readlink()` which acts similar to
+:func:`os.readlink`.
 (Contributed by Girts Folkmanis in :issue:`30618`)
 
 pprint


### PR DESCRIPTION
This is really trivial and I felt it would be a waste of everyone's time to create an issue for this, but I'm happy to do it if needed.

I was just going through the release notes, and had no way to distinguish between the two `readlink`s mentioned.

Thanks
