### PR TITLE
bpo-39552: Remove legacy backticks for $()

### DIFF
--- a/Mac/BuildScript/scripts/postflight.patch-profile
+++ b/Mac/BuildScript/scripts/postflight.patch-profile
@@ -8,23 +8,23 @@ echo "after running this script."
 PYVER=@PYVER@
 PYTHON_ROOT="/Library/Frameworks/Python.framework/Versions/@PYVER@"
 
-if [ `id -ur` = 0 ]; then
+if [ $(id -ur) = 0 ]; then
 	# Run from the installer, do some trickery to fetch the information
 	# we need.
-	theShell="`finger $USER | grep Shell: | head  -1 | awk '{ print $NF }'`"
+	theShell="$(finger $USER | grep Shell: | head  -1 | awk '{ print $NF }')"
 
 else
 	theShell="${SHELL}"
 fi
 
 # Make sure the directory ${PYTHON_ROOT}/bin is on the users PATH.
-BSH="`basename "${theShell}"`"
+BSH="$(basename "${theShell}")"
 case "${BSH}" in
 bash|ksh|sh|*csh|zsh)
-	if [ `id -ur` = 0 ]; then
-		P=`su - ${USER} -c 'echo A-X-4-X@@$PATH@@X-4-X-A' | grep 'A-X-4-X@@.*@@X-4-X-A' | sed -e 's/^A-X-4-X@@//g' -e 's/@@X-4-X-A$//g'`
+	if [ $(id -ur) = 0 ]; then
+		P=$(su - ${USER} -c 'echo A-X-4-X@@$PATH@@X-4-X-A' | grep 'A-X-4-X@@.*@@X-4-X-A' | sed -e 's/^A-X-4-X@@//g' -e 's/@@X-4-X-A$//g')
 	else
-		P="`(exec -l ${theShell} -c 'echo $PATH')`"
+		P="$( (exec -l ${theShell} -c 'echo $PATH'))"
 	fi
 	;;
 *)
@@ -34,7 +34,7 @@ bash|ksh|sh|*csh|zsh)
 esac
 
 # Now ensure that our bin directory is on $P and before /usr/bin at that
-for elem in `echo $P | tr ':' ' '`
+for elem in $(echo $P | tr ':' ' ')
 do
 	if [ "${elem}" = "${PYTHON_ROOT}/bin" ]; then
 		echo "All right, you're a python lover already"
@@ -60,7 +60,7 @@ case "${BSH}" in
 	echo "# Setting PATH for Python ${PYVER}" >> "${RC}"
 	echo "# The original version is saved in .cshrc.pysave" >> "${RC}"
 	echo "set path=(${PYTHON_ROOT}/bin "'$path'")" >> "${RC}"
-	if [ `id -ur` = 0 ]; then
+	if [ $(id -ur) = 0 ]; then
 		chown "${USER}" "${RC}"
 	fi
 	exit 0
@@ -90,10 +90,10 @@ if [ -f "${PR}" ]; then
 fi
 echo "" >> "${PR}"
 echo "# Setting PATH for Python ${PYVER}" >> "${PR}"
-echo "# The original version is saved in `basename ${PR}`.pysave" >> "${PR}"
+echo "# The original version is saved in $(basename ${PR}).pysave" >> "${PR}"
 echo 'PATH="'"${PYTHON_ROOT}/bin"':${PATH}"' >> "${PR}"
 echo 'export PATH' >> "${PR}"
-if [ `id -ur` = 0 ]; then
+if [ $(id -ur) = 0 ]; then
 	chown "${USER}" "${PR}"
 fi
 exit 0

--- a/Modules/_decimal/tests/runall-memorydebugger.sh
+++ b/Modules/_decimal/tests/runall-memorydebugger.sh
@@ -34,7 +34,7 @@ case $@ in
 esac
 
 # gmake required
-GMAKE=`which gmake`
+GMAKE=$(which gmake)
 if [ X"$GMAKE" = X"" ]; then
     GMAKE=make
 fi
@@ -42,8 +42,8 @@ fi
 # Pretty print configurations
 print_config ()
 {
-    len=`echo $@ | wc -c`
-    margin="#%"`expr \( 74 - $len \) / 2`"s"
+    len=$(echo $@ | wc -c)
+    margin="#%"$(expr \( 74 - $len \) / 2)"s"
 
     echo ""
     echo "# ========================================================================"
@@ -98,7 +98,7 @@ for config in $CONFIGS; do
         case "$config" in
             # Valgrind has no support for 80 bit long double arithmetic.
             ppro) valgrind= ;;
-            auto) case `uname -m` in
+            auto) case $(uname -m) in
                       i386|i486|i586|i686) valgrind= ;;
                   esac
         esac
@@ -152,7 +152,7 @@ for config in $CONFIGS; do
         case "$config" in
             # Valgrind has no support for 80 bit long double arithmetic.
             ppro) valgrind= ;;
-            auto) case `uname -m` in
+            auto) case $(uname -m) in
                       i386|i486|i586|i686) valgrind= ;;
                   esac
         esac

--- a/Modules/ld_so_aix.in
+++ b/Modules/ld_so_aix.in
@@ -69,12 +69,12 @@ if test ! -n "$*"; then
   echo $usage; exit 2
 fi
 
-makexp=`dirname $0`/makexp_aix
+makexp=$(dirname $0)/makexp_aix
 test -x "${makexp}" || makexp="@abs_srcdir@/makexp_aix"
 
 # Check for existence of compiler.
 CC=$1; shift
-whichcc=`which $CC`
+whichcc=$(which $CC)
 
 if test ! -x "$whichcc"; then
   echo "ld_so_aix: Compiler '$CC' not found; exiting."
@@ -101,7 +101,7 @@ do
 	fi
 	;;
     -e* | -Wl,-e*)
-	entry=`echo $1 | sed -e "s/-Wl,//" -e "s/-e//"`
+	entry=$(echo $1 | sed -e "s/-Wl,//" -e "s/-e//")
 	;;
     -o)
 	if test -z "$2"; then
@@ -111,13 +111,13 @@ do
 	fi
 	;;
     -o*)
-	objfile=`echo $1 | sed "s/-o//"`
+	objfile=$(echo $1 | sed "s/-o//")
 	;;
     -bI:* | -Wl,-bI:*)
-	impfile=`echo $1 | sed -e "s/-Wl,//" -e "s/-bI://"`
+	impfile=$(echo $1 | sed -e "s/-Wl,//" -e "s/-bI://")
 	;;
     -bE:* | -Wl,-bE:*)
-	expfile=`echo $1 | sed -e "s/-Wl,//" -e "s/-bE://"`
+	expfile=$(echo $1 | sed -e "s/-Wl,//" -e "s/-bE://")
 	;;
     *.o | *.a)
 	objs="$objs $1"
@@ -149,7 +149,7 @@ if test -z "$objfile"; then
   objfile=shr.o
 fi
 
-filename=`basename $objfile | sed "s/\.[^.]*$//"`
+filename=$(basename $objfile | sed "s/\.[^.]*$//")
 
 # If -bE: wasn't specified, assume "-bE:$filename.exp"
 if test -z "$expfile"; then
@@ -159,7 +159,7 @@ fi
 # Default entry symbol for Python modules = init[modulename]
 # Can be overridden by providing a -e argument.
 if test -z "$entry"; then
-  entry=PyInit_`echo $filename | sed "s/module.*//"`
+  entry=PyInit_$(echo $filename | sed "s/module.*//")
 fi
 
 #echo "ld_so_aix: Debug info section"

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -70,7 +70,7 @@ done
 # (Not all systems have dirname)
 case $libdir in
 '')	case $0 in
-	*/*)	libdir=`echo $0 | sed 's,/[^/]*$,,'`;;
+	*/*)	libdir=$(echo $0 | sed 's,/[^/]*$,,');;
 	*)	libdir=.;;
 	esac;;
 esac
@@ -87,7 +87,7 @@ NL='\
 
 # Setup to link with extra libraries when making shared extensions.
 # Currently, only Cygwin needs this baggage.
-case `uname -s` in
+case $(uname -s) in
 CYGWIN*) if test $libdir = .
 	 then
 	 	ExtraLibDir=.
@@ -128,7 +128,7 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 		while echo $line | grep '\\$' > /dev/null
 		do
 			read extraline
-			line=`echo $line| sed s/.$//`$extraline
+			line=$(echo $line| sed s/.$//)$extraline
 		done
 
 		# Output DEFS in reverse order so first definition overrides
@@ -175,7 +175,7 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 			*.sl)		libs="$libs $arg";;
 			/*.o)		libs="$libs $arg";;
 			*.def)		libs="$libs $arg";;
-			*.o)		srcs="$srcs `basename $arg .o`.c";;
+			*.o)		srcs="$srcs $(basename $arg .o).c";;
 			*.[cC])		srcs="$srcs $arg";;
 			*.m)		srcs="$srcs $arg";; # Objective-C src
 			*.cc)		srcs="$srcs $arg";;
@@ -213,13 +213,13 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 		for src in $srcs
 		do
 			case $src in
-			*.c)   obj=`basename $src .c`.o; cc='$(CC)';;
-			*.cc)  obj=`basename $src .cc`.o; cc='$(CXX)';;
-			*.c++) obj=`basename $src .c++`.o; cc='$(CXX)';;
-			*.C)   obj=`basename $src .C`.o; cc='$(CXX)';;
-			*.cxx) obj=`basename $src .cxx`.o; cc='$(CXX)';;
-			*.cpp) obj=`basename $src .cpp`.o; cc='$(CXX)';;
-			*.m)   obj=`basename $src .m`.o; cc='$(CC)';; # Obj-C
+			*.c)   obj=$(basename $src .c).o; cc='$(CC)';;
+			*.cc)  obj=$(basename $src .cc).o; cc='$(CXX)';;
+			*.c++) obj=$(basename $src .c++).o; cc='$(CXX)';;
+			*.C)   obj=$(basename $src .C).o; cc='$(CXX)';;
+			*.cxx) obj=$(basename $src .cxx).o; cc='$(CXX)';;
+			*.cpp) obj=$(basename $src .cpp).o; cc='$(CXX)';;
+			*.m)   obj=$(basename $src .m).o; cc='$(CC)';; # Obj-C
 			*)     continue;;
 			esac
 			obj="$srcdir/$obj"

--- a/Modules/makexp_aix
+++ b/Modules/makexp_aix
@@ -35,12 +35,12 @@ shift; shift;
 inputFiles=$*
 automsg="Generated automatically by makexp_aix"
 notemsg="NOTE: lists _all_ global symbols defined in the above file(s)."
-curwdir=`pwd`
+curwdir=$(pwd)
 
 # Create the export file and setup the header info
 echo "#!"$toAppendStr > $expFileName
 echo "*" >> $expFileName
-echo "* $automsg  (`date -u`)" >> $expFileName
+echo "* $automsg  ($(date -u))" >> $expFileName
 echo "*" >> $expFileName
 echo "* Base Directory: $curwdir" >> $expFileName
 echo "* Input File(s) : $inputFiles" >> $expFileName

--- a/config.guess
+++ b/config.guess
@@ -32,7 +32,7 @@ timestamp='2018-03-08'
 # Please send patches to <config-patches@gnu.org>.
 
 
-me=`echo "$0" | sed -e 's,.*/,,'`
+me=$(echo "$0" | sed -e 's,.*/,,')
 
 usage="\
 Usage: $0 [OPTION]
@@ -127,10 +127,10 @@ if (test -f /.attbin/uname) >/dev/null 2>&1 ; then
 	PATH=$PATH:/.attbin ; export PATH
 fi
 
-UNAME_MACHINE=`(uname -m) 2>/dev/null` || UNAME_MACHINE=unknown
-UNAME_RELEASE=`(uname -r) 2>/dev/null` || UNAME_RELEASE=unknown
-UNAME_SYSTEM=`(uname -s) 2>/dev/null`  || UNAME_SYSTEM=unknown
-UNAME_VERSION=`(uname -v) 2>/dev/null` || UNAME_VERSION=unknown
+UNAME_MACHINE=$( (uname -m) 2>/dev/null) || UNAME_MACHINE=unknown
+UNAME_RELEASE=$( (uname -r) 2>/dev/null) || UNAME_RELEASE=unknown
+UNAME_SYSTEM=$( (uname -s) 2>/dev/null)  || UNAME_SYSTEM=unknown
+UNAME_VERSION=$( (uname -v) 2>/dev/null) || UNAME_VERSION=unknown
 
 case "$UNAME_SYSTEM" in
 Linux|GNU|GNU/*)
@@ -149,7 +149,7 @@ Linux|GNU|GNU/*)
 	LIBC=gnu
 	#endif
 	EOF
-	eval "`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`"
+	eval "$($CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^LIBC' | sed 's, ,,g')"
 
 	# If ldd exists, use it to detect musl libc.
 	if command -v ldd >/dev/null && \
@@ -175,10 +175,10 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	# Note: NetBSD doesn't particularly care about the vendor
 	# portion of the name.  We always set it to "unknown".
 	sysctl="sysctl -n hw.machine_arch"
-	UNAME_MACHINE_ARCH=`(uname -p 2>/dev/null || \
+	UNAME_MACHINE_ARCH=$( (uname -p 2>/dev/null || \
 	    "/sbin/$sysctl" 2>/dev/null || \
 	    "/usr/sbin/$sysctl" 2>/dev/null || \
-	    echo unknown)`
+	    echo unknown))
 	case "$UNAME_MACHINE_ARCH" in
 	    armeb) machine=armeb-unknown ;;
 	    arm*) machine=arm-unknown ;;
@@ -186,8 +186,8 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	    sh3eb) machine=sh-unknown ;;
 	    sh5el) machine=sh5le-unknown ;;
 	    earmv*)
-		arch=`echo "$UNAME_MACHINE_ARCH" | sed -e 's,^e\(armv[0-9]\).*$,\1,'`
-		endian=`echo "$UNAME_MACHINE_ARCH" | sed -ne 's,^.*\(eb\)$,\1,p'`
+		arch=$(echo "$UNAME_MACHINE_ARCH" | sed -e 's,^e\(armv[0-9]\).*$,\1,')
+		endian=$(echo "$UNAME_MACHINE_ARCH" | sed -ne 's,^.*\(eb\)$,\1,p')
 		machine="${arch}${endian}"-unknown
 		;;
 	    *) machine="$UNAME_MACHINE_ARCH"-unknown ;;
@@ -218,7 +218,7 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	case "$UNAME_MACHINE_ARCH" in
 	    earm*)
 		expr='s/^earmv[0-9]/-eabi/;s/eb$//'
-		abi=`echo "$UNAME_MACHINE_ARCH" | sed -e "$expr"`
+		abi=$(echo "$UNAME_MACHINE_ARCH" | sed -e "$expr")
 		;;
 	esac
 	# The OS release
@@ -231,7 +231,7 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 		release='-gnu'
 		;;
 	    *)
-		release=`echo "$UNAME_RELEASE" | sed -e 's/[-_].*//' | cut -d. -f1,2`
+		release=$(echo "$UNAME_RELEASE" | sed -e 's/[-_].*//' | cut -d. -f1,2)
 		;;
 	esac
 	# Since CPU_TYPE-MANUFACTURER-KERNEL-OPERATING_SYSTEM:
