### PR TITLE
bpo-39968: move extension modules' macros of get_module_state() to inline function.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-15-13-51-10.bpo-39968.f-Xi39.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-15-13-51-10.bpo-39968.f-Xi39.rst
@@ -1,0 +1,1 @@
+Use inline function to replace extension modules' get_module_state macros.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -21,21 +21,27 @@ typedef struct {
     long field_limit;   /* max parsed field size */
 } _csvstate;
 
-#define _csvstate(o) ((_csvstate *)PyModule_GetState(o))
+static inline _csvstate*
+get_csv_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (_csvstate *)state;
+}
 
 static int
 _csv_clear(PyObject *m)
 {
-    Py_CLEAR(_csvstate(m)->error_obj);
-    Py_CLEAR(_csvstate(m)->dialects);
+    Py_CLEAR(get_csv_state(m)->error_obj);
+    Py_CLEAR(get_csv_state(m)->dialects);
     return 0;
 }
 
 static int
 _csv_traverse(PyObject *m, visitproc visit, void *arg)
 {
-    Py_VISIT(_csvstate(m)->error_obj);
-    Py_VISIT(_csvstate(m)->dialects);
+    Py_VISIT(get_csv_state(m)->error_obj);
+    Py_VISIT(get_csv_state(m)->dialects);
     return 0;
 }
 
@@ -1647,15 +1653,15 @@ PyInit__csv(void)
         return NULL;
 
     /* Set the field limit */
-    _csvstate(module)->field_limit = 128 * 1024;
+    get_csv_state(module)->field_limit = 128 * 1024;
     /* Do I still need to add this var to the Module Dict? */
 
     /* Add _dialects dictionary */
-    _csvstate(module)->dialects = PyDict_New();
-    if (_csvstate(module)->dialects == NULL)
+    get_csv_state(module)->dialects = PyDict_New();
+    if (get_csv_state(module)->dialects == NULL)
         return NULL;
-    Py_INCREF(_csvstate(module)->dialects);
-    if (PyModule_AddObject(module, "_dialects", _csvstate(module)->dialects))
+    Py_INCREF(get_csv_state(module)->dialects);
+    if (PyModule_AddObject(module, "_dialects", get_csv_state(module)->dialects))
         return NULL;
 
     /* Add quote styles into dictionary */
@@ -1671,10 +1677,10 @@ PyInit__csv(void)
         return NULL;
 
     /* Add the CSV exception object to the module. */
-    _csvstate(module)->error_obj = PyErr_NewException("_csv.Error", NULL, NULL);
-    if (_csvstate(module)->error_obj == NULL)
+    get_csv_state(module)->error_obj = PyErr_NewException("_csv.Error", NULL, NULL);
+    if (get_csv_state(module)->error_obj == NULL)
         return NULL;
-    Py_INCREF(_csvstate(module)->error_obj);
-    PyModule_AddObject(module, "Error", _csvstate(module)->error_obj);
+    Py_INCREF(get_csv_state(module)->error_obj);
+    PyModule_AddObject(module, "Error", get_csv_state(module)->error_obj);
     return module;
 }

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -101,7 +101,13 @@ static struct PyModuleDef elementtreemodule;
 /* Given a module object (assumed to be _elementtree), get its per-module
  * state.
  */
