### PR TITLE
Minor Documentation Improvements

### DIFF
--- a/Doc/c-api/iter.rst
+++ b/Doc/c-api/iter.rst
@@ -29,7 +29,7 @@ something like this::
        /* propagate error */
    }
 
-   while (item = PyIter_Next(iterator)) {
+   while ((item = PyIter_Next(iterator))) {
        /* do something with item */
        ...
        /* release reference when done */

--- a/Doc/includes/custom.c
+++ b/Doc/includes/custom.c
@@ -37,7 +37,7 @@ PyInit_custom(void)
     Py_INCREF(&CustomType);
     if (PyModule_AddObject(m, "Custom", (PyObject *) &CustomType) < 0) {
         Py_DECREF(&CustomType);
-        PY_DECREF(m);
+        Py_DECREF(m);
         return NULL;
     }
 


### PR DESCRIPTION
The added parentheses around the `PyIter_Next` assignment suppress the following warning which gcc throws without:

```sh
warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
```

The other change is a typo fix