### PR TITLE
bpo-39502: Fix 64-bit Python PyTime_localtime() on AIX 

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-30-14-36-31.bpo-39502.IJu0rl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-30-14-36-31.bpo-39502.IJu0rl.rst
@@ -1,2 +1,2 @@
-Fix :func:`time.localtime` on 64-bit AIX  to support years before 1902 and after 2038
-Patch by M Felt
+Fix :func:`time.localtime` on 64-bit AIX  to support years before 1902 and after 2038.
+Patch by M Felt.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-30-14-36-31.bpo-39502.IJu0rl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-30-14-36-31.bpo-39502.IJu0rl.rst
@@ -1,0 +1,2 @@
+Fix :func:`time.localtime` on 64-bit AIX  to support years before 1902 and after 2038
+Patch by M Felt

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1059,7 +1059,7 @@ _PyTime_localtime(time_t t, struct tm *tm)
     return 0;
 #else /* !MS_WINDOWS */
 
-#ifdef _AIX
+#if defined(_AIX) && (SIZEOF_TIME_T == 4)
     /* bpo-34373: AIX does not return NULL if t is too small or too large */
     if (t < -2145916800 /* 1902-01-01 */
        || t > 2145916800 /* 2038-01-01 */) {

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1059,7 +1059,7 @@ _PyTime_localtime(time_t t, struct tm *tm)
     return 0;
 #else /* !MS_WINDOWS */
 
-#if defined(_AIX) && (SIZEOF_TIME_T == 4)
+#if defined(_AIX) && (SIZEOF_TIME_T < 8)
     /* bpo-34373: AIX does not return NULL if t is too small or too large */
     if (t < -2145916800 /* 1902-01-01 */
        || t > 2145916800 /* 2038-01-01 */) {


### PR DESCRIPTION
so that only 32-bit is range tested for overflow

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39502](https://bugs.python.org/issue39502) -->
https://bugs.python.org/issue39502
<!-- /issue-number -->
