### PR TITLE
bpo-39944: Fix type handling in UserString.join

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1232,7 +1232,9 @@ class UserString(_collections_abc.Sequence):
     def isspace(self): return self.data.isspace()
     def istitle(self): return self.data.istitle()
     def isupper(self): return self.data.isupper()
-    def join(self, seq): return self.data.join(seq)
+    def join(self, seq):
+        items = (x.data if isinstance(x, UserString) else x for x in seq)
+        return self.__class__(self.data.join(items))
     def ljust(self, width, *args):
         return self.__class__(self.data.ljust(width, *args))
     def lower(self): return self.__class__(self.data.lower())

--- a/Lib/test/test_userstring.py
+++ b/Lib/test/test_userstring.py
@@ -26,6 +26,7 @@ class UserStringTest(
             result,
             realresult
         )
+        self.assertEqual(type(result), type(realresult))
 
     def checkraises(self, exc, obj, methodname, *args):
         obj = self.fixtype(obj)

--- a/Misc/NEWS.d/next/Library/2020-03-12-06-48-37.bpo-39944.LpV0ki.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-12-06-48-37.bpo-39944.LpV0ki.rst
@@ -1,0 +1,1 @@
+UserString.join() now correctly accepts and returns UserStrings.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39944](https://bugs.python.org/issue39944) -->
https://bugs.python.org/issue39944
<!-- /issue-number -->
