### PR TITLE
bpo-39831: Fix a reference leak in PyErr_WarnEx().

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -859,11 +859,11 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
         int rc;
 
         if (PyErr_Occurred()) {
-            return 0;
+            goto handle_error;
         }
         *registry = PyDict_New();
         if (*registry == NULL)
-            return 0;
+            goto handle_error;
 
          rc = _PyDict_SetItemId(globals, &PyId___warningregistry__, *registry);
          if (rc < 0)
@@ -893,6 +893,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
        dangling reference. */
     Py_XDECREF(*registry);
     Py_XDECREF(*module);
+    Py_XDECREF(*filename);
     return 0;
 }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39831](https://bugs.python.org/issue39831) -->
https://bugs.python.org/issue39831
<!-- /issue-number -->
