### PR TITLE
black run over mock files

### DIFF
--- a/Lib/unittest/test/testmock/__init__.py
+++ b/Lib/unittest/test/testmock/__init__.py
@@ -6,6 +6,7 @@ import unittest
 here = os.path.dirname(__file__)
 loader = unittest.defaultTestLoader
 
+
 def load_tests(*args):
     suite = unittest.TestSuite()
     for fn in os.listdir(here):

--- a/Lib/unittest/test/testmock/__main__.py
+++ b/Lib/unittest/test/testmock/__main__.py
@@ -8,8 +8,9 @@ def load_tests(loader, standard_tests, pattern):
     pattern = pattern or "test*.py"
     # We are inside unittest.test.testmock, so the top-level is three notches up
     top_level_dir = os.path.dirname(os.path.dirname(os.path.dirname(this_dir)))
-    package_tests = loader.discover(start_dir=this_dir, pattern=pattern,
-                                    top_level_dir=top_level_dir)
+    package_tests = loader.discover(
+        start_dir=this_dir, pattern=pattern, top_level_dir=top_level_dir
+    )
     standard_tests.addTests(package_tests)
     return standard_tests
 

--- a/Lib/unittest/test/testmock/support.py
+++ b/Lib/unittest/test/testmock/support.py
@@ -9,7 +9,8 @@ def is_instance(obj, klass):
 class SomeClass(object):
     class_attribute = None
 
-    def wibble(self): pass
+    def wibble(self):
+        pass
 
 
 class X(object):

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -7,8 +7,17 @@ from contextlib import contextmanager
 
 from asyncio import run, iscoroutinefunction
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock, Mock,
-                           create_autospec, sentinel, _CallList)
+from unittest.mock import (
+    ANY,
+    call,
+    AsyncMock,
+    patch,
+    MagicMock,
+    Mock,
+    create_autospec,
+    sentinel,
+    _CallList,
+)
 
 
 def tearDownModule():
@@ -18,8 +27,10 @@ def tearDownModule():
 class AsyncClass:
     def __init__(self):
         pass
+
     async def async_method(self):
         pass
+
     def normal_method(self):
         pass
 
@@ -36,14 +47,18 @@ class AwaitableClass:
     def __await__(self):
         yield
 
+
 async def async_func():
     pass
+
 
 async def async_func_args(a, b, *, c):
     pass
 
+
 def normal_func():
     pass
+
 
 class NormalClass(object):
     def a(self):
@@ -68,6 +83,7 @@ class AsyncPatchDecoratorTest(unittest.TestCase):
         @patch.object(AsyncClass, 'async_method')
         def test_async(mock_method):
             self.assertTrue(iscoroutinefunction(mock_method))
+
         test_async()
 
     def test_is_async_patch(self):
@@ -163,7 +179,9 @@ class AsyncMockTest(unittest.TestCase):
         self.assertTrue(iscoroutinefunction(mock))
 
     def test_iscoroutinefunction_function(self):
-        async def foo(): pass
+        async def foo():
+            pass
+
         mock = AsyncMock(foo)
         self.assertTrue(iscoroutinefunction(mock))
         self.assertTrue(inspect.iscoroutinefunction(mock))
@@ -176,7 +194,9 @@ class AsyncMockTest(unittest.TestCase):
         self.assertIn('assert_awaited', dir(mock))
 
     def test_iscoroutinefunction_normal_function(self):
-        def foo(): pass
+        def foo():
+            pass
+
         mock = AsyncMock(foo)
         self.assertTrue(iscoroutinefunction(mock))
         self.assertTrue(inspect.iscoroutinefunction(mock))
@@ -216,6 +236,7 @@ class AsyncAutospecTest(unittest.TestCase):
     def test_create_autospec(self):
         spec = create_autospec(async_func_args)
         awaitable = spec(1, 2, c=3)
+
         async def main():
             await awaitable
 
@@ -239,11 +260,11 @@ class AsyncAutospecTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             spec.assert_any_await(e=1)
 
-
     def test_patch_with_autospec(self):
-
         async def test_async():
-            with patch(f"{__name__}.async_func_args", autospec=True) as mock_method:
+            with patch(
+                f"{__name__}.async_func_args", autospec=True
+            ) as mock_method:
                 awaitable = mock_method(1, 2, c=3)
                 self.assertIsInstance(mock_method.mock, AsyncMock)
 
@@ -361,6 +382,7 @@ class AsyncSpecTest(unittest.TestCase):
         @patch.object(NormalClass, 'a', spec=async_func)
         def test_attribute_not_async_spec_is(mock_async_func):
             self.assertIsInstance(mock_async_func, AsyncMock)
+
         test_attribute_not_async_spec_is()
 
     def test_spec_async_attributes(self):
@@ -377,6 +399,7 @@ class AsyncSpecSetTest(unittest.TestCase):
         @patch.object(AsyncClass, 'async_method', spec_set=True)
         def test_async(async_method):
             self.assertIsInstance(async_method, AsyncMock)
+
         test_async()
 
     def test_is_async_AsyncMock(self):
@@ -413,6 +436,7 @@ class AsyncArguments(IsolatedAsyncioTestCase):
     async def test_add_side_effect_exception(self):
         async def addition(var):
             return var + 1
+
         mock = AsyncMock(addition, side_effect=Exception('err'))
         with self.assertRaises(Exception):
             await mock(5)
@@ -420,6 +444,7 @@ class AsyncArguments(IsolatedAsyncioTestCase):
     async def test_add_side_effect_coroutine(self):
         async def addition(var):
             return var + 1
+
         mock = AsyncMock(side_effect=addition)
         result = await mock(5)
         self.assertEqual(result, 6)
@@ -427,6 +452,7 @@ class AsyncArguments(IsolatedAsyncioTestCase):
     async def test_add_side_effect_normal_function(self):
         def addition(var):
             return var + 1
+
         mock = AsyncMock(side_effect=addition)
         result = await mock(5)
         self.assertEqual(result, 6)
@@ -486,6 +512,7 @@ class AsyncArguments(IsolatedAsyncioTestCase):
         value = asyncio.Future()
 
         ran = False
+
         async def inner():
             nonlocal ran
             ran = True
@@ -501,6 +528,7 @@ class AsyncArguments(IsolatedAsyncioTestCase):
         value = 1
 
         ran = False
+
         def inner():
             nonlocal ran
             ran = True
@@ -511,6 +539,7 @@ class AsyncArguments(IsolatedAsyncioTestCase):
         self.assertEqual(result, value)
         mock.assert_awaited()
         self.assertTrue(ran)
+
 
 class AsyncMagicMethods(unittest.TestCase):
     def test_async_magic_methods_return_async_mocks(self):
@@ -550,8 +579,8 @@ class AsyncMagicMethods(unittest.TestCase):
         self.assertTrue(iscoroutinefunction(m_mock.__aenter__))
         self.assertTrue(iscoroutinefunction(m_mock.__aexit__))
 
-class AsyncContextManagerTest(unittest.TestCase):
 
+class AsyncContextManagerTest(unittest.TestCase):
     class WithAsyncContextManager:
         async def __aenter__(self, *args, **kwargs):
             return self
@@ -589,7 +618,9 @@ class AsyncContextManagerTest(unittest.TestCase):
             self.assertEqual(result, {'json': 123})
 
         for mock_type in [AsyncMock, MagicMock]:
-            with self.subTest(f"test set return value of aenter with {mock_type}"):
+            with self.subTest(
+                f"test set return value of aenter with {mock_type}"
+            ):
                 inner_test(mock_type)
 
     def test_mock_supports_async_context_manager(self):
@@ -616,7 +647,6 @@ class AsyncContextManagerTest(unittest.TestCase):
         for mock_type in [AsyncMock, MagicMock]:
             with self.subTest(f"test context manager magics with {mock_type}"):
                 inner_test(mock_type)
-
 
     def test_mock_customize_async_context_manager(self):
         instance = self.WithAsyncContextManager()
@@ -687,8 +717,10 @@ class AsyncIteratorTest(unittest.TestCase):
     def test_aiter_set_return_value(self):
         mock_iter = AsyncMock(name="tester")
         mock_iter.__aiter__.return_value = [1, 2, 3]
+
         async def main():
             return [i async for i in mock_iter]
+
         result = run(main())
         self.assertEqual(result, [1, 2, 3])
 
@@ -705,9 +737,10 @@ class AsyncIteratorTest(unittest.TestCase):
             self.assertTrue(iscoroutinefunction(mock_instance.__anext__))
 
         for mock_type in [AsyncMock, MagicMock]:
-            with self.subTest(f"test aiter and anext corourtine with {mock_type}"):
+            with self.subTest(
+                f"test aiter and anext corourtine with {mock_type}"
+            ):
                 inner_test(mock_type)
-
 
     def test_mock_async_for(self):
         async def iterate(iterator):
@@ -718,10 +751,10 @@ class AsyncIteratorTest(unittest.TestCase):
             return accumulator
 
         expected = ["FOO", "BAR", "BAZ"]
+
         def test_default(mock_type):
             mock_instance = mock_type(self.WithAsyncIterator())
             self.assertEqual(run(iterate(mock_instance)), [])
-
 
         def test_set_return_value(mock_type):
             mock_instance = mock_type(self.WithAsyncIterator())
@@ -850,7 +883,7 @@ class AsyncMockAssert(unittest.TestCase):
             self.mock('foo')
         with assertNeverAwaited(self):
             self.mock('baz')
-        mock_kalls = ([call(), call('foo'), call('baz')])
+        mock_kalls = [call(), call('foo'), call('baz')]
         self.assertEqual(self.mock.mock_calls, mock_kalls)
 
     def test_assert_has_mock_calls_on_async_mock_with_spec(self):
@@ -864,7 +897,10 @@ class AsyncMockAssert(unittest.TestCase):
         with assertNeverAwaited(self):
             a_class_mock.async_method(1, 2, 3, a=4, b=5)
         method_kalls = [call(), call(1, 2, 3, a=4, b=5)]
-        mock_kalls = [call.async_method(), call.async_method(1, 2, 3, a=4, b=5)]
+        mock_kalls = [
+            call.async_method(),
+            call.async_method(1, 2, 3, a=4, b=5),
+        ]
         self.assertEqual(a_class_mock.async_method.mock_calls, method_kalls)
         self.assertEqual(a_class_mock.mock_calls, mock_kalls)
 
@@ -874,14 +910,19 @@ class AsyncMockAssert(unittest.TestCase):
         with assertNeverAwaited(self):
             self.mock.something_else.something(6, cake=sentinel.Cake)
 
-        self.assertEqual(self.mock.method_calls, [
-            ("something", (3,), {'fish': None}),
-            ("something_else.something", (6,), {'cake': sentinel.Cake})
-        ],
-            "method calls not recorded correctly")
-        self.assertEqual(self.mock.something_else.method_calls,
-                         [("something", (6,), {'cake': sentinel.Cake})],
-                         "method calls not recorded correctly")
+        self.assertEqual(
+            self.mock.method_calls,
+            [
+                ("something", (3,), {'fish': None}),
+                ("something_else.something", (6,), {'cake': sentinel.Cake}),
+            ],
+            "method calls not recorded correctly",
+        )
+        self.assertEqual(
+            self.mock.something_else.method_calls,
+            [("something", (6,), {'cake': sentinel.Cake})],
+            "method calls not recorded correctly",
+        )
 
     def test_async_arg_lists(self):
         def assert_attrs(mock):
@@ -995,7 +1036,8 @@ class AsyncMockAssert(unittest.TestCase):
 
     def test_awaits_asserts_with_any(self):
         class Foo:
-            def __eq__(self, other): pass
+            def __eq__(self, other):
+                pass
 
         run(self._runnable_test(Foo(), 1))
 
@@ -1005,7 +1047,8 @@ class AsyncMockAssert(unittest.TestCase):
 
     def test_awaits_asserts_with_spec_and_any(self):
         class Foo:
-            def __eq__(self, other): pass
+            def __eq__(self, other):
+                pass
 
         mock_with_spec = AsyncMock(spec=Foo)
 
@@ -1044,28 +1087,36 @@ class AsyncMockAssert(unittest.TestCase):
             self.mock.assert_not_awaited()
 
     def test_assert_has_awaits_not_matching_spec_error(self):
-        async def f(x=None): pass
+        async def f(x=None):
+            pass
 
         self.mock = AsyncMock(spec=f)
         run(self._runnable_test(1))
 
         with self.assertRaisesRegex(
-                AssertionError,
-                '^{}$'.format(
-                    re.escape('Awaits not found.\n'
-                              'Expected: [call()]\n'
-                              'Actual: [call(1)]'))) as cm:
+            AssertionError,
+            '^{}$'.format(
+                re.escape(
+                    'Awaits not found.\n'
+                    'Expected: [call()]\n'
+                    'Actual: [call(1)]'
+                )
+            ),
+        ) as cm:
             self.mock.assert_has_awaits([call()])
         self.assertIsNone(cm.exception.__cause__)
 
         with self.assertRaisesRegex(
-                AssertionError,
-                '^{}$'.format(
-                    re.escape(
-                        'Error processing expected awaits.\n'
-                        "Errors: [None, TypeError('too many positional "
-                        "arguments')]\n"
-                        'Expected: [call(), call(1, 2)]\n'
-                        'Actual: [call(1)]'))) as cm:
+            AssertionError,
+            '^{}$'.format(
+                re.escape(
+                    'Error processing expected awaits.\n'
+                    "Errors: [None, TypeError('too many positional "
+                    "arguments')]\n"
+                    'Expected: [call(), call(1, 2)]\n'
+                    'Actual: [call(1)]'
+                )
+            ),
+        ) as cm:
             self.mock.assert_has_awaits([call(), call(1, 2)])
         self.assertIsInstance(cm.exception.__cause__, TypeError)

--- a/Lib/unittest/test/testmock/testcallable.py
+++ b/Lib/unittest/test/testmock/testcallable.py
@@ -6,19 +6,20 @@ import unittest
 from unittest.test.testmock.support import is_instance, X, SomeClass
 
 from unittest.mock import (
-    Mock, MagicMock, NonCallableMagicMock,
-    NonCallableMock, patch, create_autospec,
-    CallableMixin
+    Mock,
+    MagicMock,
+    NonCallableMagicMock,
+    NonCallableMock,
+    patch,
+    create_autospec,
+    CallableMixin,
 )
 
 
-
 class TestCallable(unittest.TestCase):
-
     def assertNotCallable(self, mock):
         self.assertTrue(is_instance(mock, NonCallableMagicMock))
         self.assertFalse(is_instance(mock, CallableMixin))
-
 
     def test_non_callable(self):
         for mock in NonCallableMagicMock(), NonCallableMock():
@@ -26,11 +27,9 @@ class TestCallable(unittest.TestCase):
             self.assertFalse(hasattr(mock, '__call__'))
             self.assertIn(mock.__class__.__name__, repr(mock))
 
-
     def test_hierarchy(self):
         self.assertTrue(issubclass(MagicMock, Mock))
         self.assertTrue(issubclass(NonCallableMagicMock, NonCallableMock))
-
 
     def test_attributes(self):
         one = NonCallableMock()
@@ -38,7 +37,6 @@ class TestCallable(unittest.TestCase):
 
         two = NonCallableMagicMock()
         self.assertTrue(issubclass(type(two.two), MagicMock))
-
 
     def test_subclasses(self):
         class MockSub(Mock):
@@ -53,7 +51,6 @@ class TestCallable(unittest.TestCase):
         two = MagicSub()
         self.assertTrue(issubclass(type(two.two), MagicSub))
 
-
     def test_patch_spec(self):
         patcher = patch('%s.X' % __name__, spec=True)
         mock = patcher.start()
@@ -64,7 +61,6 @@ class TestCallable(unittest.TestCase):
 
         self.assertNotCallable(instance)
         self.assertRaises(TypeError, instance)
-
 
     def test_patch_spec_set(self):
         patcher = patch('%s.X' % __name__, spec_set=True)
@@ -77,7 +73,6 @@ class TestCallable(unittest.TestCase):
         self.assertNotCallable(instance)
         self.assertRaises(TypeError, instance)
 
-
     def test_patch_spec_instance(self):
         patcher = patch('%s.X' % __name__, spec=X())
         mock = patcher.start()
@@ -85,7 +80,6 @@ class TestCallable(unittest.TestCase):
 
         self.assertNotCallable(mock)
         self.assertRaises(TypeError, mock)
-
 
     def test_patch_spec_set_instance(self):
         patcher = patch('%s.X' % __name__, spec_set=X())
@@ -95,10 +89,10 @@ class TestCallable(unittest.TestCase):
         self.assertNotCallable(mock)
         self.assertRaises(TypeError, mock)
 
-
     def test_patch_spec_callable_class(self):
         class CallableX(X):
-            def __call__(self): pass
+            def __call__(self):
+                pass
 
         class Sub(CallableX):
             pass
@@ -114,8 +108,9 @@ class TestCallable(unittest.TestCase):
 
                     self.assertTrue(is_instance(instance, MagicMock))
                     # inherited spec
-                    self.assertRaises(AttributeError, getattr, instance,
-                                      'foobarbaz')
+                    self.assertRaises(
+                        AttributeError, getattr, instance, 'foobarbaz'
+                    )
 
                     result = instance()
                     # instance is callable, result has no spec
@@ -126,7 +121,6 @@ class TestCallable(unittest.TestCase):
                     result.foo(3, 2, 1)
                     result.foo.assert_called_once_with(3, 2, 1)
 
-
     def test_create_autospec(self):
         mock = create_autospec(X)
         instance = mock()
@@ -135,7 +129,6 @@ class TestCallable(unittest.TestCase):
         mock = create_autospec(X())
         self.assertRaises(TypeError, mock)
 
-
     def test_create_autospec_instance(self):
         mock = create_autospec(SomeClass, instance=True)
 
@@ -143,7 +136,7 @@ class TestCallable(unittest.TestCase):
         mock.wibble()
         mock.wibble.assert_called_once_with()
 
-        self.assertRaises(TypeError, mock.wibble, 'some',  'args')
+        self.assertRaises(TypeError, mock.wibble, 'some', 'args')
 
 
 if __name__ == "__main__":

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -4,22 +4,34 @@ import types
 import unittest
 
 from unittest.mock import (
-    call, _Call, create_autospec, MagicMock,
-    Mock, ANY, _CallList, patch, PropertyMock, _callable
+    call,
+    _Call,
+    create_autospec,
+    MagicMock,
+    Mock,
+    ANY,
+    _CallList,
+    patch,
+    PropertyMock,
+    _callable,
 )
 
 from datetime import datetime
 from functools import partial
 
-class SomeClass(object):
-    def one(self, a, b): pass
-    def two(self): pass
-    def three(self, a=None): pass
 
+class SomeClass(object):
+    def one(self, a, b):
+        pass
+
+    def two(self):
+        pass
+
+    def three(self, a=None):
+        pass
 
 
 class AnyTest(unittest.TestCase):
-
     def test_any(self):
         self.assertEqual(ANY, object())
 
@@ -35,19 +47,21 @@ class AnyTest(unittest.TestCase):
         self.assertEqual(repr(ANY), '<ANY>')
         self.assertEqual(str(ANY), '<ANY>')
 
-
     def test_any_and_datetime(self):
         mock = Mock()
         mock(datetime.now(), foo=datetime.now())
 
         mock.assert_called_with(ANY, foo=ANY)
 
-
     def test_any_mock_calls_comparison_order(self):
         mock = Mock()
+
         class Foo(object):
-            def __eq__(self, other): pass
-            def __ne__(self, other): pass
+            def __eq__(self, other):
+                pass
+
+            def __ne__(self, other):
+                pass
 
         for d in datetime.now(), Foo():
             mock.reset_mock()
@@ -59,7 +73,8 @@ class AnyTest(unittest.TestCase):
             expected = [
                 call(ANY, foo=ANY, bar=ANY),
                 call.method(ANY, zinga=ANY, alpha=ANY),
-                call(), call().method(a1=ANY, z99=ANY)
+                call(),
+                call().method(a1=ANY, z99=ANY),
             ]
             self.assertEqual(expected, mock.mock_calls)
             self.assertEqual(mock.mock_calls, expected)
@@ -67,7 +82,8 @@ class AnyTest(unittest.TestCase):
     def test_any_no_spec(self):
         # This is a regression test for bpo-37555
         class Foo:
-            def __eq__(self, other): pass
+            def __eq__(self, other):
+                pass
 
         mock = Mock()
         mock(Foo(), 1)
@@ -78,7 +94,8 @@ class AnyTest(unittest.TestCase):
     def test_any_and_spec_set(self):
         # This is a regression test for bpo-37555
         class Foo:
-            def __eq__(self, other): pass
+            def __eq__(self, other):
+                pass
 
         mock = Mock(spec=Foo)
 
@@ -87,8 +104,8 @@ class AnyTest(unittest.TestCase):
         mock.assert_called_with(ANY, 1)
         mock.assert_any_call(ANY, 1)
 
-class CallTest(unittest.TestCase):
 
+class CallTest(unittest.TestCase):
     def test_call_with_call(self):
         kall = _Call()
         self.assertEqual(kall, _Call())
@@ -125,7 +142,6 @@ class CallTest(unittest.TestCase):
         self.assertEqual(kall, _Call(((), {'a': 3})))
         self.assertEqual(kall, _Call(({'a': 3},)))
 
-
     def test_empty__Call(self):
         args = _Call()
 
@@ -133,17 +149,16 @@ class CallTest(unittest.TestCase):
         self.assertEqual(args, ('foo',))
         self.assertEqual(args, ((),))
         self.assertEqual(args, ('foo', ()))
-        self.assertEqual(args, ('foo',(), {}))
+        self.assertEqual(args, ('foo', (), {}))
         self.assertEqual(args, ('foo', {}))
         self.assertEqual(args, ({},))
-
 
     def test_named_empty_call(self):
         args = _Call(('foo', (), {}))
 
         self.assertEqual(args, ('foo',))
         self.assertEqual(args, ('foo', ()))
-        self.assertEqual(args, ('foo',(), {}))
+        self.assertEqual(args, ('foo', (), {}))
         self.assertEqual(args, ('foo', {}))
 
         self.assertNotEqual(args, ((),))
@@ -152,7 +167,6 @@ class CallTest(unittest.TestCase):
         self.assertNotEqual(args, ('bar',))
         self.assertNotEqual(args, ('bar', ()))
         self.assertNotEqual(args, ('bar', {}))
-
 
     def test_call_with_args(self):
         args = _Call(((1, 2, 3), {}))
@@ -163,7 +177,6 @@ class CallTest(unittest.TestCase):
         self.assertEqual(args, ((1, 2, 3), {}))
         self.assertEqual(args.args, (1, 2, 3))
         self.assertEqual(args.kwargs, {})
-
 
     def test_named_call_with_args(self):
         args = _Call(('foo', (1, 2, 3), {}))
@@ -176,7 +189,6 @@ class CallTest(unittest.TestCase):
         self.assertNotEqual(args, ((1, 2, 3),))
         self.assertNotEqual(args, ((1, 2, 3), {}))
 
-
     def test_call_with_kwargs(self):
         args = _Call(((), dict(a=3, b=4)))
 
@@ -186,7 +198,6 @@ class CallTest(unittest.TestCase):
         self.assertEqual(args, ((), dict(a=3, b=4)))
         self.assertEqual(args.args, ())
         self.assertEqual(args.kwargs, dict(a=3, b=4))
-
 
     def test_named_call_with_kwargs(self):
         args = _Call(('foo', (), dict(a=3, b=4)))
