### PR TITLE
[issue39165][bpo-39165][Lib/re] implement findalliter() and findfirst()

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-12-30-09-28-18.bpo-39165.PDwctF.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-30-09-28-18.bpo-39165.PDwctF.rst
@@ -1,0 +1,6 @@
+Added ``findalliter(pattern, string, flags=0)`` which returns an iterator
+over values like those returned by ``findall(pattern, string, flags=0)``.
+
+Added ``findfirst(pattern, string, flags=0, default=_undefined)`` which
+returns the first value from ``findalliter()``, and returns ``default`` when
+supplied, or raises ``ValueError`` when there are no matches.


### PR DESCRIPTION

* Implement `findfirst()` in terms of `first()` and `findalliter()`. 
* Reimplement `findall(...)` as `return list(findalliter(...))`

<!-- issue-number: [bpo-39165](https://bugs.python.org/issue39165) -->
https://bugs.python.org/issue39165
<!-- /issue-number -->
