### PR TITLE
[3.8] bpo-38916: Document array.array deprecation

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -173,6 +173,8 @@ The following data items and methods are also supported:
 
    Deprecated alias for :meth:`frombytes`.
 
+   .. deprecated-removed:: 3.2 3.9
+
 
 .. method:: array.fromunicode(s)
 
@@ -234,6 +236,8 @@ The following data items and methods are also supported:
 .. method:: array.tostring()
 
    Deprecated alias for :meth:`tobytes`.
+
+   .. deprecated-removed:: 3.2 3.9
 
 
 .. method:: array.tounicode()


### PR DESCRIPTION
array.array: Document that tostring() and fromstring() deprecated
aliases will be removed in Python 3.9.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38916](https://bugs.python.org/issue38916) -->
https://bugs.python.org/issue38916
<!-- /issue-number -->
