### PR TITLE
bpo-39505: delete the redundant '/' in $env:VIRTUAL_ENV

### DIFF
--- a/Lib/venv/scripts/common/Activate.ps1
+++ b/Lib/venv/scripts/common/Activate.ps1
@@ -168,7 +168,6 @@ if ($VenvDir) {
 } else {
     Write-Verbose "VenvDir not given as a parameter, using parent directory name as VenvDir."
     $VenvDir = $VenvExecDir.Parent.FullName.TrimEnd("\\/")
-    $VenvDir = $VenvDir.Insert($VenvDir.Length, "/")
     Write-Verbose "VenvDir=$VenvDir"
 }
 

--- a/Misc/NEWS.d/next/Library/2020-01-31-09-32-19.bpo-39505.drA2Qa.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-31-09-32-19.bpo-39505.drA2Qa.rst
@@ -1,0 +1,5 @@
+When windows users use "python -m venv ENV_DIR", a python virtual environment will be created in ENV_DIR.
+Powershell users use ENV_DIR\Scripts\Activate.ps1 to activate virtual environment.
+In powershell, a environment variable, "$env:VIRTUAL_ENV", is set and used by many tools to determine that there is an activated venv. In bash, it is "$VIRTUAL_ENV"
+In python3.8 and python3.9, $env:VIRTUAL_ENV has a redundant '/' in the end.
+This '/' matters because many tools use this environment variable, for example, oh-my-posh will take "test_venv/" as virtual environment name rather than "test_venv"(Although venv's activate.ps1 itself's default prompt is correct). And from the perspective of semantics and consistency with other platform, the '/' is redundant.

--- a/Misc/NEWS.d/next/Library/2020-01-31-09-32-19.bpo-39505.drA2Qa.rst
+++ b/Misc/NEWS.d/next/Library/2020-01-31-09-32-19.bpo-39505.drA2Qa.rst
@@ -1,5 +1,0 @@
-When windows users use "python -m venv ENV_DIR", a python virtual environment will be created in ENV_DIR.
-Powershell users use ENV_DIR\Scripts\Activate.ps1 to activate virtual environment.
-In powershell, a environment variable, "$env:VIRTUAL_ENV", is set and used by many tools to determine that there is an activated venv. In bash, it is "$VIRTUAL_ENV"
-In python3.8 and python3.9, $env:VIRTUAL_ENV has a redundant '/' in the end.
-This '/' matters because many tools use this environment variable, for example, oh-my-posh will take "test_venv/" as virtual environment name rather than "test_venv"(Although venv's activate.ps1 itself's default prompt is correct). And from the perspective of semantics and consistency with other platform, the '/' is redundant.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Copy from [bpo-39505](https://bugs.python.org/issue39505)

When windows users use "python -m venv ENV_DIR", a python virtual environment will be created in ENV_DIR. 
Powershell users use ENV_DIR\Scripts\Activate.ps1 to activate virtual environment.
In powershell, a environment variable, "$env:VIRTUAL_ENV", is set and used by many tools to determine that there is an activated venv. In bash, it is "$VIRTUAL_ENV"
In python3.8 and python3.9, $env:VIRTUAL_ENV has a redundant '/', for example:
```
PS C:\Users\Test> python -m venv test_venv
PS C:\Users\Test> .\test_venv\Scripts\Activate.ps1
PS C:\Users\Test> $env:VIRTUAL_ENV
C:\Users\Test\test_venv/
```

using python3.7, or using virtualenv with python3.8 or 3.9, or in linux, there will be no such a '/' in the end.

This '/' matters because many tools use this environment variable, for example, oh-my-posh will take "test_venv/" as virtual environment name rather than "test_venv"(Although venv's activate.ps1 itself's default prompt is correct). And from the perspective of semantics and consistency with other platform, the '/' is redundant.


<!-- issue-number: [bpo-39505](https://bugs.python.org/issue39505) -->
https://bugs.python.org/issue39505
<!-- /issue-number -->
