### PR TITLE
bpo-39630: Update pointers to string literals to be const char *

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -475,7 +475,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno, void *Py_UNUSED(ignore
         if (new_stack.depth > current_stack.depth ||
             top_block(&new_stack)->start_line != current_block_at_new_depth->start_line) {
             unsigned char target_kind = top_block(&new_stack)->kind;
-            char *msg;
+            const char *msg;
             if (target_kind == POP_EXCEPT) {
                 msg = "can't jump into an 'except' block as there's no exception";
             }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -12,10 +12,10 @@ static PyObject *gen_close(PyGenObject *, PyObject *);
 static PyObject *async_gen_asend_new(PyAsyncGenObject *, PyObject *);
 static PyObject *async_gen_athrow_new(PyAsyncGenObject *, PyObject *);
 
-static char *NON_INIT_CORO_MSG = "can't send non-None value to a "
+static const char *NON_INIT_CORO_MSG = "can't send non-None value to a "
                                  "just-started coroutine";
 
-static char *ASYNC_GEN_IGNORED_EXIT_MSG =
+static const char *ASYNC_GEN_IGNORED_EXIT_MSG =
                                  "async generator ignored GeneratorExit";
 
 static inline int

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1407,7 +1407,7 @@ static PyObject *surrogateescape_errors(PyObject *self, PyObject *exc)
 static int _PyCodecRegistry_Init(void)
 {
     static struct {
-        char *name;
+        const char *name;
         PyMethodDef def;
     } methods[] =
     {

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -614,7 +614,7 @@ PyErr_SetFromErrnoWithFilenameObjects(PyObject *exc, PyObject *filenameObject, P
 
 #ifndef MS_WINDOWS
     if (i != 0) {
-        char *s = strerror(i);
+        const char *s = strerror(i);
         message = PyUnicode_DecodeLocale(s, "surrogateescape");
     }
     else {


### PR DESCRIPTION
Here are some fixes of char * pointers to literals that should be const char * in these four files.

+++ Objects/frameobject.c
+++ Objects/genobject.c
+++ Python/codecs.c
+++ Python/errors.c

<!-- issue-number: [bpo-39630](https://bugs.python.org/issue39630) -->
https://bugs.python.org/issue39630
<!-- /issue-number -->
