### PR TITLE
bpo-39361: Document the removal of tp_print

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -318,6 +318,11 @@ Build and C API Changes
   removed in Python 3.3.
   (Contributed by Victor Stinner in :issue:`38896`.)
 
+* The ``tp_print`` slot of :ref:`PyTypeObject <type-structs>` has been removed.
+  It was used for printing objects to files in Python 2.7 and before. Since 
+  Python 3.0, it has been ignored and unused.
+  (Contributed by Jeroen Demeyer in :issue:`36974`.)
+
 
 Deprecated
 ==========

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -319,7 +319,7 @@ Build and C API Changes
   (Contributed by Victor Stinner in :issue:`38896`.)
 
 * The ``tp_print`` slot of :ref:`PyTypeObject <type-structs>` has been removed.
-  It was used for printing objects to files in Python 2.7 and before. Since 
+  It was used for printing objects to files in Python 2.7 and before. Since
   Python 3.0, it has been ignored and unused.
   (Contributed by Jeroen Demeyer in :issue:`36974`.)
 


### PR DESCRIPTION
Looks like there are still some remnants of `tp_print` in `test_defaultdict.py`: https://github.com/python/cpython/blob/beea26b57e8c80f1eff0f967a0f9d083a7dc3d66/Lib/test/test_defaultdict.py#L79-L94

The tp_print function was removed as part of https://github.com/python/cpython/commit/346f1a82bd525b3053d18a5b130ef2e70d4c1858 but the test exercising that path was never changed. Should changing that be done here as well or a separate issue/PR?

<!-- issue-number: [bpo-39361](https://bugs.python.org/issue39361) -->
https://bugs.python.org/issue39361
<!-- /issue-number -->
