### PR TITLE
bpo-39342: Expose X509_V_FLAG_ALLOW_PROXY_CERTS in ssl module

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -634,6 +634,13 @@ Constants
 
    .. versionadded:: 3.4
 
+.. data:: VERIFY_ALLOW_PROXY_CERTS
+
+   Possible value for :attr:`SSLContext.verify_flags` to enables proxy
+   certificate verification.
+
+   .. versionadded:: 3.9
+
 .. data:: VERIFY_X509_TRUSTED_FIRST
 
    Possible value for :attr:`SSLContext.verify_flags`. It instructs OpenSSL to

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -639,7 +639,7 @@ Constants
    Possible value for :attr:`SSLContext.verify_flags` to enables proxy
    certificate verification.
 
-   .. versionadded:: 3.9
+   .. versionadded:: 3.10
 
 .. data:: VERIFY_X509_TRUSTED_FIRST
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1305,6 +1305,8 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(ctx.verify_flags, ssl.VERIFY_CRL_CHECK_CHAIN)
         ctx.verify_flags = ssl.VERIFY_DEFAULT
         self.assertEqual(ctx.verify_flags, ssl.VERIFY_DEFAULT)
+        ctx.verify_flags = ssl.VERIFY_ALLOW_PROXY_CERTS
+        self.assertEqual(ctx.verify_flags, ssl.VERIFY_ALLOW_PROXY_CERTS)
         # supports any value
         ctx.verify_flags = ssl.VERIFY_CRL_CHECK_LEAF | ssl.VERIFY_X509_STRICT
         self.assertEqual(ctx.verify_flags,

--- a/Misc/NEWS.d/next/Library/2020-01-15-11-15-35.bpo-39342.S8PuJO.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-15-11-15-35.bpo-39342.S8PuJO.rst
@@ -1,0 +1,4 @@
+Expose ``X509_V_FLAG_ALLOW_PROXY_CERTS`` as
+:data:`~ssl.VERIFY_ALLOW_PROXY_CERTS` to allow proxy certificate validation
+as explained in
+https://www.openssl.org/docs/man1.1.1/man7/proxy-certificates.html.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -6181,6 +6181,8 @@ sslmodule_init_constants(PyObject *m)
                             X509_V_FLAG_CRL_CHECK|X509_V_FLAG_CRL_CHECK_ALL);
     PyModule_AddIntConstant(m, "VERIFY_X509_STRICT",
                             X509_V_FLAG_X509_STRICT);
+    PyModule_AddIntConstant(m, "VERIFY_ALLOW_PROXY_CERTS",
+                            X509_V_FLAG_ALLOW_PROXY_CERTS);
 #ifdef X509_V_FLAG_TRUSTED_FIRST
     PyModule_AddIntConstant(m, "VERIFY_X509_TRUSTED_FIRST",
                             X509_V_FLAG_TRUSTED_FIRST);


### PR DESCRIPTION
Exposes the `X509_V_FLAG_ALLOW_PROXY_CERTS` constant as `ssl.VERIFY_ALLOW_PROXY_CERTS` to allow for proxy certificate validation as described in: https://www.openssl.org/docs/man1.1.1/man7/proxy-certificates.html

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-39342](https://bugs.python.org/issue39342) -->
https://bugs.python.org/issue39342
<!-- /issue-number -->

Automerge-Triggered-By: GH:tiran