### PR TITLE
[3.8] bpo-39184: Add audit events to functions in `fcntl`, `msvcrt`, `os`, `resource`,  `shutil`, `signal`, `syslog` (GH-18407)

### DIFF
--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -57,6 +57,8 @@ The module defines the following functions:
 
    If the :c:func:`fcntl` fails, an :exc:`OSError` is raised.
 
+   .. audit-event:: fcntl.fcntl fd,cmd,arg fcntl.fcntl
+
 
 .. function:: ioctl(fd, request, arg=0, mutate_flag=True)
 
@@ -106,6 +108,8 @@ The module defines the following functions:
       >>> buf
       array('h', [13341])
 
+   .. audit-event:: fcntl.ioctl fd,request,arg fcntl.ioctl
+
 
 .. function:: flock(fd, operation)
 
@@ -115,6 +119,8 @@ The module defines the following functions:
    using :c:func:`fcntl`.)
 
    If the :c:func:`flock` fails, an :exc:`OSError` exception is raised.
+
+   .. audit-event:: fcntl.flock fd,operation fcntl.flock
 
 
 .. function:: lockf(fd, cmd, len=0, start=0, whence=0)
@@ -148,6 +154,8 @@ The module defines the following functions:
    The default for *start* is 0, which means to start at the beginning of the file.
    The default for *len* is 0 which means to lock to the end of the file.  The
    default for *whence* is also 0.
+
+   .. audit-event:: fcntl.lockf fd,cmd,len,start,whence fcntl.lockf
 
 Examples (all on a SVR4 compliant system)::
 

--- a/Doc/library/msvcrt.rst
+++ b/Doc/library/msvcrt.rst
@@ -42,6 +42,8 @@ File Operations
    regions in a file may be locked at the same time, but may not overlap.  Adjacent
    regions are not merged; they must be unlocked individually.
 
+   .. audit-event:: msvcrt.locking fd,mode,nbytes msvcrt.locking
+
 
 .. data:: LK_LOCK
           LK_RLCK
@@ -77,11 +79,15 @@ File Operations
    and :const:`os.O_TEXT`.  The returned file descriptor may be used as a parameter
    to :func:`os.fdopen` to create a file object.
 
+   .. audit-event:: msvcrt.open_osfhandle handle,flags msvcrt.open_osfhandle
+
 
 .. function:: get_osfhandle(fd)
 
    Return the file handle for the file descriptor *fd*.  Raises :exc:`OSError` if
    *fd* is not recognized.
+
+   .. audit-event:: msvcrt.get_osfhandle fd msvcrt.get_osfhandle
 
 
 .. _msvcrt-console:

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -451,6 +451,8 @@ process and user.
    calls to :func:`putenv` don't update ``os.environ``, so it is actually
    preferable to assign to items of ``os.environ``.
 
+   .. audit-event:: os.putenv key,value os.putenv
+
 
 .. function:: setegid(egid)
 
@@ -643,6 +645,8 @@ process and user.
    calls to :func:`unsetenv` don't update ``os.environ``, so it is actually
    preferable to delete items of ``os.environ``.
 
+   .. audit-event:: os.unsetenv key os.unsetenv
+
    .. availability:: most flavors of Unix.
 
 
@@ -768,6 +772,8 @@ as internal buffering of data.
    docs for :func:`chmod` for possible values of *mode*.  As of Python 3.3, this
    is equivalent to ``os.chmod(fd, mode)``.
 
+   .. audit-event:: os.chmod path,mode,dir_fd os.fchmod
+
    .. availability:: Unix.
 
 
@@ -777,6 +783,8 @@ as internal buffering of data.
    and *gid*.  To leave one of the ids unchanged, set it to -1.  See
    :func:`chown`.  As of Python 3.3, this is equivalent to ``os.chown(fd, uid,
    gid)``.
+
+   .. audit-event:: os.chown path,uid,gid,dir_fd os.fchown
 
    .. availability:: Unix.
 
@@ -884,6 +892,8 @@ as internal buffering of data.
    *cmd* specifies the command to use - one of :data:`F_LOCK`, :data:`F_TLOCK`,
    :data:`F_ULOCK` or :data:`F_TEST`.
    *len* specifies the section of the file to lock.
+
+   .. audit-event:: os.lockf fd,cmd,len os.lockf
 
    .. availability:: Unix.
 
@@ -1602,6 +1612,8 @@ features:
    This function can raise :exc:`OSError` and subclasses such as
    :exc:`FileNotFoundError`, :exc:`PermissionError`, and :exc:`NotADirectoryError`.
 
+   .. audit-event:: os.chdir path os.chdir
+
    .. versionadded:: 3.3
       Added support for specifying *path* as a file descriptor
       on some platforms.
@@ -1629,6 +1641,8 @@ features:
    * :data:`stat.SF_SNAPSHOT`
 
    This function can support :ref:`not following symlinks <follow_symlinks>`.
+
+   .. audit-event:: os.chflags path,flags os.chflags
 
    .. availability:: Unix.
 
@@ -1675,6 +1689,8 @@ features:
       read-only flag with it (via the ``stat.S_IWRITE`` and ``stat.S_IREAD``
       constants or a corresponding integer value).  All other bits are ignored.
 
+   .. audit-event:: os.chmod path,mode,dir_fd os.chmod
+
    .. versionadded:: 3.3
       Added support for specifying *path* as an open file descriptor,
       and the *dir_fd* and *follow_symlinks* arguments.
@@ -1694,6 +1710,8 @@ features:
 
    See :func:`shutil.chown` for a higher-level function that accepts names in
    addition to numeric ids.
