### PR TITLE
bpo-36144: Add PEP 584 operators to collections.ChainMap

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -116,6 +116,9 @@ The class can be used to simulate nested scopes and is useful in templating.
         >>> list(combined)
         ['music', 'art', 'opera']
 
+    .. versionchanged:: 3.9
+       Added support for ``|`` and ``|=`` operators, specified in :pep:`584`.
+
 .. seealso::
 
     * The `MultiContext class

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -961,6 +961,24 @@ class ChainMap(_collections_abc.MutableMapping):
         'Clear maps[0], leaving maps[1:] intact.'
         self.maps[0].clear()
 
+    def __ior__(self, other):
+        self.maps[0].update(other)
+        return self
+
+    def __or__(self, other):
+        if isinstance(other, _collections_abc.Mapping):
+            m = self.maps[0].copy()
+            m.update(other)
+            return self.__class__(m, *self.maps[1:])
+        return NotImplemented
+
+    def __ror__(self, other):
+        if isinstance(other, _collections_abc.MutableMapping):
+            m = other.copy()
+            for child in self.maps[::-1]:
+                m.update(child)
+            return self.__class__(m)
+        return NotImplemented
 
 ################################################################################
 ### UserDict

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -962,7 +962,7 @@ class ChainMap(_collections_abc.MutableMapping):
         self.maps[0].clear()
 
     def __ior__(self, other):
-        self.maps[0].update(other)
+        self.maps[0] |= other
         return self
 
     def __or__(self, other):
@@ -973,12 +973,13 @@ class ChainMap(_collections_abc.MutableMapping):
         return NotImplemented
 
     def __ror__(self, other):
-        if isinstance(other, _collections_abc.MutableMapping):
-            m = other.copy()
-            for child in self.maps[::-1]:
+        if isinstance(other, _collections_abc.Mapping):
+            m = dict(other)
+            for child in reversed(self.maps):
                 m.update(child)
             return self.__class__(m)
         return NotImplemented
+
 
 ################################################################################
 ### UserDict

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -247,7 +247,7 @@ class TestChainMap(unittest.TestCase):
         tmp = cm2 | d # testing between chainmap and mapping
         self.assertEqual(tmp.maps, [cm2.maps[0] | d, *cm2.maps[1:]])
         self.assertEqual((d | cm2).maps, [d | dict(cm2)])
-        cm2 |= d 
+        cm2 |= d
         self.assertEqual(tmp, cm2)
 
         # testing behavior between chainmap and iterable key-value pairs

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -235,18 +235,18 @@ class TestChainMap(unittest.TestCase):
     def test_union_operators(self):
         cm1 = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
         cm2 = ChainMap(dict(a=10, e=5), dict(b=20, d=4))
-        cm3 = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
+        cm3 = cm1.copy()
         d = dict(a=10, c=30)
         pairs = [('c', 3), ('p',0)]
 
         tmp = cm1 | cm2 # testing between chainmaps
-        self.assertEqual(tmp, ChainMap(cm1.maps[0] | dict(cm2), *cm1.maps[1:]))
+        self.assertEqual(tmp.maps, [cm1.maps[0] | dict(cm2), *cm1.maps[1:]])
         cm1 |= cm2
         self.assertEqual(tmp, cm1)
         
         tmp = cm2 | d # testing between chainmap and mapping
-        self.assertEqual(tmp, ChainMap(cm2.maps[0] | d, *cm2.maps[1:]))
-        self.assertEqual(d | cm2, ChainMap(d | dict(cm2)))
+        self.assertEqual(tmp.maps, [cm2.maps[0] | d, *cm2.maps[1:]])
+        self.assertEqual((d | cm2).maps, [d | dict(cm2)])
         cm2 |= d 
         self.assertEqual(tmp, cm2)
 
@@ -254,8 +254,7 @@ class TestChainMap(unittest.TestCase):
         with self.assertRaises(TypeError):
             cm3 | pairs
         cm3 |= pairs
-        self.assertEqual(cm3, ChainMap(cm3.maps[0] | dict(pairs), *cm3.maps[1:]))
-
+        self.assertEqual(cm3.maps, [cm3.maps[0] | dict(pairs), *cm3.maps[1:]])
 
 ################################################################################
 ### Named Tuples

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -236,25 +236,26 @@ class TestChainMap(unittest.TestCase):
         a = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
         b = ChainMap(dict(a=10, e=5), dict(b=20, d=4))
         c = dict(a=10, c=30)
+        d = [('a', 1), ('c',3)]
 
-        ## Testing | operator between chainmaps
-        d = a | b
-        self.assertEqual(d, ChainMap(a.maps[0] | dict(b), *a.maps[1:]))
-
-        ## Testing |= operator between chainmaps
+        e = a | b # testing between chainmaps
+        self.assertEqual(e, ChainMap(a.maps[0] | dict(b), *a.maps[1:]))
         a |= b
-        self.assertEqual(d, a)
+        self.assertEqual(e, a)
+        
+        f = b | c # testing between chainmap and mapping
+        self.assertEqual(f, ChainMap(b.maps[0] | c, *b.maps[1:]))
+        g = c | b
+        self.assertEqual(g, ChainMap(c | dict(b)))
+        b |= c 
+        self.assertEqual(f, b)
 
-        ## Testing | operator between chainmap and mapping, and vice versa
-        e = b | c
-        self.assertEqual(e, ChainMap(b.maps[0] | c, *b.maps[1:]))
+        # testing behavior between chainmap and iterable key-value pairs
+        with self.assertRaises(TypeError):
+            a | d
+        a |= d 
+        self.assertEqual(a, ChainMap(a.maps[0] | dict(d)), *a.maps[1:])
 
-        f = c | b
-        self.assertEqual(f, ChainMap(c | dict(b)))
-
-        ## Testing |= operator between chainmap and mapping 
-        b |= c
-        self.assertEqual(e, b)
 
 ################################################################################
 ### Named Tuples

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -232,6 +232,30 @@ class TestChainMap(unittest.TestCase):
         for k, v in dict(a=1, B=20, C=30, z=100).items():             # check get
             self.assertEqual(d.get(k, 100), v)
 
+    def test_issue584(self):
+        'Tests for changes in issue584 dealing with | and |= operators'
+        a = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
+        b = ChainMap(dict(a=10, e=5), dict(b=20, d=4))
+        c = dict(a = 10, c = 30)
+
+        ## Testing | operator between chainmaps
+        d = a | b
+        self.assertEqual(d, ChainMap(a.maps[0] | dict(b), *a.maps[1:]))
+
+        ## Testing |= operator between chainmaps
+        a |= b
+        self.assertEqual(d, a)
+
+        ## Testing | operator between chainmap and mapping, and vice versa
+        e = b | c
+        self.assertEqual(e, ChainMap(e.maps[0] | c, *b.maps[1:]))
+
+        f = c | b
+        self.assertEqual(f, ChainMap(c | dict(b)))
+
+        ## Testing |= operator between chainmap and mapping 
+        b |= c
+        self.assertEqual(e,b)
 
 ################################################################################
 ### Named Tuples

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -259,11 +259,11 @@ class TestChainMap(unittest.TestCase):
         # testing proper return types for ChainMap and it's subclasses
         class Subclass(ChainMap):
             pass
- 
+
         class SubclassRor(ChainMap):
             def __ror__(self, other):
                 return super().__ror__(other)
-        
+
         tmp = ChainMap() | ChainMap()
         self.assertIs(type(tmp), ChainMap)
         self.assertIs(type(tmp.maps[0]), dict)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -256,6 +256,28 @@ class TestChainMap(unittest.TestCase):
         cm3 |= pairs
         self.assertEqual(cm3.maps, [cm3.maps[0] | dict(pairs), *cm3.maps[1:]])
 
+        # testing proper return types for ChainMap and it's subclasses
+        class Subclass(ChainMap):
+            pass
+ 
+        class SubclassRor(ChainMap):
+            def __ror__(self, other):
+                return super().__ror__(other)
+        
+        tmp = ChainMap() | ChainMap()
+        self.assertIs(type(tmp), ChainMap)
+        self.assertIs(type(tmp.maps[0]), dict)
+        tmp = ChainMap() | Subclass()
+        self.assertIs(type(tmp), ChainMap)
+        self.assertIs(type(tmp.maps[0]), dict)
+        tmp = Subclass() | ChainMap()
+        self.assertIs(type(tmp), Subclass)
+        self.assertIs(type(tmp.maps[0]), dict)
+        tmp = ChainMap() | SubclassRor()
+        self.assertIs(type(tmp), SubclassRor)
+        self.assertIs(type(tmp.maps[0]), dict)
+
+
 ################################################################################
 ### Named Tuples
 ################################################################################

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -232,11 +232,10 @@ class TestChainMap(unittest.TestCase):
         for k, v in dict(a=1, B=20, C=30, z=100).items():             # check get
             self.assertEqual(d.get(k, 100), v)
 
-    def test_issue584(self):
-        'Tests for changes in issue584 dealing with | and |= operators'
+    def test_union_operators(self):
         a = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
         b = ChainMap(dict(a=10, e=5), dict(b=20, d=4))
-        c = dict(a = 10, c = 30)
+        c = dict(a=10, c=30)
 
         ## Testing | operator between chainmaps
         d = a | b
@@ -248,14 +247,14 @@ class TestChainMap(unittest.TestCase):
 
         ## Testing | operator between chainmap and mapping, and vice versa
         e = b | c
-        self.assertEqual(e, ChainMap(e.maps[0] | c, *b.maps[1:]))
+        self.assertEqual(e, ChainMap(b.maps[0] | c, *b.maps[1:]))
 
         f = c | b
         self.assertEqual(f, ChainMap(c | dict(b)))
 
         ## Testing |= operator between chainmap and mapping 
         b |= c
-        self.assertEqual(e,b)
+        self.assertEqual(e, b)
 
 ################################################################################
 ### Named Tuples

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -235,8 +235,9 @@ class TestChainMap(unittest.TestCase):
     def test_union_operators(self):
         cm1 = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
         cm2 = ChainMap(dict(a=10, e=5), dict(b=20, d=4))
+        cm3 = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
         d = dict(a=10, c=30)
-        pairs = [('a', 1), ('c',3)]
+        pairs = [('c', 3), ('p',0)]
 
         tmp = cm1 | cm2 # testing between chainmaps
         self.assertEqual(tmp, ChainMap(cm1.maps[0] | dict(cm2), *cm1.maps[1:]))
@@ -251,9 +252,9 @@ class TestChainMap(unittest.TestCase):
 
         # testing behavior between chainmap and iterable key-value pairs
         with self.assertRaises(TypeError):
-            cm1 | pairs
-        cm1 |= pairs
-        self.assertEqual(cm1, ChainMap(cm1.maps[0] | dict(pairs)), *cm1.maps[1:])
+            cm3 | pairs
+        cm3 |= pairs
+        self.assertEqual(cm3, ChainMap(cm3.maps[0] | dict(pairs), *cm3.maps[1:]))
 
 
 ################################################################################

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -233,28 +233,27 @@ class TestChainMap(unittest.TestCase):
             self.assertEqual(d.get(k, 100), v)
 
     def test_union_operators(self):
-        a = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
-        b = ChainMap(dict(a=10, e=5), dict(b=20, d=4))
-        c = dict(a=10, c=30)
-        d = [('a', 1), ('c',3)]
+        cm1 = ChainMap(dict(a=1, b=2), dict(c=3, d=4))
+        cm2 = ChainMap(dict(a=10, e=5), dict(b=20, d=4))
+        d = dict(a=10, c=30)
+        pairs = [('a', 1), ('c',3)]
 
-        e = a | b # testing between chainmaps
-        self.assertEqual(e, ChainMap(a.maps[0] | dict(b), *a.maps[1:]))
-        a |= b
-        self.assertEqual(e, a)
+        tmp = cm1 | cm2 # testing between chainmaps
+        self.assertEqual(tmp, ChainMap(cm1.maps[0] | dict(cm2), *cm1.maps[1:]))
+        cm1 |= cm2
+        self.assertEqual(tmp, cm1)
         
-        f = b | c # testing between chainmap and mapping
-        self.assertEqual(f, ChainMap(b.maps[0] | c, *b.maps[1:]))
-        g = c | b
-        self.assertEqual(g, ChainMap(c | dict(b)))
-        b |= c 
-        self.assertEqual(f, b)
+        tmp = cm2 | d # testing between chainmap and mapping
+        self.assertEqual(tmp, ChainMap(cm2.maps[0] | d, *cm2.maps[1:]))
+        self.assertEqual(d | cm2, ChainMap(d | dict(cm2)))
+        cm2 |= d 
+        self.assertEqual(tmp, cm2)
 
         # testing behavior between chainmap and iterable key-value pairs
         with self.assertRaises(TypeError):
-            a | d
-        a |= d 
-        self.assertEqual(a, ChainMap(a.maps[0] | dict(d)), *a.maps[1:])
+            cm1 | pairs
+        cm1 |= pairs
+        self.assertEqual(cm1, ChainMap(cm1.maps[0] | dict(pairs)), *cm1.maps[1:])
 
 
 ################################################################################

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -243,7 +243,7 @@ class TestChainMap(unittest.TestCase):
         self.assertEqual(tmp.maps, [cm1.maps[0] | dict(cm2), *cm1.maps[1:]])
         cm1 |= cm2
         self.assertEqual(tmp, cm1)
-        
+
         tmp = cm2 | d # testing between chainmap and mapping
         self.assertEqual(tmp.maps, [cm2.maps[0] | d, *cm2.maps[1:]])
         self.assertEqual((d | cm2).maps, [d | dict(cm2)])

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -233,6 +233,7 @@ Floris Bruynooghe
 Matt Bryant
 Stan Bubrouski
 Brandt Bucher
+Curtis Bucher
 Colm Buckley
 Erik de Bueger
 Jan-Hein Bührman

--- a/Misc/NEWS.d/next/Library/2020-03-07-11-26-08.bpo-36144.FG9jqy.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-07-11-26-08.bpo-36144.FG9jqy.rst
@@ -1,1 +1,1 @@
-Added :pep:`584` operators to :class:`collections.ChainMap`.
+Added :pep:`584` operators (| and |=) to :class:`collections.ChainMap`.

--- a/Misc/NEWS.d/next/Library/2020-03-07-11-26-08.bpo-36144.FG9jqy.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-07-11-26-08.bpo-36144.FG9jqy.rst
@@ -1,1 +1,1 @@
-Added :pep:`584` operators (| and |=) to :class:`collections.ChainMap`.
+Added :pep:`584` operators (``|`` and ``|=``) to :class:`collections.ChainMap`.

--- a/Misc/NEWS.d/next/Library/2020-03-07-11-26-08.bpo-36144.FG9jqy.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-07-11-26-08.bpo-36144.FG9jqy.rst
@@ -1,0 +1,1 @@
+Added :pep:`584` operators to :class:`collections.ChainMap`.


### PR DESCRIPTION
Update collections.ChainMap to include | and |= operators.

<!-- issue-number: [bpo-36144](https://bugs.python.org/issue36144) -->
https://bugs.python.org/issue36144
<!-- /issue-number -->
