### PR TITLE
Use relative imports in mock and its tests to help backporting

### DIFF
--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -3,7 +3,7 @@ import inspect
 import re
 import unittest
 
-from asyncio import run
+from asyncio import run, iscoroutinefunction
 from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock, Mock,
                            create_autospec, sentinel, _CallList)
 
@@ -55,7 +55,7 @@ class AsyncPatchDecoratorTest(unittest.TestCase):
     def test_is_coroutine_function_patch(self):
         @patch.object(AsyncClass, 'async_method')
         def test_async(mock_method):
-            self.assertTrue(asyncio.iscoroutinefunction(mock_method))
+            self.assertTrue(iscoroutinefunction(mock_method))
         test_async()
 
     def test_is_async_patch(self):
@@ -116,7 +116,7 @@ class AsyncPatchCMTest(unittest.TestCase):
     def test_is_async_function_cm(self):
         def test_async():
             with patch.object(AsyncClass, 'async_method') as mock_method:
-                self.assertTrue(asyncio.iscoroutinefunction(mock_method))
+                self.assertTrue(iscoroutinefunction(mock_method))
 
         test_async()
 
@@ -148,12 +148,12 @@ class AsyncPatchCMTest(unittest.TestCase):
 class AsyncMockTest(unittest.TestCase):
     def test_iscoroutinefunction_default(self):
         mock = AsyncMock()
-        self.assertTrue(asyncio.iscoroutinefunction(mock))
+        self.assertTrue(iscoroutinefunction(mock))
 
     def test_iscoroutinefunction_function(self):
         async def foo(): pass
         mock = AsyncMock(foo)
-        self.assertTrue(asyncio.iscoroutinefunction(mock))
+        self.assertTrue(iscoroutinefunction(mock))
         self.assertTrue(inspect.iscoroutinefunction(mock))
 
     def test_isawaitable(self):
@@ -166,7 +166,7 @@ class AsyncMockTest(unittest.TestCase):
     def test_iscoroutinefunction_normal_function(self):
         def foo(): pass
         mock = AsyncMock(foo)
-        self.assertTrue(asyncio.iscoroutinefunction(mock))
+        self.assertTrue(iscoroutinefunction(mock))
         self.assertTrue(inspect.iscoroutinefunction(mock))
 
     def test_future_isfuture(self):
@@ -214,7 +214,7 @@ class AsyncAutospecTest(unittest.TestCase):
 
         run(main())
 
-        self.assertTrue(asyncio.iscoroutinefunction(spec))
+        self.assertTrue(iscoroutinefunction(spec))
         self.assertTrue(asyncio.iscoroutine(awaitable))
         self.assertEqual(spec.await_count, 1)
         self.assertEqual(spec.await_args, call(1, 2, c=3))
@@ -235,7 +235,7 @@ class AsyncAutospecTest(unittest.TestCase):
                 awaitable = mock_method(1, 2, c=3)
                 self.assertIsInstance(mock_method.mock, AsyncMock)
 
-                self.assertTrue(asyncio.iscoroutinefunction(mock_method))
+                self.assertTrue(iscoroutinefunction(mock_method))
                 self.assertTrue(asyncio.iscoroutine(awaitable))
                 self.assertTrue(inspect.isawaitable(awaitable))
 
@@ -371,13 +371,13 @@ class AsyncSpecSetTest(unittest.TestCase):
 
     def test_is_async_AsyncMock(self):
         mock = AsyncMock(spec_set=AsyncClass.async_method)
-        self.assertTrue(asyncio.iscoroutinefunction(mock))
+        self.assertTrue(iscoroutinefunction(mock))
         self.assertIsInstance(mock, AsyncMock)
 
     def test_is_child_AsyncMock(self):
         mock = MagicMock(spec_set=AsyncClass)
-        self.assertTrue(asyncio.iscoroutinefunction(mock.async_method))
-        self.assertFalse(asyncio.iscoroutinefunction(mock.normal_method))
+        self.assertTrue(iscoroutinefunction(mock.async_method))
+        self.assertFalse(iscoroutinefunction(mock.normal_method))
         self.assertIsInstance(mock.async_method, AsyncMock)
         self.assertIsInstance(mock.normal_method, MagicMock)
         self.assertIsInstance(mock, MagicMock)
@@ -537,8 +537,8 @@ class AsyncMagicMethods(unittest.TestCase):
         self.assertIsInstance(m_mock.__aenter__, AsyncMock)
         self.assertIsInstance(m_mock.__aexit__, AsyncMock)
         # AsyncMocks are also coroutine functions
