### PR TITLE
bpo-38373: Change list overallocating strategy.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-11-12-28-16.bpo-38373.FE9S21.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-11-12-28-16.bpo-38373.FE9S21.rst
@@ -1,0 +1,2 @@
+Chaged list overallocation strategy. It no longer overallocates if the new
+size is closer to overalocated size than to the old size and adds padding.


### PR DESCRIPTION
* Add padding to make the allocated size multiple of 4.
* Do not overallocate if the new size is closer to overalocated size
  than to the old size.


<!-- issue-number: [bpo-38373](https://bugs.python.org/issue38373) -->
https://bugs.python.org/issue38373
<!-- /issue-number -->
