### PR TITLE
bpo-39498 Start linking the security warnings in the stdlib modules

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -80,6 +80,8 @@ library that Python uses on your platform. On most platforms the
 .. versionadded:: 3.6
    :func:`blake2b` and :func:`blake2s` were added.
 
+.. _hashlib-usedforsecurity:
+
 .. versionchanged:: 3.9
    All hashlib constructors take a keyword-only argument *usedforsecurity*
    with default value ``True``. A false value allows the use of insecure and

--- a/Doc/library/index.rst
+++ b/Doc/library/index.rst
@@ -75,3 +75,4 @@ the `Python Package Index <https://pypi.org>`_.
    unix.rst
    superseded.rst
    undoc.rst
+   security_warnings.rst

--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -152,6 +152,8 @@ in :mod:`logging` itself) and defining handlers which are declared either in
    send it to the socket as a sequence of bytes preceded by a four-byte length
    string packed in binary using ``struct.pack('>L', n)``.
 
+   .. _logging-eval-security:
+
    .. note::
 
       Because portions of the configuration are passed through

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1187,6 +1187,7 @@ For example:
     >>> arr2
     array('i', [0, 1, 2, 3, 4, 0, 0, 0, 0, 0])
 
+.. _multiprocessing-recv-pickle-security:
 
 .. warning::
 

--- a/Doc/library/security_warnings.rst
+++ b/Doc/library/security_warnings.rst
@@ -1,0 +1,14 @@
+.. _security-warnings:
+
+.. index:: single: security considerations
+
+Security Considerations
+=======================
+
+The following modules have specific security considerations:
+
+* :mod:`ssl` : :ref:`SSL/TLS security considerations <ssl-security>`
+* :mod:`cgi` : :ref:`CGI security considerations <cgi-security>`
+* :mod:`pickle` : :ref:`Restricting globals in pickle <pickle-restrict>`
+* :mod:`subprocess` : :ref:`Subprocess security considerations <subprocess-security>`
+* :mod:`xml` : :ref:`XML vulnerabilities <xml-vulnerabilities>`

--- a/Doc/library/security_warnings.rst
+++ b/Doc/library/security_warnings.rst
@@ -7,8 +7,22 @@ Security Considerations
 
 The following modules have specific security considerations:
 
-* :mod:`ssl` : :ref:`SSL/TLS security considerations <ssl-security>`
-* :mod:`cgi` : :ref:`CGI security considerations <cgi-security>`
-* :mod:`pickle` : :ref:`Restricting globals in pickle <pickle-restrict>`
-* :mod:`subprocess` : :ref:`Subprocess security considerations <subprocess-security>`
-* :mod:`xml` : :ref:`XML vulnerabilities <xml-vulnerabilities>`
+* :mod:`cgi`: :ref:`CGI security considerations <cgi-security>`
+* :mod:`hashlib`: :ref:`all constructors take a "usedforsecurity" keyword-only
+  argument disabling known insecure and blocked algorithms
+  <hashlib-usedforsecurity>`
+* :mod:`http.server` is not suitable for production use, only implementing
+  basic security checks
+* :mod:`logging`: :ref:`Logging configuration uses eval()
+  <logging-eval-security>`
+* :mod:`multiprocessing`: :ref:`Connection.recv() uses pickle
+  <multiprocessing-recv-pickle-security>`
+* :mod:`pickle`: :ref:`Restricting globals in pickle <pickle-restrict>`
+* :mod:`random` shouldn't be used for security purposes, use :mod:`secrets`
+  instead
+* :mod:`ssl`: :ref:`SSL/TLS security considerations <ssl-security>`
+* :mod:`subprocess`: :ref:`Subprocess security considerations
+  <subprocess-security>`
+* :mod:`xml`: :ref:`XML vulnerabilities <xml-vulnerabilities>`
+* :mod:`zipfile`: :ref:`maliciously prepared .zip files can cause disk volume
+  exhaustion <zipfile-resources-limitations>`

--- a/Doc/library/security_warnings.rst
+++ b/Doc/library/security_warnings.rst
@@ -20,9 +20,13 @@ The following modules have specific security considerations:
 * :mod:`pickle`: :ref:`Restricting globals in pickle <pickle-restrict>`
 * :mod:`random` shouldn't be used for security purposes, use :mod:`secrets`
   instead
+* :mod:`shelve`: :ref:`shelve is based on pickle and thus unsuitable for
+  dealing with untrusted sources <shelve-security>`
 * :mod:`ssl`: :ref:`SSL/TLS security considerations <ssl-security>`
 * :mod:`subprocess`: :ref:`Subprocess security considerations
   <subprocess-security>`
+* :mod:`tempfile`: :ref:`mktemp is deprecated due to vulnerability to race
+  conditions <tempfile-mktemp-deprecated>`
 * :mod:`xml`: :ref:`XML vulnerabilities <xml-vulnerabilities>`
 * :mod:`zipfile`: :ref:`maliciously prepared .zip files can cause disk volume
   exhaustion <zipfile-resources-limitations>`

--- a/Doc/library/shelve.rst
+++ b/Doc/library/shelve.rst
@@ -54,6 +54,8 @@ lots of shared  sub-objects.  The keys are ordinary strings.
           with shelve.open('spam') as db:
               db['eggs'] = 'eggs'
 
+.. _shelve-security:
+
 .. warning::
 
    Because the :mod:`shelve` module is backed by :mod:`pickle`, it is insecure

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -710,6 +710,7 @@ Exceptions defined in this module all inherit from :exc:`SubprocessError`.
    .. versionadded:: 3.3
       The :exc:`SubprocessError` base class was added.
 
+.. _subprocess-security:
 
 Security Considerations
 -----------------------

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -344,6 +344,7 @@ Here are some examples of typical usage of the :mod:`tempfile` module::
     >>>
     # directory and contents have been removed
 
+.. _tempfile-mktemp-deprecated:
 
 Deprecated functions and variables
 ----------------------------------

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -886,6 +886,8 @@ Exceeding limitations on different file systems can cause decompression failed.
 Such as allowable characters in the directory entries, length of the file name,
 length of the pathname, size of a single file, and number of files, etc.
 
+.. _zipfile-resources-limitations:
+
 Resources limitations
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/Misc/NEWS.d/next/Documentation/2020-01-30-05-18-48.bpo-39498.Nu3sFL.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-30-05-18-48.bpo-39498.Nu3sFL.rst
@@ -1,0 +1,1 @@
+Add a "Security Considerations" index linking to standard library modules that have explicitly documented security considerations.

--- a/Misc/NEWS.d/next/Documentation/2020-01-30-05-18-48.bpo-39498.Nu3sFL.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-30-05-18-48.bpo-39498.Nu3sFL.rst
@@ -1,1 +1,1 @@
-Add a "Security Considerations" index linking to standard library modules that have explicitly documented security considerations.
+Add a "Security Considerations" index which links to standard library modules that have explicitly documented security considerations.


### PR DESCRIPTION
Within the documentation, there are some really important security considerations for standard library modules. e.g. subprocess, ssl, pickle, xml.

There is currently no "index" of these, so you have to go hunting for them. They're easter eggs within the docs. There isn't a unique admonition type either, so you have to search across many criteria.

In particular for security researchers, it would be useful to consolidate and signpost these security best-practices in one index.

This PR links to some of the existing ones that I found.

<!-- issue-number: [bpo-39498](https://bugs.python.org/issue39498) -->
https://bugs.python.org/issue39498
<!-- /issue-number -->
