### PR TITLE
Doc: fix MinGW library generation command

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -2109,7 +2109,7 @@ Changes in the C API
 
   .. code-block:: shell
 
-      gendef python38.dll > tmp.def
+      gendef - python38.dll > tmp.def
       dlltool --dllname python38.dll --def tmp.def --output-lib libpython38.a
 
   The location of an installed :file:`pythonXY.dll` will depend on the


### PR DESCRIPTION
To print the exports to stdout, the gendef command requires the option "-". Without this option, no output is generated.