### PR TITLE
gh-84083: support equality comparisons in dis.Bytecode

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -325,6 +325,12 @@ and :meth:`~datetime.datetime.isocalendar()` of :class:`datetime.datetime`
 methods now returns a :func:`~collections.namedtuple` instead of a :class:`tuple`.
 (Contributed by Dong-hee Na in :issue:`24416`.)
 
+dis
+---
+
+:class:`dis.Bytecode` objects now support equality comparisons. (Contributed
+by Batuhan Taskaya in :issue:`39902`.)
+
 fcntl
 -----
 

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -536,6 +536,16 @@ class Bytecode:
                                lasti=offset)
             return output.getvalue()
 
+    def __eq__(self, other):
+        if isinstance(other, Bytecode):
+            return (self.codeobj, self.first_line, self.current_offset) == (
+                other.codeobj,
+                other.first_line,
+                other.current_offset,
+            )
+        else:
+            return NotImplemented
+
 
 def _test():
     """Simple test program to disassemble a file."""

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1202,5 +1202,16 @@ class BytecodeTests(unittest.TestCase):
         b = dis.Bytecode.from_traceback(tb)
         self.assertEqual(b.dis(), dis_traceback)
 
+    def test_equality(self):
+        self.assertEqual(dis.Bytecode("print(1)"), dis.Bytecode("print(1)"))
+        self.assertNotEqual(dis.Bytecode("print(1)"), dis.Bytecode("print(2)"))
+        self.assertNotEqual(
+            dis.Bytecode("print(1)", first_line=3), dis.Bytecode("print(1)")
+        )
+        self.assertNotEqual(
+            dis.Bytecode("print(1)", current_offset=5),
+            dis.Bytecode("print(1)"),
+        )
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-03-08-15-16-45.bpo-39902.HoE484.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-08-15-16-45.bpo-39902.HoE484.rst
@@ -1,0 +1,2 @@
+Added support for equality comparisons in ``dis.Bytecode`` objects. Patch by
+Batuhan Taskaya.


### PR DESCRIPTION


<!-- issue-number: [bpo-39902](https://bugs.python.org/issue39902) -->
https://bugs.python.org/issue39902
<!-- /issue-number -->

<!-- gh-issue-number: gh-84083 -->
* Issue: gh-84083
<!-- /gh-issue-number -->
