### PR TITLE
Tracemalloc docs - Print entire file path

### DIFF
--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -203,9 +203,8 @@ ignoring ``<frozen importlib._bootstrap>`` and ``<unknown>`` files::
         for index, stat in enumerate(top_stats[:limit], 1):
             frame = stat.traceback[0]
             # replace "/path/to/module/file.py" with "module/file.py"
-            filename = os.sep.join(frame.filename.split(os.sep)[-2:])
             print("#%s: %s:%s: %.1f KiB"
-                  % (index, filename, frame.lineno, stat.size / 1024))
+                  % (index, frame.filename, frame.lineno, stat.size / 1024))
             line = linecache.getline(frame.filename, frame.lineno).strip()
             if line:
                 print('    %s' % line)

--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -202,7 +202,6 @@ ignoring ``<frozen importlib._bootstrap>`` and ``<unknown>`` files::
         print("Top %s lines" % limit)
         for index, stat in enumerate(top_stats[:limit], 1):
             frame = stat.traceback[0]
-            # replace "/path/to/module/file.py" with "module/file.py"
             print("#%s: %s:%s: %.1f KiB"
                   % (index, frame.filename, frame.lineno, stat.size / 1024))
             line = linecache.getline(frame.filename, frame.lineno).strip()


### PR DESCRIPTION
The tracemalloc example given in the 'Pretty top' section of the docs outputs the 10 lines allocating the most memory in the format "module/file.py".

While trying to investigate a memory leak on a project, using the aforementioned example produced a not so useful output. 

The change proposed here would printout the entire path.