### PR TITLE
bpo-38614: Use test.support.LOOPBACK_TIMEOUT constant

### DIFF
--- a/Lib/test/ssl_servers.py
+++ b/Lib/test/ssl_servers.py
@@ -49,7 +49,7 @@ class RootedHTTPRequestHandler(SimpleHTTPRequestHandler):
     server_version = "TestHTTPS/1.0"
     root = here
     # Avoid hanging when a request gets interrupted by the client
-    timeout = 5
+    timeout = support.LOOPBACK_TIMEOUT
 
     def translate_path(self, path):
         """Translate a /-separated PATH to the local filename syntax.

--- a/Lib/test/test_asyncio/functional.py
+++ b/Lib/test/test_asyncio/functional.py
@@ -7,6 +7,7 @@ import select
 import socket
 import tempfile
 import threading
+from test import support
 
 
 class FunctionalTestCaseMixin:
@@ -49,7 +50,7 @@ class FunctionalTestCaseMixin:
     def tcp_server(self, server_prog, *,
                    family=socket.AF_INET,
                    addr=None,
-                   timeout=5,
+                   timeout=support.LOOPBACK_TIMEOUT,
                    backlog=1,
                    max_clients=10):
 
@@ -72,7 +73,7 @@ class FunctionalTestCaseMixin:
 
     def tcp_client(self, client_prog,
                    family=socket.AF_INET,
-                   timeout=10):
+                   timeout=support.LOOPBACK_TIMEOUT):
 
         sock = socket.socket(family, socket.SOCK_STREAM)
 

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -724,7 +724,7 @@ class EventLoopTestsMixin:
         sock = socket.socket()
         self.addCleanup(sock.close)
         coro = self.loop.connect_accepted_socket(
-            MyProto, sock, ssl_handshake_timeout=1)
+            MyProto, sock, ssl_handshake_timeout=support.LOOPBACK_TIMEOUT)
         with self.assertRaisesRegex(
                 ValueError,
                 'ssl_handshake_timeout is only meaningful with ssl'):

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -3,6 +3,7 @@
 import logging
 import socket
 import sys
+from test import support
 import unittest
 import weakref
 from unittest import mock
@@ -699,7 +700,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                     ssl=client_sslctx,
                     server_hostname='',
                     loop=self.loop,
-                    ssl_handshake_timeout=1.0)
+                    ssl_handshake_timeout=support.LOOPBACK_TIMEOUT)
 
         with self.tcp_server(server,
                              max_clients=1,

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -139,7 +139,7 @@ class SilentWSGIRequestHandler(WSGIRequestHandler):
 
 class SilentWSGIServer(WSGIServer):
 
-    request_timeout = 2
+    request_timeout = support.LOOPBACK_TIMEOUT
 
     def get_request(self):
         request, client_addr = super().get_request()
@@ -220,7 +220,7 @@ if hasattr(socket, 'AF_UNIX'):
 
     class UnixWSGIServer(UnixHTTPServer, WSGIServer):
 
-        request_timeout = 2
+        request_timeout = support.LOOPBACK_TIMEOUT
 
         def server_bind(self):
             UnixHTTPServer.server_bind(self)

--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -21,7 +21,7 @@ from unittest import TestCase, skipUnless
 from test import support
 from test.support import HOST, HOSTv6
 
-TIMEOUT = 3
+TIMEOUT = support.LOOPBACK_TIMEOUT
 # the dummy data returned by server over the data channel when
 # RETR, LIST, NLST, MLSD commands are issued
 RETR_DATA = 'abcde12345\r\n' * 1000

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -109,7 +109,7 @@ else:
 
 
 class SimpleIMAPHandler(socketserver.StreamRequestHandler):
-    timeout = 1
+    timeout = support.LOOPBACK_TIMEOUT
     continuation = None
     capabilities = ''
 

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -245,7 +245,8 @@ class DebuggingServerTests(unittest.TestCase):
 
     def testBasic(self):
         # connect
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         smtp.quit()
 
     def testSourceAddress(self):
@@ -253,7 +254,8 @@ class DebuggingServerTests(unittest.TestCase):
         src_port = support.find_unused_port()
         try:
             smtp = smtplib.SMTP(self.host, self.port, local_hostname='localhost',
-                                timeout=3, source_address=(self.host, src_port))
+                                timeout=support.LOOPBACK_TIMEOUT,
+                                source_address=(self.host, src_port))
             self.addCleanup(smtp.close)
             self.assertEqual(smtp.source_address, (self.host, src_port))
             self.assertEqual(smtp.local_hostname, 'localhost')
@@ -264,14 +266,16 @@ class DebuggingServerTests(unittest.TestCase):
             raise
 
     def testNOOP(self):
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         expected = (250, b'OK')
         self.assertEqual(smtp.noop(), expected)
         smtp.quit()
 
     def testRSET(self):
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         expected = (250, b'OK')
         self.assertEqual(smtp.rset(), expected)
@@ -279,7 +283,8 @@ class DebuggingServerTests(unittest.TestCase):
 
     def testELHO(self):
         # EHLO isn't implemented in DebuggingServer
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         expected = (250, b'\nSIZE 33554432\nHELP')
         self.assertEqual(smtp.ehlo(), expected)
@@ -287,7 +292,8 @@ class DebuggingServerTests(unittest.TestCase):
 
     def testEXPNNotImplemented(self):
         # EXPN isn't implemented in DebuggingServer
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         expected = (502, b'EXPN not implemented')
         smtp.putcmd('EXPN')
@@ -295,7 +301,8 @@ class DebuggingServerTests(unittest.TestCase):
         smtp.quit()
 
     def testVRFY(self):
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         expected = (252, b'Cannot VRFY user, but will accept message ' + \
                          b'and attempt delivery')
@@ -306,7 +313,8 @@ class DebuggingServerTests(unittest.TestCase):
     def testSecondHELO(self):
         # check that a second HELO returns a message that it's a duplicate
         # (this behavior is specific to smtpd.SMTPChannel)
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.helo()
         expected = (503, b'Duplicate HELO/EHLO')
@@ -314,7 +322,8 @@ class DebuggingServerTests(unittest.TestCase):
         smtp.quit()
 
     def testHELP(self):
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         self.assertEqual(smtp.help(), b'Supported commands: EHLO HELO MAIL ' + \
                                       b'RCPT DATA RSET NOOP QUIT VRFY')
@@ -323,7 +332,8 @@ class DebuggingServerTests(unittest.TestCase):
     def testSend(self):
         # connect and send mail
         m = 'A test message'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.sendmail('John', 'Sally', m)
         # XXX(nnorwitz): this test is flaky and dies with a bad file descriptor
@@ -340,7 +350,8 @@ class DebuggingServerTests(unittest.TestCase):
 
     def testSendBinary(self):
         m = b'A test message'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.sendmail('John', 'Sally', m)
         # XXX (see comment in testSend)
@@ -356,7 +367,8 @@ class DebuggingServerTests(unittest.TestCase):
     def testSendNeedingDotQuote(self):
         # Issue 12283
         m = '.A test\n.mes.sage.'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.sendmail('John', 'Sally', m)
         # XXX (see comment in testSend)
@@ -371,7 +383,8 @@ class DebuggingServerTests(unittest.TestCase):
 
     def testSendNullSender(self):
         m = 'A test message'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.sendmail('<>', 'Sally', m)
         # XXX (see comment in testSend)
@@ -389,7 +402,8 @@ class DebuggingServerTests(unittest.TestCase):
 
     def testSendMessage(self):
         m = email.mime.text.MIMEText('A test message')
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.send_message(m, from_addr='John', to_addrs='Sally')
         # XXX (see comment in testSend)
@@ -414,7 +428,8 @@ class DebuggingServerTests(unittest.TestCase):
         m['To'] = 'John'
         m['CC'] = 'Sally, Fred'
         m['Bcc'] = 'John Root <root@localhost>, "Dinsdale" <warped@silly.walks.com>'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.send_message(m)
         # XXX (see comment in testSend)
@@ -448,7 +463,8 @@ class DebuggingServerTests(unittest.TestCase):
         m = email.mime.text.MIMEText('A test message')
         m['From'] = 'foo@bar.com'
         m['To'] = 'John, Dinsdale'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.send_message(m)
         # XXX (see comment in testSend)
@@ -476,7 +492,8 @@ class DebuggingServerTests(unittest.TestCase):
         m = email.mime.text.MIMEText('A test message')
         m['From'] = 'foo@bar.com'
         m['To'] = 'John, Dinsdale'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.send_message(m, from_addr='joe@example.com', to_addrs='foo@example.net')
         # XXX (see comment in testSend)
@@ -507,7 +524,8 @@ class DebuggingServerTests(unittest.TestCase):
         m['From'] = 'Bernard, Bianca'
         m['Sender'] = 'the_rescuers@Rescue-Aid-Society.com'
         m['To'] = 'John, Dinsdale'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.send_message(m)
         # XXX (see comment in testSend)
@@ -540,7 +558,8 @@ class DebuggingServerTests(unittest.TestCase):
         m['Resent-From'] = 'holy@grail.net'
         m['Resent-To'] = 'Martha <my_mom@great.cooker.com>, Jeff'
         m['Resent-Bcc'] = 'doe@losthope.net'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.send_message(m)
         # XXX (see comment in testSend)
@@ -579,7 +598,8 @@ class DebuggingServerTests(unittest.TestCase):
         m['Resent-Date'] = 'Thu, 2 Jan 1970 17:42:00 +0000'
         m['Resent-To'] = 'holy@grail.net'
         m['Resent-From'] = 'Martha <my_mom@great.cooker.com>, Jeff'
-        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         with self.assertRaises(ValueError):
             smtp.send_message(m)
@@ -1130,7 +1150,8 @@ class SMTPSimTests(unittest.TestCase):
 
     def test_smtputf8_NotSupportedError_if_no_server_support(self):
         smtp = smtplib.SMTP(
-            HOST, self.port, local_hostname='localhost', timeout=3)
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.ehlo()
         self.assertTrue(smtp.does_esmtp)
@@ -1145,7 +1166,8 @@ class SMTPSimTests(unittest.TestCase):
 
     def test_send_unicode_without_SMTPUTF8(self):
         smtp = smtplib.SMTP(
-            HOST, self.port, local_hostname='localhost', timeout=3)
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         self.assertRaises(UnicodeEncodeError, smtp.sendmail, 'Alice', 'Böb', '')
         self.assertRaises(UnicodeEncodeError, smtp.mail, 'Älice')
@@ -1158,15 +1180,16 @@ class SMTPSimTests(unittest.TestCase):
         msg['To'] = 'Dinsdale'
         msg['Subject'] = 'Nudge nudge, wink, wink \u1F609'
         smtp = smtplib.SMTP(
-            HOST, self.port, local_hostname='localhost', timeout=3)
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         with self.assertRaises(smtplib.SMTPNotSupportedError):
             smtp.send_message(msg)
 
     def test_name_field_not_included_in_envelop_addresses(self):
         smtp = smtplib.SMTP(
-            HOST, self.port, local_hostname='localhost', timeout=3
-        )
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
 
         message = EmailMessage()
@@ -1242,7 +1265,8 @@ class SMTPUTF8SimTests(unittest.TestCase):
 
     def test_test_server_supports_extensions(self):
         smtp = smtplib.SMTP(
-            HOST, self.port, local_hostname='localhost', timeout=3)
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.ehlo()
         self.assertTrue(smtp.does_esmtp)
@@ -1251,7 +1275,8 @@ class SMTPUTF8SimTests(unittest.TestCase):
     def test_send_unicode_with_SMTPUTF8_via_sendmail(self):
         m = '¡a test message containing unicode!'.encode('utf-8')
         smtp = smtplib.SMTP(
-            HOST, self.port, local_hostname='localhost', timeout=3)
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.sendmail('Jőhn', 'Sálly', m,
                       mail_options=['BODY=8BITMIME', 'SMTPUTF8'])
@@ -1265,7 +1290,8 @@ class SMTPUTF8SimTests(unittest.TestCase):
     def test_send_unicode_with_SMTPUTF8_via_low_level_API(self):
         m = '¡a test message containing unicode!'.encode('utf-8')
         smtp = smtplib.SMTP(
-            HOST, self.port, local_hostname='localhost', timeout=3)
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         smtp.ehlo()
         self.assertEqual(
@@ -1301,7 +1327,8 @@ class SMTPUTF8SimTests(unittest.TestCase):
             oh là là, know what I mean, know what I mean?
             """)
         smtp = smtplib.SMTP(
-            HOST, self.port, local_hostname='localhost', timeout=3)
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
         self.addCleanup(smtp.close)
         self.assertEqual(smtp.send_message(msg), {})
         self.assertEqual(self.serv.last_mailfrom, 'főo@bar.com')

