### PR TITLE
Document __spec__.location 'frozen' value

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -576,6 +576,9 @@ the module.
    When ``__package__`` is not defined, ``__spec__.parent`` is used as
    a fallback.
 
+   If the module comes from frozen code, ``__spec__.location`` is set
+   to ``'frozen'``.
+
    .. versionadded:: 3.4
 
    .. versionchanged:: 3.6


### PR DESCRIPTION
As noted in https://docs.python.org/3/whatsnew/3.4.html :
« If you must know that a module comes from frozen code
then you can see if the module’s `__spec__.location` is
set to 'frozen', check if the loader is a subclass of
importlib.machinery.FrozenImporter, or if Python 2
compatibility is necessary you can use imp.is_frozen(). »