### PR TITLE
bpo-30988: Add InvalidHeaderDefect for Trailing Periods

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -565,11 +565,15 @@ class DisplayName(Phrase):
             return res.value
         if res[0].token_type == 'cfws':
             res.pop(0)
+        elif res[0].token_type == 'dot':
+            pass  # 'dot' ValueTerminal does not have a token_type
         else:
             if res[0][0].token_type == 'cfws':
                 res[0] = TokenList(res[0][1:])
         if res[-1].token_type == 'cfws':
             res.pop()
+        elif res[-1].token_type == 'dot':
+            pass  # 'dot' ValueTerminal does not have a token_type
         else:
             if res[-1][-1].token_type == 'cfws':
                 res[-1] = TokenList(res[-1][:-1])
@@ -1419,10 +1423,6 @@ def get_phrase(value):
             phrase.defects.append(errors.ObsoleteHeaderDefect(
                 "period in 'phrase'"))
             value = value[1:]
-            if value[0] in PHRASE_ENDS:
-                value = " " + value
-                phrase.defects.append(errors.InvalidHeaderDefect(
-                    "trailing period in 'phrase' with no CFWS"))
         else:
             try:
                 token, value = get_word(value)

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1419,6 +1419,10 @@ def get_phrase(value):
             phrase.defects.append(errors.ObsoleteHeaderDefect(
                 "period in 'phrase'"))
             value = value[1:]
+                if value[0] in PHRASE_ENDS:
+                value = " " + value
+                phrase.defects.append(errors.InvalidHeaderDefect(
+                    "trailing period in 'phrase' with no CFWS"))
         else:
             try:
                 token, value = get_word(value)

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1419,7 +1419,7 @@ def get_phrase(value):
             phrase.defects.append(errors.ObsoleteHeaderDefect(
                 "period in 'phrase'"))
             value = value[1:]
-                if value[0] in PHRASE_ENDS:
+            if value[0] in PHRASE_ENDS:
                 value = " " + value
                 phrase.defects.append(errors.InvalidHeaderDefect(
                     "trailing period in 'phrase' with no CFWS"))


### PR DESCRIPTION
When an email header address field contains a period directly before the angle bracket, the default header policy raises an Attribute error, rather than adding a header defect.

This issue is referenced in the eml_parser as 27257, but I am not sure if this is the correct issue.
GOVCERT-LU/eml_parser#41

https://github.com/GOVCERT-LU/eml_parser/blob/f98980a77d9c7d914d97525a62294075c0ce42d9/tests/test_emlparser.py#L136

This was only checked with Python 3.7.3 (v3.7.3:ef4ec6ed12, Mar 25 2019, 21:26:53).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-27257](https://bugs.python.org/issue27257) -->
https://bugs.python.org/issue27257
<!-- /issue-number -->
