### PR TITLE
bpo-39270: Remove dead assignment from config_init_module_search_paths.

### DIFF
--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -240,9 +240,8 @@ config_init_module_search_paths(PyConfig *config, _PyPathConfig *pathconfig)
 
     const wchar_t *sys_path = pathconfig->module_search_path;
     const wchar_t delim = DELIM;
-    const wchar_t *p = sys_path;
     while (1) {
-        p = wcschr(sys_path, delim);
+        const wchar_t *p = wcschr(sys_path, delim);
         if (p == NULL) {
             p = sys_path + wcslen(sys_path); /* End of string */
         }


### PR DESCRIPTION
I took [Victor Stinner's suggestion](https://github.com/python/cpython/pull/16267/files#r364216448) to move the declaration of p into the loop.

<!-- issue-number: [bpo-39270](https://bugs.python.org/issue39270) -->
https://bugs.python.org/issue39270
<!-- /issue-number -->
