### PR TITLE
bpo-39973: Fix the docs for PyObject_GenericSetDict()

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -128,7 +128,7 @@ Object Protocol
    .. versionadded:: 3.3
 
 
-.. c:function:: int PyObject_GenericSetDict(PyObject *o, void *context)
+.. c:function:: int PyObject_GenericSetDict(PyObject *o, PyObject *value, void *context)
 
    A generic implementation for the setter of a ``__dict__`` descriptor. This
    implementation does not allow the dictionary to be deleted.

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -1673,7 +1673,8 @@ PyObject_GenericSetAttr:PyObject*:name:0:
 PyObject_GenericSetAttr:PyObject*:value:+1:
 
 PyObject_GenericSetDict:int:::
-PyObject_GenericSetDict:PyObject*:o:+1:
+PyObject_GenericSetDict:PyObject*:o:0:
+PyObject_GenericSetDict:PyObject*:value:+1:
 PyObject_GenericSetDict:void*:context::
 
 PyObject_GetAttr:PyObject*::+1:


### PR DESCRIPTION
PyObject_GenericSetDict() takes three arguments, not two.


<!-- issue-number: [bpo-39973](https://bugs.python.org/issue39973) -->
https://bugs.python.org/issue39973
<!-- /issue-number -->
