### PR TITLE
[3.8] bpo-39831: Fix a reference leak in PyErr_WarnEx(). (GH-18750)

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -856,11 +856,11 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
         int rc;
 
         if (PyErr_Occurred()) {
-            return 0;
+            goto handle_error;
         }
         *registry = PyDict_New();
         if (*registry == NULL)
-            return 0;
+            goto handle_error;
 
          rc = _PyDict_SetItemId(globals, &PyId___warningregistry__, *registry);
          if (rc < 0)
@@ -890,6 +890,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
        dangling reference. */
     Py_XDECREF(*registry);
     Py_XDECREF(*module);
+    Py_XDECREF(*filename);
     return 0;
 }
 


### PR DESCRIPTION
(cherry picked from commit 2d2f855)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>

<!-- issue-number: [bpo-39831](https://bugs.python.org/issue39831) -->
https://bugs.python.org/issue39831
<!-- /issue-number -->
