### PR TITLE
bpo-39736: const strings in Modules/_datetimemodule.c and Modules/_testbuffer.c

### DIFF
--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4179,11 +4179,11 @@ static PyObject *
 time_isoformat(PyDateTime_Time *self, PyObject *args, PyObject *kw)
 {
     char buf[100];
-    char *timespec = NULL;
+    const char *timespec = NULL;
     static char *keywords[] = {"timespec", NULL};
     PyObject *result;
     int us = TIME_GET_MICROSECOND(self);
-    static char *specs[][2] = {
+    static const char *specs[][2] = {
         {"hours", "%02d"},
         {"minutes", "%02d:%02d"},
         {"seconds", "%02d:%02d:%02d"},
@@ -5415,7 +5415,7 @@ datetime_isoformat(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
     char buffer[100];
     PyObject *result = NULL;
     int us = DATE_GET_MICROSECOND(self);
-    static char *specs[][2] = {
+    static const char *specs[][2] = {
         {"hours", "%04d-%02d-%02d%c%02d"},
         {"minutes", "%04d-%02d-%02d%c%02d:%02d"},
         {"seconds", "%04d-%02d-%02d%c%02d:%02d:%02d"},

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -2050,7 +2050,7 @@ static PyObject *
 ndarray_get_format(NDArrayObject *self, void *closure)
 {
     Py_buffer *base = &self->head->base;
-    char *fmt = base->format ? base->format : "";
+    const char *fmt = base->format ? base->format : "";
     return PyUnicode_FromString(fmt);
 }
 


### PR DESCRIPTION
In Modules/_datetimemodule.c, the char *timespec and char *specs[] can be made const.  Their contents are never modified.

In ndarray_get_format in Modules/_testbuffer.c, char *fmt can be made const.

<!-- issue-number: [bpo-39736](https://bugs.python.org/issue39736) -->
https://bugs.python.org/issue39736
<!-- /issue-number -->
