### PR TITLE
[3.8] bpo-39016: type_mro_modified produces negative refcount

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -318,8 +318,6 @@ type_mro_modified(PyTypeObject *type, PyObject *bases) {
             goto clear;
         if (mro_meth != type_mro_meth)
             goto clear;
-        Py_XDECREF(mro_meth);
-        Py_XDECREF(type_mro_meth);
     }
     n = PyTuple_GET_SIZE(bases);
     for (i = 0; i < n; i++) {
@@ -336,8 +334,6 @@ type_mro_modified(PyTypeObject *type, PyObject *bases) {
     }
     return;
  clear:
-    Py_XDECREF(mro_meth);
-    Py_XDECREF(type_mro_meth);
     type->tp_flags &= ~(Py_TPFLAGS_HAVE_VERSION_TAG|
                         Py_TPFLAGS_VALID_VERSION_TAG);
 }


### PR DESCRIPTION
In the "if (custom) {" branch, lookup_maybe_method, which uses
borrowed references, is not handled correctly.
Solved by removing all PyXDECREF calls.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39016](https://bugs.python.org/issue39016) -->
https://bugs.python.org/issue39016
<!-- /issue-number -->
