### PR TITLE
bpo-38982: Fix asyncio PidfdChildWatcher on waitpid() error

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-12-05-18-21-26.bpo-38982.W3u-03.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-05-18-21-26.bpo-38982.W3u-03.rst
@@ -1,0 +1,5 @@
+Fix asyncio ``PidfdChildWatcher``: handle ``waitpid()`` error. If
+``waitpid()`` is called elsewhere, ``waitpid()`` call fails with
+:exc:`ChildProcessError`: use return code 255 in this case, and log a
+warning. It ensures that the pidfd file descriptor is closed if this error
+occurs.


### PR DESCRIPTION
If waitpid() is called elsewhere, waitpid() call fails with
ChildProcessError: use return code 255 in this case, and log a
warning. It ensure that the pidfd file descriptor is closed if this
error occurs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38982](https://bugs.python.org/issue38982) -->
https://bugs.python.org/issue38982
<!-- /issue-number -->
