### PR TITLE
bpo-39871: Fix possible SystemErrors in math.{atan2,copysign,remainder}()

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1997,10 +1997,16 @@ class MathTests(unittest.TestCase):
         # copysign(), or remainder() cannot be converted to a float.
         class F:
             def __float__(self):
+                self.converted = True
                 1/0
         for func in math.atan2, math.copysign, math.remainder:
+            y = F()
             with self.assertRaises(TypeError):
-                func('', F())
+                func("not a number", y)
+
+            # There should not have been any attempt to convert the second
+            # argument to a float.
+            self.assertFalse(getattr(y, "converted", False))
 
     # Custom assertions.
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1992,6 +1992,16 @@ class MathTests(unittest.TestCase):
             with self.subTest(x=x):
                 self.assertEqual(math.ulp(-x), math.ulp(x))
 
+    def test_issue39871(self):
+        # A SystemError should not be raised if the first arg to atan2(),
+        # copysign(), or remainder() cannot be converted to a float.
+        class F:
+            def __float__(self):
+                1/0
+        for func in math.atan2, math.copysign, math.remainder:
+            with self.assertRaises(TypeError):
+                func('', F())
+
     # Custom assertions.
 
     def assertIsNaN(self, value):

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-06-06-12-37.bpo-39871.dCAj_2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-06-06-12-37.bpo-39871.dCAj_2.rst
@@ -1,2 +1,3 @@
 Fix a possible :exc:`SystemError` in ``math.{atan2,copysign,remainder}()``
-when the first argument cannot be converted to a :class:`float`.
+when the first argument cannot be converted to a :class:`float`. Patch by
+Zachary Spytz.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-06-06-12-37.bpo-39871.dCAj_2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-06-06-12-37.bpo-39871.dCAj_2.rst
@@ -1,0 +1,2 @@
+Fix a possible :exc:`SystemError` in ``math.{atan2,copysign,remainder}()``
+when the first argument cannot be converted to a :class:`float`.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1106,9 +1106,13 @@ math_2(PyObject *const *args, Py_ssize_t nargs,
     if (!_PyArg_CheckPositional(funcname, nargs, 2, 2))
         return NULL;
     x = PyFloat_AsDouble(args[0]);
-    y = PyFloat_AsDouble(args[1]);
-    if ((x == -1.0 || y == -1.0) && PyErr_Occurred())
+    if (x == -1.0 && PyErr_Occurred()) {
         return NULL;
+    }
+    y = PyFloat_AsDouble(args[1]);
+    if (y == -1.0 && PyErr_Occurred()) {
+        return NULL;
+    }
     errno = 0;
     r = (*func)(x, y);
     if (Py_IS_NAN(r)) {


### PR DESCRIPTION
In math_2(), the first PyFloat_AsDouble() call should be checked
for failure before the second call.

<!-- issue-number: [bpo-39871](https://bugs.python.org/issue39871) -->
https://bugs.python.org/issue39871
<!-- /issue-number -->
