### PR TITLE
bpo-39381: Fix asyncio.get_event_loop() documentation

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -38,8 +38,10 @@ an event loop:
 
 .. function:: get_event_loop()
 
-   Get the current event loop.  If there is no current event loop set
-   in the current OS thread and :func:`set_event_loop` has not yet
+   Get the current event loop.
+
+   If there is no current event loop set in the current OS thread,
+   the OS thread is main, and :func:`set_event_loop` has not yet
    been called, asyncio will create a new event loop and set it as the
    current one.
 

--- a/Misc/NEWS.d/next/Documentation/2020-01-18-15-37-56.bpo-39381.wTWe8d.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-18-15-37-56.bpo-39381.wTWe8d.rst
@@ -1,0 +1,2 @@
+Mention in docs that :func:`asyncio.get_event_loop` implicitly creates new
+event loop only if called from the main thread.


### PR DESCRIPTION
Mention that the function implicitly creates a new event loop only if called from the main thread.


<!-- issue-number: [bpo-39381](https://bugs.python.org/issue39381) -->
https://bugs.python.org/issue39381
<!-- /issue-number -->
