### PR TITLE
bpo-39460: Disable test_zipfile.test_add_file_after_2107()

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -609,6 +609,10 @@ class StoredTestsWithSourceFile(AbstractTestsWithSourceFile,
             zinfo = zipfp.getinfo(TESTFN)
             self.assertEqual(zinfo.date_time, (1980, 1, 1, 0, 0, 0))
 
+    # Disable the test because it fails on Fedora Rawhide with XFS filesystem
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1795576
+    # https://bugs.python.org/issue39460#msg360952
+    @unittest.skipIf(True, "FIXME: bpo-39460: VFS and/or XFS bug")
     def test_add_file_after_2107(self):
         # Set atime and mtime to 2108-12-30
         try:

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -609,16 +609,24 @@ class StoredTestsWithSourceFile(AbstractTestsWithSourceFile,
             zinfo = zipfp.getinfo(TESTFN)
             self.assertEqual(zinfo.date_time, (1980, 1, 1, 0, 0, 0))
 
-    # Disable the test because it fails on Fedora Rawhide with XFS filesystem
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1795576
-    # https://bugs.python.org/issue39460#msg360952
-    @unittest.skipIf(True, "FIXME: bpo-39460: VFS and/or XFS bug")
     def test_add_file_after_2107(self):
         # Set atime and mtime to 2108-12-30
         try:
             os.utime(TESTFN, (4386268800, 4386268800))
         except OverflowError:
             self.skipTest('Host fs cannot set timestamp to required value.')
+
+        mtime_ns = os.stat(TESTFN).st_mtime_ns
+        if mtime_ns != (4386268800 * 10**9):
+            # XFS filesystem is limited to 32-bit timestamp, but the syscall
+            # didn't fail. Moreover, there is a VFS bug which returns
+            # a cached timestamp which is different than the value on disk.
+            #
+            # Test st_mtime_ns rather than st_mtime to avoid rounding issues.
+            #
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1795576
+            # https://bugs.python.org/issue39460#msg360952
+            self.skipTest(f"Linux VFS/XFS kernel bug detected: {mtime_ns=}")
 
         with zipfile.ZipFile(TESTFN2, "w") as zipfp:
             self.assertRaises(struct.error, zipfp.write, TESTFN)


### PR DESCRIPTION
Disable the test because it fails on Fedora Rawhide with XFS
filesystem.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39460](https://bugs.python.org/issue39460) -->
https://bugs.python.org/issue39460
<!-- /issue-number -->
