### PR TITLE
bpo-39271: Remove dead assignment from pattern_subx

### DIFF
--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -1002,7 +1002,6 @@ pattern_subx(PatternObject* self, PyObject* ptemplate, PyObject* string,
         int literal;
         view.buf = NULL;
         ptr = getstring(ptemplate, &n, &isbytes, &charsize, &view);
-        b = charsize;
         if (ptr) {
             if (charsize == 1)
                 literal = memchr(ptr, '\\', n) == NULL;


### PR DESCRIPTION
This is a straightforward simplification.

<!-- issue-number: [bpo-39271](https://bugs.python.org/issue39271) -->
https://bugs.python.org/issue39271
<!-- /issue-number -->
