### PR TITLE
bpo-39216: Fix constant folding optimization for positional only arguments

### DIFF
--- a/Lib/test/test_positional_only_arg.py
+++ b/Lib/test/test_positional_only_arg.py
@@ -1,5 +1,6 @@
 """Unit tests for the positional only argument syntax specified in PEP 570."""
 
+import dis
 import pickle
 import unittest
 
@@ -418,6 +419,17 @@ class PositionalOnlyTestCase(unittest.TestCase):
 
     def test_annotations(self):
         assert global_inner_has_pos_only().__annotations__ == {'x': int}
+
+    def test_annotations_constant_fold(self):
+        def g():
+            def f(x: not (int is int), /): ...
+
+        # without constant folding we end up with
+        # COMPARE_OP(is), UNARY_NOT
+        # with constant folding we should expect a COMPARE_OP(is not)
+        codes = [(i.opname, i.argval) for i in dis.get_instructions(g)]
+        self.assertNotIn(('UNARY_NOT', None), codes)
+        self.assertIn(('COMPARE_OP', 'is not'), codes)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-05-06-55-52.bpo-39216.74jLh9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-05-06-55-52.bpo-39216.74jLh9.rst
@@ -1,0 +1,2 @@
+Fix constant folding optimization for positional only arguments - by Anthony
+Sottile.

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -617,6 +617,7 @@ astfold_comprehension(comprehension_ty node_, PyArena *ctx_, int optimize_)
 static int
 astfold_arguments(arguments_ty node_, PyArena *ctx_, int optimize_)
 {
+    CALL_SEQ(astfold_arg, arg_ty, node_->posonlyargs);
     CALL_SEQ(astfold_arg, arg_ty, node_->args);
     CALL_OPT(astfold_arg, arg_ty, node_->vararg);
     CALL_SEQ(astfold_arg, arg_ty, node_->kwonlyargs);


### PR DESCRIPTION


<!-- issue-number: [bpo-39216](https://bugs.python.org/issue39216) -->
https://bugs.python.org/issue39216
<!-- /issue-number -->
