### PR TITLE
bpo-37207: Use vertorcall for list()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-09-10-54-31.bpo-37207.bLjgLS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-09-10-54-31.bpo-37207.bLjgLS.rst
@@ -1,2 +1,2 @@
-Speed up calls to ``list()`` by using the PEP 590 ``vectorcall``
+Speed up calls to ``list()`` by using the :pep:`590` ``vectorcall``
 calling convention. Patch by Mark Shannon.

--- a/Misc/NEWS.d/next/Core and Builtins/2019-06-09-10-54-31.bpo-37207.bLjgLS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-06-09-10-54-31.bpo-37207.bLjgLS.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``list()`` by using the PEP 590 ``vectorcall``
+calling convention. Patch by Mark Shannon.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2721,13 +2721,11 @@ static PyObject *
 list_vectorcall(PyObject *type, PyObject * const*args,
                 size_t nargsf, PyObject *kwnames)
 {
-    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
-        PyErr_Format(PyExc_TypeError, "list() takes no keyword arguments");
+    if (!_PyArg_NoKwnames("list", kwnames)) {
         return NULL;
     }
     Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
-    if (nargs > 1) {
-        PyErr_Format(PyExc_TypeError, "list() expected at most 1 argument, got %zd", nargs);
+    if (!_PyArg_CheckPositional("list", nargs, 0, 1)) {
         return NULL;
     }
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2725,9 +2725,9 @@ list_vectorcall(PyObject *type, PyObject * const*args,
         PyErr_Format(PyExc_TypeError, "list() takes no keyword arguments");
         return NULL;
     }
-    size_t nargs = PyVectorcall_NARGS(nargsf);
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
     if (nargs > 1) {
-        PyErr_Format(PyExc_TypeError, "list() expected at most 1 argument, got %zu", nargs);
+        PyErr_Format(PyExc_TypeError, "list() expected at most 1 argument, got %zd", nargs);
         return NULL;
     }
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2736,10 +2736,11 @@ list_vectorcall(PyObject *type, PyObject * const*args,
     if (list == NULL) {
         return NULL;
     }
-    PyObject *iterator = nargs ? args[0] : NULL;
-    if (list___init___impl((PyListObject *)list, iterator)) {
-        Py_DECREF(list);
-        return NULL;
+    if (nargs) {
+        if (list___init___impl((PyListObject *)list, args[0])) {
+            Py_DECREF(list);
+            return NULL;
+        }
     }
     return list;
 }


### PR DESCRIPTION
This continues the `list()` part of #13930. The complete pull request is stalled on discussions around dicts, but `list()` should not be controversial. (Range was done in #18464 and I plan to open PRs for other parts if this is merged.)
I did two small changes on top of Mark's code.


<!-- issue-number: [bpo-37207](https://bugs.python.org/issue37207) -->
https://bugs.python.org/issue37207
<!-- /issue-number -->
