### PR TITLE
bpo-39040: Fix parsing of email mime headers with whitespace between encoded-words.

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1226,13 +1226,11 @@ def get_bare_quoted_string(value):
                 valid_ew = True
             except errors.HeaderParseError:
                 token, value = get_qcontent(value)
-
             # Collapse the whitespace between two encoded words that occur in a
             # bare-quoted-string.
             if valid_ew and len(bare_quoted_string) > 1:
                 if (bare_quoted_string[-1].token_type == 'fws' and
                         bare_quoted_string[-2].token_type == 'encoded-word'):
-
                     bare_quoted_string[-1] = EWWhiteSpaceTerminal(
                         bare_quoted_string[-1], 'fws')
         else:

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1218,12 +1218,23 @@ def get_bare_quoted_string(value):
         if value[0] in WSP:
             token, value = get_fws(value)
         elif value[:2] == '=?':
+            valid_ew = False
             try:
                 token, value = get_encoded_word(value)
                 bare_quoted_string.defects.append(errors.InvalidHeaderDefect(
                     "encoded word inside quoted string"))
+                valid_ew = True
             except errors.HeaderParseError:
                 token, value = get_qcontent(value)
+
+            # Collapse the whitespace between two encoded words that occur in a
+            # bare-quoted-string.
+            if valid_ew and len(bare_quoted_string) > 1:
+                if (bare_quoted_string[-1].token_type == 'fws' and
+                        bare_quoted_string[-2].token_type == 'encoded-word'):
+
+                    bare_quoted_string[-1] = EWWhiteSpaceTerminal(
+                        bare_quoted_string[-1], 'fws')
         else:
             token, value = get_qcontent(value)
         bare_quoted_string.append(token)

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -885,13 +885,12 @@ class TestContentDisposition(TestHeaderBase):
             ),
 
         'parameter_value_with_fws_between_tokens': (
-            'attachment; filename="=?utf-8?q?FileName=  WithSpaces.pdf"',
+            'attachment; filename="File =?utf-8?q?Name?= With Spaces.pdf"',
             'attachment',
-            {'filename': '=?utf-8?q?FileName=  WithSpaces.pdf'},
-            [],
-            'attachment; filename="=?utf-8?q?FileName=  WithSpaces.pdf"',
-            ('Content-Disposition: attachment;\n'
-             ' filename="=?utf-8?q?FileName=  WithSpaces.pdf"\n'),
+            {'filename': 'File Name With Spaces.pdf'},
+            [errors.InvalidHeaderDefect],
+            'attachment; filename="File Name With Spaces.pdf"',
+            ('Content-Disposition: attachment; filename="File Name With Spaces.pdf"\n'),
             )
     }
 

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -873,6 +873,16 @@ class TestContentDisposition(TestHeaderBase):
             {'filename': 'foo'},
             [errors.InvalidHeaderDefect]),
 
+        'invalid_value_with_fws_bw_ew': (
+            'attachment; filename="=?UTF-8?Q?Schulbesuchsbest=C3=A4ttigung=2E?='
+            '               =?UTF-8?Q?pdf?="',
+            'attachment',
+            {'filename': 'Schulbesuchsbestättigung.pdf'},
+            [errors.InvalidHeaderDefect]*3,
+            ('attachment; filename="Schulbesuchsbestättigung.pdf"'),
+            ('Content-Disposition: attachment;\n'
+             ' filename*=utf-8\'\'Schulbesuchsbest%C3%A4ttigung.pdf\n'),
+            )
     }
 
 

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -873,7 +873,7 @@ class TestContentDisposition(TestHeaderBase):
             {'filename': 'foo'},
             [errors.InvalidHeaderDefect]),
 
-        'invalid_value_with_fws_bw_ew': (
+        'invalid_parameter_value_with_fws_between_ew': (
             'attachment; filename="=?UTF-8?Q?Schulbesuchsbest=C3=A4ttigung=2E?='
             '               =?UTF-8?Q?pdf?="',
             'attachment',
@@ -882,6 +882,16 @@ class TestContentDisposition(TestHeaderBase):
             ('attachment; filename="Schulbesuchsbestättigung.pdf"'),
             ('Content-Disposition: attachment;\n'
              ' filename*=utf-8\'\'Schulbesuchsbest%C3%A4ttigung.pdf\n'),
+            ),
+
+        'parameter_value_with_fws_between_tokens': (
+            'attachment; filename="File Name With Spaces.pdf"',
+            'attachment',
+            {'filename': 'File Name With Spaces.pdf'},
+            [],
+            'attachment; filename="File Name With Spaces.pdf"',
+            ('Content-Disposition: attachment; '
+             'filename="File Name With Spaces.pdf"\n'),
             )
     }
 

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -885,13 +885,13 @@ class TestContentDisposition(TestHeaderBase):
             ),
 
         'parameter_value_with_fws_between_tokens': (
-            'attachment; filename="File Name With Spaces.pdf"',
+            'attachment; filename="=?utf-8?q?FileName=  WithSpaces.pdf"',
             'attachment',
-            {'filename': 'File Name With Spaces.pdf'},
+            {'filename': '=?utf-8?q?FileName=  WithSpaces.pdf'},
             [],
-            'attachment; filename="File Name With Spaces.pdf"',
-            ('Content-Disposition: attachment; '
-             'filename="File Name With Spaces.pdf"\n'),
+            'attachment; filename="=?utf-8?q?FileName=  WithSpaces.pdf"',
+            ('Content-Disposition: attachment;\n'
+             ' filename="=?utf-8?q?FileName=  WithSpaces.pdf"\n'),
             )
     }
 

--- a/Misc/NEWS.d/next/Library/2019-12-15-18-47-20.bpo-39040.tKa0Qs.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-15-18-47-20.bpo-39040.tKa0Qs.rst
@@ -1,0 +1,2 @@
+Fix parsing of invalid Content-Disposition email headers by collapsing
+whitespace between encoded words in a bare-quote-string.

--- a/Misc/NEWS.d/next/Library/2019-12-15-18-47-20.bpo-39040.tKa0Qs.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-15-18-47-20.bpo-39040.tKa0Qs.rst
@@ -1,2 +1,2 @@
-Fix parsing of invalid Content-Disposition email headers by collapsing
-whitespace between encoded words in a bare-quote-string.
+Fix parsing of invalid mime headers parameters by collapsing whitespace between
+encoded words in a bare-quote-string.


### PR DESCRIPTION
In certain malformed content-disposition headers, parameter values are quoted
and split as encoded words on two lines with extra whitespaces. This fixes the
issue by removing the extra whitespace between the two encoded words.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-39040](https://bugs.python.org/issue39040) -->
https://bugs.python.org/issue39040
<!-- /issue-number -->
