### PR TITLE
bpo-37304: compiler dosen't support in(de)crement operation

### DIFF
--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -5698,7 +5698,7 @@ def _sqrt_nearest(n, a):
 
     b=0
     while a != b:
-        b, a = a, a--n//a>>1
+        b, a = a, a-n//a>>1
     return a
 
 def _rshift_nearest(x, shift):

--- a/Lib/test/sortperf.py
+++ b/Lib/test/sortperf.py
@@ -118,7 +118,7 @@ def tabulate(r):
             L = L * (n // 4)
             # Force the elements to be distinct objects, else timings can be
             # artificially low.
-            L = list(map(lambda x: --x, L))
+            L = list(map(lambda x: x, L))
         doit(L) # ~sort
         del L
 

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -902,7 +902,7 @@ Module(
         self.assertEqual(ast.literal_eval('+3.25'), 3.25)
         self.assertEqual(ast.literal_eval('-3.25'), -3.25)
         self.assertEqual(repr(ast.literal_eval('-0.0')), '-0.0')
-        self.assertRaises(ValueError, ast.literal_eval, '++6')
+        self.assertRaises(SyntaxError, ast.literal_eval, '++6')
         self.assertRaises(ValueError, ast.literal_eval, '+True')
         self.assertRaises(ValueError, ast.literal_eval, '2+3')
 

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -173,7 +173,6 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         eq('not not great')
         eq('~great')
         eq('+value')
-        eq('++value')
         eq('-1')
         eq('~int and not v1 ^ 123 + v2 | True')
         eq('a + (not b)')

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -1436,7 +1436,11 @@ class GrammarTests(unittest.TestCase):
         x = -1
         x = ~1
         x = ~1 ^ 1 & 1 | 1 & 1 ^ -1
-        x = -1*1/1 + 1*1 - ---1*1
+        check_syntax_error(self, "x = ++1")
+        check_syntax_error(self, "x = 1++")
+        check_syntax_error(self, "x = --1")
+        check_syntax_error(self, "x = 1--")
+        check_syntax_error(self, "x = -1*1/1 + 1*1 - ---1*1")
 
     def test_selectors(self):
         ### trailer: '(' [testlist] ')' | '[' subscript ']' | '.' NAME

--- a/Lib/test/test_unary.py
+++ b/Lib/test/test_unary.py
@@ -7,7 +7,6 @@ class UnaryOpTestCase(unittest.TestCase):
     def test_negative(self):
         self.assertTrue(-2 == 0 - 2)
         self.assertEqual(-0, 0)
-        self.assertEqual(--2, 2)
         self.assertTrue(-2 == 0 - 2)
         self.assertTrue(-2.0 == 0 - 2.0)
         self.assertTrue(-2j == 0 - 2j)
@@ -15,16 +14,16 @@ class UnaryOpTestCase(unittest.TestCase):
     def test_positive(self):
         self.assertEqual(+2, 2)
         self.assertEqual(+0, 0)
-        self.assertEqual(++2, 2)
         self.assertEqual(+2, 2)
         self.assertEqual(+2.0, 2.0)
         self.assertEqual(+2j, 2j)
+        self.assertRaises(SyntaxError, eval, "++2")
 
     def test_invert(self):
         self.assertTrue(-2 == 0 - 2)
         self.assertEqual(-0, 0)
-        self.assertEqual(--2, 2)
         self.assertTrue(-2 == 0 - 2)
+        self.assertRaises(SyntaxError, eval, "--2")
 
     def test_no_overflow(self):
         nines = "9" * 32

--- a/Misc/NEWS.d/next/Core and Builtins/2020-01-31-15-51-53.bpo-37304.MRdEFD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-01-31-15-51-53.bpo-37304.MRdEFD.rst
@@ -1,0 +1,2 @@
+Compiler should not support in(de)crement operation.
+It will raise a ``SyntaxError`` if user use in(de)crement operation.

--- a/Parser/token.c
+++ b/Parser/token.c
@@ -132,11 +132,13 @@ PyToken_TwoChars(int c1, int c2)
         break;
     case '+':
         switch (c2) {
+        case '+': return ERRORTOKEN;
         case '=': return PLUSEQUAL;
         }
         break;
     case '-':
         switch (c2) {
+        case '-': return ERRORTOKEN;
         case '=': return MINEQUAL;
         case '>': return RARROW;
         }

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1706,6 +1706,9 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
     {
         int c2 = tok_nextc(tok);
         int token = PyToken_TwoChars(c, c2);
+        if (token == ERRORTOKEN) {
+            return syntaxerror(tok, "invalid syntax");
+        }
         if (token != OP) {
             int c3 = tok_nextc(tok);
             int token3 = PyToken_ThreeChars(c, c2, c3);


### PR DESCRIPTION
Before(3.6 version):
![image](https://user-images.githubusercontent.com/9103416/73547512-11968f00-447a-11ea-89ae-ef4a7af64b7b.png)


After this PR merged:
![image](https://user-images.githubusercontent.com/9103416/73547559-312db780-447a-11ea-9466-0e5530d216a5.png)


<!-- issue-number: [bpo-37304](https://bugs.python.org/issue37304) -->
https://bugs.python.org/issue37304
<!-- /issue-number -->
