### PR TITLE
bpo-39571: Fix clang warning on PyTypeObject typedef

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -190,7 +190,7 @@ typedef struct {
  * backwards-compatibility */
 typedef Py_ssize_t printfunc;
 
-typedef struct _typeobject {
+struct _typeobject {
     PyObject_VAR_HEAD
     const char *tp_name; /* For printing, in format "<module>.<name>" */
     Py_ssize_t tp_basicsize, tp_itemsize; /* For allocation */
@@ -271,7 +271,7 @@ typedef struct _typeobject {
 
     destructor tp_finalize;
     vectorcallfunc tp_vectorcall;
-} PyTypeObject;
+};
 
 /* The *real* layout of a type object when allocated on the heap */
 typedef struct _heaptypeobject {


### PR DESCRIPTION
Only define PyTypeObject type once.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39571](https://bugs.python.org/issue39571) -->
https://bugs.python.org/issue39571
<!-- /issue-number -->
