### PR TITLE
bpo-39019: Implement missing __class_getitem__ for SpooledTemporaryFile

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -649,8 +649,9 @@ class SpooledTemporaryFile:
 
         See PEP 484 and PEP 560 for more details. For example,
         `SpooledTemporaryFile[str]` is a valid expression at runtime (type
-        argument `str` indicates the type used for mode). Note, no type
-        checking happens at runtime, but a static type checker can be used.
+        argument `str` indicates whether the file is open in bytes or text
+        mode). Note, no type checking happens at runtime, but a static type
+        checker can be used.
         """
         return cls
 

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -644,6 +644,14 @@ class SpooledTemporaryFile:
                                    'dir': dir, 'errors': errors}
 
     def __class_getitem__(cls, type):
+        """Provide minimal support for using this class as generic
+        (for example in type annotations).
+
+        See PEP 484 and PEP 560 for more details. For example,
+        `SpooledTemporaryFile[str]` is a valid expression at runtime (type
+        argument `str` indicates the type used for mode). Note, no type
+        checking happens at runtime, but a static type checker can be used.
+        """
         return cls
 
     def _check(self, file):

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -643,6 +643,9 @@ class SpooledTemporaryFile:
                                    'encoding': encoding, 'newline': newline,
                                    'dir': dir, 'errors': errors}
 
+    def __class_getitem__(cls, type):
+        return cls
+
     def _check(self, file):
         if self._rolled: return
         max_size = self._max_size

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1229,6 +1229,8 @@ class TestSpooledTemporaryFile(BaseTestCase):
         self.assertTrue(f._rolled)
         self.assertEqual(os.fstat(f.fileno()).st_size, 20)
 
+    def test_class_getitem(self):
+        self.assertIs(tempfile.SpooledTemporaryFile[bytes], tempfile.SpooledTemporaryFile)
 
 if tempfile.NamedTemporaryFile is not tempfile.TemporaryFile:
 

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1230,7 +1230,8 @@ class TestSpooledTemporaryFile(BaseTestCase):
         self.assertEqual(os.fstat(f.fileno()).st_size, 20)
 
     def test_class_getitem(self):
-        self.assertIs(tempfile.SpooledTemporaryFile[bytes], tempfile.SpooledTemporaryFile)
+        self.assertIs(tempfile.SpooledTemporaryFile[bytes],
+                      tempfile.SpooledTemporaryFile)
 
 if tempfile.NamedTemporaryFile is not tempfile.TemporaryFile:
 

--- a/Misc/NEWS.d/next/Library/2019-12-10-21-11-05.bpo-39019.YIlgZ7.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-10-21-11-05.bpo-39019.YIlgZ7.rst
@@ -1,1 +1,1 @@
-Implement ``__class_getitem__`` for ``tempfile.SpooledTemporaryFile``.
+Implement ``__class_getitem__`` for :class:`tempfile.SpooledTemporaryFile`.

--- a/Misc/NEWS.d/next/Library/2019-12-10-21-11-05.bpo-39019.YIlgZ7.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-10-21-11-05.bpo-39019.YIlgZ7.rst
@@ -1,0 +1,1 @@
+Implement ``__class_getitem__`` for ``tempfile.SpooledTemporaryFile``.

--- a/Misc/NEWS.d/next/Library/2019-12-10-21-11-05.bpo-39019.YIlgZ7.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-10-21-11-05.bpo-39019.YIlgZ7.rst
@@ -1,1 +1,1 @@
-Implement ``__class_getitem__`` for :class:`tempfile.SpooledTemporaryFile`.
+Implement dummy ``__class_getitem__`` for :class:`tempfile.SpooledTemporaryFile`.


### PR DESCRIPTION


<!-- issue-number: [bpo-39019](https://bugs.python.org/issue39019) -->
https://bugs.python.org/issue39019
<!-- /issue-number -->
