### PR TITLE
gh-77069: add context info to ast.literal_eval error messages

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -971,6 +971,22 @@ Module(
         malformed = ast.Dict(keys=[ast.Constant(1)], values=[ast.Constant(2), ast.Constant(3)])
         self.assertRaises(ValueError, ast.literal_eval, malformed)
 
+    def test_literal_eval_message(self):
+        tests = {
+            "2 * 5": "in literal context",
+            "[] + []": "in binary operation context",
+            "+''": "in unary operation context",
+            ast.Dict(
+                keys=[ast.Constant(1)], values=[]
+            ): "in dictionary context",
+            ast.BinOp(
+                ast.Constant(1), ast.Add(), "oops"
+            ): "malformed node or string: 'oops'",
+        }
+        for test, message in tests.items():
+            with self.subTest(test=test, expected_message=message):
+                self.assertRaisesRegex(ValueError, message, ast.literal_eval, test)
+
     def test_bad_integer(self):
         # issue13436: Bad error message with invalid numeric values
         body = [ast.ImportFrom(module='time',

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -338,7 +338,10 @@ non-important content
         self.assertIsNone(g.__doc__)
 
     def test_literal_eval(self):
-        with self.assertRaisesRegex(ValueError, 'malformed node or string'):
+        with self.assertRaisesRegex(
+            ValueError,
+            'malformed node or string in literal context'
+        ):
             ast.literal_eval("f'x'")
 
     def test_ast_compile_time_concat(self):

--- a/Misc/NEWS.d/next/Library/2019-12-19-18-20-08.bpo-32888.J5XUjV.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-19-18-20-08.bpo-32888.J5XUjV.rst
@@ -1,0 +1,2 @@
+Enhance :func:`ast.literal_eval` error messages with context information. Original
+patch is written by Chris Angelico, improved and maintained by Batuhan Taskaya.


### PR DESCRIPTION
Based on changes from #340.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32888](https://bugs.python.org/issue32888) -->
https://bugs.python.org/issue32888
<!-- /issue-number -->

<!-- gh-issue-number: gh-77069 -->
* Issue: gh-77069
<!-- /gh-issue-number -->
