### PR TITLE
bpo-39348: Fix code highlight for the SOCK_NONBLOCK example

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -565,7 +565,9 @@ The following functions all create :ref:`socket objects <socket-objects>`.
       When :const:`SOCK_NONBLOCK` or :const:`SOCK_CLOEXEC`
       bit flags are applied to *type* they are cleared, and
       :attr:`socket.type` will not reflect them.  They are still passed
-      to the underlying system `socket()` call.  Therefore::
+      to the underlying system `socket()` call.  Therefore,
+
+      ::
 
           sock = socket.socket(
               socket.AF_INET,


### PR DESCRIPTION
The previous double colon was wrongly place directly after Therefore.
Which produced a block without syntax highlighting. This fixes it
by separating the double colon from the text. As a result, sphinx now
properly highlights the python code.



<!-- issue-number: [bpo-39348](https://bugs.python.org/issue39348) -->
https://bugs.python.org/issue39348
<!-- /issue-number -->


Automerge-Triggered-By: @Mariatta