### PR TITLE
Fix Lock.locked() to remove extra bold highlighting

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -497,6 +497,7 @@ All methods are executed atomically.
       There is no return value.
 
    .. method:: locked()
+
       Return true if the lock is acquired.
 
 


### PR DESCRIPTION
Hoping this is simple enough not to require bpo (blame @warsaw )