### PR TITLE
bpo-36184: Port python-gdb.py to FreeBSD

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2020-03-09-13-28-13.bpo-36184.BMPJ0D.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-03-09-13-28-13.bpo-36184.BMPJ0D.rst
@@ -1,0 +1,4 @@
+Port python-gdb.py to FreeBSD. python-gdb.py now checks for "take_gil"
+function name to check if a frame tries to acquire the GIL, instead of
+checking for "pthread_cond_timedwait" which is specific to Linux and can be
+a different condition than the GIL.

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1600,7 +1600,7 @@ class Frame(object):
         # This assumes the _POSIX_THREADS version of Python/ceval_gil.h:
         name = self._gdbframe.name()
         if name:
-            return 'pthread_cond_timedwait' in name
+            return (name == 'take_gil')
 
     def is_gc_collect(self):
         '''Is this frame "collect" within the garbage-collector?'''


### PR DESCRIPTION
python-gdb.py now checks for "take_gil" function name to check if a
frame tries to acquire the GIL, instead of checking for
"pthread_cond_timedwait" which is specific to Linux and can be a
diferent condition than the GIL.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36184](https://bugs.python.org/issue36184) -->
https://bugs.python.org/issue36184
<!-- /issue-number -->
