### PR TITLE
bpo-39891: [difflib] add parameter 'ignorecase' to get_close_matches()

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -192,7 +192,7 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
    See :ref:`difflib-interface` for a more detailed example.
 
 
-.. function:: get_close_matches(word, possibilities, n=3, cutoff=0.6, ignorecase=False)
+.. function:: get_close_matches(word, possibilities, n=3, cutoff=0.6)
 
    Return a list of the best "good enough" matches.  *word* is a sequence for which
    close matches are desired (typically a string), and *possibilities* is a list of
@@ -203,10 +203,6 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
 
    Optional argument *cutoff* (default ``0.6``) is a float in the range [0, 1].
    Possibilities that don't score at least that similar to *word* are ignored.
-
-   Optional argument *ignorecase* (default ``False``) dictates whether the
-   uppercase/lowercase counterpart of a character in ``word`` or ``possibilities`` is
-   considered equivalent or not.
 
    The best (no more than *n*) matches among the possibilities are returned in a
    list, sorted by similarity score, most similar first.
@@ -220,10 +216,28 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
       []
       >>> get_close_matches('accept', keyword.kwlist)
       ['except']
-      >>> get_close_matches('apple', ['APPLE'], ignorecase=True)
-      ['APPLE']
-      >>> get_close_matches('apple', ['APPLE'])
-      []
+
+
+.. function:: get_close_matches_ignorecase(word, possibilities, n=3, cutoff=0.6)
+
+   Return a list of the best "good enough" matches on a case-insensitive basis.
+   *word* is a sequence for which close matches are desired (typically a string),
+   and *possibilities* is a list of sequences against which to match *word*
+   (typically a list of strings).
+
+   Optional argument *n* (default ``3``) is the maximum number of close matches to
+   return; *n* must be greater than ``0``.
+
+   Optional argument *cutoff* (default ``0.6``) is a float in the range [0, 1].
+   Possibilities that don't score at least that similar to *word* are ignored.
+
+   The best (no more than *n*) matches among the possibilities are returned in a
+   list, sorted by similarity score, most similar first.
+
+      >>> get_close_matches_ignorecase('APPLE', ['apple'])
+      ['apple']
+      >>> get_close_matches_ignorecase('APPLE', ['APPle'])
+      ['APPle']
 
 
 .. function:: ndiff(a, b, linejunk=None, charjunk=IS_CHARACTER_JUNK)

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -192,7 +192,7 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
    See :ref:`difflib-interface` for a more detailed example.
 
 
-.. function:: get_close_matches(word, possibilities, n=3, cutoff=0.6)
+.. function:: get_close_matches(word, possibilities, n=3, cutoff=0.6, ignorecase=False)
 
    Return a list of the best "good enough" matches.  *word* is a sequence for which
    close matches are desired (typically a string), and *possibilities* is a list of
@@ -203,6 +203,10 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
 
    Optional argument *cutoff* (default ``0.6``) is a float in the range [0, 1].
    Possibilities that don't score at least that similar to *word* are ignored.
+
+   Optional argument *ignorecase* (default ``False``) dictates whether the
+   uppercase/lowercase counterpart of a character in ``word`` or ``possibilities`` is
+   considered equivalent or not.
 
    The best (no more than *n*) matches among the possibilities are returned in a
    list, sorted by similarity score, most similar first.
@@ -216,6 +220,10 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
       []
       >>> get_close_matches('accept', keyword.kwlist)
       ['except']
+      >>> get_close_matches('apple', ['APPLE'], ignorecase=True)
+      ['APPLE']
+      >>> get_close_matches('apple', ['APPLE'])
+      []
 
 
 .. function:: ndiff(a, b, linejunk=None, charjunk=IS_CHARACTER_JUNK)

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -148,7 +148,7 @@ class SequenceMatcher:
         Return an upper bound on ratio() very quickly.
     """
 
-    def __init__(self, isjunk=None, a='', b='', autojunk=True):
+    def __init__(self, isjunk=None, a='', b='', autojunk=True, ignorecase=False):
         """Construct a SequenceMatcher.
 
         Optional arg isjunk is None (the default), or a one-argument
@@ -210,6 +210,7 @@ class SequenceMatcher:
         self.isjunk = isjunk
         self.a = self.b = None
         self.autojunk = autojunk
+        self.ignorecase = ignorecase
         self.set_seqs(a, b)
 
     def set_seqs(self, a, b):
