### PR TITLE
bpo-39947: Use _PyInterpreterState_GET_UNSAFE()

### DIFF
--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1061,7 +1061,7 @@ thread_PyThread_start_new_thread(PyObject *self, PyObject *fargs)
     boot = PyMem_NEW(struct bootstate, 1);
     if (boot == NULL)
         return PyErr_NoMemory();
-    boot->interp = _PyInterpreterState_Get();
+    boot->interp = _PyInterpreterState_GET_UNSAFE();
     boot->func = func;
     boot->args = args;
     boot->keyw = keyw;
@@ -1183,7 +1183,7 @@ particular thread within a system.");
 static PyObject *
 thread__count(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
-    PyInterpreterState *interp = _PyInterpreterState_Get();
+    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
     return PyLong_FromLong(interp->num_threads);
 }
 
@@ -1542,7 +1542,7 @@ PyInit__thread(void)
     PyObject *m, *d, *v;
     double time_max;
     double timeout_max;
-    PyInterpreterState *interp = _PyInterpreterState_Get();
+    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
 
     /* Initialize types: */
     if (PyType_Ready(&localdummytype) < 0)

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -451,7 +451,7 @@ run_at_forkers(PyObject *lst, int reverse)
 void
 PyOS_BeforeFork(void)
 {
-    run_at_forkers(_PyInterpreterState_Get()->before_forkers, 1);
+    run_at_forkers(_PyInterpreterState_GET_UNSAFE()->before_forkers, 1);
 
     _PyImport_AcquireLock();
 }
@@ -462,7 +462,7 @@ PyOS_AfterFork_Parent(void)
     if (_PyImport_ReleaseLock() <= 0)
         Py_FatalError("failed releasing import lock after fork");
 
-    run_at_forkers(_PyInterpreterState_Get()->after_forkers_parent, 0);
+    run_at_forkers(_PyInterpreterState_GET_UNSAFE()->after_forkers_parent, 0);
 }
 
 void
@@ -476,7 +476,7 @@ PyOS_AfterFork_Child(void)
     _PyRuntimeState_ReInitThreads(runtime);
     _PyInterpreterState_DeleteExceptMain(runtime);
 
-    run_at_forkers(_PyInterpreterState_Get()->after_forkers_child, 0);
+    run_at_forkers(_PyInterpreterState_GET_UNSAFE()->after_forkers_child, 0);
 }
 
 static int
@@ -6177,7 +6177,7 @@ os_register_at_fork_impl(PyObject *module, PyObject *before,
         check_null_or_callable(after_in_parent, "after_in_parent")) {
         return NULL;
     }
