### PR TITLE
bpo-38883: Don't honor POSIX `HOME` in `pathlib.Path.home/expanduser` on Windows

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -253,9 +253,7 @@ class _WindowsFlavour(_Flavour):
             return 'file:' + urlquote_from_bytes(path.as_posix().encode('utf-8'))
 
     def gethomedir(self, username):
-        if 'HOME' in os.environ:
-            userhome = os.environ['HOME']
-        elif 'USERPROFILE' in os.environ:
+        if 'USERPROFILE' in os.environ:
             userhome = os.environ['USERPROFILE']
         elif 'HOMEPATH' in os.environ:
             try:

--- a/Misc/NEWS.d/next/Windows/2020-01-11-22-53-55.bpo-38883.X7FRaN.rst
+++ b/Misc/NEWS.d/next/Windows/2020-01-11-22-53-55.bpo-38883.X7FRaN.rst
@@ -1,0 +1,5 @@
+:meth:`~pathlib.Path.home()` and :meth:`~pathlib.Path.expanduser()` on Windows
+now prefer :envvar:`USERPROFILE` and no longer use :envvar:`HOME`, which is not
+normally set for regular user accounts. This makes them again behave like
+:func:`os.path.expanduser`, which was changed to ignore :envvar:`HOME` in 3.8,
+see :issue:`36264`.


### PR DESCRIPTION
In [bpo-36264](https://bugs.python.org/issue36264) os.path.expanduser was changed to ignore HOME on Windows.

Path.expanduser/home still honored HOME despite being documented as behaving the same
as os.path.expanduser. This makes them also ignore HOME so that both implementations
behave the same way again.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38883](https://bugs.python.org/issue38883) -->
https://bugs.python.org/issue38883
<!-- /issue-number -->
