### PR TITLE
bpo-37207: Use vectorcall for range()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-09-10-54-31.bpo-37207.bLjgLR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-09-10-54-31.bpo-37207.bLjgLR.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``range()`` by about 30%, by using the
+PEP 590 ``vectorcall`` calling convention. Patch by Mark Shannon.

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -72,7 +72,7 @@ make_range_object(PyTypeObject *type, PyObject *start,
    range(0, 5, -1)
 */
 static PyObject *
-range_from_array(PyTypeObject *type, PyObject *const *args, size_t num_args)
+range_from_array(PyTypeObject *type, PyObject *const *args, Py_ssize_t num_args)
 {
     rangeobject *obj;
     PyObject *start = NULL, *stop = NULL, *step = NULL;
@@ -145,7 +145,7 @@ static PyObject *
 range_vectorcall(PyTypeObject *type, PyObject *const *args,
                  size_t nargsf, PyObject *kwnames)
 {
-    size_t nargs = PyVectorcall_NARGS(nargsf);
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
     if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
         PyErr_Format(PyExc_TypeError, "range() takes no keyword arguments");
         return NULL;

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -138,6 +138,66 @@ range_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     return NULL;
 }
 
+
+static PyObject *
+range_vectorcall(PyTypeObject *type, PyObject *const *args,
+                 size_t nargsf, PyObject *kwnames)
+{
+    rangeobject *obj;
+    size_t nargs = PyVectorcall_NARGS(nargsf);
+    PyObject *start = NULL, *stop = NULL, *step = NULL;
+    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
+        PyErr_Format(PyExc_TypeError, "range() takes no keyword arguments");
+        return NULL;
+    }
+    switch(nargs) {
+        case 0:
+            PyErr_Format(PyExc_TypeError, "range() expected 1 arguments, got 0");
+            return NULL;
+        case 1:
+            stop = PyNumber_Index(args[0]);
+            if (!stop)
+                return NULL;
+            Py_INCREF(_PyLong_Zero);
+            start = _PyLong_Zero;
+            Py_INCREF(_PyLong_One);
+            step = _PyLong_One;
+            break;
+        case 3:
+            step = args[2];
+            //Intentional fall through
+        case 2:
+            /* Convert borrowed refs to owned refs */
+            start = PyNumber_Index(args[0]);
+            if (!start)
+                return NULL;
+            stop = PyNumber_Index(args[1]);
+            if (!stop) {
+                Py_DECREF(start);
+                return NULL;
+            }
+            step = validate_step(step);  /* Caution, this can clear exceptions */
+            if (!step) {
+                Py_DECREF(start);
+                Py_DECREF(stop);
+                return NULL;
+            }
+            break;
+        default:
+            PyErr_Format(PyExc_TypeError, "range() expected at most 3 arguments, got %zu", nargs);
+            return NULL;
+    }
+    obj = make_range_object(type, start, stop, step);
+    if (obj != NULL)
+        return (PyObject *) obj;
+
+    /* Failed to create object, release attributes */
+    Py_DECREF(start);
+    Py_DECREF(stop);
+    Py_DECREF(step);
+    return NULL;
+}
+
 PyDoc_STRVAR(range_doc,
 "range(stop) -> range object\n\
 range(start, stop[, step]) -> range object\n\
@@ -719,6 +779,7 @@ PyTypeObject PyRange_Type = {
         0,                      /* tp_init */
         0,                      /* tp_alloc */
         range_new,              /* tp_new */
+        .tp_vectorcall = (vectorcallfunc)range_vectorcall
 };
 
 /*********************** range Iterator **************************/

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -115,7 +115,7 @@ range_from_array(PyTypeObject *type, PyObject *const *args, Py_ssize_t num_args)
             return NULL;
         default:
             PyErr_Format(PyExc_TypeError,
-                         "range expected at most 3 arguments, got %zu",
+                         "range expected at most 3 arguments, got %zd",
                          num_args);
             return NULL;
     }


### PR DESCRIPTION
This continues the `range()` part of #13930. The complete pull request is stalled on discussions around dicts, but `range()` should not be controversial. (And I plan to open PRs for other parts if this is merged.)
On top of Mark's change, I unified `range_new` and `range_vectorcall`, which had a lot of duplicate code.

<!-- issue-number: [bpo-37207](https://bugs.python.org/issue37207) -->
https://bugs.python.org/issue37207
<!-- /issue-number -->


Automerge-Triggered-By: @encukou