### PR TITLE
bpo-39020: Fix build of module _curses for AIX

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -515,10 +515,8 @@ The module :mod:`curses` defines the following functions:
 
    Retrieves the value set by :func:`set_escdelay`.
 
-   Availability: if the ncurses library is used and on NetBSD.
-
+   .. availability:: not available with stock AIX.
    .. versionadded:: 3.9
-   .. availability:: not available with stock AIX
 
 
 .. function:: set_escdelay(ms)
@@ -527,16 +525,16 @@ The module :mod:`curses` defines the following functions:
    to distinguish between an individual escape character entered on the
    keyboard from escape sequences sent by cursor and function keys.
 
+   .. availability:: not available with stock AIX.
    .. versionadded:: 3.9
-   .. availability:: not available with stock AIX
 
 
 .. function:: get_tabsize()
 
    Retrieves the value set by :func:`set_tabsize`.
 
+   .. availability:: not available with stock AIX.
    .. versionadded:: 3.9
-   .. availability:: not available with stock AIX
 
 
 .. function:: set_tabsize(size)
@@ -544,8 +542,8 @@ The module :mod:`curses` defines the following functions:
    Sets the number of columns used by the curses library when converting a tab
    character to spaces as it adds the tab to a window.
 
+   .. availability:: not available with stock AIX.
    .. versionadded:: 3.9
-   .. availability:: not available with stock AIX
 
 
 .. function:: setsyx(y, x)

--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -520,6 +520,7 @@ The module :mod:`curses` defines the following functions:
    .. versionadded:: 3.9
    .. availability:: not available with stock AIX
 
+
 .. function:: set_escdelay(ms)
 
    Sets the number of milliseconds to wait after reading an escape character,
@@ -529,12 +530,14 @@ The module :mod:`curses` defines the following functions:
    .. versionadded:: 3.9
    .. availability:: not available with stock AIX
 
+
 .. function:: get_tabsize()
 
    Retrieves the value set by :func:`set_tabsize`.
 
    .. versionadded:: 3.9
    .. availability:: not available with stock AIX
+
 
 .. function:: set_tabsize(size)
 
@@ -543,6 +546,7 @@ The module :mod:`curses` defines the following functions:
 
    .. versionadded:: 3.9
    .. availability:: not available with stock AIX
+
 
 .. function:: setsyx(y, x)
 

--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -515,6 +515,8 @@ The module :mod:`curses` defines the following functions:
 
    Retrieves the value set by :func:`set_escdelay`.
 
+   Availability: if the ncurses library is used and on NetBSD.
+
    .. versionadded:: 3.9
    .. availability:: not available with stock AIX
 

--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -516,6 +516,7 @@ The module :mod:`curses` defines the following functions:
    Retrieves the value set by :func:`set_escdelay`.
 
    .. versionadded:: 3.9
+   .. availability:: not available with stock AIX
 
 .. function:: set_escdelay(ms)
 
@@ -524,12 +525,14 @@ The module :mod:`curses` defines the following functions:
    keyboard from escape sequences sent by cursor and function keys.
 
    .. versionadded:: 3.9
+   .. availability:: not available with stock AIX
 
 .. function:: get_tabsize()
 
    Retrieves the value set by :func:`set_tabsize`.
 
    .. versionadded:: 3.9
+   .. availability:: not available with stock AIX
 
 .. function:: set_tabsize(size)
 
@@ -537,6 +540,7 @@ The module :mod:`curses` defines the following functions:
    character to spaces as it adds the tab to a window.
 
    .. versionadded:: 3.9
+   .. availability:: not available with stock AIX
 
 .. function:: setsyx(y, x)
 

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -261,10 +261,11 @@ class TestCurses(unittest.TestCase):
         curses.putp(b'abc')
         curses.qiflush()
         curses.raw() ; curses.raw(1)
-        curses.set_escdelay(25)
-        self.assertEqual(curses.get_escdelay(), 25)
-        curses.set_tabsize(4)
-        self.assertEqual(curses.get_tabsize(), 4)
+        if hasattr(curses, 'set_escdalay'):
+            curses.set_escdelay(25)
+            self.assertEqual(curses.get_escdelay(), 25)
+            curses.set_tabsize(4)
+            self.assertEqual(curses.get_tabsize(), 4)
         if hasattr(curses, 'setsyx'):
             curses.setsyx(5,5)
         curses.tigetflag('hc')

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -264,6 +264,7 @@ class TestCurses(unittest.TestCase):
         if hasattr(curses, 'set_escdalay'):
             curses.set_escdelay(25)
             self.assertEqual(curses.get_escdelay(), 25)