@@ -240,15 +240,15 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	echo "$machine-${os}${release}${abi}"
 	exit ;;
     *:Bitrig:*:*)
-	UNAME_MACHINE_ARCH=`arch | sed 's/Bitrig.//'`
+	UNAME_MACHINE_ARCH=$(arch | sed 's/Bitrig.//')
 	echo "$UNAME_MACHINE_ARCH"-unknown-bitrig"$UNAME_RELEASE"
 	exit ;;
     *:OpenBSD:*:*)
-	UNAME_MACHINE_ARCH=`arch | sed 's/OpenBSD.//'`
+	UNAME_MACHINE_ARCH=$(arch | sed 's/OpenBSD.//')
 	echo "$UNAME_MACHINE_ARCH"-unknown-openbsd"$UNAME_RELEASE"
 	exit ;;
     *:LibertyBSD:*:*)
-	UNAME_MACHINE_ARCH=`arch | sed 's/^.*BSD\.//'`
+	UNAME_MACHINE_ARCH=$(arch | sed 's/^.*BSD\.//')
 	echo "$UNAME_MACHINE_ARCH"-unknown-libertybsd"$UNAME_RELEASE"
 	exit ;;
     *:MidnightBSD:*:*)
@@ -278,17 +278,17 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
     alpha:OSF1:*:*)
 	case $UNAME_RELEASE in
 	*4.0)
-		UNAME_RELEASE=`/usr/sbin/sizer -v | awk '{print $3}'`
+		UNAME_RELEASE=$(/usr/sbin/sizer -v | awk '{print $3}')
 		;;
 	*5.*)
-		UNAME_RELEASE=`/usr/sbin/sizer -v | awk '{print $4}'`
+		UNAME_RELEASE=$(/usr/sbin/sizer -v | awk '{print $4}')
 		;;
 	esac
 	# According to Compaq, /usr/sbin/psrinfo has been available on
 	# OSF/1 and Tru64 systems produced since 1995.  I hope that
 	# covers most systems running today.  This code pipes the CPU
 	# types through head -n 1, so we only detect the type of CPU 0.
-	ALPHA_CPU_TYPE=`/usr/sbin/psrinfo -v | sed -n -e 's/^  The alpha \(.*\) processor.*$/\1/p' | head -n 1`
+	ALPHA_CPU_TYPE=$(/usr/sbin/psrinfo -v | sed -n -e 's/^  The alpha \(.*\) processor.*$/\1/p' | head -n 1)
 	case "$ALPHA_CPU_TYPE" in
 	    "EV4 (21064)")
 		UNAME_MACHINE=alpha ;;
@@ -326,7 +326,7 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	# A Tn.n version is a released field test version.
 	# A Xn.n version is an unreleased experimental baselevel.
 	# 1.2 uses "1.2" for uname -r.
-	echo "$UNAME_MACHINE"-dec-osf"`echo "$UNAME_RELEASE" | sed -e 's/^[PVTX]//' | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`"
+	echo "$UNAME_MACHINE"-dec-osf"$(echo "$UNAME_RELEASE" | sed -e 's/^[PVTX]//' | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz)"
 	# Reset EXIT trap before exiting to avoid spurious non-zero exit code.
 	exitcode=$?
 	trap '' 0
@@ -360,7 +360,7 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	exit ;;
     Pyramid*:OSx*:*:* | MIS*:OSx*:*:* | MIS*:SMP_DC-OSx*:*:*)
 	# akee@wpdis03.wpafb.af.mil (Earle F. Ake) contributed MIS and NILE.
-	if test "`(/bin/universe) 2>/dev/null`" = att ; then
+	if test "$( (/bin/universe) 2>/dev/null)" = att ; then
 		echo pyramid-pyramid-sysv3
 	else
 		echo pyramid-pyramid-bsd
@@ -373,17 +373,17 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	echo sparc-icl-nx6
 	exit ;;
     DRS?6000:UNIX_SV:4.2*:7* | DRS?6000:isis:4.2*:7*)
-	case `/usr/bin/uname -p` in
+	case $(/usr/bin/uname -p) in
 	    sparc) echo sparc-icl-nx7; exit ;;
 	esac ;;
     s390x:SunOS:*:*)
-	echo "$UNAME_MACHINE"-ibm-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
+	echo "$UNAME_MACHINE"-ibm-solaris2"$(echo "$UNAME_RELEASE" | sed -e 's/[^.]*//')"
 	exit ;;
     sun4H:SunOS:5.*:*)
-	echo sparc-hal-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+	echo sparc-hal-solaris2"$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*//')"
 	exit ;;
     sun4*:SunOS:5.*:* | tadpole*:SunOS:5.*:*)
-	echo sparc-sun-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
+	echo sparc-sun-solaris2"$(echo "$UNAME_RELEASE" | sed -e 's/[^.]*//')"
 	exit ;;
     i86pc:AuroraUX:5.*:* | i86xen:AuroraUX:5.*:*)
 	echo i386-pc-auroraux"$UNAME_RELEASE"
@@ -402,30 +402,30 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 		SUN_ARCH=x86_64
 	    fi
 	fi
-	echo "$SUN_ARCH"-pc-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+	echo "$SUN_ARCH"-pc-solaris2"$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*//')"
 	exit ;;
     sun4*:SunOS:6*:*)
 	# According to config.sub, this is the proper way to canonicalize
 	# SunOS6.  Hard to guess exactly what SunOS6 will be like, but
 	# it's likely to be more like Solaris than SunOS4.
-	echo sparc-sun-solaris3"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+	echo sparc-sun-solaris3"$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*//')"
 	exit ;;
     sun4*:SunOS:*:*)
-	case "`/usr/bin/arch -k`" in
+	case "$(/usr/bin/arch -k)" in
 	    Series*|S4*)
-		UNAME_RELEASE=`uname -v`
+		UNAME_RELEASE=$(uname -v)
 		;;
 	esac
 	# Japanese Language versions have a version number like `4.1.3-JL'.
-	echo sparc-sun-sunos"`echo "$UNAME_RELEASE"|sed -e 's/-/_/'`"
+	echo sparc-sun-sunos"$(echo "$UNAME_RELEASE"|sed -e 's/-/_/')"
 	exit ;;
     sun3*:SunOS:*:*)
 	echo m68k-sun-sunos"$UNAME_RELEASE"
 	exit ;;
     sun*:*:4.2BSD:*)
-	UNAME_RELEASE=`(sed 1q /etc/motd | awk '{print substr($5,1,3)}') 2>/dev/null`
+	UNAME_RELEASE=$( (sed 1q /etc/motd | awk '{print substr($5,1,3)}') 2>/dev/null)
 	test "x$UNAME_RELEASE" = x && UNAME_RELEASE=3
-	case "`/bin/arch`" in
+	case "$(/bin/arch)" in
 	    sun3)
 		echo m68k-sun-sunos"$UNAME_RELEASE"
 		;;
@@ -505,8 +505,8 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	}
 EOF
 	$CC_FOR_BUILD -o "$dummy" "$dummy.c" &&
-	  dummyarg=`echo "$UNAME_RELEASE" | sed -n 's/\([0-9]*\).*/\1/p'` &&
-	  SYSTEM_NAME=`"$dummy" "$dummyarg"` &&
+	  dummyarg=$(echo "$UNAME_RELEASE" | sed -n 's/\([0-9]*\).*/\1/p') &&
+	  SYSTEM_NAME=$("$dummy" "$dummyarg") &&
 	    { echo "$SYSTEM_NAME"; exit; }
 	echo mips-mips-riscos"$UNAME_RELEASE"
 	exit ;;
@@ -533,7 +533,7 @@ EOF
 	exit ;;
     AViiON:dgux:*:*)
 	# DG/UX returns AViiON for all architectures
-	UNAME_PROCESSOR=`/usr/bin/uname -p`
+	UNAME_PROCESSOR=$(/usr/bin/uname -p)
 	if [ "$UNAME_PROCESSOR" = mc88100 ] || [ "$UNAME_PROCESSOR" = mc88110 ]
 	then
 	    if [ "$TARGET_BINARY_INTERFACE"x = m88kdguxelfx ] || \
@@ -561,7 +561,7 @@ EOF
 	echo m68k-tektronix-bsd
 	exit ;;
     *:IRIX*:*:*)
-	echo mips-sgi-irix"`echo "$UNAME_RELEASE"|sed -e 's/-/_/g'`"
+	echo mips-sgi-irix"$(echo "$UNAME_RELEASE"|sed -e 's/-/_/g')"
 	exit ;;
     ????????:AIX?:[12].1:2)   # AIX 2.2.1 or AIX 2.1.1 is RT/PC AIX.
 	echo romp-ibm-aix     # uname -m gives an 8 hex-code CPU id
@@ -571,7 +571,7 @@ EOF
 	exit ;;
     ia64:AIX:*:*)
 	if [ -x /usr/bin/oslevel ] ; then
-		IBM_REV=`/usr/bin/oslevel`
+		IBM_REV=$(/usr/bin/oslevel)
 	else
 		IBM_REV="$UNAME_VERSION.$UNAME_RELEASE"
 	fi
@@ -591,7 +591,7 @@ EOF
 			exit(0);
 			}
 EOF
-		if $CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=`"$dummy"`
+		if $CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=$("$dummy")
 		then
 			echo "$SYSTEM_NAME"
 		else
@@ -604,15 +604,15 @@ EOF
 	fi
 	exit ;;
     *:AIX:*:[4567])
-	IBM_CPU_ID=`/usr/sbin/lsdev -C -c processor -S available | sed 1q | awk '{ print $1 }'`
+	IBM_CPU_ID=$(/usr/sbin/lsdev -C -c processor -S available | sed 1q | awk '{ print $1 }')
 	if /usr/sbin/lsattr -El "$IBM_CPU_ID" | grep ' POWER' >/dev/null 2>&1; then
 		IBM_ARCH=rs6000
 	else
 		IBM_ARCH=powerpc
 	fi
 	if [ -x /usr/bin/lslpp ] ; then
-		IBM_REV=`/usr/bin/lslpp -Lqc bos.rte.libc |
-			   awk -F: '{ print $3 }' | sed s/[0-9]*$/0/`
+		IBM_REV=$(/usr/bin/lslpp -Lqc bos.rte.libc |
+			   awk -F: '{ print $3 }' | sed s/[0-9]*$/0/)
 	else
 		IBM_REV="$UNAME_VERSION.$UNAME_RELEASE"
 	fi
@@ -640,14 +640,14 @@ EOF
 	echo m68k-hp-bsd4.4
 	exit ;;
     9000/[34678]??:HP-UX:*:*)
-	HPUX_REV=`echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//'`
+	HPUX_REV=$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//')
 	case "$UNAME_MACHINE" in
 	    9000/31?)            HP_ARCH=m68000 ;;
 	    9000/[34]??)         HP_ARCH=m68k ;;
 	    9000/[678][0-9][0-9])
 		if [ -x /usr/bin/getconf ]; then
-		    sc_cpu_version=`/usr/bin/getconf SC_CPU_VERSION 2>/dev/null`
-		    sc_kernel_bits=`/usr/bin/getconf SC_KERNEL_BITS 2>/dev/null`
+		    sc_cpu_version=$(/usr/bin/getconf SC_CPU_VERSION 2>/dev/null)
+		    sc_kernel_bits=$(/usr/bin/getconf SC_KERNEL_BITS 2>/dev/null)
 		    case "$sc_cpu_version" in
 		      523) HP_ARCH=hppa1.0 ;; # CPU_PA_RISC1_0
 		      528) HP_ARCH=hppa1.1 ;; # CPU_PA_RISC1_1
@@ -694,7 +694,7 @@ EOF
 		    exit (0);
 		}
 EOF
-		    (CCOPTS="" $CC_FOR_BUILD -o "$dummy" "$dummy.c" 2>/dev/null) && HP_ARCH=`"$dummy"`
+		    (CCOPTS="" $CC_FOR_BUILD -o "$dummy" "$dummy.c" 2>/dev/null) && HP_ARCH=$("$dummy")
 		    test -z "$HP_ARCH" && HP_ARCH=hppa
 		fi ;;
 	esac
@@ -722,7 +722,7 @@ EOF
 	echo "$HP_ARCH"-hp-hpux"$HPUX_REV"
 	exit ;;
     ia64:HP-UX:*:*)
-	HPUX_REV=`echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//'`
+	HPUX_REV=$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//')
 	echo ia64-hp-hpux"$HPUX_REV"
 	exit ;;
     3050*:HI-UX:*:*)
@@ -752,7 +752,7 @@ EOF
 	  exit (0);
 	}
 EOF
-	$CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=`"$dummy"` &&
+	$CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=$("$dummy") &&
 		{ echo "$SYSTEM_NAME"; exit; }
 	echo unknown-hitachi-hiuxwe2
 	exit ;;
@@ -821,14 +821,14 @@ EOF
 	echo craynv-cray-unicosmp"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
 	exit ;;
     F30[01]:UNIX_System_V:*:* | F700:UNIX_System_V:*:*)
