### PR TITLE
bpo-38916: array.array: remove fromstring() and tostring()

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -169,11 +169,6 @@ The following data items and methods are also supported:
    a.append(x)`` except that if there is a type error, the array is unchanged.
 
 
-.. method:: array.fromstring()
-
-   Deprecated alias for :meth:`frombytes`.
-
-
 .. method:: array.fromunicode(s)
 
    Extends this array with data from the given unicode string.  The array must
@@ -229,11 +224,6 @@ The following data items and methods are also supported:
 .. method:: array.tolist()
 
    Convert the array to an ordinary list with the same items.
-
-
-.. method:: array.tostring()
-
-   Deprecated alias for :meth:`tobytes`.
 
 
 .. method:: array.tounicode()

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -279,6 +279,11 @@ Deprecated
 Removed
 =======
 
+* :class:`array.array`: ``tostring()`` and ``fromstring()`` methods have been
+  removed. They were aliases to ``tobytes()`` and ``frombytes()``, deprecated
+  since Python 3.2.
+  (Contributed by Victor Stinner in :issue:`38916`.)
+
 * The abstract base classes in :mod:`collections.abc` no longer are
   exposed in the regular :mod:`collections` module.  This will help
   create a clearer distinction between the concrete classes and the abstract

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -426,26 +426,6 @@ class BaseTest:
         b.fromlist(a.tolist())
         self.assertEqual(a, b)
 
-    def test_tofromstring(self):
-        # Warnings not raised when arguments are incorrect as Argument Clinic
-        # handles that before the warning can be raised.
-        nb_warnings = 2
-        with warnings.catch_warnings(record=True) as r:
-            warnings.filterwarnings("always",
-                                    message=r"(to|from)string\(\) is deprecated",
-                                    category=DeprecationWarning)
-            a = array.array(self.typecode, 2*self.example)
-            b = array.array(self.typecode)
-            self.assertRaises(TypeError, a.tostring, 42)
-            self.assertRaises(TypeError, b.fromstring)
-            self.assertRaises(TypeError, b.fromstring, 42)
-            b.fromstring(a.tostring())
-            self.assertEqual(a, b)
-            if a.itemsize>1:
-                self.assertRaises(ValueError, b.fromstring, "x")
-                nb_warnings += 1
-        self.assertEqual(len(r), nb_warnings)
-
     def test_tofrombytes(self):
         a = array.array(self.typecode, 2*self.example)
         b = array.array(self.typecode)

