### PR TITLE
bpo-35981: apply os.path.abspath only to basedir (for windows)

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1027,7 +1027,8 @@ def make_archive(base_name, format, root_dir=None, base_dir=None, verbose=0,
     if root_dir is not None:
         if logger is not None:
             logger.debug("changing into '%s'", root_dir)
-        base_name = os.path.abspath(base_name)
+        base_dir, base_file = os.path.split(base_name)
+        base_name = os.path.join(os.path.abspath(base_dir), base_file)
         if not dry_run:
             os.chdir(root_dir)
 


### PR DESCRIPTION
Tentative fix for 35981. Instead of applying `os.path.abspath` to the `base_name` function argument directly, we apply it to its basedir part only, leaving the file name unchanged.

This should fix the issue in Windows where `os.path.abspath("foo...bar..")` becomes `foo...bar` (i.e. trailing dots are removed). The problem is that removing the trailing dots, before the file extension is added results in wrong file name. So if the file format is `zip`, then instead of `foo...bar...zip`, we end up with `foo...bar.zip`.

Applying `os.path.abspath` to the `filename` at the end of the function is an option too, but that would mean passing the `base_name` as-is to the archive format function, which I am not sure if will work correctly in all platforms.

Credit goes to steve.dower, this PR is just a tentative fix based on one of this suggestions in the issue.

Cheers
Bruno

<!-- issue-number: [bpo-35981](https://bugs.python.org/issue35981) -->
https://bugs.python.org/issue35981
<!-- /issue-number -->
