### PR TITLE
bpo-39424: Fix the call method.

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1289,7 +1289,7 @@ class PidfdSignalTest(unittest.TestCase):
         self.assertEqual(cm.exception.errno, errno.EBADF)
         my_pidfd = os.open(f'/proc/{os.getpid()}', os.O_DIRECTORY)
         self.addCleanup(os.close, my_pidfd)
-        with self.assertRaisesRegexp(TypeError, "^siginfo must be None$"):
+        with self.assertRaisesRegex(TypeError, "^siginfo must be None$"):
             signal.pidfd_send_signal(my_pidfd, signal.SIGINT, object(), 0)
         with self.assertRaises(KeyboardInterrupt):
             signal.pidfd_send_signal(my_pidfd, signal.SIGINT)


### PR DESCRIPTION
The method assertRaisesRegexp is deprecated use assertRaisesRegex
instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39424](https://bugs.python.org/issue39424) -->
https://bugs.python.org/issue39424
<!-- /issue-number -->
