### PR TITLE
bpo-39882: Py_FatalError() logs the function name

### DIFF
--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -388,6 +388,13 @@ Process Control
    function :c:func:`abort` is called which will attempt to produce a :file:`core`
    file.
 
+   The ``Py_FatalError()`` function is replaced with a macro which logs
+   automatically the name of the current function, unless the
+   ``Py_LIMITED_API`` macro is defined.
+
+   .. versionchanged:: 3.9
+      Log the function name automatically.
+
 
 .. c:function:: void Py_Exit(int status)
 

--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -178,6 +178,12 @@ PyAPI_FUNC(void) _PyErr_WriteUnraisableMsg(
     const char *err_msg,
     PyObject *obj);
 
+PyAPI_FUNC(void) _Py_NO_RETURN _Py_FatalErrorFunc(
+    const char *func,
+    const char *message);
+
+#define Py_FatalError(message) _Py_FatalErrorFunc(__func__, message)
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -21,7 +21,11 @@ PyAPI_FUNC(void) PyErr_GetExcInfo(PyObject **, PyObject **, PyObject **);
 PyAPI_FUNC(void) PyErr_SetExcInfo(PyObject *, PyObject *, PyObject *);
 #endif
 
-/* Defined in Python/pylifecycle.c */
+/* Defined in Python/pylifecycle.c
+
+   The Py_FatalError() function is replaced with a macro which logs
+   automatically the name of the current function, unless the Py_LIMITED_API
+   macro is defined. */
 PyAPI_FUNC(void) _Py_NO_RETURN Py_FatalError(const char *message);
 
 #if defined(Py_DEBUG) || defined(Py_LIMITED_API)

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -61,8 +61,8 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(out, b'')
         # This used to cause an infinite loop.
         self.assertTrue(err.rstrip().startswith(
-                         b'Fatal Python error:'
-                         b' PyThreadState_Get: no current thread'))
+                         b'Fatal Python error: '
+                         b'PyThreadState_Get: no current thread'))
 
     def test_memoryview_from_NULL_pointer(self):
         self.assertRaises(ValueError, _testcapi.make_memoryview_from_NULL_pointer)
@@ -197,7 +197,8 @@ class CAPITest(unittest.TestCase):
             """)
             rc, out, err = assert_python_failure('-c', code)
             self.assertRegex(err.replace(b'\r', b''),
-                             br'Fatal Python error: a function returned NULL '
+                             br'Fatal Python error: _Py_CheckFunctionResult: '
+                                br'a function returned NULL '
                                 br'without setting an error\n'
                              br'Python runtime state: initialized\n'
                              br'SystemError: <built-in function '
@@ -225,8 +226,9 @@ class CAPITest(unittest.TestCase):
             """)
             rc, out, err = assert_python_failure('-c', code)
             self.assertRegex(err.replace(b'\r', b''),
-                             br'Fatal Python error: a function returned a '
-                                br'result with an error set\n'
+                             br'Fatal Python error: _Py_CheckFunctionResult: '
+                                 br'a function returned a result '
+                                 br'with an error set\n'
                              br'Python runtime state: initialized\n'
                              br'ValueError\n'
                              br'\n'
@@ -668,7 +670,7 @@ class PyMemDebugTests(unittest.TestCase):
                  r"\n"
                  r"Enable tracemalloc to get the memory block allocation traceback\n"
                  r"\n"
-                 r"Fatal Python error: bad trailing pad byte")
+                 r"Fatal Python error: _PyMem_DebugRawFree: bad trailing pad byte")
         regex = regex.format(ptr=self.PTR_REGEX)
         regex = re.compile(regex, flags=re.DOTALL)
         self.assertRegex(out, regex)
@@ -684,14 +686,14 @@ class PyMemDebugTests(unittest.TestCase):
                  r"\n"
                  r"Enable tracemalloc to get the memory block allocation traceback\n"
                  r"\n"
-                 r"Fatal Python error: bad ID: Allocated using API 'm', verified using API 'r'\n")
+                 r"Fatal Python error: _PyMem_DebugRawFree: bad ID: Allocated using API 'm', verified using API 'r'\n")
         regex = regex.format(ptr=self.PTR_REGEX)
         self.assertRegex(out, regex)
 
     def check_malloc_without_gil(self, code):
         out = self.check(code)
