### PR TITLE
gh-83650: Support relative home paths for pyvenv.cfg

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -487,6 +487,8 @@ def venv(known_paths):
                     if key == 'include-system-site-packages':
                         system_site = value.lower()
                     elif key == 'home':
+                        if value.startswith('.'):
+                            value = os.path.join(os.path.dirname(virtual_conf), value)
                         sys._home = value
 
         sys.prefix = sys.exec_prefix = site_prefix

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -787,7 +787,14 @@ calculate_pyvenv_file(PyCalculatePath *calculate,
         return status;
     }
     if (home) {
-        wcscpy_s(argv0_path, argv0_path_len, home);
+        if (home[0] == '.') {
+            /* Home path is relative to directory of pyvenv.cfg file */
+            reduce(filename);
+            join(filename, home);
+            wcscpy_s(argv0_path, argv0_path_len, filename);
+        } else {
+            wcscpy_s(argv0_path, argv0_path_len, home);
+        }
         PyMem_RawFree(home);
     }
     fclose(env_file);


### PR DESCRIPTION
Currently, the interpreter only supports absolute paths for the 'home' directory in the pyvenv.cfg file.  While this works when the interpreter is always installed at a fixed location, it impacts the portability of virtual environments and can make it notably more-difficult if multiple virtual environments are shipped with a shared interpreter and are intended to be portable and working in any directory.

Many of these issues can be solved for if 'home' can use a directory relative to the directory of the pyvenv.cfg file.  This is detected by the presence of a starting '.' in the value.

A common use-case for this is that a script-based tool (e.g. black or supervisor) may be shipped with a larger portable application where they are intended to share the same interpreter (to save on deployment size), but may have conflicting dependencies.  Since the application only depends on the executable scripts, those packages could be packaged into their own virtual environments with their dependencies.


<!-- issue-number: [bpo-39469](https://bugs.python.org/issue39469) -->
https://bugs.python.org/issue39469
<!-- /issue-number -->


<!-- gh-issue-number: gh-83650 -->
* Issue: gh-83650
<!-- /gh-issue-number -->
