### PR TITLE
bpo-38631: Avoid Py_FatalError() in PyModule_Create2()

### DIFF
--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -173,8 +173,11 @@ _add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
 PyObject *
 PyModule_Create2(struct PyModuleDef* module, int module_api_version)
 {
-    if (!_PyImport_IsInitialized(_PyInterpreterState_Get()))
-        Py_FatalError("Python import machinery not initialized");
+    if (!_PyImport_IsInitialized(_PyInterpreterState_Get())) {
+        PyErr_SetString(PyExc_SystemError,
+                        "Python import machinery not initialized");
+        return NULL;
+    }
     return _PyModule_CreateInitialized(module, module_api_version);
 }
 


### PR DESCRIPTION
If PyModule_Create2() is called when the Python import machinery is
not initialized, it now raises a SystemError and returns NULL,
instead of calling Py_FatalError() which aborts the process.

The caller must be prepared to handle NULL anyway.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38631](https://bugs.python.org/issue38631) -->
https://bugs.python.org/issue38631
<!-- /issue-number -->
