### PR TITLE
bpo-39542: Convert PyType_Check() to static inline function

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -21,14 +21,14 @@ Type Objects
 
 .. c:function:: int PyType_Check(PyObject *o)
 
-   Return true if the object *o* is a type object, including instances of types
-   derived from the standard type object.  Return false in all other cases.
+   Return non-zero if the object *o* is a type object, including instances of
+   types derived from the standard type object.  Return 0 in all other cases.
 
 
 .. c:function:: int PyType_CheckExact(PyObject *o)
 
-   Return true if the object *o* is a type object, but not a subtype of the
-   standard type object.  Return false in all other cases.
+   Return non-zero if the object *o* is a type object, but not a subtype of the
+   standard type object.  Return 0 in all other cases.
 
 
 .. c:function:: unsigned int PyType_ClearCache()
@@ -57,8 +57,8 @@ Type Objects
 
 .. c:function:: int PyType_HasFeature(PyTypeObject *o, int feature)
 
-   Return true if the type object *o* sets the feature *feature*.  Type features
-   are denoted by single bit flags.
+   Return non-zero if the type object *o* sets the feature *feature*.
+   Type features are denoted by single bit flags.
 
 
 .. c:function:: int PyType_IS_GC(PyTypeObject *o)

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -341,8 +341,6 @@ PyAPI_FUNC(int)
 _PyObject_GenericSetAttrWithDict(PyObject *, PyObject *,
                                  PyObject *, PyObject *);
 
-#define PyType_HasFeature(t,f)  (((t)->tp_flags & (f)) != 0)
-
 PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
 
 /* Safely decref `op` and set `op` to `op2`.

--- a/Misc/NEWS.d/next/C API/2020-02-05-13-14-20.bpo-39542.5mleGX.rst
+++ b/Misc/NEWS.d/next/C API/2020-02-05-13-14-20.bpo-39542.5mleGX.rst
@@ -1,0 +1,2 @@
+Convert :c:func:`PyType_HasFeature`, :c:func:`PyType_Check` and
+:c:func:`PyType_CheckExact` macros to static inline functions.


### PR DESCRIPTION
Convert PyType_HasFeature(), PyType_Check() and PyType_CheckExact()
macros to static inline functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39542](https://bugs.python.org/issue39542) -->
https://bugs.python.org/issue39542
<!-- /issue-number -->
