### PR TITLE
bpo-38901: Allow setting a venv's prompt to the basename of the current directory.

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -122,7 +122,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
     * ``prompt`` -- a String to be used after virtual environment is activated
       (defaults to ``None`` which means directory name of the environment would
-      be used). If the special string ``"."` is provided, the basename of the
+      be used). If the special string ``"."`` is provided, the basename of the
       current directory is used as the prompt.
 
     * ``upgrade_deps`` -- Update the base venv modules to the latest on PyPI

--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -122,7 +122,8 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
     * ``prompt`` -- a String to be used after virtual environment is activated
       (defaults to ``None`` which means directory name of the environment would
-      be used).
+      be used). If the special string ``"."` is provided, the basename of the
+      current directory is used as the prompt.
 
     * ``upgrade_deps`` -- Update the base venv modules to the latest on PyPI
 

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -138,6 +138,15 @@ class BasicTest(BaseTest):
         self.assertEqual(context.prompt, '(My prompt) ')
         self.assertIn("prompt = 'My prompt'\n", data)
 
+        rmtree(self.env_dir)
+        builder = venv.EnvBuilder(prompt='.')
+        cwd = os.path.basename(os.getcwd())
+        self.run_with_capture(builder.create, self.env_dir)
+        context = builder.ensure_directories(self.env_dir)
+        data = self.get_text_file_contents('pyvenv.cfg')
+        self.assertEqual(context.prompt, '(%s) ' % cwd)
+        self.assertIn("prompt = '%s'\n" % cwd, data)
+
     def test_upgrade_dependencies(self):
         builder = venv.EnvBuilder()
         bin_path = 'Scripts' if sys.platform == 'win32' else 'bin'

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -51,6 +51,8 @@ class EnvBuilder:
         self.symlinks = symlinks
         self.upgrade = upgrade
         self.with_pip = with_pip
+        if prompt == '.':  # see bpo-38901
+            prompt = os.path.basename(os.getcwd())
         self.prompt = prompt
         self.upgrade_deps = upgrade_deps
 

--- a/Misc/NEWS.d/next/Library/2020-01-10-22-30-48.bpo-38901.OdVIIb.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-10-22-30-48.bpo-38901.OdVIIb.rst
@@ -1,0 +1,3 @@
+When you specify prompt='.' or equivalently python -m venv --prompt . ...
+the basename of the current directory is used to set the created venv's
+prompt when it's activated.


### PR DESCRIPTION
When a prompt value of '.' is specified, `os.path.basename(os.getcwd())` is used to  configure the prompt for the created venv.

<!-- issue-number: [bpo-38901](https://bugs.python.org/issue38901) -->
https://bugs.python.org/issue38901
<!-- /issue-number -->
