### PR TITLE
Fixed incorrect unicodedata version in lexical_analysis.rst footnote

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -929,4 +929,4 @@ occurrence outside string literals and comments is an unconditional error:
 
 .. rubric:: Footnotes
 
-.. [#] http://www.unicode.org/Public/11.0.0/ucd/NameAliases.txt
+.. [#] http://www.unicode.org/Public/12.1.0/ucd/NameAliases.txt


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

While fiddling with the unicode documentation for issue [bpo-22593](https://bugs.python.org/issue22593), I found one of the footnote hyperlinks in Docs/reference/lexical_analysis.rst still had an old unicode version. I updated it to match the current unicode version in Tools/unicode/makeunicodedata.py and other existing links in documentation.

I'm assuming this qualifies as a trivial change, thus I have not submitted a new issue for this change.