### PR TITLE
bpo-39615: Make cpython/abstract.h compatible with C90

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -65,15 +65,19 @@ PyVectorcall_NARGS(size_t n)
 static inline vectorcallfunc
 PyVectorcall_Function(PyObject *callable)
 {
+    PyTypeObject *tp;
+    Py_ssize_t offset;
+    vectorcallfunc *ptr;
+
     assert(callable != NULL);
-    PyTypeObject *tp = Py_TYPE(callable);
+    tp = Py_TYPE(callable);
     if (!PyType_HasFeature(tp, Py_TPFLAGS_HAVE_VECTORCALL)) {
         return NULL;
     }
     assert(PyCallable_Check(callable));
-    Py_ssize_t offset = tp->tp_vectorcall_offset;
+    offset = tp->tp_vectorcall_offset;
     assert(offset > 0);
-    vectorcallfunc *ptr = (vectorcallfunc *)(((char *)callable) + offset);
+    ptr = (vectorcallfunc *)(((char *)callable) + offset);
     return *ptr;
 }
 
@@ -100,15 +104,18 @@ _PyObject_VectorcallTstate(PyThreadState *tstate, PyObject *callable,
                            PyObject *const *args, size_t nargsf,
                            PyObject *kwnames)
 {
+    vectorcallfunc func;
+    PyObject *res;
+
     assert(kwnames == NULL || PyTuple_Check(kwnames));
     assert(args != NULL || PyVectorcall_NARGS(nargsf) == 0);
 
-    vectorcallfunc func = PyVectorcall_Function(callable);
+    func = PyVectorcall_Function(callable);
     if (func == NULL) {
         Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
         return _PyObject_MakeTpCall(tstate, callable, args, nargs, kwnames);
     }
-    PyObject *res = func(callable, args, nargsf, kwnames);
+    res = func(callable, args, nargsf, kwnames);
     return _Py_CheckFunctionResult(tstate, callable, res, NULL);
 }
 
@@ -162,12 +169,16 @@ _PyObject_CallNoArg(PyObject *func) {
 static inline PyObject *
 PyObject_CallOneArg(PyObject *func, PyObject *arg)
 {
-    assert(arg != NULL);
     PyObject *_args[2];
-    PyObject **args = _args + 1;  // For PY_VECTORCALL_ARGUMENTS_OFFSET
+    PyObject **args;
+    PyThreadState *tstate;
+    size_t nargsf;
+
+    assert(arg != NULL);
+    args = _args + 1;  // For PY_VECTORCALL_ARGUMENTS_OFFSET
     args[0] = arg;
-    PyThreadState *tstate = PyThreadState_GET();
-    size_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+    tstate = PyThreadState_GET();
+    nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
     return _PyObject_VectorcallTstate(tstate, func, args, nargsf, NULL);
 }
 
@@ -185,8 +196,9 @@ PyObject_CallMethodNoArgs(PyObject *self, PyObject *name)
 static inline PyObject *
 PyObject_CallMethodOneArg(PyObject *self, PyObject *name, PyObject *arg)
 {
-    assert(arg != NULL);
     PyObject *args[2] = {self, arg};
+
+    assert(arg != NULL);
     return PyObject_VectorcallMethod(name, args,
            2 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
 }
@@ -229,8 +241,9 @@ _PyObject_CallMethodIdNoArgs(PyObject *self, _Py_Identifier *name)
 static inline PyObject *
 _PyObject_CallMethodIdOneArg(PyObject *self, _Py_Identifier *name, PyObject *arg)
 {
-    assert(arg != NULL);
     PyObject *args[2] = {self, arg};
+
+    assert(arg != NULL);
     return _PyObject_VectorcallMethodId(name, args,
            2 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
 }


### PR DESCRIPTION
Some inline functions use mixed declarations and code.  These end up
visible in third-party code that includes Python.h, which might not be
using a C99 compiler.  Fix by moving the declarations first, like in
the old days.

<!-- issue-number: [bpo-39615](https://bugs.python.org/issue39615) -->
https://bugs.python.org/issue39615
<!-- /issue-number -->
