### PR TITLE
bpo-39894: Route calls from pathlib.Path.samefile() to os.stat() via the path accessor

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1116,7 +1116,7 @@ class Path(PurePath):
         try:
             other_st = other_path.stat()
         except AttributeError:
-            other_st = os.stat(other_path)
+            other_st = self._accessor.stat(other_path)
         return os.path.samestat(st, other_st)
 
     def iterdir(self):


### PR DESCRIPTION
`Path.samefile()` calls `os.stat()` directly. It should use the path's accessor object, as `Path.stat()` does.

<!-- issue-number: [bpo-39894](https://bugs.python.org/issue39894) -->
https://bugs.python.org/issue39894
<!-- /issue-number -->
