### PR TITLE
Documentation fix on code.py

### DIFF
--- a/Doc/library/code.rst
+++ b/Doc/library/code.rst
@@ -76,7 +76,7 @@ Interactive Interpreter Objects
 
    Compile and run some source in the interpreter. Arguments are the same as for
    :func:`compile_command`; the default for *filename* is ``'<input>'``, and for
-   *symbol* is ``'single'``.  One several things can happen:
+   *symbol* is ``'single'``.  One of several things can happen:
 
    * The input is incorrect; :func:`compile_command` raised an exception
      (:exc:`SyntaxError` or :exc:`OverflowError`).  A syntax traceback will be

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -40,7 +40,7 @@ class InteractiveInterpreter:
 
         Arguments are as for compile_command().
 
-        One several things can happen:
+        One of several things can happen:
 
         1) The input is incorrect; compile_command() raised an
         exception (SyntaxError or OverflowError).  A syntax traceback


### PR DESCRIPTION
Small change to InteractiveInterpreter.runsource docstring to make it more readable.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
