### PR TITLE
bpo-39323: Fix directory separator of imghdr cli output

### DIFF
--- a/Lib/imghdr.py
+++ b/Lib/imghdr.py
@@ -148,7 +148,7 @@ def testall(list, recursive, toplevel):
     import os
     for filename in list:
         if os.path.isdir(filename):
-            print(filename + '/:', end=' ')
+            print(filename + os.sep +':', end=' ')
             if recursive or toplevel:
                 print('recursing down:')
                 import glob

--- a/Misc/NEWS.d/next/Library/2020-01-13-22-20-22.bpo-39323.PabxcF.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-13-22-20-22.bpo-39323.PabxcF.rst
@@ -1,0 +1,2 @@
+Use :data:`os.sep` instead of '/' in imghdr command line output to indicate
+directory. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
* Use `os.sep` to indicate directory separator in imghdr cli output.
* Add tests for imghdr cli.

<!-- issue-number: [bpo-39323](https://bugs.python.org/issue39323) -->
https://bugs.python.org/issue39323
<!-- /issue-number -->
