### PR TITLE
bpo-38631: Add _Py_NO_RETURN to functions calling Py_FatalError()

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -443,7 +443,7 @@ _PyObject_DebugTypeStats(FILE *out);
    NDEBUG against a Python built with NDEBUG defined.
 
    msg, expr and function can be NULL. */
-PyAPI_FUNC(void) _PyObject_AssertFailed(
+PyAPI_FUNC(void) _Py_NO_RETURN _PyObject_AssertFailed(
     PyObject *obj,
     const char *expr,
     const char *msg,

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1065,24 +1065,10 @@ faulthandler_sigsegv(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
-static void
+static void _Py_NO_RETURN
 faulthandler_fatal_error_thread(void *plock)
 {
-#ifndef __clang__
-    PyThread_type_lock *lock = (PyThread_type_lock *)plock;
-#endif
-
     Py_FatalError("in new thread");
-
-#ifndef __clang__
-    /* Issue #28152: Py_FatalError() is declared with
-       __attribute__((__noreturn__)).  GCC emits a warning without
-       "PyThread_release_lock()" (compiler bug?), but Clang is smarter and
-       emits a warning on the return. */
-
-    /* notify the caller that we are done */
-    PyThread_release_lock(lock);
-#endif
 }
 
 static PyObject *

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1646,7 +1646,7 @@ none_repr(PyObject *op)
 }
 
 /* ARGUSED */
-static void
+static void _Py_NO_RETURN
 none_dealloc(PyObject* ignore)
 {
     /* This should never get called, but we also don't want to SEGV if
@@ -1784,7 +1784,7 @@ notimplemented_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     Py_RETURN_NOTIMPLEMENTED;
 }
 
-static void
+static void _Py_NO_RETURN
 notimplemented_dealloc(PyObject* ignore)
 {
     /* This should never get called, but we also don't want to SEGV if
@@ -2225,7 +2225,7 @@ _PyTrash_thread_destroy_chain(void)
 }
 
 
-void
+void _Py_NO_RETURN
 _PyObject_AssertFailed(PyObject *obj, const char *expr, const char *msg,
                        const char *file, int line, const char *function)
 {

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2529,7 +2529,7 @@ dummy_repr(PyObject *op)
     return PyUnicode_FromString("<dummy key>");
 }
 
-static void
+static void _Py_NO_RETURN
 dummy_dealloc(PyObject* ignore)
 {
     Py_FatalError("deallocating <dummy key>");


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38631](https://bugs.python.org/issue38631) -->
https://bugs.python.org/issue38631
<!-- /issue-number -->
