### PR TITLE
bpo-39353: binascii.crc_hqx() is no longer deprecated

### DIFF
--- a/Doc/library/binascii.rst
+++ b/Doc/library/binascii.rst
@@ -132,8 +132,6 @@ The :mod:`binascii` module defines the following functions:
    *x*:sup:`16` + *x*:sup:`12` + *x*:sup:`5` + 1, often represented as
    0x1021.  This CRC is used in the binhex4 format.
 
-   .. deprecated:: 3.9
-
 
 .. function:: crc32(data[, value])
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -379,7 +379,6 @@ Deprecated
 
   * :func:`~binascii.b2a_hqx`, :func:`~binascii.a2b_hqx`
   * :func:`~binascii.rlecode_hqx`, :func:`~binascii.rledecode_hqx`
-  * :func:`~binascii.crc_hqx`
 
   (Contributed by Victor Stinner in :issue:`39353`.)
 

--- a/Lib/binhex.py
+++ b/Lib/binhex.py
@@ -200,8 +200,7 @@ class BinHex:
         self._writecrc()
 
     def _write(self, data):
-        with _ignore_deprecation_warning():
-            self.crc = binascii.crc_hqx(data, self.crc)
+        self.crc = binascii.crc_hqx(data, self.crc)
         self.ofp.write(data)
 
     def _writecrc(self):
@@ -396,8 +395,7 @@ class HexBin:
 
     def _read(self, len):
         data = self.ifp.read(len)
-        with _ignore_deprecation_warning():
-            self.crc = binascii.crc_hqx(data, self.crc)
+        self.crc = binascii.crc_hqx(data, self.crc)
         return data
 
     def _checkcrc(self):

--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -435,9 +435,6 @@ class BinASCIITest(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(binascii.rledecode_hqx(b'a\x90\n'), b'a' * 10)
 
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(binascii.crc_hqx(b'abc', 0), 40406)
-
 
 class ArrayBinASCIITest(BinASCIITest):
     def type2test(self, s):

--- a/Misc/NEWS.d/next/Library/2020-01-30-09-07-16.bpo-39353.wTl9hc.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-30-09-07-16.bpo-39353.wTl9hc.rst
@@ -1,0 +1,1 @@
+The :func:`binascii.crc_hqx` function is no longer deprecated.

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -965,11 +965,6 @@ static PyObject *
 binascii_crc_hqx_impl(PyObject *module, Py_buffer *data, unsigned int crc)
 /*[clinic end generated code: output=2fde213d0f547a98 input=56237755370a951c]*/
 {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                     "binascii.crc_hqx() is deprecated", 1) < 0) {
-        return NULL;
-    }
-
     const unsigned char *bin_data;
     Py_ssize_t len;
 


### PR DESCRIPTION
The binascii.crc_hqx() function is no longer deprecated.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39353](https://bugs.python.org/issue39353) -->
https://bugs.python.org/issue39353
<!-- /issue-number -->
