### PR TITLE
bpo-38979: fix ContextVar "__class_getitem__" method

### DIFF
--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -38,9 +38,6 @@ class ContextTest(unittest.TestCase):
 
         self.assertNotEqual(hash(c), hash('aaa'))
 
-    def test_context_var_new_2(self):
-        self.assertIsNone(contextvars.ContextVar[int])
-
     @isolated_context
     def test_context_var_repr_1(self):
         c = contextvars.ContextVar('a')
@@ -360,6 +357,10 @@ class ContextTest(unittest.TestCase):
         finally:
             tp.shutdown()
         self.assertEqual(results, list(range(10)))
+
+    def test_contextvar_getitem(self):
+        clss = contextvars.ContextVar
+        self.assertEqual(clss[str], clss)
 
 
 # HAMT Tests

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -361,10 +361,6 @@ class ContextTest(unittest.TestCase):
             tp.shutdown()
         self.assertEqual(results, list(range(10)))
 
-    def test_contextvar_getitem(self):
-        clss = contextvars.ContextVar
-        self.assertEqual(clss[str], clss)
-
 
 # HAMT Tests
 

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -361,6 +361,10 @@ class ContextTest(unittest.TestCase):
             tp.shutdown()
         self.assertEqual(results, list(range(10)))
 
+    def test_contextvar_getitem(self):
+        clss = contextvars.ContextVar
+        self.assertEqual(clss[str], clss)
+
 
 # HAMT Tests
 

--- a/Misc/NEWS.d/next/Library/2019-12-07-16-32-42.bpo-38979.q0sIHy.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-07-16-32-42.bpo-38979.q0sIHy.rst
@@ -1,3 +1,1 @@
-return class from __class_getitem__ to simplify subclassing. E.g. `clss =
-contextvars.ContextVar[str]` returned `None` instead of `<class
-'ContextVar'>`
+return class from ``__class_getitem__`` to simplify subclassing.

--- a/Misc/NEWS.d/next/Library/2019-12-07-16-32-42.bpo-38979.q0sIHy.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-07-16-32-42.bpo-38979.q0sIHy.rst
@@ -1,0 +1,3 @@
+return class from __class_getitem__ to simplify subclassing. E.g. `clss =
+contextvars.ContextVar[str]` returned `None` instead of `<class
+'ContextVar'>`

--- a/Misc/NEWS.d/next/Library/2019-12-07-16-32-42.bpo-38979.q0sIHy.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-07-16-32-42.bpo-38979.q0sIHy.rst
@@ -1,1 +1,1 @@
-return class from ``__class_getitem__`` to simplify subclassing.
+Return class from ``ContextVar.__class_getitem__`` to simplify subclassing.

--- a/Python/context.c
+++ b/Python/context.c
@@ -1010,9 +1010,10 @@ _contextvars_ContextVar_reset(PyContextVar *self, PyObject *token)
 
 
 static PyObject *
-contextvar_cls_getitem(PyObject *self, PyObject *args)
+contextvar_cls_getitem(PyObject *self, PyObject *arg)
 {
-    Py_RETURN_NONE;
+    Py_INCREF(self);
+    return self;
 }
 
 static PyMemberDef PyContextVar_members[] = {
@@ -1025,7 +1026,7 @@ static PyMethodDef PyContextVar_methods[] = {
     _CONTEXTVARS_CONTEXTVAR_SET_METHODDEF
     _CONTEXTVARS_CONTEXTVAR_RESET_METHODDEF
     {"__class_getitem__", contextvar_cls_getitem,
-        METH_VARARGS | METH_STATIC, NULL},
+        METH_O | METH_CLASS, NULL},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
now contextvars.ContextVar "__class_getitem__" method returns ContextVar class, not None. 

<!-- issue-number: [bpo-38979](https://bugs.python.org/issue38979) -->
https://bugs.python.org/issue38979
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov