### PR TITLE
bpo-13601: always use line-buffering for sys.stderr

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1448,8 +1448,9 @@ always available.
 
    * When interactive, the ``stdout`` stream is line-buffered. Otherwise,
      it is block-buffered like regular text files.  The ``stderr`` stream
-     is line-buffered in both cases.  You can override this behaviour with
-     the :option:`-u` command-line option.
+     is line-buffered in both cases.  You can make both streams unbuffered
+     by passing the :option:`-u` command-line option or setting the
+     :envvar:`PYTHONUNBUFFERED` environment variable.
 
    .. versionchanged:: 3.9
       Use line-buffering for non-interactive ``stderr``.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1446,9 +1446,10 @@ always available.
      for the Windows console, this only applies when
      :envvar:`PYTHONLEGACYWINDOWSSTDIO` is also set.
 
-   * When interactive, ``stdout`` and ``stderr`` streams are line-buffered.
-     Otherwise, they are block-buffered like regular text files.  You can
-     override this value with the :option:`-u` command-line option.
+   * When interactive, the ``stdout`` stream is line-buffered. Otherwise,
+     it is block-buffered like regular text files.  The ``stderr`` stream
+     is line-buffered in both cases.  You can override this behaviour with
+     the :option:`-u` command-line option.
 
    .. note::
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1453,7 +1453,7 @@ always available.
      :envvar:`PYTHONUNBUFFERED` environment variable.
 
    .. versionchanged:: 3.9
-      Use line-buffering for non-interactive ``stderr``.
+      Make non-interactive ``stderr`` line-buffered instead of fully buffered.
 
    .. note::
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1451,6 +1451,9 @@ always available.
      is line-buffered in both cases.  You can override this behaviour with
      the :option:`-u` command-line option.
 
+   .. versionchanged:: 3.9
+      Use line-buffering for non-interactive ``stderr``.
+
    .. note::
 
       To write or read binary data from/to the standard streams, use the

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1453,7 +1453,8 @@ always available.
      :envvar:`PYTHONUNBUFFERED` environment variable.
 
    .. versionchanged:: 3.9
-      Make non-interactive ``stderr`` line-buffered instead of fully buffered.
+      Non-interactive ``stderr`` is now line-buffered instead of fully
+      buffered.
 
    .. note::
 

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -249,23 +249,6 @@ class CmdLineTest(unittest.TestCase):
         for attr, value in cases:
             self.assertEqual(get_value(attr), value, f'{attr} is not {value}')
 
-    def test_non_interactive_output_buffering_functional(self):
-        cases = [
-            # Binary stdout is unbuffered.
-            ('sys.stdout.buffer', b'x\n', b'y', b'', b''),
-            # Binary stderr is unbuffered (can't be line-buffered).
-            ('sys.stderr.buffer', b'x\n', b'y', b'', b''),
-            # Text stdout is unbuffered.
-            ('sys.stdout', 'x\n', 'y', b'', b''),
-            # Text stderr is line-buffered.
-            ('sys.stderr', 'x\n', 'y', b'', b'x\n'),
-        ]
-        for buf, txt1, txt2, out_ok, err_ok in cases:
-            code = f'import os, sys; {buf}.write({txt1!r}); {buf}.write({txt2!r}); os._exit(0)'
-            rc, out, err = assert_python_ok('-c', code)
-            self.assertEqual(out.replace(b'\r\n', b'\n'), out_ok)
-            self.assertEqual(err.replace(b'\r\n', b'\n'), err_ok)
-
     def test_unbuffered_output(self):
         # Test expected operation of the '-u' switch
         for stream in ('stdout', 'stderr'):

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -220,16 +220,6 @@ class CmdLineTest(unittest.TestCase):
         )
         check_output(text)
 
