### PR TITLE
bpo-37207: Use PEP 590 vectorcall to speed up tuple()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-12-02-41-12.bpo-37207.ye7OM3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-12-02-41-12.bpo-37207.ye7OM3.rst
@@ -1,2 +1,2 @@
-Speed up calls to ``tuple()`` by using the PEP 590 ``vectorcall`` calling
+Speed up calls to ``tuple()`` by using the :pep:`590` ``vectorcall`` calling
 convention. Patch by Dong-hee Na.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-12-02-41-12.bpo-37207.ye7OM3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-12-02-41-12.bpo-37207.ye7OM3.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``tuple()`` by using the PEP 590 ``vectorcall`` calling
+convention. Patch by Dong-hee Na.

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -706,6 +706,26 @@ tuple_new_impl(PyTypeObject *type, PyObject *iterable)
 }
 
 static PyObject *
+tuple_vectorcall(PyObject *type, PyObject * const*args,
+                 size_t nargsf, PyObject *kwnames)
+{
+    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
+        PyErr_Format(PyExc_TypeError, "tuple() takes no keyword arguments");
+        return NULL;
+    }
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (nargs > 1) {
+        PyErr_Format(PyExc_TypeError, "tuple() expected at most 1 argument, got %zd", nargs);
+        return NULL;
+    }
+
+    if (nargs) {
+        return tuple_new_impl((PyTypeObject *)type, args[0]);
+    }
+    return PyTuple_New(0);
+}
+
+static PyObject *
 tuple_subtype_new(PyTypeObject *type, PyObject *iterable)
 {
     PyObject *tmp, *newobj, *item;
@@ -863,6 +883,7 @@ PyTypeObject PyTuple_Type = {
     0,                                          /* tp_alloc */
     tuple_new,                                  /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
+    .tp_vectorcall = tuple_vectorcall,
 };
 
 /* The following function breaks the notion that tuples are immutable:


### PR DESCRIPTION
Master
```
./python.exe -m pyperf timeit "tuple()"
.....................
Mean +- std dev: 262 ns +- 9 ns

./python.exe -m pyperf timeit "tuple((1, 2, 3, 4, 5))"
.....................
Mean +- std dev: 361 ns +- 15 ns
./python.exe -m pyperf timeit "tuple([1, 2, 3, 4, 5])"
.....................
Mean +- std dev: 927 ns +- 29 ns
```
PEP-590
```
./python.exe -m pyperf timeit "tuple()"
.....................
Mean +- std dev: 176 ns +- 11 ns

./python.exe -m pyperf timeit "tuple((1, 2, 3, 4, 5))"
.....................
Mean +- std dev: 203 ns +- 13 ns

./python.exe -m pyperf timeit "tuple([1, 2, 3, 4, 5])"
.....................
Mean +- std dev: 714 ns +- 35 ns
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37207](https://bugs.python.org/issue37207) -->
https://bugs.python.org/issue37207
<!-- /issue-number -->
