### PR TITLE
bpo-39007: Add auditing events to functions in winreg

### DIFF
--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -320,9 +320,17 @@ accessible to C code.  They all work with the current interpreter thread's
    arguments to this function will be consumed, using it may cause reference
    leaks.)
 
+   Note that ``#`` format characters should always be treated as
+   ``Py_ssize_t``, regardless of whether ``PY_SSIZE_T_CLEAN`` was defined.
+
    :func:`sys.audit` performs the same function from Python code.
 
    .. versionadded:: 3.8
+
+   .. versionchanged:: 3.8.2
+
+      Require ``Py_ssize_t`` for ``#`` format characters. Previously, an
+      unavoidable deprecation warning was raised.
 
 
 .. c:function:: int PySys_AddAuditHook(Py_AuditHookFunction hook, void *userData)

--- a/Doc/library/winreg.rst
+++ b/Doc/library/winreg.rst
@@ -53,6 +53,8 @@ This module offers the following functions:
    The return value is the handle of the opened key. If the function fails, an
    :exc:`OSError` exception is raised.
 
+   .. audit-event:: winreg.ConnectRegistry computer_name,key winreg.ConnectRegistry
+
    .. versionchanged:: 3.3
       See :ref:`above <exception-changed>`.
 
@@ -74,6 +76,10 @@ This module offers the following functions:
 
    The return value is the handle of the opened key. If the function fails, an
    :exc:`OSError` exception is raised.
+
+   .. audit-event:: winreg.CreateKey key,sub_key,access winreg.CreateKey
+
+   .. audit-event:: winreg.OpenKey/result key winreg.CreateKey
 
    .. versionchanged:: 3.3
       See :ref:`above <exception-changed>`.
@@ -103,6 +109,10 @@ This module offers the following functions:
    The return value is the handle of the opened key. If the function fails, an
    :exc:`OSError` exception is raised.
 
+   .. audit-event:: winreg.CreateKey key,sub_key,access winreg.CreateKeyEx
+
+   .. audit-event:: winreg.OpenKey/result key winreg.CreateKeyEx
+
    .. versionadded:: 3.2
 
    .. versionchanged:: 3.3
@@ -123,6 +133,8 @@ This module offers the following functions:
 
    If the method succeeds, the entire key, including all of its values, is removed.
    If the method fails, an :exc:`OSError` exception is raised.
+
+   .. audit-event:: winreg.DeleteKey key,sub_key,access winreg.DeleteKey
 
    .. versionchanged:: 3.3
       See :ref:`above <exception-changed>`.
@@ -158,6 +170,8 @@ This module offers the following functions:
 
    On unsupported Windows versions, :exc:`NotImplementedError` is raised.
 
+   .. audit-event:: winreg.DeleteKey key,sub_key,access winreg.DeleteKeyEx
+
    .. versionadded:: 3.2
 
    .. versionchanged:: 3.3
@@ -173,6 +187,8 @@ This module offers the following functions:
 
    *value* is a string that identifies the value to remove.
 
+   .. audit-event:: winreg.DeleteValue key,value winreg.DeleteValue
+
 
 .. function:: EnumKey(key, index)
 
@@ -186,6 +202,8 @@ This module offers the following functions:
    The function retrieves the name of one subkey each time it is called.  It is
    typically called repeatedly until an :exc:`OSError` exception is
    raised, indicating, no more values are available.
+
+   .. audit-event:: winreg.EnumKey key,index winreg.EnumKey
 
    .. versionchanged:: 3.3
       See :ref:`above <exception-changed>`.
@@ -220,6 +238,8 @@ This module offers the following functions:
    |       | :meth:`SetValueEx`)                        |
    +-------+--------------------------------------------+
 
+   .. audit-event:: winreg.EnumValue key,index winreg.EnumValue
+
    .. versionchanged:: 3.3
       See :ref:`above <exception-changed>`.
 
