### PR TITLE
bpo-29636: json.tool: Add document for indentation options.

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -738,6 +738,12 @@ Command line options
 
    .. versionadded:: 3.8
 
+.. cmdoption:: --indent, --tab, --no-indent, --compact
+
+   Mutually exclusive options for whitespace control
+
+   .. versionadded:: 3.9
+
 .. cmdoption:: -h, --help
 
    Show the help message.

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -31,8 +31,8 @@ def main():
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
     parser.add_argument('--json-lines', action='store_true', default=False,
-                        help='parse input using the jsonlines format. '
-                        'Use with --no-indent or --compact to produce valid jsonlines output.')
+                        help='parse input using the JSON Lines format. '
+                        'Use with --no-indent or --compact to produce valid JSON Lines output.')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--indent', default=4, type=int,
                        help='separate items with newlines and use this number '

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -31,7 +31,8 @@ def main():
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
     parser.add_argument('--json-lines', action='store_true', default=False,
-                        help='parse input using the jsonlines format')
+                        help='parse input using the jsonlines format. '
+                        'Use with --no-indent or --compact to produce valid jsonlines output.')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--indent', default=4, type=int,
                        help='separate items with newlines and use this number '

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -2,7 +2,7 @@ import os
 import sys
 import textwrap
 import unittest
-from subprocess import Popen, PIPE
+from subprocess import check_call
 from test import support
 from test.support.script_helper import assert_python_ok
 
@@ -84,10 +84,9 @@ class TestTool(unittest.TestCase):
 
     def test_stdin_stdout(self):
         args = sys.executable, '-m', 'json.tool'
-        with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
-            out, err = proc.communicate(self.data.encode())
-        self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
-        self.assertEqual(err, b'')
+        process = check_call(args, input=self.data, capture_output=True, text=True)
+        self.assertEqual(process.stdout, self.expect)
+        self.assertEqual(process.stderr, '')
 
     def _create_infile(self, data=None):
         infile = support.TESTFN
@@ -131,10 +130,9 @@ class TestTool(unittest.TestCase):
 
     def test_jsonlines(self):
         args = sys.executable, '-m', 'json.tool', '--json-lines'
-        with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
-            out, err = proc.communicate(self.jsonlines_raw.encode())
-        self.assertEqual(out.splitlines(), self.jsonlines_expect.encode().splitlines())
-        self.assertEqual(err, b'')
+        process = check_call(args, input=self.jsonlines_raw, capture_output=True, text=True)
+        self.assertEqual(process.stdout, self.jsonlines_expect)
+        self.assertEqual(process.stderr, '')
 
     def test_help_flag(self):
         rc, out, err = assert_python_ok('-m', 'json.tool', '-h')
@@ -151,42 +149,38 @@ class TestTool(unittest.TestCase):
         self.assertEqual(err, b'')
 
     def test_indent(self):
-        json_stdin = b'[1, 2]'
+        input_ = '[1, 2]'
         expect = textwrap.dedent('''\
         [
           1,
           2
         ]
-        ''').encode()
+        ''')
         args = sys.executable, '-m', 'json.tool', '--indent', '2'
-        with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
-            json_stdout, err = proc.communicate(json_stdin)
-        self.assertEqual(expect.splitlines(), json_stdout.splitlines())
-        self.assertEqual(err, b'')
+        process = check_call(args, input=input_, capture_output=True, text=True)
+        self.assertEqual(process.stdout, expect)
+        self.assertEqual(process.stderr, '')
 
     def test_no_indent(self):
-        json_stdin = b'[1,\n2]'
-        expect = b'[1, 2]'
+        input_ = '[1,\n2]'
+        expect = '[1, 2]'
         args = sys.executable, '-m', 'json.tool', '--no-indent'
-        with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
-            json_stdout, err = proc.communicate(json_stdin)
-        self.assertEqual(expect.splitlines(), json_stdout.splitlines())
-        self.assertEqual(err, b'')
+        process = check_call(args, input=input_, capture_output=True, text=True)
+        self.assertEqual(process.stdout, expect)
+        self.assertEqual(process.stderr, '')
 
     def test_tab(self):
-        json_stdin = b'[1, 2]'
-        expect = b'[\n\t1,\n\t2\n]\n'
+        input_ = '[1, 2]'
+        expect = '[\n\t1,\n\t2\n]\n'
         args = sys.executable, '-m', 'json.tool', '--tab'
-        with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
-            json_stdout, err = proc.communicate(json_stdin)
-        self.assertEqual(expect.splitlines(), json_stdout.splitlines())
-        self.assertEqual(err, b'')
+        process = check_call(args, input=input_, capture_output=True, text=True)
+        self.assertEqual(process.stdout, expect)
+        self.assertEqual(process.stderr, '')
 
     def test_compact(self):
-        json_stdin = b'[ 1 ,\n 2]'
-        expect = b'[1,2]'
+        input_ = '[ 1 ,\n 2]'
+        expect = '[1,2]'
         args = sys.executable, '-m', 'json.tool', '--compact'
-        with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
-            json_stdout, err = proc.communicate(json_stdin)
-        self.assertEqual(expect.splitlines(), json_stdout.splitlines())
-        self.assertEqual(err, b'')
+        process = check_call(args, input=input_, capture_output=True, text=True)
+        self.assertEqual(process.stdout, expect)
+        self.assertEqual(process.stderr, '')

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -2,7 +2,7 @@ import os
 import sys
 import textwrap
 import unittest
-from subprocess import check_call
+import subprocess
 from test import support
 from test.support.script_helper import assert_python_ok
 
@@ -84,7 +84,7 @@ class TestTool(unittest.TestCase):
 
     def test_stdin_stdout(self):
         args = sys.executable, '-m', 'json.tool'
-        process = check_call(args, input=self.data, capture_output=True, text=True)
+        process = subprocess.run(args, input=self.data, capture_output=True, text=True, check=True)
         self.assertEqual(process.stdout, self.expect)
         self.assertEqual(process.stderr, '')
 
@@ -130,7 +130,7 @@ class TestTool(unittest.TestCase):
 
     def test_jsonlines(self):
         args = sys.executable, '-m', 'json.tool', '--json-lines'
-        process = check_call(args, input=self.jsonlines_raw, capture_output=True, text=True)
+        process = subprocess.run(args, input=self.jsonlines_raw, capture_output=True, text=True, check=True)
         self.assertEqual(process.stdout, self.jsonlines_expect)
         self.assertEqual(process.stderr, '')
 
@@ -157,7 +157,7 @@ class TestTool(unittest.TestCase):
         ]
         ''')
         args = sys.executable, '-m', 'json.tool', '--indent', '2'
