### PR TITLE
bpo-39824: module_traverse() don't call m_traverse if md_state=NULL

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -196,23 +196,47 @@ or request "multi-phase initialization" by returning the definition struct itsel
    .. c:member:: traverseproc m_traverse
 
       A traversal function to call during GC traversal of the module object, or
-      ``NULL`` if not needed. This function may be called before module state
-      is allocated (:c:func:`PyModule_GetState()` may return `NULL`),
-      and before the :c:member:`Py_mod_exec` function is executed.
+      ``NULL`` if not needed.
+
+      This function is not called if the module state was requested but is not
+      allocated yet. This is the case immediately after the module is created
+      and before the module is executed (:c:data:`Py_mod_exec` function). More
+      precisely, this function is not called if :c:member:`m_size` is greater
+      than 0 and the module state (as returned by :c:func:`PyModule_GetState`)
+      is ``NULL``.
+
+      .. versionchanged:: 3.9
+         No longer called before the module state is allocated.
 
    .. c:member:: inquiry m_clear
 
       A clear function to call during GC clearing of the module object, or
-      ``NULL`` if not needed. This function may be called before module state
-      is allocated (:c:func:`PyModule_GetState()` may return `NULL`),
-      and before the :c:member:`Py_mod_exec` function is executed.
+      ``NULL`` if not needed.
+
+      This function is not called if the module state was requested but is not
+      allocated yet. This is the case immediately after the module is created
+      and before the module is executed (:c:data:`Py_mod_exec` function). More
+      precisely, this function is not called if :c:member:`m_size` is greater
+      than 0 and the module state (as returned by :c:func:`PyModule_GetState`)
+      is ``NULL``.
+
+      .. versionchanged:: 3.9
+         No longer called before the module state is allocated.
 
    .. c:member:: freefunc m_free
 
-      A function to call during deallocation of the module object, or ``NULL`` if
-      not needed. This function may be called before module state
-      is allocated (:c:func:`PyModule_GetState()` may return `NULL`),
-      and before the :c:member:`Py_mod_exec` function is executed.
+      A function to call during deallocation of the module object, or ``NULL``
+      if not needed.
+
+      This function is not called if the module state was requested but is not
+      allocated yet. This is the case immediately after the module is created
+      and before the module is executed (:c:data:`Py_mod_exec` function). More
+      precisely, this function is not called if :c:member:`m_size` is greater
+      than 0 and the module state (as returned by :c:func:`PyModule_GetState`)
+      is ``NULL``.
+
+      .. versionchanged:: 3.9
+         No longer called before the module state is allocated.
 
 Single-phase initialization
 ...........................

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -503,6 +503,17 @@ Build and C API Changes
   *tstate* parameter (``PyThreadState*``).
   (Contributed by Victor Stinner in :issue:`38500`.)
 
+* Extension modules: :c:member:`~PyModuleDef.m_traverse`,
+  :c:member:`~PyModuleDef.m_clear` and :c:member:`~PyModuleDef.m_free`
+  functions of :c:type:`PyModuleDef` are no longer called if the module state
+  was requested but is not allocated yet. This is the case immediately after
+  the module is created and before the module is executed
+  (:c:data:`Py_mod_exec` function). More precisely, this function is not called
+  if :c:member:`~PyModuleDef.m_size` is greater than 0 and the module state (as
+  returned by :c:func:`PyModule_GetState`) is ``NULL``.
+
+  Extension modules without module state (``m_size <= 0``) are not affected.
+
 
 Deprecated
 ==========

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -508,7 +508,7 @@ Build and C API Changes
   functions of :c:type:`PyModuleDef` are no longer called if the module state
   was requested but is not allocated yet. This is the case immediately after
   the module is created and before the module is executed
