### PR TITLE
bpo-38631: Avoid Py_FatalError() in _memory_release()

### DIFF
--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1048,7 +1048,8 @@ _memory_release(PyMemoryViewObject *self)
         return -1;
     }
 
-    Py_FatalError("_memory_release(): negative export count");
+    PyErr_SetString(PyExc_SystemError,
+                    "_memory_release(): negative export count");
     return -1;
 }
 


### PR DESCRIPTION
If the export count is negative, _memory_release() now raises a
SystemError and returns -1, rather than calling Py_FatalError()
which aborts the process.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38631](https://bugs.python.org/issue38631) -->
https://bugs.python.org/issue38631
<!-- /issue-number -->
