### PR TITLE
gh-83581: Do not pass MANPAGER value to shell in pydoc

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1506,8 +1506,8 @@ def plain(text):
 
 def pipepager(text, cmd):
     """Page through text by feeding it to another program."""
-    import subprocess
-    proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE)
+    import subprocess, shlex
+    proc = subprocess.Popen(shlex.split(cmd), stdin=subprocess.PIPE)
     try:
         with io.TextIOWrapper(proc.stdin, errors='backslashreplace') as pipe:
             try:

--- a/Misc/NEWS.d/next/Library/2020-01-22-19-29-51.bpo-39400.E2b-EH.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-22-19-29-51.bpo-39400.E2b-EH.rst
@@ -1,0 +1,1 @@
+Changed pydoc's interpretation of the MANPAGER variable to better match man's.


### PR DESCRIPTION
pipepager in pydoc passes documentation content to a pager using Popen with shell=True.

Shell parsing is incompatible with the interpretation of MANPAGER by the ubiquitous man program from man-db.

`man man`:
> The [$MANPAGER] value may be a simple command name or a command with arguments, and may use shell quoting (backslashes, single quotes, or double quotes).  It may not use pipes to connect multiple commands; if you need that, use a wrapper script [...]

The difference in interpretation can make some valid values of MANPAGER cause pydoc to fail, but not man. For example,

```
$ printf "%s\n" $MANPAGER | cat -v -
env
LESS_TERMCAP_mb=^[[01;31m
LESS_TERMCAP_me=^[[00m
LESS_TERMCAP_md=^[[01;31m
LESS_TERMCAP_so=^[[44m^[[01;30m
LESS_TERMCAP_se=^[[00m
LESS_TERMCAP_us=^[[01;32m
LESS_TERMCAP_ue=^[[00m
less
$ man man # works as intended
$ pydoc pydoc # fails
/bin/sh: 31m: command not found
/bin/sh: 31m: command not found
/bin/sh: 30m: command not found
/bin/sh: 32m: command not found
```
In pydoc, the shell has split the unquoted terminal control sequences at the `;`.

If we really want to borrow the MANPAGER variable from man, Python should match man's interpretation of the value. Python already has a built in parser that closely matches man's use of MANPAGER in `shlex.split`, so for compatibility we can use that instead.

If Python is not wiling to match man's interpretation of MANPAGER, it think should reference only the PAGER value instead, as is already described in [the documentation](https://docs.python.org/3/library/pydoc.html) (no mention of MANPAGER):

> When printing output to the console, pydoc attempts to paginate the output for easier reading. If the PAGER environment variable is set, pydoc will use its value as a pagination program.

<!-- issue-number: [bpo-39400](https://bugs.python.org/issue39400) -->
https://bugs.python.org/issue39400
<!-- /issue-number -->


<!-- gh-issue-number: gh-83581 -->
* Issue: gh-83581
<!-- /gh-issue-number -->
