### PR TITLE
bpo-38374: Remove weakref.ReferenceError from docs

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -983,9 +983,6 @@ Notes:
    This is a base class for other standard exceptions.
 
 (2)
-   This is the same as :exc:`weakref.ReferenceError`.
-
-(3)
    Only defined on Windows; protect code that uses this by testing that the
    preprocessor macro ``MS_WINDOWS`` is defined.
 

--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -327,12 +327,6 @@ objects.
    types.
 
 
-.. exception:: ReferenceError
-
-   Exception raised when a proxy object is used but the underlying object has been
-   collected.  This is the same as the standard :exc:`ReferenceError` exception.
-
-
 .. seealso::
 
    :pep:`205` - Weak References


### PR DESCRIPTION
Reflecting changes to the code, removed weakref.ReferenceError from weakref.rst and exceptions.rst.

Issue submitter provided evidence that the `weakref.ReferenceError` alias for `ReferenceError` was removed from the code in 2007.  Working with @gvanrossum at PyCascades CPython sprint we looked at the code and confirmed that `weakref.ReferenceError` was no longer in `weakref.py`.

Based on that analysis I removed references `weakref.ReferenceError` from the two documents where it was still being referenced: `weakref.rst` and `exceptions.rst`. 

<!-- issue-number: [bpo-38374](https://bugs.python.org/issue38374) -->
https://bugs.python.org/issue38374
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum