### PR TITLE
Updates functools.py with consistent quotes

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -13,7 +13,7 @@ __all__ = ['update_wrapper', 'wraps', 'WRAPPER_ASSIGNMENTS', 'WRAPPER_UPDATES',
            'total_ordering', 'cmp_to_key', 'lru_cache', 'reduce',
            'TopologicalSorter', 'CycleError',
            'partial', 'partialmethod', 'singledispatch', 'singledispatchmethod',
-           "cached_property"]
+           'cached_property']
 
 from abc import get_cache_token
 from collections import namedtuple


### PR DESCRIPTION
I have noticed that `'` quotes are used everywhere except this particular case,
which was introduced in https://github.com/python/cpython/pull/18726

So, this is a trivial fix to enforce better consistency.

Automerge-Triggered-By: @csabella