### PR TITLE
bpo-31711: On SSLObject.write method, added assert that data has content. 

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -894,7 +894,10 @@ class SSLObject:
 
         The 'data' argument must support the buffer interface.
         """
-        return self._sslobj.write(data)
+        if data != b'':
+            return self._sslobj.write(data)
+        else:
+            return ""
 
     def getpeercert(self, binary_form=False):
         """Returns a formatted version of the data in the certificate provided

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -894,10 +894,10 @@ class SSLObject:
 
         The 'data' argument must support the buffer interface.
         """
-        if data != b'':
+        if data:
             return self._sslobj.write(data)
         else:
-            return ""
+            return 0
 
     def getpeercert(self, binary_form=False):
         """Returns a formatted version of the data in the certificate provided


### PR DESCRIPTION
This avoid to rise ssl.SSLEOFError on petition that has no content on response.

<!-- issue-number: [bpo-31711](https://bugs.python.org/issue31711) -->
https://bugs.python.org/issue31711
<!-- /issue-number -->
