### PR TITLE
bpo-39176: Fix wrong term 'named assignment'

### DIFF
--- a/Lib/test/test_named_expressions.py
+++ b/Lib/test/test_named_expressions.py
@@ -32,7 +32,7 @@ class NamedExpressionInvalidTest(unittest.TestCase):
     def test_named_expression_invalid_06(self):
         code = """((a, b) := (1, 2))"""
 
-        with self.assertRaisesRegex(SyntaxError, "cannot use named assignment with tuple"):
+        with self.assertRaisesRegex(SyntaxError, "cannot use assignment expressions with tuple"):
             exec(code, {}, {})
 
     def test_named_expression_invalid_07(self):
@@ -90,7 +90,7 @@ class NamedExpressionInvalidTest(unittest.TestCase):
         code = """(lambda: x := 1)"""
 
         with self.assertRaisesRegex(SyntaxError,
-            "cannot use named assignment with lambda"):
+            "cannot use assignment expressions with lambda"):
             exec(code, {}, {})
 
     def test_named_expression_invalid_16(self):

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -45,7 +45,7 @@ SyntaxError: cannot assign to True
 
 >>> (True := 1)
 Traceback (most recent call last):
-SyntaxError: cannot use named assignment with True
+SyntaxError: cannot use assignment expressions with True
 
 >>> obj.__debug__ = 1
 Traceback (most recent call last):

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -1955,7 +1955,7 @@ ast_for_namedexpr(struct compiling *c, const node *n)
     if (target->kind != Name_kind) {
         const char *expr_name = get_expr_name(target);
         if (expr_name != NULL) {
-            ast_error(c, n, "cannot use named assignment with %s", expr_name);
+            ast_error(c, n, "cannot use assignment expressions with %s", expr_name);
         }
         return NULL;
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-39176](https://bugs.python.org/issue39176) -->
https://bugs.python.org/issue39176
<!-- /issue-number -->
