### PR TITLE
bpo-39152: add missing ttk.Scale.configure return value

### DIFF
--- a/Lib/tkinter/test/widget_tests.py
+++ b/Lib/tkinter/test/widget_tests.py
@@ -210,8 +210,7 @@ class AbstractWidgetTest(AbstractTkTest):
         widget = self.create()
         keys = widget.keys()
         # XXX
-        if not isinstance(widget, Scale):
-            self.assertEqual(sorted(keys), sorted(widget.configure()))
+        self.assertEqual(sorted(keys), sorted(widget.configure()))
         for k in keys:
             widget[k]
         # Test if OPTIONS contains all keys

--- a/Lib/tkinter/test/widget_tests.py
+++ b/Lib/tkinter/test/widget_tests.py
@@ -3,7 +3,6 @@
 import unittest
 import sys
 import tkinter
-from tkinter.ttk import Scale
 from tkinter.test.support import (AbstractTkTest, tcl_version, requires_tcl,
                                   get_tk_patchlevel, pixels_conv, tcl_obj_eq)
 import test.support
@@ -63,11 +62,9 @@ class AbstractWidgetTest(AbstractTkTest):
             eq = tcl_obj_eq
         self.assertEqual2(widget[name], expected, eq=eq)
         self.assertEqual2(widget.cget(name), expected, eq=eq)
-        # XXX
-        if not isinstance(widget, Scale):
-            t = widget.configure(name)
-            self.assertEqual(len(t), 5)
-            self.assertEqual2(t[4], expected, eq=eq)
+        t = widget.configure(name)
+        self.assertEqual(len(t), 5)
+        self.assertEqual2(t[4], expected, eq=eq)
 
     def checkInvalidParam(self, widget, name, value, errmsg=None, *,
                           keep_orig=True):
@@ -209,7 +206,6 @@ class AbstractWidgetTest(AbstractTkTest):
     def test_keys(self):
         widget = self.create()
         keys = widget.keys()
-        # XXX
         self.assertEqual(sorted(keys), sorted(widget.configure()))
         for k in keys:
             widget[k]

--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -1084,9 +1084,9 @@ class Scale(Widget, tkinter.Scale):
 
         Setting a value for any of the "from", "from_" or "to" options
         generates a <<RangeChanged>> event."""
-        if cnf:
+        retval = Widget.configure(self, cnf, **kw)
+        if not isinstance(cnf, (type(None), str)):
             kw.update(cnf)
-        retval = Widget.configure(self, **kw)
         if any(['from' in kw, 'from_' in kw, 'to' in kw]):
             self.event_generate('<<RangeChanged>>')
         return retval

--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -1086,9 +1086,10 @@ class Scale(Widget, tkinter.Scale):
         generates a <<RangeChanged>> event."""
         if cnf:
             kw.update(cnf)
-        Widget.configure(self, **kw)
+        retval = Widget.configure(self, **kw)
         if any(['from' in kw, 'from_' in kw, 'to' in kw]):
             self.event_generate('<<RangeChanged>>')
+        return retval
 
 
     def get(self, x=None, y=None):

--- a/Misc/NEWS.d/next/Library/2020-01-03-18-02-50.bpo-39152.JgPjCC.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-03-18-02-50.bpo-39152.JgPjCC.rst
@@ -1,0 +1,2 @@
+Add missing ttk.Scale.configure return value.  ttk.Scale().configure() now
+returns a configuration.  Change posted by Giovanni Lombardo.

--- a/Misc/NEWS.d/next/Library/2020-01-03-18-02-50.bpo-39152.JgPjCC.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-03-18-02-50.bpo-39152.JgPjCC.rst
@@ -1,2 +1,2 @@
-Add missing ttk.Scale.configure return value.  ttk.Scale().configure() now
-returns a configuration.  Change posted by Giovanni Lombardo.
+Fix ttk.Scale.configure([name]) to return configuration tuple for name
+or all options.  Giovanni Lombardo contributed part of the patch.


### PR DESCRIPTION
tkinter.ttk.Scale().configure([name]) now returns a configuration tuple for name
or a list thereof for all options.  Based on patch Giovanni Lombardo.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39152](https://bugs.python.org/issue39152) -->
https://bugs.python.org/issue39152
<!-- /issue-number -->