@@ -199,7 +210,6 @@ class CallTest(unittest.TestCase):
         self.assertNotEqual(args, (dict(a=3, b=4),))
         self.assertNotEqual(args, ((), dict(a=3, b=4)))
 
-
     def test_call_with_args_call_empty_name(self):
         args = _Call(((1, 2, 3), {}))
 
@@ -207,12 +217,10 @@ class CallTest(unittest.TestCase):
         self.assertEqual(call(1, 2, 3), args)
         self.assertIn(call(1, 2, 3), [args])
 
-
     def test_call_ne(self):
         self.assertNotEqual(_Call(((1, 2, 3),)), call(1, 2))
         self.assertFalse(_Call(((1, 2, 3),)) != call(1, 2, 3))
         self.assertTrue(_Call(((1, 2), {})) != call(1, 2, 3))
-
 
     def test_call_non_tuples(self):
         kall = _Call(((1, 2, 3),))
@@ -220,15 +228,17 @@ class CallTest(unittest.TestCase):
             self.assertNotEqual(kall, value)
             self.assertFalse(kall == value)
 
-
     def test_repr(self):
         self.assertEqual(repr(_Call()), 'call()')
         self.assertEqual(repr(_Call(('foo',))), 'call.foo()')
 
-        self.assertEqual(repr(_Call(((1, 2, 3), {'a': 'b'}))),
-                         "call(1, 2, 3, a='b')")
-        self.assertEqual(repr(_Call(('bar', (1, 2, 3), {'a': 'b'}))),
-                         "call.bar(1, 2, 3, a='b')")
+        self.assertEqual(
+            repr(_Call(((1, 2, 3), {'a': 'b'}))), "call(1, 2, 3, a='b')"
+        )
+        self.assertEqual(
+            repr(_Call(('bar', (1, 2, 3), {'a': 'b'}))),
+            "call.bar(1, 2, 3, a='b')",
+        )
 
         self.assertEqual(repr(call), 'call')
         self.assertEqual(str(call), 'call')
@@ -238,42 +248,40 @@ class CallTest(unittest.TestCase):
         self.assertEqual(repr(call(zz='thing')), "call(zz='thing')")
 
         self.assertEqual(repr(call().foo), 'call().foo')
-        self.assertEqual(repr(call(1).foo.bar(a=3).bing),
-                         'call().foo.bar().bing')
         self.assertEqual(
-            repr(call().foo(1, 2, a=3)),
-            "call().foo(1, 2, a=3)"
+            repr(call(1).foo.bar(a=3).bing), 'call().foo.bar().bing'
         )
+        self.assertEqual(repr(call().foo(1, 2, a=3)), "call().foo(1, 2, a=3)")
         self.assertEqual(repr(call()()), "call()()")
         self.assertEqual(repr(call(1)(2)), "call()(2)")
         self.assertEqual(
-            repr(call()().bar().baz.beep(1)),
-            "call()().bar().baz.beep(1)"
+            repr(call()().bar().baz.beep(1)), "call()().bar().baz.beep(1)"
         )
-
 
     def test_call(self):
         self.assertEqual(call(), ('', (), {}))
-        self.assertEqual(call('foo', 'bar', one=3, two=4),
-                         ('', ('foo', 'bar'), {'one': 3, 'two': 4}))
+        self.assertEqual(
+            call('foo', 'bar', one=3, two=4),
+            ('', ('foo', 'bar'), {'one': 3, 'two': 4}),
+        )
 
         mock = Mock()
         mock(1, 2, 3)
         mock(a=3, b=6)
-        self.assertEqual(mock.call_args_list,
-                         [call(1, 2, 3), call(a=3, b=6)])
+        self.assertEqual(mock.call_args_list, [call(1, 2, 3), call(a=3, b=6)])
 
     def test_attribute_call(self):
         self.assertEqual(call.foo(1), ('foo', (1,), {}))
-        self.assertEqual(call.bar.baz(fish='eggs'),
-                         ('bar.baz', (), {'fish': 'eggs'}))
+        self.assertEqual(
+            call.bar.baz(fish='eggs'), ('bar.baz', (), {'fish': 'eggs'})
+        )
 
         mock = Mock()
-        mock.foo(1, 2 ,3)
+        mock.foo(1, 2, 3)
         mock.bar.baz(a=3, b=6)
-        self.assertEqual(mock.method_calls,
-                         [call.foo(1, 2, 3), call.bar.baz(a=3, b=6)])
-
+        self.assertEqual(
+            mock.method_calls, [call.foo(1, 2, 3), call.bar.baz(a=3, b=6)]
+        )
 
     def test_extended_call(self):
         result = call(1).foo(2).bar(3, a=4)
@@ -294,14 +302,12 @@ class CallTest(unittest.TestCase):
         self.assertEqual(mock.mock_calls[-1], last_call)
         self.assertEqual(mock.mock_calls, last_call.call_list())
 
-
     def test_extended_not_equal(self):
         a = call(x=1).foo
         b = call(x=2).foo
         self.assertEqual(a, a)
         self.assertEqual(b, b)
         self.assertNotEqual(a, b)
-
 
     def test_nested_calls_not_equal(self):
         a = call(x=1).foo().bar
@@ -310,7 +316,6 @@ class CallTest(unittest.TestCase):
         self.assertEqual(b, b)
         self.assertNotEqual(a, b)
 
-
     def test_call_list(self):
         mock = MagicMock()
         mock(1)
@@ -318,19 +323,16 @@ class CallTest(unittest.TestCase):
 
         mock = MagicMock()
         mock(1).method(2)
-        self.assertEqual(call(1).method(2).call_list(),
-                         mock.mock_calls)
+        self.assertEqual(call(1).method(2).call_list(), mock.mock_calls)
 
         mock = MagicMock()
         mock(1).method(2)(3)
-        self.assertEqual(call(1).method(2)(3).call_list(),
-                         mock.mock_calls)
+        self.assertEqual(call(1).method(2)(3).call_list(), mock.mock_calls)
 
         mock = MagicMock()
         int(mock(1).method(2)(3).foo.bar.baz(4)(5))
         kall = call(1).method(2)(3).foo.bar.baz(4)(5).__int__()
         self.assertEqual(kall.call_list(), mock.mock_calls)
-
 
     def test_call_any(self):
         self.assertEqual(call, ANY)
@@ -339,7 +341,6 @@ class CallTest(unittest.TestCase):
         int(m)
         self.assertEqual(m.mock_calls, [ANY])
         self.assertEqual([ANY], m.mock_calls)
-
 
     def test_two_args_call(self):
         args = _Call(((1, 2), {'a': 3}), two=True)
@@ -360,42 +361,42 @@ class CallTest(unittest.TestCase):
         m().foo()['bar']()
         self.assertEqual(
             m.mock_calls,
-            [call(), call().foo(), call().foo().__getitem__('bar'), call().foo().__getitem__()()]
+            [
+                call(),
+                call().foo(),
+                call().foo().__getitem__('bar'),
+                call().foo().__getitem__()(),
+            ],
         )
         m = MagicMock()
         m().foo()['bar'] = 1
         self.assertEqual(
             m.mock_calls,
-            [call(), call().foo(), call().foo().__setitem__('bar', 1)]
+            [call(), call().foo(), call().foo().__setitem__('bar', 1)],
         )
         m = MagicMock()
         iter(m().foo())
         self.assertEqual(
-            m.mock_calls,
-            [call(), call().foo(), call().foo().__iter__()]
+            m.mock_calls, [call(), call().foo(), call().foo().__iter__()]
         )
 
 
 class SpecSignatureTest(unittest.TestCase):
-
     def _check_someclass_mock(self, mock):
         self.assertRaises(AttributeError, getattr, mock, 'foo')
         mock.one(1, 2)
         mock.one.assert_called_with(1, 2)
-        self.assertRaises(AssertionError,
-                          mock.one.assert_called_with, 3, 4)
+        self.assertRaises(AssertionError, mock.one.assert_called_with, 3, 4)
         self.assertRaises(TypeError, mock.one, 1)
 
         mock.two()
         mock.two.assert_called_with()
-        self.assertRaises(AssertionError,
-                          mock.two.assert_called_with, 3)
+        self.assertRaises(AssertionError, mock.two.assert_called_with, 3)
         self.assertRaises(TypeError, mock.two, 1)
 
         mock.three()
         mock.three.assert_called_with()
-        self.assertRaises(AssertionError,
-                          mock.three.assert_called_with, 3)
+        self.assertRaises(AssertionError, mock.three.assert_called_with, 3)
         self.assertRaises(TypeError, mock.three, 3, 2)
 
         mock.three(1)
@@ -404,16 +405,16 @@ class SpecSignatureTest(unittest.TestCase):
         mock.three(a=1)
         mock.three.assert_called_with(a=1)
 
-
     def test_basic(self):
         mock = create_autospec(SomeClass)
         self._check_someclass_mock(mock)
         mock = create_autospec(SomeClass())
         self._check_someclass_mock(mock)
 
-
     def test_create_autospec_return_value(self):
-        def f(): pass
+        def f():
+            pass
+
         mock = create_autospec(f, return_value='foo')
         self.assertEqual(mock(), 'foo')
 
@@ -423,33 +424,33 @@ class SpecSignatureTest(unittest.TestCase):
         mock = create_autospec(Foo, return_value='foo')
         self.assertEqual(mock(), 'foo')
 
-
     def test_autospec_reset_mock(self):
         m = create_autospec(int)
         int(m)
         m.reset_mock()
         self.assertEqual(m.__int__.call_count, 0)
 
-
     def test_mocking_unbound_methods(self):
         class Foo(object):
-            def foo(self, foo): pass
+            def foo(self, foo):
+                pass
+
         p = patch.object(Foo, 'foo')
         mock_foo = p.start()
         Foo().foo(1)
 
         mock_foo.assert_called_with(1)
 
-
     def test_create_autospec_keyword_arguments(self):
         class Foo(object):
             a = 3
+
         m = create_autospec(Foo, a='3')
         self.assertEqual(m.a, '3')
 
-
     def test_create_autospec_keyword_only_arguments(self):
-        def foo(a, *, b=None): pass
+        def foo(a, *, b=None):
+            pass
 
         m = create_autospec(foo)
         m(1)
@@ -459,16 +460,17 @@ class SpecSignatureTest(unittest.TestCase):
         m(2, b=3)
         m.assert_called_with(2, b=3)
 
-
     def test_function_as_instance_attribute(self):
         obj = SomeClass()
-        def f(a): pass
+
+        def f(a):
+            pass
+
         obj.f = f
 
         mock = create_autospec(obj)
         mock.f('bing')
         mock.f.assert_called_with('bing')
-
 
     def test_spec_as_list(self):
         # because spec as a list of strings in the mock constructor means
@@ -487,7 +489,6 @@ class SpecSignatureTest(unittest.TestCase):
         mock.foo.append.assert_called_with(3)
         self.assertRaises(AttributeError, getattr, mock.foo, 'foo')
 
-
     def test_attributes(self):
         class Sub(SomeClass):
             attr = SomeClass()
@@ -497,11 +498,8 @@ class SpecSignatureTest(unittest.TestCase):
         for mock in (sub_mock, sub_mock.attr):
             self._check_someclass_mock(mock)
 
-
     def test_spec_has_descriptor_returning_function(self):
-
         class CrazyDescriptor(object):
-
             def __get__(self, obj, type_):
                 if obj is None:
                     return lambda x: None
@@ -517,13 +515,10 @@ class SpecSignatureTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             mock.some_attr(1, 2)
 
-
     def test_spec_has_function_not_in_bases(self):
-
         class CrazyClass(object):
-
             def __dir__(self):
-                return super(CrazyClass, self).__dir__()+['crazy']
+                return super(CrazyClass, self).__dir__() + ['crazy']
 
             def __getattr__(self, item):
                 if item == 'crazy':
@@ -542,13 +537,14 @@ class SpecSignatureTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             mock.crazy(1, 2)
 
-
     def test_builtin_functions_types(self):
         # we could replace builtin functions / methods with a function
         # with *args / **kwargs signature. Using the builtin method type
         # as a spec seems to work fairly well though.
         class BuiltinSubclass(list):
-            def bar(self, arg): pass
+            def bar(self, arg):
+                pass
+
             sorted = sorted
             attr = {}
 
@@ -569,7 +565,6 @@ class SpecSignatureTest(unittest.TestCase):
         mock.attr.pop(3)
         mock.attr.pop.assert_called_with(3)
         self.assertRaises(AttributeError, getattr, mock.attr, 'foo')
-
 
     def test_method_calls(self):
         class Sub(SomeClass):
@@ -592,7 +587,6 @@ class SpecSignatureTest(unittest.TestCase):
         )
         self.assertEqual(mock.method_calls, expected)
 
-
     def test_magic_methods(self):
         class BuiltinSubclass(list):
             attr = {}
@@ -606,7 +600,6 @@ class SpecSignatureTest(unittest.TestCase):
         self.assertIsInstance(mock['foo'], MagicMock)
         self.assertIsInstance(mock.attr['foo'], MagicMock)
 
-
     def test_spec_set(self):
         class Sub(SomeClass):
             attr = SomeClass()
@@ -618,17 +611,21 @@ class SpecSignatureTest(unittest.TestCase):
             self.assertRaises(AttributeError, setattr, mock, 'foo', 'bar')
             self.assertRaises(AttributeError, setattr, mock.attr, 'foo', 'bar')
 
-
     def test_descriptors(self):
         class Foo(object):
             @classmethod
-            def f(cls, a, b): pass
+            def f(cls, a, b):
+                pass
+
             @staticmethod
-            def g(a, b): pass
+            def g(a, b):
+                pass
 
-        class Bar(Foo): pass
+        class Bar(Foo):
+            pass
 
-        class Baz(SomeClass, Bar): pass
+        class Baz(SomeClass, Bar):
+            pass
 
         for spec in (Foo, Foo(), Bar, Bar(), Baz, Baz()):
             mock = create_autospec(spec)
@@ -638,10 +635,11 @@ class SpecSignatureTest(unittest.TestCase):
             mock.g(3, 4)
             mock.g.assert_called_once_with(3, 4)
 
-
     def test_recursive(self):
         class A(object):
-            def a(self): pass
+            def a(self):
+                pass
+
             foo = 'foo bar baz'
             bar = foo
 
@@ -660,12 +658,14 @@ class SpecSignatureTest(unittest.TestCase):
         mock.foo.lower()
         self.assertRaises(AssertionError, mock.bar.lower.assert_called_with)
 
-
     def test_spec_inheritance_for_classes(self):
         class Foo(object):
-            def a(self, x): pass
+            def a(self, x):
+                pass
+
             class Bar(object):
-                def f(self, y): pass
+                def f(self, y):
+                    pass
 
         class_mock = create_autospec(Foo)
 
@@ -698,7 +698,6 @@ class SpecSignatureTest(unittest.TestCase):
         instance_mock.Bar().f.assert_called_with(y=6)
         self.assertRaises(AttributeError, getattr, instance_mock.Bar(), 'g')
 
-
     def test_inherit(self):
         class Foo(object):
             a = 3
@@ -722,7 +721,6 @@ class SpecSignatureTest(unittest.TestCase):
         call_result = mock.Foo()
         self.assertRaises(AttributeError, getattr, call_result, 'b')
 
-
     def test_builtins(self):
         # used to fail with infinite recursion
         create_autospec(1)
@@ -743,9 +741,9 @@ class SpecSignatureTest(unittest.TestCase):
         create_autospec(False)
         create_autospec(True)
 
-
     def test_function(self):
-        def f(a, b): pass
+        def f(a, b):
+            pass
 
         mock = create_autospec(f)
         self.assertRaises(TypeError, mock)
@@ -761,12 +759,13 @@ class SpecSignatureTest(unittest.TestCase):
         mock.f.assert_called_with(3, 4)
         mock.f.assert_called_with(a=3, b=4)
 
-
     def test_skip_attributeerrors(self):
         class Raiser(object):
             def __get__(self, obj, type=None):
                 if obj is None:
-                    raise AttributeError('Can only be accessed via an instance')
+                    raise AttributeError(
+                        'Can only be accessed via an instance'
+                    )
 
         class RaiserClass(object):
             raiser = Raiser()
@@ -785,10 +784,10 @@ class SpecSignatureTest(unittest.TestCase):
         obj = s.raiser
         obj.foo, obj.bar
 
-
     def test_signature_class(self):
         class Foo(object):
-            def __init__(self, a, b=3): pass
+            def __init__(self, a, b=3):
+                pass
 
         mock = create_autospec(Foo)
 
@@ -803,19 +802,21 @@ class SpecSignatureTest(unittest.TestCase):
         mock.assert_called_with(a=4, b=5)
         self.assertRaises(AssertionError, mock.assert_called_with, a=5, b=4)
 
-
     def test_class_with_no_init(self):
         # this used to raise an exception
         # due to trying to get a signature from object.__init__
         class Foo(object):
             pass
-        create_autospec(Foo)
 
+        create_autospec(Foo)
 
     def test_signature_callable(self):
         class Callable(object):
-            def __init__(self, x, y): pass
-            def __call__(self, a): pass
+            def __init__(self, x, y):
+                pass
+
+            def __call__(self, a):
+                pass
 
         mock = create_autospec(Callable)
         mock(1, 2)
@@ -839,7 +840,6 @@ class SpecSignatureTest(unittest.TestCase):
         mock('a')
         mock.assert_called_with('a')
 
-
     def test_signature_noncallable(self):
         class NonCallable(object):
             def __init__(self):
@@ -856,7 +856,6 @@ class SpecSignatureTest(unittest.TestCase):
         self.assertRaises(TypeError, mock)
         self.assertRaises(TypeError, mock, 'a')
 
-
     def test_create_autospec_none(self):
         class Foo(object):
             bar = None
@@ -868,10 +867,10 @@ class SpecSignatureTest(unittest.TestCase):
         none.foo()
         none.foo.assert_called_once_with()
 
-
     def test_autospec_functions_with_self_in_odd_place(self):
         class Foo(object):
-            def f(a, self): pass
+            def f(a, self):
+                pass
 
         a = create_autospec(Foo)
         a.f(10)
@@ -881,7 +880,6 @@ class SpecSignatureTest(unittest.TestCase):
         a.f.assert_called_with(10)
         a.f.assert_called_with(self=10)
 
-
     def test_autospec_data_descriptor(self):
         class Descriptor(object):
             def __init__(self, value):
@@ -890,7 +888,8 @@ class SpecSignatureTest(unittest.TestCase):
             def __get__(self, obj, cls=None):
                 return self
 
-            def __set__(self, obj, value): pass
+            def __set__(self, obj, value):
+                pass
 
         class MyProperty(property):
             pass
@@ -899,10 +898,12 @@ class SpecSignatureTest(unittest.TestCase):
             __slots__ = ['slot']
 
             @property
-            def prop(self): pass
+            def prop(self):
+                pass
 
             @MyProperty
-            def subprop(self): pass
+            def subprop(self):
+                pass
 
             desc = Descriptor(42)
 
@@ -925,7 +926,6 @@ class SpecSignatureTest(unittest.TestCase):
         # plain data descriptor
         check_data_descriptor(foo.desc)
 
-
     def test_autospec_on_bound_builtin_function(self):
         meth = types.MethodType(time.ctime, time.time())
         self.assertIsInstance(meth(), str)
@@ -938,12 +938,10 @@ class SpecSignatureTest(unittest.TestCase):
         mocked(4, 5, 6)
         mocked.assert_called_once_with(4, 5, 6)
 
-
     def test_autospec_getattr_partial_function(self):
         # bpo-32153 : getattr returning partial functions without
         # __name__ should not create AttributeError in create_autospec
         class Foo:
-
             def __getattr__(self, attribute):
                 return partial(lambda name: name, attribute)
 
@@ -951,10 +949,9 @@ class SpecSignatureTest(unittest.TestCase):
         autospec = create_autospec(proxy)
         self.assertFalse(hasattr(autospec, '__name__'))
 
-
     def test_spec_inspect_signature(self):
-
-        def myfunc(x, y): pass
+        def myfunc(x, y):
+            pass
 
         mock = create_autospec(myfunc)
         mock(1, 2)
@@ -964,13 +961,11 @@ class SpecSignatureTest(unittest.TestCase):
         self.assertEqual(mock.mock_calls, [call(1, 2), call(x=1, y=2)])
         self.assertRaises(TypeError, mock, 1)
 
-
     def test_spec_inspect_signature_annotations(self):
-
-        def foo(a: int, b: int=10, *, c:int) -> int:
+        def foo(a: int, b: int = 10, *, c: int) -> int:
             return a + b + c
 
-        self.assertEqual(foo(1, 2 , c=3), 6)
+        self.assertEqual(foo(1, 2, c=3), 6)
         mock = create_autospec(foo)
         mock(1, 2, c=3)
         mock(1, c=3)
@@ -980,33 +975,35 @@ class SpecSignatureTest(unittest.TestCase):
         self.assertRaises(TypeError, mock, 1)
         self.assertRaises(TypeError, mock, 1, 2, 3, c=4)
 
-
     def test_spec_function_no_name(self):
         func = lambda: 'nope'
         mock = create_autospec(func)
         self.assertEqual(mock.__name__, 'funcopy')
 
-
     def test_spec_function_assert_has_calls(self):
-        def f(a): pass
+        def f(a):
+            pass
+
         mock = create_autospec(f)
         mock(1)
         mock.assert_has_calls([call(1)])
         with self.assertRaises(AssertionError):
             mock.assert_has_calls([call(2)])
 
-
     def test_spec_function_assert_any_call(self):
-        def f(a): pass
+        def f(a):
+            pass
+
         mock = create_autospec(f)
         mock(1)
         mock.assert_any_call(1)
         with self.assertRaises(AssertionError):
             mock.assert_any_call(2)
 
-
     def test_spec_function_reset_mock(self):
-        def f(a): pass
+        def f(a):
+            pass
+
         rv = Mock()
         mock = create_autospec(f, return_value=rv)
         mock(1)(2)
@@ -1018,7 +1015,6 @@ class SpecSignatureTest(unittest.TestCase):
 
 
 class TestCallList(unittest.TestCase):
-
     def test_args_list_contains_call_list(self):
         mock = Mock()
         self.assertIsInstance(mock.call_args_list, _CallList)
@@ -1043,7 +1039,6 @@ class TestCallList(unittest.TestCase):
         self.assertNotIn(call('fish'), mock.call_args_list)
         self.assertNotIn([call('fish')], mock.call_args_list)
 
-
     def test_call_list_str(self):
         mock = Mock()
         mock(1, 2)
@@ -1057,7 +1052,6 @@ class TestCallList(unittest.TestCase):
             " call.foo.bar().baz('fish', cat='dog')]"
         )
         self.assertEqual(str(mock.mock_calls), expected)
-
 
     def test_propertymock(self):
         p = patch('%s.SomeClass.one' % __name__, new_callable=PropertyMock)
@@ -1076,7 +1070,6 @@ class TestCallList(unittest.TestCase):
         finally:
             p.stop()
 
-
     def test_propertymock_returnvalue(self):
         m = MagicMock()
         p = PropertyMock()
@@ -1089,37 +1082,44 @@ class TestCallList(unittest.TestCase):
 
 
 class TestCallablePredicate(unittest.TestCase):
-
     def test_type(self):
         for obj in [str, bytes, int, list, tuple, SomeClass]:
             self.assertTrue(_callable(obj))
 
     def test_call_magic_method(self):
         class Callable:
