### PR TITLE
bpo-39879: Update docs dict preserve insertion order

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -425,6 +425,14 @@ Mappings
       equal (e.g., ``1`` and ``1.0``) then they can be used interchangeably to index
       the same dictionary entry.
 
+      .. versionchanged:: 3.7
+         Dictionaries preserve insertion order, meaning that keys will be produced
+         in the same order they were added sequencially over the dictionary.
+         Replacing an existing key does not change the order, however removing a key
+         and re-inserting it will add it to the end instead of keeping its old place.
+         Note that older Python versions dictionaries do not preserve insertion order.
+         This behavior was an implementation detail of CPython from 3.6.   
+         
       Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -431,7 +431,7 @@ Mappings
          Replacing an existing key does not change the order, however removing a key
          and re-inserting it will add it to the end instead of keeping its old place.
          Note that older Python versions dictionaries do not preserve insertion order.
-         This behavior was an implementation detail of CPython from 3.6.   
+         This behavior was an implementation detail of CPython from 3.6.
 
       Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -425,14 +425,6 @@ Mappings
       equal (e.g., ``1`` and ``1.0``) then they can be used interchangeably to index
       the same dictionary entry.
 
-      .. versionchanged:: 3.7
-         Dictionaries preserve insertion order, meaning that keys will be produced
-         in the same order they were added sequencially over the dictionary.
-         Replacing an existing key does not change the order, however removing a key
-         and re-inserting it will add it to the end instead of keeping its old place.
-         Note that older Python versions dictionaries do not preserve insertion order.
-         This behavior was an implementation detail of CPython from 3.6.   
-         
       Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -425,6 +425,8 @@ Mappings
       equal (e.g., ``1`` and ``1.0``) then they can be used interchangeably to index
       the same dictionary entry.
 
+			Contrary to older Python `see release notes of Python 3.7 : <https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights>`_ versions (older than 3.7), the insertion-order is now preserved in a dict thus dict objects behaves the same way as `collection.OrderedDict <https://docs.python.org/3/library/collections.html#collections.OrderedDict>`_.
+
       Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -426,7 +426,7 @@ Mappings
       the same dictionary entry.
 
       Dictionaries preserve insertion order, meaning that keys will be produced
-      in the same order they were added sequencially over the dictionary.
+      in the same order they were added sequentially over the dictionary.
       Replacing an existing key does not change the order, however removing a key
       and re-inserting it will add it to the end instead of keeping its old place.
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -425,12 +425,14 @@ Mappings
       equal (e.g., ``1`` and ``1.0``) then they can be used interchangeably to index
       the same dictionary entry.
 
-      Dictionaries preserve insertion order, meaning that keys will be produced
-      in the same order they were added sequencially over the dictionary.
-      Replacing an existing key does not change the order, however removing a key
-      and re-inserting it will add it to the end instead of keeping its old place.
-      Note that older Python versions dictionaries do not preserve insertion order.
-
+      .. versionchanged:: 3.7
+         Dictionaries preserve insertion order, meaning that keys will be produced
+         in the same order they were added sequencially over the dictionary.
+         Replacing an existing key does not change the order, however removing a key
+         and re-inserting it will add it to the end instead of keeping its old place.
+         Note that older Python versions dictionaries do not preserve insertion order.
+         This behavior was an implementation detail of CPython from 3.6.   
+         
       Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -425,7 +425,7 @@ Mappings
       equal (e.g., ``1`` and ``1.0``) then they can be used interchangeably to index
       the same dictionary entry.
 
-			Contrary to older Python `see release notes of Python 3.7 : <https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights>`_ versions (older than 3.7), the insertion-order is now preserved in a dict thus dict objects behaves the same way as `collection.OrderedDict <https://docs.python.org/3/library/collections.html#collections.OrderedDict>`_.
+			Contrary to older Python `see release notes of Python 3.7 : <https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights>`_ versions (older than 3.7), the insertion-order is now preserved in a dict thus dict objects behaves the same way as `collections.OrderedDict <https://docs.python.org/3/library/collections.html#collections.OrderedDict>`_.
 
       Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -442,8 +442,9 @@ Mappings
       module.
 
       .. versionchanged:: 3.7
