### PR TITLE
bpo-39002: Fix simple typo: tranlation -> translation (GH-17517)

### DIFF
--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -2192,7 +2192,7 @@ class TestQuantiles(unittest.TestCase):
                 quantiles(padded_data, n=n, method='inclusive'),
                 (n, data),
             )
-            # Invariant under tranlation and scaling
+            # Invariant under translation and scaling
             def f(x):
                 return 3.5 * x - 1234.675
             exp = list(map(f, expected))
@@ -2232,7 +2232,7 @@ class TestQuantiles(unittest.TestCase):
                 result = quantiles(map(datatype, data), n=n, method="inclusive")
                 self.assertTrue(all(type(x) == datatype) for x in result)
                 self.assertEqual(result, list(map(datatype, expected)))
-            # Invariant under tranlation and scaling
+            # Invariant under translation and scaling
             def f(x):
                 return 3.5 * x - 1234.675
             exp = list(map(f, expected))

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1900,3 +1900,4 @@ Robert Leenders
 Tim Hopper
 Dan Lidral-Porter
 Ngalim Siregar
+Tim Gates

--- a/Misc/NEWS.d/next/Documentation/2019-12-09-10-12-00.bpo-39002.AfgvfO.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-12-09-10-12-00.bpo-39002.AfgvfO.rst
@@ -1,0 +1,1 @@
+Fix simple typo in Lib/test/test_statistics.py.


### PR DESCRIPTION
There is a small typo in Lib/test/test_statistics.py.
Should read `translation` rather than `tranlation`.



<!-- issue-number: [bpo-39002](https://bugs.python.org/issue39002) -->
https://bugs.python.org/issue39002
<!-- /issue-number -->
