### PR TITLE
bpo-37883 - Added a new method doc to threading.Lock().locked()

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -496,6 +496,10 @@ All methods are executed atomically.
 
       There is no return value.
 
+   .. method:: locked()
+      Return true if the lock is acquired.
+
+
 
 .. _rlock-objects:
 


### PR DESCRIPTION
<!--

# Added a new method doc to threading.Lock().locked()

[bpo-37883](https://bugs.python.org/issue37883) - Added a new method doc to threading.Lock().locked()


# Backport Pull Request title

[3.7] [bpo-37883](https://bugs.python.org/issue37883) - Added a new method doc to threading.Lock().locked() (GH-17427)
[3.8] [bpo-37883](https://bugs.python.org/issue37883) - Added a new method doc to threading.Lock().locked() (GH-17427)


-->


<!-- issue-number: [bpo-37883](https://bugs.python.org/issue37883) -->
https://bugs.python.org/issue37883
<!-- /issue-number -->
