### PR TITLE
bpo-39040: added whitespaced to linesep_splitter in email.policy

### DIFF
--- a/Lib/email/policy.py
+++ b/Lib/email/policy.py
@@ -21,7 +21,7 @@ __all__ = [
     'HTTP',
     ]
 
-linesep_splitter = re.compile(r'\n|\r')
+linesep_splitter = re.compile(r'\n\s+|\r\s+')
 
 @_extend_docstrings
 class EmailPolicy(Policy):


### PR DESCRIPTION
I'm working on a mailfilter in python and used the method "get_filename" of the "EmailMessage" class.

In some cases a wrong filename was returned. The reason was, that the Content-Disposition Header had a line break and the following intention was interpreted as part of the filename.
After fixing this bug, I was able to get the right filename.

https://bugs.python.org/issue39040

I had to change "linesep_splitter" in "email.policy" to match the intention.

**Old Value:**
`linesep_splitter = re.compile(r'\n|\r')`

**New Value:**
`linesep_splitter = re.compile(r'\n\s+|\r\s+')`

<!-- issue-number: [bpo-39040](https://bugs.python.org/issue39040) -->
https://bugs.python.org/issue39040
<!-- /issue-number -->