@@ -309,6 +310,8 @@ class SequenceMatcher:
         self.b2j = b2j = {}
 
         for i, elt in enumerate(b):
+            if self.ignorecase:
+                elt = elt.lower()
             indices = b2j.setdefault(elt, [])
             indices.append(i)
 
@@ -401,7 +404,10 @@ class SequenceMatcher:
             # b2j has no junk keys, the loop is skipped if a[i] is junk
             j2lenget = j2len.get
             newj2len = {}
-            for j in b2j.get(a[i], nothing):
+            ai = a[i]
+            if self.ignorecase:
+                ai = ai.lower()
+            for j in b2j.get(ai, nothing):
                 # a[i] matches b[j]
                 if j < blo:
                     continue
@@ -657,6 +663,8 @@ class SequenceMatcher:
         if self.fullbcount is None:
             self.fullbcount = fullbcount = {}
             for elt in self.b:
+                if self.ignorecase:
+                    elt = elt.lower()
                 fullbcount[elt] = fullbcount.get(elt, 0) + 1
         fullbcount = self.fullbcount
         # avail[x] is the number of times x appears in 'b' less the
@@ -664,6 +672,8 @@ class SequenceMatcher:
         avail = {}
         availhas, matches = avail.__contains__, 0
         for elt in self.a:
+            if self.ignorecase:
+                elt = elt.lower()
             if availhas(elt):
                 numb = avail[elt]
             else:
@@ -685,7 +695,7 @@ class SequenceMatcher:
         # shorter sequence
         return _calculate_ratio(min(la, lb), la + lb)
 