+
+   .. audit-event:: os.chown path,uid,gid,dir_fd os.chown
 
    .. availability:: Unix.
 
@@ -1721,6 +1739,8 @@ features:
    descriptor *fd*.  The descriptor must refer to an opened directory, not an
    open file.  As of Python 3.3, this is equivalent to ``os.chdir(fd)``.
 
+   .. audit-event:: os.chdir path os.fchdir
+
    .. availability:: Unix.
 
 
@@ -1745,6 +1765,8 @@ features:
    not follow symbolic links.  As of Python 3.3, this is equivalent to
    ``os.chflags(path, flags, follow_symlinks=False)``.
 
+   .. audit-event:: os.chflags path,flags os.lchflags
+
    .. availability:: Unix.
 
    .. versionchanged:: 3.6
@@ -1758,6 +1780,8 @@ features:
    for possible values of *mode*.  As of Python 3.3, this is equivalent to
    ``os.chmod(path, mode, follow_symlinks=False)``.
 
+   .. audit-event:: os.chmod path,mode,dir_fd os.lchmod
+
    .. availability:: Unix.
 
    .. versionchanged:: 3.6
@@ -1768,6 +1792,8 @@ features:
    Change the owner and group id of *path* to the numeric *uid* and *gid*.  This
    function will not follow symbolic links.  As of Python 3.3, this is equivalent
    to ``os.chown(path, uid, gid, follow_symlinks=False)``.
+
+   .. audit-event:: os.chown path,uid,gid,dir_fd os.lchown
 
    .. availability:: Unix.
 
@@ -1782,6 +1808,8 @@ features:
    This function can support specifying *src_dir_fd* and/or *dst_dir_fd* to
    supply :ref:`paths relative to directory descriptors <dir_fd>`, and :ref:`not
    following symlinks <follow_symlinks>`.
+
+   .. audit-event:: os.link src,dst,src_dir_fd,dst_dir_fd os.link
 
    .. availability:: Unix, Windows.
 
@@ -1885,6 +1913,8 @@ features:
    It is also possible to create temporary directories; see the
    :mod:`tempfile` module's :func:`tempfile.mkdtemp` function.
 
+   .. audit-event:: os.mkdir path,mode,dir_fd os.mkdir
+
    .. versionadded:: 3.3
       The *dir_fd* argument.
 
@@ -1916,6 +1946,8 @@ features:
       include :data:`pardir` (eg. ".." on UNIX systems).
 
    This function handles UNC paths correctly.
+
+   .. audit-event:: os.mkdir path,mode,dir_fd os.makedirs
 
    .. versionadded:: 3.2
       The *exist_ok* parameter.
@@ -2082,6 +2114,8 @@ features:
 
    This function is semantically identical to :func:`unlink`.
 
+   .. audit-event:: os.remove path,dir_fd os.remove
+
    .. versionadded:: 3.3
       The *dir_fd* argument.
 
@@ -2101,6 +2135,8 @@ features:
    the directory ``'foo/bar/baz'``, and then remove ``'foo/bar'`` and ``'foo'`` if
    they are empty. Raises :exc:`OSError` if the leaf directory could not be
    successfully removed.
+
+   .. audit-event:: os.remove path,dir_fd os.removedirs
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
@@ -2127,6 +2163,8 @@ features:
 
    If you want cross-platform overwriting of the destination, use :func:`replace`.
 
+   .. audit-event:: os.rename src,dst,src_dir_fd,dst_dir_fd os.rename
+
    .. versionadded:: 3.3
       The *src_dir_fd* and *dst_dir_fd* arguments.
 
@@ -2146,6 +2184,8 @@ features:
       This function can fail with the new directory structure made if you lack
       permissions needed to remove the leaf directory or file.
 
+   .. audit-event:: os.rename src,dst,src_dir_fd,dst_dir_fd os.renames
+
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object` for *old* and *new*.
 
@@ -2160,6 +2200,8 @@ features:
 
    This function can support specifying *src_dir_fd* and/or *dst_dir_fd* to
    supply :ref:`paths relative to directory descriptors <dir_fd>`.
+
+   .. audit-event:: os.rename src,dst,src_dir_fd,dst_dir_fd os.replace
 
    .. versionadded:: 3.3
 
@@ -2176,6 +2218,8 @@ features:
 
    This function can support :ref:`paths relative to directory descriptors
    <dir_fd>`.
+
+   .. audit-event:: os.rmdir path,dir_fd os.rmdir
 
    .. versionadded:: 3.3
       The *dir_fd* parameter.
@@ -2820,6 +2864,8 @@ features:
       :exc:`OSError` is raised when the function is called by an unprivileged
       user.
 
+   .. audit-event:: os.symlink src,dst,dir_fd os.symlink
+
    .. availability:: Unix, Windows.
 
    .. versionchanged:: 3.2
@@ -2872,6 +2918,8 @@ features:
    traditional Unix name.  Please see the documentation for
    :func:`remove` for further information.
 
+   .. audit-event:: os.remove path,dir_fd os.unlink
+
    .. versionadded:: 3.3
       The *dir_fd* parameter.
 
@@ -2908,6 +2956,8 @@ features:
    This function can support :ref:`specifying a file descriptor <path_fd>`,
    :ref:`paths relative to directory descriptors <dir_fd>` and :ref:`not
    following symlinks <follow_symlinks>`.
+
+   .. audit-event:: os.utime path,times,ns,dir_fd os.utime
 
    .. versionadded:: 3.3
       Added support for specifying *path* as an open file descriptor,
@@ -3134,6 +3184,8 @@ These functions are all available on Linux only.
    This function can support :ref:`specifying a file descriptor <path_fd>` and
    :ref:`not following symlinks <follow_symlinks>`.
 
+   .. audit-event:: os.getxattr path,attribute os.getxattr
+
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object` for *path* and *attribute*.
 