-            def __call__(self): pass
+            def __call__(self):
+                pass
+
         instance = Callable()
         self.assertTrue(_callable(instance))
 
     def test_staticmethod(self):
         class WithStaticMethod:
             @staticmethod
-            def staticfunc(): pass
+            def staticfunc():
+                pass
+
         self.assertTrue(_callable(WithStaticMethod.staticfunc))
 
     def test_non_callable_staticmethod(self):
         class BadStaticMethod:
             not_callable = staticmethod(None)
+
         self.assertFalse(_callable(BadStaticMethod.not_callable))
 
     def test_classmethod(self):
         class WithClassMethod:
             @classmethod
-            def classfunc(cls): pass
+            def classfunc(cls):
+                pass
+
         self.assertTrue(_callable(WithClassMethod.classfunc))
 
     def test_non_callable_classmethod(self):
         class BadClassMethod:
             not_callable = classmethod(None)
+
         self.assertFalse(_callable(BadClassMethod.not_callable))
 
 

--- a/Lib/unittest/test/testmock/testmagicmethods.py
+++ b/Lib/unittest/test/testmock/testmagicmethods.py
@@ -5,9 +5,7 @@ from asyncio import iscoroutinefunction
 from unittest.mock import AsyncMock, Mock, MagicMock, _magics
 
 
-
 class TestMockingMagicMethods(unittest.TestCase):
-
     def test_deleting_magic_methods(self):
         mock = Mock()
         self.assertFalse(hasattr(mock, '__getitem__'))
@@ -17,7 +15,6 @@ class TestMockingMagicMethods(unittest.TestCase):
 
         del mock.__getitem__
         self.assertFalse(hasattr(mock, '__getitem__'))
-
 
     def test_magicmock_del(self):
         mock = MagicMock()
@@ -31,9 +28,9 @@ class TestMockingMagicMethods(unittest.TestCase):
         del mock.__getitem__
         self.assertRaises(TypeError, lambda: mock['foo'])
 
-
     def test_magic_method_wrapping(self):
         mock = Mock()
+
         def f(self, name):
             return self, 'fish'
 
@@ -45,7 +42,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock.__getitem__ = mock
         self.assertIs(mock.__getitem__, mock)
 
-
     def test_magic_methods_isolated_between_mocks(self):
         mock1 = Mock()
         mock2 = Mock()
@@ -54,13 +50,11 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(list(mock1), [])
         self.assertRaises(TypeError, lambda: list(mock2))
 
-
     def test_repr(self):
         mock = Mock()
         self.assertEqual(repr(mock), "<Mock id='%s'>" % id(mock))
         mock.__repr__ = lambda s: 'foo'
         self.assertEqual(repr(mock), 'foo')
-
 
     def test_str(self):
         mock = Mock()
@@ -68,23 +62,28 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock.__str__ = lambda s: 'foo'
         self.assertEqual(str(mock), 'foo')
 
-
     def test_dict_methods(self):
         mock = Mock()
 
         self.assertRaises(TypeError, lambda: mock['foo'])
+
         def _del():
             del mock['foo']
+
         def _set():
             mock['foo'] = 3
+
         self.assertRaises(TypeError, _del)
         self.assertRaises(TypeError, _set)
 
         _dict = {}
+
         def getitem(s, name):
             return _dict[name]
+
         def setitem(s, name, value):
             _dict[name] = value
+
         def delitem(s, name):
             del _dict[name]
 
@@ -99,7 +98,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         del mock['foo']
         self.assertEqual(_dict, {})
 
-
     def test_numeric(self):
         original = mock = Mock()
         mock.value = 0
@@ -109,13 +107,16 @@ class TestMockingMagicMethods(unittest.TestCase):
         def add(self, other):
             mock.value += other
             return self
+
         mock.__add__ = add
         self.assertEqual(mock + 3, mock)
         self.assertEqual(mock.value, 3)
 
         del mock.__add__
+
         def iadd(mock):
             mock += 3
+
         self.assertRaises(TypeError, iadd, mock)
         mock.__iadd__ = add
         mock += 6
@@ -135,13 +136,16 @@ class TestMockingMagicMethods(unittest.TestCase):
         def truediv(self, other):
             mock.value /= other
             return self
+
         mock.__truediv__ = truediv
         self.assertEqual(mock / 2, mock)
         self.assertEqual(mock.value, 16)
 
         del mock.__truediv__
+
         def itruediv(mock):
             mock /= 4
+
         self.assertRaises(TypeError, itruediv, mock)
         mock.__itruediv__ = truediv
         mock /= 8
@@ -160,9 +164,9 @@ class TestMockingMagicMethods(unittest.TestCase):
 
         def _hash(s):
             return 3
+
         mock.__hash__ = _hash
         self.assertEqual(hash(mock), 3)
-
 
     def test_nonzero(self):
         m = Mock()
@@ -171,16 +175,17 @@ class TestMockingMagicMethods(unittest.TestCase):
         m.__bool__ = lambda s: False
         self.assertFalse(bool(m))
 
-
     def test_comparison(self):
         mock = Mock()
+
         def comp(s, o):
             return True
+
         mock.__lt__ = mock.__gt__ = mock.__le__ = mock.__ge__ = comp
-        self. assertTrue(mock < 3)
-        self. assertTrue(mock > 3)
-        self. assertTrue(mock <= 3)
-        self. assertTrue(mock >= 3)
+        self.assertTrue(mock < 3)
+        self.assertTrue(mock > 3)
+        self.assertTrue(mock <= 3)
+        self.assertTrue(mock >= 3)
 
         self.assertRaises(TypeError, lambda: MagicMock() < object())
         self.assertRaises(TypeError, lambda: object() < MagicMock())
@@ -195,7 +200,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertRaises(TypeError, lambda: object() >= MagicMock())
         self.assertRaises(TypeError, lambda: MagicMock() >= MagicMock())
 
-
     def test_equality(self):
         for mock in Mock(), MagicMock():
             self.assertEqual(mock == mock, True)
@@ -207,12 +211,14 @@ class TestMockingMagicMethods(unittest.TestCase):
 
             def eq(self, other):
                 return other == 3
+
             mock.__eq__ = eq
             self.assertTrue(mock == 3)
             self.assertFalse(mock == 4)
 
             def ne(self, other):
                 return other == 3
+
             mock.__ne__ = ne
             self.assertTrue(mock != 3)
             self.assertFalse(mock != 4)
@@ -225,7 +231,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock.__ne__.return_value = False
         self.assertIsInstance(mock != 3, bool)
         self.assertEqual(mock != 3, False)
-
 
     def test_len_contains_iter(self):
         mock = Mock()
@@ -244,7 +249,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock.__iter__ = lambda s: iter('foobarbaz')
         self.assertEqual(list(mock), list('foobarbaz'))
 
-
     def test_magicmock(self):
         mock = MagicMock()
 
@@ -258,7 +262,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         for entry in _magics:
             self.assertTrue(hasattr(mock, entry))
         self.assertFalse(hasattr(mock, '__imaginary__'))
-
 
     def test_magic_mock_equality(self):
         mock = MagicMock()
@@ -322,7 +325,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(hex(mock), '0x1')
         # how to test __sizeof__ ?
 
-
     def test_magic_methods_fspath(self):
         mock = MagicMock()
         expected_path = mock.__fspath__()
@@ -331,10 +333,10 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(os.fspath(mock), expected_path)
         mock.__fspath__.assert_called_once()
 
-
     def test_magic_methods_and_spec(self):
         class Iterable(object):
-            def __iter__(self): pass
+            def __iter__(self):
+                pass
 
         mock = Mock(spec=Iterable)
         self.assertRaises(AttributeError, lambda: mock.__iter__)
@@ -344,21 +346,23 @@ class TestMockingMagicMethods(unittest.TestCase):
 
         class NonIterable(object):
             pass
+
         mock = Mock(spec=NonIterable)
         self.assertRaises(AttributeError, lambda: mock.__iter__)
 
         def set_int():
             mock.__int__ = Mock(return_value=iter([]))
+
         self.assertRaises(AttributeError, set_int)
 
         mock = MagicMock(spec=Iterable)
         self.assertEqual(list(mock), [])
         self.assertRaises(AttributeError, set_int)
 
-
     def test_magic_methods_and_spec_set(self):
         class Iterable(object):
-            def __iter__(self): pass
+            def __iter__(self):
+                pass
 
         mock = Mock(spec_set=Iterable)
         self.assertRaises(AttributeError, lambda: mock.__iter__)
@@ -368,40 +372,44 @@ class TestMockingMagicMethods(unittest.TestCase):
 
         class NonIterable(object):
             pass
+
         mock = Mock(spec_set=NonIterable)
         self.assertRaises(AttributeError, lambda: mock.__iter__)
 
         def set_int():
             mock.__int__ = Mock(return_value=iter([]))
+
         self.assertRaises(AttributeError, set_int)
 
         mock = MagicMock(spec_set=Iterable)
         self.assertEqual(list(mock), [])
         self.assertRaises(AttributeError, set_int)
 
-
     def test_setting_unsupported_magic_method(self):
         mock = MagicMock()
+
         def set_setattr():
             mock.__setattr__ = lambda self, name: None
-        self.assertRaisesRegex(AttributeError,
-            "Attempting to set unsupported magic method '__setattr__'.",
-            set_setattr
-        )
 
+        self.assertRaisesRegex(
+            AttributeError,
+            "Attempting to set unsupported magic method '__setattr__'.",
+            set_setattr,
+        )
 
     def test_attributes_and_return_value(self):
         mock = MagicMock()
         attr = mock.foo
+
         def _get_type(obj):
             # the type of every mock (or magicmock) is a custom subclass
             # so the real type is the second in the mro
             return type(obj).__mro__[1]
+
         self.assertEqual(_get_type(attr), MagicMock)
 
         returned = mock()
         self.assertEqual(_get_type(returned), MagicMock)
-
 
     def test_magic_methods_are_magic_mocks(self):
         mock = MagicMock()
@@ -410,7 +418,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock[1][2].__getitem__.return_value = 3
         self.assertEqual(mock[1][2][3], 3)
 
-
     def test_magic_method_reset_mock(self):
         mock = MagicMock()
         str(mock)
@@ -418,15 +425,15 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock.reset_mock()
         self.assertFalse(mock.__str__.called)
 
-
     def test_dir(self):
         # overriding the default implementation
         for mock in Mock(), MagicMock():
+
             def _dir(self):
                 return ['foo']
+
             mock.__dir__ = _dir
             self.assertEqual(dir(mock), ['foo'])
-
 
     def test_bound_methods(self):
         m = Mock()
@@ -438,7 +445,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         m.__iter__ = [3].__iter__
         self.assertRaises(TypeError, iter, m)
 
-
     def test_magic_method_type(self):
         class Foo(MagicMock):
             pass
@@ -446,12 +452,10 @@ class TestMockingMagicMethods(unittest.TestCase):
         foo = Foo()
         self.assertIsInstance(foo.__int__, Foo)
 
-
     def test_descriptor_from_class(self):
         m = MagicMock()
         type(m).__str__.return_value = 'foo'
         self.assertEqual(str(m), 'foo')
-
 
     def test_iterable_as_iter_return_value(self):
         m = MagicMock()
@@ -462,7 +466,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         m.__iter__.return_value = iter([4, 5, 6])
         self.assertEqual(list(m), [4, 5, 6])
         self.assertEqual(list(m), [])
-
 
     def test_matmul(self):
         m = MagicMock()

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -8,10 +8,18 @@ import unittest
 from unittest.test.testmock.support import is_instance
 from unittest import mock
 from unittest.mock import (
-    call, DEFAULT, patch, sentinel,
-    MagicMock, Mock, NonCallableMock,
-    NonCallableMagicMock, AsyncMock, _Call, _CallList,
-    create_autospec
+    call,
+    DEFAULT,
+    patch,
+    sentinel,
+    MagicMock,
+    Mock,
+    NonCallableMock,
+    NonCallableMagicMock,
+    AsyncMock,
+    _Call,
+    _CallList,
+    create_autospec,
 )
 
 
@@ -29,75 +37,90 @@ class Iter(object):
 
 
 class Something(object):
-    def meth(self, a, b, c, d=None): pass
+    def meth(self, a, b, c, d=None):
+        pass
 
     @classmethod
-    def cmeth(cls, a, b, c, d=None): pass
+    def cmeth(cls, a, b, c, d=None):
+        pass
 
     @staticmethod
-    def smeth(a, b, c, d=None): pass
+    def smeth(a, b, c, d=None):
+        pass
 
 
-def something(a): pass
+def something(a):
+    pass
 
 
 class MockTest(unittest.TestCase):
-
     def test_all(self):
         # if __all__ is badly defined then import * will raise an error
         # We have to exec it because you can't import * inside a method
         # in Python 3
         exec("from unittest.mock import *")
 
-
     def test_constructor(self):
         mock = Mock()
 
         self.assertFalse(mock.called, "called not initialised correctly")
-        self.assertEqual(mock.call_count, 0,
-                         "call_count not initialised correctly")
-        self.assertTrue(is_instance(mock.return_value, Mock),
-                        "return_value not initialised correctly")
+        self.assertEqual(
+            mock.call_count, 0, "call_count not initialised correctly"
+        )
+        self.assertTrue(
+            is_instance(mock.return_value, Mock),
+            "return_value not initialised correctly",
+        )
 
-        self.assertEqual(mock.call_args, None,
-                         "call_args not initialised correctly")
-        self.assertEqual(mock.call_args_list, [],
-                         "call_args_list not initialised correctly")
-        self.assertEqual(mock.method_calls, [],
-                          "method_calls not initialised correctly")
+        self.assertEqual(
+            mock.call_args, None, "call_args not initialised correctly"
+        )
+        self.assertEqual(
+            mock.call_args_list, [], "call_args_list not initialised correctly"
+        )
+        self.assertEqual(
+            mock.method_calls, [], "method_calls not initialised correctly"
+        )
 
         # Can't use hasattr for this test as it always returns True on a mock
-        self.assertNotIn('_items', mock.__dict__,
-                         "default mock should not have '_items' attribute")
+        self.assertNotIn(
+            '_items',
+            mock.__dict__,
+            "default mock should not have '_items' attribute",
+        )
 
-        self.assertIsNone(mock._mock_parent,
-                          "parent not initialised correctly")
-        self.assertIsNone(mock._mock_methods,
-                          "methods not initialised correctly")
-        self.assertEqual(mock._mock_children, {},
-                         "children not initialised incorrectly")
-
+        self.assertIsNone(
+            mock._mock_parent, "parent not initialised correctly"
+        )
+        self.assertIsNone(
+            mock._mock_methods, "methods not initialised correctly"
+        )
+        self.assertEqual(
+            mock._mock_children, {}, "children not initialised incorrectly"
+        )
 
     def test_return_value_in_constructor(self):
         mock = Mock(return_value=None)
-        self.assertIsNone(mock.return_value,
-                          "return value in constructor not honoured")
-
+        self.assertIsNone(
+            mock.return_value, "return value in constructor not honoured"
+        )
 
     def test_change_return_value_via_delegate(self):
-        def f(): pass
+        def f():
+            pass
+
         mock = create_autospec(f)
         mock.mock.return_value = 1
         self.assertEqual(mock(), 1)
 
-
     def test_change_side_effect_via_delegate(self):
-        def f(): pass
+        def f():
+            pass
+
         mock = create_autospec(f)
         mock.mock.side_effect = TypeError()
         with self.assertRaises(TypeError):
             mock()
-
 
     def test_repr(self):
         mock = Mock(name='foo')
@@ -111,9 +134,10 @@ class MockTest(unittest.TestCase):
             self.assertIn('%s.foo().bing' % name, repr(mock.foo().bing))
             self.assertIn('%s()' % name, repr(mock()))
             self.assertIn('%s()()' % name, repr(mock()()))
-            self.assertIn('%s()().foo.bar.baz().bing' % name,
-                          repr(mock()().foo.bar.baz().bing))
-
+            self.assertIn(
+                '%s()().foo.bar.baz().bing' % name,
+                repr(mock()().foo.bar.baz().bing),
+            )
 
     def test_repr_with_spec(self):
         class X(object):
@@ -144,7 +168,6 @@ class MockTest(unittest.TestCase):
         mock = Mock(spec=['foo'])
         self.assertNotIn("spec", repr(mock))
 
-
     def test_side_effect(self):
         mock = Mock()
 
@@ -156,48 +179,66 @@ class MockTest(unittest.TestCase):
         mock.assert_called_with(1, 2, fish=3)
 
         results = [1, 2, 3]
+
         def effect():
             return results.pop()
+
         mock.side_effect = effect
 
-        self.assertEqual([mock(), mock(), mock()], [3, 2, 1],
-                          "side effect not used correctly")
+        self.assertEqual(
+            [mock(), mock(), mock()],
+            [3, 2, 1],
+            "side effect not used correctly",
+        )
 
         mock = Mock(side_effect=sentinel.SideEffect)
-        self.assertEqual(mock.side_effect, sentinel.SideEffect,
-                          "side effect in constructor not used")
+        self.assertEqual(
+            mock.side_effect,
+            sentinel.SideEffect,
+            "side effect in constructor not used",
+        )
 
         def side_effect():
             return DEFAULT
+
         mock = Mock(side_effect=side_effect, return_value=sentinel.RETURN)
         self.assertEqual(mock(), sentinel.RETURN)
 
     def test_autospec_side_effect(self):
         # Test for issue17826
         results = [1, 2, 3]
+
         def effect():
             return results.pop()
-        def f(): pass
+
+        def f():
+            pass
 
         mock = create_autospec(f)
         mock.side_effect = [1, 2, 3]
-        self.assertEqual([mock(), mock(), mock()], [1, 2, 3],
-                          "side effect not used correctly in create_autospec")
+        self.assertEqual(
+            [mock(), mock(), mock()],
+            [1, 2, 3],
+            "side effect not used correctly in create_autospec",
+        )
         # Test where side effect is a callable
         results = [1, 2, 3]
         mock = create_autospec(f)
         mock.side_effect = effect
-        self.assertEqual([mock(), mock(), mock()], [3, 2, 1],
-                          "callable side effect not used correctly")
+        self.assertEqual(
+            [mock(), mock(), mock()],
+            [3, 2, 1],
+            "callable side effect not used correctly",
+        )
 
     def test_autospec_side_effect_exception(self):
         # Test for issue 23661
-        def f(): pass
+        def f():
+            pass
 
         mock = create_autospec(f)
         mock.side_effect = ValueError('Bazinga!')
         self.assertRaisesRegex(ValueError, 'Bazinga!', mock)
-
 
     def test_reset_mock(self):
         parent = Mock()
@@ -212,33 +253,40 @@ class MockTest(unittest.TestCase):
 
         mock.reset_mock()
 
-        self.assertEqual(mock._mock_name, "child",
-                         "name incorrectly reset")
-        self.assertEqual(mock._mock_parent, parent,
-                         "parent incorrectly reset")
-        self.assertEqual(mock._mock_methods, spec,
-                         "methods incorrectly reset")
+        self.assertEqual(mock._mock_name, "child", "name incorrectly reset")
+        self.assertEqual(mock._mock_parent, parent, "parent incorrectly reset")
+        self.assertEqual(mock._mock_methods, spec, "methods incorrectly reset")
 
         self.assertFalse(mock.called, "called not reset")
         self.assertEqual(mock.call_count, 0, "call_count not reset")
         self.assertEqual(mock.call_args, None, "call_args not reset")
         self.assertEqual(mock.call_args_list, [], "call_args_list not reset")
-        self.assertEqual(mock.method_calls, [],
-                        "method_calls not initialised correctly: %r != %r" %
-                        (mock.method_calls, []))
+        self.assertEqual(
+            mock.method_calls,
+            [],
+            "method_calls not initialised correctly: %r != %r"
+            % (mock.method_calls, []),
+        )
         self.assertEqual(mock.mock_calls, [])
 
-        self.assertEqual(mock.side_effect, sentinel.SideEffect,
-                          "side_effect incorrectly reset")
-        self.assertEqual(mock.return_value, return_value,
-                          "return_value incorrectly reset")
+        self.assertEqual(
+            mock.side_effect,
+            sentinel.SideEffect,
+            "side_effect incorrectly reset",
+        )
+        self.assertEqual(
+            mock.return_value, return_value, "return_value incorrectly reset"
+        )
         self.assertFalse(return_value.called, "return value mock not reset")
-        self.assertEqual(mock._mock_children, {'something': something},
-                          "children reset incorrectly")
-        self.assertEqual(mock.something, something,
-                          "children incorrectly cleared")
+        self.assertEqual(
+            mock._mock_children,
+            {'something': something},
+            "children reset incorrectly",
+        )
+        self.assertEqual(
+            mock.something, something, "children incorrectly cleared"
+        )
         self.assertFalse(mock.something.called, "child not reset")
-
 
     def test_reset_mock_recursion(self):
         mock = Mock()
@@ -253,41 +301,53 @@ class MockTest(unittest.TestCase):
 
     def test_call(self):
         mock = Mock()
-        self.assertTrue(is_instance(mock.return_value, Mock),
-                        "Default return_value should be a Mock")
+        self.assertTrue(
+            is_instance(mock.return_value, Mock),
+            "Default return_value should be a Mock",
+        )
 
         result = mock()
-        self.assertEqual(mock(), result,
-                         "different result from consecutive calls")
+        self.assertEqual(
+            mock(), result, "different result from consecutive calls"
+        )
         mock.reset_mock()
 
         ret_val = mock(sentinel.Arg)
         self.assertTrue(mock.called, "called not set")
         self.assertEqual(mock.call_count, 1, "call_count incorrect")
-        self.assertEqual(mock.call_args, ((sentinel.Arg,), {}),
-                         "call_args not set")
-        self.assertEqual(mock.call_args.args, (sentinel.Arg,),
-                         "call_args not set")
-        self.assertEqual(mock.call_args.kwargs, {},
-                         "call_args not set")
-        self.assertEqual(mock.call_args_list, [((sentinel.Arg,), {})],
-                         "call_args_list not initialised correctly")
+        self.assertEqual(
+            mock.call_args, ((sentinel.Arg,), {}), "call_args not set"
+        )
+        self.assertEqual(
+            mock.call_args.args, (sentinel.Arg,), "call_args not set"
+        )
+        self.assertEqual(mock.call_args.kwargs, {}, "call_args not set")
+        self.assertEqual(
+            mock.call_args_list,
+            [((sentinel.Arg,), {})],
+            "call_args_list not initialised correctly",
+        )
 
         mock.return_value = sentinel.ReturnValue
         ret_val = mock(sentinel.Arg, key=sentinel.KeyArg)
-        self.assertEqual(ret_val, sentinel.ReturnValue,
-                         "incorrect return value")
+        self.assertEqual(
+            ret_val, sentinel.ReturnValue, "incorrect return value"
+        )
 
         self.assertEqual(mock.call_count, 2, "call_count incorrect")
-        self.assertEqual(mock.call_args,
-                         ((sentinel.Arg,), {'key': sentinel.KeyArg}),
-                         "call_args not set")
-        self.assertEqual(mock.call_args_list, [
-            ((sentinel.Arg,), {}),
-            ((sentinel.Arg,), {'key': sentinel.KeyArg})
-        ],
-            "call_args_list not set")
-
+        self.assertEqual(
+            mock.call_args,
+            ((sentinel.Arg,), {'key': sentinel.KeyArg}),
+            "call_args not set",
+        )
+        self.assertEqual(
+            mock.call_args_list,
+            [
+                ((sentinel.Arg,), {}),
+                ((sentinel.Arg,), {'key': sentinel.KeyArg}),
+            ],
+            "call_args_list not set",
+        )
 
     def test_call_args_comparison(self):
         mock = Mock()
