### PR TITLE
[WIP] gh-84148: do not call linecache.checkcache in Bdb.reset

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -53,8 +53,6 @@ class Bdb:
 
     def reset(self):
         """Set values of attributes as ready to start debugging."""
-        import linecache
-        linecache.checkcache()
         self.botframe = None
         self._set_stopinfo(None, None)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39967](https://bugs.python.org/issue39967) -->
https://bugs.python.org/issue39967
<!-- /issue-number -->

<!-- gh-issue-number: gh-84148 -->
* Issue: gh-84148
<!-- /gh-issue-number -->
