### PR TITLE
bpo-39153: Clarify refcounting semantics

### DIFF
--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -62,7 +62,7 @@ Dictionary Objects
 
 .. c:function:: int PyDict_SetItem(PyObject *p, PyObject *key, PyObject *val)
 
-   Insert *value* into the dictionary *p* with a key of *key*.  *key* must be
+   Insert *val* into the dictionary *p* with a key of *key*.  *key* must be
    :term:`hashable`; if it isn't, :exc:`TypeError` will be raised. Return
    ``0`` on success or ``-1`` on failure.  This function *does not* steal a
    reference to *val*.
@@ -72,7 +72,7 @@ Dictionary Objects
 
    .. index:: single: PyUnicode_FromString()
 
-   Insert *value* into the dictionary *p* using *key* as a key. *key* should
+   Insert *val* into the dictionary *p* using *key* as a key. *key* should
    be a :c:type:`const char\*`.  The key object is created using
    ``PyUnicode_FromString(key)``.  Return ``0`` on success or ``-1`` on
    failure.  This function *does not* steal a reference to *val*.

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -64,7 +64,8 @@ Dictionary Objects
 
    Insert *value* into the dictionary *p* with a key of *key*.  *key* must be
    :term:`hashable`; if it isn't, :exc:`TypeError` will be raised. Return
-   ``0`` on success or ``-1`` on failure.
+   ``0`` on success or ``-1`` on failure.  This function *does not* steal a
+   reference to *val*.
 
 
 .. c:function:: int PyDict_SetItemString(PyObject *p, const char *key, PyObject *val)
@@ -74,7 +75,7 @@ Dictionary Objects
    Insert *value* into the dictionary *p* using *key* as a key. *key* should
    be a :c:type:`const char\*`.  The key object is created using
    ``PyUnicode_FromString(key)``.  Return ``0`` on success or ``-1`` on
-   failure.
+   failure.  This function *does not* steal a reference to *val*.
 
 
 .. c:function:: int PyDict_DelItem(PyObject *p, PyObject *key)

--- a/Doc/c-api/mapping.rst
+++ b/Doc/c-api/mapping.rst
@@ -37,7 +37,8 @@ See also :c:func:`PyObject_GetItem`, :c:func:`PyObject_SetItem` and
 
    Map the string *key* to the value *v* in object *o*.  Returns ``-1`` on
    failure.  This is the equivalent of the Python statement ``o[key] = v``.
-   See also :c:func:`PyObject_SetItem`.
+   See also :c:func:`PyObject_SetItem`.  This function *does not* steal a
+   reference to *v*.
 
 
 .. c:function:: int PyMapping_DelItem(PyObject *o, PyObject *key)

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -331,7 +331,8 @@ Object Protocol
 
    Map the object *key* to the value *v*.  Raise an exception and
    return ``-1`` on failure; return ``0`` on success.  This is the
-   equivalent of the Python statement ``o[key] = v``.
+   equivalent of the Python statement ``o[key] = v``.  This function *does
+   not* steal a reference to *v*.
 
 
 .. c:function:: int PyObject_DelItem(PyObject *o, PyObject *key)

--- a/Misc/NEWS.d/next/Documentation/2020-01-27-22-24-51.bpo-39153.Pjl8jV.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-27-22-24-51.bpo-39153.Pjl8jV.rst
@@ -1,0 +1,5 @@
+Clarify refcounting semantics for the following functions:
+ - PyObject_SetItem
+- PyMapping_SetItemString
+- PyDict_SetItem
+- PyDict_SetItemString

--- a/Misc/NEWS.d/next/Documentation/2020-01-27-22-24-51.bpo-39153.Pjl8jV.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-27-22-24-51.bpo-39153.Pjl8jV.rst
@@ -1,5 +1,5 @@
 Clarify refcounting semantics for the following functions:
- - PyObject_SetItem
+- PyObject_SetItem
 - PyMapping_SetItemString
 - PyDict_SetItem
 - PyDict_SetItemString


### PR DESCRIPTION
Clarify refcounting semantics for the following functions:

* PyObject_SetItem
* PyMapping_SetItemString
* PyDict_SetItem
* PyDict_SetItemString

<!-- issue-number: [bpo-39153](https://bugs.python.org/issue39153) -->
https://bugs.python.org/issue39153
<!-- /issue-number -->
