### PR TITLE
bpo-39378: partial of PickleState struct should be traversed.

### DIFF
--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -7917,6 +7917,7 @@ pickle_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(st->import_mapping_3to2);
     Py_VISIT(st->codecs_encode);
     Py_VISIT(st->getattr);
+    Py_VISIT(st->partial);
     return 0;
 }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39378](https://bugs.python.org/issue39378) -->
https://bugs.python.org/issue39378
<!-- /issue-number -->
