### PR TITLE
bpo-38671: Make sure to return an absolute path in pathlib._WindowsFlavour.resolve()

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -195,6 +195,7 @@ class _WindowsFlavour(_Flavour):
             if strict:
                 return self._ext_to_normal(_getfinalpathname(s))
             else:
+                s = path = os.path.abspath(s)
                 tail_parts = []  # End of the path after the first one not found
                 while True:
                     try:
@@ -202,9 +203,9 @@ class _WindowsFlavour(_Flavour):
                     except FileNotFoundError:
                         previous_s = s
                         s, tail = os.path.split(s)
-                        if previous_s == s:
-                            return os.path.join(s or os.getcwd(), *reversed(tail_parts))
                         tail_parts.append(tail)
+                        if previous_s == s:
+                            return path
                     else:
                         return os.path.join(s, *reversed(tail_parts))
         # Means fallback on absolute

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -15,7 +15,7 @@ from urllib.parse import quote_from_bytes as urlquote_from_bytes
 
 
 if os.name == 'nt':
-    from nt import _getfinalpathname
+    from nt import _getfinalpathname, _getfullpathname
 else:
     _getfinalpathname = None
 
@@ -194,7 +194,7 @@ class _WindowsFlavour(_Flavour):
             return None  # Means fallback on absolute
         if strict:
             return self._ext_to_normal(_getfinalpathname(s))
-        s = path = os.path.abspath(s)
+        s = path = _getfullpathname(s)
         previous_s = None
         tail_parts = []  # End of the path after the first one not found
         while True:
@@ -204,7 +204,8 @@ class _WindowsFlavour(_Flavour):
                 previous_s = s
                 s, tail = os.path.split(s)
                 tail_parts.append(tail)
-                if previous_s == s:  # Root reached, fallback to abspath()
+                if previous_s == s:
+                    # Root reached, fallback to _getfullpathname()
                     return path
             else:
                 return os.path.join(s, *reversed(tail_parts))

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -202,9 +202,9 @@ class _WindowsFlavour(_Flavour):
                     except FileNotFoundError:
                         previous_s = s
                         s, tail = os.path.split(s)
-                        tail_parts.append(tail)
                         if previous_s == s:
-                            return path
+                            return os.path.join(s or os.getcwd(), *reversed(tail_parts))
+                        tail_parts.append(tail)
                     else:
                         return os.path.join(s, *reversed(tail_parts))
         # Means fallback on absolute

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1799,6 +1799,16 @@ class _BasePathTest(object):
         # Non-strict
         self.assertEqual(r.resolve(strict=False), p / '3' / '4')
 
+    def test_resolve_nonexist_relative_issue38671(self):
+        p = self.cls('non', 'exist')
+
+        old_cwd = os.getcwd()
+        os.chdir(BASE)
+        try:
+            self.assertEqual(p.resolve(), self.cls(BASE, p))
+        finally:
+            os.chdir(old_cwd)
+
     def test_with(self):
         p = self.cls(BASE)
         it = p.iterdir()
@@ -2653,16 +2663,6 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
             # bpo-38883: ignore `HOME` when set on windows
             env['HOME'] = 'C:\\Users\\eve'
             check()
-
-    def test_resolve_nonexist_relative_issue38671(self):
-        p = self.cls('non', 'exist')
-
-        old_cwd = os.getcwd()
-        os.chdir(BASE)
-        try:
-            self.assertEqual(p.resolve(), self.cls(BASE, p))
-        finally:
-            os.chdir(old_cwd)
 
 
 class CompatiblePathTest(unittest.TestCase):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2654,6 +2654,16 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
             env['HOME'] = 'C:\\Users\\eve'
             check()
 
+    def test_resolve_nonexist_relative_issue38671(self):
+        p = self.cls('non', 'exist')
+
+        old_cwd = os.getcwd()
+        os.chdir(BASE)
+        try:
+            self.assertEqual(p.resolve(), self.cls(BASE, p))
+        finally:
+            os.chdir(old_cwd)
+
 
 class CompatiblePathTest(unittest.TestCase):
     """

--- a/Misc/NEWS.d/next/Library/2019-12-28-02-50-12.bpo-38671.xT4R0P.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-28-02-50-12.bpo-38671.xT4R0P.rst
@@ -1,0 +1,2 @@
+Ensure pathlib.Path.resolve(strict=False) returns an absolute path on
+Windows when the path is relative and does not exist.


### PR DESCRIPTION


<!-- issue-number: [bpo-38671](https://bugs.python.org/issue38671) -->
https://bugs.python.org/issue38671
<!-- /issue-number -->
