### PR TITLE
bpo-38858: Fix ref leak in pycore_interp_init()

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -705,24 +705,29 @@ static PyStatus
 pycore_interp_init(PyThreadState *tstate)
 {
     PyStatus status;
+    PyObject *sysmod = NULL;
 
     status = pycore_init_types(tstate);
     if (_PyStatus_EXCEPTION(status)) {
-        return status;
+        goto done;
     }
 
-    PyObject *sysmod;
     status = _PySys_Create(tstate, &sysmod);
     if (_PyStatus_EXCEPTION(status)) {
-        return status;
+        goto done;
     }
 
     status = pycore_init_builtins(tstate);
     if (_PyStatus_EXCEPTION(status)) {
-        return status;
+        goto done;
     }
 
-    return pycore_init_import_warnings(tstate, sysmod);
+    status = pycore_init_import_warnings(tstate, sysmod);
+
+done:
+    /* sys.modules['sys'] contains a strong reference to the module */
+    Py_XDECREF(sysmod);
+    return status;
 }
 
 


### PR DESCRIPTION
[bpo-38858](https://bugs.python.org/issue38858), [bpo-38997](https://bugs.python.org/issue38997): _PySys_Create() returns a strong reference to
the sys module: Py_DECREF() is needed when we are done with the
module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38858](https://bugs.python.org/issue38858) -->
https://bugs.python.org/issue38858
<!-- /issue-number -->
