### PR TITLE
gh-62433: Add SSLSocket.get_verified_chain() and SSLSocket.get_unverified_chain()

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1259,7 +1259,7 @@ SSL sockets also have the following additional methods and attributes:
    .. versionchanged:: 3.9
       IPv6 address strings no longer have a trailing new line.
 
-.. method:: SSLSocket.get_peer_cert_chain(binary_form=False)
+.. method:: SSLSocket.get_unverified_chain(binary_form=False)
 
    Returns an **unverified** certificate chain for the peer. If no chain is
    provided, returns :const:`None`. Otherwise returns a tuple of dicts

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1259,6 +1259,21 @@ SSL sockets also have the following additional methods and attributes:
    .. versionchanged:: 3.9
       IPv6 address strings no longer have a trailing new line.
 
+.. method:: SSLSocket.getpeercertchain(binary_form=False, validate=True)
+
+   Returns certificate chain for the peer. If no chain is provided, returns
+   None. Otherwise returns a tuple of dicts containing information about the
+   certificates. The chain starts with the leaf certificate and ends with the
+   root certificate. If called on the client side, the leaf certificate is the
+   peer's certificate.
+
+   If the optional argument *binary_form* is True, return a list of *binary_form*-encoded copies
+   of the certificates.
+   If the optional argument *validate* is False, return the peer's cert chain
+   without any validation and without the root CA cert.");
+
+    .. versionadded:: 3.9
+
 .. method:: SSLSocket.cipher()
 
    Returns a three-value tuple containing the name of the cipher being used, the

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1271,7 +1271,7 @@ SSL sockets also have the following additional methods and attributes:
    this method returns a tuple with each element corresponding to the
    DER-encoded form of the entire certificate as a sequence of bytes.
 
-   .. versionadded:: 3.9
+   .. versionadded:: 3.10
 
    .. warning::
       This is not a verified chain. See :meth:`ssl.SSLSocket.get_verified_chain`.
@@ -1288,7 +1288,7 @@ SSL sockets also have the following additional methods and attributes:
    this method returns a tuple with each element corresponding to the
    DER-encoded form of the entire certificate as a sequence of bytes.
 
-   .. versionadded:: 3.9
+   .. versionadded:: 3.10
 
    .. note::
      This features requires OpenSSL 1.1.0 or newer.

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1259,20 +1259,39 @@ SSL sockets also have the following additional methods and attributes:
    .. versionchanged:: 3.9
       IPv6 address strings no longer have a trailing new line.
 
-.. method:: SSLSocket.getpeercertchain(binary_form=False, validate=True)
+.. method:: SSLSocket.get_peer_cert_chain(binary_form=False)
 
-   Returns certificate chain for the peer. If no chain is provided, returns
-   None. Otherwise returns a tuple of dicts containing information about the
-   certificates. The chain starts with the leaf certificate and ends with the
-   root certificate. If called on the client side, the leaf certificate is the
-   peer's certificate.
+   Returns an **unverified** certificate chain for the peer. If no chain is
+   provided, returns :const:`None`. Otherwise returns a tuple of dicts
+   containing information about the certificates. The chain starts with the
+   leaf certificate and ends with the root certificate. Return :const:`None`
+   if the session is resumed as peers do not send certificates.
 
-   If the optional argument *binary_form* is True, return a list of *binary_form*-encoded copies
-   of the certificates.
-   If the optional argument *validate* is False, return the peer's cert chain
-   without any validation and without the root CA cert.");
+   If the ``binary_form`` parameter is :const:`True`, and a chain is available,
+   this method returns a tuple with each element corresponding to the
+   DER-encoded form of the entire certificate as a sequence of bytes.
 