-	FUJITSU_PROC=`uname -m | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`
-	FUJITSU_SYS=`uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///'`
-	FUJITSU_REL=`echo "$UNAME_RELEASE" | sed -e 's/ /_/'`
+	FUJITSU_PROC=$(uname -m | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz)
+	FUJITSU_SYS=$(uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///')
+	FUJITSU_REL=$(echo "$UNAME_RELEASE" | sed -e 's/ /_/')
 	echo "${FUJITSU_PROC}-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}"
 	exit ;;
     5000:UNIX_System_V:4.*:*)
-	FUJITSU_SYS=`uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///'`
-	FUJITSU_REL=`echo "$UNAME_RELEASE" | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/ /_/'`
+	FUJITSU_SYS=$(uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///')
+	FUJITSU_REL=$(echo "$UNAME_RELEASE" | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/ /_/')
 	echo "sparc-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}"
 	exit ;;
     i*86:BSD/386:*:* | i*86:BSD/OS:*:* | *:Ascend\ Embedded/OS:*:*)
@@ -841,14 +841,14 @@ EOF
 	echo "$UNAME_MACHINE"-unknown-bsdi"$UNAME_RELEASE"
 	exit ;;
     *:FreeBSD:*:*)
-	UNAME_PROCESSOR=`/usr/bin/uname -p`
+	UNAME_PROCESSOR=$(/usr/bin/uname -p)
 	case "$UNAME_PROCESSOR" in
 	    amd64)
 		UNAME_PROCESSOR=x86_64 ;;
 	    i386)
 		UNAME_PROCESSOR=i586 ;;
 	esac
-	echo "$UNAME_PROCESSOR"-unknown-freebsd"`echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`"
+	echo "$UNAME_PROCESSOR"-unknown-freebsd"$(echo "$UNAME_RELEASE"|sed -e 's/[-(].*//')"
 	exit ;;
     i*:CYGWIN*:*)
 	echo "$UNAME_MACHINE"-pc-cygwin
@@ -884,15 +884,15 @@ EOF
 	echo x86_64-unknown-cygwin
 	exit ;;
     prep*:SunOS:5.*:*)
-	echo powerpcle-unknown-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+	echo powerpcle-unknown-solaris2"$(echo "$UNAME_RELEASE"|sed -e 's/[^.]*//')"
 	exit ;;
     *:GNU:*:*)
 	# the GNU system
-	echo "`echo "$UNAME_MACHINE"|sed -e 's,[-/].*$,,'`-unknown-$LIBC`echo "$UNAME_RELEASE"|sed -e 's,/.*$,,'`"
+	echo "$(echo "$UNAME_MACHINE"|sed -e 's,[-/].*$,,')-unknown-$LIBC$(echo "$UNAME_RELEASE"|sed -e 's,/.*$,,')"
 	exit ;;
     *:GNU/*:*:*)
 	# other systems with GNU libc and userland
-	echo "$UNAME_MACHINE-unknown-`echo "$UNAME_SYSTEM" | sed 's,^[^/]*/,,' | tr "[:upper:]" "[:lower:]"``echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`-$LIBC"
+	echo "$UNAME_MACHINE-unknown-$(echo "$UNAME_SYSTEM" | sed 's,^[^/]*/,,' | tr "[:upper:]" "[:lower:]")$(echo "$UNAME_RELEASE"|sed -e 's/[-(].*//')-$LIBC"
 	exit ;;
     i*86:Minix:*:*)
 	echo "$UNAME_MACHINE"-pc-minix
@@ -905,7 +905,7 @@ EOF
 	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
 	exit ;;
     alpha:Linux:*:*)
-	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
+	case $(sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo) in
 	  EV5)   UNAME_MACHINE=alphaev5 ;;
 	  EV56)  UNAME_MACHINE=alphaev56 ;;
 	  PCA56) UNAME_MACHINE=alphapca56 ;;
@@ -986,7 +986,7 @@ EOF
 	#endif
 	#endif
 EOF
-	eval "`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^CPU'`"
+	eval "$($CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^CPU')"
 	test "x$CPU" != x && { echo "$CPU-unknown-linux-$LIBC"; exit; }
 	;;
     mips64el:Linux:*:*)
@@ -1006,7 +1006,7 @@ EOF
 	exit ;;
     parisc:Linux:*:* | hppa:Linux:*:*)
 	# Look for CPU level
-	case `grep '^cpu[^a-z]*:' /proc/cpuinfo 2>/dev/null | cut -d' ' -f2` in
+	case $(grep '^cpu[^a-z]*:' /proc/cpuinfo 2>/dev/null | cut -d' ' -f2) in
 	  PA7*) echo hppa1.1-unknown-linux-"$LIBC" ;;
 	  PA8*) echo hppa2.0-unknown-linux-"$LIBC" ;;
 	  *)    echo hppa-unknown-linux-"$LIBC" ;;
@@ -1086,7 +1086,7 @@ EOF
 	echo "$UNAME_MACHINE"-pc-msdosdjgpp
 	exit ;;
     i*86:*:4.*:*)
-	UNAME_REL=`echo "$UNAME_RELEASE" | sed 's/\/MP$//'`
+	UNAME_REL=$(echo "$UNAME_RELEASE" | sed 's/\/MP$//')
 	if grep Novell /usr/include/link.h >/dev/null 2>/dev/null; then
 		echo "$UNAME_MACHINE"-univel-sysv"$UNAME_REL"
 	else
@@ -1095,7 +1095,7 @@ EOF
 	exit ;;
     i*86:*:5:[678]*)
 	# UnixWare 7.x, OpenUNIX and OpenServer 6.
-	case `/bin/uname -X | grep "^Machine"` in
+	case $(/bin/uname -X | grep "^Machine") in
 	    *486*)	     UNAME_MACHINE=i486 ;;
 	    *Pentium)	     UNAME_MACHINE=i586 ;;
 	    *Pent*|*Celeron) UNAME_MACHINE=i686 ;;
@@ -1104,10 +1104,10 @@ EOF
 	exit ;;
     i*86:*:3.2:*)
 	if test -f /usr/options/cb.name; then
-		UNAME_REL=`sed -n 's/.*Version //p' </usr/options/cb.name`
+		UNAME_REL=$(sed -n 's/.*Version //p' </usr/options/cb.name)
 		echo "$UNAME_MACHINE"-pc-isc"$UNAME_REL"
 	elif /bin/uname -X 2>/dev/null >/dev/null ; then
-		UNAME_REL=`(/bin/uname -X|grep Release|sed -e 's/.*= //')`
+		UNAME_REL=$( (/bin/uname -X|grep Release|sed -e 's/.*= //'))
 		(/bin/uname -X|grep i80486 >/dev/null) && UNAME_MACHINE=i486
 		(/bin/uname -X|grep '^Machine.*Pentium' >/dev/null) \
 			&& UNAME_MACHINE=i586
@@ -1157,7 +1157,7 @@ EOF
     3[345]??:*:4.0:3.0 | 3[34]??A:*:4.0:3.0 | 3[34]??,*:*:4.0:3.0 | 3[34]??/*:*:4.0:3.0 | 4400:*:4.0:3.0 | 4850:*:4.0:3.0 | SKA40:*:4.0:3.0 | SDS2:*:4.0:3.0 | SHG2:*:4.0:3.0 | S7501*:*:4.0:3.0)
 	OS_REL=''
 	test -r /etc/.relid \
-	&& OS_REL=.`sed -n 's/[^ ]* [^ ]* \([0-9][0-9]\).*/\1/p' < /etc/.relid`
+	&& OS_REL=.$(sed -n 's/[^ ]* [^ ]* \([0-9][0-9]\).*/\1/p' < /etc/.relid)
 	/bin/uname -p 2>/dev/null | grep 86 >/dev/null \
 	  && { echo i486-ncr-sysv4.3"$OS_REL"; exit; }
 	/bin/uname -p 2>/dev/null | /bin/grep entium >/dev/null \
@@ -1168,7 +1168,7 @@ EOF
     NCR*:*:4.2:* | MPRAS*:*:4.2:*)
 	OS_REL='.3'
 	test -r /etc/.relid \
-	    && OS_REL=.`sed -n 's/[^ ]* [^ ]* \([0-9][0-9]\).*/\1/p' < /etc/.relid`
+	    && OS_REL=.$(sed -n 's/[^ ]* [^ ]* \([0-9][0-9]\).*/\1/p' < /etc/.relid)
 	/bin/uname -p 2>/dev/null | grep 86 >/dev/null \
 	    && { echo i486-ncr-sysv4.3"$OS_REL"; exit; }
 	/bin/uname -p 2>/dev/null | /bin/grep entium >/dev/null \
@@ -1201,7 +1201,7 @@ EOF
 	exit ;;
     *:SINIX-*:*:*)
 	if uname -p 2>/dev/null >/dev/null ; then
-		UNAME_MACHINE=`(uname -p) 2>/dev/null`
+		UNAME_MACHINE=$( (uname -p) 2>/dev/null)
 		echo "$UNAME_MACHINE"-sni-sysv4
 	else
 		echo ns32k-sni-sysv
@@ -1284,12 +1284,12 @@ EOF
 	echo "$UNAME_MACHINE"-apple-rhapsody"$UNAME_RELEASE"
 	exit ;;
     *:Darwin:*:*)
-	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
+	UNAME_PROCESSOR=$(uname -p) || UNAME_PROCESSOR=unknown
 	eval "$set_cc_for_build"
 	if test "$UNAME_PROCESSOR" = unknown ; then
 	    UNAME_PROCESSOR=powerpc
 	fi
-	if test "`echo "$UNAME_RELEASE" | sed -e 's/\..*//'`" -le 10 ; then
+	if test "$(echo "$UNAME_RELEASE" | sed -e 's/\..*//')" -le 10 ; then
 	    if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
 		if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
 		       (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
@@ -1320,7 +1320,7 @@ EOF
 	echo "$UNAME_PROCESSOR"-apple-darwin"$UNAME_RELEASE"
 	exit ;;
     *:procnto*:*:* | *:QNX:[0123456789]*:*)
-	UNAME_PROCESSOR=`uname -p`
+	UNAME_PROCESSOR=$(uname -p)
 	if test "$UNAME_PROCESSOR" = x86; then
 		UNAME_PROCESSOR=i386
 		UNAME_MACHINE=pc
@@ -1387,10 +1387,10 @@ EOF
 	echo mips-sei-seiux"$UNAME_RELEASE"
 	exit ;;
     *:DragonFly:*:*)
-	echo "$UNAME_MACHINE"-unknown-dragonfly"`echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`"
+	echo "$UNAME_MACHINE"-unknown-dragonfly"$(echo "$UNAME_RELEASE"|sed -e 's/[-(].*//')"
 	exit ;;
     *:*VMS:*:*)
-	UNAME_MACHINE=`(uname -p) 2>/dev/null`
+	UNAME_MACHINE=$( (uname -p) 2>/dev/null)
 	case "$UNAME_MACHINE" in
 	    A*) echo alpha-dec-vms ; exit ;;
 	    I*) echo ia64-dec-vms ; exit ;;
@@ -1400,7 +1400,7 @@ EOF
 	echo i386-pc-xenix
 	exit ;;
     i*86:skyos:*:*)
-	echo "$UNAME_MACHINE"-pc-skyos"`echo "$UNAME_RELEASE" | sed -e 's/ .*$//'`"
+	echo "$UNAME_MACHINE"-pc-skyos"$(echo "$UNAME_RELEASE" | sed -e 's/ .*$//')"
 	exit ;;
     i*86:rdos:*:*)
 	echo "$UNAME_MACHINE"-pc-rdos
@@ -1445,20 +1445,20 @@ provide the necessary information to handle your system.
 
 config.guess timestamp = $timestamp
 
-uname -m = `(uname -m) 2>/dev/null || echo unknown`
-uname -r = `(uname -r) 2>/dev/null || echo unknown`
-uname -s = `(uname -s) 2>/dev/null || echo unknown`
-uname -v = `(uname -v) 2>/dev/null || echo unknown`
+uname -m = $( (uname -m) 2>/dev/null || echo unknown)
+uname -r = $( (uname -r) 2>/dev/null || echo unknown)
+uname -s = $( (uname -s) 2>/dev/null || echo unknown)
+uname -v = $( (uname -v) 2>/dev/null || echo unknown)
 
-/usr/bin/uname -p = `(/usr/bin/uname -p) 2>/dev/null`
-/bin/uname -X     = `(/bin/uname -X) 2>/dev/null`
+/usr/bin/uname -p = $( (/usr/bin/uname -p) 2>/dev/null)
+/bin/uname -X     = $( (/bin/uname -X) 2>/dev/null)
 
-hostinfo               = `(hostinfo) 2>/dev/null`
-/bin/universe          = `(/bin/universe) 2>/dev/null`
-/usr/bin/arch -k       = `(/usr/bin/arch -k) 2>/dev/null`
-/bin/arch              = `(/bin/arch) 2>/dev/null`
-/usr/bin/oslevel       = `(/usr/bin/oslevel) 2>/dev/null`
-/usr/convex/getsysinfo = `(/usr/convex/getsysinfo) 2>/dev/null`
+hostinfo               = $( (hostinfo) 2>/dev/null)
+/bin/universe          = $( (/bin/universe) 2>/dev/null)
+/usr/bin/arch -k       = $( (/usr/bin/arch -k) 2>/dev/null)
+/bin/arch              = $( (/bin/arch) 2>/dev/null)
+/usr/bin/oslevel       = $( (/usr/bin/oslevel) 2>/dev/null)
+/usr/convex/getsysinfo = $( (/usr/convex/getsysinfo) 2>/dev/null)
 
 UNAME_MACHINE = "$UNAME_MACHINE"
 UNAME_RELEASE = "$UNAME_RELEASE"

--- a/config.sub
+++ b/config.sub
@@ -50,7 +50,7 @@ timestamp='2018-04-24'
 #	CPU_TYPE-MANUFACTURER-KERNEL-OPERATING_SYSTEM
 # It is wrong to echo any other type of specification.
 
-me=`echo "$0" | sed -e 's,.*/,,'`
+me=$(echo "$0" | sed -e 's,.*/,,')
 
 usage="\
 Usage: $0 [OPTION] CPU-MFR-OPSYS or ALIAS
@@ -112,7 +112,7 @@ esac
 
 # Separate what the user gave into CPU-COMPANY and OS or KERNEL-OS (if any).
 # Here we must recognize all the valid KERNEL-OS combinations.
