### PR TITLE
bpo-39677: dis: rename the operand of MAKE_FUNCTION from `argc` to `flags` for 3.6+

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1139,7 +1139,7 @@ All of the following opcodes use their arguments.
 .. opcode:: MAKE_FUNCTION (flags)
 
    Pushes a new function object on the stack.  From bottom to top, the consumed
-   stack must consist of values if *flags* carries a specified flag value
+   stack must consist of values if the argument carries a specified flag value
 
    * ``0x01`` a tuple of default values for positional-only and
      positional-or-keyword parameters in positional order

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1136,10 +1136,10 @@ All of the following opcodes use their arguments.
    .. versionadded:: 3.7
 
 
-.. opcode:: MAKE_FUNCTION (argc)
+.. opcode:: MAKE_FUNCTION (flags)
 
    Pushes a new function object on the stack.  From bottom to top, the consumed
-   stack must consist of values if the argument carries a specified flag value
+   stack must consist of values if *flags* carries a specified flag value
 
    * ``0x01`` a tuple of default values for positional-only and
      positional-or-keyword parameters in positional order

--- a/Misc/NEWS.d/next/Documentation/2020-02-18-14-28-31.bpo-39677.vNHqoX.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-02-18-14-28-31.bpo-39677.vNHqoX.rst
@@ -1,1 +1,1 @@
-Changed operand name of **MAKE_FUNCTION** from *argc* to *flags* for module :ref:`dis`
+Changed operand name of **MAKE_FUNCTION** from *argc* to *flags* for module :mod:`dis`

--- a/Misc/NEWS.d/next/Documentation/2020-02-18-14-28-31.bpo-39677.vNHqoX.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-02-18-14-28-31.bpo-39677.vNHqoX.rst
@@ -1,0 +1,1 @@
+Changed operand name of **MAKE_FUNCTION** from *argc* to *flags* for module :ref:`dis`


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

The semantics of MAKE_FUNCTION's operand has changed since Python 3.6, however the documentation kept its old name `argc`, however it now works the same way as other `flags` operands, hence now we change it to `flags`.


<!-- issue-number: [bpo-39677](https://bugs.python.org/issue39677) -->
https://bugs.python.org/issue39677
<!-- /issue-number -->