@@ -3148,6 +3200,8 @@ These functions are all available on Linux only.
    This function can support :ref:`specifying a file descriptor <path_fd>` and
    :ref:`not following symlinks <follow_symlinks>`.
 
+   .. audit-event:: os.listxattr path os.listxattr
+
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
 
@@ -3161,6 +3215,8 @@ These functions are all available on Linux only.
 
    This function can support :ref:`specifying a file descriptor <path_fd>` and
    :ref:`not following symlinks <follow_symlinks>`.
+
+   .. audit-event:: os.removexattr path,attribute os.removexattr
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object` for *path* and *attribute*.
@@ -3184,6 +3240,8 @@ These functions are all available on Linux only.
 
       A bug in Linux kernel versions less than 2.6.39 caused the flags argument
       to be ignored on some filesystems.
+
+   .. audit-event:: os.setxattr path,attribute,value,flags os.setxattr
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object` for *path* and *attribute*.
@@ -3246,6 +3304,8 @@ to be ignored.
    See the `Microsoft documentation
    <https://msdn.microsoft.com/44228cf2-6306-466c-8f16-f513cd3ba8b5>`_
    for more information about how DLLs are loaded.
+
+   .. audit-event:: os.add_dll_directory path os.add_dll_directory
 
    .. availability:: Windows.
 
@@ -3479,6 +3539,8 @@ written in Python, such as a mail server's external command delivery program.
    Note that some platforms including FreeBSD <= 6.3 and Cygwin have
    known issues when using ``fork()`` from a thread.
 
+   .. audit-event:: os.fork "" os.fork
+
    .. versionchanged:: 3.8
       Calling ``fork()`` in a subinterpreter is no longer supported
       (:exc:`RuntimeError` is raised).
@@ -3497,6 +3559,8 @@ written in Python, such as a mail server's external command delivery program.
    new child's process id in the parent, and *fd* is the file descriptor of the
    master end of the pseudo-terminal.  For a more portable approach, use the
    :mod:`pty` module.  If an error occurs :exc:`OSError` is raised.
+
+   .. audit-event:: os.forkpty "" os.forkpty
 
    .. versionchanged:: 3.8
       Calling ``forkpty()`` in a subinterpreter is no longer supported
@@ -3524,6 +3588,8 @@ written in Python, such as a mail server's external command delivery program.
 
    See also :func:`signal.pthread_kill`.
 
+   .. audit-event:: os.kill pid,sig os.kill
+
    .. versionadded:: 3.2
       Windows support.
 
@@ -3535,6 +3601,8 @@ written in Python, such as a mail server's external command delivery program.
       single: process; signalling
 
    Send the signal *sig* to the process group *pgid*.
+
+   .. audit-event:: os.killpg pgid,sig os.killpg
 
    .. availability:: Unix.
 

--- a/Doc/library/resource.rst
+++ b/Doc/library/resource.rst
@@ -78,6 +78,9 @@ this module for those platforms.
 
    VxWorks only supports setting :data:`RLIMIT_NOFILE`.
 
+   .. audit-event:: resource.setrlimit resource,limits resource.setrlimit
+
+
 .. function:: prlimit(pid, resource[, limits])
 
    Combines :func:`setrlimit` and :func:`getrlimit` in one function and
@@ -93,6 +96,8 @@ this module for those platforms.
    Raises :exc:`ProcessLookupError` when *pid* can't be found and
    :exc:`PermissionError` when the user doesn't have ``CAP_SYS_RESOURCE`` for
    the process.
+
+   .. audit-event:: resource.prlimit pid,resource,limits resource.prlimit
 
    .. availability:: Linux 2.6.36 or later with glibc 2.13 or later.
 

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -67,6 +67,8 @@ Directory and files operations
    a new symbolic link will be created instead of copying the
    file *src* points to.
 
+   .. audit-event:: shutil.copyfile src,dst shutil.copyfile
+
    .. versionchanged:: 3.3
       :exc:`IOError` used to be raised instead of :exc:`OSError`.
       Added *follow_symlinks* argument.
@@ -100,6 +102,8 @@ Directory and files operations
    platform; please see :func:`copystat` for more information.  If
    :func:`copymode` cannot modify symbolic links on the local platform, and it
    is asked to do so, it will do nothing and return.
+
+   .. audit-event:: shutil.copymode src,dst shutil.copymode
 
    .. versionchanged:: 3.3
       Added *follow_symlinks* argument.
@@ -146,6 +150,8 @@ Directory and files operations
       Please see :data:`os.supports_follow_symlinks`
       for more information.
 
+   .. audit-event:: shutil.copystat src,dst shutil.copystat
+
    .. versionchanged:: 3.3
       Added *follow_symlinks* argument and support for Linux extended attributes.
 
@@ -166,6 +172,10 @@ Directory and files operations
    file's creation and modification times, is not preserved.
    To preserve all file metadata from the original, use
    :func:`~shutil.copy2` instead.
+
+   .. audit-event:: shutil.copyfile src,dst shutil.copy
+
+   .. audit-event:: shutil.copymode src,dst shutil.copy
 
    .. versionchanged:: 3.3
       Added *follow_symlinks* argument.
