### PR TITLE
[3.8] bpo-35370: PyEval_SetTrace() logs unraisable error (GH-18977)

### DIFF
--- a/Misc/NEWS.d/next/C API/2020-03-13-16-44-23.bpo-35370.sXRA-r.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-13-16-44-23.bpo-35370.sXRA-r.rst
@@ -1,0 +1,2 @@
+If :c:func:`PySys_Audit` fails in :c:func:`PyEval_SetProfile` or
+:c:func:`PyEval_SetTrace`, log the error as an unraisable exception.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4686,6 +4686,7 @@ void
 PyEval_SetProfile(Py_tracefunc func, PyObject *arg)
 {
     if (PySys_Audit("sys.setprofile", NULL) < 0) {
+        _PyErr_WriteUnraisableMsg("in PyEval_SetProfile", NULL);
         return;
     }
 
@@ -4707,6 +4708,7 @@ void
 PyEval_SetTrace(Py_tracefunc func, PyObject *arg)
 {
     if (PySys_Audit("sys.settrace", NULL) < 0) {
+        _PyErr_WriteUnraisableMsg("in PyEval_SetTrace", NULL);
         return;
     }
 


### PR DESCRIPTION
If PySys_Audit() fails in PyEval_SetProfile() or PyEval_SetTrace(),
log the error as an unraisable exception.

(cherry picked from commit f6a58507820c67e8d0fb07875cd1b1d9f5e510a8)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35370](https://bugs.python.org/issue35370) -->
https://bugs.python.org/issue35370
<!-- /issue-number -->
