### PR TITLE
[3.8] bpo-38546: Fix concurrent.futures test_ressources_gced_in_workers() (GH-17652)

### DIFF
--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -87,8 +87,7 @@ class MyObject(object):
 
 
 class EventfulGCObj():
-    def __init__(self, ctx):
-        mgr = get_context(ctx).Manager()
+    def __init__(self, mgr):
         self.event = mgr.Event()
 
     def __del__(self):
@@ -848,11 +847,20 @@ class ProcessPoolExecutorTest(ExecutorTest):
     def test_ressources_gced_in_workers(self):
         # Ensure that argument for a job are correctly gc-ed after the job
         # is finished
-        obj = EventfulGCObj(self.ctx)
+        mgr = get_context(self.ctx).Manager()
+        obj = EventfulGCObj(mgr)
         future = self.executor.submit(id, obj)
         future.result()
 
         self.assertTrue(obj.event.wait(timeout=1))
+
+        # explicitly destroy the object to ensure that EventfulGCObj.__del__()
+        # is called while manager is still running.
+        obj = None
+        test.support.gc_collect()
+
+        mgr.shutdown()
+        mgr.join()
 
 
 create_executor_tests(ProcessPoolExecutorTest,

--- a/Misc/NEWS.d/next/Tests/2019-12-18-14-52-08.bpo-38546.2kxNuM.rst
+++ b/Misc/NEWS.d/next/Tests/2019-12-18-14-52-08.bpo-38546.2kxNuM.rst
@@ -1,0 +1,3 @@
+Fix test_ressources_gced_in_workers() of test_concurrent_futures: explicitly
+stop the manager to prevent leaking a child process running in the background
+after the test completes.


### PR DESCRIPTION
Fix test_ressources_gced_in_workers() of test_concurrent_futures:
explicitly stop the manager to prevent leaking a child process
running in the background after the test completes.

(cherry picked from commit 673c39331f844a80c465efd7cff88ac55c432bfb)

<!-- issue-number: [bpo-38546](https://bugs.python.org/issue38546) -->
https://bugs.python.org/issue38546
<!-- /issue-number -->
