### PR TITLE
bpo-39184: Add audit events to functions in `fcntl`, `msvcrt`, `os`, `resource`,  `shutil`, `signal`, `syslog`

### DIFF
--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -63,6 +63,8 @@ The module defines the following functions:
 
    If the :c:func:`fcntl` fails, an :exc:`OSError` is raised.
 
+   .. audit-event:: fcntl.fcntl fd,cmd,arg fcntl.fcntl
+
 
 .. function:: ioctl(fd, request, arg=0, mutate_flag=True)
 
@@ -112,6 +114,8 @@ The module defines the following functions:
       >>> buf
       array('h', [13341])
 
+   .. audit-event:: fcntl.ioctl fd,request,arg fcntl.ioctl
+
 
 .. function:: flock(fd, operation)
 
@@ -121,6 +125,8 @@ The module defines the following functions:
    using :c:func:`fcntl`.)
 
    If the :c:func:`flock` fails, an :exc:`OSError` exception is raised.
+
+   .. audit-event:: fcntl.flock fd,operation fcntl.flock
 
 
 .. function:: lockf(fd, cmd, len=0, start=0, whence=0)
@@ -154,6 +160,8 @@ The module defines the following functions:
    The default for *start* is 0, which means to start at the beginning of the file.
    The default for *len* is 0 which means to lock to the end of the file.  The
    default for *whence* is also 0.
+
+   .. audit-event:: fcntl.lockf fd,cmd,len,start,whence fcntl.lockf
 
 Examples (all on a SVR4 compliant system)::
 

--- a/Doc/library/msvcrt.rst
+++ b/Doc/library/msvcrt.rst
@@ -42,6 +42,8 @@ File Operations
    regions in a file may be locked at the same time, but may not overlap.  Adjacent
    regions are not merged; they must be unlocked individually.
 
+   .. audit-event:: msvcrt.locking fd,mode,nbytes msvcrt.locking
+
 
 .. data:: LK_LOCK
           LK_RLCK
@@ -77,11 +79,15 @@ File Operations
    and :const:`os.O_TEXT`.  The returned file descriptor may be used as a parameter
    to :func:`os.fdopen` to create a file object.
 
+   .. audit-event:: msvcrt.open_osfhandle handle,flags msvcrt.open_osfhandle
+
 
 .. function:: get_osfhandle(fd)
 
    Return the file handle for the file descriptor *fd*.  Raises :exc:`OSError` if
    *fd* is not recognized.
+
+   .. audit-event:: msvcrt.get_osfhandle fd msvcrt.get_osfhandle
 
 
 .. _msvcrt-console:

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -445,6 +445,8 @@ process and user.
       On some platforms, including FreeBSD and Mac OS X, setting ``environ`` may
       cause memory leaks. Refer to the system documentation for :c:func:`putenv`.
 
+   .. audit-event:: os.putenv key,value os.putenv
+
    .. versionchanged:: 3.9
       The function is now always available.
 
@@ -640,6 +642,8 @@ process and user.
    don't update ``os.environ``, so it is actually preferable to delete items of
    ``os.environ``.
 
+   .. audit-event:: os.unsetenv key os.unsetenv
+
    .. versionchanged:: 3.9
       The function is now always available and is also available on Windows.
 
@@ -766,6 +770,8 @@ as internal buffering of data.
    docs for :func:`chmod` for possible values of *mode*.  As of Python 3.3, this
    is equivalent to ``os.chmod(fd, mode)``.
 
+   .. audit-event:: os.chmod path,mode,dir_fd os.fchmod
+
    .. availability:: Unix.
 
 
@@ -775,6 +781,8 @@ as internal buffering of data.
    and *gid*.  To leave one of the ids unchanged, set it to -1.  See
    :func:`chown`.  As of Python 3.3, this is equivalent to ``os.chown(fd, uid,
    gid)``.
+
+   .. audit-event:: os.chown path,uid,gid,dir_fd os.fchown
 
    .. availability:: Unix.
 
@@ -882,6 +890,8 @@ as internal buffering of data.
    *cmd* specifies the command to use - one of :data:`F_LOCK`, :data:`F_TLOCK`,
    :data:`F_ULOCK` or :data:`F_TEST`.
    *len* specifies the section of the file to lock.
+
+   .. audit-event:: os.lockf fd,cmd,len os.lockf
 
    .. availability:: Unix.
 
@@ -1603,6 +1613,8 @@ features:
    This function can raise :exc:`OSError` and subclasses such as
    :exc:`FileNotFoundError`, :exc:`PermissionError`, and :exc:`NotADirectoryError`.
 
+   .. audit-event:: os.chdir path os.chdir
+
    .. versionadded:: 3.3
       Added support for specifying *path* as a file descriptor
       on some platforms.
@@ -1630,6 +1642,8 @@ features:
    * :data:`stat.SF_SNAPSHOT`
 
    This function can support :ref:`not following symlinks <follow_symlinks>`.
+
+   .. audit-event:: os.chflags path,flags os.chflags
 
    .. availability:: Unix.
 
@@ -1676,6 +1690,8 @@ features:
       read-only flag with it (via the ``stat.S_IWRITE`` and ``stat.S_IREAD``
       constants or a corresponding integer value).  All other bits are ignored.
 
+   .. audit-event:: os.chmod path,mode,dir_fd os.chmod
+
    .. versionadded:: 3.3
       Added support for specifying *path* as an open file descriptor,
       and the *dir_fd* and *follow_symlinks* arguments.
@@ -1695,6 +1711,8 @@ features:
 
    See :func:`shutil.chown` for a higher-level function that accepts names in
    addition to numeric ids.
+
+   .. audit-event:: os.chown path,uid,gid,dir_fd os.chown
 
    .. availability:: Unix.
 
@@ -1722,6 +1740,8 @@ features:
    descriptor *fd*.  The descriptor must refer to an opened directory, not an
    open file.  As of Python 3.3, this is equivalent to ``os.chdir(fd)``.
 
+   .. audit-event:: os.chdir path os.fchdir
+
    .. availability:: Unix.
 
 
@@ -1746,6 +1766,8 @@ features:
    not follow symbolic links.  As of Python 3.3, this is equivalent to
    ``os.chflags(path, flags, follow_symlinks=False)``.
 
+   .. audit-event:: os.chflags path,flags os.lchflags
+
    .. availability:: Unix.
 
    .. versionchanged:: 3.6
@@ -1759,6 +1781,8 @@ features:
    for possible values of *mode*.  As of Python 3.3, this is equivalent to
    ``os.chmod(path, mode, follow_symlinks=False)``.
 
+   .. audit-event:: os.chmod path,mode,dir_fd os.lchmod
+
    .. availability:: Unix.
 
    .. versionchanged:: 3.6
@@ -1769,6 +1793,8 @@ features:
    Change the owner and group id of *path* to the numeric *uid* and *gid*.  This
    function will not follow symbolic links.  As of Python 3.3, this is equivalent
    to ``os.chown(path, uid, gid, follow_symlinks=False)``.
+
+   .. audit-event:: os.chown path,uid,gid,dir_fd os.lchown
 
    .. availability:: Unix.
 
@@ -1783,6 +1809,8 @@ features:
    This function can support specifying *src_dir_fd* and/or *dst_dir_fd* to
    supply :ref:`paths relative to directory descriptors <dir_fd>`, and :ref:`not
    following symlinks <follow_symlinks>`.
+
+   .. audit-event:: os.link src,dst,src_dir_fd,dst_dir_fd os.link
 
    .. availability:: Unix, Windows.
 
@@ -1886,6 +1914,8 @@ features:
    It is also possible to create temporary directories; see the
    :mod:`tempfile` module's :func:`tempfile.mkdtemp` function.
 
+   .. audit-event:: os.mkdir path,mode,dir_fd os.mkdir
+
    .. versionadded:: 3.3
       The *dir_fd* argument.
 