@@ -234,6 +254,8 @@ This module offers the following functions:
 
       >>> ExpandEnvironmentStrings('%windir%')
       'C:\\Windows'
+
+   .. audit-event:: winreg.ExpandEnvironmentStrings str winreg.ExpandEnvironmentStrings
 
 
 .. function:: FlushKey(key)
@@ -279,6 +301,8 @@ This module offers the following functions:
    If *key* is a handle returned by :func:`ConnectRegistry`, then the path
    specified in *file_name* is relative to the remote computer.
 
+   .. audit-event:: winreg.LoadKey key,sub_key,file_name winreg.LoadKey
+
 
 .. function:: OpenKey(key, sub_key, reserved=0, access=KEY_READ)
               OpenKeyEx(key, sub_key, reserved=0, access=KEY_READ)
@@ -299,6 +323,10 @@ This module offers the following functions:
    The result is a new handle to the specified key.
 
    If the function fails, :exc:`OSError` is raised.
+
+   .. audit-event:: winreg.OpenKey key,sub_key,access winreg.OpenKey
+
+   .. audit-event:: winreg.OpenKey/result key winreg.OpenKey
 
    .. versionchanged:: 3.2
       Allow the use of named arguments.
@@ -330,6 +358,8 @@ This module offers the following functions:
    |       | nanoseconds since Jan 1, 1601.              |
    +-------+---------------------------------------------+
 
+   .. audit-event:: winreg.QueryInfoKey key winreg.QueryInfoKey
+
 
 .. function:: QueryValue(key, sub_key)
 
@@ -346,6 +376,8 @@ This module offers the following functions:
    retrieves the data for a key's first value that has a ``NULL`` name. But the
    underlying API call doesn't return the type, so always use
    :func:`QueryValueEx` if possible.
+
+   .. audit-event:: winreg.QueryValue key,sub_key,value_name winreg.QueryValue
 
 
 .. function:: QueryValueEx(key, value_name)
@@ -370,6 +402,8 @@ This module offers the following functions:
    |       | :meth:`SetValueEx`)                     |
    +-------+-----------------------------------------+
 
+   .. audit-event:: winreg.QueryValue key,sub_key,value_name winreg.QueryValueEx
+
 
 .. function:: SaveKey(key, file_name)
 
@@ -392,6 +426,8 @@ This module offers the following functions:
    for more details.
 
    This function passes ``NULL`` for *security_attributes* to the API.
+
+   .. audit-event:: winreg.SaveKey key,file_name winreg.SaveKey
 
 
 .. function:: SetValue(key, sub_key, type, value)
@@ -418,6 +454,8 @@ This module offers the following functions:
 
    The key identified by the *key* parameter must have been opened with
    :const:`KEY_SET_VALUE` access.
+
+   .. audit-event:: winreg.SetValue key,sub_key,type,value winreg.SetValue
 
 
 .. function:: SetValueEx(key, value_name, reserved, type, value)
@@ -447,6 +485,8 @@ This module offers the following functions:
    bytes) should be stored as files with the filenames stored in the configuration
    registry.  This helps the registry perform efficiently.
 
+   .. audit-event:: winreg.SetValue key,sub_key,type,value winreg.SetValueEx
+
 
 .. function:: DisableReflectionKey(key)
 
@@ -463,6 +503,8 @@ This module offers the following functions:
    effect.  Disabling reflection for a key does not affect reflection of any
    subkeys.
 
+   .. audit-event:: winreg.DisableReflectionKey key winreg.DisableReflectionKey
+
 
 .. function:: EnableReflectionKey(key)
 
@@ -476,6 +518,8 @@ This module offers the following functions:
 
    Restoring reflection for a key does not affect reflection of any subkeys.
 
+   .. audit-event:: winreg.EnableReflectionKey key winreg.EnableReflectionKey
+
 
 .. function:: QueryReflectionKey(key)
 
@@ -488,6 +532,8 @@ This module offers the following functions:
 
    Will generally raise :exc:`NotImplementedError` if executed on a 32-bit
    operating system.
