### PR TITLE
bpo-39796: Fix _warnings module initialization

### DIFF
--- a/Include/internal/pycore_warnings.h
+++ b/Include/internal/pycore_warnings.h
@@ -17,6 +17,8 @@ struct _warnings_runtime_state {
     long filters_version;
 };
 
+extern PyStatus _PyWarnings_InitState(PyThreadState *tstate);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -677,8 +677,9 @@ pycore_init_import_warnings(PyThreadState *tstate, PyObject *sysmod)
     const PyConfig *config = &tstate->interp->config;
     if (_Py_IsMainInterpreter(tstate)) {
         /* Initialize _warnings. */
-        if (_PyWarnings_Init() == NULL) {
-            return _PyStatus_ERR("can't initialize warnings");
+        status = _PyWarnings_InitState(tstate);
+        if (_PyStatus_EXCEPTION(status)) {
+            return status;
         }
 
         if (config->_install_importlib) {


### PR DESCRIPTION
* Add _PyWarnings_InitState() which only initializes the _warnings
  module state (tstate->interp->warnings) without creating a module
  object
* Py_InitializeFromConfig() now calls _PyWarnings_InitState() instead
  of _PyWarnings_Init()
* Rename also private functions of _warnings.c to avoid confusion
  between the public C API and the private C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39796](https://bugs.python.org/issue39796) -->
https://bugs.python.org/issue39796
<!-- /issue-number -->