--- a/Misc/NEWS.d/next/Library/2019-12-06-18-47-56.bpo-38916.K-raU8.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-06-18-47-56.bpo-38916.K-raU8.rst
@@ -1,0 +1,3 @@
+:class:`array.array`: Remove ``tostring()`` and ``fromstring()`` methods.
+They were aliases to ``tobytes()`` and ``frombytes()``, deprecated since
+Python 3.2.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1624,27 +1624,6 @@ frombytes(arrayobject *self, Py_buffer *buffer)
 }
 
 /*[clinic input]
-array.array.fromstring
-
-    buffer: Py_buffer(accept={str, buffer})
-    /
-
-Appends items from the string, interpreting it as an array of machine values, as if it had been read from a file using the fromfile() method).
-
-This method is deprecated. Use frombytes instead.
-[clinic start generated code]*/
-
-static PyObject *
-array_array_fromstring_impl(arrayobject *self, Py_buffer *buffer)
-/*[clinic end generated code: output=31c4baa779df84ce input=a3341a512e11d773]*/
-{
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
-            "fromstring() is deprecated. Use frombytes() instead.", 2) != 0)
-        return NULL;
-    return frombytes(self, buffer);
-}
-
-/*[clinic input]
 array.array.frombytes
 
     buffer: Py_buffer
@@ -1676,24 +1655,6 @@ array_array_tobytes_impl(arrayobject *self)
     } else {
         return PyErr_NoMemory();
     }
-}
-
-/*[clinic input]
-array.array.tostring
-
-Convert the array to an array of machine values and return the bytes representation.
-
-This method is deprecated. Use tobytes instead.
-[clinic start generated code]*/
-
-static PyObject *
-array_array_tostring_impl(arrayobject *self)
-/*[clinic end generated code: output=7d6bd92745a2c8f3 input=b6c0ddee7b30457e]*/
-{
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
-            "tostring() is deprecated. Use tobytes() instead.", 2) != 0)
-        return NULL;
-    return array_array_tobytes_impl(self);
 }
 
 /*[clinic input]
@@ -2283,7 +2244,6 @@ static PyMethodDef array_methods[] = {
     ARRAY_ARRAY_EXTEND_METHODDEF
     ARRAY_ARRAY_FROMFILE_METHODDEF
     ARRAY_ARRAY_FROMLIST_METHODDEF
-    ARRAY_ARRAY_FROMSTRING_METHODDEF
     ARRAY_ARRAY_FROMBYTES_METHODDEF
     ARRAY_ARRAY_FROMUNICODE_METHODDEF
     ARRAY_ARRAY_INDEX_METHODDEF
@@ -2294,7 +2254,6 @@ static PyMethodDef array_methods[] = {
     ARRAY_ARRAY_REVERSE_METHODDEF
     ARRAY_ARRAY_TOFILE_METHODDEF
     ARRAY_ARRAY_TOLIST_METHODDEF
-    ARRAY_ARRAY_TOSTRING_METHODDEF
     ARRAY_ARRAY_TOBYTES_METHODDEF
     ARRAY_ARRAY_TOUNICODE_METHODDEF
     ARRAY_ARRAY___SIZEOF___METHODDEF

--- a/Modules/clinic/arraymodule.c.h
+++ b/Modules/clinic/arraymodule.c.h
@@ -312,54 +312,6 @@ array_array_tolist(arrayobject *self, PyObject *Py_UNUSED(ignored))
     return array_array_tolist_impl(self);
 }
 
-PyDoc_STRVAR(array_array_fromstring__doc__,
-"fromstring($self, buffer, /)\n"
-"--\n"
-"\n"
-"Appends items from the string, interpreting it as an array of machine values, as if it had been read from a file using the fromfile() method).\n"
-"\n"
-"This method is deprecated. Use frombytes instead.");
-
-#define ARRAY_ARRAY_FROMSTRING_METHODDEF    \
-    {"fromstring", (PyCFunction)array_array_fromstring, METH_O, array_array_fromstring__doc__},
-
-static PyObject *
-array_array_fromstring_impl(arrayobject *self, Py_buffer *buffer);
-
-static PyObject *
-array_array_fromstring(arrayobject *self, PyObject *arg)
-{
-    PyObject *return_value = NULL;
-    Py_buffer buffer = {NULL, NULL};
-
-    if (PyUnicode_Check(arg)) {
-        Py_ssize_t len;
-        const char *ptr = PyUnicode_AsUTF8AndSize(arg, &len);
-        if (ptr == NULL) {
-            goto exit;
-        }
-        PyBuffer_FillInfo(&buffer, arg, (void *)ptr, len, 1, 0);
-    }
-    else { /* any bytes-like object */
-        if (PyObject_GetBuffer(arg, &buffer, PyBUF_SIMPLE) != 0) {
-            goto exit;
-        }
-        if (!PyBuffer_IsContiguous(&buffer, 'C')) {
-            _PyArg_BadArgument("fromstring", "argument", "contiguous buffer", arg);
-            goto exit;
-        }
-    }
-    return_value = array_array_fromstring_impl(self, &buffer);
-
-exit:
-    /* Cleanup for buffer */
-    if (buffer.obj) {
-       PyBuffer_Release(&buffer);
-    }
-
-    return return_value;
-}
-
 PyDoc_STRVAR(array_array_frombytes__doc__,
 "frombytes($self, buffer, /)\n"
 "--\n"
@@ -412,26 +364,6 @@ static PyObject *
 array_array_tobytes(arrayobject *self, PyObject *Py_UNUSED(ignored))
 {
     return array_array_tobytes_impl(self);
-}
-
-PyDoc_STRVAR(array_array_tostring__doc__,
-"tostring($self, /)\n"
-"--\n"
-"\n"
-"Convert the array to an array of machine values and return the bytes representation.\n"
-"\n"
-"This method is deprecated. Use tobytes instead.");
-
-#define ARRAY_ARRAY_TOSTRING_METHODDEF    \
-    {"tostring", (PyCFunction)array_array_tostring, METH_NOARGS, array_array_tostring__doc__},
-
-static PyObject *
-array_array_tostring_impl(arrayobject *self);
-
-static PyObject *
-array_array_tostring(arrayobject *self, PyObject *Py_UNUSED(ignored))
-{
-    return array_array_tostring_impl(self);
 }
 
 PyDoc_STRVAR(array_array_fromunicode__doc__,
@@ -599,4 +531,4 @@ PyDoc_STRVAR(array_arrayiterator___setstate____doc__,
 
 #define ARRAY_ARRAYITERATOR___SETSTATE___METHODDEF    \
     {"__setstate__", (PyCFunction)array_arrayiterator___setstate__, METH_O, array_arrayiterator___setstate____doc__},
-/*[clinic end generated code: output=6aa421571e2c0756 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f649fc0bc9f6b13a input=a9049054013a1b77]*/


### PR DESCRIPTION
`array.array: Remove tostring() and fromstring() methods.  They were
aliases to tobytes() and frombytes(), deprecated since Python 3.2.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38916](https://bugs.python.org/issue38916) -->
https://bugs.python.org/issue38916
<!-- /issue-number -->
