### PR TITLE
bpo-39383: Mention Darwin as a potential value for platform.system()

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -145,8 +145,8 @@ Cross Platform
 
 .. function:: system()
 
-   Returns the system/OS name, e.g. ``'Linux'``, ``'Windows'``, or ``'Java'``. An
-   empty string is returned if the value cannot be determined.
+   Returns the system/OS name, such as ``'Linux'``, ``'Darwin'``, ``'Java'``,
+   ``'Windows'``. An empty string is returned if the value cannot be determined.
 
 
 .. function:: system_alias(system, release, version)
@@ -260,4 +260,3 @@ Unix Platforms
    using :program:`gcc`.
 
    The file is read and scanned in chunks of *chunksize* bytes.
-


### PR DESCRIPTION
This change mentions `'Darwin'` as a possible value for
```python
platform.system()
```
in the documentation of the [platform](https://docs.python.org/3/library/platform.html#platform.system) module.

<!-- issue-number: [bpo-39383](https://bugs.python.org/issue39383) -->
https://bugs.python.org/issue39383
<!-- /issue-number -->
