### PR TITLE
bpo-39360: Ensure all workers exit when finalizing a multiprocessing Pool

### DIFF
--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -651,8 +651,6 @@ class Pool(object):
     def terminate(self):
         util.debug('terminating pool')
         self._state = TERMINATE
-        self._worker_handler._state = TERMINATE
-        self._change_notifier.put(None)
         self._terminate()
 
     def join(self):
@@ -683,6 +681,8 @@ class Pool(object):
         util.debug('finalizing pool')
 
         worker_handler._state = TERMINATE
+        change_notifier.put(None)
+
         task_handler._state = TERMINATE
 
         util.debug('helping task handler/workers to finish')

--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -651,8 +651,6 @@ class Pool(object):
     def terminate(self):
         util.debug('terminating pool')
         self._state = TERMINATE
-        self._worker_handler._state = TERMINATE
-        self._change_notifier.put(None)
         self._terminate()
 
     def join(self):
@@ -682,14 +680,11 @@ class Pool(object):
         # this is guaranteed to only be called once
         util.debug('finalizing pool')
 
-        # Explicitly do the cleanup here if it didn't come from terminate()
-        # (required for if the queue will block, if it is already closed)
-        if worker_handler._state != TERMINATE:
-            # Notify that the worker_handler state has been changed so the
-            # _handle_workers loop can be unblocked (and exited) in order to
-            # send the finalization sentinel all the workers.
-            worker_handler._state = TERMINATE
-            change_notifier.put(None)
+        # Notify that the worker_handler state has been changed so the
+        # _handle_workers loop can be unblocked (and exited) in order to
+        # send the finalization sentinel all the workers.
+        worker_handler._state = TERMINATE
+        change_notifier.put(None)
 
         task_handler._state = TERMINATE
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2785,10 +2785,10 @@ class _TestPoolWorkerLifetime(BaseTestCase):
         cmd = '''if 1:
             from multiprocessing import Pool
             class A:
-                def init(self):
+                def __init__(self):
                     self.pool = Pool(processes=1)
             def do_something(x):
-                return x1
+                return x + 1
             problem = A()
             problem.pool.map(do_something, [1,2,3])
         '''

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2784,13 +2784,16 @@ class _TestPoolWorkerLifetime(BaseTestCase):
         # tests cases against bpo-38744 and bpo-39360
         cmd = '''if 1:
             from multiprocessing import Pool
+            problem = None
             class A:
                 def __init__(self):
                     self.pool = Pool(processes=1)
-            def do_something(x):
-                return x + 1
-            problem = A()
-            problem.pool.map(do_something, [1,2,3])
+            def test():
+                global problem
+                problem = A()
+                problem.pool.map(float, tuple(range(10)))
+            if __name__ == "__main__":
+                test()
         '''
         rc, out, err = test.support.script_helper.assert_python_ok('-c', cmd)
         self.assertEqual(rc, 0)

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2780,6 +2780,21 @@ class _TestPoolWorkerLifetime(BaseTestCase):
         for (j, res) in enumerate(results):
             self.assertEqual(res.get(), sqr(j))
 
+    def test_pool_hang(self):
+        # tests cases against bpo-38744 and bpo-39360
+        cmd = '''if 1:
+            from multiprocessing import Pool
+            class A:
+                def init(self):
+                    self.pool = Pool(processes=1)
+            def do_something(x):
+                return x1
+            problem = A()
+            problem.pool.map(do_something, [1,2,3])
+        '''
+        rc, out, err = test.support.script_helper.assert_python_ok('-c', cmd)
+        self.assertEqual(rc, 0)
+
 #
 # Test of creating a customized manager class
 #

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2780,7 +2780,7 @@ class _TestPoolWorkerLifetime(BaseTestCase):
         for (j, res) in enumerate(results):
             self.assertEqual(res.get(), sqr(j))
 
-    def test_pool_hang(self):
+    def test_worker_finalization_via_atexit_handler_of_multiprocessing(self):
         # tests cases against bpo-38744 and bpo-39360
         cmd = '''if 1:
             from multiprocessing import Pool

--- a/Misc/NEWS.d/next/Library/2020-03-15-05-41-05.bpo-39360.cmcU5p.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-15-05-41-05.bpo-39360.cmcU5p.rst
@@ -1,3 +1,4 @@
 Ensure all workers exit when finalizing a :class:`multiprocessing.Pool` implicitly via the module finalization
 handlers of multiprocessing. This fixes a deadlock situation that can be experienced when the Pool is not
-properly finalized via the context manager or a call to ``multiprocessing.Pool.terminate``. Patch by Batuhan Taskaya.
+properly finalized via the context manager or a call to ``multiprocessing.Pool.terminate``. Patch by Batuhan Taskaya
+and Pablo Galindo.

--- a/Misc/NEWS.d/next/Library/2020-03-15-05-41-05.bpo-39360.cmcU5p.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-15-05-41-05.bpo-39360.cmcU5p.rst
@@ -1,2 +1,3 @@
-Ensure all workers exit when finalizing a :class:`multiprocessing.Pool`.
-Patch by Batuhan Taskaya.
+Ensure all workers exit when finalizing a :class:`multiprocessing.Pool` implicitly via the module finalization
+handlers of multiprocessing. This fixes a deadlock situation that can be experienced when the Pool is not
+properly finalized via the context manager or a call to ``multiprocessing.Pool.terminate``. Patch by Batuhan Taskaya.

--- a/Misc/NEWS.d/next/Library/2020-03-15-05-41-05.bpo-39360.cmcU5p.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-15-05-41-05.bpo-39360.cmcU5p.rst
@@ -1,0 +1,2 @@
+Ensure all workers exit when finalizing a :class:`multiprocessing.Pool`.
+Patch by Batuhan Taskaya.


### PR DESCRIPTION


<!-- issue-number: [bpo-39360](https://bugs.python.org/issue39360) -->
https://bugs.python.org/issue39360
<!-- /issue-number -->
