### PR TITLE
bpo-39102: Increase Enum performance up to 10x times (3x average)

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -667,7 +667,7 @@ class Enum(metaclass=EnumMeta):
                 for m in cls.__dict__
                 if m[0] != '_' and m not in self._member_map_
                 ]
-        return (['__class__', '__doc__', '__module__'] + added_behavior)
+        return (['__class__', '__doc__', '__module__', 'name', 'value'] + added_behavior)
 
     def __format__(self, format_spec):
         # mixed-in Enums should use the mixed-in type's __format__, otherwise

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -179,9 +179,8 @@ class EnumMeta(type):
 
         # create our new Enum type
         enum_class = super().__new__(metacls, cls, bases, classdict)
-        enum_class._member_names = []               # names in definition order
         enum_class._member_map_ = {}                 # name->value map
-        enum_class._unique_member_map_ = {}
+        enum_class._unique_member_map_ = {}          # name->unique value map
         enum_class._member_type_ = member_type
 
         dynamic_attributes = {k: v for c in enum_class.mro()
@@ -245,7 +244,6 @@ class EnumMeta(type):
             else:
                 # Aliases don't appear in member names (only in __members__).
                 enum_class._unique_member_map_[member_name] = enum_member
-                enum_class._member_names.append(member_name)
 
             dynamic_attr = dynamic_attributes.get(member_name)
             if dynamic_attr is not None:
@@ -479,7 +477,7 @@ class EnumMeta(type):
             '_member_names_ is deprecated and will be removed in 3.10, use '
             '_unique_members_map_ instead.', DeprecationWarning, stacklevel=2
         )
-        return cls._member_names
+        return list(cls._unique_member_map_)
 
     @staticmethod
     def _get_mixins_(bases):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -177,6 +177,8 @@ class EnumMeta(type):
         if '__doc__' not in classdict:
             classdict['__doc__'] = 'An enumeration.'
 
+        # convert _EnumDict() to dict() as it not used anymore and builtin dict() is faster
+        classdict = {**classdict}
         # create our new Enum type
         enum_class = super().__new__(metacls, cls, bases, classdict)
         enum_class._member_map_ = {}                 # name->value map

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -104,7 +104,7 @@ class _EnumDict(dict):
                 value = value.value
             self.members[key] = value
         super().__setitem__(key, value)
-        
+
     @property
     def _member_names(self):
         import warnings

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -745,27 +745,31 @@ class Flag(Enum):
         return bool(self._value_)
 
     def __or__(self, other):
-        if not isinstance(other, self.__class__):
+        cls = self.__class__
+        if not isinstance(other, cls):
             return NotImplemented
-        return self.__class__(self._value_ | other._value_)
+        return cls(self._value_ | other._value_)
 
     def __and__(self, other):
-        if not isinstance(other, self.__class__):
+        cls = self.__class__
+        if not isinstance(other, cls):
             return NotImplemented
-        return self.__class__(self._value_ & other._value_)
+        return cls(self._value_ & other._value_)
 
     def __xor__(self, other):
-        if not isinstance(other, self.__class__):
+        cls = self.__class__
+        if not isinstance(other, cls):
             return NotImplemented
-        return self.__class__(self._value_ ^ other._value_)
+        return cls(self._value_ ^ other._value_)
 
     def __invert__(self):
-        members, uncovered = _decompose(self.__class__, self._value_)
-        inverted = self.__class__(0)
-        for m in self.__class__:
+        cls = self.__class__
+        members, uncovered = _decompose(cls, self._value_)
+        inverted = cls(0)
+        for m in cls:
             if m not in members and not (m._value_ & self._value_):
                 inverted = inverted | m
-        return self.__class__(inverted)
+        return cls(inverted)
 
 
 class IntFlag(int, Flag):
@@ -811,20 +815,23 @@ class IntFlag(int, Flag):
         return pseudo_member
 
     def __or__(self, other):
-        if not isinstance(other, (self.__class__, int)):
+        cls = self.__class__
+        if not isinstance(other, (cls, int)):
             return NotImplemented
-        result = self.__class__(self._value_ | self.__class__(other)._value_)
+        result = cls(self._value_ | cls(other)._value_)
         return result
 
     def __and__(self, other):
