### PR TITLE
bpo-39930: Fix MSBuild detection for Build Tools

### DIFF
--- a/PCbuild/find_msbuild.bat
+++ b/PCbuild/find_msbuild.bat
@@ -32,19 +32,12 @@
 @rem VS 2017 and later provide vswhere.exe, which can be used
 @if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" goto :skip_vswhere
 @set _Py_MSBuild_Root=
-@for /F "tokens=*" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -property installationPath -latest -prerelease') DO @(set _Py_MSBuild_Root=%%i\MSBuild)
+@for /F "tokens=*" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -property installationPath -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64') DO @(set _Py_MSBuild_Root=%%i\MSBuild)
 @if not defined _Py_MSBuild_Root goto :skip_vswhere
 @for %%j in (Current 15.0) DO @if exist "%_Py_MSBuild_Root%\%%j\Bin\msbuild.exe" (set MSBUILD="%_Py_MSBuild_Root%\%%j\Bin\msbuild.exe")
 @set _Py_MSBuild_Root=
 @if defined MSBUILD @if exist %MSBUILD% (set _Py_MSBuild_Source=Visual Studio installation) & goto :found
 :skip_vswhere
-
-@rem VS 2017 sets exactly one install as the "main" install, so we may find MSBuild in there.
-@reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\SxS\VS7" /v 15.0 /reg:32 >nul 2>nul
-@if NOT ERRORLEVEL 1 @for /F "tokens=1,2*" %%i in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\SxS\VS7" /v 15.0 /reg:32') DO @(
-    @if "%%i"=="15.0" @if exist "%%k\MSBuild\15.0\Bin\msbuild.exe" @(set MSBUILD="%%k\MSBuild\15.0\Bin\msbuild.exe")
-)
-@if exist %MSBUILD% (set _Py_MSBuild_Source=Visual Studio 2017 registry) & goto :found
 
 @rem VS 2015 and earlier register MSBuild separately, so we can find it.
 @reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSBuild\ToolsVersions\14.0" /v MSBuildToolsPath /reg:32 >nul 2>nul

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -201,25 +201,38 @@ public override bool Execute() {
   </Target>
 
 
-  <Target Name="FindVCRuntime" Returns="VCRuntimeDLL">
-    <PropertyGroup Condition="$(PlatformToolset) != 'v140'">
-      <VCRedistDir>$(VCInstallDir)\Redist\MSVC\$(VCToolsRedistVersion)\</VCRedistDir>
-      <VCRedistDir Condition="$(Platform) == 'Win32'">$(VCRedistDir)x86\</VCRedistDir>
-      <VCRedistDir Condition="$(Platform) != 'Win32'">$(VCRedistDir)$(Platform)\</VCRedistDir>
-    </PropertyGroup>
+  <Target Name="FindVCRedistDir">
+    <!-- Hard coded path for VS 2015 -->
     <PropertyGroup Condition="$(PlatformToolset) == 'v140'">
       <VCRedistDir>$(VCInstallDir)\redist\</VCRedistDir>
+    </PropertyGroup>
+    <!-- Correct variable for VS 2017 and later -->
+    <PropertyGroup Condition="$(VCRedistDir) == '' and $(VCToolsRedistVersion) != ''">
+      <VCRedistDir>$(VCInstallDir)\Redist\MSVC\$(VCToolsRedistVersion)\</VCRedistDir>
+    </PropertyGroup>
+
+    <!-- Search in some broken Build Tools installs -->
+    <ItemGroup Condition="$(VCRedistDir) == ''">
+      <_RedistFiles Include="$(VCInstallDir)\Redist\MSVC\*\*.*" />
+    </ItemGroup>
+    <PropertyGroup Condition="$(VCRedistDir) == ''">
+      <VCRedistDir>%(_RedistFiles.RootDir)%(_RedistFiles.Directory)</VCRedistDir>
+    </PropertyGroup>
+
+    <PropertyGroup>
       <VCRedistDir Condition="$(Platform) == 'Win32'">$(VCRedistDir)x86\</VCRedistDir>
       <VCRedistDir Condition="$(Platform) != 'Win32'">$(VCRedistDir)$(Platform)\</VCRedistDir>
     </PropertyGroup>
 
+    <Message Text="VC Redist Directory: $(VCRedistDir)" />
+  </Target>
+
+  <Target Name="FindVCRuntime" Returns="VCRuntimeDLL" DependsOnTargets="FindVCRedistDir">
     <ItemGroup Condition="$(VCInstallDir) != ''">
       <VCRuntimeDLL Include="$(VCRedistDir)\Microsoft.VC*.CRT\vcruntime*.dll" />
-      <_AllRedist Include="$(VCInstallDir)\Redist\**" />
     </ItemGroup>
 
-    <Warning Text="vcruntime14*.dll not found under $(VCRedistDir)." Condition="@(VCRuntimeDLL) == ''" />
-    <Message Text="Found @(_AllRedist,'%0A')" Importance="high" Condition="@(VCRuntimeDLL) == ''" />
-    <Message Text="VCRuntimeDLL: @(VCRuntimeDLL)" Importance="high" />
+    <Warning Text="vcruntime*.dll not found under $(VCRedistDir)." Condition="@(VCRuntimeDLL) == ''" />
+    <Message Text="VC Runtime DLL(s):%0A- @(VCRuntimeDLL,'%0A- ')" />
   </Target>
 </Project>

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -215,9 +215,11 @@ public override bool Execute() {
 
     <ItemGroup Condition="$(VCInstallDir) != ''">
       <VCRuntimeDLL Include="$(VCRedistDir)\Microsoft.VC*.CRT\vcruntime*.dll" />
+      <_AllRedist Include="$(VCInstallDir)\Redist\**" />
     </ItemGroup>
 
-    <Warning Text="vcruntime14*.dll not found under $(VCInstallDir)" Condition="@(VCRuntimeDLL) == ''" />
+    <Warning Text="vcruntime14*.dll not found under $(VCRedistDir)." Condition="@(VCRuntimeDLL) == ''" />
+    <Message Text="Found @(_AllRedist,'%0A')" Importance="high" Condition="@(VCRuntimeDLL) == ''" />
     <Message Text="VCRuntimeDLL: @(VCRuntimeDLL)" Importance="high" />
   </Target>
 </Project>

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -206,17 +206,19 @@ public override bool Execute() {
     <PropertyGroup Condition="$(PlatformToolset) == 'v140'">
       <VCRedistDir>$(VCInstallDir)\redist\</VCRedistDir>
     </PropertyGroup>
-    <!-- Correct variable for VS 2017 and later -->
-    <PropertyGroup Condition="$(VCRedistDir) == '' and $(VCToolsRedistVersion) != ''">
-      <VCRedistDir>$(VCInstallDir)\Redist\MSVC\$(VCToolsRedistVersion)\</VCRedistDir>
-    </PropertyGroup>
 
-    <!-- Search in some broken Build Tools installs -->
-    <ItemGroup Condition="$(VCRedistDir) == ''">
+    <!-- Search for version number in some broken Build Tools installs -->
+    <ItemGroup Condition="$(VCRedistDir) == '' and $(VCToolsRedistVersion) == ''">
       <_RedistFiles Include="$(VCInstallDir)\Redist\MSVC\*\*.*" />
     </ItemGroup>
+    <PropertyGroup Condition="$(VCRedistDir) == '' and $(VCToolsRedistVersion) == ''">
+      <_RedistDir>%(_RedistFiles.Directory)</_RedistDir>
+      <VCToolsRedistVersion>$([System.IO.Path]::GetFileName($(_RedistDir.Trim(`\`))))</VCToolsRedistVersion>
+    </PropertyGroup>
+
+    <!-- Use correct path for VS 2017 and later -->
     <PropertyGroup Condition="$(VCRedistDir) == ''">
-      <VCRedistDir>%(_RedistFiles.RootDir)%(_RedistFiles.Directory)</VCRedistDir>
+      <VCRedistDir>$(VCInstallDir)\Redist\MSVC\$(VCToolsRedistVersion)\</VCRedistDir>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -225,6 +227,7 @@ public override bool Execute() {
     </PropertyGroup>
 
     <Message Text="VC Redist Directory: $(VCRedistDir)" />
+    <Message Text="VC Redist Directory: $(VCToolsRedistVersion)" />
   </Target>
 
   <Target Name="FindVCRuntime" Returns="VCRuntimeDLL" DependsOnTargets="FindVCRedistDir">

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -227,7 +227,7 @@ public override bool Execute() {
     </PropertyGroup>
 
     <Message Text="VC Redist Directory: $(VCRedistDir)" />
-    <Message Text="VC Redist Directory: $(VCToolsRedistVersion)" />
+    <Message Text="VC Redist Version: $(VCToolsRedistVersion)" />
   </Target>
 
   <Target Name="FindVCRuntime" Returns="VCRuntimeDLL" DependsOnTargets="FindVCRedistDir">


### PR DESCRIPTION
Ensure we detect Build Tools installs using the newer logic, and skip looking in the registry for VS 2017.

<!-- issue-number: [bpo-39930](https://bugs.python.org/issue39930) -->
https://bugs.python.org/issue39930
<!-- /issue-number -->