### PR TITLE
bpo-38967: Improve the error msg for reserved _sunder_ names in enum

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -75,7 +75,8 @@ class _EnumDict(dict):
                     '_order_', '_create_pseudo_member_',
                     '_generate_next_value_', '_missing_', '_ignore_',
                     ):
-                raise ValueError('_names_ are reserved for future Enum use')
+                raise ValueError(f'_sunder_ names, such as "{key}", are '
+                                  'reserved for future Enum use')
             if key == '_generate_next_value_':
                 setattr(self, '_generate_next_value', value)
             elif key == '_ignore_':

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -418,6 +418,11 @@ class TestEnum(unittest.TestCase):
                 green = 2
                 blue = 3
 
+    def test_reserved__sunder_(self):
+        with self.assertRaisesRegex(ValueError, '_sunder_ names, such as '
+                                    '"_bad_", are reserved'):
+            class Bad(Enum):
+                _bad_ = 1
 
     def test_enum_with_value_name(self):
         class Huh(Enum):


### PR DESCRIPTION


<!-- issue-number: [bpo-38967](https://bugs.python.org/issue38967) -->
https://bugs.python.org/issue38967
<!-- /issue-number -->


Automerge-Triggered-By: @ethanfurman