### PR TITLE
bpo-39562: Allow executing asynchronous comprehensions in the asyncio REPL

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -397,6 +397,7 @@ class BuiltinTest(unittest.TestCase):
             '''a = [x async for x in arange(2) async for x in arange(2)][1]''',
             '''a = [x async for x in (x async for x in arange(5))][1]''',
             '''a, = [1 for x in {x async for x in arange(1)}]''',
+            '''a = [await asyncio.sleep(0.001, x) async for x in arange(2)][1]'''
         ]
         policy = maybe_get_event_loop_policy()
         try:

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -397,7 +397,7 @@ class BuiltinTest(unittest.TestCase):
             '''a = [x async for x in arange(2) async for x in arange(2)][1]''',
             '''a = [x async for x in (x async for x in arange(5))][1]''',
             '''a, = [1 for x in {x async for x in arange(1)}]''',
-            '''a = [await asyncio.sleep(0.001, x) async for x in arange(2)][1]'''
+            '''a = [await asyncio.sleep(0, x) async for x in arange(2)][1]'''
         ]
         policy = maybe_get_event_loop_policy()
         try:

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -390,7 +390,13 @@ class BuiltinTest(unittest.TestCase):
             '''async for i in arange(1):
                    a = 1''',
             '''async with asyncio.Lock() as l:
-                   a = 1'''
+                   a = 1''',
+            '''a = [x async for x in arange(2)][1]''',
+            '''a = 1 in {x async for x in arange(2)}''',
+            '''a = {x:1 async for x in arange(1)}[0]''',
+            '''a = [x async for x in arange(2) async for x in arange(2)][1]''',
+            '''a = [x async for x in (x async for x in arange(5))][1]''',
+            '''a, = [1 for x in {x async for x in arange(1)}]''',
         ]
         policy = maybe_get_event_loop_policy()
         try:

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-12-22-13-50.bpo-39562.E2u273.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-12-22-13-50.bpo-39562.E2u273.rst
@@ -1,0 +1,2 @@
+Run asynchronous comprehensions on the top level when
+``PyCF_ALLOW_TOP_LEVEL_AWAIT`` flag given. Patch by Batuhan Taskaya.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-12-22-13-50.bpo-39562.E2u273.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-12-22-13-50.bpo-39562.E2u273.rst
@@ -1,2 +1,2 @@
-Run asynchronous comprehensions on the top level when
-``PyCF_ALLOW_TOP_LEVEL_AWAIT`` flag given. Patch by Batuhan Taskaya.
+Allow executing asynchronous comprehensions on the top level when the
+PyCF_ALLOW_TOP_LEVEL_AWAIT`` flag is given. Patch by Batuhan Taskaya.

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-12-22-13-50.bpo-39562.E2u273.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-12-22-13-50.bpo-39562.E2u273.rst
@@ -1,2 +1,2 @@
 Allow executing asynchronous comprehensions on the top level when the
-PyCF_ALLOW_TOP_LEVEL_AWAIT`` flag is given. Patch by Batuhan Taskaya.
+``PyCF_ALLOW_TOP_LEVEL_AWAIT`` flag is given. Patch by Batuhan Taskaya.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4576,11 +4576,14 @@ compiler_comprehension(struct compiler *c, expr_ty e, int type,
     PyCodeObject *co = NULL;
     comprehension_ty outermost;
     PyObject *qualname = NULL;
-    int is_async_function = c->u->u_ste->ste_coroutine;
     int is_async_generator = 0;
 
-    outermost = (comprehension_ty) asdl_seq_GET(generators, 0);
+    if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT){
+        c->u->u_ste->ste_coroutine = 1;
+    }
+    int is_async_function = c->u->u_ste->ste_coroutine;
 
+    outermost = (comprehension_ty) asdl_seq_GET(generators, 0);
     if (!compiler_enter_scope(c, name, COMPILER_SCOPE_COMPREHENSION,
                               (void *)e, e->lineno))
     {

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4578,7 +4578,7 @@ compiler_comprehension(struct compiler *c, expr_ty e, int type,
     PyObject *qualname = NULL;
     int is_async_generator = 0;
 
-    if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT){
+    if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT) {
         c->u->u_ste->ste_coroutine = 1;
     }
     int is_async_function = c->u->u_ste->ste_coroutine;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4578,7 +4578,7 @@ compiler_comprehension(struct compiler *c, expr_ty e, int type,
     PyObject *qualname = NULL;
     int is_async_generator = 0;
 
-    if (c->c_flags->cf_flags & PyCF_ALLOW_TOP_LEVEL_AWAIT) {
+    if (IS_TOP_LEVEL_AWAIT(c)) {
         c->u->u_ste->ste_coroutine = 1;
     }
     int is_async_function = c->u->u_ste->ste_coroutine;


### PR DESCRIPTION
<!-- issue-number: [bpo-39562](https://bugs.python.org/issue39562) -->
https://bugs.python.org/issue39562
<!-- /issue-number -->

Allow executing asynchronous comprehensions on the top level when the
PyCF_ALLOW_TOP_LEVEL_AWAIT flag is given.