### PR TITLE
bpo-39189: Uses the io.DEFAULT_BUFFER_SIZE variable instead of defining it again

### DIFF
--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -12,13 +12,12 @@ Functions:
 
 import os
 import stat
-from io import DEFAULT_BUFFER_SIZE
+from io import DEFAULT_BUFFER_SIZE as BUFSIZE
 from itertools import filterfalse
 
 __all__ = ['clear_cache', 'cmp', 'dircmp', 'cmpfiles', 'DEFAULT_IGNORES']
 
 _cache = {}
-BUFSIZE = DEFAULT_BUFFER_SIZE
 
 DEFAULT_IGNORES = [
     'RCS', 'CVS', 'tags', '.git', '.hg', '.bzr', '_darcs', '__pycache__']

--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -12,12 +12,12 @@ Functions:
 
 import os
 import stat
+from io import DEFAULT_BUFFER_SIZE
 from itertools import filterfalse
 
 __all__ = ['clear_cache', 'cmp', 'dircmp', 'cmpfiles', 'DEFAULT_IGNORES']
 
 _cache = {}
-BUFSIZE = 8*1024
 
 DEFAULT_IGNORES = [
     'RCS', 'CVS', 'tags', '.git', '.hg', '.bzr', '_darcs', '__pycache__']
@@ -71,7 +71,7 @@ def _sig(st):
             st.st_mtime)
 
 def _do_cmp(f1, f2):
-    bufsize = BUFSIZE
+    bufsize = DEFAULT_BUFFER_SIZE
     with open(f1, 'rb') as fp1, open(f2, 'rb') as fp2:
         while True:
             b1 = fp1.read(bufsize)

--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -18,6 +18,7 @@ from itertools import filterfalse
 __all__ = ['clear_cache', 'cmp', 'dircmp', 'cmpfiles', 'DEFAULT_IGNORES']
 
 _cache = {}
+BUFSIZE = DEFAULT_BUFFER_SIZE
 
 DEFAULT_IGNORES = [
     'RCS', 'CVS', 'tags', '.git', '.hg', '.bzr', '_darcs', '__pycache__']
@@ -71,7 +72,7 @@ def _sig(st):
             st.st_mtime)
 
 def _do_cmp(f1, f2):
-    bufsize = DEFAULT_BUFFER_SIZE
+    bufsize = BUFSIZE
     with open(f1, 'rb') as fp1, open(f2, 'rb') as fp2:
         while True:
             b1 = fp1.read(bufsize)


### PR DESCRIPTION
Hello there,

This Pull Request replaces the BUFSIZE variable with the existing one inside the `io` module.

Explanation:

I just removed the BUFSIZE global variable and replaced it with the io.DEFAULT_BUFFER_SIZE variable.

I couldn't find an open issue for this, but I do believe it does not need one, as it is a trivial issue!

I checked other branches, this problem affects below branches as well.

- [Python 2.7 Lib.py file](https://github.com/python/cpython/blob/2.7/Lib/filecmp.py)
- [Python 3.5 Lib.py file](https://github.com/python/cpython/blob/3.5/Lib/filecmp.py)
- [Python 3.6 Lib.py file](https://github.com/python/cpython/blob/3.6/Lib/filecmp.py)
- [Python 3.7 Lib.py file](https://github.com/python/cpython/blob/3.7/Lib/filecmp.py)
- [Python 3.8 Lib.py file](https://github.com/python/cpython/blob/3.8/Lib/filecmp.py)

<!-- issue-number: [bpo-39189](https://bugs.python.org/issue39189) -->
https://bugs.python.org/issue39189
<!-- /issue-number -->
