### PR TITLE
bpo-1635741: Port  _ctypes_test extension module to multiphase initialization(PEP …

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-15-07-40-11.bpo-1635741.kL7c0f.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-15-07-40-11.bpo-1635741.kL7c0f.rst
@@ -1,1 +1,0 @@
-Port _ctypes_test extension module to multiphase initialization (:pep:`489`).

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-15-07-40-11.bpo-1635741.kL7c0f.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-15-07-40-11.bpo-1635741.kL7c0f.rst
@@ -1,0 +1,1 @@
+Port _ctypes_test extension module to multiphase initialization (:pep:`489`).

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -1032,14 +1032,17 @@ EXPORT (HRESULT) KeepObject(IUnknown *punk)
 
 #endif
 
+static struct PyModuleDef_Slot _ctypes_test_slots[] = {
+    {0, NULL}
+}; 
 
 static struct PyModuleDef _ctypes_testmodule = {
     PyModuleDef_HEAD_INIT,
     "_ctypes_test",
     NULL,
-    -1,
+    0,
     module_methods,
-    NULL,
+    _ctypes_test_slots,
     NULL,
     NULL,
     NULL
@@ -1048,5 +1051,5 @@ static struct PyModuleDef _ctypes_testmodule = {
 PyMODINIT_FUNC
 PyInit__ctypes_test(void)
 {
-    return PyModule_Create(&_ctypes_testmodule);
+    return PyModuleDef_Init(&_ctypes_testmodule);
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
