### PR TITLE
[3.8] bpo-39889: Fix unparse.py for subscript. (GH-18824).

### DIFF
--- a/Lib/test/test_tools/test_unparse.py
+++ b/Lib/test/test_tools/test_unparse.py
@@ -265,6 +265,20 @@ class UnparseTestCase(ASTTestCase):
         self.check_roundtrip(r"""{**{'y': 2}, 'x': 1}""")
         self.check_roundtrip(r"""{**{'y': 2}, **{'x': 1}}""")
 
+    def test_subscript(self):
+        self.check_roundtrip("a[i]")
+        self.check_roundtrip("a[i,]")
+        self.check_roundtrip("a[i, j]")
+        self.check_roundtrip("a[()]")
+        self.check_roundtrip("a[i:j]")
+        self.check_roundtrip("a[:j]")
+        self.check_roundtrip("a[i:]")
+        self.check_roundtrip("a[i:j:k]")
+        self.check_roundtrip("a[:j:k]")
+        self.check_roundtrip("a[i::k]")
+        self.check_roundtrip("a[i:j,]")
+        self.check_roundtrip("a[i:j, k]")
+
 
 class DirectoryTestCase(ASTTestCase):
     """Test roundtrip behaviour on all files in Lib and Lib/test."""

--- a/Misc/NEWS.d/next/Tools-Demos/2020-03-07-18-01-30.bpo-39889.l1czT6.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-03-07-18-01-30.bpo-39889.l1czT6.rst
@@ -1,0 +1,3 @@
+Fixed ``unparse.py`` for extended slices containing a single element (e.g.
+``a[i:j,]``). Remove redundant tuples when index with a tuple (e.g. ``a[i,
+j]``).

--- a/Tools/parser/unparse.py
+++ b/Tools/parser/unparse.py
@@ -556,7 +556,17 @@ class Unparser:
     def _Subscript(self, t):
         self.dispatch(t.value)
         self.write("[")
-        self.dispatch(t.slice)
+        if (isinstance(t.slice, ast.Index)
+                and isinstance(t.slice.value, ast.Tuple)
+                and t.slice.value.elts):
+            if len(t.slice.value.elts) == 1:
+                elt = t.slice.value.elts[0]
+                self.dispatch(elt)
+                self.write(",")
+            else:
+                interleave(lambda: self.write(", "), self.dispatch, t.slice.value.elts)
+        else:
+            self.dispatch(t.slice)
         self.write("]")
 
     def _Starred(self, t):
@@ -581,7 +591,12 @@ class Unparser:
             self.dispatch(t.step)
 
     def _ExtSlice(self, t):
-        interleave(lambda: self.write(', '), self.dispatch, t.dims)
+        if len(t.dims) == 1:
+            elt = t.dims[0]
+            self.dispatch(elt)
+            self.write(",")
+        else:
+            interleave(lambda: self.write(', '), self.dispatch, t.dims)
 
     # argument
     def _arg(self, t):


### PR DESCRIPTION
(cherry picked from commit c4928fc1a853f3f84e2b4ec1253d0349137745e5)


<!-- issue-number: [bpo-39889](https://bugs.python.org/issue39889) -->
https://bugs.python.org/issue39889
<!-- /issue-number -->
