### PR TITLE
[WIP] bpo-38546: Add support.get_child_processes()

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3403,3 +3403,38 @@ class catch_threading_exception:
         del self.exc_value
         del self.exc_traceback
         del self.thread
+
+
+def get_child_processes(ppid):
+    """
+    Get directly child processes of parent process identifier 'pid'.
+    """
+    proc_dir = '/proc'
+    try:
+        names = os.listdir(proc_dir)
+    except FileNotFoundError:
+        return None
+
+    children = []
+    for name in names:
+        if not name.isdigit():
+            continue
+        pid = int(name)
+
+        filename = os.path.join(proc_dir, str(pid), 'status')
+        try:
+            fp = open(filename, encoding="utf-8")
+        except FileNotFoundError:
+            # process completed: ignore it
+            continue
+
+        proc_ppid = None
+        with fp:
+            for line in fp:
+                if line.startswith('PPid:'):
+                    proc_ppid = int(line[5:].strip())
+                    break
+        if proc_ppid == ppid:
+            children.append(pid)
+
+    return set(children)


### PR DESCRIPTION
libregrtest runtest() now checks if the test leaks direct child
process running in the background.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38546](https://bugs.python.org/issue38546) -->
https://bugs.python.org/issue38546
<!-- /issue-number -->
