### PR TITLE
bpo-35292: Avoid call mimetypes.init when http.server is imported

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -335,10 +335,13 @@ provides three different variants:
 
    .. attribute:: extensions_map
 
-      A dictionary mapping suffixes into MIME types. The default is
-      signified by an empty string, and is considered to be
-      ``application/octet-stream``. The mapping is used case-insensitively,
+      A dictionary mapping suffixes into MIME types, contains custom overrides
+      for the default system mappings. The mapping is used case-insensitively,
       and so should contain only lower-cased keys.
+
+      .. versionchanged:: 3.9
+         This dictionary is no longer filled with the default system mappings,
+         but only contains overrides.
 
    .. attribute:: directory
 

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -639,6 +639,12 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
     """
 
     server_version = "SimpleHTTP/" + __version__
+    extensions_map = _encodings_map_default = {
+        '.gz': 'application/gzip',
+        '.Z': 'application/octet-stream',
+        '.bz2': 'application/x-bzip2',
+        '.xz': 'application/x-xz',
+    }
 
     def __init__(self, *args, directory=None, **kwargs):
         if directory is None:
@@ -866,25 +872,16 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         slow) to look inside the data to make a better guess.
 
         """
-
         base, ext = posixpath.splitext(path)
         if ext in self.extensions_map:
             return self.extensions_map[ext]
         ext = ext.lower()
         if ext in self.extensions_map:
             return self.extensions_map[ext]
-        else:
-            return self.extensions_map['']
-
-    if not mimetypes.inited:
-        mimetypes.init() # try to read system mime.types
-    extensions_map = mimetypes.types_map.copy()
-    extensions_map.update({
-        '': 'application/octet-stream', # Default
-        '.py': 'text/plain',
-        '.c': 'text/plain',
-        '.h': 'text/plain',
-        })
+        guess, _ = mimetypes.guess_type(path)
+        if guess:
+            return guess
+        return 'application/octet-stream'
 
 
 # Utilities for CGIHTTPRequestHandler

--- a/Misc/NEWS.d/next/Library/2020-01-08-14-39-19.bpo-35292.ihRT1z.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-08-14-39-19.bpo-35292.ihRT1z.rst
@@ -1,0 +1,1 @@
+Proxy the `SimpleHTTPRequestHandler.guess_type` to `mimetypes.guess_type` so the `mimetypes.init` is called lazily to avoid unnecessary costs when :mod:`http.server` module is imported.


### PR DESCRIPTION
Proxy the `http.server.SimpleHTTPRequestHandler.guess_type` to `mimetypes.guess_type` so the `mimetypes.init` is called lazily to avoid unnecessary costs when the file is imported.

The default `extensions_map` is checked before call `mimetypes.guess_type`, with default value in `mimetypes.encodings_map`, for don't let `mimetypes.guess_type` returns the mine type besides the encoding type.

This method is implemented as https://bugs.python.org/issue35292#msg331739 said @zooba 

<!-- issue-number: [bpo-35292](https://bugs.python.org/issue35292) -->
https://bugs.python.org/issue35292
<!-- /issue-number -->
