### PR TITLE
bpo-24925: _find_lineno now finds doctest __test__ string line numbers

### DIFF
--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1097,6 +1097,14 @@ class DocTestFinder:
         if inspect.iscode(obj):
             lineno = getattr(obj, 'co_firstlineno', None)-1
 
+        # Find the line number for triple quoted __test__ strings.
+        if isinstance(obj, str):
+            # find a line in the string that is unique in source lines
+            # and start counting from there
+            for offset, line in enumerate(obj.splitlines(True)):
+                if source_lines.count(line) == 1:
+                    return source_lines.index(line) - offset
+
         # Find the line number where the docstring starts.  Assume
         # that it's the first line that begins with a quote mark.
         # Note: this could be fooled by a multiline function

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1098,7 +1098,7 @@ class DocTestFinder:
             lineno = getattr(obj, 'co_firstlineno', None)-1
 
         # Find the line number for triple quoted __test__ strings.
-        if isinstance(obj, str):
+        if isinstance(obj, str) and source_lines is not None:
             # find a line in the string that is unique in source lines
             # and start counting from there
             for offset, line in enumerate(obj.splitlines(True)):

--- a/Lib/test/doctest__test__.py
+++ b/Lib/test/doctest__test__.py
@@ -1,0 +1,22 @@
+'''A module to test if line numbers are calculated for doctests
+This test will be located properly because it in on module level.
+>>> # not unique
+>>> x = 7
+'''
+
+__test__ = {
+'q': '''
+>>> # not unique
+>>> x = 7
+>>> x/0
+''',
+'r': '''
+>>> # this one will be found because there is a unique line in it
+>>> x = 8
+>>> x/0
+''',
+}
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/Lib/test/doctest__test__.py
+++ b/Lib/test/doctest__test__.py
@@ -5,6 +5,7 @@ This test will be located properly because it in on module level.
 '''
 
 __test__ = {
+# this test will not get a line number because none of its lines are unique
 'q': '''
 >>> # not unique
 >>> x = 7

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -656,7 +656,7 @@ out the line number of a string that occurs in __test__:
     >>> from test import doctest__test__
     >>> tests = doctest.DocTestFinder().find(doctest__test__)
     >>> [e.lineno for e in tests]
-    [0, None, 11]
+    [0, None, 13]
 
 """
 

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -648,6 +648,16 @@ DocTestFinder finds the line number of each example:
     >>> test = doctest.DocTestFinder().find(f)[0]
     >>> [e.lineno for e in test.examples]
     [1, 9, 12]
+
+Finding line numbers in __test__ triple quoted strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Because Python object do not have line numbers, there is no trivial way to find
+out the line number of a string that occurs in __test__:
+    >>> from test import doctest__test__
+    >>> tests = doctest.DocTestFinder().find(doctest__test__)
+    >>> [e.lineno for e in tests]
+    [0, None, 11]
+
 """
 
     if int.__doc__: # simple check for --without-doc-strings, skip if lacking

--- a/Misc/NEWS.d/next/Library/2019-12-13-12-32-24.bpo-24295.QQPnrf.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-13-12-32-24.bpo-24295.QQPnrf.rst
@@ -1,0 +1,1 @@
+Errors found by doctest in a triple quoted string that occurs in a __test__ dictionary now give a message with the correct line number.

--- a/Misc/NEWS.d/next/Library/bpo-24925: _find_lineno now finds doctest __test__ string line numbers (PR17553)
+++ b/Misc/NEWS.d/next/Library/bpo-24925: _find_lineno now finds doctest __test__ string line numbers (PR17553)
@@ -1,0 +1,25 @@
+This patch allows to use doctest strings in a __test__ dictionary to fail with an error that included the line number
+It is meant to be used in files that look like:
+
+[lots of code]
+
+__test__ = {
+'example': '''
+    >>> print("Hello world"
+}
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()
+    
+
+And when the test fails, you get an error like:
+File "bpo-24925.py", line 8, in __main__.__test__.example
+Failed example:
+    print("Hello world"
+Exception raised:
+    Traceback (most recent call last):
+      File "C:\Program Files\Python38\lib\doctest.py", line 1336, in __run
+        exec(compile(example.source, filename, "single",
+      File "<doctest __main__.__test__.example[0]>", line 1
+    SyntaxError: unmatched ')'


### PR DESCRIPTION
If the doctest code is in a test string, _find_lineno now find the error, by looking for a line in the docstring that is unique in the source file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-24925](https://bugs.python.org/issue24925) -->
https://bugs.python.org/issue24925
<!-- /issue-number -->
