### PR TITLE
bpo-38907: In http.server script, restore binding to IPv4 on Windows.

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1282,4 +1282,16 @@ if __name__ == '__main__':
     else:
         handler_class = partial(SimpleHTTPRequestHandler,
                                 directory=args.directory)
-    test(HandlerClass=handler_class, port=args.port, bind=args.bind)
+
+    # ensure dual-stack is not disabled; ref #38907
+    class DualStackServer(ThreadingHTTPServer):
+        def server_bind(self):
+            self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            return super().server_bind()
+
+    test(
+        HandlerClass=handler_class,
+        ServerClass=DualStackServer,
+        port=args.port,
+        bind=args.bind,
+    )

--- a/Misc/NEWS.d/next/Library/2020-01-06-02-14-38.bpo-38907.F1RkCR.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-06-02-14-38.bpo-38907.F1RkCR.rst
@@ -1,0 +1,1 @@
+In http.server script, restore binding to IPv4 on Windows.


### PR DESCRIPTION
This PR takes a more surgical approach to GH-17378, addressing only the regression introduced with the dual-stack support added in 3.8 for the `http.server` command. Presumably, better support will be added to the HTTPServer and TCPServers for dual-stack support in [bpo-25667](https://bugs.python.org/issue25667) or [bpo-20215](https://bugs.python.org/issue20215), but this PR aims to minimally restore the prior expectation and not affect the behavior of those classes.

I considered writing tests for this change, but the existing tests for the `http.server` command mock out the intended behavior, so I've instead tested the change by applying the patch to Python 3.8.1 on Windows and confirmed it has the intended effect.

<!-- issue-number: [bpo-38907](https://bugs.python.org/issue38907) -->
https://bugs.python.org/issue38907
<!-- /issue-number -->