@@ -295,21 +355,24 @@ class MockTest(unittest.TestCase):
         mock(sentinel.Arg)
         mock(kw=sentinel.Kwarg)
         mock(sentinel.Arg, kw=sentinel.Kwarg)
-        self.assertEqual(mock.call_args_list, [
-            (),
-            ((sentinel.Arg,),),
-            ({"kw": sentinel.Kwarg},),
-            ((sentinel.Arg,), {"kw": sentinel.Kwarg})
-        ])
-        self.assertEqual(mock.call_args,
-                         ((sentinel.Arg,), {"kw": sentinel.Kwarg}))
+        self.assertEqual(
+            mock.call_args_list,
+            [
+                (),
+                ((sentinel.Arg,),),
+                ({"kw": sentinel.Kwarg},),
+                ((sentinel.Arg,), {"kw": sentinel.Kwarg}),
+            ],
+        )
+        self.assertEqual(
+            mock.call_args, ((sentinel.Arg,), {"kw": sentinel.Kwarg})
+        )
         self.assertEqual(mock.call_args.args, (sentinel.Arg,))
         self.assertEqual(mock.call_args.kwargs, {"kw": sentinel.Kwarg})
 
         # Comparing call_args to a long sequence should not raise
         # an exception. See issue 24857.
         self.assertFalse(mock.call_args == "a long sequence")
-
 
     def test_calls_equal_with_any(self):
         # Check that equality and non-equality is consistent even when
@@ -338,7 +401,6 @@ class MockTest(unittest.TestCase):
         self.assertFalse(call1 == 1)
         self.assertTrue(call1 != 1)
 
-
     def test_assert_called_with(self):
         mock = Mock()
         mock()
@@ -353,36 +415,34 @@ class MockTest(unittest.TestCase):
         mock(1, 2, 3, a='fish', b='nothing')
         mock.assert_called_with(1, 2, 3, a='fish', b='nothing')
 
-
     def test_assert_called_with_any(self):
         m = MagicMock()
         m(MagicMock())
         m.assert_called_with(mock.ANY)
 
-
     def test_assert_called_with_function_spec(self):
-        def f(a, b, c, d=None): pass
+        def f(a, b, c, d=None):
+            pass
 
         mock = Mock(spec=f)
 
         mock(1, b=2, c=3)
         mock.assert_called_with(1, 2, 3)
         mock.assert_called_with(a=1, b=2, c=3)
-        self.assertRaises(AssertionError, mock.assert_called_with,
-                          1, b=3, c=2)
+        self.assertRaises(AssertionError, mock.assert_called_with, 1, b=3, c=2)
         # Expected call doesn't match the spec's signature
         with self.assertRaises(AssertionError) as cm:
             mock.assert_called_with(e=8)
         self.assertIsInstance(cm.exception.__cause__, TypeError)
-
 
     def test_assert_called_with_method_spec(self):
         def _check(mock):
             mock(1, b=2, c=3)
             mock.assert_called_with(1, 2, 3)
             mock.assert_called_with(a=1, b=2, c=3)
-            self.assertRaises(AssertionError, mock.assert_called_with,
-                              1, b=3, c=2)
+            self.assertRaises(
+                AssertionError, mock.assert_called_with, 1, b=3, c=2
+            )
 
         mock = Mock(spec=Something().meth)
         _check(mock)
@@ -395,14 +455,12 @@ class MockTest(unittest.TestCase):
         mock = Mock(spec=Something().smeth)
         _check(mock)
 
-
     def test_assert_called_exception_message(self):
         msg = "Expected '{0}' to have been called"
         with self.assertRaisesRegex(AssertionError, msg.format('mock')):
             Mock().assert_called()
         with self.assertRaisesRegex(AssertionError, msg.format('test_name')):
             Mock(name="test_name").assert_called()
-
 
     def test_assert_called_once_with(self):
         mock = Mock()
@@ -424,80 +482,94 @@ class MockTest(unittest.TestCase):
         mock('foo', 'bar', baz=2)
         self.assertRaises(
             AssertionError,
-            lambda: mock.assert_called_once_with('bob', 'bar', baz=2)
+            lambda: mock.assert_called_once_with('bob', 'bar', baz=2),
         )
 
     def test_assert_called_once_with_call_list(self):
         m = Mock()
         m(1)
         m(2)
-        self.assertRaisesRegex(AssertionError,
+        self.assertRaisesRegex(
+            AssertionError,
             re.escape("Calls: [call(1), call(2)]"),
-            lambda: m.assert_called_once_with(2))
-
+            lambda: m.assert_called_once_with(2),
+        )
 
     def test_assert_called_once_with_function_spec(self):
-        def f(a, b, c, d=None): pass
+        def f(a, b, c, d=None):
+            pass
 
         mock = Mock(spec=f)
 
         mock(1, b=2, c=3)
         mock.assert_called_once_with(1, 2, 3)
         mock.assert_called_once_with(a=1, b=2, c=3)
-        self.assertRaises(AssertionError, mock.assert_called_once_with,
-                          1, b=3, c=2)
+        self.assertRaises(
+            AssertionError, mock.assert_called_once_with, 1, b=3, c=2
+        )
         # Expected call doesn't match the spec's signature
         with self.assertRaises(AssertionError) as cm:
             mock.assert_called_once_with(e=8)
         self.assertIsInstance(cm.exception.__cause__, TypeError)
         # Mock called more than once => always fails
         mock(4, 5, 6)
-        self.assertRaises(AssertionError, mock.assert_called_once_with,
-                          1, 2, 3)
-        self.assertRaises(AssertionError, mock.assert_called_once_with,
-                          4, 5, 6)
-
+        self.assertRaises(
+            AssertionError, mock.assert_called_once_with, 1, 2, 3
+        )
+        self.assertRaises(
+            AssertionError, mock.assert_called_once_with, 4, 5, 6
+        )
 
     def test_attribute_access_returns_mocks(self):
         mock = Mock()
         something = mock.something
         self.assertTrue(is_instance(something, Mock), "attribute isn't a mock")
-        self.assertEqual(mock.something, something,
-                         "different attributes returned for same name")
+        self.assertEqual(
+            mock.something,
+            something,
+            "different attributes returned for same name",
+        )
 
         # Usage example
         mock = Mock()
         mock.something.return_value = 3
 
         self.assertEqual(mock.something(), 3, "method returned wrong value")
-        self.assertTrue(mock.something.called,
-                        "method didn't record being called")
-
+        self.assertTrue(
+            mock.something.called, "method didn't record being called"
+        )
 
     def test_attributes_have_name_and_parent_set(self):
         mock = Mock()
         something = mock.something
 
-        self.assertEqual(something._mock_name, "something",
-                         "attribute name not set correctly")
-        self.assertEqual(something._mock_parent, mock,
-                         "attribute parent not set correctly")
-
+        self.assertEqual(
+            something._mock_name,
+            "something",
+            "attribute name not set correctly",
+        )
+        self.assertEqual(
+            something._mock_parent, mock, "attribute parent not set correctly"
+        )
 
     def test_method_calls_recorded(self):
         mock = Mock()
         mock.something(3, fish=None)
         mock.something_else.something(6, cake=sentinel.Cake)
 
-        self.assertEqual(mock.something_else.method_calls,
-                          [("something", (6,), {'cake': sentinel.Cake})],
-                          "method calls not recorded correctly")
-        self.assertEqual(mock.method_calls, [
-            ("something", (3,), {'fish': None}),
-            ("something_else.something", (6,), {'cake': sentinel.Cake})
-        ],
-            "method calls not recorded correctly")
-
+        self.assertEqual(
+            mock.something_else.method_calls,
+            [("something", (6,), {'cake': sentinel.Cake})],
+            "method calls not recorded correctly",
+        )
+        self.assertEqual(
+            mock.method_calls,
+            [
+                ("something", (3,), {'fish': None}),
+                ("something_else.something", (6,), {'cake': sentinel.Cake}),
+            ],
+            "method calls not recorded correctly",
+        )
 
     def test_method_calls_compare_easily(self):
         mock = Mock()
@@ -508,8 +580,9 @@ class MockTest(unittest.TestCase):
         mock = Mock()
         mock.something('different')
         self.assertEqual(mock.method_calls, [('something', ('different',))])
-        self.assertEqual(mock.method_calls,
-                         [('something', ('different',), {})])
+        self.assertEqual(
+            mock.method_calls, [('something', ('different',), {})]
+        )
 
         mock = Mock()
         mock.something(x=1)
@@ -518,10 +591,10 @@ class MockTest(unittest.TestCase):
 
         mock = Mock()
         mock.something('different', some='more')
-        self.assertEqual(mock.method_calls, [
-            ('something', ('different',), {'some': 'more'})
-        ])
-
+        self.assertEqual(
+            mock.method_calls,
+            [('something', ('different',), {'some': 'more'})],
+        )
 
     def test_only_allowed_methods_exist(self):
         for spec in ['something'], ('something',):
@@ -533,15 +606,18 @@ class MockTest(unittest.TestCase):
                 self.assertRaisesRegex(
                     AttributeError,
                     "Mock object has no attribute 'something_else'",
-                    getattr, mock, 'something_else'
+                    getattr,
+                    mock,
+                    'something_else',
                 )
-
 
     def test_from_spec(self):
         class Something(object):
             x = 3
             __something__ = None
-            def y(self): pass
+
+            def y(self):
+                pass
 
         def test_attributes(mock):
             # should work
@@ -551,17 +627,20 @@ class MockTest(unittest.TestCase):
             self.assertRaisesRegex(
                 AttributeError,
                 "Mock object has no attribute 'z'",
-                getattr, mock, 'z'
+                getattr,
+                mock,
+                'z',
             )
             self.assertRaisesRegex(
                 AttributeError,
                 "Mock object has no attribute '__foobar__'",
-                getattr, mock, '__foobar__'
+                getattr,
+                mock,
+                '__foobar__',
             )
 
         test_attributes(Mock(spec=Something))
         test_attributes(Mock(spec=Something()))
-
 
     def test_wraps_calls(self):
         real = Mock()
@@ -574,7 +653,6 @@ class MockTest(unittest.TestCase):
         mock(1, 2, fish=3)
         real.assert_called_with(1, 2, fish=3)
 
-
     def test_wraps_prevents_automatic_creation_of_mocks(self):
         class Real(object):
             pass
@@ -584,7 +662,6 @@ class MockTest(unittest.TestCase):
 
         self.assertRaises(AttributeError, lambda: mock.new_attr())
 
-
     def test_wraps_call_with_nondefault_return_value(self):
         real = Mock()
 
@@ -593,7 +670,6 @@ class MockTest(unittest.TestCase):
 
         self.assertEqual(mock(), 3)
         self.assertFalse(real.called)
-
 
     def test_wraps_attributes(self):
         class Real(object):
@@ -610,8 +686,9 @@ class MockTest(unittest.TestCase):
         Real.attribute.frog.assert_called_with(1, 2, fish=3)
         self.assertEqual(result, Real.attribute.frog())
 
-
-    def test_customize_wrapped_object_with_side_effect_iterable_with_default(self):
+    def test_customize_wrapped_object_with_side_effect_iterable_with_default(
+        self,
+    ):
         class Real(object):
             def method(self):
                 return sentinel.ORIGINAL_VALUE
@@ -624,10 +701,10 @@ class MockTest(unittest.TestCase):
         self.assertEqual(mock.method(), sentinel.ORIGINAL_VALUE)
         self.assertRaises(StopIteration, mock.method)
 
-
     def test_customize_wrapped_object_with_side_effect_iterable(self):
         class Real(object):
-            def method(self): pass
+            def method(self):
+                pass
 
         real = Real()
         mock = Mock(wraps=real)
@@ -637,10 +714,10 @@ class MockTest(unittest.TestCase):
         self.assertEqual(mock.method(), sentinel.VALUE2)
         self.assertRaises(StopIteration, mock.method)
 
-
     def test_customize_wrapped_object_with_side_effect_exception(self):
         class Real(object):
-            def method(self): pass
+            def method(self):
+                pass
 
         real = Real()
         mock = Mock(wraps=real)
@@ -648,10 +725,11 @@ class MockTest(unittest.TestCase):
 
         self.assertRaises(RuntimeError, mock.method)
 
-
     def test_customize_wrapped_object_with_side_effect_function(self):
         class Real(object):
-            def method(self): pass
+            def method(self):
+                pass
+
         def side_effect():
             return sentinel.VALUE
 
@@ -661,10 +739,10 @@ class MockTest(unittest.TestCase):
 
         self.assertEqual(mock.method(), sentinel.VALUE)
 
-
     def test_customize_wrapped_object_with_return_value(self):
         class Real(object):
-            def method(self): pass
+            def method(self):
+                pass
 
         real = Real()
         mock = Mock(wraps=real)
@@ -672,11 +750,11 @@ class MockTest(unittest.TestCase):
 
         self.assertEqual(mock.method(), sentinel.VALUE)
 
-
     def test_customize_wrapped_object_with_return_value_and_side_effect(self):
         # side_effect should always take precedence over return_value.
         class Real(object):
-            def method(self): pass
+            def method(self):
+                pass
 
         real = Real()
         mock = Mock(wraps=real)
@@ -687,11 +765,11 @@ class MockTest(unittest.TestCase):
         self.assertEqual(mock.method(), sentinel.VALUE2)
         self.assertRaises(StopIteration, mock.method)
 
-
     def test_customize_wrapped_object_with_return_value_and_side_effect2(self):
         # side_effect can return DEFAULT to default to return_value
         class Real(object):
-            def method(self): pass
+            def method(self):
+                pass
 
         real = Real()
         mock = Mock(wraps=real)
@@ -700,10 +778,12 @@ class MockTest(unittest.TestCase):
 
         self.assertEqual(mock.method(), sentinel.VALUE)
 
-
-    def test_customize_wrapped_object_with_return_value_and_side_effect_default(self):
+    def test_customize_wrapped_object_with_return_value_and_side_effect_default(
+        self,
+    ):
         class Real(object):
-            def method(self): pass
+            def method(self):
+                pass
 
         real = Real()
         mock = Mock(wraps=real)
@@ -713,7 +793,6 @@ class MockTest(unittest.TestCase):
         self.assertEqual(mock.method(), sentinel.VALUE1)
         self.assertEqual(mock.method(), sentinel.RETURN)
         self.assertRaises(StopIteration, mock.method)
-
 
     def test_magic_method_wraps_dict(self):
         data = {'foo': 'bar'}
@@ -744,23 +823,18 @@ class MockTest(unittest.TestCase):
         del data['baz']
         self.assertEqual(wrapped_dict.get('baz'), None)
 
-
     def test_magic_method_wraps_class(self):
-
         class Foo:
-
             def __getitem__(self, index):
                 return index
 
             def __custom_method__(self):
                 return "foo"
 
-
         klass = MagicMock(wraps=Foo)
         obj = klass()
         self.assertEqual(obj.__getitem__(2), 2)
         self.assertEqual(obj.__custom_method__(), "foo")
-
 
     def test_exceptional_side_effect(self):
         mock = Mock(side_effect=AttributeError)
@@ -769,7 +843,6 @@ class MockTest(unittest.TestCase):
         mock = Mock(side_effect=AttributeError('foo'))
         self.assertRaises(AttributeError, mock)
 
-
     def test_baseexceptional_side_effect(self):
         mock = Mock(side_effect=KeyboardInterrupt)
         self.assertRaises(KeyboardInterrupt, mock)
@@ -777,19 +850,19 @@ class MockTest(unittest.TestCase):
         mock = Mock(side_effect=KeyboardInterrupt('foo'))
         self.assertRaises(KeyboardInterrupt, mock)
 
-
     def test_assert_called_with_message(self):
         mock = Mock()
-        self.assertRaisesRegex(AssertionError, 'not called',
-                                mock.assert_called_with)
-
+        self.assertRaisesRegex(
+            AssertionError, 'not called', mock.assert_called_with
+        )
 
     def test_assert_called_once_with_message(self):
         mock = Mock(name='geoffrey')
-        self.assertRaisesRegex(AssertionError,
-                     r"Expected 'geoffrey' to be called once\.",
-                     mock.assert_called_once_with)
-
+        self.assertRaisesRegex(
+            AssertionError,
+            r"Expected 'geoffrey' to be called once\.",
+            mock.assert_called_once_with,
+        )
 
     def test__name__(self):
         mock = Mock()
@@ -798,16 +871,15 @@ class MockTest(unittest.TestCase):
         mock.__name__ = 'foo'
         self.assertEqual(mock.__name__, 'foo')
 
-
     def test_spec_list_subclass(self):
         class Sub(list):
             pass
+
         mock = Mock(spec=Sub(['foo']))
 
         mock.append(3)
         mock.append.assert_called_with(3)
         self.assertRaises(AttributeError, getattr, mock, 'foo')
-
 
     def test_spec_class(self):
         class X(object):
@@ -828,7 +900,6 @@ class MockTest(unittest.TestCase):
         mock = Mock(spec_set=X())
         self.assertIsInstance(mock, X)
 
-
     def test_spec_class_no_object_base(self):
         class X:
             pass
@@ -848,7 +919,6 @@ class MockTest(unittest.TestCase):
         mock = Mock(spec_set=X())
         self.assertIsInstance(mock, X)
 
-
     def test_setting_attribute_with_spec_set(self):
         class X(object):
             y = 3
@@ -857,12 +927,12 @@ class MockTest(unittest.TestCase):
         mock.x = 'foo'
 
         mock = Mock(spec_set=X)
+
         def set_attr():
             mock.x = 'foo'
 
         mock.y = 'foo'
         self.assertRaises(AttributeError, set_attr)
-
 
     def test_copy(self):
         current = sys.getrecursionlimit()
@@ -873,13 +943,14 @@ class MockTest(unittest.TestCase):
         # this segfaults without the fix in place
         copy.copy(Mock())
 
-
     def test_subclass_with_properties(self):
         class SubClass(Mock):
             def _get(self):
                 return 3
+
             def _set(self, value):
                 raise NameError('strange error')
+
             some_attribute = property(_get, _set)
 
         s = SubClass(spec_set=SubClass)
@@ -887,15 +958,17 @@ class MockTest(unittest.TestCase):
 
         def test():
             s.some_attribute = 3
+
         self.assertRaises(NameError, test)
 
         def test():
             s.foo = 'bar'
-        self.assertRaises(AttributeError, test)
 
+        self.assertRaises(AttributeError, test)
 
     def test_setting_call(self):
         mock = Mock()
+
         def __call__(self, a):
             self._increment_mock_call(a)
             return self._mock_call(a)
@@ -905,7 +978,6 @@ class MockTest(unittest.TestCase):
         mock.assert_called_with('one')
 
         self.assertRaises(TypeError, mock, 'one', 'two')
-
 
     def test_dir(self):
         mock = Mock()
@@ -929,7 +1001,6 @@ class MockTest(unittest.TestCase):
         mock.__iter__ = lambda s: iter([])
         self.assertIn('__iter__', dir(mock))
 
-
     def test_dir_from_spec(self):
         mock = Mock(spec=unittest.TestCase)
         testcase_attrs = set(dir(unittest.TestCase))
@@ -941,7 +1012,6 @@ class MockTest(unittest.TestCase):
         # shadow a sys attribute
         mock.version = 3
         self.assertEqual(dir(mock).count('version'), 1)
-
 
     def test_filter_dir(self):
         patcher = patch.object(mock, 'FILTER_DIR', False)
@@ -955,7 +1025,6 @@ class MockTest(unittest.TestCase):
         finally:
             patcher.stop()
 
-
     def test_dir_does_not_include_deleted_attributes(self):
         mock = Mock()
         mock.child.return_value = 1
@@ -964,7 +1033,6 @@ class MockTest(unittest.TestCase):
         del mock.child
         self.assertNotIn('child', dir(mock))
 
-
     def test_configure_mock(self):
         mock = Mock(foo='bar')
         self.assertEqual(mock.foo, 'bar')
@@ -972,8 +1040,11 @@ class MockTest(unittest.TestCase):
         mock = MagicMock(foo='bar')
         self.assertEqual(mock.foo, 'bar')
 
-        kwargs = {'side_effect': KeyError, 'foo.bar.return_value': 33,
-                  'foo': MagicMock()}
+        kwargs = {
+            'side_effect': KeyError,
+            'foo.bar.return_value': 33,
+            'foo': MagicMock(),
+        }
         mock = Mock(**kwargs)
         self.assertRaises(KeyError, mock)
         self.assertEqual(mock.foo.bar(), 33)
@@ -985,14 +1056,12 @@ class MockTest(unittest.TestCase):
         self.assertEqual(mock.foo.bar(), 33)
         self.assertIsInstance(mock.foo, MagicMock)
 
-
     def assertRaisesWithMsg(self, exception, message, func, *args, **kwargs):
         # needed because assertRaisesRegex doesn't work easily with newlines
         with self.assertRaises(exception) as context:
             func(*args, **kwargs)
         msg = str(context.exception)
         self.assertEqual(msg, message)
-
 
     def test_assert_called_with_failure_message(self):
         mock = NonCallableMock()
@@ -1001,23 +1070,33 @@ class MockTest(unittest.TestCase):
         expected = "mock(1, '2', 3, bar='foo')"
         message = 'expected call not found.\nExpected: %s\nActual: %s'
         self.assertRaisesWithMsg(
-            AssertionError, message % (expected, actual),
-            mock.assert_called_with, 1, '2', 3, bar='foo'
+            AssertionError,
+            message % (expected, actual),
+            mock.assert_called_with,
+            1,
+            '2',
+            3,
+            bar='foo',
         )
 
         mock.foo(1, '2', 3, foo='foo')
 
-
         asserters = [
-            mock.foo.assert_called_with, mock.foo.assert_called_once_with
+            mock.foo.assert_called_with,
+            mock.foo.assert_called_once_with,
         ]
         for meth in asserters:
             actual = "foo(1, '2', 3, foo='foo')"
             expected = "foo(1, '2', 3, bar='foo')"
             message = 'expected call not found.\nExpected: %s\nActual: %s'
             self.assertRaisesWithMsg(
-                AssertionError, message % (expected, actual),
-                meth, 1, '2', 3, bar='foo'
+                AssertionError,
+                message % (expected, actual),
+                meth,
+                1,
+                '2',
+                3,
+                bar='foo',
             )
 
         # just kwargs
@@ -1026,8 +1105,7 @@ class MockTest(unittest.TestCase):
             expected = "foo(bar='foo')"
             message = 'expected call not found.\nExpected: %s\nActual: %s'
             self.assertRaisesWithMsg(
-                AssertionError, message % (expected, actual),
-                meth, bar='foo'
+                AssertionError, message % (expected, actual), meth, bar='foo'
             )
 
         # just args
@@ -1036,8 +1114,7 @@ class MockTest(unittest.TestCase):
             expected = "foo(1, 2, 3)"
             message = 'expected call not found.\nExpected: %s\nActual: %s'
             self.assertRaisesWithMsg(
-                AssertionError, message % (expected, actual),
-                meth, 1, 2, 3
+                AssertionError, message % (expected, actual), meth, 1, 2, 3
             )
 
         # empty
@@ -1048,7 +1125,6 @@ class MockTest(unittest.TestCase):
             self.assertRaisesWithMsg(
                 AssertionError, message % (expected, actual), meth
             )
