### PR TITLE
bpo-39008: Require Py_ssize_t for PySys_Audit formats rather than raise a deprecation warning

### DIFF
--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -320,9 +320,17 @@ accessible to C code.  They all work with the current interpreter thread's
    arguments to this function will be consumed, using it may cause reference
    leaks.)
 
+   Note that ``#`` format characters should always be treated as
+   ``Py_ssize_t``, regardless of whether ``PY_SSIZE_T_CLEAN`` was defined.
+
    :func:`sys.audit` performs the same function from Python code.
 
    .. versionadded:: 3.8
+
+   .. versionchanged:: 3.8.2
+
+      Require ``Py_ssize_t`` for ``#`` format characters. Previously, an
+      unavoidable deprecation warning was raised.
 
 
 .. c:function:: int PySys_AddAuditHook(Py_AuditHookFunction hook, void *userData)

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-09-10-38-51.bpo-39008.Rrp6f1.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-09-10-38-51.bpo-39008.Rrp6f1.rst
@@ -1,0 +1,3 @@
+:c:func:`PySys_Audit` now requires ``Py_ssize_t`` to be used for size
+arguments in the format string, regardless of whethen ``PY_SSIZE_T_CLEAN``
+was defined at include time.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -181,7 +181,7 @@ PySys_Audit(const char *event, const char *argFormat, ...)
     if (argFormat && argFormat[0]) {
         va_list args;
         va_start(args, argFormat);
-        eventArgs = Py_VaBuildValue(argFormat, args);
+        eventArgs = _Py_VaBuildValue_SizeT(argFormat, args);
         va_end(args);
         if (eventArgs && !PyTuple_Check(eventArgs)) {
             PyObject *argTuple = PyTuple_Pack(1, eventArgs);


### PR DESCRIPTION


<!-- issue-number: [bpo-39008](https://bugs.python.org/issue39008) -->
https://bugs.python.org/issue39008
<!-- /issue-number -->
