### PR TITLE
bpo-38943: Fix IDLE autocomplete window not always appearing

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,9 @@ Released on 2020-10-05?
 ======================================
 
 
+bpo-38943: Fix autocomplete windows not always appearing on some
+systems.  Patch by Johnny Najera.
+
 bpo-38944: Excape key now closes IDLE completion windows.  Patch by
 Johnny Najera.
 

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -256,7 +256,7 @@ class AutoCompleteWindow:
         else:
             # place acw above current line
             new_y -= acw_height
-        self.widget.after(1, acw.wm_geometry, "+%d+%d" % (x, y))
+        self.widget.after(1, acw.wm_geometry, "+%d+%d" % (new_x, new_y))
 
         if platform.system().startswith('Windows'):
             # See issue 15786. When on Windows platform, Tk will misbehave

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -17,7 +17,7 @@ KEYPRESS_VIRTUAL_EVENT_NAME = "<<autocompletewindow-keypress>>"
 # before the default specific IDLE function
 KEYPRESS_SEQUENCES = ("<Key>", "<Key-BackSpace>", "<Key-Return>", "<Key-Tab>",
                       "<Key-Up>", "<Key-Down>", "<Key-Home>", "<Key-End>",
-                      "<Key-Prior>", "<Key-Next>")
+                      "<Key-Prior>", "<Key-Next>", "<Key-Escape>")
 KEYRELEASE_VIRTUAL_EVENT_NAME = "<<autocompletewindow-keyrelease>>"
 KEYRELEASE_SEQUENCE = "<KeyRelease>"
 LISTUPDATE_SEQUENCE = "<B1-ButtonRelease>"
@@ -256,7 +256,7 @@ class AutoCompleteWindow:
         else:
             # place acw above current line
             new_y -= acw_height
-        acw.wm_geometry("+%d+%d" % (new_x, new_y))
+        self.widget.after(1, lambda: self._update_geometry(acw, new_x, new_y))
 
         if platform.system().startswith('Windows'):
             # See issue 15786. When on Windows platform, Tk will misbehave
@@ -266,6 +266,9 @@ class AutoCompleteWindow:
             self.winconfigid = None
 
         self.is_configuring = False
+
+    def _update_geometry(self, acw, x, y):
+        acw.wm_geometry("+%d+%d" % (x, y))
 
     def _hide_event_check(self):
         if not self.autocompletewindow:

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -256,7 +256,8 @@ class AutoCompleteWindow:
         else:
             # place acw above current line
             new_y -= acw_height
-        self.widget.after(1, acw.wm_geometry, "+%d+%d" % (new_x, new_y))
+        acw.wm_geometry("+%d+%d" % (new_x, new_y))
+        acw.update_idletasks()
 
         if platform.system().startswith('Windows'):
             # See issue 15786. When on Windows platform, Tk will misbehave

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -256,7 +256,7 @@ class AutoCompleteWindow:
         else:
             # place acw above current line
             new_y -= acw_height
-        self.widget.after(1, acw.wm_geometry, "+%d+%d" % (x, y)) 
+        self.widget.after(1, acw.wm_geometry, "+%d+%d" % (x, y))
 
         if platform.system().startswith('Windows'):
             # See issue 15786. When on Windows platform, Tk will misbehave

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -17,7 +17,7 @@ KEYPRESS_VIRTUAL_EVENT_NAME = "<<autocompletewindow-keypress>>"
 # before the default specific IDLE function
 KEYPRESS_SEQUENCES = ("<Key>", "<Key-BackSpace>", "<Key-Return>", "<Key-Tab>",
                       "<Key-Up>", "<Key-Down>", "<Key-Home>", "<Key-End>",
-                      "<Key-Prior>", "<Key-Next>", "<Key-Escape>")
+                      "<Key-Prior>", "<Key-Next>")
 KEYRELEASE_VIRTUAL_EVENT_NAME = "<<autocompletewindow-keyrelease>>"
 KEYRELEASE_SEQUENCE = "<KeyRelease>"
 LISTUPDATE_SEQUENCE = "<B1-ButtonRelease>"

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -256,7 +256,7 @@ class AutoCompleteWindow:
         else:
             # place acw above current line
             new_y -= acw_height
-        self.widget.after(1, lambda: self._update_geometry(acw, new_x, new_y))
+        self.widget.after(1, acw.wm_geometry, "+%d+%d" % (x, y)) 
 
         if platform.system().startswith('Windows'):
             # See issue 15786. When on Windows platform, Tk will misbehave

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -267,9 +267,6 @@ class AutoCompleteWindow:
 
         self.is_configuring = False
 
-    def _update_geometry(self, acw, x, y):
-        acw.wm_geometry("+%d+%d" % (x, y))
-
     def _hide_event_check(self):
         if not self.autocompletewindow:
             return

--- a/Misc/NEWS.d/next/IDLE/2019-11-29-23-44-11.bpo-38943.8pUKKs.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-11-29-23-44-11.bpo-38943.8pUKKs.rst
@@ -1,1 +1,2 @@
-Fix autocomplete window not showing on some systems because of the context in which wm_geometry is called.
+Fix IDLE autocomplete windows not always appearing on some systems.
+Patch by Johnny Najera.

--- a/Misc/NEWS.d/next/IDLE/2019-11-29-23-44-11.bpo-38943.8pUKKs.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-11-29-23-44-11.bpo-38943.8pUKKs.rst
@@ -1,0 +1,1 @@
+Fix autocomplete window not showing on some systems because of the context in which wm_geometry is called.


### PR DESCRIPTION
<!-- issue-number: [bpo-38943](https://bugs.python.org/issue38943) -->
https://bugs.python.org/issue38943
<!-- /issue-number -->
In some systems the function winconfig_event is called in a context in which wm_geometry has no effect.