### PR TITLE
bpo-15795: Preserve permissions on UNIX (based/like) systems

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-03-03-13-50-37.bpo-15795.qQkxN0.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-03-13-50-37.bpo-15795.qQkxN0.rst
@@ -1,0 +1,1 @@
+Preserve permissions when extracting zip files on POSIX systems. Only do so if the zip file was created on a Unix-like system.


### PR DESCRIPTION
The reasoning behind this is that the unzip command (Info-ZIP) on pretty much every unix system will preserve the permissions by default.
The Info-ZIP unzip command is shipped with all currently supported versions of:
- MacOS
- OpenBSD and NetBSD
- Probably every manjor Linux distribution

Here is a list: https://pkgs.org/download/unzip

In this pull request the permissions are only preserved if a zip file is extracted on a posix system and the zipfile was made on a UNIX system. Permissions are also set for directories.

<!-- issue-number: [bpo-15795](https://bugs.python.org/issue15795) -->
https://bugs.python.org/issue15795
<!-- /issue-number -->
