### PR TITLE
bpo-38870: Correctly unparse empty docstrings

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1006,6 +1006,7 @@ class _Unparser(NodeVisitor):
             # Preserve quotes in the docstring by escaping them
             value = value.replace("\\", "\\\\")
             value = value.replace('"""', '""\"')
+            value = value.replace("\r", "\\r")
             if value[-1] == '"':
                 value = value.replace('"', '\\"', -1)
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1004,7 +1004,7 @@ class _Unparser(NodeVisitor):
         # Preserve quotes in the docstring by escaping them
         value = node.value.replace("\\", "\\\\")
         value = value.replace('"""', '""\"')
-        if len(value) > 0 and value[-1] == '"':
+        if value and value[-1] == '"':
             value = value.replace('"', '\\"', -1)
 
         self.write(f'"""{value}"""')

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1001,11 +1001,13 @@ class _Unparser(NodeVisitor):
         if node.kind == "u":
             self.write("u")
 
-        # Preserve quotes in the docstring by escaping them
-        value = node.value.replace("\\", "\\\\")
-        value = value.replace('"""', '""\"')
-        if value and value[-1] == '"':
-            value = value.replace('"', '\\"', -1)
+        value = node.value
+        if value:
+            # Preserve quotes in the docstring by escaping them
+            value = value.replace("\\", "\\\\")
+            value = value.replace('"""', '""\"')
+            if value[-1] == '"':
+                value = value.replace('"', '\\"', -1)
 
         self.write(f'"""{value}"""')
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1004,7 +1004,7 @@ class _Unparser(NodeVisitor):
         # Preserve quotes in the docstring by escaping them
         value = node.value.replace("\\", "\\\\")
         value = value.replace('"""', '""\"')
-        if value[-1] == '"':
+        if len(value) > 0 and value[-1] == '"':
             value = value.replace('"', '\\"', -1)
 
         self.write(f'"""{value}"""')

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -354,6 +354,7 @@ class CosmeticTestCase(ASTTestCase):
             empty newline"""''',
             '"""With some \t"""',
             '"""Foo "bar" baz """',
+            '""""""',
         )
 
         for prefix in docstring_prefixes:

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -363,6 +363,8 @@ class CosmeticTestCase(ASTTestCase):
             '"""Foo "bar" baz """',
             '"""\\r"""',
             '""""""',
+            '"""\'\'\'"""',
+            '"""\'\'\'\'\'\'"""',
         )
 
         for prefix in docstring_prefixes:

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -304,11 +304,18 @@ class UnparseTestCase(ASTTestCase):
     def test_docstrings(self):
         docstrings = (
             'this ends with double quote"',
-            'this includes a """triple quote"""'
+            'this includes a """triple quote"""',
+            '\r',
+            '\\r',
+            '\t',
+            '\\t',
+            '\n',
+            '\\n',
+            '\r\\r\t\\t\n\\n'
         )
         for docstring in docstrings:
             # check as Module docstrings for easy testing
-            self.check_ast_roundtrip(f"'{docstring}'")
+            self.check_ast_roundtrip(f"'''{docstring}'''")
 
 
 class CosmeticTestCase(ASTTestCase):
@@ -354,6 +361,7 @@ class CosmeticTestCase(ASTTestCase):
             empty newline"""''',
             '"""With some \t"""',
             '"""Foo "bar" baz """',
+            '"""\\r"""',
             '""""""',
         )
 


### PR DESCRIPTION
This bug was introduced in #17760 
<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->


Automerge-Triggered-By: @pablogsal