### PR TITLE
[3.8] Fix typos in Misc/NEWS.d

### DIFF
--- a/Misc/NEWS.d/3.8.0.rst
+++ b/Misc/NEWS.d/3.8.0.rst
@@ -18,7 +18,7 @@ When cyclic garbage collection (gc) runs finalizers that resurrect
 unreachable objects, the current gc run ends, without collecting any cyclic
 trash.  However, the statistics reported by ``collect()`` and
 ``get_stats()`` claimed that all cyclic trash found was collected, and that
-the resurrected objects were collected.  Changed the stats to report that
+the resurrected objects were collected.   Changed the stats to report that
 none were collected.
 
 ..

--- a/Misc/NEWS.d/3.8.0.rst
+++ b/Misc/NEWS.d/3.8.0.rst
@@ -18,7 +18,7 @@ When cyclic garbage collection (gc) runs finalizers that resurrect
 unreachable objects, the current gc run ends, without collecting any cyclic
 trash.  However, the statistics reported by ``collect()`` and
 ``get_stats()`` claimed that all cyclic trash found was collected, and that
-the resurrected objects were collected.   Changed the stats to report that
+the resurrected objects were collected. Changed the stats to report that
 none were collected.
 
 ..
@@ -101,7 +101,7 @@ now never fails (except MemoryError).
 .. nonce: go_jFf
 .. section: Documentation
 
-Add list of no-longer-escaped chars to re.escape documentation
+Add list of no-longer-escaped chars to re.escape documentation.
 
 ..
 
@@ -123,7 +123,7 @@ Python slowest buildbots.
 .. nonce: scr2LO
 .. section: Windows
 
-Fix error message in activate.bat
+Fix error message in activate.bat.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0.rst
+++ b/Misc/NEWS.d/3.8.0.rst
@@ -18,7 +18,7 @@ When cyclic garbage collection (gc) runs finalizers that resurrect
 unreachable objects, the current gc run ends, without collecting any cyclic
 trash.  However, the statistics reported by ``collect()`` and
 ``get_stats()`` claimed that all cyclic trash found was collected, and that
-the resurrected objects were collected. Changed the stats to report that
+the resurrected objects were collected.  Changed the stats to report that
 none were collected.
 
 ..

--- a/Misc/NEWS.d/3.8.1.rst
+++ b/Misc/NEWS.d/3.8.1.rst
@@ -26,7 +26,7 @@ the "elif" keyword and not to its condition, making it consistent with the
 .. section: Core and Builtins
 
 :c:func:`PySys_Audit` now requires ``Py_ssize_t`` to be used for size
-arguments in the format string, regardless of whethen ``PY_SSIZE_T_CLEAN``
+arguments in the format string, regardless of whether ``PY_SSIZE_T_CLEAN``
 was defined at include time.
 
 ..
@@ -36,7 +36,7 @@ was defined at include time.
 .. nonce: QDtIxI
 .. section: Library
 
-Update importliib.metadata to include improvements from importlib_metadata
+Update importlib.metadata to include improvements from importlib_metadata
 1.3 including better serialization of EntryPoints and improved documentation
 for custom finders.
 
@@ -95,7 +95,7 @@ Prevent failure of test_relative_path in test_py_compile on macOS Catalina.
 .. nonce: _3xjKG
 .. section: IDLE
 
-Excape key now closes IDLE completion windows.  Patch by Johnny Najera.
+Escape key now closes IDLE completion windows.  Patch by Johnny Najera.
 
 ..
 


### PR DESCRIPTION
With reference to corrections to [news in 3.9.0a2.rst](https://github.com/python/cpython/pull/17665) backporting some typo corrections to 3.8.0/3.8.1. 