### PR TITLE
bpo-39413: Use _wputenv(), not SetEnvironmentVariableW()

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -715,7 +715,9 @@ class _Environ(MutableMapping):
 try:
     _putenv = putenv
 except NameError:
-    _putenv = lambda key, value: None
+    def _putenv(key, value):
+        # do nothing
+        return
 else:
     if "putenv" not in __all__:
         __all__.append("putenv")
@@ -723,7 +725,17 @@ else:
 try:
     _unsetenv = unsetenv
 except NameError:
-    _unsetenv = lambda key: _putenv(key, "")
+    if name == 'nt':
+        def unsetenv(key):
+            """Delete an environment variable."""
+            _putenv(key, "")
+
+        if "unsetenv" not in __all__:
+            __all__.append("unsetenv")
+        _unsetenv = unsetenv
+    else:
+        def _unsetenv(key):
+            _putenv(key, "")
 else:
     if "unsetenv" not in __all__:
         __all__.append("unsetenv")

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -6125,43 +6125,7 @@ exit:
 
 #endif /* defined(HAVE_PUTENV) && !defined(MS_WINDOWS) */
 
-#if defined(MS_WINDOWS)
-
-PyDoc_STRVAR(os_unsetenv__doc__,
-"unsetenv($module, name, /)\n"
-"--\n"
-"\n"
-"Delete an environment variable.");
-
-#define OS_UNSETENV_METHODDEF    \
-    {"unsetenv", (PyCFunction)os_unsetenv, METH_O, os_unsetenv__doc__},
-
-static PyObject *
-os_unsetenv_impl(PyObject *module, PyObject *name);
-
-static PyObject *
-os_unsetenv(PyObject *module, PyObject *arg)
-{
-    PyObject *return_value = NULL;
-    PyObject *name;
-
-    if (!PyUnicode_Check(arg)) {
-        _PyArg_BadArgument("unsetenv", "argument", "str", arg);
-        goto exit;
-    }
-    if (PyUnicode_READY(arg) == -1) {
-        goto exit;
-    }
-    name = arg;
-    return_value = os_unsetenv_impl(module, name);
-
-exit:
-    return return_value;
-}
-
-#endif /* defined(MS_WINDOWS) */
-
-#if (defined(HAVE_UNSETENV) && !defined(MS_WINDOWS))
+#if defined(HAVE_UNSETENV)
 
 PyDoc_STRVAR(os_unsetenv__doc__,
 "unsetenv($module, name, /)\n"
@@ -6193,7 +6157,7 @@ exit:
     return return_value;
 }
 
-#endif /* (defined(HAVE_UNSETENV) && !defined(MS_WINDOWS)) */
+#endif /* defined(HAVE_UNSETENV) */
 
 PyDoc_STRVAR(os_strerror__doc__,
 "strerror($module, code, /)\n"
@@ -8809,4 +8773,4 @@ exit:
 #ifndef OS__REMOVE_DLL_DIRECTORY_METHODDEF
     #define OS__REMOVE_DLL_DIRECTORY_METHODDEF
 #endif /* !defined(OS__REMOVE_DLL_DIRECTORY_METHODDEF) */
-/*[clinic end generated code: output=6e739a2715712e88 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=51ba5b9536420cea input=a9049054013a1b77]*/


### PR DESCRIPTION
Don't implement os.unsetenv() in C using
SetEnvironmentVariableW(name, NULL) anymore, but implement it in
Python as os.putenv(name, ""). _wputenv() is preferred since it
updates the CRT, whereas SetEnvironmentVariableW(name, NULL) does
not.

Replace also lambda functions with regular functions to get named
functions, to ease debug.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39413](https://bugs.python.org/issue39413) -->
https://bugs.python.org/issue39413
<!-- /issue-number -->
