### PR TITLE
[3.7] bpo-39031: Include elif keyword when producing lineno/col-offset info for if_stmt (GH-17582)

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -64,6 +64,8 @@ exec_tests = [
     "while v:pass",
     # If
     "if v:pass",
+    # If-Elif
+    "if a:\n  pass\nelif b:\n  pass",
     # With
     "with x as y: pass",
     "with x as y, z as q: pass",
@@ -597,6 +599,12 @@ class ASTHelpers_Test(unittest.TestCase):
         self.assertIsNone(ast.get_docstring(node.body[0]))
         node = ast.parse('async def foo():\n  x = "not docstring"')
         self.assertIsNone(ast.get_docstring(node.body[0]))
+
+    def test_elif_stmt_start_position(self):
+        node = ast.parse('if a:\n    pass\nelif b:\n    pass\n')
+        elif_stmt = node.body[0].orelse[0]
+        self.assertEqual(elif_stmt.lineno, 3)
+        self.assertEqual(elif_stmt.col_offset, 0)
 
     def test_literal_eval(self):
         self.assertEqual(ast.literal_eval('[1, 2, 3]'), [1, 2, 3])
@@ -1235,6 +1243,7 @@ exec_results = [
 ('Module', [('For', (1, 0), ('Name', (1, 4), 'v', ('Store',)), ('Name', (1, 9), 'v', ('Load',)), [('Pass', (1, 11))], [])]),
 ('Module', [('While', (1, 0), ('Name', (1, 6), 'v', ('Load',)), [('Pass', (1, 8))], [])]),
 ('Module', [('If', (1, 0), ('Name', (1, 3), 'v', ('Load',)), [('Pass', (1, 5))], [])]),
+('Module', [('If', (1, 0), ('Name', (1, 3), 'a', ('Load',)), [('Pass', (2, 2))], [('If', (3, 0), ('Name', (3, 5), 'b', ('Load',)), [('Pass', (4, 2))], [])])]),
 ('Module', [('With', (1, 0), [('withitem', ('Name', (1, 5), 'x', ('Load',)), ('Name', (1, 10), 'y', ('Store',)))], [('Pass', (1, 13))])]),
 ('Module', [('With', (1, 0), [('withitem', ('Name', (1, 5), 'x', ('Load',)), ('Name', (1, 10), 'y', ('Store',))), ('withitem', ('Name', (1, 13), 'z', ('Load',)), ('Name', (1, 18), 'q', ('Store',)))], [('Pass', (1, 21))])]),
 ('Module', [('Raise', (1, 0), ('Call', (1, 6), ('Name', (1, 6), 'Exception', ('Load',)), [('Str', (1, 16), 'string')], []), None)]),

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-12-21-05-43.bpo-39031.imlCYZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-12-21-05-43.bpo-39031.imlCYZ.rst
@@ -1,0 +1,2 @@
+When parsing an "elif" node, lineno and col_offset of the node now point to the "elif" keyword and not to its condition, making it consistent with the "if" node.
+Patch by Lysandros Nikolaou.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -3622,8 +3622,8 @@ ast_for_if_stmt(struct compiling *c, const node *n)
 
             asdl_seq_SET(newobj, 0,
                          If(expression, suite_seq, orelse,
-                            LINENO(CHILD(n, off)),
-                            CHILD(n, off)->n_col_offset, c->c_arena));
+                            LINENO(CHILD(n, off - 1)),
+                            CHILD(n, off - 1)->n_col_offset, c->c_arena));
             orelse = newobj;
         }
         expression = ast_for_expr(c, CHILD(n, 1));


### PR DESCRIPTION
When parsing an "elif" node, lineno and col_offset of the node now point to the "elif" keyword and not to its condition, making it consistent with the "if" node.

https://bugs.python.org/issue39031

Automerge-Triggered-By: @pablogsal.
(cherry picked from commit 025a602af7ee284d8db6955c26016f3f27d35536)

Co-authored-by: Lysandros Nikolaou <lisandrosnik@gmail.com>

<!-- issue-number: [bpo-39031](https://bugs.python.org/issue39031) -->
https://bugs.python.org/issue39031
<!-- /issue-number -->
