### PR TITLE
bpo-38614: Use test.support.INTERNET_TIMEOUT constant

### DIFF
--- a/Lib/test/test_nntplib.py
+++ b/Lib/test/test_nntplib.py
@@ -19,7 +19,6 @@ except ImportError:
     ssl = None
 
 
-TIMEOUT = 30
 certfile = os.path.join(os.path.dirname(__file__), 'keycert3.pem')
 
 if ssl is not None:
@@ -270,12 +269,18 @@ class NetworkedNNTPTestsMixin:
             return True
 
         try:
-            with self.NNTP_CLASS(self.NNTP_HOST, timeout=TIMEOUT, usenetrc=False) as server:
+            server = self.NNTP_CLASS(self.NNTP_HOST,
+                                     timeout=support.INTERNET_TIMEOUT,
+                                     usenetrc=False)
+            with server:
                 self.assertTrue(is_connected())
                 self.assertTrue(server.help())
             self.assertFalse(is_connected())
 
-            with self.NNTP_CLASS(self.NNTP_HOST, timeout=TIMEOUT, usenetrc=False) as server:
+            server = self.NNTP_CLASS(self.NNTP_HOST,
+                                     timeout=support.INTERNET_TIMEOUT,
+                                     usenetrc=False)
+            with server:
                 server.quit()
             self.assertFalse(is_connected())
         except SSLError as ssl_err:
@@ -307,7 +312,8 @@ class NetworkedNNTPTests(NetworkedNNTPTestsMixin, unittest.TestCase):
         support.requires("network")
         with support.transient_internet(cls.NNTP_HOST):
             try:
-                cls.server = cls.NNTP_CLASS(cls.NNTP_HOST, timeout=TIMEOUT,
+                cls.server = cls.NNTP_CLASS(cls.NNTP_HOST,
+                                            timeout=support.INTERNET_TIMEOUT,
                                             usenetrc=False)
             except SSLError as ssl_err:
                 # matches "[SSL: DH_KEY_TOO_SMALL] dh key too small"

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -10,8 +10,6 @@ import sys
 
 support.requires("network")
 
-TIMEOUT = 60  # seconds
-
 
 def _retry_thrice(func, exc, *args, **kwargs):
     for i in range(3):
@@ -227,7 +225,7 @@ class OtherNetworkTests(unittest.TestCase):
 
                 with support.transient_internet(url):
                     try:
-                        f = urlopen(url, req, TIMEOUT)
+                        f = urlopen(url, req, support.INTERNET_TIMEOUT)
                     # urllib.error.URLError is a subclass of OSError
                     except OSError as err:
                         if expected_err:

--- a/Lib/test/test_urllibnet.py
+++ b/Lib/test/test_urllibnet.py
@@ -16,10 +16,8 @@ support.requires('network')
 class URLTimeoutTest(unittest.TestCase):
     # XXX this test doesn't seem to test anything useful.
 
-    TIMEOUT = 30.0
-
     def setUp(self):
-        socket.setdefaulttimeout(self.TIMEOUT)
+        socket.setdefaulttimeout(support.INTERNET_TIMEOUT)
 
     def tearDown(self):
         socket.setdefaulttimeout(None)


### PR DESCRIPTION
Replace hardcoded timeout constants in tests with INTERNET_TIMEOUT of
test.support, so it's easier to ajdust this timeout for all tests at
once.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38614](https://bugs.python.org/issue38614) -->
https://bugs.python.org/issue38614
<!-- /issue-number -->
