### PR TITLE
bpo-39393: Misleading error message on dependent DLL resolution failure

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-01-20-23-42-53.bpo-39393.gWlJDG.rst
+++ b/Misc/NEWS.d/next/Windows/2020-01-20-23-42-53.bpo-39393.gWlJDG.rst
@@ -1,0 +1,2 @@
+Improve the error message when attempting to load a DLL with unresolved
+dependencies.

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1311,8 +1311,9 @@ static PyObject *load_library(PyObject *self, PyObject *args)
 
     if (err == ERROR_MOD_NOT_FOUND) {
         PyErr_Format(PyExc_FileNotFoundError,
-                     ("Could not find module '%.500S'. Try using "
-                      "the full path with constructor syntax."),
+                     ("Could not find module '%.500S' (or one of its "
+                      "dependencies). Try using the full path with "
+                      "constructor syntax."),
                      nameobj);
         return NULL;
     } else if (err) {


### PR DESCRIPTION
Improve the error message when attempting to load a DLL with
unresolved dependencies.

<!-- issue-number: [bpo-39393](https://bugs.python.org/issue39393) -->
https://bugs.python.org/issue39393
<!-- /issue-number -->
