### PR TITLE
bpo-38524: clarify example a bit and improve formatting

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1657,13 +1657,16 @@ class' :attr:`~object.__dict__`.
 
    .. note::
 
-      ``__set_name__`` is only called implicitly as part of the ``type`` constructor, so
-      it will need to be called explicitly with the appropriate parameters when a
-      descriptor is added to a class after initial creation::
+      :meth:`__set_name__` is only called implicitly as part of the
+      :class:`type` constructor, so it will need to be called explicitly with
+      the appropriate parameters when a descriptor is added to a class after
+      initial creation::
 
+         class A:
+            pass
          descr = custom_descriptor()
-         cls.attr = descr
-         descr.__set_name__(cls, 'attr')
+         A.attr = descr
+         descr.__set_name__(A, 'attr')
 
       See :ref:`class-object-creation` for more details.
 


### PR DESCRIPTION
After merging PR GH-17364, I noticed that `__set_name__` and `type` were not formatted as references, and that the code example could use a bit more context for clarity.

CC @DahlitzFlorian 

<!-- issue-number: [bpo-38524](https://bugs.python.org/issue38524) -->
https://bugs.python.org/issue38524
<!-- /issue-number -->
