### PR TITLE
bpo-39656: Ensure `bin/python3.#` is always present in virtual environments

### DIFF
--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -243,7 +243,7 @@ class EnvBuilder:
             copier(context.executable, path)
             if not os.path.islink(path):
                 os.chmod(path, 0o755)
-            for suffix in ('python', 'python3'):
+            for suffix in ('python', 'python3', f'python3.{sys.version_info[1]}'):
                 path = os.path.join(binpath, suffix)
                 if not os.path.exists(path):
                     # Issue 18807: make copies if

--- a/Misc/NEWS.d/next/Library/2020-03-16-11-38-45.bpo-39656.MaNOgm.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-16-11-38-45.bpo-39656.MaNOgm.rst
@@ -1,0 +1,2 @@
+Ensure ``bin/python3.#`` is always present in virtual environments on POSIX
+platforms - by Anthony Sottile.


### PR DESCRIPTION


<!-- issue-number: [bpo-39656](https://bugs.python.org/issue39656) -->
https://bugs.python.org/issue39656
<!-- /issue-number -->
