### PR TITLE
bpo-39646: Remove compile warnings in unicodeobject.c

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12207,8 +12207,8 @@ PyUnicode_IsIdentifier(PyObject *self)
         return 0;
     }
 
-    int kind;
-    void *data;
+    int kind = 0;
+    void *data = NULL;
     wchar_t *wstr;
     if (ready) {
         kind = PyUnicode_KIND(self);


### PR DESCRIPTION


<!-- issue-number: [bpo-39646](https://bugs.python.org/issue39646) -->
https://bugs.python.org/issue39646
<!-- /issue-number -->