-
 
     def test_mock_calls(self):
         mock = MagicMock()
@@ -1070,24 +1146,24 @@ class MockTest(unittest.TestCase):
 
         mock = MagicMock()
         mock().foo(1, 2, 3, a=4, b=5)
-        expected = [
-            ('', (), {}), ('().foo', (1, 2, 3), dict(a=4, b=5))
-        ]
+        expected = [('', (), {}), ('().foo', (1, 2, 3), dict(a=4, b=5))]
         self.assertEqual(mock.mock_calls, expected)
-        self.assertEqual(mock.return_value.foo.mock_calls,
-                         [('', (1, 2, 3), dict(a=4, b=5))])
-        self.assertEqual(mock.return_value.mock_calls,
-                         [('foo', (1, 2, 3), dict(a=4, b=5))])
+        self.assertEqual(
+            mock.return_value.foo.mock_calls, [('', (1, 2, 3), dict(a=4, b=5))]
+        )
+        self.assertEqual(
+            mock.return_value.mock_calls, [('foo', (1, 2, 3), dict(a=4, b=5))]
+        )
 
         mock = MagicMock()
         mock().foo.bar().baz()
         expected = [
-            ('', (), {}), ('().foo.bar', (), {}),
-            ('().foo.bar().baz', (), {})
+            ('', (), {}),
+            ('().foo.bar', (), {}),
+            ('().foo.bar().baz', (), {}),
         ]
         self.assertEqual(mock.mock_calls, expected)
-        self.assertEqual(mock().mock_calls,
-                         call.foo.bar().baz().call_list())
+        self.assertEqual(mock().mock_calls, call.foo.bar().baz().call_list())
 
         for kwargs in dict(), dict(name='bar'):
             mock = MagicMock(**kwargs)
@@ -1109,24 +1185,27 @@ class MockTest(unittest.TestCase):
 
             mock = MagicMock(**kwargs)
             mock(1)(2)(3).a.b.c(4)
-            self.assertEqual(mock.mock_calls,
-                             call(1)(2)(3).a.b.c(4).call_list())
-            self.assertEqual(mock().mock_calls,
-                             call(2)(3).a.b.c(4).call_list())
-            self.assertEqual(mock()().mock_calls,
-                             call(3).a.b.c(4).call_list())
+            self.assertEqual(
+                mock.mock_calls, call(1)(2)(3).a.b.c(4).call_list()
+            )
+            self.assertEqual(
+                mock().mock_calls, call(2)(3).a.b.c(4).call_list()
+            )
+            self.assertEqual(mock()().mock_calls, call(3).a.b.c(4).call_list())
 
             mock = MagicMock(**kwargs)
             int(mock().foo.bar().baz())
             last_call = ('().foo.bar().baz().__int__', (), {})
             self.assertEqual(mock.mock_calls[-1], last_call)
-            self.assertEqual(mock().mock_calls,
-                             call.foo.bar().baz().__int__().call_list())
-            self.assertEqual(mock().foo.bar().mock_calls,
-                             call.baz().__int__().call_list())
-            self.assertEqual(mock().foo.bar().baz.mock_calls,
-                             call().__int__().call_list())
-
+            self.assertEqual(
+                mock().mock_calls, call.foo.bar().baz().__int__().call_list()
+            )
+            self.assertEqual(
+                mock().foo.bar().mock_calls, call.baz().__int__().call_list()
+            )
+            self.assertEqual(
+                mock().foo.bar().baz.mock_calls, call().__int__().call_list()
+            )
 
     def test_child_mock_call_equal(self):
         m = Mock()
@@ -1137,13 +1216,11 @@ class MockTest(unittest.TestCase):
         # but child should look like this:
         self.assertEqual(result.mock_calls, [call.wibble()])
 
-
     def test_mock_call_not_equal_leaf(self):
         m = Mock()
         m.foo().something()
         self.assertNotEqual(m.mock_calls[1], call.foo().different())
         self.assertEqual(m.mock_calls[0], call.foo())
-
 
     def test_mock_call_not_equal_non_leaf(self):
         m = Mock()
@@ -1151,25 +1228,21 @@ class MockTest(unittest.TestCase):
         self.assertNotEqual(m.mock_calls[1], call.baz().bar())
         self.assertNotEqual(m.mock_calls[0], call.baz())
 
-
     def test_mock_call_not_equal_non_leaf_params_different(self):
         m = Mock()
         m.foo(x=1).bar()
         # This isn't ideal, but there's no way to fix it without breaking backwards compatibility:
         self.assertEqual(m.mock_calls[1], call.foo(x=2).bar())
 
-
     def test_mock_call_not_equal_non_leaf_attr(self):
         m = Mock()
         m.foo.bar()
         self.assertNotEqual(m.mock_calls[0], call.baz.bar())
 
-
     def test_mock_call_not_equal_non_leaf_call_versus_attr(self):
         m = Mock()
         m.foo.bar()
         self.assertNotEqual(m.mock_calls[0], call.foo().bar())
-
 
     def test_mock_call_repr(self):
         m = Mock()
@@ -1178,18 +1251,15 @@ class MockTest(unittest.TestCase):
         self.assertEqual(repr(m.mock_calls[1]), 'call.foo().bar()')
         self.assertEqual(repr(m.mock_calls[2]), 'call.foo().bar().baz.bob()')
 
-
     def test_mock_call_repr_loop(self):
         m = Mock()
         m.foo = m
         repr(m.foo())
         self.assertRegex(repr(m.foo()), r"<Mock name='mock\(\)' id='\d+'>")
 
-
     def test_mock_calls_contains(self):
         m = Mock()
         self.assertFalse([call()] in m.mock_calls)
-
 
     def test_subclassing(self):
         class Subclass(Mock):
@@ -1207,13 +1277,12 @@ class MockTest(unittest.TestCase):
         self.assertNotIsInstance(mock.foo, Subclass)
         self.assertNotIsInstance(mock(), Subclass)
 
-
     def test_arg_lists(self):
         mocks = [
             Mock(),
             MagicMock(),
             NonCallableMock(),
-            NonCallableMagicMock()
+            NonCallableMagicMock(),
         ]
 
         def assert_attrs(mock):
@@ -1242,7 +1311,6 @@ class MockTest(unittest.TestCase):
             mock.reset_mock()
             assert_attrs(mock)
 
-
     def test_call_args_two_tuple(self):
         mock = Mock()
         mock(1, a=3)
@@ -1257,7 +1325,6 @@ class MockTest(unittest.TestCase):
             self.assertEqual(len(call_args), 2)
             self.assertEqual(expected[0], call_args[0])
             self.assertEqual(expected[1], call_args[1])
-
 
     def test_side_effect_iterator(self):
         mock = Mock(side_effect=iter([1, 2, 3]))
@@ -1274,14 +1341,15 @@ class MockTest(unittest.TestCase):
 
         class Foo(object):
             pass
+
         mock = MagicMock(side_effect=Foo)
         self.assertIsInstance(mock(), Foo)
 
         mock = Mock(side_effect=Iter())
-        self.assertEqual([mock(), mock(), mock(), mock()],
-                         ['this', 'is', 'an', 'iter'])
+        self.assertEqual(
+            [mock(), mock(), mock(), mock()], ['this', 'is', 'an', 'iter']
+        )
         self.assertRaises(StopIteration, mock)
-
 
     def test_side_effect_iterator_exceptions(self):
         for Klass in Mock, MagicMock:
@@ -1291,7 +1359,6 @@ class MockTest(unittest.TestCase):
             self.assertEqual(m(), 3)
             self.assertRaises(KeyError, m)
             self.assertEqual(m(), 6)
-
 
     def test_side_effect_setting_iterator(self):
         mock = Mock()
@@ -1309,8 +1376,9 @@ class MockTest(unittest.TestCase):
 
         this_iter = Iter()
         mock.side_effect = this_iter
-        self.assertEqual([mock(), mock(), mock(), mock()],
-                         ['this', 'is', 'an', 'iter'])
+        self.assertEqual(
+            [mock(), mock(), mock(), mock()], ['this', 'is', 'an', 'iter']
+        )
         self.assertRaises(StopIteration, mock)
         self.assertIs(mock.side_effect, this_iter)
 
@@ -1328,18 +1396,21 @@ class MockTest(unittest.TestCase):
         mock(b=6)
 
         kalls = [
-            call(1, 2), ({'a': 3},),
-            ((3, 4),), ((), {'a': 3}),
-            ('', (1, 2)), ('', {'a': 3}),
-            ('', (1, 2), {}), ('', (), {'a': 3})
+            call(1, 2),
+            ({'a': 3},),
+            ((3, 4),),
+            ((), {'a': 3}),
+            ('', (1, 2)),
+            ('', {'a': 3}),
+            ('', (1, 2), {}),
+            ('', (), {'a': 3}),
         ]
         for kall in kalls:
             mock.assert_has_calls([kall], any_order=True)
 
         for kall in call(1, '2'), call(b=3), call(), 3, None, 'foo':
             self.assertRaises(
-                AssertionError, mock.assert_has_calls,
-                [kall], any_order=True
+                AssertionError, mock.assert_has_calls, [kall], any_order=True
             )
 
         kall_lists = [
@@ -1359,15 +1430,19 @@ class MockTest(unittest.TestCase):
         ]
         for kall_list in kall_lists:
             self.assertRaises(
-                AssertionError, mock.assert_has_calls,
-                kall_list, any_order=True
+                AssertionError,
+                mock.assert_has_calls,
+                kall_list,
+                any_order=True,
             )
 
     def test_assert_has_calls(self):
         kalls1 = [
-                call(1, 2), ({'a': 3},),
-                ((3, 4),), call(b=6),
-                ('', (1,), {'b': 6}),
+            call(1, 2),
+            ({'a': 3},),
+            ((3, 4),),
+            call(b=6),
+            ('', (1,), {'b': 6}),
         ]
         kalls2 = [call.foo(), call.bar(1)]
         kalls2.extend(call.spam().baz(a=3).call_list())
@@ -1392,27 +1467,30 @@ class MockTest(unittest.TestCase):
         for mock, kalls in mocks:
             for i in range(len(kalls)):
                 for step in 1, 2, 3:
-                    these = kalls[i:i+step]
+                    these = kalls[i : i + step]
                     mock.assert_has_calls(these)
 
                     if len(these) > 1:
                         self.assertRaises(
                             AssertionError,
                             mock.assert_has_calls,
-                            list(reversed(these))
+                            list(reversed(these)),
                         )
-
 
     def test_assert_has_calls_nested_spec(self):
         class Something:
+            def __init__(self):
+                pass
 
-            def __init__(self): pass
-            def meth(self, a, b, c, d=None): pass
+            def meth(self, a, b, c, d=None):
+                pass
 
             class Foo:
+                def __init__(self, a):
+                    pass
 
-                def __init__(self, a): pass
-                def meth1(self, a, b): pass
+                def meth1(self, a, b):
+                    pass
 
         mock_class = create_autospec(Something)
 
@@ -1431,17 +1509,17 @@ class MockTest(unittest.TestCase):
 
         mock_class.reset_mock()
 
-        invalid_calls = [call.meth(1),
-                         call.non_existent(1),
-                         call.Foo().non_existent(1),
-                         call.Foo().meth(1, 2, 3, 4)]
+        invalid_calls = [
+            call.meth(1),
+            call.non_existent(1),
+            call.Foo().non_existent(1),
+            call.Foo().meth(1, 2, 3, 4),
+        ]
 
         for kall in invalid_calls:
-            self.assertRaises(AssertionError,
-                              mock_class.assert_has_calls,
-                              [kall]
+            self.assertRaises(
+                AssertionError, mock_class.assert_has_calls, [kall]
             )
-
 
     def test_assert_has_calls_nested_without_spec(self):
         m = MagicMock()
@@ -1450,9 +1528,9 @@ class MockTest(unittest.TestCase):
         calls = call.one().two().three().call_list()
         m.assert_has_calls(calls)
 
-
     def test_assert_has_calls_with_function_spec(self):
-        def f(a, b, c, d=None): pass
+        def f(a, b, c, d=None):
+            pass
 
         mock = Mock(spec=f)
 
@@ -1463,7 +1541,7 @@ class MockTest(unittest.TestCase):
             ('', (1, 2, 3), {}),
             ('', (4, 5, 6), {'d': 7}),
             ((10, 11, 12), {}),
-            ]
+        ]
         mock.assert_has_calls(calls)
         mock.assert_has_calls(calls, any_order=True)
         mock.assert_has_calls(calls[1:])
@@ -1483,29 +1561,36 @@ class MockTest(unittest.TestCase):
         mock.assert_has_calls(calls[:-1], any_order=True)
 
     def test_assert_has_calls_not_matching_spec_error(self):
-        def f(x=None): pass
+        def f(x=None):
+            pass
 
         mock = Mock(spec=f)
         mock(1)
 
         with self.assertRaisesRegex(
-                AssertionError,
-                '^{}$'.format(
-                    re.escape('Calls not found.\n'
-                              'Expected: [call()]\n'
-                              'Actual: [call(1)]'))) as cm:
+            AssertionError,
+            '^{}$'.format(
+                re.escape(
+                    'Calls not found.\n'
+                    'Expected: [call()]\n'
+                    'Actual: [call(1)]'
+                )
+            ),
+        ) as cm:
             mock.assert_has_calls([call()])
         self.assertIsNone(cm.exception.__cause__)
 
-
         with self.assertRaisesRegex(
-                AssertionError,
-                '^{}$'.format(
-                    re.escape(
-                        'Error processing expected calls.\n'
-                        "Errors: [None, TypeError('too many positional arguments')]\n"
-                        "Expected: [call(), call(1, 2)]\n"
-                        'Actual: [call(1)]'))) as cm:
+            AssertionError,
+            '^{}$'.format(
+                re.escape(
+                    'Error processing expected calls.\n'
+                    "Errors: [None, TypeError('too many positional arguments')]\n"
+                    "Expected: [call(), call(1, 2)]\n"
+                    'Actual: [call(1)]'
+                )
+            ),
+        ) as cm:
             mock.assert_has_calls([call(), call(1, 2)])
         self.assertIsInstance(cm.exception.__cause__, TypeError)
 
@@ -1519,24 +1604,13 @@ class MockTest(unittest.TestCase):
         mock.assert_any_call(a=3)
         mock.assert_any_call(1, b=6)
 
-        self.assertRaises(
-            AssertionError,
-            mock.assert_any_call
-        )
-        self.assertRaises(
-            AssertionError,
-            mock.assert_any_call,
-            1, 3
-        )
-        self.assertRaises(
-            AssertionError,
-            mock.assert_any_call,
-            a=4
-        )
-
+        self.assertRaises(AssertionError, mock.assert_any_call)
+        self.assertRaises(AssertionError, mock.assert_any_call, 1, 3)
+        self.assertRaises(AssertionError, mock.assert_any_call, a=4)
 
     def test_assert_any_call_with_function_spec(self):
-        def f(a, b, c, d=None): pass
+        def f(a, b, c, d=None):
+            pass
 
         mock = Mock(spec=f)
 
@@ -1546,44 +1620,42 @@ class MockTest(unittest.TestCase):
         mock.assert_any_call(a=1, b=2, c=3)
         mock.assert_any_call(4, 5, 6, 7)
         mock.assert_any_call(a=4, b=5, c=6, d=7)
-        self.assertRaises(AssertionError, mock.assert_any_call,
-                          1, b=3, c=2)
+        self.assertRaises(AssertionError, mock.assert_any_call, 1, b=3, c=2)
         # Expected call doesn't match the spec's signature
         with self.assertRaises(AssertionError) as cm:
             mock.assert_any_call(e=8)
         self.assertIsInstance(cm.exception.__cause__, TypeError)
 
-
     def test_mock_calls_create_autospec(self):
-        def f(a, b): pass
+        def f(a, b):
+            pass
+
         obj = Iter()
         obj.f = f
 
-        funcs = [
-            create_autospec(f),
-            create_autospec(obj).f
-        ]
+        funcs = [create_autospec(f), create_autospec(obj).f]
         for func in funcs:
             func(1, 2)
             func(3, 4)
 
-            self.assertEqual(
-                func.mock_calls, [call(1, 2), call(3, 4)]
-            )
+            self.assertEqual(func.mock_calls, [call(1, 2), call(3, 4)])
 
-    #Issue21222
+    # Issue21222
     def test_create_autospec_with_name(self):
         m = mock.create_autospec(object(), name='sweet_func')
         self.assertIn('sweet_func', repr(m))
 
-    #Issue23078
+    # Issue23078
     def test_create_autospec_classmethod_and_staticmethod(self):
         class TestClass:
             @classmethod
-            def class_method(cls): pass
+            def class_method(cls):
+                pass
 
             @staticmethod
-            def static_method(): pass
+            def static_method():
+                pass
+
         for method in ('class_method', 'static_method'):
             with self.subTest(method=method):
                 mock_method = mock.create_autospec(getattr(TestClass, method))
@@ -1591,7 +1663,7 @@ class MockTest(unittest.TestCase):
                 mock_method.assert_called_once_with()
                 self.assertRaises(TypeError, mock_method, 'extra_arg')
 
-    #Issue21238
+    # Issue21238
     def test_mock_unsafe(self):
         m = Mock()
         msg = "Attributes cannot start with 'assert' or 'assret'"
@@ -1603,7 +1675,7 @@ class MockTest(unittest.TestCase):
         m.assert_foo_call()
         m.assret_foo_call()
 
-    #Issue21262
+    # Issue21262
     def test_assert_not_called(self):
         m = Mock()
         m.hello.assert_not_called()
@@ -1614,9 +1686,11 @@ class MockTest(unittest.TestCase):
     def test_assert_not_called_message(self):
         m = Mock()
         m(1, 2)
-        self.assertRaisesRegex(AssertionError,
+        self.assertRaisesRegex(
+            AssertionError,
             re.escape("Calls: [call(1, 2)]"),
-            m.assert_not_called)
+            m.assert_not_called,
+        )
 
     def test_assert_called(self):
         m = Mock()
@@ -1643,9 +1717,11 @@ class MockTest(unittest.TestCase):
         m = Mock()
         m(1, 2)
         m(3)
-        self.assertRaisesRegex(AssertionError,
+        self.assertRaisesRegex(
+            AssertionError,
             re.escape("Calls: [call(1, 2), call(3)]"),
-            m.assert_called_once)
+            m.assert_called_once,
+        )
 
     def test_assert_called_once_message_not_called(self):
         m = Mock()
@@ -1653,31 +1729,31 @@ class MockTest(unittest.TestCase):
             m.assert_called_once()
         self.assertNotIn("Calls:", str(e.exception))
 
-    #Issue37212 printout of keyword args now preserves the original order
+    # Issue37212 printout of keyword args now preserves the original order
     def test_ordered_call_signature(self):
         m = Mock()
         m.hello(name='hello', daddy='hero')
         text = "call(name='hello', daddy='hero')"
         self.assertEqual(repr(m.hello.call_args), text)
 
-    #Issue21270 overrides tuple methods for mock.call objects
+    # Issue21270 overrides tuple methods for mock.call objects
     def test_override_tuple_methods(self):
         c = call.count()
-        i = call.index(132,'hello')
+        i = call.index(132, 'hello')
         m = Mock()
         m.count()
-        m.index(132,"hello")
+        m.index(132, "hello")
         self.assertEqual(m.method_calls[0], c)
         self.assertEqual(m.method_calls[1], i)
 
     def test_reset_return_sideeffect(self):
-        m = Mock(return_value=10, side_effect=[2,3])
+        m = Mock(return_value=10, side_effect=[2, 3])
         m.reset_mock(return_value=True, side_effect=True)
         self.assertIsInstance(m.return_value, Mock)
         self.assertEqual(m.side_effect, None)
 
     def test_reset_return(self):
-        m = Mock(return_value=10, side_effect=[2,3])
+        m = Mock(return_value=10, side_effect=[2, 3])
         m.reset_mock(return_value=True)
         self.assertIsInstance(m.return_value, Mock)
         self.assertNotEqual(m.side_effect, None)
@@ -1703,14 +1779,14 @@ class MockTest(unittest.TestCase):
     def test_mock_add_spec(self):
         class _One(object):
             one = 1
+
         class _Two(object):
             two = 2
+
         class Anything(object):
             one = two = three = 'four'
 
-        klasses = [
-            Mock, MagicMock, NonCallableMock, NonCallableMagicMock
-        ]
+        klasses = [Mock, MagicMock, NonCallableMock, NonCallableMagicMock]
         for Klass in list(klasses):
             klasses.append(lambda K=Klass: K(spec=Anything))
             klasses.append(lambda K=Klass: K(spec_set=Anything))
@@ -1718,7 +1794,7 @@ class MockTest(unittest.TestCase):
         for Klass in klasses:
             for kwargs in dict(), dict(spec_set=True):
                 mock = Klass()
-                #no error
+                # no error
                 mock.one, mock.two, mock.three
 
                 for One, Two in [(_One, _Two), (['one'], ['two'])]:
@@ -1726,9 +1802,7 @@ class MockTest(unittest.TestCase):
                         mock.mock_add_spec(One, **kwargs)
 
                         mock.one
-                        self.assertRaises(
-                            AttributeError, getattr, mock, 'two'
-                        )
+                        self.assertRaises(AttributeError, getattr, mock, 'two')
                         self.assertRaises(
                             AttributeError, getattr, mock, 'three'
                         )
@@ -1738,9 +1812,7 @@ class MockTest(unittest.TestCase):
                             )
 
                         mock.mock_add_spec(Two, **kwargs)
