### PR TITLE
bpo-36220: STORE_GLOBAL: Support dict subclasses for globals.

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2314,8 +2314,12 @@ main_loop:
         case TARGET(STORE_GLOBAL): {
             PyObject *name = GETITEM(names, oparg);
             PyObject *v = POP();
+            PyObject *ns = f->f_globals;
             int err;
-            err = PyDict_SetItem(f->f_globals, name, v);
+            if (PyDict_CheckExact(ns))
+                err = PyDict_SetItem(ns, name, v);
+            else
+                err = PyObject_SetItem(ns, name, v);
             Py_DECREF(v);
             if (err != 0)
                 goto error;


### PR DESCRIPTION
If globals are not concrete `dict` type, use PyObject_SetItem() on it,
instead of PyDict_SetItem(). This is similar how STORE_NAME deals
with locals already. (And also similar to how some (but not all)
LOAD_* opcodes deal globals/locals),

Given that on the module level, locals and globals are the same,
this change fixed the situation when:

exec("foo = 1", my_globals)

and

exec("global foo; foo = 1", my_globals)

(where "my_globals" is a dict subclass, intended to trace namespace
operations)

lead to different behavior, where in first case, my_globals.__setitem__()
is called (because STORE_NAME opcode is generated), while in second case,
it's not called (because STORE_GLOBAL is generated).

Note that this change is not related in any way to security sandboxing
(in a sense that this change doesn't make any claims in regard to
improvements to such secuirty sandboxing matters). Instead, it's intended
to make the light-weight instrumentation of Python code for generic
purposes more consistent and predictable (e.g. to collect statistics,
profile code, etc).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36220](https://bugs.python.org/issue36220) -->
https://bugs.python.org/issue36220
<!-- /issue-number -->