-        if not isinstance(other, (self.__class__, int)):
+        cls = self.__class__
+        if not isinstance(other, (cls, int)):
             return NotImplemented
-        return self.__class__(self._value_ & self.__class__(other)._value_)
+        return cls(self._value_ & cls(other)._value_)
 
     def __xor__(self, other):
-        if not isinstance(other, (self.__class__, int)):
+        cls = self.__class__
+        if not isinstance(other, (cls, int)):
             return NotImplemented
-        return self.__class__(self._value_ ^ self.__class__(other)._value_)
+        return cls(self._value_ ^ cls(other)._value_)
 
     __ror__ = __or__
     __rand__ = __and__

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -213,11 +213,11 @@ class EnumMeta(type):
         # auto-numbering ;)
         for member_name, value in enum_members.items():
             if not isinstance(value, tuple):
-                args = (value,)
+                args = (value, )
             else:
                 args = value
-            if member_type is tuple:  # special case for tuple enums
-                args = (args,)  # wrap it one more time
+            if member_type is tuple:   # special case for tuple enums
+                args = (args, )     # wrap it one more time
             if not use_args:
                 enum_member = __new__(enum_class)
                 if not hasattr(enum_member, '_value_'):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -813,7 +813,9 @@ class IntFlag(int, Flag):
     def _create_pseudo_member_(cls, value):
         pseudo_member = cls._value2member_map_.get(value, None)
         if pseudo_member is None:
-            need_to_create = [value]
+            # using dict with flag values as keys for faster lookups
+            # can't use set() because it is not a sequence
+            need_to_create = {value: ...}
             # get unaccounted for bits
             _, extra_flags = _decompose(cls, value)
             # timer = 10
@@ -824,7 +826,7 @@ class IntFlag(int, Flag):
                 if (flag_value not in cls._value2member_map_ and
                         flag_value not in need_to_create
                         ):
-                    need_to_create.append(flag_value)
+                    need_to_create[flag_value] = ...
                 if extra_flags == -flag_value:
                     extra_flags = 0
                 else:

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -883,8 +883,6 @@ class IntFlag(int, Flag):
                 pseudo_member = int.__new__(cls, value)
                 pseudo_member._name_ = None
                 pseudo_member._value_ = value
-                object.__setattr__(pseudo_member, 'name', None)
-                object.__setattr__(pseudo_member, 'value', value)
                 # use setdefault in case another thread already created a composite
                 # with this value
                 pseudo_member = cls._value2member_map_.setdefault(value, pseudo_member)

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -366,7 +366,7 @@ class EnumMeta(type):
         return MappingProxyType(cls._member_map_)
 
     def __repr__(cls):
-        return f'<enum {cls.__name__!r}'
+        return f'<enum {cls.__name__!r}>'
 
     def __reversed__(cls):
         return reversed(cls._unique_member_map_.values())

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2420,7 +2420,7 @@ class _ParameterKind(enum.IntEnum):
     VAR_KEYWORD = 4
 
     def __str__(self):
-        return self._name_
+        return self.name
 
     @property
     def description(self):

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -153,17 +153,17 @@ class RegexFlag(enum.IntFlag):
     DEBUG = sre_compile.SRE_FLAG_DEBUG # dump pattern after compilation
 
     def __repr__(self):
-        if self._name_ is not None:
-            return f're.{self._name_}'
-        value = self._value_
+        if self.name is not None:
+            return f're.{self.name}'
+        value = self.value
         members = []
         negative = value < 0
         if negative:
             value = ~value
         for m in self.__class__:
-            if value & m._value_:
-                value &= ~m._value_
-                members.append(f're.{m._name_}')
+            if value & m.value:
+                value &= ~m.value
+                members.append(f're.{m.name}')
         if value:
             members.append(hex(value))
         res = '|'.join(members)

--- a/Lib/test/test_dynamicclassattribute.py
+++ b/Lib/test/test_dynamicclassattribute.py
@@ -295,6 +295,36 @@ class PropertySubclassTests(unittest.TestCase):
         self.assertEqual(Foo.__dict__['spam'].__doc__, "a new docstring")
 
 
