### PR TITLE
Fix typo in multiprocessing.pool.AsyncResult.successful doc.

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2279,7 +2279,7 @@ with the :class:`Pool` class.
    .. method:: successful()
 
       Return whether the call completed without raising an exception.  Will
-      raise :exc:`AssertionError` if the result is not ready.
+      raise :exc:`ValueError` if the result is not ready.
 
       .. versionchanged:: 3.7
          If the result is not ready, :exc:`ValueError` is raised instead of


### PR DESCRIPTION
Since 3.7 `successful` raises a `ValueError` as explained in the next text block from the documentation:

_Changed in version 3.7: If the result is not ready, ValueError is raised instead of AssertionError._

No issue associated with this PR.
Should be backported in 3.7 and 3.8.

Automerge-Triggered-By: @pitrou