-#define ET_STATE(mod) ((elementtreestate *) PyModule_GetState(mod))
+static inline elementtreestate*
+get_elementtree_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (elementtreestate *)state;
+}
 
 /* Find the module instance imported in the currently running sub-interpreter
  * and get its state.
@@ -112,7 +118,7 @@ static struct PyModuleDef elementtreemodule;
 static int
 elementtree_clear(PyObject *m)
 {
-    elementtreestate *st = ET_STATE(m);
+    elementtreestate *st = get_elementtree_state(m);
     Py_CLEAR(st->parseerror_obj);
     Py_CLEAR(st->deepcopy_obj);
     Py_CLEAR(st->elementpath_obj);
@@ -124,7 +130,7 @@ elementtree_clear(PyObject *m)
 static int
 elementtree_traverse(PyObject *m, visitproc visit, void *arg)
 {
-    elementtreestate *st = ET_STATE(m);
+    elementtreestate *st = get_elementtree_state(m);
     Py_VISIT(st->parseerror_obj);
     Py_VISIT(st->deepcopy_obj);
     Py_VISIT(st->elementpath_obj);
@@ -4377,7 +4383,7 @@ PyInit__elementtree(void)
     m = PyModule_Create(&elementtreemodule);
     if (!m)
         return NULL;
-    st = ET_STATE(m);
+    st = get_elementtree_state(m);
 
     if (!(temp = PyImport_ImportModule("copy")))
         return NULL;

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -52,7 +52,14 @@ typedef struct {
     PyTypeObject *EVPtype;
 } _hashlibstate;
 
-#define _hashlibstate(o) ((_hashlibstate *)PyModule_GetState(o))
+static inline _hashlibstate*
+get_hashlib_state(PyObject *module)
+{
+    _hashlibstate *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (_hashlibstate *)state;
+}
+
 #define _hashlibstate_global ((_hashlibstate *)PyModule_GetState(PyState_FindModule(&_hashlibmodule)))
 
 
@@ -1112,7 +1119,7 @@ static struct PyMethodDef EVP_functions[] = {
 static int
 hashlib_traverse(PyObject *m, visitproc visit, void *arg)
 {
-    _hashlibstate *state = _hashlibstate(m);
+    _hashlibstate *state = get_hashlib_state(m);
     Py_VISIT(state->EVPtype);
     return 0;
 }
@@ -1120,7 +1127,7 @@ hashlib_traverse(PyObject *m, visitproc visit, void *arg)
 static int
 hashlib_clear(PyObject *m)
 {
-    _hashlibstate *state = _hashlibstate(m);
+    _hashlibstate *state = get_hashlib_state(m);
     Py_CLEAR(state->EVPtype);
     return 0;
 }
@@ -1168,7 +1175,7 @@ PyInit__hashlib(void)
     PyTypeObject *EVPtype = (PyTypeObject *)PyType_FromSpec(&EVPtype_spec);
     if (EVPtype == NULL)
         return NULL;
-    _hashlibstate(m)->EVPtype = EVPtype;
+    get_hashlib_state(m)->EVPtype = EVPtype;
 
     openssl_md_meth_names = generate_hash_name_list();
     if (openssl_md_meth_names == NULL) {
@@ -1180,8 +1187,8 @@ PyInit__hashlib(void)
         return NULL;
     }
 
-    Py_INCREF((PyObject *)_hashlibstate(m)->EVPtype);
-    PyModule_AddObject(m, "HASH", (PyObject *)_hashlibstate(m)->EVPtype);
+    Py_INCREF((PyObject *)get_hashlib_state(m)->EVPtype);
+    PyModule_AddObject(m, "HASH", (PyObject *)get_hashlib_state(m)->EVPtype);
 
     PyState_AddModule(m, &_hashlibmodule);
     return m;

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -55,7 +55,7 @@ typedef struct {
 static inline _hashlibstate*
 get_hashlib_state(PyObject *module)
 {
-    _hashlibstate *state = PyModule_GetState(module);
+    void *state = PyModule_GetState(module);
     assert(state != NULL);
     return (_hashlibstate *)state;
 }

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -573,13 +573,20 @@ PyNumber_AsOff_t(PyObject *item, PyObject *err)
     return result;
 }
 
+static inline _PyIO_State*
+get_io_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (_PyIO_State *)state;
+}
 
 _PyIO_State *
 _PyIO_get_module_state(void)
 {
     PyObject *mod = PyState_FindModule(&_PyIO_Module);
     _PyIO_State *state;
-    if (mod == NULL || (state = IO_MOD_STATE(mod)) == NULL) {
+    if (mod == NULL || (state = get_io_state(mod)) == NULL) {
         PyErr_SetString(PyExc_RuntimeError,
                         "could not find io module state "
                         "(interpreter shutdown?)");
@@ -615,7 +622,7 @@ _PyIO_get_locale_module(_PyIO_State *state)
 
 static int
 iomodule_traverse(PyObject *mod, visitproc visit, void *arg) {
-    _PyIO_State *state = IO_MOD_STATE(mod);
+    _PyIO_State *state = get_io_state(mod);
     if (!state->initialized)
         return 0;
     if (state->locale_module != NULL) {
@@ -628,7 +635,7 @@ iomodule_traverse(PyObject *mod, visitproc visit, void *arg) {
 
 static int
 iomodule_clear(PyObject *mod) {
-    _PyIO_State *state = IO_MOD_STATE(mod);
+    _PyIO_State *state = get_io_state(mod);
     if (!state->initialized)
         return 0;
     if (state->locale_module != NULL)
@@ -674,7 +681,7 @@ PyInit__io(void)
     _PyIO_State *state = NULL;
     if (m == NULL)
         return NULL;
-    state = IO_MOD_STATE(m);
+    state = get_io_state(m);
     state->initialized = 0;
 
 #define ADD_TYPE(type, name) \

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -68,8 +68,15 @@ typedef struct {
 
 static struct PyModuleDef _posixsubprocessmodule;
 
-#define _posixsubprocessstate(o) ((_posixsubprocessstate *)PyModule_GetState(o))
-#define _posixsubprocessstate_global _posixsubprocessstate(PyState_FindModule(&_posixsubprocessmodule))
+static inline _posixsubprocessstate*
+get_posixsubprocess_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (_posixsubprocessstate *)state;
+}
+
+#define _posixsubprocessstate_global get_posixsubprocess_state(PyState_FindModule(&_posixsubprocessmodule))
 
 /* If gc was disabled, call gc.enable().  Return 0 on success. */
 static int
