### PR TITLE
bpo-39417: Fix broken link to guide to building venvs

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -27,7 +27,7 @@ See :pep:`405` for more information about Python virtual environments.
 .. seealso::
 
    `Python Packaging User Guide: Creating and using virtual environments
-   <https://packaging.python.org/installing/#creating-virtual-environments>`__
+   <https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment>`__
 
 
 Creating virtual environments


### PR DESCRIPTION
# Fix broken link in python packaging user guide

```
[bpo-39417](https://bugs.python.org/issue39417): Fix broken link to "See also: Python Packaging User Guide: Creating and using virtual environments"
```

<!-- issue-number: [bpo-39417](https://bugs.python.org/issue39417) -->
https://bugs.python.org/issue39417
<!-- /issue-number -->
