### PR TITLE
bpo-38944: Escape key now closes IDLE completion windows.

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,9 @@ Released on 2020-10-05?
 ======================================
 
 
+bpo-38944: Excape key now closes IDLE completion windows.  Patch by
+Johnny Najera.
+
 bpo-38862: 'Strip Trailing Whitespace' on the Format menu removes extra
 newlines at the end of non-shell files.
 

--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -17,7 +17,7 @@ KEYPRESS_VIRTUAL_EVENT_NAME = "<<autocompletewindow-keypress>>"
 # before the default specific IDLE function
 KEYPRESS_SEQUENCES = ("<Key>", "<Key-BackSpace>", "<Key-Return>", "<Key-Tab>",
                       "<Key-Up>", "<Key-Down>", "<Key-Home>", "<Key-End>",
-                      "<Key-Prior>", "<Key-Next>")
+                      "<Key-Prior>", "<Key-Next>", "<Key-Escape>")
 KEYRELEASE_VIRTUAL_EVENT_NAME = "<<autocompletewindow-keyrelease>>"
 KEYRELEASE_SEQUENCE = "<KeyRelease>"
 LISTUPDATE_SEQUENCE = "<B1-ButtonRelease>"

--- a/Misc/NEWS.d/next/IDLE/2019-11-30-12-10-36.bpo-38944._3xjKG.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-11-30-12-10-36.bpo-38944._3xjKG.rst
@@ -1,1 +1,1 @@
-Fixing Idle autocomplete window doesn't close on Escape key.
+Excape key now closes IDLE completion windows.  Patch by Johnny Najera.

--- a/Misc/NEWS.d/next/IDLE/2019-11-30-12-10-36.bpo-38944._3xjKG.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-11-30-12-10-36.bpo-38944._3xjKG.rst
@@ -1,1 +1,1 @@
-Fixing Idle autocomplete window doesn't close on Escape key
+Fixing Idle autocomplete window doesn't close on Escape key.

--- a/Misc/NEWS.d/next/IDLE/2019-11-30-12-10-36.bpo-38944._3xjKG.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-11-30-12-10-36.bpo-38944._3xjKG.rst
@@ -1,0 +1,1 @@
+Fixing Idle autocomplete window doesn't close on Escape key


### PR DESCRIPTION
Autocomplete window is not closed on Escape key on some Ubuntu systems. This is because the key press never make it to the event.

<!-- issue-number: [bpo-38944](https://bugs.python.org/issue38944) -->
https://bugs.python.org/issue38944
<!-- /issue-number -->
