### PR TITLE
bpo-27413: json.tool: Add `--no-ensure-ascii` option.

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -732,6 +732,12 @@ Command line options
 
    .. versionadded:: 3.5
 
+.. cmdoption:: --no-ensure-ascii
+
+   Disable escaping of non-ascii characters, see :func:`json.dumps` for more information.
+
+   .. versionadded:: 3.9
+
 .. cmdoption:: --json-lines
 
    Parse every input line as separate JSON object.

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -30,6 +30,8 @@ def main():
                         default=sys.stdout)
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
+    parser.add_argument('--no-ensure-ascii', dest='ensure_ascii', action='store_false',
+                        help='disable escaping of non-ASCII characters')
     parser.add_argument('--json-lines', action='store_true', default=False,
                         help='parse input using the jsonlines format')
     group = parser.add_mutually_exclusive_group()
@@ -49,6 +51,7 @@ def main():
     dump_args = {
         'sort_keys': options.sort_keys,
         'indent': options.indent,
+        'ensure_ascii': options.ensure_ascii,
     }
     if options.compact:
         dump_args['indent'] = None

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -190,3 +190,25 @@ class TestTool(unittest.TestCase):
             json_stdout, err = proc.communicate(json_stdin)
         self.assertEqual(expect.splitlines(), json_stdout.splitlines())
         self.assertEqual(err, b'')
+
+    def test_no_ensure_ascii_flag(self):
+        infile = self._create_infile('{"key":"💩"}')
+        outfile = support.TESTFN + '.out'
+        self.addCleanup(os.remove, outfile)
+        assert_python_ok('-m', 'json.tool', '--no-ensure-ascii', infile, outfile)
+        with open(outfile, "rb") as f:
+            lines = f.read().splitlines()
+        # asserting utf-8 encoded output file
+        expected = [b'{', b'    "key": "\xf0\x9f\x92\xa9"', b"}"]
+        self.assertEqual(lines, expected)
+
+    def test_ensure_ascii_default(self):
+        infile = self._create_infile('{"key":"💩"}')
+        outfile = support.TESTFN + '.out'
+        self.addCleanup(os.remove, outfile)
+        assert_python_ok('-m', 'json.tool', infile, outfile)
+        with open(outfile, "rb") as f:
+            lines = f.read().splitlines()
+        # asserting an ascii encoded output file
+        expected = [b'{', rb'    "key": "\ud83d\udca9"', b"}"]
+        self.assertEqual(lines, expected)

--- a/Misc/NEWS.d/next/Library/2019-12-05-02-02-58.bpo-27413.212Th2.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-05-02-02-58.bpo-27413.212Th2.rst
@@ -1,0 +1,2 @@
+Added ability to pass through ``ensure_ascii`` options to json.dumps in the
+``json.tool`` command-line interface.


### PR DESCRIPTION
Added ability to pass through `ensure_ascii` options to json.dumps in the `json.tool` command-line interface.

Some motivation: https://stackoverflow.com/questions/52712674/how-to-use-json-tool-from-the-shell-to-validate-and-pretty-print-language-files

<!-- issue-number: [bpo-27413](https://bugs.python.org/issue27413) -->
https://bugs.python.org/issue27413
<!-- /issue-number -->
