### PR TITLE
bpo-39916: Use os.scandir() as context manager in Path.glob().

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -527,7 +527,8 @@ class _WildcardSelector(_Selector):
 
     def _select_from(self, parent_path, is_dir, exists, scandir):
         try:
-            entries = list(scandir(parent_path))
+            with scandir(parent_path) as scandir_it:
+                entries = list(scandir_it)
             for entry in entries:
                 if self.dironly:
                     try:
@@ -557,7 +558,8 @@ class _RecursiveWildcardSelector(_Selector):
     def _iterate_directories(self, parent_path, is_dir, scandir):
         yield parent_path
         try:
-            entries = list(scandir(parent_path))
+            with scandir(parent_path) as scandir_it:
+                entries = list(scandir_it)
             for entry in entries:
                 entry_is_dir = False
                 try:

--- a/Misc/NEWS.d/next/Library/2020-03-09-18-56-27.bpo-39916.BHHyp3.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-09-18-56-27.bpo-39916.BHHyp3.rst
@@ -1,0 +1,2 @@
+More reliable use of ``os.scandir()`` in ``Path.glob()``. It no longer emits
+a ResourceWarning when interrupted.


### PR DESCRIPTION


<!-- issue-number: [bpo-39916](https://bugs.python.org/issue39916) -->
https://bugs.python.org/issue39916
<!-- /issue-number -->
