### PR TITLE
bpo-39459: include missing test files in windows installer too

### DIFF
--- a/PCbuild/lib.pyproj
+++ b/PCbuild/lib.pyproj
@@ -1125,6 +1125,8 @@
     <Compile Include="test\test_import\data\package\submodule.py" />
     <Compile Include="test\test_import\data\package2\submodule1.py" />
     <Compile Include="test\test_import\data\package2\submodule2.py" />
+    <Compile Include="test\test_import\data\unwritable\__init__.py" />
+    <Compile Include="test\test_import\data\unwritable\x.py" />
     <Compile Include="test\test_import\__init__.py" />
     <Compile Include="test\test_import\__main__.py" />
     <Compile Include="test\test_index.py" />


### PR DESCRIPTION
Some test files were missing, this adds them to the Windows installer.


<!-- issue-number: [bpo-39459](https://bugs.python.org/issue39459) -->
https://bugs.python.org/issue39459
<!-- /issue-number -->
