### PR TITLE
bpo-30566: Fix IndexError when using punycode codec

### DIFF
--- a/Lib/encodings/punycode.py
+++ b/Lib/encodings/punycode.py
@@ -143,7 +143,7 @@ def decode_generalized_number(extended, extpos, bias, errors):
             digit = char - 22 # 0x30-26
         elif errors == "strict":
             raise UnicodeError("Invalid extended code point '%s'"
-                               % extended[extpos])
+                               % extended[extpos-1])
         else:
             return extpos, None
         t = T(j, bias)

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1343,6 +1343,18 @@ class PunycodeTest(unittest.TestCase):
             puny = puny.decode("ascii").encode("ascii")
             self.assertEqual(uni, puny.decode("punycode"))
 
+    def test_decode_invalid(self):
+        testcases = [
+            (b"xn--w&", "strict", UnicodeError()),
+            (b"xn--w&", "ignore", "xn-"),
+        ]
+        for puny, errors, expected in testcases:
+            with self.subTest(puny=puny, errors=errors):
+                if isinstance(expected, Exception):
+                    self.assertRaises(UnicodeError, puny.decode, "punycode", errors)
+                else:
+                    self.assertEqual(puny.decode("punycode", errors), expected)
+
 
 # From http://www.gnu.org/software/libidn/draft-josefsson-idn-test-vectors.html
 nameprep_tests = [

--- a/Misc/NEWS.d/next/Library/2020-02-24-03-45-28.bpo-30566.qROxty.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-24-03-45-28.bpo-30566.qROxty.rst
@@ -1,0 +1,2 @@
+Fix :exc:`IndexError` when trying to decode an invalid string with punycode
+codec.


### PR DESCRIPTION
Trying to decode an invalid string with the punycode codec
shoud raise UnicodeError.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-30566](https://bugs.python.org/issue30566) -->
https://bugs.python.org/issue30566
<!-- /issue-number -->
