### PR TITLE
bpo-36051: Fix compiler warning.

### DIFF
--- a/Objects/stringlib/join.h
+++ b/Objects/stringlib/join.h
@@ -20,7 +20,7 @@ STRINGLIB(bytes_join)(PyObject *sep, PyObject *iterable)
     Py_buffer static_buffers[NB_STATIC_BUFFERS];
 #define GIL_THRESHOLD 1048576
     int drop_gil = 1;
-    PyThreadState *save;
+    PyThreadState *save = NULL;
 
     seq = PySequence_Fast(iterable, "can only join an iterable");
     if (seq == NULL) {


### PR DESCRIPTION


<!-- issue-number: [bpo-36051](https://bugs.python.org/issue36051) -->
https://bugs.python.org/issue36051
<!-- /issue-number -->


Automerge-Triggered-By: @methane