### PR TITLE
bpo-39603: Prevent header injection in http methods

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1089,8 +1089,9 @@ class HTTPConnection:
         else:
             raise CannotSendRequest(self.__state)
 
-        # Save the method for use later in the response phase
         self._validate_method(method)
+
+        # Save the method for use later in the response phase
         self._method = method
 
         url = url or '/'

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -147,6 +147,10 @@ _contains_disallowed_url_pchar_re = re.compile('[\x00-\x20\x7f]')
 #  _is_allowed_url_pchars_re = re.compile(r"^[/!$&'()*+,;=:@%a-zA-Z0-9._~-]+$")
 # We are more lenient for assumed real world compatibility purposes.
 
+# These characters are not allowed within HTTP method names
+# to prevent http header injection.
+_contains_disallowed_method_pchar_re = re.compile('[\x00-\x1f]')
+
 # We always set the Content-Length header for these methods because some
 # servers will otherwise respond with a 411
 _METHODS_EXPECTING_BODY = {'PATCH', 'POST', 'PUT'}
@@ -1086,6 +1090,7 @@ class HTTPConnection:
             raise CannotSendRequest(self.__state)
 
         # Save the method for use later in the response phase
+        self._validate_method(method)
         self._method = method
 
         url = url or '/'
@@ -1174,6 +1179,15 @@ class HTTPConnection:
     def _encode_request(self, request):
         # ASCII also helps prevent CVE-2019-9740.
         return request.encode('ascii')
+
+    def _validate_method(self, method):
+        """Validate a method name for putrequest."""
+        # prevent http header injection
+        match = _contains_disallowed_method_pchar_re.search(method)
+        if match:
+            raise ValueError(
+                    f"method can't contain control characters. {method!r} "
+                    f"(found at least {match.group()!r})")
 
     def _validate_path(self, url):
         """Validate a url for putrequest."""

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -364,6 +364,28 @@ class HeaderTests(TestCase):
         self.assertEqual(lines[3], "header: Second: val2")
 
 
+class HttpMethodTests(TestCase):
+    def test_invalid_method_names(self):
+        methods = (
+            'GET\r',
+            'POST\n',
+            'PUT\n\r',
+            'POST\nValue',
+            'POST\nHOST:abc',
+            'GET\nrHost:abc\n',
+            'POST\rRemainder:\r',
+            'GET\rHOST:\n',
+            '\nPUT'
+        )
+
+        for method in methods:
+            with self.assertRaisesRegex(
+                    ValueError, "method can't contain control characters"):
+                conn = client.HTTPConnection('example.com')
+                conn.sock = FakeSocket(None)
+                conn.request(method=method, url="/")
+
+
 class TransferEncodingTest(TestCase):
     expected_body = b"It's just a flesh wound"
 

--- a/Misc/NEWS.d/next/Security/2020-02-12-14-17-39.bpo-39603.Gt3RSg.rst
+++ b/Misc/NEWS.d/next/Security/2020-02-12-14-17-39.bpo-39603.Gt3RSg.rst
@@ -1,2 +1,2 @@
-Prevent http header injection by encoding method parameter in
-http.client.putrequest(...) to ASCII.
+Prevent http header injection by rejecting control characters in
+http.client.putrequest(...).

--- a/Misc/NEWS.d/next/Security/2020-02-12-14-17-39.bpo-39603.Gt3RSg.rst
+++ b/Misc/NEWS.d/next/Security/2020-02-12-14-17-39.bpo-39603.Gt3RSg.rst
@@ -1,0 +1,2 @@
+Prevent http header injection by encoding method parameter in
+http.client.putrequest(...) to ASCII.


### PR DESCRIPTION
reject control chars in http method in http.client.putrequest to prevent http header injection

<!-- issue-number: [bpo-39603](https://bugs.python.org/issue39603) -->
https://bugs.python.org/issue39603
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum