### PR TITLE
bpo-38588: Fix possible crashes in dict and list when calling PyObject_RichCompareBool

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1237,6 +1237,16 @@ class DictTest(unittest.TestCase):
         dict_b = {X(): X()}
         self.assertTrue(dict_a == dict_b)
 
+        # test fix for seg fault reported in issue 38588 part 1.
+        class Y:
+            def __eq__(self, other):
+                dict_d.clear()
+                return True
+
+        dict_c = {0: Y()}
+        dict_d = {0: set()}
+        self.assertTrue(dict_c == dict_d)
+
     def test_fromkeys_operator_modifying_dict_operand(self):
         # test fix for seg fault reported in issue 27945 part 4a.
         class X(int):

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1221,7 +1221,7 @@ class DictTest(unittest.TestCase):
         support.check_free_after_iterating(self, lambda d: iter(d.items()), dict)
 
     def test_equal_operator_modifying_operand(self):
-        # test fix for seg fault reported in issue 27945 part 3.
+        # test fix for seg fault reported in bpo-27945 part 3.
         class X():
             def __del__(self):
                 dict_b.clear()
@@ -1237,7 +1237,7 @@ class DictTest(unittest.TestCase):
         dict_b = {X(): X()}
         self.assertTrue(dict_a == dict_b)
 
-        # test fix for seg fault reported in issue 38588 part 1.
+        # test fix for seg fault reported in bpo-38588 part 1.
         class Y:
             def __eq__(self, other):
                 dict_d.clear()

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -163,6 +163,30 @@ class ListTest(list_tests.CommonTest):
         with self.assertRaises(TypeError):
             (3,) + L([1,2])
 
+    def test_equal_operator_modifying_operand(self):
+        class X:
+            def __eq__(self,other) :
+                list2.clear()
+                return NotImplemented
+
+        class Y:
+            def __eq__(self, other):
+                list1.clear()
+                return NotImplemented
+
+        class Z:
+            def __eq__(self, other):
+                list3.clear()
+                return NotImplemented
+
+        list1 = [X()]
+        list2 = [Y()]
+        self.assertTrue(list1 == list2)
+
+        list3 = [Z()]
+        list4 = [1]
+        self.assertFalse(list3 == list4)
+
     @cpython_only
     def test_preallocation(self):
         iterable = [0] * 10

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -164,6 +164,7 @@ class ListTest(list_tests.CommonTest):
             (3,) + L([1,2])
 
     def test_equal_operator_modifying_operand(self):
+        # test fix for seg fault reported in issue 38588 part 2.
         class X:
             def __eq__(self,other) :
                 list2.clear()

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -164,7 +164,7 @@ class ListTest(list_tests.CommonTest):
             (3,) + L([1,2])
 
     def test_equal_operator_modifying_operand(self):
-        # test fix for seg fault reported in issue 38588 part 2.
+        # test fix for seg fault reported in bpo-38588 part 2.
         class X:
             def __eq__(self,other) :
                 list2.clear()

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-29-19-13-54.bpo-38588.pgXnNS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-29-19-13-54.bpo-38588.pgXnNS.rst
@@ -1,1 +1,2 @@
-Fix the segfault when dict comparision with modifying operand.
+Fix possible crashes in dict and list when calling
+:c:func:`PyObject_RichCompareBool`.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-29-19-13-54.bpo-38588.pgXnNS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-29-19-13-54.bpo-38588.pgXnNS.rst
@@ -1,0 +1,1 @@
+Fix the segfault when dict comparision with modifying operand.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2777,9 +2777,11 @@ dict_equal(PyDictObject *a, PyDictObject *b)
                     return -1;
                 return 0;
             }
+            Py_INCREF(bval);
             cmp = PyObject_RichCompareBool(aval, bval, Py_EQ);
             Py_DECREF(key);
             Py_DECREF(aval);
+            Py_DECREF(bval);
             if (cmp <= 0)  /* error or not equal */
                 return cmp;
         }

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2653,8 +2653,15 @@ list_richcompare(PyObject *v, PyObject *w, int op)
 
     /* Search for the first index where items are different */
     for (i = 0; i < Py_SIZE(vl) && i < Py_SIZE(wl); i++) {
+        PyObject *vitem = vl->ob_item[i];
+        PyObject *witem = wl->ob_item[i];
+
+        Py_INCREF(vitem);
+        Py_INCREF(witem);
         int k = PyObject_RichCompareBool(vl->ob_item[i],
                                          wl->ob_item[i], Py_EQ);
+        Py_DECREF(vitem);
+        Py_DECREF(witem);
         if (k < 0)
             return NULL;
         if (!k)


### PR DESCRIPTION
Based on LCatro's report

<!-- issue-number: [bpo-38588](https://bugs.python.org/issue38588) -->
https://bugs.python.org/issue38588
<!-- /issue-number -->