@@ -1917,6 +1947,8 @@ features:
       include :data:`pardir` (eg. ".." on UNIX systems).
 
    This function handles UNC paths correctly.
+
+   .. audit-event:: os.mkdir path,mode,dir_fd os.makedirs
 
    .. versionadded:: 3.2
       The *exist_ok* parameter.
@@ -2083,6 +2115,8 @@ features:
 
    This function is semantically identical to :func:`unlink`.
 
+   .. audit-event:: os.remove path,dir_fd os.remove
+
    .. versionadded:: 3.3
       The *dir_fd* argument.
 
@@ -2102,6 +2136,8 @@ features:
    the directory ``'foo/bar/baz'``, and then remove ``'foo/bar'`` and ``'foo'`` if
    they are empty. Raises :exc:`OSError` if the leaf directory could not be
    successfully removed.
+
+   .. audit-event:: os.remove path,dir_fd os.removedirs
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
@@ -2128,6 +2164,8 @@ features:
 
    If you want cross-platform overwriting of the destination, use :func:`replace`.
 
+   .. audit-event:: os.rename src,dst,src_dir_fd,dst_dir_fd os.rename
+
    .. versionadded:: 3.3
       The *src_dir_fd* and *dst_dir_fd* arguments.
 
@@ -2147,6 +2185,8 @@ features:
       This function can fail with the new directory structure made if you lack
       permissions needed to remove the leaf directory or file.
 
+   .. audit-event:: os.rename src,dst,src_dir_fd,dst_dir_fd os.renames
+
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object` for *old* and *new*.
 
@@ -2161,6 +2201,8 @@ features:
 
    This function can support specifying *src_dir_fd* and/or *dst_dir_fd* to
    supply :ref:`paths relative to directory descriptors <dir_fd>`.
+
+   .. audit-event:: os.rename src,dst,src_dir_fd,dst_dir_fd os.replace
 
    .. versionadded:: 3.3
 
@@ -2177,6 +2219,8 @@ features:
 
    This function can support :ref:`paths relative to directory descriptors
    <dir_fd>`.
+
+   .. audit-event:: os.rmdir path,dir_fd os.rmdir
 
    .. versionadded:: 3.3
       The *dir_fd* parameter.
@@ -2821,6 +2865,8 @@ features:
       :exc:`OSError` is raised when the function is called by an unprivileged
       user.
 
+   .. audit-event:: os.symlink src,dst,dir_fd os.symlink
+
    .. availability:: Unix, Windows.
 
    .. versionchanged:: 3.2
@@ -2873,6 +2919,8 @@ features:
    traditional Unix name.  Please see the documentation for
    :func:`remove` for further information.
 
+   .. audit-event:: os.remove path,dir_fd os.unlink
+
    .. versionadded:: 3.3
       The *dir_fd* parameter.
 
@@ -2909,6 +2957,8 @@ features:
    This function can support :ref:`specifying a file descriptor <path_fd>`,
    :ref:`paths relative to directory descriptors <dir_fd>` and :ref:`not
    following symlinks <follow_symlinks>`.
+
+   .. audit-event:: os.utime path,times,ns,dir_fd os.utime
 
    .. versionadded:: 3.3
       Added support for specifying *path* as an open file descriptor,
@@ -3135,6 +3185,8 @@ These functions are all available on Linux only.
    This function can support :ref:`specifying a file descriptor <path_fd>` and
    :ref:`not following symlinks <follow_symlinks>`.
 
+   .. audit-event:: os.getxattr path,attribute os.getxattr
+
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object` for *path* and *attribute*.
 
@@ -3149,6 +3201,8 @@ These functions are all available on Linux only.
    This function can support :ref:`specifying a file descriptor <path_fd>` and
    :ref:`not following symlinks <follow_symlinks>`.
 
+   .. audit-event:: os.listxattr path os.listxattr
+
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
 
@@ -3162,6 +3216,8 @@ These functions are all available on Linux only.
 
    This function can support :ref:`specifying a file descriptor <path_fd>` and
    :ref:`not following symlinks <follow_symlinks>`.
+
+   .. audit-event:: os.removexattr path,attribute os.removexattr
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object` for *path* and *attribute*.
@@ -3185,6 +3241,8 @@ These functions are all available on Linux only.
 
       A bug in Linux kernel versions less than 2.6.39 caused the flags argument
       to be ignored on some filesystems.
+
+   .. audit-event:: os.setxattr path,attribute,value,flags os.setxattr
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object` for *path* and *attribute*.
@@ -3247,6 +3305,8 @@ to be ignored.
    See the `Microsoft documentation
    <https://msdn.microsoft.com/44228cf2-6306-466c-8f16-f513cd3ba8b5>`_
    for more information about how DLLs are loaded.
+
+   .. audit-event:: os.add_dll_directory path os.add_dll_directory
 
    .. availability:: Windows.
 
@@ -3480,6 +3540,8 @@ written in Python, such as a mail server's external command delivery program.
    Note that some platforms including FreeBSD <= 6.3 and Cygwin have
    known issues when using ``fork()`` from a thread.
 
+   .. audit-event:: os.fork "" os.fork
+
    .. versionchanged:: 3.8
       Calling ``fork()`` in a subinterpreter is no longer supported
       (:exc:`RuntimeError` is raised).
@@ -3498,6 +3560,8 @@ written in Python, such as a mail server's external command delivery program.
    new child's process id in the parent, and *fd* is the file descriptor of the
    master end of the pseudo-terminal.  For a more portable approach, use the
    :mod:`pty` module.  If an error occurs :exc:`OSError` is raised.
+
+   .. audit-event:: os.forkpty "" os.forkpty
 
    .. versionchanged:: 3.8
       Calling ``forkpty()`` in a subinterpreter is no longer supported
@@ -3525,6 +3589,8 @@ written in Python, such as a mail server's external command delivery program.
 
    See also :func:`signal.pthread_kill`.
 
+   .. audit-event:: os.kill pid,sig os.kill
+
    .. versionadded:: 3.2
       Windows support.
 
@@ -3536,6 +3602,8 @@ written in Python, such as a mail server's external command delivery program.
       single: process; signalling
 
    Send the signal *sig* to the process group *pgid*.
+
+   .. audit-event:: os.killpg pgid,sig os.killpg
 
    .. availability:: Unix.
 

--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -78,6 +78,9 @@ this module for those platforms.
 
    VxWorks only supports setting :data:`RLIMIT_NOFILE`.
 
+   .. audit-event:: resource.setrlimit resource,limits resource.setrlimit
+
+
 .. function:: prlimit(pid, resource[, limits])
 
    Combines :func:`setrlimit` and :func:`getrlimit` in one function and
@@ -93,6 +96,8 @@ this module for those platforms.
    Raises :exc:`ProcessLookupError` when *pid* can't be found and
    :exc:`PermissionError` when the user doesn't have ``CAP_SYS_RESOURCE`` for
    the process.
+
+   .. audit-event:: resource.prlimit pid,resource,limits resource.prlimit
 
    .. availability:: Linux 2.6.36 or later with glibc 2.13 or later.
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -67,6 +67,8 @@ Directory and files operations
    a new symbolic link will be created instead of copying the
    file *src* points to.
 
+   .. audit-event:: shutil.copyfile src,dst shutil.copyfile
+
    .. versionchanged:: 3.3
       :exc:`IOError` used to be raised instead of :exc:`OSError`.
       Added *follow_symlinks* argument.
@@ -100,6 +102,8 @@ Directory and files operations
    platform; please see :func:`copystat` for more information.  If
    :func:`copymode` cannot modify symbolic links on the local platform, and it
    is asked to do so, it will do nothing and return.
+
+   .. audit-event:: shutil.copymode src,dst shutil.copymode
 
    .. versionchanged:: 3.3
       Added *follow_symlinks* argument.
