### PR TITLE
bpo-39279: Don't allow non-ASCII digits in platform.py

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -246,7 +246,7 @@ def _norm_version(version, build=''):
 
 _ver_output = re.compile(r'(?:([\w ]+) ([\w.]+) '
                          r'.*'
-                         r'\[.* ([\d.]+)\])')
+                         r'\[.* ([0-9.]+)\])')
 
 # Examples of VER command output:
 #
@@ -956,10 +956,10 @@ _ironpython_sys_version_parser = re.compile(
 
 # IronPython covering 2.6 and 2.7
 _ironpython26_sys_version_parser = re.compile(
-    r'([\d.]+)\s*'
+    r'([0-9.]+)\s*'
     r'\(IronPython\s*'
-    r'[\d.]+\s*'
-    r'\(([\d.]+)\) on ([\w.]+ [\d.]+(?: \(\d+-bit\))?)\)'
+    r'[0-9.]+\s*'
+    r'\(([0-9.]+)\) on ([\w.]+ [0-9.]+(?: \([0-9]+-bit\))?)\)'
 )
 
 _pypy_sys_version_parser = re.compile(

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -353,5 +353,22 @@ class PlatformTest(unittest.TestCase):
                     self.assertEqual(platform.platform(), expected)
 
 
+    def test_non_ascii_digits_windows_version(self):
+        # Non-ASCII digits must be rejected in version numbers.
+        version_strings = {
+            'Microsoft Windows [Version 6.1.7601]': ('Microsoft', 'Windows', '6.1.7601'),
+            'Microsoft Windows [Version ٦.1.7601]': None, # East-arabic numerals
+            'Microsoft Windows [Version 6.１.7601]': None, # Full-width numerals
+            'Microsoft Windows [Version 6.1.760１]': None, # Full-width numerals
+        }
+        for version_string, expected_groups in version_strings.items():
+            if match := platform._ver_output.match(version_string):
+                self.assertIsNotNone(expected_groups)
+                self.assertEqual(expected_groups, match.groups())
+            else:
+                self.assertIsNone(expected_groups)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-01-09-23-03-37.bpo-39279.32v0pl.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-09-23-03-37.bpo-39279.32v0pl.rst
@@ -1,0 +1,1 @@
+Don't allow non-ASCII digits in version numbers specified in platform.py.


### PR DESCRIPTION
The `platform.py` module takes non-Ascii digits in regexes in places it shouldn't. e.g. digits like ٢ and ５ and accepted, when only the Ascii digits between 0-9 should be accepted.

<!-- issue-number: [bpo-39279](https://bugs.python.org/issue39279) -->
https://bugs.python.org/issue39279
<!-- /issue-number -->
