### PR TITLE
bpo-13487: Use sys.modules.copy() in inspect for thread safety

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -741,7 +741,7 @@ def getmodule(object, _filename=None):
         return sys.modules.get(modulesbyfile[file])
     # Update the filename to module name cache and check yet again
     # Copy sys.modules in order to cope with changes while iterating
-    for modname, module in list(sys.modules.items()):
+    for modname, module in sys.modules.copy().items():
         if ismodule(module) and hasattr(module, '__file__'):
             f = module.__file__
             if f == _filesbymodname.get(modname, None):

--- a/Misc/NEWS.d/next/Library/2020-03-04-16-10-59.bpo-13487.gqe4Fb.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-04-16-10-59.bpo-13487.gqe4Fb.rst
@@ -1,0 +1,3 @@
+Avoid a possible *"RuntimeError: dictionary changed size during iteration"*
+from :func:`inspect.getmodule` when it tried to loop through
+:attr:`sys.modules`.


### PR DESCRIPTION
`list(sys.modules.items())` was apparently not immune to "dictionary
changed size during iteration" errors.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-13487](https://bugs.python.org/issue13487) -->
https://bugs.python.org/issue13487
<!-- /issue-number -->
