### PR TITLE
[3.7] bpo-16575: Disabled checks for union types being passed by value. (GH-17960)

### DIFF
--- a/Lib/ctypes/test/test_structures.py
+++ b/Lib/ctypes/test/test_structures.py
@@ -532,6 +532,7 @@ class StructureTestCase(unittest.TestCase):
             self.assertEqual(f2, [0x4567, 0x0123, 0xcdef, 0x89ab,
                                   0x3210, 0x7654, 0xba98, 0xfedc])
 
+    @unittest.skipIf(True, 'Test disabled for now - see bpo-16575/bpo-16576')
     def test_union_by_value(self):
         # See bpo-16575
 
@@ -612,7 +613,7 @@ class StructureTestCase(unittest.TestCase):
         self.assertEqual(test5.nested.an_int, 0)
         self.assertEqual(test5.another_int, 0)
 
-    #@unittest.skipIf('s390' in MACHINE, 'Test causes segfault on S390')
+    @unittest.skipIf(True, 'Test disabled for now - see bpo-16575/bpo-16576')
     def test_bitfield_by_value(self):
         # See bpo-16576
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2277,6 +2277,23 @@ converters_from_argtypes(PyObject *ob)
     for (i = 0; i < nArgs; ++i) {
         PyObject *tp = PyTuple_GET_ITEM(ob, i);
         PyObject *cnv;
+/*
+ *      The following checks, relating to bpo-16575 and bpo-16576, have been
+ *      disabled. The reason is that, although there is a definite problem with
+ *      how libffi handles unions (https://github.com/libffi/libffi/issues/33),
+ *      there are numerous libraries which pass structures containing unions
+ *      by values - especially on Windows but examples also exist on Linux
+ *      (https://bugs.python.org/msg359834).
+ *
+ *      It may not be possible to get proper support for unions and bitfields
+ *      until support is forthcoming in libffi, but for now, adding the checks
+ *      has caused problems in otherwise-working software, which suggests it
+ *      is better to disable the checks.
+ *
+ *      Although specific examples reported relate specifically to unions and
+ *      not bitfields, the bitfields check is also being disabled as a
+ *      precaution.
+
         StgDictObject *stgdict = PyType_stgdict(tp);
 
         if (stgdict != NULL) {
@@ -2304,6 +2321,8 @@ converters_from_argtypes(PyObject *ob)
                 return NULL;
             }
         }
+ */
+
         cnv = PyObject_GetAttrString(tp, "from_param");
         if (!cnv)
             goto argtypes_error_1;


### PR DESCRIPTION
Although the underlying libffi issue remains open, adding these checks have caused problems in third-party projects which are in widespread use. See the issue for examples.

The corresponding tests have also been skipped.

<!-- issue-number: [bpo-16575](https://bugs.python.org/issue16575) -->
https://bugs.python.org/issue16575
<!-- /issue-number -->
