### PR TITLE
bpo-38547: Fix test_pty if the process is the session leader

### DIFF
--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -66,15 +66,26 @@ def _readline(fd):
 # XXX(nnorwitz):  these tests leak fds when there is an error.
 class PtyTest(unittest.TestCase):
     def setUp(self):
-        # isatty() and close() can hang on some platforms.  Set an alarm
-        # before running the test to make sure we don't hang forever.
         old_alarm = signal.signal(signal.SIGALRM, self.handle_sig)
         self.addCleanup(signal.signal, signal.SIGALRM, old_alarm)
+
+        old_sighup = signal.signal(signal.SIGHUP, self.handle_sighup)
+        self.addCleanup(signal.signal, signal.SIGHUP, old_alarm)
+
+        # isatty() and close() can hang on some platforms. Set an alarm
+        # before running the test to make sure we don't hang forever.
         self.addCleanup(signal.alarm, 0)
         signal.alarm(10)
 
     def handle_sig(self, sig, frame):
         self.fail("isatty hung")
+
+    @staticmethod
+    def handle_sighup(sig, frame):
+        # if the process is the session leader, os.close(master_fd)
+        # of "master_fd, slave_name = pty.master_open()" raises SIGHUP
+        # signal: just ignore the signal.
+        pass
 
     def test_basic(self):
         try:
@@ -122,8 +133,10 @@ class PtyTest(unittest.TestCase):
         self.assertEqual(b'For my pet fish, Eric.\n', normalize_output(s2))
 
         os.close(slave_fd)
+        # closing master_fd can raise a SIGHUP if the process is
+        # the session leader: we installed a SIGHUP signal handler
+        # to ignore this signal.
         os.close(master_fd)
-
 
     def test_fork(self):
         debug("calling pty.fork()")

--- a/Misc/NEWS.d/next/Tests/2019-12-09-11-32-34.bpo-38547.Juw54e.rst
+++ b/Misc/NEWS.d/next/Tests/2019-12-09-11-32-34.bpo-38547.Juw54e.rst
@@ -1,0 +1,3 @@
+Fix test_pty: if the process is the session leader, closing the master file
+descriptor raises a SIGHUP signal: simply ignore SIGHUP when running the
+tests.


### PR DESCRIPTION
Fix test_pty: if the process is the session leader, closing the
master file descriptor raises a SIGHUP signal: simply ignore SIGHUP
when running the tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38547](https://bugs.python.org/issue38547) -->
https://bugs.python.org/issue38547
<!-- /issue-number -->
