### PR TITLE
bpo-39245: Switch to public API for Vectorcall

### DIFF
--- a/Doc/c-api/call.rst
+++ b/Doc/c-api/call.rst
@@ -108,12 +108,12 @@ function as with any other callable.
 
    In CPython 3.8, the vectorcall API and related functions were available
    provisionally under names with a leading underscore:
-   ``PyObject_Vectorcall``, ``Py_TPFLAGS_HAVE_VECTORCALL``,
-   ``PyObject_VectorcallMethod``, ``PyVectorcall_Function``,
-   ``PyObject_CallOneArg``, ``PyObject_CallMethodNoArgs``,
-   ``PyObject_CallMethodOneArg``.
+   ``_PyObject_Vectorcall``, ``_Py_TPFLAGS_HAVE_VECTORCALL``,
+   ``_PyObject_VectorcallMethod``, ``_PyVectorcall_Function``,
+   ``_PyObject_CallOneArg``, ``_PyObject_CallMethodNoArgs``,
+   ``_PyObject_CallMethodOneArg``.
    Additionally, ``PyObject_VectorcallDict`` was available as
-   ``PyObject_VectorcallDict``.
+   ``_PyObject_FastCallDict``.
    The old names are still defined as aliases of the new, non-underscored names.
 
 

--- a/Doc/c-api/call.rst
+++ b/Doc/c-api/call.rst
@@ -108,12 +108,12 @@ function as with any other callable.
 
    In CPython 3.8, the vectorcall API and related functions were available
    provisionally under names with a leading underscore:
-   ``_PyObject_Vectorcall``, ``_Py_TPFLAGS_HAVE_VECTORCALL``,
-   ``_PyObject_VectorcallMethod``, ``_PyVectorcall_Function``,
-   ``_PyObject_CallOneArg``, ``_PyObject_CallMethodNoArgs``,
-   ``_PyObject_CallMethodOneArg``.
+   ``PyObject_Vectorcall``, ``Py_TPFLAGS_HAVE_VECTORCALL``,
+   ``PyObject_VectorcallMethod``, ``PyVectorcall_Function``,
+   ``PyObject_CallOneArg``, ``PyObject_CallMethodNoArgs``,
+   ``PyObject_CallMethodOneArg``.
    Additionally, ``PyObject_VectorcallDict`` was available as