+
+   .. audit-event:: winreg.QueryReflectionKey key winreg.QueryReflectionKey
 
 
 .. _constants:
@@ -740,6 +786,9 @@ integer handle, and also disconnect the Windows handle from the handle object.
    After calling this function, the handle is effectively invalidated, but the
    handle is not closed.  You would call this function when you need the
    underlying Win32 handle to exist beyond the lifetime of the handle object.
+
+   .. audit-event:: winreg.PyHKEY.Detach key winreg.PyHKEY.Detach
+
 
 .. method:: PyHKEY.__enter__()
             PyHKEY.__exit__(\*exc_info)

--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -304,6 +304,29 @@ def test_unraisablehook():
     write_unraisable_exc(RuntimeError("nonfatal-error"), "for audit hook test", None)
 
 
+def test_winreg():
+    from winreg import OpenKey, EnumKey, CloseKey, HKEY_LOCAL_MACHINE
+
+    def hook(event, args):
+        if not event.startswith("winreg."):
+            return
+        print(event, *args)
+
+    sys.addaudithook(hook)
+
+    k = OpenKey(HKEY_LOCAL_MACHINE, "Software")
+    EnumKey(k, 0)
+    try:
+        EnumKey(k, 10000)
+    except OSError:
+        pass
+    else:
+        raise RuntimeError("Expected EnumKey(HKLM, 10000) to fail")
+
+    kv = k.Detach()
+    CloseKey(kv)
+
+
 if __name__ == "__main__":
     from test.libregrtest.setup import suppress_msvcrt_asserts
 

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -104,6 +104,20 @@ class AuditTest(unittest.TestCase):
             "RuntimeError('nonfatal-error') Exception ignored for audit hook test",
         )
 
+    def test_winreg(self):
+        support.import_module("winreg")
+        returncode, events, stderr = self.run_python("test_winreg")
+        if returncode:
+            self.fail(stderr)
+
+        self.assertEqual(events[0][0], "winreg.OpenKey")
+        self.assertEqual(events[1][0], "winreg.OpenKey/result")
+        expected = events[1][2]
+        self.assertTrue(expected)
+        self.assertSequenceEqual(["winreg.EnumKey", " ", f"{expected} 0"], events[2])
+        self.assertSequenceEqual(["winreg.EnumKey", " ", f"{expected} 10000"], events[3])
+        self.assertSequenceEqual(["winreg.PyHKEY.Detach", " ", expected], events[4])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-09-10-38-51.bpo-39008.Rrp6f1.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-09-10-38-51.bpo-39008.Rrp6f1.rst
@@ -1,0 +1,3 @@
+:c:func:`PySys_Audit` now requires ``Py_ssize_t`` to be used for size
+arguments in the format string, regardless of whethen ``PY_SSIZE_T_CLEAN``
+was defined at include time.

--- a/Misc/NEWS.d/next/Windows/2019-12-09-10-40-34.bpo-39007.vtarxo.rst
+++ b/Misc/NEWS.d/next/Windows/2019-12-09-10-40-34.bpo-39007.vtarxo.rst
@@ -1,0 +1,1 @@
+Add auditing events to functions in :mod:`winreg`.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -181,7 +181,7 @@ PySys_Audit(const char *event, const char *argFormat, ...)
     if (argFormat && argFormat[0]) {
         va_list args;
         va_start(args, argFormat);
-        eventArgs = Py_VaBuildValue(argFormat, args);
+        eventArgs = _Py_VaBuildValue_SizeT(argFormat, args);
         va_end(args);
         if (eventArgs && !PyTuple_Check(eventArgs)) {
             PyObject *argTuple = PyTuple_Pack(1, eventArgs);


### PR DESCRIPTION
This PR also requires the fix in #17540.

<!-- issue-number: [bpo-39007](https://bugs.python.org/issue39007) -->
https://bugs.python.org/issue39007
<!-- /issue-number -->
