### PR TITLE
bpo-39406: os.putenv() avoids putenv_dict on Windows

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -819,7 +819,9 @@ dir_fd_converter(PyObject *o, void *p)
     }
 }
 
-#ifdef HAVE_PUTENV
+/* Windows: _wputenv(env) copies the *env* string and doesn't require the
+   caller to manage the variable memory. */
+#if defined(HAVE_PUTENV) && !defined(MS_WINDOWS)
 #  define PY_PUTENV_DICT
 #endif
 
@@ -10130,8 +10132,10 @@ os_putenv_impl(PyObject *module, PyObject *name, PyObject *value)
         posix_error();
         goto error;
     }
+    /* _wputenv(env) copies the *env* string and doesn't require the caller
+       to manage the variable memory. */
+    Py_DECREF(unicode);
 
-    posix_putenv_dict_setitem(name, unicode);
     Py_RETURN_NONE;
 
 error:


### PR DESCRIPTION
Windows: _wputenv(env) copies the *env* string and doesn't require
the caller to manage the variable memory.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39406](https://bugs.python.org/issue39406) -->
https://bugs.python.org/issue39406
<!-- /issue-number -->
