### PR TITLE
[3.5] bpo-38945: UU Encoding: Don't let newline in filename corrupt the output format (GH-17418)

### DIFF
--- a/Lib/encodings/uu_codec.py
+++ b/Lib/encodings/uu_codec.py
@@ -20,6 +20,10 @@ def uu_encode(input, errors='strict', filename='<data>', mode=0o666):
     read = infile.read
     write = outfile.write
 
+    # Remove newline chars from filename
+    filename = filename.replace('\n','\\n')
+    filename = filename.replace('\r','\\r')
+
     # Encode
     write(('begin %o %s\n' % (mode & 0o777, filename)).encode('ascii'))
     chunk = read(45)

--- a/Lib/test/test_uu.py
+++ b/Lib/test/test_uu.py
@@ -115,6 +115,15 @@ class UUTest(unittest.TestCase):
             decoded = codecs.decode(encodedtext, "uu_codec")
             self.assertEqual(decoded, plaintext)
 
+    def test_newlines_escaped(self):
+        # Test newlines are escaped with uu.encode
+        inp = io.BytesIO(plaintext)
+        out = io.BytesIO()
+        filename = "test.txt\n\roverflow.txt"
+        safefilename = b"test.txt\\n\\roverflow.txt"
+        uu.encode(inp, out, filename)
+        self.assertIn(safefilename, out.getvalue())
+
 class UUStdIOTest(unittest.TestCase):
 
     def setUp(self):

--- a/Lib/uu.py
+++ b/Lib/uu.py
@@ -73,6 +73,13 @@ def encode(in_file, out_file, name=None, mode=None):
             name = '-'
         if mode is None:
             mode = 0o666
+
+        #
+        # Remove newline chars from name
+        #
+        name = name.replace('\n','\\n')
+        name = name.replace('\r','\\r')
+
         #
         # Write the data
         #

--- a/Misc/NEWS.d/next/Security/2019-12-01-22-44-40.bpo-38945.ztmNXc.rst
+++ b/Misc/NEWS.d/next/Security/2019-12-01-22-44-40.bpo-38945.ztmNXc.rst
@@ -1,0 +1,1 @@
+Newline characters have been escaped when performing uu encoding to prevent them from overflowing into to content section of the encoded file. This prevents malicious or accidental modification of data during the decoding process.


### PR DESCRIPTION
(cherry picked from commit a62ad4730c9b575f140f24074656c0257c86a09a)

Co-authored-by: Matthew Rollings <1211162+stealthcopter@users.noreply.github.com>


<!-- issue-number: [bpo-38945](https://bugs.python.org/issue38945) -->
https://bugs.python.org/issue38945
<!-- /issue-number -->
