### PR TITLE
bpo-29298: Fix crash for required subparsers in argparse

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -727,6 +727,8 @@ def _get_action_name(argument):
         return argument.metavar
     elif argument.dest not in (None, SUPPRESS):
         return argument.dest
+    elif argument.choices not in (None, SUPPRESS):
+        return "{" + ','.join(argument.choices.keys()) + "}"
     else:
         return None
 

--- a/Misc/NEWS.d/next/Library/2020-02-20-01-53-01.bpo-29298.laIn2S.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-20-01-53-01.bpo-29298.laIn2S.rst
@@ -1,0 +1,1 @@
+Fix crash in argparse when using subparsers and Required is set to True.

--- a/Misc/NEWS.d/next/Library/2020-02-20-01-53-01.bpo-29298.laIn2S.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-20-01-53-01.bpo-29298.laIn2S.rst
@@ -1,1 +1,2 @@
-Fix crash in argparse when using subparsers and Required is set to True.
+Fix crash in :mod:`argparse` when using subparsers and its required attribute
+is set to True.


### PR DESCRIPTION
When an instance of subparsers is has required=True, and no subparser is found,
an uncaught exception was thrown.

OS: Windows - Cygwin
Python Version: 3.8.0b4
This issue still appears to be present in master

Fixes the following stack trace:
...
File "/usr/lib/python3.8/argparse.py", line 1760, in parse_args
args, argv = self.parse_known_args(args, namespace)
File "/usr/lib/python3.8/argparse.py", line 1792, in parse_known_args
namespace, args = self._parse_known_args(args, namespace)
File "/usr/lib/python3.8/argparse.py", line 2027, in _parse_known_args
', '.join(required_actions))
TypeError: sequence item 0: expected str instance, NoneType found

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-29298](https://bugs.python.org/issue29298) -->
https://bugs.python.org/issue29298
<!-- /issue-number -->
