### PR TITLE
bpo-39826: add getConnection() hook to logging HTTPHandler

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1173,6 +1173,20 @@ class HTTPHandler(logging.Handler):
         """
         return record.__dict__
 
+    def getConnection(self, host, secure):
+        """
+        get a HTTP[S]Connection.
+
+        Override when a custom connection is required, for example if
+        there is a proxy.
+        """
+        import http.client
+        if secure:
+            connection = http.client.HTTPSConnection(host, context=self.context)
+        else:
+            connection = http.client.HTTPConnection(host)
+        return connection
+
     def emit(self, record):
         """
         Emit a record.
@@ -1180,12 +1194,9 @@ class HTTPHandler(logging.Handler):
         Send the record to the Web server as a percent-encoded dictionary
         """
         try:
-            import http.client, urllib.parse
+            import urllib.parse
             host = self.host
-            if self.secure:
-                h = http.client.HTTPSConnection(host, context=self.context)
-            else:
-                h = http.client.HTTPConnection(host)
+            h = self.getConnection(host, self.secure)
             url = self.url
             data = urllib.parse.urlencode(self.mapLogRecord(record))
             if self.method == "GET":

--- a/Misc/NEWS.d/next/Library/2020-03-02-15-15-01.bpo-39826.DglHk7.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-02-15-15-01.bpo-39826.DglHk7.rst
@@ -1,0 +1,1 @@
+Add getConnection method to logging HTTPHandler to enable custom connections.


### PR DESCRIPTION
This PR enables it easily extend HTTPHandler to provide a custom connection, for example to use a proxy, without having to reimplement `emit`.






<!-- issue-number: [bpo-39826](https://bugs.python.org/issue39826) -->
https://bugs.python.org/issue39826
<!-- /issue-number -->
