### PR TITLE
gh-79200: support IPAddress in asyncio.start_server()

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -73,6 +73,9 @@ and work with streams:
 
       The *ssl_handshake_timeout* parameter.
 
+   .. versionadded:: 3.9
+      Added support for IPAddress
+
 .. coroutinefunction:: start_server(client_connected_cb, host=None, \
                           port=None, \*, loop=None, limit=None, \
                           family=socket.AF_UNSPEC, \
@@ -105,6 +108,9 @@ and work with streams:
    .. versionadded:: 3.7
 
       The *ssl_handshake_timeout* and *start_serving* parameters.
+
+   .. versionadded:: 3.9
+      Added support for IPAddress
 
 
 .. rubric:: Unix Sockets

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -73,7 +73,7 @@ and work with streams:
 
       The *ssl_handshake_timeout* parameter.
 
-   .. versionadded:: 3.9
+   .. versionadded:: 3.10
       Added support for IPAddress
 
 .. coroutinefunction:: start_server(client_connected_cb, host=None, \

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -109,7 +109,7 @@ and work with streams:
 
       The *ssl_handshake_timeout* and *start_serving* parameters.
 
-   .. versionadded:: 3.9
+   .. versionadded:: 3.10
       Added support for IPAddress
 
 

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -139,6 +139,8 @@ def _ipaddr_info(host, port, family, type, proto, flowinfo=0, scopeid=0):
 
     if isinstance(host, bytes):
         host = host.decode('idna')
+    # Even though we're calling str() on host (so we'll convert arbitrary objects to str),
+    # we're restricting it to a valid IP address later when calling socket.inet_pton().
     host = str(host)
     if '%' in host:
         # Linux's inet_pton doesn't accept an IPv6 zone index after host,

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -139,6 +139,7 @@ def _ipaddr_info(host, port, family, type, proto, flowinfo=0, scopeid=0):
 
     if isinstance(host, bytes):
         host = host.decode('idna')
+    host = str(host)
     if '%' in host:
         # Linux's inet_pton doesn't accept an IPv6 zone index after host,
         # like '::1%lo0'.

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -17,6 +17,7 @@ from test.test_asyncio import utils as test_utils
 from test import support
 from test.support.script_helper import assert_python_ok
 from test.support import socket_helper
+from ipaddress import IPv4Address, IPv6Address
 
 
 MOCK_ANY = mock.ANY
@@ -77,6 +78,11 @@ class BaseEventTests(test_utils.TestCase):
             (INET, DGRAM, UDP, '', ('1.2.3.4', 1)),
             base_events._ipaddr_info('1.2.3.4', 1, UNSPEC, DGRAM, UDP))
 
+        # IPv4Address
+        self.assertEqual(
+            (INET, DGRAM, UDP, '', ('1.2.3.4', 1)),
+            base_events._ipaddr_info(IPv4Address('1.2.3.4'), 1, UNSPEC, DGRAM, UDP))
+
         # Socket type STREAM implies TCP protocol.
         self.assertEqual(
             (INET, STREAM, TCP, '', ('1.2.3.4', 1)),
@@ -103,6 +109,11 @@ class BaseEventTests(test_utils.TestCase):
             self.assertEqual(
                 (INET6, STREAM, TCP, '', ('::3', 1, 0, 0)),
                 base_events._ipaddr_info('::3', 1, UNSPEC, STREAM, TCP))
+
+            # IPv6Address 
+            self.assertEqual(
+                (INET6, STREAM, TCP, '', ('::3', 1, 0, 0)),
+                base_events._ipaddr_info(IPv6Address('::3'), 1, UNSPEC, STREAM, TCP))
 
             # IPv6 address with family IPv4.
             self.assertIsNone(

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -110,7 +110,7 @@ class BaseEventTests(test_utils.TestCase):
                 (INET6, STREAM, TCP, '', ('::3', 1, 0, 0)),
                 base_events._ipaddr_info('::3', 1, UNSPEC, STREAM, TCP))
 
-            # IPv6Address 
+            # IPv6Address
             self.assertEqual(
                 (INET6, STREAM, TCP, '', ('::3', 1, 0, 0)),
                 base_events._ipaddr_info(IPv6Address('::3'), 1, UNSPEC, STREAM, TCP))

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -346,6 +346,7 @@ David M. Cooke
 Jason R. Coombs
 Garrett Cooper
 Greg Copeland
+Max Coplan 🤘
 Ian Cordasco
 Aldo Cortesi
 Mircea Cosbuc

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -346,7 +346,7 @@ David M. Cooke
 Jason R. Coombs
 Garrett Cooper
 Greg Copeland
-Max Coplan 🤘
+Max Coplan
 Ian Cordasco
 Aldo Cortesi
 Mircea Cosbuc

--- a/Misc/NEWS.d/next/Library/2020-06-10-01-33-27.bpo-35019.dwhOOO.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-10-01-33-27.bpo-35019.dwhOOO.rst
@@ -1,0 +1,1 @@
+support IPAddress in asyncio.start_server()

--- a/Misc/NEWS.d/next/Library/2020-06-10-01-33-27.bpo-35019.dwhOOO.rst
+++ b/Misc/NEWS.d/next/Library/2020-06-10-01-33-27.bpo-35019.dwhOOO.rst
@@ -1,1 +1,1 @@
-support IPAddress in asyncio.start_server()
+Added support for IPAddress in asyncio.start_server()


### PR DESCRIPTION
Add support for new Python3 IPv4Address inet type.  This is tested and forwards and backwards compatible with different host types.

<!-- gh-issue-number: gh-79200 -->
* Issue: gh-79200
<!-- /gh-issue-number -->
