### PR TITLE
bpo-39128: Added happy_eyeballs_delay, interleave to function signature

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -443,7 +443,7 @@ Opening network connections
 
    .. versionadded:: 3.8
 
-      The *happy_eyeballs_delay* and *interleave* parameters.
+      Added the *happy_eyeballs_delay* and *interleave* parameters.
 
    .. versionadded:: 3.7
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -353,7 +353,8 @@ Opening network connections
                           host=None, port=None, \*, ssl=None, \
                           family=0, proto=0, flags=0, sock=None, \
                           local_addr=None, server_hostname=None, \
-                          ssl_handshake_timeout=None)
+                          ssl_handshake_timeout=None, \
+                          happy_eyeballs_delay=None, interleave=None)
 
    Open a streaming transport connection to a given
    address specified by *host* and *port*.


### PR DESCRIPTION
…in documentation

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# [bpo-39128](https://bugs.python.org/issue39128) Added happy_eyeballs_delay, interleave to function signature

# [3.9] 39128 - Added happy_eyeballs_delay, interleave to function signature (GH-18315)
# [3.8] 39128 - Added happy_eyeballs_delay, interleave to function signature (GH-18315)

-->


<!-- issue-number: [bpo-39128](https://bugs.python.org/issue39128) -->
https://bugs.python.org/issue39128
<!-- /issue-number -->
