### PR TITLE
bpo-39763: Change test to check for `subprocess.check_output` during setup.py build phase

### DIFF
--- a/Lib/_aix_support.py
+++ b/Lib/_aix_support.py
@@ -7,7 +7,7 @@ from sysconfig import get_config_var
 # if not available, the config_vars are also definitely not available
 # supply substitutes to bootstrap the build
 try:
-    import subprocess
+    from subprocess import check_output
     _have_subprocess = True
     _tmp_bd = get_config_var("AIX_BUILDDATE")
     _bgt = get_config_var("BUILD_GNU_TYPE")
@@ -50,7 +50,7 @@ def _aix_bosmp64():
     """
     if _have_subprocess:
         # We expect all AIX systems to have lslpp installed in this location
-        out = subprocess.check_output(["/usr/bin/lslpp", "-Lqc", "bos.mp64"])
+        out = check_output(["/usr/bin/lslpp", "-Lqc", "bos.mp64"])
         out = out.decode("utf-8").strip().split(":")  # type: ignore
         # Use str() and int() to help mypy see types
         return str(out[2]), int(out[-1])

--- a/Misc/NEWS.d/next/Library/2020-03-08-10-29-50.bpo-39763.yEI7A+.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-08-10-29-50.bpo-39763.yEI7A+.rst
@@ -1,4 +1,0 @@
-Update test in `Lib/_aix_support.py` to check for `subprocess.check_output()` rather
-than `subprocess` as a loadable module because 1ec63b62035e73111e204a0e03b83503e1c58f2e
-now provides a minimal subprocess via setup.py.
-Patch by M. Felt.

--- a/Misc/NEWS.d/next/Library/2020-03-08-10-29-50.bpo-39763.yEI7A+.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-08-10-29-50.bpo-39763.yEI7A+.rst
@@ -1,0 +1,4 @@
+Update test in `Lib/_aix_support.py` to check for `subprocess.check_output()` rather
+than `subprocess` as a loadable module because 1ec63b62035e73111e204a0e03b83503e1c58f2e
+now provides a minimal subprocess via setup.py.
+Patch by M. Felt.

--- a/Misc/NEWS.d/next/Library/2020-03-08-10-43-22.bpo-39763.rBb9GN.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-08-10-43-22.bpo-39763.rBb9GN.rst
@@ -1,0 +1,4 @@
+Update test in `Lib/_aix_support.py` to check for `subprocess.check_output()` rather
+than `subprocess` as a loadable module because 1ec63b62035e73111e204a0e03b83503e1c58f2e
+now provides a minimal subprocess via setup.py.
+Patch by M. Felt.


### PR DESCRIPTION
Check for `subprocess.check_output()` rather than `subprocess` as a loadable module
as 1ec63b62035e73111e204a0e03b83503e1c58f2e now provides a minimal `subprocess` via setup.py.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39763](https://bugs.python.org/issue39763) -->
https://bugs.python.org/issue39763
<!-- /issue-number -->
