### PR TITLE
bpo-39139: To be clear what depreciation relates to i.e Collections ABS

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -33,10 +33,13 @@ Python's general purpose built-in containers, :class:`dict`, :class:`list`,
 :class:`UserString`     wrapper around string objects for easier string subclassing
 =====================   ====================================================================
 
+Collections Abstract Base Classes
+---------------------------------
+
 .. deprecated-removed:: 3.3 3.9
-    Moved :ref:`collections-abstract-base-classes` to the :mod:`collections.abc` module.
-    For backwards compatibility, they continue to be visible in this module through
-    Python 3.8.
+    
+Moved :ref:`collections-abstract-base-classes` to the :mod:`collections.abc` module.
+For backwards compatibility, they continue to be visible in this module through Python 3.8.
 
 
 :class:`ChainMap` objects

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -37,7 +37,7 @@ Collections Abstract Base Classes
 ---------------------------------
 
 .. deprecated-removed:: 3.3 3.9
-    
+
 Moved :ref:`collections-abstract-base-classes` to the :mod:`collections.abc` module.
 For backwards compatibility, they continue to be visible in this module through Python 3.8.
 


### PR DESCRIPTION
I think there is a need to add a title for this depreciation as it's not clear what it relates to. Is collection module or something else depreciated? Only after looking into it bit more it was apparent that it relates to some relocation of the sub classes.
I know these lines will be deleted at v3.9 probably but as it stands now it's confusing.

<!-- issue-number: [bpo-39139](https://bugs.python.org/issue39139) -->
https://bugs.python.org/issue39139
<!-- /issue-number -->
