### PR TITLE
bpo-34480: fix bug where match variable is used prior to being defined

### DIFF
--- a/Lib/_markupbase.py
+++ b/Lib/_markupbase.py
@@ -156,6 +156,7 @@ class ParserBase:
             # look for MS Office ]> ending
             match= _msmarkedsectionclose.search(rawdata, i+3)
         else:
+            match = None
             self.error('unknown status keyword %r in marked section' % rawdata[i+3:j])
         if not match:
             return -1


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34480](https://bugs.python.org/issue34480) -->
https://bugs.python.org/issue34480
<!-- /issue-number -->
