### PR TITLE
bpo-38870: Remove dead code related with argument unparsing

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1199,11 +1199,8 @@ class _Unparser(NodeVisitor):
         # keyword-only arguments
         if node.kwonlyargs:
             for a, d in zip(node.kwonlyargs, node.kw_defaults):
-                if first:
-                    first = False
-                else:
-                    self.write(", ")
-                self.traverse(a),
+                self.write(", ")
+                self.traverse(a)
                 if d:
                     self.write("=")
                     self.traverse(d)

--- a/Misc/NEWS.d/next/Library/2019-12-15-15-22-04.bpo-38870.YHJpq5.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-15-15-22-04.bpo-38870.YHJpq5.rst
@@ -1,0 +1,1 @@
+Remove dead code from ``ast._Unparser`` related with argument unparsing.

--- a/Misc/NEWS.d/next/Library/2019-12-15-15-22-04.bpo-38870.YHJpq5.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-15-15-22-04.bpo-38870.YHJpq5.rst
@@ -1,1 +1,0 @@
-Remove dead code from ``ast._Unparser`` related with argument unparsing.


### PR DESCRIPTION
It looks like there are no ways this code to fall down `first = False` block. Because of this statement;
https://github.com/python/cpython/blob/94d2c8df1a7657015a2fcdb4c4d43392f91f8348/Lib/ast.py#L1187-L1189

<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->
