### PR TITLE
bpo-39492: Fix a reference cycle between reducer_override and a Pickler instance

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3499,6 +3499,37 @@ class AbstractHookTests(unittest.TestCase):
                         ValueError, 'The reducer just failed'):
                     p.dump(h)
 
+    def test_reducer_override_no_reference_cycle(self):
+        # bpo-39492: reducer_override used to induce a spurious reference cycle
+        # inside the Pickler object, that could prevent all serialized objects
+        # from being garbage-collected without explicity invoking gc.collect.
+
+        for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(proto=proto):
+                def f():
+                    pass
+
+                collect = threading.Event()
+                _ = weakref.ref(f, lambda obj: collect.set())
+
+                bio = io.BytesIO()
+                p = self.pickler_class(bio, proto)
+                p.dump(f)
+                new_f = pickle.loads(bio.getvalue())
+                assert new_f == 5
+
+                del p
+                del f
+
+                # There is no reference to f anymore. If p was gc'd,  so should
+                # be f.
+                for i in range(10):
+                    collected = collect.wait(timeout=0.1)
+                    if collected:
+                        break
+
+                self.assertTrue(collected)
+
 
 class AbstractDispatchTableTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-30-01-14-42.bpo-39492.eTuy0F.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-30-01-14-42.bpo-39492.eTuy0F.rst
@@ -1,0 +1,1 @@
+Fix a reference cycle in the C Pickler that was preventing the garbage collection of deleted, pickled objects.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4455,12 +4455,13 @@ static int
 dump(PicklerObject *self, PyObject *obj)
 {
     const char stop_op = STOP;
+    int status = 0;
     PyObject *tmp;
     _Py_IDENTIFIER(reducer_override);
 
     if (_PyObject_LookupAttrId((PyObject *)self, &PyId_reducer_override,
                                &tmp) < 0) {
-        return -1;
+      goto error;
     }
     /* Cache the reducer_override method, if it exists. */
     if (tmp != NULL) {
@@ -4477,7 +4478,7 @@ dump(PicklerObject *self, PyObject *obj)
         assert(self->proto >= 0 && self->proto < 256);
         header[1] = (unsigned char)self->proto;
         if (_Pickler_Write(self, header, 2) < 0)
-            return -1;
+            goto error;
         if (self->proto >= 4)
             self->framing = 1;
     }
@@ -4485,9 +4486,15 @@ dump(PicklerObject *self, PyObject *obj)
     if (save(self, obj, 0) < 0 ||
         _Pickler_Write(self, &stop_op, 1) < 0 ||
         _Pickler_CommitFrame(self) < 0)
-        return -1;
+        goto error;
+    if (0) {
+  error:
+        status = -1;
+    }
+
     self->framing = 0;
-    return 0;
+    Py_CLEAR(self->reducer_override);
+    return status;
 }
 
 /*[clinic input]


### PR DESCRIPTION
This also needs a backport to 3.8

<!-- issue-number: [bpo-39492](https://bugs.python.org/issue39492) -->
https://bugs.python.org/issue39492
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou