### PR TITLE
Simplify control flow when exiting the interpreter.

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -434,42 +434,6 @@ if check_impl_detail(cpython=True) and ctypes is not None:
             tt.join()
             self.assertEqual(LAST_FREED, 500)
 
-        @cpython_only
-        def test_clean_stack_on_return(self):
-
-            def f(x):
-                return x
-
-            code = f.__code__
-            ct = type(f.__code__)
-
-            # Insert an extra LOAD_FAST, this duplicates the value of
-            # 'x' in the stack, leaking it if the frame is not properly
-            # cleaned up upon exit.
-
-            bytecode = list(code.co_code)
-            bytecode.insert(-2, opcode.opmap['LOAD_FAST'])
-            bytecode.insert(-2, 0)
-
-            c = ct(code.co_argcount, code.co_posonlyargcount,
-                   code.co_kwonlyargcount, code.co_nlocals, code.co_stacksize+1,
-                   code.co_flags, bytes(bytecode),
-                   code.co_consts, code.co_names, code.co_varnames,
-                   code.co_filename, code.co_name, code.co_firstlineno,
-                   code.co_lnotab, code.co_freevars, code.co_cellvars)
-            new_function = type(f)(c, f.__globals__, 'nf', f.__defaults__, f.__closure__)
-
-            class Var:
-                pass
-            the_object = Var()
-            var = weakref.ref(the_object)
-
-            new_function(the_object)
-
-            # Check if the_object is leaked
-            del the_object
-            assert var() is None
-
 
 def test_main(verbose=None):
     from test import test_code

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1913,7 +1913,8 @@ main_loop:
         case TARGET(RETURN_VALUE): {
             retval = POP();
             assert(f->f_iblock == 0);
-            goto exit_returning;
+            assert(EMPTY());
+            goto exiting;
         }
 
         case TARGET(GET_AITER): {
@@ -2083,7 +2084,7 @@ main_loop:
             /* and repeat... */
             assert(f->f_lasti >= (int)sizeof(_Py_CODEUNIT));
             f->f_lasti -= sizeof(_Py_CODEUNIT);
-            goto exit_yielding;
+            goto exiting;
         }
 
         case TARGET(YIELD_VALUE): {
@@ -2100,7 +2101,7 @@ main_loop:
             }
 
             f->f_stacktop = stack_pointer;
-            goto exit_yielding;
+            goto exiting;
         }
 
         case TARGET(POP_EXCEPT): {
@@ -3626,15 +3627,13 @@ exception_unwind:
     assert(retval == NULL);
     assert(_PyErr_Occurred(tstate));
 
-exit_returning:
-
     /* Pop remaining stack entries. */
     while (!EMPTY()) {
         PyObject *o = POP();
         Py_XDECREF(o);
     }
 
-exit_yielding:
+exiting:
     if (tstate->use_tracing) {
         if (tstate->c_tracefunc) {
             if (call_trace_protected(tstate->c_tracefunc, tstate->c_traceobj,


### PR DESCRIPTION
Skip the stack emptying step for RETURN_VALUE, as the compiler now ensures that the stack is empty.

Remove test that generates invalid bytecode.
Maybe we should have a bytecode verifier, but that's not the job of the interpreter.

No change in behaviour, so no news or BPO issue needed.