### PR TITLE
Fix compiler warning on Windows.

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -23,8 +23,8 @@
 
 #include "Python.h"
 
-#include "Python-ast.h"
 #include "pycore_pystate.h"   /* _PyInterpreterState_GET_UNSAFE() */
+#include "Python-ast.h"
 #include "ast.h"
 #include "code.h"
 #include "symtable.h"


### PR DESCRIPTION
Looks like https://github.com/python/cpython/commit/c96be811fa7da8ddcea18cc7 introduced an include for `pycore_pystate.h` in `compile.c`. This file indirectly includes Windows header files through the use of conditional variables. 

Since there is a conflict between the `Python-ast.h` YIELD macro and the windows YIELD macro: https://github.com/python/cpython/blob/master/Include/Python-ast.h#L12

we have to include this file before Windows headers to avoid redeclaring the macro and running into this warning: https://github.com/python/cpython/runs/390843969#step:3:570