### PR TITLE
bpo-39497: Remove unused variable from pysqlite_cursor_executescript

### DIFF
--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -611,7 +611,6 @@ static PyObject *
 pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
 {
     PyObject* script_obj;
-    PyObject* script_str = NULL;
     const char* script_cstr;
     sqlite3_stmt* statement;
     int rc;
@@ -685,8 +684,6 @@ pysqlite_cursor_executescript(pysqlite_Cursor* self, PyObject* args)
     }
 
 error:
-    Py_XDECREF(script_str);
-
     if (PyErr_Occurred()) {
         return NULL;
     } else {


### PR DESCRIPTION


<!-- issue-number: [bpo-39497](https://bugs.python.org/issue39497) -->
https://bugs.python.org/issue39497
<!-- /issue-number -->
