### PR TITLE
bpo-38992: avoid fsum test failure from constant-folding

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -676,7 +676,6 @@ class MathTests(unittest.TestCase):
              float.fromhex('0x1.df11f45f4e61ap+2')),
             ([(-1.)**n/n for n in range(1, 1001)],
              float.fromhex('-0x1.62a2af1bd3624p-1')),
-            ([1.7**(i+1)-1.7**i for i in range(1000)] + [-1.7**1000], -1.0),
             ([1e16, 1., 1e-16], 10000000000000002.0),
             ([1e16-2., 1.-2.**-53, -(1e16-2.), -(1.-2.**-53)], 0.0),
             # exercise code for resizing partials array
@@ -684,6 +683,13 @@ class MathTests(unittest.TestCase):
              [-2.**1022],
              float.fromhex('0x1.5555555555555p+970')),
             ]
+
+        # Telescoping sum, with exact differences (due to Sterbenz)
+        terms = [1.7**i for i in range(1001)]
+        test_values.append((
+            [terms[i+1] - terms[i] for i in range(1000)] + [-terms[1000]],
+            -terms[0]
+        ))
 
         for i, (vals, expected) in enumerate(test_values):
             try:

--- a/Misc/NEWS.d/next/Tests/2019-12-08-15-11-06.bpo-38992.cVoHOZ.rst
+++ b/Misc/NEWS.d/next/Tests/2019-12-08-15-11-06.bpo-38992.cVoHOZ.rst
@@ -1,0 +1,1 @@
+Fix a test for :func:`math.fsum` that was failing due to constant folding.


### PR DESCRIPTION
This is a tentative fix for the issue described at https://bugs.python.org/issue38992. One of the tests 
 for `math.fsum` was failing on a cross-compiled Python, due to two different values of a constant (`1.7**1000`) being used.

The change in this PR ensures that each power of `1.7` used in the `fsum` test is only computed once, so that there's no danger of using two different values of `1.7**1000`.

<!-- issue-number: [bpo-38992](https://bugs.python.org/issue38992) -->
https://bugs.python.org/issue38992
<!-- /issue-number -->
