### PR TITLE
bpo-35370: PyEval_SetTrace() logs unraisable error

### DIFF
--- a/Misc/NEWS.d/next/C API/2020-03-13-16-44-23.bpo-35370.sXRA-r.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-13-16-44-23.bpo-35370.sXRA-r.rst
@@ -1,0 +1,2 @@
+If :c:func:`PySys_Audit` fails in :c:func:`PyEval_SetProfile` or
+:c:func:`PyEval_SetTrace`, log the error as an unraisable exception.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4620,7 +4620,10 @@ void
 PyEval_SetProfile(Py_tracefunc func, PyObject *arg)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    (void)_PyEval_SetProfile(tstate, func, arg);
+    if (_PyEval_SetProfile(tstate, func, arg) < 0) {
+        /* Log PySys_Audit() error */
+        _PyErr_WriteUnraisableMsg("in PyEval_SetProfile", NULL);
+    }
 }
 
 int
@@ -4661,7 +4664,10 @@ void
 PyEval_SetTrace(Py_tracefunc func, PyObject *arg)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    (void)_PyEval_SetTrace(tstate, func, arg);
+    if (_PyEval_SetTrace(tstate, func, arg) < 0) {
+        /* Log PySys_Audit() error */
+        _PyErr_WriteUnraisableMsg("in PyEval_SetTrace", NULL);
+    }
 }
 
 


### PR DESCRIPTION
If PySys_Audit() fails in PyEval_SetProfile() or PyEval_SetTrace(),
log the error as an unraisable exception.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35370](https://bugs.python.org/issue35370) -->
https://bugs.python.org/issue35370
<!-- /issue-number -->
