### PR TITLE
bpo-39632: Fix ctypes variadic function call convention

### DIFF
--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -3,7 +3,7 @@
 import os as _os, sys as _sys
 import types as _types
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from _ctypes import Union, Structure, Array
 from _ctypes import _Pointer
@@ -559,5 +559,19 @@ for kind in [c_ushort, c_uint, c_ulong, c_ulonglong]:
     elif sizeof(kind) == 4: c_uint32 = kind
     elif sizeof(kind) == 8: c_uint64 = kind
 del(kind)
+
+# _ctypes needs the following types for variadic function type promotion
+import _ctypes
+_ctypes.c_int = c_int
+_ctypes.c_uint = c_uint
+_ctypes.c_int8 = c_int8
+_ctypes.c_uint8 = c_uint8
+_ctypes.c_int16 = c_int16
+_ctypes.c_uint16 = c_uint16
+_ctypes.c_int32 = c_int32
+_ctypes.c_uint32 = c_uint32
+_ctypes.c_int64 = c_int64
+_ctypes.c_uint64 = c_uint64
+_ctypes.c_double = c_double
 
 _reset_cache()

--- a/Lib/ctypes/test/test_python_api.py
+++ b/Lib/ctypes/test/test_python_api.py
@@ -68,7 +68,7 @@ class PythonAPITestCase(unittest.TestCase):
 
     def test_PyOS_snprintf(self):
         PyOS_snprintf = pythonapi.PyOS_snprintf
-        PyOS_snprintf.argtypes = POINTER(c_char), c_size_t, c_char_p
+        PyOS_snprintf.argtypes = POINTER(c_char), c_size_t, c_char_p, ...
 
         buf = c_buffer(256)
         PyOS_snprintf(buf, sizeof(buf), b"Hello from %s", b"ctypes")

--- a/Misc/NEWS.d/next/Library/2020-02-19-11-56-22.bpo-39632.7jCbTV.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-19-11-56-22.bpo-39632.7jCbTV.rst
@@ -1,0 +1,6 @@
+Fix and improve ctypes variadic function support. Functions that take a
+variable number of arguments should now be declared using an Ellipsis (...)
+as their last argument (just as a prototype for a C function).  ctypes variadic
+functions declared this way automatically perform the default argument
+promotion (small integer types are promoted to c_int and c_float is promoted to
+double).

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -341,6 +341,29 @@ EXPORT(double) _testfunc_d_bhilfd(signed char b, short h, int i, long l, float f
     return (double)(b + h + i + l + f + d);
 }
 
+EXPORT(double) _testfunc_d_bhilfd_var(int dummy, ...)
+{
+    signed char b;
+    short h;
+    int i;
+    long l;
+    float f;
+    double d;
+    va_list argptr;
+    va_start(argptr, dummy);
+    b = (signed char)va_arg(argptr, int);
+    h = (short)va_arg(argptr, int);
+    i = va_arg(argptr, int);
+    l = va_arg(argptr, long);
+    f = (float)va_arg(argptr, double);
+    d = va_arg(argptr, double);
+    va_end(argptr);
+/*      printf("_testfunc_d_bhilfd_var got %d %d %d %ld %f %f\n",
+               b, h, i, l, f, d);
+*/
+    return (double)(b + h + i + l + f + d);
+}
+
 EXPORT(long double) _testfunc_D_bhilfD(signed char b, short h, int i, long l, float f, long double d)
 {
 /*      printf("_testfunc_d_bhilfd got %d %d %d %ld %f %f\n",

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1195,9 +1195,13 @@ PyObject *_ctypes_callproc(PPROC pProc,
            than the length of the argtypes tuple.
            This is checked in _ctypes::PyCFuncPtr_Call
         */
-        if (argtypes && argtype_count > i) {
+        if (argtypes && (argtype_count > i || argtype_count != argcount)) {
             PyObject *v;
-            converter = PyTuple_GET_ITEM(argtypes, i);
+            if (i < argtype_count) {
+                converter = PyTuple_GET_ITEM(argtypes, i);
+            } else {
+                converter = PyTuple_GET_ITEM(argtypes, argtype_count -1);
+            }
             v = PyObject_CallOneArg(converter, arg);
             if (v == NULL) {
                 _ctypes_extend_error(PyExc_ArgError, "argument %zd: ", i+1);
@@ -1631,8 +1635,8 @@ static const char sizeof_doc[] =
 "sizeof(C instance) -> integer\n"
 "Return the size in bytes of a C instance";
 
-static PyObject *
-sizeof_func(PyObject *self, PyObject *obj)
+PyObject *
+_ctypes_sizeof_func(PyObject *self, PyObject *obj)
 {
     StgDictObject *dict;
 
@@ -1996,7 +2000,7 @@ PyMethodDef _ctypes_module_methods[] = {
      {"_dyld_shared_cache_contains_path", py_dyld_shared_cache_contains_path, METH_VARARGS, "check if path is in the shared cache"},
 #endif
     {"alignment", align_func, METH_O, alignment_doc},
-    {"sizeof", sizeof_func, METH_O, sizeof_doc},
+    {"sizeof", _ctypes_sizeof_func, METH_O, sizeof_doc},
     {"byref", byref, METH_VARARGS, byref_doc},
     {"addressof", addressof, METH_O, addressof_doc},
     {"call_function", call_function, METH_VARARGS },

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -278,6 +278,9 @@ PyObject *_ctypes_callproc(PPROC pProc,
                     PyObject *restype,
                     PyObject *checker);
 
+PyObject *
+_ctypes_sizeof_func(PyObject *self, PyObject *obj);
+
 
 #define FUNCFLAG_STDCALL 0x0
 #define FUNCFLAG_CDECL   0x1


### PR DESCRIPTION
On armhf and for variadic functions (and contrary to non-variadic
functions), the VFP co-processor registers are not used for float
argument parameter passing. This specificity was completely
disregarded by ctypes which used `ffi_prep_cif` systematically
to prepare the parameter passing of a function while it should
use `ffi_prep_cif_var` for variadic functions instead.

As such variadic function call with float arguments through ctypes
was broken on armhf targets.

This change fixes and improves ctypes variadic function support.
Functions that take a variable number of arguments should now be
declared using an Ellipsis (...) as their last argument (just as
a prototype for a C function). ctypes variadic functions declared
this way automatically perform the default argument promotion.
Small integer types are promoted to c_int and c_float is promoted
to c_double.

I am new to CPython development but I think that without the
introduction of the Ellipsis in functions argtypes this could be
backported to the 3.7 and 3.8 maintenance branches.

For reference/see also:
- https://sourceware.org/ml/libffi-discuss/2016/msg00043.html
- https://bugs.python.org/issue17580
- https://github.com/spacepy/spacepy/issues/20
- https://en.cppreference.com/w/c/language/conversion#Default_argument_promotions


<!-- issue-number: [bpo-39632](https://bugs.python.org/issue39632) -->
https://bugs.python.org/issue39632
<!-- /issue-number -->
