### PR TITLE
[3.8] bpo-39080: Starred Expression's column offset fix when inside a CALL (GH-17645)

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -209,6 +209,8 @@ eval_tests = [
   "1 < 2 < 3",
   # Call
   "f(1,2,c=3,*d,**e)",
+  # Call with multi-character starred
+  "f(*[0, 1])",
   # Call with a generator argument
   "f(a for a in b)",
   # Num
@@ -814,6 +816,12 @@ class ASTHelpers_Test(unittest.TestCase):
         elif_stmt = node.body[0].orelse[0]
         self.assertEqual(elif_stmt.lineno, 3)
         self.assertEqual(elif_stmt.col_offset, 0)
+
+    def test_starred_expr_end_position_within_call(self):
+        node = ast.parse('f(*[0, 1])')
+        starred_expr = node.body[0].value.args[0]
+        self.assertEqual(starred_expr.end_lineno, 1)
+        self.assertEqual(starred_expr.end_col_offset, 9)
 
     def test_literal_eval(self):
         self.assertEqual(ast.literal_eval('[1, 2, 3]'), [1, 2, 3])
@@ -1868,6 +1876,7 @@ eval_results = [
 ('Expression', ('GeneratorExp', (1, 0), ('Tuple', (1, 1), [('Name', (1, 2), 'a', ('Load',)), ('Name', (1, 4), 'b', ('Load',))], ('Load',)), [('comprehension', ('List', (1, 11), [('Name', (1, 12), 'a', ('Store',)), ('Name', (1, 14), 'b', ('Store',))], ('Store',)), ('Name', (1, 20), 'c', ('Load',)), [], 0)])),
 ('Expression', ('Compare', (1, 0), ('Constant', (1, 0), 1, None), [('Lt',), ('Lt',)], [('Constant', (1, 4), 2, None), ('Constant', (1, 8), 3, None)])),
 ('Expression', ('Call', (1, 0), ('Name', (1, 0), 'f', ('Load',)), [('Constant', (1, 2), 1, None), ('Constant', (1, 4), 2, None), ('Starred', (1, 10), ('Name', (1, 11), 'd', ('Load',)), ('Load',))], [('keyword', 'c', ('Constant', (1, 8), 3, None)), ('keyword', None, ('Name', (1, 15), 'e', ('Load',)))])),
+('Expression', ('Call', (1, 0), ('Name', (1, 0), 'f', ('Load',)), [('Starred', (1, 2), ('List', (1, 3), [('Constant', (1, 4), 0, None), ('Constant', (1, 7), 1, None)], ('Load',)), ('Load',))], [])),
 ('Expression', ('Call', (1, 0), ('Name', (1, 0), 'f', ('Load',)), [('GeneratorExp', (1, 1), ('Name', (1, 2), 'a', ('Load',)), [('comprehension', ('Name', (1, 8), 'a', ('Store',)), ('Name', (1, 13), 'b', ('Load',)), [], 0)])], [])),
 ('Expression', ('Constant', (1, 0), 10, None)),
 ('Expression', ('Constant', (1, 0), 'string', None)),

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-17-21-45-36.bpo-39080.OrxEVS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-17-21-45-36.bpo-39080.OrxEVS.rst
@@ -1,0 +1,1 @@
+Fix the value of *end_col_offset* for Starred Expression AST nodes when they are among the elements in the *args* attribute of Call AST nodes.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -3126,7 +3126,7 @@ ast_for_call(struct compiling *c, const node *n, expr_ty func,
                     return NULL;
                 starred = Starred(e, Load, LINENO(chch),
                         chch->n_col_offset,
-                        chch->n_end_lineno, chch->n_end_col_offset,
+                        e->end_lineno, e->end_col_offset,
                         c->c_arena);
                 if (!starred)
                     return NULL;


### PR DESCRIPTION
… 
Co-Authored-By: Pablo Galindo <Pablogsal@gmail.com>
(cherry picked from commit 50d4f12958bf806a4e1a1021d70cfd5d448c5cba)

Co-authored-by: Lysandros Nikolaou <lisandrosnik@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39080](https://bugs.python.org/issue39080) -->
https://bugs.python.org/issue39080
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal