### PR TITLE
bpo-39900: Route calls from pathlib.Path.__bytes__() to os.fsencode() via the accessor

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -447,6 +447,8 @@ class _NormalAccessor(_Accessor):
     def readlink(self, path):
         return os.readlink(path)
 
+    fsencode = staticmethod(os.fsencode)
+
 
 _normal_accessor = _NormalAccessor()
 
@@ -1093,6 +1095,11 @@ class Path(PurePath):
         return self._accessor.open(self, flags, mode)
 
     # Public API
+
+    def __bytes__(self):
+        """Return the bytes representation of the path.  This is only
+        recommended to use under Unix."""
+        return self._accessor.fsencode(self)
 
     @classmethod
     def cwd(cls):


### PR DESCRIPTION
This PR routes makes `Path.__bytes__()` call `os.fsencode()` only via the path's accessor

It's questionable whether `PurePath.__bytes__()` (which continues to call `os.fsencode()` directly) should exist at all, given `os.fsencode()` will encode to the local filesystem encoding, whereas pure paths shouldn't rely on any local FS semantics AFAIK.

<!-- issue-number: [bpo-39900](https://bugs.python.org/issue39900) -->
https://bugs.python.org/issue39900
<!-- /issue-number -->
