### PR TITLE
bpo-39793: use the same domain on make_msgid tests

### DIFF
--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3342,9 +3342,10 @@ multipart/report
             '.test-idstring@testdomain-string>')
 
     def test_make_msgid_default_domain(self):
+        domain = getfqdn() # ensure the domain wont change (bpo-39793)
         self.assertTrue(
-            email.utils.make_msgid().endswith(
-                '@' + getfqdn() + '>'))
+            email.utils.make_msgid(domain=domain).endswith(
+                '@' + domain + '>'))
 
     def test_Generator_linend(self):
         # Issue 14645.

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -11,8 +11,8 @@ import textwrap
 from io import StringIO, BytesIO
 from itertools import chain
 from random import choice
-from socket import getfqdn
 from threading import Thread
+from unittest.mock import patch
 
 import email
 import email.policy
@@ -3342,10 +3342,11 @@ multipart/report
             '.test-idstring@testdomain-string>')
 
     def test_make_msgid_default_domain(self):
-        domain = getfqdn() # ensure the domain wont change (bpo-39793)
-        self.assertTrue(
-            email.utils.make_msgid(domain=domain).endswith(
-                '@' + domain + '>'))
+        with patch('socket.getfqdn') as mock_getfqdn:
+            mock_getfqdn.return_value = domain = 'pythontest.example.com'
+            self.assertTrue(
+                email.utils.make_msgid().endswith(
+                    '@' + domain + '>'))
 
     def test_Generator_linend(self):
         # Issue 14645.

--- a/Misc/NEWS.d/next/Tests/2020-02-29-12-58-17.bpo-39793.Og2SUN.rst
+++ b/Misc/NEWS.d/next/Tests/2020-02-29-12-58-17.bpo-39793.Og2SUN.rst
@@ -1,0 +1,1 @@
+Use the same domain when testing ``make_msgid``. Patch by Batuhan Taskaya.


### PR DESCRIPTION


<!-- issue-number: [bpo-39793](https://bugs.python.org/issue39793) -->
https://bugs.python.org/issue39793
<!-- /issue-number -->
