### PR TITLE
bpo-12915: Fix test to recognize when filesystem encoding cannot encode Unicode string

### DIFF
--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -246,7 +246,12 @@ class PkgutilTests(unittest.TestCase):
 
         for uw in unicode_words:
             d = os.path.join(self.dirname, uw)
-            os.makedirs(d, exist_ok=True)
+            try:
+                os.makedirs(d, exist_ok=True)
+            except  UnicodeEncodeError:
+                # catch errors such as: 'latin-1' codec can't encode characters
+                #                        in position 17-19: ordinal not in range(256) 
+                continue
             # make an empty __init__.py file
             f = os.path.join(d, '__init__.py')
             with open(f, 'w') as f:

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -250,7 +250,7 @@ class PkgutilTests(unittest.TestCase):
                 os.makedirs(d, exist_ok=True)
             except  UnicodeEncodeError:
                 # catch errors such as: 'latin-1' codec can't encode characters
-                #                        in position 17-19: ordinal not in range(256) 
+                #                        in position 17-19: ordinal not in range(256)
                 continue
             # make an empty __init__.py file
             f = os.path.join(d, '__init__.py')

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -249,8 +249,7 @@ class PkgutilTests(unittest.TestCase):
             try:
                 os.makedirs(d, exist_ok=True)
             except  UnicodeEncodeError:
-                # catch errors such as: 'latin-1' codec can't encode characters
-                #                        in position 17-19: ordinal not in range(256)
+                # When filesystem encoding cannot encode uw: skip this test
                 continue
             # make an empty __init__.py file
             f = os.path.join(d, '__init__.py')

--- a/Misc/NEWS.d/next/Tests/2020-03-01-13-49-52.bpo-12915.pQsDV1.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-01-13-49-52.bpo-12915.pQsDV1.rst
@@ -1,0 +1,3 @@
+When filesystem encoding cannot encode the Unicode string used for a filename
+continue testing with the next example.
+Patch by M Felt.

--- a/Misc/NEWS.d/next/Tests/2020-03-01-13-49-52.bpo-12915.pQsDV1.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-01-13-49-52.bpo-12915.pQsDV1.rst
@@ -1,3 +1,0 @@
-When filesystem encoding cannot encode the Unicode string used for a filename
-continue testing with the next example.
-Patch by M Felt.


### PR DESCRIPTION
When filesystem encoding cannot encode the Unicode string used for a filename

continue testing with the next example.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-12915](https://bugs.python.org/issue12915) -->
https://bugs.python.org/issue12915
<!-- /issue-number -->
