### PR TITLE
Redefine snprintf only for msvc

### DIFF
--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -311,7 +311,7 @@ PyAPI_FUNC(int) PyUnicodeTranslateError_SetReason(
    not rely on any particular behavior; eventually the C99 defn may
    be reliable.
 */
-#if defined(MS_WIN32) && !defined(HAVE_SNPRINTF)
+#if defined(_MSC_VER) && !defined(HAVE_SNPRINTF)
 # define HAVE_SNPRINTF
 # define snprintf _snprintf
 # define vsnprintf _vsnprintf


### PR DESCRIPTION
This should only be enabled specifically for visual studio compiler,
not all windows platforms
(msvc<14 actually, see also https://bugs.python.org/issue36020)

Fixes build with MinGW
