### PR TITLE
bpo-35108: handle exceptions in inspect.getmembers

### DIFF
--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1213,6 +1213,17 @@ class TestClassesAndFunctions(unittest.TestCase):
         attrs = [a[0] for a in inspect.getmembers(C)]
         self.assertNotIn('missing', attrs)
 
+    def test_getmembers_property_raises_exception(self):
+        # bpo-35108
+        class A:
+            @property
+            def f(self):
+                raise NotImplementedError
+
+        self.assertIn(("f", A.f), inspect.getmembers(A()))
+
+
+
 class TestIsDataDescriptor(unittest.TestCase):
 
     def test_custom_descriptors(self):

--- a/Misc/NEWS.d/next/Library/2020-02-03-09-21-13.bpo-35108.7iPRPL.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-03-09-21-13.bpo-35108.7iPRPL.rst
@@ -1,0 +1,1 @@
+Handle proprties raising exceptions in :meth:`inspect.getmembers`.


### PR DESCRIPTION
Makes inspect.getmembers robust to classes that raise exceptions
other than AttributeError in properties.

In https://bugs.python.org/issue35108, @tirkarthi suggested using `getattr_static` for these types of properties. It would also suggested that

> there might be still cases where getattr_static triggers an exception too where we need to decide whether to skip the attribute from being listed and if so with a test for the scenario.

I wasn't able to construct a test case that raised an exception in `getattr_static`, so I haven't implemented the suggestion that we skip the attribute in this case. Happy to add a test case if anyone is able to provide some guidance.

<!-- issue-number: [bpo-35108](https://bugs.python.org/issue35108) -->
https://bugs.python.org/issue35108
<!-- /issue-number -->
