### PR TITLE
bpo-39467: allow user to deprecate CLI arguments

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -698,6 +698,15 @@ The add_argument() method
    * default_ - The value produced if the argument is absent from the
      command line.
 
+   * deprecated_ - Define if the argument is deprecated.
+
+   * deprecated_reason_ - Custome deprecation warning message to display if
+     the argument is deprecated.
+
+   * deprecated_pending_ - Define if the deprecation is pending. The argument
+     is obsolete and expected to be deprecated in the future, but is not
+     deprecated at the moment.
+
    * type_ - The type to which the command-line argument should be converted.
 
    * choices_ - A container of the allowable values for the argument.
@@ -1051,6 +1060,72 @@ command-line argument was not present::
    >>> parser.parse_args(['--foo', '1'])
    Namespace(foo='1')
 
+
+deprecated
+^^^^^^^^^^
+
+During projects lifecycle some arguments could be removed from the
+command line, before removing these arguments definitively you would inform
+your user that arguments are deprecated and will be removed.
+The ``deprecated`` keyword argument of
+:meth:`~ArgumentParser.add_argument`, whose value default to ``False``,
+specifies if the argument is deprecated and will be removed
+from the command-line available arguments in the future.
+For arguments, if ``deprecated`` is ``True`` then a warning (``DeprecationWarning``) will be
+emitted if the argument is given by user in the command line parameters::
+
+    >>> import argparse
+    >>> parser = argparse.ArgumentParser()
+    >>> parser.add_argument('bar', default=1)
+    >>> parser.add_argument('--foo', default=2, deprecated=True)
+    >>> parser.parse_args(['test'])
+    Namespace(bar='test', foo='2')
+    >>> parser.parse_args(['test', '--foo', '4'])
+    /home/cpython/Lib/argparse.py:1979: DeprecationWarning: Usage of parameter foo are deprecated
+    Namespace(bar='test', foo='4')
+
+
+deprecated_reason
+^^^^^^^^^^^^^^^^^
+
+Custome deprecation warning message to display if the argument is deprecated.
+If not given then a standard message will be displayed.
+The ``deprecated_reason`` keyword argument of
+:meth:`~ArgumentParser.add_argument`, allow to define a custome message to
+display if the argument is deprecated and given by user in the command line parameters::
+
+    >>> import argparse
+    >>> parser = argparse.ArgumentParser()
+    >>> parser.add_argument('bar', default=1)
+    >>> parser.add_argument('--foo', default=2, deprecated=True, deprecated_reason='my custom message')
+    >>> parser.parse_args(['test'])
+    Namespace(bar='test', foo='2')
+    >>> parser.parse_args(['test', '--foo', '4'])
+    /home/cpython/Lib/argparse.py:1979: DeprecationWarning: my custome message
+    Namespace(bar='test', foo='4')
+
+deprecated_pending
+^^^^^^^^^^^^^^^^^^
+
+Define if the deprecation is pending. Could be used to define that an argument
+is obsolete and expected to be deprecated in the future, but is not
+deprecated at the moment.
+The ``deprecated_pending`` keyword argument of
+:meth:`~ArgumentParser.add_argument`, whose value default to ``False``,
+specifies if the argument is obsolete and expected to be deprecated in the future.
+For arguments, if ``deprecated_pending`` is ``True`` then a warning
+(``PendingDeprecationWarning``) will be emitted if the argument is given by
+user in the command line parameters::
+
+    >>> import argparse
+    >>> parser = argparse.ArgumentParser()
+    >>> parser.add_argument('bar', default=1)
+    >>> parser.add_argument('--foo', default=2, deprecated=True, deprecated_pending=True)
+    >>> parser.parse_args(['test'])
+    Namespace(bar='test', foo='2')
+    >>> parser.parse_args(['test', '--foo', '4'])
+    /home/cpython/Lib/argparse.py:1979: PendingDeprecationWarning: The argument foo is obsolete and expected to be deprecated in the future
+    Namespace(bar='test', foo='4')
 
 type
 ^^^^

--- a/Misc/NEWS.d/next/Library/2020-01-28-08-58-50.bpo-39467.yWrrL_.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-28-08-58-50.bpo-39467.yWrrL_.rst
@@ -1,0 +1,1 @@
+Allow to deprecate CLI arguments with argparse


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# [bpo-39467](https://bugs.python.org/issue39467): allow user to deprecate CLI arguments

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
# [bpo-39467](https://bugs.python.org/issue39467): allow user to deprecate CLI arguments

Today it's not possible to deprecate CLI arguments designed with argparse, it could be useful to introduce deprecation feature in argparse to allow developers to inform their apps's users when an argument is planed to be removed in the future.

These changes allow developers to deprecate CLI arguments.

<!-- issue-number: [bpo-39467](https://bugs.python.org/issue39467) -->
https://bugs.python.org/issue39467
<!-- /issue-number -->
