### PR TITLE
bpo-38991: Remove test.support.strip_python_stderr()

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -686,13 +686,6 @@ The :mod:`test.support` module defines the following functions:
    ``sys.stdout`` if it's not set.
 
 
-.. function:: strip_python_strerr(stderr)
-
-   Strip the *stderr* of a Python process from potential debug output
-   emitted by the interpreter.  This will typically be run on the result of
-   :meth:`subprocess.Popen.communicate`.
-
-
 .. function:: args_from_interpreter_flags()
 
    Return a list of command line arguments reproducing the current settings
@@ -1499,6 +1492,9 @@ script execution tests.
    in a subprocess.  The values can include ``__isolated``, ``__cleanenv``,
    ``__cwd``, and ``TERM``.
 
+   .. versionchanged:: 3.9
+      The function no longer strips whitespaces from *stderr*.
+
 
 .. function:: assert_python_ok(*args, **env_vars)
 
@@ -1512,6 +1508,9 @@ script execution tests.
    Python is started in isolated mode (command line option ``-I``),
    except if the ``__isolated`` keyword is set to ``False``.
 
+   .. versionchanged:: 3.9
+      The function no longer strips whitespaces from *stderr*.
+
 
 .. function:: assert_python_failure(*args, **env_vars)
 
@@ -1520,6 +1519,9 @@ script execution tests.
    stdout, stderr)`` tuple.
 
    See :func:`assert_python_ok` for more options.
+
+   .. versionchanged:: 3.9
+      The function no longer strips whitespaces from *stderr*.
 
 
 .. function:: spawn_python(*args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kw)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2512,16 +2512,6 @@ def swap_item(obj, item, new_val):
             if item in obj:
                 del obj[item]
 
-def strip_python_stderr(stderr):
-    """Strip the stderr of a Python process from potential debug output
-    emitted by the interpreter.
-
-    This will typically be run on the result of the communicate() method
-    of a subprocess.Popen object.
-    """
-    stderr = re.sub(br"\[\d+ refs, \d+ blocks\]\r?\n?", b"", stderr).strip()
-    return stderr
-
 requires_type_collecting = unittest.skipIf(hasattr(sys, 'getcounts'),
                         'types are immortal if COUNT_ALLOCS is defined')
 

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -11,7 +11,7 @@ import py_compile
 import zipfile
 
 from importlib.util import source_from_cache
-from test.support import make_legacy_pyc, strip_python_stderr
+from test.support import make_legacy_pyc
 
 
 # Cached result of the expensive test performed in the function below.
@@ -134,7 +134,6 @@ def run_python_until_end(*args, **env_vars):
             proc.kill()
             subprocess._cleanup()
     rc = proc.returncode
-    err = strip_python_stderr(err)
     return _PythonRunResult(rc, out, err), cmd_line
 
 def _assert_python(expected_success, /, *args, **env_vars):

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -332,10 +332,10 @@ class CmdLineTest(unittest.TestCase):
 
         if sys.platform == 'win32':
             self.assertEqual(b'1\r\n2\r\n', out)
-            self.assertEqual(b'3\r\n4', err)
+            self.assertEqual(b'3\r\n4\r\n', err)
         else:
             self.assertEqual(b'1\n2\n', out)
-            self.assertEqual(b'3\n4', err)
+            self.assertEqual(b'3\n4\n', err)
 
     def test_unmached_quote(self):
         # Issue #10206: python program starting with unmatched quote
@@ -391,7 +391,7 @@ class CmdLineTest(unittest.TestCase):
             stderr=subprocess.PIPE,
             preexec_fn=preexec)
         out, err = p.communicate()
-        self.assertEqual(support.strip_python_stderr(err), b'')
+        self.assertEqual(err, b'')
         self.assertEqual(p.returncode, 42)
 
     def test_no_stdin(self):

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -535,7 +535,7 @@ class CmdLineTest(unittest.TestCase):
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = stderr.decode('ascii').split('\n')
-            self.assertEqual(len(text), 4)
+            self.assertEqual(len(text), 5)
             self.assertTrue(text[0].startswith('Traceback'))
             self.assertTrue(text[1].startswith('  File '))
             self.assertTrue(text[3].startswith('NameError'))
@@ -579,7 +579,7 @@ class CmdLineTest(unittest.TestCase):
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = stderr.decode('ascii')
-            self.assertEqual(text, "some text")
+            self.assertEqual(text.rstrip(), "some text")
 
     def test_syntaxerror_unindented_caret_position(self):
         script = "1 + 1 = 2\n"

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -71,9 +71,8 @@ class FaultHandlerTests(unittest.TestCase):
         with support.SuppressCrashReport():
             process = script_helper.spawn_python('-c', code, pass_fds=pass_fds)
             with process:
-                stdout, stderr = process.communicate()
+                output, stderr = process.communicate()
                 exitcode = process.wait()
-        output = support.strip_python_stderr(stdout)
         output = output.decode('ascii', 'backslashreplace')
         if filename:
             self.assertEqual(output, '')

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1,7 +1,7 @@
 import unittest
 import unittest.mock
 from test.support import (verbose, refcount_test, run_unittest,
-                          strip_python_stderr, cpython_only, start_threads,
+                          cpython_only, start_threads,
                           temp_dir, requires_type_collecting, TESTFN, unlink,
                           import_module)
 from test.support.script_helper import assert_python_ok, make_script
@@ -671,8 +671,8 @@ class GCTests(unittest.TestCase):
             p.stdout.close()
             p.stderr.close()
             self.assertEqual(p.returncode, 0)
-            self.assertEqual(stdout.strip(), b"")
-            return strip_python_stderr(stderr)
+            self.assertEqual(stdout, b"")
+            return stderr
 
         stderr = run_command(code % "0")
         self.assertIn(b"ResourceWarning: gc: 2 uncollectable objects at "

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -653,7 +653,6 @@ class TestSupport(unittest.TestCase):
     # run_doctest
     # threading_cleanup
     # reap_threads
-    # strip_python_stderr
     # can_symlink
     # skip_unless_symlink
     # SuppressCrashReport

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1219,7 +1219,8 @@ class A:
 a=A()
         """
         rc, out, err = assert_python_ok("-c", code)
-        self.assertEqual(err.decode(), '<string>:7: UserWarning: test')
+        self.assertEqual(err.decode().rstrip(),
+                         '<string>:7: UserWarning: test')
 
     def test_late_resource_warning(self):
         # Issue #21925: Emitting a ResourceWarning late during the Python

--- a/Misc/NEWS.d/next/Tests/2019-12-07-00-52-09.bpo-38991.JE3_o-.rst
+++ b/Misc/NEWS.d/next/Tests/2019-12-07-00-52-09.bpo-38991.JE3_o-.rst
@@ -1,0 +1,5 @@
+:mod:`test.support`: :func:`~test.support.run_python_until_end`,
+:func:`~test.support.assert_python_ok` and
+:func:`~test.support.assert_python_failure` functions no longer strip
+whitespaces from stderr. Remove ``test.support.strip_python_stderr()``
+function.


### PR DESCRIPTION
test.support: run_python_until_end(), assert_python_ok() and
assert_python_failure() functions no longer strip whitespaces from
stderr.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38991](https://bugs.python.org/issue38991) -->
https://bugs.python.org/issue38991
<!-- /issue-number -->
