### PR TITLE
bpo-24916: Change the way to get the python version.

### DIFF
--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -280,7 +280,10 @@ class install(Command):
         # $platbase in the other installation directories and not worry
         # about needing recursive variable expansion (shudder).
 
-        py_version = sys.version.split()[0]
+        py_version = '{major}.{minor}.{micro}'.format(
+            major=sys.version_info.major, minor=sys.version_info.minor,
+            micro=sys.version_info.micro)
+
         (prefix, exec_prefix) = get_config_vars('prefix', 'exec_prefix')
         try:
             abiflags = sys.abiflags

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -83,10 +83,9 @@ _INSTALL_SCHEMES = {
 
 _SCHEME_KEYS = ('stdlib', 'platstdlib', 'purelib', 'platlib', 'include',
                 'scripts', 'data')
-
- # FIXME don't rely on sys.version here, its format is an implementation detail
- # of CPython, use sys.version_info or sys.hexversion
-_PY_VERSION = sys.version.split()[0]
+_PY_VERSION = '{major}.{minor}.{micro}'.format(
+    major=sys.version_info.major, minor=sys.version_info.minor,
+    micro=sys.version_info.micro)
 _PY_VERSION_SHORT = '%d.%d' % sys.version_info[:2]
 _PY_VERSION_SHORT_NO_DOT = '%d%d' % sys.version_info[:2]
 _PREFIX = os.path.normpath(sys.prefix)


### PR DESCRIPTION
Use sys.version_info instead sys.version to get the python version.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-24916](https://bugs.python.org/issue24916) -->
https://bugs.python.org/issue24916
<!-- /issue-number -->
