### PR TITLE
bpo-39559: Remove unused, undocumented argument from uuid.getnode

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -757,7 +757,7 @@ else:
 
 _node = None
 
-def getnode(*, getters=None):
+def getnode():
     """Get the hardware address as a 48-bit positive integer.
 
     The first time this runs, it may launch a separate program, which could

--- a/Misc/NEWS.d/next/Library/2020-02-05-18-29-14.bpo-39559.L8i5YB.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-05-18-29-14.bpo-39559.L8i5YB.rst
@@ -1,0 +1,1 @@
+Remove unused, undocumented argument ``getters`` from :func:`uuid.getnode`


### PR DESCRIPTION
Argument was made useless by [bpo-28009](https://bugs.python.org/issue28009)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39559](https://bugs.python.org/issue39559) -->
https://bugs.python.org/issue39559
<!-- /issue-number -->