-    interp = _PyInterpreterState_Get();
+    interp = _PyInterpreterState_GET_UNSAFE();
 
     if (register_at_forker(&interp->before_forkers, before)) {
         return NULL;
@@ -6208,7 +6208,7 @@ os_fork1_impl(PyObject *module)
 {
     pid_t pid;
 
-    if (_PyInterpreterState_Get() != PyInterpreterState_Main()) {
+    if (_PyInterpreterState_GET_UNSAFE() != PyInterpreterState_Main()) {
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }
@@ -6243,7 +6243,7 @@ os_fork_impl(PyObject *module)
 {
     pid_t pid;
 
-    if (_PyInterpreterState_Get() != PyInterpreterState_Main()) {
+    if (_PyInterpreterState_GET_UNSAFE() != PyInterpreterState_Main()) {
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }
@@ -6851,7 +6851,7 @@ os_forkpty_impl(PyObject *module)
     int master_fd = -1;
     pid_t pid;
 
-    if (_PyInterpreterState_Get() != PyInterpreterState_Main()) {
+    if (_PyInterpreterState_GET_UNSAFE() != PyInterpreterState_Main()) {
         PyErr_SetString(PyExc_RuntimeError, "fork not supported for subinterpreters");
         return NULL;
     }

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -174,7 +174,7 @@ _add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
 PyObject *
 PyModule_Create2(struct PyModuleDef* module, int module_api_version)
 {
-    if (!_PyImport_IsInitialized(_PyInterpreterState_Get())) {
+    if (!_PyImport_IsInitialized(_PyInterpreterState_GET_UNSAFE())) {
         PyErr_SetString(PyExc_SystemError,
                         "Python import machinery not initialized");
         return NULL;
@@ -699,7 +699,7 @@ module_dealloc(PyModuleObject *m)
 static PyObject *
 module_repr(PyModuleObject *m)
 {
-    PyInterpreterState *interp = _PyInterpreterState_Get();
+    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
 
     return PyObject_CallMethod(interp->importlib, "_module_repr", "O", m);
 }

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -32,7 +32,7 @@ static int _PyCodecRegistry_Init(void); /* Forward */
 
 int PyCodec_Register(PyObject *search_function)
 {
-    PyInterpreterState *interp = _PyInterpreterState_Get();
+    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
     if (interp->codec_search_path == NULL && _PyCodecRegistry_Init())
         goto onError;
     if (search_function == NULL) {
@@ -187,7 +187,7 @@ int _PyCodec_Forget(const char *encoding)
     PyObject *v;
     int result;
 
-    PyInterpreterState *interp = _PyInterpreterState_Get();
+    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
     if (interp->codec_search_path == NULL) {
         return -1;
     }
@@ -620,7 +620,7 @@ PyObject *_PyCodec_DecodeText(PyObject *object,
    Return 0 on success, -1 on error */
 int PyCodec_RegisterError(const char *name, PyObject *error)
 {
-    PyInterpreterState *interp = _PyInterpreterState_Get();
+    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
     if (interp->codec_search_path == NULL && _PyCodecRegistry_Init())
         return -1;
     if (!PyCallable_Check(error)) {
@@ -1492,7 +1492,7 @@ static int _PyCodecRegistry_Init(void)
         }
     };
 
-    PyInterpreterState *interp = _PyInterpreterState_Get();
+    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
     PyObject *mod;
 
     if (interp->codec_search_path != NULL)

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -2,7 +2,7 @@
 /* Support for dynamic loading of extension modules */
 
 #include "Python.h"
-#include "pycore_pystate.h"
+#include "pycore_pystate.h"   // _PyInterpreterState_GET_UNSAFE()
 #include "importdl.h"
 
 #include <sys/types.h>
@@ -94,7 +94,7 @@ _PyImport_FindSharedFuncptr(const char *prefix,
         }
     }
 
-    dlopenflags = _PyInterpreterState_Get()->dlopenflags;
+    dlopenflags = _PyInterpreterState_GET_UNSAFE()->dlopenflags;
 
     handle = dlopen(pathname, dlopenflags);
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -642,7 +642,7 @@ long
 PyImport_GetMagicNumber(void)
 {
     long res;
-    PyInterpreterState *interp = _PyInterpreterState_Get();
+    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
     PyObject *external, *pyc_magic;
 
     external = PyObject_GetAttrString(interp->importlib, "_bootstrap_external");
@@ -2412,7 +2412,7 @@ PyInit__imp(void)
         goto failure;
     }
 
-    const wchar_t *mode = _PyInterpreterState_Get()->config.check_hash_pycs_mode;
+    const wchar_t *mode = _PyInterpreterState_GET_UNSAFE()->config.check_hash_pycs_mode;
     PyObject *pyc_mode = PyUnicode_FromWideChar(mode, -1);
     if (pyc_mode == NULL) {
         goto failure;

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -2572,8 +2572,8 @@ _Py_GetConfigsAsDict(void)
     Py_CLEAR(dict);
 
     /* pre config */
-    PyInterpreterState *interp = _PyInterpreterState_Get();
-    const PyPreConfig *pre_config = &_PyRuntime.preconfig;
+    PyThreadState *tstate = _PyThreadState_GET();
+    const PyPreConfig *pre_config = &tstate->interp->runtime->preconfig;
     dict = _PyPreConfig_AsDict(pre_config);
     if (dict == NULL) {
         goto error;
@@ -2584,7 +2584,7 @@ _Py_GetConfigsAsDict(void)
     Py_CLEAR(dict);
 
     /* core config */
-    const PyConfig *config = &interp->config;
+    const PyConfig *config = &tstate->interp->config;
     dict = config_as_dict(config);
     if (dict == NULL) {
         goto error;

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -95,7 +95,7 @@ PyRun_InteractiveLoopFlags(FILE *fp, const char *filename_str, PyCompilerFlags *
     PyCompilerFlags local_flags = _PyCompilerFlags_INIT;
     int nomem_count = 0;
 #ifdef Py_REF_DEBUG
-    int show_ref_count = _PyInterpreterState_Get()->config.show_ref_count;
+    int show_ref_count = _PyInterpreterState_GET_UNSAFE()->config.show_ref_count;
 #endif
 
     filename = PyUnicode_DecodeFSDefault(filename_str);
@@ -346,7 +346,7 @@ set_main_loader(PyObject *d, const char *filename, const char *loader_name)
     filename_obj = PyUnicode_DecodeFSDefault(filename);
     if (filename_obj == NULL)
         return -1;
-    PyInterpreterState *interp = _PyInterpreterState_Get();
+    PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
     bootstrap = PyObject_GetAttrString(interp->importlib,
                                        "_bootstrap_external");
     if (bootstrap != NULL) {
@@ -1117,7 +1117,7 @@ run_eval_code_obj(PyCodeObject *co, PyObject *globals, PyObject *locals)
 
     /* Set globals['__builtins__'] if it doesn't exist */
     if (globals != NULL && PyDict_GetItemString(globals, "__builtins__") == NULL) {
-        PyInterpreterState *interp = _PyInterpreterState_Get();
+        PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
         if (PyDict_SetItemString(globals, "__builtins__", interp->builtins) < 0) {
             return NULL;
         }

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -92,7 +92,7 @@ PyThread_init_thread(void)
 size_t
 PyThread_get_stacksize(void)
 {
-    return _PyInterpreterState_Get()->pythread_stacksize;
+    return _PyInterpreterState_GET_UNSAFE()->pythread_stacksize;
 }
 
 /* Only platforms defining a THREAD_SET_STACKSIZE() macro


### PR DESCRIPTION
Replace _PyInterpreterState_Get() function call with
_PyInterpreterState_GET_UNSAFE() macro which is more efficient but
don't check if tstate or interp is NULL.

_Py_GetConfigsAsDict() now uses _PyThreadState_GET().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39947](https://bugs.python.org/issue39947) -->
https://bugs.python.org/issue39947
<!-- /issue-number -->
