### PR TITLE
bpo-39136: Fixed typos

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1189,7 +1189,7 @@ It is usually the only Python interpreter in a process.  Unlike sub-interpreters
 the main interpreter has unique process-global responsibilities like signal
 handling.  It is also responsible for execution during runtime initialization and
 is usually the active interpreter during runtime finalization.  The
-:c:func:`PyInterpreterState_Main` funtion returns a pointer to its state.
+:c:func:`PyInterpreterState_Main` function returns a pointer to its state.
 
 You can switch between sub-interpreters using the :c:func:`PyThreadState_Swap`
 function. You can create and destroy them using the following functions:

--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -757,7 +757,7 @@ configuration, and then override some parameters::
         PyConfig config;
         PyConfig_InitPythonConfig(&config);
 
-        /* Set the program name before reading the configuraton
+        /* Set the program name before reading the configuration
            (decode byte string from the locale encoding).
 
            Implicitly preinitialize Python. */

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -350,7 +350,7 @@ Accessing attributes of extension types
    .. _pymemberdef-offsets:
 
    Heap allocated types (created using :c:func:`PyType_FromSpec` or similar),
-   ``PyMemberDef`` may contain defintitions for the special members
+   ``PyMemberDef`` may contain definitions for the special members
    ``__dictoffset__`` and ``__weaklistoffset__``, corresponding to
    :c:member:`~PyTypeObject.tp_dictoffset` and
    :c:member:`~PyTypeObject.tp_weaklistoffset` in type objects.

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1019,7 +1019,7 @@ That's a tough one, in general.  First, here are a list of things to
 remember before diving further:
 
 * Performance characteristics vary across Python implementations.  This FAQ
-  focusses on :term:`CPython`.
+  focuses on :term:`CPython`.
 * Behaviour can vary across operating systems, especially when talking about
   I/O or multi-threading.
 * You should always find the hot spots in your program *before* attempting to

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -168,7 +168,7 @@ and classes for traversing abstract syntax trees:
    back with :func:`ast.parse`.
 
    .. warning::
-      The produced code string will not necesarily be equal to the original
+      The produced code string will not necessarily be equal to the original
       code that generated the :class:`ast.AST` object.
 
    .. versionadded:: 3.9

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -1577,7 +1577,7 @@ script execution tests.
 The :mod:`test.support.bytecode_helper` module provides support for testing
 and inspecting bytecode generation.
 
-The module defines the follwing class:
+The module defines the following class:
 
 .. class:: BytecodeTestCase(unittest.TestCase)
 

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -6,7 +6,7 @@ Released on 2020-10-05?
 bpo-38943: Fix autocomplete windows not always appearing on some
 systems.  Patch by Johnny Najera.
 
-bpo-38944: Excape key now closes IDLE completion windows.  Patch by
+bpo-38944: Escape key now closes IDLE completion windows.  Patch by
 Johnny Najera.
 
 bpo-38862: 'Strip Trailing Whitespace' on the Format menu removes extra

--- a/Lib/tkinter/tix.py
+++ b/Lib/tkinter/tix.py
@@ -1890,7 +1890,7 @@ class Grid(TixWidget, XView, YView):
         containing the current size setting of the given column.  When
         option-value pairs are given, the corresponding options of the
         size setting of the given column are changed. Options may be one
-        of the follwing:
+        of the following:
               pad0 pixels
                      Specifies the paddings to the left of a column.
               pad1 pixels
@@ -1915,7 +1915,7 @@ class Grid(TixWidget, XView, YView):
         When no option-value pair is given, this command returns a list con-
         taining the current size setting of the given row . When option-value
         pairs are given, the corresponding options of the size setting of the
-        given row are changed. Options may be one of the follwing:
+        given row are changed. Options may be one of the following:
               pad0 pixels
                      Specifies the paddings to the top of a row.
               pad1 pixels

--- a/Misc/NEWS.d/3.9.0a2.rst
+++ b/Misc/NEWS.d/3.9.0a2.rst
@@ -69,7 +69,7 @@ the "elif" keyword and not to its condition, making it consistent with the
 .. nonce: 8OyT5P
 .. section: Core and Builtins
 
-In Python 3.9.0a1, sys.argv[0] was made an asolute path if a filename was
+In Python 3.9.0a1, sys.argv[0] was made an absolute path if a filename was
 specified on the command line. Revert this change, since most users expect
 sys.argv to be unmodified.
 
@@ -516,7 +516,7 @@ from a coroutine.
 .. section: Library
 
 AsyncMock fix for return values that are awaitable types.  This also covers
-side_effect iterable values that happend to be awaitable, and wraps
+side_effect iterable values that happened to be awaitable, and wraps
 callables that return an awaitable type. Before these awaitables were being
 awaited instead of being returned as is.
 
@@ -893,7 +893,7 @@ previous `import posix`. Patch by Benoît Hudson.
 .. nonce: _3xjKG
 .. section: IDLE
 
-Excape key now closes IDLE completion windows.  Patch by Johnny Najera.
+Escape key now closes IDLE completion windows.  Patch by Johnny Najera.
 
 ..
 


### PR DESCRIPTION
Fixed the following typos:
function -> function in Doc/c-api/init.rst 
configuraton -> configuration in Doc/c-api/init_config.rst
defintitions -> defintitions in Doc/c-api/structures.rst
focusses  -> focuses in Doc/faq/programming.rst
necesarily -> necessarily  in Doc/library/ast.rst
follwing -> following in Doc/library/test.rst
Excape -> Escape in Lib/idlelib/NEWS.txt
follwing -> following in Lib/tkinter/tix.py
asolute -> absolute, happend -> happened,  Excape -> Escape in Misc/NEWS.d/3.9.0a2.rst


<!-- issue-number: [bpo-39136](https://bugs.python.org/issue39136) -->
https://bugs.python.org/issue39136
<!-- /issue-number -->
