### PR TITLE
bpo-39261: Remove dead assignment from pyinit_config

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -749,7 +749,6 @@ pyinit_config(_PyRuntimeState *runtime,
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
-    config = &tstate->interp->config;
     *tstate_p = tstate;
 
     status = pycore_interp_init(tstate);


### PR DESCRIPTION
Victor Stinner has confirmed that this assignment is unnecessary: https://github.com/python/cpython/pull/16267/files#r364216184

<!-- issue-number: [bpo-39261](https://bugs.python.org/issue39261) -->
https://bugs.python.org/issue39261
<!-- /issue-number -->
