### PR TITLE
bpo-39073: validate Address parts to disallow CRLF

### DIFF
--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -48,6 +48,12 @@ class Address:
                 raise a_s.all_defects[0]
             username = a_s.local_part
             domain = a_s.domain
+        else:
+            self._validate_part(username)
+            self._validate_part(domain)
+
+        self._validate_part(display_name)
+
         self._display_name = display_name
         self._username = username
         self._domain = domain
@@ -99,6 +105,10 @@ class Address:
                 self.username == other.username and
                 self.domain == other.domain)
 
+    def _validate_part(self, value):
+        """Parts cannot contain CRLF for security reasons."""
+        if '\r\n' in value:
+            raise ValueError("invalid address; address parts cannot contain CRLF")
 
 class Group:
 

--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -53,7 +53,6 @@ class Address:
                 raise a_s.all_defects[0]
             username = a_s.local_part
             domain = a_s.domain
-
         self._display_name = display_name
         self._username = username
         self._domain = domain
@@ -104,6 +103,7 @@ class Address:
         return (self.display_name == other.display_name and
                 self.username == other.username and
                 self.domain == other.domain)
+
 
 class Group:
 

--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -34,7 +34,7 @@ class Address:
 
         inputs = ''.join(filter(None, (display_name, username, domain, addr_spec)))
         if '\r' in inputs or '\n' in inputs:
-            raise ValueError("invalid inputs; address parts cannot contain CR / LF")
+            raise ValueError("invalid arguments; address parts cannot contain CR or LF")
 
         # This clause with its potential 'raise' may only happen when an
         # application program creates an Address object using an addr_spec

--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -31,6 +31,11 @@ class Address:
         without any Content Transfer Encoding.
 
         """
+
+        inputs = ''.join(filter(None, (display_name, username, domain, addr_spec)))
+        if '\r' in inputs or '\n' in inputs:
+            raise ValueError("invalid inputs; address parts cannot contain CR / LF")
+
         # This clause with its potential 'raise' may only happen when an
         # application program creates an Address object using an addr_spec
         # keyword.  The email library code itself must always supply username
@@ -48,11 +53,6 @@ class Address:
                 raise a_s.all_defects[0]
             username = a_s.local_part
             domain = a_s.domain
-        else:
-            self._validate_part(username)
-            self._validate_part(domain)
-
-        self._validate_part(display_name)
 
         self._display_name = display_name
         self._username = username
@@ -104,11 +104,6 @@ class Address:
         return (self.display_name == other.display_name and
                 self.username == other.username and
                 self.domain == other.domain)
-
-    def _validate_part(self, value):
-        """Parts cannot contain CRLF for security reasons."""
-        if '\r\n' in value:
-            raise ValueError("invalid address; address parts cannot contain CRLF")
 
 class Group:
 

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1439,9 +1439,12 @@ class TestAddressAndGroup(TestEmailBase):
 
     def test_crlf_in_constructor_args_raises(self):
         cases = (
-            dict(display_name='example.com\r'),
-            dict(display_name='example.com\n'),
-            dict(display_name='example.com\r\n'),
+            dict(display_name='foo\r'),
+            dict(display_name='foo\n'),
+            dict(display_name='foo\r\n'),
+            dict(domain='example.com\r'),
+            dict(domain='example.com\n'),
+            dict(domain='example.com\r\n'),
             dict(username='wok\r'),
             dict(username='wok\n'),
             dict(username='wok\r\n'),

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1453,7 +1453,7 @@ class TestAddressAndGroup(TestEmailBase):
             dict(addr_spec='wok@example.com\r\n')
         )
         for kwargs in cases:
-            with self.subTest(kwargs=kwargs), self.assertRaisesRegex(ValueError, "invalid inputs"):
+            with self.subTest(kwargs=kwargs), self.assertRaisesRegex(ValueError, "invalid arguments"):
                 Address(**kwargs)
 
     def test_non_ascii_username_in_addr_spec_raises(self):

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1437,17 +1437,21 @@ class TestAddressAndGroup(TestEmailBase):
     #    with self.assertRaises(ValueError):
     #        Address('foo', 'wők', 'example.com')
 
-    def test_crlf_in_display_name_raises(self):
-        with self.assertRaisesRegex(ValueError, "invalid address"):
-            Address(display_name='example.com\r\n')
-
-    def test_crlf_in_username_raises(self):
-        with self.assertRaisesRegex(ValueError, "invalid address"):
-            Address(username='hello\r\n')
-
-    def test_crlf_in_domain_raises(self):
-        with self.assertRaisesRegex(ValueError, "invalid address"):
-            Address(domain='example.com\r\n')
+    def test_crlf_in_constructor_args_raises(self):
+        cases = (
+            dict(display_name='example.com\r'),
+            dict(display_name='example.com\n'),
+            dict(display_name='example.com\r\n'),
+            dict(username='wok\r'),
+            dict(username='wok\n'),
+            dict(username='wok\r\n'),
+            dict(addr_spec='wok@example.com\r'),
+            dict(addr_spec='wok@example.com\n'),
+            dict(addr_spec='wok@example.com\r\n')
+        )
+        for kwargs in cases:
+            with self.subTest(kwargs=kwargs), self.assertRaisesRegex(ValueError, "invalid inputs"):
+                Address(**kwargs)
 
     def test_non_ascii_username_in_addr_spec_raises(self):
         with self.assertRaises(ValueError):

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1437,6 +1437,18 @@ class TestAddressAndGroup(TestEmailBase):
     #    with self.assertRaises(ValueError):
     #        Address('foo', 'wők', 'example.com')
 
+    def test_crlf_in_display_name_raises(self):
+        with self.assertRaisesRegex(ValueError, "invalid address"):
+            Address(display_name='example.com\r\n')
+
+    def test_crlf_in_username_raises(self):
+        with self.assertRaisesRegex(ValueError, "invalid address"):
+            Address(username='hello\r\n')
+
+    def test_crlf_in_domain_raises(self):
+        with self.assertRaisesRegex(ValueError, "invalid address"):
+            Address(domain='example.com\r\n')
+
     def test_non_ascii_username_in_addr_spec_raises(self):
         with self.assertRaises(ValueError):
             Address('foo', addr_spec='wők@example.com')

--- a/Misc/NEWS.d/next/Security/2020-03-15-01-28-36.bpo-39073.6Szd3i.rst
+++ b/Misc/NEWS.d/next/Security/2020-03-15-01-28-36.bpo-39073.6Szd3i.rst
@@ -1,0 +1,1 @@
+Validate email.headerregistry.Address to disallow CRLF in address parts (username, domain, display_name).

--- a/Misc/NEWS.d/next/Security/2020-03-15-01-28-36.bpo-39073.6Szd3i.rst
+++ b/Misc/NEWS.d/next/Security/2020-03-15-01-28-36.bpo-39073.6Szd3i.rst
@@ -1,1 +1,1 @@
-Validate email.headerregistry.Address to disallow CRLF in address parts (username, domain, display_name).
+Disallow CR or LF in email.headerregistry.Address arguments to guard against header injection attacks.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Validate email.headerregistry.Address to disallow CRLF in address parts (username, domain, display_name)

<!-- issue-number: [bpo-39073](https://bugs.python.org/issue39073) -->
https://bugs.python.org/issue39073
<!-- /issue-number -->
