### PR TITLE
bpo-39765: Document caveats for asyncio add_signal_handler()

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1049,7 +1049,7 @@ Unix signals
    
    While signal handlers registered using :func:`signal.signal` will
    typically be called immediately, handlers registered using this
-   method are subject to potential delays while waiting for other 
+   method are subject to potential delays while waiting for other
    work in the given event loop to be completed.
    
    Any event handler set for the same signal via :func:`signal.signal`

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1046,6 +1046,14 @@ Unix signals
 
    Like :func:`signal.signal`, this function must be invoked in the main
    thread.
+   
+   While signal handlers registered using :func:`signal.signal` will
+   typically be called immediately, handlers registered using this
+   method are subject to potential delays while waiting for other 
+   work in the given event loop to be completed.
+   
+   Any event handler set for the same signal via :func:`signal.signal`
+   is implicitly removed by this method.
 
 .. method:: loop.remove_signal_handler(sig)
 

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1046,7 +1046,7 @@ Unix signals
 
    Like :func:`signal.signal`, this function must be invoked in the main
    thread.
-   
+
    While signal handlers registered using :func:`signal.signal` will typically be
    called without significant delays as seen from the perspective of an
    interactive user, signal callbacks in asyncio are subject to additional

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1047,13 +1047,13 @@ Unix signals
    Like :func:`signal.signal`, this function must be invoked in the main
    thread.
    
-   While signal handlers registered using :func:`signal.signal` will
-   typically be called immediately, handlers registered using this
-   method are subject to potential delays while waiting for other
-   work in the given event loop to be completed.
-   
-   Any event handler set for the same signal via :func:`signal.signal`
-   is implicitly removed by this method.
+   While signal handlers registered using :func:`signal.signal` will typically be
+   called without significant delays as seen from the perspective of an
+   interactive user, signal callbacks in asyncio are subject to additional
+   delays while waiting for other work in the given event loop to be completed.
+
+   Any event handler set for the same signal via :func:`signal.signal` is
+   implicitly removed by this method.
 
 .. method:: loop.remove_signal_handler(sig)
 


### PR DESCRIPTION
Add information about potential delays in callbacks registered by this function, and a note about the side effect that corresponding handlers registered directly by signal.signal() are implicitly removed.

<!-- issue-number: [bpo-39765](https://bugs.python.org/issue39765) -->
https://bugs.python.org/issue39765
<!-- /issue-number -->
