### PR TITLE
bpo-39883: Use BSD0 license for code in docs

### DIFF
--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -72,6 +72,18 @@ make these releases possible.
 Terms and conditions for accessing or otherwise using Python
 ============================================================
 
+Python software and documentation are licensed under the
+:ref:`PSF License Agreement <PSF-license>`.
+Starting with Python X.X.X, examples, recipes, and other code in
+the documentation are dual licensed under the PSF License Agreement
+and the :ref:`Zero-Clause BSD license <BSD0>`.
+
+Some software incorporated into Python is under different licenses.
+The licenses are listed with code falling under that license.
+See :ref:`OtherLicenses` for an incomplete list of these licenses.
+
+
+.. _PSF-license:
 
 PSF LICENSE AGREEMENT FOR PYTHON |release|
 ------------------------------------------
@@ -257,6 +269,27 @@ CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
    ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
    SOFTWARE.
 
+
+.. _BSD0:
+
+ZERO-CLAUSE BSD LICENSE FOR CODE IN THE PYTHON |release| DOCUMENTATION
+----------------------------------------------------------------------
+
+.. parsed-literal::
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+    REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+    INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+    LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+    OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+    PERFORMANCE OF THIS SOFTWARE.
+
+
+.. _OtherLicenses:
 
 Licenses and Acknowledgements for Incorporated Software
 =======================================================

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -74,7 +74,7 @@ Terms and conditions for accessing or otherwise using Python
 
 Python software and documentation are licensed under the
 :ref:`PSF License Agreement <PSF-license>`.
-Starting with Python X.X.X, examples, recipes, and other code in
+Starting with Python 3.8.6, examples, recipes, and other code in
 the documentation are dual licensed under the PSF License Agreement
 and the :ref:`Zero-Clause BSD license <BSD0>`.
 

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -74,6 +74,7 @@ Terms and conditions for accessing or otherwise using Python
 
 Python software and documentation are licensed under the
 :ref:`PSF License Agreement <PSF-license>`.
+
 Starting with Python 3.8.6, examples, recipes, and other code in
 the documentation are dual licensed under the PSF License Agreement
 and the :ref:`Zero-Clause BSD license <BSD0>`.

--- a/LICENSE
+++ b/LICENSE
@@ -59,6 +59,16 @@ direction to make these releases possible.
 B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
 ===============================================================
 
+Python software and documentation are licensed under the
+Python Software Foundation License Version 2.
+Starting with Python X.X.X, examples, recipes, and other code in
+the documentation are dual licensed under the PSF License Version 2
+and the Zero-Clause BSD license.
+
+Some software incorporated into Python is under different licenses.
+The licenses are listed with code falling under that license.
+
+
 PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
 --------------------------------------------
 
@@ -252,3 +262,19 @@ FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ZERO-CLAUSE BSD LICENSE FOR CODE IN THE PYTHON |release| DOCUMENTATION
+----------------------------------------------------------------------
+
+.. parsed-literal::
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -61,7 +61,7 @@ B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
 
 Python software and documentation are licensed under the
 Python Software Foundation License Version 2.
-Starting with Python X.X.X, examples, recipes, and other code in
+Starting with Python 3.8.6, examples, recipes, and other code in
 the documentation are dual licensed under the PSF License Version 2
 and the Zero-Clause BSD license.
 

--- a/LICENSE
+++ b/LICENSE
@@ -263,10 +263,8 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-ZERO-CLAUSE BSD LICENSE FOR CODE IN THE PYTHON |release| DOCUMENTATION
+ZERO-CLAUSE BSD LICENSE FOR CODE IN THE PYTHON DOCUMENTATION
 ----------------------------------------------------------------------
-
-.. parsed-literal::
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.

--- a/LICENSE
+++ b/LICENSE
@@ -61,6 +61,7 @@ B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
 
 Python software and documentation are licensed under the
 Python Software Foundation License Version 2.
+
 Starting with Python 3.8.6, examples, recipes, and other code in
 the documentation are dual licensed under the PSF License Version 2
 and the Zero-Clause BSD license.

--- a/Misc/NEWS.d/next/Documentation/2020-03-07-03-53-39.bpo-39883.1tnb4-.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-03-07-03-53-39.bpo-39883.1tnb4-.rst
@@ -1,0 +1,1 @@
+Make code, examples, and recipes in the Python documentation be licensed under the more permissive BSD0 license in addition to the existing Python 2.0 license.


### PR DESCRIPTION
**NOTE** Please do *not* accept this pull request.  It needs to be discussed and approved by the PSF board. (**UPDATE:** The PSF board approved it. We are going ahead.)

On the Python-ideas mailing list, we [discussed](https://mail.python.org/archives/list/python-ideas@python.org/thread/OZDSGC3I72J4GU375L7FLBLLTYXNLE34/#GMIRRC56RPHDSNQ75KNZQ466U3BE7KZY) making the code in the documentation under a more permissive license to make it easier for people to re-use it.   Specifically, the idea is to use the [BSD zero clause](https://spdx.org/licenses/0BSD.html) license to remove essentially all restrictions on the use of that code.

Guido van Rossum liked the idea, so per his request I am submitting a pull request as the first stage in getting this change potentially implemented.  I will then submit this pull request, and the accompanying pull request python/python-docs-theme#36, to the PSF board for discussion.  It will also likely need a review by a lawyer.

This specific request adds additional information on what, specifically, the current license is, the part about code in the documentation being under the 0BSD license, the text of the 0BSD license, and a bit about other parts being under other licenses (I am particularly unsure that the last part should be in there at all).

The current format will likely change substantially, and changes to the CPython side may not end up being necessary.  Guido seemed to think that simply a blurb in the online documentation footer may be sufficient.  The code that generates the footer is in the [python/python-docs-theme](https://github.com/python/python-docs-theme/) project and the change has been submitted there in pull request python/python-docs-theme#36.

Comments are appreciated. 

*Edit*: Added information about additional pull request.

<!-- issue-number: [bpo-39883](https://bugs.python.org/issue39883) -->
https://bugs.python.org/issue39883
<!-- /issue-number -->