-  (:c:data:`Py_mod_exec` function). More precisely, this function is not called
+  (:c:data:`Py_mod_exec` function). More precisely, these functions are not called
   if :c:member:`~PyModuleDef.m_size` is greater than 0 and the module state (as
   returned by :c:func:`PyModule_GetState`) is ``NULL``.
 

--- a/Lib/test/test_importlib/extension/test_loader.py
+++ b/Lib/test/test_importlib/extension/test_loader.py
@@ -267,29 +267,6 @@ class MultiPhaseExtensionModuleTests(abc.LoaderTests):
                 self.assertEqual(module.__name__, name)
                 self.assertEqual(module.__doc__, "Module named in %s" % lang)
 
-    @unittest.skipIf(not hasattr(sys, 'gettotalrefcount'),
-            '--with-pydebug has to be enabled for this test')
-    def test_bad_traverse(self):
-        ''' Issue #32374: Test that traverse fails when accessing per-module
-            state before Py_mod_exec was executed.
-            (Multiphase initialization modules only)
-        '''
-        script = """if True:
-                try:
-                    from test import support
-                    import importlib.util as util
-                    spec = util.find_spec('_testmultiphase')
-                    spec.name = '_testmultiphase_with_bad_traverse'
-
-                    with support.SuppressCrashReport():
-                        m = spec.loader.create_module(spec)
-                except:
-                    # Prevent Python-level exceptions from
-                    # ending the process with non-zero status
-                    # (We are testing for a crash in C-code)
-                    pass"""
-        assert_python_failure("-c", script)
-
 
 (Frozen_MultiPhaseExtensionModuleTests,
  Source_MultiPhaseExtensionModuleTests

--- a/Misc/NEWS.d/next/C API/2020-03-02-11-29-45.bpo-39824.71_ZMn.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-02-11-29-45.bpo-39824.71_ZMn.rst
@@ -3,7 +3,7 @@ Extension modules: :c:member:`~PyModuleDef.m_traverse`,
 of :c:type:`PyModuleDef` are no longer called if the module state was requested
 but is not allocated yet. This is the case immediately after the module is
 created and before the module is executed (:c:data:`Py_mod_exec` function). More
-precisely, this function is not called if :c:member:`~PyModuleDef.m_size` is
+precisely, these functions are not called if :c:member:`~PyModuleDef.m_size` is
 greater than 0 and the module state (as returned by
 :c:func:`PyModule_GetState`) is ``NULL``.
 

--- a/Misc/NEWS.d/next/C API/2020-03-02-11-29-45.bpo-39824.71_ZMn.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-02-11-29-45.bpo-39824.71_ZMn.rst
@@ -1,0 +1,10 @@
+Extension modules: :c:member:`~PyModuleDef.m_traverse`,
+:c:member:`~PyModuleDef.m_clear` and :c:member:`~PyModuleDef.m_free` functions
+of :c:type:`PyModuleDef` are no longer called if the module state was requested
+but is not allocated yet. This is the case immediately after the module is
+created and before the module is executed (:c:data:`Py_mod_exec` function). More
+precisely, this function is not called if :c:member:`~PyModuleDef.m_size` is
+greater than 0 and the module state (as returned by
+:c:func:`PyModule_GetState`) is ``NULL``.
+
+Extension modules without module state (``m_size <= 0``) are not affected.

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -778,9 +778,7 @@ static int
 locale_traverse(PyObject *m, visitproc visit, void *arg)
 {
     _locale_state *state = (_locale_state*)PyModule_GetState(m);
-    if (state) {
-        Py_VISIT(state->Error);
-    }
+    Py_VISIT(state->Error);
     return 0;
 }
 
@@ -788,9 +786,7 @@ static int
 locale_clear(PyObject *m)
 {
     _locale_state *state = (_locale_state*)PyModule_GetState(m);
-    if (state) {
-        Py_CLEAR(state->Error);
-    }
+    Py_CLEAR(state->Error);
     return 0;
 }
 

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -229,15 +229,14 @@ atexit_m_traverse(PyObject *self, visitproc visit, void *arg)
     atexitmodule_state *modstate;
 
     modstate = (atexitmodule_state *)PyModule_GetState(self);
-    if (modstate != NULL) {
-        for (i = 0; i < modstate->ncallbacks; i++) {
-            atexit_callback *cb = modstate->atexit_callbacks[i];
-            if (cb == NULL)
-                continue;
-            Py_VISIT(cb->func);
-            Py_VISIT(cb->args);
-            Py_VISIT(cb->kwargs);
-        }
+
+    for (i = 0; i < modstate->ncallbacks; i++) {
+        atexit_callback *cb = modstate->atexit_callbacks[i];
+        if (cb == NULL)
+            continue;
+        Py_VISIT(cb->func);
+        Py_VISIT(cb->args);
+        Py_VISIT(cb->kwargs);
     }
     return 0;
 }
@@ -247,9 +246,7 @@ atexit_m_clear(PyObject *self)
 {
     atexitmodule_state *modstate;
     modstate = (atexitmodule_state *)PyModule_GetState(self);
-    if (modstate != NULL) {
-        atexit_cleanup(modstate);
-    }
+    atexit_cleanup(modstate);
     return 0;
 }
 
@@ -258,10 +255,8 @@ atexit_free(PyObject *m)
 {
     atexitmodule_state *modstate;
     modstate = (atexitmodule_state *)PyModule_GetState(m);
-    if (modstate != NULL) {
-        atexit_cleanup(modstate);
-        PyMem_Free(modstate->atexit_callbacks);
-    }
+    atexit_cleanup(modstate);
+    PyMem_Free(modstate->atexit_callbacks);
 }
 
 PyDoc_STRVAR(atexit_unregister__doc__,

--- a/Modules/audioop.c
+++ b/Modules/audioop.c
@@ -1926,9 +1926,7 @@ static int
 audioop_traverse(PyObject *module, visitproc visit, void *arg)
 {
     audioop_state *state = (audioop_state *)PyModule_GetState(module);
-    if (state) {
-        Py_VISIT(state->AudioopError);
-    }
+    Py_VISIT(state->AudioopError);
     return 0;
 }
 
@@ -1936,9 +1934,7 @@ static int
 audioop_clear(PyObject *module)
 {
     audioop_state *state = (audioop_state *)PyModule_GetState(module);
-    if (state) {
-        Py_CLEAR(state->AudioopError);
-    }
+    Py_CLEAR(state->AudioopError);
     return 0;
 }
 

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -1653,10 +1653,8 @@ static int
 binascii_traverse(PyObject *module, visitproc visit, void *arg)
 {
     binascii_state *state = get_binascii_state(module);
-    if (state) {
-        Py_VISIT(state->Error);
-        Py_VISIT(state->Incomplete);
-    }
+    Py_VISIT(state->Error);
+    Py_VISIT(state->Incomplete);
     return 0;
 }
 
@@ -1664,10 +1662,8 @@ static int
 binascii_clear(PyObject *module)
 {
     binascii_state *state = get_binascii_state(module);
-    if (state) {
-        Py_CLEAR(state->Error);
-        Py_CLEAR(state->Incomplete);
-    }
+    Py_CLEAR(state->Error);
+    Py_CLEAR(state->Incomplete);
     return 0;
 }
 
@@ -1686,7 +1682,7 @@ static struct PyModuleDef binasciimodule = {
     binascii_slots,
     binascii_traverse,
     binascii_clear,
-    binascii_free 
+    binascii_free
 };
 
 PyMODINIT_FUNC


### PR DESCRIPTION
Extension modules: m_traverse, m_clear and m_free functions of
PyModuleDef are no longer called before the module state is
allocated. Extension modules with no module state (m_size <= 0) are
no affected.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39824](https://bugs.python.org/issue39824) -->
https://bugs.python.org/issue39824
<!-- /issue-number -->
