### PR TITLE
bpo-39906: add follow_symlinks parameter to pathlib.Path.stat() and chmod()

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -713,10 +713,13 @@ call fails (for example because the path doesn't exist).
    .. versionadded:: 3.5
 
 
-.. method:: Path.stat()
+.. method:: Path.stat(*, follow_symlinks=True)
 
    Return a :class:`os.stat_result` object containing information about this path, like :func:`os.stat`.
    The result is looked up at each call to this method.
+
+   This method normally follows symlinks; to stat a symlink add the argument
+   ``follow_symlinks=False``, or use :meth:`~Path.lstat`.
 
    ::
 
@@ -726,10 +729,18 @@ call fails (for example because the path doesn't exist).
       >>> p.stat().st_mtime
       1327883547.852554
 
+   .. versionchanged:: 3.10
+      The *follow_symlinks* parameter was added.
 
-.. method:: Path.chmod(mode)
+.. method:: Path.chmod(mode, *, follow_symlinks=True)
 
-   Change the file mode and permissions, like :func:`os.chmod`::
+   Change the file mode and permissions, like :func:`os.chmod`.
+
+   This method normally follows symlinks. Some Unix flavours support changing
+   permissions on the symlink itself; on these platforms you may add the
+   argument ``follow_symlinks=False``, or use :meth:`~Path.lchmod`.
+
+   ::
 
       >>> p = Path('setup.py')
       >>> p.stat().st_mode
@@ -738,6 +749,8 @@ call fails (for example because the path doesn't exist).
       >>> p.stat().st_mode
       33060
 
+   .. versionchanged:: 3.10
+      The *follow_symlinks* parameter was added.
 
 .. method:: Path.exists()
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -393,8 +393,6 @@ class _NormalAccessor(_Accessor):
 
     stat = os.stat
 
-    lstat = os.lstat
-
     open = os.open
 
     listdir = os.listdir
@@ -402,12 +400,6 @@ class _NormalAccessor(_Accessor):
     scandir = os.scandir
 
     chmod = os.chmod
-
-    if hasattr(os, "lchmod"):
-        lchmod = os.lchmod
-    else:
-        def lchmod(self, path, mode):
-            raise NotImplementedError("os.lchmod() not available on this system")
 
     mkdir = os.mkdir
 
@@ -1191,12 +1183,12 @@ class Path(PurePath):
         normed = self._flavour.pathmod.normpath(s)
         return self._from_parts((normed,))
 
-    def stat(self):
+    def stat(self, *, follow_symlinks=True):
         """
         Return the result of the stat() system call on this path, like
         os.stat() does.
         """
-        return self._accessor.stat(self)
+        return self._accessor.stat(self, follow_symlinks=follow_symlinks)
 
     def owner(self):
         """
@@ -1286,18 +1278,18 @@ class Path(PurePath):
             if not exist_ok or not self.is_dir():
                 raise
 
-    def chmod(self, mode):
+    def chmod(self, mode, *, follow_symlinks=True):
         """
         Change the permissions of the path, like os.chmod().
         """
-        self._accessor.chmod(self, mode)
+        self._accessor.chmod(self, mode, follow_symlinks=follow_symlinks)
 
     def lchmod(self, mode):
         """
         Like chmod(), except if the path points to a symlink, the symlink's
         permissions are changed, rather than its target's.
         """
-        self._accessor.lchmod(self, mode)
+        self.chmod(mode, follow_symlinks=False)
 
     def unlink(self, missing_ok=False):
         """
@@ -1321,7 +1313,7 @@ class Path(PurePath):
         Like stat(), except if the path points to a symlink, the symlink's
         status information is returned, rather than its target's.
         """
-        return self._accessor.lstat(self)
+        return self.stat(follow_symlinks=False)
 
     def link_to(self, target):
         """

--- a/Misc/NEWS.d/next/Library/2020-03-30-00-13-27.bpo-39906.eaR3fN.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-30-00-13-27.bpo-39906.eaR3fN.rst
@@ -1,0 +1,1 @@
+:meth:`pathlib.Path.stat` and :meth:`~pathlib.Path.chmod` now accept a *follow_symlinks* keyword-only argument for consistency with corresponding functions in the :mod:`os` module.


### PR DESCRIPTION
Backwards-compatible change that makes this work:

```python
import pathlib
p = pathlib.Path("/some/symlink")
assert p.stat(follow_symlinks=True) == p.stat()
assert p.stat(follow_symlinks=False) == p.lstat()
```

This brings pathlib in line with the newish `follow_symlinks` parameters in `os` functions, and arguably provides a more explicit (and nicer?) interface.

For consistency I've applied the same change to `chmod()`, though as far as I can tell, changing permissions on symlinks is only available on some BSDs (see [bpo-7479](https://bugs.python.org/issue7479))

<!-- issue-number: [bpo-39906](https://bugs.python.org/issue39906) -->
https://bugs.python.org/issue39906
<!-- /issue-number -->
