### PR TITLE
bpo-39769: Fix compileall ddir for subpkgs.

### DIFF
--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -143,7 +143,7 @@ runtime.
 Public functions
 ----------------
 
-.. function:: compile_dir(dir, maxlevels=sys.getrecursionlimit(), ddir=None, force=False, rx=None, quiet=0, legacy=False, optimize=-1, workers=1, invalidation_mode=None, stripdir=None, prependdir=None, limit_sl_dest=None)
+.. function:: compile_dir(dir, maxlevels=sys.getrecursionlimit(), ddir=None, force=False, rx=None, quiet=0, legacy=False, optimize=-1, workers=1, invalidation_mode=None, \*, stripdir=None, prependdir=None, limit_sl_dest=None)
 
    Recursively descend the directory tree named by *dir*, compiling all :file:`.py`
    files along the way. Return a true value if all the files compiled successfully,
@@ -221,7 +221,7 @@ Public functions
    .. versionchanged:: 3.9
       Added *stripdir*, *prependdir* and *limit_sl_dest* arguments.
 
-.. function:: compile_file(fullname, ddir=None, force=False, rx=None, quiet=0, legacy=False, optimize=-1, invalidation_mode=None)
+.. function:: compile_file(fullname, ddir=None, force=False, rx=None, quiet=0, legacy=False, optimize=-1, invalidation_mode=None, \*, stripdir=None, prependdir=None, limit_sl_dest=None)
 
    Compile the file with path *fullname*. Return a true value if the file
    compiled successfully, and a false value otherwise.

--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -46,7 +46,7 @@ def _walk_dir(dir, maxlevels, quiet=0):
 
 def compile_dir(dir, maxlevels=None, ddir=None, force=False,
                 rx=None, quiet=0, legacy=False, optimize=-1, workers=1,
-                invalidation_mode=None, stripdir=None,
+                invalidation_mode=None, *, stripdir=None,
                 prependdir=None, limit_sl_dest=None):
     """Byte-compile all modules in the given directory tree.
 
@@ -72,6 +72,13 @@ def compile_dir(dir, maxlevels=None, ddir=None, force=False,
                    the defined path
     """
     ProcessPoolExecutor = None
+    if ddir is not None and (stripdir is not None or prependdir is not None):
+        raise ValueError(("Destination dir (ddir) cannot be used "
+                          "in combination with stripdir or prependdir"))
+    if ddir:
+        stripdir = dir
+        prependdir = ddir
+        ddir = None
     if workers < 0:
         raise ValueError('workers must be greater or equal to 0')
     if workers != 1:
