### PR TITLE
Remove note saying patch is straightforward

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1327,8 +1327,7 @@ patch
 
 .. note::
 
-    :func:`patch` is straightforward to use. The key is to do the patching in the
-    right namespace. See the section `where to patch`_.
+    The key is to do the patching in the right namespace. See the section `where to patch`_.
 
 .. function:: patch(target, new=DEFAULT, spec=None, create=False, spec_set=None, autospec=None, new_callable=None, **kwargs)
 


### PR DESCRIPTION
While `unittest.mock.patch` is a great thing, it is not straightforward. If it were straightforward there wouldn't be such a huge amount of documentation for it, and frankly, when myself and others who I've read about often struggle to figure out what on earth `patch()` wants, coming to the docs to read that it's straightforward is not helpful.