### PR TITLE
Add test cases for dataclasses.

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -498,18 +498,6 @@ class TestCase(unittest.TestCase):
         self.assertNotEqual(C(3), C(4, 10))
         self.assertNotEqual(C(3, 10), C(4, 10))
 
-    def test_dataclass_params_repr(self):
-        @dataclass(init=True, repr=True)
-        class C:
-            pass
-
-        repr_output = repr(C.__dataclass_params__)
-        expected_output = "_DataclassParams(init=True,repr=True," \
-                          "eq=True,order=False,unsafe_hash=False," \
-                          "frozen=False)"
-
-        self.assertEqual(repr_output, expected_output)
-
     def test_hash_field_rules(self):
         # Test all 6 cases of:
         #  hash=True/False/None

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -45,6 +45,25 @@ class TestCase(unittest.TestCase):
         o = C(42)
         self.assertEqual(o.x, 42)
 
+    def test_field_default_default_factory_error(self):
+        msg = "cannot specify both default and default_factory"
+        with self.assertRaisesRegex(ValueError, msg):
+            @dataclass
+            class C:
+                x: int = field(default=1, default_factory=int)
+
+    def test_field_repr(self):
+        int_field = field(default=1, init=True, repr=False)
+        int_field.name = "id"
+        repr_output = repr(int_field)
+        expected_output = "Field(name='id',type=None," \
+                           f"default=1,default_factory={MISSING!r}," \
+                           "init=True,repr=False,hash=None," \
+                           "compare=True,metadata=mappingproxy({})," \
+                           "_field_type=None)"
+
+        self.assertEqual(repr_output, expected_output)
+
     def test_named_init_params(self):
         @dataclass
         class C:
@@ -478,6 +497,18 @@ class TestCase(unittest.TestCase):
         self.assertEqual(C(1, 10), C(1, 20))
         self.assertNotEqual(C(3), C(4, 10))
         self.assertNotEqual(C(3, 10), C(4, 10))
+
+    def test_dataclass_params_repr(self):
+        @dataclass(init=True, repr=True)
+        class C:
+            pass
+
+        repr_output = repr(C.__dataclass_params__)
+        expected_output = "_DataclassParams(init=True,repr=True," \
+                          "eq=True,order=False,unsafe_hash=False," \
+                          "frozen=False)"
+
+        self.assertEqual(repr_output, expected_output)
 
     def test_hash_field_rules(self):
         # Test all 6 cases of:


### PR DESCRIPTION
* Add test for `ValueError` to be raised when both default and default_factory are passed to a field.
* Add test for repr output of field and dataclass params. These can be removed or made to assert basic structure of repr if it's very rigid.

Added missing coverage cases based on https://codecov.io/gh/python/cpython/src/2e6a8efa837410327b593dc83c57492253b1201e/Lib/dataclasses.py

Thanks