### PR TITLE
bpo-35561: Fix valgrind warnings in selectmodule.c

### DIFF
--- a/Misc/valgrind-python.supp
+++ b/Misc/valgrind-python.supp
@@ -264,6 +264,14 @@
 }
 
 {
+   Uninitialised byte(s) false alarm, see bpo-35561
+   Memcheck:Param
+   epoll_ctl(event)
+   fun:epoll_ctl
+   fun:pyepoll_internal_ctl
+}
+
+{
    ZLIB problems, see test_gzip
    Memcheck:Cond
    obj:/lib/libz.so.1.2.3


### PR DESCRIPTION
Update Misc/valgrind-python.supp to suppress the false alarm.


<!-- issue-number: [bpo-35561](https://bugs.python.org/issue35561) -->
https://bugs.python.org/issue35561
<!-- /issue-number -->
