### PR TITLE
bpo-39524: Fixed doc-string in ast._pad_whitespace

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -302,7 +302,7 @@ def _splitlines_no_ff(source):
 
 
 def _pad_whitespace(source):
-    """Replace all chars except '\f\t' in a line with spaces."""
+    r"""Replace all chars except '\f\t' in a line with spaces."""
     result = ''
     for c in source:
         if c in '\f\t':


### PR DESCRIPTION
# Escape sequences in doc string of ast._pad_whitespace

```
[bpo-39524](https://bugs.python.org/issue39524): Replaced \f with \\f and \t with \\t so when doc string is read by inspect.getdoc, literal '\f\t' is returned.
```


<!-- issue-number: [bpo-39524](https://bugs.python.org/issue39524) -->
https://bugs.python.org/issue39524
<!-- /issue-number -->
