### PR TITLE
[3.7] Add PYTHONUTF8 to commandline usage. (GH-17587)

### DIFF
--- a/Modules/main.c
+++ b/Modules/main.c
@@ -131,6 +131,7 @@ static const char usage_5[] =
 "PYTHONHOME   : alternate <prefix> directory (or <prefix>%lc<exec_prefix>).\n"
 "               The default module search path uses %s.\n"
 "PYTHONCASEOK : ignore case in 'import' statements (Windows).\n"
+"PYTHONUTF8: if set to 1, enable the UTF-8 mode.\n"
 "PYTHONIOENCODING: Encoding[:errors] used for stdin/stdout/stderr.\n"
 "PYTHONFAULTHANDLER: dump the Python traceback on fatal errors.\n";
 static const char usage_6[] =


### PR DESCRIPTION
Co-Authored-By: Victor Stinner <vstinner@python.org>
(cherry picked from commit 95826c773a9004fc5b3c89de55f800504685ab21)