### PR TITLE
[WIP] bpo-39873: _PyObject_CAST() check if the object is valid

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -371,7 +371,7 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
 
 #define Py_XSETREF(op, op2)                     \
     do {                                        \
-        PyObject *_py_tmp = _PyObject_CAST(op); \
+        PyObject *_py_tmp = _PyObject_XCAST(op);\
         (op) = (op2);                           \
         Py_XDECREF(_py_tmp);                    \
     } while (0)

--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -24,7 +24,7 @@ _PyObject_INIT(PyObject *op, PyTypeObject *typeobj)
 }
 
 #define PyObject_INIT(op, typeobj) \
-    _PyObject_INIT(_PyObject_CAST(op), (typeobj))
+    _PyObject_INIT(_PyObject_CAST_RAW(op), (typeobj))
 
 static inline PyVarObject*
 _PyObject_INIT_VAR(PyVarObject *op, PyTypeObject *typeobj, Py_ssize_t size)
@@ -36,7 +36,7 @@ _PyObject_INIT_VAR(PyVarObject *op, PyTypeObject *typeobj, Py_ssize_t size)
 }
 
 #define PyObject_INIT_VAR(op, typeobj, size) \
-    _PyObject_INIT_VAR(_PyVarObject_CAST(op), (typeobj), (size))
+    _PyObject_INIT_VAR(_PyVarObject_CAST_RAW(op), (typeobj), (size))
 
 
 /* This function returns the number of allocated memory blocks, regardless of size */

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -1739,7 +1739,8 @@ _PyTraceMalloc_NewReference(PyObject *op)
     }
 
     uintptr_t ptr;
-    PyTypeObject *type = Py_TYPE(op);
+    /* Avoid Py_TYPE() since op is not valid yet */
+    PyTypeObject *type = op->ob_type;
     if (PyType_IS_GC(type)) {
         ptr = (uintptr_t)((char *)op - sizeof(PyGC_Head));
     }

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -117,7 +117,8 @@ PyFloat_FromDouble(double fval)
 {
     PyFloatObject *op = free_list;
     if (op != NULL) {
-        free_list = (PyFloatObject *) Py_TYPE(op);
+        /* Avoid Py_TYPE() since op is not valid */
+        free_list = (PyFloatObject *)((PyObject*)op)->ob_type;
         numfree--;
     } else {
         op = (PyFloatObject*) PyObject_MALLOC(sizeof(PyFloatObject));
@@ -2004,7 +2005,8 @@ PyFloat_ClearFreeList(void)
     PyFloatObject *f = free_list, *next;
     int i = numfree;
     while (f) {
-        next = (PyFloatObject*) Py_TYPE(f);
+        /* Avoid Py_TYPE() since op is not valid */
+        next = (PyFloatObject*)((PyObject*)f)->ob_type;
         PyObject_FREE(f);
         f = next;
     }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -403,11 +403,7 @@ _PyObject_Dump(PyObject* op)
     PyObject *error_type, *error_value, *error_traceback;
     PyErr_Fetch(&error_type, &error_value, &error_traceback);
 
-    if (refcnt <= 0) {
-        op->ob_refcnt = 1;
-    }
     (void)PyObject_Print(op, stderr, 0);
-    op->ob_refcnt = refcnt;
     fflush(stderr);
 
     PyErr_Restore(error_type, error_value, error_traceback);

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -393,8 +393,10 @@ PyStructSequence_InitType2(PyTypeObject *type, PyStructSequence_Desc *desc)
     }
 #endif
 
-    /* PyTypeObject has already been initialized */
-    if (Py_REFCNT(type) != 0) {
+    /* PyTypeObject has already been initialized
+
+       Avoid Py_REFCNT() since the type is not valid yet. */
+    if (((PyObject*)type)->ob_refcnt != 0) {
         PyErr_BadInternalCall();
         return -1;
     }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5330,12 +5330,15 @@ PyType_Ready(PyTypeObject *type)
 
     /* Initialize ob_type if NULL.      This means extensions that want to be
        compilable separately on Windows can call PyType_Ready() instead of
-       initializing the ob_type field of their type objects. */
-    /* The test for base != NULL is really unnecessary, since base is only
+       initializing the ob_type field of their type objects.
+
+       The test for base != NULL is really unnecessary, since base is only
        NULL when type is &PyBaseObject_Type, and we know its ob_type is
        not NULL (it's initialized to &PyType_Type).      But coverity doesn't
-       know that. */
-    if (Py_IS_TYPE(type, NULL) && base != NULL) {
+       know that.
+
+       Avoid Py_IS_TYPE(type, NULL) since the type is not valid yet. */
+    if (((PyObject*)type)->ob_type == NULL && base != NULL) {
         Py_SET_TYPE(type, Py_TYPE(base));
     }
 

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -181,7 +181,8 @@ _PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *fp)
         m = NULL;
         goto error;
     }
-    if (Py_IS_TYPE(m, NULL)) {
+    /* Don't use Py_IS_TYPE(m, NULL) which would fail in debug mode */
+    if (m->ob_type == NULL) {
         /* This can happen when a PyModuleDef is returned without calling
          * PyModuleDef_Init on it
          */


### PR DESCRIPTION
In debug mode, _PyObject_CAST() now checks if the argument is valid
Python object. The new _PyObject_Cast() function is a tradeoff
between correctness and performance: it implements way less checks
than _PyObject_CheckConsistency(). It only checks 3 things:

* check the pointer itself with _PyMem_IsPtrFreed()
* check that ob_refcnt >= 0
* check ob_type with _PyMem_IsPtrFreed()

Tolerate ob_refcnt==0 to allow to use _PyObject_CAST() in deallocator
functions like unicode_dealloc().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39873](https://bugs.python.org/issue39873) -->
https://bugs.python.org/issue39873
<!-- /issue-number -->