+        if hasattr(curses, 'set_tabsize'):
             curses.set_tabsize(4)
             self.assertEqual(curses.get_tabsize(), 4)
         if hasattr(curses, 'setsyx'):

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-01-15-35-40.bpo-39020.r0dGRM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-01-15-35-40.bpo-39020.r0dGRM.rst
@@ -1,3 +1,3 @@
 AIX stock libcurses does not support
-func:`curses.get_escdelay`, func:`curses.set_escdelay`, func:`curses.get_tabsize and `func:`curses.set_tabsize`
+:func:`curses.get_escdelay`, :func:`curses.set_escdelay`, :func:`curses.get_tabsize` and :func:`curses.set_tabsize`.
 Patch by M Felt

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-01-15-35-40.bpo-39020.r0dGRM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-01-15-35-40.bpo-39020.r0dGRM.rst
@@ -1,3 +1,3 @@
 AIX stock libcurses does not support
 :func:`curses.get_escdelay`, :func:`curses.set_escdelay`, :func:`curses.get_tabsize` and :func:`curses.set_tabsize`.
-Patch by M Felt
+Patch by M. Felt.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-01-15-35-40.bpo-39020.r0dGRM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-01-15-35-40.bpo-39020.r0dGRM.rst
@@ -1,3 +1,3 @@
 AIX stock libcurses does not support
-func:`curses.get_escdelay`, func:`curses.set_escdelay`, func:`curses.get_tabsize, `func:`curses.set_tabsize`
+func:`curses.get_escdelay`, func:`curses.set_escdelay`, func:`curses.get_tabsize and `func:`curses.set_tabsize`
 Patch by M Felt

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-01-15-35-40.bpo-39020.r0dGRM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-01-15-35-40.bpo-39020.r0dGRM.rst
@@ -1,0 +1,3 @@
+AIX stock libcurses does not support
+func:`curses.get_escdelay`, func:`curses.set_escdelay`, func:`curses.get_tabsize, `func:`curses.set_tabsize`
+Patch by M Felt

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3255,6 +3255,10 @@ _curses_setupterm_impl(PyObject *module, const char *term, int fd)
     Py_RETURN_NONE;
 }
 
+#if !defined(_AIX) || defined(NCURSES_VERSION)
+/* bpo-39020 - stock AIX curses does not include ESCDELAY
+ * a third-party addtion of (gnu) ncurses might
+ */
 /*[clinic input]
 _curses.get_escdelay
 
@@ -3334,6 +3338,7 @@ _curses_set_tabsize_impl(PyObject *module, int size)
 
     return PyCursesCheckERR(set_tabsize(size), "set_tabsize");
 }
+#endif
 
 /*[clinic input]
 _curses.intrflush

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3255,10 +3255,7 @@ _curses_setupterm_impl(PyObject *module, const char *term, int fd)
     Py_RETURN_NONE;
 }
 
-#if !defined(_AIX) || defined(NCURSES_VERSION)
-/* bpo-39020 - stock AIX curses does not include ESCDELAY
- * a third-party addtion of (gnu) ncurses might
- */
+#if (!defined(_AIX) || (defined(NCURSES_VERSION))
 /*[clinic input]
 _curses.get_escdelay
 
@@ -3338,7 +3335,7 @@ _curses_set_tabsize_impl(PyObject *module, int size)
 
     return PyCursesCheckERR(set_tabsize(size), "set_tabsize");
 }
-#endif
+#endif/* (!defined(_AIX) || (defined(NCURSES_VERSION)) */
 
 /*[clinic input]
 _curses.intrflush

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3255,7 +3255,7 @@ _curses_setupterm_impl(PyObject *module, const char *term, int fd)
     Py_RETURN_NONE;
 }
 
-#if (!defined(_AIX) || (defined(NCURSES_VERSION))
+#if !defined(_AIX) || defined(NCURSES_VERSION)
 /*[clinic input]
 _curses.get_escdelay
 
@@ -3335,7 +3335,7 @@ _curses_set_tabsize_impl(PyObject *module, int size)
 
     return PyCursesCheckERR(set_tabsize(size), "set_tabsize");
 }
-#endif/* (!defined(_AIX) || (defined(NCURSES_VERSION)) */
+#endif /* !defined(_AIX) || defined(NCURSES_VERSION) */
 
 /*[clinic input]
 _curses.intrflush

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -3041,6 +3041,7 @@ exit:
 }
 
 #if (!defined(_AIX) || defined(NCURSES_VERSION))
+
 PyDoc_STRVAR(_curses_get_escdelay__doc__,
 "get_escdelay($module, /)\n"
 "--\n"
@@ -3062,6 +3063,10 @@ _curses_get_escdelay(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _curses_get_escdelay_impl(module);
 }
+
+#endif /* (!defined(_AIX) || defined(NCURSES_VERSION)) */
+
+#if (!defined(_AIX) || defined(NCURSES_VERSION))
 
 PyDoc_STRVAR(_curses_set_escdelay__doc__,
 "set_escdelay($module, ms, /)\n"
@@ -3103,6 +3108,10 @@ exit:
     return return_value;
 }
 