-maybe_os=`echo "$1" | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\2/'`
+maybe_os=$(echo "$1" | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\2/')
 case $maybe_os in
   nto-qnx* | linux-gnu* | linux-android* | linux-dietlibc | linux-newlib* | \
   linux-musl* | linux-uclibc* | uclinux-uclibc* | uclinux-gnu* | kfreebsd*-gnu* | \
@@ -120,16 +120,16 @@ case $maybe_os in
   kopensolaris*-gnu* | cloudabi*-eabi* | \
   storm-chaos* | os2-emx* | rtmk-nova*)
     os=-$maybe_os
-    basic_machine=`echo "$1" | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`
+    basic_machine=$(echo "$1" | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/')
     ;;
   android-linux)
     os=-linux-android
-    basic_machine=`echo "$1" | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`-unknown
+    basic_machine=$(echo "$1" | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/')-unknown
     ;;
   *)
-    basic_machine=`echo "$1" | sed 's/-[^-]*$//'`
+    basic_machine=$(echo "$1" | sed 's/-[^-]*$//')
     if [ "$basic_machine" != "$1" ]
-    then os=`echo "$1" | sed 's/.*-/-/'`
+    then os=$(echo "$1" | sed 's/.*-/-/')
     else os=; fi
     ;;
 esac
@@ -178,44 +178,44 @@ case $os in
 		;;
 	-sco6)
 		os=-sco5v6
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-sco5)
 		os=-sco3.2v5
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-sco4)
 		os=-sco3.2v4
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-sco3.2.[4-9]*)
-		os=`echo $os | sed -e 's/sco3.2./sco3.2v/'`
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		os=$(echo $os | sed -e 's/sco3.2./sco3.2v/')
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-sco3.2v[4-9]*)
 		# Don't forget version if it is 3.2v4 or newer.
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-sco5v6*)
 		# Don't forget version if it is 3.2v4 or newer.
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-sco*)
 		os=-sco3.2v2
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-udk*)
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-isc)
 		os=-isc2.2
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-clix*)
 		basic_machine=clipper-intergraph
 		;;
 	-isc*)
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-pc/')
 		;;
 	-lynx*178)
 		os=-lynxos178
@@ -227,7 +227,7 @@ case $os in
 		os=-lynxos
 		;;
 	-ptx*)
-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-sequent/'`
+		basic_machine=$(echo "$1" | sed -e 's/86-.*/86-sequent/')
 		;;
 	-psos*)
 		os=-psos
@@ -495,7 +495,7 @@ case $basic_machine in
 		basic_machine=x86_64-pc
 		;;
 	amd64-*)
-		basic_machine=x86_64-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=x86_64-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	amdahl)
 		basic_machine=580-amdahl
@@ -540,7 +540,7 @@ case $basic_machine in
 		os=-linux
 		;;
 	blackfin-*)
-		basic_machine=bfin-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=bfin-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		os=-linux
 		;;
 	bluegene*)
@@ -548,13 +548,13 @@ case $basic_machine in
 		os=-cnk
 		;;
 	c54x-*)
-		basic_machine=tic54x-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=tic54x-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	c55x-*)
-		basic_machine=tic55x-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=tic55x-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	c6x-*)
-		basic_machine=tic6x-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=tic6x-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	c90)
 		basic_machine=c90-cray
@@ -652,7 +652,7 @@ case $basic_machine in
 		os=$os"spe"
 		;;
 	e500v[12]-*)
-		basic_machine=powerpc-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=powerpc-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		os=$os"spe"
 		;;
 	ebmon29k)
@@ -756,19 +756,19 @@ case $basic_machine in
 		basic_machine=i370-ibm
 		;;
 	i*86v32)
-		basic_machine=`echo "$1" | sed -e 's/86.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86.*/86-pc/')
 		os=-sysv32
 		;;
 	i*86v4*)
-		basic_machine=`echo "$1" | sed -e 's/86.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86.*/86-pc/')
 		os=-sysv4
 		;;
 	i*86v)
-		basic_machine=`echo "$1" | sed -e 's/86.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86.*/86-pc/')
 		os=-sysv
 		;;
 	i*86sol2)
-		basic_machine=`echo "$1" | sed -e 's/86.*/86-pc/'`
+		basic_machine=$(echo "$1" | sed -e 's/86.*/86-pc/')
 		os=-solaris2
 		;;
 	i386mach)
@@ -794,14 +794,14 @@ case $basic_machine in
 		os=-sysv
 		;;
 	leon-*|leon[3-9]-*)
-		basic_machine=sparc-`echo "$basic_machine" | sed 's/-.*//'`
+		basic_machine=sparc-$(echo "$basic_machine" | sed 's/-.*//')
 		;;
 	m68knommu)
 		basic_machine=m68k-unknown
 		os=-linux
 		;;
 	m68knommu-*)
-		basic_machine=m68k-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=m68k-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		os=-linux
 		;;
 	magnum | m3230)
@@ -835,10 +835,10 @@ case $basic_machine in
 		os=-mint
 		;;
 	mips3*-*)
-		basic_machine=`echo "$basic_machine" | sed -e 's/mips3/mips64/'`
+		basic_machine=$(echo "$basic_machine" | sed -e 's/mips3/mips64/')
 		;;
 	mips3*)
-		basic_machine=`echo "$basic_machine" | sed -e 's/mips3/mips64/'`-unknown
+		basic_machine=$(echo "$basic_machine" | sed -e 's/mips3/mips64/')-unknown
 		;;
 	monitor)
 		basic_machine=m68k-rom68k
@@ -857,7 +857,7 @@ case $basic_machine in
 		os=-msdos
 		;;
 	ms1-*)
-		basic_machine=`echo "$basic_machine" | sed -e 's/ms1-/mt-/'`
+		basic_machine=$(echo "$basic_machine" | sed -e 's/ms1-/mt-/')
 		;;
 	msys)
 		basic_machine=i686-pc
@@ -982,7 +982,7 @@ case $basic_machine in
 		os=-linux
 		;;
 	parisc-*)
-		basic_machine=hppa-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=hppa-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		os=-linux
 		;;
 	pbd)
@@ -998,7 +998,7 @@ case $basic_machine in
 		basic_machine=i386-pc
 		;;
 	pc98-*)
-		basic_machine=i386-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=i386-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	pentium | p5 | k5 | k6 | nexgen | viac3)
 		basic_machine=i586-pc
@@ -1013,16 +1013,16 @@ case $basic_machine in
 		basic_machine=i786-pc
 		;;
 	pentium-* | p5-* | k5-* | k6-* | nexgen-* | viac3-*)
-		basic_machine=i586-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=i586-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	pentiumpro-* | p6-* | 6x86-* | athlon-*)
-		basic_machine=i686-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=i686-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	pentiumii-* | pentium2-* | pentiumiii-* | pentium3-*)
-		basic_machine=i686-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=i686-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	pentium4-*)
-		basic_machine=i786-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=i786-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	pn)
 		basic_machine=pn-gould
@@ -1032,23 +1032,23 @@ case $basic_machine in
 	ppc | ppcbe)	basic_machine=powerpc-unknown
 		;;
 	ppc-* | ppcbe-*)
-		basic_machine=powerpc-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=powerpc-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	ppcle | powerpclittle)
 		basic_machine=powerpcle-unknown
 		;;
 	ppcle-* | powerpclittle-*)
-		basic_machine=powerpcle-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=powerpcle-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	ppc64)	basic_machine=powerpc64-unknown
 		;;
-	ppc64-*) basic_machine=powerpc64-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+	ppc64-*) basic_machine=powerpc64-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	ppc64le | powerpc64little)
 		basic_machine=powerpc64le-unknown
 		;;
 	ppc64le-* | powerpc64little-*)
-		basic_machine=powerpc64le-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=powerpc64le-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	ps2)
 		basic_machine=i386-ibm
@@ -1124,7 +1124,7 @@ case $basic_machine in
 		os=-sysv4
 		;;
 	strongarm-* | thumb-*)
-		basic_machine=arm-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+		basic_machine=arm-$(echo "$basic_machine" | sed 's/^[^-]*-//')
 		;;
 	sun2)
 		basic_machine=m68000-sun
@@ -1257,7 +1257,7 @@ case $basic_machine in
 		basic_machine=xps100-honeywell
 		;;
 	xscale-* | xscalee[bl]-*)
-		basic_machine=`echo "$basic_machine" | sed 's/^xscale/arm/'`
+		basic_machine=$(echo "$basic_machine" | sed 's/^xscale/arm/')
 		;;
 	ymp)
 		basic_machine=ymp-cray
@@ -1327,10 +1327,10 @@ esac
 # Here we canonicalize certain aliases for manufacturers.
 case $basic_machine in
 	*-digital*)
-		basic_machine=`echo "$basic_machine" | sed 's/digital.*/dec/'`
+		basic_machine=$(echo "$basic_machine" | sed 's/digital.*/dec/')
 		;;
 	*-commodore*)
-		basic_machine=`echo "$basic_machine" | sed 's/commodore.*/cbm/'`
+		basic_machine=$(echo "$basic_machine" | sed 's/commodore.*/cbm/')
 		;;
 	*)
 		;;
@@ -1348,7 +1348,7 @@ case $os in
 		os=-auroraux
 		;;
 	-solaris1 | -solaris1.*)
-		os=`echo $os | sed -e 's|solaris1|sunos4|'`
+		os=$(echo $os | sed -e 's|solaris1|sunos4|')
 		;;
 	-solaris)
 		os=-solaris2
@@ -1357,7 +1357,7 @@ case $os in
 		os=-sysv4.2uw
 		;;
 	-gnu/linux*)
-		os=`echo $os | sed -e 's|gnu/linux|linux-gnu|'`
+		os=$(echo $os | sed -e 's|gnu/linux|linux-gnu|')
 		;;
 	# es1800 is here to avoid being matched by es* (a different OS)
 	-es1800*)
@@ -1409,26 +1409,26 @@ case $os in
 	-nto-qnx*)
 		;;
 	-nto*)
-		os=`echo $os | sed -e 's|nto|nto-qnx|'`
+		os=$(echo $os | sed -e 's|nto|nto-qnx|')
 		;;
 	-sim | -xray | -os68k* | -v88r* \
 	      | -windows* | -osx | -abug | -netware* | -os9* \
 	      | -macos* | -mpw* | -magic* | -mmixware* | -mon960* | -lnews*)
 		;;
 	-mac*)
-		os=`echo "$os" | sed -e 's|mac|macos|'`
+		os=$(echo "$os" | sed -e 's|mac|macos|')
 		;;
 	-linux-dietlibc)
 		os=-linux-dietlibc
 		;;
 	-linux*)
-		os=`echo $os | sed -e 's|linux|linux-gnu|'`
+		os=$(echo $os | sed -e 's|linux|linux-gnu|')
 		;;
 	-sunos5*)
-		os=`echo "$os" | sed -e 's|sunos5|solaris2|'`
+		os=$(echo "$os" | sed -e 's|sunos5|solaris2|')
 		;;
 	-sunos6*)
-		os=`echo "$os" | sed -e 's|sunos6|solaris3|'`
+		os=$(echo "$os" | sed -e 's|sunos6|solaris3|')
 		;;
 	-opened*)
 		os=-openedition
@@ -1471,7 +1471,7 @@ case $os in
 		;;
 	# Preserve the version number of sinix5.
 	-sinix5.*)
-		os=`echo $os | sed -e 's|sinix|sysv|'`
+		os=$(echo $os | sed -e 's|sinix|sysv|')
 		;;
 	-sinix*)
 		os=-sysv4
@@ -1530,7 +1530,7 @@ case $os in
 		;;
 	*)
 		# Get rid of the `-' at the beginning of $os.
-		os=`echo $os | sed 's/[^-]*-//'`
+		os=$(echo $os | sed 's/[^-]*-//')
 		echo Invalid configuration \`"$1"\': system \`"$os"\' not recognized 1>&2
 		exit 1
 		;;
@@ -1790,7 +1790,7 @@ case $basic_machine in
 				vendor=stratus
 				;;
 		esac
-		basic_machine=`echo "$basic_machine" | sed "s/unknown/$vendor/"`
+		basic_machine=$(echo "$basic_machine" | sed "s/unknown/$vendor/")
 		;;
 esac
 

--- a/configure
+++ b/configure
@@ -24,7 +24,7 @@ if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then :
   alias -g '${1+"$@"}'='"$@"'
   setopt NO_GLOB_SUBST
 else
-  case `(set -o) 2>/dev/null` in #(
+  case $( (set -o) 2>/dev/null) in #(
   *posix*) :
     set -o posix ;; #(
   *) :
@@ -43,14 +43,14 @@ as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo$as_echo
 # Prefer a ksh shell builtin over an external printf program on Solaris,
 # but without wasting forks for bash or zsh.
 if test -z "$BASH_VERSION$ZSH_VERSION" \
-    && (test "X`print -r -- $as_echo`" = "X$as_echo") 2>/dev/null; then
+    && (test "X$(print -r -- $as_echo)" = "X$as_echo") 2>/dev/null; then # TODO check superfluous params!!!
   as_echo='print -r --'
   as_echo_n='print -rn --'
-elif (test "X`printf %s $as_echo`" = "X$as_echo") 2>/dev/null; then
+elif (test "X$(printf %s $as_echo)" = "X$as_echo") 2>/dev/null; then
   as_echo='printf %s\n'
   as_echo_n='printf %s'
 else
-  if test "X`(/usr/ucb/echo -n -n $as_echo) 2>/dev/null`" = "X-n $as_echo"; then
+  if test "X$( (/usr/ucb/echo -n -n $as_echo) 2>/dev/null)" = "X-n $as_echo"; then
     as_echo_body='eval /usr/ucb/echo -n "$1$as_nl"'
     as_echo_n='/usr/ucb/echo -n'
   else
@@ -325,11 +325,11 @@ as_fn_mkdir_p ()
     as_dirs=
     while :; do
       case $as_dir in #(
-      *\'*) as_qdir=`$as_echo "$as_dir" | sed "s/'/'\\\\\\\\''/g"`;; #'(
+      *\'*) as_qdir=$($as_echo "$as_dir" | sed "s/'/'\\\\\\\\''/g");; #'(
       *) as_qdir=$as_dir;;
       esac
       as_dirs="'$as_qdir' $as_dirs"
-      as_dir=`$as_dirname -- "$as_dir" ||
+      as_dir=$($as_dirname -- "$as_dir" ||
 $as_expr X"$as_dir" : 'X\(.*[^/]\)//*[^/][^/]*/*$' \| \
 	 X"$as_dir" : 'X\(//\)[^/]' \| \
 	 X"$as_dir" : 'X\(//\)$' \| \
@@ -351,7 +351,7 @@ $as_echo X"$as_dir" |
 	    s//\1/
 	    q
 	  }
