### PR TITLE
bpo-39440: Update sum comment.

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2440,7 +2440,11 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
              empty = []
              sum([[x] for x in range(10)], empty)
 
-           would change the value of empty. */
+           would change the value of empty. In fact, using
+           in-place addition rather that binary addition for
+           any of the steps introduces subtle behavior changes:
+           
+           https://bugs.python.org/issue18305 */
         temp = PyNumber_Add(result, item);
         Py_DECREF(result);
         Py_DECREF(item);


### PR DESCRIPTION
Broken `sum`-speedup ideas have surfaced twice over the last few days. At least one was based on this comment, which leads contributors to believe that using in-place addition for later iterations should be fine.

I'm just updating the comment with a link to the previous discussion to avoid further confusion and misguided efforts.

<!-- issue-number: [bpo-39440](https://bugs.python.org/issue39440) -->
https://bugs.python.org/issue39440
<!-- /issue-number -->