@@ -944,16 +951,16 @@ static PyMethodDef module_methods[] = {
 
 
 static int _posixsubprocess_traverse(PyObject *m, visitproc visit, void *arg) {
-    Py_VISIT(_posixsubprocessstate(m)->disable);
-    Py_VISIT(_posixsubprocessstate(m)->enable);
-    Py_VISIT(_posixsubprocessstate(m)->isenabled);
+    Py_VISIT(get_posixsubprocess_state(m)->disable);
+    Py_VISIT(get_posixsubprocess_state(m)->enable);
+    Py_VISIT(get_posixsubprocess_state(m)->isenabled);
     return 0;
 }
 
 static int _posixsubprocess_clear(PyObject *m) {
-    Py_CLEAR(_posixsubprocessstate(m)->disable);
-    Py_CLEAR(_posixsubprocessstate(m)->enable);
-    Py_CLEAR(_posixsubprocessstate(m)->isenabled);
+    Py_CLEAR(get_posixsubprocess_state(m)->disable);
+    Py_CLEAR(get_posixsubprocess_state(m)->enable);
+    Py_CLEAR(get_posixsubprocess_state(m)->isenabled);
     return 0;
 }
 
@@ -989,9 +996,9 @@ PyInit__posixsubprocess(void)
       return NULL;
     }
 
-    _posixsubprocessstate(m)->disable = PyUnicode_InternFromString("disable");
-    _posixsubprocessstate(m)->enable = PyUnicode_InternFromString("enable");
-    _posixsubprocessstate(m)->isenabled = PyUnicode_InternFromString("isenabled");
+    get_posixsubprocess_state(m)->disable = PyUnicode_InternFromString("disable");
+    get_posixsubprocess_state(m)->enable = PyUnicode_InternFromString("enable");
+    get_posixsubprocess_state(m)->isenabled = PyUnicode_InternFromString("isenabled");
 
     PyState_AddModule(m, &_posixsubprocessmodule);
     return m;

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -84,11 +84,17 @@ typedef struct {
     PyObject *Long___abs__;
 } _randomstate;
 
