### PR TITLE
bpo-37224: Improve test__xxsubinterpreters.DestroyTests

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -763,8 +763,7 @@ class DestroyTests(TestBase):
                 msg=f"Interp {interp} should be running before destruction.")
 
             with self.assertRaises(RuntimeError,
-                msg=f"Should not be able to destroy interp {interp} while"
-                           " it's still running."):
+                    msg=f"Should not be able to destroy interp {interp} while it's still running."):
                 interpreters.destroy(interp)
             self.assertTrue(interpreters.is_running(interp))
 

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -759,7 +759,12 @@ class DestroyTests(TestBase):
         main, = interpreters.list_all()
         interp = interpreters.create()
         with _running(interp):
-            with self.assertRaises(RuntimeError):
+            self.assertTrue(interpreters.is_running(interp),
+                msg=f"Interp {interp} should be running before destruction.")
+
+            with self.assertRaises(RuntimeError,
+                msg=f"Should not be able to destroy interp {interp} while"
+                           " it's still running."):
                 interpreters.destroy(interp)
             self.assertTrue(interpreters.is_running(interp))
 

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -760,10 +760,10 @@ class DestroyTests(TestBase):
         interp = interpreters.create()
         with _running(interp):
             self.assertTrue(interpreters.is_running(interp),
-                msg=f"Interp {interp} should be running before destruction.")
+                            msg=f"Interp {interp} should be running before destruction.")
 
             with self.assertRaises(RuntimeError,
-                    msg=f"Should not be able to destroy interp {interp} while it's still running."):
+                                   msg=f"Should not be able to destroy interp {interp} while it's still running."):
                 interpreters.destroy(interp)
             self.assertTrue(interpreters.is_running(interp))
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Adds an additional assertion check based on a race condition for `test__xxsubinterpreters.DestroyTests.test_still_running` discovered in the bpo issue.

<!-- issue-number: [bpo-37224](https://bugs.python.org/issue37224) -->
https://bugs.python.org/issue37224
<!-- /issue-number -->


Automerge-Triggered-By: @ericsnowcurrently