### PR TITLE
bpo-39416: Document some restrictions on the default string representations of numeric classes

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -186,19 +186,19 @@ Ellipsis
    :meth:`__repr__` and :meth:`__str__`, have the following
    properties:
 
-      * They are valid numeric literals which, when passed to their
-        class constructor, produce an object having the value of the
-        original numeric.
+   * They are valid numeric literals which, when passed to their
+     class constructor, produce an object having the value of the
+     original numeric.
 
-      * The representation is in base 10, when possible.
+   * The representation is in base 10, when possible.
 
-      * Leading zeros, possibly excepting a single zero before a
-        decimal point, are not shown.
+   * Leading zeros, possibly excepting a single zero before a
+     decimal point, are not shown.
 
-      * Trailing zeros, possibly excepting a single zero after a
-        decimal point, are not shown.
+   * Trailing zeros, possibly excepting a single zero after a
+     decimal point, are not shown.
 
-      * A sign is shown only when the number is negative.
+   * A sign is shown only when the number is negative.
 
    Python distinguishes between integers, floating point numbers, and complex
    numbers:

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -182,6 +182,24 @@ Ellipsis
    related to mathematical numbers, but subject to the limitations of numerical
    representation in computers.
 
+   The string representations of the Numeric classes, computed by
+   :meth:`__repr__` and :meth:`__str__`, have the following
+   properties:
+
+      * They are valid numeric literals which, when passed to their
+        class constructor, produce an object having the value of the
+        original numeric.
+
+      * The representation is in base 10, when possible.
+
+      * Leading zeros, possibly excepting a single zero before a
+        decimal point, are not shown.
+
+      * Trailing zeros, possibly excepting a single zero after a
+        decimal point, are not shown.
+
+      * A sign is shown only when the number is negative.
+
    Python distinguishes between integers, floating point numbers, and complex
    numbers:
 

--- a/Misc/NEWS.d/next/Documentation/2020-01-22-05-14-53.bpo-39416.uYjhEm.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-22-05-14-53.bpo-39416.uYjhEm.rst
@@ -1,0 +1,1 @@
+Put minimal, sane, restrictions on the default string representations of Python's Numeric classes.

--- a/Misc/NEWS.d/next/Documentation/2020-01-22-05-14-53.bpo-39416.uYjhEm.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-22-05-14-53.bpo-39416.uYjhEm.rst
@@ -1,1 +1,1 @@
-Put minimal, sane, restrictions on the default string representations of Python's Numeric classes.
+Document some restrictions on the default string representations of numeric classes.


### PR DESCRIPTION
[bpo-39416](https://bugs.python.org/issue39416): Document string representations of the Numeric classes

This is a change to the specification of the Python language.

The idea here is to put sane minimal limits on the Python language's default
representations of its Numeric classes.  That way "Marty's Robotic Massage Parlor
and Python Interpreter" implementation of Python won't do anything too
crazy.

Some discussion in the email thread:
Subject: Documenting Python's float.__str__()
https://mail.python.org/archives/list/python-dev@python.org/thread/FV22TKT3S2Q3P7PNN6MCXI6IX3HRRNAL/

<!-- issue-number: [bpo-39416](https://bugs.python.org/issue39416) -->
https://bugs.python.org/issue39416
<!-- /issue-number -->

Automerge-Triggered-By: GH:merwok