### PR TITLE
gh-72499: Provide a message better suited to AIX when LONG_BIT definition is wrong

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -713,20 +713,20 @@ extern char * _getpty(int *, int, mode_t, int);
 #endif
 
 #if LONG_BIT != 8 * SIZEOF_LONG
-#if !defined(_AIX)
+#ifndef _AIX
 /* 04-Oct-2000 LONG_BIT is apparently (mis)defined as 64 on some recent
  * 32-bit platforms using gcc.  We try to catch that here at compile-time
  * rather than waiting for integer multiplication to trigger bogus
  * overflows.
  */
 #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
-#else /* defined(_AIX) */
+#else
 /* By default, AIX compiles, links, archives, etc. as 32-bit
  * When Python is built as 64-bit executable the AIX utilities will complain
- * For AIX, the better hint is that OBJECT_MODE is not corrrect
+ * For AIX, the better hint is that OBJECT_MODE is not correct
  */
 #error "LONG_BIT definition appears wrong. Is OBJECT_MODE set correctly (32 or 64)?"
-#endif /* !defined(_AIX) */
+#endif
 #endif /* LONG_BIT != 8 * SIZEOF_LONG */
 
 #ifdef __cplusplus

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -713,13 +713,21 @@ extern char * _getpty(int *, int, mode_t, int);
 #endif
 
 #if LONG_BIT != 8 * SIZEOF_LONG
+#if !defined(_AIX)
 /* 04-Oct-2000 LONG_BIT is apparently (mis)defined as 64 on some recent
  * 32-bit platforms using gcc.  We try to catch that here at compile-time
  * rather than waiting for integer multiplication to trigger bogus
  * overflows.
  */
 #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
-#endif
+#else /* defined(_AIX) */
+/* By default, AIX compiles, links, archives, etc. as 32-bit
+ * When Python is built as 64-bit executable the AIX utilities will complain
+ * For AIX, the better hint is that OBJECT_MODE is not corrrect
+ */
+#error "LONG_BIT definition appears wrong. Is OBJECT_MODE set correctly (32 or 64)?"
+#endif /* !defined(_AIX) */
+#endif /* LONG_BIT != 8 * SIZEOF_LONG */
 
 #ifdef __cplusplus
 }

--- a/Misc/NEWS.d/next/Build/2020-02-02-12-49-45.bpo-28312.hFvQgS.rst
+++ b/Misc/NEWS.d/next/Build/2020-02-02-12-49-45.bpo-28312.hFvQgS.rst
@@ -1,0 +1,3 @@
+Provide a message better suited to AIX when LONG_BIT definition is wrong by
+mentioning OBJECT_MODE setting, rather than gcc/glibc (not native to AIX).
+Patch by M. Felt.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-28312](https://bugs.python.org/issue28312) -->
https://bugs.python.org/issue28312
<!-- /issue-number -->
The importance of this change is to help Python users who are trying to install additional modules that are not pure Python - especially if the Python build they are using is 64-bit.

There is nothing wrong with their build, or libraries, or compiler. However, by default AIX assumes that OBJECT_MODE (aka ABI) is 32-bit and this gcc/libc messages shows up.

The _first time you see this message_ it may be awhile before you find on your own, or using a search engine - that you need to add OBJECT_MODE=64 to your environment and then everything works as expected.

Years ago, when I created the issue, it took _awhile_ to find the solution. Every now and then I get a query re this message - so I hope you will consider including a better hint for AIX users of Python.

<!-- gh-issue-number: gh-72499 -->
* Issue: gh-72499
<!-- /gh-issue-number -->
