### PR TITLE
bpo-39603: Prevent header injection in http methods

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1086,7 +1086,8 @@ class HTTPConnection:
             raise CannotSendRequest(self.__state)
 
         # Save the method for use later in the response phase
-        self._method = method
+        # ASCII helps prevent http header injection
+        self._method = method.encode('ascii')
 
         url = url or '/'
         self._validate_path(url)

--- a/Misc/NEWS.d/next/Security/2020-02-12-14-17-39.bpo-39603.Gt3RSg.rst
+++ b/Misc/NEWS.d/next/Security/2020-02-12-14-17-39.bpo-39603.Gt3RSg.rst
@@ -1,0 +1,2 @@
+Prevent http header injection by encoding method parameter in
+http.client.putrequest(...) to ASCII.


### PR DESCRIPTION
encode control chars in http method in `http.client.putrequest` to ASCII to prevent http header injection.

<!-- issue-number: [bpo-39603](https://bugs.python.org/issue39603) -->
https://bugs.python.org/issue39603
<!-- /issue-number -->
