### PR TITLE
bpo-38965: Fix stuck in test_stack_overflow tests.

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-12-04-08-46-23.bpo-38965.Yl4gI2asdfa.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-04-08-46-23.bpo-38965.Yl4gI2asdfa.rst
@@ -1,0 +1,2 @@
+After update to GCC10, the testcase is stuck and
+a pragma needs to be added.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1169,6 +1169,11 @@ faulthandler_fatal_error_py(PyObject *self, PyObject *args)
 #endif
 static
 uintptr_t
+#ifdef __GNUC__
+  /* For the very same reason, the GCC compiler can turn the tail
+   * call into a loop.  */
+__attribute__((optimize("-O0")))
+#endif
 stack_overflow(uintptr_t min_sp, uintptr_t max_sp, size_t *depth)
 {
     /* allocate 4096 bytes on the stack at each call */


### PR DESCRIPTION
After update to GCC10, the testcase is stuck and
a pragma needs to be added.


<!-- issue-number: [bpo-38965](https://bugs.python.org/issue38965) -->
https://bugs.python.org/issue38965
<!-- /issue-number -->
