### PR TITLE
Fix coverage run on Github Actions.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,7 @@ jobs:
         || true
     - name: 'Publish code coverage results'
       run: |
-        ./.venv/bin/python -m coverage xml
+        source ./.venv/bin/activate
         bash <(curl -s https://codecov.io/bash)
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Coverage now succeeds on Travis-CI.  But it is failing on Actions.
Use the same script to report.