### PR TITLE
gh-76984: Handle DATA correctly for LMTP with multiple RCPT

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -53,7 +53,7 @@ import sys
 from email.base64mime import body_encode as encode_base64
 
 __all__ = ["SMTPException", "SMTPNotSupportedError", "SMTPServerDisconnected", "SMTPResponseException",
-           "SMTPSenderRefused", "SMTPRecipientsRefused", "SMTPDataError",
+           "SMTPSenderRefused", "SMTPRecipientsRefused", "SMTPDataError", "LMTPDataError",
            "SMTPConnectError", "SMTPHeloError", "SMTPAuthenticationError",
            "quoteaddr", "quotedata", "SMTP"]
 
@@ -127,6 +127,18 @@ class SMTPRecipientsRefused(SMTPException):
 
 class SMTPDataError(SMTPResponseException):
     """The SMTP server didn't accept the data."""
+
+class LMTPDataError(SMTPResponseException):
+    """The LMTP server didn't accept the data.
+
+    The errors for each recipient are accessible through the attribute
+    'recipients', which is a dictionary of exactly the same sort as
+    SMTP.sendmail() returns.
+    """
+
+    def __init__(self, recipients):
+        self.recipients = recipients
+        self.args = (recipients,)
 
 class SMTPConnectError(SMTPResponseException):
     """Error during connection establishment."""
@@ -844,6 +856,9 @@ class SMTP:
          SMTPDataError          The server replied with an unexpected
                                 error code (other than a refusal of
                                 a recipient).
+         LMTPDataError          The server replied with an unexpected
+                                error code (other than a refusal of
+                                a recipient) for ALL recipients.
          SMTPNotSupportedError  The mail_options parameter includes 'SMTPUTF8'
                                 but the SMTPUTF8 extension is not supported by
                                 the server.
@@ -886,12 +901,15 @@ class SMTP:
             else:
                 self._rset()
             raise SMTPSenderRefused(code, resp, from_addr)
+        rcpts = []
         senderrs = {}
         if isinstance(to_addrs, str):
             to_addrs = [to_addrs]
         for each in to_addrs:
             (code, resp) = self.rcpt(each, rcpt_options)
-            if (code != 250) and (code != 251):
+            if (code == 250) or (code == 251):
+                rcpts.append(each)
+            else:
                 senderrs[each] = (code, resp)
             if code == 421:
                 self.close()
@@ -900,13 +918,26 @@ class SMTP:
             # the server refused all our recipients
             self._rset()
             raise SMTPRecipientsRefused(senderrs)
-        (code, resp) = self.data(msg)
-        if code != 250:
-            if code == 421:
-                self.close()
-            else:
+        if hasattr(self, 'multi_data'):
+            rcpt_errs_size = len(senderrs)
+            for rcpt, code, resp in self.multi_data(msg, rcpts):
+                if code != 250:
+                    senderrs[rcpt] = (code, resp)
+                if code == 421:
+                    self.close()
+                    raise LMTPDataError(senderrs)
+            if rcpt_errs_size + len(rcpts) == len(senderrs):
+                # the server refused all our recipients
                 self._rset()
-            raise SMTPDataError(code, resp)
+                raise LMTPDataError(senderrs)
+        else:
+            code, resp = self.data(msg)
+            if code != 250:
+                if code == 421:
+                    self.close()
+                else:
+                    self._rset()
+                raise SMTPDataError(code, resp)
         #if we got here then somebody got our mail
         return senderrs
 
@@ -1097,6 +1128,27 @@ class LMTP(SMTP):
         if self.debuglevel > 0:
             self._print_debug('connect:', msg)
         return (code, msg)
+
+    def multi_data(self, msg, rcpts):
+        """SMTP 'DATA' command -- sends message data to server
+
+        Differs from data in that it yields multiple results for each
+        recipient. This is necessary for LMTP processing and different
+        from SMTP processing.
+
+        Automatically quotes lines beginning with a period per rfc821.
+        Raises SMTPDataError if there is an unexpected reply to the
+        DATA command; the return value from this method is the final
+        response code received when the all data is sent.  If msg
+        is a string, lone '\\r' and '\\n' characters are converted to
+        '\\r\\n' characters.  If msg is bytes, it is transmitted as is.
+        """
+        yield (rcpts[0],) + super().data(msg)
+        for rcpt in rcpts[1:]:
+            (code, msg) = self.getreply()
+            if self.debuglevel > 0:
+                self._print_debug('connect:', msg)
+            yield (rcpt, code, msg)
 
 
 # Test the sendmail method, which tests most of the others.

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -1332,7 +1332,25 @@ class SMTPSimTests(unittest.TestCase):
         with self.assertRaises(smtplib.SMTPDataError):
             smtp.sendmail('John@foo.org', ['Sally@foo.org'], 'test message')
         self.assertIsNone(smtp.sock)
