### PR TITLE
bpo-39689: Do not test undefined casts to _Bool (GH-18964)

### DIFF
--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -2754,6 +2754,10 @@ class TestBufferProtocol(unittest.TestCase):
         # be 1D, at least one format must be 'c', 'b' or 'B'.
         for _tshape in gencastshapes():
             for char in fmtdict['@']:
+                # Casts to _Bool are undefined if the source contains values
+                # other than 0 or 1.
+                if char == "?":
+                    continue
                 tfmt = ('', '@')[randrange(2)] + char
                 tsize = struct.calcsize(tfmt)
                 n = prod(_tshape) * tsize


### PR DESCRIPTION
  - When casting to _Bool, arrays should only contain zeros or ones.

<!-- issue-number: [bpo-39689](https://bugs.python.org/issue39689) -->
https://bugs.python.org/issue39689
<!-- /issue-number -->
