### PR TITLE
bpo-38076 Clear the interpreter state only after clearing module globals

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3685,7 +3685,7 @@ def _to_memoryview(buf):
 
 class CTextIOWrapperTest(TextIOWrapperTest):
     io = io
-    shutdown_error = "RuntimeError: could not find io module state"
+    shutdown_error = "LookupError: unknown encoding: ascii"
 
     def test_initialization(self):
         r = self.BytesIO(b"\xc3\xa9\n\n")

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -7,6 +7,7 @@ import struct
 import sys
 
 from test import support
+from test.support.script_helper import assert_python_ok
 
 ISBIGENDIAN = sys.byteorder == "big"
 

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -652,6 +652,23 @@ class StructTest(unittest.TestCase):
         s2 = struct.Struct(s.format.encode())
         self.assertEqual(s2.format, s.format)
 
+    def test_struct_cleans_up_at_runtime_shutdown(self):
+        code = """if 1:
+            import struct
+
+            class C:
+                def __init__(self):
+                    self.pack = struct.pack
+                def __del__(self):
+                    self.pack('I', -42)
+
+            struct.x = C()
+            """
+        rc, stdout, stderr = assert_python_ok("-c", code)
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout.rstrip(), b"")
+        self.assertIn(b"Exception ignored in:", stderr)
+        self.assertIn(b"C.__del__", stderr)
 
 class UnpackIteratorTest(unittest.TestCase):
     """

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -857,6 +857,23 @@ class SysModuleTest(unittest.TestCase):
         self.assertIn(b'sys.flags', out[0])
         self.assertIn(b'sys.float_info', out[1])
 
+    def test_sys_ignores_cleaning_up_user_data(self):
+        code = """if 1:
+            import _struct, sys
+
+            class C:
+                def __init__(self):
+                    self.pack = struct.pack
+                def __del__(self):
+                    self.pack('I', -42)
+
+            sys.x = C()
+            """
+        rc, stdout, stderr = assert_python_ok('-c', code)
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout.rstrip(), b"")
+        self.assertEqual(stderr.rstrip(), b"")
+
     @unittest.skipUnless(hasattr(sys, 'getandroidapilevel'),
                          'need sys.getandroidapilevel()')
     def test_getandroidapilevel(self):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -859,7 +859,7 @@ class SysModuleTest(unittest.TestCase):
 
     def test_sys_ignores_cleaning_up_user_data(self):
         code = """if 1:
-            import _struct, sys
+            import struct, sys
 
             class C:
                 def __init__(self):

--- a/Misc/NEWS.d/next/C API/2020-01-17-11-37-05.bpo-38076.cxfw2x.rst
+++ b/Misc/NEWS.d/next/C API/2020-01-17-11-37-05.bpo-38076.cxfw2x.rst
@@ -1,0 +1,2 @@
+Fix to clear the interpreter state only after clearing module globals to
+guarantee module state access from C Extensions during runtime destruction

--- a/Python/import.c
+++ b/Python/import.c
@@ -566,8 +566,6 @@ _PyImport_Cleanup(PyThreadState *tstate)
         _PyErr_Clear(tstate);
     }
     Py_XDECREF(dict);
-    /* Clear module dict copies stored in the interpreter state */
-    _PyInterpreterState_ClearModules(interp);
     /* Collect references */
     _PyGC_CollectNoFail();
     /* Dump GC stats before it's too late, since it uses the warnings
@@ -608,6 +606,9 @@ _PyImport_Cleanup(PyThreadState *tstate)
         }
         Py_DECREF(weaklist);
     }
+
+    /* Clear module dict copies stored in the interpreter state */
+    _PyInterpreterState_ClearModules(interp);
 
     /* Next, delete sys and builtins (in that order) */
     if (verbose) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -607,9 +607,6 @@ _PyImport_Cleanup(PyThreadState *tstate)
         Py_DECREF(weaklist);
     }
 
-    /* Clear module dict copies stored in the interpreter state */
-    _PyInterpreterState_ClearModules(interp);
-
     /* Next, delete sys and builtins (in that order) */
     if (verbose) {
         PySys_FormatStderr("# cleanup[3] wiping sys\n");
@@ -619,6 +616,9 @@ _PyImport_Cleanup(PyThreadState *tstate)
         PySys_FormatStderr("# cleanup[3] wiping builtins\n");
     }
     _PyModule_ClearDict(interp->builtins);
+
+    /* Clear module dict copies stored in the interpreter state */
+    _PyInterpreterState_ClearModules(interp);
 
     /* Clear and delete the modules directory.  Actual modules will
        still be there only if imported during the execution of some


### PR DESCRIPTION
Currently, during runtime destruction, `_PyImport_Cleanup` is clearing the interpreter state before clearing out the modules themselves. This leads to a segfault on modules that rely on the module state to clear themselves up.

For example, let's take the small snippet added in the issue by @DinoV :
```
import _struct

class C:
    def __init__(self):
        self.pack = _struct.pack
    def __del__(self):
        self.pack('I', -42)

_struct.x = C()
```

The module `_struct` uses the module state to run `pack`. Therefore, the module state has to be alive until after the module has been cleared out to successfully run `C.__del__`. This happens at line 606, when `_PyImport_Cleanup` calls `_PyModule_Clear`. In fact, the loop that calls `_PyModule_Clear` has in its comments: 

> Now, if there are any modules left alive, clear their globals to minimize potential leaks.  All C extension modules actually end up here, since they are kept alive in the interpreter state.

That means that we can't clear the module state (which is used by C Extensions) before we run that loop.

Moving `_PyInterpreterState_ClearModules` until after it, fixes the segfault in the code snippet.

Finally, this updates a test in `io` to correctly assert the error that it now throws (since it now finds the io module state). The test that uses this is: `test_create_at_shutdown_without_encoding`. Given this test is now working is a proof that the module state now stays alive even when `__del__` is called at module destruction time. Thus, I didn't add a new tests for this.

<!-- issue-number: [bpo-38076](https://bugs.python.org/issue38076) -->
https://bugs.python.org/issue38076
<!-- /issue-number -->


Automerge-Triggered-By: @encukou