### PR TITLE
Correct typo for negative range step

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1285,7 +1285,7 @@ loops.
    ``r[i] < stop``.
 
    For a negative *step*, the contents of the range are still determined by
-   the formula ``r[i] = start + step*i``, but the constraints are ``i >= 0``
+   the formula ``r[i] = start + step*i``, but the constraints are ``i <= 0``
    and ``r[i] > stop``.
 
    A range object will be empty if ``r[0]`` does not meet the value


### PR DESCRIPTION
I believe there is a typo in the documentation for negative step using the range type.
https://docs.python.org/3/library/stdtypes.html#ranges

For a positive step value it is correct:
"For a positive step... where i >= 0 and r[i] < stop."

However:
"For a negative step... i >= 0 and r[i] > stop"

Both of the constraints on `i` given for the negative step are "greater than", which does not seem to indicate the real behavior. It should be "i <= 0".

Here we see `i` less than or equal to zero and not greater than or equal to, when using a negative step value:
```
In [3]: for i in range(0, 5, -1): print(i)

In [4]: for i in range(0, -5, -1): print(i)
0
-1
-2
-3
-4
```

Per the PR template I have not opened an issue in the Bug Tracker: "Trivial changes, like fixing a typo, do not need an issue."