### PR TITLE
PyLong_AsLongLong() docs should refer to 'long long' rather than 'long'

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -177,7 +177,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    :c:type:`PyLongObject`.
 
    Raise :exc:`OverflowError` if the value of *obj* is out of range for a
-   :c:type:`long`.
+   :c:type:`long long`.
 
    Returns ``-1`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 


### PR DESCRIPTION
In the docs for [PyLong_AsLongLong()](https://docs.python.org/3/c-api/long.html#c.PyLong_AsLongLong), it states that an Overflow exception will be raised if the value is out of range for a C-style `long` integer type.  I believe this should refer to `long long`, to align with the rest of the description of this function.

The docs for the other functions in `Doc/c-api/long.rst` appear to be correct.

This seems like a trivial docs change, but if I need to raise a bug issue for it, do let me know.