### PR TITLE
venv: Suppress warning message when bash hashing is disabled.

### DIFF
--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -18,7 +18,7 @@ deactivate () {
     # be called to get it to forget past commands.  Without forgetting
     # past commands the $PATH changes we made may not be respected
     if [ -n "${BASH:-}" -o -n "${ZSH_VERSION:-}" ] ; then
-        hash -r
+        hash -r 2> /dev/null
     fi
 
     if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
@@ -62,5 +62,5 @@ fi
 # be called to get it to forget past commands.  Without forgetting
 # past commands the $PATH changes we made may not be respected
 if [ -n "${BASH:-}" -o -n "${ZSH_VERSION:-}" ] ; then
-    hash -r
+    hash -r 2> /dev/null
 fi


### PR DESCRIPTION
When using python's built-in venv activaton script warnings are printed when hashing is disabled in bash or zsh, like;

`bash: hash: hashing disabled`

This output is not really useful to the end-user and has been disabled in `virtualenv` for long.

This commit is based on:
https://github.com/pypa/virtualenv/commit/28e85bcd80d04b2a7ebce0e1d0b02d432b7e5593

It would be nice to backport this to all relevant versions if possible.

_Edit: this issue seems very small, so I did not bother with an issue or a NEWS entry, let me know if you think this might still be required._