### PR TITLE
bpo-32894: Support unparsing of infinity numbers in ast_unparser.c

### DIFF
--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -5,6 +5,7 @@ from test import support
 from textwrap import dedent
 import os
 import re
+import sys
 
 rx = re.compile(r'\((\S+).py, line (\d+)')
 
@@ -307,6 +308,16 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         self.assertAnnotationEqual("f'{x=!r}'", expected="f'x={x!r}'")
         self.assertAnnotationEqual("f'{x=!a}'", expected="f'x={x!a}'")
         self.assertAnnotationEqual("f'{x=!s:*^20}'", expected="f'x={x!s:*^20}'")
+
+    def test_infinity_numbers(self):
+        inf = "1e" + repr(sys.float_info.max_10_exp + 1)
+        infj = f"{inf}j"
+        self.assertAnnotationEqual("1e1000", expected=inf)
+        self.assertAnnotationEqual("1e1000j", expected=infj)
+        self.assertAnnotationEqual("(1e1000, 1e1000j)", expected=f"({inf}, {infj})")
+        self.assertAnnotationEqual("'inf'")
+        self.assertAnnotationEqual("('inf', 1e1000, 'infxxx', 1e1000j)", expected=f"('inf', {inf}, 'infxxx', {infj})")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -314,6 +314,7 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         infj = f"{inf}j"
         self.assertAnnotationEqual("1e1000", expected=inf)
         self.assertAnnotationEqual("1e1000j", expected=infj)
+        self.assertAnnotationEqual("-1e1000", expected=f"-{inf}")
         self.assertAnnotationEqual("3+1e1000j", expected=f"(3+{infj})")
         self.assertAnnotationEqual("(1e1000, 1e1000j)", expected=f"({inf}, {infj})")
         self.assertAnnotationEqual("'inf'")

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -315,10 +315,11 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         self.assertAnnotationEqual("1e1000", expected=inf)
         self.assertAnnotationEqual("1e1000j", expected=infj)
         self.assertAnnotationEqual("-1e1000", expected=f"-{inf}")
-        self.assertAnnotationEqual("3+1e1000j", expected=f"(3+{infj})")
+        self.assertAnnotationEqual("3+1e1000j", expected=f"3 + {infj}")
         self.assertAnnotationEqual("(1e1000, 1e1000j)", expected=f"({inf}, {infj})")
         self.assertAnnotationEqual("'inf'")
         self.assertAnnotationEqual("('inf', 1e1000, 'infxxx', 1e1000j)", expected=f"('inf', {inf}, 'infxxx', {infj})")
+        self.assertAnnotationEqual("(1e1000, (1e1000j,))", expected=f"({inf}, ({infj},))")
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -314,6 +314,7 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         infj = f"{inf}j"
         self.assertAnnotationEqual("1e1000", expected=inf)
         self.assertAnnotationEqual("1e1000j", expected=infj)
+        self.assertAnnotationEqual("3+1e1000j", expected=f"(3+{infj})")
         self.assertAnnotationEqual("(1e1000, 1e1000j)", expected=f"({inf}, {infj})")
         self.assertAnnotationEqual("'inf'")
         self.assertAnnotationEqual("('inf', 1e1000, 'infxxx', 1e1000j)", expected=f"('inf', {inf}, 'infxxx', {infj})")

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-01-21-36-49.bpo-32894.5g_UQr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-01-21-36-49.bpo-32894.5g_UQr.rst
@@ -1,0 +1,1 @@
+Support unparsing of infinity numbers in postponed annotations

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-01-21-36-49.bpo-32894.5g_UQr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-01-21-36-49.bpo-32894.5g_UQr.rst
@@ -1,1 +1,1 @@
-Support unparsing of infinity numbers in postponed annotations
+Support unparsing of infinity numbers in postponed annotations. Patch by Batuhan Taşkaya.

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -1,7 +1,7 @@
+#include <float.h>   /* DBL_MAX_10_EXP */
 #include <stdbool.h>
 #include "Python.h"
 #include "Python-ast.h"
