### PR TITLE
bpo-39200: Correct the error message for min/max builtin function

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -949,7 +949,9 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(max(1, 2.0, 3), 3)
         self.assertEqual(max(1.0, 2, 3), 3)
 
-        self.assertRaises(TypeError, max)
+        with self.assertRaisesRegex(TypeError, r'max expected at least 1 argument, got 0'):
+            max()
+
         self.assertRaises(TypeError, max, 42)
         self.assertRaises(ValueError, max, ())
         class BadSeq:
@@ -1003,7 +1005,9 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(min(1, 2.0, 3), 1)
         self.assertEqual(min(1.0, 2, 3), 1.0)
 
-        self.assertRaises(TypeError, min)
+        with self.assertRaisesRegex(TypeError, r'min expected at least 1 argument, got 0'):
+            min()
+
         self.assertRaises(TypeError, min, 42)
         self.assertRaises(ValueError, min, ())
         class BadSeq:

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -949,7 +949,10 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(max(1, 2.0, 3), 3)
         self.assertEqual(max(1.0, 2, 3), 3)
 
-        with self.assertRaisesRegex(TypeError, r'max expected at least 1 argument, got 0'):
+        with self.assertRaisesRegex(
+            TypeError,
+            'max expected at least 1 argument, got 0'
+        ):
             max()
 
         self.assertRaises(TypeError, max, 42)
@@ -1005,7 +1008,10 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(min(1, 2.0, 3), 1)
         self.assertEqual(min(1.0, 2, 3), 1.0)
 
-        with self.assertRaisesRegex(TypeError, r'min expected at least 1 argument, got 0'):
+        with self.assertRaisesRegex(
+            TypeError,
+            'min expected at least 1 argument, got 0'
+        ):
             min()
 
         self.assertRaises(TypeError, min, 42)

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-04-01-14-32.bpo-39200.8Z9DYp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-04-01-14-32.bpo-39200.8Z9DYp.rst
@@ -1,0 +1,2 @@
+Correct the error message when calling to min/max builtin function with no
+arguments. Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-04-01-14-32.bpo-39200.8Z9DYp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-04-01-14-32.bpo-39200.8Z9DYp.rst
@@ -1,2 +1,2 @@
-Correct the error message when calling to min/max builtin function with no
-arguments. Patch by Dong-hee Na.
+Correct the error message when calling the :func:`min` or :func:`max` with
+no arguments. Patch by Dong-hee Na.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1591,8 +1591,12 @@ min_max(PyObject *args, PyObject *kwds, int op)
 
     if (positional)
         v = args;
-    else if (!PyArg_UnpackTuple(args, name, 1, 1, &v))
+    else if (!PyArg_UnpackTuple(args, name, 1, 1, &v)) {
+        if (PyExceptionClass_Check(PyExc_TypeError)) {
+            PyErr_Format(PyExc_TypeError, "%s expected at least 1 argument, got 0", name);
+        }
         return NULL;
+    }
 
     emptytuple = PyTuple_New(0);
     if (emptytuple == NULL)

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1589,8 +1589,9 @@ min_max(PyObject *args, PyObject *kwds, int op)
     const int positional = PyTuple_Size(args) > 1;
     int ret;
 
-    if (positional)
+    if (positional) {
         v = args;
+    }
     else if (!PyArg_UnpackTuple(args, name, 1, 1, &v)) {
         if (PyExceptionClass_Check(PyExc_TypeError)) {
             PyErr_Format(PyExc_TypeError, "%s expected at least 1 argument, got 0", name);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39200](https://bugs.python.org/issue39200) -->
https://bugs.python.org/issue39200
<!-- /issue-number -->
