### PR TITLE
bpo-38691 Ignore pythoncaseok tests

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1829,6 +1829,9 @@ are always available.  They are listed here in alphabetical order.
       Negative values for *level* are no longer supported (which also changes
       the default value to 0).
 
+   .. versionchanged:: 3.9
+      When the command line options :option:`-E` or :option:`-I` are being used,
+      the environment variable :envvar:`PYTHONCASEOK` is now ignored.
 
 .. rubric:: Footnotes
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -587,6 +587,9 @@ Changes in the Python API
   since the *buffering* parameter has been removed.
   (Contributed by Victor Stinner in :issue:`39357`.)
 
+* The :mod:`importlib` module now ignores the :envvar:`PYTHONCASEOK`
+  environment variable when the :option:`-E` or :option:`-I` command line
+  options are being used.
 
 CPython bytecode changes
 ------------------------

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -34,8 +34,8 @@ def _make_relax_case():
             key = b'PYTHONCASEOK'
 
         def _relax_case():
-            """True if filenames must be checked case-insensitively."""
-            return key in _os.environ
+            """True if filenames must be checked case-insensitively and ignore environment flags are not set."""
+            return not sys.flags.ignore_environment and key in _os.environ
     else:
         def _relax_case():
             """True if filenames must be checked case-insensitively."""

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -35,7 +35,7 @@ def _make_relax_case():
 
         def _relax_case():
             """True if filenames must be checked case-insensitively."""
-            return not sys.flags.ignore_environment and key in _os.environ
+            return key in _os.environ
     else:
         def _relax_case():
             """True if filenames must be checked case-insensitively."""

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -35,7 +35,7 @@ def _make_relax_case():
 
         def _relax_case():
             """True if filenames must be checked case-insensitively."""
-            return key in _os.environ
+            return not sys.flags.ignore_environment and key in _os.environ
     else:
         def _relax_case():
             """True if filenames must be checked case-insensitively."""

--- a/Misc/NEWS.d/next/Library/2020-02-11-13-01-38.bpo-38691.oND8Sk.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-11-13-01-38.bpo-38691.oND8Sk.rst
@@ -1,2 +1,0 @@
-The :mod:`importlib` module now ignores the :envvar:`PYTHONCASEOK`
-environment variable when :option:`-E` or :option:`-I` command line option is used.

--- a/Misc/NEWS.d/next/Library/2020-02-11-13-01-38.bpo-38691.oND8Sk.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-11-13-01-38.bpo-38691.oND8Sk.rst
@@ -1,0 +1,1 @@
+Updated :meth:`importlib._bootstrap_external._make_relax_case` to ignore :envvar:`PYTHONCASEOK` when -E or -I flags are used.

--- a/Misc/NEWS.d/next/Library/2020-02-11-13-01-38.bpo-38691.oND8Sk.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-11-13-01-38.bpo-38691.oND8Sk.rst
@@ -1,2 +1,2 @@
-The :mod:`importlib` module now ignore the :envvar:`PYTHONCASEOK`
+The :mod:`importlib` module now ignores the :envvar:`PYTHONCASEOK`
 environment variable when :option:`-E` or :option:`-I` command line option is used.

--- a/Misc/NEWS.d/next/Library/2020-02-11-13-01-38.bpo-38691.oND8Sk.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-11-13-01-38.bpo-38691.oND8Sk.rst
@@ -1,1 +1,2 @@
-Updated :meth:`importlib._bootstrap_external._make_relax_case` to ignore :envvar:`PYTHONCASEOK` when -E or -I flags are used.
+The :mod:`importlib` module now ignore the :envvar:`PYTHONCASEOK`
+environment variable when :option:`-E` or :option:`-I` command line option is used.

--- a/Misc/NEWS.d/next/Library/2020-02-23-02-09-03.bpo-38691.oND8Sk.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-23-02-09-03.bpo-38691.oND8Sk.rst
@@ -1,0 +1,1 @@
+Updated :meth:`importlib._bootstrap_external._make_relax_case` to ignore :envvar:`PYTHONCASEOK` when -E or -I flags are used.


### PR DESCRIPTION
# [bpo-38691](https://bugs.python.org/issue38691) Ignore pythoncaseok tests

# [3.9] [bpo-38691](https://bugs.python.org/issue38691) Added a switch to ignore PYTHONCASEOK when -E or -I flags passed (GH-18612)

<!-- issue-number: [bpo-38691](https://bugs.python.org/issue38691) -->
https://bugs.python.org/issue38691
<!-- /issue-number -->
