### PR TITLE
gh-83897: Raise on conflicting subparser names.

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1162,6 +1162,13 @@ class _SubParsersAction(Action):
 
         aliases = kwargs.pop('aliases', ())
 
+        if name in self._name_parser_map:
+            raise ArgumentError(self, _('conflicting subparser: %s') % name)
+        for alias in aliases:
+            if alias in self._name_parser_map:
+                raise ArgumentError(
+                    self, _('conflicting subparser alias: %s') % alias)
+
         # create a pseudo-action to hold the choice help
         if 'help' in kwargs:
             help = kwargs.pop('help')

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4603,6 +4603,19 @@ class TestConflictHandling(TestCase):
               --spam NEW_SPAM
             '''))
 
+    def test_subparser_conflict(self):
+        parser = argparse.ArgumentParser()
+        sp = parser.add_subparsers()
+        sp.add_parser('fullname', aliases=['alias'])
+        self.assertRaises(argparse.ArgumentError,
+                          sp.add_parser, 'fullname')
+        self.assertRaises(argparse.ArgumentError,
+                          sp.add_parser, 'alias')
+        self.assertRaises(argparse.ArgumentError,
+                          sp.add_parser, 'other', aliases=['fullname'])
+        self.assertRaises(argparse.ArgumentError,
+                          sp.add_parser, 'other', aliases=['alias'])
+
 
 # =============================
 # Help and Version option tests

--- a/Misc/NEWS.d/next/Library/2020-02-22-12-02-11.bpo-39716.z2WhDQ.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-22-12-02-11.bpo-39716.z2WhDQ.rst
@@ -1,0 +1,3 @@
+Raise an ArgumentError when the same subparser name is added twice to an
+`argparse.ArgumentParser`.  This is consistent with the (default) behavior
+when the same option string is added twice to an ArgumentParser.


### PR DESCRIPTION
Raise an ArgumentError when the same subparser name is added twice to an
ArgumentParser.  This is consistent with the (default) behavior when the
same option string is added twice to an ArgumentParser.

(Support for `conflict_handler="resolve"` could be considered as a
followup feature, although real use cases seem even rarer than
"resolve"ing option-strings.)

Automerge-Triggered-By: GH:rhettinger

<!-- gh-issue-number: gh-83897 -->
* Issue: gh-83897
<!-- /gh-issue-number -->
