### PR TITLE
bpo-39288: Add examples to math.nextafter() documentation

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -219,6 +219,13 @@ Number-theoretic and representation functions
 
    If *x* is equal to *y*, return *y*.
 
+   Examples:
+
+   * ``math.nextafter(x, math.inf)`` goes up: towards positive infinity.
+   * ``math.nextafter(x, -math.inf)`` goes down: towards minus infinity.
+   * ``math.nextafter(x, 0.0)`` goes towards zero.
+   * ``math.nextafter(x, math.copysign(math.inf, x))`` goes away from zero.
+
    .. versionadded:: 3.9
 
 .. function:: perm(n, k=None)


### PR DESCRIPTION


<!-- issue-number: [bpo-39288](https://bugs.python.org/issue39288) -->
https://bugs.python.org/issue39288
<!-- /issue-number -->
