### PR TITLE
Add PyInterpreterState.fs_codec.utf8

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -102,6 +102,7 @@ struct _is {
        Later, it is set to a non-NULL string by _PyUnicode_InitEncodings(). */
     struct {
         char *encoding;   /* Filesystem encoding (encoded to UTF-8) */
+        int utf8;         /* encoding=="utf-8"? */
         char *errors;     /* Filesystem errors (encoded to UTF-8) */
         _Py_error_handler error_handler;
     } fs_codec;


### PR DESCRIPTION
Add a fast-path for UTF-8 encoding in PyUnicode_EncodeFSDefault()
and PyUnicode_DecodeFSDefaultAndSize().

Add _PyUnicode_FiniEncodings() helper function for _PyUnicode_Fini().