### PR TITLE
bpo-38572: Raise an unsupported error when an underlying stream does not support fileno()

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -863,7 +863,9 @@ class _BufferedIOMixin(BufferedIOBase):
     ### Lower-level APIs ###
 
     def fileno(self):
-        return self.raw.fileno()
+        if hasattr(self.raw, 'fileno'):
+            return self.raw.fileno()
+        self._unsupported('fileno')
 
     def isatty(self):
         return self.raw.isatty()

--- a/Misc/NEWS.d/next/Library/2019-12-03-11-58-29.bpo-38572.-0krPb.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-03-11-58-29.bpo-38572.-0krPb.rst
@@ -1,0 +1,12 @@
+Raise an unsupported error when an underlying stream does not support
+fileno()
+
+Buffered readers and writers wrap an underlying `raw` stream, with most
+requests being passed to that stream. Unfortunately, the wrappers offer a
+`fileno` API, implemented as `raw.fileno`, but if the underlying stream does
+not support this operation, the exposed `fileno` API will raise an
+`AttributeError` instead of specifying that the wrapped stream does not
+support the operation via `UnsupportedOperation` error. Buffered readers and
+writers now check that the underlying stream has a `fileno` attribute,
+raising `UnsupportedOperation` if that is not the case. Patch by Claudiu
+Popa.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -599,6 +599,9 @@ static PyObject *
 buffered_fileno(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
+    if (!PyObject_HasAttr(self->raw, _PyIO_str_fileno)) {
+        return bufferediobase_unsupported("fileno");
+    }
     return _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_fileno);
 }
 


### PR DESCRIPTION
Buffered readers and writers wrap an underlying `raw` stream, with most requests being passed to that stream. Unfortunately, the wrappers offer a `fileno` API, implemented as `raw.fileno`, but if the underlying stream does not support this operation, the exposed `fileno` API will raise an
`AttributeError` instead of specifying that the wrapped stream does not support the operation via `UnsupportedOperation` error. Buffered readers and writers now check that the underlying stream has a `fileno` attribute, raising `UnsupportedOperation` if that is not the case.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

https://bugs.python.org/issue38572


<!-- issue-number: [bpo-38572](https://bugs.python.org/issue38572) -->
https://bugs.python.org/issue38572
<!-- /issue-number -->
