### PR TITLE
bpo-39185 Add the d[etailed] and q[uiet] verbosity levels for msbuild

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-01-02-01-11-53.bpo-39185.T4herN.rst
+++ b/Misc/NEWS.d/next/Windows/2020-01-02-01-11-53.bpo-39185.T4herN.rst
@@ -1,0 +1,1 @@
+The build.bat script has additional options for very-quiet output (-q) and very-verbose output (-vv)

--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -75,8 +75,8 @@ if "%~1"=="-d" (set conf=Debug) & shift & goto CheckOpts
 if "%~1"=="-m" (set parallel=/m) & shift & goto CheckOpts
 if "%~1"=="-M" (set parallel=) & shift & goto CheckOpts
 if "%~1"=="-v" (set verbose=/v:n) & shift & goto CheckOpts
-if "%~1"=="-vv" (set verbose=/v:d) & shift & goto CheckOpts
-if "%~1"=="-q" (set verbose=/v:q) & shift & goto CheckOpts
+if "%~1"=="-vv" (set verbose=/v:d /ds) & shift & goto CheckOpts
+if "%~1"=="-q" (set verbose=/v:q /nologo /clp:summary) & shift & goto CheckOpts
 if "%~1"=="-k" (set kill=true) & shift & goto CheckOpts
 if "%~1"=="--pgo" (set do_pgo=true) & shift & goto CheckOpts
 if "%~1"=="--pgo-job" (set do_pgo=true) & (set pgo_job=%~2) & shift & shift & goto CheckOpts

--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -27,6 +27,8 @@ echo.      building externals.
 echo.  -m  Enable parallel build (enabled by default)
 echo.  -M  Disable parallel build
 echo.  -v  Increased output messages
+echo.  -vv Verbose output messages
+echo.  -q  Quiet output messages (errors and warnings only)
 echo.  -k  Attempt to kill any running Pythons before building (usually done
 echo.      automatically by the pythoncore project)
 echo.  --pgo          Build with Profile-Guided Optimization.  This flag
@@ -73,6 +75,8 @@ if "%~1"=="-d" (set conf=Debug) & shift & goto CheckOpts
 if "%~1"=="-m" (set parallel=/m) & shift & goto CheckOpts
 if "%~1"=="-M" (set parallel=) & shift & goto CheckOpts
 if "%~1"=="-v" (set verbose=/v:n) & shift & goto CheckOpts
+if "%~1"=="-vv" (set verbose=/v:d) & shift & goto CheckOpts
+if "%~1"=="-q" (set verbose=/v:q) & shift & goto CheckOpts
 if "%~1"=="-k" (set kill=true) & shift & goto CheckOpts
 if "%~1"=="--pgo" (set do_pgo=true) & shift & goto CheckOpts
 if "%~1"=="--pgo-job" (set do_pgo=true) & (set pgo_job=%~2) & shift & shift & goto CheckOpts


### PR DESCRIPTION
Add the d[etailed] and q[uiet] verbosity levels for msbuild as options in build.bat

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39185](https://bugs.python.org/issue39185) -->
https://bugs.python.org/issue39185
<!-- /issue-number -->
