### PR TITLE
[3.6] bpo-39545: document that await does not work in f-strings

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -730,7 +730,7 @@ Functions defined with ``async def`` syntax are always coroutine functions,
 even if they do not contain ``await`` or ``async`` keywords.
 
 It is a :exc:`SyntaxError` to use ``yield from`` expressions in
-``async def`` coroutines.
+``async def`` coroutines. Using ``await`` in :keyword:`f-strings` will also produce a :exc:`SyntaxError`.
 
 An example of a coroutine function::
 


### PR DESCRIPTION



<!-- issue-number: [bpo-39545](https://bugs.python.org/issue39545) -->
https://bugs.python.org/issue39545
<!-- /issue-number -->
