### PR TITLE
bpo-37413: Deprecate sys._enablelegacywindowsfsencoding()

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1411,6 +1411,8 @@ always available.
    .. versionadded:: 3.6
       See :pep:`529` for more details.
 
+   .. deprecated-removed:: 3.9 3.10
+
 .. data:: stdin
           stdout
           stderr

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -437,6 +437,10 @@ Deprecated
 
   (Contributed by Victor Stinner in :issue:`39353`.)
 
+* The :func:`sys._enablelegacywindowsfsencoding` function added to Python 3.6
+  by :pep:`529` is now deprecated and will be removed in Python 3.10.
+  (Contributed by Victor Stinner in :issue:`37413`.)
+
 
 Removed
 =======

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -919,6 +919,8 @@ class SysModuleTest(unittest.TestCase):
                          'needs sys._enablelegacywindowsfsencoding()')
     def test__enablelegacywindowsfsencoding(self):
         code = ('import sys',
+                'import warnings',
+                "warnings.simplefilter('ignore', DeprecationWarning)",
                 'sys._enablelegacywindowsfsencoding()',
                 'print(sys.getfilesystemencoding(), sys.getfilesystemencodeerrors())')
         rc, out, err = assert_python_ok('-c', '; '.join(code))

--- a/Misc/NEWS.d/next/Library/2020-02-07-08-59-10.bpo-37413.AT-1gd.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-07-08-59-10.bpo-37413.AT-1gd.rst
@@ -1,0 +1,2 @@
+The :func:`sys._enablelegacywindowsfsencoding` function added to Python 3.6
+by :pep:`529` is now deprecated and will be removed in Python 3.10.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1483,6 +1483,12 @@ static PyObject *
 sys__enablelegacywindowsfsencoding_impl(PyObject *module)
 /*[clinic end generated code: output=f5c3855b45e24fe9 input=2bfa931a20704492]*/
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "sys._enablelegacywindowsfsencoding() is deprecated",
+                     1) < 0) {
+        return NULL;
+    }
+
     if (_PyUnicode_EnableLegacyWindowsFSEncoding() < 0) {
         return NULL;
     }


### PR DESCRIPTION
The sys._enablelegacywindowsfsencoding() function added to Python 3.6
by PEP 529 is now deprecated and will be removed in Python 3.10.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37413](https://bugs.python.org/issue37413) -->
https://bugs.python.org/issue37413
<!-- /issue-number -->
