### PR TITLE
Fix parameter names in assertIn() docs

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -910,10 +910,10 @@ Test cases
       .. versionadded:: 3.1
 
 
-   .. method:: assertIn(first, second, msg=None)
-               assertNotIn(first, second, msg=None)
+   .. method:: assertIn(member, container, msg=None)
+               assertNotIn(member, container, msg=None)
 
-      Test that *first* is (or is not) in *second*.
+      Test that *member* is (or is not) in *container*.
 
       .. versionadded:: 3.1
 


### PR DESCRIPTION
The names "member" and "container" for the arguments are also used in the module and shown with the help() function, and are immediately understandable in this context, contrary to "first" and "second".

Automerge-Triggered-By: @aeros