### PR TITLE
[workflow] Use gcc matcher to make warnings prominent

### DIFF
--- a/.github/problem-matchers/gcc.json
+++ b/.github/problem-matchers/gcc.json
@@ -1,0 +1,18 @@
+{
+    "__comment": "Taken from vscode-cpptools's Extension/package.json gcc rule",
+    "problemMatcher": [
+        {
+            "owner": "gcc-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,8 @@ jobs:
       OPENSSL_VER: 1.1.1f
     steps:
     - uses: actions/checkout@v2
+    - name: Register gcc problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install Dependencies
       run: sudo ./.github/workflows/posix-deps-apt.sh
     - name: 'Restore OpenSSL build'


### PR DESCRIPTION
This makes warnings and errors from the compiler very prominent so this should help prevent warnings from sneaking into the code base and catch them in review.

You can see a demo of this in action here: https://github.com/ammaraskar/cpython/pull/16/files#diff-4d35cf8992b795c5e97e9c8b6167cb34

or in screenshot form:

![example-pull-request](https://user-images.githubusercontent.com/773529/74932513-01eed400-53b0-11ea-8c71-a726148aa036.png)

(This PR is sort of a mirror to https://github.com/python/cpython/pull/18532 but for the linux builds.)