-	  s/.*/./; q'`
+	  s/.*/./; q')
       test -d "$as_dir" && break
     done
     test -z "$as_dirs" || eval "mkdir $as_dirs"
@@ -398,7 +398,7 @@ if (eval "test \$(( 1 + 1 )) = 2") 2>/dev/null; then :
 else
   as_fn_arith ()
   {
-    as_val=`expr "$@" || test $? -eq 1`
+    as_val=$(expr "$@" || test $? -eq 1)
   }
 fi # as_fn_arith
 
@@ -420,25 +420,25 @@ as_fn_error ()
 } # as_fn_error
 
 if expr a : '\(a\)' >/dev/null 2>&1 &&
-   test "X`expr 00001 : '.*\(...\)'`" = X001; then
+   test "X$(expr 00001 : '.*\(...\)')" = X001; then
   as_expr=expr
 else
   as_expr=false
 fi
 
-if (basename -- /) >/dev/null 2>&1 && test "X`basename -- / 2>&1`" = "X/"; then
+if (basename -- /) >/dev/null 2>&1 && test "X$(basename -- / 2>&1)" = "X/"; then
   as_basename=basename
 else
   as_basename=false
 fi
 
-if (as_dir=`dirname -- /` && test "X$as_dir" = X/) >/dev/null 2>&1; then
+if (as_dir=$(dirname -- /) && test "X$as_dir" = X/) >/dev/null 2>&1; then
   as_dirname=dirname
 else
   as_dirname=false
 fi
 
-as_me=`$as_basename -- "$0" ||
+as_me=$($as_basename -- "$0" ||
 $as_expr X/"$0" : '.*/\([^/][^/]*\)/*$' \| \
 	 X"$0" : 'X\(//\)$' \| \
 	 X"$0" : 'X\(/\)' \| . 2>/dev/null ||
@@ -455,7 +455,7 @@ $as_echo X/"$0" |
 	    s//\1/
 	    q
 	  }
-	  s/.*/./; q'`
+	  s/.*/./; q')
 
 # Avoid depending upon Character Ranges.
 as_cr_letters='abcdefghijklmnopqrstuvwxyz'
@@ -501,12 +501,12 @@ as_cr_alnum=$as_cr_Letters$as_cr_digits
 }
 
 ECHO_C= ECHO_N= ECHO_T=
-case `echo -n x` in #(((((
+case $(echo -n x) in #(((((
 -n*)
-  case `echo 'xy\c'` in
+  case $(echo 'xy\c') in
   *c*) ECHO_T='	';;	# ECHO_T is single tab character.
   xy)  ECHO_C='\c';;
-  *)   echo `echo ksh88 bug on AIX 6.1` > /dev/null
+  *)   echo $(echo ksh88 bug on AIX 6.1) > /dev/null
        ECHO_T='	';;
   esac;;
 *)
@@ -563,7 +563,7 @@ exec 6>&1
 # Name of the host.
 # hostname on some systems (SVR3.2, old GNU/Linux) returns a bogus exit status,
 # so uname gets run too.
-ac_hostname=`(hostname || uname -n) 2>/dev/null | sed 1q`
+ac_hostname=$( (hostname || uname -n) 2>/dev/null | sed 1q)
 
 #
 # Initializations.
@@ -919,7 +919,7 @@ do
   fi
 
   case $ac_option in
-  *=?*) ac_optarg=`expr "X$ac_option" : '[^=]*=\(.*\)'` ;;
+  *=?*) ac_optarg=$(expr "X$ac_option" : '[^=]*=\(.*\)') ;;
   *=)   ac_optarg= ;;
   *)    ac_optarg=yes ;;
   esac
@@ -963,12 +963,12 @@ do
     datarootdir=$ac_optarg ;;
 
   -disable-* | --disable-*)
-    ac_useropt=`expr "x$ac_option" : 'x-*disable-\(.*\)'`
+    ac_useropt=$(expr "x$ac_option" : 'x-*disable-\(.*\)')
     # Reject names that are not valid shell variable names.
     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
       as_fn_error $? "invalid feature name: $ac_useropt"
     ac_useropt_orig=$ac_useropt
-    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
+    ac_useropt=$($as_echo "$ac_useropt" | sed 's/[-+.]/_/g')
     case $ac_user_opts in
       *"
 "enable_$ac_useropt"
@@ -989,12 +989,12 @@ do
     dvidir=$ac_optarg ;;
 
   -enable-* | --enable-*)
-    ac_useropt=`expr "x$ac_option" : 'x-*enable-\([^=]*\)'`
+    ac_useropt=$(expr "x$ac_option" : 'x-*enable-\([^=]*\)')
     # Reject names that are not valid shell variable names.
     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
       as_fn_error $? "invalid feature name: $ac_useropt"
     ac_useropt_orig=$ac_useropt
-    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
+    ac_useropt=$($as_echo "$ac_useropt" | sed 's/[-+.]/_/g')
     case $ac_user_opts in
       *"
 "enable_$ac_useropt"
@@ -1193,12 +1193,12 @@ do
     ac_init_version=: ;;
 
   -with-* | --with-*)
-    ac_useropt=`expr "x$ac_option" : 'x-*with-\([^=]*\)'`
+    ac_useropt=$(expr "x$ac_option" : 'x-*with-\([^=]*\)')
     # Reject names that are not valid shell variable names.
     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
       as_fn_error $? "invalid package name: $ac_useropt"
     ac_useropt_orig=$ac_useropt
-    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
+    ac_useropt=$($as_echo "$ac_useropt" | sed 's/[-+.]/_/g')
     case $ac_user_opts in
       *"
 "with_$ac_useropt"
@@ -1209,12 +1209,12 @@ do
     eval with_$ac_useropt=\$ac_optarg ;;
 
   -without-* | --without-*)
-    ac_useropt=`expr "x$ac_option" : 'x-*without-\(.*\)'`
+    ac_useropt=$(expr "x$ac_option" : 'x-*without-\(.*\)')
     # Reject names that are not valid shell variable names.
     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
       as_fn_error $? "invalid package name: $ac_useropt"
     ac_useropt_orig=$ac_useropt
-    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
+    ac_useropt=$($as_echo "$ac_useropt" | sed 's/[-+.]/_/g')
     case $ac_user_opts in
       *"
 "with_$ac_useropt"
@@ -1247,7 +1247,7 @@ Try \`$0 --help' for more information"
     ;;
 
   *=*)
-    ac_envvar=`expr "x$ac_option" : 'x\([^=]*\)='`
+    ac_envvar=$(expr "x$ac_option" : 'x\([^=]*\)=')
     # Reject names that are not valid shell variable names.
     case $ac_envvar in #(
       '' | [0-9]* | *[!_$as_cr_alnum]* )
@@ -1268,7 +1268,7 @@ Try \`$0 --help' for more information"
 done
 
 if test -n "$ac_prev"; then
-  ac_option=--`echo $ac_prev | sed 's/_/-/g'`
+  ac_option=--$(echo $ac_prev | sed 's/_/-/g')
   as_fn_error $? "missing argument to $ac_option"
 fi
 
@@ -1290,7 +1290,7 @@ do
   # Remove trailing slashes.
   case $ac_val in
     */ )
-      ac_val=`expr "X$ac_val" : 'X\(.*[^/]\)' \| "X$ac_val" : 'X\(.*\)'`
+      ac_val=$(expr "X$ac_val" : 'X\(.*[^/]\)' \| "X$ac_val" : 'X\(.*\)')
       eval $ac_var=\$ac_val;;
   esac
   # Be sure to have absolute directory names.
@@ -1323,9 +1323,9 @@ test -n "$host_alias" && ac_tool_prefix=$host_alias-
 test "$silent" = yes && exec 6>/dev/null
 
 
-ac_pwd=`pwd` && test -n "$ac_pwd" &&
-ac_ls_di=`ls -di .` &&
-ac_pwd_ls_di=`cd "$ac_pwd" && ls -di .` ||
+ac_pwd=$(pwd) && test -n "$ac_pwd" &&
+ac_ls_di=$(ls -di .) &&
+ac_pwd_ls_di=$(cd "$ac_pwd" && ls -di .) ||
   as_fn_error $? "working directory cannot be determined"
 test "X$ac_ls_di" = "X$ac_pwd_ls_di" ||
   as_fn_error $? "pwd does not report name of working directory"
@@ -1335,7 +1335,7 @@ test "X$ac_ls_di" = "X$ac_pwd_ls_di" ||
 if test -z "$srcdir"; then
   ac_srcdir_defaulted=yes
   # Try the directory containing this script, then the parent directory.
-  ac_confdir=`$as_dirname -- "$as_myself" ||
+  ac_confdir=$($as_dirname -- "$as_myself" ||
 $as_expr X"$as_myself" : 'X\(.*[^/]\)//*[^/][^/]*/*$' \| \
 	 X"$as_myself" : 'X\(//\)[^/]' \| \
 	 X"$as_myself" : 'X\(//\)$' \| \
@@ -1357,7 +1357,7 @@ $as_echo X"$as_myself" |
 	    s//\1/
 	    q
 	  }
-	  s/.*/./; q'`
+	  s/.*/./; q')
   srcdir=$ac_confdir
   if test ! -r "$srcdir/$ac_unique_file"; then
     srcdir=..
@@ -1370,9 +1370,9 @@ if test ! -r "$srcdir/$ac_unique_file"; then
   as_fn_error $? "cannot find sources ($ac_unique_file) in $srcdir"
 fi
 ac_msg="sources are in $srcdir, but \`cd $srcdir' does not work"
-ac_abs_confdir=`(
+ac_abs_confdir=$( (
 	cd "$srcdir" && test -r "./$ac_unique_file" || as_fn_error $? "$ac_msg"
-	pwd)`
+	pwd))
 # When building in place, set srcdir=.
 if test "$ac_abs_confdir" = "$ac_pwd"; then
   srcdir=.
@@ -1381,7 +1381,7 @@ fi
 # Double slashes in file names in object file debugging info
 # mess up M-x gdb in Emacs.
 case $srcdir in
-*/) srcdir=`expr "X$srcdir" : 'X\(.*[^/]\)' \| "X$srcdir" : 'X\(.*\)'`;;
+*/) srcdir=$(expr "X$srcdir" : 'X\(.*[^/]\)' \| "X$srcdir" : 'X\(.*\)');;
 esac
 for ac_var in $ac_precious_vars; do
   eval ac_env_${ac_var}_set=\${${ac_var}+set}
@@ -1598,16 +1598,16 @@ if test "$ac_init_help" = "recursive"; then
   # If there are subdirs, report their specific --help.
   for ac_dir in : $ac_subdirs_all; do test "x$ac_dir" = x: && continue
     test -d "$ac_dir" ||
-      { cd "$srcdir" && ac_pwd=`pwd` && srcdir=. && test -d "$ac_dir"; } ||
+      { cd "$srcdir" && ac_pwd=$(pwd) && srcdir=. && test -d "$ac_dir"; } ||
       continue
     ac_builddir=.
 
 case "$ac_dir" in
 .) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
 *)
-  ac_dir_suffix=/`$as_echo "$ac_dir" | sed 's|^\.[\\/]||'`
+  ac_dir_suffix=/$($as_echo "$ac_dir" | sed 's|^\.[\\/]||')
   # A ".." for each directory in $ac_dir_suffix.
-  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
+  ac_top_builddir_sub=$($as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||')
   case $ac_top_builddir_sub in
   "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
   *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
@@ -2262,8 +2262,8 @@ $as_echo "$ac_res" >&6; }
 ac_fn_c_check_decl ()
 {
   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  as_decl_name=`echo $2|sed 's/ *(.*//'`
-  as_decl_use=`echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g'`
+  as_decl_name=$(echo $2|sed 's/ *(.*//')
+  as_decl_use=$(echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g')
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
 $as_echo_n "checking whether $as_decl_name is declared... " >&6; }
 if eval \${$3+:} false; then :
@@ -2374,22 +2374,22 @@ cat <<_ASUNAME
 ## Platform. ##
 ## --------- ##
 
-hostname = `(hostname || uname -n) 2>/dev/null | sed 1q`
-uname -m = `(uname -m) 2>/dev/null || echo unknown`
-uname -r = `(uname -r) 2>/dev/null || echo unknown`
-uname -s = `(uname -s) 2>/dev/null || echo unknown`
-uname -v = `(uname -v) 2>/dev/null || echo unknown`
+hostname = $( (hostname || uname -n) 2>/dev/null | sed 1q)
+uname -m = $( (uname -m) 2>/dev/null || echo unknown)
+uname -r = $( (uname -r) 2>/dev/null || echo unknown)
+uname -s = $( (uname -s) 2>/dev/null || echo unknown)
+uname -v = $( (uname -v) 2>/dev/null || echo unknown)
 
-/usr/bin/uname -p = `(/usr/bin/uname -p) 2>/dev/null || echo unknown`
-/bin/uname -X     = `(/bin/uname -X) 2>/dev/null     || echo unknown`
+/usr/bin/uname -p = $( (/usr/bin/uname -p) 2>/dev/null || echo unknown)
+/bin/uname -X     = $( (/bin/uname -X) 2>/dev/null     || echo unknown)
 
-/bin/arch              = `(/bin/arch) 2>/dev/null              || echo unknown`
-/usr/bin/arch -k       = `(/usr/bin/arch -k) 2>/dev/null       || echo unknown`
-/usr/convex/getsysinfo = `(/usr/convex/getsysinfo) 2>/dev/null || echo unknown`
-/usr/bin/hostinfo      = `(/usr/bin/hostinfo) 2>/dev/null      || echo unknown`
-/bin/machine           = `(/bin/machine) 2>/dev/null           || echo unknown`
-/usr/bin/oslevel       = `(/usr/bin/oslevel) 2>/dev/null       || echo unknown`
-/bin/universe          = `(/bin/universe) 2>/dev/null          || echo unknown`
+/bin/arch              = $( (/bin/arch) 2>/dev/null              || echo unknown)
+/usr/bin/arch -k       = $( (/usr/bin/arch -k) 2>/dev/null       || echo unknown)
+/usr/convex/getsysinfo = $( (/usr/convex/getsysinfo) 2>/dev/null || echo unknown)
+/usr/bin/hostinfo      = $( (/usr/bin/hostinfo) 2>/dev/null      || echo unknown)
+/bin/machine           = $( (/bin/machine) 2>/dev/null           || echo unknown)
+/usr/bin/oslevel       = $( (/usr/bin/oslevel) 2>/dev/null       || echo unknown)
+/bin/universe          = $( (/bin/universe) 2>/dev/null          || echo unknown)
 
 _ASUNAME
 
@@ -2433,7 +2433,7 @@ do
     | -silent | --silent | --silen | --sile | --sil)
       continue ;;
     *\'*)
