### PR TITLE
bpo-39619 Fix os.chroot on HP-UX 11.31

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-13-07-35-00.bpo-39619.inb_master_chroot.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-13-07-35-00.bpo-39619.inb_master_chroot.rst
@@ -1,0 +1,1 @@
+Enable use of `os.chroot()` on HP-UX systems.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-13-07-35-00.bpo-39619.inb_master_chroot.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-13-07-35-00.bpo-39619.inb_master_chroot.rst
@@ -1,1 +1,1 @@
-Enable use of `os.chroot()` on HP-UX systems.
+Enable use of :func:`os.chroot` on HP-UX systems.

--- a/configure
+++ b/configure
@@ -782,6 +782,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -895,6 +896,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1147,6 +1149,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1284,7 +1295,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1437,6 +1448,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -3424,6 +3436,12 @@ $as_echo "#define _BSD_SOURCE 1" >>confdefs.h
   # On VxWorks, defining _XOPEN_SOURCE causes compile failures
   # in network headers still using system V types.
   VxWorks/*)
+    define_xopen_source=no
+    ;;
+
+  # On HP-UX, defining _XOPEN_SOURCE to 600 or greater hides
+  # chroot() and other functions
+  hp*|HP*)
     define_xopen_source=no
     ;;
 

--- a/configure.ac
+++ b/configure.ac
@@ -533,6 +533,12 @@ case $ac_sys_system/$ac_sys_release in
     define_xopen_source=no
     ;;
 
+  # On HP-UX, defining _XOPEN_SOURCE to 600 or greater hides
+  # chroot() and other functions
+  hp*|HP*)
+    define_xopen_source=no
+    ;;
+
 esac
 
 if test $define_xopen_source = yes


### PR DESCRIPTION
Setting `-D_XOPEN_SOURCE=700` on HP-UX causes system functions such as chroot to be undefined.  This change stops `_XOPEN_SOURCE` being set on HP-UX


<!-- issue-number: [bpo-39619](https://bugs.python.org/issue39619) -->
https://bugs.python.org/issue39619
<!-- /issue-number -->
