### PR TITLE
bpo-39382: Avoid dangling object use in abstract_issubclass()

### DIFF
--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -261,6 +261,8 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
 
         class B:
             def __init__(self):
+                # setting this here increases the chances of exhibiting the bug,
+                # probably due to memory layout changes.
                 self.x = 1
 
             @property

--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -251,6 +251,25 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
         # blown
         self.assertRaises(RecursionError, blowstack, isinstance, '', str)
 
+    def test_issubclass_refcount_handling(self):
+        # bpo-39382: abstract_issubclass() didn't hold item reference while
+        # peeking in the bases tuple, in the single inheritance case.
+        class A:
+            @property
+            def __bases__(self):
+                return (int, )
+
+        class B:
+            def __init__(self):
+                self.x = 1
+
+            @property
+            def __bases__(self):
+                return (A(), )
+
+        self.assertEqual(True, issubclass(B(), int))
+
+
 def blowstack(fxn, arg, compare_to):
     # Make sure that calling isinstance with a deeply nested tuple for its
     # argument will raise RecursionError eventually.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -592,6 +592,7 @@ Karan Goel
 Jeroen Van Goey
 Christoph Gohlke
 Tim Golden
+Yonatan Goldschmidt
 Mark Gollahon
 Guilherme Gonçalves
 Tiago Gonçalves

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-18-01-40-13.bpo-39382.OLSJu9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-18-01-40-13.bpo-39382.OLSJu9.rst
@@ -1,3 +1,2 @@
-Hold reference to ``__bases__`` tuple item before releasing the tuple itself
-in ``abstract_issubclass()``, avoiding a use-after-free in the next loop
-iteration.
+Fix a use-after-free in the single inheritance path of ``issubclass()``, when
+the ``__bases__`` of an object has a single reference, and so does its first item.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-18-01-40-13.bpo-39382.OLSJu9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-18-01-40-13.bpo-39382.OLSJu9.rst
@@ -1,0 +1,3 @@
+Hold reference to ``__bases__`` tuple item before releasing the tuple itself
+in ``abstract_issubclass()``, avoiding a use-after-free in the next loop
+iteration.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-02-18-01-40-13.bpo-39382.OLSJu9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-02-18-01-40-13.bpo-39382.OLSJu9.rst
@@ -1,2 +1,3 @@
 Fix a use-after-free in the single inheritance path of ``issubclass()``, when
 the ``__bases__`` of an object has a single reference, and so does its first item.
+Patch by Yonatan Goldschmidt.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2377,11 +2377,17 @@ abstract_issubclass(PyObject *derived, PyObject *cls)
     PyObject *bases = NULL;
     Py_ssize_t i, n;
     int r = 0;
+    int derived_ref = 0;
 
     while (1) {
-        if (derived == cls)
+        if (derived == cls) {
+            if (derived_ref)
+                Py_DECREF(derived);
             return 1;
+        }
         bases = abstract_get_bases(derived);
+        if (derived_ref)
+            Py_DECREF(derived);
         if (bases == NULL) {
             if (PyErr_Occurred())
                 return -1;
@@ -2395,6 +2401,8 @@ abstract_issubclass(PyObject *derived, PyObject *cls)
         /* Avoid recursivity in the single inheritance case */
         if (n == 1) {
             derived = PyTuple_GET_ITEM(bases, 0);
+            Py_INCREF(derived);
+            derived_ref = 1;
             Py_DECREF(bases);
             continue;
         }

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -2377,17 +2377,18 @@ abstract_issubclass(PyObject *derived, PyObject *cls)
     PyObject *bases = NULL;
     Py_ssize_t i, n;
     int r = 0;
-    int derived_ref = 0;
 
     while (1) {
         if (derived == cls) {
-            if (derived_ref)
-                Py_DECREF(derived);
+            Py_XDECREF(bases); /* See below comment */
             return 1;
         }
-        bases = abstract_get_bases(derived);
-        if (derived_ref)
-            Py_DECREF(derived);
+        /* Use XSETREF to drop bases reference *after* finishing with
+           derived; bases might be the only reference to it.
+           XSETREF is used instead of SETREF, because bases is NULL on the
+           first iteration of the loop.
+        */
+        Py_XSETREF(bases, abstract_get_bases(derived));
         if (bases == NULL) {
             if (PyErr_Occurred())
                 return -1;
@@ -2401,9 +2402,6 @@ abstract_issubclass(PyObject *derived, PyObject *cls)
         /* Avoid recursivity in the single inheritance case */
         if (n == 1) {
             derived = PyTuple_GET_ITEM(bases, 0);
-            Py_INCREF(derived);
-            derived_ref = 1;
-            Py_DECREF(bases);
             continue;
         }
         for (i = 0; i < n; i++) {


### PR DESCRIPTION
Take a reference of `__bases__` tuple item before releasing the tuple reference,
as it may destroy the tuple, possibly destroying (some of) its items.

@serhiy-storchaka, I will look into your suggestion in the bpo and see if I can reproduce it with a short snippet, so I can add tests for it. I will also think of some way to simplify the code, this function became too complicated with this change, perhaps it's time to break it?

Therefore, opening as a draft for the meantime.

<!-- issue-number: [bpo-39382](https://bugs.python.org/issue39382) -->
https://bugs.python.org/issue39382
<!-- /issue-number -->
