### PR TITLE
bpo-38871: Fix lib2to3 to be able to use in edge cases of filter

### DIFF
--- a/Lib/lib2to3/fixes/fix_filter.py
+++ b/Lib/lib2to3/fixes/fix_filter.py
@@ -17,7 +17,7 @@ Python 2.6 figure it out.
 from .. import fixer_base
 from ..pytree import Node
 from ..pygram import python_symbols as syms
-from ..fixer_util import Name, ArgList, ListComp, in_special_context
+from ..fixer_util import Name, ArgList, ListComp, in_special_context, parenthesize
 
 
 class FixFilter(fixer_base.ConditionalFix):
@@ -65,10 +65,14 @@ class FixFilter(fixer_base.ConditionalFix):
                 trailers.append(t.clone())
 
         if "filter_lambda" in results:
+            xp = results.get("xp").clone()
+            if xp.type == syms.test:
+                xp.prefix = ""
+                xp = parenthesize(xp)
+
             new = ListComp(results.get("fp").clone(),
                            results.get("fp").clone(),
-                           results.get("it").clone(),
-                           results.get("xp").clone())
+                           results.get("it").clone(), xp)
             new = Node(syms.power, [new] + trailers, prefix="")
 
         elif "none" in results:

--- a/Lib/lib2to3/tests/test_fixers.py
+++ b/Lib/lib2to3/tests/test_fixers.py
@@ -2954,6 +2954,11 @@ class Test_filter(FixerTestCase):
         a = """x = [x for x in range(10) if x%2 == 0]"""
         self.check(b, a)
 
+        # bpo-38871
+        b = """filter(lambda x: True if x > 2 else False, [1, 2, 3])"""
+        a = """[x for x in [1, 2, 3] if (True if x > 2 else False)]"""
+        self.check(b, a)
+
     def test_filter_trailers(self):
         b = """x = filter(None, 'abc')[0]"""
         a = """x = [_f for _f in 'abc' if _f][0]"""

--- a/Misc/NEWS.d/next/Library/2020-01-01-18-44-52.bpo-38871.3EEOLg.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-01-18-44-52.bpo-38871.3EEOLg.rst
@@ -1,1 +1,3 @@
-Fix :mod:`lib2to3` to be able to use in edge cases when handling filter
+Updated the logic of :mod:`lib2to3` when handling filter based statement
+with lambda expression is needed to be parenthesized.
+Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Library/2020-01-01-18-44-52.bpo-38871.3EEOLg.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-01-18-44-52.bpo-38871.3EEOLg.rst
@@ -1,0 +1,1 @@
+Fix :mod:`lib2to3` to be able to use in edge cases when handling filter

--- a/Misc/NEWS.d/next/Library/2020-01-01-18-44-52.bpo-38871.3EEOLg.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-01-18-44-52.bpo-38871.3EEOLg.rst
@@ -1,3 +1,2 @@
-Updated the logic of :mod:`lib2to3` when handling filter based statement
-with lambda expression is needed to be parenthesized.
-Patch by Dong-hee Na.
+Correctly parenthesize filter-based statements that contain lambda
+expressions in mod:`lib2to3`. Patch by Dong-hee Na.


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38871](https://bugs.python.org/issue38871) -->
https://bugs.python.org/issue38871
<!-- /issue-number -->
