### PR TITLE
[3.8] bpo-39191: Fix RuntimeWarning in asyncio test (GH-17863)

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -547,7 +547,7 @@ class BaseEventLoop(events.AbstractEventLoop):
                     'asyncgen': agen
                 })
 
-    def _check_runnung(self):
+    def _check_running(self):
         if self.is_running():
             raise RuntimeError('This event loop is already running')
         if events._get_running_loop() is not None:
@@ -557,7 +557,7 @@ class BaseEventLoop(events.AbstractEventLoop):
     def run_forever(self):
         """Run until stop() is called."""
         self._check_closed()
-        self._check_runnung()
+        self._check_running()
         self._set_coroutine_origin_tracking(self._debug)
         self._thread_id = threading.get_ident()
 
@@ -589,7 +589,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         Return the Future's result, or raise its exception.
         """
         self._check_closed()
-        self._check_runnung()
+        self._check_running()
 
         new_task = not futures.isfuture(future)
         future = tasks.ensure_future(future, loop=self)

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -258,8 +258,12 @@ class EventLoopTestsMixin:
             self.assertTrue(self.loop.is_running())
             self.loop.run_until_complete(coro1())
 
-        self.assertRaises(
-            RuntimeError, self.loop.run_until_complete, coro2())
+        with self.assertWarnsRegex(
+            RuntimeWarning,
+            r"coroutine \S+ was never awaited"
+        ):
+            self.assertRaises(
+                RuntimeError, self.loop.run_until_complete, coro2())
 
     # Note: because of the default Windows timing granularity of
     # 15.6 msec, we use fairly long sleep times here (~100 msec).


### PR DESCRIPTION
https://bugs.python.org/issue39191.
(cherry picked from commit 10ac0cded26d91c3468e5e5a87cecad7fc0bcebd)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>


<!-- issue-number: [bpo-39191](https://bugs.python.org/issue39191) -->
https://bugs.python.org/issue39191
<!-- /issue-number -->
