### PR TITLE
bpo-29778: Fix incorrect NULL check

### DIFF
--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -150,7 +150,7 @@ _PyWideStringList_Join(const PyWideStringList *list, wchar_t sep)
 static PyStatus
 _PyPathConfig_InitDLLPath(void)
 {
-    if (_Py_dll_path == NULL) {
+    if (_Py_dll_path != NULL) {
         /* Already set: nothing to do */
         return _PyStatus_OK();
     }


### PR DESCRIPTION
The commit below introduced a NULL check which causes a call to _PyPathConfig_InitDLLPath()
to be skipped if _Py_dll_path == NULL.

https://github.com/python/cpython/commit/c422167749f92d4170203e996a2c619c818335ea#diff-87aed37b4704d4e1513be6378c9c7fe6R169


<!-- issue-number: [bpo-29778](https://bugs.python.org/issue29778) -->
https://bugs.python.org/issue29778
<!-- /issue-number -->
