### PR TITLE
bpo-39035: travis: Don't use beta group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: c
 dist: xenial
-group: beta
 
 # To cache doc-building dependencies and C compiler output.
 cache:


### PR DESCRIPTION
I hope this makes Travis more stable.

<!-- issue-number: [bpo-39035](https://bugs.python.org/issue39035) -->
https://bugs.python.org/issue39035
<!-- /issue-number -->
