### PR TITLE
bpo-38325: Fix test_winconsoleio

### DIFF
--- a/Lib/test/test_winconsoleio.py
+++ b/Lib/test/test_winconsoleio.py
@@ -144,6 +144,10 @@ class WindowsConsoleIOTests(unittest.TestCase):
         self.assertStdinRoundTrip('ϼўТλФЙ')
         # Combining characters
         self.assertStdinRoundTrip('A͏B ﬖ̳AA̝')
+
+    # bpo-38325
+    @unittest.skipIf(True, "Handling Non-BMP characters is broken")
+    def test_input_nonbmp(self):
         # Non-BMP
         self.assertStdinRoundTrip('\U00100000\U0010ffff\U0010fffd')
 
@@ -163,6 +167,8 @@ class WindowsConsoleIOTests(unittest.TestCase):
 
                 self.assertEqual(actual, expected, 'stdin.read({})'.format(read_count))
 
+    # bpo-38325
+    @unittest.skipIf(True, "Handling Non-BMP characters is broken")
     def test_partial_surrogate_reads(self):
         # Test that reading less than 1 full character works when stdin
         # contains surrogate pairs that cannot be decoded to UTF-8 without

--- a/Misc/NEWS.d/next/Tests/2020-02-11-00-38-32.bpo-38325.HgmfoE.rst
+++ b/Misc/NEWS.d/next/Tests/2020-02-11-00-38-32.bpo-38325.HgmfoE.rst
@@ -1,0 +1,1 @@
+Skip tests on non-BMP characters of test_winconsoleio.


### PR DESCRIPTION
Skip tests on non-BMP characters of test_winconsoleio.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38325](https://bugs.python.org/issue38325) -->
https://bugs.python.org/issue38325
<!-- /issue-number -->
