### PR TITLE
[3.8] bpo-39413: os.unsetenv() is not available on Windows

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -643,7 +643,7 @@ process and user.
    calls to :func:`unsetenv` don't update ``os.environ``, so it is actually
    preferable to delete items of ``os.environ``.
 
-   .. availability:: most flavors of Unix, Windows.
+   .. availability:: most flavors of Unix.
 
 
 .. _os-newstreams:


### PR DESCRIPTION
Update os.unsetenv() documentation: it is not available on Windows.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39413](https://bugs.python.org/issue39413) -->
https://bugs.python.org/issue39413
<!-- /issue-number -->
