### PR TITLE
bpo-39183: Fix formatting in library/ensurepip

### DIFF
--- a/Doc/library/ensurepip.rst
+++ b/Doc/library/ensurepip.rst
@@ -74,7 +74,7 @@ options:
   script will *not* be installed.
 
 * ``--default-pip``: if a "default pip" installation is requested, the
-   ``pip`` script will be installed in addition to the two regular scripts.
+  ``pip`` script will be installed in addition to the two regular scripts.
 
 Providing both of the script selection options will trigger an exception.
 


### PR DESCRIPTION
Remove extra space to fix formatting and avoid from splitting text in to strings.

<!-- issue-number: [bpo-39183](https://bugs.python.org/issue39183) -->
https://bugs.python.org/issue39183
<!-- /issue-number -->


Automerge-Triggered-By: @alex