### PR TITLE
bpo-3950: fix docs for default locale of gettext

### DIFF
--- a/Doc/library/gettext.rst
+++ b/Doc/library/gettext.rst
@@ -724,8 +724,8 @@ implementations, and valuable experience to the creation of this module:
 .. [#] The default locale directory is system dependent; for example, on RedHat Linux
    it is :file:`/usr/share/locale`, but on Solaris it is :file:`/usr/lib/locale`.
    The :mod:`gettext` module does not try to support these system dependent
-   defaults; instead its default is :file:`{sys.prefix}/share/locale` (see
-   :data:`sys.prefix`). For this reason, it is always best to call
+   defaults; instead its default is :file:`{sys.base_prefix}/share/locale` (see
+   :data:`sys.base_prefix`). For this reason, it is always best to call
    :func:`bindtextdomain` with an explicit absolute path at the start of your
    application.
 


### PR DESCRIPTION
documentation for default locale directory in Doc/library/gettext.rst changed to match gettext implementation line 63.

<!-- issue-number: [bpo-3950](https://bugs.python.org/issue3950) -->
https://bugs.python.org/issue3950
<!-- /issue-number -->
