### PR TITLE
bpo-39542: Declare _Py_AddToAllObjects() in pycore_object.h

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -82,6 +82,7 @@ extern void _PyDebug_PrintTotalRefs(void);
 #endif
 
 #ifdef Py_TRACE_REFS
+extern void _Py_AddToAllObjects(PyObject *op, int force);
 extern void _Py_PrintReferences(FILE *);
 extern void _Py_PrintReferenceAddresses(FILE *);
 #endif

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -93,7 +93,7 @@ static PyObject refchain = {&refchain, &refchain};
  * way, though; exceptions include statically allocated type objects, and
  * statically allocated singletons (like Py_True and Py_None).
  */
-static void
+void
 _Py_AddToAllObjects(PyObject *op, int force)
 {
 #ifdef  Py_DEBUG

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include "ast.h"
 #undef Yield   /* undefine macro conflicting with <winbase.h> */
+#include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"
 #include "pycore_tupleobject.h"
@@ -2443,7 +2444,7 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
            would change the value of empty. In fact, using
            in-place addition rather that binary addition for
            any of the steps introduces subtle behavior changes:
-           
+
            https://bugs.python.org/issue18305 */
         temp = PyNumber_Add(result, item);
         Py_DECREF(result);


### PR DESCRIPTION
_Py_AddToAllObjects() is used in bltinmodule.c and typeobject.c when
Py_TRACE_REFS is defined.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39542](https://bugs.python.org/issue39542) -->
https://bugs.python.org/issue39542
<!-- /issue-number -->
