### PR TITLE
bpo-39860: lib/configparser; Support multiple sections in get()

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1143,8 +1143,9 @@ class RawConfigParser(MutableMapping):
 
         """
         var_dict = {}
+        section_is_iterable = not isinstance(section, str) and hasattr(section, '__iter__')
+        section_list = section if section_is_iterable else [section]
 
-        section_list = section if hasattr(section, '__iter__') else [section]
         map_list = []
 
         if vars:

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1143,7 +1143,8 @@ class RawConfigParser(MutableMapping):
 
         """
         var_dict = {}
-        section_list = [section] if isinstance(section, str) else section
+
+        section_list = section if hasattr(section, '__iter__') else [section]
         map_list = []
 
         if vars:

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -763,7 +763,7 @@ class RawConfigParser(MutableMapping):
         self.read_file(fp, source=filename)
 
     def get(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
-        """Get an option value for a given section.
+        """Get an option value for a given section (or list of sections).
 
         If `vars' is provided, it must be a dictionary. The option is looked up
         in `vars' (if provided), `section', and in `DEFAULTSECT' in that order.
@@ -1139,22 +1139,26 @@ class RawConfigParser(MutableMapping):
     def _unify_values(self, section, vars):
         """Create a sequence of lookups with 'vars' taking priority over
         the 'section' which takes priority over the DEFAULTSECT.
+        'section' can be a string or list (specialised to generalised)
 
         """
-        sectiondict = {}
-        try:
-            sectiondict = self._sections[section]
-        except KeyError:
-            if section != self.default_section:
-                raise NoSectionError(section) from None
-        # Update with the entry specific variables
-        vardict = {}
+        var_dict = {}
+        section_list = [section] if isinstance(section, str) else section
+        map_list = []
+
         if vars:
             for key, value in vars.items():
                 if value is not None:
                     value = str(value)
-                vardict[self.optionxform(key)] = value
-        return _ChainMap(vardict, sectiondict, self._defaults)
+                var_dict[self.optionxform(key)] = value
+        map_list.append(var_dict)
+        for section_item in section_list:
+            if section_item in self._sections:
+                map_list.append(self._sections[section_item])
+            elif section_item != self.default_section:
+                raise NoSectionError(section_item) from None
+        map_list.append(self._defaults)
+        return _ChainMap(*map_list)
 
     def _convert_to_boolean(self, value):
         """Return a boolean value translating from other types if necessary.

--- a/Misc/NEWS.d/next/Library/2020-03-05-10-58-58.bpo-39860.MUCf7D.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-05-10-58-58.bpo-39860.MUCf7D.rst
@@ -1,0 +1,4 @@
+This allows the configparser.get method to accept an iterable of sections, (as well as continue to support a string) so that it can use cascading defaults, as expected by systems such as MySQL.  
+For example, cf. https://dev.mysql.com/doc/refman/8.0/en/option-files.html#option-file-syntax
+
+"List more general option groups first and more specific groups later. For example, a [client] group is more general because it is read by all client programs, whereas a [mysqldump] group is read only by mysqldump. Options specified later override options specified earlier, so putting the option groups in the order [client], [mysqldump] enables mysqldump-specific options to override [client] options."


### PR DESCRIPTION
This implements a backward-compatible approach to supporting multiple sections, per specifications as foun in e.g. Mysql

https://dev.mysql.com/doc/refman/8.0/en/option-files.html#option-file-syntax
_"List more general option groups first and more specific groups later. For example, a [client] group is more general because it is read by all client programs, whereas a [mysqldump] group is read only by mysqldump. Options specified later override options specified earlier."_

<!-- issue-number: [bpo-39860](https://bugs.python.org/issue39860) -->
https://bugs.python.org/issue39860
<!-- /issue-number -->
