### PR TITLE
bpo-39082: Fix: AsyncMock is unable to correctly patch static/class methods

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -48,6 +48,8 @@ _safe_super = super
 def _is_async_obj(obj):
     if _is_instance_mock(obj) and not isinstance(obj, AsyncMock):
         return False
+    if isinstance(obj, (classmethod, staticmethod)):
+        return asyncio.iscoroutinefunction(obj.__func__)
     return asyncio.iscoroutinefunction(obj) or inspect.isawaitable(obj)
 
 

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -19,6 +19,14 @@ class AsyncClass:
     def normal_method(self):
         pass
 
+    @classmethod
+    async def async_class_method(cls):
+        pass
+
+    @staticmethod
+    async def async_static_method():
+        pass
+
 class AwaitableClass:
     def __await__(self):
         yield
@@ -66,6 +74,20 @@ class AsyncPatchDecoratorTest(unittest.TestCase):
 
     def test_is_AsyncMock_patch(self):
         @patch.object(AsyncClass, 'async_method')
+        def test_async(mock_method):
+            self.assertIsInstance(mock_method, AsyncMock)
+
+        test_async()
+
+    def test_is_AsyncMock_patch_staticmethod(self):
+        @patch.object(AsyncClass, 'async_static_method')
+        def test_async(mock_method):
+            self.assertIsInstance(mock_method, AsyncMock)
+
+        test_async()
+
+    def test_is_AsyncMock_patch_classmethod(self):
+        @patch.object(AsyncClass, 'async_class_method')
         def test_async(mock_method):
             self.assertIsInstance(mock_method, AsyncMock)
 


### PR DESCRIPTION
Essentially, patching a coroutinefunction decorated with `@classmethod` or `@staticmethod` does not currently work correctly. Instead of creating an `AsyncMock()`, `patch()` uses a `Mock()`, which fails when it's awaited on.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39082](https://bugs.python.org/issue39082) -->
https://bugs.python.org/issue39082
<!-- /issue-number -->
