### PR TITLE
bpo-38942: Fix possible assertion failures in csv.Dialect()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-29-13-22-14.bpo-38942.0zWIcK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-29-13-22-14.bpo-38942.0zWIcK.rst
@@ -1,0 +1,1 @@
+Fix possible assertion failures when creating a :class:`csv.Dialect` object.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -394,8 +394,14 @@ dialect_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     Py_XINCREF(strict);
     if (dialect != NULL) {
 #define DIALECT_GETATTR(v, n) \
-        if (v == NULL) \
-            v = PyObject_GetAttrString(dialect, n)
+        if (v == NULL) { \
+            if ((v = PyObject_GetAttrString(dialect, n)) == NULL) { \
+                if (!PyErr_ExceptionMatches(PyExc_AttributeError)) { \
+                    goto err; \
+                } \
+                PyErr_Clear(); \
+            } \
+        }
         DIALECT_GETATTR(delimiter, "delimiter");
         DIALECT_GETATTR(doublequote, "doublequote");
         DIALECT_GETATTR(escapechar, "escapechar");
@@ -404,7 +410,6 @@ dialect_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         DIALECT_GETATTR(quoting, "quoting");
         DIALECT_GETATTR(skipinitialspace, "skipinitialspace");
         DIALECT_GETATTR(strict, "strict");
-        PyErr_Clear();
     }
 
     /* check types and convert to C values */


### PR DESCRIPTION



<!-- issue-number: [bpo-38942](https://bugs.python.org/issue38942) -->
https://bugs.python.org/issue38942
<!-- /issue-number -->