@@ -146,6 +150,8 @@ Directory and files operations
       Please see :data:`os.supports_follow_symlinks`
       for more information.
 
+   .. audit-event:: shutil.copystat src,dst shutil.copystat
+
    .. versionchanged:: 3.3
       Added *follow_symlinks* argument and support for Linux extended attributes.
 
@@ -166,6 +172,10 @@ Directory and files operations
    file's creation and modification times, is not preserved.
    To preserve all file metadata from the original, use
    :func:`~shutil.copy2` instead.
+
+   .. audit-event:: shutil.copyfile src,dst shutil.copy
+
+   .. audit-event:: shutil.copymode src,dst shutil.copy
 
    .. versionchanged:: 3.3
       Added *follow_symlinks* argument.
@@ -193,6 +203,10 @@ Directory and files operations
    :func:`copy2` uses :func:`copystat` to copy the file metadata.
    Please see :func:`copystat` for more information
    about platform support for modifying symbolic link metadata.
+
+   .. audit-event:: shutil.copyfile src,dst shutil.copy2
+
+   .. audit-event:: shutil.copystat src,dst shutil.copy2
 
    .. versionchanged:: 3.3
       Added *follow_symlinks* argument, try to copy extended
@@ -342,6 +356,8 @@ Directory and files operations
    *copy_function* allows the move to succeed when it is not possible to also
    copy the metadata, at the expense of not copying any of the metadata.
 
+   .. audit-event:: shutil.move src,dst shutil.move
+
    .. versionchanged:: 3.3
       Added explicit symlink handling for foreign filesystems, thus adapting
       it to the behavior of GNU's :program:`mv`.
@@ -380,6 +396,8 @@ Directory and files operations
    least one argument is required.
 
    See also :func:`os.chown`, the underlying function.
+
+   .. audit-event:: shutil.chown path,user,group shutil.chown
 
    .. availability:: Unix.
 
@@ -631,6 +649,8 @@ provided.  They rely on the :mod:`zipfile` and :mod:`tarfile` modules.
    will use the archive file name extension and see if an unpacker was
    registered for that extension.  In case none is found,
    a :exc:`ValueError` is raised.
+
+   .. audit-event:: shutil.unpack_archive filename,extract_dir,format shutil.unpack_archive
 
    .. versionchanged:: 3.7
       Accepts a :term:`path-like object` for *filename* and *extract_dir*.

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -277,6 +277,8 @@ The :mod:`signal` module defines the following functions:
    If *signalnum* is 0, then no signal is sent, but error checking is still
    performed; this can be used to check if the target thread is still running.
 
+   .. audit-event:: signal.pthread_kill thread_id,signalnum signal.pthread_kill
+
    .. availability:: Unix.  See the man page :manpage:`pthread_kill(3)` for further
       information.
 

--- a/Doc/library/syslog.rst
+++ b/Doc/library/syslog.rst
@@ -31,6 +31,8 @@ The module defines the following functions:
    If :func:`openlog` has not been called prior to the call to :func:`syslog`,
    ``openlog()`` will be called with no arguments.
 
+   .. audit-event:: syslog.syslog priority,message syslog.syslog
+
 
 .. function:: openlog([ident[, logoption[, facility]]])
 
@@ -44,6 +46,8 @@ The module defines the following functions:
    field -- see below for possible values to combine.  The optional *facility*
    keyword argument (default is :const:`LOG_USER`) sets the default facility for
    messages which do not have a facility explicitly encoded.
+
+   .. audit-event:: syslog.openlog ident,logoption,facility syslog.openlog
 
    .. versionchanged:: 3.2
       In previous versions, keyword arguments were not allowed, and *ident* was
@@ -60,6 +64,8 @@ The module defines the following functions:
    :func:`openlog` hasn't already been called), and *ident* and other
    :func:`openlog` parameters are reset to defaults.
 
+   .. audit-event:: syslog.closelog "" syslog.closelog
+
 
 .. function:: setlogmask(maskpri)
 
@@ -69,6 +75,8 @@ The module defines the following functions:
    calculates the mask for the individual priority *pri*.  The function
    ``LOG_UPTO(pri)`` calculates the mask for all priorities up to and including
    *pri*.
+
+   .. audit-event:: syslog.setlogmask maskpri syslog.setlogmask
 
 The module defines the following constants:
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -235,6 +235,8 @@ def copyfile(src, dst, *, follow_symlinks=True):
     symlink will be created instead of copying the file it points to.
 
     """
+    sys.audit("shutil.copyfile", src, dst)
+
     if _samefile(src, dst):
         raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
 
@@ -289,6 +291,8 @@ def copymode(src, dst, *, follow_symlinks=True):
     (e.g. Linux) this method does nothing.
 
     """
+    sys.audit("shutil.copymode", src, dst)
+
     if not follow_symlinks and _islink(src) and os.path.islink(dst):
         if hasattr(os, 'lchmod'):
             stat_func, chmod_func = os.lstat, os.lchmod
@@ -340,6 +344,8 @@ def copystat(src, dst, *, follow_symlinks=True):
     If the optional flag `follow_symlinks` is not set, symlinks aren't
     followed if and only if both `src` and `dst` are symlinks.
     """
+    sys.audit("shutil.copystat", src, dst)
+
     def _nop(*args, ns=None, follow_symlinks=None):
         pass
 
@@ -778,6 +784,7 @@ def move(src, dst, copy_function=copy2):
     the issues this implementation glosses over.
 
     """
+    sys.audit("shutil.move", src, dst)
     real_dst = dst
     if os.path.isdir(dst):
         if _samefile(src, dst):
@@ -1208,6 +1215,8 @@ def unpack_archive(filename, extract_dir=None, format=None):
 
     In case none is found, a ValueError is raised.
     """
+    sys.audit("shutil.unpack_archive", filename, extract_dir, format)
+
     if extract_dir is None:
         extract_dir = os.getcwd()
 
@@ -1275,6 +1284,7 @@ def chown(path, user=None, group=None):
     user and group can be the uid/gid or the user/group names, and in that case,
     they are converted to their respective uid/gid.
     """
+    sys.audit('shutil.chown', path, user, group)
 
     if user is None and group is None:
         raise ValueError("user and/or group must be set")

--- a/Misc/NEWS.d/next/Security/2020-02-07-23-54-18.bpo-39184.v-ue-v.rst
+++ b/Misc/NEWS.d/next/Security/2020-02-07-23-54-18.bpo-39184.v-ue-v.rst
@@ -1,0 +1,1 @@
+Add audit events to functions in `fcntl`, `msvcrt`, `os`, `resource`, `shutil`, `signal` and `syslog`.

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -66,6 +66,11 @@ fcntl_fcntl_impl(PyObject *module, int fd, int code, PyObject *arg)
     char buf[1024];
     int async_err = 0;
 
