### PR TITLE
Revert "bpo-38870: Remove dependency on contextlib to avoid performance regression on import (GH-17376)"

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -597,22 +597,15 @@ class _Unparser(NodeVisitor):
         self._buffer.clear()
         return value
 
-    class _Block:
+    @contextmanager
+    def block(self):
         """A context manager for preparing the source for blocks. It adds
         the character':', increases the indentation on enter and decreases
         the indentation on exit."""
-        def __init__(self, unparser):
-            self.unparser = unparser
-
-        def __enter__(self):
-            self.unparser.write(":")
-            self.unparser._indent += 1
-
-        def __exit__(self, exc_type, exc_value, traceback):
-            self.unparser._indent -= 1
-
-    def block(self):
-        return self._Block(self)
+        self.write(":")
+        self._indent += 1
+        yield
+        self._indent -= 1
 
     @contextmanager
     def delimit(self, start, end):


### PR DESCRIPTION
This reverts commit ded8888fbc33011dd39b7b1c86a5adfacc4943f3 as per the discussion on https://bugs.python.org/issue39069

<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal