### PR TITLE
bpo-33961: Adjusted dataclasses docs to correct exceptions raised. (GH-7917)

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -60,8 +60,9 @@ Module-level decorators, classes, and functions
 
    The :func:`dataclass` decorator will add various "dunder" methods to
    the class, described below.  If any of the added methods already
-   exist on the class, a :exc:`TypeError` will be raised.  The decorator
-   returns the same class that is called on: no new class is created.
+   exist on the class, the behavior depends on the parameter, as documented
+   below. The decorator returns the same class that is called on; no new
+   class is created.
 
    If :func:`dataclass` is used just as a simple decorator with no parameters,
    it acts as if it has the default values documented in this
@@ -115,7 +116,7 @@ Module-level decorators, classes, and functions
 
      If the class already defines any of :meth:`__lt__`,
      :meth:`__le__`, :meth:`__gt__`, or :meth:`__ge__`, then
-     :exc:`ValueError` is raised.
+     :exc:`TypeError` is raised.
 
    - ``unsafe_hash``: If ``False`` (the default), a :meth:`__hash__` method
      is generated according to how ``eq`` and ``frozen`` are set.


### PR DESCRIPTION
This PR adds a cherry-picked commit from a PR merged by mistake into 3.7 instead of into master - see #7917 for details.
This needs to be backported to 3.8 as well.

<!-- issue-number: [bpo-33961](https://bugs.python.org/issue33961) -->
https://bugs.python.org/issue33961
<!-- /issue-number -->
