### PR TITLE
 bpo-39776: Lock ++interp->tstate_next_unique_id. (GH-18746)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-02-20-12-33.bpo-39776.fNaxi_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-02-20-12-33.bpo-39776.fNaxi_.rst
@@ -1,0 +1,6 @@
+Fix race condition where threads created by PyGILState_Ensure() could get a
+duplicate id.
+
+This affects consumers of tstate->id like the contextvar caching machinery,
+which could return invalid cached objects under heavy thread load (observed
+in embedded scenarios).

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -606,13 +606,12 @@ new_threadstate(PyInterpreterState *interp, int init)
     tstate->context = NULL;
     tstate->context_ver = 1;
 
-    tstate->id = ++interp->tstate_next_unique_id;
-
     if (init) {
         _PyThreadState_Init(tstate);
     }
 
     HEAD_LOCK(runtime);
+    tstate->id = ++interp->tstate_next_unique_id;
     tstate->prev = NULL;
     tstate->next = interp->tstate_head;
     if (tstate->next)


### PR DESCRIPTION
  - Threads created by PyGILState_Ensure() could have a duplicate tstate->id.


<!-- issue-number: [bpo-39776](https://bugs.python.org/issue39776) -->
https://bugs.python.org/issue39776
<!-- /issue-number -->
