### PR TITLE
bpo-17422:language reference should specify restrictions on class namespace

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1932,8 +1932,8 @@ metaclass (if any) and the metaclasses (i.e. ``type(cls)``) of all specified
 base classes. The most derived metaclass is one which is a subtype of *all*
 of these candidate metaclasses. If none of the candidate metaclasses meets
 that criterion, then the class definition will fail with ``TypeError``.
-.. _prepare:
 
+.. _prepare:
 Preparing the class namespace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1932,7 +1932,10 @@ metaclass (if any) and the metaclasses (i.e. ``type(cls)``) of all specified
 base classes. The most derived metaclass is one which is a subtype of *all*
 of these candidate metaclasses. If none of the candidate metaclasses meets
 that criterion, then the class definition will fail with ``TypeError``.
+
+
 .. _prepare:
+
 Preparing the class namespace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1945,6 +1948,7 @@ as ``namespace = metaclass.__prepare__(name, bases, **kwds)`` (where the
 additional keyword arguments, if any, come from the class definition). The
 +namespace returned by ``__prepare__`` is passed in to ``__new__``, but when
 +the final class object is created the namespace is copied into a new ``dict``.
+The ``__prepare__`` method should be implemented as a :func:`classmethod`.
 
 If the metaclass has no ``__prepare__`` attribute, then the class namespace
 is initialised as an empty :func:`dict`.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1947,7 +1947,7 @@ additional keyword arguments, if any, come from the class definition). The
 +the final class object is created the namespace is copied into a new ``dict``.
 
 If the metaclass has no ``__prepare__`` attribute, then the class namespace
- is initialised as an empty :func:`dict` instance.
+is initialised as an empty :func:`dict`.
 
 .. seealso::
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1932,7 +1932,6 @@ metaclass (if any) and the metaclasses (i.e. ``type(cls)``) of all specified
 base classes. The most derived metaclass is one which is a subtype of *all*
 of these candidate metaclasses. If none of the candidate metaclasses meets
 that criterion, then the class definition will fail with ``TypeError``.
-
 .. _prepare:
 Preparing the class namespace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1946,8 +1946,8 @@ Once the appropriate metaclass has been identified, then the class namespace
 is prepared. If the metaclass has a ``__prepare__`` attribute, it is called
 as ``namespace = metaclass.__prepare__(name, bases, **kwds)`` (where the
 additional keyword arguments, if any, come from the class definition). The
-+namespace returned by ``__prepare__`` is passed in to ``__new__``, but when
-+the final class object is created the namespace is copied into a new ``dict``.
+namespace returned by ``__prepare__`` is passed in to ``__new__``, but when
+the final class object is created the namespace is copied into a new ``dict``.
 The ``__prepare__`` method should be implemented as a :func:`classmethod`.
 
 If the metaclass has no ``__prepare__`` attribute, then the class namespace

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1946,9 +1946,9 @@ Once the appropriate metaclass has been identified, then the class namespace
 is prepared. If the metaclass has a ``__prepare__`` attribute, it is called
 as ``namespace = metaclass.__prepare__(name, bases, **kwds)`` (where the
 additional keyword arguments, if any, come from the class definition). The
+``__prepare__`` method should be implemented as a :func:`classmethod`. The
 namespace returned by ``__prepare__`` is passed in to ``__new__``, but when
 the final class object is created the namespace is copied into a new ``dict``.
-The ``__prepare__`` method should be implemented as a :func:`classmethod`.
 
 If the metaclass has no ``__prepare__`` attribute, then the class namespace
 is initialised as an empty :func:`dict`.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1932,7 +1932,6 @@ metaclass (if any) and the metaclasses (i.e. ``type(cls)``) of all specified
 base classes. The most derived metaclass is one which is a subtype of *all*
 of these candidate metaclasses. If none of the candidate metaclasses meets
 that criterion, then the class definition will fail with ``TypeError``.
-
 .. _prepare:
 
 Preparing the class namespace

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1933,7 +1933,6 @@ base classes. The most derived metaclass is one which is a subtype of *all*
 of these candidate metaclasses. If none of the candidate metaclasses meets
 that criterion, then the class definition will fail with ``TypeError``.
 
-
 .. _prepare:
 
 Preparing the class namespace
@@ -1946,10 +1945,11 @@ Once the appropriate metaclass has been identified, then the class namespace
 is prepared. If the metaclass has a ``__prepare__`` attribute, it is called
 as ``namespace = metaclass.__prepare__(name, bases, **kwds)`` (where the
 additional keyword arguments, if any, come from the class definition). The
-``__prepare__`` method should be implemented as a :func:`classmethod`.
++namespace returned by ``__prepare__`` is passed in to ``__new__``, but when
++the final class object is created the namespace is copied into a new ``dict``.
 
 If the metaclass has no ``__prepare__`` attribute, then the class namespace
-is initialised as an empty ordered mapping.
+ is initialised as an empty :func:`dict` instance.
 
 .. seealso::
 

--- a/Misc/NEWS.d/next/Documentation/2020-02-19-11-13-47.bpo-17422.g7_9zz.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-02-19-11-13-47.bpo-17422.g7_9zz.rst
@@ -1,1 +1,1 @@
-The language reference now specifies restrictions on class namespaces.
+The language reference now specifies restrictions on class namespaces.  Adapted from a patch by Ethan Furman.

--- a/Misc/NEWS.d/next/Documentation/2020-02-19-11-13-47.bpo-17422.g7_9zz.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-02-19-11-13-47.bpo-17422.g7_9zz.rst
@@ -1,1 +1,1 @@
-Language reference should specify restrictions on class namespace.
+The language reference now specifies restrictions on class namespaces.

--- a/Misc/NEWS.d/next/Documentation/2020-02-19-11-13-47.bpo-17422.g7_9zz.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-02-19-11-13-47.bpo-17422.g7_9zz.rst
@@ -1,0 +1,1 @@
+Language reference should specify restrictions on :class:"namespace".

--- a/Misc/NEWS.d/next/Documentation/2020-02-19-11-13-47.bpo-17422.g7_9zz.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-02-19-11-13-47.bpo-17422.g7_9zz.rst
@@ -1,1 +1,1 @@
-Language reference should specify restrictions on :class:"namespace".
+Language reference should specify restrictions on class namespace.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-17422](https://bugs.python.org/issue17422) -->
https://bugs.python.org/issue17422
<!-- /issue-number -->