-#define _randomstate(o) ((_randomstate *)PyModule_GetState(o))
+static inline _randomstate*
+get_random_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (_randomstate *)state;
+}
 
 static struct PyModuleDef _randommodule;
 
-#define _randomstate_global _randomstate(PyState_FindModule(&_randommodule))
+#define _randomstate_global get_random_state(PyState_FindModule(&_randommodule))
 
 typedef struct {
     PyObject_HEAD
@@ -561,15 +567,15 @@ PyDoc_STRVAR(module_doc,
 static int
 _random_traverse(PyObject *module, visitproc visit, void *arg)
 {
-    Py_VISIT(_randomstate(module)->Random_Type);
+    Py_VISIT(get_random_state(module)->Random_Type);
     return 0;
 }
 
 static int
 _random_clear(PyObject *module)
 {
-    Py_CLEAR(_randomstate(module)->Random_Type);
-    Py_CLEAR(_randomstate(module)->Long___abs__);
+    Py_CLEAR(get_random_state(module)->Random_Type);
+    Py_CLEAR(get_random_state(module)->Long___abs__);
     return 0;
 }
 
@@ -606,7 +612,7 @@ PyInit__random(void)
         Py_DECREF(Random_Type);
         return NULL;
     }
-    _randomstate(m)->Random_Type = Random_Type;
+    get_random_state(m)->Random_Type = Random_Type;
 
     Py_INCREF(Random_Type);
     PyModule_AddObject(m, "Random", Random_Type);
@@ -624,7 +630,7 @@ PyInit__random(void)
 
     Py_DECREF(longtype);
     Py_DECREF(longval);
-    _randomstate(m)->Long___abs__ = abs;
+    get_random_state(m)->Long___abs__ = abs;
 
     return m;
 

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -37,8 +37,16 @@ static PyStructSequence_Desc struct_group_type_desc = {
 typedef struct {
   PyTypeObject *StructGrpType;
 } grpmodulestate;
-#define modulestate(o) ((grpmodulestate *)PyModule_GetState(o))
-#define modulestate_global modulestate(PyState_FindModule(&grpmodule))
+
+static inline grpmodulestate*
+get_grp_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (grpmodulestate *)state;
+}
+
+#define modulestate_global get_grp_state(PyState_FindModule(&grpmodule))
 
 static struct PyModuleDef grpmodule;
 
@@ -320,12 +328,12 @@ according to the password database.  Check both databases to get\n\
 complete membership information.)");
 
 static int grpmodule_traverse(PyObject *m, visitproc visit, void *arg) {
-    Py_VISIT(modulestate(m)->StructGrpType);
+    Py_VISIT(get_grp_state(m)->StructGrpType);
     return 0;
 }
 
 static int grpmodule_clear(PyObject *m) {
-    Py_CLEAR(modulestate(m)->StructGrpType);
+    Py_CLEAR(get_grp_state(m)->StructGrpType);
     return 0;
 }
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -842,7 +842,14 @@ typedef struct {
 
 static struct PyModuleDef posixmodule;
 
-#define _posixstate(o) ((_posixstate *)PyModule_GetState(o))
+static inline _posixstate*
+get_posix_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (_posixstate *)state;
+}
+
 #define _posixstate_global ((_posixstate *)PyModule_GetState(PyState_FindModule(&posixmodule)))
 
 /*
@@ -2103,48 +2110,48 @@ statresult_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 static int
 _posix_clear(PyObject *module)
 {
-    Py_CLEAR(_posixstate(module)->billion);
-    Py_CLEAR(_posixstate(module)->DirEntryType);
-    Py_CLEAR(_posixstate(module)->ScandirIteratorType);
+    Py_CLEAR(get_posix_state(module)->billion);
+    Py_CLEAR(get_posix_state(module)->DirEntryType);
+    Py_CLEAR(get_posix_state(module)->ScandirIteratorType);
 #if defined(HAVE_SCHED_SETPARAM) || defined(HAVE_SCHED_SETSCHEDULER) || defined(POSIX_SPAWN_SETSCHEDULER) || defined(POSIX_SPAWN_SETSCHEDPARAM)
-    Py_CLEAR(_posixstate(module)->SchedParamType);
+    Py_CLEAR(get_posix_state(module)->SchedParamType);
 #endif
-    Py_CLEAR(_posixstate(module)->StatResultType);
-    Py_CLEAR(_posixstate(module)->StatVFSResultType);
-    Py_CLEAR(_posixstate(module)->TerminalSizeType);
-    Py_CLEAR(_posixstate(module)->TimesResultType);
-    Py_CLEAR(_posixstate(module)->UnameResultType);
+    Py_CLEAR(get_posix_state(module)->StatResultType);
+    Py_CLEAR(get_posix_state(module)->StatVFSResultType);
+    Py_CLEAR(get_posix_state(module)->TerminalSizeType);
+    Py_CLEAR(get_posix_state(module)->TimesResultType);
+    Py_CLEAR(get_posix_state(module)->UnameResultType);
 #if defined(HAVE_WAITID) && !defined(__APPLE__)
-    Py_CLEAR(_posixstate(module)->WaitidResultType);
+    Py_CLEAR(get_posix_state(module)->WaitidResultType);
 #endif
 #if defined(HAVE_WAIT3) || defined(HAVE_WAIT4)
-    Py_CLEAR(_posixstate(module)->struct_rusage);
+    Py_CLEAR(get_posix_state(module)->struct_rusage);
 #endif
-    Py_CLEAR(_posixstate(module)->st_mode);
+    Py_CLEAR(get_posix_state(module)->st_mode);
     return 0;
 }
 
 static int
 _posix_traverse(PyObject *module, visitproc visit, void *arg)
 {
-    Py_VISIT(_posixstate(module)->billion);
-    Py_VISIT(_posixstate(module)->DirEntryType);
-    Py_VISIT(_posixstate(module)->ScandirIteratorType);
+    Py_VISIT(get_posix_state(module)->billion);
+    Py_VISIT(get_posix_state(module)->DirEntryType);
+    Py_VISIT(get_posix_state(module)->ScandirIteratorType);
 #if defined(HAVE_SCHED_SETPARAM) || defined(HAVE_SCHED_SETSCHEDULER) || defined(POSIX_SPAWN_SETSCHEDULER) || defined(POSIX_SPAWN_SETSCHEDPARAM)
-    Py_VISIT(_posixstate(module)->SchedParamType);
+    Py_VISIT(get_posix_state(module)->SchedParamType);
 #endif
-    Py_VISIT(_posixstate(module)->StatResultType);
-    Py_VISIT(_posixstate(module)->StatVFSResultType);
-    Py_VISIT(_posixstate(module)->TerminalSizeType);
-    Py_VISIT(_posixstate(module)->TimesResultType);
-    Py_VISIT(_posixstate(module)->UnameResultType);
+    Py_VISIT(get_posix_state(module)->StatResultType);
+    Py_VISIT(get_posix_state(module)->StatVFSResultType);
+    Py_VISIT(get_posix_state(module)->TerminalSizeType);
+    Py_VISIT(get_posix_state(module)->TimesResultType);
+    Py_VISIT(get_posix_state(module)->UnameResultType);
 #if defined(HAVE_WAITID) && !defined(__APPLE__)
-    Py_VISIT(_posixstate(module)->WaitidResultType);
+    Py_VISIT(get_posix_state(module)->WaitidResultType);
 #endif
 #if defined(HAVE_WAIT3) || defined(HAVE_WAIT4)
-    Py_VISIT(_posixstate(module)->struct_rusage);
+    Py_VISIT(get_posix_state(module)->struct_rusage);
 #endif
-    Py_VISIT(_posixstate(module)->st_mode);
+    Py_VISIT(get_posix_state(module)->st_mode);
     return 0;
 }
 
@@ -4673,7 +4680,7 @@ os_uname_impl(PyObject *module)
     if (res < 0)
         return posix_error();
 
-    PyObject *UnameResultType = _posixstate(module)->UnameResultType;
+    PyObject *UnameResultType = get_posix_state(module)->UnameResultType;
     value = PyStructSequence_New((PyTypeObject *)UnameResultType);
     if (value == NULL)
         return NULL;
@@ -7840,7 +7847,7 @@ os_waitid_impl(PyObject *module, idtype_t idtype, id_t id, int options)
     if (si.si_pid == 0)
         Py_RETURN_NONE;
 
-    PyObject *WaitidResultType = _posixstate(module)->WaitidResultType;
+    PyObject *WaitidResultType = get_posix_state(module)->WaitidResultType;
     result = PyStructSequence_New((PyTypeObject *)WaitidResultType);
     if (!result)
         return NULL;
@@ -12407,7 +12414,7 @@ get_terminal_size(PyObject *self, PyObject *args)
     }
 #endif /* TERMSIZE_USE_CONIO */
 
