### PR TITLE
bpo-38858: new_interpreter() reuses _PySys_Create()

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -40,7 +40,6 @@ extern PyObject * _PyBuiltin_Init(PyThreadState *tstate);
 extern PyStatus _PySys_Create(
     PyThreadState *tstate,
     PyObject **sysmod_p);
-extern PyStatus _PySys_SetPreliminaryStderr(PyObject *sysdict);
 extern PyStatus _PySys_ReadPreinitWarnOptions(PyWideStringList *options);
 extern PyStatus _PySys_ReadPreinitXOptions(PyConfig *config);
 extern int _PySys_InitMain(PyThreadState *tstate);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -622,6 +622,8 @@ pycore_init_types(PyThreadState *tstate)
 static PyStatus
 pycore_init_builtins(PyThreadState *tstate)
 {
+    assert(!_PyErr_Occurred(tstate));
+
     PyObject *bimod = _PyBuiltin_Init(tstate);
     if (bimod == NULL) {
         goto error;
@@ -649,6 +651,9 @@ pycore_init_builtins(PyThreadState *tstate)
         goto error;
     }
     Py_DECREF(bimod);
+
+    assert(!_PyErr_Occurred(tstate));
+
     return _PyStatus_OK();
 
 error:
@@ -660,13 +665,14 @@ error:
 static PyStatus
 pycore_init_import_warnings(PyThreadState *tstate, PyObject *sysmod)
 {
-    const PyConfig *config = &tstate->interp->config;
+    assert(!_PyErr_Occurred(tstate));
 
     PyStatus status = _PyImportHooks_Init(tstate);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
 
+    const PyConfig *config = &tstate->interp->config;
     if (_Py_IsMainInterpreter(tstate)) {
         /* Initialize _warnings. */
         if (_PyWarnings_Init() == NULL) {
@@ -688,6 +694,9 @@ pycore_init_import_warnings(PyThreadState *tstate, PyObject *sysmod)
             return status;
         }
     }
+
+    assert(!_PyErr_Occurred(tstate));
+
     return _PyStatus_OK();
 }
 
@@ -929,6 +938,8 @@ _Py_ReconfigureMainInterpreter(PyThreadState *tstate)
 static PyStatus
 init_interp_main(PyThreadState *tstate)
 {
+    assert(!_PyErr_Occurred(tstate));
+
     PyStatus status;
     int is_main_interp = _Py_IsMainInterpreter(tstate);
     PyInterpreterState *interp = tstate->interp;
@@ -950,10 +961,10 @@ init_interp_main(PyThreadState *tstate)
         if (_PyTime_Init() < 0) {
             return _PyStatus_ERR("can't initialize time");
         }
+    }
 
-        if (_PySys_InitMain(tstate) < 0) {
-            return _PyStatus_ERR("can't finish initializing sys");
-        }
+    if (_PySys_InitMain(tstate) < 0) {
+        return _PyStatus_ERR("can't finish initializing sys");
     }
 
     status = init_importlib_external(tstate);
@@ -1030,6 +1041,8 @@ init_interp_main(PyThreadState *tstate)
         emit_stderr_warning_for_legacy_locale(interp->runtime);
 #endif
     }
+
+    assert(!_PyErr_Occurred(tstate));
 
     return _PyStatus_OK();
 }
@@ -1534,70 +1547,40 @@ new_interpreter(PyThreadState **tstate_p)
 
     status = _PyConfig_Copy(&interp->config, config);
     if (_PyStatus_EXCEPTION(status)) {
-        goto done;
+        goto error;
     }
     config = &interp->config;
 
     status = pycore_init_types(tstate);
-
-    /* XXX The following is lax in error checking */
-    PyObject *modules = PyDict_New();
-    if (modules == NULL) {
-        status = _PyStatus_ERR("can't make modules dictionary");
-        goto done;
+    if (_PyStatus_EXCEPTION(status)) {
+        goto error;
     }
-    interp->modules = modules;
 
-    PyObject *sysmod = _PyImport_FindBuiltin(tstate, "sys");
-    if (sysmod != NULL) {
-        interp->sysdict = PyModule_GetDict(sysmod);
-        if (interp->sysdict == NULL) {
-            goto handle_exc;
-        }
-        Py_INCREF(interp->sysdict);
-        PyDict_SetItemString(interp->sysdict, "modules", modules);
-        if (_PySys_InitMain(tstate) < 0) {
-            status = _PyStatus_ERR("can't finish initializing sys");
-            goto done;
-        }
-    }
-    else if (_PyErr_Occurred(tstate)) {
-        goto handle_exc;
+    PyObject *sysmod;
+    status = _PySys_Create(tstate, &sysmod);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
     }
 
     status = pycore_init_builtins(tstate);
     if (_PyStatus_EXCEPTION(status)) {
-        goto done;
+        goto error;
     }
 
-    if (sysmod != NULL) {
-        status = _PySys_SetPreliminaryStderr(interp->sysdict);
-        if (_PyStatus_EXCEPTION(status)) {
-            goto done;
-        }
-
-        status = pycore_init_import_warnings(tstate, sysmod);
-        if (_PyStatus_EXCEPTION(status)) {
-            goto done;
-        }
-
-        status = init_interp_main(tstate);
-        if (_PyStatus_EXCEPTION(status)) {
-            goto done;
-        }
+    status = pycore_init_import_warnings(tstate, sysmod);
+    if (_PyStatus_EXCEPTION(status)) {
+        goto error;
     }
 
-    if (_PyErr_Occurred(tstate)) {
-        goto handle_exc;
+    status = init_interp_main(tstate);
+    if (_PyStatus_EXCEPTION(status)) {
+        goto error;
     }
 
     *tstate_p = tstate;
     return _PyStatus_OK();
 
-handle_exc:
-    status = _PyStatus_OK();
-
-done:
+error:
     *tstate_p = NULL;
 
     /* Oops, it didn't work.  Undo it all. */


### PR DESCRIPTION
new_interpreter() now calls _PySys_Create() to create a new sys
module isolated from the main interpreter. It now calls
_PySys_InitCore() and _PyImport_FixupBuiltin().

init_interp_main() now calls _PySys_InitMain().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38858](https://bugs.python.org/issue38858) -->
https://bugs.python.org/issue38858
<!-- /issue-number -->
