### PR TITLE
bpo-39171: Missing root in tkinter simpledialog.py _QueryDialog

### DIFF
--- a/Lib/tkinter/simpledialog.py
+++ b/Lib/tkinter/simpledialog.py
@@ -260,7 +260,15 @@ class _QueryDialog(Dialog):
                  parent = None):
 
         if not parent:
-            parent = tkinter._default_root
+            if tkinter._default_root:
+                parent = tkinter._default_root
+            elif tkinter._support_default_root:
+                parent = tkinter.Tk()
+                parent.withdraw()
+            else:
+                raise RuntimeError(
+                    "No parent specified and tkinter is "
+                    "configured to not support default root")
 
         self.prompt   = prompt
         self.minvalue = minvalue

--- a/Misc/NEWS.d/next/Core and Builtins/2019-12-31-19-06-02.bpo-39171.cmXDsX.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-12-31-19-06-02.bpo-39171.cmXDsX.rst
@@ -1,0 +1,1 @@
+Creating missing parent in tkinter simpledialog when possible.


### PR DESCRIPTION
My first pull request. I hope this will be obviously linked to https://bugs.python.org/issue39171. 

<!-- issue-number: [bpo-39171](https://bugs.python.org/issue39171) -->
https://bugs.python.org/issue39171
<!-- /issue-number -->