@@ -111,7 +118,7 @@ def compile_dir(dir, maxlevels=None, ddir=None, force=False,
 
 def compile_file(fullname, ddir=None, force=False, rx=None, quiet=0,
                  legacy=False, optimize=-1,
-                 invalidation_mode=None, stripdir=None, prependdir=None,
+                 invalidation_mode=None, *, stripdir=None, prependdir=None,
                  limit_sl_dest=None):
     """Byte-compile one file.
 

--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -75,7 +75,7 @@ def compile_dir(dir, maxlevels=None, ddir=None, force=False,
     if ddir is not None and (stripdir is not None or prependdir is not None):
         raise ValueError(("Destination dir (ddir) cannot be used "
                           "in combination with stripdir or prependdir"))
-    if ddir:
+    if ddir is not None:
         stripdir = dir
         prependdir = ddir
         ddir = None

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -212,7 +212,7 @@ class CompileallTestsBase:
         compileall.compile_dir(self.directory, quiet=True, maxlevels=depth)
         self.assertTrue(os.path.isfile(pyc_filename))
 
-    def _test_ddir_only(self, *, parallel=True):
+    def _test_ddir_only(self, *, ddir, parallel=True):
         """Recursive compile_dir ddir must contain package paths; bpo39769."""
         fullpath = ["test", "foo"]
         path = self.directory
@@ -223,7 +223,6 @@ class CompileallTestsBase:
             script_helper.make_script(path, "__init__", "")
             mods.append(script_helper.make_script(path, "mod",
                                                   "def fn(): 1/0\nfn()\n"))
-        ddir = "<a prefix>"
         compileall.compile_dir(
                 self.directory, quiet=True, ddir=ddir,
                 workers=2 if parallel else 1)
@@ -239,12 +238,20 @@ class CompileallTestsBase:
             self.assertIn(f'"{expected_in}"', os.fsdecode(err))
 
     def test_ddir_only_one_worker(self):
-        """Recursive compile_dir ddir must contain package paths; bpo39769."""
-        return self._test_ddir_only(parallel=False)
+        """Recursive compile_dir ddir= contains package paths; bpo39769."""
+        return self._test_ddir_only(ddir="<a prefix>", parallel=False)
 
-    def test_ddir_only_multiple_workers(self):
-        """Recursive compile_dir ddir must contain package paths; bpo39769."""
-        return self._test_ddir_only(parallel=True)
+    def test_ddir_multiple_workers(self):
+        """Recursive compile_dir ddir= contains package paths; bpo39769."""
+        return self._test_ddir_only(ddir="<a prefix>", parallel=True)
+
+    def test_ddir_empty_only_one_worker(self):
+        """Recursive compile_dir ddir='' contains package paths; bpo39769."""
+        return self._test_ddir_only(ddir="", parallel=False)
+
+    def test_ddir_empty_multiple_workers(self):
+        """Recursive compile_dir ddir='' contains package paths; bpo39769."""
+        return self._test_ddir_only(ddir="", parallel=True)
 
     def test_strip_only(self):
         fullpath = ["test", "build", "real", "path"]

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -227,19 +227,16 @@ class CompileallTestsBase:
         compileall.compile_dir(
                 self.directory, quiet=True, ddir=ddir,
                 workers=2 if parallel else 1)
-        assert mods
+        self.assertTrue(mods)
         for mod in mods:
-            assert mod.startswith(self.directory)
+            self.assertTrue(mod.startswith(self.directory), mod)
             modcode = importlib.util.cache_from_source(mod)
             modpath = mod[len(self.directory+os.sep):]
             _, _, err = script_helper.assert_python_failure(modcode)
             expected_in = os.path.join(ddir, modpath)
             mod_code_obj = test.test_importlib.util.get_code_from_pyc(modcode)
             self.assertEqual(mod_code_obj.co_filename, expected_in)
-            self.assertIn(
-                f'"{expected_in}"',
-                str(err, encoding=sys.getdefaultencoding())
-            )
+            self.assertIn(f'"{expected_in}"', os.fsdecode(err))
 
     def test_ddir_only_one_worker(self):
         """Recursive compile_dir ddir must contain package paths; bpo39769."""

--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -7,6 +7,7 @@ import importlib
 from importlib import machinery, util, invalidate_caches
 from importlib.abc import ResourceReader
 import io
+import marshal
 import os
 import os.path
 from pathlib import Path, PurePath
@@ -116,6 +117,16 @@ def submodule(parent, name, pkg_dir, content=''):
     with open(path, 'w') as subfile:
         subfile.write(content)
     return '{}.{}'.format(parent, name), path
+
+
+def get_code_from_pyc(pyc_path):
+    """Reads a pyc file and returns the unmarshalled code object within.
+
+    No header validation is performed.
+    """
+    with open(pyc_path, 'rb') as pyc_f:
+        pyc_f.seek(16)
+        return marshal.load(pyc_f)
 
 
 @contextlib.contextmanager

--- a/Misc/NEWS.d/next/Library/2020-02-27-00-40-21.bpo-39769.hJmxu4.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-27-00-40-21.bpo-39769.hJmxu4.rst
@@ -1,0 +1,4 @@
+The :func:`compileall.compile_dir` function's *ddir* parameter and the
+compileall command line flag `-d` no longer write the wrong pathname to the
+generated pyc file for submodules beneath the root of the directory tree
+being compiled.  This fixes a regression introduced with Python 3.5.


### PR DESCRIPTION
Fixes `compileall.compile_dir()`'s `ddir` parameter and `compileall` command
line flag `-d` to no longer write the wrong pathname to the generated
pyc file for submodules beneath the root of the directory tree being
compiled.  This fixes a regression introduced with Python 3.5.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39769](https://bugs.python.org/issue39769) -->
https://bugs.python.org/issue39769
<!-- /issue-number -->
