### PR TITLE
bpo-39350: Fix regression introduced when fractions.gcd was removed

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -13,6 +13,12 @@ import sys
 __all__ = ['Fraction']
 
 
+def _gcd(a, b):
+     # Supports non-integers for backward compatibility.
+     while b:
+         a, b = b, a%b
+     return a
+
 # Constants related to the hash implementation;  hash(x) is based
 # on the reduction of x modulo the prime _PyHASH_MODULUS.
 _PyHASH_MODULUS = sys.hash_info.modulus

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -14,10 +14,10 @@ __all__ = ['Fraction']
 
 
 def _gcd(a, b):
-     # Supports non-integers for backward compatibility.
-     while b:
-         a, b = b, a%b
-     return a
+    # Supports non-integers for backward compatibility.
+    while b:
+        a, b = b, a%b
+    return a
 
 # Constants related to the hash implementation;  hash(x) is based
 # on the reduction of x modulo the prime _PyHASH_MODULUS.

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -666,6 +666,24 @@ class FractionTest(unittest.TestCase):
         r = F(13, 7)
         self.assertRaises(AttributeError, setattr, r, 'a', 10)
 
+    def test_gcd_compatibility_branch(self):
+        # Regression test for bugs.python.org/issue39350
+
+        class myint(int):
+            def __mul__(self, other):
+                return myint(int(self)*int(other))
+
+            @property
+            def numerator(self):
+                return self
+
+            @property
+            def denominator(self):
+                return myint(1)
+
+        myhalf = F(myint(1), myint(2))
+        self.assertEqual(myhalf, F(1, 2))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-02-02-10-38-59.bpo-39350.8V69hi.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-02-10-38-59.bpo-39350.8V69hi.rst
@@ -1,0 +1,3 @@
+Revert removal of ``fractions._gcd``. That removal caused breakage when
+using ``fractions.Fraction`` with integer-like values (for example NumPy
+integers).


### PR DESCRIPTION
This PR is a quick fix for the breakage introduced in #18021, which removed the `_gcd` function while the core code was still using it.

Possibly the behaviour of `Fraction` for non-integers should be different, but I think it makes sense to fix the breakage immediately and then discuss whether we want to make behavioural changes.

~No news entry needed, because the broken code hasn't make it into any release or prerelease.~ (EDIT: not true, unfortunately : @hroncok pointed out in comments below that the regression was released in 3.9.0a3)

<!-- issue-number: [bpo-39350](https://bugs.python.org/issue39350) -->
https://bugs.python.org/issue39350
<!-- /issue-number -->
