### PR TITLE
bpo-39663: IDLE: Add additional tests for pyparse

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,8 @@ Released on 2020-10-05?
 ======================================
 
 
+bpo-39663: Add tests for pyparse find_good_parse_start().
+
 bpo-39600: Remove duplicate font names from configuration list.
 
 bpo-38792: Close a shell calltip if a :exc:`KeyboardInterrupt`

--- a/Lib/idlelib/idle_test/test_pyparse.py
+++ b/Lib/idlelib/idle_test/test_pyparse.py
@@ -58,17 +58,18 @@ class PyParseTest(unittest.TestCase):
         p = self.parser
         setcode = p.set_code
         start = p.find_good_parse_start
+        def char_in_string_false(index): return False
 
         # First line starts with 'def' and ends with ':', then 0 is the pos.
         setcode('def spam():\n')
-        eq(start(is_char_in_string=lambda index: False), 0)
+        eq(start(char_in_string_false), 0)
 
         # First line begins with a keyword in the list and ends
         # with an open brace, then 0 is the pos.  This is how
         # hyperparser calls this function as the newline is not added
         # in the editor, but rather on the call to setcode.
         setcode('class spam( ' + ' \n')
-        eq(start(is_char_in_string=lambda index: False), 0)
+        eq(start(char_in_string_false), 0)
 
         # Split def across lines.
         setcode('"""This is a module docstring"""\n'
@@ -90,7 +91,7 @@ class PyParseTest(unittest.TestCase):
 
         # Make all text look like it's not in a string.  This means that it
         # found a good start position.
-        eq(start(is_char_in_string=lambda index: False), 44)
+        eq(start(char_in_string_false), 44)
 
         # If the beginning of the def line is not in a string, then it
         # returns that as the index.
@@ -109,7 +110,7 @@ class PyParseTest(unittest.TestCase):
                 '    def __init__(self, a, b=True):\n'
                 '        pass\n'
                 )
-        eq(start(is_char_in_string=lambda index: False), 44)
+        eq(start(char_in_string_false), 44)
         eq(start(is_char_in_string=lambda index: index > 44), 44)
         eq(start(is_char_in_string=lambda index: index >= 44), 33)
         # When the def line isn't split, this returns which doesn't match the

--- a/Lib/idlelib/idle_test/test_pyparse.py
+++ b/Lib/idlelib/idle_test/test_pyparse.py
@@ -59,6 +59,17 @@ class PyParseTest(unittest.TestCase):
         setcode = p.set_code
         start = p.find_good_parse_start
 
+        # First line starts with 'def' and ends with ':', then 0 is the pos.
+        setcode('def spam():\n')
+        eq(start(is_char_in_string=lambda index: False), 0)
+
+        # First line begins with a keyword in the list and ends
+        # with an open brace, then 0 is the pos.  This is how
+        # hyperparser calls this function as the newline is not added
+        # in the editor, but rather on the call to setcode.
+        setcode('class spam( ' + ' \n')
+        eq(start(is_char_in_string=lambda index: False), 0)
+
         # Split def across lines.
         setcode('"""This is a module docstring"""\n'
                 'class C():\n'

--- a/Misc/NEWS.d/next/IDLE/2020-02-17-21-09-03.bpo-39663.wexcsH.rst
+++ b/Misc/NEWS.d/next/IDLE/2020-02-17-21-09-03.bpo-39663.wexcsH.rst
@@ -1,0 +1,1 @@
+Add tests for pyparse find_good_parse_start().


### PR DESCRIPTION
Add test cases when `find_good_parse_start` would return 0 instead of None.


<!-- issue-number: [bpo-39663](https://bugs.python.org/issue39663) -->
https://bugs.python.org/issue39663
<!-- /issue-number -->
