### PR TITLE
bpo-39114: Fix tracing of except handlers with name binding

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -481,6 +481,30 @@ class TraceTestCase(unittest.TestCase):
             [(0, 'call'),
              (1, 'line')])
 
+    def test_18_except_with_name(self):
+        def func():
+            try:
+                try:
+                    raise Exception
+                except Exception as e:
+                    raise
+                    x = "Something"
+                    y = "Something"
+            except Exception:
+                pass
+
+        self.run_and_compare(func,
+            [(0, 'call'),
+             (1, 'line'),
+             (2, 'line'),
+             (3, 'line'),
+             (3, 'exception'),
+             (4, 'line'),
+             (5, 'line'),
+             (8, 'line'),
+             (9, 'line'),
+             (9, 'return')])
+
 
 class SkipLineEventsTraceTestCase(TraceTestCase):
     """Repeat the trace tests, but with per-line events skipped"""

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -505,6 +505,27 @@ class TraceTestCase(unittest.TestCase):
              (9, 'line'),
              (9, 'return')])
 
+    def test_19_except_with_finally(self):
+        def func():
+            try:
+                try:
+                    raise Exception
+                finally:
+                    y = "Something"
+            except Exception:
+                b = 23
+
+        self.run_and_compare(func,
+            [(0, 'call'),
+             (1, 'line'),
+             (2, 'line'),
+             (3, 'line'),
+             (3, 'exception'),
+             (5, 'line'),
+             (6, 'line'),
+             (7, 'line'),
+             (7, 'return')])
+
 
 class SkipLineEventsTraceTestCase(TraceTestCase):
     """Repeat the trace tests, but with per-line events skipped"""

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-31-18-25-45.bpo-39114.WG9alt.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-31-18-25-45.bpo-39114.WG9alt.rst
@@ -1,0 +1,2 @@
+Fix incorrent line execution reporting in trace functions when tracing
+exception handlers with name binding. Patch by Pablo Galindo.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3611,7 +3611,8 @@ exception_unwind:
                 PUSH(exc);
                 JUMPTO(handler);
                 if (_Py_TracingPossible(ceval) &&
-                    (f->f_lasti < instr_lb || f->f_lasti >= instr_ub)) {
+                    ((f->f_lasti < instr_lb || f->f_lasti >= instr_ub) ||
+                    !(f->f_lasti == instr_lb || f->f_lasti < instr_prev))) {
                     /* Make sure that we trace line after exception */
                     instr_prev = INT_MAX;
                 }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3610,7 +3610,8 @@ exception_unwind:
                 PUSH(val);
                 PUSH(exc);
                 JUMPTO(handler);
-                if (_Py_TracingPossible(ceval)) {
+                if (_Py_TracingPossible(ceval) &&
+                    (f->f_lasti < instr_lb || f->f_lasti >= instr_ub)) {
                     /* Make sure that we trace line after exception */
                     instr_prev = INT_MAX;
                 }


### PR DESCRIPTION


<!-- issue-number: [bpo-39114](https://bugs.python.org/issue39114) -->
https://bugs.python.org/issue39114
<!-- /issue-number -->
