### PR TITLE
bpo-39485: fix corner-case in method-detection of mock

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2748,7 +2748,7 @@ def _must_skip(spec, entry, is_type):
             continue
         if isinstance(result, (staticmethod, classmethod)):
             return False
-        elif isinstance(getattr(result, '__get__', None), MethodWrapperTypes):
+        elif isinstance(result, FunctionTypes):
             # Normal method => skip if looked up on type
             # (if looked up on instance, self is already skipped)
             return is_type
@@ -2776,10 +2776,6 @@ FunctionTypes = (
     type(create_autospec),
     # instance method
     type(ANY.__eq__),
-)
-
-MethodWrapperTypes = (
-    type(ANY.__eq__.__get__),
 )
 
 

--- a/Misc/NEWS.d/next/Library/2020-01-29-14-58-27.bpo-39485.Zy3ot6.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-29-14-58-27.bpo-39485.Zy3ot6.rst
@@ -1,0 +1,3 @@
+Fix a bug in :func:`unittest.mock.create_autospec` that would complain about
+the wrong number of arguments for custom descriptors defined in an extension
+module returning functions.


### PR DESCRIPTION
As described in the issue, replace check for whether something is a method in the mock module. The
previous version fails on PyPy, because there no method wrappers exist (everything looks like a regular Python-defined function). Thus the `isinstance(getattr(result, '__get__', None), MethodWrapperTypes)` check returns `True` for any descriptor, not just methods.

This condition could also return erronously `True` in CPython for C-defined descriptors.

Instead to decide whether something is a method, just check directly whether it's a function defined on the class. This passes all tests on CPython and fixes the bug on PyPy.

/cc @cjw296

<!-- issue-number: [bpo-39485](https://bugs.python.org/issue39485) -->
https://bugs.python.org/issue39485
<!-- /issue-number -->