+class TestSetClassAttr(unittest.TestCase):
+    def test_set_class_attr(self):
+        class Foo:
+            def __init__(self, value):
+                self._value = value
+                self._spam = 'spam'
+
+            @DynamicClassAttribute
+            def value(self):
+                return self._value
+
+            spam = DynamicClassAttribute(
+                lambda s: s._spam,
+                alias='my_shiny_spam'
+            )
+
+        self.assertFalse(hasattr(Foo, 'value'))
+        self.assertFalse(hasattr(Foo, 'name'))
+
+        foo_bar = Foo('bar')
+        value_desc = Foo.__dict__['value']
+        value_desc.set_class_attr(Foo, foo_bar)
+        self.assertIs(Foo.value, foo_bar)
+        self.assertEqual(Foo.value.value, 'bar')
+
+        foo_baz = Foo('baz')
+        Foo.my_shiny_spam = foo_baz
+        self.assertIs(Foo.spam, foo_baz)
+        self.assertEqual(Foo.spam.spam, 'spam')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3040,5 +3040,17 @@ class TestIntEnumConvert(unittest.TestCase):
                 filter=lambda x: x.startswith('CONVERT_TEST_'))
 
 
+class TestEnumNamesDeprecation(unittest.TestCase):
+    @unittest.skipUnless(sys.version_info[:2] == (3, 9),
+                         '_convert was deprecated in 3.9')
+    def test_convert_warn(self):
+        with self.assertWarns(DeprecationWarning):
+            _ = enum.IntEnum._member_names_
+
+    @unittest.skipUnless(sys.version_info >= (3, 10), '_convert was removed in 3.10')
+    def test_convert_raise(self):
+        with self.assertRaises(AttributeError):
+            _ = enum.IntEnum._member_names_
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1079,9 +1079,9 @@ class TestEnum(unittest.TestCase):
         class auto_enum(type(Enum)):
             def __new__(metacls, cls, bases, classdict):
                 temp = type(classdict)()
-                names = set(classdict._member_names)
+                names = classdict.members.keys()
                 i = 0
-                for k in classdict._member_names:
+                for k in classdict.members:
                     v = classdict[k]
                     if v is Ellipsis:
                         v = i
@@ -3051,6 +3051,26 @@ class TestEnumNamesDeprecation(unittest.TestCase):
     def test_convert_raise(self):
         with self.assertRaises(AttributeError):
             _ = enum.IntEnum._member_names_
+
+
+class TestEnumDictAttrsDeprecation(unittest.TestCase):
+    @unittest.skipUnless(sys.version_info[:2] == (3, 9),
+                         '_convert was deprecated in 3.9')
+    def test_convert_warn(self):
+        with self.assertWarns(DeprecationWarning):
+            _ = enum._EnumDict()._member_names
+
+        with self.assertWarns(DeprecationWarning):
+            _ = enum._EnumDict()._last_values
+
+    @unittest.skipUnless(sys.version_info >= (3, 10), '_convert was removed in 3.10')
+    def test_convert_raise(self):
+        with self.assertRaises(AttributeError):
+            _ = enum._EnumDict()._member_names
+
+        with self.assertRaises(AttributeError):
+            _ = enum._EnumDict()._last_values
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -185,7 +185,7 @@ class TestEnum(unittest.TestCase):
         Season = self.Season
         self.assertEqual(
             set(dir(Season.WINTER)),
-            set(['__class__', '__doc__', '__module__', 'name', 'value']),
+            set(['__class__', '__doc__', '__module__']),
             )
 
     def test_dir_with_added_behavior(self):
@@ -200,7 +200,7 @@ class TestEnum(unittest.TestCase):
                 )
         self.assertEqual(
                 set(dir(Test.this)),
-                set(['__class__', '__doc__', '__module__', 'name', 'value', 'wowser']),
+                set(['__class__', '__doc__', '__module__', 'wowser']),
                 )
 
     def test_dir_on_sub_with_behavior_on_super(self):
@@ -212,7 +212,7 @@ class TestEnum(unittest.TestCase):
             sample = 5
         self.assertEqual(
                 set(dir(SubEnum.sample)),
-                set(['__class__', '__doc__', '__module__', 'name', 'value', 'invisible']),
+                set(['__class__', '__doc__', '__module__', 'invisible']),
                 )
 
     def test_enum_in_enum_out(self):
