### PR TITLE
[WIP] bpo-39413: os.unsetenv() uses _wputenv() on Windows

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -715,7 +715,9 @@ class _Environ(MutableMapping):
 try:
     _putenv = putenv
 except NameError:
-    _putenv = lambda key, value: None
+    def _putenv(key, value):
+        # do nothing
+        return
 else:
     if "putenv" not in __all__:
         __all__.append("putenv")
@@ -723,7 +725,9 @@ else:
 try:
     _unsetenv = unsetenv
 except NameError:
-    _unsetenv = lambda key: _putenv(key, "")
+    def _unsetenv(key):
+        # set the environment variable to an empty string
+        _putenv(key, "")
 else:
     if "unsetenv" not in __all__:
         __all__.append("unsetenv")

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -955,10 +955,12 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
 
     # On OS X < 10.6, unsetenv() doesn't return a value (bpo-13415).
     @support.requires_mac_ver(10, 6)
-    def test_unset_error(self):
-        # "=" is not allowed in a variable name
-        key = 'key='
-        self.assertRaises(OSError, os.environ.__delitem__, key)
+    def test_unsetenv_error(self):
+        self.assertRaises(OSError, os.unsetenv, '=key')
+        # On Windows, only names starting with "=" are invalid
+        if sys.platform != "win32":
+            self.assertRaises(OSError, os.unsetenv, 'ke=y')
+            self.assertRaises(OSError, os.unsetenv, 'key=')
 
     def test_key_type(self):
         missing = 'missingkey'

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -6034,7 +6034,7 @@ exit:
 
 #endif /* (defined(HAVE_POSIX_FADVISE) && !defined(POSIX_FADVISE_AIX_BUG)) */
 
-#if defined(HAVE_PUTENV) && defined(MS_WINDOWS)
+#if defined(MS_WINDOWS)
 
 PyDoc_STRVAR(os_putenv__doc__,
 "putenv($module, name, value, /)\n"
@@ -6080,9 +6080,9 @@ exit:
     return return_value;
 }
 
-#endif /* defined(HAVE_PUTENV) && defined(MS_WINDOWS) */
+#endif /* defined(MS_WINDOWS) */
 
-#if defined(HAVE_PUTENV) && !defined(MS_WINDOWS)
+#if (defined(HAVE_PUTENV) && !defined(MS_WINDOWS))
 
 PyDoc_STRVAR(os_putenv__doc__,
 "putenv($module, name, value, /)\n"
@@ -6123,7 +6123,7 @@ exit:
     return return_value;
 }
 
-#endif /* defined(HAVE_PUTENV) && !defined(MS_WINDOWS) */
+#endif /* (defined(HAVE_PUTENV) && !defined(MS_WINDOWS)) */
 
 #if defined(MS_WINDOWS)
 
@@ -8809,4 +8809,4 @@ exit:
 #ifndef OS__REMOVE_DLL_DIRECTORY_METHODDEF
     #define OS__REMOVE_DLL_DIRECTORY_METHODDEF
 #endif /* !defined(OS__REMOVE_DLL_DIRECTORY_METHODDEF) */
-/*[clinic end generated code: output=6e739a2715712e88 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=773b0e49560f08dc input=a9049054013a1b77]*/


### PR DESCRIPTION
os.unsetenv() uses _wputenv() rather than SetEnvironmentVariableW():
_wputenv() updates the CRT, whereas SetEnvironmentVariableW() does
not.

Replace also lambda functions with regular functions to get named
functions, to ease debug.

<!-- issue-number: [bpo-39413](https://bugs.python.org/issue39413) -->
https://bugs.python.org/issue39413
<!-- /issue-number -->
