### PR TITLE
bpo-39575: Change -lgcov to --coverage

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -513,7 +513,7 @@ profile-opt: profile-run-stamp
 coverage:
 	@echo "Building with support for coverage checking:"
 	$(MAKE) clean
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS="$(CFLAGS) -O0 -pg -fprofile-arcs -ftest-coverage" LIBS="$(LIBS) -lgcov"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS="$(CFLAGS) -O0 -pg --coverage" LIBS="$(LIBS) --coverage"
 
 coverage-lcov:
 	@echo "Creating Coverage HTML report with LCOV:"


### PR DESCRIPTION
This allows clang to get rid of the dependency on libgcov.
When linking, GCC passes -lgcov while clang passes the path to libclang_rt.profile-$arch.a


<!-- issue-number: [bpo-39575](https://bugs.python.org/issue39575) -->
https://bugs.python.org/issue39575
<!-- /issue-number -->
