### PR TITLE
bpo-39048: Look up __aenter__ before __aexit__ in the async with statement

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -844,8 +844,8 @@ The following code::
 is semantically equivalent to::
 
     manager = (EXPRESSION)
-    aexit = type(manager).__aexit__
     aenter = type(manager).__aenter__
+    aexit = type(manager).__aexit__
     value = await aenter(manager)
     hit_except = False
 

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -1203,35 +1203,41 @@ class CoroutineTest(unittest.TestCase):
             def __aenter__(self):
                 pass
 
+        body_executed = False
         async def foo():
             async with CM():
-                pass
+                body_executed = True
 
         with self.assertRaisesRegex(AttributeError, '__aexit__'):
             run_async(foo())
+        self.assertFalse(body_executed)
 
     def test_with_3(self):
         class CM:
             def __aexit__(self):
                 pass
 
+        body_executed = False
         async def foo():
             async with CM():
-                pass
+                body_executed = True
 
         with self.assertRaisesRegex(AttributeError, '__aenter__'):
             run_async(foo())
+        self.assertFalse(body_executed)
 
     def test_with_4(self):
         class CM:
             pass
 
+        body_executed = False
         async def foo():
             async with CM():
-                pass
+                body_executed = True
 
         with self.assertRaisesRegex(AttributeError, '__aenter__'):
             run_async(foo())
+        self.assertFalse(body_executed)
 
     def test_with_5(self):
         # While this test doesn't make a lot of sense,

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -1224,17 +1224,13 @@ class CoroutineTest(unittest.TestCase):
 
     def test_with_4(self):
         class CM:
-            def __enter__(self):
-                pass
-
-            def __exit__(self):
-                pass
+            pass
 
         async def foo():
             async with CM():
                 pass
 
-        with self.assertRaisesRegex(AttributeError, '__aexit__'):
+        with self.assertRaisesRegex(AttributeError, '__aenter__'):
             run_async(foo())
 
     def test_with_5(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1219,6 +1219,7 @@ Elena Oat
 Jon Oberheide
 Milan Oberkirch
 Pascal Oberndoerfer
+Géry Ogam
 Jeffrey Ollie
 Adam Olsen
 Bryan Olson

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-13-14-45-22.bpo-39048.iPsj81.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-13-14-45-22.bpo-39048.iPsj81.rst
@@ -1,2 +1,4 @@
-Change the lookup order of the :meth:`__aenter__` and :meth:`__aexit__` methods
-for the ``async with`` statement. Patch by Géry Ogam.
+Improve the displayed error message when incorrect types are passed to ``async
+with`` statements by looking up the :meth:`__aenter__` special method before
+the :meth:`__aexit__` special method when entering an asynchronous context
+manager. Patch by Géry Ogam.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-13-14-45-22.bpo-39048.iPsj81.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-13-14-45-22.bpo-39048.iPsj81.rst
@@ -1,0 +1,2 @@
+Change the lookup order of the :meth:`__aenter__` and :meth:`__aexit__` methods
+for the ``async with`` statement. Patch by Géry Ogam.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3156,18 +3156,19 @@ main_loop:
         case TARGET(BEFORE_ASYNC_WITH): {
             _Py_IDENTIFIER(__aexit__);
             _Py_IDENTIFIER(__aenter__);
-
             PyObject *mgr = TOP();
-            PyObject *exit = special_lookup(tstate, mgr, &PyId___aexit__),
-                     *enter;
+            PyObject *enter = special_lookup(tstate, mgr, &PyId___aenter__);
             PyObject *res;
-            if (exit == NULL)
+            if (enter == NULL) {
                 goto error;
+            }
+            PyObject *exit = special_lookup(tstate, mgr, &PyId___aexit__);
+            if (exit == NULL) {
+                Py_DECREF(enter);
+                goto error;
+            }
             SET_TOP(exit);
-            enter = special_lookup(tstate, mgr, &PyId___aenter__);
             Py_DECREF(mgr);
-            if (enter == NULL)
-                goto error;
             res = _PyObject_CallNoArg(enter);
             Py_DECREF(enter);
             if (res == NULL)

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3154,8 +3154,8 @@ main_loop:
         }
 
         case TARGET(BEFORE_ASYNC_WITH): {
-            _Py_IDENTIFIER(__aexit__);
             _Py_IDENTIFIER(__aenter__);
+            _Py_IDENTIFIER(__aexit__);
             PyObject *mgr = TOP();
             PyObject *enter = special_lookup(tstate, mgr, &PyId___aenter__);
             PyObject *res;
@@ -3189,8 +3189,8 @@ main_loop:
         }
 
         case TARGET(SETUP_WITH): {
-            _Py_IDENTIFIER(__exit__);
             _Py_IDENTIFIER(__enter__);
+            _Py_IDENTIFIER(__exit__);
             PyObject *mgr = TOP();
             PyObject *enter = special_lookup(tstate, mgr, &PyId___enter__);
             PyObject *res;


### PR DESCRIPTION
This PR will introduce the following changes:

- look up the `__aenter__` method before the `__aexit__` method in the `async with` statement;
- add assertions testing that these lookups are performed before executing the body of the `async with` statement;
- update the documentation accordingly.

<!-- issue-number: [bpo-39048](https://bugs.python.org/issue39048) -->
https://bugs.python.org/issue39048
<!-- /issue-number -->