-    PyObject *TerminalSizeType = _posixstate(self)->TerminalSizeType;
+    PyObject *TerminalSizeType = get_posix_state(self)->TerminalSizeType;
     termsize = PyStructSequence_New((PyTypeObject *)TerminalSizeType);
     if (termsize == NULL)
         return NULL;
@@ -13425,7 +13432,7 @@ os_scandir_impl(PyObject *module, path_t *path)
         return NULL;
     }
 
-    PyObject *ScandirIteratorType = _posixstate(module)->ScandirIteratorType;
+    PyObject *ScandirIteratorType = get_posix_state(module)->ScandirIteratorType;
     iterator = PyObject_New(ScandirIterator, (PyTypeObject *)ScandirIteratorType);
     if (!iterator)
         return NULL;
@@ -14643,7 +14650,7 @@ INITFUNC(void)
     }
     Py_INCREF(WaitidResultType);
     PyModule_AddObject(m, "waitid_result", WaitidResultType);
-    _posixstate(m)->WaitidResultType = WaitidResultType;
+    get_posix_state(m)->WaitidResultType = WaitidResultType;
 #endif
 
     stat_result_desc.name = "os.stat_result"; /* see issue #19209 */
@@ -14656,7 +14663,7 @@ INITFUNC(void)
     }
     Py_INCREF(StatResultType);
     PyModule_AddObject(m, "stat_result", StatResultType);