@@ -193,6 +203,10 @@ Directory and files operations
    :func:`copy2` uses :func:`copystat` to copy the file metadata.
    Please see :func:`copystat` for more information
    about platform support for modifying symbolic link metadata.
+
+   .. audit-event:: shutil.copyfile src,dst shutil.copy2
+
+   .. audit-event:: shutil.copystat src,dst shutil.copy2
 
    .. versionchanged:: 3.3
       Added *follow_symlinks* argument, try to copy extended
@@ -342,6 +356,8 @@ Directory and files operations
    *copy_function* allows the move to succeed when it is not possible to also
    copy the metadata, at the expense of not copying any of the metadata.
 
+   .. audit-event:: shutil.move src,dst shutil.move
+
    .. versionchanged:: 3.3
       Added explicit symlink handling for foreign filesystems, thus adapting
       it to the behavior of GNU's :program:`mv`.
@@ -377,6 +393,8 @@ Directory and files operations
    least one argument is required.
 
    See also :func:`os.chown`, the underlying function.
+
+   .. audit-event:: shutil.chown path,user,group shutil.chown
 
    .. availability:: Unix.
 
@@ -628,6 +646,8 @@ provided.  They rely on the :mod:`zipfile` and :mod:`tarfile` modules.
    will use the archive file name extension and see if an unpacker was
    registered for that extension.  In case none is found,
    a :exc:`ValueError` is raised.
+
+   .. audit-event:: shutil.unpack_archive filename,extract_dir,format shutil.unpack_archive
 
    .. versionchanged:: 3.7
       Accepts a :term:`path-like object` for *filename* and *extract_dir*.

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -264,6 +264,8 @@ The :mod:`signal` module defines the following functions:
    If *signalnum* is 0, then no signal is sent, but error checking is still
    performed; this can be used to check if the target thread is still running.
 
+   .. audit-event:: signal.pthread_kill thread_id,signalnum signal.pthread_kill
+
    .. availability:: Unix.  See the man page :manpage:`pthread_kill(3)` for further
       information.
 

--- a/Doc/library/syslog.rst
+++ b/Doc/library/syslog.rst
@@ -31,6 +31,8 @@ The module defines the following functions:
    If :func:`openlog` has not been called prior to the call to :func:`syslog`,
    ``openlog()`` will be called with no arguments.
 
+   .. audit-event:: syslog.syslog priority,message syslog.syslog
+
 
 .. function:: openlog([ident[, logoption[, facility]]])
 
@@ -44,6 +46,8 @@ The module defines the following functions:
    field -- see below for possible values to combine.  The optional *facility*
    keyword argument (default is :const:`LOG_USER`) sets the default facility for
    messages which do not have a facility explicitly encoded.
+
+   .. audit-event:: syslog.openlog ident,logoption,facility syslog.openlog
 
    .. versionchanged:: 3.2
       In previous versions, keyword arguments were not allowed, and *ident* was
@@ -60,6 +64,8 @@ The module defines the following functions:
    :func:`openlog` hasn't already been called), and *ident* and other
    :func:`openlog` parameters are reset to defaults.
 
+   .. audit-event:: syslog.closelog "" syslog.closelog
+
 
 .. function:: setlogmask(maskpri)
 
@@ -69,6 +75,8 @@ The module defines the following functions:
    calculates the mask for the individual priority *pri*.  The function
    ``LOG_UPTO(pri)`` calculates the mask for all priorities up to and including
    *pri*.
+
+   .. audit-event:: syslog.setlogmask maskpri syslog.setlogmask
 
 The module defines the following constants:
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -235,6 +235,8 @@ def copyfile(src, dst, *, follow_symlinks=True):
     symlink will be created instead of copying the file it points to.
 
     """
+    sys.audit("shutil.copyfile", src, dst)
+
     if _samefile(src, dst):
         raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
 
@@ -289,6 +291,8 @@ def copymode(src, dst, *, follow_symlinks=True):
     (e.g. Linux) this method does nothing.
 
     """
+    sys.audit("shutil.copymode", src, dst)
+
     if not follow_symlinks and _islink(src) and os.path.islink(dst):
         if hasattr(os, 'lchmod'):
             stat_func, chmod_func = os.lstat, os.lchmod
@@ -340,6 +344,8 @@ def copystat(src, dst, *, follow_symlinks=True):
     If the optional flag `follow_symlinks` is not set, symlinks aren't
     followed if and only if both `src` and `dst` are symlinks.
     """
+    sys.audit("shutil.copystat", src, dst)
+
     def _nop(*args, ns=None, follow_symlinks=None):
         pass
 
@@ -766,6 +772,7 @@ def move(src, dst, copy_function=copy2):
     the issues this implementation glosses over.
 
     """
+    sys.audit("shutil.move", src, dst)
     real_dst = dst
     if os.path.isdir(dst):
         if _samefile(src, dst):
@@ -1193,6 +1200,8 @@ def unpack_archive(filename, extract_dir=None, format=None):
 
     In case none is found, a ValueError is raised.
     """
+    sys.audit("shutil.unpack_archive", filename, extract_dir, format)
+
     if extract_dir is None:
         extract_dir = os.getcwd()
 
@@ -1260,6 +1269,7 @@ def chown(path, user=None, group=None):
     user and group can be the uid/gid or the user/group names, and in that case,
     they are converted to their respective uid/gid.
     """
+    sys.audit('shutil.chown', path, user, group)
 
     if user is None and group is None:
         raise ValueError("user and/or group must be set")

