### PR TITLE
bpo-39107: Update Tcl/Tk on macOS AND Windows

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -227,8 +227,8 @@ def library_recipes():
     if internalTk():
         result.extend([
           dict(
-              name="Tcl 8.6.8",
-              url="ftp://ftp.tcl.tk/pub/tcl//tcl8_6/tcl8.6.8-src.tar.gz",
+              name="Tcl 8.6.10",
+              url="ftp://ftp.tcl.tk/pub/tcl//tcl8_6/tcl8.6.10-src.tar.gz",
               checksum='81656d3367af032e0ae6157eff134f89',
               buildDir="unix",
               configure_pre=[
@@ -243,11 +243,11 @@ def library_recipes():
                   },
               ),
           dict(
-              name="Tk 8.6.8",
-              url="ftp://ftp.tcl.tk/pub/tcl//tcl8_6/tk8.6.8-src.tar.gz",
+              name="Tk 8.6.10",
+              url="ftp://ftp.tcl.tk/pub/tcl//tcl8_6/tk8.6.10-src.tar.gz",
               checksum='5e0faecba458ee1386078fb228d008ba',
               patches=[
-                  "tk868_on_10_8_10_9.patch",
+                  "tk8610_on_10_8_10_9.patch",
                    ],
               buildDir="unix",
               configure_pre=[

--- a/Mac/BuildScript/tk8610_on_10_8_10_9.patch
+++ b/Mac/BuildScript/tk8610_on_10_8_10_9.patch
@@ -5,8 +5,8 @@ not introduced until OS X 10.10.
 
 Patch from MacPorts project and reported upstream:
 https://trac.macports.org/ticket/55649
---- tk8.6.8/macosx/tkMacOSXXStubs.c.orig	2017-12-06 09:25:08.000000000 -0600
-+++ tk8.6.8-patched/macosx/tkMacOSXXStubs.c	2018-01-06 19:34:17.000000000 -0600
+--- tk8.6.10/macosx/tkMacOSXXStubs.c.orig	2017-12-06 09:25:08.000000000 -0600
++++ tk8.6.10-patched/macosx/tkMacOSXXStubs.c	2018-01-06 19:34:17.000000000 -0600
 @@ -175,7 +175,7 @@
      {
  	int major, minor, patch;

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -55,8 +55,8 @@ set libraries=%libraries%                                       bzip2-1.0.6
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi
 if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1d
 set libraries=%libraries%                                       sqlite-3.31.1.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.9.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.9.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.10.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.10.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tix-8.4.3.6
 set libraries=%libraries%                                       xz-5.2.2
 set libraries=%libraries%                                       zlib-1.2.11

--- a/PCbuild/tcltk.props
+++ b/PCbuild/tcltk.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TclMajorVersion>8</TclMajorVersion>
     <TclMinorVersion>6</TclMinorVersion>
-    <TclPatchLevel>9</TclPatchLevel>
+    <TclPatchLevel>1</TclPatchLevel>
     <TclRevision>0</TclRevision>
     <TkMajorVersion>$(TclMajorVersion)</TkMajorVersion>
     <TkMinorVersion>$(TclMinorVersion)</TkMinorVersion>


### PR DESCRIPTION
Updates Tcl/Tk to 3.8.10. Check issue 39107. I don't know if I have done it right, let me know if I need to make changes.

<!-- issue-number: [bpo-39107](https://bugs.python.org/issue39107) -->
https://bugs.python.org/issue39107
<!-- /issue-number -->
