### PR TITLE
bpo-39200: Correct the error message for range() empty constructor

### DIFF
--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -92,10 +92,16 @@ class RangeTest(unittest.TestCase):
         self.assertEqual(len(r), sys.maxsize)
 
     def test_range_constructor_error_messages(self):
-        with self.assertRaisesRegex(TypeError, "range expected at least 1 argument, got 0"):
+        with self.assertRaisesRegex(
+                TypeError,
+                "range expected at least 1 argument, got 0"
+        ):
             range()
 
-        with self.assertRaisesRegex(TypeError, "range expected at most 3 arguments, got 6"):
+        with self.assertRaisesRegex(
+                TypeError,
+                "range expected at most 3 arguments, got 6"
+        ):
             range(1, 2, 3, 4, 5, 6)
 
     def test_large_operands(self):

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -91,6 +91,13 @@ class RangeTest(unittest.TestCase):
         r = range(-sys.maxsize, sys.maxsize, 2)
         self.assertEqual(len(r), sys.maxsize)
 
+    def test_range_constructor_error_messages(self):
+        with self.assertRaisesRegex(TypeError, "range expected at least 1 argument, got 0"):
+            range()
+
+        with self.assertRaisesRegex(TypeError, "range expected at most 3 arguments, got 6"):
+            range(1, 2, 3, 4, 5, 6)
+
     def test_large_operands(self):
         x = range(10**20, 10**20+10, 3)
         self.assertEqual(len(x), 4)

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-03-14-50-14.bpo-39200.Ip2_iI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-03-14-50-14.bpo-39200.Ip2_iI.rst
@@ -1,0 +1,2 @@
+Correct the error message when trying to construct :class:`range` objects
+with no arguments. Patch by Pablo Galindo.

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -81,7 +81,7 @@ range_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     switch (num_args) {
         case 3:
             step = PyTuple_GET_ITEM(args, 2);
-            /* FALLTHRU */
+            /* fallthrough */
         case 2:
             start = PyTuple_GET_ITEM(args, 0);
             start = PyNumber_Index(start);
@@ -115,10 +115,13 @@ range_new(PyTypeObject *type, PyObject *args, PyObject *kw)
             step = _PyLong_One;
             break;
         case 0:
-            PyErr_SetString(PyExc_TypeError, "range expected at least 1 argument, got 0");
+            PyErr_SetString(PyExc_TypeError,
+                            "range expected at least 1 argument, got 0");
             return NULL;
         default:
-            PyErr_Format(PyExc_TypeError, "range expected at most 3 arguments, got %zd", num_args);
+            PyErr_Format(PyExc_TypeError, 
+                         "range expected at most 3 arguments, got %zd",
+                         num_args);
             return NULL;
     }
 

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -78,8 +78,12 @@ range_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         return NULL;
 
     if (PyTuple_Size(args) <= 1) {
-        if (!PyArg_UnpackTuple(args, "range", 1, 1, &stop))
+        if (!PyArg_UnpackTuple(args, "range", 1, 1, &stop)) {
+            if (PyExceptionClass_Check(PyExc_TypeError)) {
+                PyErr_SetString(PyExc_TypeError, "range expected at least 1 argument, got 0");
+            }
             return NULL;
+        }
         stop = PyNumber_Index(stop);
         if (!stop)
             return NULL;

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -118,7 +118,7 @@ range_new(PyTypeObject *type, PyObject *args, PyObject *kw)
             PyErr_SetString(PyExc_TypeError, "range expected at least 1 argument, got 0");
             return NULL;
         default:
-            PyErr_Format(PyExc_TypeError, "range expected at most 3 arguments, got %i", num_args);
+            PyErr_Format(PyExc_TypeError, "range expected at most 3 arguments, got %zd", num_args);
             return NULL;
     }
 

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -77,41 +77,49 @@ range_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     if (!_PyArg_NoKeywords("range", kw))
         return NULL;
 
-    if (PyTuple_Size(args) <= 1) {
-        if (!PyArg_UnpackTuple(args, "range", 1, 1, &stop)) {
-            if (PyExceptionClass_Check(PyExc_TypeError)) {
-                PyErr_SetString(PyExc_TypeError, "range expected at least 1 argument, got 0");
+    Py_ssize_t num_args = PyTuple_GET_SIZE(args);
+    switch (num_args) {
+        case 3:
+            step = PyTuple_GET_ITEM(args, 2);
+            /* FALLTHRU */
+        case 2:
+            start = PyTuple_GET_ITEM(args, 0);
+            start = PyNumber_Index(start);
+            if (!start) {
+                return NULL;
             }
-            return NULL;
-        }
-        stop = PyNumber_Index(stop);
-        if (!stop)
-            return NULL;
-        Py_INCREF(_PyLong_Zero);
-        start = _PyLong_Zero;
-        Py_INCREF(_PyLong_One);
-        step = _PyLong_One;
-    }
-    else {
-        if (!PyArg_UnpackTuple(args, "range", 2, 3,
-                               &start, &stop, &step))
-            return NULL;
 
-        /* Convert borrowed refs to owned refs */
-        start = PyNumber_Index(start);
-        if (!start)
+            stop = PyTuple_GET_ITEM(args, 1);
+            stop = PyNumber_Index(stop);
+            if (!stop) {
+                Py_DECREF(start);
+                return NULL;
+            }
+
+            step = validate_step(step);
+            if (!step) {
+                Py_DECREF(start);
+                Py_DECREF(stop);
+                return NULL;
+            }
+            break;
+        case 1:
+            stop = PyTuple_GET_ITEM(args, 0);
+            stop = PyNumber_Index(stop);
+            if (!stop) {
+                return NULL;
+            }
+            Py_INCREF(_PyLong_Zero);
+            start = _PyLong_Zero;
+            Py_INCREF(_PyLong_One);
+            step = _PyLong_One;
+            break;
+        case 0:
+            PyErr_SetString(PyExc_TypeError, "range expected at least 1 argument, got 0");
             return NULL;
-        stop = PyNumber_Index(stop);
-        if (!stop) {
-            Py_DECREF(start);
+        default:
+            PyErr_Format(PyExc_TypeError, "range expected at most 3 arguments, got %i", num_args);
             return NULL;
-        }
-        step = validate_step(step);    /* Caution, this can clear exceptions */
-        if (!step) {
-            Py_DECREF(start);
-            Py_DECREF(stop);
-            return NULL;
-        }
     }
 
     obj = make_range_object(type, start, stop, step);


### PR DESCRIPTION


<!-- issue-number: [bpo-39200](https://bugs.python.org/issue39200) -->
https://bugs.python.org/issue39200
<!-- /issue-number -->
