### PR TITLE
gh-83913: encode UIDs in XML as CF$UID

### DIFF
--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -42,7 +42,8 @@ or :class:`datetime.datetime` objects.
    by NSKeyedArchiver and NSKeyedUnarchiver.
 
 .. versionchanged:: 3.9
-   Old API removed.
+   Old API removed.  Support added for reading and writing :class:`UID` tokens in XML
+   plists.
 
 .. seealso::
 

--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -155,9 +155,16 @@ The following constants are available:
 
 .. data:: FMT_BINARY
 
-   The binary format for plist files
-
+   The binary format for plist files.
+   
    .. versionadded:: 3.4
+
+
+.. data:: CFUID_KEY
+
+   The dictionary key used to represent a UID in XML-format plist files.
+ 
+   .. versionadded :: 3.13
 
 
 Examples

--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -136,7 +136,7 @@ The following classes are available:
 .. class:: UID(data)
 
    Wraps an :class:`int`.  This is used when reading or writing NSKeyedArchiver
-   encoded data, which contains UID (see Wikipedia).
+   encoded data, which contains UID (see Swift foundation source).
 
    It has one attribute, :attr:`data`, which can be used to retrieve the int value
    of the UID.  :attr:`data` must be in the range ``0 <= data < 2**64``.

--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -156,14 +156,14 @@ The following constants are available:
 .. data:: FMT_BINARY
 
    The binary format for plist files.
-   
+
    .. versionadded:: 3.4
 
 
 .. data:: CFUID_KEY
 
    The dictionary key used to represent a UID in XML-format plist files.
- 
+
    .. versionadded :: 3.13
 
 

--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -48,6 +48,8 @@ or :class:`datetime.datetime` objects.
 
    `PList manual page <https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/PropertyLists/>`_
       Apple's documentation of the file format.
+   `Property list <https://en.wikipedia.org/wiki/Property_list>`_
+      Wikipedia's description of the format and archiers.
 
 
 This module defines the following functions:
@@ -130,7 +132,7 @@ The following classes are available:
 .. class:: UID(data)
 
    Wraps an :class:`int`.  This is used when reading or writing NSKeyedArchiver
-   encoded data, which contains UID (see PList manual).
+   encoded data, which contains UID (see Wikipedia).
 
    It has one attribute, :attr:`data`, which can be used to retrieve the int value
    of the UID.  :attr:`data` must be in the range ``0 <= data < 2**64``.

--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -44,7 +44,7 @@ or :class:`datetime.datetime` objects.
 .. versionchanged:: 3.9
    Old API removed.
 
-.. versionchanged:: 3.10
+.. versionchanged:: 3.13
    Support added for reading and writing :class:`UID` tokens in XML
    plists.
 

--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -42,7 +42,10 @@ or :class:`datetime.datetime` objects.
    by NSKeyedArchiver and NSKeyedUnarchiver.
 
 .. versionchanged:: 3.9
-   Old API removed.  Support added for reading and writing :class:`UID` tokens in XML
+   Old API removed.
+
+.. versionchanged:: 3.10
+   Support added for reading and writing :class:`UID` tokens in XML
    plists.
 
 .. seealso::
@@ -50,7 +53,7 @@ or :class:`datetime.datetime` objects.
    `PList manual page <https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/PropertyLists/>`_
       Apple's documentation of the file format.
    `Property list <https://en.wikipedia.org/wiki/Property_list>`_
