### PR TITLE
bpo-39390: fix argument types for ignore callback of shutil.copytree

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -442,7 +442,7 @@ def ignore_patterns(*patterns):
 def _copytree(entries, src, dst, symlinks, ignore, copy_function,
               ignore_dangling_symlinks, dirs_exist_ok=False):
     if ignore is not None:
-        ignored_names = ignore(src, {x.name for x in entries})
+        ignored_names = ignore(os.fspath(src), [x.name for x in entries])
     else:
         ignored_names = set()
 

--- a/Misc/NEWS.d/next/Library/2020-01-23-21-34-29.bpo-39390.D2tSXk.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-23-21-34-29.bpo-39390.D2tSXk.rst
@@ -1,0 +1,2 @@
+Fixed a regression with the `ignore` callback of :func:`shutil.copytree`.
+The argument types are now str and List[str] again.


### PR DESCRIPTION
The directory being copied.

```
In [21]: !tree
.
├── derp.txt
├── herp.txt
└── subdir
    └── subdireentry.txt

1 directory, 3 files
```

An ignore function for debugging.

```
In [23]: def _ignore(*args):
    ...:     print("ignore args:", args)
    ...:     return []
```

Python 3.7

```
In [25]: shutil.copytree(".", "/tmp/copytree37", ignore=_ignore)
ignore args: ('.', ['derp.txt', 'herp.txt', 'subdir'])
ignore args: ('./subdir', ['subdireentry.txt'])
Out[25]: '/tmp/copytree37'
In [26]: sys.version
Out[26]: '3.7.5 (default, Nov 20 2019, 09:21:52) \n[GCC 9.2.1 20191008]'
```

Python 3.8

```
In [32]: shutil.copytree(".", "/tmp/copytree38", ignore=_ignore)
ignore args: ('.', {'herp.txt', 'subdir', 'derp.txt'})
ignore args: (<DirEntry 'subdir'>, {'subdireentry.txt'})
Out[32]: '/tmp/copytree38'
In [33]: sys.version
Out[33]: '3.8.1 | packaged by conda-forge | (default, Jan  5 2020, 20:58:18) \n[GCC 7.3.0]'
``` 

<!-- issue-number: [bpo-39390](https://bugs.python.org/issue39390) -->
https://bugs.python.org/issue39390
<!-- /issue-number -->
