### PR TITLE
bpo-39757: Use IDNA to encode domain part in email address

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -497,8 +497,10 @@ class Domain(TokenList):
 
     @property
     def domain(self):
-        return ''.join(super().value.split())
+        return ''.join(super().value.split()).encode('idna').decode('ascii')
 
+    def __str__(self):
+        return super().__str__().encode('idna').decode('ascii')
 
 class DotAtom(TokenList):
     token_type = 'dot-atom'

--- a/Lib/test/test_email/test_generator.py
+++ b/Lib/test/test_email/test_generator.py
@@ -271,6 +271,38 @@ class TestBytesGenerator(TestGeneratorBase, TestEmailBase):
         g.flatten(msg)
         self.assertEqual(s.getvalue(), expected)
 
+    def test_unicode_domain_transforms_idna(self):
+        msg = EmailMessage()
+        msg['From'] = "john@examplé.com"
+        msg['To'] = "Joe <joe@examplé.com>"
+
+        expected = textwrap.dedent("""\
+            From: john@xn--exampl-gva.com
+            To: Joe <joe@xn--exampl-gva.com>
+
+            """).encode('ascii').replace(b'\n', b'\r\n')
+
+        s = io.BytesIO()
+        g = BytesGenerator(s, policy=policy.SMTP)
+        g.flatten(msg)
+        self.assertEqual(s.getvalue(), expected)
+
+    def test_unicode_domain_transforms_idna_smtputf8_policy(self):
+        msg = EmailMessage()
+        msg['From'] = "john@examplé.com"
+        msg['To'] = "Joe <joe@examplé.com>"
+
+        expected = textwrap.dedent("""\
+            From: john@xn--exampl-gva.com
+            To: Joe <joe@xn--exampl-gva.com>
+
+            """).encode('utf-8').replace(b'\n', b'\r\n')
+
+        s = io.BytesIO()
+        g = BytesGenerator(s, policy=policy.SMTPUTF8)
+        g.flatten(msg)
+        self.assertEqual(s.getvalue(), expected)
+
     def test_smtputf8_policy(self):
         msg = EmailMessage()
         msg['From'] = "Páolo <főo@bar.com>"

--- a/Misc/NEWS.d/next/Library/2020-02-27-11-31-12.bpo-39757.FC-lgv.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-27-11-31-12.bpo-39757.FC-lgv.rst
@@ -1,0 +1,1 @@
+Add IDNA support in email addresses in email.message.EmailMessage


### PR DESCRIPTION
While b64/qp can be used to encode most non-ascii headers, the domain
part of an email address must conform IDNA ([rfc5890], [rfc5891]) thus
be encoded using the punycode algorithm ([rfc3492]).

[rfc5890]: https://tools.ietf.org/html/rfc5890
[rfc5891]: https://tools.ietf.org/html/rfc5891
[rfc3492]: https://tools.ietf.org/html/rfc3492

<!-- issue-number: [bpo-39757](https://bugs.python.org/issue39757) -->
https://bugs.python.org/issue39757
<!-- /issue-number -->
