### PR TITLE
bpo-39351: Remove base64.encodestring()

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -235,12 +235,6 @@ The legacy interface:
 
    .. versionadded:: 3.1
 
-.. function:: decodestring(s)
-
-   Deprecated alias of :func:`decodebytes`.
-
-   .. deprecated:: 3.1
-
 
 .. function:: encode(input, output)
 
@@ -260,12 +254,6 @@ The legacy interface:
    there is a trailing newline, as per :rfc:`2045` (MIME).
 
    .. versionadded:: 3.1
-
-.. function:: encodestring(s)
-
-   Deprecated alias of :func:`encodebytes`.
-
-   .. deprecated:: 3.1
 
 
 An example usage of the module:

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -411,6 +411,11 @@ Removed
   of :pep:`442`. Patch by Joannah Nanjekye.
   (Contributed by Joannah Nanjekye in :issue:`15088`)
 
+* ``base64.encodestring()`` and ``base64.decodestring()``, aliases deprecated
+  since Python 3.1, have been removed: use :func:`base64.encodebytes` and
+  :func:`base64.decodebytes` instead.
+  (Contributed by Victor Stinner in :issue:`39351`.)
+
 
 Porting to Python 3.9
 =====================

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -531,27 +531,11 @@ def encodebytes(s):
         pieces.append(binascii.b2a_base64(chunk))
     return b"".join(pieces)
 
-def encodestring(s):
-    """Legacy alias of encodebytes()."""
-    import warnings
-    warnings.warn("encodestring() is a deprecated alias since 3.1, "
-                  "use encodebytes()",
-                  DeprecationWarning, 2)
-    return encodebytes(s)
-
 
 def decodebytes(s):
     """Decode a bytestring of base-64 data into a bytes object."""
     _input_type_check(s)
     return binascii.a2b_base64(s)
-
-def decodestring(s):
-    """Legacy alias of decodebytes()."""
-    import warnings
-    warnings.warn("decodestring() is a deprecated alias since Python 3.1, "
-                  "use decodebytes()",
-                  DeprecationWarning, 2)
-    return decodebytes(s)
 
 
 # Usable as a script...

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -18,14 +18,6 @@ class LegacyBase64TestCase(unittest.TestCase):
         int_data = memoryview(b"1234").cast('I')
         self.assertRaises(TypeError, f, int_data)
 
-    def test_encodestring_warns(self):
-        with self.assertWarns(DeprecationWarning):
-            base64.encodestring(b"www.python.org")
-
-    def test_decodestring_warns(self):
-        with self.assertWarns(DeprecationWarning):
-            base64.decodestring(b"d3d3LnB5dGhvbi5vcmc=\n")
-
     def test_encodebytes(self):
         eq = self.assertEqual
         eq(base64.encodebytes(b"www.python.org"), b"d3d3LnB5dGhvbi5vcmc=\n")

--- a/Misc/NEWS.d/next/Library/2020-01-16-09-27-28.bpo-39351.a-FQdv.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-16-09-27-28.bpo-39351.a-FQdv.rst
@@ -1,0 +1,3 @@
+Remove ``base64.encodestring()`` and ``base64.decodestring()``, aliases
+deprecated since Python 3.1: use :func:`base64.encodebytes` and
+:func:`base64.decodebytes` instead.


### PR DESCRIPTION
Remove base64.encodestring() and base64.decodestring(), aliases
deprecated since Python 3.1: use base64.encodebytes() and
base64.decodebytes() instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39351](https://bugs.python.org/issue39351) -->
https://bugs.python.org/issue39351
<!-- /issue-number -->
