### PR TITLE
Fixed grammar in comment in Mac/build-installer.py

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -61,7 +61,7 @@ from plistlib import Plist
 try:
     from plistlib import writePlist
 except ImportError:
-    # We're run using python2.3
+    # Run from python2.3
     def writePlist(plist, path):
         plist.write(path)
 


### PR DESCRIPTION
Fixed grammar

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
A simple grammatical error in the build script