### PR TITLE
bpo-32989: IDLE - remove unneeded parameter 

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -6,7 +6,8 @@ Released on 2020-10-05?
 bpo-39050: Make Settings dialog Help button work again.
 
 bpo-32989: Add tests for editor newline_and_indent_event method.
-Remove dead code from pyparse find_good_parse_start method.
+Remove unneeded arguments and dead code from pyparse
+find_good_parse_start method.
 
 bpo-38943: Fix autocomplete windows not always appearing on some
 systems.  Patch by Johnny Najera.

--- a/Lib/idlelib/pyparse.py
+++ b/Lib/idlelib/pyparse.py
@@ -133,7 +133,7 @@ class Parser:
         self.code = s
         self.study_level = 0
 
-    def find_good_parse_start(self, is_char_in_string, _synchre=_synchre):
+    def find_good_parse_start(self, is_char_in_string):
         """
         Return index of a good place to begin parsing, as close to the
         end of the string as possible.  This will be the start of some


### PR DESCRIPTION
IDLE does not pass a non-default _synchre in any of its calls to
pyparse.find_good_parse_start.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32989](https://bugs.python.org/issue32989) -->
https://bugs.python.org/issue32989
<!-- /issue-number -->
