### PR TITLE
bpo-26067: Do not fail test_shutil / chown when gid/uid cannot be resolved

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1666,12 +1666,18 @@ class TestMisc(BaseTest, unittest.TestCase):
         shutil.chown(dirname, group=gid)
         check_chown(dirname, gid=gid)
 
-        user = pwd.getpwuid(uid)[0]
-        group = grp.getgrgid(gid)[0]
-        shutil.chown(filename, user, group)
-        check_chown(filename, uid, gid)
-        shutil.chown(dirname, user, group)
-        check_chown(dirname, uid, gid)
+        try:
+            user = pwd.getpwuid(uid)[0]
+            group = grp.getgrgid(gid)[0]
+        except KeyError:
+            # In case the uid/gid cannot be resolved.
+            user = None
+            group = None
+        if user is not None and group is not None:
+            shutil.chown(filename, user, group)
+            check_chown(filename, uid, gid)
+            shutil.chown(dirname, user, group)
+            check_chown(dirname, uid, gid)
 
 
 class TestWhich(BaseTest, unittest.TestCase):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1669,15 +1669,13 @@ class TestMisc(BaseTest, unittest.TestCase):
         try:
             user = pwd.getpwuid(uid)[0]
             group = grp.getgrgid(gid)[0]
-        except KeyError:
-            # In case the uid/gid cannot be resolved.
-            user = None
-            group = None
-        if user is not None and group is not None:
             shutil.chown(filename, user, group)
             check_chown(filename, uid, gid)
             shutil.chown(dirname, user, group)
             check_chown(dirname, uid, gid)
+        except KeyError:
+            # On some systems uid/gid cannot be resolved.
+            pass
 
 
 class TestWhich(BaseTest, unittest.TestCase):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1669,13 +1669,14 @@ class TestMisc(BaseTest, unittest.TestCase):
         try:
             user = pwd.getpwuid(uid)[0]
             group = grp.getgrgid(gid)[0]
+         except KeyError:
+            # On some systems uid/gid cannot be resolved.
+            pass
+        else:
             shutil.chown(filename, user, group)
             check_chown(filename, uid, gid)
             shutil.chown(dirname, user, group)
             check_chown(dirname, uid, gid)
-        except KeyError:
-            # On some systems uid/gid cannot be resolved.
-            pass
 
 
 class TestWhich(BaseTest, unittest.TestCase):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1669,7 +1669,7 @@ class TestMisc(BaseTest, unittest.TestCase):
         try:
             user = pwd.getpwuid(uid)[0]
             group = grp.getgrgid(gid)[0]
-         except KeyError:
+        except KeyError:
             # On some systems uid/gid cannot be resolved.
             pass
         else:

--- a/Misc/NEWS.d/next/Tests/2020-03-16-20-54-55.bpo-26067.m18_VV.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-16-20-54-55.bpo-26067.m18_VV.rst
@@ -1,1 +1,1 @@
-- Do not fail test_shutil test_chown test when uid or gid of user cannot be resolved to a name.
+Do not fail test_shutil test_chown test when uid or gid of user cannot be resolved to a name.

--- a/Misc/NEWS.d/next/Tests/2020-03-16-20-54-55.bpo-26067.m18_VV.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-16-20-54-55.bpo-26067.m18_VV.rst
@@ -1,0 +1,1 @@
+- Do not fail test_shutil test_chown test when uid or gid of user cannot be resolved to a name.


### PR DESCRIPTION
There is no guarantee that the users primary uid or gid can be resolved
in the unix group/account databases. Skip the last part of the chown
test if we cannot resolve the gid or uid to a name.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-26067](https://bugs.python.org/issue26067) -->
https://bugs.python.org/issue26067
<!-- /issue-number -->
