### PR TITLE
bpo-38986: Make repr of C accelerated TaskWakeupMethWrapper the same as of pure Python version

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-12-06-15-11-42.bpo-38986.bg6iZt.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-06-15-11-42.bpo-38986.bg6iZt.rst
@@ -1,0 +1,2 @@
+Make repr of C accelerated TaskWakeupMethWrapper the same as of pure Python
+version.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1808,6 +1808,21 @@ TaskWakeupMethWrapper_dealloc(TaskWakeupMethWrapper *o)
     Py_TYPE(o)->tp_free(o);
 }
 
+static PyObject *
+TaskWakeupMethWrapper_get___self__(TaskWakeupMethWrapper *o, void *Py_UNUSED(ignored))
+{
+    if (o->ww_task) {
+        Py_INCREF(o->ww_task);
+        return (PyObject*)o->ww_task;
+    }
+    Py_RETURN_NONE;
+}
+
+static PyGetSetDef TaskWakeupMethWrapper_getsetlist[] = {
+    {"__self__", (getter)TaskWakeupMethWrapper_get___self__, NULL, NULL},
+    {NULL} /* Sentinel */
+};
+
 static PyTypeObject TaskWakeupMethWrapper_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "TaskWakeupMethWrapper",
@@ -1819,6 +1834,7 @@ static PyTypeObject TaskWakeupMethWrapper_Type = {
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_traverse = (traverseproc)TaskWakeupMethWrapper_traverse,
     .tp_clear = (inquiry)TaskWakeupMethWrapper_clear,
+    .tp_getset = TaskWakeupMethWrapper_getsetlist,
 };
 
 static PyObject *
@@ -3251,7 +3267,7 @@ module_init(void)
     }
     if (module_initialized != 0) {
         return 0;
-    } 
+    }
     else {
         module_initialized = 1;
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-38986](https://bugs.python.org/issue38986) -->
https://bugs.python.org/issue38986
<!-- /issue-number -->
