### PR TITLE
bpo-39262: Use specific out-of-memory message in _sharedexception_bind

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -221,8 +221,9 @@ _sharedexception_bind(PyObject *exctype, PyObject *exc, PyObject *tb)
     if (err->name == NULL) {
         if (PyErr_ExceptionMatches(PyExc_MemoryError)) {
             failure = "out of memory copying exception type name";
+        } else {
+            failure = "unable to encode and copy exception type name";
         }
-        failure = "unable to encode and copy exception type name";
         goto finally;
     }
 
@@ -237,8 +238,9 @@ _sharedexception_bind(PyObject *exctype, PyObject *exc, PyObject *tb)
         if (err->msg == NULL) {
             if (PyErr_ExceptionMatches(PyExc_MemoryError)) {
                 failure = "out of memory copying exception message";
+            } else {
+                failure = "unable to encode and copy exception message";
             }
-            failure = "unable to encode and copy exception message";
             goto finally;
         }
     }


### PR DESCRIPTION
Paul Ganssle previously commented "This appears to be an actual bugfix." https://github.com/python/cpython/pull/16267/files#r325855163

<!-- issue-number: [bpo-39262](https://bugs.python.org/issue39262) -->
https://bugs.python.org/issue39262
<!-- /issue-number -->
