### PR TITLE
bpo-39890: Don't mangle the AST when compiling starred assignments

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-07-12-35-31.bpo-39890.zr6CNx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-07-12-35-31.bpo-39890.zr6CNx.rst
@@ -1,0 +1,1 @@
+Don't mutate the ast when compiling starred assignments.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-07-12-35-31.bpo-39890.zr6CNx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-07-12-35-31.bpo-39890.zr6CNx.rst
@@ -1,1 +1,1 @@
-Don't mutate the ast when compiling starred assignments.
+Don't mutate the AST when compiling starred assignments.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-07-12-35-31.bpo-39890.zr6CNx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-07-12-35-31.bpo-39890.zr6CNx.rst
@@ -1,1 +1,0 @@
-Don't mutate the AST when compiling starred assignments.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3765,7 +3765,6 @@ assignment_helper(struct compiler *c, asdl_seq *elts)
                     "star-unpacking assignment");
             ADDOP_I(c, UNPACK_EX, (i + ((n-i-1) << 8)));
             seen_star = 1;
-            asdl_seq_SET(elts, i, elt->v.Starred.value);
         }
         else if (elt->kind == Starred_kind) {
             return compiler_error(c,
@@ -3775,7 +3774,10 @@ assignment_helper(struct compiler *c, asdl_seq *elts)
     if (!seen_star) {
         ADDOP_I(c, UNPACK_SEQUENCE, n);
     }
-    VISIT_SEQ(c, expr, elts);
+    for (i = 0; i < n; i++) {
+        expr_ty elt = asdl_seq_GET(elts, i);
+        VISIT(c, expr, elt->kind != Starred_kind ? elt : elt->v.Starred.value);
+    }
     return 1;
 }
 


### PR DESCRIPTION
It looks like `assignment_helper` is the only place where we actually change the semantic meaning of the AST during compilation (a starred name is changed to a regular name as a shortcut).

This probably isn't a great idea, and it would bite us later if we started making multiple passes or reusing the AST or something.

<!-- issue-number: [bpo-39890](https://bugs.python.org/issue39890) -->
https://bugs.python.org/issue39890
<!-- /issue-number -->
