### PR TITLE
bpo-39874: Creation heappush of maxheap version

### DIFF
--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -198,6 +198,10 @@ def _heapify_max(x):
     n = len(x)
     for i in reversed(range(n//2)):
         _siftup_max(x, i)
+def heappush_max(heap, item):
+    heap.append(item)
+    _siftdown_max(heap,0,len(heap)-1)
+
 
 # 'heap' is a heap at all indices >= startpos, except possibly for pos.  pos
 # is the index of a leaf with a possibly out-of-order value.  Restore the

--- a/Misc/NEWS.d/next/Library/2020-03-06-10-33-59.bpo-39874.UXLIYq.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-06-10-33-59.bpo-39874.UXLIYq.rst
@@ -1,0 +1,1 @@
+heappush function of maxheap version does not exist in Lib/heapq.py


### PR DESCRIPTION
The function name and comment follow other origin functions.


<!-- issue-number: [[bpo-39874](https://bugs.python.org/issue39874)](https://bugs.python.org/issue3874) -->
https://bugs.python.org/issue3874
<!-- /issue-number -->
