### PR TITLE
bpo-39392: Turtle overlap fill depends on OS

### DIFF
--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -1051,6 +1051,11 @@ Filling
 
    Fill the shape drawn after the last call to :func:`begin_fill`.
 
+   Whether or not overlap regions for self-intersecting polygons
+   or multiple shapes are filled depends on the operating system graphics,
+   type of overlap, and number of overlaps.  For example, the Turtle star
+   above may be either all yellow or have some white regions.
+
    .. doctest::
       :skipif: _tkinter is None
 

--- a/Misc/NEWS.d/next/Documentation/2020-01-27-18-18-42.bpo-39392.oiqcLO.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-27-18-18-42.bpo-39392.oiqcLO.rst
@@ -1,0 +1,1 @@
+Explain that when filling with turtle, overlap regions may be left unfilled.


### PR DESCRIPTION
Whether or not overlap regions for self-intersecting polygons
or multiple shapes are filled depends on the operating system graphics,
typeof overlap, and number of overlaps.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39392](https://bugs.python.org/issue39392) -->
https://bugs.python.org/issue39392
<!-- /issue-number -->
