### PR TITLE
[3.7] bpo-39847: EnterNonRecursiveMutex() uses GetTickCount64() (GH-18780)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-03-04-17-05-11.bpo-39847.C3N2m3.rst
+++ b/Misc/NEWS.d/next/Windows/2020-03-04-17-05-11.bpo-39847.C3N2m3.rst
@@ -1,0 +1,2 @@
+Avoid hang when computer is hibernated whilst waiting for a mutex (for
+lock-related objects from :mod:`threading`) around 49-day uptime.

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -75,16 +75,16 @@ EnterNonRecursiveMutex(PNRMUTEX mutex, DWORD milliseconds)
         }
     } else if (milliseconds != 0) {
         /* wait at least until the target */
-        DWORD now, target = GetTickCount() + milliseconds;
+        ULONGLONG now, target = GetTickCount64() + milliseconds;
         while (mutex->locked) {
             if (PyCOND_TIMEDWAIT(&mutex->cv, &mutex->cs, (long long)milliseconds*1000) < 0) {
                 result = WAIT_FAILED;
                 break;
             }
-            now = GetTickCount();
+            now = GetTickCount64();
             if (target <= now)
                 break;
-            milliseconds = target-now;
+            milliseconds = (DWORD)(target-now);
         }
     }
     if (!mutex->locked) {


### PR DESCRIPTION
The 32-bit (49-day) TickCount relied on in EnterNonRecursiveMutex can overflow
in the gap between the 'target' time and the 'now' time WaitForSingleObjectEx
returns, causing the loop to think it needs to wait another 49 days. This is
most likely to happen when the machine is hibernated during
WaitForSingleObjectEx.

This makes acquiring a lock/event/etc from the _thread or threading module
appear to never timeout.

Replace with GetTickCount64 - this is OK now Python no longer supports XP which
lacks it, and is in use for time.monotonic().

Co-authored-by: And Clover <and.clover@bromium.com>
(cherry picked from commit 64838ce)

Co-authored-by: bobince <and+github@doxdesk.com>


<!-- issue-number: [bpo-39847](https://bugs.python.org/issue39847) -->
https://bugs.python.org/issue39847
<!-- /issue-number -->


Automerge-Triggered-By: @vstinner