### PR TITLE
bpo-35561: Fix valgrind warnings in selectmodule.c

### DIFF
--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1426,7 +1426,7 @@ select_epoll_fromfd_impl(PyTypeObject *type, int fd)
 static PyObject *
 pyepoll_internal_ctl(int epfd, int op, int fd, unsigned int events)
 {
-    struct epoll_event ev;
+    struct epoll_event ev = {0};
     int result;
 
     if (epfd < 0)


### PR DESCRIPTION


<!-- issue-number: [bpo-35561](https://bugs.python.org/issue35561) -->
https://bugs.python.org/issue35561
<!-- /issue-number -->
