### PR TITLE
bpo-38848: compileall fails when the platform lacks a working sem_open()

### DIFF
--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -79,6 +79,10 @@ def compile_dir(dir, maxlevels=None, ddir=None, force=False,
             # Only import when needed, as low resource platforms may
             # fail to import it
             from concurrent.futures import ProcessPoolExecutor
+            # bpo-38848: The multiprocessing module used by
+            # ProcessPoolExecutor is not functional when the
+            # multiprocessing.synchronize module cannot be imported.
+            import multiprocessing.synchronize
         except ImportError:
             workers = 1
     if maxlevels is None:

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -169,6 +169,10 @@ class CompileallTestsBase:
 
     @mock.patch('concurrent.futures.ProcessPoolExecutor')
     def test_compile_pool_called(self, pool_mock):
+        # bpo-38848: The multiprocessing module used by
+        # ProcessPoolExecutor is not functional when the
+        # multiprocessing.synchronize module cannot be imported.
+        support.import_module('multiprocessing.synchronize')
         compileall.compile_dir(self.directory, quiet=True, workers=5)
         self.assertTrue(pool_mock.called)
 
@@ -179,6 +183,10 @@ class CompileallTestsBase:
 
     @mock.patch('concurrent.futures.ProcessPoolExecutor')
     def test_compile_workers_cpu_count(self, pool_mock):
+        # bpo-38848: The multiprocessing module used by
+        # ProcessPoolExecutor is not functional when the
+        # multiprocessing.synchronize module cannot be imported.
+        support.import_module('multiprocessing.synchronize')
         compileall.compile_dir(self.directory, quiet=True, workers=0)
         self.assertEqual(pool_mock.call_args[1]['max_workers'], None)
 

--- a/Misc/NEWS.d/next/Library/2020-01-17-23-49-45.bpo-38848.4BVD4m.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-17-23-49-45.bpo-38848.4BVD4m.rst
@@ -1,0 +1,1 @@
+Fix :mod:`compileall` when the platform lacks a functional ``sem_open()``.


### PR DESCRIPTION
Co-Authored-By: Xavier de Gaye <xdegaye@gmail.com>



<!-- issue-number: [bpo-38848](https://bugs.python.org/issue38848) -->
https://bugs.python.org/issue38848
<!-- /issue-number -->
