### PR TITLE
bpo-39239: epoll.unregister() no longer ignores EBADF

### DIFF
--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -355,6 +355,9 @@ Edge and Level Trigger Polling (epoll) Objects
 
    Remove a registered file descriptor from the epoll object.
 
+   .. versionchanged:: 3.9
+      The method no longer ignores the :data:`~errno.EBADF` error.
+
 
 .. method:: epoll.poll(timeout=None, maxevents=-1)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -382,6 +382,10 @@ Changes in the Python API
 * The :mod:`venv` activation scripts no longer special-case when
   ``__VENV_PROMPT__`` is set to ``""``.
 
+* The :meth:`select.epoll.unregister` method no longer ignores the
+  :data:`~errno.EBADF` error.
+  (Contributed by Victor Stinner in :issue:`39239`.)
+
 
 CPython bytecode changes
 ------------------------

--- a/Lib/test/test_epoll.py
+++ b/Lib/test/test_epoll.py
@@ -225,7 +225,10 @@ class TestEPoll(unittest.TestCase):
         self.assertFalse(then - now > 0.01)
 
         server.close()
-        ep.unregister(fd)
+
+        with self.assertRaises(OSError) as cm:
+            ep.unregister(fd)
+        self.assertEqual(cm.exception.errno, errno.EBADF)
 
     def test_close(self):
         open_file = open(__file__, "rb")

--- a/Misc/NEWS.d/next/Library/2020-01-07-01-02-44.bpo-39239.r7vecs.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-07-01-02-44.bpo-39239.r7vecs.rst
@@ -1,0 +1,2 @@
+The :meth:`select.epoll.unregister` method no longer ignores the
+:data:`~errno.EBADF` error.

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1447,11 +1447,6 @@ pyepoll_internal_ctl(int epfd, int op, int fd, unsigned int events)
          * though this argument is ignored. */
         Py_BEGIN_ALLOW_THREADS
         result = epoll_ctl(epfd, op, fd, &ev);
-        if (errno == EBADF) {
-            /* fd already closed */
-            result = 0;
-            errno = 0;
-        }
         Py_END_ALLOW_THREADS
         break;
     default:


### PR DESCRIPTION
The select.epoll.unregister() method no longer ignores the EBADF
error.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39239](https://bugs.python.org/issue39239) -->
https://bugs.python.org/issue39239
<!-- /issue-number -->
