### PR TITLE
bpo-38588: Optimize list comparison.

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2664,6 +2664,9 @@ list_richcompare(PyObject *v, PyObject *w, int op)
     for (i = 0; i < Py_SIZE(vl) && i < Py_SIZE(wl); i++) {
         PyObject *vitem = vl->ob_item[i];
         PyObject *witem = wl->ob_item[i];
+        if (vitem == witem) {
+            continue;
+        }
 
         Py_INCREF(vitem);
         Py_INCREF(witem);


### PR DESCRIPTION
Mitigate performance regression of the list comparison caused by
2d5bf56.

<!-- issue-number: [bpo-38588](https://bugs.python.org/issue38588) -->
https://bugs.python.org/issue38588
<!-- /issue-number -->
