### PR TITLE
bpo-39006: Fix asyncio when the ssl module is missing

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -40,6 +40,11 @@ def _test_selector_event(selector, fd, event):
         return bool(key.events & event)
 
 
+def _check_ssl_socket(sock):
+    if ssl is not None and isinstance(sock, ssl.SSLSocket):
+        raise TypeError("Socket cannot be of type SSLSocket")
+
+
 class BaseSelectorEventLoop(base_events.BaseEventLoop):
     """Selector event loop.
 
@@ -348,8 +353,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         The maximum amount of data to be received at once is specified by
         nbytes.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            raise TypeError("Socket cannot be of type SSLSocket")
+        _check_ssl_socket(sock)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         try:
@@ -388,8 +392,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         The received data is written into *buf* (a writable buffer).
         The return value is the number of bytes written.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            raise TypeError("Socket cannot be of type SSLSocket")
+        _check_ssl_socket(sock)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         try:
@@ -429,8 +432,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         raised, and there is no way to determine how much data, if any, was
         successfully processed by the receiving end of the connection.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            raise TypeError("Socket cannot be of type SSLSocket")
+        _check_ssl_socket(sock)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         try:
@@ -478,8 +480,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
 
         This method is a coroutine.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            raise TypeError("Socket cannot be of type SSLSocket")
+        _check_ssl_socket(sock)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
 
@@ -541,8 +542,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         object usable to send and receive data on the connection, and address
         is the address bound to the socket on the other end of the connection.
         """
-        if isinstance(sock, ssl.SSLSocket):
-            raise TypeError("Socket cannot be of type SSLSocket")
+        _check_ssl_socket(sock)
         if self._debug and sock.gettimeout() != 0:
             raise ValueError("the socket must be non-blocking")
         fut = self.create_future()

--- a/Misc/NEWS.d/next/Library/2019-12-09-14-40-09.bpo-39006.v4VsPg.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-09-14-40-09.bpo-39006.v4VsPg.rst
@@ -1,0 +1,2 @@
+Fix asyncio when the ssl module is missing: only check for ssl.SSLSocket
+instance if the ssl module is available.


### PR DESCRIPTION
Fix asyncio when the ssl module is missing: only check for
ssl.SSLSocket instance if the ssl module is available.

<!-- issue-number: [bpo-39006](https://bugs.python.org/issue39006) -->
https://bugs.python.org/issue39006
<!-- /issue-number -->
