### PR TITLE
bpo-39491: Mention Annotated in get_origin() docstring

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1380,8 +1380,8 @@ def _strip_annotations(t):
 def get_origin(tp):
     """Get the unsubscripted version of a type.
 
-    This supports generic types, Callable, Tuple, Union, Literal, Final and ClassVar.
-    Return None for unsupported types. Examples::
+    This supports generic types, Callable, Tuple, Union, Literal, Final, ClassVar
+    and Annotated. Return None for unsupported types. Examples::
 
         get_origin(Literal[42]) is Literal
         get_origin(int) is None


### PR DESCRIPTION
I forgot to do it in https://github.com/python/cpython/pull/18260. This is so minor I believe bpo-reference and a news entry can be skipped.

<!-- issue-number: [bpo-39491](https://bugs.python.org/issue39491) -->
https://bugs.python.org/issue39491
<!-- /issue-number -->
