### PR TITLE
bpo-39567: Document audit for os.walk, os.fwalk, Path.glob and Path.rglob.

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3003,6 +3003,8 @@ features:
           for name in dirs:
               os.rmdir(os.path.join(root, name))
 
+   .. audit-event:: os.walk top,topdown,onerror,followlinks os.walk
+
    .. versionchanged:: 3.5
       This function now calls :func:`os.scandir` instead of :func:`os.listdir`,
       making it faster by reducing the number of calls to :func:`os.stat`.
@@ -3061,6 +3063,8 @@ features:
               os.unlink(name, dir_fd=rootfd)
           for name in dirs:
               os.rmdir(name, dir_fd=rootfd)
+
+   .. audit-event:: os.fwalk top,topdown,onerror,follow_symlinks,dir_fd os.fwalk
 
    .. availability:: Unix.
 

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -763,6 +763,8 @@ call fails (for example because the path doesn't exist).
       Using the "``**``" pattern in large directory trees may consume
       an inordinate amount of time.
 
+   .. audit-event:: pathlib.Path.glob self,pattern pathlib.Path.glob
+
 
 .. method:: Path.group()
 
@@ -1024,6 +1026,8 @@ call fails (for example because the path doesn't exist).
        PosixPath('pathlib.py'),
        PosixPath('setup.py'),
        PosixPath('test_pathlib.py')]
+
+   .. audit-event:: pathlib.Path.rglob self,pattern pathlib.Path.rglob
 
 
 .. method:: Path.rmdir()


### PR DESCRIPTION


<!-- issue-number: [bpo-39567](https://bugs.python.org/issue39567) -->
https://bugs.python.org/issue39567
<!-- /issue-number -->
