### PR TITLE
bpo-39237: Remove redundant call to round from delta_new

### DIFF
--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2489,7 +2489,6 @@ delta_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         int x_is_odd;
         PyObject *temp;
 
-        whole_us = round(leftover_us);
         if (fabs(whole_us - leftover_us) == 0.5) {
             /* We're exactly halfway between two integers.  In order
              * to do round-half-to-even, we must determine whether x


### PR DESCRIPTION
Split from https://github.com/python/cpython/pull/16267

<!-- issue-number: [bpo-39237](https://bugs.python.org/issue39237) -->
https://bugs.python.org/issue39237
<!-- /issue-number -->
