### PR TITLE
bpo-39770: Remove unnecessary descriptor counting

### DIFF
--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2991,7 +2991,6 @@ array_modexec(PyObject *m)
 {
     char buffer[Py_ARRAY_LENGTH(descriptors)], *p;
     PyObject *typecodes;
-    Py_ssize_t size = 0;
     const struct arraydescr *descr;
 
     if (PyType_Ready(&Arraytype) < 0)
@@ -3007,10 +3006,6 @@ array_modexec(PyObject *m)
     if (PyModule_AddObject(m, "array", (PyObject *)&Arraytype) < 0) {
         Py_DECREF((PyObject *)&Arraytype);
         return -1;
-    }
-
-    for (descr=descriptors; descr->typecode != '\0'; descr++) {
-        size++;
     }
 
     p = buffer;


### PR DESCRIPTION
The array_modexec function in Modules/arraymodule.c has a loop that calculates the number of elements in the descriptors array.  This size was used at one point, but is no longer.  The loop can be removed.

<!-- issue-number: [bpo-39770](https://bugs.python.org/issue39770) -->
https://bugs.python.org/issue39770
<!-- /issue-number -->
