### PR TITLE
Py_DECREF: only pass filename if Py_REF_DEBUG is defined

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -461,8 +461,11 @@ static inline void _Py_INCREF(PyObject *op)
 
 #define Py_INCREF(op) _Py_INCREF(_PyObject_CAST(op))
 
-static inline void _Py_DECREF(const char *filename, int lineno,
-                              PyObject *op)
+static inline void _Py_DECREF(
+#ifdef Py_REF_DEBUG
+    const char *filename, int lineno,
+#endif
+    PyObject *op)
 {
     (void)filename; /* may be unused, shut up -Wunused-parameter */
     (void)lineno; /* may be unused, shut up -Wunused-parameter */
@@ -479,7 +482,11 @@ static inline void _Py_DECREF(const char *filename, int lineno,
     }
 }
 
-#define Py_DECREF(op) _Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
+#ifdef Py_REF_DEBUG
+#  define Py_DECREF(op) _Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
+#else
+#  define Py_DECREF(op) _Py_DECREF(_PyObject_CAST(op))
+#endif
 
 
 /* Safely decref `op` and set `op` to NULL, especially useful in tp_clear

--- a/Include/object.h
+++ b/Include/object.h
@@ -467,8 +467,6 @@ static inline void _Py_DECREF(
 #endif
     PyObject *op)
 {
-    (void)filename; /* may be unused, shut up -Wunused-parameter */
-    (void)lineno; /* may be unused, shut up -Wunused-parameter */
     _Py_DEC_REFTOTAL;
     if (--op->ob_refcnt != 0) {
 #ifdef Py_REF_DEBUG


### PR DESCRIPTION
Filename and line numbers are not needed when Py_REF_DEBUG are not
defined.

The static inline _Py_DECREF() function was introduced by
commit 2aaf0c12041bcaadd7f2cc5a54450eefd7a6ff12.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