-        self.assertEqual(self.serv._SMTPchannel.rcpt_count, 0)
+        self.assertEqual(self.serv._SMTPchannel.rset_count, 0)
+
+    def test_421_from_multi_data_cmd(self):
+        class MySimSMTPChannel(SimSMTPChannel):
+            def found_terminator(self):
+                if self.smtp_state == self.DATA:
+                    self.push('250 ok')
+                    self.push('421 closing')
+                else:
+                    super().found_terminator()
+        self.serv.channel_class = MySimSMTPChannel
+        smtp = smtplib.LMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
+        smtp.noop()
+        with self.assertRaises(smtplib.LMTPDataError) as r:
+            smtp.sendmail('John@foo.org', ['Sally@foo.org', 'Frank@foo.org', 'George@foo.org'], 'test message')
+        self.assertEqual(r.exception.recipients, {'Frank@foo.org': (421, b'closing')})
+        self.assertIsNone(smtp.sock)
+        self.assertEqual(self.serv._SMTPchannel.rset_count, 0)
 
     def test_smtputf8_NotSupportedError_if_no_server_support(self):
         smtp = smtplib.SMTP(
@@ -1398,6 +1416,69 @@ class SMTPSimTests(unittest.TestCase):
 
         self.assertIn(['mail from:<John> size=14'], self.serv._SMTPchannel.all_received_lines)
         self.assertIn(['rcpt to:<Sally>'], self.serv._SMTPchannel.all_received_lines)
+
+    def test_lmtp_multi_error(self):
+        class MySimSMTPChannel(SimSMTPChannel):
+            def found_terminator(self):
+                if self.smtp_state == self.DATA:
+                    self.push('452 full')
+                    self.push('250 ok')
+                else:
+                    super().found_terminator()
+            def smtp_RCPT(self, arg):
+                if self.rcpt_count == 0:
+                    self.rcpt_count += 1
+                    self.push('450 busy')
+                else:
+                    super().smtp_RCPT(arg)
+        self.serv.channel_class = MySimSMTPChannel
+
+        smtp = smtplib.LMTP(
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
+        self.addCleanup(smtp.close)
+
+        message = EmailMessage()
+        message['From'] = 'John@foo.org'
+        message['To'] = 'Sally@foo.org, Frank@foo.org, George@foo.org'
+
+        self.assertDictEqual(smtp.send_message(message), {
+            'Sally@foo.org': (450, b'busy'), 'Frank@foo.org': (452, b'full')
+        })
+
+    def test_lmtp_all_error(self):
+        class MySimSMTPChannel(SimSMTPChannel):
+            def found_terminator(self):
+                if self.smtp_state == self.DATA:
+                    self.push('452 full')
+                    self.received_lines = []
+                    self.smtp_state = self.COMMAND
+                    self.set_terminator(b'\r\n')
+                else:
+                    super().found_terminator()
+            def smtp_RCPT(self, arg):
+                if self.rcpt_count == 0:
+                    self.rcpt_count += 1
+                    self.push('450 busy')
+                else:
+                    super().smtp_RCPT(arg)
+        self.serv.channel_class = MySimSMTPChannel
+
+        smtp = smtplib.LMTP(
+            HOST, self.port, local_hostname='localhost',
+            timeout=support.LOOPBACK_TIMEOUT)
+        self.addCleanup(smtp.close)
+
+        message = EmailMessage()
+        message['From'] = 'John@foo.org'
+        message['To'] = 'Sally@foo.org, Frank@foo.org'
+
+        with self.assertRaises(smtplib.LMTPDataError) as r:
+            smtp.send_message(message)
+        self.assertEqual(r.exception.recipients, {
+            'Sally@foo.org': (450, b'busy'), 'Frank@foo.org': (452, b'full')
+        })
+        self.assertEqual(self.serv._SMTPchannel.rset_count, 1)
 
 
 class SimSMTPUTF8Server(SimSMTPServer):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1278,6 +1278,7 @@ Jason Michalski
 Franck Michea
 Vincent Michel
 Trent Mick
+Jacob Middag
 Tom Middleton
 Thomas Miedema
 Stan Mihai

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1283,6 +1283,7 @@ Jason Michalski
 Franck Michea
 Vincent Michel
 Trent Mick
+Jacob Middag
 Tom Middleton
 Thomas Miedema
 Stan Mihai

--- a/Misc/NEWS.d/next/Library/2020-03-10-09-21-29.gh-issue-76984.czXc6a.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-10-09-21-29.gh-issue-76984.czXc6a.rst
@@ -1,0 +1,2 @@
+:class:`smtplib.LMTP` now reads all replies to the DATA command when a
+message has multiple successful recipients. Patch by Jacob Middag.


### PR DESCRIPTION
Conform RFC 2033, the LMTP protocol gives for each successful recipient a reply.
The smtplib only reads one. This gives problems sending more than one message
with multiple recipients in a connection. See https://bugs.python.org/issue32803

To be backwards compatible, I added a new method `multi_data` to support a `DATA` command with multiple replies. I modeled it after `data` and wanted to keep the error handling in the `sendmail` method. Because we need to close the connection once we receive a 421, I chose to yield the results instead of returning a list. Similar to the multiple RCTP solution, I only raise an Exception if all recipients fail.

I am not sure about the naming of `LMTPDataError`. It breaks the structure of all errors beginning with LMTP, but it is really a specific LMTP error. An alternative could be `SMTPMultiDataError`.

I also fixed the assertion in `test_421_from_data_cmd`. I think it should compare `rset_count` and not `rcpt_count`. The `rcpt_count` is only modified if `rcpt_response` is used. The purpose of the test is to be sure the method closed instead of reset.


<!-- issue-number: [bpo-32803](https://bugs.python.org/issue32803) -->
https://bugs.python.org/issue32803
<!-- /issue-number -->


<!-- gh-issue-number: gh-76984 -->
* Issue: gh-76984
<!-- /gh-issue-number -->
