### PR TITLE
bpo-39234: Doc: `enum.auto()` incrementation value not specified.

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -56,6 +56,7 @@ helper, :class:`auto`.
 .. class:: auto
 
     Instances are replaced with an appropriate value for Enum members.
+    Increment starts at 1 not 0.
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -55,8 +55,7 @@ helper, :class:`auto`.
 
 .. class:: auto
 
-    Instances are replaced with an appropriate value for Enum members.
-    Increment starts at 1 not 0.
+    Instances are replaced with an appropriate value for Enum members. Initial value starts at 1.
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 


### PR DESCRIPTION
enum in C starts at 0, while `enum.auto()` in Python starts at 1, thus needs to be specified.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39234](https://bugs.python.org/issue39234) -->
https://bugs.python.org/issue39234
<!-- /issue-number -->
