### PR TITLE
 bpo-39885: IDLE context menu clears selection 

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,9 @@ Released on 2020-10-05?
 ======================================
 
 
+bpo-39885: Since clicking to get an IDLE context menu moves the
+cursor, any text selection should be and now is cleared.
+
 bpo-39852: Edit "Go to line" now clears any selection, preventing
 accidental deletion.  It also updates Ln and Col on the status bar.
 

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -499,6 +499,7 @@ class EditorWindow(object):
     rmenu = None
 
     def right_menu_event(self, event):
+        self.text.tag_remove("sel", "1.0", "end")
         self.text.mark_set("insert", "@%d,%d" % (event.x, event.y))
         if not self.rmenu:
             self.make_rmenu()

--- a/Misc/NEWS.d/next/IDLE/2020-03-08-14-27-36.bpo-39885.29ERiR.rst
+++ b/Misc/NEWS.d/next/IDLE/2020-03-08-14-27-36.bpo-39885.29ERiR.rst
@@ -1,0 +1,2 @@
+Since clicking to get an IDLE context menu moves the cursor,
+any text selection should be and now is cleared.


### PR DESCRIPTION
Since clicking to get an IDLE context menu moves the cursor,
any text selection should be and now is cleared.


<!-- issue-number: [bpo-39885](https://bugs.python.org/issue39885) -->
https://bugs.python.org/issue39885
<!-- /issue-number -->
