### PR TITLE
bpo-1635741: Remove redundant _Py_INC_TPALLOCS in _Py_NewReference()

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -439,7 +439,6 @@ static inline void _Py_NewReference(PyObject *op)
         _PyTraceMalloc_NewReference(op);
     }
     _Py_INC_TPALLOCS(op);
-    _Py_INC_REFTOTAL;
     Py_REFCNT(op) = 1;
 }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
