### PR TITLE
bpo-39354: Fix format and format_map of UserString

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1180,9 +1180,9 @@ class UserString(_collections_abc.Sequence):
             sub = sub.data
         return self.data.find(sub, start, end)
     def format(self, /, *args, **kwds):
-        return self.data.format(*args, **kwds)
+        return self.__class__(self.data.format(*args, **kwds))
     def format_map(self, mapping):
-        return self.data.format_map(mapping)
+        return self.__class__(self.data.format_map(mapping))
     def index(self, sub, start=0, end=_sys.maxsize):
         return self.data.index(sub, start, end)
     def isalpha(self): return self.data.isalpha()

--- a/Lib/test/test_userstring.py
+++ b/Lib/test/test_userstring.py
@@ -65,6 +65,19 @@ class UserStringTest(
         # Check that errors defaults to 'strict'
         self.checkraises(UnicodeError, '\ud800', 'encode', None, None)
 
+    def test_format_type(self):
+        class UserStringSubclass(UserString):
+            pass
+
+        self.assertIsInstance(
+            UserStringSubclass('Hello, {}!').format('World'),
+            UserStringSubclass
+        )
+        self.assertIsInstance(
+            UserStringSubclass('Hello, {name}!').format_map({'name': 'World'}),
+            UserStringSubclass
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-01-16-09-32-15.bpo-39354.5aPQgS.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-16-09-32-15.bpo-39354.5aPQgS.rst
@@ -1,0 +1,1 @@
+Fix ``UserString.format()`` and ``UserString.format_map()`` to return ``UserString`` instance rather than a string.


### PR DESCRIPTION
The `format` and `format_map` of `collections.UserString` produce a string instead of UserString instance.

<!-- issue-number: [bpo-39354](https://bugs.python.org/issue39354) -->
https://bugs.python.org/issue39354
<!-- /issue-number -->
