### PR TITLE
bpo-39640: os.fdatasync: fall back to fsync() on POSIX systems withou…

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -801,7 +801,7 @@ as internal buffering of data.
    .. availability:: Unix.
 
    .. note::
-      This function is not available on MacOS.
+      This function falls back to fsync() on MacOS.
 
 
 .. function:: fpathconf(fd, name)

--- a/Misc/NEWS.d/next/macOS/2020-02-15-19-30-41.bpo-39640.wmbK5T.rst
+++ b/Misc/NEWS.d/next/macOS/2020-02-15-19-30-41.bpo-39640.wmbK5T.rst
@@ -1,0 +1,1 @@
+Fall back fdatasync() to fsync() on POSIX systems if not supported (MacOS-specific).

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -798,6 +798,44 @@ exit:
 
 #endif /* defined(HAVE_FDATASYNC) */
 
+#if (defined(HAVE_FSYNC) && !defined(HAVE_FDATASYNC))
+
+PyDoc_STRVAR(os_fdatasync__doc__,
+"fdatasync($module, /, fd)\n"
+"--\n"
+"\n"
+"Force write of fd to disk (fall back to fsync due to OS restrictions).");
+
+#define OS_FDATASYNC_METHODDEF    \
+    {"fdatasync", (PyCFunction)(void(*)(void))os_fdatasync, METH_FASTCALL|METH_KEYWORDS, os_fdatasync__doc__},
+
+static PyObject *
+os_fdatasync_impl(PyObject *module, int fd);
+
+static PyObject *
+os_fdatasync(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"fd", NULL};
+    static _PyArg_Parser _parser = {NULL, _keywords, "fdatasync", 0};
+    PyObject *argsbuf[1];
+    int fd;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 1, 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    if (!fildes_converter(args[0], &fd)) {
+        goto exit;
+    }
+    return_value = os_fdatasync_impl(module, fd);
+
+exit:
+    return return_value;
+}
+
+#endif /* (defined(HAVE_FSYNC) && !defined(HAVE_FDATASYNC)) */
+
 #if defined(HAVE_CHOWN)
 
 PyDoc_STRVAR(os_chown__doc__,
@@ -8919,4 +8957,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=a0fbdea47249ee0c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d67025b82d89a5a1 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3390,6 +3390,25 @@ os_fdatasync_impl(PyObject *module, int fd)
 }
 #endif /* HAVE_FDATASYNC */
 
+#if defined(HAVE_FSYNC) && !defined(HAVE_FDATASYNC)
+
+/*[clinic input]
+os.fdatasync
+
+    fd: fildes
+
+Force write of fd to disk (fall back to fsync due to OS restrictions).
+[clinic start generated code]*/
+
+static PyObject *
+os_fdatasync_impl(PyObject *module, int fd)
+/*[clinic end generated code: output=b4b9698b5d7e26dd input=da69dbf8705ef4d0]*/
+{
+    return posix_fildes_fd(fd, fsync);
+}
+
+#endif /* defined(HAVE_FSYNC) and not defined(HAVE_FDATASYNC) */
+
 
 #ifdef HAVE_CHOWN
 /*[clinic input]


### PR DESCRIPTION
…t fdatasync() support

POSIX fdatasync() is similar to fsync() but it tries not to sync non-needed
metadata. If POSIX OS doesn't have it - it's safe to use fsync()
(If we need to sync data to disk - we have to use one of these functions).

This change helps to run code with fdatasync() on MacOS without fallbacks
in Python code.

That it's a usual practice:
- https://github.com/libuv/libuv/pull/1580/files/bdd987a9b4347164e31e22d2d5ce06fbb5ebc859
- https://rev.ng/gitlab/revng/qemu/commit/6f1953c4c14566d3303709869fd26201828b3ccf

Signed-off-by: George Melikov <mail@gmelikov.ru>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39640](https://bugs.python.org/issue39640) -->
https://bugs.python.org/issue39640
<!-- /issue-number -->
