### PR TITLE
bpo-39019: Implement missing __class_getitem__ for subprocess classes

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -446,6 +446,9 @@ class CompletedProcess(object):
             args.append('stderr={!r}'.format(self.stderr))
         return "{}({})".format(type(self).__name__, ', '.join(args))
 
+    def __class_getitem__(cls, type):
+        return cls
+
     def check_returncode(self):
         """Raise CalledProcessError if the exit code is non-zero."""
         if self.returncode:
@@ -986,6 +989,9 @@ class Popen(object):
         if len(obj_repr) > 80:
             obj_repr = obj_repr[:76] + "...>"
         return obj_repr
+
+    def __class_getitem__(cls, type):
+        return cls
 
     @property
     def universal_newlines(self):

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -447,7 +447,17 @@ class CompletedProcess(object):
         return "{}({})".format(type(self).__name__, ', '.join(args))
 
     def __class_getitem__(cls, type):
+        """Provide minimal support for using this class as generic
+        (for example in type annotations).
+
+        See PEP 484 and PEP 560 for more details. For example,
+        `CompletedProcess[bytes]` is a valid expression at runtime
+        (type argument `bytes` indicates the type used for stdout).
+        Note, no type checking happens at runtime, but a static type
+        checker can be used.
+        """
         return cls
+
 
     def check_returncode(self):
         """Raise CalledProcessError if the exit code is non-zero."""
@@ -991,6 +1001,14 @@ class Popen(object):
         return obj_repr
 
     def __class_getitem__(cls, type):
+        """Provide minimal support for using this class as generic
+        (for example in type annotations).
+
+        See PEP 484 and PEP 560 for more details. For example, `Popen[bytes]`
+        is a valid expression at runtime (type argument `bytes` indicates the
+        type used for stdout). Note, no type checking happens at runtime, but
+        a static type checker can be used.
+        """
         return cls
 
     @property

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1437,6 +1437,9 @@ class ProcessTestCase(BaseTestCase):
             subprocess.Popen(['exit', '0'], cwd='/some/nonexistent/directory')
         self.assertEqual(c.exception.filename, '/some/nonexistent/directory')
 
+    def test_class_getitems(self):
+        self.assertIs(subprocess.Popen[bytes], subprocess.Popen)
+        self.assertIs(subprocess.CompletedProcess[str], subprocess.CompletedProcess)
 
 class RunFuncTestCase(BaseTestCase):
     def run_python(self, code, **kwargs):

--- a/Misc/NEWS.d/next/Library/2019-12-10-21-03-34.bpo-39019.i8RpMZ.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-10-21-03-34.bpo-39019.i8RpMZ.rst
@@ -1,0 +1,2 @@
+Implement dummy ``__class_getitem__`` for ``subprocess.Popen``,
+``subprocess.CompletedProcess``


### PR DESCRIPTION
(It also includes a fix for a news entry from a previous PR, GH-17498)

<!-- issue-number: [bpo-39019](https://bugs.python.org/issue39019) -->
https://bugs.python.org/issue39019
<!-- /issue-number -->
