### PR TITLE
bpo-39318: Catch a failure in NamedTemporaryFile to prevent leaking a descriptor

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -543,10 +543,16 @@ def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
         file = _io.open(fd, mode, buffering=buffering,
                         newline=newline, encoding=encoding, errors=errors)
 
-        return _TemporaryFileWrapper(file, name, delete)
     except BaseException:
         _os.unlink(name)
         _os.close(fd)
+        raise
+
+    try:
+        return _TemporaryFileWrapper(file, name, delete)
+    except BaseException:
+        _os.unlink(name)
+        file.close()
         raise
 
 if _os.name != 'posix' or _sys.platform == 'cygwin':

--- a/Misc/NEWS.d/next/Library/2020-01-13-13-36-05.bpo-39318.236VwO.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-13-13-36-05.bpo-39318.236VwO.rst
@@ -1,0 +1,1 @@
+Fix a file descriptor leak in NamedTemporaryFile under unusual circumstances.


### PR DESCRIPTION
This happened in the real world because someone mocked
_TemporaryFileWrapper to raise an OSError. See
https://nedbatchelder.com/blog/202001/bug_915_solved.html for more
details.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39318](https://bugs.python.org/issue39318) -->
https://bugs.python.org/issue39318
<!-- /issue-number -->
