### PR TITLE
[3.7] bpo-39191: Don't spawn a task before failing (GH-17796).

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -518,14 +518,17 @@ class BaseEventLoop(events.AbstractEventLoop):
                     'asyncgen': agen
                 })
 
-    def run_forever(self):
-        """Run until stop() is called."""
-        self._check_closed()
+    def _check_runnung(self):
         if self.is_running():
             raise RuntimeError('This event loop is already running')
         if events._get_running_loop() is not None:
             raise RuntimeError(
                 'Cannot run the event loop while another loop is running')
+
+    def run_forever(self):
+        """Run until stop() is called."""
+        self._check_closed()
+        self._check_runnung()
         self._set_coroutine_origin_tracking(self._debug)
         self._thread_id = threading.get_ident()
 
@@ -557,6 +560,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         Return the Future's result, or raise its exception.
         """
         self._check_closed()
+        self._check_runnung()
 
         new_task = not futures.isfuture(future)
         future = tasks.ensure_future(future, loop=self)

--- a/Misc/NEWS.d/next/Library/2020-01-02-17-28-03.bpo-39191.ur_scy.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-02-17-28-03.bpo-39191.ur_scy.rst
@@ -1,0 +1,3 @@
+Perform a check for running loop before starting a new task in
+``loop.run_until_complete()`` to fail fast; it prevents the side effect of
+new task spawning before exception raising.


### PR DESCRIPTION
(cherry picked from commit 3a5de511596f17575de082dcb8d43d63b2bd2da9)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39191](https://bugs.python.org/issue39191) -->
https://bugs.python.org/issue39191
<!-- /issue-number -->
