### PR TITLE
Fix compiler warning in Objects/unicodeobject.c

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15950,7 +15950,7 @@ _PyUnicode_Fini(PyThreadState *tstate)
     interp->fs_codec.encoding = NULL;
     PyMem_RawFree(interp->fs_codec.errors);
     interp->fs_codec.errors = NULL;
-    interp->config.filesystem_errors = _Py_ERROR_UNKNOWN;
+    interp->config.filesystem_errors = (wchar_t *)_Py_ERROR_UNKNOWN;
 }
 
 


### PR DESCRIPTION
This fixes:

```
Objects/unicodeobject.c:15953:40: warning: expression which evaluates to zero treated as a null pointer constant of type 'wchar_t *' (aka 'int *') [-Wnon-literal-null-conversion]
    interp->config.filesystem_errors = _Py_ERROR_UNKNOWN;
                                       ^~~~~~~~~~~~~~~~~
1 warning generated.
```

Automerge-Triggered-By: @pablogsal