### PR TITLE
[3.8] bpo-38410: Properly handle PySys_Audit() failures

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-10-09-08-14-25.bpo-38410._YyoMV.rst
+++ b/Misc/NEWS.d/next/Library/2019-10-09-08-14-25.bpo-38410._YyoMV.rst
@@ -1,0 +1,2 @@
+Properly handle :func:`sys.audit` failures in
+:func:`sys.set_asyncgen_hooks`. Based on patch by Zackery Spytz.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4742,37 +4742,11 @@ _PyEval_GetCoroutineOriginTrackingDepth(void)
     return tstate->coroutine_origin_tracking_depth;
 }
 
-void
-_PyEval_SetAsyncGenFirstiter(PyObject *firstiter)
-{
-    PyThreadState *tstate = _PyThreadState_GET();
-
-    if (PySys_Audit("sys.set_asyncgen_hook_firstiter", NULL) < 0) {
-        return;
-    }
-
-    Py_XINCREF(firstiter);
-    Py_XSETREF(tstate->async_gen_firstiter, firstiter);
-}
-
 PyObject *
 _PyEval_GetAsyncGenFirstiter(void)
 {
     PyThreadState *tstate = _PyThreadState_GET();
     return tstate->async_gen_firstiter;
-}
-
-void
-_PyEval_SetAsyncGenFinalizer(PyObject *finalizer)
-{
-    PyThreadState *tstate = _PyThreadState_GET();
-
-    if (PySys_Audit("sys.set_asyncgen_hook_finalizer", NULL) < 0) {
-        return;
-    }
-
-    Py_XINCREF(finalizer);
-    Py_XSETREF(tstate->async_gen_finalizer, finalizer);
 }
 
 PyObject *


### PR DESCRIPTION
_PyEval_SetAsyncGenFinalizer() and _PyEval_SetAsyncGenFirstiter()
didn't include proper error handling for their PySys_Audit() calls.

Co-authored-by: Zackery Spytz <zspytz@gmail.com>

<!-- issue-number: [bpo-38410](https://bugs.python.org/issue38410) -->
https://bugs.python.org/issue38410
<!-- /issue-number -->
