### PR TITLE
bpo-38546: Fix concurrent.futures test_ressources_gced_in_workers()

### DIFF
--- a/Misc/NEWS.d/next/Tests/2019-12-18-14-52-08.bpo-38546.2kxNuM.rst
+++ b/Misc/NEWS.d/next/Tests/2019-12-18-14-52-08.bpo-38546.2kxNuM.rst
@@ -1,0 +1,3 @@
+Fix test_ressources_gced_in_workers() of test_concurrent_futures: explicitly
+stop the manager to prevent leaking a child process running in the background
+after the test completes.


### PR DESCRIPTION
Fix test_ressources_gced_in_workers() of test_concurrent_futures:
explicitly stop the manager to prevent leaking a child process
running in the background after the test completes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38546](https://bugs.python.org/issue38546) -->
https://bugs.python.org/issue38546
<!-- /issue-number -->
