### PR TITLE
Minor change on threading.Thread.native_id documentation.

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -357,13 +357,12 @@ since it is impossible to detect the termination of alien threads.
 
    .. attribute:: native_id
 
-      The native integral thread ID of this thread.
+      The Thread ID (``TID``) of this thread, as assigned by the OS (kernel).
       This is a non-negative integer, or ``None`` if the thread has not
       been started. See the :func:`get_native_id` function.
-      This represents the Thread ID (``TID``) as assigned to the
-      thread by the OS (kernel).  Its value may be used to uniquely identify
-      this particular thread system-wide (until the thread terminates,
-      after which the value may be recycled by the OS).
+      This value may be used to uniquely identify this particular thread
+      system-wide (until the thread terminates, after which the value
+      may be recycled by the OS).
 
       .. note::
 


### PR DESCRIPTION
Remove duplication in `threading.Thread.native_id` documentation, so resulting documentation is more consistent with the `threading.Thread.ident`.

Issue initially raised [here](https://github.com/python/python-docs-fr/pull/1122#discussion_r369236634) (in French). 

No issue associated to this PR.

Automerge-Triggered-By: @csabella