### PR TITLE
bpo-39907: Improve performance of `pathlib.Path.iterdir()` by using `os.scandir()` under the hood

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -400,8 +400,6 @@ class _NormalAccessor(_Accessor):
 
     open = os.open
 
-    listdir = os.listdir
-
     scandir = os.scandir
 
     chmod = os.chmod
@@ -1125,11 +1123,8 @@ class Path(PurePath):
         """
         if self._closed:
             self._raise_closed()
-        for name in self._accessor.listdir(self):
-            if name in {'.', '..'}:
-                # Yielding a path object for these makes little sense
-                continue
-            yield self._make_child_relpath(name)
+        for entry in self._accessor.scandir(self):
+            yield self._make_child_relpath(entry.name)
             if self._closed:
                 self._raise_closed()
 


### PR DESCRIPTION
Per PEP 471:

> It returns a generator instead of a list, so that scandir acts as a true iterator instead of returning the full list immediately.

By using `scandir()` we avoid allocating a full list of directory children, and we don't need to worry about `"."` and `".."` entries. Also simplifies the accessor interface a tiny bit.

<!-- issue-number: [bpo-39907](https://bugs.python.org/issue39907) -->
https://bugs.python.org/issue39907
<!-- /issue-number -->
