### PR TITLE
bpo-39530: Fix misleading statement about mixed-type numeric comparisons

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -261,8 +261,10 @@ and imaginary parts.
 Python fully supports mixed arithmetic: when a binary arithmetic operator has
 operands of different numeric types, the operand with the "narrower" type is
 widened to that of the other, where integer is narrower than floating point,
-which is narrower than complex.  Comparisons between numbers of mixed type use
-the same rule. [2]_ The constructors :func:`int`, :func:`float`, and
+which is narrower than complex. A comparison between numbers of different types
+behaves as though the exact values of those numbers were being compared. [2]_
+
+The constructors :func:`int`, :func:`float`, and
 :func:`complex` can be used to produce numbers of a specific type.
 
 All numeric types (except complex) support the following operations (for priorities of

--- a/Misc/NEWS.d/next/Documentation/2020-02-23-13-26-40.bpo-39530._bCvzQ.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-02-23-13-26-40.bpo-39530._bCvzQ.rst
@@ -1,0 +1,1 @@
+Fix misleading documentation about mixed-type numeric comparisons.


### PR DESCRIPTION
There's a misleading statement in the documentation that suggests that (for example) an integer-to-float comparison is performed by first converting the integer to a float and then comparing the floats. This PR fixes that statement.

<!-- issue-number: [bpo-39530](https://bugs.python.org/issue39530) -->
https://bugs.python.org/issue39530
<!-- /issue-number -->
