### PR TITLE
bpo-39877: Remove useless PyEval_InitThreads() calls

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -121,9 +121,6 @@ PyAPI_FUNC(PyObject *) PyEval_EvalFrameEx(struct _frame *f, int exc);
    WARNING: NEVER NEST CALLS TO Py_BEGIN_ALLOW_THREADS AND
    Py_END_ALLOW_THREADS!!!
 
-   The function PyEval_InitThreads() should be called only from
-   init_thread() in "_threadmodule.c".
-
    Note that not yet all candidates have been converted to use this
    mechanism!
 */

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -267,9 +267,8 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def test_bpo20891(self):
         """
-        bpo-20891: Calling PyGILState_Ensure in a non-Python thread before
-        calling PyEval_InitThreads() must not crash. PyGILState_Ensure() must
-        call PyEval_InitThreads() for us in this case.
+        bpo-20891: Calling PyGILState_Ensure in a non-Python thread must not
+        crash.
         """
         out, err = self.run_embedded_interpreter("test_bpo20891")
         self.assertEqual(out, '')

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5695,7 +5695,6 @@ PyInit__ctypes(void)
    ob_type is the metatype (the 'type'), defaults to PyType_Type,
    tp_base is the base type, defaults to 'object' aka PyBaseObject_Type.
 */
-    PyEval_InitThreads();
     m = PyModule_Create(&_ctypesmodule);
     if (!m)
         return NULL;

--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -423,7 +423,6 @@ static void LoadPython(void)
 {
     if (!Py_IsInitialized()) {
         Py_Initialize();
-        PyEval_InitThreads();
     }
 }
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2728,8 +2728,6 @@ test_thread_state(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    /* Ensure Python is set up for threading */
-    PyEval_InitThreads();
     thread_done = PyThread_allocate_lock();
     if (thread_done == NULL)
         return PyErr_NoMemory();
@@ -4174,8 +4172,6 @@ call_in_temporary_c_thread(PyObject *self, PyObject *callback)
     PyObject *res = NULL;
     test_c_thread_t test_c_thread;
     long thread;
-
-    PyEval_InitThreads();
 
     test_c_thread.start_event = PyThread_allocate_lock();
     test_c_thread.exit_event = PyThread_allocate_lock();

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1074,7 +1074,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
     Py_INCREF(func);
     Py_INCREF(args);
     Py_XINCREF(keyw);
-    PyEval_InitThreads(); /* Start the interpreter's thread-awareness */
+
     ident = PyThread_start_new_thread(t_bootstrap, (void*) boot);
     if (ident == PYTHREAD_INVALID_THREAD_ID) {
         PyErr_SetString(ThreadError, "can't start new thread");

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -62,7 +62,6 @@ static int test_repeated_init_and_subinterpreters(void)
         _testembed_Py_Initialize();
         mainstate = PyThreadState_Get();
 
-        PyEval_InitThreads();
         PyEval_ReleaseThread(mainstate);
 
         gilstate = PyGILState_Ensure();
@@ -252,9 +251,8 @@ static int test_bpo20891(void)
     /* the test doesn't support custom memory allocators */
     putenv("PYTHONMALLOC=");
 
-    /* bpo-20891: Calling PyGILState_Ensure in a non-Python thread before
-       calling PyEval_InitThreads() must not crash. PyGILState_Ensure() must
-       call PyEval_InitThreads() for us in this case. */
+    /* bpo-20891: Calling PyGILState_Ensure in a non-Python thread must not
+       crash. */
     PyThread_type_lock lock = PyThread_allocate_lock();
     if (!lock) {
         fprintf(stderr, "PyThread_allocate_lock failed!");

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -345,7 +345,7 @@ PyEval_AcquireThread(PyThreadState *tstate)
     _PyRuntimeState *runtime = tstate->interp->runtime;
     struct _ceval_runtime_state *ceval = &runtime->ceval;
 
-    /* Check someone has called PyEval_InitThreads() to create the lock */
+    /* Check that _PyEval_InitThreads() was called to create the lock */
     assert(gil_created(&ceval->gil));
 
     take_gil(ceval, tstate);
@@ -541,9 +541,7 @@ Py_AddPendingCall(int (*func)(void *), void *arg)
 static int
 handle_signals(_PyRuntimeState *runtime)
 {
-    /* Only handle signals on main thread.  PyEval_InitThreads must
-     * have been called already.
-     */
+    /* Only handle signals on main thread */
     if (PyThread_get_thread_ident() != runtime->main_thread) {
         return 0;
     }


### PR DESCRIPTION
Py_Initialize() calls PyEval_InitThreads() since Python 3.7. It's no
longer needed to call it explicitly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39877](https://bugs.python.org/issue39877) -->
https://bugs.python.org/issue39877
<!-- /issue-number -->