-    _posixstate(m)->StatResultType = StatResultType;
+    get_posix_state(m)->StatResultType = StatResultType;
     structseq_new = ((PyTypeObject *)StatResultType)->tp_new;
     ((PyTypeObject *)StatResultType)->tp_new = statresult_new;
 
@@ -14667,7 +14674,7 @@ INITFUNC(void)
     }
     Py_INCREF(StatVFSResultType);
     PyModule_AddObject(m, "statvfs_result", StatVFSResultType);
-    _posixstate(m)->StatVFSResultType = StatVFSResultType;
+    get_posix_state(m)->StatVFSResultType = StatVFSResultType;
 #ifdef NEED_TICKS_PER_SECOND
 #  if defined(HAVE_SYSCONF) && defined(_SC_CLK_TCK)
     ticks_per_second = sysconf(_SC_CLK_TCK);
@@ -14686,7 +14693,7 @@ INITFUNC(void)
     }
     Py_INCREF(SchedParamType);
     PyModule_AddObject(m, "sched_param", SchedParamType);
-    _posixstate(m)->SchedParamType = SchedParamType;
+    get_posix_state(m)->SchedParamType = SchedParamType;
     ((PyTypeObject *)SchedParamType)->tp_new = os_sched_param;
 #endif
 
@@ -14697,14 +14704,14 @@ INITFUNC(void)
     }
     Py_INCREF(TerminalSizeType);
     PyModule_AddObject(m, "terminal_size", TerminalSizeType);