-    .. versionadded:: 3.9
+   .. versionadded:: 3.9
+
+   .. warning::
+      This is not a verified chain. See :meth:`ssl.SSLSocket.get_verified_chain`.
+
+.. method:: SSLSocket.get_verified_chain(binary_form=False)
+
+   Returns a verified certificate chain for the peer. If no chain is provided,
+   returns :const:`None`. Otherwise returns a tuple of dicts containing
+   information about the certificates. The chain starts with the leaf
+   certificate and ends with the root certificate. Return :const:`None` if the
+   session is resumed as peers do not send certificates.
+
+   If the ``binary_form`` parameter is :const:`True`, and a chain is available,
+   this method returns a tuple with each element corresponding to the
+   DER-encoded form of the entire certificate as a sequence of bytes.
+
+   .. versionadded:: 3.9
+
+   .. note::
+     This features requires OpenSSL 1.1.0 or newer.
 
 .. method:: SSLSocket.cipher()
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -905,6 +905,13 @@ class SSLObject:
         """
         return self._sslobj.getpeercert(binary_form)
 
+    def getpeercertchain(self, binary_form=False, validate=True):
+        """"Returns the certificate chain of the SSL connection
+        as tuple of dicts.
+
+        Return None if no chain is provieded."""
+        return self._sslobj.getpeercertchain(binary_form, validate)
+
     def selected_npn_protocol(self):
         """Return the currently selected NPN protocol as a string, or ``None``
         if a next protocol was not negotiated or if NPN is not supported by one
@@ -1122,6 +1129,12 @@ class SSLSocket(socket):
         self._checkClosed()
         self._check_connected()
         return self._sslobj.getpeercert(binary_form)
+
+    @_sslcopydoc
+    def getpeercertchain(self, binary_form=False, validate=True):
+        self._checkClosed()
+        self._check_connected()
+        return self._sslobj.getpeercertchain(binary_form, validate)
 
     @_sslcopydoc
     def selected_npn_protocol(self):

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -905,12 +905,12 @@ class SSLObject:
         """
         return self._sslobj.getpeercert(binary_form)
 
-    def get_peer_cert_chain(self, binary_form=False):
+    def get_unverified_chain(self, binary_form=False):
         """"Returns the certificate chain of the SSL connection as a tuple of
         dicts. It is *not* a verified chain.
 
         Return ``None`` if no chain is provided."""
-        return self._sslobj.get_peer_cert_chain(binary_form)
+        return self._sslobj.get_unverified_chain(binary_form)
 
     if hasattr(_ssl._SSLSocket, 'get_verified_chain'):
         def get_verified_chain(self, binary_form=False):
@@ -1139,10 +1139,10 @@ class SSLSocket(socket):
         return self._sslobj.getpeercert(binary_form)
 
     @_sslcopydoc
-    def get_peer_cert_chain(self, binary_form=False):
+    def get_unverified_chain(self, binary_form=False):
         self._checkClosed()
         self._check_connected()
-        return self._sslobj.get_peer_cert_chain(binary_form)
+        return self._sslobj.get_unverified_chain(binary_form)
 
     if hasattr(_ssl._SSLSocket, 'get_verified_chain'):
         @_sslcopydoc

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -905,12 +905,20 @@ class SSLObject:
         """
         return self._sslobj.getpeercert(binary_form)
 
-    def getpeercertchain(self, binary_form=False, validate=True):
-        """"Returns the certificate chain of the SSL connection
-        as tuple of dicts.
+    def get_peer_cert_chain(self, binary_form=False):
+        """"Returns the certificate chain of the SSL connection as a tuple of
+        dicts. It is *not* a verified chain.
 