-      ac_arg=`$as_echo "$ac_arg" | sed "s/'/'\\\\\\\\''/g"` ;;
+      ac_arg=$($as_echo "$ac_arg" | sed "s/'/'\\\\\\\\''/g") ;;
     esac
     case $ac_pass in
     1) as_fn_append ac_configure_args0 " '$ac_arg'" ;;
@@ -2662,8 +2662,8 @@ $as_echo "$as_me: error: \`$ac_var' was not set in the previous run" >&2;}
     *)
       if test "x$ac_old_val" != "x$ac_new_val"; then
 	# differences in whitespace do not lead to failure.
-	ac_old_val_w=`echo x $ac_old_val`
-	ac_new_val_w=`echo x $ac_new_val`
+	ac_old_val_w=$(echo x $ac_old_val)
+	ac_new_val_w=$(echo x $ac_new_val)
 	if test "$ac_old_val_w" != "$ac_new_val_w"; then
 	  { $as_echo "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' has changed since the previous run:" >&5
 $as_echo "$as_me: error: \`$ac_var' has changed since the previous run:" >&2;}
@@ -2682,7 +2682,7 @@ $as_echo "$as_me:   current value: \`$ac_new_val'" >&2;}
   # Pass precious variables to config.status.
   if test "$ac_new_set" = set; then
     case $ac_new_val in
-    *\'*) ac_arg=$ac_var=`$as_echo "$ac_new_val" | sed "s/'/'\\\\\\\\''/g"` ;;
+    *\'*) ac_arg=$ac_var=$($as_echo "$ac_new_val" | sed "s/'/'\\\\\\\\''/g") ;;
     *) ac_arg=$ac_var=$ac_new_val ;;
     esac
     case " $ac_configure_args " in
@@ -2830,10 +2830,10 @@ if ${ac_cv_build+:} false; then :
 else
   ac_build_alias=$build_alias
 test "x$ac_build_alias" = x &&
-  ac_build_alias=`$SHELL "$ac_aux_dir/config.guess"`
+  ac_build_alias=$($SHELL "$ac_aux_dir/config.guess")
 test "x$ac_build_alias" = x &&
   as_fn_error $? "cannot guess build type; you must specify one" "$LINENO" 5
-ac_cv_build=`$SHELL "$ac_aux_dir/config.sub" $ac_build_alias` ||
+ac_cv_build=$($SHELL "$ac_aux_dir/config.sub" $ac_build_alias) ||
   as_fn_error $? "$SHELL $ac_aux_dir/config.sub $ac_build_alias failed" "$LINENO" 5
 
 fi
@@ -2854,7 +2854,7 @@ shift; shift
 # except with old shells:
 build_os=$*
 IFS=$ac_save_IFS
-case $build_os in *\ *) build_os=`echo "$build_os" | sed 's/ /-/g'`;; esac
+case $build_os in *\ *) build_os=$(echo "$build_os" | sed 's/ /-/g');; esac
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking host system type" >&5
@@ -2865,7 +2865,7 @@ else
   if test "x$host_alias" = x; then
   ac_cv_host=$ac_cv_build
 else
-  ac_cv_host=`$SHELL "$ac_aux_dir/config.sub" $host_alias` ||
+  ac_cv_host=$($SHELL "$ac_aux_dir/config.sub" $host_alias) ||
     as_fn_error $? "$SHELL $ac_aux_dir/config.sub $host_alias failed" "$LINENO" 5
 fi
 
@@ -2887,7 +2887,7 @@ shift; shift
 # except with old shells:
 host_os=$*
 IFS=$ac_save_IFS
-case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
+case $host_os in *\ *) host_os=$(echo "$host_os" | sed 's/ /-/g');; esac
 
 
 
@@ -2968,7 +2968,7 @@ fi
 
 
 if test "$prefix" != "/"; then
-    prefix=`echo "$prefix" | sed -e 's/\/$//g'`
+    prefix=$(echo "$prefix" | sed -e 's/\/$//g')
 fi
 
 
@@ -3030,7 +3030,7 @@ if test "${enable_universalsdk+set}" = set; then :
 	yes)
 		# Locate the best usable SDK, see Mac/README for more
 		# information
-		enableval="`/usr/bin/xcodebuild -version -sdk macosx Path 2>/dev/null`"
+		enableval="$(/usr/bin/xcodebuild -version -sdk macosx Path 2>/dev/null)"
 		if ! ( echo $enableval | grep -E '\.sdk' 1>/dev/null )
 		then
 			enableval=/Developer/SDKs/MacOSX10.4u.sdk
@@ -3079,11 +3079,11 @@ ARCH_RUN_32BIT=""
 # For backward compatibility reasons we prefer to select '32-bit' if available,
 # otherwise use 'intel'
 UNIVERSAL_ARCHS="32-bit"
-if test "`uname -s`" = "Darwin"
+if test "$(uname -s)" = "Darwin"
 then
 	if test -n "${UNIVERSALSDK}"
 	then
-		if test -z "`/usr/bin/file -L "${UNIVERSALSDK}/usr/lib/libSystem.dylib" | grep ppc`"
+		if test -z "$(/usr/bin/file -L "${UNIVERSALSDK}/usr/lib/libSystem.dylib" | grep ppc)"
 		then
 			UNIVERSAL_ARCHS="intel"
 		fi
@@ -3116,7 +3116,7 @@ if test "${with_framework_name+set}" = set; then :
   withval=$with_framework_name;
     PYTHONFRAMEWORK=${withval}
     PYTHONFRAMEWORKDIR=${withval}.framework
-    PYTHONFRAMEWORKIDENTIFIER=org.python.`echo $withval | tr 'A-Z' 'a-z'`
+    PYTHONFRAMEWORKIDENTIFIER=org.python.$(echo $withval | tr 'A-Z' 'a-z')
 
 else
 
@@ -3182,8 +3182,8 @@ if test "${enable_framework+set}" = set; then :
 			;;
 
 		*/Library/Frameworks)
-			MDIR="`dirname "${enableval}"`"
-			MDIR="`dirname "${MDIR}"`"
+			MDIR="$(dirname "${enableval}")"
+			MDIR="$(dirname "${MDIR}")"
 			FRAMEWORKINSTALLAPPSPREFIX="${MDIR}/Applications"
 
 			if test "${prefix}" = "NONE"; then
@@ -3291,18 +3291,18 @@ then
 	esac
 	ac_sys_release=
     else
-	ac_sys_system=`uname -s`
+	ac_sys_system=$(uname -s)
 	if test "$ac_sys_system" = "AIX" \
 	-o "$ac_sys_system" = "UnixWare" -o "$ac_sys_system" = "OpenUNIX"; then
-		ac_sys_release=`uname -v`
+		ac_sys_release=$(uname -v)
 	else
-		ac_sys_release=`uname -r`
+		ac_sys_release=$(uname -r)
 	fi
     fi
-    ac_md_system=`echo $ac_sys_system |
-			tr -d '/ ' | tr '[A-Z]' '[a-z]'`
-    ac_md_release=`echo $ac_sys_release |
-			tr -d '/ ' | sed 's/^[A-Z]\.//' | sed 's/\..*//'`
+    ac_md_system=$(echo $ac_sys_system |
+			tr -d '/ ' | tr '[A-Z]' '[a-z]')
+    ac_md_release=$(echo $ac_sys_release |
+			tr -d '/ ' | sed 's/^[A-Z]\.//' | sed 's/\..*//')
     MACHDEP="$ac_md_system$ac_md_release"
 
     case $MACHDEP in
@@ -3412,7 +3412,7 @@ $as_echo "#define _BSD_SOURCE 1" >>confdefs.h
   AIX/4)
     define_xopen_source=no;;
   AIX/5)
-    if test `uname -r` -eq 1; then
+    if test $(uname -r) -eq 1; then
       define_xopen_source=no
     fi
     ;;
@@ -3522,7 +3522,7 @@ then
 
 		if test -n "$found_gcc" -a -n "$found_clang"
 		then
-			if test -n "`"$found_gcc" --version | grep llvm-gcc`"
+			if test -n "$("$found_gcc" --version | grep llvm-gcc)"
 			then
 				{ $as_echo "$as_me:${as_lineno-$LINENO}: Detected llvm-gcc, falling back to clang" >&5
 $as_echo "$as_me: Detected llvm-gcc, falling back to clang" >&6;}
@@ -3540,13 +3540,13 @@ $as_echo "$as_me: No GCC found, use CLANG" >&6;}
 
 		elif test -z "$found_gcc" -a -z "$found_clang"
 		then
-			found_clang=`/usr/bin/xcrun -find clang 2>/dev/null`
+			found_clang=$(/usr/bin/xcrun -find clang 2>/dev/null)
 			if test -n "${found_clang}"
 			then
 				{ $as_echo "$as_me:${as_lineno-$LINENO}: Using clang from Xcode.app" >&5
 $as_echo "$as_me: Using clang from Xcode.app" >&6;}
 				CC="${found_clang}"
-				CXX="`/usr/bin/xcrun -find clang++`"
+				CXX="$(/usr/bin/xcrun -find clang++)"
 
 			# else: use default behaviour
 			fi
@@ -3899,7 +3899,7 @@ ac_clean_files="$ac_clean_files a.out a.out.dSYM a.exe b.out"
 # of exeext.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
 $as_echo_n "checking whether the C compiler works... " >&6; }
-ac_link_default=`$as_echo "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
+ac_link_default=$($as_echo "$ac_link" | sed 's/ -o *conftest[^ ]*//')
 
 # The possible output files:
 ac_files="a.out conftest.exe conftest a.exe a_out.exe b.out conftest.*"
@@ -3943,7 +3943,7 @@ do
     *.* )
 	if test "${ac_cv_exeext+set}" = set && test "$ac_cv_exeext" != no;
 	then :; else
-	   ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
+	   ac_cv_exeext=$(expr "$ac_file" : '[^.]*\(\..*\)'0)
 	fi
 	# We set ac_cv_exeext here because the later test for it is not
 	# safe: cross compilers may not add the suffix if given an `-o'
@@ -4003,7 +4003,7 @@ for ac_file in conftest.exe conftest conftest.*; do
   test -f "$ac_file" || continue
   case $ac_file in
     *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
-    *.* ) ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
+    *.* ) ac_cv_exeext=$(expr "$ac_file" : '[^.]*\(\..*\)')
 	  break;;
     * ) break;;
   esac
@@ -4112,7 +4112,7 @@ $as_echo "$ac_try_echo"; } >&5
   test -f "$ac_file" || continue;
   case $ac_file in
     *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM ) ;;
-    *) ac_cv_objext=`expr "$ac_file" : '.*\.\(.*\)'`
+    *) ac_cv_objext=$(expr "$ac_file" : '.*\.\(.*\)')
        break;;
   esac
 done
@@ -4498,7 +4498,7 @@ do
       as_fn_executable_p "$ac_path_GREP" || continue
 # Check for GNU ac_path_GREP and select it if it is found.
   # Check for GNU $ac_path_GREP
-case `"$ac_path_GREP" --version 2>&1` in
+case $("$ac_path_GREP" --version 2>&1) in
 *GNU*)
   ac_cv_path_GREP="$ac_path_GREP" ac_path_GREP_found=:;;
 *)
@@ -4567,7 +4567,7 @@ do
       as_fn_executable_p "$ac_path_SED" || continue
 # Check for GNU ac_path_SED and select it if it is found.
   # Check for GNU $ac_path_SED
-case `"$ac_path_SED" --version 2>&1` in
+case $("$ac_path_SED" --version 2>&1) in
 *GNU*)
   ac_cv_path_SED="$ac_path_SED" ac_path_SED_found=:;;
 *)
@@ -5319,7 +5319,7 @@ cat >> conftest.c <<EOF
 EOF
 
 if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
-  PLATFORM_TRIPLET=`grep -v '^#' conftest.out | grep -v '^ *$' | tr -d ' 	'`
+  PLATFORM_TRIPLET=$(grep -v '^#' conftest.out | grep -v '^ *$' | tr -d ' 	')
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PLATFORM_TRIPLET" >&5
 $as_echo "$PLATFORM_TRIPLET" >&6; }
 else
@@ -5396,7 +5396,7 @@ do
       as_fn_executable_p "$ac_path_EGREP" || continue
 # Check for GNU ac_path_EGREP and select it if it is found.
   # Check for GNU $ac_path_EGREP
-case `"$ac_path_EGREP" --version 2>&1` in
+case $("$ac_path_EGREP" --version 2>&1) in
 *GNU*)
   ac_cv_path_EGREP="$ac_path_EGREP" ac_path_EGREP_found=:;;
 *)
@@ -5557,12 +5557,12 @@ fi
 for ac_header in sys/types.h sys/stat.h stdlib.h string.h memory.h strings.h \
 		  inttypes.h stdint.h unistd.h
 do :
-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+  as_ac_Header=$($as_echo "ac_cv_header_$ac_header" | $as_tr_sh)
 ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
 "
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_header" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -5644,8 +5644,8 @@ arm_arch = __ARM_ARCH
 EOF
 
 if $CPP $CPPFLAGS conftest.c >conftest.out 2>/dev/null; then
