### PR TITLE
closes bpo-39859: Do not downcast result of hstrerror

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -658,7 +658,7 @@ set_herror(int h_error)
     PyObject *v;
 
 #ifdef HAVE_HSTRERROR
-    v = Py_BuildValue("(is)", h_error, (char *)hstrerror(h_error));
+    v = Py_BuildValue("(is)", h_error, (const char *)hstrerror(h_error));
 #else
     v = Py_BuildValue("(is)", h_error, "host not found");
 #endif

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -658,7 +658,7 @@ set_herror(int h_error)
     PyObject *v;
 
 #ifdef HAVE_HSTRERROR
-    v = Py_BuildValue("(is)", h_error, (const char *)hstrerror(h_error));
+    v = Py_BuildValue("(is)", h_error, hstrerror(h_error));
 #else
     v = Py_BuildValue("(is)", h_error, "host not found");
 #endif


### PR DESCRIPTION
set_herror builds a string by calling hstrerror but downcasts its return value to char *.  It should be const char *.


<!-- issue-number: [bpo-39859](https://bugs.python.org/issue39859) -->
https://bugs.python.org/issue39859
<!-- /issue-number -->


Automerge-Triggered-By: @benjaminp