### PR TITLE
bpo-39915: Ensure await_args_list is updated according to the order in which coroutines were awaited

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2171,7 +2171,7 @@ class AsyncMockMixin(Base):
         # This is nearly just like super(), except for special handling
         # of coroutines
 
-        _call = self.call_args
+        _call = _Call((args, kwargs), two=True)
         self.await_count += 1
         self.await_args = _call
         self.await_args_list.append(_call)

--- a/Lib/unittest/test/testmock/testasync.py
+++ b/Lib/unittest/test/testmock/testasync.py
@@ -500,6 +500,17 @@ class AsyncArguments(IsolatedAsyncioTestCase):
         mock.assert_awaited()
         self.assertTrue(ran)
 
+    async def test_await_args_list_order(self):
+        async_mock = AsyncMock()
+        mock2 = async_mock(2)
+        mock1 = async_mock(1)
+        await mock1
+        await mock2
+        async_mock.assert_has_awaits([call(1), call(2)])
+        self.assertEqual(async_mock.await_args_list, [call(1), call(2)])
+        self.assertEqual(async_mock.call_args_list, [call(2), call(1)])
+
+
 class AsyncMagicMethods(unittest.TestCase):
     def test_async_magic_methods_return_async_mocks(self):
         m_mock = MagicMock()

--- a/Misc/NEWS.d/next/Library/2020-03-10-19-38-47.bpo-39915.CjPeiY.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-10-19-38-47.bpo-39915.CjPeiY.rst
@@ -1,0 +1,4 @@
+Ensure :attr:`unittest.mock.AsyncMock.await_args_list` has call objects in
+the order of awaited arguments instead of using
+:attr:`unittest.mock.Mock.call_args` which has the last value of the call.
+Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
`await_args_list` should be updated with the arguments with which the mock was awaited instead of using `call_args` which has the last call object.

<!-- issue-number: [bpo-39915](https://bugs.python.org/issue39915) -->
https://bugs.python.org/issue39915
<!-- /issue-number -->
