### PR TITLE
bpo-39277, pytime: Fix overflow check on double to int cast

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-01-10-10-45-08.bpo-39277.A2qvZ2.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-10-10-45-08.bpo-39277.A2qvZ2.rst
@@ -1,0 +1,2 @@
+Fix :func:`time.sleep` to properly detect integer overflow when converting a
+floating-point number of seconds to an integer.

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -151,7 +151,7 @@ _PyTime_DoubleToDenominator(double d, time_t *sec, long *numerator,
     }
     assert(0.0 <= floatpart && floatpart < denominator);
 
-    if (!_Py_InIntegralTypeRange(time_t, intpart)) {
+    if (!_Py_DoubleInIntegralTypeRange(time_t, intpart)) {
         error_time_t_overflow();
         return -1;
     }
@@ -204,7 +204,7 @@ _PyTime_ObjectToTime_t(PyObject *obj, time_t *sec, _PyTime_round_t round)
         d = _PyTime_Round(d, round);
         (void)modf(d, &intpart);
 
-        if (!_Py_InIntegralTypeRange(time_t, intpart)) {
+        if (!_Py_DoubleInIntegralTypeRange(time_t, intpart)) {
             error_time_t_overflow();
             return -1;
         }
@@ -389,7 +389,7 @@ _PyTime_FromDouble(_PyTime_t *t, double value, _PyTime_round_t round,
     d *= (double)unit_to_ns;
     d = _PyTime_Round(d, round);
 
-    if (!_Py_InIntegralTypeRange(_PyTime_t, d)) {
+    if (!_Py_DoubleInIntegralTypeRange(_PyTime_t, d)) {
         _PyTime_overflow();
         return -1;
     }


### PR DESCRIPTION
Fix time.sleep() to properly detect integer overflow when converting
a floating-point number of seconds to an integer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39277](https://bugs.python.org/issue39277) -->
https://bugs.python.org/issue39277
<!-- /issue-number -->
