### PR TITLE
bpo-39901: Move `pathlib.Path.owner()` and `group()` implementations into the path accessor

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -447,6 +447,20 @@ class _NormalAccessor(_Accessor):
     def readlink(self, path):
         return os.readlink(path)
 
+    def owner(self, path):
+        try:
+            import pwd
+            return pwd.getpwuid(self.stat(path).st_uid).pw_name
+        except ImportError:
+            raise NotImplementedError("Path.owner() is unsupported on this system")
+
+    def group(self, path):
+        try:
+            import grp
+            return grp.getgrgid(self.stat(path).st_gid).gr_name
+        except ImportError:
+            raise NotImplementedError("Path.group() is unsupported on this system")
+
 
 _normal_accessor = _NormalAccessor()
 
@@ -1209,15 +1223,13 @@ class Path(PurePath):
         """
         Return the login name of the file owner.
         """
-        import pwd
-        return pwd.getpwuid(self.stat().st_uid).pw_name
+        return self._accessor.owner(self)
 
     def group(self):
         """
         Return the group name of the file gid.
         """
-        import grp
-        return grp.getgrgid(self.stat().st_gid).gr_name
+        return self._accessor.group(self)
 
     def open(self, mode='r', buffering=-1, encoding=None,
              errors=None, newline=None):
@@ -1574,12 +1586,6 @@ class WindowsPath(Path, PureWindowsPath):
     On a Windows system, instantiating a Path should return this object.
     """
     __slots__ = ()
-
-    def owner(self):
-        raise NotImplementedError("Path.owner() is unsupported on this system")
-
-    def group(self):
-        raise NotImplementedError("Path.group() is unsupported on this system")
 
     def is_mount(self):
         raise NotImplementedError("Path.is_mount() is unsupported on this system")


### PR DESCRIPTION
Given the `pwd` and `grp` modules make system calls and provide information about the *local* system, I believe these implementations should live in `pathlib._NormalAccessor` for consistency with other methods that do "impure" things.

<!-- issue-number: [bpo-39901](https://bugs.python.org/issue39901) -->
https://bugs.python.org/issue39901
<!-- /issue-number -->
