### PR TITLE
bpo-38937: exec lines from .pth files in a copy of the site.py globals

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -59,7 +59,8 @@ additional items (one per line) to be added to ``sys.path``.  Non-existing items
 are never added to ``sys.path``, and no check is made that the item refers to a
 directory rather than a file.  No item is added to ``sys.path`` more than
 once.  Blank lines and lines beginning with ``#`` are skipped.  Lines starting
-with ``import`` (followed by space or tab) are executed.
+with ``import`` (followed by space or tab) are executed in a copy of the
+:mod:`site` module's global namespace.
 
 .. note::
 

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -166,7 +166,7 @@ def addpackage(sitedir, name, known_paths):
                 continue
             try:
                 if line.startswith(("import ", "import\t")):
-                    exec(line)
+                    exec(line, globals().copy())
                     continue
                 line = line.rstrip()
                 dir, dircase = makepath(sitedir, line)

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -167,6 +167,14 @@ class HelperFunctionsTests(unittest.TestCase):
             if isinstance(path, str):
                 self.assertNotIn("abc\x00def", path)
 
+    def test_pth_exc_namespacing(self):
+        # Issue 38937
+        contents = "import sys; x = 5; [print(x + i) for i in range(5)]\n"
+        pth_dir, pth_fn = self.make_pth(contents)
+        with captured_stderr() as err_out:
+            self.assertFalse(site.addpackage(pth_dir, pth_fn, set()))
+        self.assertEqual(err_out.getvalue(), "")
+
     def test_addsitedir(self):
         # Same tests for test_addpackage since addsitedir() essentially just
         # calls addpackage() for every .pth file in the directory

--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-28-20-24-55.bpo-38937.JMTSg8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-28-20-24-55.bpo-38937.JMTSg8.rst
@@ -1,0 +1,1 @@
+exec lines from ``.pth`` files in a copy of the :mod:`site` module's globals


### PR DESCRIPTION
Each line of a `.pth` file is `exec()`'d in its own namespace, which is a copy of the `site` module's global namespace. It's a copy so that the code in `.pth` files can't actually modify the `site` module just by defining a variable (previously it could!), and it's the globals of the `site` module rather than an empty dict in order to be backward compatible with `.pth` files that may be using some of those globals like `sys` or `os` without explicitly importing them.

Each line gets its own copy of the namespace, so the lines can't use each other's variables, preserving the deliberate limitation that code in `.pth` files is limited to one line.

<!-- issue-number: [bpo-38937](https://bugs.python.org/issue38937) -->
https://bugs.python.org/issue38937
<!-- /issue-number -->