-  ANDROID_API_LEVEL=`sed -n -e '/__ANDROID_API__/d' -e 's/^android_api = //p' conftest.out`
-  _arm_arch=`sed -n -e '/__ARM_ARCH/d' -e 's/^arm_arch = //p' conftest.out`
+  ANDROID_API_LEVEL=$(sed -n -e '/__ANDROID_API__/d' -e 's/^android_api = //p' conftest.out)
+  _arm_arch=$(sed -n -e '/__ARM_ARCH/d' -e 's/^arm_arch = //p' conftest.out)
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ANDROID_API_LEVEL" >&5
 $as_echo "$ANDROID_API_LEVEL" >&6; }
   if test -z "$ANDROID_API_LEVEL"; then
@@ -5783,7 +5783,7 @@ then
 	AIX*)
 	   exp_extra="\"\""
 	   if test $ac_sys_release -ge 5 -o \
-		   $ac_sys_release -eq 4 -a `uname -r` -ge 2 ; then
+		   $ac_sys_release -eq 4 -a $(uname -r) -ge 2 ; then
 	       exp_extra="."
 	   fi
 	   LINKCC="\$(srcdir)/Modules/makexp_aix Modules/python.exp $exp_extra \$(LIBRARY); $LINKCC";;
@@ -5806,9 +5806,9 @@ $as_echo "$LINKCC" >&6; }
 $as_echo_n "checking for GNU ld... " >&6; }
 ac_prog=ld
 if test "$GCC" = yes; then
-       ac_prog=`$CC -print-prog-name=ld`
+       ac_prog=$($CC -print-prog-name=ld)
 fi
-case `"$ac_prog" -V 2>&1 < /dev/null` in
+case $("$ac_prog" -V 2>&1 < /dev/null) in
       *GNU*)
           GNULD=yes;;
       *)
@@ -5882,7 +5882,7 @@ $as_echo_n "checking LDLIBRARY... " >&6; }
 if test "$enable_framework"
 then
   LDLIBRARY='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-  RUNSHARED=DYLD_FRAMEWORK_PATH=`pwd`${DYLD_FRAMEWORK_PATH:+:${DYLD_FRAMEWORK_PATH}}
+  RUNSHARED=DYLD_FRAMEWORK_PATH=$(pwd)${DYLD_FRAMEWORK_PATH:+:${DYLD_FRAMEWORK_PATH}}
   BLDLIBRARY=''
 else
   BLDLIBRARY='$(LDLIBRARY)'
@@ -5902,7 +5902,7 @@ $as_echo "#define Py_ENABLE_SHARED 1" >>confdefs.h
     SunOS*)
 	  LDLIBRARY='libpython$(LDVERSION).so'
 	  BLDLIBRARY='-Wl,-R,$(LIBDIR) -L. -lpython$(LDVERSION)'
-	  RUNSHARED=LD_LIBRARY_PATH=`pwd`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+	  RUNSHARED=LD_LIBRARY_PATH=$(pwd)${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 	  INSTSONAME="$LDLIBRARY".$SOVERSION
 	  if test "$with_pydebug" != yes
 	  then
@@ -5912,7 +5912,7 @@ $as_echo "#define Py_ENABLE_SHARED 1" >>confdefs.h
     Linux*|GNU*|NetBSD*|FreeBSD*|DragonFly*|OpenBSD*)
 	  LDLIBRARY='libpython$(LDVERSION).so'
 	  BLDLIBRARY='-L. -lpython$(LDVERSION)'
-	  RUNSHARED=LD_LIBRARY_PATH=`pwd`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+	  RUNSHARED=LD_LIBRARY_PATH=$(pwd)${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 	  INSTSONAME="$LDLIBRARY".$SOVERSION
 	  if test "$with_pydebug" != yes
           then
@@ -5920,7 +5920,7 @@ $as_echo "#define Py_ENABLE_SHARED 1" >>confdefs.h
 	  fi
 	  ;;
     hp*|HP*)
-	  case `uname -m` in
+	  case $(uname -m) in
 		ia64)
 			LDLIBRARY='libpython$(LDVERSION).so'
 			;;
@@ -5929,16 +5929,16 @@ $as_echo "#define Py_ENABLE_SHARED 1" >>confdefs.h
 			;;
 	  esac
 	  BLDLIBRARY='-Wl,+b,$(LIBDIR) -L. -lpython$(LDVERSION)'
-	  RUNSHARED=SHLIB_PATH=`pwd`${SHLIB_PATH:+:${SHLIB_PATH}}
+	  RUNSHARED=SHLIB_PATH=$(pwd)${SHLIB_PATH:+:${SHLIB_PATH}}
 	  ;;
     Darwin*)
     	LDLIBRARY='libpython$(LDVERSION).dylib'
 	BLDLIBRARY='-L. -lpython$(LDVERSION)'
-	RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
+	RUNSHARED=DYLD_LIBRARY_PATH=$(pwd)${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
 	;;
     AIX*)
 	LDLIBRARY='libpython$(LDVERSION).so'
-	RUNSHARED=LIBPATH=`pwd`${LIBPATH:+:${LIBPATH}}
+	RUNSHARED=LIBPATH=$(pwd)${LIBPATH:+:${LIBPATH}}
 	;;
 
   esac
@@ -6237,7 +6237,7 @@ case $as_dir/ in #((
 	    echo one > conftest.one
 	    echo two > conftest.two
 	    mkdir conftest.dir
-	    if "$as_dir/$ac_prog$ac_exec_ext" -c conftest.one conftest.two "`pwd`/conftest.dir" &&
+	    if "$as_dir/$ac_prog$ac_exec_ext" -c conftest.one conftest.two "$(pwd)/conftest.dir" &&
 	      test -s conftest.one && test -s conftest.two &&
 	      test -s conftest.dir/conftest.one &&
 	      test -s conftest.dir/conftest.two
@@ -6293,7 +6293,7 @@ do
     for ac_prog in mkdir gmkdir; do
 	 for ac_exec_ext in '' $ac_executable_extensions; do
 	   as_fn_executable_p "$as_dir/$ac_prog$ac_exec_ext" || continue
-	   case `"$as_dir/$ac_prog$ac_exec_ext" --version 2>&1` in #(
+	   case $("$as_dir/$ac_prog$ac_exec_ext" --version 2>&1) in #(
 	     'mkdir (GNU coreutils) '* | \
 	     'mkdir (coreutils) '* | \
 	     'mkdir (fileutils) '4.1*)
@@ -6465,14 +6465,14 @@ llvm_bin_dir=''
 llvm_path="${PATH}"
 if test "${CC}" = "clang"
 then
-  clang_bin=`which clang`
+  clang_bin=$(which clang)
   # Some systems install clang elsewhere as a symlink to the real path
   # which is where the related llvm tools are located.
   if test -L "${clang_bin}"
   then
-    clang_dir=`dirname "${clang_bin}"`
-    clang_bin=`readlink "${clang_bin}"`
-    llvm_bin_dir="${clang_dir}/"`dirname "${clang_bin}"`
+    clang_dir=$(dirname "${clang_bin}")
+    clang_bin=$(readlink "${clang_bin}")
+    llvm_bin_dir="${clang_dir}/"$(dirname "${clang_bin}")
     llvm_path="${llvm_path}${PATH_SEPARATOR}${llvm_bin_dir}"
   fi
 fi
@@ -6610,7 +6610,7 @@ fi
       fi
       if test "$ac_sys_system" = "Darwin" -a "${LLVM_AR_FOUND}" = "not-found"
       then
-        found_llvm_ar=`/usr/bin/xcrun -find llvm-ar 2>/dev/null`
+        found_llvm_ar=$(/usr/bin/xcrun -find llvm-ar 2>/dev/null)
         if test -n "${found_llvm_ar}"
         then
           LLVM_AR='/usr/bin/xcrun llvm-ar'
@@ -6774,7 +6774,7 @@ else
 fi
 if test "$ac_sys_system" = "Darwin" -a "${LLVM_PROF_FOUND}" = "not-found"
 then
-  found_llvm_profdata=`/usr/bin/xcrun -find llvm-profdata 2>/dev/null`
+  found_llvm_profdata=$(/usr/bin/xcrun -find llvm-profdata 2>/dev/null)
   if test -n "${found_llvm_profdata}"
   then
     # llvm-profdata isn't directly in $PATH in some cases.
@@ -7260,7 +7260,7 @@ fi
     # if so, only then enable the warning.
     if test $ac_cv_enable_unreachable_code_warning = yes && \
         test "$Py_DEBUG" != "true" && \
-        test -z "`$CC --version 2>/dev/null | grep 'Free Software Foundation'`"
+        test -z "$($CC --version 2>/dev/null | grep 'Free Software Foundation')"
     then
       BASECFLAGS="$BASECFLAGS -Wunreachable-code"
     else
@@ -7495,10 +7495,10 @@ $as_echo "$CC" >&6; }
 
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking which MACOSX_DEPLOYMENT_TARGET to use" >&5
 $as_echo_n "checking which MACOSX_DEPLOYMENT_TARGET to use... " >&6; }
-        cur_target_major=`sw_vers -productVersion | \
-                sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/'`
-        cur_target_minor=`sw_vers -productVersion | \
-                sed 's/\([0-9]*\)\.\([0-9]*\).*/\2/'`
+        cur_target_major=$(sw_vers -productVersion | \
+                sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/')
+        cur_target_minor=$(sw_vers -productVersion | \
+                sed 's/\([0-9]*\)\.\([0-9]*\).*/\2/')
         cur_target="${cur_target_major}.${cur_target_minor}"
         if test ${cur_target_major} -eq 10 && \
            test ${cur_target_minor} -ge 3 && \
@@ -7515,7 +7515,7 @@ $as_echo_n "checking which MACOSX_DEPLOYMENT_TARGET to use... " >&6; }
                     ;;
                 esac
             else
-                if test `/usr/bin/arch` = "i386"
+                if test $(/usr/bin/arch) = "i386"
                 then
                     # 10.4 was the first release to support Intel archs
                     cur_target="10.4"
@@ -7941,11 +7941,11 @@ libutil.h sys/resource.h netpacket/packet.h sysexits.h bluetooth.h \
 linux/tipc.h linux/random.h spawn.h util.h alloca.h endian.h \
 sys/endian.h sys/sysmacros.h linux/memfd.h linux/wait.h sys/memfd.h sys/mman.h
 do :
-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+  as_ac_Header=$($as_echo "ac_cv_header_$ac_header" | $as_tr_sh)
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_header" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -7954,7 +7954,7 @@ done
 
 ac_header_dirent=no
 for ac_hdr in dirent.h sys/ndir.h sys/dir.h ndir.h; do
-  as_ac_Header=`$as_echo "ac_cv_header_dirent_$ac_hdr" | $as_tr_sh`
+  as_ac_Header=$($as_echo "ac_cv_header_dirent_$ac_hdr" | $as_tr_sh)
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_hdr that defines DIR" >&5
 $as_echo_n "checking for $ac_hdr that defines DIR... " >&6; }
 if eval \${$as_ac_Header+:} false; then :
@@ -7986,7 +7986,7 @@ eval ac_res=\$$as_ac_Header
 $as_echo "$ac_res" >&6; }
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_hdr" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_hdr" | $as_tr_cpp) 1
 _ACEOF
 
 ac_header_dirent=$ac_hdr; break
@@ -8271,7 +8271,7 @@ done
 # On Linux, can.h and can/raw.h require sys/socket.h
 for ac_header in linux/can.h linux/can/raw.h linux/can/bcm.h
 do :
-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+  as_ac_Header=$($as_echo "ac_cv_header_$ac_header" | $as_tr_sh)
 ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
@@ -8280,7 +8280,7 @@ ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "
 "
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_header" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -9246,12 +9246,12 @@ case $ac_sys_system/$ac_sys_release in
     if test "${enable_universalsdk}"; then
 	    :
     else
-        LIBTOOL_CRUFT="${LIBTOOL_CRUFT} -arch_only `/usr/bin/arch`"
+        LIBTOOL_CRUFT="${LIBTOOL_CRUFT} -arch_only $(/usr/bin/arch)"
     fi
     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
   Darwin/*)
-    gcc_version=`gcc -dumpversion`
+    gcc_version=$(gcc -dumpversion)
     if test ${gcc_version} '<' 4.0
         then
             LIBTOOL_CRUFT="-lcc_dynamic"
@@ -9286,7 +9286,7 @@ fi
 
 
     if test "${ac_osx_32bit}" = "yes"; then
-    	case `/usr/bin/arch` in
+    	case $(/usr/bin/arch) in
     	i386)
     		MACOSX_DEFAULT_ARCH="i386"
     		;;
@@ -9298,7 +9298,7 @@ fi
     		;;
     	esac
     else
-    	case `/usr/bin/arch` in
+    	case $(/usr/bin/arch) in
     	i386)
     		MACOSX_DEFAULT_ARCH="x86_64"
     		;;
@@ -9368,7 +9368,7 @@ $as_echo_n "checking the extension of shared libraries... " >&6; }
 if test -z "$SHLIB_SUFFIX"; then
 	case $ac_sys_system in
 	hp*|HP*)
-		case `uname -m` in
+		case $(uname -m) in
 			ia64) SHLIB_SUFFIX=.so;;
 	  		*)    SHLIB_SUFFIX=.sl;;
 		esac
@@ -9440,10 +9440,10 @@ then
 		# Use -undefined dynamic_lookup whenever possible (10.3 and later).
 		# This allows an extension to be used in any Python
 
-		dep_target_major=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
-				sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/'`
-		dep_target_minor=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
-				sed 's/\([0-9]*\)\.\([0-9]*\).*/\2/'`
+		dep_target_major=$(echo ${MACOSX_DEPLOYMENT_TARGET} | \
+				sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/')
+		dep_target_minor=$(\echo ${MACOSX_DEPLOYMENT_TARGET} | \
+				sed 's/\([0-9]*\)\.\([0-9]*\).*/\2/')
 		if test ${dep_target_major} -eq 10 && \
 		   test ${dep_target_minor} -le 2
 		then
@@ -9472,7 +9472,7 @@ then
 		LDSHARED='$(CC) -shared'
 		LDCXXSHARED='$(CXX) -shared';;
 	FreeBSD*)
