### PR TITLE
bpo-39517: fix runpy.run_path() when using pathlike objects

### DIFF
--- a/Lib/runpy.py
+++ b/Lib/runpy.py
@@ -15,6 +15,7 @@ import importlib.machinery # importlib first so we can test #15386 via -m
 import importlib.util
 import io
 import types
+import os
 from pkgutil import read_code, get_importer
 
 __all__ = [
@@ -229,11 +230,12 @@ def _get_main_module_details(error=ImportError):
 
 def _get_code_from_file(run_name, fname):
     # Check for a compiled file first
-    with io.open_code(fname) as f:
+    decoded_path = os.path.abspath(os.fsdecode(fname))
+    with io.open_code(decoded_path) as f:
         code = read_code(f)
     if code is None:
         # That didn't work, so try it as normal source code
-        with io.open_code(fname) as f:
+        with io.open_code(decoded_path) as f:
             code = compile(f.read(), fname, 'exec')
     return code, fname
 

--- a/Lib/test/test_runpy.py
+++ b/Lib/test/test_runpy.py
@@ -8,6 +8,7 @@ import tempfile
 import importlib, importlib.machinery, importlib.util
 import py_compile
 import warnings
+import pathlib
 from test.support import (
     forget, make_legacy_pyc, unload, verbose, no_tracing,
     create_empty_file, temp_dir)
@@ -649,6 +650,14 @@ class RunPathTestCase(unittest.TestCase, CodeExecutionMixin):
         with temp_dir() as script_dir:
             mod_name = 'script'
             script_name = self._make_test_script(script_dir, mod_name)
+            self._check_script(script_name, "<run_path>", script_name,
+                               script_name, expect_spec=False)
+
+    def test_basic_script_with_path_object(self):
+        with temp_dir() as script_dir:
+            mod_name = 'script'
+            script_name = pathlib.Path(self._make_test_script(script_dir,
+                                                              mod_name))
             self._check_script(script_name, "<run_path>", script_name,
                                script_name, expect_spec=False)
 

--- a/Misc/NEWS.d/next/Library/2020-02-29-11-20-50.bpo-39517.voQZb8.rst
+++ b/Misc/NEWS.d/next/Library/2020-02-29-11-20-50.bpo-39517.voQZb8.rst
@@ -1,0 +1,1 @@
+Fix runpy.run_path() when using pathlike objects


### PR DESCRIPTION


<!-- issue-number: [bpo-39517](https://bugs.python.org/issue39517) -->
https://bugs.python.org/issue39517
<!-- /issue-number -->
