### PR TITLE
bpo-39028: Performance enhancement in keyword extraction

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-17-23-20-51.bpo-39028.SND4TB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-17-23-20-51.bpo-39028.SND4TB.rst
@@ -1,0 +1,1 @@
+Slightly improve the speed of keyword argument parsing with many kwargs by strengthening the assumption that kwargs are interned strings.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2053,14 +2053,18 @@ find_keyword(PyObject *kwnames, PyObject *const *kwstack, PyObject *key)
     Py_ssize_t i, nkwargs;
 
     nkwargs = PyTuple_GET_SIZE(kwnames);
-    for (i=0; i < nkwargs; i++) {
+    for (i = 0; i < nkwargs; i++) {
         PyObject *kwname = PyTuple_GET_ITEM(kwnames, i);
 
-        /* ptr==ptr should match in most cases since keyword keys
-           should be interned strings */
+        /* kwname == key will normally find a match in since keyword keys
+           should be interned strings; if not retry below in a new loop. */
         if (kwname == key) {
             return kwstack[i];
         }
+    }
+
+    for (i = 0; i < nkwargs; i++) {
+        PyObject *kwname = PyTuple_GET_ITEM(kwnames, i);
         assert(PyUnicode_Check(kwname));
         if (_PyUnicode_EQ(kwname, key)) {
             return kwstack[i];


### PR DESCRIPTION
All keywords should first be checked for pointer identity. Only
after that failed for all keywords (unlikely) should unicode
equality be used.
The original code would call unicode equality on any non-matching
keyword argument. Meaning calling it often e.g. when a function
has many kwargs but only the last one is provided.

---

Unless I am missing something big, this seems like it was the original intention, and simple typo. It may make sense to backport?

I have to admit, I have not actually recompiled and timed this, I may do that tomorrow (but I have never had the need to compile python, so need to look up how).

<!-- issue-number: [bpo-39028](https://bugs.python.org/issue39028) -->
https://bugs.python.org/issue39028
<!-- /issue-number -->
