### PR TITLE
bpo-38840: Incorrect __all__ in multiprocessing.managers

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -33,10 +33,11 @@ from . import util
 from . import get_context
 try:
     from . import shared_memory
-    HAS_SHMEM = True
-    __all__.append('SharedMemoryManager')
 except ImportError:
     HAS_SHMEM = False
+else:
+    HAS_SHMEM = True
+    __all__.append('SharedMemoryManager')
 
 #
 # Register some things for pickling

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -8,8 +8,7 @@
 # Licensed to PSF under a Contributor Agreement.
 #
 
-__all__ = [ 'BaseManager', 'SyncManager', 'BaseProxy', 'Token',
-            'SharedMemoryManager' ]
+__all__ = [ 'BaseManager', 'SyncManager', 'BaseProxy', 'Token' ]
 
 #
 # Imports
@@ -35,6 +34,7 @@ from . import get_context
 try:
     from . import shared_memory
     HAS_SHMEM = True
+    __all__.append('SharedMemoryManager')
 except ImportError:
     HAS_SHMEM = False
 

--- a/Misc/NEWS.d/next/Library/2020-01-16-23-41-16.bpo-38840.VzzYZz.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-16-23-41-16.bpo-38840.VzzYZz.rst
@@ -1,0 +1,1 @@
+Fix ``test___all__`` on platforms lacking a shared memory implementation.


### PR DESCRIPTION
This was causing test___all__ to fail on platforms lacking a shared
memory implementation.

Co-Authored-By: Xavier de Gaye <xdegaye@gmail.com>

<!-- issue-number: [bpo-38840](https://bugs.python.org/issue38840) -->
https://bugs.python.org/issue38840
<!-- /issue-number -->
