### PR TITLE
bpo-39290: Add support for import_as_names for traverse_imports

### DIFF
--- a/Lib/lib2to3/fixes/fix_import.py
+++ b/Lib/lib2to3/fixes/fix_import.py
@@ -27,9 +27,9 @@ def traverse_imports(names):
             yield node.value
         elif node.type == syms.dotted_name:
             yield "".join([ch.value for ch in node.children])
-        elif node.type == syms.dotted_as_name:
+        elif node.type in {syms.dotted_as_name, syms.import_as_name}:
             pending.append(node.children[0])
-        elif node.type == syms.dotted_as_names:
+        elif node.type in {syms.dotted_as_names, syms.import_as_names}:
             pending.extend(node.children[::-2])
         else:
             raise AssertionError("unknown node type")

--- a/Misc/NEWS.d/next/Library/2020-01-10-20-22-04.bpo-39290.RsTxpx.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-10-20-22-04.bpo-39290.RsTxpx.rst
@@ -1,0 +1,2 @@
+Add imports_as_name support to ``traverse_imports`` in
+``lib2to3.fixes.fix_import``.


### PR DESCRIPTION


<!-- issue-number: [bpo-39290](https://bugs.python.org/issue39290) -->
https://bugs.python.org/issue39290
<!-- /issue-number -->
