### PR TITLE
bpo-39609: set the thread_name_prefix for the default asyncio executor

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -806,7 +806,9 @@ class BaseEventLoop(events.AbstractEventLoop):
             # Only check when the default executor is being used
             self._check_default_executor()
             if executor is None:
-                executor = concurrent.futures.ThreadPoolExecutor()
+                executor = concurrent.futures.ThreadPoolExecutor(
+                    thread_name_prefix='asyncio'
+                )
                 self._default_executor = executor
         return futures.wrap_future(
             executor.submit(func, *args), loop=self)

--- a/Misc/NEWS.d/next/Library/2020-02-11-19-45-31.bpo-39609.dk40Uw.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-11-19-45-31.bpo-39609.dk40Uw.rst
@@ -1,0 +1,1 @@
+Add thread_name_prefix to default asyncio executor


### PR DESCRIPTION
Just a small debugging improvement to identify the asyncio executor threads.

<!-- issue-number: [bpo-39609](https://bugs.python.org/issue39609) -->
https://bugs.python.org/issue39609
<!-- /issue-number -->


Automerge-Triggered-By: @asvetlov