### PR TITLE
bpo-38870: Throw ValueError on invalid yield from usage

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -735,10 +735,10 @@ class _Unparser(NodeVisitor):
 
     def visit_YieldFrom(self, node):
         with self.delimit("(", ")"):
-            self.write("yield from")
-            if node.value:
-                self.write(" ")
-                self.traverse(node.value)
+            self.write("yield from ")
+            if not node.value:
+                raise ValueError("Node can't be used without a value attribute.")
+            self.traverse(node.value)
 
     def visit_Raise(self, node):
         self.fill("raise")

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -278,6 +278,8 @@ class UnparseTestCase(ASTTestCase):
     def test_invalid_set(self):
         self.check_invalid(ast.Set(elts=[]))
 
+    def test_invalid_yield_from(self):
+        self.check_invalid(ast.YieldFrom(value=None))
 
 class DirectoryTestCase(ASTTestCase):
     """Test roundtrip behaviour on all files in Lib and Lib/test."""


### PR DESCRIPTION


<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->
