### PR TITLE
bpo-39396: Fix math.nextafter(-0.0, +0.0) on AIX 7.1

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-01-21-09-00-42.bpo-39396.6UXQXE.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-21-09-00-42.bpo-39396.6UXQXE.rst
@@ -1,0 +1,1 @@
+Fix ``math.nextafter(-0.0, +0.0)`` on AIX 7.1.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -3287,8 +3287,14 @@ static PyObject *
 math_nextafter_impl(PyObject *module, double x, double y)
 /*[clinic end generated code: output=750c8266c1c540ce input=02b2d50cd1d9f9b6]*/
 {
-    double f = nextafter(x, y);
-    return PyFloat_FromDouble(f);
+#if defined(_AIX)
+    if (x == y) {
+        /* On AIX 7.1, libm nextafter(-0.0, +0.0) returns -0.0.
+           Bug fixed in bos.adt.libm 7.2.2.0 by APAR IV95512. */
+        return PyFloat_FromDouble(y);
+    }
+#endif
+    return PyFloat_FromDouble(nextafter(x, y));
 }
 
 


### PR DESCRIPTION
Move also math.nextafter() on math.ulp() tests from IsCloseTests to
MathTests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39396](https://bugs.python.org/issue39396) -->
https://bugs.python.org/issue39396
<!-- /issue-number -->
