### PR TITLE
bpo-39157: Skip test_pidfd_send_signal if the system does not have enough privileges to use pidfd

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1284,6 +1284,8 @@ class PidfdSignalTest(unittest.TestCase):
             signal.pidfd_send_signal(0, signal.SIGINT)
         if cm.exception.errno == errno.ENOSYS:
             self.skipTest("kernel does not support pidfds")
+        elif cm.exception.errno == errno.EPERM:
+            self.skipTest("Not enough privileges to use pidfs")
         self.assertEqual(cm.exception.errno, errno.EBADF)
         my_pidfd = os.open(f'/proc/{os.getpid()}', os.O_DIRECTORY)
         self.addCleanup(os.close, my_pidfd)


### PR DESCRIPTION


<!-- issue-number: [bpo-39157](https://bugs.python.org/issue39157) -->
https://bugs.python.org/issue39157
<!-- /issue-number -->
