### PR TITLE
bpo-39555: Fix distutils test to handle _d suffix on Windows debug build

### DIFF
--- a/Lib/distutils/tests/test_build_ext.py
+++ b/Lib/distutils/tests/test_build_ext.py
@@ -312,8 +312,8 @@ class BuildExtTestCase(TempdirManager,
         dist = Distribution({'name': 'xx', 'ext_modules': modules})
         cmd = self.build_ext(dist)
         cmd.ensure_finalized()
-        self.assertRegex(cmd.get_ext_filename(modules[0].name), r'foo\..*')
-        self.assertRegex(cmd.get_ext_filename(modules[1].name), r'föö\..*')
+        self.assertRegex(cmd.get_ext_filename(modules[0].name), r'foo(_d)?\..*')
+        self.assertRegex(cmd.get_ext_filename(modules[1].name), r'föö(_d)?\..*')
         self.assertEqual(cmd.get_export_symbols(modules[0]), ['PyInit_foo'])
         self.assertEqual(cmd.get_export_symbols(modules[1]), ['PyInitU_f_gkaa'])
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39555](https://bugs.python.org/issue39555) -->
https://bugs.python.org/issue39555
<!-- /issue-number -->
