### PR TITLE
[3.8] bpo-38295: Prevent failure of test_relative_path in test_py_compile on macOS Catalina

### DIFF
--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -51,7 +51,7 @@ class SourceDateEpochTestMeta(type(unittest.TestCase)):
 class PyCompileTestsBase:
 
     def setUp(self):
-        self.directory = tempfile.mkdtemp()
+        self.directory = tempfile.mkdtemp(dir=os.getcwd())
         self.source_path = os.path.join(self.directory, '_test.py')
         self.pyc_path = self.source_path + 'c'
         self.cache_path = importlib.util.cache_from_source(self.source_path)

--- a/Misc/NEWS.d/next/macOS/2019-12-17-03-43-04.bpo-38295.hgDvlB.rst
+++ b/Misc/NEWS.d/next/macOS/2019-12-17-03-43-04.bpo-38295.hgDvlB.rst
@@ -1,0 +1,1 @@
+Prevent failure of test_relative_path in test_py_compile on macOS Catalina.


### PR DESCRIPTION


<!-- issue-number: [bpo-38295](https://bugs.python.org/issue38295) -->
https://bugs.python.org/issue38295
<!-- /issue-number -->
