### PR TITLE
[2.7] bpo-27973 - urlretrive fails on second ftp transfer.

### DIFF
--- a/Lib/test/test_urllibnet.py
+++ b/Lib/test/test_urllibnet.py
@@ -1,4 +1,3 @@
-import tempfile
 import unittest
 from test import test_support
 from test.test_urllib2net import skip_ftp_test_on_travis
@@ -224,9 +223,10 @@ class urlopen_FTPTest(unittest.TestCase):
 
         with test_support.transient_internet(self.FTP_TEST_FILE):
             try:
-                for _ in range(self.NUM_FTP_RETRIEVES):
-                    with tempfile.NamedTemporaryFile() as fp:
-                        urllib.FancyURLopener().retrieve(self.FTP_TEST_FILE, fp.name)
+                for file_num in range(self.NUM_FTP_RETRIEVES):
+                    with test_support.temp_dir() as td:
+                        urllib.FancyURLopener().retrieve(self.FTP_TEST_FILE,
+                                                         os.path.join(td, str(file_num)))
             except IOError as e:
                 self.fail("Failed FTP retrieve while accessing ftp url "
                           "multiple times.\n Error message was : %s" % e)


### PR DESCRIPTION
Fix the permission denied errors on Windows.

This is a fix for the permission denied error observed on windows buildbots.

```
Tests result: FAILURE then FAILURE
test test_urllibnet failed -- Traceback (most recent call last):
  File "D:\cygwin\home\db3l\buildarea\2.7.bolen-windows7\build\lib\test\test_urllibnet.py", line 232, in test_multiple_ftp_retrieves
    "multiple times.\n Error message was : %s" % e)
AssertionError: Failed FTP retrieve while accessing ftp url multiple times.
 Error message was : [Errno 13] Permission denied: 'd:\\temp\\tmpiuquqa'
Example failure:

https://buildbot.python.org/all/#/builders/209/builds/4
```

<!-- issue-number: [bpo-27973](https://bugs.python.org/issue27973) -->
https://bugs.python.org/issue27973
<!-- /issue-number -->