-    def test_interactive_output_buffering(self):
-        cases = [
-            ('sys.stdout.write_through', False),
-            ('sys.stdout.line_buffering', True),
-            ('sys.stderr.write_through', False),
-            ('sys.stderr.line_buffering', True),
-        ]
-        for attr, value in cases:
-            self.assertEqual(eval(attr), value, f'{attr} is not {value}')
-
     def test_non_interactive_output_buffering(self):
         def get_value(attr):
             code = f'import sys; print({attr})'

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -234,8 +234,8 @@ class CmdLineTest(unittest.TestCase):
         for buf, txt1, txt2, out_ok, err_ok in cases:
             code = f'import os, sys; {buf}.write({txt1!r}); {buf}.write({txt2!r}); os._exit(0)'
             rc, out, err = assert_python_ok('-c', code)
-            self.assertEqual(out, out_ok)
-            self.assertEqual(err, err_ok)
+            self.assertEqual(out.replace(b'\r\n', b'\n'), out_ok)
+            self.assertEqual(err.replace(b'\r\n', b'\n'), err_ok)
 
     def test_unbuffered_output(self):
         # Test expected operation of the '-u' switch

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -222,10 +222,8 @@ class CmdLineTest(unittest.TestCase):
 
     def test_interactive_output_buffering(self):
         cases = [
-            ('sys.stdout.isatty()', True),
             ('sys.stdout.write_through', False),
             ('sys.stdout.line_buffering', True),
-            ('sys.stderr.isatty()', True),
             ('sys.stderr.write_through', False),
             ('sys.stderr.line_buffering', True),
         ]

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -219,6 +219,24 @@ class CmdLineTest(unittest.TestCase):
         )
         check_output(text)
 
+    def test_non_interactive_output_buffering(self):
+        # Test buffering for stdout and stderr.
+        cases = [
+            # Binary stdout is unbuffered.
+            ('sys.stdout.buffer', b'x\n', b'y', b'', b''),
+            # Binary stderr is unbuffered (can't be line-buffered).
+            ('sys.stderr.buffer', b'x\n', b'y', b'', b''),
+            # Text stdout is unbuffered.
+            ('sys.stdout', 'x\n', 'y', b'', b''),
+            # Text stderr is line-buffered.
+            ('sys.stderr', 'x\n', 'y', b'', b'x\n'),
+        ]
+        for buf, txt1, txt2, out_ok, err_ok in cases:
+            code = f'import os, sys; {buf}.write({txt1!r}); {buf}.write({txt2!r}); os._exit(0)'
+            rc, out, err = assert_python_ok('-c', code)
+            self.assertEqual(out, out_ok)
+            self.assertEqual(err, err_ok)
+
     def test_unbuffered_output(self):
         # Test expected operation of the '-u' switch
         for stream in ('stdout', 'stderr'):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1500,6 +1500,7 @@ Steven Scott
 Nick Seidenman
 Michael Seifert
 Žiga Seilnacht
+Jendrik Seipp
 Michael Selik
 Yury Selivanov
 Fred Sells

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-17-22-32-11.bpo-13601.vNP4LC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-17-22-32-11.bpo-13601.vNP4LC.rst
@@ -1,0 +1,2 @@
+``sys.stderr`` is always line-buffered now, even if ``stderr`` is
+redirected to a file.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-17-22-32-11.bpo-13601.vNP4LC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-17-22-32-11.bpo-13601.vNP4LC.rst
@@ -1,2 +1,6 @@
-``sys.stderr`` is always line-buffered now, even if ``stderr`` is
-redirected to a file.
+By default, ``sys.stderr`` is line-buffered now, even if ``stderr`` is
+redirected to a file. You can still make ``sys.stderr`` unbuffered by
+passing the :option:`-u` command-line option or setting the
+:envvar:`PYTHONUNBUFFERED` environment variable.
+
+(Contributed by Jendrik Seipp in bpo-13601.)

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1812,7 +1812,7 @@ create_stdio(const PyConfig *config, PyObject* io,
         write_through = Py_True;
     else
         write_through = Py_False;
-    if (isatty && buffered_stdio)
+    if (buffered_stdio && (isatty || fd == fileno(stderr)))
         line_buffering = Py_True;
     else
         line_buffering = Py_False;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Fixes https://bugs.python.org/issue13601

<!-- issue-number: [bpo-13601](https://bugs.python.org/issue13601) -->
https://bugs.python.org/issue13601
<!-- /issue-number -->
