### PR TITLE
Use a sphinx specific Github action to better show warnings

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -33,6 +33,10 @@ jobs:
       run: make -C Doc/ PYTHON=../python venv
     - name: 'Build documentation'
       run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W -j4" doctest suspicious html
+    - name: 'Build documentation with warnings'
+      uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "Doc/"
     - name: 'Upload'
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,12 +31,12 @@ jobs:
       run: make -s -j4
     - name: 'Install build dependencies'
       run: make -C Doc/ PYTHON=../python venv
-    - name: 'Build documentation'
-      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W -j4" doctest suspicious html
-    - name: 'Build documentation with warnings'
+    - name: 'Build documentation showing warnings'
       uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "Doc/"
+    - name: 'Build documentation'
+      run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W -j4" doctest suspicious html
     - name: 'Upload'
       uses: actions/upload-artifact@v1
       with:

--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -2,7 +2,7 @@
 
 *****************
 Dealing with Bugs
-*****************
+**************
 
 Python is a mature programming language which has established a reputation for
 stability.  In order to maintain this reputation, the developers would like to


### PR DESCRIPTION
Testing this out real quick, this shows warnings and errors inline on Github pull requests so it should better help people who want to contribute simple doc changes.