### PR TITLE
bpo-39019: Implement missing __class_getitem__ for http.cookies.Morsel

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -293,6 +293,9 @@ class Morsel(dict):
         for key in self._reserved:
             dict.__setitem__(self, key, "")
 
+    def __class_getitem__(cls, type):
+        return cls
+
     @property
     def key(self):
         return self._key

--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -294,6 +294,14 @@ class Morsel(dict):
             dict.__setitem__(self, key, "")
 
     def __class_getitem__(cls, type):
+        """Provide minimal support for using this class as generic
+        (for example in type annotations).
+
+        See PEP 484 and PEP 560 for more details. For example, `Morsel[T]`
+        is a valid expression at runtime (type argument `T` indicates the
+        type used for mode). Note, no type checking happens at runtime, but
+        a static type checker can be used.
+        """
         return cls
 
     @property

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -479,6 +479,9 @@ class MorselTests(unittest.TestCase):
                 r'Set-Cookie: key=coded_val; '
                 r'expires=\w+, \d+ \w+ \d+ \d+:\d+:\d+ \w+')
 
+    def test_class_getitem(self):
+        self.assertIs(cookies.Morsel[str], cookies.Morsel)
+
 def test_main():
     run_unittest(CookieTests, MorselTests)
     run_doctest(cookies)

--- a/Misc/NEWS.d/next/Library/2019-12-10-21-27-37.bpo-39019.7o43Gq.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-10-21-27-37.bpo-39019.7o43Gq.rst
@@ -1,1 +1,1 @@
-Implement ``__class_getitem__`` for ``http.cookies.Morsel``.
+Implement dummy ``__class_getitem__`` for ``http.cookies.Morsel``.

--- a/Misc/NEWS.d/next/Library/2019-12-10-21-27-37.bpo-39019.7o43Gq.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-10-21-27-37.bpo-39019.7o43Gq.rst
@@ -1,0 +1,1 @@
+Implement ``__class_getitem__`` for ``http.cookies.Morsel``.


### PR DESCRIPTION


<!-- issue-number: [bpo-39019](https://bugs.python.org/issue39019) -->
https://bugs.python.org/issue39019
<!-- /issue-number -->
