### PR TITLE
bpo-39357: Remove buffering parameter of bz2.BZ2File

### DIFF
--- a/Doc/library/bz2.rst
+++ b/Doc/library/bz2.rst
@@ -65,7 +65,7 @@ All of the classes in this module may safely be accessed from multiple threads.
       Accepts a :term:`path-like object`.
 
 
-.. class:: BZ2File(filename, mode='r', buffering=None, compresslevel=9)
+.. class:: BZ2File(filename, mode='r', *, compresslevel=9)
 
    Open a bzip2-compressed file in binary mode.
 
@@ -80,8 +80,6 @@ All of the classes in this module may safely be accessed from multiple threads.
 
    If *filename* is a file object (rather than an actual file name), a mode of
    ``'w'`` does not truncate the file, and is instead equivalent to ``'a'``.
-
-   The *buffering* argument is ignored. Its use is deprecated since Python 3.0.
 
    If *mode* is ``'w'`` or ``'a'``, *compresslevel* can be an integer between
    ``1`` and ``9`` specifying the level of compression: ``1`` produces the
@@ -110,9 +108,6 @@ All of the classes in this module may safely be accessed from multiple threads.
       .. versionadded:: 3.3
 
 
-   .. deprecated:: 3.0
-      The keyword argument *buffering* was deprecated and is now ignored.
-
    .. versionchanged:: 3.1
       Support for the :keyword:`with` statement was added.
 
@@ -137,6 +132,13 @@ All of the classes in this module may safely be accessed from multiple threads.
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
+
+   .. versionchanged:: 3.9
+      The *buffering* parameter has been removed. It was ignored and deprecated
+      since Python 3.0. Pass an open file object to control how the file is
+      opened.
+
+      The *compresslevel* parameter became keyword-only.
 
 
 Incremental (de)compression

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -420,6 +420,12 @@ Removed
   3.5 (:issue:`22486`): use :func:`math.gcd` instead.
   (Contributed by Victor Stinner in :issue:`39350`.)
 
+* The *buffering* parameter of :class:`bz2.BZ2File` has been removed. Since
+  Python 3.0, it was ignored and using it was emitting
+  :exc:`DeprecationWarning`. Pass an open file object to control how the file
+  is opened.
+  (Contributed by Victor Stinner in :issue:`39357`.)
+
 
 Porting to Python 3.9
 =====================
@@ -450,6 +456,10 @@ Changes in the Python API
 * The :meth:`select.epoll.unregister` method no longer ignores the
   :data:`~errno.EBADF` error.
   (Contributed by Victor Stinner in :issue:`39239`.)
+
+* The *compresslevel* parameter of :class:`bz2.BZ2File` became keyword-only,
+  since the *buffering* parameter has been removed.
+  (Contributed by Victor Stinner in :issue:`39357`.)
 
 
 CPython bytecode changes

--- a/Lib/bz2.py
+++ b/Lib/bz2.py
@@ -24,8 +24,6 @@ _MODE_READ     = 1
 # Value 2 no longer used
 _MODE_WRITE    = 3
 
-_sentinel = object()
-
 
 class BZ2File(_compression.BaseStream):
 
@@ -38,7 +36,7 @@ class BZ2File(_compression.BaseStream):
     returned as bytes, and data to be written should be given as bytes.
     """
 
-    def __init__(self, filename, mode="r", buffering=_sentinel, compresslevel=9):
+    def __init__(self, filename, mode="r", *, compresslevel=9):
         """Open a bzip2-compressed file.
 
         If filename is a str, bytes, or PathLike object, it gives the
@@ -64,12 +62,6 @@ class BZ2File(_compression.BaseStream):
         self._fp = None
         self._closefp = False
         self._mode = _MODE_CLOSED
-
-        if buffering is not _sentinel:
-            warnings.warn("Use of 'buffering' argument is deprecated and ignored "
-                          "since Python 3.0.",
-                          DeprecationWarning,
-                          stacklevel=2)
 
         if not (1 <= compresslevel <= 9):
             raise ValueError("compresslevel must be between 1 and 9")

--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -100,6 +100,9 @@ class BZ2FileTest(BaseTest):
         self.assertRaises(ValueError, BZ2File, os.devnull, compresslevel=0)
         self.assertRaises(ValueError, BZ2File, os.devnull, compresslevel=10)
 
+        # compresslevel is keyword-only
+        self.assertRaises(TypeError, BZ2File, os.devnull, "r", 3)
+
     def testRead(self):
         self.createTempFile()
         with BZ2File(self.filename) as bz2f:

--- a/Misc/NEWS.d/next/Library/2020-01-16-11-24-00.bpo-39357.bCwx-h.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-16-11-24-00.bpo-39357.bCwx-h.rst
@@ -1,0 +1,4 @@
+Remove the *buffering* parameter of :class:`bz2.BZ2File`. Since Python 3.0, it
+was ignored and using it was emitting :exc:`DeprecationWarning`. Pass an open
+file object, to control how the file is opened. The *compresslevel* parameter
+becomes keyword-only.


### PR DESCRIPTION
Remove the buffering parameter of bz2.BZ2File. Since Python 3.0, it
was ignored and using it was emitting a DeprecationWarning. Pass an
open file object to control how the file is opened.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39357](https://bugs.python.org/issue39357) -->
https://bugs.python.org/issue39357
<!-- /issue-number -->
