### PR TITLE
bpo-38662: Invoke pip via runpy, in ensurepip

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -38,7 +38,7 @@ def _run_pip(args, additional_paths=None):
     finally:
         sys.argv[:] = backup_argv
 
-    raise SystemError("pip have not exited, that should never happen")
+    raise SystemError("pip did not exit, this should never happen")
 
 
 def version():

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -31,9 +31,10 @@ def _run_pip(args, additional_paths=None):
     backup_argv = sys.argv[:]
     sys.argv[1:] = args
     try:
+        # run_module() alters sys.modules and sys.argv, but restore them at exit
         runpy.run_module("pip", run_name="__main__", alter_sys=True)
-    except SystemExit as e:
-        return e.code
+    except SystemExit as exc:
+        return exc.code
     finally:
         sys.argv[:] = backup_argv
 

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -31,7 +31,7 @@ def _run_pip(args, additional_paths=None):
     backup_argv = sys.argv[:]
     sys.argv[1:] = args
     try:
-        # run_module() alters sys.modules and sys.argv, but restore them at exit
+        # run_module() alters sys.modules and sys.argv, but restores them at exit
         runpy.run_module("pip", run_name="__main__", alter_sys=True)
     except SystemExit as exc:
         return exc.code

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -1,6 +1,7 @@
 import os
 import os.path
 import sys
+import runpy
 import tempfile
 from importlib import resources
 
@@ -26,9 +27,17 @@ def _run_pip(args, additional_paths=None):
     if additional_paths is not None:
         sys.path = additional_paths + sys.path
 
-    # Install the bundled software
-    import pip._internal
-    return pip._internal.main(args)
+    # Invoke pip as if it's the main module, and catch the exit.
+    backup_argv = sys.argv[:]
+    sys.argv[1:] = args
+    try:
+        runpy.run_module("pip", run_name="__main__", alter_sys=True)
+    except SystemExit as e:
+        return e.code
+    finally:
+        sys.argv[:] = backup_argv
+
+    raise SystemError("pip have not exited, that should never happen")
 
 
 def version():

--- a/Misc/NEWS.d/next/Library/2020-03-10-15-32-31.bpo-38662.o1DMXj.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-10-15-32-31.bpo-38662.o1DMXj.rst
@@ -1,0 +1,4 @@
+The ``ensurepip`` module now invokes ``pip`` via the ``runpy`` module.
+Hence it is no longer tightly coupled with the internal API of the bundled
+``pip`` version, allowing easier updates to a newer ``pip`` version both
+internally and for distributors.


### PR DESCRIPTION
This way, any changes to the internal pip API won't mean ensurepip needs to be
changed as well. Also, distributors can update their pip wheels independent on
CPython release schedule.

Co-Authored-By: @pradyunsg

Closes https://github.com/python/cpython/pull/17029
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38662](https://bugs.python.org/issue38662) -->
https://bugs.python.org/issue38662
<!-- /issue-number -->
