### PR TITLE
bpo-39350: Fix fractions for int subclasses

### DIFF
--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -84,6 +84,10 @@ another rational number, or from a string.
       The :class:`Fraction` constructor now accepts :class:`float` and
       :class:`decimal.Decimal` instances.
 
+   .. versionchanged:: 3.9
+      The :func:`math.gcd` function is now used to normalize the *numerator*
+      and *denominator*. :func:`math.gcd` always return a :class:`int` type.
+      Previously, the GCD type depended on *numerator* and *denominator*.
 
    .. attribute:: numerator
 

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -155,13 +155,9 @@ class Fraction(numbers.Rational):
         if denominator == 0:
             raise ZeroDivisionError('Fraction(%s, 0)' % numerator)
         if _normalize:
-            if type(numerator) is int is type(denominator):
-                # *very* normal case
-                g = math.gcd(numerator, denominator)
-                if denominator < 0:
-                    g = -g
-            else:
-                g = _gcd(numerator, denominator)
+            g = math.gcd(numerator, denominator)
+            if denominator < 0:
+                g = -g
             numerator //= g
             denominator //= g
         self._numerator = numerator

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -703,6 +703,28 @@ class FractionTest(unittest.TestCase):
         r = F(13, 7)
         self.assertRaises(AttributeError, setattr, r, 'a', 10)
 
+    def test_int_subclass(self):
+        class myint(int):
+            def __mul__(self, other):
+                return type(self)(int(self) * int(other))
+            def __floordiv__(self, other):
+                return type(self)(int(self) // int(other))
+            def __mod__(self, other):
+                x = type(self)(int(self) % int(other))
+                return x
+            @property
+            def numerator(self):
+                return type(self)(int(self))
+            @property
+            def denominator(self):
+                return type(self)(1)
+
+        f = fractions.Fraction(myint(1 * 3), myint(2 * 3))
+        self.assertEqual(f.numerator, 1)
+        self.assertEqual(f.denominator, 2)
+        self.assertEqual(type(f.numerator), myint)
+        self.assertEqual(type(f.denominator), myint)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-02-06-13-34-52.bpo-39350.wRwup1.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-06-13-34-52.bpo-39350.wRwup1.rst
@@ -1,0 +1,5 @@
+Fix regression in :class:`fractions.Fraction` if the numerator and/or the
+denominator is an :class:`int` subclass. The :func:`math.gcd` function is now
+used to normalize the *numerator* and *denominator*. :func:`math.gcd` always
+return a :class:`int` type. Previously, the GCD type depended on *numerator*
+and *denominator*.


### PR DESCRIPTION
Fix regression in fractions.Fraction if the numerator and/or the
denominator is an int subclass.

<!-- issue-number: [bpo-39350](https://bugs.python.org/issue39350) -->
https://bugs.python.org/issue39350
<!-- /issue-number -->