-   ``_PyObject_FastCallDict``.
+   ``PyObject_VectorcallDict``.
    The old names are still defined as aliases of the new, non-underscored names.
 
 

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -67,7 +67,7 @@ PyVectorcall_Function(PyObject *callable)
 {
     assert(callable != NULL);
     PyTypeObject *tp = Py_TYPE(callable);
-    if (!PyType_HasFeature(tp, _Py_TPFLAGS_HAVE_VECTORCALL)) {
+    if (!PyType_HasFeature(tp, Py_TPFLAGS_HAVE_VECTORCALL)) {
         return NULL;
     }
     assert(PyCallable_Check(callable));
@@ -122,13 +122,13 @@ PyObject_Vectorcall(PyObject *callable, PyObject *const *args,
 }
 
 // Backwards compatibility aliases for API that was provisional in Python 3.8
-#define _PyObject_Vectorcall PyObject_Vectorcall
-#define _PyObject_VectorcallMethod PyObject_VectorcallMethod
-#define _PyObject_FastCallDict PyObject_VectorcallDict
-#define _PyVectorcall_Function PyVectorcall_Function
-#define _PyObject_CallOneArg PyObject_CallOneArg
-#define _PyObject_CallMethodNoArgs PyObject_CallMethodNoArgs
-#define _PyObject_CallMethodOneArg PyObject_CallMethodOneArg
+#define PyObject_Vectorcall PyObject_Vectorcall
+#define PyObject_VectorcallMethod PyObject_VectorcallMethod
+#define PyObject_VectorcallDict PyObject_VectorcallDict
+#define PyVectorcall_Function PyVectorcall_Function
+#define PyObject_CallOneArg PyObject_CallOneArg
+#define PyObject_CallMethodNoArgs PyObject_CallMethodNoArgs
+#define PyObject_CallMethodOneArg PyObject_CallMethodOneArg
 
 /* Same as PyObject_Vectorcall except that keyword arguments are passed as
    dict, which may be NULL if there are no keyword arguments. */
@@ -178,7 +178,7 @@ PyAPI_FUNC(PyObject *) PyObject_VectorcallMethod(
 static inline PyObject *
 PyObject_CallMethodNoArgs(PyObject *self, PyObject *name)
 {
-    return _PyObject_VectorcallMethod(name, &self,
+    return PyObject_VectorcallMethod(name, &self,
            1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
 }
 
@@ -187,7 +187,7 @@ PyObject_CallMethodOneArg(PyObject *self, PyObject *name, PyObject *arg)
 {
     assert(arg != NULL);
     PyObject *args[2] = {self, arg};
-    return _PyObject_VectorcallMethod(name, args,
+    return PyObject_VectorcallMethod(name, args,
            2 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
 }
 

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -122,13 +122,13 @@ PyObject_Vectorcall(PyObject *callable, PyObject *const *args,
 }
 
 // Backwards compatibility aliases for API that was provisional in Python 3.8
-#define PyObject_Vectorcall PyObject_Vectorcall
-#define PyObject_VectorcallMethod PyObject_VectorcallMethod
-#define PyObject_VectorcallDict PyObject_VectorcallDict
-#define PyVectorcall_Function PyVectorcall_Function
-#define PyObject_CallOneArg PyObject_CallOneArg
-#define PyObject_CallMethodNoArgs PyObject_CallMethodNoArgs
-#define PyObject_CallMethodOneArg PyObject_CallMethodOneArg
+#define _PyObject_Vectorcall PyObject_Vectorcall
+#define _PyObject_VectorcallMethod PyObject_VectorcallMethod
+#define _PyObject_FastCallDict PyObject_VectorcallDict
+#define _PyVectorcall_Function PyVectorcall_Function
+#define _PyObject_CallOneArg PyObject_CallOneArg
+#define _PyObject_CallMethodNoArgs PyObject_CallMethodNoArgs
+#define _PyObject_CallMethodOneArg PyObject_CallMethodOneArg
 
 /* Same as PyObject_Vectorcall except that keyword arguments are passed as
    dict, which may be NULL if there are no keyword arguments. */

--- a/Include/object.h
+++ b/Include/object.h
@@ -297,7 +297,7 @@ given type object has a specified feature.
 #ifndef Py_LIMITED_API
 #define Py_TPFLAGS_HAVE_VECTORCALL (1UL << 11)
 // Backwards compatibility alias for API that was provisional in Python 3.8
-#define _Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
+#define Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
 #endif
 
 /* Set if the type is 'ready' -- fully initialized */

--- a/Include/object.h
+++ b/Include/object.h
@@ -297,7 +297,7 @@ given type object has a specified feature.
 #ifndef Py_LIMITED_API
 #define Py_TPFLAGS_HAVE_VECTORCALL (1UL << 11)
 // Backwards compatibility alias for API that was provisional in Python 3.8
-#define Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
+#define _Py_TPFLAGS_HAVE_VECTORCALL Py_TPFLAGS_HAVE_VECTORCALL
 #endif
 
 /* Set if the type is 'ready' -- fully initialized */

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -468,7 +468,7 @@ class FastCallTests(unittest.TestCase):
                     self.check_result(result, expected)
 
     def test_vectorcall_dict(self):
-        # Test _PyObject_FastCallDict()
+        # Test PyObject_VectorcallDict()
 
         for func, args, expected in self.CALLS_POSARGS:
             with self.subTest(func=func, args=args):
@@ -487,7 +487,7 @@ class FastCallTests(unittest.TestCase):
                 self.check_result(result, expected)
 
     def test_vectorcall(self):
-        # Test _PyObject_Vectorcall()
+        # Test PyObject_Vectorcall()
 
         for func, args, expected in self.CALLS_POSARGS:
             with self.subTest(func=func, args=args):
@@ -594,7 +594,7 @@ class TestPEP590(unittest.TestCase):
         # 1. vectorcall using PyVectorcall_Call()
         #   (only for objects that support vectorcall directly)
         # 2. normal call
-        # 3. vectorcall using _PyObject_Vectorcall()
+        # 3. vectorcall using PyObject_Vectorcall()
         # 4. call as bound method
         # 5. call using functools.partial
 

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -678,7 +678,7 @@ The :keyword:`assert` statement now works properly if the
 
 Removed object cache (``free_list``) for bound method objects.  Temporary
 bound method objects are less used than before thanks to the ``LOAD_METHOD``
-opcode and the ``_PyObject_VectorcallMethod`` C API.
+opcode and the ``PyObject_VectorcallMethod`` C API.
 
 ..
 
@@ -5676,7 +5676,7 @@ Exclude Python-ast.h, ast.h and asdl.h from the limited API.
 .. nonce: vftT4f
 .. section: C API
 
-Add new function ``_PyObject_CallOneArg`` for calling an object with one
+Add new function ``PyObject_CallOneArg`` for calling an object with one
 positional argument.
 
 ..
@@ -5696,8 +5696,8 @@ Add :func:`PyConfig_SetWideStringList` function.
 .. section: C API
 
 Add fast functions for calling methods:
-:c:func:`_PyObject_VectorcallMethod`, :c:func:`_PyObject_CallMethodNoArgs`
-and :c:func:`_PyObject_CallMethodOneArg`.
+:c:func:`PyObject_VectorcallMethod`, :c:func:`PyObject_CallMethodNoArgs`
+and :c:func:`PyObject_CallMethodOneArg`.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -678,7 +678,7 @@ The :keyword:`assert` statement now works properly if the
 
 Removed object cache (``free_list``) for bound method objects.  Temporary
 bound method objects are less used than before thanks to the ``LOAD_METHOD``
-opcode and the ``PyObject_VectorcallMethod`` C API.
+opcode and the ``_PyObject_VectorcallMethod`` C API.
 
 ..
 
@@ -5676,7 +5676,7 @@ Exclude Python-ast.h, ast.h and asdl.h from the limited API.
 .. nonce: vftT4f
 .. section: C API
 
-Add new function ``PyObject_CallOneArg`` for calling an object with one
+Add new function ``_PyObject_CallOneArg`` for calling an object with one
 positional argument.
 
 ..
@@ -5696,8 +5696,8 @@ Add :func:`PyConfig_SetWideStringList` function.
 .. section: C API
 
 Add fast functions for calling methods:
-:c:func:`PyObject_VectorcallMethod`, :c:func:`PyObject_CallMethodNoArgs`
-and :c:func:`PyObject_CallMethodOneArg`.
+:c:func:`_PyObject_VectorcallMethod`, :c:func:`_PyObject_CallMethodNoArgs`
+and :c:func:`_PyObject_CallMethodOneArg`.
 
 ..
 

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -142,7 +142,7 @@ _is_coroutine(PyObject *coro)
        Do this check after 'future_init()'; in case we need to raise
        an error, __del__ needs a properly initialized object.
     */
-    PyObject *res = _PyObject_CallOneArg(asyncio_iscoroutine_func, coro);
+    PyObject *res = PyObject_CallOneArg(asyncio_iscoroutine_func, coro);
     if (res == NULL) {
         return -1;
     }
@@ -367,7 +367,7 @@ call_soon(PyObject *loop, PyObject *func, PyObject *arg, PyObject *ctx)
         }
         stack[nargs] = (PyObject *)ctx;
 
-        handle = _PyObject_Vectorcall(callable, stack, nargs, context_kwname);
+        handle = PyObject_Vectorcall(callable, stack, nargs, context_kwname);
         Py_DECREF(callable);
     }
 
@@ -1287,7 +1287,7 @@ static PyObject *
 _asyncio_Future__repr_info_impl(FutureObj *self)
 /*[clinic end generated code: output=fa69e901bd176cfb input=f21504d8e2ae1ca2]*/
 {
-    return _PyObject_CallOneArg(asyncio_future_repr_info_func, (PyObject *)self);
+    return PyObject_CallOneArg(asyncio_future_repr_info_func, (PyObject *)self);
 }
 
 static PyObject *
@@ -1363,7 +1363,7 @@ FutureObj_finalize(FutureObj *fut)
 
     func = _PyObject_GetAttrId(fut->fut_loop, &PyId_call_exception_handler);
     if (func != NULL) {
-        PyObject *res = _PyObject_CallOneArg(func, context);
+        PyObject *res = PyObject_CallOneArg(func, context);
         if (res == NULL) {
             PyErr_WriteUnraisable(func);
         }
@@ -2126,13 +2126,13 @@ _asyncio_Task_current_task_impl(PyTypeObject *type, PyObject *loop)
             Py_DECREF(current_task_func);
             return NULL;
         }
-        ret = _PyObject_CallOneArg(current_task_func, loop);
+        ret = PyObject_CallOneArg(current_task_func, loop);
         Py_DECREF(current_task_func);
         Py_DECREF(loop);
         return ret;
     }
     else {
-        ret = _PyObject_CallOneArg(current_task_func, loop);
+        ret = PyObject_CallOneArg(current_task_func, loop);
         Py_DECREF(current_task_func);
         return ret;
     }
@@ -2168,7 +2168,7 @@ _asyncio_Task_all_tasks_impl(PyTypeObject *type, PyObject *loop)
         return NULL;
     }
 
-    res = _PyObject_CallOneArg(all_tasks_func, loop);
+    res = PyObject_CallOneArg(all_tasks_func, loop);
     Py_DECREF(all_tasks_func);
     return res;
 }
@@ -2181,7 +2181,7 @@ static PyObject *
 _asyncio_Task__repr_info_impl(TaskObj *self)
 /*[clinic end generated code: output=6a490eb66d5ba34b input=3c6d051ed3ddec8b]*/
 {
-    return _PyObject_CallOneArg(asyncio_task_repr_info_func, (PyObject *)self);
+    return PyObject_CallOneArg(asyncio_task_repr_info_func, (PyObject *)self);
 }
 
 /*[clinic input]
@@ -2431,7 +2431,7 @@ TaskObj_finalize(TaskObj *task)
 
     func = _PyObject_GetAttrId(task->task_loop, &PyId_call_exception_handler);
     if (func != NULL) {
-        PyObject *res = _PyObject_CallOneArg(func, context);
+        PyObject *res = PyObject_CallOneArg(func, context);
         if (res == NULL) {
             PyErr_WriteUnraisable(func);
         }
@@ -2571,7 +2571,7 @@ task_set_error_soon(TaskObj *task, PyObject *et, const char *format, ...)
         return NULL;
     }
 
-    PyObject *e = _PyObject_CallOneArg(et, msg);
+    PyObject *e = PyObject_CallOneArg(et, msg);
     Py_DECREF(msg);
     if (e == NULL) {
         return NULL;
@@ -2841,7 +2841,7 @@ task_step_impl(TaskObj *task, PyObject *exc)
         PyObject *stack[2];
         stack[0] = wrapper;
         stack[1] = (PyObject *)task->task_context;
-        res = _PyObject_Vectorcall(add_cb, stack, 1, context_kwname);
+        res = PyObject_Vectorcall(add_cb, stack, 1, context_kwname);
         Py_DECREF(add_cb);
         Py_DECREF(wrapper);
         if (res == NULL) {

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -512,7 +512,7 @@ deque_copy(PyObject *deque, PyObject *Py_UNUSED(ignored))
         return NULL;
     }
     if (old_deque->maxlen < 0)
-        result = _PyObject_CallOneArg((PyObject *)(Py_TYPE(deque)), deque);
+        result = PyObject_CallOneArg((PyObject *)(Py_TYPE(deque)), deque);
     else
         result = PyObject_CallFunction((PyObject *)(Py_TYPE(deque)), "Oi",
                                        deque, old_deque->maxlen, NULL);

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -514,10 +514,10 @@ _call_dialect(PyObject *dialect_inst, PyObject *kwargs)
 {
     PyObject *type = (PyObject *)&Dialect_Type;
     if (dialect_inst) {
-        return _PyObject_FastCallDict(type, &dialect_inst, 1, kwargs);
+        return PyObject_VectorcallDict(type, &dialect_inst, 1, kwargs);
     }
     else {
-        return _PyObject_FastCallDict(type, NULL, 0, kwargs);
+        return PyObject_VectorcallDict(type, NULL, 0, kwargs);
     }
 }
 
@@ -1240,7 +1240,7 @@ csv_writerow(WriterObj *self, PyObject *seq)
     if (line == NULL) {
         return NULL;
     }
-    result = _PyObject_CallOneArg(self->write, line);
+    result = PyObject_CallOneArg(self->write, line);
     Py_DECREF(line);
     return result;
 }

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -945,7 +945,7 @@ static PyObject *GetResult(PyObject *restype, void *result, PyObject *checker)
     if (!checker || !retval)
         return retval;
 
-    v = _PyObject_CallOneArg(checker, retval);
+    v = PyObject_CallOneArg(checker, retval);
     if (v == NULL)
         _PyTraceback_Add("GetResult", "_ctypes/callproc.c", __LINE__-2);
     Py_DECREF(retval);
@@ -1138,7 +1138,7 @@ PyObject *_ctypes_callproc(PPROC pProc,
         if (argtypes && argtype_count > i) {
             PyObject *v;
             converter = PyTuple_GET_ITEM(argtypes, i);
-            v = _PyObject_CallOneArg(converter, arg);
+            v = PyObject_CallOneArg(converter, arg);
             if (v == NULL) {
                 _ctypes_extend_error(PyExc_ArgError, "argument %zd: ", i+1);
                 goto cleanup;
@@ -1835,7 +1835,7 @@ pointer(PyObject *self, PyObject *arg)
 
     typ = PyDict_GetItemWithError(_ctypes_ptrtype_cache, (PyObject *)Py_TYPE(arg));
     if (typ) {
-        return _PyObject_CallOneArg(typ, arg);
+        return PyObject_CallOneArg(typ, arg);
     }
     else if (PyErr_Occurred()) {
         return NULL;
@@ -1843,7 +1843,7 @@ pointer(PyObject *self, PyObject *arg)
     typ = POINTER(NULL, (PyObject *)Py_TYPE(arg));
     if (typ == NULL)
         return NULL;
-    result = _PyObject_CallOneArg(typ, arg);
+    result = PyObject_CallOneArg(typ, arg);
     Py_DECREF(typ);
     return result;
 }

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -2671,7 +2671,7 @@ treebuilder_append_event(TreeBuilderObject *self, PyObject *action,
         PyObject *event = PyTuple_Pack(2, action, node);
         if (event == NULL)
             return -1;
-        res = _PyObject_CallOneArg(self->events_append, event);
+        res = PyObject_CallOneArg(self->events_append, event);
         Py_DECREF(event);
         if (res == NULL)
             return -1;
@@ -2837,7 +2837,7 @@ treebuilder_handle_comment(TreeBuilderObject* self, PyObject* text)
     }
 
     if (self->comment_factory) {
-        comment = _PyObject_CallOneArg(self->comment_factory, text);
+        comment = PyObject_CallOneArg(self->comment_factory, text);
         if (!comment)
             return NULL;
 
@@ -3179,7 +3179,7 @@ expat_set_error(enum XML_Error error_code, Py_ssize_t line, Py_ssize_t column,
     if (errmsg == NULL)
         return;
 
-    error = _PyObject_CallOneArg(st->parseerror_obj, errmsg);
+    error = PyObject_CallOneArg(st->parseerror_obj, errmsg);
     Py_DECREF(errmsg);
     if (!error)
         return;
@@ -3242,7 +3242,7 @@ expat_default_handler(XMLParserObject* self, const XML_Char* data_in,
                 (TreeBuilderObject*) self->target, value
                 );
         else if (self->handle_data)
-            res = _PyObject_CallOneArg(self->handle_data, value);
+            res = PyObject_CallOneArg(self->handle_data, value);
         else
             res = NULL;
         Py_XDECREF(res);
@@ -3353,7 +3353,7 @@ expat_data_handler(XMLParserObject* self, const XML_Char* data_in,
         /* shortcut */
         res = treebuilder_handle_data((TreeBuilderObject*) self->target, data);
     else if (self->handle_data)
-        res = _PyObject_CallOneArg(self->handle_data, data);
+        res = PyObject_CallOneArg(self->handle_data, data);
     else
         res = NULL;
 
@@ -3380,7 +3380,7 @@ expat_end_handler(XMLParserObject* self, const XML_Char* tag_in)
     else if (self->handle_end) {
         tag = makeuniversal(self, tag_in);
         if (tag) {
-            res = _PyObject_CallOneArg(self->handle_end, tag);
+            res = PyObject_CallOneArg(self->handle_end, tag);
             Py_DECREF(tag);
         }
     }
@@ -3467,7 +3467,7 @@ expat_end_ns_handler(XMLParserObject* self, const XML_Char* prefix_in)
         if (!prefix)
             return;
 
-        res = _PyObject_CallOneArg(self->handle_end_ns, prefix);
+        res = PyObject_CallOneArg(self->handle_end_ns, prefix);
         Py_DECREF(prefix);
     }
 
@@ -3499,7 +3499,7 @@ expat_comment_handler(XMLParserObject* self, const XML_Char* comment_in)
         if (!comment)
             return;
 
-        res = _PyObject_CallOneArg(self->handle_comment, comment);
+        res = PyObject_CallOneArg(self->handle_comment, comment);
         Py_XDECREF(res);
         Py_DECREF(comment);
     }

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -440,7 +440,7 @@ static PyTypeObject partial_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE |
-        Py_TPFLAGS_HAVE_VECTORCALL,    /* tp_flags */
+        Py_TPFLAGS_HAVE_VECTORCALL,     /* tp_flags */
     partial_doc,                        /* tp_doc */
     (traverseproc)partial_traverse,     /* tp_traverse */
     0,                                  /* tp_clear */

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -213,7 +213,7 @@ partial_vectorcall(partialobject *pto, PyObject *const *args,
 static void
 partial_setvectorcall(partialobject *pto)
 {
-    if (_PyVectorcall_Function(pto->fn) == NULL) {
+    if (PyVectorcall_Function(pto->fn) == NULL) {
         /* Don't use vectorcall if the underlying function doesn't support it */
         pto->vectorcall = NULL;
     }
@@ -440,7 +440,7 @@ static PyTypeObject partial_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE |
-        _Py_TPFLAGS_HAVE_VECTORCALL,    /* tp_flags */
+        Py_TPFLAGS_HAVE_VECTORCALL,    /* tp_flags */
     partial_doc,                        /* tp_doc */
     (traverseproc)partial_traverse,     /* tp_traverse */
     0,                                  /* tp_clear */

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -461,7 +461,7 @@ static PyObject *
 buffered_simple_flush(buffered *self, PyObject *args)
 {
     CHECK_INITIALIZED(self)
-    return _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_flush);
+    return PyObject_CallMethodNoArgs(self->raw, _PyIO_str_flush);
 }
 
 static int
@@ -513,7 +513,7 @@ buffered_close(buffered *self, PyObject *args)
     }
     /* flush() will most probably re-take the lock, so drop it first */
     LEAVE_BUFFERED(self)
-    res = _PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
+    res = PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
     if (!ENTER_BUFFERED(self))
         return NULL;
     if (res == NULL)
@@ -521,7 +521,7 @@ buffered_close(buffered *self, PyObject *args)
     else
         Py_DECREF(res);
 
-    res = _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_close);
+    res = PyObject_CallMethodNoArgs(self->raw, _PyIO_str_close);
 
     if (self->buffer) {
         PyMem_Free(self->buffer);
@@ -545,7 +545,7 @@ buffered_detach(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *raw, *res;
     CHECK_INITIALIZED(self)
-    res = _PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
+    res = PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
     if (res == NULL)
         return NULL;
     Py_DECREF(res);
@@ -562,21 +562,21 @@ static PyObject *
 buffered_seekable(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
-    return _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_seekable);
+    return PyObject_CallMethodNoArgs(self->raw, _PyIO_str_seekable);
 }
 
 static PyObject *
 buffered_readable(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
-    return _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_readable);
+    return PyObject_CallMethodNoArgs(self->raw, _PyIO_str_readable);
 }
 
 static PyObject *
 buffered_writable(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
-    return _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_writable);
+    return PyObject_CallMethodNoArgs(self->raw, _PyIO_str_writable);
 }
 
 static PyObject *
