### PR TITLE
bpo-1294959: Fix typo for new attribute platlibdir.

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -356,7 +356,7 @@ running.
 sys
 ---
 
-Add a new :attr:`sys.platlitdir` attribute: name of the platform-specific
+Add a new :attr:`sys.platlibdir` attribute: name of the platform-specific
 library directory. It is used to build the path of platform-specific dynamic
 libraries and the path of the standard library. It is equal to ``"lib"`` on
 most platforms.  On Fedora and SuSE, it is equal to ``"lib64"`` on 64-bit
@@ -407,7 +407,7 @@ Build and C API Changes
 =======================
 
 * Add ``--with-platlibdir`` option to the ``configure`` script: name of the
-  platform-specific library directory, stored in the new :attr:`sys.platlitdir`
+  platform-specific library directory, stored in the new :attr:`sys.platlibdir`
   attribute. See :attr:`sys.platlibdir` attribute for more information.
   (Contributed by Jan Matějek, Matěj Cepl, Charalampos Stratakis and Victor Stinner in :issue:`1294959`.)
 

--- a/Misc/NEWS.d/next/Build/2020-02-06-18-08-25.bpo-1294959.AZPg4R.rst
+++ b/Misc/NEWS.d/next/Build/2020-02-06-18-08-25.bpo-1294959.AZPg4R.rst
@@ -1,5 +1,5 @@
 Add ``--with-platlibdir`` option to the configure script: name of the
-platform-specific library directory, stored in the new :attr:`sys.platlitdir`
+platform-specific library directory, stored in the new :attr:`sys.platlibdir`
 attribute. It is used to build the path of platform-specific dynamic libraries
 and the path of the standard library. It is equal to ``"lib"`` on most
 platforms. On Fedora and SuSE, it is equal to ``"lib64"`` on 64-bit platforms.


### PR DESCRIPTION
Received email on the docs mailing list to fix a typo from `sys.platlitdir` which doesn't exist to the correct new attribute `sys.platlibdir`


<!-- issue-number: [bpo-1294959](https://bugs.python.org/issue1294959) -->
https://bugs.python.org/issue1294959
<!-- /issue-number -->


Automerge-Triggered-By: @vstinner