### PR TITLE
bpo-38270: Fix indentation of test_hmac assertions

### DIFF
--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -367,7 +367,7 @@ class ConstructorTestCase(unittest.TestCase):
                           digestmod="sha256")
         except Exception:
             self.fail("Constructor call with bytearray arguments raised exception.")
-            self.assertEqual(h.hexdigest(), self.expected)
+        self.assertEqual(h.hexdigest(), self.expected)
 
     @requires_hashdigest('sha256')
     def test_with_memoryview_msg(self):
@@ -375,7 +375,7 @@ class ConstructorTestCase(unittest.TestCase):
             h = hmac.HMAC(b"key", memoryview(b"hash this!"), digestmod="sha256")
         except Exception:
             self.fail("Constructor call with memoryview msg raised exception.")
-            self.assertEqual(h.hexdigest(), self.expected)
+        self.assertEqual(h.hexdigest(), self.expected)
 
     @requires_hashdigest('sha256')
     def test_withmodule(self):


### PR DESCRIPTION
Since https://github.com/python/cpython/commit/c64a1a61e6fc542cada40eb069a239317e1af36e two assertions were indented and thus ignored when running test_hmac.

This PR fixes it. As the change is quite trivial I didn't add a NEWS entry.

<!-- issue-number: [bpo-38270](https://bugs.python.org/issue38270) -->
https://bugs.python.org/issue38270
<!-- /issue-number -->


Automerge-Triggered-By: @tiran