### PR TITLE
bpo-39493: Fix definition of IO.closed in typing.py

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1831,6 +1831,7 @@ class IO(Generic[AnyStr]):
     def close(self) -> None:
         pass
 
+    @property
     @abstractmethod
     def closed(self) -> bool:
         pass

--- a/Misc/NEWS.d/next/Library/2020-01-30-01-13-19.bpo-39493.CbFRi7.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-30-01-13-19.bpo-39493.CbFRi7.rst
@@ -1,0 +1,1 @@
+Mark ``typing.IO.closed`` as a property


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39493](https://bugs.python.org/issue39493) -->
https://bugs.python.org/issue39493
<!-- /issue-number -->
