### PR TITLE
Converted pyclbr.py to use f-string

### DIFF
--- a/Lib/pyclbr.py
+++ b/Lib/pyclbr.py
@@ -125,7 +125,7 @@ def _readmodule(module, path, inpackage=None):
     """
     # Compute the full module name (prepending inpackage if set).
     if inpackage is not None:
-        fullmodule = "%s.%s" % (inpackage, module)
+        fullmodule = f"{inpackage}.{module}"
     else:
         fullmodule = module
 
@@ -148,7 +148,7 @@ def _readmodule(module, path, inpackage=None):
         submodule = module[i+1:]
         parent = _readmodule(package, path, inpackage)
         if inpackage is not None:
-            package = "%s.%s" % (inpackage, package)
+            package = f"{inpackage}.{package}"
         if not '__path__' in parent:
             raise ImportError('No package named {}'.format(package))
         return _readmodule(submodule, parent['__path__'], package)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

There were two use of the old '%' string formatting and I changed
them to the modern f-string version.
