### PR TITLE
bpo-38932: Make Mock.reset_mock() pass return_value and side_effect values to reset_mock on child mock objects

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -592,7 +592,7 @@ class NonCallableMock(Base):
         for child in self._mock_children.values():
             if isinstance(child, _SpecState) or child is _deleted:
                 continue
-            child.reset_mock(visited)
+            child.reset_mock(visited, return_value=return_value, side_effect=side_effect)
 
         ret = self._mock_return_value
         if _is_instance_mock(ret) and ret is not self:

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1635,6 +1635,12 @@ class MockTest(unittest.TestCase):
         self.assertIsInstance(m.return_value, Mock)
         self.assertNotEqual(m.side_effect, None)
 
+    def test_reset_sideeffect(self):
+        m = Mock(return_value=10, side_effect=[2, 3])
+        m.reset_mock(side_effect=True)
+        self.assertEqual(m.return_value, 10)
+        self.assertEqual(m.side_effect, None)
+
     def test_reset_return_with_children(self):
         m = MagicMock(f=MagicMock(return_value=1))
         self.assertEqual(m.f(), 1)

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1635,11 +1635,17 @@ class MockTest(unittest.TestCase):
         self.assertIsInstance(m.return_value, Mock)
         self.assertNotEqual(m.side_effect, None)
 
-    def test_reset_sideeffect(self):
-        m = Mock(return_value=10, side_effect=[2,3])
+    def test_reset_return_with_children(self):
+        m = MagicMock(f=MagicMock(return_value=1))
+        self.assertEqual(m.f(), 1)
+        m.reset_mock(return_value=True)
+        self.assertNotEqual(m.f(), 1)
+
+    def test_reset_return_with_children_side_effect(self):
+        m = MagicMock(f=MagicMock(side_effect=[2, 3]))
+        self.assertNotEqual(m.f.side_effect, None)
         m.reset_mock(side_effect=True)
-        self.assertEqual(m.return_value, 10)
-        self.assertEqual(m.side_effect, None)
+        self.assertEqual(m.f.side_effect, None)
 
     def test_mock_add_spec(self):
         class _One(object):

--- a/Misc/NEWS.d/next/Library/2020-01-25-13-41-27.bpo-38932.1pu_8I.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-25-13-41-27.bpo-38932.1pu_8I.rst
@@ -1,0 +1,1 @@
+Mock fully resets child objects on reset_mock(). Patch by Vegard Stikbakke


### PR DESCRIPTION
[Issue on issue tracker](https://bugs.python.org/issue38932).

The `Mock` class from `unittest` has a method `reset_mock`, which takes optional arguments `return_value` and `side_effect`, both with default values `False`.

In the body of `reset_mock`, `reset_mock` is called recursively on all the `_mock_children` of the `Mock` object. However, here the arguments are not passed. I realize this may be a feature and not a bug, but this caused some confusion in the test suite at the company where I work, where we thought we reset our mocked objects properly, but we didn't.

This means that if you have a `Mock` object with children that are also mocked, and methods on these have been directly mocked, then it is not enough to call `reset_mock` on the parent object.

This is my first attempt at a contribution to Python. I have most likely done something wrong, and I will do my best to help further.

<!-- issue-number: [bpo-38932](https://bugs.python.org/issue38932) -->
https://bugs.python.org/issue38932
<!-- /issue-number -->
