### PR TITLE
bpo-39395: Clear env vars set by Python at exit

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-20-13-13-33.bpo-39395.-Khif5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-20-13-13-33.bpo-39395.-Khif5.rst
@@ -1,0 +1,2 @@
+Environment variables set by :data:`os.environ` and :func:`os.putenv` are now
+cleared at exit. Python manages their memory which is released at exit.


### PR DESCRIPTION
Environment variables set by os.environ and os.putenv() are now
cleared at exit. Python manages their memory which is released
at exit.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39395](https://bugs.python.org/issue39395) -->
https://bugs.python.org/issue39395
<!-- /issue-number -->
