### PR TITLE
Do not fail the coverage test if fail to update results

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,8 +64,8 @@ jobs:
         || true
     - name: 'Publish code coverage results'
       run: |
-        ./.venv/bin/python -m coverage xml
-        bash <(curl -s https://codecov.io/bash)
+        ./.venv/bin/python -m coverage xml || true
+        bash <(curl -s https://codecov.io/bash) || true
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Some times the Coverage test fails due to no coverage data to upload due to the test suite failing:

```
  Publish code coverage results0s
##[error]Process completed with exit code 1.
Run ./.venv/bin/python -m coverage xml
  ./.venv/bin/python -m coverage xml
  bash <(curl -s https://codecov.io/bash)
  shell: /bin/bash -e {0}
  env:
    OPENSSL_VER: 1.1.1d
    CODECOV_TOKEN: ***
No data to report.
##[error]Process completed with exit code 1.
```

This is the only sub-step that fails and is very noisy as github sends emails post-merge about this.