### PR TITLE
bpo-39937: modify iter() suggestion to Element.iter()

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -600,7 +600,8 @@ Removed
 
 * Methods ``getchildren()`` and ``getiterator()`` in the
   :mod:`~xml.etree.ElementTree` module have been removed.  They were
-  deprecated in Python 3.2.  Use functions :func:`list` and :func:`iter`
+  deprecated in Python 3.2.  Use functions :func:`list` and
+  :meth:`Element.iter()<xml.etree.ElementTree.Element.iter>`
   instead.  The ``xml.etree.cElementTree`` module has been removed.
   (Contributed by Serhiy Storchaka in :issue:`36543`.)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -600,7 +600,8 @@ Removed
 
 * Methods ``getchildren()`` and ``getiterator()`` in the
   :mod:`~xml.etree.ElementTree` module have been removed.  They were
-  deprecated in Python 3.2.  Use functions :func:`list` and :func:`iter`
+  deprecated in Python 3.2.  Use functions :func:`list` and 
+  :meth:`Element.iter()<xml.etree.ElementTree.Element.iter>`
   instead.  The ``xml.etree.cElementTree`` module has been removed.
   (Contributed by Serhiy Storchaka in :issue:`36543`.)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -598,11 +598,13 @@ Removed
   Use :meth:`~threading.Thread.is_alive()` instead.
   (Contributed by Dong-hee Na in :issue:`37804`.)
 
-* Methods ``getchildren()`` and ``getiterator()`` in the
-  :mod:`~xml.etree.ElementTree` module have been removed.  They were
-  deprecated in Python 3.2.  Use functions :func:`list` and
-  :meth:`Element.iter()<xml.etree.ElementTree.Element.iter>`
-  instead.  The ``xml.etree.cElementTree`` module has been removed.
+* Methods ``getchildren()`` and ``getiterator()`` of classes
+  :class:`~xml.etree.ElementTree.ElementTree` and
+  :class:`~xml.etree.ElementTree.Element` in the :mod:`~xml.etree.ElementTree`
+  module have been removed.  They were deprecated in Python 3.2.
+  Use ``iter(x)`` or ``list(x)`` instead of ``x.getchildren()`` and
+  ``x.iter()`` or ``list(x.iter())`` instead of ``x.getiterator()``.
+  The ``xml.etree.cElementTree`` module has been removed.
   (Contributed by Serhiy Storchaka in :issue:`36543`.)
 
 * The old :mod:`plistlib` API has been removed, it was deprecated since Python

--- a/Misc/NEWS.d/next/Documentation/2020-03-11-18-08-00.bpo-39937.3tf0xl.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-03-11-18-08-00.bpo-39937.3tf0xl.rst
@@ -1,0 +1,3 @@
+In the whatsnew section, under the point which mentions the deprecation of getchildren() and getiterator() through bpo-36543, it is suggested to use iter() instead.
+
+Ideally there should be a suggestion to use Element.iter() instead.

--- a/Misc/NEWS.d/next/Documentation/2020-03-11-18-08-00.bpo-39937.3tf0xl.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-03-11-18-08-00.bpo-39937.3tf0xl.rst
@@ -1,3 +1,0 @@
-In the whatsnew section, under the point which mentions the deprecation of getchildren() and getiterator() through bpo-36543, it is suggested to use iter() instead.
-
-Ideally there should be a suggestion to use Element.iter() instead.


### PR DESCRIPTION
In the whatsnew section, under the point which mentions the deprecation of getchildren() and getiterator()
through [bpo-36543](https://bugs.python.org/issue36543), it is suggested to use iter() instead.

Ideally there should be a suggestion to use Element.iter() instead.

The commits does the above modification.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39937](https://bugs.python.org/issue39937) -->
https://bugs.python.org/issue39937
<!-- /issue-number -->
