### PR TITLE
bpo-37708: random.choice no longer causes errors

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -299,7 +299,13 @@ class Random(_random.Random):
             i = self._randbelow(len(seq))
         except ValueError:
             raise IndexError('Cannot choose from an empty sequence') from None
-        return seq[i]
+        if hasattr(seq, '__getitem__'):
+            return seq[i]
+        else:
+            for (seqindex, item) in enumerate(seq):
+                if seqindex == i:
+                    return item
+            return seq[i]
 
     def shuffle(self, x, random=None):
         """Shuffle list x in place, and return None.


### PR DESCRIPTION
random.choice (and random.Random.choice) no longer causes errors if seq is not subscriptable
I realize that this may be rejected, but I have now experienced two locations where this issue has bothered me. The modification uses an optimized method to handle non-subscriptable objects.

<!-- issue-number: [bpo-37708](https://bugs.python.org/issue37708) -->
https://bugs.python.org/issue37708
<!-- /issue-number -->
