### PR TITLE
bpo-37228: Fix warnings in test_asyncio.test_base_events

### DIFF
--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1814,7 +1814,10 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             reuse_address=False)
 
         with self.assertWarns(DeprecationWarning):
-            self.loop.run_until_complete(coro)
+            transport, protocol = self.loop.run_until_complete(coro)
+            transport.close()
+            self.loop.run_until_complete(protocol.done)
+            self.assertEqual('CLOSED', protocol.state)
 
     @patch_socket
     def test_create_datagram_endpoint_nosoreuseport(self, m_socket):
@@ -1824,7 +1827,6 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         coro = self.loop.create_datagram_endpoint(
             lambda: MyDatagramProto(loop=self.loop),
             local_addr=('127.0.0.1', 0),
-            reuse_address=False,
             reuse_port=True)
 
         self.assertRaises(ValueError, self.loop.run_until_complete, coro)
@@ -1843,7 +1845,6 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         coro = self.loop.create_datagram_endpoint(
             lambda: MyDatagramProto(loop=self.loop),
             local_addr=('1.2.3.4', 0),
-            reuse_address=False,
             reuse_port=reuseport_supported)
 
         t, p = self.loop.run_until_complete(coro)


### PR DESCRIPTION
Co-authored-by: @tirkarthi 

The security patch https://github.com/python/cpython/pull/17311 (which was backported to 3.8, 3.7, and 3.6) added a few subtle warnings, including a `ResourceWarning` and two `DeprecationWarning`s in test_asyncio.test_base_events. @tirkarthi discovered the warnings, and proposed a fix for the `ResourceWarning`. See the bpo issue for more details.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37228](https://bugs.python.org/issue37228) -->
https://bugs.python.org/issue37228
<!-- /issue-number -->