-    _posixstate(m)->TerminalSizeType = TerminalSizeType;
+    get_posix_state(m)->TerminalSizeType = TerminalSizeType;
 
     /* initialize scandir types */
     PyObject *ScandirIteratorType = PyType_FromSpec(&ScandirIteratorType_spec);
     if (ScandirIteratorType == NULL) {
         return NULL;
     }
-    _posixstate(m)->ScandirIteratorType = ScandirIteratorType;
+    get_posix_state(m)->ScandirIteratorType = ScandirIteratorType;
 
     PyObject *DirEntryType = PyType_FromSpec(&DirEntryType_spec);
     if (DirEntryType == NULL) {
@@ -14712,7 +14719,7 @@ INITFUNC(void)
     }
     Py_INCREF(DirEntryType);
     PyModule_AddObject(m, "DirEntry", DirEntryType);
-    _posixstate(m)->DirEntryType = DirEntryType;
+    get_posix_state(m)->DirEntryType = DirEntryType;
 
     times_result_desc.name = MODNAME ".times_result";
     PyObject *TimesResultType = (PyObject *)PyStructSequence_NewType(&times_result_desc);
@@ -14721,7 +14728,7 @@ INITFUNC(void)
     }
     Py_INCREF(TimesResultType);
     PyModule_AddObject(m, "times_result", TimesResultType);
-    _posixstate(m)->TimesResultType = TimesResultType;
+    get_posix_state(m)->TimesResultType = TimesResultType;
 
     PyTypeObject *UnameResultType = PyStructSequence_NewType(&uname_result_desc);
     if (UnameResultType == NULL) {
@@ -14729,7 +14736,7 @@ INITFUNC(void)
     }
     Py_INCREF(UnameResultType);
     PyModule_AddObject(m, "uname_result", (PyObject *)UnameResultType);
-    _posixstate(m)->UnameResultType = (PyObject *)UnameResultType;
+    get_posix_state(m)->UnameResultType = (PyObject *)UnameResultType;
 
 #ifdef __APPLE__
     /*
@@ -14769,15 +14776,15 @@ INITFUNC(void)
 
 #endif /* __APPLE__ */
 
-    if ((_posixstate(m)->billion = PyLong_FromLong(1000000000)) == NULL)
+    if ((get_posix_state(m)->billion = PyLong_FromLong(1000000000)) == NULL)
         return NULL;
 #if defined(HAVE_WAIT3) || defined(HAVE_WAIT4)
-    _posixstate(m)->struct_rusage = PyUnicode_InternFromString("struct_rusage");
-    if (_posixstate(m)->struct_rusage == NULL)
+    get_posix_state(m)->struct_rusage = PyUnicode_InternFromString("struct_rusage");
+    if (get_posix_state(m)->struct_rusage == NULL)
         return NULL;
 #endif
-    _posixstate(m)->st_mode = PyUnicode_InternFromString("st_mode");
-    if (_posixstate(m)->st_mode == NULL)
+    get_posix_state(m)->st_mode = PyUnicode_InternFromString("st_mode");
+    if (get_posix_state(m)->st_mode == NULL)
         return NULL;
 
     /* suppress "function not used" warnings */

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -50,8 +50,16 @@ exception is raised if the entry asked for cannot be found.");
 typedef struct {
     PyTypeObject *StructPwdType;
 } pwdmodulestate;