-      Wikipedia's description of the format and archiers.
+      Wikipedia's description of the format and archivers.
 
 
 This module defines the following functions:

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -55,7 +55,7 @@ Parse Plist example:
     print(pl["foo"])
 """
 __all__ = [
-    "InvalidFileException", "FMT_XML", "FMT_BINARY", "load", "dump", "loads", "dumps", "UID", "CFUID"
+    "InvalidFileException", "FMT_XML", "FMT_BINARY", "load", "dump", "loads", "dumps", "UID", "CFUID_KEY"
 ]
 
 import binascii
@@ -113,7 +113,7 @@ PLISTHEADER = b"""\
 """
 
 # CF$UID KEY
-CFUID = "CF$UID"
+CFUID_KEY = "CF$UID"
 
 
 # Regex to find any control chars, except for \t \n and \r
@@ -245,8 +245,8 @@ class _PlistParser:
                              (self.current_key,self.parser.CurrentLineNumber))
         d = self.stack.pop()
         # Unmarshal CF$UID to UID and replace the dict node
-        if len(d) == 1 and CFUID in d and isinstance(d[CFUID], int):
-            uid = UID(d[CFUID])
+        if len(d) == 1 and CFUID_KEY in d and isinstance(d[CFUID_KEY], int):
+            uid = UID(d[CFUID_KEY])
             if self.previous_dict_key:
                 self.stack[-1][self.previous_dict_key] = uid
             elif not self.stack:

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -112,6 +112,9 @@ PLISTHEADER = b"""\
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 """
 
+# CF$UID KEY
+CFUID = "CF$UID"
+
 
 # Regex to find any control chars, except for \t \n and \r
 _controlCharPat = re.compile(
@@ -242,14 +245,14 @@ class _PlistParser:
                              (self.current_key,self.parser.CurrentLineNumber))
         d = self.stack.pop()
         # Unmarshal CF$UID to UID and replace the dict node
-        if len(d) == 1 and "CF$UID" in d and isinstance(d["CF$UID"], int):
-            uid = UID(d["CF$UID"])
+        if len(d) == 1 and CFUID in d and isinstance(d[CFUID], int):
+            uid = UID(d[CFUID])
             if self.previous_dict_key:
                 self.stack[-1][self.previous_dict_key] = uid
             elif not self.stack:
                 self.root = uid
             else:
-                assert isinstance(self.stack[-1], type([]))
+                # self.stack[-1] can only be a list
                 self.stack[-1][-1] = uid
 
     def end_key(self):

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -377,7 +377,7 @@ class _PlistWriter(_DumbXMLWriter):
         elif isinstance(value, (tuple, list)):
             self.write_array(value)
 
-        elif isinstance(value, plist.UID):
+        elif isinstance(value, UID):
             self.write_dict({"CF$UID": int(value.data)})
 
         else:

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -365,6 +365,9 @@ class _PlistWriter(_DumbXMLWriter):
         elif isinstance(value, (tuple, list)):
             self.write_array(value)
 
+        elif isinstance(value, plist.UID):
+            self.write_dict({"CF$UID": int(value.data)})
+
         else:
             raise TypeError("unsupported type: %s" % type(value))
 

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -55,7 +55,7 @@ Parse Plist example:
     print(pl["foo"])
 """
 __all__ = [
-    "InvalidFileException", "FMT_XML", "FMT_BINARY", "load", "dump", "loads", "dumps", "UID"
+    "InvalidFileException", "FMT_XML", "FMT_BINARY", "load", "dump", "loads", "dumps", "UID", "CFUID"
 ]
 
 import binascii

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -245,7 +245,7 @@ class _PlistParser:
         if len(d) == 1 and "CF$UID" in d and isinstance(d["CF$UID"], int):
             uid = UID(d["CF$UID"])
             if self.previous_dict_key:
-                stack[-1][self.previous_dict_key] = uid
+                self.stack[-1][self.previous_dict_key] = uid
             elif not self.stack:
                 self.root = uid
             else:

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -533,7 +533,7 @@ class TestPlistlib(unittest.TestCase):
             'uid63': UID(2 ** 63)
         }
         self.assertEqual(plistlib.loads(plistlib.dumps(dict_data, fmt=plistlib.FMT_BINARY)), dict_data)
-        self.assertEqual(plistlib.loads(plistlib.dumps(dict_data, fmt=plistlib.FMT_XML)), data)
+        self.assertEqual(plistlib.loads(plistlib.dumps(dict_data, fmt=plistlib.FMT_XML)), dict_data)
 
     def test_uid_data(self):
         uid = UID(1)

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -522,8 +522,9 @@ class TestPlistlib(unittest.TestCase):
 
     def test_uid(self):
         data = UID(1)
