### PR TITLE
 bpo-34118: memoryview, range, and tuple are classes 

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -952,7 +952,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. _func-memoryview:
-.. function:: memoryview(obj)
+.. class:: memoryview(obj)
    :noindex:
 
    Return a "memory view" object created from the given argument.  See
@@ -1408,7 +1408,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. _func-range:
-.. function:: range(stop)
+.. class:: range(stop)
               range(start, stop[, step])
    :noindex:
 
@@ -1655,7 +1655,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. _func-tuple:
-.. function:: tuple([iterable])
+.. class:: tuple([iterable])
    :noindex:
 
    Rather than being a function, :class:`tuple` is actually an immutable

--- a/Misc/NEWS.d/next/IDLE/2019-12-30-16-44-07.bpo-34118.FaNW0a.rst
+++ b/Misc/NEWS.d/next/IDLE/2019-12-30-16-44-07.bpo-34118.FaNW0a.rst
@@ -1,0 +1,2 @@
+Tag memoryview, range, and tuple as classes, the same as list, etcetera, in
+the library manual built-in functions list.


### PR DESCRIPTION
Tag memoryview, range, and tuple as classes, the same as list, etcetera, in
the library manual built-in functions list.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34118](https://bugs.python.org/issue34118) -->
https://bugs.python.org/issue34118
<!-- /issue-number -->
