### PR TITLE
bpo-27873: Update docstring for multiprocessing.Pool.map

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2169,7 +2169,8 @@ with the :class:`Pool` class.
    .. method:: map(func, iterable[, chunksize])
 
       A parallel equivalent of the :func:`map` built-in function (it supports only
-      one *iterable* argument though).  It blocks until the result is ready.
+      one *iterable* argument though, for multiple iterables see :meth:`starmap`).
+      It blocks until the result is ready.
 
       This method chops the iterable into a number of chunks which it submits to
       the process pool as separate tasks.  The (approximate) size of these


### PR DESCRIPTION
Update docstring for `multiprocessing.Pool.map` to mention `pool.starmap()`.

Prev PR: https://github.com/python/cpython/pull/17367  @aeros

<!-- issue-number: [bpo-27873](https://bugs.python.org/issue27873) -->
https://bugs.python.org/issue27873
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou