### PR TITLE
bpo-39622: Use a custom signal handler in asyncio.run()

### DIFF
--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -432,6 +432,11 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                     self.remove_writer(fd)
         fut.add_done_callback(cb)
 
+    def _interrupt_main_thread(self):
+        # We send a signal instead of using _thread.interrupt_main() to be able
+        # to interrupt the selector.
+        os.kill(os.getpid(), signal.SIGINT)
+
 
 class _UnixReadPipeTransport(transports.ReadTransport):
 

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -9,6 +9,7 @@ import socket
 import struct
 import time
 import weakref
+import _thread
 
 from . import events
 from . import base_subprocess
@@ -299,6 +300,13 @@ class PipeServer(object):
 
 class _WindowsSelectorEventLoop(selector_events.BaseSelectorEventLoop):
     """Windows version of selector event loop."""
+
+    def _interrupt_main_thread(self):
+        # We could use os.kill(os.getpid(), signal.CTRL_C_EVENT), but in windows
+        # it is a console event, which means if other processes that are running
+        # in this console (for example when using multiprocessing) will receive
+        # the event as well.
+        _thread.interrupt_main()
 
 
 class ProactorEventLoop(proactor_events.BaseProactorEventLoop):

--- a/Lib/test/test_asyncio/test_runners.py
+++ b/Lib/test/test_asyncio/test_runners.py
@@ -177,3 +177,12 @@ class RunTests(BaseTest):
 
         self.assertIsNone(spinner.ag_frame)
         self.assertFalse(spinner.ag_running)
+
+    def test_asyncio_run_interrupted_on_main_thread(self):
+        async def do_nothing_forever():
+            while True:
+                await asyncio.sleep(0)
+
+        with self.assertRaises(KeyboardInterrupt),\
+                test_utils.run_delayed(test_utils.interrupt_main, 0.1):
+            asyncio.run(do_nothing_forever())

--- a/Misc/NEWS.d/next/Library/2020-02-23-21-46-06.bpo-39622.wF8tGO.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-23-21-46-06.bpo-39622.wF8tGO.rst
@@ -1,0 +1,1 @@
+Fixed issues with SIGINT handling in asyncio.run() by switching to a custom SIGINT handler.


### PR DESCRIPTION
In short - the default python SIGINT handler can cause the event loop to lose handles and get stuck. Therefore when running a loop we should use a SIGINT handler more fitting to the situation.
See detailed explanation (and bug demo scripts) here - [https://bugs.python.org/issue39622](https://bugs.python.org/issue39622)

<!-- issue-number: [bpo-39622](https://bugs.python.org/issue39622) -->
https://bugs.python.org/issue39622
<!-- /issue-number -->
