### PR TITLE
Doc: sys.__unraisablehook__ and bytearray.hex separators are new in 3.8

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2416,7 +2416,7 @@ data and are closely related to string objects in a variety of other ways.
    A reverse conversion function exists to transform a bytes object into its
    hexadecimal representation.
 
-   .. method:: hex()
+   .. method:: hex([sep[, bytes_per_sep]])
 
       Return a string object containing two hexadecimal digits for each
       byte in the instance.
@@ -2510,7 +2510,7 @@ objects.
    A reverse conversion function exists to transform a bytearray object into its
    hexadecimal representation.
 
-   .. method:: hex()
+   .. method:: hex([sep[, bytes_per_sep]])
 
       Return a string object containing two hexadecimal digits for each
       byte in the instance.
@@ -2518,25 +2518,12 @@ objects.
       >>> bytearray(b'\xf0\xf1\xf2').hex()
       'f0f1f2'
 
-      If you want to make the hex string easier to read, you can specify a
-      single character separator *sep* parameter to include in the output.
-      By default between each byte.  A second optional *bytes_per_sep*
-      parameter controls the spacing.  Positive values calculate the
-      separator position from the right, negative values from the left.
-
-      >>> value = bytearray(b'\xf0\xf1\xf2')
-      >>> value.hex('-')
-      'f0-f1-f2'
-      >>> value.hex('_', 2)
-      'f0_f1f2'
-      >>> bytearray(b'UUDDLRLRAB').hex(' ', -4)
-      '55554444 4c524c52 4142'
-
       .. versionadded:: 3.5
 
       .. versionchanged:: 3.8
-         :meth:`bytearray.hex` now supports optional *sep* and *bytes_per_sep*
-         parameters to insert separators between bytes in the hex output.
+         Similar to :meth:`bytes.hex`, :meth:`bytearray.hex` now supports
+         optional *sep* and *bytes_per_sep* parameters to insert separators
+         between bytes in the hex output.
 
 Since bytearray objects are sequences of integers (akin to a list), for a
 bytearray object *b*, ``b[0]`` will be an integer, while ``b[0:1]`` will be
@@ -3691,7 +3678,7 @@ copying.
          in-memory Fortran order is preserved. For non-contiguous views, the
          data is converted to C first. *order=None* is the same as *order='C'*.
 
-   .. method:: hex()
+   .. method:: hex([sep[, bytes_per_sep]])
 
       Return a string object containing two hexadecimal digits for each
       byte in the buffer. ::
@@ -3701,6 +3688,11 @@ copying.
          '616263'
 
       .. versionadded:: 3.5
+
+      .. versionchanged:: 3.8
+         Similar to :meth:`bytes.hex`, :meth:`memoryview.hex` now supports
+         optional *sep* and *bytes_per_sep* parameters to insert separators
+         between bytes in the hex output.
 
    .. method:: tolist()
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2518,7 +2518,25 @@ objects.
       >>> bytearray(b'\xf0\xf1\xf2').hex()
       'f0f1f2'
 
+      If you want to make the hex string easier to read, you can specify a
+      single character separator *sep* parameter to include in the output.
+      By default between each byte.  A second optional *bytes_per_sep*
+      parameter controls the spacing.  Positive values calculate the
+      separator position from the right, negative values from the left.
+
+      >>> value = bytearray(b'\xf0\xf1\xf2')
+      >>> value.hex('-')
+      'f0-f1-f2'
+      >>> value.hex('_', 2)
+      'f0_f1f2'
+      >>> bytearray(b'UUDDLRLRAB').hex(' ', -4)
+      '55554444 4c524c52 4142'
+
       .. versionadded:: 3.5
+
+      .. versionchanged:: 3.8
+         :meth:`bytearray.hex` now supports optional *sep* and *bytes_per_sep*
+         parameters to insert separators between bytes in the hex output.
 
 Since bytearray objects are sequences of integers (akin to a list), for a
 bytearray object *b*, ``b[0]`` will be an integer, while ``b[0:1]`` will be

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -343,6 +343,8 @@ always available.
    .. versionadded:: 3.7
       __breakpointhook__
 
+   .. versionadded:: 3.8
+      __unraisablehook__
 
 .. function:: exc_info()
 


### PR DESCRIPTION
Minor fix in documentation:

- `sys.__unraisablehook__` is new in version 3.8
- Optional `sep` and `bytes_per_sep` parameters for `bytearray.hex` is also supported in Python 3.8 (just like `bytes.hex`)

Automerge-Triggered-By: @gpshead