### PR TITLE
bpo-36017: Improve test_grp.test_errors for (big) LDAP directories

### DIFF
--- a/Misc/NEWS.d/next/Tests/2020-03-16-21-48-31.bpo-36017.DH1nwW.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-16-21-48-31.bpo-36017.DH1nwW.rst
@@ -1,0 +1,1 @@
+Use a heuristic to find nonexistent gid in test_grp test_errors test that works better for network directory services such as LDAP.


### PR DESCRIPTION
There is no guarantee that the group database returned on a unix system is
complete. It is typically cut short when LDAP directories are configured
for bigger network setups. This makes it tricky to find a nonexistent
group id by looking at the group database.

This changes the test to pick a nonexistent gid within gid 1-99 which
are typically static assigned and not managed by network directory
systems.

Also pick a group name that is extremely likely to not exist instead of
modifying the name of the first group in the database.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-36017](https://bugs.python.org/issue36017) -->
https://bugs.python.org/issue36017
<!-- /issue-number -->
