### PR TITLE
bpo-39682: make `pathlib.Path` immutable by removing (undocumented) support for "closing" a path by using it as a context manager

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1720,13 +1720,15 @@ class _BasePathTest(object):
         next(it2)
         with p:
             pass
-        # I/O operation on closed path.
-        self.assertRaises(ValueError, next, it)
-        self.assertRaises(ValueError, next, it2)
-        self.assertRaises(ValueError, p.open)
-        self.assertRaises(ValueError, p.resolve)
-        self.assertRaises(ValueError, p.absolute)
-        self.assertRaises(ValueError, p.__enter__)
+        # Using a path as a context manager is a no-op, thus the following
+        # operations should still succeed after the context manage exits.
+        next(it)
+        next(it2)
+        p.exists()
+        p.resolve()
+        p.absolute()
+        with p:
+            pass
 
     def test_chmod(self):
         p = self.cls(BASE) / 'fileA'

--- a/Misc/NEWS.d/next/Library/2020-03-08-11-00-01.bpo-39682.AxXZNz.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-08-11-00-01.bpo-39682.AxXZNz.rst
@@ -1,1 +1,3 @@
-Remove undocumented support for *closing* a `pathlib.Path` object via its context manager. The context manager magic methods remain, but they are now a no-op, making `Path` objects immutable.
+Remove undocumented support for *closing* a `pathlib.Path` object via its
+context manager. The context manager magic methods remain, but they are now a
+no-op, making `Path` objects immutable.

--- a/Misc/NEWS.d/next/Library/2020-03-08-11-00-01.bpo-39682.AxXZNz.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-08-11-00-01.bpo-39682.AxXZNz.rst
@@ -1,0 +1,1 @@
+Remove undocumented support for *closing* a `pathlib.Path` object via its context manager. The context manager magic methods remain, but they are now a no-op, making `Path` objects immutable.


### PR DESCRIPTION
This implements @pitrou's suggestion of retaining support for using a `Path` object as a context manager, but making it a no-op.

<!-- issue-number: [bpo-39682](https://bugs.python.org/issue39682) -->
https://bugs.python.org/issue39682
<!-- /issue-number -->
