### PR TITLE
bpo-39020: Fix building the _curses module on AIX

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -515,7 +515,10 @@ The module :mod:`curses` defines the following functions:
 
    Retrieves the value set by :func:`set_escdelay`.
 
+   Availability: if the ncurses library is used and on NetBSD.
+
    .. versionadded:: 3.9
+
 
 .. function:: set_escdelay(ms)
 

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -262,7 +262,8 @@ class TestCurses(unittest.TestCase):
         curses.qiflush()
         curses.raw() ; curses.raw(1)
         curses.set_escdelay(25)
-        self.assertEqual(curses.get_escdelay(), 25)
+        if hasattr(curses, 'get_escdelay'):
+            self.assertEqual(curses.get_escdelay(), 25)
         curses.set_tabsize(4)
         self.assertEqual(curses.get_tabsize(), 4)
         if hasattr(curses, 'setsyx'):

--- a/Misc/NEWS.d/next/Build/2020-02-01-15-02-08.bpo-39020.TXVP6G.rst
+++ b/Misc/NEWS.d/next/Build/2020-02-01-15-02-08.bpo-39020.TXVP6G.rst
@@ -1,0 +1,2 @@
+Fixed building the :mod:`_curses` module on AIX. :func:`curses.get_escdelay`
+is not available on AIX if use native curses library.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3255,6 +3255,7 @@ _curses_setupterm_impl(PyObject *module, const char *term, int fd)
     Py_RETURN_NONE;
 }
 
+#if !defined(_AIX) || defined(NCURSES_VERSION)
 /*[clinic input]
 _curses.get_escdelay
 
@@ -3271,6 +3272,8 @@ _curses_get_escdelay_impl(PyObject *module)
 {
     return PyLong_FromLong(ESCDELAY);
 }
+#endif /* !defined(_AIX) || defined(NCURSES_VERSION) */
+
 /*[clinic input]
 _curses.set_escdelay
     ms: int

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -3040,6 +3040,8 @@ exit:
     return return_value;
 }
 
+#if (!defined(_AIX) || defined(NCURSES_VERSION))
+
 PyDoc_STRVAR(_curses_get_escdelay__doc__,
 "get_escdelay($module, /)\n"
 "--\n"
@@ -3061,6 +3063,8 @@ _curses_get_escdelay(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _curses_get_escdelay_impl(module);
 }
+
+#endif /* (!defined(_AIX) || defined(NCURSES_VERSION)) */
 
 PyDoc_STRVAR(_curses_set_escdelay__doc__,
 "set_escdelay($module, ms, /)\n"
@@ -4638,6 +4642,10 @@ _curses_use_default_colors(PyObject *module, PyObject *Py_UNUSED(ignored))
     #define _CURSES_HAS_KEY_METHODDEF
 #endif /* !defined(_CURSES_HAS_KEY_METHODDEF) */
 
+#ifndef _CURSES_GET_ESCDELAY_METHODDEF
+    #define _CURSES_GET_ESCDELAY_METHODDEF
+#endif /* !defined(_CURSES_GET_ESCDELAY_METHODDEF) */
+
 #ifndef _CURSES_IS_TERM_RESIZED_METHODDEF
     #define _CURSES_IS_TERM_RESIZED_METHODDEF
 #endif /* !defined(_CURSES_IS_TERM_RESIZED_METHODDEF) */
@@ -4681,4 +4689,4 @@ _curses_use_default_colors(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef _CURSES_USE_DEFAULT_COLORS_METHODDEF
     #define _CURSES_USE_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_USE_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=0ca4f95323c5d585 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=581bd60f831b9fa2 input=a9049054013a1b77]*/


### PR DESCRIPTION
Make `curses.get_escdelay()` optional.


<!-- issue-number: [bpo-39020](https://bugs.python.org/issue39020) -->
https://bugs.python.org/issue39020
<!-- /issue-number -->
