### PR TITLE
bpo-27115: Move IDLE Query error blanking

### DIFF
--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -108,6 +108,7 @@ class Query(Toplevel):
                                exists=True, root=self.parent)
         self.entry_error = Label(frame, text=' ', foreground='red',
                                  font=self.error_font)
+        # Display or blank error by setting ['text'] =.
         entrylabel.grid(column=0, row=0, columnspan=3, padx=5, sticky=W)
         self.entry.grid(column=0, row=1, columnspan=3, padx=5, sticky=W+E,
                         pady=[10,0])
@@ -132,7 +133,6 @@ class Query(Toplevel):
 
     def entry_ok(self):  # Example: usually replace.
         "Return non-blank entry or None."
-        self.entry_error['text'] = ''
         entry = self.entry.get().strip()
         if not entry:
             self.showerror('blank line.')
@@ -144,6 +144,7 @@ class Query(Toplevel):
 
         Otherwise leave dialog open for user to correct entry or cancel.
         '''
+        self.entry_error['text'] = ''
         entry = self.entry_ok()
         if entry is not None:
             self.result = entry
@@ -173,7 +174,6 @@ class SectionName(Query):
 
     def entry_ok(self):
         "Return sensible ConfigParser section name or None."
-        self.entry_error['text'] = ''
         name = self.entry.get().strip()
         if not name:
             self.showerror('no name specified.')
@@ -198,7 +198,6 @@ class ModuleName(Query):
 
     def entry_ok(self):
         "Return entered module name as file path or None."
-        self.entry_error['text'] = ''
         name = self.entry.get().strip()
         if not name:
             self.showerror('no name specified.')
@@ -311,7 +310,6 @@ class HelpSource(Query):
 
     def entry_ok(self):
         "Return apparently valid (name, path) or None"
-        self.entry_error['text'] = ''
         self.path_error['text'] = ''
         name = self.item_ok()
         path = self.path_ok()
@@ -362,7 +360,6 @@ class CustomRun(Query):
 
     def entry_ok(self):
         "Return apparently valid (cli_args, restart) or None"
-        self.entry_error['text'] = ''
         cli_args = self.cli_args_ok()
         restart = self.restartvar.get()
         return None if cli_args is None else (cli_args, restart)


### PR DESCRIPTION
Move required blanking of error text to non-overridden entry_ok().
(Omit news item.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-27115](https://bugs.python.org/issue27115) -->
https://bugs.python.org/issue27115
<!-- /issue-number -->
