### PR TITLE
bpo-39674: Revert "bpo-25988: Do not expose abstract collection classes in the collections module. (GH-10596)"

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -33,7 +33,7 @@ Python's general purpose built-in containers, :class:`dict`, :class:`list`,
 :class:`UserString`     wrapper around string objects for easier string subclassing
 =====================   ====================================================================
 
-.. deprecated-removed:: 3.3 3.9
+.. deprecated-removed:: 3.3 3.10
     Moved :ref:`collections-abstract-base-classes` to the :mod:`collections.abc` module.
     For backwards compatibility, they continue to be visible in this module through
     Python 3.8.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -471,11 +471,6 @@ Removed
   since Python 3.2.
   (Contributed by Victor Stinner in :issue:`38916`.)
 
-* The abstract base classes in :mod:`collections.abc` no longer are
-  exposed in the regular :mod:`collections` module.  This will help
-  create a clearer distinction between the concrete classes and the abstract
-  base classes.
-
 * The undocumented ``sys.callstats()`` function has been removed. Since Python
   3.7, it was deprecated and always returned :const:`None`. It required a special
   build option ``CALL_PROFILE`` which was already removed in Python 3.7.

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -39,6 +39,21 @@ except ImportError:
     pass
 
 
+def __getattr__(name):
+    # For backwards compatibility, continue to make the collections ABCs
+    # through Python 3.6 available through the collections module.
+    # Note, no new collections ABCs were added in Python 3.7
+    if name in _collections_abc.__all__:
+        obj = getattr(_collections_abc, name)
+        import warnings
+        warnings.warn("Using or importing the ABCs from 'collections' instead "
+                      "of from 'collections.abc' is deprecated since Python 3.3, "
+                      "and in 3.10 it will stop working",
+                      DeprecationWarning, stacklevel=2)
+        globals()[name] = obj
+        return obj
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+
 ################################################################################
 ### OrderedDict
 ################################################################################

--- a/Misc/NEWS.d/next/Library/2020-02-18-12-31-24.bpo-39674.S_zqVM.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-18-12-31-24.bpo-39674.S_zqVM.rst
@@ -1,0 +1,4 @@
+Revert "Do not expose abstract collection classes in the collections module"
+change (bpo-25988). Aliases to ABC like collections.Mapping are kept in
+Python 3.9 to ease transition from Python 2.7, but will be removed in Python
+3.10.


### PR DESCRIPTION
This reverts commit ef092fe9905f61ca27889092ca1248a11aa74498.

Update collections __getattr__() and documentation to defer aliases
removal to Python 3.10.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39674](https://bugs.python.org/issue39674) -->
https://bugs.python.org/issue39674
<!-- /issue-number -->
