### PR TITLE
bpo-39037: Look up __enter__ before __exit__ in the with statement documentation

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -434,20 +434,20 @@ The execution of the :keyword:`with` statement with one "item" proceeds as follo
 
 The following code::
 
-    with expression as target:
-        suite
+    with EXPRESSION as TARGET:
+        SUITE
 
 is semantically equivalent to::
 
-    manager = (expression)
+    manager = (EXPRESSION)
     enter = type(manager).__enter__
     exit = type(manager).__exit__
     value = enter(manager)
     hit_except = False
 
     try:
-        target = value
-        suite
+        TARGET = value
+        SUITE
     except:
         hit_except = True
         if not exit(manager, *sys.exc_info()):
@@ -460,13 +460,13 @@ With more than one item, the context managers are processed as if multiple
 :keyword:`with` statements were nested::
 
    with A() as a, B() as b:
-       suite
+       SUITE
 
 is semantically equivalent to::
 
    with A() as a:
        with B() as b:
-           suite
+           SUITE
 
 .. versionchanged:: 3.1
    Support for multiple context expressions.
@@ -798,24 +798,25 @@ iterators.
 The following code::
 
     async for TARGET in ITER:
-        BLOCK
+        SUITE
     else:
-        BLOCK2
+        SUITE2
 
 Is semantically equivalent to::
 
     iter = (ITER)
     iter = type(iter).__aiter__(iter)
     running = True
+
     while running:
         try:
             TARGET = await type(iter).__anext__(iter)
         except StopAsyncIteration:
             running = False
         else:
-            BLOCK
+            SUITE
     else:
-        BLOCK2
+        SUITE2
 
 See also :meth:`__aiter__` and :meth:`__anext__` for details.
 
@@ -837,20 +838,20 @@ able to suspend execution in its *enter* and *exit* methods.
 
 The following code::
 
-    async with expression as target:
-        suite
+    async with EXPRESSION as TARGET:
+        SUITE
 
 is semantically equivalent to::
 
-    manager = (expression)
+    manager = (EXPRESSION)
     aexit = type(manager).__aexit__
     aenter = type(manager).__aenter__
     value = await aenter(manager)
     hit_except = False
 
     try:
-        target = value
-        suite
+        TARGET = value
+        SUITE
     except:
         hit_except = True
         if not await aexit(manager, *sys.exc_info()):

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -430,13 +430,36 @@ The execution of the :keyword:`with` statement with one "item" proceeds as follo
    value from :meth:`__exit__` is ignored, and execution proceeds at the normal
    location for the kind of exit that was taken.
 
+The following code::
+
+    with expression as target:
+        suite
+
+is semantically equivalent to::
+
+    manager = (expression)
+    value = type(manager).__enter__(manager)
+    exit = type(manager).__exit__
+    target = value
+    exception = False
+
+    try:
+        suite
+    except:
+        exception = True
+        if not exit(manager, *sys.exc_info()):
+            raise
+    finally:
+        if not exception:
+            exit(manager, None, None, None)
+
 With more than one item, the context managers are processed as if multiple
 :keyword:`with` statements were nested::
 
    with A() as a, B() as b:
        suite
 
-is equivalent to ::
+is semantically equivalent to::
 
    with A() as a:
        with B() as b:

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -398,10 +398,12 @@ The execution of the :keyword:`with` statement with one "item" proceeds as follo
 
 #. The context expression (the expression given in the :token:`with_item`) is
    evaluated to obtain a context manager.
-
-#. The context manager's :meth:`__enter__` method is invoked.
+   
+#. The context manager's :meth:`__enter__` is loaded for later use.
 
 #. The context manager's :meth:`__exit__` is loaded for later use.
+
+#. The context manager's :meth:`__enter__` method is invoked.
 
 #. If a target was included in the :keyword:`with` statement, the return value
    from :meth:`__enter__` is assigned to it.
@@ -438,9 +440,10 @@ The following code::
 is semantically equivalent to::
 
     manager = (expression)
-    value = type(manager).__enter__(manager)
+    enter = type(manager).__enter__
     exit = type(manager).__exit__
-    target = value
+    value = enter(manager)
+    target = value  # only if `as target` is present in the with statement
     exception = False
 
     try:
@@ -841,8 +844,9 @@ is semantically equivalent to::
 
     manager = (expression)
     aexit = type(manager).__aexit__
-    value = type(manager).__aenter__(manager)
-    target = await value
+    aenter = type(manager).__aenter__
+    value = await aenter(manager)
+    target = value  # only if `as target` is present in the with statement  
     exception = False
 
     try:

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -811,23 +811,26 @@ able to suspend execution in its *enter* and *exit* methods.
 
 The following code::
 
-    async with EXPR as VAR:
-        BLOCK
+    async with expression as target:
+        suite
 
