### PR TITLE
bpo-39877: Deprecate PyEval_InitThreads()

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -842,12 +842,12 @@ code, or when embedding the Python interpreter:
       single: PyEval_SaveThread()
       single: PyEval_RestoreThread()
 
-   Initialize and acquire the global interpreter lock.  It should be called in the
-   main thread before creating a second thread or engaging in any other thread
-   operations such as ``PyEval_ReleaseThread(tstate)``. It is not needed before
-   calling :c:func:`PyEval_SaveThread` or :c:func:`PyEval_RestoreThread`.
+   Deprecated function which does nothing.
 
-   This is a no-op when called for a second time.
+   In Python 3.6 and older, this function created the GIL if it didn't exist.
+
+   .. versionchanged:: 3.9
+      The function now does nothing.
 
    .. versionchanged:: 3.7
       This function is now called by :c:func:`Py_Initialize()`, so you don't
@@ -855,6 +855,8 @@ code, or when embedding the Python interpreter:
 
    .. versionchanged:: 3.2
       This function cannot be called before :c:func:`Py_Initialize()` anymore.
+
+   .. deprecated-removed:: 3.9 3.11
 
    .. index:: module: _thread
 
@@ -867,6 +869,8 @@ code, or when embedding the Python interpreter:
 
    .. versionchanged:: 3.7
       The :term:`GIL` is now initialized by :c:func:`Py_Initialize()`.
+
+   .. deprecated-removed:: 3.9 3.11
 
 
 .. c:function:: PyThreadState* PyEval_SaveThread()

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -519,6 +519,12 @@ Deprecated
 
   (Contributed by Victor Stinner in :issue:`39353`.)
 
+* The :c:func:`PyEval_InitThreads` and :c:func:`PyEval_ThreadsInitialized`
+  functions are now deprecated and will be removed in Python 3.11. Calling
+  :c:func:`PyEval_InitThreads` now does nothing. The :term:`GIL` is initialized
+  by :c:func:`Py_Initialize()` since Python 3.7.
+  (Contributed by Victor Stinner in :issue:`39877`.)
+
 
 Removed
 =======

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -128,8 +128,8 @@ PyAPI_FUNC(PyObject *) PyEval_EvalFrameEx(struct _frame *f, int exc);
 PyAPI_FUNC(PyThreadState *) PyEval_SaveThread(void);
 PyAPI_FUNC(void) PyEval_RestoreThread(PyThreadState *);
 
-PyAPI_FUNC(int)  PyEval_ThreadsInitialized(void);
-PyAPI_FUNC(void) PyEval_InitThreads(void);
+Py_DEPRECATED(3.9) PyAPI_FUNC(int) PyEval_ThreadsInitialized(void);
+Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
 Py_DEPRECATED(3.2) PyAPI_FUNC(void) PyEval_AcquireLock(void);
 /* Py_DEPRECATED(3.2) */ PyAPI_FUNC(void) PyEval_ReleaseLock(void);
 PyAPI_FUNC(void) PyEval_AcquireThread(PyThreadState *tstate);

--- a/Misc/NEWS.d/next/C API/2020-03-10-00-18-16.bpo-39877.GOYtIm.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-10-00-18-16.bpo-39877.GOYtIm.rst
@@ -1,0 +1,3 @@
+Deprecated :c:func:`PyEval_InitThreads` and
+:c:func:`PyEval_ThreadsInitialized`. Calling :c:func:`PyEval_InitThreads` now
+does nothing.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -241,12 +241,7 @@ _PyEval_InitThreads(PyThreadState *tstate)
 void
 PyEval_InitThreads(void)
 {
-    PyThreadState *tstate = _PyThreadState_GET();
-
-    PyStatus status = _PyEval_InitThreads(tstate);
-    if (_PyStatus_EXCEPTION(status)) {
-        Py_ExitStatusException(status);
-    }
+    /* Do nothing: kept for backward compatibility */
 }
 
 void


### PR DESCRIPTION
Deprecated PyEval_InitThreads() and PyEval_ThreadsInitialized().
Calling PyEval_InitThreads() now does nothing.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39877](https://bugs.python.org/issue39877) -->
https://bugs.python.org/issue39877
<!-- /issue-number -->
