### PR TITLE
Ignore NEWS snippets in code coverage stats

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,7 +5,7 @@ codecov:
 comment: off
 ignore:
   - "Doc/**/*"
-  - "Misc/*"
+  - "Misc/**/*"
   - "Mac/**/*"
   - "PC/**/*"
   - "PCbuild/**/*"


### PR DESCRIPTION
In trying to work out what was wrong with the code coverage stats on #18066,
I realised we weren't ignoring the `Misc/NEWS.d` subdirectory correctly.
