### PR TITLE
bpo-39855: Fix test_subprocess if nobody user doesn't exist

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1791,7 +1791,12 @@ class POSIXProcessTestCase(BaseTestCase):
         name_uid = "nobody" if sys.platform != 'darwin' else "unknown"
 
         if pwd is not None:
-            test_users.append(name_uid)
+            try:
+                pwd.getpwnam(name_uid)
+                test_users.append(name_uid)
+            except KeyError:
+                # unknown user name
+                name_uid = None
 
         for user in test_users:
             # posix_spawn() may be used with close_fds=False
@@ -1819,7 +1824,7 @@ class POSIXProcessTestCase(BaseTestCase):
         with self.assertRaises(ValueError):
             subprocess.check_call(ZERO_RETURN_CMD, user=-1)
 
-        if pwd is None:
+        if pwd is None and name_uid is not None:
             with self.assertRaises(ValueError):
                 subprocess.check_call(ZERO_RETURN_CMD, user=name_uid)
 

--- a/Misc/NEWS.d/next/Tests/2020-03-04-23-03-01.bpo-39855.Ql5xv8.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-04-23-03-01.bpo-39855.Ql5xv8.rst
@@ -1,0 +1,3 @@
+test_subprocess.test_user() now skips the test on an user name if the user
+name doesn't exist. For example, skip the test if the user "nobody" doesn't
+exist on Linux.


### PR DESCRIPTION
test_subprocess.test_user() now skips the test on an user name if the
user name doesn't exist. For example, skip the test if the user
"nobody" doesn't exist on Linux.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39855](https://bugs.python.org/issue39855) -->
https://bugs.python.org/issue39855
<!-- /issue-number -->
