### PR TITLE
[3.8] Remove upgrade_dependencies() from venv doc (bpo-38928)

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -186,14 +186,6 @@ creation according to their needs, the :class:`EnvBuilder` class.
         Installs activation scripts appropriate to the platform into the virtual
         environment.
 
-    .. method:: upgrade_dependencies(context)
-
-       Upgrades the core venv dependency packages (currently ``pip`` and
-       ``setuptools``) in the environment. This is done by shelling out to the
-       ``pip`` executable in the environment.
-
-       .. versionadded:: 3.8
-
     .. method:: post_setup(context)
 
         A placeholder method which can be overridden in third party


### PR DESCRIPTION


<!-- issue-number: [bpo-38928](https://bugs.python.org/issue38928) -->
https://bugs.python.org/issue38928
<!-- /issue-number -->
