### PR TITLE
[3.7] bpo-39930: Ensure vcruntime140.dll is included in all Windows packages (GH-18918)

### DIFF
--- a/.github/workflows/build_msi.yml
+++ b/.github/workflows/build_msi.yml
@@ -1,0 +1,34 @@
+name: TestsMSI
+
+on:
+  push:
+    branches:
+    - master
+    - 3.8
+    - 3.7
+    paths:
+    - 'Tools/msi/**'
+  pull_request:
+    branches:
+    - master
+    - 3.8
+    - 3.7
+    paths:
+    - 'Tools/msi/**'
+
+jobs:
+  build_win32:
+    name: 'Windows (x86) Installer'
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build CPython installer
+      run: .\Tools\msi\build.bat -x86
+
+  build_win_amd64:
+    name: 'Windows (x64) Installer'
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build CPython installer
+      run: .\Tools\msi\build.bat -x64

--- a/Misc/NEWS.d/next/Windows/2020-03-11-10-15-56.bpo-39930.LGHw1j.rst
+++ b/Misc/NEWS.d/next/Windows/2020-03-11-10-15-56.bpo-39930.LGHw1j.rst
@@ -1,0 +1,2 @@
+Ensures the required :file:`vcruntime140.dll` is included in install
+packages.

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -193,4 +193,25 @@ public override bool Execute() {
     <Error Text="Unable to locate signtool.exe. Set /p:SignToolPath and rebuild" Condition="'$(_SignCommand)' == ''" />
     <Exec Command='$(_SignCommand) "$(TargetPath)" || $(_SignCommand) "$(TargetPath)" || $(_SignCommand) "$(TargetPath)"' ContinueOnError="false" />
   </Target>
+
+
+  <Target Name="FindVCRuntime" Returns="VCRuntimeDLL">
+    <PropertyGroup Condition="$(PlatformToolset) != 'v140'">
+      <VCRedistDir>$(VCInstallDir)\Redist\MSVC\$(VCToolsRedistVersion)\</VCRedistDir>
+      <VCRedistDir Condition="$(Platform) == 'Win32'">$(VCRedistDir)x86\</VCRedistDir>
+      <VCRedistDir Condition="$(Platform) != 'Win32'">$(VCRedistDir)$(Platform)\</VCRedistDir>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(PlatformToolset) == 'v140'">
+      <VCRedistDir>$(VCInstallDir)\redist\</VCRedistDir>
+      <VCRedistDir Condition="$(Platform) == 'Win32'">$(VCRedistDir)x86\</VCRedistDir>
+      <VCRedistDir Condition="$(Platform) != 'Win32'">$(VCRedistDir)$(Platform)\</VCRedistDir>
+    </PropertyGroup>
+
+    <ItemGroup Condition="$(VCInstallDir) != ''">
+      <VCRuntimeDLL Include="$(VCRedistDir)\Microsoft.VC*.CRT\vcruntime*.dll" />
+    </ItemGroup>
+
+    <Error Text="vcruntime14*.dll not found under $(VCInstallDir)" Condition="@(VCRuntimeDLL) == ''" />
+    <Message Text="VCRuntimeDLL: @(VCRuntimeDLL)" Importance="high" />
+  </Target>
 </Project>

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -460,15 +460,7 @@
     <Warning Text="Not including zlib is not a supported configuration." />
   </Target>
 
-  <PropertyGroup>
-    <VCRedistDir>$(VCInstallDir)\Redist\MSVC\$(VCToolsRedistVersion)\</VCRedistDir>
-    <VCRedistDir Condition="$(Platform) == 'Win32'">$(VCRedistDir)x86\</VCRedistDir>
-    <VCRedistDir Condition="$(Platform) != 'Win32'">$(VCRedistDir)$(Platform)\</VCRedistDir>
-  </PropertyGroup>
-  <ItemGroup Condition="$(VCInstallDir) != ''">
-    <VCRuntimeDLL Include="$(VCRedistDir)\**\vcruntime*.dll" />
-  </ItemGroup>
-  <Target Name="_CopyVCRuntime" AfterTargets="Build" Inputs="@(VCRuntimeDLL)" Outputs="$(OutDir)%(Filename)%(Extension)">
+  <Target Name="_CopyVCRuntime" AfterTargets="Build" Inputs="@(VCRuntimeDLL)" Outputs="$(OutDir)%(Filename)%(Extension)" DependsOnTargets="FindVCRuntime">
     <!-- bpo-38597: When we switch to another VCRuntime DLL, include vcruntime140.dll as well -->
     <Warning Text="A copy of vcruntime140.dll is also required" Condition="!$(VCToolsRedistVersion.StartsWith(`14.`))" />
     <Copy SourceFiles="%(VCRuntimeDLL.FullPath)" DestinationFolder="$(OutDir)" />

--- a/Tools/msi/exe/exe.wixproj
+++ b/Tools/msi/exe/exe.wixproj
@@ -11,6 +11,9 @@
         <SuppressICEs>ICE43</SuppressICEs>
     </PropertyGroup>
     <Import Project="..\msi.props" />
+    <PropertyGroup Condition="exists('$(BuildPath)vcruntime140_1.dll')">
+        <DefineConstants>$(DefineConstants);Include_Vcruntime140_1_dll=1</DefineConstants>
+    </PropertyGroup>
     <ItemGroup>
         <Compile Include="exe.wxs" />
         <Compile Include="exe_files.wxs" />

--- a/Tools/msi/exe/exe_files.wxs
+++ b/Tools/msi/exe/exe_files.wxs
@@ -30,8 +30,13 @@
                 </RegistryKey>
             </Component>
             <Component Id="vcruntime140.dll" Directory="InstallDirectory" Guid="*">
-                <File Name="vcruntime140.dll" Source="!(bindpath.redist)vcruntime140.dll" KeyPath="yes" />
+                <File Name="vcruntime140.dll" Source="vcruntime140.dll" KeyPath="yes" />
             </Component>
+<?ifdef Include_Vcruntime140_1_dll ?>
+            <Component Id="vcruntime140_1.dll" Directory="InstallDirectory" Guid="*">
+                <File Name="vcruntime140_1.dll" Source="vcruntime140_1.dll" KeyPath="yes" />
+            </Component>
+<?endif ?>
         </ComponentGroup>
     </Fragment>
 


### PR DESCRIPTION
Also adds GitHub CI test for Windows installer changes


<!-- issue-number: [bpo-39930](https://bugs.python.org/issue39930) -->
https://bugs.python.org/issue39930
<!-- /issue-number -->
