### PR TITLE
bpo-38614: Use default join_thread() timeout in tests

### DIFF
--- a/Lib/test/test_asynchat.py
+++ b/Lib/test/test_asynchat.py
@@ -14,7 +14,6 @@ import unittest.mock
 
 HOST = support.HOST
 SERVER_QUIT = b'QUIT\n'
-TIMEOUT = 3.0
 
 
 class echo_server(threading.Thread):
@@ -122,7 +121,7 @@ class TestAsynchat(unittest.TestCase):
         c.push(b"I'm not dead yet!" + term)
         c.push(SERVER_QUIT)
         asyncore.loop(use_poll=self.usepoll, count=300, timeout=.01)
-        support.join_thread(s, timeout=TIMEOUT)
+        support.join_thread(s)
 
         self.assertEqual(c.contents, [b"hello world", b"I'm not dead yet!"])
 
@@ -153,7 +152,7 @@ class TestAsynchat(unittest.TestCase):
         c.push(data)
         c.push(SERVER_QUIT)
         asyncore.loop(use_poll=self.usepoll, count=300, timeout=.01)
-        support.join_thread(s, timeout=TIMEOUT)
+        support.join_thread(s)
 
         self.assertEqual(c.contents, [data[:termlen]])
 
@@ -173,7 +172,7 @@ class TestAsynchat(unittest.TestCase):
         c.push(data)
         c.push(SERVER_QUIT)
         asyncore.loop(use_poll=self.usepoll, count=300, timeout=.01)
-        support.join_thread(s, timeout=TIMEOUT)
+        support.join_thread(s)
 
         self.assertEqual(c.contents, [])
         self.assertEqual(c.buffer, data)
@@ -185,7 +184,7 @@ class TestAsynchat(unittest.TestCase):
         p = asynchat.simple_producer(data+SERVER_QUIT, buffer_size=8)
         c.push_with_producer(p)
         asyncore.loop(use_poll=self.usepoll, count=300, timeout=.01)
-        support.join_thread(s, timeout=TIMEOUT)
+        support.join_thread(s)
 
         self.assertEqual(c.contents, [b"hello world", b"I'm not dead yet!"])
 
@@ -195,7 +194,7 @@ class TestAsynchat(unittest.TestCase):
         data = b"hello world\nI'm not dead yet!\n"
         c.push_with_producer(data+SERVER_QUIT)
         asyncore.loop(use_poll=self.usepoll, count=300, timeout=.01)
-        support.join_thread(s, timeout=TIMEOUT)
+        support.join_thread(s)
 
         self.assertEqual(c.contents, [b"hello world", b"I'm not dead yet!"])
 
@@ -206,7 +205,7 @@ class TestAsynchat(unittest.TestCase):
         c.push(b"hello world\n\nI'm not dead yet!\n")
         c.push(SERVER_QUIT)
         asyncore.loop(use_poll=self.usepoll, count=300, timeout=.01)
-        support.join_thread(s, timeout=TIMEOUT)
+        support.join_thread(s)
 
         self.assertEqual(c.contents,
                          [b"hello world", b"", b"I'm not dead yet!"])
@@ -225,7 +224,7 @@ class TestAsynchat(unittest.TestCase):
         # where the server echoes all of its data before we can check that it
         # got any down below.
         s.start_resend_event.set()
-        support.join_thread(s, timeout=TIMEOUT)
+        support.join_thread(s)
 
         self.assertEqual(c.contents, [])
         # the server might have been able to send a byte or two back, but this
@@ -246,7 +245,7 @@ class TestAsynchat(unittest.TestCase):
         self.assertRaises(TypeError, c.push, 'unicode')
         c.push(SERVER_QUIT)
         asyncore.loop(use_poll=self.usepoll, count=300, timeout=.01)
-        support.join_thread(s, timeout=TIMEOUT)
+        support.join_thread(s)
         self.assertEqual(c.contents, [b'bytes', b'bytes', b'bytes'])
 
 

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -699,7 +699,7 @@ class EventLoopTestsMixin:
         proto.transport.close()
         lsock.close()
 
-        support.join_thread(thread, timeout=1)
+        support.join_thread(thread)
         self.assertFalse(thread.is_alive())
         self.assertEqual(proto.state, 'CLOSED')
         self.assertEqual(proto.nbytes, len(message))

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -16,7 +16,6 @@ if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
 
-TIMEOUT = 3
 HAS_UNIX_SOCKETS = hasattr(socket, 'AF_UNIX')
 
 class dummysocket:
@@ -360,7 +359,7 @@ class DispatcherWithSendTests(unittest.TestCase):
 
             self.assertEqual(cap.getvalue(), data*2)
         finally:
