### PR TITLE
bpo-39524: Fixed doc-string in ast._pad_whitespace

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -274,7 +274,7 @@ def _splitlines_no_ff(source):
 
 
 def _pad_whitespace(source):
-    """Replace all chars except '\f\t' in a line with spaces."""
+    """Replace all chars except '\\f\\t' in a line with spaces."""
     result = ''
     for c in source:
         if c in '\f\t':


### PR DESCRIPTION
# Escape sequences in doc string of ast._pad_whitespace

```
[bpo-39524](https://bugs.python.org/issue39524): Replaced \f with \\f and \t with \\t so when doc string is read by inspect.getdoc, literal '\f\t' is returned.
```

```
[3.8] [bpo-39524](https://bugs.python.org/issue39524): Fixed doc-string in ast._pad_whitespace (GH-18340)
```
Note: Already done separate PR for master, and this is for the 3.8 branch which has the same issue. Note: Re-issued PR due to base change in compare from master to 3.8, sorry. Hope is correct this time.


<!-- issue-number: [bpo-39524](https://bugs.python.org/issue39524) -->
https://bugs.python.org/issue39524
<!-- /issue-number -->
