### PR TITLE
[workflow] Use MSVC problem matcher for Windows action build

### DIFF
--- a/.github/problem-matchers/msvc.json
+++ b/.github/problem-matchers/msvc.json
@@ -1,0 +1,19 @@
+{
+    "__comment": "Taken from vscode's vs/workbench/contrib/tasks/common/problemMatcher.ts msCompile rule",
+    "problemMatcher": [
+      {
+        "owner": "msvc-problem-matcher",
+        "pattern": [
+          {
+            "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+),?(\\d+)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "severity": 4,
+            "code": 5,
+            "message": 6
+          }
+        ]
+      }
+    ]
+  }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,8 @@ jobs:
     if: needs.check_source.outputs.run_tests == 'true'
     steps:
     - uses: actions/checkout@v2
+    - name: Register MSVC problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
       run: .\PCbuild\build.bat -e -p x64
     - name: Display build info


### PR DESCRIPTION
This makes warnings and errors from the compiler very prominent so this should help prevent warnings from sneaking into the code base and catch them in review. See https://discuss.python.org/t/using-github-problem-matchers-to-catch-warnings-early/4254 for more details

You can see a demo of this in action here: https://github.com/ammaraskar/cpython/pull/15/files#diff-9ba2eeca0f254ece0a9df4d7cb68e870

or in screenshot form:

![example-pull-request](https://user-images.githubusercontent.com/773529/74619714-501f8100-50eb-11ea-8df4-734d0a9af84a.png)
