### PR TITLE
bpo-39259: poplib.POP3/POP3_SSL now reject timeout = 0

### DIFF
--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -89,7 +89,7 @@ The :mod:`poplib` module provides two classes:
        certificates for you.
 
    .. versionchanged:: 3.9
-      if the *timeout* parameter is set to be zero, it will raise a
+      If the *timeout* parameter is set to be zero, it will raise a
       :class:`ValueError` to prevent the creation of a non-blocking socket.
 
 One exception is defined as an attribute of the :mod:`poplib` module:

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -48,7 +48,7 @@ The :mod:`poplib` module provides two classes:
       where ``line`` is the bytes about to be sent to the remote host.
 
    .. versionchanged:: 3.9
-      if the *timeout* parameter is set to be zero, it will raise a
+      If the *timeout* parameter is set to be zero, it will raise a
       :class:`ValueError` to prevent the creation of a non-blocking socket.
 
 .. class:: POP3_SSL(host, port=POP3_SSL_PORT, keyfile=None, certfile=None, timeout=None, context=None)
@@ -275,4 +275,3 @@ retrieves and prints all messages::
 
 At the end of the module, there is a test section that contains a more extensive
 example of usage.
-

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -47,6 +47,9 @@ The :mod:`poplib` module provides two classes:
       ``poplib.putline`` with arguments ``self`` and ``line``,
       where ``line`` is the bytes about to be sent to the remote host.
 
+   .. versionchanged:: 3.9
+      if the *timeout* parameter is set to be zero, it will raise a
+      :class:`ValueError` to prevent the creation of a non-blocking socket.
 
 .. class:: POP3_SSL(host, port=POP3_SSL_PORT, keyfile=None, certfile=None, timeout=None, context=None)
 
@@ -84,6 +87,10 @@ The :mod:`poplib` module provides two classes:
        Please use :meth:`ssl.SSLContext.load_cert_chain` instead, or let
        :func:`ssl.create_default_context` select the system's trusted CA
        certificates for you.
+
+   .. versionchanged:: 3.9
+      if the *timeout* parameter is set to be zero, it will raise a
+      :class:`ValueError` to prevent the creation of a non-blocking socket.
 
 One exception is defined as an attribute of the :mod:`poplib` module:
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -187,6 +187,13 @@ Exposed the Linux-specific :func:`os.pidfd_open` (:issue:`38692`) and
 :data:`os.P_PIDFD` (:issue:`38713`) for process management with file
 descriptors.
 
+poplib
+------
+
+:class:`~poplib.POP3` and :class:`~poplib.POP3_SSL` now raise a :class:`ValueError`
+if the given timeout for their constructor is zero to prevent the creation of
+a non-blocking socket. (Contributed by Dong-hee Na in :issue:`39259`.)
+
 threading
 ---------
 

--- a/Lib/poplib.py
+++ b/Lib/poplib.py
@@ -107,6 +107,8 @@ class POP3:
         self.welcome = self._getresp()
 
     def _create_socket(self, timeout):
+        if timeout is not None and not timeout:
+            raise ValueError('Non-blocking socket (timeout=0) is not supported')
         return socket.create_connection((self.host, self.port), timeout)
 
     def _putline(self, line):

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -505,17 +505,17 @@ class TestTimeouts(TestCase):
 
     def testTimeoutDefault(self):
         self.assertIsNone(socket.getdefaulttimeout())
-        socket.setdefaulttimeout(test_support.SHORT_TIMEOUT)
+        socket.setdefaulttimeout(test_support.LOOPBACK_TIMEOUT)
         try:
             pop = poplib.POP3(HOST, self.port)
         finally:
             socket.setdefaulttimeout(None)
-        self.assertEqual(pop.sock.gettimeout(), test_support.SHORT_TIMEOUT)
+        self.assertEqual(pop.sock.gettimeout(), test_support.LOOPBACK_TIMEOUT)
         pop.close()
 
     def testTimeoutNone(self):
         self.assertIsNone(socket.getdefaulttimeout())
-        socket.setdefaulttimeout(test_support.SHORT_TIMEOUT)
+        socket.setdefaulttimeout(30)
         try:
             pop = poplib.POP3(HOST, self.port, timeout=None)
         finally:
@@ -524,8 +524,8 @@ class TestTimeouts(TestCase):
         pop.close()
 
     def testTimeoutValue(self):
-        pop = poplib.POP3(HOST, self.port, timeout=test_support.SHORT_TIMEOUT)
-        self.assertEqual(pop.sock.gettimeout(), test_support.SHORT_TIMEOUT)
+        pop = poplib.POP3(HOST, self.port, timeout=test_support.LOOPBACK_TIMEOUT)
+        self.assertEqual(pop.sock.gettimeout(), test_support.LOOPBACK_TIMEOUT)
         pop.close()
         with self.assertRaises(ValueError):
             poplib.POP3(HOST, self.port, timeout=0)

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -481,7 +481,7 @@ class TestTimeouts(TestCase):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.settimeout(60)  # Safety net. Look issue 11812
         self.port = test_support.bind_port(self.sock)
-        self.thread = threading.Thread(target=self.server, args=(self.evt,self.sock))
+        self.thread = threading.Thread(target=self.server, args=(self.evt, self.sock))
         self.thread.daemon = True
         self.thread.start()
         self.evt.wait()
@@ -505,17 +505,17 @@ class TestTimeouts(TestCase):
 
     def testTimeoutDefault(self):
         self.assertIsNone(socket.getdefaulttimeout())
-        socket.setdefaulttimeout(30)
+        socket.setdefaulttimeout(test_support.SHORT_TIMEOUT)
         try:
             pop = poplib.POP3(HOST, self.port)
         finally:
             socket.setdefaulttimeout(None)
-        self.assertEqual(pop.sock.gettimeout(), 30)
+        self.assertEqual(pop.sock.gettimeout(), test_support.SHORT_TIMEOUT)
         pop.close()
 
     def testTimeoutNone(self):
         self.assertIsNone(socket.getdefaulttimeout())
-        socket.setdefaulttimeout(30)
+        socket.setdefaulttimeout(test_support.SHORT_TIMEOUT)
         try:
             pop = poplib.POP3(HOST, self.port, timeout=None)
         finally:
@@ -524,9 +524,11 @@ class TestTimeouts(TestCase):
         pop.close()
 
     def testTimeoutValue(self):
-        pop = poplib.POP3(HOST, self.port, timeout=30)
-        self.assertEqual(pop.sock.gettimeout(), 30)
+        pop = poplib.POP3(HOST, self.port, timeout=test_support.SHORT_TIMEOUT)
+        self.assertEqual(pop.sock.gettimeout(), test_support.SHORT_TIMEOUT)
         pop.close()
+        with self.assertRaises(ValueError):
+            poplib.POP3(HOST, self.port, timeout=0)
 
 
 def test_main():

--- a/Misc/NEWS.d/next/Library/2020-01-09-10-58-58.bpo-39259.RmDgCC.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-09-10-58-58.bpo-39259.RmDgCC.rst
@@ -1,0 +1,3 @@
+:class:`~poplib.POP3` and :class:`~poplib.POP3_SSL` now raise a
+:class:`ValueError` if the given timeout for their constructor is zero to
+prevent the creation of a non-blocking socket. Patch by Dong-hee Na.


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39259](https://bugs.python.org/issue39259) -->
https://bugs.python.org/issue39259
<!-- /issue-number -->
