### PR TITLE
[WIP] bpo-1294959: setup.py uses sys.platlibdir

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-03-11-11-13-20.bpo-1294959.eqEqJ_.rst
+++ b/Misc/NEWS.d/next/Build/2020-03-11-11-13-20.bpo-1294959.eqEqJ_.rst
@@ -1,0 +1,2 @@
+setup.py now uses :attr:`sys.platlibdir` to configure the compiler library
+directories and to locate the termcap library.

--- a/setup.py
+++ b/setup.py
@@ -692,7 +692,7 @@ class PyBuildExt(build_ext):
         # directories (i.e. '.' and 'Include') must be first.  See issue
         # 10520.
         if not CROSS_COMPILING:
-            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+            add_dir_to_list(self.compiler.library_dirs, f'/usr/local/{sys.platlibdir}')
             add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
         # only change this for cross builds for 3.3, issues on Mageia
         if CROSS_COMPILING:
@@ -993,16 +993,17 @@ class PyBuildExt(build_ext):
                 readline_extra_link_args = ()
 
             readline_libs = ['readline']
+            termcap_libdir = f'/usr/{sys.platlibdir}/termcap'
             if readline_termcap_library:
                 pass # Issue 7384: Already linked against curses or tinfo.
             elif curses_library:
                 readline_libs.append(curses_library)
             elif self.compiler.find_library_file(self.lib_dirs +
-                                                     ['/usr/lib/termcap'],
+                                                     [termcap_libdir],
                                                      'termcap'):
                 readline_libs.append('termcap')
             self.add(Extension('readline', ['readline.c'],
-                               library_dirs=['/usr/lib/termcap'],
+                               library_dirs=[termcap_libdir],
                                extra_link_args=readline_extra_link_args,
                                libraries=readline_libs))
         else:


### PR DESCRIPTION
setup.py now uses sys.platlibdir to configure the compiler library
directories and to locate the termcap library.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1294959](https://bugs.python.org/issue1294959) -->
https://bugs.python.org/issue1294959
<!-- /issue-number -->