-        self.assertEqual(plistlib.loads(plistlib.dumps(data, fmt=plistlib.FMT_BINARY)), data)
-        self.assertEqual(plistlib.loads(plistlib.dumps(data, fmt=plistlib.FMT_XML)), data)
+        for fmt in ALL_FORMATS:
+            self.assertEqual(plistlib.loads(plistlib.dumps(data, fmt=fmt)), data)
+
         dict_data = {
             'uid0': UID(0),
             'uid2': UID(2),
@@ -532,8 +533,9 @@ class TestPlistlib(unittest.TestCase):
             'uid32': UID(2 ** 32),
             'uid63': UID(2 ** 63)
         }
-        self.assertEqual(plistlib.loads(plistlib.dumps(dict_data, fmt=plistlib.FMT_BINARY)), dict_data)
-        self.assertEqual(plistlib.loads(plistlib.dumps(dict_data, fmt=plistlib.FMT_XML)), dict_data)
+        for fmt in ALL_FORMATS:
+            self.assertEqual(plistlib.loads(plistlib.dumps(dict_data, fmt=fmt)), dict_data)
+
 
     def test_uid_data(self):
         uid = UID(1)

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -523,6 +523,7 @@ class TestPlistlib(unittest.TestCase):
     def test_uid(self):
         data = UID(1)
         self.assertEqual(plistlib.loads(plistlib.dumps(data, fmt=plistlib.FMT_BINARY)), data)
+        self.assertEqual(plistlib.loads(plistlib.dumps(data, fmt=plistlib.FMT_XML)), data)
         dict_data = {
             'uid0': UID(0),
             'uid2': UID(2),
@@ -532,6 +533,7 @@ class TestPlistlib(unittest.TestCase):
             'uid63': UID(2 ** 63)
         }
         self.assertEqual(plistlib.loads(plistlib.dumps(dict_data, fmt=plistlib.FMT_BINARY)), dict_data)
+        self.assertEqual(plistlib.loads(plistlib.dumps(dict_data, fmt=plistlib.FMT_XML)), data)
 
     def test_uid_data(self):
         uid = UID(1)

--- a/Mac/Tools/plistlib_generate_testdata.py
+++ b/Mac/Tools/plistlib_generate_testdata.py
@@ -92,6 +92,10 @@ def main():
 
     keyed_archive_data = NSKeyedArchiver.archivedDataWithRootObject_("KeyArchive UID Test")
     print("    'KEYED_ARCHIVE': binascii.a2b_base64(b'''\n        %s''')," % (_encode_base64(bytes(keyed_archive_data)).decode('ascii')[:-1]))
+    nska_xml = NSKeyedArchiver.init()
+    nska_xml.outputFormat = NSPropertyListXMLFormat_v1_0
+    keyed_archive_data_xml = NSKeyedArchiver.archivedDataWithRootObject_("KeyArchive UID Test")
+    print("    'KEYED_ARCHIVE_XML': binascii.a2b_base64(b'''\n        %s''')," % (_encode_base64(bytes(keyed_archive_data)).decode('ascii')[:-1]))
     print("}")
     print()
 

--- a/Misc/NEWS.d/next/Library/2020-02-24-12-48-58.bpo-39732.4qZX4h.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-24-12-48-58.bpo-39732.4qZX4h.rst
@@ -1,0 +1,2 @@
+Add support for reading and writing :class:`plistlib.UID` tokens in XML
+plists.


### PR DESCRIPTION
This commit lets the XML writer encode UIDs in XML as a dictionary with a single key CF$UID pointing to an integer value. This is how Apple handles UIDs when writing XMLs.

~~It appears significantly harder to get the parser to replace a value it has just written, so I am not attempting it yet. I mean, I know how to replace it when the parent is a list, but when it is a dictionary it seems that I will need some extra key-saving along the stack.~~

An update has added a dict parsing replacer. Since there is always only one layer of key->dict involved, a single instance var will do.

<!-- issue-number: [bpo-39732](https://bugs.python.org/issue39732) -->
https://bugs.python.org/issue39732
<!-- /issue-number -->

<!-- gh-issue-number: gh-83913 -->
* Issue: gh-83913
<!-- /gh-issue-number -->
