### PR TITLE
bpo-39180: Added getlines function to docs for linecache module

### DIFF
--- a/Doc/library/linecache.rst
+++ b/Doc/library/linecache.rst
@@ -41,9 +41,10 @@ The :mod:`linecache` module defines the following functions:
 
 .. function:: getlines(filename, module_globals=None)
 
-   Get all lines from file named *filename*. If the file was previously cached then return from cache
-   else cache first and then return all lines. *filename* and *module_globals* behaves similar to
-   explanation in :func:`getline` sister function.
+   Get all lines from file named *filename*. If the file was previously cached
+   then return from cache else cache first and then return all lines. *filename*
+   and *module_globals* behaves similar to explanation in :func:`getline` sister
+   function.
 
 
 .. function:: clearcache()

--- a/Doc/library/linecache.rst
+++ b/Doc/library/linecache.rst
@@ -39,6 +39,13 @@ The :mod:`linecache` module defines the following functions:
    it is looked up relative to the entries in the module search path, ``sys.path``.
 
 
+.. function:: getlines(filename, module_globals=None)
+
+   Get all lines from file named *filename*. If the file was previously cached then return from cache
+   else cache first and then return all lines. *filename* and *module_globals* behaves similar to
+   explanation in :func:`getline` sister function.
+
+
 .. function:: clearcache()
 
    Clear the cache.  Use this function if you no longer need lines from files


### PR DESCRIPTION
getlines - function is missing from the documentation although it is publicly available function in the source code.

<!-- issue-number: [bpo-39180](https://bugs.python.org/issue39180) -->
https://bugs.python.org/issue39180
<!-- /issue-number -->
