### PR TITLE
Revert "bpo-36854: Move _PyRuntimeState.gc to PyInterpreterState (GH-17287)"

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -38,7 +38,7 @@ static inline void _PyObject_GC_TRACK_impl(const char *filename, int lineno,
                           filename, lineno, "_PyObject_GC_TRACK");
 
     PyThreadState *tstate = _PyThreadState_GET();
-    PyGC_Head *generation0 = tstate->interp->gc.generation0;
+    PyGC_Head *generation0 = tstate->interp->runtime->gc.generation0;
     PyGC_Head *last = (PyGC_Head*)(generation0->_gc_prev);
     _PyGCHead_SET_NEXT(last, gc);
     _PyGCHead_SET_PREV(gc, last);

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -144,7 +144,7 @@ struct _gc_runtime_state {
     Py_ssize_t long_lived_pending;
 };
 
-PyAPI_FUNC(void) _PyGC_InitState(struct _gc_runtime_state *);
+PyAPI_FUNC(void) _PyGC_InitializeRuntime(struct _gc_runtime_state *);
 
 
 /* Set the memory allocator of the specified domain to the default.

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -74,8 +74,6 @@ struct _is {
 
     int finalizing;
 
-    struct _gc_runtime_state gc;
-
     PyObject *modules;
     PyObject *modules_by_index;
     PyObject *sysdict;
@@ -132,7 +130,9 @@ struct _is {
     struct _warnings_runtime_state warnings;
 
     PyObject *audit_hooks;
-
+/*
+ * See bpo-36876: miscellaneous ad hoc statics have been moved here.
+ */
     struct {
         struct {
             int level;
@@ -239,6 +239,7 @@ typedef struct pyruntimestate {
     void (*exitfuncs[NEXITFUNCS])(void);
     int nexitfuncs;
 
+    struct _gc_runtime_state gc;
     struct _ceval_runtime_state ceval;
     struct _gilstate_runtime_state gilstate;
 

--- a/Misc/NEWS.d/next/Core and Builtins/2019-11-20-12-01-37.bpo-36854.Zga_md.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-11-20-12-01-37.bpo-36854.Zga_md.rst
@@ -1,3 +1,0 @@
-The garbage collector state becomes per interpreter
-(``PyInterpreterState.gc``), rather than being global
-(``_PyRuntimeState.gc``).

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2131,14 +2131,11 @@ finally:
 void
 _PyTrash_deposit_object(PyObject *op)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-    struct _gc_runtime_state *gcstate = &tstate->interp->gc;
-
     _PyObject_ASSERT(op, PyObject_IS_GC(op));
     _PyObject_ASSERT(op, !_PyObject_GC_IS_TRACKED(op));
     _PyObject_ASSERT(op, op->ob_refcnt == 0);
-    _PyGCHead_SET_PREV(_Py_AS_GC(op), gcstate->trash_delete_later);
-    gcstate->trash_delete_later = op;
+    _PyGCHead_SET_PREV(_Py_AS_GC(op), _PyRuntime.gc.trash_delete_later);
+    _PyRuntime.gc.trash_delete_later = op;
 }
 
 /* The equivalent API, using per-thread state recursion info */
@@ -2159,14 +2156,11 @@ _PyTrash_thread_deposit_object(PyObject *op)
 void
 _PyTrash_destroy_chain(void)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-    struct _gc_runtime_state *gcstate = &tstate->interp->gc;
-
-    while (gcstate->trash_delete_later) {
-        PyObject *op = gcstate->trash_delete_later;
+    while (_PyRuntime.gc.trash_delete_later) {
+        PyObject *op = _PyRuntime.gc.trash_delete_later;
         destructor dealloc = Py_TYPE(op)->tp_dealloc;
 
-        gcstate->trash_delete_later =
+        _PyRuntime.gc.trash_delete_later =
             (PyObject*) _PyGCHead_PREV(_Py_AS_GC(op));
 
         /* Call the deallocator directly.  This used to try to
@@ -2176,9 +2170,9 @@ _PyTrash_destroy_chain(void)
          * up distorting allocation statistics.
          */
         _PyObject_ASSERT(op, op->ob_refcnt == 0);
-        ++gcstate->trash_delete_nesting;
+        ++_PyRuntime.gc.trash_delete_nesting;
         (*dealloc)(op);
-        --gcstate->trash_delete_nesting;
+        --_PyRuntime.gc.trash_delete_nesting;
     }
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1274,9 +1274,8 @@ finalize_interp_clear(PyThreadState *tstate)
         PyGrammar_RemoveAccelerators(&_PyParser_Grammar);
 
         _PyExc_Fini();
+        _PyGC_Fini(tstate);
     }
-
-    _PyGC_Fini(tstate);
 }
 
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -58,6 +58,7 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
     runtime->open_code_userdata = open_code_userdata;
     runtime->audit_hook_head = audit_hook_head;
 
+    _PyGC_InitializeRuntime(&runtime->gc);
     _PyEval_Initialize(&runtime->ceval);
 
     PyPreConfig_InitPythonConfig(&runtime->preconfig);
@@ -213,7 +214,6 @@ PyInterpreterState_New(void)
     _PyRuntimeState *runtime = &_PyRuntime;
     interp->runtime = runtime;
 
-    _PyGC_InitState(&interp->gc);
     PyConfig_InitPythonConfig(&interp->config);
 
     interp->eval_frame = _PyEval_EvalFrameDefault;


### PR DESCRIPTION
This reverts commit 7247407c35330f3f6292f1d40606b7ba6afd5700.

<!-- issue-number: [bpo-36854](https://bugs.python.org/issue36854) -->
https://bugs.python.org/issue36854
<!-- /issue-number -->