@@ -2866,15 +2866,6 @@ class Color(enum.Enum)
  |  red = <Color.red: 1>
  |\x20\x20
  |  ----------------------------------------------------------------------
- |  Data descriptors inherited from enum.Enum:
- |\x20\x20
- |  name
- |      The name of the Enum member.
- |\x20\x20
- |  value
- |      The value of the Enum member.
- |\x20\x20
- |  ----------------------------------------------------------------------
  |  Readonly properties inherited from enum.EnumMeta:
  |\x20\x20
  |  __members__
@@ -2943,9 +2934,7 @@ class TestStdLib(unittest.TestCase):
                 ('__module__', __name__),
                 ('blue', self.Color.blue),
                 ('green', self.Color.green),
-                ('name', Enum.__dict__['name']),
                 ('red', self.Color.red),
-                ('value', Enum.__dict__['value']),
                 ))
         result = dict(inspect.getmembers(self.Color))
         self.assertEqual(values.keys(), result.keys())
@@ -2977,10 +2966,6 @@ class TestStdLib(unittest.TestCase):
                     defining_class=self.Color, object=self.Color.green),
                 Attribute(name='red', kind='data',
                     defining_class=self.Color, object=self.Color.red),
-                Attribute(name='name', kind='data',
-                    defining_class=Enum, object=Enum.__dict__['name']),
-                Attribute(name='value', kind='data',
-                    defining_class=Enum, object=Enum.__dict__['value']),
                 ]
         values.sort(key=lambda item: item.name)
         result = list(inspect.classify_class_attrs(self.Color))

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -236,6 +236,7 @@ class TestEnum(unittest.TestCase):
         self.assertEqual(
             [Season.SPRING, Season.SUMMER, Season.AUTUMN, Season.WINTER], lst)
 
+        self.assertEqual(repr(Season), "<enum 'Season'>")
         for i, season in enumerate('SPRING SUMMER AUTUMN WINTER'.split(), 1):
             e = Season(i)
             self.assertEqual(e, getattr(Season, season))

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -187,7 +187,7 @@ class TestEnum(unittest.TestCase):
         Season = self.Season
         self.assertEqual(
             set(dir(Season.WINTER)),
-            set(['__class__', '__doc__', '__module__']),
+            set(['__class__', '__doc__', '__module__', 'name', 'value']),
             )
 
     def test_dir_with_added_behavior(self):
@@ -202,7 +202,7 @@ class TestEnum(unittest.TestCase):
                 )
         self.assertEqual(
                 set(dir(Test.this)),
-                set(['__class__', '__doc__', '__module__', 'wowser']),
+                set(['__class__', '__doc__', '__module__', 'wowser', 'name', 'value']),
                 )
 
     def test_dir_on_sub_with_behavior_on_super(self):
@@ -214,7 +214,7 @@ class TestEnum(unittest.TestCase):
             sample = 5
         self.assertEqual(
                 set(dir(SubEnum.sample)),
-                set(['__class__', '__doc__', '__module__', 'invisible']),
+                set(['__class__', '__doc__', '__module__', 'invisible', 'name', 'value']),
                 )
 
     def test_enum_in_enum_out(self):

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -153,9 +153,9 @@ class DynamicClassAttribute:
     accessed through an instance and through a class.
 
     Access on instance behaves like a @property, but access on class
-    will be routed to the given alias ('_cls_attr_' + attr_name) by default
-    If such attr not present in class, AttributeError will be raised,
-    routing to __getattr__ method of class type)
+    will be routed to the given alias ('_cls_attr_' + attr_name by default)
+    You can set class attribute through descriptor using set_class_attr or directly using alias
+    If class attr is not set, AttributeError will be raised, routing to __getattr__ method of class type)
 
     This allows one to have properties active on an instance, and have virtual
     attributes on the class with the same name (see Enum for an example).
@@ -172,13 +172,13 @@ class DynamicClassAttribute:
         # support for abstract methods
         self.__isabstractmethod__ = bool(getattr(fget, '__isabstractmethod__', False))
         # define name for class attributes
-        self.class_attr_name = alias
+        self.alias = alias
 
     def __get__(self, instance, ownerclass):
         if instance is None:
             if self.__isabstractmethod__:
                 return self