-        process = check_call(args, input=input_, capture_output=True, text=True)
+        process = subprocess.run(args, input=input_, capture_output=True, text=True, check=True)
         self.assertEqual(process.stdout, expect)
         self.assertEqual(process.stderr, '')
 
@@ -165,7 +165,7 @@ class TestTool(unittest.TestCase):
         input_ = '[1,\n2]'
         expect = '[1, 2]'
         args = sys.executable, '-m', 'json.tool', '--no-indent'
-        process = check_call(args, input=input_, capture_output=True, text=True)
+        process = subprocess.run(args, input=input_, capture_output=True, text=True, check=True)
         self.assertEqual(process.stdout, expect)
         self.assertEqual(process.stderr, '')
 
@@ -173,7 +173,7 @@ class TestTool(unittest.TestCase):
         input_ = '[1, 2]'
         expect = '[\n\t1,\n\t2\n]\n'
         args = sys.executable, '-m', 'json.tool', '--tab'
-        process = check_call(args, input=input_, capture_output=True, text=True)
+        process = subprocess.run(args, input=input_, capture_output=True, text=True, check=True)
         self.assertEqual(process.stdout, expect)
         self.assertEqual(process.stderr, '')
 
@@ -181,6 +181,6 @@ class TestTool(unittest.TestCase):
         input_ = '[ 1 ,\n 2]'
         expect = '[1,2]'
         args = sys.executable, '-m', 'json.tool', '--compact'
-        process = check_call(args, input=input_, capture_output=True, text=True)
+        process = subprocess.run(args, input=input_, capture_output=True, text=True, check=True)
         self.assertEqual(process.stdout, expect)
         self.assertEqual(process.stderr, '')

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -163,7 +163,7 @@ class TestTool(unittest.TestCase):
 
     def test_no_indent(self):
         input_ = '[1,\n2]'
-        expect = '[1, 2]'
+        expect = '[1, 2]\n'
         args = sys.executable, '-m', 'json.tool', '--no-indent'
         process = subprocess.run(args, input=input_, capture_output=True, text=True, check=True)
         self.assertEqual(process.stdout, expect)
@@ -179,7 +179,7 @@ class TestTool(unittest.TestCase):
 
     def test_compact(self):
         input_ = '[ 1 ,\n 2]'
-        expect = '[1,2]'
+        expect = '[1,2]\n'
         args = sys.executable, '-m', 'json.tool', '--compact'
         process = subprocess.run(args, input=input_, capture_output=True, text=True, check=True)
         self.assertEqual(process.stdout, expect)


### PR DESCRIPTION
https://github.com/python/cpython/pull/345 added indentation options for the `json.tool` command line utility. This PR follows up with some additional modifications that I didn't have time to put in the previous PR before it was merged.

<!-- issue-number: [bpo-29636](https://bugs.python.org/issue29636) -->
https://bugs.python.org/issue29636
<!-- /issue-number -->

CC @methane 