### PR TITLE
bpo-39502: Skip test_zipfile.test_add_file_after_2107() on AIX

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -611,8 +611,13 @@ class StoredTestsWithSourceFile(AbstractTestsWithSourceFile,
 
     def test_add_file_after_2107(self):
         # Set atime and mtime to 2108-12-30
+        ts = 4386268800
         try:
-            os.utime(TESTFN, (4386268800, 4386268800))
+            time.localtime(ts)
+        except OverflowError:
+            self.skipTest(f'time.localtime({ts}) raises OverflowError')
+        try:
+            os.utime(TESTFN, (ts, ts))
         except OverflowError:
             self.skipTest('Host fs cannot set timestamp to required value.')
 

--- a/Misc/NEWS.d/next/Tests/2020-01-30-15-04-54.bpo-39502.chbpII.rst
+++ b/Misc/NEWS.d/next/Tests/2020-01-30-15-04-54.bpo-39502.chbpII.rst
@@ -1,0 +1,2 @@
+Skip test_zipfile.test_add_file_after_2107() if :func:`time.localtime` fails
+with :exc:`OverflowError`. It is the case on AIX 6.1 for example.


### PR DESCRIPTION
Skip test_zipfile.test_add_file_after_2107() if time.localtime()
fails with OverflowError. It is the case on AIX 6.1 for example.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39502](https://bugs.python.org/issue39502) -->
https://bugs.python.org/issue39502
<!-- /issue-number -->
