### PR TITLE
bpo-39899: Make pathlib use `os.path.expanduser()` to expand home directories

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -175,8 +175,8 @@ the :mod:`glob` module.)
 
    On Windows, :envvar:`USERPROFILE` will be used if set, otherwise a combination
    of :envvar:`HOMEPATH` and :envvar:`HOMEDRIVE` will be used.  An initial
-   ``~user`` is handled by stripping the last directory component from the created
-   user path derived above.
+   ``~user`` is handled by checking that the last directory component of the current
+   user's home directory matches :envvar:`USERNAME`, and replacing it if so.
 
    If the expansion fails or if the path does not begin with a tilde, the path is
    returned unchanged.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -705,7 +705,10 @@ call fails (for example because the path doesn't exist).
 .. classmethod:: Path.home()
 
    Return a new path object representing the user's home directory (as
-   returned by :func:`os.path.expanduser` with ``~`` construct)::
+   returned by :func:`os.path.expanduser` with ``~`` construct). If the home
+   directory can't be resolved, :exc:`RuntimeError` is raised.
+
+   ::
 
       >>> Path.home()
       PosixPath('/home/antoine')
@@ -773,7 +776,10 @@ call fails (for example because the path doesn't exist).
 .. method:: Path.expanduser()
 
    Return a new path with expanded ``~`` and ``~user`` constructs,
-   as returned by :meth:`os.path.expanduser`::
+   as returned by :meth:`os.path.expanduser`. If a home directory can't be
+   resolved, :exc:`RuntimeError` is raised.
+
+   ::
 
       >>> p = PosixPath('~/films/Monty Python')
       >>> p.expanduser()

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -312,11 +312,23 @@ def expanduser(path):
             drive = ''
         userhome = join(drive, os.environ['HOMEPATH'])
 
+    if i != 1: #~user
+        # Try to guess user home directory.  By default all users directories
+        # are located in the same place and are named by corresponding
+        # usernames.  If current user home directory points to nonstandard
+        # place, this guess is likely wrong, and so we bail out.
+        current_user = os.environ.get('USERNAME')
+        if current_user != basename(userhome):
+            return path
+
+        target_user = path[1:i]
+        if isinstance(target_user, bytes):
+            target_user = os.fsdecode(target_user)
+        if target_user != current_user:
+            userhome = join(dirname(userhome), target_user)
+
     if isinstance(path, bytes):
         userhome = os.fsencode(userhome)
-
-    if i != 1: #~user
-        userhome = join(dirname(userhome), path[1:i])
 
     return userhome + path[i:]
 

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -503,34 +503,47 @@ class TestNtpath(NtpathTestCase):
             env.clear()
             tester('ntpath.expanduser("~test")', '~test')
 
-            env['HOMEPATH'] = 'eric\\idle'
             env['HOMEDRIVE'] = 'C:\\'
-            tester('ntpath.expanduser("~test")', 'C:\\eric\\test')
-            tester('ntpath.expanduser("~")', 'C:\\eric\\idle')
+            env['HOMEPATH'] = 'Users\\eric'
+            env['USERNAME'] = 'eric'
+            tester('ntpath.expanduser("~test")', 'C:\\Users\\test')
+            tester('ntpath.expanduser("~")', 'C:\\Users\\eric')
 
             del env['HOMEDRIVE']
-            tester('ntpath.expanduser("~test")', 'eric\\test')
-            tester('ntpath.expanduser("~")', 'eric\\idle')
+            tester('ntpath.expanduser("~test")', 'Users\\test')
+            tester('ntpath.expanduser("~")', 'Users\\eric')
 
             env.clear()
-            env['USERPROFILE'] = 'C:\\eric\\idle'
-            tester('ntpath.expanduser("~test")', 'C:\\eric\\test')
-            tester('ntpath.expanduser("~")', 'C:\\eric\\idle')
+            env['USERPROFILE'] = 'C:\\Users\\eric'
+            env['USERNAME'] = 'eric'
+            tester('ntpath.expanduser("~test")', 'C:\\Users\\test')
+            tester('ntpath.expanduser("~")', 'C:\\Users\\eric')
             tester('ntpath.expanduser("~test\\foo\\bar")',
-                   'C:\\eric\\test\\foo\\bar')
+                   'C:\\Users\\test\\foo\\bar')
             tester('ntpath.expanduser("~test/foo/bar")',
-                   'C:\\eric\\test/foo/bar')
+                   'C:\\Users\\test/foo/bar')
             tester('ntpath.expanduser("~\\foo\\bar")',
-                   'C:\\eric\\idle\\foo\\bar')
+                   'C:\\Users\\eric\\foo\\bar')
             tester('ntpath.expanduser("~/foo/bar")',
-                   'C:\\eric\\idle/foo/bar')
+                   'C:\\Users\\eric/foo/bar')
 
             # bpo-36264: ignore `HOME` when set on windows
             env.clear()
             env['HOME'] = 'F:\\'
-            env['USERPROFILE'] = 'C:\\eric\\idle'
-            tester('ntpath.expanduser("~test")', 'C:\\eric\\test')
-            tester('ntpath.expanduser("~")', 'C:\\eric\\idle')
+            env['USERPROFILE'] = 'C:\\Users\\eric'
+            env['USERNAME'] = 'eric'
+            tester('ntpath.expanduser("~test")', 'C:\\Users\\test')
+            tester('ntpath.expanduser("~")', 'C:\\Users\\eric')
+
+            # bpo-39899: don't guess another user's home directory if
+            # `%USERNAME% != basename(%USERPROFILE%)`
+            env.clear()
+            env['USERPROFILE'] = 'C:\\Users\\eric'
+            env['USERNAME'] = 'idle'
+            tester('ntpath.expanduser("~test")', '~test')
+            tester('ntpath.expanduser("~")', 'C:\\Users\\eric')
+
+
 
     @unittest.skipUnless(nt, "abspath requires 'nt' module")
     def test_abspath(self):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2609,7 +2609,7 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
                 env.pop('USERNAME', None)
                 self.assertEqual(p1.expanduser(),
                                  P('C:/Users/alice/My Documents'))
-                self.assertRaises(KeyError, p2.expanduser)
+                self.assertRaises(RuntimeError, p2.expanduser)
                 env['USERNAME'] = 'alice'
                 self.assertEqual(p2.expanduser(),
                                  P('C:/Users/alice/My Documents'))

--- a/Misc/NEWS.d/next/Library/2020-03-09-20-36-07.bpo-39899.9adF3E.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-09-20-36-07.bpo-39899.9adF3E.rst
@@ -1,0 +1,3 @@
+:func:`os.path.expanduser()` now refuses to guess Windows home directories if the basename of current user's home directory does not match their username.
+
+:meth:`pathlib.Path.expanduser()` and :meth:`~pathlib.Path.home()` now consistently raise :exc:`RuntimeError` exception when a home directory cannot be resolved. Previously a :exc:`KeyError` exception could be raised on Windows when the ``"USERNAME"``  environment variable was unset.


### PR DESCRIPTION
os.path.expanduser(): don't guess other Windows users' home directories if the basename of the current user's home directory doesn't match their username.
    
This makes `ntpath.expanduser()` match `pathlib.Path.expanduser()` in this regard, and is more in line with `posixpath.expanduser()`'s cautious approach.
    
Also remove the near-duplicate implementation of `expanduser()` in pathlib, and by doing so fix a bug where KeyError could be raised when expanding another user's home directory on Windows.

<!-- issue-number: [bpo-39899](https://bugs.python.org/issue39899) -->
https://bugs.python.org/issue39899
<!-- /issue-number -->