-            return getattr(ownerclass, self.class_attr_name)
+            return getattr(ownerclass, self.alias)
         elif self.fget is None:
             raise AttributeError("unreadable attribute")
         return self.fget(instance)
@@ -193,12 +193,12 @@ class DynamicClassAttribute:
             raise AttributeError("can't delete attribute")
         self.fdel(instance)
 
-    def __set_name__(self, ownerclass, name):
-        if self.class_attr_name is None:
-            self.class_attr_name = f'_cls_attr_{name}'
+    def __set_name__(self, ownerclass, alias):
+        if self.alias is None:
+            self.alias = f'_cls_attr_{alias}'
 
     def set_class_attr(self, cls, value):
-        setattr(cls, self.class_attr_name, value)
+        setattr(cls, self.alias, value)
 
     def getter(self, fget):
         fdoc = fget.__doc__ if self.overwrite_doc else None

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -196,7 +196,7 @@ class DynamicClassAttribute:
 
     def set_class_attr(self, cls, value):
         setattr(cls, self.class_attr_name, value)
-    
+
     def getter(self, fget):
         fdoc = fget.__doc__ if self.overwrite_doc else None
         result = type(self)(fget, self.fset, self.fdel, fdoc or self.__doc__)

--- a/Misc/NEWS.d/next/Library/2019-12-20-12-31-41.bpo-39102.zqgDii.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-20-12-31-41.bpo-39102.zqgDii.rst
@@ -1,0 +1,2 @@
+Significantly improve speed of accessing ``Enum`` attributes and slightly improve speed of trying values. 
+Remove ``EnumMeta.__getattr__``, remove ``Enum.name`` and ``Enum.value`` ``DynamicAttributes`` (they set as enum members attributes on its creation), fasten ``Enum.__new__`` a bit. Fasten ``DynamicClassAttribute`` by adding ability to preset class attributes with ``DynamicClassAttribute.set_class_attr``


### PR DESCRIPTION
# Increase Enum performance 
https://bugs.python.org/issue39102

Partial benchmark result, to see more, check [full benchmark result and source code](https://gist.github.com/Bobronium/94b5ca3e4098669d93a6127e70359307)
```py
ATTR_ACCESS:
Testing with 10000 repeats, result is average of 10 tests:

    >>> NewEnum.foo  # 0.6069349023270748 ms
    <NewEnum.foo: 1>

    >>> OldEnum.foo  # 4.5089948174334005 ms
    <OldEnum.foo: 1>

    >>> NewEnum.foo.value  # 0.965516420197984 ms
    1

    >>> OldEnum.foo.value  # 5.234090615261106 ms
    1

    >>> NewEnum.value.value  # 0.6496817059283957 ms
    3

    >>> OldEnum.value.value  # 19.718928336346387 ms
    3

    >>> try:     NewEnum.value.value = 'new' except: pass  # 4.842046525117963 ms
    AttributeError("Can't set attribute")

    >>> try:     OldEnum.value.value = 'new' except: pass  # 24.484108522222897 ms
    AttributeError("can't set attribute")


NewEnum: total: 7.0641796 ms, average: 1.1652198 ms (Fastest)
OldEnum: total: 53.9461223 ms, average: 10.3317085 ms, ~ x8.87 times slower than NewEnum 
```
## [Full benchmark result and source code](https://gist.github.com/Bobronium/94b5ca3e4098669d93a6127e70359307)

## Changes
- Optimized `Enum.__new__`
- Remove `EnumMeta.__getattr__`,
- Store `Enum.name` and `.value` in members `__dict__` for faster access
- Deprecate getting values from `Enum._name_` and `._value_`, should use public `.name` and `.value` now
- Replace `Enum._member_names_` with `._unique_member_map_` for faster lookups and iteration
- Replace `_EmumMeta._member_names` and `._last_values` with `.members` mapping (deprecation warning on using old attrs)
- Add `_str_`, `_repr_` and `_invert_` attrs to cache results of functions of the same dunder names (x35 speed boost) (948d3de)
- Various minor improvements
- Add support for direct setting and getting class attrs on `DynamicClassAttribute` without need to use slow `__getattr__`


<!-- issue-number: [bpo-39102](https://bugs.python.org/issue39102) -->
https://bugs.python.org/issue39102
<!-- /issue-number -->
