### PR TITLE
bpo-39439: Fix Multiprocessing Python Path in Windows Virtualenv

### DIFF
--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -36,7 +36,7 @@ else:
 if WINSERVICE:
     _python_exe = os.path.join(sys.exec_prefix, 'python.exe')
 else:
-    _python_exe = sys._base_executable
+    _python_exe = sys.executable
 
 def set_executable(exe):
     global _python_exe

--- a/Misc/NEWS.d/next/Windows/2020-01-24-03-15-05.bpo-39439.sFxGfR.rst
+++ b/Misc/NEWS.d/next/Windows/2020-01-24-03-15-05.bpo-39439.sFxGfR.rst
@@ -1,0 +1,1 @@
+Honor the Python path when a virtualenv is active on Windows.


### PR DESCRIPTION
Honor the Python path when a virtualenv is active on Windows.

<!-- issue-number: [bpo-39439](https://bugs.python.org/issue39439) -->
https://bugs.python.org/issue39439
<!-- /issue-number -->