-         Older Python versions dictionaries do not preserve insertion order.
-         This behavior was an implementation detail of CPython from 3.6.
+         Dictionaries did not preserve insertion order in versions of Python before 3.6.
+         In CPython 3.6, insertion order was preserved, but it was considered
+         an implementation detail at that time rather than a language guarantee.
 
 Callable types
    .. index::

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -430,8 +430,8 @@ Mappings
       Replacing an existing key does not change the order, however removing a key
       and re-inserting it will add it to the end instead of keeping its old place.
       Note that older Python versions dictionaries do not preserve insertion order.
-      
-			Dictionaries are mutable; they can be created by the ``{...}`` notation (see
+
+      Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).
 
       .. index::

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -432,7 +432,7 @@ Mappings
          and re-inserting it will add it to the end instead of keeping its old place.
          Note that older Python versions dictionaries do not preserve insertion order.
          This behavior was an implementation detail of CPython from 3.6.   
-         
+
       Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -425,7 +425,7 @@ Mappings
       equal (e.g., ``1`` and ``1.0``) then they can be used interchangeably to index
       the same dictionary entry.
 
-			Contrary to older Python `see release notes of Python 3.7 : <https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights>`_ versions (older than 3.7), the insertion-order is now preserved in a dict thus dict objects behaves the same way as `collections.OrderedDict <https://docs.python.org/3/library/collections.html#collections.OrderedDict>`_.
+      Contrary to older Python `see release notes of Python 3.7 : <https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights>`_ versions (older than 3.7), the insertion-order is now preserved in a dict thus dict objects behaves the same way as `collections.OrderedDict <https://docs.python.org/3/library/collections.html#collections.OrderedDict>`_.
 
       Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -424,11 +424,11 @@ Mappings
       for keys obey the normal rules for numeric comparison: if two numbers compare
       equal (e.g., ``1`` and ``1.0``) then they can be used interchangeably to index
       the same dictionary entry.
-	
-	 		Dictionaries preserve insertion order, meaning that keys will be produced
-			in the same order they were added sequencially over the dictionary.
-			Replacing an existing key does not change the order, however removing a key
-			and re-inserting it will add it to the end instead of keeping its old place.
+
+      Dictionaries preserve insertion order, meaning that keys will be produced
+      in the same order they were added sequencially over the dictionary.
+      Replacing an existing key does not change the order, however removing a key
+      and re-inserting it will add it to the end instead of keeping its old place.
       Note that older Python versions dictionaries do not preserve insertion order.
       
 			Dictionaries are mutable; they can be created by the ``{...}`` notation (see

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -425,13 +425,10 @@ Mappings
       equal (e.g., ``1`` and ``1.0``) then they can be used interchangeably to index
       the same dictionary entry.
 
-      .. versionchanged:: 3.7
-         Dictionaries preserve insertion order, meaning that keys will be produced
-         in the same order they were added sequencially over the dictionary.
-         Replacing an existing key does not change the order, however removing a key
-         and re-inserting it will add it to the end instead of keeping its old place.
-         Note that older Python versions dictionaries do not preserve insertion order.
-         This behavior was an implementation detail of CPython from 3.6.
+      Dictionaries preserve insertion order, meaning that keys will be produced
+      in the same order they were added sequencially over the dictionary.
+      Replacing an existing key does not change the order, however removing a key
+      and re-inserting it will add it to the end instead of keeping its old place.
 
       Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).
@@ -443,6 +440,10 @@ Mappings
       The extension modules :mod:`dbm.ndbm` and :mod:`dbm.gnu` provide
       additional examples of mapping types, as does the :mod:`collections`
       module.
+
+      .. versionchanged:: 3.7
+         Note that older Python versions dictionaries do not preserve insertion order.
+         This behavior was an implementation detail of CPython from 3.6.
 
 Callable types
    .. index::

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -442,7 +442,7 @@ Mappings
       module.
 
       .. versionchanged:: 3.7
