### PR TITLE
bpo-39684 : Combine two if/thens. Squash uninit var warning.

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12209,20 +12209,15 @@ PyUnicode_IsIdentifier(PyObject *self)
 
     int kind = 0;
     void *data = NULL;
-    wchar_t *wstr;
+    const wchar_t *wstr = NULL;
+    Py_UCS4 ch;
     if (ready) {
         kind = PyUnicode_KIND(self);
         data = PyUnicode_DATA(self);
-    }
-    else {
-        wstr = _PyUnicode_WSTR(self);
-    }
-
-    Py_UCS4 ch;
-    if (ready) {
         ch = PyUnicode_READ(kind, data, 0);
     }
     else {
+        wstr = _PyUnicode_WSTR(self);
         ch = wstr[0];
     }
     /* PEP 3131 says that the first character must be in


### PR DESCRIPTION
These two code if/thens can be combined

    if (ready) {
        kind = PyUnicode_KIND(self);
        data = PyUnicode_DATA(self);
    }
    else {
        wstr = _PyUnicode_WSTR(self);
    }

    Py_UCS4 ch;
    if (ready) {
        ch = PyUnicode_READ(kind, data, 0);
    }
    else {
        ch = wstr[0];
    }

This is a replacement for previous PR #18557.

<!-- issue-number: [bpo-39684](https://bugs.python.org/issue39684) -->
https://bugs.python.org/issue39684
<!-- /issue-number -->
