### PR TITLE
[3.7] bpo-39831: Fix a reference leak in PyErr_WarnEx(). (GH-18750).

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -710,7 +710,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
 
         *registry = PyDict_New();
         if (*registry == NULL)
-            return 0;
+            goto handle_error;
 
          rc = PyDict_SetItemString(globals, "__warningregistry__", *registry);
          if (rc < 0)
@@ -802,6 +802,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
        dangling reference. */
     Py_XDECREF(*registry);
     Py_XDECREF(*module);
+    Py_XDECREF(*filename);
     return 0;
 }
 


### PR DESCRIPTION
(cherry picked from commit 2d2f85517f8216146a2f888d1ad4d765b3be2339)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>


<!-- issue-number: [bpo-39831](https://bugs.python.org/issue39831) -->
https://bugs.python.org/issue39831
<!-- /issue-number -->