-#define modulestate(o) ((pwdmodulestate *)PyModule_GetState(o))
-#define modulestate_global modulestate(PyState_FindModule(&pwdmodule))
+
+static inline pwdmodulestate*
+get_pwd_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (pwdmodulestate *)state;
+}
+
+#define modulestate_global get_pwd_state(PyState_FindModule(&pwdmodule))
 
 static struct PyModuleDef pwdmodule;
 
@@ -316,11 +324,11 @@ static PyMethodDef pwd_methods[] = {
 };
 
 static int pwdmodule_traverse(PyObject *m, visitproc visit, void *arg) {
-    Py_VISIT(modulestate(m)->StructPwdType);
+    Py_VISIT(get_pwd_state(m)->StructPwdType);
     return 0;
 }
 static int pwdmodule_clear(PyObject *m) {
-    Py_CLEAR(modulestate(m)->StructPwdType);
+    Py_CLEAR(get_pwd_state(m)->StructPwdType);
     return 0;
 }
 static void pwdmodule_free(void *m) {

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -86,13 +86,18 @@ typedef struct {
   PyObject *endidx;
 } readlinestate;
 
-
-#define readline_state(o) ((readlinestate *)PyModule_GetState(o))
+static inline readlinestate*
+get_readline_state(PyModule *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (readlinestate *)state;
+}
 
 static int
 readline_clear(PyObject *m)
 {
-   readlinestate *state = readline_state(m);
+   readlinestate *state = get_readline_state(m);
    Py_CLEAR(state->completion_display_matches_hook);
    Py_CLEAR(state->startup_hook);
    Py_CLEAR(state->pre_input_hook);
@@ -105,7 +110,7 @@ readline_clear(PyObject *m)
 static int
 readline_traverse(PyObject *m, visitproc visit, void *arg)
 {
-    readlinestate *state = readline_state(m);
+    readlinestate *state = get_readline_state(m);
     Py_VISIT(state->completion_display_matches_hook);
     Py_VISIT(state->startup_hook);
     Py_VISIT(state->pre_input_hook);

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -42,8 +42,16 @@ sys.stdin.fileno(), or a file object, such as sys.stdin itself.");
 typedef struct {
   PyObject *TermiosError;
 } termiosmodulestate;
-#define modulestate(o) ((termiosmodulestate *)PyModule_GetState(o))
-#define modulestate_global modulestate(PyState_FindModule(&termiosmodule))
+
+static inline termiosmodulestate*
+get_termios_state(PyObject *module)
+{
+    void *state = PyModule_GetState(module);
+    assert(state != NULL);
+    return (termiosmodulestate *)state;
+}
+
+#define modulestate_global get_termios_state(PyState_FindModule(&termiosmodule))
 
 static int fdconv(PyObject* obj, void* p)
 {
@@ -976,12 +984,12 @@ static struct constant {
 };
 
 static int termiosmodule_traverse(PyObject *m, visitproc visit, void *arg) {
-    Py_VISIT(modulestate(m)->TermiosError);
+    Py_VISIT(get_termios_state(m)->TermiosError);
     return 0;
 }
 
 static int termiosmodule_clear(PyObject *m) {
-    Py_CLEAR(modulestate(m)->TermiosError);
+    Py_CLEAR(get_termios_state(m)->TermiosError);
     return 0;
 }
 
@@ -1016,7 +1024,7 @@ PyInit_termios(void)
         return NULL;
     }
 
-    termiosmodulestate *state = PyModule_GetState(m);
+    termiosmodulestate *state = get_termios_state(m);
     state->TermiosError = PyErr_NewException("termios.error", NULL, NULL);
     if (state->TermiosError == NULL) {
         return NULL;


### PR DESCRIPTION


<!-- issue-number: [bpo-39968](https://bugs.python.org/issue39968) -->
https://bugs.python.org/issue39968
<!-- /issue-number -->
