### PR TITLE
bpo-39936: _aix_support uses _bootsubprocess

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-03-12-21-59-47.bpo-39936.Ca9IKe.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-12-21-59-47.bpo-39936.Ca9IKe.rst
@@ -1,0 +1,5 @@
+AIX: Fix _aix_support module when the subprocess is not available, when
+building Python from scratch. It now uses new private _bootsubprocess
+module, rather than having two implementations depending if subprocess is
+available or not. So _aix_support.aix_platform() result is now the same if
+subprocess is available or not.


### PR DESCRIPTION
AIX: Fix _aix_support module when the subprocess is not available,
when building Python from scratch. It now uses new private
_bootsubprocess module, rather than having two implementations
depending if subprocess is available or not. So
_aix_support.aix_platform() result is now the same if subprocess is
available or not.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39936](https://bugs.python.org/issue39936) -->
https://bugs.python.org/issue39936
<!-- /issue-number -->
