### PR TITLE
bpo-39470: Indicate that ``os.makedirs`` is equivalent to ``Path.mkdir``

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1155,6 +1155,7 @@ os and os.path                         pathlib
 :func:`os.path.abspath`                :meth:`Path.resolve`
 :func:`os.chmod`                       :meth:`Path.chmod`
 :func:`os.mkdir`                       :meth:`Path.mkdir`
+:func:`os.makedirs`                    :meth:`Path.mkdir`
 :func:`os.rename`                      :meth:`Path.rename`
 :func:`os.replace`                     :meth:`Path.replace`
 :func:`os.rmdir`                       :meth:`Path.rmdir`

--- a/Misc/NEWS.d/next/Documentation/2020-01-27-21-53-30.bpo-39470.Jaa8qb.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-27-21-53-30.bpo-39470.Jaa8qb.rst
@@ -1,0 +1,1 @@
+:func:`os.makedirs` is equivalent to ``mkdir -p`` and :meth:`Path.mkdir()` when given an optional *exist_ok* argument.

--- a/Misc/NEWS.d/next/Documentation/2020-01-27-21-53-30.bpo-39470.Jaa8qb.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-27-21-53-30.bpo-39470.Jaa8qb.rst
@@ -1,1 +1,0 @@
-:func:`os.makedirs` is equivalent to ``mkdir -p`` and :meth:`Path.mkdir()` when given an optional *exist_ok* argument.


### PR DESCRIPTION
:func:`os.makedirs` is equivalent to ``mkdir -p`` and :meth:`Path.mkdir()` when given an optional
*exist_ok* argument.

<!-- issue-number: [bpo-39470](https://bugs.python.org/issue39470) -->
https://bugs.python.org/issue39470
<!-- /issue-number -->
