### PR TITLE
bpo-39897: Remove needless `Path(self.parent)` call, which makes `is_mount()` misbehave in `Path` subclasses

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1457,9 +1457,8 @@ class Path(PurePath):
         if not self.exists() or not self.is_dir():
             return False
 
-        parent = Path(self.parent)
         try:
-            parent_dev = parent.stat().st_dev
+            parent_dev = self.parent.stat().st_dev
         except OSError:
             return False
 
@@ -1467,7 +1466,7 @@ class Path(PurePath):
         if dev != parent_dev:
             return True
         ino = self.stat().st_ino
-        parent_ino = parent.stat().st_ino
+        parent_ino = self.parent.stat().st_ino
         return ino == parent_ino
 
     def is_symlink(self):


### PR DESCRIPTION
`pathlib.Path.is_mount()` calls `Path(self.parent)`, which:

- Is needless, as `self.parent` is already a Path instance!
- Prevents effective subclassing, as `self.parent` may be a `Path` subclass with its own `stat()` implementation

This patch makes `is_mount()` use `self.parent` directly.

<!-- issue-number: [bpo-39897](https://bugs.python.org/issue39897) -->
https://bugs.python.org/issue39897
<!-- /issue-number -->
