### PR TITLE
bpo-12159: document sys.maxsize limit in len() function reference

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -892,6 +892,11 @@ are always available.  They are listed here in alphabetical order.
    sequence (such as a string, bytes, tuple, list, or range) or a collection
    (such as a dictionary, set, or frozen set).
 
+   .. impl-detail::
+
+      ``len`` raises :exc:`OverflowError` on lengths larger than
+      :data:`sys.maxsize`, such as :class:`range(2 ** 100) <range>`.
+
 
 .. _func-list:
 .. class:: list([iterable])


### PR DESCRIPTION
See: 

- BPO-12159:  "needs to be documented",
- BPO-15718:  added note to datamodel docs for `__len__` method but not `len()`, and 
- BPO-21444:  change request / wontfix

<!-- issue-number: [bpo-12159](https://bugs.python.org/issue12159) -->
https://bugs.python.org/issue12159
<!-- /issue-number -->