--- a/Misc/NEWS.d/next/Security/2020-02-07-23-54-18.bpo-39184.v-ue-v.rst
+++ b/Misc/NEWS.d/next/Security/2020-02-07-23-54-18.bpo-39184.v-ue-v.rst
@@ -1,0 +1,1 @@
+Add audit events to functions in `fcntl`, `msvcrt`, `os`, `resource`, `shutil`, `signal` and `syslog`.

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -66,6 +66,10 @@ fcntl_fcntl_impl(PyObject *module, int fd, int code, PyObject *arg)
     char buf[1024];
     int async_err = 0;
 
+    if (PySys_Audit("fcntl.fcntl", "iiO", fd, code, arg ? arg : Py_None) < 0) {
+        return NULL;
+    }
+
     if (arg != NULL) {
         int parse_result;
 
@@ -170,6 +174,11 @@ fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
     char *str;
     Py_ssize_t len;
     char buf[IOCTL_BUFSZ+1];  /* argument plus NUL byte */
+
+    if (PySys_Audit("fcntl.ioctl", "iIO", fd, code,
+                    ob_arg ? ob_arg : Py_None) < 0) {
+        return NULL;
+    }
 
     if (ob_arg != NULL) {
         if (PyArg_Parse(ob_arg, "w*:ioctl", &pstr)) {
@@ -288,6 +297,10 @@ fcntl_flock_impl(PyObject *module, int fd, int code)
     int ret;
     int async_err = 0;
 
+    if (PySys_Audit("fcntl.flock", "ii", fd, code) < 0) {
+        return NULL;
+    }
+
 #ifdef HAVE_FLOCK
     do {
         Py_BEGIN_ALLOW_THREADS
@@ -371,6 +384,11 @@ fcntl_lockf_impl(PyObject *module, int fd, int code, PyObject *lenobj,
 {
     int ret;
     int async_err = 0;
+
+    if (PySys_Audit("fcntl.lockf", "iiOOi", fd, code, lenobj ? lenobj : Py_None,
+                    startobj ? startobj : Py_None, whence) < 0) {
+        return NULL;
+    }
 
 #ifndef LOCK_SH
 #define LOCK_SH         1       /* shared lock */

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -2827,6 +2827,10 @@ os_chdir_impl(PyObject *module, path_t *path)
 {
     int result;
 
+    if (PySys_Audit("os.chdir", "(O)", path->object) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
 #ifdef MS_WINDOWS
     /* on unix, success = 0, on windows, success = !0 */
@@ -2866,6 +2870,9 @@ static PyObject *
 os_fchdir_impl(PyObject *module, int fd)
 /*[clinic end generated code: output=42e064ec4dc00ab0 input=18e816479a2fa985]*/
 {
+    if (PySys_Audit("os.chdir", "(i)", fd) < 0) {
+        return NULL;
+    }
     return posix_fildes_fd(fd, fchdir);
 }
 #endif /* HAVE_FCHDIR */
@@ -2922,6 +2929,11 @@ os_chmod_impl(PyObject *module, path_t *path, int mode, int dir_fd,
     if (follow_symlinks_specified("chmod", follow_symlinks))
         return NULL;
 #endif
+
+    if (PySys_Audit("os.chmod", "Oii", path->object, mode,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
+        return NULL;
+    }
 
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
@@ -3019,6 +3031,10 @@ os_fchmod_impl(PyObject *module, int fd, int mode)
     int res;
     int async_err = 0;
 
+    if (PySys_Audit("os.chmod", "iii", fd, mode, -1) < 0) {
+        return NULL;
+    }
+
     do {
         Py_BEGIN_ALLOW_THREADS
         res = fchmod(fd, mode);
@@ -3050,6 +3066,9 @@ os_lchmod_impl(PyObject *module, path_t *path, int mode)
 /*[clinic end generated code: output=082344022b51a1d5 input=90c5663c7465d24f]*/
 {
     int res;
+    if (PySys_Audit("os.chmod", "Oii", path->object, mode, -1) < 0) {
+        return NULL;
+    }
     Py_BEGIN_ALLOW_THREADS
     res = lchmod(path->narrow, mode);
     Py_END_ALLOW_THREADS
@@ -3092,6 +3111,10 @@ os_chflags_impl(PyObject *module, path_t *path, unsigned long flags,
         return NULL;
 #endif
 
+    if (PySys_Audit("os.chflags", "Ok", path->object, flags) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
 #ifdef HAVE_LCHFLAGS
     if (!follow_symlinks)
@@ -3127,6 +3150,9 @@ os_lchflags_impl(PyObject *module, path_t *path, unsigned long flags)
 /*[clinic end generated code: output=30ae958695c07316 input=f9f82ea8b585ca9d]*/
 {
     int res;
+    if (PySys_Audit("os.chflags", "Ok", path->object, flags) < 0) {
+        return NULL;
+    }
     Py_BEGIN_ALLOW_THREADS
     res = lchflags(path->narrow, flags);
     Py_END_ALLOW_THREADS
@@ -3289,6 +3315,11 @@ os_chown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid,
     }
 #endif
 
+    if (PySys_Audit("os.chown", "OIIi", path->object, uid, gid,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
 #ifdef HAVE_FCHOWN
     if (path->fd != -1)
@@ -3338,6 +3369,10 @@ os_fchown_impl(PyObject *module, int fd, uid_t uid, gid_t gid)
     int res;
     int async_err = 0;
 
+    if (PySys_Audit("os.chown", "iIIi", fd, uid, gid, -1) < 0) {
+        return NULL;
+    }
+
     do {
         Py_BEGIN_ALLOW_THREADS
         res = fchown(fd, uid, gid);
@@ -3370,6 +3405,9 @@ os_lchown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid)
 /*[clinic end generated code: output=25eaf6af412fdf2f input=b1c6014d563a7161]*/
 {
     int res;
+    if (PySys_Audit("os.chown", "OIIi", path->object, uid, gid, -1) < 0) {
+        return NULL;
+    }
     Py_BEGIN_ALLOW_THREADS
     res = lchown(path->narrow, uid, gid);
     Py_END_ALLOW_THREADS
@@ -3562,6 +3600,12 @@ os_link_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
         return NULL;
     }
 #endif
+
+    if (PySys_Audit("os.link", "OOii", src->object, dst->object,
+                    src_dir_fd == DEFAULT_DIR_FD ? -1 : src_dir_fd,
+                    dst_dir_fd == DEFAULT_DIR_FD ? -1 : dst_dir_fd) < 0) {
+        return NULL;
+    }
 
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
@@ -4034,6 +4078,11 @@ os_mkdir_impl(PyObject *module, path_t *path, int mode, int dir_fd)
 {
     int result;
 
+    if (PySys_Audit("os.mkdir", "Oii", path->object, mode,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
+        return NULL;
+    }
+
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
     result = CreateDirectoryW(path->wide, NULL);
@@ -4179,6 +4228,12 @@ internal_rename(path_t *src, path_t *dst, int src_dir_fd, int dst_dir_fd, int is
     }
 #endif
 
+    if (PySys_Audit("os.rename", "OOii", src->object, dst->object,
+                    src_dir_fd == DEFAULT_DIR_FD ? -1 : src_dir_fd,
+                    dst_dir_fd == DEFAULT_DIR_FD ? -1 : dst_dir_fd) < 0) {
+        return NULL;
+    }
+
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
     result = MoveFileExW(src->wide, dst->wide, flags);
@@ -4278,6 +4333,11 @@ os_rmdir_impl(PyObject *module, path_t *path, int dir_fd)
 /*[clinic end generated code: output=080eb54f506e8301 input=38c8b375ca34a7e2]*/
 {
     int result;
+
+    if (PySys_Audit("os.rmdir", "Oi", path->object,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
+        return NULL;
+    }
 
     Py_BEGIN_ALLOW_THREADS
 #ifdef MS_WINDOWS
@@ -4436,6 +4496,11 @@ os_unlink_impl(PyObject *module, path_t *path, int dir_fd)
 /*[clinic end generated code: output=621797807b9963b1 input=d7bcde2b1b2a2552]*/
 {
     int result;
+
+    if (PySys_Audit("os.remove", "Oi", path->object,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
+        return NULL;
+    }
 
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
@@ -4855,6 +4920,11 @@ os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
     }
 #endif
 
+    if (PySys_Audit("os.utime", "OOOi", path->object, times, ns ? ns : Py_None,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
+        return NULL;
+    }
+
 #ifdef MS_WINDOWS
     Py_BEGIN_ALLOW_THREADS
     hFile = CreateFileW(path->wide, FILE_WRITE_ATTRIBUTES, 0,
@@ -5156,8 +5226,7 @@ os_execv_impl(PyObject *module, path_t *path, PyObject *argv)
         return NULL;
     }
 
-    if (PySys_Audit("os.exec", "OOO", path->object ? path->object : Py_None,
-                    argv, Py_None) < 0) {
+    if (PySys_Audit("os.exec", "OOO", path->object, argv, Py_None) < 0) {
         free_string_array(argvlist, argc);
         return NULL;
     }
@@ -5233,8 +5302,7 @@ os_execve_impl(PyObject *module, path_t *path, PyObject *argv, PyObject *env)
     if (envlist == NULL)
         goto fail_0;
 
-    if (PySys_Audit("os.exec", "OOO", path->object ? path->object : Py_None,
-                    argv, env) < 0) {
+    if (PySys_Audit("os.exec", "OOO", path->object, argv, env) < 0) {
         goto fail_1;
     }
 
@@ -5587,8 +5655,7 @@ py_posix_spawn(int use_posix_spawnp, PyObject *module, path_t *path, PyObject *a
     }
     attrp = &attr;
 
-    if (PySys_Audit("os.posix_spawn", "OOO",
-                    path->object ? path->object : Py_None, argv, env) < 0) {
+    if (PySys_Audit("os.posix_spawn", "OOO", path->object, argv, env) < 0) {
         goto exit;
     }
 
@@ -5832,8 +5899,7 @@ os_spawnv_impl(PyObject *module, int mode, path_t *path, PyObject *argv)
         mode = _P_OVERLAY;
 #endif
 
-    if (PySys_Audit("os.spawn", "iOOO", mode,
-                    path->object ? path->object : Py_None, argv,
+    if (PySys_Audit("os.spawn", "iOOO", mode, path->object, argv,
                     Py_None) < 0) {
         free_string_array(argvlist, argc);
         return NULL;
@@ -5948,8 +6014,7 @@ os_spawnve_impl(PyObject *module, int mode, path_t *path, PyObject *argv,
         mode = _P_OVERLAY;
 #endif
 
-    if (PySys_Audit("os.spawn", "iOOO", mode,
-                    path->object ? path->object : Py_None, argv, env) < 0) {
+    if (PySys_Audit("os.spawn", "iOOO", mode, path->object, argv, env) < 0) {
         goto fail_2;
     }
 
@@ -6102,6 +6167,9 @@ os_fork_impl(PyObject *module)
 
     if (_PyInterpreterState_Get() != PyInterpreterState_Main()) {
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
+        return NULL;
+    }
+    if (PySys_Audit("os.fork", NULL) < 0) {
         return NULL;
     }
     PyOS_BeforeFork();
@@ -6709,6 +6777,9 @@ os_forkpty_impl(PyObject *module)
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }
+    if (PySys_Audit("os.forkpty", NULL) < 0) {
+        return NULL;
+    }
     PyOS_BeforeFork();
     pid = forkpty(&master_fd, NULL, NULL, NULL);
     if (pid == 0) {
@@ -7230,14 +7301,15 @@ Kill a process with a signal.
 static PyObject *
 os_kill_impl(PyObject *module, pid_t pid, Py_ssize_t signal)
 /*[clinic end generated code: output=8e346a6701c88568 input=61a36b86ca275ab9]*/
-#ifndef MS_WINDOWS
 {
+    if (PySys_Audit("os.kill", "in", pid, signal) < 0) {
+        return NULL;
+    }
+#ifndef MS_WINDOWS
     if (kill(pid, (int)signal) == -1)
         return posix_error();
     Py_RETURN_NONE;
-}
 #else /* !MS_WINDOWS */
-{
     PyObject *result;
     DWORD sig = (DWORD)signal;
     DWORD err;
@@ -7272,8 +7344,8 @@ os_kill_impl(PyObject *module, pid_t pid, Py_ssize_t signal)
 
     CloseHandle(handle);
     return result;
-}
 #endif /* !MS_WINDOWS */
+}
 #endif /* HAVE_KILL */
 
 
@@ -7292,6 +7364,9 @@ static PyObject *
 os_killpg_impl(PyObject *module, pid_t pgid, int signal)
 /*[clinic end generated code: output=6dbcd2f1fdf5fdba input=38b5449eb8faec19]*/
 {
+    if (PySys_Audit("os.killpg", "ii", pgid, signal) < 0) {
+        return NULL;
+    }
     /* XXX some man pages make the `pgid` parameter an int, others
        a pid_t. Since getpgrp() returns a pid_t, we assume killpg should
        take the same type. Moreover, pid_t is always at least as wide as
@@ -8035,6 +8110,11 @@ os_symlink_impl(PyObject *module, path_t *src, path_t *dst,
     int result;
 #endif
 
+    if (PySys_Audit("os.symlink", "OOi", src->object, dst->object,
+                    dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
+        return NULL;
+    }
+
 #ifdef MS_WINDOWS
 
     if (windows_has_symlink_unprivileged_flag) {
@@ -8637,6 +8717,10 @@ os_lockf_impl(PyObject *module, int fd, int command, Py_off_t length)
 /*[clinic end generated code: output=af7051f3e7c29651 input=65da41d2106e9b79]*/
 {
     int res;
+
+    if (PySys_Audit("os.lockf", "iiL", fd, command, length) < 0) {
+        return NULL;
+    }
 
     Py_BEGIN_ALLOW_THREADS
     res = lockf(fd, command, length);
@@ -10070,6 +10154,9 @@ os_putenv_impl(PyObject *module, PyObject *name, PyObject *value)
         PyErr_SetString(PyExc_ValueError, "illegal environment variable name");
         return NULL;
     }
+    if (PySys_Audit("os.putenv", "OO", name, value) < 0) {
+        return NULL;
+    }
     bytes = PyBytes_FromFormat("%s=%s", name_string, value_string);
     if (bytes == NULL) {
         return NULL;
@@ -10104,6 +10191,10 @@ os_unsetenv_impl(PyObject *module, PyObject *name)
 #ifndef HAVE_BROKEN_UNSETENV
     int err;
 #endif
+
+    if (PySys_Audit("os.unsetenv", "(O)", name) < 0) {
+        return NULL;
+    }
 
 #ifdef HAVE_BROKEN_UNSETENV
     unsetenv(PyBytes_AS_STRING(name));
@@ -11637,9 +11728,7 @@ os_startfile_impl(PyObject *module, path_t *filepath,
             "startfile not available on this platform");
     }
 
-    if (PySys_Audit("os.startfile", "Ou",
-                    filepath->object ? filepath->object : Py_None,
-                    operation) < 0) {
+    if (PySys_Audit("os.startfile", "Ou", filepath->object, operation) < 0) {
         return NULL;
     }
 
@@ -11817,6 +11906,10 @@ os_getxattr_impl(PyObject *module, path_t *path, path_t *attribute,
     if (fd_and_follow_symlinks_invalid("getxattr", path->fd, follow_symlinks))
         return NULL;
 
+    if (PySys_Audit("os.getxattr", "OO", path->object, attribute->object) < 0) {
+        return NULL;
+    }
+
     for (i = 0; ; i++) {
         void *ptr;
         ssize_t result;
@@ -11888,6 +11981,11 @@ os_setxattr_impl(PyObject *module, path_t *path, path_t *attribute,
     if (fd_and_follow_symlinks_invalid("setxattr", path->fd, follow_symlinks))
         return NULL;
 
+    if (PySys_Audit("os.setxattr", "OOy#i", path->object, attribute->object,
+                    value->buf, value->len, flags) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS;
     if (path->fd > -1)
         result = fsetxattr(path->fd, attribute->narrow,
@@ -11936,6 +12034,10 @@ os_removexattr_impl(PyObject *module, path_t *path, path_t *attribute,
     if (fd_and_follow_symlinks_invalid("removexattr", path->fd, follow_symlinks))
         return NULL;
 
+    if (PySys_Audit("os.removexattr", "OO", path->object, attribute->object) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS;
     if (path->fd > -1)
         result = fremovexattr(path->fd, attribute->narrow);
@@ -11980,6 +12082,11 @@ os_listxattr_impl(PyObject *module, path_t *path, int follow_symlinks)
 
     if (fd_and_follow_symlinks_invalid("listxattr", path->fd, follow_symlinks))
         goto exit;
+
+    if (PySys_Audit("os.listxattr", "(O)",
+                    path->object ? path->object : Py_None) < 0) {
+        return NULL;
+    }
 
     name = path->narrow ? path->narrow : ".";
 
@@ -13493,6 +13600,10 @@ os__add_dll_directory_impl(PyObject *module, path_t *path)
     PAddDllDirectory AddDllDirectory;
     DLL_DIRECTORY_COOKIE cookie = 0;
     DWORD err = 0;
+
+    if (PySys_Audit("os.add_dll_directory", "(O)", path->object) < 0) {
+        return NULL;
+    }
 
     /* For Windows 7, we have to load this. As this will be a fairly
        infrequent operation, just do it each time. Kernel32 is always

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -224,6 +224,11 @@ resource_setrlimit_impl(PyObject *module, int resource, PyObject *limits)
         return NULL;
     }
 
+    if (PySys_Audit("resource.setrlimit", "iO", resource,
+                    limits ? limits : Py_None) < 0) {
+        return NULL;
+    }
+
     if (py2rlimit(limits, &rl) < 0) {
         return NULL;
     }
@@ -266,6 +271,11 @@ resource_prlimit_impl(PyObject *module, pid_t pid, int resource,
     if (resource < 0 || resource >= RLIM_NLIMITS) {
         PyErr_SetString(PyExc_ValueError,
                         "invalid resource specified");
+        return NULL;
+    }
+
+    if (PySys_Audit("resource.prlimit", "iiO", pid, resource,
+                    limits ? limits : Py_None) < 0) {
         return NULL;
     }
 

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1233,6 +1233,10 @@ signal_pthread_kill_impl(PyObject *module, unsigned long thread_id,
 {
     int err;
 
+    if (PySys_Audit("signal.pthread_kill", "ki", thread_id, signalnum) < 0) {
+        return NULL;
+    }
+
     err = pthread_kill((pthread_t)thread_id, signalnum);
     if (err != 0) {
         errno = err;

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -144,6 +144,10 @@ syslog_openlog(PyObject * self, PyObject * args, PyObject *kwds)
             return NULL;
     }
 
+    if (PySys_Audit("syslog.openlog", "sll", ident, logopt, facility) < 0) {
+        return NULL;
+    }
+
     openlog(ident, logopt, facility);
     S_log_open = 1;
 
@@ -170,6 +174,10 @@ syslog_syslog(PyObject * self, PyObject * args)
     if (message == NULL)
         return NULL;
 
+    if (PySys_Audit("syslog.syslog", "is", priority, message) < 0) {
+        return NULL;
+    }
+
     /*  if log is not opened, open it now  */
     if (!S_log_open) {
         PyObject *openargs;
@@ -194,6 +202,9 @@ syslog_syslog(PyObject * self, PyObject * args)
 static PyObject *
 syslog_closelog(PyObject *self, PyObject *unused)
 {
+    if (PySys_Audit("syslog.closelog", NULL) < 0) {
+        return NULL;
+    }
     if (S_log_open) {
         closelog();
         Py_CLEAR(S_ident_o);
@@ -209,6 +220,9 @@ syslog_setlogmask(PyObject *self, PyObject *args)
 
     if (!PyArg_ParseTuple(args, "l;mask for priority", &maskpri))
         return NULL;
+    if (PySys_Audit("syslog.setlogmask", "(O)", args ? args : Py_None) < 0) {
+        return NULL;
+    }
     omaskpri = setlogmask(maskpri);
     return PyLong_FromLong(omaskpri);
 }

--- a/PC/msvcrtmodule.c
+++ b/PC/msvcrtmodule.c
@@ -116,6 +116,10 @@ msvcrt_locking_impl(PyObject *module, int fd, int mode, long nbytes)
 {
     int err;
 
+    if (PySys_Audit("msvcrt.locking", "iil", fd, mode, nbytes) < 0) {
+        return NULL;
+    }
+
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
     err = _locking(fd, mode, nbytes);
@@ -175,6 +179,10 @@ msvcrt_open_osfhandle_impl(PyObject *module, void *handle, int flags)
 {
     int fd;
 
+    if (PySys_Audit("msvcrt.open_osfhandle", "Ki", handle, flags) < 0) {
+        return NULL;
+    }
+
     _Py_BEGIN_SUPPRESS_IPH
     fd = _open_osfhandle((intptr_t)handle, flags);
     _Py_END_SUPPRESS_IPH
@@ -200,6 +208,10 @@ msvcrt_get_osfhandle_impl(PyObject *module, int fd)
 /*[clinic end generated code: output=aca01dfe24637374 input=5fcfde9b17136aa2]*/
 {
     intptr_t handle = -1;
+
+    if (PySys_Audit("msvcrt.get_osfhandle", "(i)", fd) < 0) {
+        return NULL;
+    }
 
     _Py_BEGIN_SUPPRESS_IPH
     handle = _get_osfhandle(fd);


### PR DESCRIPTION


<!-- issue-number: [bpo-39184](https://bugs.python.org/issue39184) -->
https://bugs.python.org/issue39184
<!-- /issue-number -->
