### PR TITLE
bpo-39510: Fix use-after-free in BufferedReader.readinto()

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -737,6 +737,11 @@ class IOTest(unittest.TestCase):
             file.seek(0)
             file.close()
             self.assertRaises(ValueError, file.read)
+        with self.open(support.TESTFN, "rb") as f:
+            file = self.open(f.fileno(), "rb", closefd=False)
+            self.assertEqual(file.read()[:3], b"egg")
+            file.close()
+            self.assertRaises(ValueError, file.readinto, bytearray(1))
 
     def test_no_closefd_with_filename(self):
         # can't use closefd in combination with a file name

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-04-10-27-41.bpo-39510.PMIh-f.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-04-10-27-41.bpo-39510.PMIh-f.rst
@@ -1,0 +1,1 @@
+Fix segfault in readinto() method on closed BufferedReader.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-04-10-27-41.bpo-39510.PMIh-f.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-04-10-27-41.bpo-39510.PMIh-f.rst
@@ -1,1 +1,1 @@
-Fix segfault in readinto() method on closed BufferedReader.
+Fix segfault in ``readinto()`` method on closed BufferedReader.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -965,6 +965,7 @@ _buffered_readinto_generic(buffered *self, Py_buffer *buffer, char readinto1)
     PyObject *res = NULL;
 
     CHECK_INITIALIZED(self)
+    CHECK_CLOSED(self, "readinto of closed file")
 
     n = Py_SAFE_DOWNCAST(READAHEAD(self), Py_off_t, Py_ssize_t);
     if (n > 0) {


### PR DESCRIPTION
When called on a closed object, readinto() segfaults on account
of a write to a freed buffer:

    ==220553== Process terminating with default action of signal 11 (SIGSEGV): dumping core
    ==220553==  Access not within mapped region at address 0x2A
    ==220553==    at 0x48408A0: memmove (vg_replace_strmem.c:1272)
    ==220553==    by 0x58DB0C: _buffered_readinto_generic (bufferedio.c:972)
    ==220553==    by 0x58DCBA: _io__Buffered_readinto_impl (bufferedio.c:1053)
    ==220553==    by 0x58DCBA: _io__Buffered_readinto (bufferedio.c.h:253)

Reproducer:

    reader = open ("/dev/zero", "rb")
    _void  = reader.read (42)
    reader.close ()
    reader.readinto (bytearray (42)) ### BANG!

The problem exists since 2012 when commit dc469454ec added code
to free the read buffer on close().

Signed-off-by: Philipp Gesang <philipp.gesang@intra2net.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39510](https://bugs.python.org/issue39510) -->
https://bugs.python.org/issue39510
<!-- /issue-number -->
