### PR TITLE
bpo-39761: Fix dtrace build with empty $DFLAGS

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-03-03-15-56-07.bpo-39761.k10aGe.rst
+++ b/Misc/NEWS.d/next/Build/2020-03-03-15-56-07.bpo-39761.k10aGe.rst
@@ -1,0 +1,1 @@
+Fix build with DTrace but without additional DFLAGS.

--- a/configure
+++ b/configure
@@ -11495,7 +11495,7 @@ if ${ac_cv_dtrace_link+:} false; then :
 else
               ac_cv_dtrace_link=no
             echo 'BEGIN{}' > conftest.d
-            "$DTRACE" "$DFLAGS" -G -s conftest.d -o conftest.o > /dev/null 2>&1 && \
+            "$DTRACE" $DFLAGS -G -s conftest.d -o conftest.o > /dev/null 2>&1 && \
                 ac_cv_dtrace_link=yes
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -3541,7 +3541,7 @@ then
         [ac_cv_dtrace_link], [dnl
             ac_cv_dtrace_link=no
             echo 'BEGIN{}' > conftest.d
-            "$DTRACE" "$DFLAGS" -G -s conftest.d -o conftest.o > /dev/null 2>&1 && \
+            "$DTRACE" $DFLAGS -G -s conftest.d -o conftest.o > /dev/null 2>&1 && \
                 ac_cv_dtrace_link=yes
       ])
     if test "$ac_cv_dtrace_link" = "yes"; then


### PR DESCRIPTION
This should fix a regression introduced in [bpo-38960](https://bugs.python.org/issue38960).

When `DFLAGS` was empty, `"$DFLAGS"` results in an empty argument (`""`). Without the quotes, an empty variable will be ignored by the shell.



<!-- issue-number: [bpo-39761](https://bugs.python.org/issue39761) -->
https://bugs.python.org/issue39761
<!-- /issue-number -->
