### PR TITLE
bpo-33165: Remove redundant stack unwind for findCaller()

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1403,6 +1403,7 @@ class Logger(Filterer):
         self.handlers = []
         self.disabled = False
         self._cache = {}
+        self.default_stack_level = 2
 
     def setLevel(self, level):
         """
@@ -1506,7 +1507,7 @@ class Logger(Filterer):
         Find the stack frame of the caller so that we can note the source
         file name, line number and function name.
         """
-        f = currentframe(2 + stacklevel)
+        f = currentframe(self.default_stack_level + stacklevel)
         #On some versions of IronPython, currentframe() returns None if
         #IronPython isn't run with -X:Frames.
         if f is not None:

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -153,14 +153,14 @@ def addLevelName(level, levelName):
         _releaseLock()
 
 if hasattr(sys, '_getframe'):
-    currentframe = lambda: sys._getframe(3)
+    currentframe = lambda level: sys._getframe(level)
 else: #pragma: no cover
-    def currentframe():
+    def currentframe(level):
         """Return the frame object for the caller's stack frame."""
         try:
             raise Exception
         except Exception:
-            return sys.exc_info()[2].tb_frame.f_back
+            return sys.exc_info()[level-1].tb_frame.f_back
 
 #
 # _srcfile is used when walking the stack to check when we've got the first
@@ -1506,17 +1506,11 @@ class Logger(Filterer):
         Find the stack frame of the caller so that we can note the source
         file name, line number and function name.
         """
-        f = currentframe()
+        f = currentframe(2 + stacklevel)
         #On some versions of IronPython, currentframe() returns None if
         #IronPython isn't run with -X:Frames.
         if f is not None:
             f = f.f_back
-        orig_f = f
-        while f and stacklevel > 1:
-            f = f.f_back
-            stacklevel -= 1
-        if not f:
-            f = orig_f
         rv = "(unknown file)", 0, "(unknown function)", None
         while hasattr(f, "f_code"):
             co = f.f_code


### PR DESCRIPTION
by directly getting the right frame on Lib/logging/__init__.py:currentframe()

This is a slight improvement for https://github.com/python/cpython/pull/7424 ([bpo-33165](https://bugs.python.org/issue33165): Added stacklevel parameter to logging APIs)

Instead of getting the fullstack trace and only then unwind the desired frames, just pass the required frame index and get it directly, i.e., without "unstacking" n frames.

I also added the frame level as a Logger attribute because when extending the default Logger and implementing/specializing the `_log` function, all stacktraces need to be increased by 1. For example, the debug_tools pypi module inherits from Logger and defines its own _log() function:
https://github.com/evandrocoan/debugtools/blob/d279bf3278f501294a72159f3aa189b7237528b2/all/debug_tools/logger.py#L166
https://github.com/evandrocoan/debugtools/blob/d279bf3278f501294a72159f3aa189b7237528b2/all/debug_tools/logger.py#L970
https://github.com/evandrocoan/debugtools/blob/d279bf3278f501294a72159f3aa189b7237528b2/all/debug_tools/logger.py#L1317


<!-- issue-number: [bpo-33165](https://bugs.python.org/issue33165) -->
https://bugs.python.org/issue33165
<!-- /issue-number -->
