### PR TITLE
bpo-38075: Fix random_seed(): use PyObject_CallOneArg()

### DIFF
--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -42,7 +42,7 @@ class TestBasicOps:
             def __hash__(self):
                 return -1729
         for arg in [None, 0, 1, -1, 10**20, -(10**20),
-                    3.14, 'a']:
+                    False, True, 3.14, 'a']:
             self.gen.seed(arg)
 
         for arg in [1+2j, tuple('abc'), MySeed()]:

--- a/Misc/NEWS.d/next/Library/2020-03-10-12-52-06.bpo-38075.qbESAF.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-10-12-52-06.bpo-38075.qbESAF.rst
@@ -1,0 +1,2 @@
+Fix the :meth:`random.Random.seed` method when a :class:`bool` is passed as the
+seed.

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -264,7 +264,6 @@ random_seed(RandomObject *self, PyObject *arg)
     uint32_t *key = NULL;
     size_t bits, keyused;
     int res;
-    PyObject *args[1];
 
     if (arg == NULL || arg == Py_None) {
        if (random_seed_urandom(self) < 0) {
@@ -286,9 +285,7 @@ random_seed(RandomObject *self, PyObject *arg)
     } else if (PyLong_Check(arg)) {
         /* Calling int.__abs__() prevents calling arg.__abs__(), which might
            return an invalid value. See issue #31478. */
-        args[0] = arg;
-        n = PyObject_Vectorcall(_randomstate_global->Long___abs__, args, 0,
-                                         NULL);
+        n = PyObject_CallOneArg(_randomstate_global->Long___abs__, arg);
     }
     else {
         Py_hash_t hash = PyObject_Hash(arg);


### PR DESCRIPTION
PyObject_Vectorcall() was misused. Use PyObject_CallOneArg() instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38075](https://bugs.python.org/issue38075) -->
https://bugs.python.org/issue38075
<!-- /issue-number -->
