### PR TITLE
[2.7] bpo-39146: Fix memory consumption in re.compile unicode

### DIFF
--- a/Lib/sre_compile.py
+++ b/Lib/sre_compile.py
@@ -271,7 +271,7 @@ def _optimize_charset(charset, fixup, fixes, isunicode):
                     else:
                         charmap[av] = 1
                 elif op is RANGE:
-                    r = range(av[0], av[1]+1)
+                    r = xrange(av[0], av[1]+1)
                     if fixup:
                         r = map(fixup, r)
                     if fixup and fixes:

--- a/Misc/NEWS.d/next/Library/2019-12-30-09-31-47.bpo-39146.bptLIc.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-30-09-31-47.bpo-39146.bptLIc.rst
@@ -1,0 +1,1 @@
+Fix memory consumption in re.compile unicode


### PR DESCRIPTION
use xrange instead of range

Signed-off-by: Zhipeng Xie <xiezhipeng1@huawei.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39146](https://bugs.python.org/issue39146) -->
https://bugs.python.org/issue39146
<!-- /issue-number -->
