### PR TITLE
bpo-39543: Remove unused _Py_Dealloc() macro

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -327,16 +327,6 @@ _PyObject_GenericSetAttrWithDict(PyObject *, PyObject *,
 
 #define PyType_HasFeature(t,f)  (((t)->tp_flags & (f)) != 0)
 
-static inline void _Py_Dealloc_inline(PyObject *op)
-{
-    destructor dealloc = Py_TYPE(op)->tp_dealloc;
-#ifdef Py_TRACE_REFS
-    _Py_ForgetReference(op);
-#endif
-    (*dealloc)(op);
-}
-#define _Py_Dealloc(op) _Py_Dealloc_inline(op)
-
 PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
 
 /* Safely decref `op` and set `op` to `op2`.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2162,8 +2162,6 @@ _PyObject_AssertFailed(PyObject *obj, const char *expr, const char *msg,
 }
 
 
-#undef _Py_Dealloc
-
 void
 _Py_Dealloc(PyObject *op)
 {


### PR DESCRIPTION
The macro was defined after Py_DECREF() and so is no longer used by
Py_DECREF().

Moving _Py_Dealloc() macro back from cpython/object.h to object.h
would require to move a lot of definitions as well: PyTypeObject and
many related types used by PyTypeObject.

Keep _Py_Dealloc() as an opaque function call to avoid leaking
implementation details in the limited C API (object.h).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39543](https://bugs.python.org/issue39543) -->
https://bugs.python.org/issue39543
<!-- /issue-number -->
