### PR TITLE
[3.6] bpo-39035: travis: Update image to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: c
-dist: trusty
-sudo: false
-group: beta
+dist: xenial
 
 # To cache doc-building dependencies and C compiler output.
 cache:


### PR DESCRIPTION
Use image same to master to ease maintainance.
Remove "group: beta" to make Travis more stable.

<!-- issue-number: [bpo-39035](https://bugs.python.org/issue39035) -->
https://bugs.python.org/issue39035
<!-- /issue-number -->
