### PR TITLE
bpo-39299: Add more tests for mimetypes and its cli.

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -563,7 +563,7 @@ def _default_mime_types():
 _default_mime_types()
 
 
-if __name__ == '__main__':
+def _main():
     import getopt
 
     USAGE = """\
@@ -607,3 +607,7 @@ More than one type argument may be given.
             guess, encoding = guess_type(gtype, strict)
             if not guess: print("I don't know anything about type", gtype)
             else: print('type:', guess, 'encoding:', encoding)
+
+
+if __name__ == '__main__':
+    _main()

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -8,10 +8,20 @@ import unittest
 from test import support
 from platform import win32_edition
 
-# Tell it we don't know about external files:
-mimetypes.knownfiles = []
-mimetypes.inited = False
-mimetypes._default_mime_types()
+
+def setUpModule():
+    global knownfiles
+    knownfiles = mimetypes.knownfiles
+
+    # Tell it we don't know about external files:
+    mimetypes.knownfiles = []
+    mimetypes.inited = False
+    mimetypes._default_mime_types()
+
+
+def tearDownModule():
+    # Restore knownfiles to its initial state
+    mimetypes.knownfiles = knownfiles
 
 
 class MimeTypesTestCase(unittest.TestCase):

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -16,8 +16,6 @@ class MimeTypesTestMixin(unittest.TestCase):
 
         # Tell it we don't know about external files:
         support.patch(self, mimetypes, 'knownfiles', [])
-        support.patch(self, mimetypes, 'inited', False)
-        mimetypes._default_mime_types()
 
 
 class MimeTypesTestCase(MimeTypesTestMixin):

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -17,7 +17,6 @@ class MimeTypesTestMixin(unittest.TestCase):
         # Tell it we don't know about external files:
         support.patch(self, mimetypes, 'knownfiles', [])
         support.patch(self, mimetypes, 'inited', False)
-        support.patch(self, mimetypes, '_db', None)
         mimetypes._default_mime_types()
 
 

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -192,8 +192,10 @@ class MimeTypesTestCase(MimeTypesTestMixin):
 
 
 @unittest.skipUnless(sys.platform.startswith("win"), "Windows only")
-class Win32MimeTypesTestCase(unittest.TestCase):
+class Win32MimeTypesTestCase(MimeTypesTestMixin):
     def setUp(self):
+        super().setUp()
+
         # ensure all entries actually come from the Windows registry
         self.original_types_map = mimetypes.types_map.copy()
         mimetypes.types_map.clear()

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -6,6 +6,7 @@ import sys
 import unittest
 
 from test import support
+from test.support import script_helper
 from platform import win32_edition
 
 # Tell it we don't know about external files:
@@ -21,6 +22,7 @@ class MimeTypesTestCase(unittest.TestCase):
     def test_default_data(self):
         eq = self.assertEqual
         eq(self.db.guess_type("foo.html"), ("text/html", None))
+        eq(self.db.guess_type("foo.HTML"), ("text/html", None))
         eq(self.db.guess_type("foo.tgz"), ("application/x-tar", "gzip"))
         eq(self.db.guess_type("foo.tar.gz"), ("application/x-tar", "gzip"))
         eq(self.db.guess_type("foo.tar.Z"), ("application/x-tar", "compress"))
@@ -30,6 +32,7 @@ class MimeTypesTestCase(unittest.TestCase):
     def test_data_urls(self):
         eq = self.assertEqual
         guess_type = self.db.guess_type
+        eq(guess_type("data:invalidDataWithoutComma"), (None, None))
         eq(guess_type("data:,thisIsTextPlain"), ("text/plain", None))
         eq(guess_type("data:;base64,thisIsTextPlain"), ("text/plain", None))
         eq(guess_type("data:text/x-foo,thisIsTextXFoo"), ("text/x-foo", None))
@@ -42,6 +45,19 @@ class MimeTypesTestCase(unittest.TestCase):
            ("x-application/x-unittest", None))
         eq(self.db.guess_extension("x-application/x-unittest"), ".pyunit")
 
+    def test_read_mime_types(self):
+        eq = self.assertEqual
+
+        # Unreadable file returns None
+        self.assertIsNone(mimetypes.read_mime_types("non-existent"))
+
+        with support.temp_dir() as directory:
+            data = "x-application/x-unittest pyunit\n"
+            file = pathlib.Path(directory, "sample.mimetype")
+            file.write_text(data)
+            mime_dict = mimetypes.read_mime_types(file)
+            eq(mime_dict[".pyunit"], "x-application/x-unittest")
+
     def test_non_standard_types(self):
         eq = self.assertEqual
         # First try strict
@@ -49,7 +65,10 @@ class MimeTypesTestCase(unittest.TestCase):
         eq(self.db.guess_extension('image/jpg', strict=True), None)
         # And then non-strict
         eq(self.db.guess_type('foo.xul', strict=False), ('text/xul', None))
+        eq(self.db.guess_type('foo.XUL', strict=False), ('text/xul', None))
+        eq(self.db.guess_type('foo.invalid', strict=False), (None, None))
         eq(self.db.guess_extension('image/jpg', strict=False), '.jpg')
+        eq(self.db.guess_extension('image/JPG', strict=False), '.jpg')
 
     def test_filename_with_url_delimiters(self):
         # bpo-38449: URL delimiters cases should be handled also.
@@ -199,6 +218,34 @@ class MiscTestCase(unittest.TestCase):
     def test__all__(self):
         support.check__all__(self, mimetypes)
 
+
+class MimetypesCliTestCase(unittest.TestCase):
+
+    def mimetypes_cmd(self, *args, **kwargs):
+        rc, out, err = script_helper.assert_python_ok('-m', 'mimetypes', *args,
+                                                      **kwargs)
+        return out.decode().strip()
+
+    def test_guess_extension(self):
+        eq = self.assertEqual
+
+        extension = self.mimetypes_cmd("-l", "-e", "image/jpg")
+        eq(extension, ".jpg")
+
+        extension = self.mimetypes_cmd("-e", "image/jpg")
+        eq(extension, "I don't know anything about type image/jpg")
+
+        extension = self.mimetypes_cmd("-e", "image/jpeg")
+        eq(extension, ".jpg")
+
+    def test_guess_type(self):
+        eq = self.assertEqual
+
+        type_info = self.mimetypes_cmd("-l", "foo.pic")
+        eq(type_info, "type: image/pict encoding: None")
+
+        type_info = self.mimetypes_cmd("foo.pic")
+        eq(type_info, "I don't know anything about type foo.pic")
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -6,7 +6,6 @@ import sys
 import unittest
 
 from test import support
-from test.support import script_helper
 from platform import win32_edition
 
 
@@ -18,6 +17,7 @@ class MimeTypesTestMixin(unittest.TestCase):
         # Tell it we don't know about external files:
         support.patch(self, mimetypes, 'knownfiles', [])
         support.patch(self, mimetypes, 'inited', False)
+        support.patch(self, mimetypes, '_db', None)
         mimetypes._default_mime_types()
 
 
@@ -223,7 +223,7 @@ class MiscTestCase(unittest.TestCase):
         support.check__all__(self, mimetypes)
 
 
-class MimetypesCliTestCase(unittest.TestCase):
+class MimetypesCliTestCase(MimeTypesTestMixin):
 
     def mimetypes_cmd(self, *args, **kwargs):
         support.patch(self, sys, "argv", [sys.executable, *args])

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -8,17 +8,15 @@ import unittest
 from test import support
 from platform import win32_edition
 
+# Tell it we don't know about external files:
+mimetypes.knownfiles = []
+mimetypes.inited = False
+mimetypes._default_mime_types()
 
-class MimeTypesTestMixin(unittest.TestCase):
 
+class MimeTypesTestCase(unittest.TestCase):
     def setUp(self):
         self.db = mimetypes.MimeTypes()
-
-        # Tell it we don't know about external files:
-        support.patch(self, mimetypes, 'knownfiles', [])
-
-
-class MimeTypesTestCase(MimeTypesTestMixin):
 
     def test_default_data(self):
         eq = self.assertEqual
@@ -190,10 +188,8 @@ class MimeTypesTestCase(MimeTypesTestMixin):
 
 
 @unittest.skipUnless(sys.platform.startswith("win"), "Windows only")
-class Win32MimeTypesTestCase(MimeTypesTestMixin):
+class Win32MimeTypesTestCase(unittest.TestCase):
     def setUp(self):
-        super().setUp()
-
         # ensure all entries actually come from the Windows registry
         self.original_types_map = mimetypes.types_map.copy()
         mimetypes.types_map.clear()
@@ -222,7 +218,7 @@ class MiscTestCase(unittest.TestCase):
         support.check__all__(self, mimetypes)
 
 
-class MimetypesCliTestCase(MimeTypesTestMixin):
+class MimetypesCliTestCase(unittest.TestCase):
 
     def mimetypes_cmd(self, *args, **kwargs):
         support.patch(self, sys, "argv", [sys.executable, *args])
@@ -268,6 +264,7 @@ class MimetypesCliTestCase(MimeTypesTestMixin):
 
         type_info = self.mimetypes_cmd("foo.pic")
         eq(type_info, "I don't know anything about type foo.pic")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* Add test for case insensitive check of types and extensions.
* Add test for data url with no comma.
* Add test for `read_mime_types`.
* Add tests for the mimetypes cli.

<!-- issue-number: [bpo-39299](https://bugs.python.org/issue39299) -->
https://bugs.python.org/issue39299
<!-- /issue-number -->
