### PR TITLE
bpo-38971: open file in codecs.open() closes if exception raised

### DIFF
--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -905,11 +905,16 @@ def open(filename, mode='r', encoding=None, errors='strict', buffering=-1):
     file = builtins.open(filename, mode, buffering)
     if encoding is None:
         return file
-    info = lookup(encoding)
-    srw = StreamReaderWriter(file, info.streamreader, info.streamwriter, errors)
-    # Add attributes to simplify introspection
-    srw.encoding = encoding
-    return srw
+
+    try:
+        info = lookup(encoding)
+        srw = StreamReaderWriter(file, info.streamreader, info.streamwriter, errors)
+        # Add attributes to simplify introspection
+        srw.encoding = encoding
+        return srw
+    except:
+        file.close()
+        raise
 
 def EncodedFile(file, data_encoding, file_encoding=None, errors='strict'):
 

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1154,18 +1154,6 @@ class UTF8SigTest(UTF8Test, unittest.TestCase):
             got = ostream.getvalue()
             self.assertEqual(got, unistring)
 
-class FileClosesOnRaiseTest(unittest.TestCase):
-    def test_file_closes_if_exception_raised(self):
-        mock_open = mock.mock_open()
-        mock_lookup = mock.Mock(side_effect=Exception)
-
-        with mock.patch('codecs.lookup', mock_lookup):
-            with mock.patch('builtins.open', mock_open) as file:
-                with self.assertRaises(Exception):
-                    codecs.open(support.TESTFN, mode = 'wt', encoding='utf-8')
-
-                file().close.assert_called()
-
 
 class EscapeDecodeTest(unittest.TestCase):
     def test_empty(self):
@@ -1725,6 +1713,14 @@ class CodecsModuleTest(unittest.TestCase):
                 codecs.encode, 'abc', 'undefined', errors)
             self.assertRaises(UnicodeError,
                 codecs.decode, b'abc', 'undefined', errors)
+
+    def test_file_closes_if_lookup_error_raised(self):
+        mock_open = mock.mock_open()
+        with mock.patch('builtins.open', mock_open) as file:
+            with self.assertRaises(LookupError):
+                codecs.open(support.TESTFN, mode = 'wt', encoding='invalid-format')
+
+            file().close.assert_called()
 
 
 class StreamReaderTest(unittest.TestCase):

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1154,6 +1154,19 @@ class UTF8SigTest(UTF8Test, unittest.TestCase):
             got = ostream.getvalue()
             self.assertEqual(got, unistring)
 
+class FileClosesOnRaiseTest(unittest.TestCase):
+    def test_file_closes_if_exception_raised(self):
+        mock_open = mock.mock_open()
+        mock_lookup = mock.Mock(side_effect=Exception)
+
+        with mock.patch('codecs.lookup', mock_lookup):
+            with mock.patch('builtins.open', mock_open) as file:
+                with self.assertRaises(Exception):
+                    codecs.open(support.TESTFN, mode = 'wt', encoding='utf-8')
+
+                file().close.assert_called()
+
+
 class EscapeDecodeTest(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(codecs.escape_decode(b""), (b"", 0))

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1718,7 +1718,7 @@ class CodecsModuleTest(unittest.TestCase):
         mock_open = mock.mock_open()
         with mock.patch('builtins.open', mock_open) as file:
             with self.assertRaises(LookupError):
-                codecs.open(support.TESTFN, mode = 'wt', encoding='invalid-format')
+                codecs.open(support.TESTFN, 'wt', 'invalid-encoding')
 
             file().close.assert_called()
 

--- a/Misc/NEWS.d/next/Library/2019-12-20-16-06-28.bpo-38971.fKRYlF.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-20-16-06-28.bpo-38971.fKRYlF.rst
@@ -1,0 +1,3 @@
+Open issue in the BPO indicated a desire to make the implementation of
+codecs.open() at parity with io.open(), which implements a try/except to
+assure file stream gets closed before an exception is raised.


### PR DESCRIPTION
https://bugs.python.org/issue38971

Open issue in the BPO indicated a desire to make the implementation of
codecs.open() at parity with io.open(), which implements a try/except to
assure file stream gets closed before an exception is raised.


<!-- issue-number: [bpo-38971](https://bugs.python.org/issue38971) -->
https://bugs.python.org/issue38971
<!-- /issue-number -->
