### PR TITLE
[3.8] bpo-38316: Fix co_stacksize documentation (GH-16983)

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -925,8 +925,8 @@ Internal types
       the first line number of the function; :attr:`co_lnotab` is a string
       encoding the mapping from bytecode offsets to line numbers (for details
       see the source code of the interpreter); :attr:`co_stacksize` is the
-      required stack size (including local variables); :attr:`co_flags` is an
-      integer encoding a number of flags for the interpreter.
+      required stack size; :attr:`co_flags` is an integer encoding a number
+      of flags for the interpreter.
 
       .. index:: object: generator
 


### PR DESCRIPTION
(cherry picked from commit d587272fe3b0fcad2f23a490e76f9f82ca7d64ef)

Co-authored-by: Batuhan Taşkaya <47358913+isidentical@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38316](https://bugs.python.org/issue38316) -->
https://bugs.python.org/issue38316
<!-- /issue-number -->


Automerge-Triggered-By: @vstinner