@@ -599,14 +599,14 @@ static PyObject *
 buffered_fileno(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
-    return _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_fileno);
+    return PyObject_CallMethodNoArgs(self->raw, _PyIO_str_fileno);
 }
 
 static PyObject *
 buffered_isatty(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
-    return _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_isatty);
+    return PyObject_CallMethodNoArgs(self->raw, _PyIO_str_isatty);
 }
 
 /* Forward decls */
@@ -670,7 +670,7 @@ _buffered_raw_tell(buffered *self)
 {
     Py_off_t n;
     PyObject *res;
-    res = _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_tell);
+    res = PyObject_CallMethodNoArgs(self->raw, _PyIO_str_tell);
     if (res == NULL)
         return -1;
     n = PyNumber_AsOff_t(res, PyExc_ValueError);
@@ -1324,7 +1324,7 @@ _io__Buffered_truncate_impl(buffered *self, PyObject *pos)
             goto end;
         Py_CLEAR(res);
     }
-    res = _PyObject_CallMethodOneArg(self->raw, _PyIO_str_truncate, pos);
+    res = PyObject_CallMethodOneArg(self->raw, _PyIO_str_truncate, pos);
     if (res == NULL)
         goto end;
     /* Reset cached position */
@@ -1351,7 +1351,7 @@ buffered_iternext(buffered *self)
         line = _buffered_readline(self, -1);
     }
     else {
-        line = _PyObject_CallMethodNoArgs((PyObject *)self,
+        line = PyObject_CallMethodNoArgs((PyObject *)self,
                                              _PyIO_str_readline);
         if (line && !PyBytes_Check(line)) {
             PyErr_Format(PyExc_OSError,
@@ -1470,7 +1470,7 @@ _bufferedreader_raw_read(buffered *self, char *start, Py_ssize_t len)
        raised (see issue #10956).
     */
     do {
-        res = _PyObject_CallMethodOneArg(self->raw, _PyIO_str_readinto, memobj);
+        res = PyObject_CallMethodOneArg(self->raw, _PyIO_str_readinto, memobj);
     } while (res == NULL && _PyIO_trap_eintr());
     Py_DECREF(memobj);
     if (res == NULL)
@@ -1569,7 +1569,7 @@ _bufferedreader_read_all(buffered *self)
         }
 
         /* Read until EOF or until read() would block. */
-        data = _PyObject_CallMethodNoArgs(self->raw, _PyIO_str_read);
+        data = PyObject_CallMethodNoArgs(self->raw, _PyIO_str_read);
         if (data == NULL)
             goto cleanup;
         if (data != Py_None && !PyBytes_Check(data)) {
@@ -1818,7 +1818,7 @@ _bufferedwriter_raw_write(buffered *self, char *start, Py_ssize_t len)
     */
     do {
         errno = 0;
-        res = _PyObject_CallMethodOneArg(self->raw, _PyIO_str_write, memobj);
+        res = PyObject_CallMethodOneArg(self->raw, _PyIO_str_write, memobj);
         errnum = errno;
     } while (res == NULL && _PyIO_trap_eintr());
     Py_DECREF(memobj);

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -235,7 +235,7 @@ _io__IOBase_close_impl(PyObject *self)
         Py_RETURN_NONE;
     }
 
-    res = _PyObject_CallMethodNoArgs(self, _PyIO_str_flush);
+    res = PyObject_CallMethodNoArgs(self, _PyIO_str_flush);
 
     PyErr_Fetch(&exc, &val, &tb);
     rc = _PyObject_SetAttrId(self, &PyId___IOBase_closed, Py_True);
@@ -281,7 +281,7 @@ iobase_finalize(PyObject *self)
            finalization process. */
         if (_PyObject_SetAttrId(self, &PyId__finalizing, Py_True))
             PyErr_Clear();
-        res = _PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_close);
+        res = PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_close);
         /* Silencing I/O errors is bad, but printing spurious tracebacks is
            equally as bad, and potentially more frequent (because of
            shutdown issues). */
@@ -382,7 +382,7 @@ _io__IOBase_seekable_impl(PyObject *self)
 PyObject *
 _PyIOBase_check_seekable(PyObject *self, PyObject *args)
 {
-    PyObject *res  = _PyObject_CallMethodNoArgs(self, _PyIO_str_seekable);
+    PyObject *res  = PyObject_CallMethodNoArgs(self, _PyIO_str_seekable);
     if (res == NULL)
         return NULL;
     if (res != Py_True) {
@@ -415,7 +415,7 @@ _io__IOBase_readable_impl(PyObject *self)
 PyObject *
 _PyIOBase_check_readable(PyObject *self, PyObject *args)
 {
-    PyObject *res = _PyObject_CallMethodNoArgs(self, _PyIO_str_readable);
+    PyObject *res = PyObject_CallMethodNoArgs(self, _PyIO_str_readable);
     if (res == NULL)
         return NULL;
     if (res != Py_True) {
@@ -448,7 +448,7 @@ _io__IOBase_writable_impl(PyObject *self)
 PyObject *
 _PyIOBase_check_writable(PyObject *self, PyObject *args)
 {
-    PyObject *res = _PyObject_CallMethodNoArgs(self, _PyIO_str_writable);
+    PyObject *res = PyObject_CallMethodNoArgs(self, _PyIO_str_writable);
     if (res == NULL)
         return NULL;
     if (res != Py_True) {
@@ -477,7 +477,7 @@ iobase_enter(PyObject *self, PyObject *args)
 static PyObject *
 iobase_exit(PyObject *self, PyObject *args)
 {
-    return _PyObject_CallMethodNoArgs(self, _PyIO_str_close);
+    return PyObject_CallMethodNoArgs(self, _PyIO_str_close);
 }
 
 /* Lower-level APIs */
@@ -556,7 +556,7 @@ _io__IOBase_readline_impl(PyObject *self, Py_ssize_t limit)
         PyObject *b;
 
         if (peek != NULL) {
-            PyObject *readahead = _PyObject_CallOneArg(peek, _PyLong_One);
+            PyObject *readahead = PyObject_CallOneArg(peek, _PyLong_One);
             if (readahead == NULL) {
                 /* NOTE: PyErr_SetFromErrno() calls PyErr_CheckSignals()
                    when EINTR occurs so we needn't do it ourselves. */
@@ -655,7 +655,7 @@ iobase_iter(PyObject *self)
 static PyObject *
 iobase_iternext(PyObject *self)
 {
-    PyObject *line = _PyObject_CallMethodNoArgs(self, _PyIO_str_readline);
+    PyObject *line = PyObject_CallMethodNoArgs(self, _PyIO_str_readline);
 
     if (line == NULL)
         return NULL;

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -408,7 +408,7 @@ stringio_iternext(stringio *self)
     }
     else {
         /* XXX is subclassing StringIO really supported? */
-        line = _PyObject_CallMethodNoArgs((PyObject *)self,
+        line = PyObject_CallMethodNoArgs((PyObject *)self,
                                              _PyIO_str_readline);
         if (line && !PyUnicode_Check(line)) {
             PyErr_Format(PyExc_OSError,

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -527,7 +527,7 @@ _io_IncrementalNewlineDecoder_getstate_impl(nldecoder_object *self)
     unsigned long long flag;
 
     if (self->decoder != Py_None) {
-        PyObject *state = _PyObject_CallMethodNoArgs(self->decoder,
+        PyObject *state = PyObject_CallMethodNoArgs(self->decoder,
            _PyIO_str_getstate);
         if (state == NULL)
             return NULL;
@@ -601,7 +601,7 @@ _io_IncrementalNewlineDecoder_reset_impl(nldecoder_object *self)
     self->seennl = 0;
     self->pendingcr = 0;
     if (self->decoder != Py_None)
-        return _PyObject_CallMethodNoArgs(self->decoder, _PyIO_str_reset);
+        return PyObject_CallMethodNoArgs(self->decoder, _PyIO_str_reset);
     else
         Py_RETURN_NONE;
 }
@@ -963,7 +963,7 @@ _textiowrapper_fix_encoder_state(textio *self)
 
     self->encoding_start_of_stream = 1;
 
-    PyObject *cookieObj = _PyObject_CallMethodNoArgs(
+    PyObject *cookieObj = PyObject_CallMethodNoArgs(
         self->buffer, _PyIO_str_tell);
     if (cookieObj == NULL) {
         return -1;
@@ -977,7 +977,7 @@ _textiowrapper_fix_encoder_state(textio *self)
 
     if (cmp == 0) {
         self->encoding_start_of_stream = 0;
-        PyObject *res = _PyObject_CallMethodOneArg(
+        PyObject *res = PyObject_CallMethodOneArg(
             self->encoder, _PyIO_str_setstate, _PyLong_Zero);
         if (res == NULL) {
             return -1;
@@ -1386,7 +1386,7 @@ _io_TextIOWrapper_reconfigure_impl(textio *self, PyObject *encoding,
         return NULL;
     }
 
-    PyObject *res = _PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
+    PyObject *res = PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
     if (res == NULL) {
         return NULL;
     }
@@ -1525,7 +1525,7 @@ _io_TextIOWrapper_detach_impl(textio *self)
 {
     PyObject *buffer, *res;
     CHECK_ATTACHED(self);
-    res = _PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
+    res = PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
     if (res == NULL)
         return NULL;
     Py_DECREF(res);
@@ -1597,7 +1597,7 @@ _textiowrapper_writeflush(textio *self)
 
     PyObject *ret;
     do {
-        ret = _PyObject_CallMethodOneArg(self->buffer, _PyIO_str_write, b);
+        ret = PyObject_CallMethodOneArg(self->buffer, _PyIO_str_write, b);
     } while (ret == NULL && _PyIO_trap_eintr());
     Py_DECREF(b);
     if (ret == NULL)
@@ -1667,7 +1667,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
         self->encoding_start_of_stream = 0;
     }
     else
-        b = _PyObject_CallMethodOneArg(self->encoder, _PyIO_str_encode, text);
+        b = PyObject_CallMethodOneArg(self->encoder, _PyIO_str_encode, text);
 
     Py_DECREF(text);
     if (b == NULL)
@@ -1718,7 +1718,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
     }
 
     if (needflush) {
-        ret = _PyObject_CallMethodNoArgs(self->buffer, _PyIO_str_flush);
+        ret = PyObject_CallMethodNoArgs(self->buffer, _PyIO_str_flush);
         if (ret == NULL)
             return NULL;
         Py_DECREF(ret);
@@ -1808,7 +1808,7 @@ textiowrapper_read_chunk(textio *self, Py_ssize_t size_hint)
         /* To prepare for tell(), we need to snapshot a point in the file
          * where the decoder's input buffer is empty.
          */
-        PyObject *state = _PyObject_CallMethodNoArgs(self->decoder,
+        PyObject *state = PyObject_CallMethodNoArgs(self->decoder,
                                                      _PyIO_str_getstate);
         if (state == NULL)
             return -1;
@@ -1849,7 +1849,7 @@ textiowrapper_read_chunk(textio *self, Py_ssize_t size_hint)
     if (chunk_size == NULL)
         goto fail;
 
-    input_chunk = _PyObject_CallMethodOneArg(self->buffer,
+    input_chunk = PyObject_CallMethodOneArg(self->buffer,
         (self->has_read1 ? _PyIO_str_read1: _PyIO_str_read),
         chunk_size);
     Py_DECREF(chunk_size);
@@ -2393,7 +2393,7 @@ _textiowrapper_decoder_setstate(textio *self, cookie_type *cookie)
        utf-16, that we are expecting a BOM).
     */
     if (cookie->start_pos == 0 && cookie->dec_flags == 0)
-        res = _PyObject_CallMethodNoArgs(self->decoder, _PyIO_str_reset);
+        res = PyObject_CallMethodNoArgs(self->decoder, _PyIO_str_reset);
     else
         res = _PyObject_CallMethodId(self->decoder, &PyId_setstate,
                                      "((yi))", "", cookie->dec_flags);
@@ -2408,11 +2408,11 @@ _textiowrapper_encoder_reset(textio *self, int start_of_stream)
 {
     PyObject *res;
     if (start_of_stream) {
-        res = _PyObject_CallMethodNoArgs(self->encoder, _PyIO_str_reset);
+        res = PyObject_CallMethodNoArgs(self->encoder, _PyIO_str_reset);
         self->encoding_start_of_stream = 1;
     }
     else {
-        res = _PyObject_CallMethodOneArg(self->encoder, _PyIO_str_setstate,
+        res = PyObject_CallMethodOneArg(self->encoder, _PyIO_str_setstate,
                                         _PyLong_Zero);
         self->encoding_start_of_stream = 0;
     }
@@ -2537,7 +2537,7 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
         goto fail;
     }
 
-    res = _PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
+    res = PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
     if (res == NULL)
         goto fail;
     Py_DECREF(res);
@@ -2552,7 +2552,7 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
     posobj = PyLong_FromOff_t(cookie.start_pos);
     if (posobj == NULL)
         goto fail;
-    res = _PyObject_CallMethodOneArg(self->buffer, _PyIO_str_seek, posobj);
+    res = PyObject_CallMethodOneArg(self->buffer, _PyIO_str_seek, posobj);
     Py_DECREF(posobj);
     if (res == NULL)
         goto fail;
@@ -2700,14 +2700,14 @@ _io_TextIOWrapper_tell_impl(textio *self)
     chars_to_skip = self->decoded_chars_used;
 
     /* Decoder state will be restored at the end */
-    saved_state = _PyObject_CallMethodNoArgs(self->decoder,
+    saved_state = PyObject_CallMethodNoArgs(self->decoder,
                                              _PyIO_str_getstate);
     if (saved_state == NULL)
         goto fail;
 
 #define DECODER_GETSTATE() do { \
         PyObject *dec_buffer; \
-        PyObject *_state = _PyObject_CallMethodNoArgs(self->decoder, \
+        PyObject *_state = PyObject_CallMethodNoArgs(self->decoder, \
             _PyIO_str_getstate); \
         if (_state == NULL) \
             goto fail; \
@@ -2870,12 +2870,12 @@ _io_TextIOWrapper_truncate_impl(textio *self, PyObject *pos)
 
     CHECK_ATTACHED(self)
 
-    res = _PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
+    res = PyObject_CallMethodNoArgs((PyObject *)self, _PyIO_str_flush);
     if (res == NULL)
         return NULL;
     Py_DECREF(res);
 
-    return _PyObject_CallMethodOneArg(self->buffer, _PyIO_str_truncate, pos);
+    return PyObject_CallMethodOneArg(self->buffer, _PyIO_str_truncate, pos);
 }
 
 static PyObject *
@@ -3084,7 +3084,7 @@ textiowrapper_iternext(textio *self)
         line = _textiowrapper_readline(self, -1);
     }
     else {
-        line = _PyObject_CallMethodNoArgs((PyObject *)self,
+        line = PyObject_CallMethodNoArgs((PyObject *)self,
                                           _PyIO_str_readline);
         if (line && !PyUnicode_Check(line)) {
             PyErr_Format(PyExc_OSError,

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -777,14 +777,14 @@ _parse_object_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t idx, Py_ss
     *next_idx_ptr = idx + 1;
 
     if (has_pairs_hook) {
-        val = _PyObject_CallOneArg(s->object_pairs_hook, rval);
+        val = PyObject_CallOneArg(s->object_pairs_hook, rval);
         Py_DECREF(rval);
         return val;
     }
 
     /* if object_hook is not None: rval = object_hook(rval) */
     if (s->object_hook != Py_None) {
-        val = _PyObject_CallOneArg(s->object_hook, rval);
+        val = PyObject_CallOneArg(s->object_hook, rval);
         Py_DECREF(rval);
         return val;
     }
@@ -890,7 +890,7 @@ _parse_constant(PyScannerObject *s, const char *constant, Py_ssize_t idx, Py_ssi
         return NULL;
 
     /* rval = parse_constant(constant) */
-    rval = _PyObject_CallOneArg(s->parse_constant, cstr);
+    rval = PyObject_CallOneArg(s->parse_constant, cstr);
     idx += PyUnicode_GET_LENGTH(cstr);
     Py_DECREF(cstr);
     *next_idx_ptr = idx;
@@ -989,7 +989,7 @@ _match_number_unicode(PyScannerObject *s, PyObject *pystr, Py_ssize_t start, Py_
                                            idx - start);
         if (numstr == NULL)
             return NULL;
-        rval = _PyObject_CallOneArg(custom_func, numstr);
+        rval = PyObject_CallOneArg(custom_func, numstr);
     }
     else {
         Py_ssize_t i, n;
@@ -1399,7 +1399,7 @@ encoder_encode_string(PyEncoderObject *s, PyObject *obj)
     if (s->fast_encode) {
         return s->fast_encode(NULL, obj);
     }
-    encoded = _PyObject_CallOneArg(s->encoder, obj);
+    encoded = PyObject_CallOneArg(s->encoder, obj);
     if (encoded != NULL && !PyUnicode_Check(encoded)) {
         PyErr_Format(PyExc_TypeError,
                      "encoder() must return a string, not %.80s",
@@ -1485,7 +1485,7 @@ encoder_listencode_obj(PyEncoderObject *s, _PyAccu *acc,
                 return -1;
             }
         }
-        newobj = _PyObject_CallOneArg(s->defaultfn, obj);
+        newobj = PyObject_CallOneArg(s->defaultfn, obj);
         if (newobj == NULL) {
             Py_XDECREF(ident);
             return -1;

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -1682,7 +1682,7 @@ methodcaller_reduce(methodcallerobject *mc, PyObject *Py_UNUSED(ignored))
 
         newargs[0] = (PyObject *)Py_TYPE(mc);
         newargs[1] = mc->name;
-        constructor = _PyObject_FastCallDict(partial, newargs, 2, mc->kwds);
+        constructor = PyObject_VectorcallDict(partial, newargs, 2, mc->kwds);
 
         Py_DECREF(partial);
         return Py_BuildValue("NO", constructor, mc->args);

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -359,7 +359,7 @@ _Pickle_FastCall(PyObject *func, PyObject *obj)
 {
     PyObject *result;
 
-    result = _PyObject_CallOneArg(func, obj);
+    result = PyObject_CallOneArg(func, obj);
     Py_DECREF(obj);
     return result;
 }
@@ -420,7 +420,7 @@ call_method(PyObject *func, PyObject *self, PyObject *obj)
         return PyObject_CallFunctionObjArgs(func, self, obj, NULL);
     }
     else {
-        return _PyObject_CallOneArg(func, obj);
+        return PyObject_CallOneArg(func, obj);
     }
 }
 
@@ -2298,7 +2298,7 @@ _Pickler_write_bytes(PicklerObject *self,
                 return -1;
             }
         }
-        result = _PyObject_CallOneArg(self->write, payload);
+        result = PyObject_CallOneArg(self->write, payload);
         Py_XDECREF(mem);
         if (result == NULL) {
             return -1;
@@ -2506,7 +2506,7 @@ save_picklebuffer(PicklerObject *self, PyObject *obj)
     }
     int in_band = 1;
     if (self->buffer_callback != NULL) {
-        PyObject *ret = _PyObject_CallOneArg(self->buffer_callback, obj);
+        PyObject *ret = PyObject_CallOneArg(self->buffer_callback, obj);
         if (ret == NULL) {
             return -1;
         }
@@ -4323,7 +4323,7 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
      * regular reduction mechanism.
      */
     if (self->reducer_override != NULL) {
-        reduce_value = _PyObject_CallOneArg(self->reducer_override, obj);
+        reduce_value = PyObject_CallOneArg(self->reducer_override, obj);
         if (reduce_value == NULL) {
             goto error;
         }

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -80,7 +80,7 @@ _enable_gc(int need_to_reenable_gc, PyObject *gc_module)
 
     if (need_to_reenable_gc) {
         PyErr_Fetch(&exctype, &val, &tb);
-        result = _PyObject_CallMethodNoArgs(
+        result = PyObject_CallMethodNoArgs(
             gc_module, _posixsubprocessstate_global->enable);
         if (exctype != NULL) {
             PyErr_Restore(exctype, val, tb);
@@ -657,7 +657,7 @@ subprocess_fork_exec(PyObject* self, PyObject *args)
         gc_module = PyImport_ImportModule("gc");
         if (gc_module == NULL)
             return NULL;
-        result = _PyObject_CallMethodNoArgs(
+        result = PyObject_CallMethodNoArgs(
             gc_module, _posixsubprocessstate_global->isenabled);
         if (result == NULL) {
             Py_DECREF(gc_module);
@@ -669,7 +669,7 @@ subprocess_fork_exec(PyObject* self, PyObject *args)
             Py_DECREF(gc_module);
             return NULL;
         }
-        result = _PyObject_CallMethodNoArgs(
+        result = PyObject_CallMethodNoArgs(
             gc_module, _posixsubprocessstate_global->disable);
         if (result == NULL) {
             Py_DECREF(gc_module);

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -287,7 +287,7 @@ random_seed(RandomObject *self, PyObject *arg)
         /* Calling int.__abs__() prevents calling arg.__abs__(), which might
            return an invalid value. See issue #31478. */
         args[0] = arg;
-        n = _PyObject_Vectorcall(_randomstate_global->Long___abs__, args, 0,
+        n = PyObject_Vectorcall(_randomstate_global->Long___abs__, args, 0,
                                          NULL);
     }
     else {

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -183,7 +183,7 @@ PyObject* pysqlite_cache_get(pysqlite_Cache* self, PyObject* key)
             }
         }
 
-        /* We cannot replace this by _PyObject_CallOneArg() since
+        /* We cannot replace this by PyObject_CallOneArg() since
          * PyObject_CallFunction() has a special case when using a
          * single tuple as argument. */
         data = PyObject_CallFunction(self->factory, "O", key);

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -308,7 +308,7 @@ PyObject* pysqlite_connection_cursor(pysqlite_Connection* self, PyObject* args, 
         factory = (PyObject*)&pysqlite_CursorType;
     }
 
-    cursor = _PyObject_CallOneArg(factory, (PyObject *)self);
+    cursor = PyObject_CallOneArg(factory, (PyObject *)self);
     if (cursor == NULL)
         return NULL;
     if (!PyObject_TypeCheck(cursor, &pysqlite_CursorType)) {
@@ -975,7 +975,7 @@ static void _trace_callback(void* user_arg, const char* statement_string)
     py_statement = PyUnicode_DecodeUTF8(statement_string,
             strlen(statement_string), "replace");
     if (py_statement) {
-        ret = _PyObject_CallOneArg((PyObject*)user_arg, py_statement);
+        ret = PyObject_CallOneArg((PyObject*)user_arg, py_statement);
         Py_DECREF(py_statement);
     }
 
@@ -1472,7 +1472,7 @@ pysqlite_connection_iterdump(pysqlite_Connection* self, PyObject* args)
         goto finally;
     }
 
-    retval = _PyObject_CallOneArg(pyfn_iterdump, (PyObject *)self);
+    retval = PyObject_CallOneArg(pyfn_iterdump, (PyObject *)self);
 
 finally:
     Py_XDECREF(module);

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -266,7 +266,7 @@ _pysqlite_fetch_one_row(pysqlite_Cursor* self)
                 item = PyBytes_FromStringAndSize(val_str, nbytes);
                 if (!item)
                     goto error;
-                converted = _PyObject_CallOneArg(converter, item);
+                converted = PyObject_CallOneArg(converter, item);
                 Py_DECREF(item);
             }
         } else {

--- a/Modules/_sqlite/microprotocols.c
+++ b/Modules/_sqlite/microprotocols.c
@@ -92,7 +92,7 @@ pysqlite_microprotocols_adapt(PyObject *obj, PyObject *proto, PyObject *alt)
     Py_DECREF(key);
     if (adapter) {
         Py_INCREF(adapter);
-        adapted = _PyObject_CallOneArg(adapter, obj);
+        adapted = PyObject_CallOneArg(adapter, obj);
         Py_DECREF(adapter);
         return adapted;
     }
@@ -105,7 +105,7 @@ pysqlite_microprotocols_adapt(PyObject *obj, PyObject *proto, PyObject *alt)
         return NULL;
     }
     if (adapter) {
-        adapted = _PyObject_CallOneArg(adapter, obj);
+        adapted = PyObject_CallOneArg(adapter, obj);
         Py_DECREF(adapter);
 
         if (adapted == Py_None) {
@@ -124,7 +124,7 @@ pysqlite_microprotocols_adapt(PyObject *obj, PyObject *proto, PyObject *alt)
         return NULL;
     }
     if (adapter) {
-        adapted = _PyObject_CallOneArg(adapter, proto);
+        adapted = PyObject_CallOneArg(adapter, proto);
         Py_DECREF(adapter);
 
         if (adapted == Py_None) {

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -1081,7 +1081,7 @@ pattern_subx(PatternObject* self, PyObject* ptemplate, PyObject* string,
             match = pattern_new_match(self, &state, 1);
             if (!match)
                 goto error;
-            item = _PyObject_CallOneArg(filter, match);
+            item = PyObject_CallOneArg(filter, match);
             Py_DECREF(match);
             if (!item)
                 goto error;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2097,7 +2097,7 @@ cache_struct_converter(PyObject *fmt, PyStructObject **ptr)
         return 0;
     }
 
-    s_object = _PyObject_CallOneArg(_structmodulestate_global->PyStructType, fmt);
+    s_object = PyObject_CallOneArg(_structmodulestate_global->PyStructType, fmt);
     if (s_object != NULL) {
         if (PyDict_GET_SIZE(cache) >= MAXCACHE)
             PyDict_Clear(cache);

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4846,7 +4846,7 @@ test_pyobject_fastcalldict(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    return _PyObject_FastCallDict(func, stack, nargs, kwargs);
+    return PyObject_VectorcallDict(func, stack, nargs, kwargs);
 }
 
 
@@ -4880,7 +4880,7 @@ test_pyobject_vectorcall(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_TypeError, "kwnames must be None or a tuple");
         return NULL;
     }
-    return _PyObject_Vectorcall(func, stack, nargs, kwnames);
+    return PyObject_Vectorcall(func, stack, nargs, kwnames);
 }
 
 
@@ -5253,7 +5253,7 @@ meth_fastcall_keywords(PyObject* self, PyObject* const* args,
     if (pyargs == NULL) {
         return NULL;
     }
-    PyObject *pykwargs = _PyObject_Vectorcall((PyObject*)&PyDict_Type,
+    PyObject *pykwargs = PyObject_Vectorcall((PyObject*)&PyDict_Type,
                                               args + nargs, 0, kwargs);
     return Py_BuildValue("NNN", _null_to_none(self), pyargs, pykwargs);
 }
@@ -6133,7 +6133,7 @@ static PyTypeObject MethodDescriptorBase_Type = {
     .tp_call = PyVectorcall_Call,
     .tp_vectorcall_offset = offsetof(MethodDescriptorObject, vectorcall),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-                Py_TPFLAGS_METHOD_DESCRIPTOR | _Py_TPFLAGS_HAVE_VECTORCALL,
+                Py_TPFLAGS_METHOD_DESCRIPTOR | Py_TPFLAGS_HAVE_VECTORCALL,
     .tp_descr_get = func_descr_get,
 };
 
@@ -6172,7 +6172,7 @@ static PyTypeObject MethodDescriptor2_Type = {
     .tp_new = MethodDescriptor2_new,
     .tp_call = PyVectorcall_Call,
     .tp_vectorcall_offset = offsetof(MethodDescriptor2Object, vectorcall),
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | _Py_TPFLAGS_HAVE_VECTORCALL,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_VECTORCALL,
 };
 
 PyDoc_STRVAR(heapgctype__doc__,

--- a/Modules/_xxtestfuzz/fuzzer.c
+++ b/Modules/_xxtestfuzz/fuzzer.c
@@ -104,7 +104,7 @@ static int fuzz_json_loads(const char* data, size_t size) {
     if (input_bytes == NULL) {
         return 0;
     }
-    PyObject* parsed = _PyObject_CallOneArg(json_loads_method, input_bytes);
+    PyObject* parsed = PyObject_CallOneArg(json_loads_method, input_bytes);
     if (parsed == NULL) {
         /* Ignore ValueError as the fuzzer will more than likely
            generate some invalid json and values */
@@ -263,7 +263,7 @@ static int fuzz_sre_match(const char* data, size_t size) {
     PyObject* pattern = compiled_patterns[idx];
     PyObject* match_callable = PyObject_GetAttrString(pattern, "match");
 
-    PyObject* matches = _PyObject_CallOneArg(match_callable, to_match);
+    PyObject* matches = PyObject_CallOneArg(match_callable, to_match);
 
     Py_XDECREF(matches);
     Py_DECREF(match_callable);

--- a/Modules/cjkcodecs/cjkcodecs.h
+++ b/Modules/cjkcodecs/cjkcodecs.h
@@ -291,7 +291,7 @@ getcodec(PyObject *self, PyObject *encoding)
     if (codecobj == NULL)
         return NULL;
 
-    r = _PyObject_CallOneArg(cofunc, codecobj);
+    r = PyObject_CallOneArg(cofunc, codecobj);
     Py_DECREF(codecobj);
 
     return r;

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -92,7 +92,7 @@ call_error_callback(PyObject *errors, PyObject *exc)
     if (cb == NULL)
         return NULL;
 
-    r = _PyObject_CallOneArg(cb, exc);
+    r = PyObject_CallOneArg(cb, exc);
     Py_DECREF(cb);
     return r;
 }

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -872,7 +872,7 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
         _PyObject_ASSERT(op, callback != NULL);
 
         /* copy-paste of weakrefobject.c's handle_callback() */
-        temp = _PyObject_CallOneArg(callback, (PyObject *)wr);
+        temp = PyObject_CallOneArg(callback, (PyObject *)wr);
         if (temp == NULL)
             PyErr_WriteUnraisable(callback);
         else

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -134,7 +134,7 @@ groupby_step(groupbyobject *gbo)
         newkey = newvalue;
         Py_INCREF(newvalue);
     } else {
-        newkey = _PyObject_CallOneArg(gbo->keyfunc, newvalue);
+        newkey = PyObject_CallOneArg(gbo->keyfunc, newvalue);
         if (newkey == NULL) {
             Py_DECREF(newvalue);
             return -1;
@@ -1219,7 +1219,7 @@ dropwhile_next(dropwhileobject *lz)
         if (lz->start == 1)
             return item;
 
-        good = _PyObject_CallOneArg(lz->func, item);
+        good = PyObject_CallOneArg(lz->func, item);
         if (good == NULL) {
             Py_DECREF(item);
             return NULL;
@@ -1382,7 +1382,7 @@ takewhile_next(takewhileobject *lz)
     if (item == NULL)
         return NULL;
 
-    good = _PyObject_CallOneArg(lz->func, item);
+    good = PyObject_CallOneArg(lz->func, item);
     if (good == NULL) {
         Py_DECREF(item);
         return NULL;
@@ -3918,7 +3918,7 @@ filterfalse_next(filterfalseobject *lz)
             ok = PyObject_IsTrue(item);
         } else {
             PyObject *good;
-            good = _PyObject_CallOneArg(lz->func, item);
+            good = PyObject_CallOneArg(lz->func, item);
             if (good == NULL) {
                 Py_DECREF(item);
                 return NULL;

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -119,7 +119,7 @@ set_error(xmlparseobject *self, enum XML_Error code)
                                   XML_ErrorString(code), lineno, column);
     if (buffer == NULL)
         return NULL;
-    err = _PyObject_CallOneArg(ErrorObject, buffer);
+    err = PyObject_CallOneArg(ErrorObject, buffer);
     Py_DECREF(buffer);
     if (  err != NULL
           && set_error_attr(err, "code", code)

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -179,7 +179,7 @@ PyObject_GetItem(PyObject *o, PyObject *key)
             return NULL;
         }
         if (meth) {
-            result = _PyObject_CallOneArg(meth, key);
+            result = PyObject_CallOneArg(meth, key);
             Py_DECREF(meth);
             return result;
         }
@@ -780,7 +780,7 @@ PyObject_Format(PyObject *obj, PyObject *format_spec)
     }
 
     /* And call it. */
-    result = _PyObject_CallOneArg(meth, format_spec);
+    result = PyObject_CallOneArg(meth, format_spec);
     Py_DECREF(meth);
 
     if (result && !PyUnicode_Check(result)) {
@@ -2502,7 +2502,7 @@ object_recursive_isinstance(PyThreadState *tstate, PyObject *inst, PyObject *cls
             return -1;
         }
 
-        PyObject *res = _PyObject_CallOneArg(checker, inst);
+        PyObject *res = PyObject_CallOneArg(checker, inst);
         _Py_LeaveRecursiveCall(tstate);
         Py_DECREF(checker);
 
@@ -2588,7 +2588,7 @@ object_issubclass(PyThreadState *tstate, PyObject *derived, PyObject *cls)
             Py_DECREF(checker);
             return ok;
         }
-        PyObject *res = _PyObject_CallOneArg(checker, derived);
+        PyObject *res = PyObject_CallOneArg(checker, derived);
         _Py_LeaveRecursiveCall(tstate);
         Py_DECREF(checker);
         if (res != NULL) {

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -89,7 +89,7 @@ _canresize(PyByteArrayObject *self)
 PyObject *
 PyByteArray_FromObject(PyObject *input)
 {
-    return _PyObject_CallOneArg((PyObject *)&PyByteArray_Type, input);
+    return PyObject_CallOneArg((PyObject *)&PyByteArray_Type, input);
 }
 
 static PyObject *
@@ -2015,7 +2015,7 @@ bytearray_fromhex_impl(PyTypeObject *type, PyObject *string)
 {
     PyObject *result = _PyBytes_FromHex(string, type == &PyByteArray_Type);
     if (type != &PyByteArray_Type && result != NULL) {
-        Py_SETREF(result, _PyObject_CallOneArg((PyObject *)type, result));
+        Py_SETREF(result, PyObject_CallOneArg((PyObject *)type, result));
     }
     return result;
 }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2259,7 +2259,7 @@ bytes_fromhex_impl(PyTypeObject *type, PyObject *string)
 {
     PyObject *result = _PyBytes_FromHex(string, 0);
     if (type != &PyBytes_Type && result != NULL) {
-        Py_SETREF(result, _PyObject_CallOneArg((PyObject *)type, result));
+        Py_SETREF(result, PyObject_CallOneArg((PyObject *)type, result));
     }
     return result;
 }

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -95,7 +95,7 @@ _PyObject_FastCallDictTstate(PyThreadState *tstate, PyObject *callable,
 {
     assert(callable != NULL);
 
-    /* _PyObject_FastCallDict() must not be called with an exception set,
+    /* PyObject_VectorcallDict() must not be called with an exception set,
        because it can clear it (directly or indirectly) and so the
        caller loses its exception */
     assert(!_PyErr_Occurred(tstate));
@@ -105,7 +105,7 @@ _PyObject_FastCallDictTstate(PyThreadState *tstate, PyObject *callable,
     assert(nargs == 0 || args != NULL);
     assert(kwargs == NULL || PyDict_Check(kwargs));
 
-    vectorcallfunc func = _PyVectorcall_Function(callable);
+    vectorcallfunc func = PyVectorcall_Function(callable);
     if (func == NULL) {
         /* Use tp_call instead */
         return _PyObject_MakeTpCall(tstate, callable, args, nargs, kwargs);
@@ -133,7 +133,7 @@ _PyObject_FastCallDictTstate(PyThreadState *tstate, PyObject *callable,
 
 
 PyObject *
-_PyObject_FastCallDict(PyObject *callable, PyObject *const *args,
+PyObject_VectorcallDict(PyObject *callable, PyObject *const *args,
                        size_t nargsf, PyObject *kwargs)
 {
     PyThreadState *tstate = _PyThreadState_GET();
@@ -204,8 +204,8 @@ PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *kwargs)
 {
     PyThreadState *tstate = _PyThreadState_GET();
 
-    /* get vectorcallfunc as in _PyVectorcall_Function, but without
-     * the _Py_TPFLAGS_HAVE_VECTORCALL check */
+    /* get vectorcallfunc as in PyVectorcall_Function, but without
+     * the Py_TPFLAGS_HAVE_VECTORCALL check */
     Py_ssize_t offset = Py_TYPE(callable)->tp_vectorcall_offset;
     if (offset <= 0) {
         _PyErr_Format(tstate, PyExc_TypeError,
@@ -259,7 +259,7 @@ _PyObject_Call(PyThreadState *tstate, PyObject *callable,
     assert(PyTuple_Check(args));
     assert(kwargs == NULL || PyDict_Check(kwargs));
 
-    if (_PyVectorcall_Function(callable) != NULL) {
+    if (PyVectorcall_Function(callable) != NULL) {
         return PyVectorcall_Call(callable, args, kwargs);
     }
     else {
@@ -796,7 +796,7 @@ object_vacall(PyThreadState *tstate, PyObject *base,
 
 
 PyObject *
-_PyObject_VectorcallMethod(PyObject *name, PyObject *const *args,
+PyObject_VectorcallMethod(PyObject *name, PyObject *const *args,
                            size_t nargsf, PyObject *kwnames)
 {
     assert(name != NULL);

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -350,7 +350,7 @@ PyTypeObject PyMethod_Type = {
     PyObject_GenericSetAttr,                    /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-    Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
+    Py_TPFLAGS_HAVE_VECTORCALL,                 /* tp_flags */
     method_doc,                                 /* tp_doc */
     (traverseproc)method_traverse,              /* tp_traverse */
     0,                                          /* tp_clear */

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -350,7 +350,7 @@ PyTypeObject PyMethod_Type = {
     PyObject_GenericSetAttr,                    /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-    _Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
+    Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
     method_doc,                                 /* tp_doc */
     (traverseproc)method_traverse,              /* tp_traverse */
     0,                                          /* tp_clear */

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -454,7 +454,7 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
     if (bound == NULL) {
         return NULL;
     }
-    PyObject *res = _PyObject_FastCallDict(bound, _PyTuple_ITEMS(args)+1,
+    PyObject *res = PyObject_VectorcallDict(bound, _PyTuple_ITEMS(args)+1,
                                            argc-1, kwds);
     Py_DECREF(bound);
     return res;
@@ -673,7 +673,7 @@ PyTypeObject PyMethodDescr_Type = {
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-    _Py_TPFLAGS_HAVE_VECTORCALL |
+    Py_TPFLAGS_HAVE_VECTORCALL |
     Py_TPFLAGS_METHOD_DESCRIPTOR,               /* tp_flags */
     0,                                          /* tp_doc */
     descr_traverse,                             /* tp_traverse */
@@ -1493,7 +1493,7 @@ property_descr_get(PyObject *self, PyObject *obj, PyObject *type)
         return NULL;
     }
 
-    return _PyObject_CallOneArg(gs->prop_get, obj);
+    return PyObject_CallOneArg(gs->prop_get, obj);
 }
 
 static int
@@ -1514,7 +1514,7 @@ property_descr_set(PyObject *self, PyObject *obj, PyObject *value)
         return -1;
     }
     if (value == NULL)
-        res = _PyObject_CallOneArg(func, obj);
+        res = PyObject_CallOneArg(func, obj);
     else
         res = PyObject_CallFunctionObjArgs(func, obj, value, NULL);
     if (res == NULL)

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2127,7 +2127,7 @@ dict_subscript(PyDictObject *mp, PyObject *key)
             _Py_IDENTIFIER(__missing__);
             missing = _PyObject_LookupSpecial((PyObject *)mp, &PyId___missing__);
             if (missing != NULL) {
-                res = _PyObject_CallOneArg(missing, key);
+                res = PyObject_CallOneArg(missing, key);
                 Py_DECREF(missing);
                 return res;
             }

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -137,7 +137,7 @@ PyFile_WriteObject(PyObject *v, PyObject *f, int flags)
         Py_DECREF(writer);
         return -1;
     }
-    result = _PyObject_CallOneArg(writer, value);
+    result = PyObject_CallOneArg(writer, value);
     Py_DECREF(value);
     Py_DECREF(writer);
     if (result == NULL)

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1490,7 +1490,7 @@ float_fromhex(PyTypeObject *type, PyObject *string)
         goto parse_error;
     result = PyFloat_FromDouble(negate ? -x : x);
     if (type != &PyFloat_Type && result != NULL) {
-        Py_SETREF(result, _PyObject_CallOneArg((PyObject *)type, result));
+        Py_SETREF(result, PyObject_CallOneArg((PyObject *)type, result));
     }
     return result;
 

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -654,7 +654,7 @@ PyTypeObject PyFunction_Type = {
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-    _Py_TPFLAGS_HAVE_VECTORCALL |
+    Py_TPFLAGS_HAVE_VECTORCALL |
     Py_TPFLAGS_METHOD_DESCRIPTOR,               /* tp_flags */
     func_new__doc__,                            /* tp_doc */
     (traverseproc)func_traverse,                /* tp_traverse */

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -58,7 +58,7 @@ _PyGen_Finalize(PyObject *self)
             /* Save the current exception, if any. */
             PyErr_Fetch(&error_type, &error_value, &error_traceback);
 
-            res = _PyObject_CallOneArg(finalizer, self);
+            res = PyObject_CallOneArg(finalizer, self);
 
             if (res == NULL) {
                 PyErr_WriteUnraisable(self);
@@ -563,7 +563,7 @@ _PyGen_SetStopIterationValue(PyObject *value)
         return 0;
     }
     /* Construct an exception instance manually with
-     * _PyObject_CallOneArg and pass it to PyErr_SetObject.
+     * PyObject_CallOneArg and pass it to PyErr_SetObject.
      *
      * We do this to handle a situation when "value" is a tuple, in which
      * case PyErr_SetObject would set the value of StopIteration to
@@ -571,7 +571,7 @@ _PyGen_SetStopIterationValue(PyObject *value)
      *
      * (See PyErr_SetObject/_PyErr_CreateException code for details.)
      */
-    e = _PyObject_CallOneArg(PyExc_StopIteration, value);
+    e = PyObject_CallOneArg(PyExc_StopIteration, value);
     if (e == NULL) {
         return -1;
     }
@@ -1264,7 +1264,7 @@ async_gen_init_hooks(PyAsyncGenObject *o)
         PyObject *res;
 
         Py_INCREF(firstiter);
-        res = _PyObject_CallOneArg(firstiter, (PyObject *)o);
+        res = PyObject_CallOneArg(firstiter, (PyObject *)o);
         Py_DECREF(firstiter);
         if (res == NULL) {
             return 1;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2226,7 +2226,7 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
         }
 
         for (i = 0; i < saved_ob_size ; i++) {
-            keys[i] = _PyObject_CallOneArg(keyfunc, saved_ob_item[i]);
+            keys[i] = PyObject_CallOneArg(keyfunc, saved_ob_item[i]);
             if (keys[i] == NULL) {
                 for (i=i-1 ; i>=0 ; i--)
                     Py_DECREF(keys[i]);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5547,7 +5547,7 @@ int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
     Py_DECREF(bytes);
 
     if (long_obj != NULL && type != &PyLong_Type) {
-        Py_SETREF(long_obj, _PyObject_CallOneArg((PyObject *)type, long_obj));
+        Py_SETREF(long_obj, PyObject_CallOneArg((PyObject *)type, long_obj));
     }
 
     return long_obj;

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1963,7 +1963,7 @@ struct_get_unpacker(const char *fmt, Py_ssize_t itemsize)
     if (format == NULL)
         goto error;
 
-    structobj = _PyObject_CallOneArg(Struct, format);
+    structobj = PyObject_CallOneArg(Struct, format);
     if (structobj == NULL)
         goto error;
 
@@ -2002,7 +2002,7 @@ struct_unpack_single(const char *ptr, struct unpacker *x)
     PyObject *v;
 
     memcpy(x->item, ptr, x->itemsize);
-    v = _PyObject_CallOneArg(x->unpack_from, x->mview);
+    v = PyObject_CallOneArg(x->unpack_from, x->mview);
     if (v == NULL)
         return NULL;
 

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -298,7 +298,7 @@ PyTypeObject PyCFunction_Type = {
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-    Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
+    Py_TPFLAGS_HAVE_VECTORCALL,                 /* tp_flags */
     0,                                          /* tp_doc */
     (traverseproc)meth_traverse,                /* tp_traverse */
     0,                                          /* tp_clear */

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -298,7 +298,7 @@ PyTypeObject PyCFunction_Type = {
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-    _Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
+    Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
     0,                                          /* tp_doc */
     (traverseproc)meth_traverse,                /* tp_traverse */
     0,                                          /* tp_clear */

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -738,7 +738,7 @@ module_getattro(PyModuleObject *m, PyObject *name)
         _Py_IDENTIFIER(__getattr__);
         getattr = _PyDict_GetItemId(m->md_dict, &PyId___getattr__);
         if (getattr) {
-            return _PyObject_CallOneArg(getattr, name);
+            return PyObject_CallOneArg(getattr, name);
         }
         mod_name = _PyDict_GetItemId(m->md_dict, &PyId___name__);
         if (mod_name && PyUnicode_Check(mod_name)) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3665,7 +3665,7 @@ PyTypeObject PyType_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
     Py_TPFLAGS_BASETYPE | Py_TPFLAGS_TYPE_SUBCLASS |
-    Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
+    Py_TPFLAGS_HAVE_VECTORCALL,                 /* tp_flags */
     type_doc,                                   /* tp_doc */
     (traverseproc)type_traverse,                /* tp_traverse */
     (inquiry)type_clear,                        /* tp_clear */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1465,7 +1465,7 @@ static PyObject*
 call_unbound_noarg(int unbound, PyObject *func, PyObject *self)
 {
     if (unbound) {
-        return _PyObject_CallOneArg(func, self);
+        return PyObject_CallOneArg(func, self);
     }
     else {
         return _PyObject_CallNoArg(func);
@@ -3665,7 +3665,7 @@ PyTypeObject PyType_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
     Py_TPFLAGS_BASETYPE | Py_TPFLAGS_TYPE_SUBCLASS |
-    _Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
+    Py_TPFLAGS_HAVE_VECTORCALL,                /* tp_flags */
     type_doc,                                   /* tp_doc */
     (traverseproc)type_traverse,                /* tp_traverse */
     (inquiry)type_clear,                        /* tp_clear */
@@ -5196,17 +5196,17 @@ inherit_slots(PyTypeObject *type, PyTypeObject *base)
     /* tp_hash see tp_richcompare */
     {
         /* Always inherit tp_vectorcall_offset to support PyVectorcall_Call().
-         * If _Py_TPFLAGS_HAVE_VECTORCALL is not inherited, then vectorcall
+         * If Py_TPFLAGS_HAVE_VECTORCALL is not inherited, then vectorcall
          * won't be used automatically. */
         COPYSLOT(tp_vectorcall_offset);
 
-        /* Inherit _Py_TPFLAGS_HAVE_VECTORCALL for non-heap types
+        /* Inherit Py_TPFLAGS_HAVE_VECTORCALL for non-heap types
         * if tp_call is not overridden */
         if (!type->tp_call &&
-            (base->tp_flags & _Py_TPFLAGS_HAVE_VECTORCALL) &&
+            (base->tp_flags & Py_TPFLAGS_HAVE_VECTORCALL) &&
             !(type->tp_flags & Py_TPFLAGS_HEAPTYPE))
         {
-            type->tp_flags |= _Py_TPFLAGS_HAVE_VECTORCALL;
+            type->tp_flags |= Py_TPFLAGS_HAVE_VECTORCALL;
         }
         COPYSLOT(tp_call);
     }
@@ -5282,14 +5282,14 @@ PyType_Ready(PyTypeObject *type)
 
     /* Consistency checks for PEP 590:
      * - Py_TPFLAGS_METHOD_DESCRIPTOR requires tp_descr_get
-     * - _Py_TPFLAGS_HAVE_VECTORCALL requires tp_call and
+     * - Py_TPFLAGS_HAVE_VECTORCALL requires tp_call and
      *   tp_vectorcall_offset > 0
      * To avoid mistakes, we require this before inheriting.
      */
     if (type->tp_flags & Py_TPFLAGS_METHOD_DESCRIPTOR) {
         _PyObject_ASSERT((PyObject *)type, type->tp_descr_get != NULL);
     }
-    if (type->tp_flags & _Py_TPFLAGS_HAVE_VECTORCALL) {
+    if (type->tp_flags & Py_TPFLAGS_HAVE_VECTORCALL) {
         _PyObject_ASSERT((PyObject *)type, type->tp_vectorcall_offset > 0);
         _PyObject_ASSERT((PyObject *)type, type->tp_call != NULL);
     }
@@ -6614,7 +6614,7 @@ call_attribute(PyObject *self, PyObject *attr, PyObject *name)
         else
             attr = descr;
     }
-    res = _PyObject_CallOneArg(attr, name);
+    res = PyObject_CallOneArg(attr, name);
     Py_XDECREF(descr);
     return res;
 }
@@ -7575,7 +7575,7 @@ init_subclass(PyTypeObject *type, PyObject *kwds)
     }
 
 
-    result = _PyObject_FastCallDict(func, NULL, 0, kwds);
+    result = PyObject_VectorcallDict(func, NULL, 0, kwds);
     Py_DECREF(func);
     if (result == NULL) {
         return -1;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -4250,7 +4250,7 @@ unicode_decode_call_errorhandler_wchar(
     if (*exceptionObject == NULL)
         goto onError;
 
-    restuple = _PyObject_CallOneArg(*errorHandler, *exceptionObject);
+    restuple = PyObject_CallOneArg(*errorHandler, *exceptionObject);
     if (restuple == NULL)
         goto onError;
     if (!PyTuple_Check(restuple)) {
@@ -4354,7 +4354,7 @@ unicode_decode_call_errorhandler_writer(
     if (*exceptionObject == NULL)
         goto onError;
 
-    restuple = _PyObject_CallOneArg(*errorHandler, *exceptionObject);
+    restuple = PyObject_CallOneArg(*errorHandler, *exceptionObject);
     if (restuple == NULL)
         goto onError;
     if (!PyTuple_Check(restuple)) {
@@ -6801,7 +6801,7 @@ unicode_encode_call_errorhandler(const char *errors,
     if (*exceptionObject == NULL)
         return NULL;
 
-    restuple = _PyObject_CallOneArg(*errorHandler, *exceptionObject);
+    restuple = PyObject_CallOneArg(*errorHandler, *exceptionObject);
     if (restuple == NULL)
         return NULL;
     if (!PyTuple_Check(restuple)) {
@@ -8783,7 +8783,7 @@ unicode_translate_call_errorhandler(const char *errors,
     if (*exceptionObject == NULL)
         return NULL;
 
-    restuple = _PyObject_CallOneArg(*errorHandler, *exceptionObject);
+    restuple = PyObject_CallOneArg(*errorHandler, *exceptionObject);
     if (restuple == NULL)
         return NULL;
     if (!PyTuple_Check(restuple)) {

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -933,7 +933,7 @@ PyWeakref_GetObject(PyObject *ref)
 static void
 handle_callback(PyWeakReference *ref, PyObject *callback)
 {
-    PyObject *cbresult = _PyObject_CallOneArg(callback, (PyObject *)ref);
+    PyObject *cbresult = PyObject_CallOneArg(callback, (PyObject *)ref);
 
     if (cbresult == NULL)
         PyErr_WriteUnraisable(callback);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -593,7 +593,7 @@ call_show_warning(PyObject *category, PyObject *text, PyObject *message,
     if (msg == NULL)
         goto error;
 
-    res = _PyObject_CallOneArg(show_fn, msg);
+    res = PyObject_CallOneArg(show_fn, msg);
     Py_DECREF(show_fn);
     Py_DECREF(msg);
 
@@ -654,7 +654,7 @@ warn_explicit(PyObject *category, PyObject *message,
     }
     else {
         text = message;
-        message = _PyObject_CallOneArg(category, message);
+        message = PyObject_CallOneArg(category, message);
         if (message == NULL)
             goto cleanup;
     }
@@ -997,7 +997,7 @@ get_source_line(PyObject *module_globals, int lineno)
         return NULL;
     }
     /* Call get_source() to get the source code. */
-    source = _PyObject_CallOneArg(get_source, module_name);
+    source = PyObject_CallOneArg(get_source, module_name);
     Py_DECREF(get_source);
     Py_DECREF(module_name);
     if (!source) {
@@ -1284,7 +1284,7 @@ _PyErr_WarnUnawaitedCoroutine(PyObject *coro)
     int warned = 0;
     PyObject *fn = get_warnings_attr(&PyId__warn_unawaited_coroutine, 1);
     if (fn) {
-        PyObject *res = _PyObject_CallOneArg(fn, coro);
+        PyObject *res = PyObject_CallOneArg(fn, coro);
         Py_DECREF(fn);
         if (res || PyErr_ExceptionMatches(PyExc_RuntimeWarning)) {
             warned = 1;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -56,7 +56,7 @@ update_bases(PyObject *bases, PyObject *const *args, Py_ssize_t nargs)
             }
             continue;
         }
-        new_base = _PyObject_CallOneArg(meth, bases);
+        new_base = PyObject_CallOneArg(meth, bases);
         Py_DECREF(meth);
         if (!new_base) {
             goto error;
@@ -203,7 +203,7 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
     }
     else {
         PyObject *pargs[2] = {name, bases};
-        ns = _PyObject_FastCallDict(prep, pargs, 2, mkw);
+        ns = PyObject_VectorcallDict(prep, pargs, 2, mkw);
         Py_DECREF(prep);
     }
     if (ns == NULL) {
@@ -229,7 +229,7 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
             }
         }
         PyObject *margs[3] = {name, bases, ns};
-        cls = _PyObject_FastCallDict(meta, margs, 3, mkw);
+        cls = PyObject_VectorcallDict(meta, margs, 3, mkw);
         if (cls != NULL && PyType_Check(cls) && PyCell_Check(cell)) {
             PyObject *cell_cls = PyCell_GET(cell);
             if (cell_cls != cls) {
@@ -489,7 +489,7 @@ builtin_breakpoint(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyOb
     }
 
     Py_INCREF(hook);
-    PyObject *retval = _PyObject_Vectorcall(hook, args, nargs, keywords);
+    PyObject *retval = PyObject_Vectorcall(hook, args, nargs, keywords);
     Py_DECREF(hook);
     return retval;
 }
@@ -575,7 +575,7 @@ filter_next(filterobject *lz)
             ok = PyObject_IsTrue(item);
         } else {
             PyObject *good;
-            good = _PyObject_CallOneArg(lz->func, item);
+            good = PyObject_CallOneArg(lz->func, item);
             if (good == NULL) {
                 Py_DECREF(item);
                 return NULL;
@@ -1631,7 +1631,7 @@ min_max(PyObject *args, PyObject *kwds, int op)
     while (( item = PyIter_Next(it) )) {
         /* get the value from the key function */
         if (keyfunc != NULL) {
-            val = _PyObject_CallOneArg(keyfunc, item);
+            val = PyObject_CallOneArg(keyfunc, item);
             if (val == NULL)
                 goto Fail_it_item;
         }
@@ -2178,7 +2178,7 @@ builtin_round_impl(PyObject *module, PyObject *number, PyObject *ndigits)
     if (ndigits == Py_None)
         result = _PyObject_CallNoArg(round);
     else
-        result = _PyObject_CallOneArg(round, ndigits);
+        result = PyObject_CallOneArg(round, ndigits);
     Py_DECREF(round);
     return result;
 }
@@ -2234,7 +2234,7 @@ builtin_sorted(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject
     }
 
     assert(nargs >= 1);
-    v = _PyObject_Vectorcall(callable, args + 1, nargs - 1, kwnames);
+    v = PyObject_Vectorcall(callable, args + 1, nargs - 1, kwnames);
     Py_DECREF(callable);
     if (v == NULL) {
         Py_DECREF(newlist);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1874,7 +1874,7 @@ main_loop:
                 Py_DECREF(value);
                 goto error;
             }
-            res = _PyObject_CallOneArg(hook, value);
+            res = PyObject_CallOneArg(hook, value);
             Py_DECREF(value);
             if (res == NULL)
                 goto error;
@@ -3271,7 +3271,7 @@ main_loop:
             assert(!PyLong_Check(exc));
             exit_func = PEEK(7);
             PyObject *stack[4] = {NULL, exc, val, tb};
-            res = _PyObject_Vectorcall(exit_func, stack + 1,
+            res = PyObject_Vectorcall(exit_func, stack + 1,
                     3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
             if (res == NULL)
                 goto error;
@@ -4846,7 +4846,7 @@ trace_call_function(PyThreadState *tstate,
 {
     PyObject *x;
     if (PyCFunction_Check(func)) {
-        C_TRACE(x, _PyObject_Vectorcall(func, args, nargs, kwnames));
+        C_TRACE(x, PyObject_Vectorcall(func, args, nargs, kwnames));
         return x;
     }
     else if (Py_TYPE(func) == &PyMethodDescr_Type && nargs > 0) {
@@ -4862,13 +4862,13 @@ trace_call_function(PyThreadState *tstate,
         if (func == NULL) {
             return NULL;
         }
-        C_TRACE(x, _PyObject_Vectorcall(func,
+        C_TRACE(x, PyObject_Vectorcall(func,
                                         args+1, nargs-1,
                                         kwnames));
         Py_DECREF(func);
         return x;
     }
-    return _PyObject_Vectorcall(func, args, nargs | PY_VECTORCALL_ARGUMENTS_OFFSET, kwnames);
+    return PyObject_Vectorcall(func, args, nargs | PY_VECTORCALL_ARGUMENTS_OFFSET, kwnames);
 }
 
 /* Issue #29227: Inline call_function() into _PyEval_EvalFrameDefault()
@@ -4887,7 +4887,7 @@ call_function(PyThreadState *tstate, PyObject ***pp_stack, Py_ssize_t oparg, PyO
         x = trace_call_function(tstate, func, stack, nargs, kwnames);
     }
     else {
-        x = _PyObject_Vectorcall(func, stack, nargs | PY_VECTORCALL_ARGUMENTS_OFFSET, kwnames);
+        x = PyObject_Vectorcall(func, stack, nargs | PY_VECTORCALL_ARGUMENTS_OFFSET, kwnames);
     }
 
     assert((x != NULL) ^ (_PyErr_Occurred(tstate) != NULL));

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -147,7 +147,7 @@ PyObject *_PyCodec_Lookup(const char *encoding)
         func = PyList_GetItem(interp->codec_search_path, i);
         if (func == NULL)
             goto onError;
-        result = _PyObject_CallOneArg(func, v);
+        result = PyObject_CallOneArg(func, v);
         if (result == NULL)
             goto onError;
         if (result == Py_None) {
@@ -317,7 +317,7 @@ PyObject *codec_getstreamcodec(const char *encoding,
     if (errors != NULL)
         streamcodec = PyObject_CallFunction(codeccls, "Os", stream, errors);
     else
-        streamcodec = _PyObject_CallOneArg(codeccls, stream);
+        streamcodec = PyObject_CallOneArg(codeccls, stream);
     Py_DECREF(codecs);
     return streamcodec;
 }

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -93,7 +93,7 @@ _PyErr_CreateException(PyObject *exception, PyObject *value)
         return PyObject_Call(exception, value, NULL);
     }
     else {
-        return _PyObject_CallOneArg(exception, value);
+        return PyObject_CallOneArg(exception, value);
     }
 }
 
@@ -907,7 +907,7 @@ PyErr_SetImportErrorSubclass(PyObject *exception, PyObject *msg,
         goto done;
     }
 
-    error = _PyObject_FastCallDict(exception, &msg, 1, kwargs);
+    error = PyObject_VectorcallDict(exception, &msg, 1, kwargs);
     if (error != NULL) {
         _PyErr_SetObject(tstate, (PyObject *)Py_TYPE(error), error);
         Py_DECREF(error);
@@ -1422,7 +1422,7 @@ _PyErr_WriteUnraisableMsg(const char *err_msg_str, PyObject *obj)
         goto default_hook;
     }
 
-    PyObject *res = _PyObject_CallOneArg(hook, hook_args);
+    PyObject *res = PyObject_CallOneArg(hook, hook_args);
     Py_DECREF(hook_args);
     if (res != NULL) {
         Py_DECREF(res);

--- a/Python/import.c
+++ b/Python/import.c
@@ -1206,7 +1206,7 @@ get_path_importer(PyThreadState *tstate, PyObject *path_importer_cache,
         PyObject *hook = PyList_GetItem(path_hooks, j);
         if (hook == NULL)
             return NULL;
-        importer = _PyObject_CallOneArg(hook, p);
+        importer = PyObject_CallOneArg(hook, p);
         if (importer != NULL)
             break;
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -519,7 +519,7 @@ sys_breakpointhook(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyOb
         return NULL;
     }
     PyMem_RawFree(envar);
-    PyObject *retval = _PyObject_Vectorcall(hook, args, nargs, keywords);
+    PyObject *retval = PyObject_Vectorcall(hook, args, nargs, keywords);
     Py_DECREF(hook);
     return retval;
 


### PR DESCRIPTION
Continuation of https://github.com/python/cpython/pull/17893

The [NEWS entry](https://github.com/python/cpython/blob/master/Misc/NEWS.d/next/C%20API/2020-01-07-13-46-40.[bpo-39245](https://bugs.python.org/issue39245).G7wog6.rst) was added there.

<!-- issue-number: [bpo-39245](https://bugs.python.org/issue39245) -->
https://bugs.python.org/issue39245
<!-- /issue-number -->
