### PR TITLE
bpo-22640: Fix function signature of quiet in docs

### DIFF
--- a/Doc/library/py_compile.rst
+++ b/Doc/library/py_compile.rst
@@ -27,7 +27,7 @@ byte-code cache files in the directory containing the source code.
    Exception raised when an error occurs while attempting to compile the file.
 
 
-.. function:: compile(file, cfile=None, dfile=None, doraise=False, optimize=-1, invalidation_mode=PycInvalidationMode.TIMESTAMP)
+.. function:: compile(file, cfile=None, dfile=None, doraise=False, optimize=-1, invalidation_mode=PycInvalidationMode.TIMESTAMP, quiet=0)
 
    Compile a source file to byte-code and write out the byte-code cache file.
    The source code is loaded from the file named *file*.  The byte-code is


### PR DESCRIPTION
just a trivial fix for the signature, i guess this needs backport to 3.8

<!-- issue-number: [[bpo-22640](https://bugs.python.org/issue22640)](https://bugs.python.org/issue38731) -->
https://bugs.python.org/issue22640
<!-- /issue-number -->
