### PR TITLE
bpo-39184: Add audit events to command execution functions in os and pty modules

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3316,6 +3316,8 @@ to be ignored.
    you can check whether or not it is available using :data:`os.supports_fd`.
    If it is unavailable, using it will raise a :exc:`NotImplementedError`.
 
+   .. audit-event:: os.spawn mode,path,args,env os.spawn
+
    .. availability:: Unix, Windows.
 
    .. versionadded:: 3.3
@@ -3672,6 +3674,8 @@ written in Python, such as a mail server's external command delivery program.
    :c:data:`POSIX_SPAWN_SETSCHEDPARAM` and :c:data:`POSIX_SPAWN_SETSCHEDULER`
    flags.
 
+   .. audit-event:: os.posix_spawn path,argv,env os.posix_spawn
+
    .. versionadded:: 3.8
 
    .. availability:: Unix.
@@ -3685,6 +3689,8 @@ written in Python, such as a mail server's external command delivery program.
    Similar to :func:`posix_spawn` except that the system searches
    for the *executable* file in the list of directories specified by the
    :envvar:`PATH` environment variable (in the same way as for ``execvp(3)``).
+
+   .. audit-event:: os.posix_spawn path,argv,env os.posix_spawn
 
    .. versionadded:: 3.8
 
@@ -3786,6 +3792,8 @@ written in Python, such as a mail server's external command delivery program.
       L = ['cp', 'index.html', '/dev/null']
       os.spawnvpe(os.P_WAIT, 'cp', L, os.environ)
 
+   .. audit-event:: os.exec path,args,env os.exec
+
    .. availability:: Unix, Windows.  :func:`spawnlp`, :func:`spawnlpe`, :func:`spawnvp`
       and :func:`spawnvpe` are not available on Windows.  :func:`spawnle` and
       :func:`spawnve` are not thread-safe on Windows; we advise you to use the
@@ -3854,6 +3862,8 @@ written in Python, such as a mail server's external command delivery program.
    To reduce interpreter startup overhead, the Win32 :c:func:`ShellExecute`
    function is not resolved until this function is first called.  If the function
    cannot be resolved, :exc:`NotImplementedError` will be raised.
+
+   .. audit-event:: os.startfile path,operation os.startfile
 
    .. availability:: Windows.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3316,7 +3316,7 @@ to be ignored.
    you can check whether or not it is available using :data:`os.supports_fd`.
    If it is unavailable, using it will raise a :exc:`NotImplementedError`.
 
-   .. audit-event:: os.spawn mode,path,args,env os.spawn
+   .. audit-event:: os.exec path,args,env os.execl
 
    .. availability:: Unix, Windows.
 
@@ -3690,7 +3690,7 @@ written in Python, such as a mail server's external command delivery program.
    for the *executable* file in the list of directories specified by the
    :envvar:`PATH` environment variable (in the same way as for ``execvp(3)``).
 
-   .. audit-event:: os.posix_spawn path,argv,env os.posix_spawn
+   .. audit-event:: os.posix_spawn path,argv,env os.posix_spawnp
 
    .. versionadded:: 3.8
 
@@ -3792,7 +3792,7 @@ written in Python, such as a mail server's external command delivery program.
       L = ['cp', 'index.html', '/dev/null']
       os.spawnvpe(os.P_WAIT, 'cp', L, os.environ)
 
-   .. audit-event:: os.exec path,args,env os.exec
+   .. audit-event:: os.spawn mode,path,args,env os.spawnl
 
    .. availability:: Unix, Windows.  :func:`spawnlp`, :func:`spawnlpe`, :func:`spawnvp`
       and :func:`spawnvpe` are not available on Windows.  :func:`spawnle` and

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -69,6 +69,7 @@ The :mod:`pty` module defines the following functions:
    *select* throws an error on your platform when passed three empty lists. This
    is a bug, documented in `issue 26228 <https://bugs.python.org/issue26228>`_.
 
+   .. audit-event:: pty.spawn argv pty.spawn
 
    .. versionchanged:: 3.4
       :func:`spawn` now returns the status value from :func:`os.waitpid`

--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -8,6 +8,7 @@
 
 from select import select
 import os
+import sys
 import tty
 
 __all__ = ["openpty","fork","spawn"]
@@ -151,6 +152,7 @@ def spawn(argv, master_read=_read, stdin_read=_read):
     """Create a spawned process."""
     if type(argv) == type(''):
         argv = (argv,)
+    sys.audit('pty.spawn', argv)
     pid, master_fd = fork()
     if pid == CHILD:
         os.execlp(argv[0], *argv)

--- a/Misc/NEWS.d/next/Security/2020-01-07-00-42-08.bpo-39184.fe7NgK.rst
+++ b/Misc/NEWS.d/next/Security/2020-01-07-00-42-08.bpo-39184.fe7NgK.rst
@@ -1,0 +1,1 @@
+Add audit events to command execution functions in os and pty modules.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5237,6 +5237,12 @@ os_execv_impl(PyObject *module, path_t *path, PyObject *argv)
         return NULL;
     }
 