-        self.assertTrue(asyncio.iscoroutinefunction(m_mock.__aenter__))
-        self.assertTrue(asyncio.iscoroutinefunction(m_mock.__aexit__))
+        self.assertTrue(iscoroutinefunction(m_mock.__aenter__))
+        self.assertTrue(iscoroutinefunction(m_mock.__aexit__))
 
 class AsyncContextManagerTest(unittest.TestCase):
 
@@ -688,11 +688,11 @@ class AsyncIteratorTest(unittest.TestCase):
             mock_instance = mock_type(instance)
             # Check that the mock and the real thing bahave the same
             # __aiter__ is not actually async, so not a coroutinefunction
-            self.assertFalse(asyncio.iscoroutinefunction(instance.__aiter__))
-            self.assertFalse(asyncio.iscoroutinefunction(mock_instance.__aiter__))
+            self.assertFalse(iscoroutinefunction(instance.__aiter__))
+            self.assertFalse(iscoroutinefunction(mock_instance.__aiter__))
             # __anext__ is async
-            self.assertTrue(asyncio.iscoroutinefunction(instance.__anext__))
-            self.assertTrue(asyncio.iscoroutinefunction(mock_instance.__anext__))
+            self.assertTrue(iscoroutinefunction(instance.__anext__))
+            self.assertTrue(iscoroutinefunction(mock_instance.__anext__))
 
         for mock_type in [AsyncMock, MagicMock]:
             with self.subTest(f"test aiter and anext corourtine with {mock_type}"):
@@ -749,7 +749,7 @@ class AsyncMockAssert(unittest.TestCase):
         with self.assertWarns(RuntimeWarning):
             # Will raise a warning because never awaited
             mock.async_method()
-        self.assertTrue(asyncio.iscoroutinefunction(mock.async_method))
+        self.assertTrue(iscoroutinefunction(mock.async_method))
         mock.async_method.assert_called()
         mock.async_method.assert_called_once()
         mock.async_method.assert_called_once_with()

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -4,6 +4,7 @@ import re
 import unittest
 
 from asyncio import run, iscoroutinefunction
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock, Mock,
                            create_autospec, sentinel, _CallList)
 
@@ -390,7 +391,7 @@ class AsyncSpecSetTest(unittest.TestCase):
             self.assertIsInstance(cm, MagicMock)
 
 
-class AsyncArguments(unittest.IsolatedAsyncioTestCase):
+class AsyncArguments(IsolatedAsyncioTestCase):
     async def test_add_return_value(self):
         async def addition(self, var):
             return var + 1

--- a/Lib/unittest/test/testmock/testmagicmethods.py
+++ b/Lib/unittest/test/testmock/testmagicmethods.py
@@ -1,8 +1,8 @@
-import asyncio
 import math
 import unittest
 import os
 import sys
+from asyncio import iscoroutinefunction
 from unittest.mock import AsyncMock, Mock, MagicMock, _magics
 
 
@@ -286,8 +286,8 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(math.trunc(mock), mock.__trunc__())
         self.assertEqual(math.floor(mock), mock.__floor__())
         self.assertEqual(math.ceil(mock), mock.__ceil__())
-        self.assertTrue(asyncio.iscoroutinefunction(mock.__aexit__))
-        self.assertTrue(asyncio.iscoroutinefunction(mock.__aenter__))
+        self.assertTrue(iscoroutinefunction(mock.__aexit__))
+        self.assertTrue(iscoroutinefunction(mock.__aenter__))
         self.assertIsInstance(mock.__aenter__, AsyncMock)
         self.assertIsInstance(mock.__aexit__, AsyncMock)
 
@@ -312,8 +312,8 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(math.trunc(mock), mock.__trunc__())
         self.assertEqual(math.floor(mock), mock.__floor__())
         self.assertEqual(math.ceil(mock), mock.__ceil__())
-        self.assertTrue(asyncio.iscoroutinefunction(mock.__aexit__))
-        self.assertTrue(asyncio.iscoroutinefunction(mock.__aenter__))
+        self.assertTrue(iscoroutinefunction(mock.__aexit__))
+        self.assertTrue(iscoroutinefunction(mock.__aenter__))
         self.assertIsInstance(mock.__aenter__, AsyncMock)
         self.assertIsInstance(mock.__aexit__, AsyncMock)
 


### PR DESCRIPTION
I stopped short of putting comments at the top of each file explaining the import style, but I've tagged everyone I know of who's active in mock's development right now to ask if you can keep an eye out for `import foo; foo.bar` usage for things that aren't in Python 3.6+.

`from foo import bar` makes it much easier to backport just what's necessary and stops patches failing to apply cleanly going forwards.

@mariocj89 - tagging you too for reference :-)