### PR TITLE
bpo-39135: remove 'time.clock()' mention in docs

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -218,7 +218,6 @@ Functions
    Supported clock names and the corresponding functions to read their value
    are:
 
-   * ``'clock'``: :func:`time.clock`
    * ``'monotonic'``: :func:`time.monotonic`
    * ``'perf_counter'``: :func:`time.perf_counter`
    * ``'process_time'``: :func:`time.process_time`


### PR DESCRIPTION
`time.clock()` was removed in Python 3.8, but it was still mentioned
in `Doc/library/time.rst` for when `time.get_clock_info()` is given the
argument `'clock'`. This commit removes that mention.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39135](https://bugs.python.org/issue39135) -->
https://bugs.python.org/issue39135
<!-- /issue-number -->
