### PR TITLE
bpo-39567: Add audit for os.walk(), os.fwalk(), Path.glob() and Path.rglob().

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -336,7 +336,10 @@ def walk(top, topdown=True, onerror=None, followlinks=False):
             dirs.remove('CVS')  # don't visit CVS directories
 
     """
-    top = fspath(top)
+    sys.audit("os.walk", top, topdown, onerror, followlinks)
+    return _walk(fspath(top), topdown, onerror, followlinks)
+
+def _walk(top, topdown, onerror, followlinks):
     dirs = []
     nondirs = []
     walk_dirs = []
@@ -410,11 +413,11 @@ def walk(top, topdown=True, onerror=None, followlinks=False):
             # the caller can replace the directory entry during the "yield"
             # above.
             if followlinks or not islink(new_path):
-                yield from walk(new_path, topdown, onerror, followlinks)
+                yield from _walk(new_path, topdown, onerror, followlinks)
     else:
         # Recurse into sub-directories
         for new_path in walk_dirs:
-            yield from walk(new_path, topdown, onerror, followlinks)
+            yield from _walk(new_path, topdown, onerror, followlinks)
         # Yield after recursion if going bottom up
         yield top, dirs, nondirs
 
@@ -455,6 +458,7 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
             if 'CVS' in dirs:
                 dirs.remove('CVS')  # don't visit CVS directories
         """
+        sys.audit("os.fwalk", top, topdown, onerror, follow_symlinks, dir_fd)
         if not isinstance(top, int) or not hasattr(top, '__index__'):
             top = fspath(top)
         # Note: To guard against symlink races, we use the standard

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1134,6 +1134,7 @@ class Path(PurePath):
         """Iterate over this subtree and yield all existing files (of any
         kind, including directories) matching the given relative pattern.
         """
+        sys.audit("pathlib.Path.glob", self, pattern)
         if not pattern:
             raise ValueError("Unacceptable pattern: {!r}".format(pattern))
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
@@ -1148,6 +1149,7 @@ class Path(PurePath):
         directories) matching the given relative pattern, anywhere in
         this subtree.
         """
+        sys.audit("pathlib.Path.rglob", self, pattern)
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
         if drv or root:
             raise NotImplementedError("Non-relative patterns are unsupported")

--- a/Misc/NEWS.d/next/Library/2020-02-06-10-23-32.bpo-39567.VpFBxt.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-06-10-23-32.bpo-39567.VpFBxt.rst
@@ -1,0 +1,2 @@
+Added audit for :func:`os.walk`, :func:`os.fwalk`, :meth:`pathlib.Path.glob`
+and :meth:`pathlib.Path.rglob`.


### PR DESCRIPTION


<!-- issue-number: [bpo-39567](https://bugs.python.org/issue39567) -->
https://bugs.python.org/issue39567
<!-- /issue-number -->