+#endif /* (!defined(_AIX) || defined(NCURSES_VERSION)) */
+
+#if (!defined(_AIX) || defined(NCURSES_VERSION))
+
 PyDoc_STRVAR(_curses_get_tabsize__doc__,
 "get_tabsize($module, /)\n"
 "--\n"
@@ -3123,6 +3132,10 @@ _curses_get_tabsize(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _curses_get_tabsize_impl(module);
 }
+
+#endif /* (!defined(_AIX) || defined(NCURSES_VERSION)) */
+
+#if (!defined(_AIX) || defined(NCURSES_VERSION))
 
 PyDoc_STRVAR(_curses_set_tabsize__doc__,
 "set_tabsize($module, size, /)\n"
@@ -3162,6 +3175,7 @@ _curses_set_tabsize(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
+
 #endif /* (!defined(_AIX) || defined(NCURSES_VERSION)) */
 
 PyDoc_STRVAR(_curses_intrflush__doc__,
@@ -4699,4 +4713,4 @@ _curses_use_default_colors(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef _CURSES_USE_DEFAULT_COLORS_METHODDEF
     #define _CURSES_USE_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_USE_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=3c505fbea1c54cec input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b7c7076f2302e456 input=a9049054013a1b77]*/

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -3040,6 +3040,10 @@ exit:
     return return_value;
 }
 
+#if !defined(_AIX) || defined(NCURSES_VERSION)
+/* bpo-39020 - stock AIX curses does not include ESCDELAY
+ * a third-party addtion of (gnu) ncurses might
+ */
 PyDoc_STRVAR(_curses_get_escdelay__doc__,
 "get_escdelay($module, /)\n"
 "--\n"
@@ -3161,6 +3165,7 @@ _curses_set_tabsize(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
+#endif 
 
 PyDoc_STRVAR(_curses_intrflush__doc__,
 "intrflush($module, flag, /)\n"
@@ -4637,6 +4642,22 @@ _curses_use_default_colors(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef _CURSES_HAS_KEY_METHODDEF
     #define _CURSES_HAS_KEY_METHODDEF
 #endif /* !defined(_CURSES_HAS_KEY_METHODDEF) */
+
+#ifndef _CURSES_GET_ESCDELAY_METHODDEF
+    #define _CURSES_GET_ESCDELAY_METHODDEF
+#endif /* !defined(_CURSES_GET_ESCDELAY_METHODDEF) */
+
+#ifndef _CURSES_SET_ESCDELAY_METHODDEF
+    #define _CURSES_SET_ESCDELAY_METHODDEF
+#endif /* !defined(_CURSES_SET_ESCDELAY_METHODDEF) */
+
+#ifndef _CURSES_GET_TABSIZE_METHODDEF
+    #define _CURSES_GET_TABSIZE_METHODDEF
+#endif /* !defined(_CURSES_GET_TABSIZE_METHODDEF) */
+
+#ifndef _CURSES_SET_TABSIZE_METHODDEF
+    #define _CURSES_SET_TABSIZE_METHODDEF
+#endif /* !defined(_CURSES_SET_TABSIZE_METHODDEF) */
 
 #ifndef _CURSES_IS_TERM_RESIZED_METHODDEF
     #define _CURSES_IS_TERM_RESIZED_METHODDEF

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -3040,10 +3040,7 @@ exit:
     return return_value;
 }
 
-#if !defined(_AIX) || defined(NCURSES_VERSION)
-/* bpo-39020 - stock AIX curses does not include ESCDELAY
- * a third-party addtion of (gnu) ncurses might
- */
+#if (!defined(_AIX) || defined(NCURSES_VERSION))
 PyDoc_STRVAR(_curses_get_escdelay__doc__,
 "get_escdelay($module, /)\n"
 "--\n"
@@ -3165,7 +3162,7 @@ _curses_set_tabsize(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-#endif 
+#endif /* (!defined(_AIX) || defined(NCURSES_VERSION)) */
 
 PyDoc_STRVAR(_curses_intrflush__doc__,
 "intrflush($module, flag, /)\n"

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -4699,4 +4699,4 @@ _curses_use_default_colors(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef _CURSES_USE_DEFAULT_COLORS_METHODDEF
     #define _CURSES_USE_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_USE_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=0ca4f95323c5d585 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3c505fbea1c54cec input=a9049054013a1b77]*/


### PR DESCRIPTION
Stock AIX libcurses misses the functions needed to support
func:`curses.get_escdelay`, func:`curses.set_escdelay`, func:`curses.get_tabsize and `func:`curses.set_tabsize`
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39020](https://bugs.python.org/issue39020) -->
https://bugs.python.org/issue39020
<!-- /issue-number -->