-        Return None if no chain is provieded."""
-        return self._sslobj.getpeercertchain(binary_form, validate)
+        Return ``None`` if no chain is provided."""
+        return self._sslobj.get_peer_cert_chain(binary_form)
+
+    if hasattr(_ssl._SSLSocket, 'get_verified_chain'):
+        def get_verified_chain(self, binary_form=False):
+            """"Returns the verified certificate chain of the SSL connection as a
+            tuple of dicts.
+
+            Return ``None`` if no chain is provided."""
+            return self._sslobj.get_verified_chain(binary_form)
 
     def selected_npn_protocol(self):
         """Return the currently selected NPN protocol as a string, or ``None``
@@ -1131,10 +1139,17 @@ class SSLSocket(socket):
         return self._sslobj.getpeercert(binary_form)
 
     @_sslcopydoc
-    def getpeercertchain(self, binary_form=False, validate=True):
+    def get_peer_cert_chain(self, binary_form=False):
         self._checkClosed()
         self._check_connected()
-        return self._sslobj.getpeercertchain(binary_form, validate)
+        return self._sslobj.get_peer_cert_chain(binary_form)
+
+    if hasattr(_ssl._SSLSocket, 'get_verified_chain'):
+        @_sslcopydoc
+        def get_verified_chain(self, binary_form=False):
+            self._checkClosed()
+            self._check_connected()
+            return self._sslobj.get_verified_chain(binary_form)
 
     @_sslcopydoc
     def selected_npn_protocol(self):

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2160,7 +2160,7 @@ class SimpleBackgroundTests(unittest.TestCase):
             self.assertTrue(cert)
         self.assertEqual(len(ctx.get_ca_certs()), 1)
 
-    def test_get_peer_cert_chain(self):
+    def test_get_unverified_chain(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
         ctx.verify_mode = ssl.CERT_REQUIRED
         ctx.load_verify_locations(capath=CAPATH)
@@ -2169,8 +2169,8 @@ class SimpleBackgroundTests(unittest.TestCase):
             try:
                 peer_cert = s.getpeercert()
                 peer_cert_bin = s.getpeercert(True)
-                chain_no_validate = s.get_peer_cert_chain()
-                chain_bin_no_validate = s.get_peer_cert_chain(True)
+                chain_no_validate = s.get_unverified_chain()
+                chain_bin_no_validate = s.get_unverified_chain(True)
             finally:
                 self.assertTrue(peer_cert)
                 self.assertTrue(peer_cert_bin)

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2169,15 +2169,24 @@ class SimpleBackgroundTests(unittest.TestCase):
             try:
                 peer_cert = s.getpeercert()
                 peer_cert_bin = s.getpeercert(True)
-                chain = s.getpeercertchain()
-                chain_bin = s.getpeercertchain(True)
+                if IS_OPENSSL_1_1_0:
+                    chain = s.getpeercertchain()
+                    chain_bin = s.getpeercertchain(True)
+                else:
+                    self.assertRaisesRegex(
+                        Exception, r'only supported by OpenSSL 1\.1\.0',
+                        s.getpeercertchain)
+                    self.assertRaisesRegex(
+                        Exception, r'only supported by OpenSSL 1\.1\.0',
+                        s.getpeercertchain, True)
                 chain_no_validate = s.getpeercertchain(validate=False)
                 chain_bin_no_validate = s.getpeercertchain(True, False)
             finally:
                 self.assertTrue(peer_cert)
-                self.assertEqual(len(chain), 2)
                 self.assertTrue(peer_cert_bin)
-                self.assertEqual(len(chain_bin), 2)
+                if IS_OPENSSL_1_1_0:
+                    self.assertEqual(len(chain), 2)
+                    self.assertEqual(len(chain_bin), 2)
 
                 # ca cert
                 ca_certs = ctx.get_ca_certs()
@@ -2185,8 +2194,9 @@ class SimpleBackgroundTests(unittest.TestCase):
                 test_get_ca_certsert = ca_certs[0]
                 ca_cert_bin = ctx.get_ca_certs(True)[0]
 
-                self.assertEqual(chain, (peer_cert, test_get_ca_certsert))
-                self.assertEqual(chain_bin, (peer_cert_bin, ca_cert_bin))
+                if IS_OPENSSL_1_1_0:
+                    self.assertEqual(chain, (peer_cert, test_get_ca_certsert))
+                    self.assertEqual(chain_bin, (peer_cert_bin, ca_cert_bin))
                 self.assertEqual(chain_no_validate, (peer_cert,))
                 self.assertEqual(chain_bin_no_validate, (peer_cert_bin,))
 

--- a/Misc/NEWS.d/next/Library/2020-01-10-16-06-13.bpo-18233.EsqH1K.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-10-16-06-13.bpo-18233.EsqH1K.rst
@@ -1,0 +1,1 @@
+Add :meth:`ssl.SSLSocket.getpeercertchain` for accessing the certificate chain of SSL connections.

--- a/Misc/NEWS.d/next/Library/2020-01-10-16-06-13.bpo-18233.EsqH1K.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-10-16-06-13.bpo-18233.EsqH1K.rst
@@ -1,1 +1,1 @@
-Add :meth:`ssl.SSLSocket.get_peer_cert_chain` and :meth:`ssl.SSLSocket.get_verified_chain` for accessing the certificate chain of SSL connections.
+Add :meth:`ssl.SSLSocket.get_unverified_chain` and :meth:`ssl.SSLSocket.get_verified_chain` for accessing the certificate chain of SSL connections.

--- a/Misc/NEWS.d/next/Library/2020-01-10-16-06-13.bpo-18233.EsqH1K.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-10-16-06-13.bpo-18233.EsqH1K.rst
@@ -1,1 +1,1 @@
-Add :meth:`ssl.SSLSocket.getpeercertchain` for accessing the certificate chain of SSL connections.
+Add :meth:`ssl.SSLSocket.get_peer_cert_chain` and :meth:`ssl.SSLSocket.get_verified_chain` for accessing the certificate chain of SSL connections.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2130,13 +2130,13 @@ chain_to_pyobject(STACK_OF(X509) *peer_chain, int binary_mode)
 }
 
 /*[clinic input]
-_ssl._SSLSocket.get_peer_cert_chain
+_ssl._SSLSocket.get_unverified_chain
     der as binary_mode: bool = False
 [clinic start generated code]*/
 
 static PyObject *
-_ssl__SSLSocket_get_peer_cert_chain_impl(PySSLSocket *self, int binary_mode)
-/*[clinic end generated code: output=2fc1e5dce85798ba input=3dd8f43730febaa9]*/
+_ssl__SSLSocket_get_unverified_chain_impl(PySSLSocket *self, int binary_mode)
+/*[clinic end generated code: output=a84c4e7bb50f3477 input=842931a7d60f135e]*/
 {
     STACK_OF(X509) *peer_chain; /* reference */
 
@@ -3089,7 +3089,7 @@ static PyMethodDef PySSLMethods[] = {
     _SSL__SSLSOCKET_GET_CHANNEL_BINDING_METHODDEF
     _SSL__SSLSOCKET_CIPHER_METHODDEF
     _SSL__SSLSOCKET_SHARED_CIPHERS_METHODDEF
-    _SSL__SSLSOCKET_GET_PEER_CERT_CHAIN_METHODDEF
+    _SSL__SSLSOCKET_GET_UNVERIFIED_CHAIN_METHODDEF
 #ifdef OPENSSL_VERSION_1_1
     _SSL__SSLSOCKET_GET_VERIFIED_CHAIN_METHODDEF
 #endif

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2187,6 +2187,11 @@ _ssl__SSLSocket_getpeercertchain_impl(PySSLSocket *self, int binary_mode,
 #endif
     } else {
         peer_chain = SSL_get_peer_cert_chain(self->ssl);
+        if (self->socket_type == PY_SSL_SERVER) {
+            X509 *peer_cert = SSL_get_peer_certificate(self->ssl);
+            if (peer_cert != NULL)
+                sk_X509_insert(peer_chain, peer_cert, 0);
+        }
     }
 
     if (peer_chain == NULL) {

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -122,6 +122,56 @@ _ssl__SSLSocket_cipher(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_cipher_impl(self);
 }
 
+PyDoc_STRVAR(_ssl__SSLSocket_getpeercertchain__doc__,
+"getpeercertchain($self, /, der=False, validate=True)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLSOCKET_GETPEERCERTCHAIN_METHODDEF    \
+    {"getpeercertchain", (PyCFunction)(void(*)(void))_ssl__SSLSocket_getpeercertchain, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLSocket_getpeercertchain__doc__},
+
+static PyObject *
+_ssl__SSLSocket_getpeercertchain_impl(PySSLSocket *self, int binary_mode,
+                                      int validate);
+
+static PyObject *
+_ssl__SSLSocket_getpeercertchain(PySSLSocket *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"der", "validate", NULL};
+    static _PyArg_Parser _parser = {NULL, _keywords, "getpeercertchain", 0};
+    PyObject *argsbuf[2];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
+    int binary_mode = 0;
+    int validate = 1;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 0, 2, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    if (!noptargs) {
+        goto skip_optional_pos;
+    }
+    if (args[0]) {
+        binary_mode = PyObject_IsTrue(args[0]);
+        if (binary_mode < 0) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_pos;
+        }
+    }
+    validate = PyObject_IsTrue(args[1]);
+    if (validate < 0) {
+        goto exit;
+    }
+skip_optional_pos:
+    return_value = _ssl__SSLSocket_getpeercertchain_impl(self, binary_mode, validate);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLSocket_version__doc__,
 "version($self, /)\n"
 "--\n"
@@ -1447,4 +1497,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=2bb53a80040c9b35 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7898c106854115f2 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -122,23 +122,23 @@ _ssl__SSLSocket_cipher(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_cipher_impl(self);
 }
 
-PyDoc_STRVAR(_ssl__SSLSocket_get_peer_cert_chain__doc__,
-"get_peer_cert_chain($self, /, der=False)\n"
+PyDoc_STRVAR(_ssl__SSLSocket_get_unverified_chain__doc__,
+"get_unverified_chain($self, /, der=False)\n"
 "--\n"
 "\n");
 
-#define _SSL__SSLSOCKET_GET_PEER_CERT_CHAIN_METHODDEF    \
-    {"get_peer_cert_chain", (PyCFunction)(void(*)(void))_ssl__SSLSocket_get_peer_cert_chain, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLSocket_get_peer_cert_chain__doc__},
+#define _SSL__SSLSOCKET_GET_UNVERIFIED_CHAIN_METHODDEF    \
+    {"get_unverified_chain", (PyCFunction)(void(*)(void))_ssl__SSLSocket_get_unverified_chain, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLSocket_get_unverified_chain__doc__},
 
 static PyObject *
-_ssl__SSLSocket_get_peer_cert_chain_impl(PySSLSocket *self, int binary_mode);
+_ssl__SSLSocket_get_unverified_chain_impl(PySSLSocket *self, int binary_mode);
 
 static PyObject *
-_ssl__SSLSocket_get_peer_cert_chain(PySSLSocket *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_ssl__SSLSocket_get_unverified_chain(PySSLSocket *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"der", NULL};
-    static _PyArg_Parser _parser = {NULL, _keywords, "get_peer_cert_chain", 0};
+    static _PyArg_Parser _parser = {NULL, _keywords, "get_unverified_chain", 0};
     PyObject *argsbuf[1];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
     int binary_mode = 0;
@@ -155,7 +155,7 @@ _ssl__SSLSocket_get_peer_cert_chain(PySSLSocket *self, PyObject *const *args, Py
         goto exit;
     }
 skip_optional_pos:
-    return_value = _ssl__SSLSocket_get_peer_cert_chain_impl(self, binary_mode);
+    return_value = _ssl__SSLSocket_get_unverified_chain_impl(self, binary_mode);
 
 exit:
     return return_value;
@@ -1533,4 +1533,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=db4f0808302f242f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3f880c7260e778fd input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -122,55 +122,87 @@ _ssl__SSLSocket_cipher(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_cipher_impl(self);
 }
 
-PyDoc_STRVAR(_ssl__SSLSocket_getpeercertchain__doc__,
-"getpeercertchain($self, /, der=False, validate=True)\n"
+PyDoc_STRVAR(_ssl__SSLSocket_get_peer_cert_chain__doc__,
+"get_peer_cert_chain($self, /, der=False)\n"
 "--\n"
 "\n");
 
-#define _SSL__SSLSOCKET_GETPEERCERTCHAIN_METHODDEF    \
-    {"getpeercertchain", (PyCFunction)(void(*)(void))_ssl__SSLSocket_getpeercertchain, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLSocket_getpeercertchain__doc__},
+#define _SSL__SSLSOCKET_GET_PEER_CERT_CHAIN_METHODDEF    \
+    {"get_peer_cert_chain", (PyCFunction)(void(*)(void))_ssl__SSLSocket_get_peer_cert_chain, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLSocket_get_peer_cert_chain__doc__},
 
 static PyObject *
-_ssl__SSLSocket_getpeercertchain_impl(PySSLSocket *self, int binary_mode,
-                                      int validate);
+_ssl__SSLSocket_get_peer_cert_chain_impl(PySSLSocket *self, int binary_mode);
 
 static PyObject *
-_ssl__SSLSocket_getpeercertchain(PySSLSocket *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_ssl__SSLSocket_get_peer_cert_chain(PySSLSocket *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"der", "validate", NULL};
-    static _PyArg_Parser _parser = {NULL, _keywords, "getpeercertchain", 0};
-    PyObject *argsbuf[2];
+    static const char * const _keywords[] = {"der", NULL};
+    static _PyArg_Parser _parser = {NULL, _keywords, "get_peer_cert_chain", 0};
+    PyObject *argsbuf[1];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
     int binary_mode = 0;
-    int validate = 1;
 
-    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 0, 2, 0, argsbuf);
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 0, 1, 0, argsbuf);
     if (!args) {
         goto exit;
     }
     if (!noptargs) {
         goto skip_optional_pos;
     }
-    if (args[0]) {
-        binary_mode = PyObject_IsTrue(args[0]);
-        if (binary_mode < 0) {
-            goto exit;
-        }
-        if (!--noptargs) {
-            goto skip_optional_pos;
-        }
-    }
-    validate = PyObject_IsTrue(args[1]);
-    if (validate < 0) {
+    binary_mode = PyObject_IsTrue(args[0]);
+    if (binary_mode < 0) {
         goto exit;
     }
 skip_optional_pos:
-    return_value = _ssl__SSLSocket_getpeercertchain_impl(self, binary_mode, validate);
+    return_value = _ssl__SSLSocket_get_peer_cert_chain_impl(self, binary_mode);
 
 exit:
     return return_value;
 }
+
+#if defined(OPENSSL_VERSION_1_1)
+
+PyDoc_STRVAR(_ssl__SSLSocket_get_verified_chain__doc__,
+"get_verified_chain($self, /, der=False)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLSOCKET_GET_VERIFIED_CHAIN_METHODDEF    \
+    {"get_verified_chain", (PyCFunction)(void(*)(void))_ssl__SSLSocket_get_verified_chain, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLSocket_get_verified_chain__doc__},
+
+static PyObject *
+_ssl__SSLSocket_get_verified_chain_impl(PySSLSocket *self, int binary_mode);
+
+static PyObject *
+_ssl__SSLSocket_get_verified_chain(PySSLSocket *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"der", NULL};
+    static _PyArg_Parser _parser = {NULL, _keywords, "get_verified_chain", 0};
+    PyObject *argsbuf[1];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 0;
+    int binary_mode = 0;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 0, 1, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    if (!noptargs) {
+        goto skip_optional_pos;
+    }
+    binary_mode = PyObject_IsTrue(args[0]);
+    if (binary_mode < 0) {
+        goto exit;
+    }
+skip_optional_pos:
+    return_value = _ssl__SSLSocket_get_verified_chain_impl(self, binary_mode);
+
+exit:
+    return return_value;
+}
+
+#endif /* defined(OPENSSL_VERSION_1_1) */
 
 PyDoc_STRVAR(_ssl__SSLSocket_version__doc__,
 "version($self, /)\n"
@@ -1470,6 +1502,10 @@ exit:
 
 #endif /* defined(_MSC_VER) */
 
+#ifndef _SSL__SSLSOCKET_GET_VERIFIED_CHAIN_METHODDEF
+    #define _SSL__SSLSOCKET_GET_VERIFIED_CHAIN_METHODDEF
+#endif /* !defined(_SSL__SSLSOCKET_GET_VERIFIED_CHAIN_METHODDEF) */
+
 #ifndef _SSL__SSLSOCKET_SELECTED_NPN_PROTOCOL_METHODDEF
     #define _SSL__SSLSOCKET_SELECTED_NPN_PROTOCOL_METHODDEF
 #endif /* !defined(_SSL__SSLSOCKET_SELECTED_NPN_PROTOCOL_METHODDEF) */
@@ -1497,4 +1533,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=7898c106854115f2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=db4f0808302f242f input=a9049054013a1b77]*/


### PR DESCRIPTION
Based on the patch provided by Christian Heimes (christian.heimes) and updated by Mariusz Masztalerczuk (mmasztalerczuk). Updated to use `SSL_get0_verified_chain` in OpenSSL 1.1 as suggested by Jörn Heissler (joernheissler).

Tested with both OpenSSL 1.0.2 and 1.1.1 using the included test and:
```python
import ssl
import socket
ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
ctx.load_default_certs()
good_hosts = [
    'google.com',
    'example.com',
]
bad_hosts = [
    'expired.badssl.com',
    'self-signed.badssl.com',
    'untrusted-root.badssl.com',
]
for host in good_hosts + bad_hosts:
    print('host =', host)
    ctx.verify_mode = ssl.CERT_NONE
    with ctx.wrap_socket(socket.socket(socket.AF_INET), server_hostname=host) as s:
        s.connect((host, 443))
        chain_no_validate = s.getpeercertchain(validate=False)
        try:
            chain_validate = s.getpeercertchain(validate=True)
        except Exception as e:
            if host in bad_hosts:
                print('Failed as expected with', e)
            else:
                raise Exception('Failed to validate good host')
        else:
            if host not in good_hosts:
                raise Exception('Managed to validate bad host')
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-18233](https://bugs.python.org/issue18233) -->
https://bugs.python.org/issue18233
<!-- /issue-number -->

<!-- gh-issue-number: gh-62433 -->
* Issue: gh-62433
<!-- /gh-issue-number -->
