### PR TITLE
bpo-39605: Fix some casts to not cast away const

### DIFF
--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2025,7 +2025,7 @@ find_control_char(int kind, const char *s, const char *end, Py_UCS4 ch)
 {
     if (kind == PyUnicode_1BYTE_KIND) {
         assert(ch < 256);
-        return (char *) memchr((void *) s, (char) ch, end - s);
+        return (char *) memchr((const void *) s, (char) ch, end - s);
     }
     for (;;) {
         while (PyUnicode_READ(kind, s, 0) > ch)
@@ -2043,7 +2043,7 @@ _PyIO_find_line_ending(
     int translated, int universal, PyObject *readnl,
     int kind, const char *start, const char *end, Py_ssize_t *consumed)
 {
-    Py_ssize_t len = ((char*)end - (char*)start)/kind;
+    Py_ssize_t len = (end - start)/kind;
 
     if (translated) {
         /* Newlines are already translated, only search for \n */

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -12,7 +12,7 @@ PyObject*
 _Py_bytes_isspace(const char *cptr, Py_ssize_t len)
 {
     const unsigned char *p
-        = (unsigned char *) cptr;
+        = (const unsigned char *) cptr;
     const unsigned char *e;
 
     /* Shortcut for single character strings */
@@ -42,7 +42,7 @@ PyObject*
 _Py_bytes_isalpha(const char *cptr, Py_ssize_t len)
 {
     const unsigned char *p
-        = (unsigned char *) cptr;
+        = (const unsigned char *) cptr;
     const unsigned char *e;
 
     /* Shortcut for single character strings */
@@ -72,7 +72,7 @@ PyObject*
 _Py_bytes_isalnum(const char *cptr, Py_ssize_t len)
 {
     const unsigned char *p
-        = (unsigned char *) cptr;
+        = (const unsigned char *) cptr;
     const unsigned char *e;
 
     /* Shortcut for single character strings */
@@ -123,7 +123,7 @@ _Py_bytes_isascii(const char *cptr, Py_ssize_t len)
             /* Help allocation */
             const char *_p = p;
             while (_p < aligned_end) {
-                unsigned long value = *(unsigned long *) _p;
+                unsigned long value = *(const unsigned long *) _p;
                 if (value & ASCII_CHAR_MASK) {
                     Py_RETURN_FALSE;
                 }
@@ -154,7 +154,7 @@ PyObject*
 _Py_bytes_isdigit(const char *cptr, Py_ssize_t len)
 {
     const unsigned char *p
-        = (unsigned char *) cptr;
+        = (const unsigned char *) cptr;
     const unsigned char *e;
 
     /* Shortcut for single character strings */
@@ -184,7 +184,7 @@ PyObject*
 _Py_bytes_islower(const char *cptr, Py_ssize_t len)
 {
     const unsigned char *p
-        = (unsigned char *) cptr;
+        = (const unsigned char *) cptr;
     const unsigned char *e;
     int cased;
 
@@ -218,7 +218,7 @@ PyObject*
 _Py_bytes_isupper(const char *cptr, Py_ssize_t len)
 {
     const unsigned char *p
-        = (unsigned char *) cptr;
+        = (const unsigned char *) cptr;
     const unsigned char *e;
     int cased;
 
@@ -254,7 +254,7 @@ PyObject*
 _Py_bytes_istitle(const char *cptr, Py_ssize_t len)
 {
     const unsigned char *p
-        = (unsigned char *) cptr;
+        = (const unsigned char *) cptr;
     const unsigned char *e;
     int cased, previous_is_cased;
 

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1682,8 +1682,8 @@ unpack_single(const char *ptr, const char *fmt)
     switch (fmt[0]) {
 
     /* signed integers and fast path for 'B' */
-    case 'B': uc = *((unsigned char *)ptr); goto convert_uc;
-    case 'b': ld =   *((signed char *)ptr); goto convert_ld;
+    case 'B': uc = *((const unsigned char *)ptr); goto convert_uc;
+    case 'b': ld =   *((const signed char *)ptr); goto convert_ld;
     case 'h': UNPACK_SINGLE(ld, ptr, short); goto convert_ld;
     case 'i': UNPACK_SINGLE(ld, ptr, int); goto convert_ld;
     case 'l': UNPACK_SINGLE(ld, ptr, long); goto convert_ld;
@@ -2684,8 +2684,8 @@ unpack_cmp(const char *p, const char *q, char fmt,
     switch (fmt) {
 
     /* signed integers and fast path for 'B' */
-    case 'B': return *((unsigned char *)p) == *((unsigned char *)q);
-    case 'b': return *((signed char *)p) == *((signed char *)q);
+    case 'B': return *((const unsigned char *)p) == *((const unsigned char *)q);
+    case 'b': return *((const signed char *)p) == *((const signed char *)q);
     case 'h': CMP_SINGLE(p, q, short); return equal;
     case 'i': CMP_SINGLE(p, q, int); return equal;
     case 'l': CMP_SINGLE(p, q, long); return equal;

--- a/Objects/stringlib/asciilib.h
+++ b/Objects/stringlib/asciilib.h
@@ -18,7 +18,7 @@
 #define STRINGLIB_TODECIMAL      Py_UNICODE_TODECIMAL
 #define STRINGLIB_STR            PyUnicode_1BYTE_DATA
 #define STRINGLIB_LEN            PyUnicode_GET_LENGTH
-#define STRINGLIB_NEW(STR,LEN)   _PyUnicode_FromASCII((char*)(STR),(LEN))
+#define STRINGLIB_NEW(STR,LEN)   _PyUnicode_FromASCII((const char*)(STR),(LEN))
 #define STRINGLIB_CHECK          PyUnicode_Check
 #define STRINGLIB_CHECK_EXACT    PyUnicode_CheckExact
 

--- a/Objects/stringlib/codecs.h
+++ b/Objects/stringlib/codecs.h
@@ -46,7 +46,7 @@ STRINGLIB(utf8_decode)(const char **inptr, const char *end,
                     /* Read a whole long at a time (either 4 or 8 bytes),
                        and do a fast unrolled copy if it only contains ASCII
                        characters. */
-                    unsigned long value = *(unsigned long *) _s;
+                    unsigned long value = *(const unsigned long *) _s;
                     if (value & ASCII_CHAR_MASK)
                         break;
 #if PY_LITTLE_ENDIAN
@@ -515,7 +515,7 @@ STRINGLIB(utf16_decode)(const unsigned char **inptr, const unsigned char *e,
             /* Fast path for runs of in-range non-surrogate chars. */
             const unsigned char *_q = q;
             while (_q < aligned_end) {
-                unsigned long block = * (unsigned long *) _q;
+                unsigned long block = * (const unsigned long *) _q;
                 if (native_ordering) {
                     /* Can use buffer directly */
                     if (block & FAST_CHAR_MASK)

--- a/Objects/stringlib/find_max_char.h
+++ b/Objects/stringlib/find_max_char.h
@@ -28,7 +28,7 @@ STRINGLIB(find_max_char)(const STRINGLIB_CHAR *begin, const STRINGLIB_CHAR *end)
             /* Help register allocation */
             const unsigned char *_p = p;
             while (_p < aligned_end) {
-                unsigned long value = *(unsigned long *) _p;
+                unsigned long value = *(const unsigned long *) _p;
                 if (value & UCS1_ASCII_CHAR_MASK)
                     return 255;
                 _p += SIZEOF_LONG;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -172,8 +172,8 @@ extern "C" {
 #define _PyUnicode_CONVERT_BYTES(from_type, to_type, begin, end, to) \
     do {                                                \
         to_type *_to = (to_type *)(to);                \
-        const from_type *_iter = (from_type *)(begin);  \
-        const from_type *_end = (from_type *)(end);     \
+        const from_type *_iter = (const from_type *)(begin);\
+        const from_type *_end = (const from_type *)(end);\
         Py_ssize_t n = (_end) - (_iter);                \
         const from_type *_unrolled_end =                \
             _iter + _Py_SIZE_ROUND_DOWN(n, 4);          \
@@ -964,21 +964,21 @@ findchar(const void *s, int kind,
         if ((Py_UCS1) ch != ch)
             return -1;
         if (direction > 0)
-            return ucs1lib_find_char((Py_UCS1 *) s, size, (Py_UCS1) ch);
+            return ucs1lib_find_char((const Py_UCS1 *) s, size, (Py_UCS1) ch);
         else
-            return ucs1lib_rfind_char((Py_UCS1 *) s, size, (Py_UCS1) ch);
+            return ucs1lib_rfind_char((const Py_UCS1 *) s, size, (Py_UCS1) ch);
     case PyUnicode_2BYTE_KIND:
         if ((Py_UCS2) ch != ch)
             return -1;
         if (direction > 0)
-            return ucs2lib_find_char((Py_UCS2 *) s, size, (Py_UCS2) ch);
+            return ucs2lib_find_char((const Py_UCS2 *) s, size, (Py_UCS2) ch);
         else
-            return ucs2lib_rfind_char((Py_UCS2 *) s, size, (Py_UCS2) ch);
+            return ucs2lib_rfind_char((const Py_UCS2 *) s, size, (Py_UCS2) ch);
     case PyUnicode_4BYTE_KIND:
         if (direction > 0)
-            return ucs4lib_find_char((Py_UCS4 *) s, size, ch);
+            return ucs4lib_find_char((const Py_UCS4 *) s, size, ch);
         else
-            return ucs4lib_rfind_char((Py_UCS4 *) s, size, ch);
+            return ucs4lib_rfind_char((const Py_UCS4 *) s, size, ch);
     default:
         Py_UNREACHABLE();
     }
@@ -4921,7 +4921,7 @@ ascii_decode(const char *start, const char *end, Py_UCS1 *dest)
             /* Help allocation */
             const char *_p = p;
             while (_p < aligned_end) {
-                unsigned long value = *(unsigned long *) _p;
+                unsigned long value = *(const unsigned long *) _p;
                 if (value & ASCII_CHAR_MASK)
                     break;
                 _p += SIZEOF_LONG;
@@ -5472,7 +5472,7 @@ PyUnicode_DecodeUTF32Stateful(const char *s,
     PyObject *errorHandler = NULL;
     PyObject *exc = NULL;
 
-    q = (unsigned char *)s;
+    q = (const unsigned char *)s;
     e = q + size;
 
     if (byteorder)
@@ -5797,7 +5797,7 @@ PyUnicode_DecodeUTF16Stateful(const char *s,
     PyObject *exc = NULL;
     const char *encoding;
 
-    q = (unsigned char *)s;
+    q = (const unsigned char *)s;
     e = q + size;
 
     if (byteorder)
@@ -6726,7 +6726,7 @@ PyUnicode_DecodeLatin1(const char *s,
                        const char *errors)
 {
     /* Latin-1 is equivalent to the first 256 ordinals in Unicode. */
-    return _PyUnicode_FromUCS1((unsigned char*)s, size);
+    return _PyUnicode_FromUCS1((const unsigned char*)s, size);
 }
 
 /* create or adjust a UnicodeEncodeError */
@@ -13784,7 +13784,7 @@ _PyUnicodeWriter_WriteASCIIString(_PyUnicodeWriter *writer,
     if (len == -1)
         len = strlen(ascii);
 
-    assert(ucs1lib_find_max_char((Py_UCS1*)ascii, (Py_UCS1*)ascii + len) < 128);
+    assert(ucs1lib_find_max_char((const Py_UCS1*)ascii, (const Py_UCS1*)ascii + len) < 128);
 
     if (writer->buffer == NULL && !writer->overallocate) {
         PyObject *str;
@@ -13843,7 +13843,7 @@ _PyUnicodeWriter_WriteLatin1String(_PyUnicodeWriter *writer,
 {
     Py_UCS4 maxchar;
 
-    maxchar = ucs1lib_find_max_char((Py_UCS1*)str, (Py_UCS1*)str + len);
+    maxchar = ucs1lib_find_max_char((const Py_UCS1*)str, (const Py_UCS1*)str + len);
     if (_PyUnicodeWriter_Prepare(writer, len, maxchar) == -1)
         return -1;
     unicode_write_cstr(writer->buffer, writer->pos, str, len);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3420,7 +3420,7 @@ PyUnicode_Decode(const char *s,
 
     /* Decode via the codec registry */
     buffer = NULL;
-    if (PyBuffer_FillInfo(&info, NULL, (void *)s, size, 1, PyBUF_FULL_RO) < 0)
+    if (PyBuffer_FillInfo(&info, NULL, (const void *)s, size, 1, PyBUF_FULL_RO) < 0)
         goto onError;
     buffer = PyMemoryView_FromBuffer(&info);
     if (buffer == NULL)

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5440,7 +5440,7 @@ dtrace_function_entry(PyFrameObject *f)
     funcname = PyUnicode_AsUTF8(f->f_code->co_name);
     lineno = PyCode_Addr2Line(f->f_code, f->f_lasti);
 
-    PyDTrace_FUNCTION_ENTRY((char *)filename, (char *)funcname, lineno);
+    PyDTrace_FUNCTION_ENTRY(filename, funcname, lineno);
 }
 
 static void
@@ -5454,7 +5454,7 @@ dtrace_function_return(PyFrameObject *f)
     funcname = PyUnicode_AsUTF8(f->f_code->co_name);
     lineno = PyCode_Addr2Line(f->f_code, f->f_lasti);
 
-    PyDTrace_FUNCTION_RETURN((char *)filename, (char *)funcname, lineno);
+    PyDTrace_FUNCTION_RETURN(filename, funcname, lineno);
 }
 
 /* DTrace equivalent of maybe_call_line_trace. */
@@ -5486,7 +5486,7 @@ maybe_dtrace_line(PyFrameObject *frame,
         co_name = PyUnicode_AsUTF8(frame->f_code->co_name);
         if (!co_name)
             co_name = "?";
-        PyDTrace_LINE((char *)co_filename, (char *)co_name, line);
+        PyDTrace_LINE(co_filename, co_name, line);
     }
     *instr_prev = frame->f_lasti;
 }

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -734,7 +734,7 @@ r_byte(RFILE *p)
     else {
         const char *ptr = r_string(1, p);
         if (ptr != NULL)
-            c = *(unsigned char *) ptr;
+            c = *(const unsigned char *) ptr;
     }
     return c;
 }

--- a/Python/pyhash.c
+++ b/Python/pyhash.c
@@ -366,7 +366,7 @@ static PyHash_FuncDef PyHash_Func = {fnv, "fnv", 8 * SIZEOF_PY_HASH_T,
 static uint64_t
 siphash24(uint64_t k0, uint64_t k1, const void *src, Py_ssize_t src_sz) {
     uint64_t b = (uint64_t)src_sz << 56;
-    const uint8_t *in = (uint8_t*)src;
+    const uint8_t *in = (const uint8_t*)src;
 
     uint64_t v0 = k0 ^ 0x736f6d6570736575ULL;
     uint64_t v1 = k1 ^ 0x646f72616e646f6dULL;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -204,7 +204,7 @@ PySys_Audit(const char *event, const char *argFormat, ...)
 
     /* Dtrace USDT point */
     if (dtrace) {
-        PyDTrace_AUDIT((char *)event, (void *)eventArgs);
+        PyDTrace_AUDIT(event, (void *)eventArgs);
     }
 
     /* Call interpreter hooks */


### PR DESCRIPTION
`gcc -Wcast-qual` turns up a number of instances of casting away constness of pointers.  Some of these can be safely modified, by either:

Adding the `const` to the type cast, as in:

    -    return _PyUnicode_FromUCS1((unsigned char*)s, size);
    +    return _PyUnicode_FromUCS1((const unsigned char*)s, size);

or, Removing the cast entirely, because it's not necessary (but probably was at one time), as in:

    -    PyDTrace_FUNCTION_ENTRY((char *)filename, (char *)funcname, lineno);
    +    PyDTrace_FUNCTION_ENTRY(filename, funcname, lineno);

These changes will not change code, but they will make it much easier to check for errors in consts.

<!-- issue-number: [bpo-39605](https://bugs.python.org/issue39605) -->
https://bugs.python.org/issue39605
<!-- /issue-number -->