-            support.join_thread(t, timeout=TIMEOUT)
+            support.join_thread(t)
 
 
 @unittest.skipUnless(hasattr(asyncore, 'file_wrapper'),
@@ -788,7 +787,7 @@ class BaseTestAPI:
                 except OSError:
                     pass
         finally:
-            support.join_thread(t, timeout=TIMEOUT)
+            support.join_thread(t)
 
 class TestAPI_UseIPv4Sockets(BaseTestAPI):
     family = socket.AF_INET

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -238,7 +238,7 @@ class NewIMAPTestsMixin():
         # cleanup the server
         self.server.shutdown()
         self.server.server_close()
-        support.join_thread(self.thread, 3.0)
+        support.join_thread(self.thread)
         # Explicitly clear the attribute to prevent dangling thread
         self.thread = None
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -869,16 +869,13 @@ class TestSMTPServer(smtpd.SMTPServer):
         """
         asyncore.loop(poll_interval, map=self._map)
 
-    def stop(self, timeout=None):
+    def stop(self):
         """
         Stop the thread by closing the server instance.
         Wait for the server thread to terminate.
-
-        :param timeout: How long to wait for the server thread
-                        to terminate.
         """
         self.close()
-        support.join_thread(self._thread, timeout)
+        support.join_thread(self._thread)
         self._thread = None
         asyncore.close_all(map=self._map, ignore_all=True)
 
@@ -922,16 +919,13 @@ class ControlMixin(object):
         self.ready.set()
         super(ControlMixin, self).serve_forever(poll_interval)
 
-    def stop(self, timeout=None):
+    def stop(self):
         """
         Tell the server thread to stop, and wait for it to do so.
-
-        :param timeout: How long to wait for the server thread
-                        to terminate.
         """
         self.shutdown()
         if self._thread is not None:
-            support.join_thread(self._thread, timeout)
+            support.join_thread(self._thread)
             self._thread = None
         self.server_close()
         self.ready.clear()
@@ -1699,7 +1693,7 @@ class SocketHandlerTest(BaseTest):
                 self.root_logger.removeHandler(self.sock_hdlr)
                 self.sock_hdlr.close()
             if self.server:
-                self.server.stop(2.0)
+                self.server.stop()
         finally:
             BaseTest.tearDown(self)
 
@@ -1736,7 +1730,7 @@ class SocketHandlerTest(BaseTest):
         # one-second timeout on socket.create_connection() (issue #16264).
         self.sock_hdlr.retryStart = 2.5
         # Kill the server
-        self.server.stop(2.0)
+        self.server.stop()
         # The logging call should try to connect, which should fail
         try:
             raise RuntimeError('Deliberate mistake')
@@ -1810,7 +1804,7 @@ class DatagramHandlerTest(BaseTest):
         """Shutdown the UDP server."""
         try:
             if self.server:
-                self.server.stop(2.0)
+                self.server.stop()
             if self.sock_hdlr:
                 self.root_logger.removeHandler(self.sock_hdlr)
                 self.sock_hdlr.close()
@@ -1891,7 +1885,7 @@ class SysLogHandlerTest(BaseTest):
         """Shutdown the server."""
         try:
             if self.server:
-                self.server.stop(2.0)
+                self.server.stop()
             if self.sl_hdlr:
                 self.root_logger.removeHandler(self.sl_hdlr)
                 self.sl_hdlr.close()
@@ -2028,7 +2022,7 @@ class HTTPHandlerTest(BaseTest):
                 self.assertEqual(d['funcName'], ['test_output'])
                 self.assertEqual(d['msg'], [msg])
 
-            self.server.stop(2.0)
+            self.server.stop()
             self.root_logger.removeHandler(self.h_hdlr)
             self.h_hdlr.close()
 
@@ -3228,7 +3222,7 @@ class ConfigDictTest(BaseTest):
         finally:
             t.ready.wait(2.0)
             logging.config.stopListening()
-            support.join_thread(t, 2.0)
+            support.join_thread(t)
 
     def test_listen_config_10_ok(self):
         with support.captured_stdout() as output:

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -63,7 +63,7 @@ class BlockingTestMixin:
                           block_func)
             return self.result
         finally:
-            support.join_thread(thread, 10) # make sure the thread terminates
+            support.join_thread(thread) # make sure the thread terminates
 
     # Call this instead if block_func is supposed to raise an exception.
     def do_exceptional_blocking_test(self,block_func, block_args, trigger_func,
@@ -79,7 +79,7 @@ class BlockingTestMixin:
                 self.fail("expected exception of kind %r" %
                                  expected_exception_class)
         finally:
-            support.join_thread(thread, 10) # make sure the thread terminates
+            support.join_thread(thread) # make sure the thread terminates
             if not thread.startedEvent.is_set():
                 self.fail("trigger thread ended but event never set")
 

--- a/Lib/test/test_sched.py
+++ b/Lib/test/test_sched.py
@@ -82,7 +82,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(q.get(timeout=TIMEOUT), 5)
         self.assertTrue(q.empty())
         timer.advance(1000)
-        support.join_thread(t, timeout=TIMEOUT)
+        support.join_thread(t)
         self.assertTrue(q.empty())
         self.assertEqual(timer.time(), 5)
 
@@ -137,7 +137,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(q.get(timeout=TIMEOUT), 4)
         self.assertTrue(q.empty())
         timer.advance(1000)
-        support.join_thread(t, timeout=TIMEOUT)
+        support.join_thread(t)
         self.assertTrue(q.empty())
         self.assertEqual(timer.time(), 4)
 


### PR DESCRIPTION
Tests no longer pass a timeout value to join_thread() of
test.support: use the default join_thread() timeout instead
(SHORT_TIMEOUT constant of test.support).

<!-- issue-number: [bpo-38614](https://bugs.python.org/issue38614) -->
https://bugs.python.org/issue38614
<!-- /issue-number -->