-                        self.assertRaises(
-                            AttributeError, getattr, mock, 'one'
-                        )
+                        self.assertRaises(AttributeError, getattr, mock, 'one')
                         mock.two
                         self.assertRaises(
                             AttributeError, getattr, mock, 'three'
@@ -1752,7 +1824,6 @@ class MockTest(unittest.TestCase):
             # note that creating a mock, setting an instance attribute, and
             # *then* setting a spec doesn't work. Not the intended use case
 
-
     def test_mock_add_spec_magic_methods(self):
         for Klass in MagicMock, NonCallableMagicMock:
             mock = Klass()
@@ -1763,16 +1834,20 @@ class MockTest(unittest.TestCase):
 
             mock = Klass()
             mock['foo']
-            mock.__int__.return_value =4
+            mock.__int__.return_value = 4
 
             mock.mock_add_spec(int)
             self.assertEqual(int(mock), 4)
             self.assertRaises(TypeError, lambda: mock['foo'])
 
-
     def test_adding_child_mock(self):
-        for Klass in (NonCallableMock, Mock, MagicMock, NonCallableMagicMock,
-                      AsyncMock):
+        for Klass in (
+            NonCallableMock,
+            Mock,
+            MagicMock,
+            NonCallableMagicMock,
+            AsyncMock,
+        ):
             mock = Klass()
 
             mock.foo = Mock()
@@ -1794,7 +1869,6 @@ class MockTest(unittest.TestCase):
             self.assertEqual(mock.method_calls, [])
             self.assertEqual(mock.mock_calls, [])
 
-
     def test_adding_return_value_mock(self):
         for Klass in Mock, MagicMock:
             mock = Klass()
@@ -1803,11 +1877,11 @@ class MockTest(unittest.TestCase):
             mock()()
             self.assertEqual(mock.mock_calls, [call(), call()()])
 
-
     def test_manager_mock(self):
         class Foo(object):
             one = 'one'
             two = 'two'
+
         manager = Mock()
         p1 = patch.object(Foo, 'one')
         p2 = patch.object(Foo, 'two')
@@ -1824,7 +1898,6 @@ class MockTest(unittest.TestCase):
         Foo.one()
 
         self.assertEqual(manager.mock_calls, [call.two(), call.one()])
-
 
     def test_magic_methods_mock_calls(self):
         for Klass in Mock, MagicMock:
@@ -1875,13 +1948,15 @@ class MockTest(unittest.TestCase):
             mock_filehandle = mock_namedtemp.return_value
             mock_write = mock_filehandle.write
             mock_write.side_effect = OSError('Test 2 Error')
+
             def attempt():
                 tempfile.NamedTemporaryFile().write('asd')
+
             self.assertRaises(OSError, attempt)
 
     def test_mock_open_alter_readline(self):
         mopen = mock.mock_open(read_data='foo\nbarn')
-        mopen.return_value.readline.side_effect = lambda *args:'abc'
+        mopen.return_value.readline.side_effect = lambda *args: 'abc'
         first = mopen().readline()
         second = mopen().readline()
         self.assertEqual('abc', first)
@@ -1927,7 +2002,6 @@ class MockTest(unittest.TestCase):
             self.assertEqual(repr(m), original_repr)
             self.assertEqual(repr(m.a()), original_repr)
 
-
     def test_attach_mock(self):
         classes = Mock, MagicMock, NonCallableMagicMock, NonCallableMock
         for Klass in classes:
@@ -1944,7 +2018,6 @@ class MockTest(unittest.TestCase):
                 self.assertEqual(m.mock_calls, [call.bar.baz(1)])
                 self.assertEqual(m.method_calls, [call.bar.baz(1)])
 
-
     def test_attach_mock_return_value(self):
         classes = Mock, MagicMock, NonCallableMagicMock, NonCallableMock
         for Klass in Mock, MagicMock:
@@ -1959,7 +2032,6 @@ class MockTest(unittest.TestCase):
 
                 m2.foo()
                 self.assertEqual(m.mock_calls, call().foo().call_list())
-
 
     def test_attach_mock_patch_autospec(self):
         parent = Mock()
@@ -1980,14 +2052,15 @@ class MockTest(unittest.TestCase):
             self.assertIn('mock.child', repr(parent.child.mock))
             self.assertEqual(mock_func.mock._extract_mock_name(), 'mock.child')
 
-
     def test_attach_mock_patch_autospec_signature(self):
         with mock.patch(f'{__name__}.Something.meth', autospec=True) as mocked:
             manager = Mock()
             manager.attach_mock(mocked, 'attach_meth')
             obj = Something()
             obj.meth(1, 2, 3, d=4)
-            manager.assert_has_calls([call.attach_meth(mock.ANY, 1, 2, 3, d=4)])
+            manager.assert_has_calls(
+                [call.attach_meth(mock.ANY, 1, 2, 3, d=4)]
+            )
             obj.meth.assert_has_calls([call(mock.ANY, 1, 2, 3, d=4)])
             mocked.assert_has_calls([call(mock.ANY, 1, 2, 3, d=4)])
 
@@ -2004,15 +2077,19 @@ class MockTest(unittest.TestCase):
             manager.attach_mock(mocked, 'attach_obj')
             obj = Something()
             obj.meth(1, 2, 3, d=4)
-            manager.assert_has_calls([call.attach_obj(),
-                                      call.attach_obj().meth(1, 2, 3, d=4)])
+            manager.assert_has_calls(
+                [call.attach_obj(), call.attach_obj().meth(1, 2, 3, d=4)]
+            )
             obj.meth.assert_has_calls([call(1, 2, 3, d=4)])
             mocked.assert_has_calls([call(), call().meth(1, 2, 3, d=4)])
 
-
     def test_attribute_deletion(self):
-        for mock in (Mock(), MagicMock(), NonCallableMagicMock(),
-                     NonCallableMock()):
+        for mock in (
+            Mock(),
+            MagicMock(),
+            NonCallableMagicMock(),
+            NonCallableMock(),
+        ):
             self.assertTrue(hasattr(mock, 'm'))
 
             del mock.m
@@ -2022,11 +2099,14 @@ class MockTest(unittest.TestCase):
             self.assertFalse(hasattr(mock, 'f'))
             self.assertRaises(AttributeError, getattr, mock, 'f')
 
-
     def test_mock_does_not_raise_on_repeated_attribute_deletion(self):
         # bpo-20239: Assigning and deleting twice an attribute raises.
-        for mock in (Mock(), MagicMock(), NonCallableMagicMock(),
-                     NonCallableMock()):
+        for mock in (
+            Mock(),
+            MagicMock(),
+            NonCallableMagicMock(),
+            NonCallableMock(),
+        ):
             mock.foo = 3
             self.assertTrue(hasattr(mock, 'foo'))
             self.assertEqual(mock.foo, 3)
@@ -2041,14 +2121,16 @@ class MockTest(unittest.TestCase):
             del mock.foo
             self.assertFalse(hasattr(mock, 'foo'))
 
-
     def test_mock_raises_when_deleting_nonexistent_attribute(self):
-        for mock in (Mock(), MagicMock(), NonCallableMagicMock(),
-                     NonCallableMock()):
+        for mock in (
+            Mock(),
+            MagicMock(),
+            NonCallableMagicMock(),
+            NonCallableMock(),
+        ):
             del mock.foo
             with self.assertRaises(AttributeError):
                 del mock.foo
-
 
     def test_reset_mock_does_not_raise_on_attr_deletion(self):
         # bpo-31177: reset_mock should not raise AttributeError when attributes
@@ -2058,7 +2140,6 @@ class MockTest(unittest.TestCase):
         del mock.child
         mock.reset_mock()
         self.assertFalse(hasattr(mock, 'child'))
-
 
     def test_class_assignable(self):
         for mock in Mock(), MagicMock():
@@ -2082,10 +2163,9 @@ class MockTest(unittest.TestCase):
         self.assertEqual(type(call.parent), _Call)
         self.assertEqual(type(call.parent().parent), _Call)
 
-
     def test_parent_propagation_with_create_autospec(self):
-
-        def foo(a, b): pass
+        def foo(a, b):
+            pass
 
         mock = Mock()
         mock.child = create_autospec(foo)
@@ -2096,8 +2176,8 @@ class MockTest(unittest.TestCase):
         self.assertIn('mock.child', repr(mock.child.mock))
 
     def test_parent_propagation_with_autospec_attach_mock(self):
-
-        def foo(a, b): pass
+        def foo(a, b):
+            pass
 
         parent = Mock()
         parent.attach_mock(create_autospec(foo, name='bar'), 'child')
@@ -2106,7 +2186,6 @@ class MockTest(unittest.TestCase):
         self.assertRaises(TypeError, parent.child, 1)
         self.assertEqual(parent.child.mock_calls, [call.child(1, 2)])
         self.assertIn('mock.child', repr(parent.child.mock))
-
 
     def test_isinstance_under_settrace(self):
         # bpo-36593 : __class__ is not set for a class that has __class__
@@ -2122,8 +2201,9 @@ class MockTest(unittest.TestCase):
         # Directly using __setattr__ on unittest.mock causes current imported
         # reference to be updated. Use a lambda so that during cleanup the
         # re-imported new reference is updated.
-        self.addCleanup(lambda patch: setattr(unittest.mock, 'patch', patch),
-                        old_patch)
+        self.addCleanup(
+            lambda patch: setattr(unittest.mock, 'patch', patch), old_patch
+        )
 
         with patch.dict('sys.modules'):
             del sys.modules['unittest.mock']
@@ -2136,11 +2216,18 @@ class MockTest(unittest.TestCase):
             sys.settrace(trace)
 
             from unittest.mock import (
-                Mock, MagicMock, NonCallableMock, NonCallableMagicMock
+                Mock,
+                MagicMock,
+                NonCallableMock,
+                NonCallableMagicMock,
             )
 
             mocks = [
-                Mock, MagicMock, NonCallableMock, NonCallableMagicMock, AsyncMock
+                Mock,
+                MagicMock,
+                NonCallableMock,
+                NonCallableMagicMock,
+                AsyncMock,
             ]
 
             for mock in mocks:

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -12,9 +12,17 @@ from unittest.test.testmock.support import SomeClass, is_instance
 
 from test.test_importlib.util import uncache
 from unittest.mock import (
-    NonCallableMock, CallableMixin, sentinel,
-    MagicMock, Mock, NonCallableMagicMock, patch, _patch,
-    DEFAULT, call, _get_target
+    NonCallableMock,
+    CallableMixin,
+    sentinel,
+    MagicMock,
+    Mock,
+    NonCallableMagicMock,
+    patch,
+    _patch,
+    DEFAULT,
+    call,
+    _get_target,
 )
 
 
@@ -28,40 +36,55 @@ def _get_proxy(obj, get_only=True):
     class Proxy(object):
         def __getattr__(self, name):
             return getattr(obj, name)
+
     if not get_only:
+
         def __setattr__(self, name, value):
             setattr(obj, name, value)
+
         def __delattr__(self, name):
             delattr(obj, name)
+
         Proxy.__setattr__ = __setattr__
         Proxy.__delattr__ = __delattr__
     return Proxy()
 
 
 # for use in the test
-something  = sentinel.Something
-something_else  = sentinel.SomethingElse
+something = sentinel.Something
+something_else = sentinel.SomethingElse
 
 
 class Foo(object):
-    def __init__(self, a): pass
-    def f(self, a): pass
-    def g(self): pass
+    def __init__(self, a):
+        pass
+
+    def f(self, a):
+        pass
+
+    def g(self):
+        pass
+
     foo = 'bar'
 
     @staticmethod
-    def static_method(): pass
+    def static_method():
+        pass
 
     @classmethod
-    def class_method(cls): pass
+    def class_method(cls):
+        pass
 
     class Bar(object):
-        def a(self): pass
+        def a(self):
+            pass
+
 
 foo_name = '%s.Foo' % __name__
 
 
-def function(a, b=Foo): pass
+def function(a, b=Foo):
+    pass
 
 
 class Container(object):
@@ -81,9 +104,7 @@ class Container(object):
         return iter(self.values)
 
 
-
 class PatchTest(unittest.TestCase):
-
     def assertNotCallable(self, obj, magic=True):
         MockClass = NonCallableMagicMock
         if not magic:
@@ -93,18 +114,20 @@ class PatchTest(unittest.TestCase):
         self.assertTrue(is_instance(obj, MockClass))
         self.assertFalse(is_instance(obj, CallableMixin))
 
-
     def test_single_patchobject(self):
         class Something(object):
             attribute = sentinel.Original
 
         @patch.object(Something, 'attribute', sentinel.Patched)
         def test():
-            self.assertEqual(Something.attribute, sentinel.Patched, "unpatched")
+            self.assertEqual(
+                Something.attribute, sentinel.Patched, "unpatched"
+            )
 
         test()
-        self.assertEqual(Something.attribute, sentinel.Original,
-                         "patch not restored")
+        self.assertEqual(
+            Something.attribute, sentinel.Original, "patch not restored"
+        )
 
     def test_patchobject_with_string_as_target(self):
         msg = "'Something' must be the actual object to be patched, not a str"
@@ -120,9 +143,9 @@ class PatchTest(unittest.TestCase):
             self.assertIsNone(Something.attribute, "unpatched")
 
         test()
-        self.assertEqual(Something.attribute, sentinel.Original,
-                         "patch not restored")
-
+        self.assertEqual(
+            Something.attribute, sentinel.Original, "patch not restored"
+        )
 
     def test_multiple_patchobject(self):
         class Something(object):
@@ -132,21 +155,25 @@ class PatchTest(unittest.TestCase):
         @patch.object(Something, 'attribute', sentinel.Patched)
         @patch.object(Something, 'next_attribute', sentinel.Patched2)
         def test():
-            self.assertEqual(Something.attribute, sentinel.Patched,
-                             "unpatched")
-            self.assertEqual(Something.next_attribute, sentinel.Patched2,
-                             "unpatched")
+            self.assertEqual(
+                Something.attribute, sentinel.Patched, "unpatched"
+            )
+            self.assertEqual(
+                Something.next_attribute, sentinel.Patched2, "unpatched"
+            )
 
         test()
-        self.assertEqual(Something.attribute, sentinel.Original,
-                         "patch not restored")
-        self.assertEqual(Something.next_attribute, sentinel.Original2,
-                         "patch not restored")
-
+        self.assertEqual(
+            Something.attribute, sentinel.Original, "patch not restored"
+        )
+        self.assertEqual(
+            Something.next_attribute, sentinel.Original2, "patch not restored"
+        )
 
     def test_object_lookup_is_quite_lazy(self):
         global something
         original = something
+
         @patch('%s.something' % __name__, sentinel.Something2)
         def test():
             pass
@@ -158,61 +185,79 @@ class PatchTest(unittest.TestCase):
         finally:
             something = original
 
-
     def test_patch(self):
         @patch('%s.something' % __name__, sentinel.Something2)
         def test():
-            self.assertEqual(PTModule.something, sentinel.Something2,
-                             "unpatched")
+            self.assertEqual(
+                PTModule.something, sentinel.Something2, "unpatched"
+            )
 
         test()
-        self.assertEqual(PTModule.something, sentinel.Something,
-                         "patch not restored")
+        self.assertEqual(
+            PTModule.something, sentinel.Something, "patch not restored"
+        )
 
         @patch('%s.something' % __name__, sentinel.Something2)
         @patch('%s.something_else' % __name__, sentinel.SomethingElse)
         def test():
-            self.assertEqual(PTModule.something, sentinel.Something2,
-                             "unpatched")
-            self.assertEqual(PTModule.something_else, sentinel.SomethingElse,
-                             "unpatched")
+            self.assertEqual(
+                PTModule.something, sentinel.Something2, "unpatched"
+            )
+            self.assertEqual(
+                PTModule.something_else, sentinel.SomethingElse, "unpatched"
+            )
 
-        self.assertEqual(PTModule.something, sentinel.Something,
-                         "patch not restored")
-        self.assertEqual(PTModule.something_else, sentinel.SomethingElse,
-                         "patch not restored")
+        self.assertEqual(
+            PTModule.something, sentinel.Something, "patch not restored"
+        )
+        self.assertEqual(
+            PTModule.something_else,
+            sentinel.SomethingElse,
+            "patch not restored",
+        )
 
         # Test the patching and restoring works a second time
         test()
 
-        self.assertEqual(PTModule.something, sentinel.Something,
-                         "patch not restored")
-        self.assertEqual(PTModule.something_else, sentinel.SomethingElse,
-                         "patch not restored")
+        self.assertEqual(
+            PTModule.something, sentinel.Something, "patch not restored"
+        )
+        self.assertEqual(
+            PTModule.something_else,
+            sentinel.SomethingElse,
+            "patch not restored",
+        )
 
         mock = Mock()
         mock.return_value = sentinel.Handle
+
         @patch('%s.open' % builtin_string, mock)
         def test():
-            self.assertEqual(open('filename', 'r'), sentinel.Handle,
-                             "open not patched")
+            self.assertEqual(
+                open('filename', 'r'), sentinel.Handle, "open not patched"
+            )
+
         test()
         test()
 
         self.assertNotEqual(open, mock, "patch not restored")
 
-
     def test_patch_class_attribute(self):
-        @patch('%s.SomeClass.class_attribute' % __name__,
-               sentinel.ClassAttribute)
+        @patch(
+            '%s.SomeClass.class_attribute' % __name__, sentinel.ClassAttribute
+        )
         def test():
-            self.assertEqual(PTModule.SomeClass.class_attribute,
-                             sentinel.ClassAttribute, "unpatched")
+            self.assertEqual(
+                PTModule.SomeClass.class_attribute,
+                sentinel.ClassAttribute,
+                "unpatched",
+            )
+
         test()
 
-        self.assertIsNone(PTModule.SomeClass.class_attribute,
-                          "patch not restored")
-
+        self.assertIsNone(
+            PTModule.SomeClass.class_attribute, "patch not restored"
+        )
 
     def test_patchobject_with_default_mock(self):
         class Test(object):
@@ -221,32 +266,56 @@ class PatchTest(unittest.TestCase):
 
         @patch.object(Test, 'something')
         def test(mock):
-            self.assertEqual(mock, Test.something,
-                             "Mock not passed into test function")
-            self.assertIsInstance(mock, MagicMock,
-                            "patch with two arguments did not create a mock")
+            self.assertEqual(
+                mock, Test.something, "Mock not passed into test function"
+            )
+            self.assertIsInstance(
+                mock,
+                MagicMock,
+                "patch with two arguments did not create a mock",
+            )
 
         test()
 
         @patch.object(Test, 'something')
         @patch.object(Test, 'something2')
         def test(this1, this2, mock1, mock2):
-            self.assertEqual(this1, sentinel.this1,
-                             "Patched function didn't receive initial argument")
-            self.assertEqual(this2, sentinel.this2,
-                             "Patched function didn't receive second argument")
-            self.assertEqual(mock1, Test.something2,
-                             "Mock not passed into test function")
-            self.assertEqual(mock2, Test.something,
-                             "Second Mock not passed into test function")
-            self.assertIsInstance(mock2, MagicMock,
-                            "patch with two arguments did not create a mock")
-            self.assertIsInstance(mock2, MagicMock,
-                            "patch with two arguments did not create a mock")
+            self.assertEqual(
+                this1,
+                sentinel.this1,
+                "Patched function didn't receive initial argument",
+            )
+            self.assertEqual(
+                this2,
+                sentinel.this2,
+                "Patched function didn't receive second argument",
+            )
+            self.assertEqual(
+                mock1, Test.something2, "Mock not passed into test function"
+            )
+            self.assertEqual(
+                mock2,
+                Test.something,
+                "Second Mock not passed into test function",
+            )
+            self.assertIsInstance(
+                mock2,
+                MagicMock,
+                "patch with two arguments did not create a mock",
+            )
+            self.assertIsInstance(
+                mock2,
+                MagicMock,
+                "patch with two arguments did not create a mock",
+            )
 
             # A hack to test that new mocks are passed the second time
-            self.assertNotEqual(outerMock1, mock1, "unexpected value for mock1")
-            self.assertNotEqual(outerMock2, mock2, "unexpected value for mock1")
+            self.assertNotEqual(
+                outerMock1, mock1, "unexpected value for mock1"
+            )
+            self.assertNotEqual(
+                outerMock2, mock2, "unexpected value for mock1"
+            )
             return mock1, mock2
 
         outerMock1 = outerMock2 = None
@@ -254,7 +323,6 @@ class PatchTest(unittest.TestCase):
 
         # Test that executing a second time creates new mocks
         test(sentinel.this1, sentinel.this2)
-
 
     def test_patch_with_spec(self):
         @patch('%s.SomeClass' % __name__, spec=SomeClass)
@@ -265,18 +333,18 @@ class PatchTest(unittest.TestCase):
 
         test()
 
-
     def test_patchobject_with_spec(self):
         @patch.object(SomeClass, 'class_attribute', spec=SomeClass)
         def test(MockAttribute):
             self.assertEqual(SomeClass.class_attribute, MockAttribute)
-            self.assertTrue(is_instance(SomeClass.class_attribute.wibble,
-                                       MagicMock))
-            self.assertRaises(AttributeError,
-                              lambda: SomeClass.class_attribute.not_wibble)
+            self.assertTrue(
+                is_instance(SomeClass.class_attribute.wibble, MagicMock)
+            )
+            self.assertRaises(
+                AttributeError, lambda: SomeClass.class_attribute.not_wibble
+            )
 
         test()
-
 
     def test_patch_with_spec_as_list(self):
         @patch('%s.SomeClass' % __name__, spec=['wibble'])
@@ -287,18 +355,18 @@ class PatchTest(unittest.TestCase):
 
         test()
 
-
     def test_patchobject_with_spec_as_list(self):
         @patch.object(SomeClass, 'class_attribute', spec=['wibble'])
         def test(MockAttribute):
             self.assertEqual(SomeClass.class_attribute, MockAttribute)
-            self.assertTrue(is_instance(SomeClass.class_attribute.wibble,
-                                       MagicMock))
-            self.assertRaises(AttributeError,
-                              lambda: SomeClass.class_attribute.not_wibble)
+            self.assertTrue(
+                is_instance(SomeClass.class_attribute.wibble, MagicMock)
+            )
+            self.assertRaises(
+                AttributeError, lambda: SomeClass.class_attribute.not_wibble
+            )
 
         test()
-
 
     def test_nested_patch_with_spec_as_list(self):
         # regression test for nested decorators
@@ -308,8 +376,8 @@ class PatchTest(unittest.TestCase):
             self.assertEqual(SomeClass, MockSomeClass)
             self.assertTrue(is_instance(SomeClass.wibble, MagicMock))
             self.assertRaises(AttributeError, lambda: SomeClass.not_wibble)
-        test()
 
+        test()
 
     def test_patch_with_spec_as_boolean(self):
         @patch('%s.SomeClass' % __name__, spec=True)
@@ -322,7 +390,6 @@ class PatchTest(unittest.TestCase):
 
         test()
 
-
     def test_patch_object_with_spec_as_boolean(self):
         @patch.object(PTModule, 'SomeClass', spec=True)
         def test(MockSomeClass):
@@ -333,7 +400,6 @@ class PatchTest(unittest.TestCase):
             self.assertRaises(AttributeError, lambda: MockSomeClass.not_wibble)
 
         test()
-
 
     def test_patch_class_acts_with_spec_is_inherited(self):
         @patch('%s.SomeClass' % __name__, spec=True)
@@ -348,7 +414,6 @@ class PatchTest(unittest.TestCase):
 
         test()
 
-
     def test_patch_with_create_mocks_non_existent_attributes(self):
         @patch('%s.frooble' % builtin_string, sentinel.Frooble, create=True)
         def test():
@@ -356,7 +421,6 @@ class PatchTest(unittest.TestCase):
 
         test()
         self.assertRaises(NameError, lambda: frooble)
-
 
     def test_patchobject_with_create_mocks_non_existent_attributes(self):
         @patch.object(SomeClass, 'frooble', sentinel.Frooble, create=True)
@@ -366,31 +430,33 @@ class PatchTest(unittest.TestCase):
         test()
         self.assertFalse(hasattr(SomeClass, 'frooble'))
 
-
     def test_patch_wont_create_by_default(self):
         with self.assertRaises(AttributeError):
+
             @patch('%s.frooble' % builtin_string, sentinel.Frooble)
-            def test(): pass
+            def test():
+                pass
 
             test()
         self.assertRaises(NameError, lambda: frooble)
 
-
     def test_patchobject_wont_create_by_default(self):
         with self.assertRaises(AttributeError):
+
             @patch.object(SomeClass, 'ord', sentinel.Frooble)
-            def test(): pass
+            def test():
+                pass
+
             test()
         self.assertFalse(hasattr(SomeClass, 'ord'))
 
-
     def test_patch_builtins_without_create(self):
-        @patch(__name__+'.ord')
+        @patch(__name__ + '.ord')
         def test_ord(mock_ord):
             mock_ord.return_value = 101
             return ord('c')
 
-        @patch(__name__+'.open')
+        @patch(__name__ + '.open')
         def test_open(mock_open):
             m = mock_open.return_value
             m.read.return_value = 'abcd'
@@ -403,7 +469,6 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(test_ord(), 101)
         self.assertEqual(test_open(), 'abcd')
 
-
     def test_patch_with_static_methods(self):
         class Foo(object):
             @staticmethod
@@ -413,20 +478,21 @@ class PatchTest(unittest.TestCase):
         @patch.object(Foo, 'woot', staticmethod(lambda: sentinel.Patched))
         def anonymous():
             self.assertEqual(Foo.woot(), sentinel.Patched)
+
         anonymous()
 
         self.assertEqual(Foo.woot(), sentinel.Static)
 
-
     def test_patch_local(self):
         foo = sentinel.Foo
+
         @patch.object(sentinel, 'Foo', 'Foo')
         def anonymous():
             self.assertEqual(sentinel.Foo, 'Foo')
+
         anonymous()
 
         self.assertEqual(sentinel.Foo, foo)
-
 
     def test_patch_slots(self):
         class Foo(object):
@@ -438,10 +504,10 @@ class PatchTest(unittest.TestCase):
         @patch.object(foo, 'Foo', 'Foo')
         def anonymous():
             self.assertEqual(foo.Foo, 'Foo')
+
         anonymous()
 
         self.assertEqual(foo.Foo, sentinel.Foo)
-
 
     def test_patchobject_class_decorator(self):
         class Something(object):
@@ -449,11 +515,16 @@ class PatchTest(unittest.TestCase):
 
         class Foo(object):
             def test_method(other_self):
-                self.assertEqual(Something.attribute, sentinel.Patched,
-                                 "unpatched")
+                self.assertEqual(
+                    Something.attribute, sentinel.Patched, "unpatched"
+                )
+
             def not_test_method(other_self):
-                self.assertEqual(Something.attribute, sentinel.Original,
-                                 "non-test method patched")
+                self.assertEqual(
+                    Something.attribute,
+                    sentinel.Original,
+                    "non-test method patched",
+                )
 
         Foo = patch.object(Something, 'attribute', sentinel.Patched)(Foo)
 
@@ -461,9 +532,9 @@ class PatchTest(unittest.TestCase):
         f.test_method()
         f.not_test_method()
 
-        self.assertEqual(Something.attribute, sentinel.Original,
-                         "patch not restored")
-
+        self.assertEqual(
+            Something.attribute, sentinel.Original, "patch not restored"
+        )
 
     def test_patch_class_decorator(self):
         class Something(object):
@@ -474,22 +545,29 @@ class PatchTest(unittest.TestCase):
             test_class_attr = 'whatever'
 
             def test_method(other_self, mock_something):
-                self.assertEqual(PTModule.something, mock_something,
-                                 "unpatched")
+                self.assertEqual(
+                    PTModule.something, mock_something, "unpatched"
+                )
+
             def not_test_method(other_self):
-                self.assertEqual(PTModule.something, sentinel.Something,
-                                 "non-test method patched")
+                self.assertEqual(
+                    PTModule.something,
+                    sentinel.Something,
+                    "non-test method patched",
+                )
+
         Foo = patch('%s.something' % __name__)(Foo)
 
         f = Foo()
         f.test_method()
         f.not_test_method()
 
-        self.assertEqual(Something.attribute, sentinel.Original,
-                         "patch not restored")
-        self.assertEqual(PTModule.something, sentinel.Something,
-                         "patch not restored")
-
+        self.assertEqual(
+            Something.attribute, sentinel.Original, "patch not restored"
+        )
+        self.assertEqual(
+            PTModule.something, sentinel.Something, "patch not restored"
+        )
 
     def test_patchobject_twice(self):
         class Something(object):
@@ -499,13 +577,15 @@ class PatchTest(unittest.TestCase):
         @patch.object(Something, 'attribute', sentinel.Patched)
         @patch.object(Something, 'attribute', sentinel.Patched)
         def test():
-            self.assertEqual(Something.attribute, sentinel.Patched, "unpatched")
+            self.assertEqual(
+                Something.attribute, sentinel.Patched, "unpatched"
+            )
 
         test()
 
-        self.assertEqual(Something.attribute, sentinel.Original,
-                         "patch not restored")
-
+        self.assertEqual(
+            Something.attribute, sentinel.Original, "patch not restored"
+        )
 
     def test_patch_dict(self):
         foo = {'initial': object(), 'other': 'something'}
@@ -539,11 +619,10 @@ class PatchTest(unittest.TestCase):
 
         self.assertEqual(foo, original)
 
-
     def test_patch_dict_with_container_object(self):
         foo = Container()
         foo['initial'] = object()
-        foo['other'] =  'something'
+        foo['other'] = 'something'
 
         original = foo.values.copy()
 
@@ -565,7 +644,6 @@ class PatchTest(unittest.TestCase):
         test()
 
         self.assertEqual(foo.values, original)
-
 
     def test_patch_dict_with_clear(self):
         foo = {'initial': object(), 'other': 'something'}
@@ -597,11 +675,10 @@ class PatchTest(unittest.TestCase):
 
         self.assertEqual(foo, original)
 
-
     def test_patch_dict_with_container_object_and_clear(self):
         foo = Container()
         foo['initial'] = object()
-        foo['other'] =  'something'
+        foo['other'] = 'something'
 
         original = foo.values.copy()
 
@@ -623,13 +700,11 @@ class PatchTest(unittest.TestCase):
 
         self.assertEqual(foo.values, original)
 
-
     def test_patch_dict_as_context_manager(self):
         foo = {'a': 'b'}
         with patch.dict(foo, a='c') as patched:
             self.assertEqual(patched, {'a': 'c'})
         self.assertEqual(foo, {'a': 'b'})
-
 
     def test_name_preserved(self):
         foo = {}
@@ -638,10 +713,10 @@ class PatchTest(unittest.TestCase):
         @patch('%s.SomeClass' % __name__, object(), autospec=True)
         @patch.object(SomeClass, object())
         @patch.dict(foo)
-        def some_name(): pass
+        def some_name():
+            pass
 
         self.assertEqual(some_name.__name__, 'some_name')
-
 
     def test_patch_with_exception(self):
         foo = {}
@@ -655,14 +730,12 @@ class PatchTest(unittest.TestCase):
 
         self.assertEqual(foo, {})
 
-
     def test_patch_dict_with_string(self):
         @patch.dict('os.environ', {'konrad_delong': 'some value'})
         def test():
             self.assertIn('konrad_delong', os.environ)
 
         test()
-
 
     def test_patch_dict_decorator_resolution(self):
         # bpo-35512: Ensure that patch with a string target resolves to
@@ -680,7 +753,6 @@ class PatchTest(unittest.TestCase):
         finally:
             support.target = original
 
-
     def test_patch_spec_set(self):
         @patch('%s.SomeClass' % __name__, spec=SomeClass, spec_set=True)
         def test(MockClass):
@@ -693,6 +765,7 @@ class PatchTest(unittest.TestCase):
             MockClass.z = 'foo'
 
         self.assertRaises(AttributeError, test)
+
         @patch('%s.SomeClass' % __name__, spec_set=True)
         def test(MockClass):
             MockClass.z = 'foo'
@@ -705,7 +778,6 @@ class PatchTest(unittest.TestCase):
 
         self.assertRaises(AttributeError, test)
 
-
     def test_spec_set_inherit(self):
         @patch('%s.SomeClass' % __name__, spec_set=True)
         def test(MockClass):
@@ -713,7 +785,6 @@ class PatchTest(unittest.TestCase):
             instance.z = 'foo'
 
         self.assertRaises(AttributeError, test)
-
 
     def test_patch_start_stop(self):
         original = something
@@ -727,12 +798,10 @@ class PatchTest(unittest.TestCase):
             patcher.stop()
         self.assertIs(something, original)
 
-
     def test_stop_without_start(self):
         # bpo-36366: calling stop without start will return None.
         patcher = patch(foo_name, 'bar', 3)
         self.assertIsNone(patcher.stop())
-
 
     def test_stop_idempotent(self):
         # bpo-36366: calling stop on an already stopped patch will return None.
@@ -741,7 +810,6 @@ class PatchTest(unittest.TestCase):
         patcher.start()
         patcher.stop()
         self.assertIsNone(patcher.stop())
-
 
     def test_patchobject_start_stop(self):
         original = something
@@ -754,7 +822,6 @@ class PatchTest(unittest.TestCase):
         finally:
             patcher.stop()
         self.assertIs(something, original)
-
 
     def test_patch_dict_start_stop(self):
         d = {'foo': 'bar'}
@@ -769,7 +836,6 @@ class PatchTest(unittest.TestCase):
             patcher.stop()
         self.assertEqual(d, original)
 
-
     def test_patch_dict_class_decorator(self):
         this = self
         d = {'spam': 'eggs'}
@@ -778,6 +844,7 @@ class PatchTest(unittest.TestCase):
         class Test(object):
             def test_first(self):
                 this.assertEqual(d, {'foo': 'bar'})
+
             def test_second(self):
                 this.assertEqual(d, {'foo': 'bar'})
 
@@ -800,10 +867,10 @@ class PatchTest(unittest.TestCase):
         test.test_second()
         self.assertEqual(d, original)
 
-
     def test_get_only_proxy(self):
         class Something(object):
             foo = 'foo'
+
         class SomethingElse:
             foo = 'foo'
 
@@ -813,15 +880,16 @@ class PatchTest(unittest.TestCase):
             @patch.object(proxy, 'foo', 'bar')
             def test():
                 self.assertEqual(proxy.foo, 'bar')
+
             test()
             self.assertEqual(proxy.foo, 'foo')
             self.assertEqual(thing.foo, 'foo')
             self.assertNotIn('foo', proxy.__dict__)
 
-
     def test_get_set_delete_proxy(self):
         class Something(object):
             foo = 'foo'
+
         class SomethingElse:
             foo = 'foo'
 
@@ -831,15 +899,18 @@ class PatchTest(unittest.TestCase):
             @patch.object(proxy, 'foo', 'bar')
             def test():
                 self.assertEqual(proxy.foo, 'bar')
+
             test()
             self.assertEqual(proxy.foo, 'foo')
             self.assertEqual(thing.foo, 'foo')
             self.assertNotIn('foo', proxy.__dict__)
 
-
     def test_patch_keyword_args(self):
-        kwargs = {'side_effect': KeyError, 'foo.bar.return_value': 33,
-                  'foo': MagicMock()}
+        kwargs = {
+            'side_effect': KeyError,
+            'foo.bar.return_value': 33,
+            'foo': MagicMock(),
+        }
 
         patcher = patch(foo_name, **kwargs)
         mock = patcher.start()
@@ -849,10 +920,12 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(mock.foo.bar(), 33)
         self.assertIsInstance(mock.foo, MagicMock)
 
-
     def test_patch_object_keyword_args(self):
-        kwargs = {'side_effect': KeyError, 'foo.bar.return_value': 33,
-                  'foo': MagicMock()}
+        kwargs = {
+            'side_effect': KeyError,
+            'foo.bar.return_value': 33,
+            'foo': MagicMock(),
+        }
 
         patcher = patch.object(Foo, 'f', **kwargs)
         mock = patcher.start()
@@ -861,7 +934,6 @@ class PatchTest(unittest.TestCase):
         self.assertRaises(KeyError, mock)
         self.assertEqual(mock.foo.bar(), 33)
         self.assertIsInstance(mock.foo, MagicMock)
-
 
     def test_patch_dict_keyword_args(self):
         original = {'foo': 'bar'}
@@ -877,16 +949,22 @@ class PatchTest(unittest.TestCase):
 
         self.assertEqual(original, copy)
 
-
     def test_autospec(self):
         class Boo(object):
-            def __init__(self, a): pass
-            def f(self, a): pass
-            def g(self): pass
+            def __init__(self, a):
+                pass
+
+            def f(self, a):
+                pass
+
+            def g(self):
+                pass
+
             foo = 'bar'
 
             class Bar(object):
-                def a(self): pass
+                def a(self):
+                    pass
 
         def _test(mock):
             mock(1)
@@ -944,7 +1022,6 @@ class PatchTest(unittest.TestCase):
         # test patching a second time works
         test()
 
-
     def test_autospec_function(self):
         @patch('%s.function' % __name__, autospec=True)
         def test(mock):
@@ -964,29 +1041,24 @@ class PatchTest(unittest.TestCase):
 
         test()
 
-
     def test_autospec_keywords(self):
-        @patch('%s.function' % __name__, autospec=True,
-               return_value=3)
+        @patch('%s.function' % __name__, autospec=True, return_value=3)
         def test(mock_function):
-            #self.assertEqual(function.abc, 'foo')
+            # self.assertEqual(function.abc, 'foo')
             return function(1, 2)
 
         result = test()
         self.assertEqual(result, 3)
-
 
     def test_autospec_staticmethod(self):
         with patch('%s.Foo.static_method' % __name__, autospec=True) as method:
             Foo.static_method()
             method.assert_called_once_with()
 
-
     def test_autospec_classmethod(self):
         with patch('%s.Foo.class_method' % __name__, autospec=True) as method:
             Foo.class_method()
             method.assert_called_once_with()
-
 
     def test_autospec_with_new(self):
         patcher = patch('%s.function' % __name__, new=3, autospec=True)
@@ -995,7 +1067,6 @@ class PatchTest(unittest.TestCase):
         module = sys.modules[__name__]
         patcher = patch.object(module, 'function', new=3, autospec=True)
         self.assertRaises(TypeError, patcher.start)
-
 
     def test_autospec_with_object(self):
         class Bar(Foo):
@@ -1009,7 +1080,6 @@ class PatchTest(unittest.TestCase):
         finally:
             patcher.stop()
 
-
     def test_autospec_inherits(self):
         FooClass = Foo
         patcher = patch(foo_name, autospec=True)
@@ -1019,7 +1089,6 @@ class PatchTest(unittest.TestCase):
             self.assertIsInstance(mock(3), FooClass)
         finally:
             patcher.stop()
-
 
     def test_autospec_name(self):
         patcher = patch(foo_name, autospec=True)
@@ -1033,11 +1102,11 @@ class PatchTest(unittest.TestCase):
         finally:
             patcher.stop()
 
-
     def test_tracebacks(self):
         @patch.object(Foo, 'f', object())
         def test():
             raise AssertionError
+
         try:
             test()
         except:
@@ -1046,7 +1115,6 @@ class PatchTest(unittest.TestCase):
         result = unittest.TextTestResult(None, None, 0)
         traceback = result._exc_info_to_string(err, self)
         self.assertIn('raise AssertionError', traceback)
-
 
     def test_new_callable_patch(self):
         patcher = patch(foo_name, new_callable=NonCallableMagicMock)
@@ -1060,7 +1128,6 @@ class PatchTest(unittest.TestCase):
         for mock in m1, m2:
             self.assertNotCallable(m1)
 
-
     def test_new_callable_patch_object(self):
         patcher = patch.object(Foo, 'f', new_callable=NonCallableMagicMock)
 
@@ -1073,10 +1140,10 @@ class PatchTest(unittest.TestCase):
         for mock in m1, m2:
             self.assertNotCallable(m1)
 
-
     def test_new_callable_keyword_arguments(self):
         class Bar(object):
             kwargs = None
+
             def __init__(self, **kwargs):
                 Bar.kwargs = kwargs
 
@@ -1088,10 +1155,10 @@ class PatchTest(unittest.TestCase):
         finally:
             patcher.stop()
 
-
     def test_new_callable_spec(self):
         class Bar(object):
             kwargs = None
+
             def __init__(self, **kwargs):
                 Bar.kwargs = kwargs
 
@@ -1109,48 +1176,54 @@ class PatchTest(unittest.TestCase):
         finally:
             patcher.stop()
 
-
     def test_new_callable_create(self):
         non_existent_attr = '%s.weeeee' % foo_name
         p = patch(non_existent_attr, new_callable=NonCallableMock)
         self.assertRaises(AttributeError, p.start)
 
-        p = patch(non_existent_attr, new_callable=NonCallableMock,
-                  create=True)
+        p = patch(non_existent_attr, new_callable=NonCallableMock, create=True)
         m = p.start()
         try:
             self.assertNotCallable(m, magic=False)
         finally:
             p.stop()
 
-
     def test_new_callable_incompatible_with_new(self):
         self.assertRaises(
             ValueError, patch, foo_name, new=object(), new_callable=MagicMock
         )
         self.assertRaises(
-            ValueError, patch.object, Foo, 'f', new=object(),
-            new_callable=MagicMock
+            ValueError,
+            patch.object,
+            Foo,
+            'f',
+            new=object(),
+            new_callable=MagicMock,
         )
-
 
     def test_new_callable_incompatible_with_autospec(self):
         self.assertRaises(
-            ValueError, patch, foo_name, new_callable=MagicMock,
-            autospec=True
+            ValueError, patch, foo_name, new_callable=MagicMock, autospec=True
         )
         self.assertRaises(
-            ValueError, patch.object, Foo, 'f', new_callable=MagicMock,
-            autospec=True
+            ValueError,
+            patch.object,
+            Foo,
+            'f',
+            new_callable=MagicMock,
+            autospec=True,
         )
-
 
     def test_new_callable_inherit_for_mocks(self):
         class MockSub(Mock):
             pass
 
         MockClasses = (
-            NonCallableMock, NonCallableMagicMock, MagicMock, Mock, MockSub
+            NonCallableMock,
+            NonCallableMagicMock,
+            MagicMock,
+            Mock,
+            MockSub,
         )
         for Klass in MockClasses:
             for arg in 'spec', 'spec_set':
@@ -1162,7 +1235,6 @@ class PatchTest(unittest.TestCase):
                     self.assertRaises(AttributeError, getattr, instance, 'x')
                 finally:
                     p.stop()
-
 
     def test_new_callable_inherit_non_mock(self):
         class NotAMock(object):
@@ -1179,12 +1251,11 @@ class PatchTest(unittest.TestCase):
 
         self.assertEqual(m.spec, Foo)
 
-
     def test_new_callable_class_decorating(self):
         test = self
         original = Foo
-        class SomeTest(object):
 
+        class SomeTest(object):
             def _test(self, mock_foo):
                 test.assertIsNot(Foo, original)
                 test.assertIs(Foo, mock_foo)
@@ -1192,6 +1263,7 @@ class PatchTest(unittest.TestCase):
 
             def test_two(self, mock_foo):
                 self._test(mock_foo)
+
             def test_one(self, mock_foo):
                 self._test(mock_foo)
 
@@ -1199,7 +1271,6 @@ class PatchTest(unittest.TestCase):
         SomeTest().test_one()
         SomeTest().test_two()
         self.assertIs(Foo, original)
-
 
     def test_patch_multiple(self):
         original_foo = Foo
@@ -1222,7 +1293,6 @@ class PatchTest(unittest.TestCase):
             self.assertEqual(Foo.f, original_f)
             self.assertEqual(Foo.g, original_g)
 
-
         @patch.multiple(foo_name, f=3, g=4)
         def test():
             self.assertIs(Foo, original_foo)
@@ -1231,11 +1301,9 @@ class PatchTest(unittest.TestCase):
 
         test()
 
-
     def test_patch_multiple_no_kwargs(self):
         self.assertRaises(ValueError, patch.multiple, foo_name)
         self.assertRaises(ValueError, patch.multiple, Foo)
-
 
     def test_patch_multiple_create_mocks(self):
         original_foo = Foo
@@ -1254,7 +1322,6 @@ class PatchTest(unittest.TestCase):
         test()
         self.assertEqual(Foo.f, original_f)
         self.assertEqual(Foo.g, original_g)
-
 
     def test_patch_multiple_create_mocks_different_order(self):
         original_f = Foo.f
@@ -1275,7 +1342,6 @@ class PatchTest(unittest.TestCase):
         test()
         self.assertEqual(Foo.f, original_f)
         self.assertEqual(Foo.g, original_g)
-
 
     def test_patch_multiple_stacked_decorators(self):
         original_foo = Foo
@@ -1319,7 +1385,6 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(Foo.f, original_f)
         self.assertEqual(Foo.g, original_g)
 
-
     def test_patch_multiple_create_mocks_patcher(self):
         original_foo = Foo
         original_f = Foo.f
@@ -1344,7 +1409,6 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(Foo.f, original_f)
         self.assertEqual(Foo.g, original_g)
 
-
     def test_patch_multiple_decorating_class(self):
         test = self
         original_foo = Foo
@@ -1352,7 +1416,6 @@ class PatchTest(unittest.TestCase):
         original_g = Foo.g
 
         class SomeTest(object):
-
             def _test(self, f, foo):
                 test.assertIs(Foo, original_foo)
                 test.assertIs(Foo.f, f)
@@ -1363,12 +1426,13 @@ class PatchTest(unittest.TestCase):
 
             def test_two(self, f, foo):
                 self._test(f, foo)
+
             def test_one(self, f, foo):
                 self._test(f, foo)
 
-        SomeTest = patch.multiple(
-            foo_name, f=DEFAULT, g=3, foo=DEFAULT
-        )(SomeTest)
+        SomeTest = patch.multiple(foo_name, f=DEFAULT, g=3, foo=DEFAULT)(
+            SomeTest
+        )
 
         thing = SomeTest()
         thing.test_one()
@@ -1376,7 +1440,6 @@ class PatchTest(unittest.TestCase):
 
         self.assertEqual(Foo.f, original_f)
         self.assertEqual(Foo.g, original_g)
-
 
     def test_patch_multiple_create(self):
         patcher = patch.multiple(Foo, blam='blam')
@@ -1390,7 +1453,6 @@ class PatchTest(unittest.TestCase):
             patcher.stop()
 
         self.assertFalse(hasattr(Foo, 'blam'))
-
 
     def test_patch_multiple_spec_set(self):
         # if spec_set works then we can assume that spec and autospec also
@@ -1407,14 +1469,11 @@ class PatchTest(unittest.TestCase):
         finally:
             patcher.stop()
 
-
     def test_patch_multiple_new_callable(self):
         class Thing(object):
             pass
 
-        patcher = patch.multiple(
-            Foo, f=DEFAULT, g=DEFAULT, new_callable=Thing
-        )
+        patcher = patch.multiple(Foo, f=DEFAULT, g=DEFAULT, new_callable=Thing)
         result = patcher.start()
         try:
             self.assertIs(Foo.f, result['f'])
@@ -1425,7 +1484,6 @@ class PatchTest(unittest.TestCase):
         finally:
             patcher.stop()
 
-
     def test_nested_patch_failure(self):
         original_f = Foo.f
         original_g = Foo.g
@@ -1433,23 +1491,25 @@ class PatchTest(unittest.TestCase):
         @patch.object(Foo, 'g', 1)
         @patch.object(Foo, 'missing', 1)
         @patch.object(Foo, 'f', 1)
-        def thing1(): pass
+        def thing1():
+            pass
 
         @patch.object(Foo, 'missing', 1)
         @patch.object(Foo, 'g', 1)
         @patch.object(Foo, 'f', 1)
-        def thing2(): pass
+        def thing2():
+            pass
 
         @patch.object(Foo, 'g', 1)
         @patch.object(Foo, 'f', 1)
         @patch.object(Foo, 'missing', 1)
-        def thing3(): pass
+        def thing3():
+            pass
 
         for func in thing1, thing2, thing3:
             self.assertRaises(AttributeError, func)
             self.assertEqual(Foo.f, original_f)
             self.assertEqual(Foo.g, original_g)
-
 
     def test_new_callable_failure(self):
         original_f = Foo.f
@@ -1462,24 +1522,26 @@ class PatchTest(unittest.TestCase):
         @patch.object(Foo, 'g', 1)
         @patch.object(Foo, 'foo', new_callable=crasher)
         @patch.object(Foo, 'f', 1)
-        def thing1(): pass
+        def thing1():
+            pass
 
         @patch.object(Foo, 'foo', new_callable=crasher)
         @patch.object(Foo, 'g', 1)
         @patch.object(Foo, 'f', 1)
-        def thing2(): pass
+        def thing2():
+            pass
 
         @patch.object(Foo, 'g', 1)
         @patch.object(Foo, 'f', 1)
         @patch.object(Foo, 'foo', new_callable=crasher)
-        def thing3(): pass
+        def thing3():
+            pass
 
         for func in thing1, thing2, thing3:
             self.assertRaises(NameError, func)
             self.assertEqual(Foo.f, original_f)
             self.assertEqual(Foo.g, original_g)
             self.assertEqual(Foo.foo, original_foo)
-
 
     def test_patch_multiple_failure(self):
         original_f = Foo.f
@@ -1498,12 +1560,12 @@ class PatchTest(unittest.TestCase):
             patcher.additional_patchers = additionals
 
             @patcher
-            def func(): pass
+            def func():
+                pass
 
             self.assertRaises(AttributeError, func)
             self.assertEqual(Foo.f, original_f)
             self.assertEqual(Foo.g, original_g)
-
 
     def test_patch_multiple_new_callable_failure(self):
         original_f = Foo.f
@@ -1526,24 +1588,24 @@ class PatchTest(unittest.TestCase):
             patcher.additional_patchers = additionals
 
             @patcher
-            def func(): pass
+            def func():
+                pass
 
             self.assertRaises(NameError, func)
             self.assertEqual(Foo.f, original_f)
             self.assertEqual(Foo.g, original_g)
             self.assertEqual(Foo.foo, original_foo)
 
-
     def test_patch_multiple_string_subclasses(self):
         Foo = type('Foo', (str,), {'fish': 'tasty'})
         foo = Foo()
+
         @patch.multiple(foo, fish='nearly gone')
         def test():
             self.assertEqual(foo.fish, 'nearly gone')
 
         test()
         self.assertEqual(foo.fish, 'tasty')
-
 
     @patch('unittest.mock.patch.TEST_PREFIX', 'foo')
     def test_patch_test_prefix(self):
@@ -1552,10 +1614,13 @@ class PatchTest(unittest.TestCase):
 
             def foo_one(self):
                 return self.thing
+
             def foo_two(self):
                 return self.thing
+
             def test_one(self):
                 return self.thing
+
             def test_two(self):
                 return self.thing
 
@@ -1567,28 +1632,29 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(foo.test_one(), 'original')
         self.assertEqual(foo.test_two(), 'original')
 
-
     @patch('unittest.mock.patch.TEST_PREFIX', 'bar')
     def test_patch_dict_test_prefix(self):
         class Foo(object):
             def bar_one(self):
                 return dict(the_dict)
+
             def bar_two(self):
                 return dict(the_dict)
+
             def test_one(self):
                 return dict(the_dict)
+
             def test_two(self):
                 return dict(the_dict)
 
         the_dict = {'key': 'original'}
         Foo = patch.dict(the_dict, key='changed')(Foo)
 
-        foo =Foo()
+        foo = Foo()
         self.assertEqual(foo.bar_one(), {'key': 'changed'})
         self.assertEqual(foo.bar_two(), {'key': 'changed'})
         self.assertEqual(foo.test_one(), {'key': 'original'})
         self.assertEqual(foo.test_two(), {'key': 'original'})
-
 
     def test_patch_with_spec_mock_repr(self):
         for arg in ('spec', 'autospec', 'spec_set'):
@@ -1596,23 +1662,28 @@ class PatchTest(unittest.TestCase):
             m = p.start()
             try:
                 self.assertIn(" name='SomeClass'", repr(m))
-                self.assertIn(" name='SomeClass.class_attribute'",
-                              repr(m.class_attribute))
+                self.assertIn(
+                    " name='SomeClass.class_attribute'",
+                    repr(m.class_attribute),
+                )
                 self.assertIn(" name='SomeClass()'", repr(m()))
-                self.assertIn(" name='SomeClass().class_attribute'",
-                              repr(m().class_attribute))
+                self.assertIn(
+                    " name='SomeClass().class_attribute'",
+                    repr(m().class_attribute),
+                )
             finally:
                 p.stop()
 
-
     def test_patch_nested_autospec_repr(self):
         with patch('unittest.test.testmock.support', autospec=True) as m:
-            self.assertIn(" name='support.SomeClass.wibble()'",
-                          repr(m.SomeClass.wibble()))
-            self.assertIn(" name='support.SomeClass().wibble()'",
-                          repr(m.SomeClass().wibble()))
-
-
+            self.assertIn(
+                " name='support.SomeClass.wibble()'",
+                repr(m.SomeClass.wibble()),
+            )
+            self.assertIn(
+                " name='support.SomeClass().wibble()'",
+                repr(m.SomeClass().wibble()),
+            )
 
     def test_mock_calls_with_patch(self):
         for arg in ('spec', 'autospec', 'spec_set'):
@@ -1640,7 +1711,6 @@ class PatchTest(unittest.TestCase):
             finally:
                 p.stop()
 
-
     def test_patch_imports_lazily(self):
         p1 = patch('squizz.squozz')
         self.assertRaises(ImportError, p1.start)
@@ -1664,13 +1734,13 @@ class PatchTest(unittest.TestCase):
             def __exit__(self, etype=None, val=None, tb=None):
                 _patch.__exit__(self, etype, val, tb)
                 holder.exc_info = etype, val, tb
+
             stop = __exit__
 
         def with_custom_patch(target):
             getter, attribute = _get_target(target)
             return custom_patch(
-                getter, attribute, DEFAULT, None, False, None,
-                None, None, {}
+                getter, attribute, DEFAULT, None, False, None, None, None, {}
             )
 
         @with_custom_patch('squizz.squozz')
@@ -1684,16 +1754,18 @@ class PatchTest(unittest.TestCase):
             self.assertRaises(RuntimeError, test)
 
         self.assertIs(holder.exc_info[0], RuntimeError)
-        self.assertIsNotNone(holder.exc_info[1],
-                            'exception value not propagated')
-        self.assertIsNotNone(holder.exc_info[2],
-                            'exception traceback not propagated')
-
+        self.assertIsNotNone(
+            holder.exc_info[1], 'exception value not propagated'
+        )
+        self.assertIsNotNone(
+            holder.exc_info[2], 'exception traceback not propagated'
+        )
 
     def test_create_and_specs(self):
         for kwarg in ('spec', 'spec_set', 'autospec'):
-            p = patch('%s.doesnotexist' % __name__, create=True,
-                      **{kwarg: True})
+            p = patch(
+                '%s.doesnotexist' % __name__, create=True, **{kwarg: True}
+            )
             self.assertRaises(TypeError, p.start)
             self.assertRaises(NameError, lambda: doesnotexist)
 
@@ -1701,7 +1773,6 @@ class PatchTest(unittest.TestCase):
             p = patch(MODNAME, create=True, **{kwarg: True})
             p.start()
             p.stop()
-
 
     def test_multiple_specs(self):
         original = PTModule
@@ -1720,7 +1791,6 @@ class PatchTest(unittest.TestCase):
             self.assertRaises(TypeError, p.start)
             self.assertIs(PTModule, original)
 
-
     def test_specs_false_instead_of_none(self):
         p = patch(MODNAME, spec=False, spec_set=False, autospec=False)
         mock = p.start()
@@ -1731,7 +1801,6 @@ class PatchTest(unittest.TestCase):
         finally:
             p.stop()
 
-
     def test_falsey_spec(self):
         for kwarg in ('spec', 'autospec', 'spec_set'):
             p = patch(MODNAME, **{kwarg: 0})
@@ -1741,18 +1810,17 @@ class PatchTest(unittest.TestCase):
             finally:
                 p.stop()
 
-
     def test_spec_set_true(self):
         for kwarg in ('spec', 'autospec'):
             p = patch(MODNAME, spec_set=True, **{kwarg: True})
             m = p.start()
             try:
-                self.assertRaises(AttributeError, setattr, m,
-                                  'doesnotexist', 'something')
+                self.assertRaises(
+                    AttributeError, setattr, m, 'doesnotexist', 'something'
+                )
                 self.assertRaises(AttributeError, getattr, m, 'doesnotexist')
             finally:
                 p.stop()
-
 
     def test_callable_spec_as_list(self):
         spec = ('__call__',)
@@ -1763,7 +1831,6 @@ class PatchTest(unittest.TestCase):
         finally:
             p.stop()
 
-
     def test_not_callable_spec_as_list(self):
         spec = ('foo', 'bar')
         p = patch(MODNAME, spec=spec)
@@ -1772,7 +1839,6 @@ class PatchTest(unittest.TestCase):
             self.assertFalse(callable(m))
         finally:
             p.stop()
-
 
     def test_patch_stopall(self):
         unlink = os.unlink
@@ -1793,6 +1859,7 @@ class PatchTest(unittest.TestCase):
 
     def test_stopall_lifo(self):
         stopped = []
+
         class thing(object):
             one = two = three = None
 
@@ -1801,8 +1868,19 @@ class PatchTest(unittest.TestCase):
                 def stop(self):
                     stopped.append(attribute)
                     return super(mypatch, self).stop()
-            return mypatch(lambda: thing, attribute, None, None,
-                           False, None, None, None, {})
+
+            return mypatch(
+                lambda: thing,
+                attribute,
+                None,
+                None,
+                False,
+                None,
+                None,
+                None,
+                {},
+            )
+
         [get_patch(val).start() for val in ("one", "two", "three")]
         patch.stopall()
 
@@ -1833,7 +1911,6 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(dic2, origdic2)
         self.assertEqual(dic3, origdic3)
 
-
     def test_patch_and_patch_dict_stopall(self):
         original_unlink = os.unlink
         original_chdir = os.chdir
@@ -1858,12 +1935,12 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(dic1, origdic1)
         self.assertEqual(dic2, origdic2)
 
-
     def test_special_attrs(self):
         def foo(x=0):
             """TEST"""
             return x
-        with patch.object(foo, '__defaults__', (1, )):
+
+        with patch.object(foo, '__defaults__', (1,)):
             self.assertEqual(foo(), 1)
         self.assertEqual(foo(), 0)
 
@@ -1875,13 +1952,14 @@ class PatchTest(unittest.TestCase):
             self.assertEqual(foo.__module__, "testpatch2")
         self.assertEqual(foo.__module__, 'unittest.test.testmock.testpatch')
 
-        with patch.object(foo, '__annotations__', dict([('s', 1, )])):
-            self.assertEqual(foo.__annotations__, dict([('s', 1, )]))
+        with patch.object(foo, '__annotations__', dict([('s', 1,)])):
+            self.assertEqual(foo.__annotations__, dict([('s', 1,)]))
         self.assertEqual(foo.__annotations__, dict())
 
         def foo(*a, x=0):
             return x
-        with patch.object(foo, '__kwdefaults__', dict([('x', 1, )])):
+
+        with patch.object(foo, '__kwdefaults__', dict([('x', 1,)])):
             self.assertEqual(foo(), 1)
         self.assertEqual(foo(), 0)
 
@@ -1909,6 +1987,7 @@ class PatchTest(unittest.TestCase):
 
         # make sure it's there
         import unittest.test.testmock.support
+
         # now make sure it's not:
         with patch.dict('sys.modules'):
             del sys.modules['unittest.test.testmock.support']
@@ -1920,17 +1999,18 @@ class PatchTest(unittest.TestCase):
             @patch('unittest.test.testmock.support.X')
             def test(mock):
                 pass
-            test()
 
+            test()
 
     def test_invalid_target(self):
         with self.assertRaises(TypeError):
             patch('')
 
-
     def test_cant_set_kwargs_when_passing_a_mock(self):
         @patch('unittest.test.testmock.support.X', new=object(), x=1)
-        def test(): pass
+        def test():
+            pass
+
         with self.assertRaises(TypeError):
             test()
 

--- a/Lib/unittest/test/testmock/testsealable.py
+++ b/Lib/unittest/test/testmock/testsealable.py
@@ -3,14 +3,14 @@ from unittest import mock
 
 
 class SampleObject:
+    def method_sample1(self):
+        pass
 
-    def method_sample1(self): pass
-
-    def method_sample2(self): pass
+    def method_sample2(self):
+        pass
 
 
 class TestSealable(unittest.TestCase):
-
     def test_attributes_return_more_mocks_by_default(self):
         m = mock.Mock()
 
@@ -160,7 +160,9 @@ class TestSealable(unittest.TestCase):
         mock.seal(m)
         with self.assertRaises(AttributeError) as cm:
             m.test1.test2.test3.test4.boom
-        self.assertIn("mock_name.test1.test2.test3.test4.boom", str(cm.exception))
+        self.assertIn(
+            "mock_name.test1.test2.test3.test4.boom", str(cm.exception)
+        )
 
     def test_call_chain_is_maintained(self):
         m = mock.Mock()

--- a/Lib/unittest/test/testmock/testsentinel.py
+++ b/Lib/unittest/test/testmock/testsentinel.py
@@ -5,18 +5,22 @@ from unittest.mock import sentinel, DEFAULT
 
 
 class SentinelTest(unittest.TestCase):
-
     def testSentinels(self):
-        self.assertEqual(sentinel.whatever, sentinel.whatever,
-                         'sentinel not stored')
-        self.assertNotEqual(sentinel.whatever, sentinel.whateverelse,
-                            'sentinel should be unique')
-
+        self.assertEqual(
+            sentinel.whatever, sentinel.whatever, 'sentinel not stored'
+        )
+        self.assertNotEqual(
+            sentinel.whatever,
+            sentinel.whateverelse,
+            'sentinel should be unique',
+        )
 
     def testSentinelName(self):
-        self.assertEqual(str(sentinel.whatever), 'sentinel.whatever',
-                         'sentinel name incorrect')
-
+        self.assertEqual(
+            str(sentinel.whatever),
+            'sentinel.whatever',
+            'sentinel name incorrect',
+        )
 
     def testDEFAULT(self):
         self.assertIs(DEFAULT, sentinel.DEFAULT)
@@ -26,7 +30,7 @@ class SentinelTest(unittest.TestCase):
         self.assertRaises(AttributeError, lambda: sentinel.__bases__)
 
     def testPickle(self):
-        for proto in range(pickle.HIGHEST_PROTOCOL+1):
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.subTest(protocol=proto):
                 pickled = pickle.dumps(sentinel.whatever, proto)
                 unpickled = pickle.loads(pickled)

--- a/Lib/unittest/test/testmock/testwith.py
+++ b/Lib/unittest/test/testmock/testwith.py
@@ -5,21 +5,19 @@ from unittest.test.testmock.support import is_instance
 from unittest.mock import MagicMock, Mock, patch, sentinel, mock_open, call
 
 
+something = sentinel.Something
+something_else = sentinel.SomethingElse
 
-something  = sentinel.Something
-something_else  = sentinel.SomethingElse
 
-
-class SampleException(Exception): pass
+class SampleException(Exception):
+    pass
 
 
 class WithTest(unittest.TestCase):
-
     def test_with_statement(self):
         with patch('%s.something' % __name__, sentinel.Something2):
             self.assertEqual(something, sentinel.Something2, "unpatched")
         self.assertEqual(something, sentinel.Something)
-
 
     def test_with_statement_exception(self):
         with self.assertRaises(SampleException):
@@ -28,41 +26,43 @@ class WithTest(unittest.TestCase):
                 raise SampleException()
         self.assertEqual(something, sentinel.Something)
 
-
     def test_with_statement_as(self):
         with patch('%s.something' % __name__) as mock_something:
             self.assertEqual(something, mock_something, "unpatched")
-            self.assertTrue(is_instance(mock_something, MagicMock),
-                            "patching wrong type")
+            self.assertTrue(
+                is_instance(mock_something, MagicMock), "patching wrong type"
+            )
         self.assertEqual(something, sentinel.Something)
-
 
     def test_patch_object_with_statement(self):
         class Foo(object):
             something = 'foo'
+
         original = Foo.something
         with patch.object(Foo, 'something'):
             self.assertNotEqual(Foo.something, original, "unpatched")
         self.assertEqual(Foo.something, original)
 
-
     def test_with_statement_nested(self):
         with catch_warnings(record=True):
-            with patch('%s.something' % __name__) as mock_something, patch('%s.something_else' % __name__) as mock_something_else:
+            with patch('%s.something' % __name__) as mock_something, patch(
+                '%s.something_else' % __name__
+            ) as mock_something_else:
                 self.assertEqual(something, mock_something, "unpatched")
-                self.assertEqual(something_else, mock_something_else,
-                                 "unpatched")
+                self.assertEqual(
+                    something_else, mock_something_else, "unpatched"
+                )
 
         self.assertEqual(something, sentinel.Something)
         self.assertEqual(something_else, sentinel.SomethingElse)
 
-
     def test_with_statement_specified(self):
-        with patch('%s.something' % __name__, sentinel.Patched) as mock_something:
+        with patch(
+            '%s.something' % __name__, sentinel.Patched
+        ) as mock_something:
             self.assertEqual(something, mock_something, "unpatched")
             self.assertEqual(mock_something, sentinel.Patched, "wrong patch")
         self.assertEqual(something, sentinel.Something)
-
 
     def testContextManagerMocking(self):
         mock = Mock()
@@ -75,7 +75,6 @@ class WithTest(unittest.TestCase):
         mock.__enter__.assert_called_with()
         mock.__exit__.assert_called_with(None, None, None)
 
-
     def test_context_manager_with_magic_mock(self):
         mock = MagicMock()
 
@@ -85,31 +84,32 @@ class WithTest(unittest.TestCase):
         mock.__enter__.assert_called_with()
         self.assertTrue(mock.__exit__.called)
 
-
     def test_with_statement_same_attribute(self):
-        with patch('%s.something' % __name__, sentinel.Patched) as mock_something:
+        with patch(
+            '%s.something' % __name__, sentinel.Patched
+        ) as mock_something:
             self.assertEqual(something, mock_something, "unpatched")
 
             with patch('%s.something' % __name__) as mock_again:
                 self.assertEqual(something, mock_again, "unpatched")
 
-            self.assertEqual(something, mock_something,
-                             "restored with wrong instance")
+            self.assertEqual(
+                something, mock_something, "restored with wrong instance"
+            )
 
         self.assertEqual(something, sentinel.Something, "not restored")
-
 
     def test_with_statement_imbricated(self):
         with patch('%s.something' % __name__) as mock_something:
             self.assertEqual(something, mock_something, "unpatched")
 
             with patch('%s.something_else' % __name__) as mock_something_else:
-                self.assertEqual(something_else, mock_something_else,
-                                 "unpatched")
+                self.assertEqual(
+                    something_else, mock_something_else, "unpatched"
+                )
 
         self.assertEqual(something, sentinel.Something)
         self.assertEqual(something_else, sentinel.SomethingElse)
-
 
     def test_dict_context_manager(self):
         foo = {}
@@ -126,7 +126,8 @@ class WithTest(unittest.TestCase):
 
     def test_double_patch_instance_method(self):
         class C:
-            def f(self): pass
+            def f(self):
+                pass
 
         c = C()
 
@@ -140,7 +141,6 @@ class WithTest(unittest.TestCase):
 
 
 class TestMockOpen(unittest.TestCase):
-
     def test_mock_open(self):
         mock = mock_open()
         with patch('%s.open' % __name__, mock, create=True) as patched:
@@ -149,7 +149,6 @@ class TestMockOpen(unittest.TestCase):
 
         mock.assert_called_once_with('foo')
 
-
     def test_mock_open_context_manager(self):
         mock = mock_open()
         handle = mock.return_value
@@ -157,8 +156,12 @@ class TestMockOpen(unittest.TestCase):
             with open('foo') as f:
                 f.read()
 
-        expected_calls = [call('foo'), call().__enter__(), call().read(),
-                          call().__exit__(None, None, None)]
+        expected_calls = [
+            call('foo'),
+            call().__enter__(),
+            call().read(),
+            call().__exit__(None, None, None),
+        ]
         self.assertEqual(mock.mock_calls, expected_calls)
         self.assertIs(f, handle)
 
@@ -171,10 +174,15 @@ class TestMockOpen(unittest.TestCase):
                 f.read()
 
         expected_calls = [
-            call('foo'), call().__enter__(), call().read(),
+            call('foo'),
+            call().__enter__(),
+            call().read(),
             call().__exit__(None, None, None),
-            call('bar'), call().__enter__(), call().read(),
-            call().__exit__(None, None, None)]
+            call('bar'),
+            call().__enter__(),
+            call().read(),
+            call().__exit__(None, None, None),
+        ]
         self.assertEqual(mock.mock_calls, expected_calls)
 
     def test_explicit_mock(self):
