### PR TITLE
bpo-39121: write gzip header OS information

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -17,6 +17,15 @@ FTEXT, FHCRC, FEXTRA, FNAME, FCOMMENT = 1, 2, 4, 8, 16
 
 READ, WRITE = 1, 2
 
+# OS field values as specified in RFC 1952
+_OS_CODES = {
+    'unix': b'\x03',
+    'ntfs': b'\x0b',
+    'unknown': b'\xff'
+}
+_OS_UNIX = ('linux', 'freebsd', 'netbsd', 'openbsd', 'darwin', 'sunos', 'aix')
+_OS_NTFS = ('win32')
+
 _COMPRESS_LEVEL_FAST = 1
 _COMPRESS_LEVEL_TRADEOFF = 6
 _COMPRESS_LEVEL_BEST = 9
@@ -264,7 +273,12 @@ class GzipFile(_compression.BaseStream):
         else:
             xfl = b'\000'
         self.fileobj.write(xfl)
-        self.fileobj.write(b'\377')
+        if sys.platform.startswith(_OS_UNIX):
+            self.fileobj.write(_OS_CODES['unix'])
+        elif sys.platform.startswith(_OS_NTFS):
+            self.fileobj.write(_OS_CODES['ntfs'])
+        else:
+            self.fileobj.write(_OS_CODES['unknown'])
         if fname:
             self.fileobj.write(fname + b'\000')
 

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -315,7 +315,12 @@ class TestGzip(BaseTest):
 
     def test_metadata(self):
         mtime = 123456789
-
+        if sys.platform.startswith(gzip._OS_UNIX):
+            os_code = gzip._OS_CODES['unix']
+        elif sys.platform.startswith(gzip._OS_NTFS):
+            os_code = gzip._OS_CODES['ntfs']
+        else:
+            os_code = gzip._OS_CODES['unknown']
         with gzip.GzipFile(self.filename, 'w', mtime = mtime) as fWrite:
             fWrite.write(data1)
 
@@ -338,7 +343,7 @@ class TestGzip(BaseTest):
             self.assertEqual(xflByte, b'\x02') # maximum compression
 
             osByte = fRead.read(1)
-            self.assertEqual(osByte, b'\xff') # OS "unknown" (OS-independent)
+            self.assertEqual(osByte, os_code) # gzip OS code
 
             # Since the FNAME flag is set, the zero-terminated filename follows.
             # RFC 1952 specifies that this is the name of the input file, if any.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1072,6 +1072,7 @@ Grzegorz Makarewicz
 David Malcolm
 Greg Malcolm
 William Mallard
+Robert Mandic
 Ken Manheimer
 Vladimir Marangozov
 Colin Marc

--- a/Misc/NEWS.d/next/Library/2019-12-23-03-21-38.bpo-39121.HgPaAz.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-23-03-21-38.bpo-39121.HgPaAz.rst
@@ -1,0 +1,2 @@
+Writing gzip files sets 10th byte of the gzip header (the OS information)
+based on :attr:`sys.platform` Patch by Robert Mandic.


### PR DESCRIPTION


<!-- issue-number: [bpo-39121](https://bugs.python.org/issue39121) -->
https://bugs.python.org/issue39121
<!-- /issue-number -->
