### PR TITLE
bpo-39450 Stripped whitespace before parsing the docstring in TestCase.shortDescription

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -512,7 +512,7 @@ class TestCase(object):
         the specified test method's docstring.
         """
         doc = self._testMethodDoc
-        return doc and doc.split("\n")[0].strip() or None
+        return doc.strip().split("\n")[0].strip() if doc else None
 
 
     def id(self):

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -612,11 +612,12 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
 
     def testShortDescriptionWhitespaceTrimming(self):
         """
-            Tests shortDescription() whitespace is trimmed, so that the first line of nonwhite-space text becomes the docstring.
+            Tests shortDescription() whitespace is trimmed, so that the first
+            line of nonwhite-space text becomes the docstring.
         """
         self.assertEqual(
             self.shortDescription(),
-            'Tests shortDescription() whitespace is trimmed, so that the first line of nonwhite-space text becomes the docstring.')
+            'Tests shortDescription() whitespace is trimmed, so that the first')
 
     def testAddTypeEqualityFunc(self):
         class SadSnake(object):

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -610,6 +610,14 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
                  'Tests shortDescription() for a method with a longer '
                  'docstring.')
 
+    def testShortDescriptionWhitespaceTrimming(self):
+        """
+            Tests shortDescription() whitespace is trimmed, so that the first line of nonwhite-space text becomes the docstring.
+        """
+        self.assertEqual(
+            self.shortDescription(),
+            'Tests shortDescription() whitespace is trimmed, so that the first line of nonwhite-space text becomes the docstring.')
+
     def testAddTypeEqualityFunc(self):
         class SadSnake(object):
             """Dummy class for test_addTypeEqualityFunc."""

--- a/Misc/NEWS.d/next/Library/2020-02-02-14-46-34.bpo-39450.48R274.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-02-14-46-34.bpo-39450.48R274.rst
@@ -1,0 +1,2 @@
+Striped whitespace from docstring before returning it from
+:func:`unittest.case.shortDescription`.


### PR DESCRIPTION
# Pull Request title
Removed whitespace from Testcase shortDescription
https://bugs.python.org/msg360666

```
[bpo-39450](https://bugs.python.org/issue39450): Stripped whitespace before parsing the docstring in the Lib.unittest.case.TestCase:shortDescription() return.
```



<!-- issue-number: [bpo-39450](https://bugs.python.org/issue39450) -->
https://bugs.python.org/issue39450
<!-- /issue-number -->
