### PR TITLE
[3.7] bpo-38092: Reduce overhead when using multiprocessing in a Windows virtual environment (GH-16098)

### DIFF
--- a/Lib/multiprocessing/popen_spawn_win32.py
+++ b/Lib/multiprocessing/popen_spawn_win32.py
@@ -69,7 +69,7 @@ class Popen(object):
             try:
                 hp, ht, pid, tid = _winapi.CreateProcess(
                     python_exe, cmd,
-                    env, None, False, 0, None, None, None)
+                    None, None, False, 0, env, None, None)
                 _winapi.CloseHandle(ht)
             except:
                 _winapi.CloseHandle(rhandle)

--- a/Misc/NEWS.d/next/Windows/2020-01-24-03-07-14.bpo-39439.rwMWDR.rst
+++ b/Misc/NEWS.d/next/Windows/2020-01-24-03-07-14.bpo-39439.rwMWDR.rst
@@ -1,0 +1,1 @@
+Reduce overhead when using multiprocessing in a Windows virtual environment


### PR DESCRIPTION
Backport [bpo-38092](https://bugs.python.org/issue38092) to Python 3.7

Refs [bpo-39439](https://bugs.python.org/issue39439)

<!-- issue-number: [bpo-38092](https://bugs.python.org/issue38092) -->
https://bugs.python.org/issue38092
<!-- /issue-number -->
