### PR TITLE
bpo-39390: Update shutil.copytree doc - Add versionchanged 3.8 notice for ignore callable

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -274,9 +274,10 @@ Directory and files operations
       
    .. versionchanged:: 3.8
       The types of the arguments to the *ignore* callable have changed. The
-      first argument (the directory being visited) is a func:`os.DirEntry` or
-      a func:`pathlib.Path`; Previously it was a string. The second argument
-      is a set of strings; previously it was a list of strings.
+      first argument (the directory being visited) can be a string, a
+      func:`os.DirEntry` or a func:`pathlib.Path`; Previously it was a string.
+      The second argument is a set of strings; previously it was a list of
+      strings.
 
 .. function:: rmtree(path, ignore_errors=False, onerror=None)
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -271,6 +271,12 @@ Directory and files operations
 
    .. versionadded:: 3.8
       The *dirs_exist_ok* parameter.
+      
+   .. versionchanged:: 3.8
+      The types of the arguments to the *ignore* callable have changed. The
+      first argument (the directory being visited) is a func:`os.DirEntry` or
+      a func:`pathlib.Path`; Previously it was a string. The second argument
+      is a set of strings; previously it was a list of strings.
 
 .. function:: rmtree(path, ignore_errors=False, onerror=None)
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -271,7 +271,7 @@ Directory and files operations
 
    .. versionadded:: 3.8
       The *dirs_exist_ok* parameter.
-      
+
    .. versionchanged:: 3.8
       The types of the arguments to the *ignore* callable have changed. The
       first argument (the directory being visited) can be a string, a


### PR DESCRIPTION
The directory being copied.

```
In [21]: !tree
.
├── derp.txt
├── herp.txt
└── subdir
    └── subdireentry.txt

1 directory, 3 files
```

An ignore function for debugging.

```
In [23]: def _ignore(*args):
    ...:     print("ignore args:", args)
    ...:     return []
```

Python 3.7

```
In [25]: shutil.copytree(".", "/tmp/copytree37", ignore=_ignore)
ignore args: ('.', ['derp.txt', 'herp.txt', 'subdir'])
ignore args: ('./subdir', ['subdireentry.txt'])
Out[25]: '/tmp/copytree37'
In [26]: sys.version
Out[26]: '3.7.5 (default, Nov 20 2019, 09:21:52) \n[GCC 9.2.1 20191008]'
```

Python 3.8

```
In [32]: shutil.copytree(".", "/tmp/copytree38", ignore=_ignore)
ignore args: ('.', {'herp.txt', 'subdir', 'derp.txt'})
ignore args: (<DirEntry 'subdir'>, {'subdireentry.txt'})
Out[32]: '/tmp/copytree38'
In [33]: sys.version
Out[33]: '3.8.1 | packaged by conda-forge | (default, Jan  5 2020, 20:58:18) \n[GCC 7.3.0]'
``` 

<!-- issue-number: [bpo-39390](https://bugs.python.org/issue39390) -->
https://bugs.python.org/issue39390
<!-- /issue-number -->