@@ -187,7 +195,6 @@ class TestMockOpen(unittest.TestCase):
 
         mock.assert_called_once_with('foo')
 
-
     def test_read_data(self):
         mock = mock_open(read_data='foo')
         with patch('%s.open' % __name__, mock, create=True):
@@ -195,7 +202,6 @@ class TestMockOpen(unittest.TestCase):
             result = h.read()
 
         self.assertEqual(result, 'foo')
-
 
     def test_readline_data(self):
         # Check that readline will return all the lines from the fake file
@@ -218,7 +224,6 @@ class TestMockOpen(unittest.TestCase):
             result = h.readline()
         self.assertEqual(result, 'foo')
         self.assertEqual(h.readline(), '')
-
 
     def test_dunder_iter_data(self):
         # Check that dunder_iter will return all the lines from the fake file.
@@ -264,14 +269,12 @@ class TestMockOpen(unittest.TestCase):
 
         self.assertEqual(result, ['foo\n', 'bar\n', 'baz'])
 
-
     def test_read_bytes(self):
         mock = mock_open(read_data=b'\xc6')
         with patch('%s.open' % __name__, mock, create=True):
             with open('abc', 'rb') as f:
                 result = f.read()
         self.assertEqual(result, b'\xc6')
-
 
     def test_readline_bytes(self):
         m = mock_open(read_data=b'abc\ndef\nghi\n')
