### PR TITLE
bpo-39234: `enum.auto()` default initial value as 1

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -55,7 +55,7 @@ helper, :class:`auto`.
 
 .. class:: auto
 
-    Instances are replaced with an appropriate value for Enum members. Initial value starts at 1.
+    Instances are replaced with an appropriate value for Enum members.  By default, the initial value starts at 1
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -56,6 +56,7 @@ helper, :class:`auto`.
 .. class:: auto
 
     Instances are replaced with an appropriate value for Enum members.
+    Increment starts at 1 not 0.
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -55,8 +55,7 @@ helper, :class:`auto`.
 
 .. class:: auto
 
-    Instances are replaced with an appropriate value for Enum members.
-    Increment starts at 1 not 0.
+    Instances are replaced with an appropriate value for Enum members. Initial value starts at 1.
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -55,7 +55,7 @@ helper, :class:`auto`.
 
 .. class:: auto
 
-    Instances are replaced with an appropriate value for Enum members.  By default, the initial value starts at 1
+    Instances are replaced with an appropriate value for Enum members.  By default, the initial value starts at 1.
 
 .. versionadded:: 3.6  ``Flag``, ``IntFlag``, ``auto``
 


### PR DESCRIPTION
Updated as Eric mentioned "By default, the initial value starts at 1"

<!-- issue-number: [bpo-39234](https://bugs.python.org/issue39234) -->
https://bugs.python.org/issue39234
<!-- /issue-number -->


Automerge-Triggered-By: @ericvsmith