### PR TITLE
Fix host datatype in addr of socket.create_server example.

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -878,7 +878,7 @@ def create_server(address, *, family=AF_INET, backlog=None, reuse_port=False,
     connections. When false it will explicitly disable this option on
     platforms that enable it by default (e.g. Linux).
 
-    >>> with create_server((None, 8000)) as server:
+    >>> with create_server(('', 8000)) as server:
     ...     while True:
     ...         conn, addr = server.accept()
     ...         # handle new connection


### PR DESCRIPTION
The example raises a `TypeError` that host part of addr should be str, bytes or bytearray expected.