### PR TITLE
bpo-39889: Fix ast.unparse() for subscript.

### DIFF
--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -344,6 +344,20 @@ class CosmeticTestCase(ASTTestCase):
         self.check_src_roundtrip("call((yield x))")
         self.check_src_roundtrip("return x + (yield x)")
 
+    def test_subscript(self):
+        self.check_src_roundtrip("a[i]")
+        self.check_src_roundtrip("a[i,]")
+        self.check_src_roundtrip("a[i, j]")
+        self.check_src_roundtrip("a[()]")
+        self.check_src_roundtrip("a[i:j]")
+        self.check_src_roundtrip("a[:j]")
+        self.check_src_roundtrip("a[i:]")
+        self.check_src_roundtrip("a[i:j:k]")
+        self.check_src_roundtrip("a[:j:k]")
+        self.check_src_roundtrip("a[i::k]")
+        self.check_src_roundtrip("a[i:j,]")
+        self.check_src_roundtrip("a[i:j, k]")
+
     def test_docstrings(self):
         docstrings = (
             '"""simple doc string"""',

--- a/Misc/NEWS.d/next/Library/2020-03-07-16-44-51.bpo-39889.3RYqeX.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-07-16-44-51.bpo-39889.3RYqeX.rst
@@ -1,0 +1,3 @@
+Fixed :func:`ast.unparse` for extended slices containing a single element
+(e.g. ``a[i:j,]``). Remove redundant tuples when index with a tuple (e.g.
+``a[i, j]``).


### PR DESCRIPTION


<!-- issue-number: [bpo-39889](https://bugs.python.org/issue39889) -->
https://bugs.python.org/issue39889
<!-- /issue-number -->