+    if (PySys_Audit("fcntl.fcntl", "iiO", fd, code,
+                    arg ? arg : PyLong_FromLong(0)) < 0) {
+        return NULL;
+    }
+
     if (arg != NULL) {
         int parse_result;
 
@@ -170,6 +175,11 @@ fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
     char *str;
     Py_ssize_t len;
     char buf[IOCTL_BUFSZ+1];  /* argument plus NUL byte */
+
+    if (PySys_Audit("fcntl.ioctl", "iIO", fd, code,
+                    ob_arg ? ob_arg : PyLong_FromLong(0)) < 0) {
+        return NULL;
+    }
 
     if (ob_arg != NULL) {
         if (PyArg_Parse(ob_arg, "w*:ioctl", &pstr)) {
@@ -288,6 +298,10 @@ fcntl_flock_impl(PyObject *module, int fd, int code)
     int ret;
     int async_err = 0;
 
+    if (PySys_Audit("fcntl.flock", "ii", fd, code) < 0) {
+        return NULL;
+    }
+
 #ifdef HAVE_FLOCK
     do {
         Py_BEGIN_ALLOW_THREADS
@@ -371,6 +385,13 @@ fcntl_lockf_impl(PyObject *module, int fd, int code, PyObject *lenobj,
 {
     int ret;
     int async_err = 0;
+
+    if (PySys_Audit("fcntl.lockf", "iiOOi", fd, code,
+                    lenobj ? lenobj : PyLong_FromLong(0),
+                    startobj ? startobj : PyLong_FromLong(0),
+                    whence) < 0) {
+        return NULL;
+    }
 
 #ifndef LOCK_SH
 #define LOCK_SH         1       /* shared lock */

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -66,8 +66,7 @@ fcntl_fcntl_impl(PyObject *module, int fd, int code, PyObject *arg)
     char buf[1024];
     int async_err = 0;
 
-    if (PySys_Audit("fcntl.fcntl", "iiO", fd, code,
-                    arg ? arg : PyLong_FromLong(0)) < 0) {
+    if (PySys_Audit("fcntl.fcntl", "iiO", fd, code, arg ? arg : Py_None) < 0) {
         return NULL;
     }
 
@@ -177,7 +176,7 @@ fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
     char buf[IOCTL_BUFSZ+1];  /* argument plus NUL byte */
 
     if (PySys_Audit("fcntl.ioctl", "iIO", fd, code,
-                    ob_arg ? ob_arg : PyLong_FromLong(0)) < 0) {
+                    ob_arg ? ob_arg : Py_None) < 0) {
         return NULL;
     }
 
@@ -386,10 +385,8 @@ fcntl_lockf_impl(PyObject *module, int fd, int code, PyObject *lenobj,
     int ret;
     int async_err = 0;
 
-    if (PySys_Audit("fcntl.lockf", "iiOOi", fd, code,
-                    lenobj ? lenobj : PyLong_FromLong(0),
-                    startobj ? startobj : PyLong_FromLong(0),
-                    whence) < 0) {
+    if (PySys_Audit("fcntl.lockf", "iiOOi", fd, code, lenobj ? lenobj : Py_None,
+                    startobj ? startobj : Py_None, whence) < 0) {
         return NULL;
     }
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2911,6 +2911,11 @@ os_chdir_impl(PyObject *module, path_t *path)
 {
     int result;
 
+    if (PySys_Audit("os.chdir", "O",
+                    path->object ? path->object : Py_None) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
 #ifdef MS_WINDOWS
     /* on unix, success = 0, on windows, success = !0 */
@@ -2950,6 +2955,9 @@ static PyObject *
 os_fchdir_impl(PyObject *module, int fd)
 /*[clinic end generated code: output=42e064ec4dc00ab0 input=18e816479a2fa985]*/
 {
+    if (PySys_Audit("os.chdir", "i", fd) < 0) {
+        return NULL;
+    }
     return posix_fildes_fd(fd, fchdir);
 }
 #endif /* HAVE_FCHDIR */
@@ -3006,6 +3014,13 @@ os_chmod_impl(PyObject *module, path_t *path, int mode, int dir_fd,
     if (follow_symlinks_specified("chmod", follow_symlinks))
         return NULL;
 #endif
+
+    if (PySys_Audit("os.chmod", "OiO",
+                    path->object ? path->object : Py_None, mode,
+                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
+                   ) < 0) {
+        return NULL;
+    }
 
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
@@ -3103,6 +3118,10 @@ os_fchmod_impl(PyObject *module, int fd, int mode)
     int res;
     int async_err = 0;
 
+    if (PySys_Audit("os.chmod", "iiO", fd, mode, Py_None) < 0) {
+        return NULL;
+    }
+
     do {
         Py_BEGIN_ALLOW_THREADS
         res = fchmod(fd, mode);
@@ -3134,6 +3153,10 @@ os_lchmod_impl(PyObject *module, path_t *path, int mode)
 /*[clinic end generated code: output=082344022b51a1d5 input=90c5663c7465d24f]*/
 {
     int res;
+    if (PySys_Audit("os.chmod", "OiO", path->object ? path->object : Py_None,
+                    mode, Py_None) < 0) {
+        return NULL;
+    }
     Py_BEGIN_ALLOW_THREADS
     res = lchmod(path->narrow, mode);
     Py_END_ALLOW_THREADS
@@ -3176,6 +3199,11 @@ os_chflags_impl(PyObject *module, path_t *path, unsigned long flags,
         return NULL;
 #endif
 
+    if (PySys_Audit("os.chflags", "Ok", path->object ? path->object : Py_None,
+                    flags) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
 #ifdef HAVE_LCHFLAGS
     if (!follow_symlinks)
@@ -3211,6 +3239,10 @@ os_lchflags_impl(PyObject *module, path_t *path, unsigned long flags)
 /*[clinic end generated code: output=30ae958695c07316 input=f9f82ea8b585ca9d]*/
 {
     int res;
+    if (PySys_Audit("os.chflags", "Ok", path->object ? path->object : Py_None,
+                    flags) < 0) {
+        return NULL;
+    }
     Py_BEGIN_ALLOW_THREADS
     res = lchflags(path->narrow, flags);
     Py_END_ALLOW_THREADS
@@ -3373,6 +3405,13 @@ os_chown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid,
     }
 #endif
 
+    if (PySys_Audit("os.chown", "OIIO",
+                    path->object ? path->object : Py_None, uid, gid,
+                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
+                   ) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
 #ifdef HAVE_FCHOWN
     if (path->fd != -1)
@@ -3422,6 +3461,10 @@ os_fchown_impl(PyObject *module, int fd, uid_t uid, gid_t gid)
     int res;
     int async_err = 0;
 
+    if (PySys_Audit("os.chown", "iIIO", fd, uid, gid, Py_None) < 0) {
+        return NULL;
+    }
+
     do {
         Py_BEGIN_ALLOW_THREADS
         res = fchown(fd, uid, gid);
@@ -3454,6 +3497,10 @@ os_lchown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid)
 /*[clinic end generated code: output=25eaf6af412fdf2f input=b1c6014d563a7161]*/
 {
     int res;
+    if (PySys_Audit("os.chown", "OIIO", path->object ? path->object : Py_None,
+                    uid, gid, Py_None) < 0) {
+        return NULL;
+    }
     Py_BEGIN_ALLOW_THREADS
     res = lchown(path->narrow, uid, gid);
     Py_END_ALLOW_THREADS
@@ -3646,6 +3693,16 @@ os_link_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
         return NULL;
     }
 #endif
+
+    if (PySys_Audit("os.link", "OOOO",
+                    src->object ? src->object : Py_None,
+                    dst->object ? dst->object : Py_None,
+                    src_dir_fd == DEFAULT_DIR_FD ?
+                        Py_None : PyLong_FromLong(src_dir_fd),
+                    dst_dir_fd == DEFAULT_DIR_FD ?
+                        Py_None : PyLong_FromLong(dst_dir_fd)) < 0) {
+        return NULL;
+    }
 
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
@@ -4114,6 +4171,13 @@ os_mkdir_impl(PyObject *module, path_t *path, int mode, int dir_fd)
 {
     int result;
 
+    if (PySys_Audit("os.mkdir", "OiO",
+                    path->object ? path->object : Py_None, mode,
+                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
+                   ) < 0) {
+        return NULL;
+    }
+
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
     result = CreateDirectoryW(path->wide, NULL);
@@ -4259,6 +4323,16 @@ internal_rename(path_t *src, path_t *dst, int src_dir_fd, int dst_dir_fd, int is
     }
 #endif
 
+    if (PySys_Audit("os.rename", "OOOO",
+                    src->object ? src->object : Py_None,
+                    dst->object ? dst->object : Py_None,
+                    src_dir_fd == DEFAULT_DIR_FD ?
+                        Py_None : PyLong_FromLong(src_dir_fd),
+                    dst_dir_fd == DEFAULT_DIR_FD ?
+                        Py_None : PyLong_FromLong(dst_dir_fd)) < 0) {
+        return NULL;
+    }
+
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
     result = MoveFileExW(src->wide, dst->wide, flags);
@@ -4358,6 +4432,13 @@ os_rmdir_impl(PyObject *module, path_t *path, int dir_fd)
 /*[clinic end generated code: output=080eb54f506e8301 input=38c8b375ca34a7e2]*/
 {
     int result;
+
+    if (PySys_Audit("os.rmdir", "OO",
+                    path->object ? path->object : Py_None,
+                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
+                   ) < 0) {
+        return NULL;
+    }
 
     Py_BEGIN_ALLOW_THREADS
 #ifdef MS_WINDOWS
@@ -4516,6 +4597,13 @@ os_unlink_impl(PyObject *module, path_t *path, int dir_fd)
 /*[clinic end generated code: output=621797807b9963b1 input=d7bcde2b1b2a2552]*/
 {
     int result;
+
+    if (PySys_Audit("os.remove", "OO",
+                    path->object ? path->object : Py_None,
+                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
+                   ) < 0) {
+        return NULL;
+    }
 
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
@@ -4932,6 +5020,13 @@ os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
         return NULL;
     }
 #endif
+
+    if (PySys_Audit("os.utime", "OOOO", path->object ? path->object : Py_None,
+                    times ? times : Py_None, ns ? ns : Py_None,
+                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
+                   ) < 0) {
+        return NULL;
+    }
 
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
@@ -6182,6 +6277,9 @@ os_fork_impl(PyObject *module)
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }
+    if (PySys_Audit("os.fork", NULL) < 0) {
+        return NULL;
+    }
     PyOS_BeforeFork();
     pid = fork();
     if (pid == 0) {
@@ -6788,6 +6886,9 @@ os_forkpty_impl(PyObject *module)
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }
+    if (PySys_Audit("os.forkpty", NULL) < 0) {
+        return NULL;
+    }
     PyOS_BeforeFork();
     pid = forkpty(&master_fd, NULL, NULL, NULL);
     if (pid == 0) {
@@ -7309,14 +7410,15 @@ Kill a process with a signal.
 static PyObject *
 os_kill_impl(PyObject *module, pid_t pid, Py_ssize_t signal)
 /*[clinic end generated code: output=8e346a6701c88568 input=61a36b86ca275ab9]*/
-#ifndef MS_WINDOWS
 {
+    if (PySys_Audit("os.kill", "in", pid, signal) < 0) {
+        return NULL;
+    }
+#ifndef MS_WINDOWS
     if (kill(pid, (int)signal) == -1)
         return posix_error();
     Py_RETURN_NONE;
-}
 #else /* !MS_WINDOWS */
-{
     PyObject *result;
     DWORD sig = (DWORD)signal;
     DWORD err;
@@ -7351,8 +7453,8 @@ os_kill_impl(PyObject *module, pid_t pid, Py_ssize_t signal)
 
     CloseHandle(handle);
     return result;
-}
 #endif /* !MS_WINDOWS */
+}
 #endif /* HAVE_KILL */
 
 
@@ -7371,6 +7473,9 @@ static PyObject *
 os_killpg_impl(PyObject *module, pid_t pgid, int signal)
 /*[clinic end generated code: output=6dbcd2f1fdf5fdba input=38b5449eb8faec19]*/
 {
+    if (PySys_Audit("os.killpg", "ii", pgid, signal) < 0) {
+        return NULL;
+    }
     /* XXX some man pages make the `pgid` parameter an int, others
        a pid_t. Since getpgrp() returns a pid_t, we assume killpg should
        take the same type. Moreover, pid_t is always at least as wide as
@@ -8143,6 +8248,14 @@ os_symlink_impl(PyObject *module, path_t *src, path_t *dst,
     int result;
 #endif
 
+    if (PySys_Audit("os.symlink", "OOO",
+                    src->object ? src->object : Py_None,
+                    dst->object ? dst->object : Py_None,
+                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
+                   ) < 0) {
+        return NULL;
+    }
+
 #ifdef MS_WINDOWS
 
     if (windows_has_symlink_unprivileged_flag) {
@@ -8744,6 +8857,10 @@ os_lockf_impl(PyObject *module, int fd, int command, Py_off_t length)
 /*[clinic end generated code: output=af7051f3e7c29651 input=65da41d2106e9b79]*/
 {
     int res;
+
+    if (PySys_Audit("os.lockf", "iiL", fd, command, length) < 0) {
+        return NULL;
+    }
 
     Py_BEGIN_ALLOW_THREADS
     res = lockf(fd, command, length);
@@ -10147,6 +10264,10 @@ static PyObject *
 os_putenv_impl(PyObject *module, PyObject *name, PyObject *value)
 /*[clinic end generated code: output=d29a567d6b2327d2 input=ba586581c2e6105f]*/
 {
+    if (PySys_Audit("os.putenv", "OO", name ? name : Py_None,
+                    value ? value : Py_None) < 0) {
+        return NULL;
+    }
     return win32_putenv(name, value);
 }
 #else
@@ -10172,6 +10293,11 @@ os_putenv_impl(PyObject *module, PyObject *name, PyObject *value)
         return NULL;
     }
 
+    if (PySys_Audit("os.putenv", "OO", name ? name : Py_None,
+                    value ? value : Py_None) < 0) {
+        return NULL;
+    }
+
     if (setenv(name_string, value_string, 1)) {
         return posix_error();
     }
@@ -10193,6 +10319,9 @@ static PyObject *
 os_unsetenv_impl(PyObject *module, PyObject *name)
 /*[clinic end generated code: output=54c4137ab1834f02 input=4d6a1747cc526d2f]*/
 {
+    if (PySys_Audit("os.unsetenv", "O", name ? name : Py_None) < 0) {
+        return NULL;
+    }
     return win32_putenv(name, NULL);
 }
 #else
@@ -10208,6 +10337,9 @@ static PyObject *
 os_unsetenv_impl(PyObject *module, PyObject *name)
 /*[clinic end generated code: output=54c4137ab1834f02 input=2bb5288a599c7107]*/
 {
+    if (PySys_Audit("os.unsetenv", "O", name ? name : Py_None) < 0) {
+        return NULL;
+    }
 #ifdef HAVE_BROKEN_UNSETENV
     unsetenv(PyBytes_AS_STRING(name));
 #else
@@ -11910,6 +12042,11 @@ os_getxattr_impl(PyObject *module, path_t *path, path_t *attribute,
     if (fd_and_follow_symlinks_invalid("getxattr", path->fd, follow_symlinks))
         return NULL;
 
+    if (PySys_Audit("os.getxattr", "OO", path->object ? path->object : Py_None,
+                    attribute->object ? attribute->object : Py_None) < 0) {
+        return NULL;
+    }
+
     for (i = 0; ; i++) {
         void *ptr;
         ssize_t result;
@@ -11981,6 +12118,12 @@ os_setxattr_impl(PyObject *module, path_t *path, path_t *attribute,
     if (fd_and_follow_symlinks_invalid("setxattr", path->fd, follow_symlinks))
         return NULL;
 
+    if (PySys_Audit("os.setxattr", "OOy#i", path->object ? path->object : Py_None,
+                    attribute->object ? attribute->object : Py_None,
+                    value->buf, value->len, flags) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS;
     if (path->fd > -1)
         result = fsetxattr(path->fd, attribute->narrow,
@@ -12029,6 +12172,11 @@ os_removexattr_impl(PyObject *module, path_t *path, path_t *attribute,
     if (fd_and_follow_symlinks_invalid("removexattr", path->fd, follow_symlinks))
         return NULL;
 
+    if (PySys_Audit("os.removexattr", "OO", path->object ? path->object : Py_None,
+                    attribute->object ? attribute->object : Py_None) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS;
     if (path->fd > -1)
         result = fremovexattr(path->fd, attribute->narrow);
@@ -12073,6 +12221,11 @@ os_listxattr_impl(PyObject *module, path_t *path, int follow_symlinks)
 
     if (fd_and_follow_symlinks_invalid("listxattr", path->fd, follow_symlinks))
         goto exit;
+
+    if (PySys_Audit("os.listxattr", "O",
+                    path->object ? path->object : Py_None) < 0) {
+        return NULL;
+    }
 
     name = path->narrow ? path->narrow : ".";
 
@@ -13549,6 +13702,11 @@ os__add_dll_directory_impl(PyObject *module, path_t *path)
     PAddDllDirectory AddDllDirectory;
     DLL_DIRECTORY_COOKIE cookie = 0;
     DWORD err = 0;
+
+    if (PySys_Audit("os.add_dll_directory", "O",
+                    path->object ? path->object : Py_None) < 0) {
+        return NULL;
+    }
 
     /* For Windows 7, we have to load this. As this will be a fairly
        infrequent operation, just do it each time. Kernel32 is always

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2911,8 +2911,7 @@ os_chdir_impl(PyObject *module, path_t *path)
 {
     int result;
 
-    if (PySys_Audit("os.chdir", "(O)",
-                    path->object ? path->object : Py_None) < 0) {
+    if (PySys_Audit("os.chdir", "(O)", path->object) < 0) {
         return NULL;
     }
 
@@ -3015,10 +3014,8 @@ os_chmod_impl(PyObject *module, path_t *path, int mode, int dir_fd,
         return NULL;
 #endif
 
-    if (PySys_Audit("os.chmod", "OiO",
-                    path->object ? path->object : Py_None, mode,
-                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
-                   ) < 0) {
+    if (PySys_Audit("os.chmod", "Oii", path->object, mode,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
         return NULL;
     }
 
@@ -3118,7 +3115,7 @@ os_fchmod_impl(PyObject *module, int fd, int mode)
     int res;
     int async_err = 0;
 
-    if (PySys_Audit("os.chmod", "iiO", fd, mode, Py_None) < 0) {
+    if (PySys_Audit("os.chmod", "iii", fd, mode, -1) < 0) {
         return NULL;
     }
 
@@ -3153,8 +3150,7 @@ os_lchmod_impl(PyObject *module, path_t *path, int mode)
 /*[clinic end generated code: output=082344022b51a1d5 input=90c5663c7465d24f]*/
 {
     int res;
-    if (PySys_Audit("os.chmod", "OiO", path->object ? path->object : Py_None,
-                    mode, Py_None) < 0) {
+    if (PySys_Audit("os.chmod", "Oii", path->object, mode, -1) < 0) {
         return NULL;
     }
     Py_BEGIN_ALLOW_THREADS
@@ -3199,8 +3195,7 @@ os_chflags_impl(PyObject *module, path_t *path, unsigned long flags,
         return NULL;
 #endif
 
-    if (PySys_Audit("os.chflags", "Ok", path->object ? path->object : Py_None,
-                    flags) < 0) {
+    if (PySys_Audit("os.chflags", "Ok", path->object, flags) < 0) {
         return NULL;
     }
 
@@ -3239,8 +3234,7 @@ os_lchflags_impl(PyObject *module, path_t *path, unsigned long flags)
 /*[clinic end generated code: output=30ae958695c07316 input=f9f82ea8b585ca9d]*/
 {
     int res;
-    if (PySys_Audit("os.chflags", "Ok", path->object ? path->object : Py_None,
-                    flags) < 0) {
+    if (PySys_Audit("os.chflags", "Ok", path->object, flags) < 0) {
         return NULL;
     }
     Py_BEGIN_ALLOW_THREADS
@@ -3405,10 +3399,8 @@ os_chown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid,
     }
 #endif
 
-    if (PySys_Audit("os.chown", "OIIO",
-                    path->object ? path->object : Py_None, uid, gid,
-                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
-                   ) < 0) {
+    if (PySys_Audit("os.chown", "OIIi", path->object, uid, gid,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
         return NULL;
     }
 
@@ -3461,7 +3453,7 @@ os_fchown_impl(PyObject *module, int fd, uid_t uid, gid_t gid)
     int res;
     int async_err = 0;
 
-    if (PySys_Audit("os.chown", "iIIO", fd, uid, gid, Py_None) < 0) {
+    if (PySys_Audit("os.chown", "iIIi", fd, uid, gid, -1) < 0) {
         return NULL;
     }
 
@@ -3497,8 +3489,7 @@ os_lchown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid)
 /*[clinic end generated code: output=25eaf6af412fdf2f input=b1c6014d563a7161]*/
 {
     int res;
-    if (PySys_Audit("os.chown", "OIIO", path->object ? path->object : Py_None,
-                    uid, gid, Py_None) < 0) {
+    if (PySys_Audit("os.chown", "OIIi", path->object, uid, gid, -1) < 0) {
         return NULL;
     }
     Py_BEGIN_ALLOW_THREADS
@@ -3694,13 +3685,9 @@ os_link_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
     }
 #endif
 
-    if (PySys_Audit("os.link", "OOOO",
-                    src->object ? src->object : Py_None,
-                    dst->object ? dst->object : Py_None,
-                    src_dir_fd == DEFAULT_DIR_FD ?
-                        Py_None : PyLong_FromLong(src_dir_fd),
-                    dst_dir_fd == DEFAULT_DIR_FD ?
-                        Py_None : PyLong_FromLong(dst_dir_fd)) < 0) {
+    if (PySys_Audit("os.link", "OOii", src->object, dst->object,
+                    src_dir_fd == DEFAULT_DIR_FD ? -1 : src_dir_fd,
+                    dst_dir_fd == DEFAULT_DIR_FD ? -1 : dst_dir_fd) < 0) {
         return NULL;
     }
 
@@ -4171,10 +4158,8 @@ os_mkdir_impl(PyObject *module, path_t *path, int mode, int dir_fd)
 {
     int result;
 
-    if (PySys_Audit("os.mkdir", "OiO",
-                    path->object ? path->object : Py_None, mode,
-                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
-                   ) < 0) {
+    if (PySys_Audit("os.mkdir", "Oii", path->object, mode,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
         return NULL;
     }
 
@@ -4323,13 +4308,9 @@ internal_rename(path_t *src, path_t *dst, int src_dir_fd, int dst_dir_fd, int is
     }
 #endif
 
-    if (PySys_Audit("os.rename", "OOOO",
-                    src->object ? src->object : Py_None,
-                    dst->object ? dst->object : Py_None,
-                    src_dir_fd == DEFAULT_DIR_FD ?
-                        Py_None : PyLong_FromLong(src_dir_fd),
-                    dst_dir_fd == DEFAULT_DIR_FD ?
-                        Py_None : PyLong_FromLong(dst_dir_fd)) < 0) {
+    if (PySys_Audit("os.rename", "OOii", src->object, dst->object,
+                    src_dir_fd == DEFAULT_DIR_FD ? -1 : src_dir_fd,
+                    dst_dir_fd == DEFAULT_DIR_FD ? -1 : dst_dir_fd) < 0) {
         return NULL;
     }
 
@@ -4433,10 +4414,8 @@ os_rmdir_impl(PyObject *module, path_t *path, int dir_fd)
 {
     int result;
 
-    if (PySys_Audit("os.rmdir", "OO",
-                    path->object ? path->object : Py_None,
-                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
-                   ) < 0) {
+    if (PySys_Audit("os.rmdir", "Oi", path->object,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
         return NULL;
     }
 
@@ -4598,10 +4577,8 @@ os_unlink_impl(PyObject *module, path_t *path, int dir_fd)
 {
     int result;
 
-    if (PySys_Audit("os.remove", "OO",
-                    path->object ? path->object : Py_None,
-                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
-                   ) < 0) {
+    if (PySys_Audit("os.remove", "Oi", path->object,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
         return NULL;
     }
 
@@ -5021,10 +4998,8 @@ os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
     }
 #endif
 
-    if (PySys_Audit("os.utime", "OOOO", path->object ? path->object : Py_None,
-                    times ? times : Py_None, ns ? ns : Py_None,
-                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
-                   ) < 0) {
+    if (PySys_Audit("os.utime", "OOOi", path->object, times, ns ? ns : Py_None,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
         return NULL;
     }
 
@@ -5329,8 +5304,7 @@ os_execv_impl(PyObject *module, path_t *path, PyObject *argv)
         return NULL;
     }
 
-    if (PySys_Audit("os.exec", "OOO", path->object ? path->object : Py_None,
-                    argv, Py_None) < 0) {
+    if (PySys_Audit("os.exec", "OOO", path->object, argv, Py_None) < 0) {
         free_string_array(argvlist, argc);
         return NULL;
     }
@@ -5406,8 +5380,7 @@ os_execve_impl(PyObject *module, path_t *path, PyObject *argv, PyObject *env)
     if (envlist == NULL)
         goto fail_0;
 
-    if (PySys_Audit("os.exec", "OOO", path->object ? path->object : Py_None,
-                    argv, env) < 0) {
+    if (PySys_Audit("os.exec", "OOO", path->object, argv, env) < 0) {
         goto fail_1;
     }
 
@@ -5760,8 +5733,7 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
     }
     attrp = &attr;
 
-    if (PySys_Audit("os.posix_spawn", "OOO",
-                    path->object ? path->object : Py_None, argv, env) < 0) {
+    if (PySys_Audit("os.posix_spawn", "OOO", path->object, argv, env) < 0) {
         goto exit;
     }
 
@@ -6005,8 +5977,7 @@ os_spawnv_impl(PyObject *module, int mode, path_t *path, PyObject *argv)
         mode = _P_OVERLAY;
 #endif
 
-    if (PySys_Audit("os.spawn", "iOOO", mode,
-                    path->object ? path->object : Py_None, argv,
+    if (PySys_Audit("os.spawn", "iOOO", mode, path->object, argv,
                     Py_None) < 0) {
         free_string_array(argvlist, argc);
         return NULL;
@@ -6121,8 +6092,7 @@ os_spawnve_impl(PyObject *module, int mode, path_t *path, PyObject *argv,
         mode = _P_OVERLAY;
 #endif
 
-    if (PySys_Audit("os.spawn", "iOOO", mode,
-                    path->object ? path->object : Py_None, argv, env) < 0) {
+    if (PySys_Audit("os.spawn", "iOOO", mode, path->object, argv, env) < 0) {
         goto fail_2;
     }
 
@@ -8248,11 +8218,8 @@ os_symlink_impl(PyObject *module, path_t *src, path_t *dst,
     int result;
 #endif
 
-    if (PySys_Audit("os.symlink", "OOO",
-                    src->object ? src->object : Py_None,
-                    dst->object ? dst->object : Py_None,
-                    dir_fd == DEFAULT_DIR_FD ? Py_None : PyLong_FromLong(dir_fd)
-                   ) < 0) {
+    if (PySys_Audit("os.symlink", "OOi", src->object, dst->object,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
         return NULL;
     }
 
@@ -10264,8 +10231,7 @@ static PyObject *
 os_putenv_impl(PyObject *module, PyObject *name, PyObject *value)
 /*[clinic end generated code: output=d29a567d6b2327d2 input=ba586581c2e6105f]*/
 {
-    if (PySys_Audit("os.putenv", "OO", name ? name : Py_None,
-                    value ? value : Py_None) < 0) {
+    if (PySys_Audit("os.putenv", "OO", name, value) < 0) {
         return NULL;
     }
     return win32_putenv(name, value);
@@ -10293,8 +10259,7 @@ os_putenv_impl(PyObject *module, PyObject *name, PyObject *value)
         return NULL;
     }
 
-    if (PySys_Audit("os.putenv", "OO", name ? name : Py_None,
-                    value ? value : Py_None) < 0) {
+    if (PySys_Audit("os.putenv", "OO", name, value) < 0) {
         return NULL;
     }
 
@@ -10319,7 +10284,7 @@ static PyObject *
 os_unsetenv_impl(PyObject *module, PyObject *name)
 /*[clinic end generated code: output=54c4137ab1834f02 input=4d6a1747cc526d2f]*/
 {
-    if (PySys_Audit("os.unsetenv", "(O)", name ? name : Py_None) < 0) {
+    if (PySys_Audit("os.unsetenv", "(O)", name) < 0) {
         return NULL;
     }
     return win32_putenv(name, NULL);
@@ -10337,7 +10302,7 @@ static PyObject *
 os_unsetenv_impl(PyObject *module, PyObject *name)
 /*[clinic end generated code: output=54c4137ab1834f02 input=2bb5288a599c7107]*/
 {
-    if (PySys_Audit("os.unsetenv", "(O)", name ? name : Py_None) < 0) {
+    if (PySys_Audit("os.unsetenv", "(O)", name) < 0) {
         return NULL;
     }
 #ifdef HAVE_BROKEN_UNSETENV
@@ -11862,9 +11827,7 @@ os_startfile_impl(PyObject *module, path_t *filepath,
             "startfile not available on this platform");
     }
 
-    if (PySys_Audit("os.startfile", "Ou",
-                    filepath->object ? filepath->object : Py_None,
-                    operation) < 0) {
+    if (PySys_Audit("os.startfile", "Ou", filepath->object, operation) < 0) {
         return NULL;
     }
 
@@ -12042,8 +12005,7 @@ os_getxattr_impl(PyObject *module, path_t *path, path_t *attribute,
     if (fd_and_follow_symlinks_invalid("getxattr", path->fd, follow_symlinks))
         return NULL;
 
-    if (PySys_Audit("os.getxattr", "OO", path->object ? path->object : Py_None,
-                    attribute->object ? attribute->object : Py_None) < 0) {
+    if (PySys_Audit("os.getxattr", "OO", path->object, attribute->object) < 0) {
         return NULL;
     }
 
@@ -12118,8 +12080,7 @@ os_setxattr_impl(PyObject *module, path_t *path, path_t *attribute,
     if (fd_and_follow_symlinks_invalid("setxattr", path->fd, follow_symlinks))
         return NULL;
 
-    if (PySys_Audit("os.setxattr", "OOy#i", path->object ? path->object : Py_None,
-                    attribute->object ? attribute->object : Py_None,
+    if (PySys_Audit("os.setxattr", "OOy#i", path->object, attribute->object,
                     value->buf, value->len, flags) < 0) {
         return NULL;
     }
@@ -12172,8 +12133,7 @@ os_removexattr_impl(PyObject *module, path_t *path, path_t *attribute,
     if (fd_and_follow_symlinks_invalid("removexattr", path->fd, follow_symlinks))
         return NULL;
 
-    if (PySys_Audit("os.removexattr", "OO", path->object ? path->object : Py_None,
-                    attribute->object ? attribute->object : Py_None) < 0) {
+    if (PySys_Audit("os.removexattr", "OO", path->object, attribute->object) < 0) {
         return NULL;
     }
 
@@ -13703,8 +13663,7 @@ os__add_dll_directory_impl(PyObject *module, path_t *path)
     DLL_DIRECTORY_COOKIE cookie = 0;
     DWORD err = 0;
 
-    if (PySys_Audit("os.add_dll_directory", "(O)",
-                    path->object ? path->object : Py_None) < 0) {
+    if (PySys_Audit("os.add_dll_directory", "(O)", path->object) < 0) {
         return NULL;
     }
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2911,7 +2911,7 @@ os_chdir_impl(PyObject *module, path_t *path)
 {
     int result;
 
-    if (PySys_Audit("os.chdir", "O",
+    if (PySys_Audit("os.chdir", "(O)",
                     path->object ? path->object : Py_None) < 0) {
         return NULL;
     }
@@ -2955,7 +2955,7 @@ static PyObject *
 os_fchdir_impl(PyObject *module, int fd)
 /*[clinic end generated code: output=42e064ec4dc00ab0 input=18e816479a2fa985]*/
 {
-    if (PySys_Audit("os.chdir", "i", fd) < 0) {
+    if (PySys_Audit("os.chdir", "(i)", fd) < 0) {
         return NULL;
     }
     return posix_fildes_fd(fd, fchdir);
@@ -10319,7 +10319,7 @@ static PyObject *
 os_unsetenv_impl(PyObject *module, PyObject *name)
 /*[clinic end generated code: output=54c4137ab1834f02 input=4d6a1747cc526d2f]*/
 {
-    if (PySys_Audit("os.unsetenv", "O", name ? name : Py_None) < 0) {
+    if (PySys_Audit("os.unsetenv", "(O)", name ? name : Py_None) < 0) {
         return NULL;
     }
     return win32_putenv(name, NULL);
@@ -10337,7 +10337,7 @@ static PyObject *
 os_unsetenv_impl(PyObject *module, PyObject *name)
 /*[clinic end generated code: output=54c4137ab1834f02 input=2bb5288a599c7107]*/
 {
-    if (PySys_Audit("os.unsetenv", "O", name ? name : Py_None) < 0) {
+    if (PySys_Audit("os.unsetenv", "(O)", name ? name : Py_None) < 0) {
         return NULL;
     }
 #ifdef HAVE_BROKEN_UNSETENV
@@ -12222,7 +12222,7 @@ os_listxattr_impl(PyObject *module, path_t *path, int follow_symlinks)
     if (fd_and_follow_symlinks_invalid("listxattr", path->fd, follow_symlinks))
         goto exit;
 
-    if (PySys_Audit("os.listxattr", "O",
+    if (PySys_Audit("os.listxattr", "(O)",
                     path->object ? path->object : Py_None) < 0) {
         return NULL;
     }
@@ -13703,7 +13703,7 @@ os__add_dll_directory_impl(PyObject *module, path_t *path)
     DLL_DIRECTORY_COOKIE cookie = 0;
     DWORD err = 0;
 
-    if (PySys_Audit("os.add_dll_directory", "O",
+    if (PySys_Audit("os.add_dll_directory", "(O)",
                     path->object ? path->object : Py_None) < 0) {
         return NULL;
     }

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -224,6 +224,11 @@ resource_setrlimit_impl(PyObject *module, int resource, PyObject *limits)
         return NULL;
     }
 
+    if (PySys_Audit("resource.setrlimit", "iO", resource,
+                    limits ? limits : Py_None) < 0) {
+        return NULL;
+    }
+
     if (py2rlimit(limits, &rl) < 0) {
         return NULL;
     }
@@ -266,6 +271,11 @@ resource_prlimit_impl(PyObject *module, pid_t pid, int resource,
     if (resource < 0 || resource >= RLIM_NLIMITS) {
         PyErr_SetString(PyExc_ValueError,
                         "invalid resource specified");
+        return NULL;
+    }
+
+    if (PySys_Audit("resource.prlimit", "iiO", pid, resource,
+                    limits ? limits : Py_None) < 0) {
         return NULL;
     }
 

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1236,6 +1236,10 @@ signal_pthread_kill_impl(PyObject *module, unsigned long thread_id,
 {
     int err;
 
+    if (PySys_Audit("signal.pthread_kill", "ki", thread_id, signalnum) < 0) {
+        return NULL;
+    }
+
     err = pthread_kill((pthread_t)thread_id, signalnum);
     if (err != 0) {
         errno = err;

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -220,7 +220,7 @@ syslog_setlogmask(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "l;mask for priority", &maskpri))
         return NULL;
-    if (PySys_Audit("syslog.setlogmask", "O", args ? args : Py_None) < 0) {
+    if (PySys_Audit("syslog.setlogmask", "(O)", args ? args : Py_None) < 0) {
         return NULL;
     }
     omaskpri = setlogmask(maskpri);

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -144,6 +144,10 @@ syslog_openlog(PyObject * self, PyObject * args, PyObject *kwds)
             return NULL;
     }
 
+    if (PySys_Audit("syslog.openlog", "sll", ident, logopt, facility) < 0) {
+        return NULL;
+    }
+
     openlog(ident, logopt, facility);
     S_log_open = 1;
 
@@ -170,6 +174,10 @@ syslog_syslog(PyObject * self, PyObject * args)
     if (message == NULL)
         return NULL;
 
+    if (PySys_Audit("syslog.syslog", "is", priority, message) < 0) {
+        return NULL;
+    }
+
     /*  if log is not opened, open it now  */
     if (!S_log_open) {
         PyObject *openargs;
@@ -194,6 +202,9 @@ syslog_syslog(PyObject * self, PyObject * args)
 static PyObject *
 syslog_closelog(PyObject *self, PyObject *unused)
 {
+    if (PySys_Audit("syslog.closelog", NULL) < 0) {
+        return NULL;
+    }
     if (S_log_open) {
         closelog();
         Py_CLEAR(S_ident_o);
@@ -209,6 +220,9 @@ syslog_setlogmask(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "l;mask for priority", &maskpri))
         return NULL;
+    if (PySys_Audit("syslog.setlogmask", "O", args ? args : Py_None) < 0) {
+        return NULL;
+    }
     omaskpri = setlogmask(maskpri);
     return PyLong_FromLong(omaskpri);
 }

--- a/PC/msvcrtmodule.c
+++ b/PC/msvcrtmodule.c
@@ -116,6 +116,10 @@ msvcrt_locking_impl(PyObject *module, int fd, int mode, long nbytes)
 {
     int err;
 
+    if (PySys_Audit("msvcrt.locking", "iil", fd, mode, nbytes) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
     err = _locking(fd, mode, nbytes);
@@ -175,6 +179,10 @@ msvcrt_open_osfhandle_impl(PyObject *module, void *handle, int flags)
 {
     int fd;
 
+    if (PySys_Audit("msvcrt.open_osfhandle", "Ki", handle, flags) < 0) {
+        return NULL;
+    }
+
     _Py_BEGIN_SUPPRESS_IPH
     fd = _open_osfhandle((intptr_t)handle, flags);
     _Py_END_SUPPRESS_IPH
@@ -200,6 +208,10 @@ msvcrt_get_osfhandle_impl(PyObject *module, int fd)
 /*[clinic end generated code: output=aca01dfe24637374 input=5fcfde9b17136aa2]*/
 {
     intptr_t handle = -1;
+
+    if (PySys_Audit("msvcrt.get_osfhandle", "i", fd) < 0) {
+        return NULL;
+    }
 
     _Py_BEGIN_SUPPRESS_IPH
     handle = _get_osfhandle(fd);

--- a/PC/msvcrtmodule.c
+++ b/PC/msvcrtmodule.c
@@ -209,7 +209,7 @@ msvcrt_get_osfhandle_impl(PyObject *module, int fd)
 {
     intptr_t handle = -1;
 
-    if (PySys_Audit("msvcrt.get_osfhandle", "i", fd) < 0) {
+    if (PySys_Audit("msvcrt.get_osfhandle", "(i)", fd) < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
Add audit events to the following functions:

- all functions in `fcntl` and `syslog`
- file operations in `msvcrt`, `os` and `shutil`
- os.putenv/unsetenv
- os.add_dll_directory
- os.fork/forkpty
- os.kill/killpg
- resource.setrlimit, resource.prlimit
- signal.pthread_kill

<!-- issue-number: [bpo-39184](https://bugs.python.org/issue39184) -->
https://bugs.python.org/issue39184
<!-- /issue-number -->