-        expected = ('Fatal Python error: Python memory allocator called '
-                    'without holding the GIL')
+        expected = ('Fatal Python error: _PyMem_DebugMalloc: '
+                    'Python memory allocator called without holding the GIL')
         self.assertIn(expected, out)
 
     def test_pymem_malloc_without_gil(self):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1078,8 +1078,9 @@ class ExceptionTests(unittest.TestCase):
         """
         with SuppressCrashReport():
             rc, out, err = script_helper.assert_python_failure("-c", code)
-            self.assertIn(b'Fatal Python error: Cannot recover from '
-                          b'MemoryErrors while normalizing exceptions.', err)
+            self.assertIn(b'Fatal Python error: _PyErr_NormalizeException: '
+                          b'Cannot recover from MemoryErrors while '
+                          b'normalizing exceptions.', err)
 
     @cpython_only
     def test_MemoryError(self):

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -123,7 +123,9 @@ class FaultHandlerTests(unittest.TestCase):
         self.assertRegex(output, regex)
         self.assertNotEqual(exitcode, 0)
 
-    def check_fatal_error(self, code, line_number, name_regex, **kw):
+    def check_fatal_error(self, code, line_number, name_regex, func=None, **kw):
+        if func:
+            name_regex = '%s: %s' % (func, name_regex)
         fatal_error = 'Fatal Python error: %s' % name_regex
         self.check_error(code, line_number, fatal_error, **kw)
 
@@ -173,6 +175,7 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'in new thread',
             know_current_thread=False,
+            func='faulthandler_fatal_error_thread',
             py_fatal_error=True)
 
     def test_sigabrt(self):
@@ -230,6 +233,7 @@ class FaultHandlerTests(unittest.TestCase):
             """,
             2,
             'xyz',
+            func='faulthandler_fatal_error_py',
             py_fatal_error=True)
 
     def test_fatal_error_without_gil(self):
