### PR TITLE
[2.7] Revert bpo-27973 - urlretrive fails on second ftp transfer."

### DIFF
--- a/Lib/test/test_urllibnet.py
+++ b/Lib/test/test_urllibnet.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 from test import test_support
 from test.test_urllib2net import skip_ftp_test_on_travis
@@ -223,10 +224,9 @@ class urlopen_FTPTest(unittest.TestCase):
 
         with test_support.transient_internet(self.FTP_TEST_FILE):
             try:
-                for file_num in range(self.NUM_FTP_RETRIEVES):
-                    with test_support.temp_dir() as td:
-                        urllib.FancyURLopener().retrieve(self.FTP_TEST_FILE,
-                                                         os.path.join(td, str(file_num)))
+                for _ in range(self.NUM_FTP_RETRIEVES):
+                    with tempfile.NamedTemporaryFile() as fp:
+                        urllib.FancyURLopener().retrieve(self.FTP_TEST_FILE, fp.name)
             except IOError as e:
                 self.fail("Failed FTP retrieve while accessing ftp url "
                           "multiple times.\n Error message was : %s" % e)


### PR DESCRIPTION
Reverts python/cpython#17774

<!-- issue-number: [bpo-27973](https://bugs.python.org/issue27973) -->
https://bugs.python.org/issue27973
<!-- /issue-number -->
