### PR TITLE
Add a missing space after a period in 'typing.TypedDict' documentation

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1004,7 +1004,7 @@ The module defines the following classes, functions and decorators:
           x: int
           y: int
 
-   This means that a point2D TypedDict can have any of the keys omitted.A type
+   This means that a point2D TypedDict can have any of the keys omitted. A type
    checker is only expected to support a literal False or True as the value of
    the total argument. True is the default, and makes all items defined in the
    class body be required.


### PR DESCRIPTION


Automerge-Triggered-By: @brettcannon