### PR TITLE
bpo-39198: Ensure logging global lock is released on exception in isEnabledFor

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-01-02-20-21-03.bpo-39198.nzwGyG.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-02-20-21-03.bpo-39198.nzwGyG.rst
@@ -1,0 +1,1 @@
+If an exception were to be thrown in `Logger.isEnabledFor` (say, by asyncio timeouts or stopit) , the `logging` global lock may not be released appropriately, resulting in deadlock.  This change wraps that block of code with `try...finally` to ensure the lock is released.


### PR DESCRIPTION
This is a relatively small change which makes it easier to reason about the global `_acquireLock()` behavior inside of `isEnabledFor`:

1. Other callsites call `_releaseLock` inside of a `finally` block, ensuring that the lock is released even if exceptions are thrown ([Example](https://github.com/python/cpython/blob/7b778d643f7a948346544ea495d52a98b2386180/Lib/logging/__init__.py#L153)). This diff's primary goal is to ensure `_releaseLock` is called inside a finally block.
      1. This makes it easier to prove the correctness of `isEnabledFor`, because we no longer need to assert than no exceptions are thrown in order for the lock to be released.
      1. When using libraries like [`stopit`](https://pypi.org/project/stopit/), this ensures the lock is released even if exceptions are injected.
2. Nested `try` statements are stylistically bad.  Instead, create a helper function to contain the uncached behavior of determining if a logger is enabled for a particular status.



<!-- issue-number: [bpo-39198](https://bugs.python.org/issue39198) -->
https://bugs.python.org/issue39198
<!-- /issue-number -->
