### PR TITLE
bpo-20443: No longer make sys.argv[0] absolute for script

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -223,12 +223,13 @@ class CmdLineTest(unittest.TestCase):
 
     def test_script_abspath(self):
         # pass the script using the relative path, expect the absolute path
-        # in __file__ and sys.argv[0]
+        # in __file__
         with support.temp_cwd() as script_dir:
             self.assertTrue(os.path.isabs(script_dir), script_dir)
 
             script_name = _make_test_script(script_dir, 'script')
-            self._check_script(os.path.basename(script_name), script_name, script_name,
+            relative_name = os.path.basename(script_name)
+            self._check_script(relative_name, script_name, relative_name,
                                script_dir, None,
                                importlib.machinery.SourceFileLoader)
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -858,10 +858,9 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         preconfig = {
             'allocator': PYMEM_ALLOCATOR_DEBUG,
         }
-        script_abspath = os.path.abspath('script.py')
         config = {
-            'argv': [script_abspath],
-            'run_filename': script_abspath,
+            'argv': ['script.py'],
+            'run_filename': os.path.abspath('script.py'),
             'dev_mode': 1,
             'faulthandler': 1,
             'warnoptions': ['default'],

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-09-17-05-53.bpo-20443.8OyT5P.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-09-17-05-53.bpo-20443.8OyT5P.rst
@@ -1,0 +1,3 @@
+In Python 3.9.0a1, sys.argv[0] was made an asolute path if a filename was
+specified on the command line. Revert this change, since most users expect
+sys.argv to be unmodified.

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2198,10 +2198,6 @@ config_update_argv(PyConfig *config, Py_ssize_t opt_index)
         /* Force sys.argv[0] = '-m'*/
         arg0 = L"-m";
     }
-    else if (config->run_filename != NULL) {
-        /* run_filename is converted to an absolute path: update argv */
-        arg0 = config->run_filename;
-    }
 
     if (arg0 != NULL) {
         arg0 = _PyMem_RawWcsdup(arg0);


### PR DESCRIPTION
In Python 3.9.0a1, sys.argv[0] was made an asolute path if a filename
was specified on the command line. Revert this change, since most
users expect sys.argv to be unmodified.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-20443](https://bugs.python.org/issue20443) -->
https://bugs.python.org/issue20443
<!-- /issue-number -->
