### PR TITLE
bpo-39594: Fix typo in os.times documentation

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3912,10 +3912,8 @@ written in Python, such as a mail server's external command delivery program.
 
    See the Unix manual page
    :manpage:`times(2)` and :manpage:`times(3)` manual page on Unix or `the GetProcessTimes MSDN
-   <https://docs.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocesstimes>`
-   _ on Windows.
-   On Windows, only :attr:`user` and :attr:`system` are known; the other
-   attributes are zero.
+   <https://docs.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocesstimes>`_
+   on Windows. On Windows, only :attr:`user` and :attr:`system` are known; the other attributes are zero.
 
    .. availability:: Unix, Windows.
 


### PR DESCRIPTION
There was an extra space in the url markup, causing the documentation not rendered properly.
<!-- issue-number: [bpo-39594](https://bugs.python.org/issue39594) -->
https://bugs.python.org/issue39594
<!-- /issue-number -->


Automerge-Triggered-By: @Mariatta