### PR TITLE
bpo-39551: mock patch should match behavior of import from when module isn't present in sys.modules

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1227,7 +1227,9 @@ def _dot_lookup(thing, comp, import_path):
         return getattr(thing, comp)
     except AttributeError:
         __import__(import_path)
-        return getattr(thing, comp)
+        if hasattr(thing, comp):
+            return getattr(thing, comp)
+        return sys.modules[import_path]
 
 
 def _importer(target):

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -1664,6 +1664,20 @@ class PatchTest(unittest.TestCase):
             p1.stop()
         self.assertEqual(squizz.squozz, 3)
 
+    def test_patch_from_sys_modules(self):
+        squizz = type(sys)('squizz')
+        squizz_squozz = type(sys)('squizz.squozz')
+        squizz_squozz.x = 42
+
+        with uncache('squizz'), uncache('squizz.squozz'):
+            sys.modules['squizz'] = squizz
+            sys.modules['squizz.squozz'] = squizz_squozz
+            p1 = patch('squizz.squozz.x', 100)
+            p1.start()
+            self.assertEqual(squizz_squozz.x, 100)
+            p1.stop()
+            self.assertEqual(squizz_squozz.x, 42)
+
     def test_patch_propagates_exc_on_exit(self):
         class holder:
             exc_info = None, None, None

--- a/Misc/NEWS.d/next/Library/2020-02-04-21-12-44.bpo-39551.sAsGPl.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-04-21-12-44.bpo-39551.sAsGPl.rst
@@ -1,0 +1,1 @@
+mock.patch will now fallback to sys.modules if a child package isn't published on its parent


### PR DESCRIPTION
The fix for [bpo-17636](https://bugs.python.org/issue17636) added support for falling back to sys.modules when a module isn't directly present on the module.  But mock doesn't have the same behavior - it'll try the import, and then try to get the value off the object.  If it's not there it just errors out.

Instead it should also consult sys.modules to be consistent with import semantics.

This checks to see if the attribute is defined, and if it is returns it matching the existing behavior. If the attribute isn't defined it'll fallback to sys.modules.

<!-- issue-number: [bpo-39551](https://bugs.python.org/issue39551) -->
https://bugs.python.org/issue39551
<!-- /issue-number -->