@@ -239,6 +243,7 @@ class FaultHandlerTests(unittest.TestCase):
             """,
             2,
             'xyz',
+            func='faulthandler_fatal_error_py',
             py_fatal_error=True)
 
     @unittest.skipIf(sys.platform.startswith('openbsd'),

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4247,7 +4247,8 @@ class CMiscIOTest(MiscIOTest):
         err = res.err.decode()
         if res.rc != 0:
             # Failure: should be a fatal error
-            pattern = (r"Fatal Python error: could not acquire lock "
+            pattern = (r"Fatal Python error: _enter_buffered_busy: "
+                       r"could not acquire lock "
                        r"for <(_io\.)?BufferedWriter name='<{stream_name}>'> "
                        r"at interpreter shutdown, possibly due to "
                        r"daemon threads".format_map(locals()))

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -269,6 +269,8 @@ class SysModuleTest(unittest.TestCase):
         finally:
             sys.setrecursionlimit(oldlimit)
 
+    # The error message is specific to CPython
+    @test.support.cpython_only
     def test_recursionlimit_fatalerror(self):
         # A fatal error occurs if a second recursion limit is hit when recovering
         # from a first one.
@@ -290,7 +292,8 @@ class SysModuleTest(unittest.TestCase):
                 err = sub.communicate()[1]
                 self.assertTrue(sub.returncode, sub.returncode)
                 self.assertIn(
-                    b"Fatal Python error: Cannot recover from stack overflow",
+                    b"Fatal Python error: _Py_CheckRecursiveCall: "
+                    b"Cannot recover from stack overflow",
                     err)
 
     def test_getwindowsversion(self):

--- a/Misc/NEWS.d/next/C API/2020-03-06-23-56-04.bpo-39882.Iqhcqm.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-06-23-56-04.bpo-39882.Iqhcqm.rst
@@ -1,3 +1,3 @@
-The :c:func`Py_FatalError` function is replaced with a macro which logs
+The :c:func:`Py_FatalError` function is replaced with a macro which logs
 automatically the name of the current function, unless the ``Py_LIMITED_API``
 macro is defined.

--- a/Misc/NEWS.d/next/C API/2020-03-06-23-56-04.bpo-39882.Iqhcqm.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-06-23-56-04.bpo-39882.Iqhcqm.rst
@@ -1,0 +1,3 @@
+The :c:func`Py_FatalError` function is replaced with a macro which logs
+automatically the name of the current function, unless the ``Py_LIMITED_API``
+macro is defined.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -54,8 +54,9 @@ s_push(stack *s, const dfa *d, node *parent)
 static void
 s_pop(stack *s)
 {
-    if (s_empty(s))
-        Py_FatalError("s_pop: parser stack underflow -- FATAL");
+    if (s_empty(s)) {
+        Py_FatalError("parser stack underflow");
+    }
     s->s_top++;
 }
 

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1031,10 +1031,12 @@ static void
 tok_backup(struct tok_state *tok, int c)
 {
     if (c != EOF) {
-        if (--tok->cur < tok->buf)
-            Py_FatalError("tok_backup: beginning of buffer");
-        if (*tok->cur != c)
+        if (--tok->cur < tok->buf) {
+            Py_FatalError("beginning of buffer");
+        }
+        if (*tok->cur != c) {
             *tok->cur = c;
+        }
     }
 }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -282,7 +282,7 @@ PyEval_AcquireLock(void)
     struct _ceval_runtime_state *ceval = &runtime->ceval;
     PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);
     if (tstate == NULL) {
-        Py_FatalError("PyEval_AcquireLock: current thread state is NULL");
+        Py_FatalError("current thread state is NULL");
     }
     take_gil(ceval, tstate);
     exit_thread_if_finalizing(tstate);
@@ -313,7 +313,7 @@ PyEval_AcquireThread(PyThreadState *tstate)
     take_gil(ceval, tstate);
     exit_thread_if_finalizing(tstate);
     if (_PyThreadState_Swap(&runtime->gilstate, tstate) != NULL) {
-        Py_FatalError("PyEval_AcquireThread: non-NULL old thread state");
+        Py_FatalError("non-NULL old thread state");
     }
 }
 
@@ -325,7 +325,7 @@ PyEval_ReleaseThread(PyThreadState *tstate)
     _PyRuntimeState *runtime = tstate->interp->runtime;
     PyThreadState *new_tstate = _PyThreadState_Swap(&runtime->gilstate, NULL);
     if (new_tstate != tstate) {
-        Py_FatalError("PyEval_ReleaseThread: wrong thread state");
+        Py_FatalError("wrong thread state");
     }
     drop_gil(&runtime->ceval, tstate);
 }
@@ -372,7 +372,7 @@ PyEval_SaveThread(void)
     struct _ceval_runtime_state *ceval = &runtime->ceval;
     PyThreadState *tstate = _PyThreadState_Swap(&runtime->gilstate, NULL);
     if (tstate == NULL) {
-        Py_FatalError("PyEval_SaveThread: NULL tstate");
+        Py_FatalError("NULL tstate");
     }
     assert(gil_created(&ceval->gil));
     drop_gil(ceval, tstate);
@@ -1235,7 +1235,7 @@ main_loop:
             if (_Py_atomic_load_relaxed(&ceval->gil_drop_request)) {
                 /* Give another thread a chance */
                 if (_PyThreadState_Swap(&runtime->gilstate, NULL) != tstate) {
-                    Py_FatalError("ceval: tstate mix-up");
+                    Py_FatalError("tstate mix-up");
                 }
                 drop_gil(ceval, tstate);
 
@@ -1247,7 +1247,7 @@ main_loop:
                 exit_thread_if_finalizing(tstate);
 
                 if (_PyThreadState_Swap(&runtime->gilstate, tstate) != NULL) {
-                    Py_FatalError("ceval: orphan tstate");
+                    Py_FatalError("orphan tstate");
                 }
             }
             /* Check for asynchronous exceptions. */

--- a/Python/import.c
+++ b/Python/import.c
@@ -310,7 +310,7 @@ PyImport_GetModuleDict(void)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
     if (interp->modules == NULL) {
-        Py_FatalError("PyImport_GetModuleDict: no module dictionary!");
+        Py_FatalError("no module dictionary");
     }
     return interp->modules;
 }
@@ -982,8 +982,7 @@ PyImport_ExecCodeModuleWithPathnames(const char *name, PyObject *co,
         _Py_IDENTIFIER(_get_sourcefile);
 
         if (interp == NULL) {
-            Py_FatalError("PyImport_ExecCodeModuleWithPathnames: "
-                          "no interpreter!");
+            Py_FatalError("no interpreter!");
         }
 
         external= PyObject_GetAttrString(interp->importlib,

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -515,7 +515,7 @@ Py_SetPath(const wchar_t *path)
         || _Py_path_config.exec_prefix == NULL
         || _Py_path_config.module_search_path == NULL)
     {
-        Py_FatalError("Py_SetPath() failed: out of memory");
+        Py_FatalError("out of memory");
     }
 }
 
@@ -536,7 +536,7 @@ Py_SetPythonHome(const wchar_t *home)
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     if (_Py_path_config.home == NULL) {
-        Py_FatalError("Py_SetPythonHome() failed: out of memory");
+        Py_FatalError("out of memory");
     }
 }
 
@@ -557,7 +557,7 @@ Py_SetProgramName(const wchar_t *program_name)
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     if (_Py_path_config.program_name == NULL) {
-        Py_FatalError("Py_SetProgramName() failed: out of memory");
+        Py_FatalError("out of memory");
     }
 }
 
@@ -577,7 +577,7 @@ _Py_SetProgramFullPath(const wchar_t *program_full_path)
     PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     if (_Py_path_config.program_full_path == NULL) {
-        Py_FatalError("_Py_SetProgramFullPath() failed: out of memory");
+        Py_FatalError("out of memory");
     }
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1611,10 +1611,10 @@ Py_EndInterpreter(PyThreadState *tstate)
     PyInterpreterState *interp = tstate->interp;
 
     if (tstate != _PyThreadState_GET()) {
-        Py_FatalError("Py_EndInterpreter: thread is not current");
+        Py_FatalError("thread is not current");
     }
     if (tstate->frame != NULL) {
-        Py_FatalError("Py_EndInterpreter: thread still has a frame");
+        Py_FatalError("thread still has a frame");
     }
     interp->finalizing = 1;
 
@@ -1624,7 +1624,7 @@ Py_EndInterpreter(PyThreadState *tstate)
     call_py_exitfuncs(tstate);
 
     if (tstate != interp->tstate_head || tstate->next != NULL) {
-        Py_FatalError("Py_EndInterpreter: not the last thread");
+        Py_FatalError("not the last thread");
     }
 
     _PyImport_Cleanup(tstate);
@@ -2240,10 +2240,18 @@ exit:
     }
 }
 
+#undef Py_FatalError
+
 void _Py_NO_RETURN
 Py_FatalError(const char *msg)
 {
     fatal_error(NULL, msg, -1);
+}
+
+void _Py_NO_RETURN
+_Py_FatalErrorFunc(const char *func, const char *msg)
+{
+    fatal_error(func, msg, -1);
 }
 
 void _Py_NO_RETURN

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -327,20 +327,20 @@ PyInterpreterState_Delete(PyInterpreterState *interp)
     PyInterpreterState **p;
     for (p = &interpreters->head; ; p = &(*p)->next) {
         if (*p == NULL) {
-            Py_FatalError("PyInterpreterState_Delete: invalid interp");
+            Py_FatalError("invalid interp");
         }
         if (*p == interp) {
             break;
         }
     }
     if (interp->tstate_head != NULL) {
-        Py_FatalError("PyInterpreterState_Delete: remaining threads");
+        Py_FatalError("remaining threads");
     }
     *p = interp->next;
     if (interpreters->main == interp) {
         interpreters->main = NULL;
         if (interpreters->head != NULL) {
-            Py_FatalError("PyInterpreterState_Delete: remaining subinterpreters");
+            Py_FatalError("remaining subinterpreters");
         }
     }
     HEAD_UNLOCK(runtime);
@@ -363,7 +363,7 @@ _PyInterpreterState_DeleteExceptMain(_PyRuntimeState *runtime)
 
     PyThreadState *tstate = _PyThreadState_Swap(gilstate, NULL);
     if (tstate != NULL && tstate->interp != interpreters->main) {
-        Py_FatalError("PyInterpreterState_DeleteExceptMain: not main interpreter");
+        Py_FatalError("not main interpreter");
     }
 
     HEAD_LOCK(runtime);
@@ -389,7 +389,7 @@ _PyInterpreterState_DeleteExceptMain(_PyRuntimeState *runtime)
     HEAD_UNLOCK(runtime);
 
     if (interpreters->head == NULL) {
-        Py_FatalError("PyInterpreterState_DeleteExceptMain: missing main");
+        Py_FatalError("missing main");
     }
     _PyThreadState_Swap(gilstate, tstate);
 }
@@ -400,11 +400,11 @@ _PyInterpreterState_Get(void)
 {
     PyThreadState *tstate = _PyThreadState_GET();
     if (tstate == NULL) {
-        Py_FatalError("_PyInterpreterState_Get(): no current thread state");
+        Py_FatalError("no current thread state");
     }
     PyInterpreterState *interp = tstate->interp;
     if (interp == NULL) {
-        Py_FatalError("_PyInterpreterState_Get(): no current interpreter");
+        Py_FatalError("no current interpreter");
     }
     return interp;
 }
@@ -695,7 +695,7 @@ int
 PyState_AddModule(PyObject* module, struct PyModuleDef* def)
 {
     if (!def) {
-        Py_FatalError("PyState_AddModule: Module Definition is NULL");
+        Py_FatalError("Module Definition is NULL");
         return -1;
     }
 
@@ -706,7 +706,7 @@ PyState_AddModule(PyObject* module, struct PyModuleDef* def)
         index < PyList_GET_SIZE(interp->modules_by_index) &&
         module == PyList_GET_ITEM(interp->modules_by_index, index))
     {
-        Py_FatalError("PyState_AddModule: Module already added!");
+        Py_FatalError("Module already added");
         return -1;
     }
     return _PyState_AddModule(tstate, module, def);
@@ -724,15 +724,15 @@ PyState_RemoveModule(struct PyModuleDef* def)
     }
     state = _PyInterpreterState_GET_UNSAFE();
     if (index == 0) {
-        Py_FatalError("PyState_RemoveModule: Module index invalid.");
+        Py_FatalError("Module index invalid");
         return -1;
     }
     if (state->modules_by_index == NULL) {
-        Py_FatalError("PyState_RemoveModule: Interpreters module-list not accessible.");
+        Py_FatalError("Interpreters module-list not accessible.");
         return -1;
     }
     if (index > PyList_GET_SIZE(state->modules_by_index)) {
-        Py_FatalError("PyState_RemoveModule: Module index out of bounds.");
+        Py_FatalError("Module index out of bounds.");
         return -1;
     }
     Py_INCREF(Py_None);
@@ -819,11 +819,11 @@ tstate_delete_common(PyThreadState *tstate,
 {
     _PyRuntimeState *runtime = tstate->interp->runtime;
     if (tstate == NULL) {
-        Py_FatalError("PyThreadState_Delete: NULL tstate");
+        Py_FatalError("NULL tstate");
     }
     PyInterpreterState *interp = tstate->interp;
     if (interp == NULL) {
-        Py_FatalError("PyThreadState_Delete: NULL interp");
+        Py_FatalError("NULL interp");
     }
     HEAD_LOCK(runtime);
     if (tstate->prev)
@@ -850,7 +850,7 @@ _PyThreadState_Delete(PyThreadState *tstate, int check_current)
     struct _gilstate_runtime_state *gilstate = &tstate->interp->runtime->gilstate;
     if (check_current) {
         if (tstate == _PyRuntimeGILState_GetThreadState(gilstate)) {
-            Py_FatalError("PyThreadState_Delete: tstate is still current");
+            Py_FatalError("tstate is still current");
         }
     }
     tstate_delete_common(tstate, gilstate);
@@ -869,9 +869,9 @@ _PyThreadState_DeleteCurrent(_PyRuntimeState *runtime)
 {
     struct _gilstate_runtime_state *gilstate = &runtime->gilstate;
     PyThreadState *tstate = _PyRuntimeGILState_GetThreadState(gilstate);
-    if (tstate == NULL)
-        Py_FatalError(
-            "PyThreadState_DeleteCurrent: no current tstate");
+    if (tstate == NULL) {
+        Py_FatalError("no current tstate");
+    }
     tstate_delete_common(tstate, gilstate);
     _PyRuntimeGILState_SetThreadState(gilstate, NULL);
     PyEval_ReleaseLock();
@@ -932,9 +932,9 @@ PyThreadState *
 PyThreadState_Get(void)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    if (tstate == NULL)
-        Py_FatalError("PyThreadState_Get: no current thread");
-
+    if (tstate == NULL) {
+        Py_FatalError("no current thread");
+    }
     return tstate;
 }
 


### PR DESCRIPTION
The Py_FatalError() function is replaced with a macro which logs
automatically the name of the current function, unless the
Py_LIMITED_API macro is defined.

Changes:

* Add _Py_FatalErrorFunc() function.
* Remove the function name from the message of Py_FatalError() calls
  which included the function name.
* Update tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39882](https://bugs.python.org/issue39882) -->
https://bugs.python.org/issue39882
<!-- /issue-number -->
