### PR TITLE
[3.8] bpo-39884: Add method name in "bad call flags" error (GH-18944)

### DIFF
--- a/Misc/NEWS.d/next/C API/2020-03-12-00-27-26.bpo-39884.CGOJBO.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-12-00-27-26.bpo-39884.CGOJBO.rst
@@ -1,0 +1,2 @@
+:c:func:`PyDescr_NewMethod` and :c:func:`PyCFunction_NewEx` now include the
+method name in the SystemError "bad call flags" error message to ease debug.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -892,7 +892,8 @@ PyDescr_NewMethod(PyTypeObject *type, PyMethodDef *method)
             vectorcall = method_vectorcall_O;
             break;
         default:
-            PyErr_SetString(PyExc_SystemError, "bad call flags");
+            PyErr_Format(PyExc_SystemError,
+                         "%s() method: bad call flags", method->ml_name);
             return NULL;
     }
 

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -62,7 +62,8 @@ PyCFunction_NewEx(PyMethodDef *ml, PyObject *self, PyObject *module)
             vectorcall = cfunction_vectorcall_O;
             break;
         default:
-            PyErr_SetString(PyExc_SystemError, "bad call flags");
+            PyErr_Format(PyExc_SystemError,
+                         "%s() method: bad call flags", ml->ml_name);
             return NULL;
     }
 


### PR DESCRIPTION
PyDescr_NewMethod() and PyCFunction_NewEx() now include the method
name in the SystemError "bad call flags" error message to ease debug.

(cherry picked from commit c7d2d69d95b263ee5f83511bc6fbe53acdc24ea3)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39884](https://bugs.python.org/issue39884) -->
https://bugs.python.org/issue39884
<!-- /issue-number -->