-Is semantically equivalent to::
+is semantically equivalent to::
 
-    mgr = (EXPR)
-    aexit = type(mgr).__aexit__
-    aenter = type(mgr).__aenter__(mgr)
+    manager = (expression)
+    aexit = type(manager).__aexit__
+    value = type(manager).__aenter__(manager)
+    target = await value
+    exception = False
 
-    VAR = await aenter
     try:
-        BLOCK
+        suite
     except:
-        if not await aexit(mgr, *sys.exc_info()):
+        exception = True
+        if not await aexit(manager, *sys.exc_info()):
             raise
-    else:
-        await aexit(mgr, None, None, None)
+    finally:
+        if not exception:
+            await aexit(manager, None, None, None)
 
 See also :meth:`__aenter__` and :meth:`__aexit__` for details.
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -443,17 +443,17 @@ is semantically equivalent to::
     enter = type(manager).__enter__
     exit = type(manager).__exit__
     value = enter(manager)
-    exception = False
+    hit_except = False
 
     try:
         target = value  # only if `as target` is present in the with statement
         suite
     except:
-        exception = True
+        hit_except = True
         if not exit(manager, *sys.exc_info()):
             raise
     finally:
-        if not exception:
+        if not hit_except:
             exit(manager, None, None, None)
 
 With more than one item, the context managers are processed as if multiple
@@ -846,17 +846,17 @@ is semantically equivalent to::
     aexit = type(manager).__aexit__
     aenter = type(manager).__aenter__
     value = await aenter(manager)
-    exception = False
+    hit_except = False
 
     try:
         target = value  # only if `as target` is present in the with statement  
         suite
     except:
-        exception = True
+        hit_except = True
         if not await aexit(manager, *sys.exc_info()):
             raise
     finally:
-        if not exception:
+        if not hit_except:
             await aexit(manager, None, None, None)
 
 See also :meth:`__aenter__` and :meth:`__aexit__` for details.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -443,10 +443,10 @@ is semantically equivalent to::
     enter = type(manager).__enter__
     exit = type(manager).__exit__
     value = enter(manager)
-    target = value  # only if `as target` is present in the with statement
     exception = False
 
     try:
+        target = value  # only if `as target` is present in the with statement
         suite
     except:
         exception = True
@@ -846,10 +846,10 @@ is semantically equivalent to::
     aexit = type(manager).__aexit__
     aenter = type(manager).__aenter__
     value = await aenter(manager)
-    target = value  # only if `as target` is present in the with statement  
     exception = False
 
     try:
+        target = value  # only if `as target` is present in the with statement  
         suite
     except:
         exception = True

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -399,9 +399,9 @@ The execution of the :keyword:`with` statement with one "item" proceeds as follo
 #. The context expression (the expression given in the :token:`with_item`) is
    evaluated to obtain a context manager.
 
-#. The context manager's :meth:`__exit__` is loaded for later use.
-
 #. The context manager's :meth:`__enter__` method is invoked.
+
+#. The context manager's :meth:`__exit__` is loaded for later use.
 
 #. If a target was included in the :keyword:`with` statement, the return value
    from :meth:`__enter__` is assigned to it.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -398,7 +398,7 @@ The execution of the :keyword:`with` statement with one "item" proceeds as follo
 
 #. The context expression (the expression given in the :token:`with_item`) is
    evaluated to obtain a context manager.
-   
+
 #. The context manager's :meth:`__enter__` is loaded for later use.
 
 #. The context manager's :meth:`__exit__` is loaded for later use.
@@ -446,7 +446,7 @@ is semantically equivalent to::
     hit_except = False
 
     try:
-        target = value  # only if `as target` is present in the with statement
+        target = value
         suite
     except:
         hit_except = True
@@ -849,7 +849,7 @@ is semantically equivalent to::
     hit_except = False
 
     try:
-        target = value  # only if `as target` is present in the with statement  
+        target = value
         suite
     except:
         hit_except = True


### PR DESCRIPTION
This PR will make these changes to the [Compound statements](https://docs.python.org/3/reference/compound_stmts.html) chapter of the language documentation:

- fix the trial order of the `__exit__` and `__enter__` methods in the `with` statement;
- add the equivalent `try` statement of the `with` statement (since it is already given for the `async with` statement);
- replace the `else` clause with a `finally` clause in the equivalent `try` statement of the `async with` statement, in order to also handle the case when there is a non-local goto statement (`break`, `continue`, `return`) in the suite (cf. https://stackoverflow.com/questions/59322585/what-is-the-exact-try-statement-equivalent-of-the-with-statement-in-python).

<!-- issue-number: [bpo-39037](https://bugs.python.org/issue39037) -->
https://bugs.python.org/issue39037
<!-- /issue-number -->