@@ -284,14 +287,12 @@ class TestMockOpen(unittest.TestCase):
         self.assertEqual(line2, b'def\n')
         self.assertEqual(line3, b'ghi\n')
 
-
     def test_readlines_bytes(self):
         m = mock_open(read_data=b'abc\ndef\nghi\n')
         with patch('%s.open' % __name__, m, create=True):
             with open('abc', 'rb') as f:
                 result = f.readlines()
         self.assertEqual(result, [b'abc\n', b'def\n', b'ghi\n'])
-
 
     def test_mock_open_read_with_argument(self):
         # At one point calling read with an argument was broken
@@ -304,7 +305,6 @@ class TestMockOpen(unittest.TestCase):
         f = mock()
         self.assertEqual(f.read(10), some_data[:10])
         self.assertEqual(f.read(10), some_data[10:])
-
 
     def test_interleaved_reads(self):
         # Test that calling read, readline, and readlines pulls data
@@ -324,7 +324,6 @@ class TestMockOpen(unittest.TestCase):
             rest = h.read()
         self.assertEqual(line1, 'foo\n')
         self.assertEqual(rest, 'bar\nbaz\n')
-
 
     def test_overriding_return_values(self):
         mock = mock_open(read_data='foo')


### PR DESCRIPTION
Putting this up to see what people think. @mariocj89: you too!

I like it overall, the only rough edge is that we'd need to find a way to tell coverage to ignore all 
```
def foo(..):
    pass
```
methods on the backport. @nedbat - can you think of any coverage config that would help with that?

If it's not possible, I could just exclude those from the diff. 

I did try just sorting out the mishmash of different whitespace between methods, classes, etc by hand but that ends up being pretty arduous.