### PR TITLE
Valgrind no longer supports --db-attach=yes.

### DIFF
--- a/Modules/_decimal/tests/runall-memorydebugger.sh
+++ b/Modules/_decimal/tests/runall-memorydebugger.sh
@@ -18,7 +18,7 @@ CONFIGS_64="x64 uint128 ansi64 universal"
 CONFIGS_32="ppro ansi32 ansi-legacy universal"
 
 VALGRIND="valgrind --tool=memcheck --leak-resolution=high \
-          --db-attach=yes --suppressions=Misc/valgrind-python.supp"
+          --suppressions=Misc/valgrind-python.supp"
 
 # Get args
 case $@ in


### PR DESCRIPTION
Small change that would have taken one minute with the previous mercurial setup. Now:

  - Try to commit directly, commit is refused.

  - Update `CPython` clone.

  - Try to login to GitHub, login is refused because of device "verification".

  - Fetch Email that contains a "verification" code.

  - Enter the code.

  - Open pull request.

  - Wait for GitHub buildbots (30 min).

  - Merge.

  - Look at Python buildbots.

