### PR TITLE
bpo-39943: Remove unused arg from find_nfc_index()

### DIFF
--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -623,7 +623,7 @@ nfd_nfkd(PyObject *self, PyObject *input, int k)
 }
 
 static int
-find_nfc_index(PyObject *self, struct reindex* nfc, Py_UCS4 code)
+find_nfc_index(const struct reindex* nfc, Py_UCS4 code)
 {
     unsigned int index;
     for (index = 0; nfc[index].start; index++) {
@@ -709,7 +709,7 @@ nfc_nfkc(PyObject *self, PyObject *input, int k)
       }
 
       /* code is still input[i] here */
-      f = find_nfc_index(self, nfc_first, code);
+      f = find_nfc_index(nfc_first, code);
       if (f == -1) {
           output[o++] = code;
           i++;
@@ -732,7 +732,7 @@ nfc_nfkc(PyObject *self, PyObject *input, int k)
                   continue;
               }
           }
-          l = find_nfc_index(self, nfc_last, code1);
+          l = find_nfc_index(nfc_last, code1);
           /* i1 cannot be combined with i. If i1
              is a starter, we don't need to look further.
              Otherwise, record the combining class. */
@@ -757,7 +757,7 @@ nfc_nfkc(PyObject *self, PyObject *input, int k)
           assert(cskipped < 20);
           skipped[cskipped++] = i1;
           i1++;
-          f = find_nfc_index(self, nfc_first, output[o]);
+          f = find_nfc_index(nfc_first, output[o]);
           if (f == -1)
               break;
       }


### PR DESCRIPTION
Remove unused arg from find_nfc_index()

<!-- issue-number: [bpo-39943](https://bugs.python.org/issue39943) -->
https://bugs.python.org/issue39943
<!-- /issue-number -->
