### PR TITLE
Fix outdated comment in _strptime.py

### DIFF
--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -182,7 +182,7 @@ class TimeRE(dict):
             self.locale_time = LocaleTime()
         base = super()
         base.__init__({
-            # The " \d" part of the regex is to make %c from ANSI C work
+            # The " [1-9]" part of the regex is to make %c from ANSI C work
             'd': r"(?P<d>3[0-1]|[1-2]\d|0[1-9]|[1-9]| [1-9])",
             'f': r"(?P<f>[0-9]{1,6})",
             'H': r"(?P<H>2[0-3]|[0-1]\d|\d)",


### PR DESCRIPTION
Can I please get the tags for skipping bpo and skipping a news item?

Automerge-Triggered-By: @pganssle