-		if [ "`$CC -dM -E - </dev/null | grep __ELF__`" != "" ]
+		if [ "$($CC -dM -E - </dev/null | grep __ELF__)" != "" ]
 		then
 			LDSHARED='$(CC) -shared'
 			LDCXXSHARED='$(CXX) -shared'
@@ -9480,12 +9480,12 @@ then
 			LDSHARED="ld -Bshareable"
 		fi;;
 	OpenBSD*)
-		if [ "`$CC -dM -E - </dev/null | grep __ELF__`" != "" ]
+		if [ "$($CC -dM -E - </dev/null | grep __ELF__)" != "" ]
 		then
 				LDSHARED='$(CC) -shared $(CCSHARED)'
 				LDCXXSHARED='$(CXX) -shared $(CCSHARED)'
 		else
-				case `uname -r` in
+				case $(uname -r) in
 				[01].* | 2.[0-7] | 2.[0-7].*)
 				   LDSHARED="ld -Bshareable ${LDFLAGS}"
 				   ;;
@@ -9528,7 +9528,7 @@ then
 	case $ac_sys_system/$ac_sys_release in
 	SunOS*) if test "$GCC" = yes;
 		then CCSHARED="-fPIC";
-		elif test `uname -p` = sparc;
+		elif test $(uname -p) = sparc;
 		then CCSHARED="-xcode=pic32";
 		else CCSHARED="-Kpic";
 		fi;;
@@ -9588,7 +9588,7 @@ then
 	SCO_SV*) LINKFORSHARED="-Wl,-Bexport";;
 	ReliantUNIX*) LINKFORSHARED="-W1 -Blargedynsym";;
 	FreeBSD*|NetBSD*|OpenBSD*|DragonFly*)
-		if [ "`$CC -dM -E - </dev/null | grep __ELF__`" != "" ]
+		if [ "$($CC -dM -E - </dev/null | grep __ELF__)" != "" ]
 		then
 			LINKFORSHARED="-Wl,--export-dynamic"
 		fi;;
@@ -9795,11 +9795,11 @@ fi
 # checks for uuid.h location
 for ac_header in uuid/uuid.h uuid.h
 do :
-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+  as_ac_Header=$($as_echo "ac_cv_header_$ac_header" | $as_tr_sh)
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_header" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -10457,7 +10457,7 @@ $as_echo "$as_me: WARNING: --with(out)-system-ffi is ignored on this platform" >
 fi
 
 if test "$with_system_ffi" = "yes" && test -n "$PKG_CONFIG"; then
-    LIBFFI_INCLUDEDIR="`"$PKG_CONFIG" libffi --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ *$//'`"
+    LIBFFI_INCLUDEDIR="$("$PKG_CONFIG" libffi --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ *$//')"
 else
     LIBFFI_INCLUDEDIR=""
 fi
@@ -10543,7 +10543,7 @@ if test x$with_dbmliborder = xyes
 then
 as_fn_error $? "proper usage is --with-dbmliborder=db1:db2:..." "$LINENO" 5
 else
-  for db in `echo $with_dbmliborder | sed 's/:/ /g'`; do
+  for db in $(echo $with_dbmliborder | sed 's/:/ /g'); do
     if test x$db != xndbm && test x$db != xgdbm && test x$db != xbdb
     then
       as_fn_error $? "proper usage is --with-dbmliborder=db1:db2:..." "$LINENO" 5
@@ -11560,11 +11560,11 @@ for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  truncate uname unlinkat utimensat utimes waitid waitpid wait3 wait4 \
  wcscoll wcsftime wcsxfrm wmemcmp writev _getpty rtpSpawn
 do :
-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+  as_ac_var=$($as_echo "ac_cv_func_$ac_func" | $as_tr_sh)
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
 if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_func" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -12684,11 +12684,11 @@ done
 # check for long file support functions
 for ac_func in fseek64 fseeko fstatvfs ftell64 ftello statvfs
 do :
-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+  as_ac_var=$($as_echo "ac_cv_func_$ac_func" | $as_tr_sh)
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
 if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_func" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -14501,11 +14501,11 @@ LIBS="$LIBS $LIBM"
 
 for ac_func in acosh asinh atanh copysign erf erfc expm1 finite gamma
 do :
-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+  as_ac_var=$($as_echo "ac_cv_func_$ac_func" | $as_tr_sh)
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
 if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_func" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -14513,11 +14513,11 @@ done
 
 for ac_func in hypot lgamma log1p log2 round tgamma
 do :
-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+  as_ac_var=$($as_echo "ac_cv_func_$ac_func" | $as_tr_sh)
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
 if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_func" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -15175,7 +15175,7 @@ $as_echo_n "checking ABIFLAGS... " >&6; }
 $as_echo "$ABIFLAGS" >&6; }
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking SOABI" >&5
 $as_echo_n "checking SOABI... " >&6; }
-SOABI='cpython-'`echo $VERSION | tr -d .`${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+SOABI='cpython-'$(echo $VERSION | tr -d .)${ABIFLAGS}${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SOABI" >&5
 $as_echo "$SOABI" >&6; }
 
@@ -15183,7 +15183,7 @@ $as_echo "$SOABI" >&6; }
 if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
   # Similar to SOABI but remove "d" flag from ABIFLAGS
 
-  ALT_SOABI='cpython-'`echo $VERSION | tr -d .``echo $ABIFLAGS | tr -d d`${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
+  ALT_SOABI='cpython-'$(echo $VERSION | tr -d .)$(echo $ABIFLAGS | tr -d d)${PLATFORM_TRIPLET:+-$PLATFORM_TRIPLET}
 
 cat >>confdefs.h <<_ACEOF
 #define ALT_SOABI "${ALT_SOABI}"
@@ -15924,11 +15924,11 @@ fi
 
 for ac_header in curses.h ncurses.h
 do :
-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+  as_ac_Header=$($as_echo "ac_cv_header_$ac_header" | $as_tr_sh)
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_header" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -16643,7 +16643,7 @@ esac
 
 
 
-for h in `(cd $srcdir;echo Python/thread_*.h)`
+for h in $( (cd $srcdir;echo Python/thread_*.h))
 do
   THREADHEADERS="$THREADHEADERS \$(srcdir)/$h"
 done
@@ -17078,11 +17078,11 @@ ${ac_includes_default}
 "
 for ac_func in shm_open shm_unlink
 do :
-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+  as_ac_var=$($as_echo "ac_cv_func_$ac_func" | $as_tr_sh)
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
 if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+#define $($as_echo "HAVE_$ac_func" | $as_tr_cpp) 1
 _ACEOF
 
 fi
@@ -17204,10 +17204,10 @@ else
 fi
 
             if test x"$PKG_CONFIG" != x""; then
-                OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
+                OPENSSL_LDFLAGS=$($PKG_CONFIG openssl --libs-only-L 2>/dev/null)
                 if test $? = 0; then
-                    OPENSSL_LIBS=`$PKG_CONFIG openssl --libs-only-l 2>/dev/null`
-                    OPENSSL_INCLUDES=`$PKG_CONFIG openssl --cflags-only-I 2>/dev/null`
+                    OPENSSL_LIBS=$($PKG_CONFIG openssl --libs-only-l 2>/dev/null)
+                    OPENSSL_INCLUDES=$($PKG_CONFIG openssl --cflags-only-I 2>/dev/null)
                     found=true
                 fi
             fi
@@ -17420,7 +17420,7 @@ _ACEOF
 # Ultrix sh set writes to stderr and can't be redirected directly,
 # and sets the high bit in the cache file unless we assign to the vars.
 (
-  for ac_var in `(set) 2>&1 | sed -n 's/^\([a-zA-Z_][a-zA-Z0-9_]*\)=.*/\1/p'`; do
+  for ac_var in $( (set) 2>&1 | sed -n 's/^\([a-zA-Z_][a-zA-Z0-9_]*\)=.*/\1/p'); do
     eval ac_val=\$$ac_var
     case $ac_val in #(
     *${as_nl}*)
@@ -17437,7 +17437,7 @@ $as_echo "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
   done
 
   (set) 2>&1 |
-    case $as_nl`(ac_space=' '; set) 2>&1` in #(
+    case $as_nl$( (ac_space=' '; set) 2>&1) in #(
     *${as_nl}ac_space=\ *)
       # `set' does not quote correctly, so add quotes: double-quote
       # substitution turns \\\\ into \\, and sed turns \\ into \.
@@ -17496,7 +17496,7 @@ U=
 for ac_i in : $LIBOBJS; do test "x$ac_i" = x: && continue
   # 1. Remove the extension, and $U if already installed.
   ac_script='s/\$U\././;s/\.o$//;s/\.obj$//'
-  ac_i=`$as_echo "$ac_i" | sed "$ac_script"`
+  ac_i=$($as_echo "$ac_i" | sed "$ac_script")
   # 2. Prepend LIBOBJDIR.  When used with automake>=1.10 LIBOBJDIR
   #    will be set to the directory where LIBOBJS objects are built.
   as_fn_append ac_libobjs " \${LIBOBJDIR}$ac_i\$U.$ac_objext"
@@ -18172,13 +18172,13 @@ _ACEOF
   echo "_ACEOF"
 } >conf$$subs.sh ||
   as_fn_error $? "could not make $CONFIG_STATUS" "$LINENO" 5
-ac_delim_num=`echo "$ac_subst_vars" | grep -c '^'`
+ac_delim_num=$(echo "$ac_subst_vars" | grep -c '^')
 ac_delim='%!_!# '
 for ac_last_try in false false false false false :; do
   . ./conf$$subs.sh ||
     as_fn_error $? "could not make $CONFIG_STATUS" "$LINENO" 5
 
-  ac_delim_n=`sed -n "s/.*$ac_delim\$/X/p" conf$$subs.awk | grep -c X`
+  ac_delim_n=$(sed -n "s/.*$ac_delim\$/X/p" conf$$subs.awk | grep -c X)
   if test $ac_delim_n = $ac_delim_num; then
     break
   elif $ac_last_try; then
@@ -18316,7 +18316,7 @@ _ACEOF
 # handling of long lines.
 ac_delim='%!_!# '
 for ac_last_try in false false :; do
-  ac_tt=`sed -n "/$ac_delim/p" confdefs.h`
+  ac_tt=$(sed -n "/$ac_delim/p" confdefs.h)
   if test -z "$ac_tt"; then
     break
   elif $ac_last_try; then

--- a/install-sh
+++ b/install-sh
@@ -232,7 +232,7 @@ if test -z "$dir_arg"; then
       else
         u_plus_rw='% 200'
       fi
-      cp_umask=`expr '(' 777 - $mode % 1000 ')' $u_plus_rw`;;
+      cp_umask=$(expr '(' 777 - $mode % 1000 ')' $u_plus_rw);;
     *)
       if test -z "$stripcmd"; then
         u_plus_rw=
@@ -278,14 +278,14 @@ do
         exit 1
       fi
       dstdir=$dst
-      dstbase=`basename "$src"`
+      dstbase=$(basename "$src")
       case $dst in
 	*/) dst=$dst$dstbase;;
 	*)  dst=$dst/$dstbase;;
       esac
       dstdir_status=0
     else
-      dstdir=`dirname "$dst"`
+      dstdir=$(dirname "$dst")
       test -d "$dstdir"
       dstdir_status=$?
     fi
@@ -303,17 +303,17 @@ do
       '')
         # Create intermediate dirs using mode 755 as modified by the umask.
         # This is like FreeBSD 'install' as of 1997-10-28.
-        umask=`umask`
+        umask=$(umask)
         case $stripcmd.$umask in
           # Optimize common cases.
           *[2367][2367]) mkdir_umask=$umask;;
           .*0[02][02] | .[02][02] | .[02]) mkdir_umask=22;;
 
           *[0-7])
-            mkdir_umask=`expr $umask + 22 \
+            mkdir_umask=$(expr $umask + 22 \
               - $umask % 100 % 40 + $umask % 20 \
               - $umask % 10 % 4 + $umask % 2
-            `;;
+            );;
           *) mkdir_umask=$umask,go-w;;
         esac
 
@@ -352,14 +352,14 @@ do
                    # other-writable bit of parent directory when it shouldn't.
                    # FreeBSD 6.1 mkdir -m -p sets mode of existing directory.
                    test_tmpdir="$tmpdir/a"
-                   ls_ld_tmpdir=`ls -ld "$test_tmpdir"`
+                   ls_ld_tmpdir=$(ls -ld "$test_tmpdir")
                    case $ls_ld_tmpdir in
                      d????-?r-*) different_mode=700;;
                      d????-?--*) different_mode=755;;
                      *) false;;
                    esac &&
                    $mkdirprog -m$different_mode -p -- "$test_tmpdir" && {
-                     ls_ld_tmpdir_1=`ls -ld "$test_tmpdir"`
+                     ls_ld_tmpdir_1=$(ls -ld "$test_tmpdir")
                      test "$ls_ld_tmpdir" = "$ls_ld_tmpdir_1"
                    }
                  }
@@ -417,7 +417,7 @@ do
             test -d "$prefix" || exit 1
           else
             case $prefix in
-              *\'*) qprefix=`echo "$prefix" | sed "s/'/'\\\\\\\\''/g"`;;
+              *\'*) qprefix=$(echo "$prefix" | sed "s/'/'\\\\\\\\''/g");;
               *) qprefix=$prefix;;
             esac
             prefixes="$prefixes '$qprefix'"
@@ -466,8 +466,8 @@ do
 
     # If -C, don't bother to copy if it wouldn't change the file.
     if $copy_on_change &&
-       old=`LC_ALL=C ls -dlL "$dst"     2>/dev/null` &&
-       new=`LC_ALL=C ls -dlL "$dsttmp"  2>/dev/null` &&
+       old=$(LC_ALL=C ls -dlL "$dst"     2>/dev/null) &&
+       new=$(LC_ALL=C ls -dlL "$dsttmp"  2>/dev/null) &&
        set -f &&
        set X $old && old=:$2:$4:$5:$6 &&
        set X $new && new=:$2:$4:$5:$6 &&


### PR DESCRIPTION
```
[bpo-39552](https://bugs.python.org/issue39552): Remove legacy backticks for $(), some more need doing but this is a good first stop
```

Where: https://bugs.python.org/issue39552


<!-- issue-number: [bpo-39552](https://bugs.python.org/issue39552) -->
https://bugs.python.org/issue39552
<!-- /issue-number -->
