### PR TITLE
bpo-39274: Ensure `Fraction.__bool__` returns a bool

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -647,7 +647,9 @@ class Fraction(numbers.Rational):
 
     def __bool__(a):
         """a != 0"""
-        return a._numerator != 0
+        # bpo-39274: Use bool() because (a._numerator != 0) can return an
+        # object which is not a bool.
+        return bool(a._numerator)
 
     # support for pickling, copy, and deepcopy
 

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -6,6 +6,7 @@ import math
 import numbers
 import operator
 import fractions
+import functools
 import sys
 import unittest
 import warnings
@@ -345,6 +346,42 @@ class FractionTest(unittest.TestCase):
                                float(F(int('2'*400+'7'), int('3'*400+'1'))))
 
         self.assertTypedEquals(0.1+0j, complex(F(1,10)))
+
+    def testBoolGuarateesBoolReturn(self):
+        # Ensure that __bool__ is used on numerator which guarantees a bool
+        # return.  See also bpo-39274.
+        @functools.total_ordering
+        class CustomValue:
+            denominator = 1
+
+            def __init__(self, value):
+                self.value = value
+
+            def __bool__(self):
+                return bool(self.value)
+
+            @property
+            def numerator(self):
+                # required to preserve `self` during instantiation
+                return self
+
+            def __eq__(self, other):
+                raise AssertionError("Avoid comparisons in Fraction.__bool__")
+
+            __lt__ = __eq__
+
+        # We did not implement all abstract methods, so register:
+        numbers.Rational.register(CustomValue)
+
+        numerator = CustomValue(1)
+        r = F(numerator)
+        # ensure the numerator was not lost during instantiation:
+        self.assertIs(r.numerator, numerator)
+        self.assertIs(bool(r), True)
+
+        numerator = CustomValue(0)
+        r = F(numerator)
+        self.assertIs(bool(r), False)
 
     def testRound(self):
         self.assertTypedEquals(F(-200), round(F(-150), -2))

--- a/Misc/NEWS.d/next/Library/2020-01-15-23-13-03.bpo-39274.lpc0-n.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-15-23-13-03.bpo-39274.lpc0-n.rst
@@ -1,0 +1,1 @@
+``bool(fraction.Fraction)`` now returns a boolean even if (numerator != 0) does not return a boolean (ex: numpy number).


### PR DESCRIPTION
Some numerator types used (specifically NumPy) decides to not
return a python boolean for the `!=` operation. Using the equivalent
call to `bool()` guarantees a bool return also for such types.

Closes [bpo-39274](https://bugs.python.org/issue39274)

https://bugs.python.org/issue39274

<!-- issue-number: [bpo-39274](https://bugs.python.org/issue39274) -->
https://bugs.python.org/issue39274
<!-- /issue-number -->
