### PR TITLE
bpo-37207: Use PEP 590 vectorcall to speed up set()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-15-23-16-00.bpo-37207.6XbnQA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-15-23-16-00.bpo-37207.6XbnQA.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``set()`` by using the :pep:`590` ``vectorcall`` calling
+convention. Patch by Dong-hee Na.

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2018,8 +2018,9 @@ static PyObject*
 set_vectorcall(PyObject *type, PyObject * const*args,
                size_t nargsf, PyObject *kwnames)
 {
-    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
-        PyErr_Format(PyExc_TypeError, "set() takes no keyword arguments");
+    assert(PyType_Check(type));
+
+    if (!_PyArg_NoKwnames("set", kwnames)) {
         return NULL;
     }
 
@@ -2027,8 +2028,6 @@ set_vectorcall(PyObject *type, PyObject * const*args,
     if (!_PyArg_CheckPositional("set", nargs, 0, 1)) {
         return NULL;
     }
-
-    assert(PyType_Check(type));
 
     if (nargs) {
         return make_new_set((PyTypeObject *)type, args[0]);

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2014,6 +2014,29 @@ set_init(PySetObject *self, PyObject *args, PyObject *kwds)
     return set_update_internal(self, iterable);
 }
 
+static PyObject*
+set_vectorcall(PyObject *type, PyObject * const*args,
+               size_t nargsf, PyObject *kwnames)
+{
+    if (kwnames && PyTuple_GET_SIZE(kwnames) != 0) {
+        PyErr_Format(PyExc_TypeError, "set() takes no keyword arguments");
+        return NULL;
+    }
+
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (!_PyArg_CheckPositional("set", nargs, 0, 1)) {
+        return NULL;
+    }
+
+    assert(PyType_Check(type));
+
+    if (nargs) {
+        return make_new_set((PyTypeObject *)type, args[0]);
+    }
+
+    return make_new_set((PyTypeObject *)type, NULL);
+}
+
 static PySequenceMethods set_as_sequence = {
     set_len,                            /* sq_length */
     0,                                  /* sq_concat */
@@ -2162,6 +2185,7 @@ PyTypeObject PySet_Type = {
     PyType_GenericAlloc,                /* tp_alloc */
     set_new,                            /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
+    .tp_vectorcall = set_vectorcall,
 };
 
 /* frozenset object ********************************************************/


### PR DESCRIPTION
## PEP 590
```
./python.exe -m pyperf timeit "set([1, 2, 3, 4, 5])"
.....................
Mean +- std dev: 2.00 us +- 0.04 us

./python.exe -m pyperf timeit "set((1, 2, 3, 4, 5))"
.....................
Mean +- std dev: 1.65 us +- 0.04 us

./python.exe -m pyperf timeit "set()"
.....................
Mean +- std dev: 448 ns +- 15 ns
```

## Master
```
./python.exe -m pyperf timeit "set([1, 2, 3, 4, 5])"
.....................
Mean +- std dev: 2.30 us +- 0.04 us

./python.exe -m pyperf timeit "set((1, 2, 3, 4, 5))"
.....................
Mean +- std dev: 1.84 us +- 0.05 us

./python.exe -m pyperf timeit "set()"
.....................
Mean +- std dev: 528 ns +- 16 ns

```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37207](https://bugs.python.org/issue37207) -->
https://bugs.python.org/issue37207
<!-- /issue-number -->
