### PR TITLE
fix typo: add space

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -109,8 +109,8 @@ source.
    Many standard library modules contain code that is invoked on their execution
    as a script.  An example is the :mod:`timeit` module::
 
-       python -mtimeit -s 'setup here' 'benchmarked code here'
-       python -mtimeit -h # for details
+       python -m timeit -s 'setup here' 'benchmarked code here'
+       python -m timeit -h # for details
 
    .. audit-event:: cpython.run_module module-name cmdoption-m
 


### PR DESCRIPTION
Fix typo in cmdline.rst
Add space between the `-m` option and the module name (`timeit`).



Automerge-Triggered-By: @Mariatta