### PR TITLE
bpo-39350: Remove deprecated fractions.gcd()

### DIFF
--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -172,18 +172,6 @@ another rational number, or from a string.
       method can also be accessed through the :func:`round` function.
 
 
-.. function:: gcd(a, b)
-
-   Return the greatest common divisor of the integers *a* and *b*.  If either
-   *a* or *b* is nonzero, then the absolute value of ``gcd(a, b)`` is the
-   largest integer that divides both *a* and *b*.  ``gcd(a,b)`` has the same
-   sign as *b* if *b* is nonzero; otherwise it takes the sign of *a*.  ``gcd(0,
-   0)`` returns ``0``.
-
-   .. deprecated:: 3.5
-      Use :func:`math.gcd` instead.
-
-
 .. seealso::
 
    Module :mod:`numbers`

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -416,6 +416,10 @@ Removed
   :func:`base64.decodebytes` instead.
   (Contributed by Victor Stinner in :issue:`39351`.)
 
+* ``fractions.gcd()`` function has been removed, it was deprecated since Python
+  3.5 (:issue:`22486`): use :func:`math.gcd` instead.
+  (Contributed by Victor Stinner in :issue:`39350`.)
+
 
 Porting to Python 3.9
 =====================

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -10,30 +10,8 @@ import operator
 import re
 import sys
 
-__all__ = ['Fraction', 'gcd']
+__all__ = ['Fraction']
 
-
-
-def gcd(a, b):
-    """Calculate the Greatest Common Divisor of a and b.
-
-    Unless b==0, the result will have the same sign as b (so that when
-    b is divided by it, the result comes out positive).
-    """
-    import warnings
-    warnings.warn('fractions.gcd() is deprecated. Use math.gcd() instead.',
-                  DeprecationWarning, 2)
-    if type(a) is int is type(b):
-        if (b or a) < 0:
-            return -math.gcd(a, b)
-        return math.gcd(a, b)
-    return _gcd(a, b)
-
-def _gcd(a, b):
-    # Supports non-integers for backward compatibility.
-    while b:
-        a, b = b, a%b
-    return a
 
 # Constants related to the hash implementation;  hash(x) is based
 # on the reduction of x modulo the prime _PyHASH_MODULUS.

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -12,7 +12,7 @@ import warnings
 from copy import copy, deepcopy
 from pickle import dumps, loads
 F = fractions.Fraction
-gcd = fractions.gcd
+
 
 class DummyFloat(object):
     """Dummy float class for testing comparisons with Fractions"""
@@ -80,30 +80,6 @@ class DummyRational(object):
 
 class DummyFraction(fractions.Fraction):
     """Dummy Fraction subclass for copy and deepcopy testing."""
-
-class GcdTest(unittest.TestCase):
-
-    def testMisc(self):
-        # fractions.gcd() is deprecated
-        with self.assertWarnsRegex(DeprecationWarning, r'fractions\.gcd'):
-            gcd(1, 1)
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', r'fractions\.gcd',
-                                    DeprecationWarning)
-            self.assertEqual(0, gcd(0, 0))
-            self.assertEqual(1, gcd(1, 0))
-            self.assertEqual(-1, gcd(-1, 0))
-            self.assertEqual(1, gcd(0, 1))
-            self.assertEqual(-1, gcd(0, -1))
-            self.assertEqual(1, gcd(7, 1))
-            self.assertEqual(-1, gcd(7, -1))
-            self.assertEqual(1, gcd(-23, 15))
-            self.assertEqual(12, gcd(120, 84))
-            self.assertEqual(-12, gcd(84, -120))
-            self.assertEqual(gcd(120.0, 84), 12.0)
-            self.assertEqual(gcd(120, 84.0), 12.0)
-            self.assertEqual(gcd(F(120), F(84)), F(12))
-            self.assertEqual(gcd(F(120, 77), F(84, 55)), F(12, 385))
 
 
 def _components(r):
@@ -689,6 +665,7 @@ class FractionTest(unittest.TestCase):
         # Issue 4998
         r = F(13, 7)
         self.assertRaises(AttributeError, setattr, r, 'a', 10)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-01-16-09-15-40.bpo-39350.ZQx0uY.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-16-09-15-40.bpo-39350.ZQx0uY.rst
@@ -1,0 +1,2 @@
+Remove ``fractions.gcd()`` function, deprecated since Python 3.5
+(:issue:`22486`): use :func:`math.gcd` instead.


### PR DESCRIPTION
Remove fractions.gcd() function, deprecated since Python 3.5
([bpo-22486](https://bugs.python.org/issue22486)): use math.gcd() instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39350](https://bugs.python.org/issue39350) -->
https://bugs.python.org/issue39350
<!-- /issue-number -->
