### PR TITLE
bpo-39659: Route calls from pathlib.Path to os.getcwd() via the path accessor

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -187,7 +187,7 @@ class _WindowsFlavour(_Flavour):
     def resolve(self, path, strict=False):
         s = str(path)
         if not s:
-            return os.getcwd()
+            return path._accessor.getcwd()
         previous_s = None
         if _getfinalpathname is not None:
             if strict:
@@ -352,7 +352,7 @@ class _PosixFlavour(_Flavour):
             return path
         # NOTE: according to POSIX, getcwd() cannot contain path components
         # which are symlinks.
-        base = '' if path.is_absolute() else os.getcwd()
+        base = '' if path.is_absolute() else accessor.getcwd()
         return _resolve(base, str(path)) or sep
 
     def is_reserved(self, parts):
@@ -468,6 +468,8 @@ class _NormalAccessor(_Accessor):
             return grp.getgrgid(self.stat(path).st_gid).gr_name
         except ImportError:
             raise NotImplementedError("Path.group() is unsupported on this system")
+
+    getcwd = os.getcwd
 
 
 _normal_accessor = _NormalAccessor()
@@ -1104,7 +1106,7 @@ class Path(PurePath):
         """Return a new path pointing to the current working directory
         (as returned by os.getcwd()).
         """
-        return cls(os.getcwd())
+        return cls(cls()._accessor.getcwd())
 
     @classmethod
     def home(cls):
@@ -1173,7 +1175,7 @@ class Path(PurePath):
             return self
         # FIXME this must defer to the specific flavour (and, under Windows,
         # use nt._getfullpathname())
-        return self._from_parts([os.getcwd()] + self._parts)
+        return self._from_parts([self._accessor.getcwd()] + self._parts)
 
     def resolve(self, strict=False):
         """


### PR DESCRIPTION
(from the bug description:) Whereas most calls to `os` functions from `pathlib.Path` methods happen via `pathlib._Accessor` methods, retrieving the current working directory does not. This problem occurs when calling the `pathlib.Path.cwd()`, `~resolve()` and `~absolute()` methods.

<!-- issue-number: [bpo-39659](https://bugs.python.org/issue39659) -->
https://bugs.python.org/issue39659
<!-- /issue-number -->