-#include "float.h"
 
 static PyObject *_str_open_br;
 static PyObject *_str_dbl_open_br;
@@ -65,7 +65,7 @@ static int
 append_repr(_PyUnicodeWriter *writer, PyObject *obj)
 {
     if (PyFloat_CheckExact(obj) && Py_IS_INFINITY(PyFloat_AS_DOUBLE(obj))) {
-        return _PyUnicodeWriter_WriteStr(writer, _str_inf);
+        return _PyUnicodeWriter_WriteStr(writer, _str_replace_inf);
     }
     PyObject *repr = PyObject_Repr(obj);
 
@@ -926,14 +926,13 @@ maybe_init_static_strings(void)
         return -1;
     }
     if (!_str_inf &&
-        !(_str_inf = PyUnicode_InternFromString("inf"))) {
+        !(_str_inf = PyUnicode_FromString("inf"))) {
         return -1;
     }
     if (!_str_replace_inf &&
         !(_str_replace_inf = PyUnicode_FromFormat("1e%d", 1 + DBL_MAX_10_EXP))) {
         return -1;
     }
-    PyUnicode_InternInPlace(&_str_replace_inf);
     return 0;
 }
 

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -730,10 +730,7 @@ append_ast_constant(_PyUnicodeWriter *writer, PyObject *constant)
     if (PyTuple_CheckExact(constant)) {
         Py_ssize_t i, elem_count;
 
-        elem_count = PySequence_Length(constant);
-        if (elem_count == -1) {
-            return -1;
-        }
+        elem_count = PyTuple_GET_SIZE(constant);
         APPEND_STR("(");
         for (i = 0; i < elem_count; i++) {
             APPEND_STR_IF(i > 0, ", ");

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -64,16 +64,14 @@ append_charp(_PyUnicodeWriter *writer, const char *charp)
 static int
 append_repr(_PyUnicodeWriter *writer, PyObject *obj)
 {
-    if (PyFloat_CheckExact(obj) && Py_IS_INFINITY(PyFloat_AS_DOUBLE(obj))) {
-        return _PyUnicodeWriter_WriteStr(writer, _str_replace_inf);
-    }
     PyObject *repr = PyObject_Repr(obj);
 
     if (!repr) {
         return -1;
     }
 
-    if (PyComplex_CheckExact(obj))
+    if ((PyFloat_CheckExact(obj) && Py_IS_INFINITY(PyFloat_AS_DOUBLE(obj))) ||
+       PyComplex_CheckExact(obj))
     {
         PyObject *new_repr = PyUnicode_Replace(
             repr,

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -68,11 +68,12 @@ replace_inf_value(PyObject *repr)
     }
     PyObject *inf_value = PyUnicode_FromFormat("1e%d", 1 + DBL_MAX_10_EXP);
     if (!inf_value) {
+        Py_DECREF(inf_str);
         return NULL;
     }
     PyObject *result = PyUnicode_Replace(repr, inf_str, inf_value, -1);
-    Py_DECREF(inf_str);
     Py_DECREF(inf_value);
+    Py_DECREF(inf_str);
     return result;
 }
 
@@ -727,7 +728,6 @@ static int
 append_ast_constant(_PyUnicodeWriter *writer, PyObject *constant)
 {
     if (PyTuple_CheckExact(constant)) {
-        int ret;
         Py_ssize_t i, elem_count;
 
         elem_count = PySequence_Length(constant);
@@ -737,8 +737,8 @@ append_ast_constant(_PyUnicodeWriter *writer, PyObject *constant)
         APPEND_STR("(");
         for (i = 0; i < elem_count; i++) {
             APPEND_STR_IF(i > 0, ", ");
-            if ((ret = append_repr(writer, PyTuple_GET_ITEM(constant, i))) != 0) {
-                return ret;
+            if (append_repr(writer, PyTuple_GET_ITEM(constant, i)) < 0) {
+                return -1;
             }
         }
 

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -71,7 +71,6 @@ replace_inf_value(PyObject *repr)
         return NULL;
     }
     PyObject *result = PyUnicode_Replace(repr, inf_str, inf_value, -1);
-    Py_DECREF(repr);
     Py_DECREF(inf_str);
     Py_DECREF(inf_value);
     return result;
@@ -86,8 +85,13 @@ append_repr(_PyUnicodeWriter *writer, PyObject *obj)
     if (!repr) {
         return -1;
     }
-    if ((PyFloat_CheckExact(obj) || PyComplex_CheckExact(obj)) && !(repr = replace_inf_value(repr))) {
-        return -1;
+    if ((PyFloat_CheckExact(obj) || PyComplex_CheckExact(obj))) {
+        PyObject *new_repr = replace_inf_value(repr);
+        Py_DECREF(repr);
+        if (!new_repr) {
+            return -1;
+        }
+        repr = new_repr;
     }
     ret = _PyUnicodeWriter_WriteStr(writer, repr);
     Py_DECREF(repr);

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -725,7 +725,7 @@ append_ast_constant(_PyUnicodeWriter *writer, PyObject *constant)
         APPEND_STR("(");
         for (i = 0; i < elem_count; i++) {
             APPEND_STR_IF(i > 0, ", ");
-            if (append_repr(writer, PyTuple_GET_ITEM(constant, i)) < 0) {
+            if (append_ast_constant(writer, PyTuple_GET_ITEM(constant, i)) < 0) {
                 return -1;
             }
         }

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -64,14 +64,16 @@ append_charp(_PyUnicodeWriter *writer, const char *charp)
 static int
 append_repr(_PyUnicodeWriter *writer, PyObject *obj)
 {
-    int ret;
-    PyObject *repr;
-    repr = PyObject_Repr(obj);
+    if (PyFloat_CheckExact(obj) && Py_IS_INFINITY(PyFloat_AS_DOUBLE(obj))) {
+        return _PyUnicodeWriter_WriteStr(writer, _str_inf);
+    }
+    PyObject *repr = PyObject_Repr(obj);
+
     if (!repr) {
         return -1;
     }
-    if ((PyFloat_CheckExact(obj) && Py_IS_INFINITY(PyFloat_AS_DOUBLE(obj))) ||
-       PyComplex_CheckExact(obj))
+
+    if (PyComplex_CheckExact(obj))
     {
         PyObject *new_repr = PyUnicode_Replace(
             repr,
@@ -85,7 +87,7 @@ append_repr(_PyUnicodeWriter *writer, PyObject *obj)
         }
         repr = new_repr;
     }
-    ret = _PyUnicodeWriter_WriteStr(writer, repr);
+    int ret = _PyUnicodeWriter_WriteStr(writer, repr);
     Py_DECREF(repr);
     return ret;
 }

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -61,13 +61,6 @@ append_charp(_PyUnicodeWriter *writer, const char *charp)
         } \
     } while (0)
 
-static PyObject *
-replace_inf_value(PyObject *repr)
-{
-    PyObject *result = PyUnicode_Replace(repr, _str_inf, _str_replace_inf, -1);
-    return result;
-}
-
 static int
 append_repr(_PyUnicodeWriter *writer, PyObject *obj)
 {
@@ -80,7 +73,12 @@ append_repr(_PyUnicodeWriter *writer, PyObject *obj)
     if ((PyFloat_CheckExact(obj) && Py_IS_INFINITY(PyFloat_AS_DOUBLE(obj))) ||
        PyComplex_CheckExact(obj))
     {
-        PyObject *new_repr = replace_inf_value(repr);
+        PyObject *new_repr = PyUnicode_Replace(
+            repr,
+            _str_inf,
+            _str_replace_inf,
+            -1
+        );
         Py_DECREF(repr);
         if (!new_repr) {
             return -1;


### PR DESCRIPTION


<!-- issue-number: [bpo-32894](https://bugs.python.org/issue32894) -->
https://bugs.python.org/issue32894
<!-- /issue-number -->
