### PR TITLE
bpo-39621: Make buf arg to md5_compress be const

### DIFF
--- a/Modules/md5module.c
+++ b/Modules/md5module.c
@@ -119,7 +119,7 @@ typedef struct {
     a = (a + I(b,c,d) + M + t); a = ROLc(a, s) + b;
 
 
-static void md5_compress(struct md5_state *md5, unsigned char *buf)
+static void md5_compress(struct md5_state *md5, const unsigned char *buf)
 {
     MD5_INT32 i, W[16], a, b, c, d;
 
@@ -242,7 +242,7 @@ md5_process(struct md5_state *md5, const unsigned char *in, Py_ssize_t inlen)
 
     while (inlen > 0) {
         if (md5->curlen == 0 && inlen >= MD5_BLOCKSIZE) {
-           md5_compress(md5, (unsigned char *)in);
+           md5_compress(md5, in);
            md5->length    += MD5_BLOCKSIZE * 8;
            in             += MD5_BLOCKSIZE;
            inlen          -= MD5_BLOCKSIZE;


### PR DESCRIPTION
The function md5_compress does not modify its buffer argument.

    static void md5_compress(struct md5_state *md5, unsigned char *buf)

buf should be const.

<!-- issue-number: [bpo-39621](https://bugs.python.org/issue39621) -->
https://bugs.python.org/issue39621
<!-- /issue-number -->
