### PR TITLE
bpo-39019: Implement missing __class_getitem__ for os.DirEntry

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3655,6 +3655,9 @@ class TestDirEntry(unittest.TestCase):
         import pickle
         self.assertRaises(TypeError, pickle.dumps, entry, filename)
 
+    def test_class_getitem(self):
+        self.assertIs(os.DirEntry[str], os.DirEntry)
+
 
 class TestScandir(unittest.TestCase):
     check_no_resource_warning = support.check_no_resource_warning

--- a/Misc/NEWS.d/next/Library/2019-12-10-21-22-20.bpo-39019.SkVoG0.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-10-21-22-20.bpo-39019.SkVoG0.rst
@@ -1,0 +1,1 @@
+Implement ``__class_getitem__`` for ``os.DirEntry``.

--- a/Misc/NEWS.d/next/Library/2019-12-10-21-22-20.bpo-39019.SkVoG0.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-10-21-22-20.bpo-39019.SkVoG0.rst
@@ -1,1 +1,1 @@
-Implement ``__class_getitem__`` for ``os.DirEntry``.
+Implement dummy ``__class_getitem__`` for ``os.DirEntry``.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12791,6 +12791,13 @@ os_DirEntry___fspath___impl(DirEntry *self)
     return self->path;
 }
 
+static PyObject *
+DirEntry_cls_getitem(PyObject *cls, PyObject *type)
+{
+    Py_INCREF(cls);
+    return cls;
+}
+
 static PyMemberDef DirEntry_members[] = {
     {"name", T_OBJECT_EX, offsetof(DirEntry, name), READONLY,
      "the entry's base filename, relative to scandir() \"path\" argument"},
@@ -12808,6 +12815,7 @@ static PyMethodDef DirEntry_methods[] = {
     OS_DIRENTRY_STAT_METHODDEF
     OS_DIRENTRY_INODE_METHODDEF
     OS_DIRENTRY___FSPATH___METHODDEF
+    {"__class_getitem__", DirEntry_cls_getitem, METH_O|METH_CLASS, NULL},
     {NULL}
 };
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39019](https://bugs.python.org/issue39019) -->
https://bugs.python.org/issue39019
<!-- /issue-number -->
