### PR TITLE
bpo-39130: Dict reversed was added in v3.8 so should say in the doc as well

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4351,6 +4351,8 @@ pairs within braces, for example: ``{'jack': 4098, 'sjoerd': 4127}`` or ``{4098:
       Return a reverse iterator over the keys of the dictionary. This is a
       shortcut for ``reversed(d.keys())``.
 
+      .. versionadded:: 3.8
+
    .. method:: setdefault(key[, default])
 
       If *key* is in the dictionary, return its value.  If not, insert *key*


### PR DESCRIPTION
To be consistent with document layout, it should say when the feature was added.
Although it's mentioned few other places in the doc but it's not explicitly say that at that place.

<!-- issue-number: [bpo-39130](https://bugs.python.org/issue39130) -->
https://bugs.python.org/issue39130
<!-- /issue-number -->


Automerge-Triggered-By: @csabella