### PR TITLE
bpo-39158: ast.literal_eval() doesn't support empty sets

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -194,6 +194,9 @@ and classes for traversing abstract syntax trees:
    .. versionchanged:: 3.2
       Now allows bytes and set literals.
 
+   .. versionchanged:: 3.9
+      Now supports creating empty sets with ``'set()'``.
+
 
 .. function:: get_docstring(node, clean=True)
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -82,6 +82,9 @@ def literal_eval(node_or_string):
             return list(map(_convert, node.elts))
         elif isinstance(node, Set):
             return set(map(_convert, node.elts))
+        elif (isinstance(node, Call) and isinstance(node.func, Name) and
+              node.func.id == 'set' and node.args == node.keywords == []):
+            return set()
         elif isinstance(node, Dict):
             return dict(zip(map(_convert, node.keys),
                             map(_convert, node.values)))

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -891,6 +891,7 @@ Module(
         self.assertEqual(ast.literal_eval('(True, False, None)'), (True, False, None))
         self.assertEqual(ast.literal_eval('{1, 2, 3}'), {1, 2, 3})
         self.assertEqual(ast.literal_eval('b"hi"'), b"hi")
+        self.assertEqual(ast.literal_eval('set()'), set())
         self.assertRaises(ValueError, ast.literal_eval, 'foo()')
         self.assertEqual(ast.literal_eval('6'), 6)
         self.assertEqual(ast.literal_eval('+6'), 6)

--- a/Misc/NEWS.d/next/Library/2019-12-29-15-44-38.bpo-39158.cxVoOR.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-29-15-44-38.bpo-39158.cxVoOR.rst
@@ -1,0 +1,1 @@
+ast.literal_eval() now supports empty sets.


### PR DESCRIPTION


<!-- issue-number: [bpo-39158](https://bugs.python.org/issue39158) -->
https://bugs.python.org/issue39158
<!-- /issue-number -->
