### PR TITLE
bpo-37860: Update netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
     base = "Doc/"
     command = "make html"
-    publish = "Doc/build/html"
+    publish = "build/html"


### PR DESCRIPTION
Testing netlify, attempts to deploy "Doc/Doc/build/html" and fails with error:

```
4:21:33 PM: failed during stage 'building site': Deploy directory 'Doc/Doc/build/html' does not exist
```

Despite netlify docs saying "If a base directory has been specified, include it in the publish directory path." for the publish key.

Opening this PR to test if this resolves the issue... and test the preview hook.

<!-- issue-number: [bpo-37860](https://bugs.python.org/issue37860) -->
https://bugs.python.org/issue37860
<!-- /issue-number -->
