### PR TITLE
bpo-39534: Clarify return in finally

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -388,15 +388,32 @@ example::
      File "<stdin>", line 2, in <module>
    KeyboardInterrupt
 
-If a :keyword:`finally` clause is present, the :keyword:`finally` clause will execute as the last task before the :keyword:`try` statement completes. The :keyword:`finally` clause runs whether or not the :keyword:`try` statement produces an exception. The following points discuss more complex cases when an exception occurs:
+If a :keyword:`finally` clause is present, the :keyword:`finally`
+clause will execute as the last task before the :keyword:`try`
+statement completes. The :keyword:`finally` clause runs whether or not
+the :keyword:`try` statement produces an exception. The following
+points discuss more complex cases when an exception occurs:
 
-* If an exception occurs during execution of the :keyword:`!try` clause, the exception may be handled by an :keyword:`except` clause. If the exception is not handled by an :keyword:`except` clause, the exception is re-raised after the :keyword:`!finally` clause has been executed.
+* If an exception occurs during execution of the :keyword:`!try`
+  clause, the exception may be handled by an :keyword:`except`
+  clause. If the exception is not handled by an :keyword:`except`
+  clause, the exception is re-raised after the :keyword:`!finally`
+  clause has been executed.
 
-* An exception could occur during execution of an :keyword:`!except` or :keyword:`!else` clause. Again, the exception is re-raised after the :keyword:`!finally` clause has been executed.
+* An exception could occur during execution of an :keyword:`!except`
+  or :keyword:`!else` clause. Again, the exception is re-raised after
+  the :keyword:`!finally` clause has been executed.
 
-* If the :keyword:`!try` statement reaches a :keyword:`break`, :keyword:`continue` or :keyword:`return` statement, the :keyword:`finally` clause will execute just prior to the :keyword:`break`, :keyword:`continue` or :keyword:`return` statement's execution.
+* If the :keyword:`!try` statement reaches a :keyword:`break`,
+  :keyword:`continue` or :keyword:`return` statement, the
+  :keyword:`finally` clause will execute just prior to the
+  :keyword:`break`, :keyword:`continue` or :keyword:`return`
+  statement's execution.
 
-* If a :keyword:`finally` clause includes a :keyword:`return` statement, the returned value will be the one from the :keyword:`finally` clause's :keyword:`return` statement, not the value from the :keyword:`try` clause's :keyword:`return` statement.
+* If a :keyword:`finally` clause includes a :keyword:`return`
+  statement, the returned value will be the one from the
+  :keyword:`finally` clause's :keyword:`return` statement, not the
+  value from the :keyword:`try` clause's :keyword:`return` statement.
 
 For example::
 

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -396,7 +396,7 @@ If a :keyword:`finally` clause is present, the :keyword:`finally` clause will ex
 
 * If the :keyword:`!try` statement reaches a :keyword:`break`, :keyword:`continue` or :keyword:`return` statement, the :keyword:`finally` clause will execute just prior to the :keyword:`break`, :keyword:`continue` or :keyword:`return` statement's execution.
 
-* If a :keyword:`finally` clause includes a :keyword:`return` statement, the :keyword:`finally` clause's :keyword:`return` statement will execute before, and instead of, the :keyword:`return` statement in a :keyword:`try` clause.
+* If a :keyword:`finally` clause includes a :keyword:`return` statement, the returned value will be the one from the :keyword:`finally` clause's :keyword:`return` statement, not the value from the :keyword:`try` clause's :keyword:`return` statement.
 
 For example::
 

--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -388,15 +388,15 @@ example::
      File "<stdin>", line 2, in <module>
    KeyboardInterrupt
 
-If a :keyword:`finally` clause is present, the :keyword:`finally`
+If a :keyword:`finally` clause is present, the :keyword:`!finally`
 clause will execute as the last task before the :keyword:`try`
-statement completes. The :keyword:`finally` clause runs whether or not
-the :keyword:`try` statement produces an exception. The following
+statement completes. The :keyword:`!finally` clause runs whether or
+not the :keyword:`!try` statement produces an exception. The following
 points discuss more complex cases when an exception occurs:
 
 * If an exception occurs during execution of the :keyword:`!try`
   clause, the exception may be handled by an :keyword:`except`
-  clause. If the exception is not handled by an :keyword:`except`
+  clause. If the exception is not handled by an :keyword:`!except`
   clause, the exception is re-raised after the :keyword:`!finally`
   clause has been executed.
 
@@ -406,14 +406,15 @@ points discuss more complex cases when an exception occurs:
 
 * If the :keyword:`!try` statement reaches a :keyword:`break`,
   :keyword:`continue` or :keyword:`return` statement, the
-  :keyword:`finally` clause will execute just prior to the
-  :keyword:`break`, :keyword:`continue` or :keyword:`return`
+  :keyword:`!finally` clause will execute just prior to the
+  :keyword:`!break`, :keyword:`!continue` or :keyword:`!return`
   statement's execution.
 
-* If a :keyword:`finally` clause includes a :keyword:`return`
+* If a :keyword:`!finally` clause includes a :keyword:`!return`
   statement, the returned value will be the one from the
-  :keyword:`finally` clause's :keyword:`return` statement, not the
-  value from the :keyword:`try` clause's :keyword:`return` statement.
+  :keyword:`!finally` clause's :keyword:`!return` statement, not the
+  value from the :keyword:`!try` clause's :keyword:`!return`
+  statement.
 
 For example::
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

I rewrapped the lines around my edit in another commit, to see just my wording change, select the first commit only.

<!-- issue-number: [bpo-39534](https://bugs.python.org/issue39534) -->
https://bugs.python.org/issue39534
<!-- /issue-number -->
