### PR TITLE
bpo-39058:  Preserve attribute order in the repr for argparse.Namespace()

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -129,7 +129,7 @@ class _AttributeHolder(object):
         return '%s(%s)' % (type_name, ', '.join(arg_strings))
 
     def _get_kwargs(self):
-        return sorted(self.__dict__.items())
+        return list(self.__dict__.items())
 
     def _get_args(self):
         return []

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4687,7 +4687,7 @@ class TestStrings(TestCase):
 
     def test_namespace(self):
         ns = argparse.Namespace(foo=42, bar='spam')
-        string = "Namespace(bar='spam', foo=42)"
+        string = "Namespace(foo=42, bar='spam')"
         self.assertStringEqual(ns, string)
 
     def test_namespace_starkwargs_notidentifier(self):

--- a/Misc/NEWS.d/next/Library/2019-12-15-19-17-10.bpo-39058.7ci-vd.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-15-19-17-10.bpo-39058.7ci-vd.rst
@@ -1,0 +1,4 @@
+In the argparse module, the repr for Namespace() and other argument holders
+now displayed in the order attributes were added.  Formerly, it displayed in
+alphabetical order even though argument order is preserved the user visible
+parts of the module.


### PR DESCRIPTION


<!-- issue-number: [bpo-39058](https://bugs.python.org/issue39058) -->
https://bugs.python.org/issue39058
<!-- /issue-number -->