-         Note that older Python versions dictionaries do not preserve insertion order.
+         Older Python versions dictionaries do not preserve insertion order.
          This behavior was an implementation detail of CPython from 3.6.
 
 Callable types

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -424,10 +424,14 @@ Mappings
       for keys obey the normal rules for numeric comparison: if two numbers compare
       equal (e.g., ``1`` and ``1.0``) then they can be used interchangeably to index
       the same dictionary entry.
-
-      Contrary to older Python `see release notes of Python 3.7 : <https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights>`_ versions (older than 3.7), the insertion-order is now preserved in a dict thus dict objects behaves the same way as `collections.OrderedDict <https://docs.python.org/3/library/collections.html#collections.OrderedDict>`_.
-
-      Dictionaries are mutable; they can be created by the ``{...}`` notation (see
+	
+	 		Dictionaries preserve insertion order, meaning that keys will be produced
+			in the same order they were added sequencially over the dictionary.
+			Replacing an existing key does not change the order, however removing a key
+			and re-inserting it will add it to the end instead of keeping its old place.
+      Note that older Python versions dictionaries do not preserve insertion order.
+      
+			Dictionaries are mutable; they can be created by the ``{...}`` notation (see
       section :ref:`dict`).
 
       .. index::

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -39,6 +39,7 @@ Ray Allen
 Billy G. Allie
 Jamiel Almeida
 Kevin Altis
+Samy Lahfa
 Skyler Leigh Amador
 Joe Amenta
 Rose Ames

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1236,6 +1236,7 @@ Jeffrey Ollie
 Adam Olsen
 Bryan Olson
 Grant Olson
+Furkan Onder
 Koray Oner
 Piet van Oostrum
 Tomas Oppelstrup

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -39,6 +39,7 @@ Ray Allen
 Billy G. Allie
 Jamiel Almeida
 Kevin Altis
+Samy Lahfa
 Skyler Leigh Amador
 Joe Amenta
 Rose Ames
@@ -1235,6 +1236,7 @@ Jeffrey Ollie
 Adam Olsen
 Bryan Olson
 Grant Olson
+Furkan Onder
 Koray Oner
 Piet van Oostrum
 Tomas Oppelstrup

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -39,7 +39,6 @@ Ray Allen
 Billy G. Allie
 Jamiel Almeida
 Kevin Altis
-Samy Lahfa
 Skyler Leigh Amador
 Joe Amenta
 Rose Ames
@@ -1236,7 +1235,6 @@ Jeffrey Ollie
 Adam Olsen
 Bryan Olson
 Grant Olson
-Furkan Onder
 Koray Oner
 Piet van Oostrum
 Tomas Oppelstrup

--- a/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
@@ -1,2 +1,0 @@
-Update docs dict preserve insertion order and added that thus dict object behaves the same as collections.OrderedDict objects.
-Patch by Furkan Onder and Samy Lahfa.

--- a/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
@@ -1,0 +1,1 @@
+Update docs dict preserve insertion order and added that thus dict object behaves the same as collections.OrderedDict objects.

--- a/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
@@ -1,0 +1,2 @@
+Update docs dict preserve insertion order and added that thus dict object behaves the same as collections.OrderedDict objects.
+Patch by Furkan Onder and Samy Lahfa.

--- a/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
@@ -1,1 +1,2 @@
 Update docs dict preserve insertion order and added that thus dict object behaves the same as collections.OrderedDict objects.
+Patch by Furkan Onder and Samy Lahfa.

--- a/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-03-16-18-12-02.bpo-39879.CnQ7Cv.rst
@@ -1,2 +1,2 @@
-Update docs dict preserve insertion order and added that thus dict object behaves the same as collections.OrderedDict objects.
+Updated :ref:`datamodel` docs to include :func:`dict` insertion order preservation.
 Patch by Furkan Onder and Samy Lahfa.


### PR DESCRIPTION
- Added in language reference that dict are now insertion-ordered since Python version 3.7
~~- Behavior of dict are now the same as the behavior of collections.OrderedDict~~

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39879](https://bugs.python.org/issue39879) -->
https://bugs.python.org/issue39879
<!-- /issue-number -->