--- a/Lib/test/test_timeout.py
+++ b/Lib/test/test_timeout.py
@@ -199,10 +199,7 @@ class TCPTimeoutTestCase(TimeoutTestCase):
 
         skip = True
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        # Use a timeout of 3 seconds.  Why 3?  Because it's more than 1, and
-        # less than 5.  i.e. no particular reason.  Feel free to tweak it if
-        # you feel a different value would be more appropriate.
-        timeout = 3
+        timeout = support.LOOPBACK_TIMEOUT
         sock.settimeout(timeout)
         try:
             sock.connect((whitehole))

--- a/Misc/NEWS.d/next/Tests/2019-12-10-14-26-23.bpo-38614.89JpNh.rst
+++ b/Misc/NEWS.d/next/Tests/2019-12-10-14-26-23.bpo-38614.89JpNh.rst
@@ -1,0 +1,3 @@
+Replace hardcoded timeout constants in tests with
+:data:`~test.support.LOOPBACK_TIMEOUT` of :mod:`test.support`, so it's easier
+to ajdust this timeout for all tests at once.


### PR DESCRIPTION
Replace hardcoded timeout constants in tests with LOOPBACK_TIMEOUT of
test.support, so it's easier to ajdust this timeout for all tests at
once.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38614](https://bugs.python.org/issue38614) -->
https://bugs.python.org/issue38614
<!-- /issue-number -->
