### PR TITLE
Fix download.html

### DIFF
--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -40,7 +40,7 @@ Python in one of various formats, follow one of links in this table.</p>
 
 <p>These archives contain all the content in the documentation.</p>
 
-<p>HTML Help (<tt>.chm</tt>) files are made available in the "Windows" section
+<p>HTML Help (.chm) files are made available in the "Windows" section
 on the <a href="https://www.python.org/downloads/release/python-{{ release.replace('.', '') }}/">Python
 download page</a>.</p>
 

--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -40,7 +40,7 @@ Python in one of various formats, follow one of links in this table.</p>
 
 <p>These archives contain all the content in the documentation.</p>
 
-<p>HTML Help (.chm) files are made available in the "Windows" section
+<p>HTML Help (<code>.chm</code>) files are made available in the "Windows" section
 on the <a href="https://www.python.org/downloads/release/python-{{ release.replace('.', '') }}/">Python
 download page</a>.</p>
 


### PR DESCRIPTION
`<tt>` is not allowed here.

See https://validator.w3.org/nu/?doc=https%3A%2F%2Fdocs.python.org%2F3%2Fdownload.html
