### PR TITLE
bpo-39055: Reject a trailing \n in base64.b64decode() with validate=True.

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -82,7 +82,7 @@ def b64decode(s, altchars=None, validate=False):
         altchars = _bytes_from_decode_data(altchars)
         assert len(altchars) == 2, repr(altchars)
         s = s.translate(bytes.maketrans(altchars, b'+/'))
-    if validate and not re.match(b'^[A-Za-z0-9+/]*={0,2}$', s):
+    if validate and not re.fullmatch(b'[A-Za-z0-9+/]*={0,2}', s):
         raise binascii.Error('Non-base64 digit found')
     return binascii.a2b_base64(s)
 

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -250,6 +250,7 @@ class BaseXYTestCase(unittest.TestCase):
                  (b'3d}==', b'\xdd'),
                  (b'@@', b''),
                  (b'!', b''),
+                 (b"YWJj\n", b"abc"),
                  (b'YWJj\nYWI=', b'abcab'))
         funcs = (
             base64.b64decode,

--- a/Misc/NEWS.d/next/Library/2019-12-15-19-23-23.bpo-39055.FmN3un.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-15-19-23-23.bpo-39055.FmN3un.rst
@@ -1,0 +1,2 @@
+:func:`base64.b64decode` with ``validate=True`` raises now a binascii.Error
+if the input ends with a single ``\n``.


### PR DESCRIPTION


<!-- issue-number: [bpo-39055](https://bugs.python.org/issue39055) -->
https://bugs.python.org/issue39055
<!-- /issue-number -->