+    if (PySys_Audit("os.exec", "OOO", path->object ? path->object : Py_None,
+                    argv, Py_None) < 0) {
+        free_string_array(argvlist, argc);
+        return NULL;
+    }
+
     _Py_BEGIN_SUPPRESS_IPH
 #ifdef HAVE_WEXECV
     _wexecv(path->wide, argvlist);
@@ -5280,7 +5286,7 @@ os_execve_impl(PyObject *module, path_t *path, PyObject *argv, PyObject *env)
     if (!PyList_Check(argv) && !PyTuple_Check(argv)) {
         PyErr_SetString(PyExc_TypeError,
                         "execve: argv must be a tuple or list");
-        goto fail;
+        goto fail_0;
     }
     argc = PySequence_Size(argv);
     if (argc < 1) {
@@ -5291,22 +5297,27 @@ os_execve_impl(PyObject *module, path_t *path, PyObject *argv, PyObject *env)
     if (!PyMapping_Check(env)) {
         PyErr_SetString(PyExc_TypeError,
                         "execve: environment must be a mapping object");
-        goto fail;
+        goto fail_0;
     }
 
     argvlist = parse_arglist(argv, &argc);
     if (argvlist == NULL) {
-        goto fail;
+        goto fail_0;
     }
     if (!argvlist[0][0]) {
         PyErr_SetString(PyExc_ValueError,
             "execve: argv first element cannot be empty");
-        goto fail;
+        goto fail_0;
     }
 
     envlist = parse_envlist(env, &envc);
     if (envlist == NULL)
-        goto fail;
+        goto fail_0;
+
+    if (PySys_Audit("os.exec", "OOO", path->object ? path->object : Py_None,
+                    argv, env) < 0) {
+        goto fail_1;
+    }
 
     _Py_BEGIN_SUPPRESS_IPH
 #ifdef HAVE_FEXECVE
@@ -5324,9 +5335,9 @@ os_execve_impl(PyObject *module, path_t *path, PyObject *argv, PyObject *env)
     /* If we get here it's definitely an error */
 
     posix_path_error(path);
-
+  fail_1:
     free_string_array(envlist, envc);
-  fail:
+  fail_0:
     if (argvlist)
         free_string_array(argvlist, argc);
     return NULL;
@@ -5657,6 +5668,11 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
     }
     attrp = &attr;
 
+    if (PySys_Audit("os.posix_spawn", "OOO",
+                    path->object ? path->object : Py_None, argv, env) < 0) {
+        goto exit;
+    }
+
     _Py_BEGIN_SUPPRESS_IPH
 #ifdef HAVE_POSIX_SPAWNP
     if (use_posix_spawnp) {
@@ -5897,6 +5913,13 @@ os_spawnv_impl(PyObject *module, int mode, path_t *path, PyObject *argv)
         mode = _P_OVERLAY;
 #endif
 
+    if (PySys_Audit("os.spawn", "iOOO", mode,
+                    path->object ? path->object : Py_None, argv,
+                    Py_None) < 0) {
+        free_string_array(argvlist, argc);
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
 #ifdef HAVE_WSPAWNV
@@ -6006,6 +6029,11 @@ os_spawnve_impl(PyObject *module, int mode, path_t *path, PyObject *argv,
         mode = _P_OVERLAY;
 #endif
 
+    if (PySys_Audit("os.spawn", "iOOO", mode,
+                    path->object ? path->object : Py_None, argv, env) < 0) {
+        goto fail_2;
+    }
+
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
 #ifdef HAVE_WSPAWNV
@@ -6024,6 +6052,7 @@ os_spawnve_impl(PyObject *module, int mode, path_t *path, PyObject *argv,
     else
         res = Py_BuildValue(_Py_PARSE_INTPTR, spawnval);
 
+  fail_2:
     while (--envc >= 0)
         PyMem_DEL(envlist[envc]);
     PyMem_DEL(envlist);
@@ -11711,6 +11740,12 @@ os_startfile_impl(PyObject *module, path_t *filepath,
            NotImplementedError. */
         return PyErr_Format(PyExc_NotImplementedError,
             "startfile not available on this platform");
+    }
+
+    if (PySys_Audit("os.startfile", "Ou",
+                    filepath->object ? filepath->object : Py_None,
+                    operation) < 0) {
+        return NULL;
     }
 
     Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
Add audit events to the following functions:

- os.exec*
- os.spawn*
- os.posix_spawn*
- os.startfile
- pty.spawn

https://bugs.python.org/issue39184

<!-- issue-number: [bpo-39184](https://bugs.python.org/issue39184) -->
https://bugs.python.org/issue39184
<!-- /issue-number -->
