### PR TITLE
Small tweak for importlib.resources

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -529,7 +529,8 @@ ABC hierarchy::
     .. abstractmethod:: is_resource(name)
 
         Returns ``True`` if the named *name* is considered a resource.
-        :exc:`FileNotFoundError` is raised if *name* does not exist.
+
+        The abstract method always returns ``False``.
 
     .. abstractmethod:: contents()
 

--- a/Lib/importlib/abc.py
+++ b/Lib/importlib/abc.py
@@ -382,7 +382,7 @@ class ResourceReader(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def contents(self):
         """Return an iterable of strings over the contents of the package."""
-        return []
+        return ()
 
 
 _register(ResourceReader, machinery.SourceFileLoader)

--- a/Lib/importlib/abc.py
+++ b/Lib/importlib/abc.py
@@ -377,7 +377,7 @@ class ResourceReader(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def is_resource(self, name):
         """Return True if the named 'name' is consider a resource."""
-        raise FileNotFoundError
+        return False
 
     @abc.abstractmethod
     def contents(self):

--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -333,8 +333,7 @@ class ResourceReaderDefaultsTests(ABCTestHarness):
             self.ins.resource_path('dummy_file')
 
     def test_is_resource(self):
-        with self.assertRaises(FileNotFoundError):
-            self.ins.is_resource('dummy_file')
+        self.assertFalse(self.ins.is_resource('dummy_file'))
 
     def test_contents(self):
         self.assertEqual([], list(self.ins.contents()))


### PR DESCRIPTION
* Fix documentation for ResourceReader.is_resource(). This method never throws an exception.
* Sync return value for abstract method ResourceReader.contents with [importlib.resources.contents](https://github.com/python/cpython/blob/master/Lib/importlib/resources.py#L256).