### PR TITLE
bpo-39649: Remove obsolete check for `__args__` in bdb.Bdb.format_stack_entry

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -548,14 +548,7 @@ class Bdb:
             s += frame.f_code.co_name
         else:
             s += "<lambda>"
-        if '__args__' in frame.f_locals:
-            args = frame.f_locals['__args__']
-        else:
-            args = None
-        if args:
-            s += reprlib.repr(args)
-        else:
-            s += '()'
+        s += '()'
         if '__return__' in frame.f_locals:
             rv = frame.f_locals['__return__']
             s += '->'

--- a/Misc/NEWS.d/next/Library/2020-02-23-21-27-10.bpo-39649.qiubSp.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-23-21-27-10.bpo-39649.qiubSp.rst
@@ -1,0 +1,1 @@
+Remove obsolete check for `__args__` in bdb.Bdb.format_stack_entry.


### PR DESCRIPTION
Appears to be obsolete since 75bb54c3d8.

<!-- issue-number: [bpo-39649](https://bugs.python.org/issue39649) -->
https://bugs.python.org/issue39649
<!-- /issue-number -->