-def get_close_matches(word, possibilities, n=3, cutoff=0.6):
+def get_close_matches(word, possibilities, n=3, cutoff=0.6, ignorecase=False):
     """Use SequenceMatcher to return list of the best "good enough" matches.
 
     word is a sequence for which close matches are desired (typically a
@@ -719,7 +729,7 @@ def get_close_matches(word, possibilities, n=3, cutoff=0.6):
     if not 0.0 <= cutoff <= 1.0:
         raise ValueError("cutoff must be in [0.0, 1.0]: %r" % (cutoff,))
     result = []
-    s = SequenceMatcher()
+    s = SequenceMatcher(ignorecase=ignorecase)
     s.set_seq2(word)
     for x in possibilities:
         s.set_seq1(x)

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -60,6 +60,44 @@ class TestAutojunk(unittest.TestCase):
         self.assertAlmostEqual(sm.ratio(), 0.9975, places=3)
         self.assertEqual(sm.bpopular, set())
 
+class TestIgnorecase(unittest.TestCase):
+    """
+    Tests for the ignorecase parameter added to SequenceMatcher in 3.9.
+    When ignorecase=True, SequenceMatcher should consider any equivalent
+    uppercase or lowercase characters in either seq1 or seq2 to be equal.
+    """
+    def test_lowercase_matches_uppercase(self):
+        # seq1 is lowercase, seq2 is uppercase. Check they are deemed equivalent.
+        seq1 = 'apple'
+        seq2 = seq1.upper()
+        sm = difflib.SequenceMatcher(None, seq1, seq2, ignorecase=True)
+        self.assertEqual(sm.quick_ratio(), 1)
+        self.assertEqual(sm.ratio(), 1)
+
+    def test_uppercase_matches_lowercase(self):
+        # seq1 is uppercase, seq2 is lowercase. Check they are deemed equivalent.
+        seq1 = 'APPLE'
+        seq2 = seq1.lower()
+        sm = difflib.SequenceMatcher(None, seq1, seq2, ignorecase=True)
+        self.assertEqual(sm.quick_ratio(), 1)
+        self.assertEqual(sm.ratio(), 1)
+
+    def test_uppercase_does_not_match_lowercase_without_ignorecase(self):
+        # Test that the behaviour with ignorecase=False is that the two strings
+        # are considered inequivalent.
+        seq1 = 'apple'
+        seq2 = 'APPLE'
+        sm = difflib.SequenceMatcher(None, seq1, seq2, ignorecase=False)
+        self.assertEqual(sm.ratio(), 0)
+
+    def test_mixed_case_matches_mixed_case(self):
+        # Test that the same string with each character having the inverse casing of
+        # the other string's character are still considered equivalent when
+        # ignorecase=True
+        seq1 = 'aPPle'
+        seq2 = 'AppLE'
+        sm = difflib.SequenceMatcher(None, seq1, seq2, ignorecase=True)
+        self.assertEqual(sm.ratio(), 1)
 
 class TestSFbugs(unittest.TestCase):
     def test_ratio_for_null_seqn(self):
@@ -505,7 +543,7 @@ def test_main():
     difflib.HtmlDiff._default_prefix = 0
     Doctests = doctest.DocTestSuite(difflib)
     run_unittest(
-        TestWithAscii, TestAutojunk, TestSFpatches, TestSFbugs,
+        TestWithAscii, TestAutojunk, TestIgnorecase, TestSFpatches, TestSFbugs,
         TestOutputFormat, TestBytes, TestJunkAPIs, Doctests)
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2019-07-17-08-26-14.bpo-34788.pwV1OK.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-17-08-26-14.bpo-34788.pwV1OK.rst
@@ -1,6 +1,2 @@
 Add support for scoped IPv6 addresses to :mod:`ipaddress`. Patch by Oleksandr 
 Pavliuk.
-
-Add *ignorecase* parameter to :func:`get_close_matches` that considers lowercase
-and uppercase characters in provided strings as equivalent. Patch by Brian
-Gallagher.

--- a/Misc/NEWS.d/next/Library/2019-07-17-08-26-14.bpo-34788.pwV1OK.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-17-08-26-14.bpo-34788.pwV1OK.rst
@@ -1,2 +1,6 @@
 Add support for scoped IPv6 addresses to :mod:`ipaddress`. Patch by Oleksandr 
 Pavliuk.
+
+Add new function get_close_matches_ignorecase() that provides the same functionality
+get_close_matches() provides, but on a case-insensitive basis. Patch by Brian
+Gallagher.

--- a/Misc/NEWS.d/next/Library/2019-07-17-08-26-14.bpo-34788.pwV1OK.rst
+++ b/Misc/NEWS.d/next/Library/2019-07-17-08-26-14.bpo-34788.pwV1OK.rst
@@ -1,2 +1,6 @@
 Add support for scoped IPv6 addresses to :mod:`ipaddress`. Patch by Oleksandr 
 Pavliuk.
+
+Add *ignorecase* parameter to :func:`get_close_matches` that considers lowercase
+and uppercase characters in provided strings as equivalent. Patch by Brian
+Gallagher.


### PR DESCRIPTION
This change adds an optional boolean parameter called `ignorecase` to difflib.get_close_matches().

Previously, get_close_matches doesn't consider the uppercase counterpart of a lowercase character in a string equivalent, or vice versa.

Example:
```
>>> get_close_matches("apple", ["APPLE"])
[]
>>> get_close_matches("apple", ["aPPLe"])
[]
```

When ignorecase is provided and set to True, the underlying SequenceMatcher class used by get_close_matches() will consider uppercase and lowercase characters to be equivalent.

Example:
```
>>> get_close_matches("apple", ["APPLE"], ignorecase=True)
['APPLE']
>>> get_close_matches("apple", ["aPPLe"], ignorecase=True)
['aPPLe']
```

The criteria for what determines an uppercase/lowercase variant of the same character is left up to the implementation of string.lower(), as the ignorecase parameter ultimately normalizes all strings to their lowercase equivalent.

One potential issue that was raised with this change in https://bugs.python.org/issue39891 is that this behaviour could be just as easily left up to the application code. While that's true, this change has two advantages over that approach:

1. It's currently undocumented that get_close_matches() won't match the uppercase/lowercase equivalent of a string, so a user of the function may not know to perform this case normalization.
2. There's no easy way I can think of to carry this out on the application side without incurring extra memory overhead by normalizing all the strings and maintaining a mapping back to their un-normalized forms. This change dodges that entirely, by just converting the strings to their lowercase equivalents in the internal data structures used by the SequenceMatcher. For example, some application code might do the following to implement the behaviour `ignorecase` provides:

```
>>> from difflib import get_close_matches
>>> word = 'apple'
>>> possibilities = ['apPLE', 'APPLE', 'APE', 'Banana', 'Fruit', 'PEAR', 'CoCoNuT']
>>> normalized_possibilities = {p.lower(): p for p in possibilities}
>>> result = get_close_matches(word, normalized_possibilities.keys())
>>> result
['apple', 'ape']
>>> normalized_result = [normalized_possibilities[r] for r in result]
>>> normalized_result
['APPLE', 'APE']
```

<!-- issue-number: [bpo-39891](https://bugs.python.org/issue39891) -->
https://bugs.python.org/issue39891
<!-- /issue-number -->
