### PR TITLE
bpo-25872: Fix KeyError in linecache when multithreaded

### DIFF
--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -73,10 +73,10 @@ def checkcache(filename=None):
         try:
             stat = os.stat(fullname)
         except OSError:
-            del cache[filename]
+            cache.pop(filename, None)
             continue
         if size != stat.st_size or mtime != stat.st_mtime:
-            del cache[filename]
+            cache.pop(filename, None)
 
 
 def updatecache(filename, module_globals=None):
@@ -86,7 +86,7 @@ def updatecache(filename, module_globals=None):
 
     if filename in cache:
         if len(cache[filename]) != 1:
-            del cache[filename]
+            cache.pop(filename, None)
     if not filename or (filename.startswith('<') and filename.endswith('>')):
         return []
 


### PR DESCRIPTION
Fixes https://bugs.python.org/issue25872

The crash that this fixes occurs when using traceback and other modules from multiple threads.

https://bugs.python.org/issue25872

<!-- issue-number: [bpo-25872](https://bugs.python.org/issue25872) -->
https://bugs.python.org/issue25872
<!-- /issue-number -->
