### PR TITLE
bpo-38870: Fix error when running with -uall in test_unparse

### DIFF
--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -303,17 +303,17 @@ class DirectoryTestCase(ASTTestCase):
             if not item.name.startswith("bad")
         ]
 
-        tests_to_run_always = {item for item in items if
-                               item.name in cls.run_always_files}
-
         # Test limited subset of files unless the 'cpu' resource is specified.
         if not test.support.is_resource_enabled("cpu"):
+
+            tests_to_run_always = {item for item in items if
+                                   item.name in cls.run_always_files}
+
             items = set(random.sample(items, 10))
 
-        # Make sure that at least tests that heavily use grammar features are
-        # considered to reduce the change of missing something.
-
-        items = list(items | tests_to_run_always)
+            # Make sure that at least tests that heavily use grammar features are
+            # always considered in order to reduce the chance of missing something.
+            items = list(items | tests_to_run_always)
 
         # bpo-31174: Store the names sample to always test the same files.
         # It prevents false alarms when hunting reference leaks.


### PR DESCRIPTION


<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->
