### PR TITLE
[3.8] bpo-39828: Fix json.tool to catch BrokenPipeError (GH-18779).

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -52,4 +52,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except BrokenPipeError as exc:
+        sys.exit(exc.errno)

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -1,7 +1,9 @@
+import errno
 import os
 import sys
 import textwrap
 import unittest
+
 from subprocess import Popen, PIPE
 from test import support
 from test.support.script_helper import assert_python_ok
@@ -149,3 +151,12 @@ class TestTool(unittest.TestCase):
         self.assertEqual(out.splitlines(),
                          self.expect_without_sort_keys.encode().splitlines())
         self.assertEqual(err, b'')
+
+    @unittest.skipIf(sys.platform =="win32", "The test is failed with ValueError on Windows")
+    def test_broken_pipe_error(self):
+        cmd = [sys.executable, '-m', 'json.tool']
+        proc = Popen(cmd, stdout=PIPE, stdin=PIPE)
+        # bpo-39828: Closing before json.tool attempts to write into stdout.
+        proc.stdout.close()
+        proc.communicate(b'"{}"')
+        self.assertEqual(proc.returncode, errno.EPIPE)

--- a/Misc/NEWS.d/next/Library/2020-03-05-00-57-49.bpo-39828.yWq9NJ.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-05-00-57-49.bpo-39828.yWq9NJ.rst
@@ -1,0 +1,1 @@
+Fix :mod:`json.tool` to catch :exc:`BrokenPipeError`. Patch by Dong-hee Na.


### PR DESCRIPTION
(cherry picked from commit 700cb587303461d5a96456c56902cfdd8ad50e2d)

Co-authored-by: Dong-hee Na <donghee.na92@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39828](https://bugs.python.org/issue39828) -->
https://bugs.python.org/issue39828
<!-- /issue-number -->


Automerge-Triggered-By: @vstinner