### PR TITLE
bpo-39164: errors: add and expose _PyErr_GetExcInfo

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -76,6 +76,7 @@ typedef PyOSErrorObject PyWindowsErrorObject;
 
 PyAPI_FUNC(void) _PyErr_SetKeyError(PyObject *);
 _PyErr_StackItem *_PyErr_GetTopmostException(PyThreadState *tstate);
+PyAPI_FUNC(void) _PyErr_GetExcInfo(PyThreadState *, PyObject **, PyObject **, PyObject **);
 
 /* Context manipulation (PEP 3134) */
 

--- a/Misc/NEWS.d/next/C API/2019-12-30-10-43-52.bpo-39164.WEV0uu.rst
+++ b/Misc/NEWS.d/next/C API/2019-12-30-10-43-52.bpo-39164.WEV0uu.rst
@@ -1,0 +1,1 @@
+Add a private ``_PyErr_GetExcInfo()`` function to retrieve exception information of the specified Python thread state.

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -433,19 +433,25 @@ PyErr_Clear(void)
 
 
 void
-PyErr_GetExcInfo(PyObject **p_type, PyObject **p_value, PyObject **p_traceback)
+_PyErr_GetExcInfo(PyThreadState *tstate,
+                  PyObject **p_type, PyObject **p_value, PyObject **p_traceback)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-
     _PyErr_StackItem *exc_info = _PyErr_GetTopmostException(tstate);
     *p_type = exc_info->exc_type;
     *p_value = exc_info->exc_value;
     *p_traceback = exc_info->exc_traceback;
 
-
     Py_XINCREF(*p_type);
     Py_XINCREF(*p_value);
     Py_XINCREF(*p_traceback);
+}
+
+
+void
+PyErr_GetExcInfo(PyObject **p_type, PyObject **p_value, PyObject **p_traceback)
+{
+    PyThreadState *tstate = _PyThreadState_GET();
+    return _PyErr_GetExcInfo(tstate, p_type, p_value, p_traceback);
 }
 
 void


### PR DESCRIPTION
This adds a new function named _PyErr_GetExcInfo that is a variation of the
original PyErr_GetExcInfo taking a PyThreadState as its first argument.
That function allows to retrieve the exceptions information of any Python
thread — not only the current one.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39164](https://bugs.python.org/issue39164) -->
https://bugs.python.org/issue39164
<!-- /issue-number -->
