### PR TITLE
[WIP] bpo-39984: Add PyInterpreterState.ceval

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -15,9 +15,10 @@ struct _frame;
 
 #include "pycore_pystate.h"   /* PyInterpreterState.eval_frame */
 
-PyAPI_FUNC(void) _Py_FinishPendingCalls(PyThreadState *tstate);
-PyAPI_FUNC(void) _PyEval_Initialize(struct _ceval_runtime_state *);
-PyAPI_FUNC(void) _PyEval_FiniThreads(
+extern void _Py_FinishPendingCalls(PyThreadState *tstate);
+extern void _PyEval_InitializeRuntime(struct _ceval_runtime_state *);
+extern void _PyEval_InitializeInterp(struct _ceval_state *);
+extern void _PyEval_FiniThreads(
     struct _ceval_runtime_state *ceval);
 PyAPI_FUNC(void) _PyEval_SignalReceived(
     struct _ceval_runtime_state *ceval);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -34,7 +34,6 @@ struct _pending_calls {
 };
 
 struct _ceval_runtime_state {
-    int recursion_limit;
     /* Records whether tracing is on for any thread.  Counts the number
        of threads for which tstate->c_tracefunc is non-NULL, so if the
        value is 0, we know we don't have to check this thread's
@@ -50,6 +49,10 @@ struct _ceval_runtime_state {
     /* Request for checking signals. */
     _Py_atomic_int signals_pending;
     struct _gil_runtime_state gil;
+};
+
+struct _ceval_state {
+    int recursion_limit;
 };
 
 /* interpreter state */
@@ -75,6 +78,7 @@ struct _is {
 
     int finalizing;
 
+    struct _ceval_state ceval;
     struct _gc_runtime_state gc;
 
     PyObject *modules;

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-17-01-55-33.bpo-39984.y5Chgb.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-17-01-55-33.bpo-39984.y5Chgb.rst
@@ -1,0 +1,3 @@
+subinterpreters: Move ``_PyRuntimeState.ceval.recursion_limit`` to
+``PyInterpreterState.ceval.recursion_limit``: make the limit
+per-interpreter.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -638,26 +638,31 @@ Py_MakePendingCalls(void)
 int _Py_CheckRecursionLimit = Py_DEFAULT_RECURSION_LIMIT;
 
 void
-_PyEval_Initialize(struct _ceval_runtime_state *state)
+_PyEval_InitializeRuntime(struct _ceval_runtime_state *ceval)
 {
-    state->recursion_limit = Py_DEFAULT_RECURSION_LIMIT;
     _Py_CheckRecursionLimit = Py_DEFAULT_RECURSION_LIMIT;
-    _gil_initialize(&state->gil);
+    _gil_initialize(&ceval->gil);
+}
+
+void
+_PyEval_InitializeInterp(struct _ceval_state *ceval)
+{
+    ceval->recursion_limit = Py_DEFAULT_RECURSION_LIMIT;
 }
 
 int
 Py_GetRecursionLimit(void)
 {
-    struct _ceval_runtime_state *ceval = &_PyRuntime.ceval;
-    return ceval->recursion_limit;
+    PyThreadState *tstate = _PyThreadState_GET();
+    return tstate->interp->ceval.recursion_limit;
 }
 
 void
 Py_SetRecursionLimit(int new_limit)
 {
-    struct _ceval_runtime_state *ceval = &_PyRuntime.ceval;
-    ceval->recursion_limit = new_limit;
-    _Py_CheckRecursionLimit = ceval->recursion_limit;
+    PyThreadState *tstate = _PyThreadState_GET();
+    tstate->interp->ceval.recursion_limit = new_limit;
+    _Py_CheckRecursionLimit = new_limit;
 }
 
 /* The function _Py_EnterRecursiveCall() only calls _Py_CheckRecursiveCall()
@@ -668,8 +673,7 @@ Py_SetRecursionLimit(int new_limit)
 int
 _Py_CheckRecursiveCall(PyThreadState *tstate, const char *where)
 {
-    _PyRuntimeState *runtime = tstate->interp->runtime;
-    int recursion_limit = runtime->ceval.recursion_limit;
+    int recursion_limit = tstate->interp->ceval.recursion_limit;
 
 #ifdef USE_STACKCHECK
     tstate->stackcheck_counter = 0;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -58,7 +58,7 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
     runtime->open_code_userdata = open_code_userdata;
     runtime->audit_hook_head = audit_hook_head;
 
-    _PyEval_Initialize(&runtime->ceval);
+    _PyEval_InitializeRuntime(&runtime->ceval);
 
     PyPreConfig_InitPythonConfig(&runtime->preconfig);
 
@@ -213,6 +213,7 @@ PyInterpreterState_New(void)
     _PyRuntimeState *runtime = &_PyRuntime;
     interp->runtime = runtime;
 
+    _PyEval_InitializeInterp(&interp->ceval);
     _PyGC_InitState(&interp->gc);
     PyConfig_InitPythonConfig(&interp->config);
 


### PR DESCRIPTION
subinterpreters: Move _PyRuntimeState.ceval.recursion_limit to
PyInterpreterState.ceval.recursion_limit: make the limit
per-interpreter.

Make _Py_FinishPendingCalls() and _PyEval_FiniThreads() functions
private.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39984](https://bugs.python.org/issue39984) -->
https://bugs.python.org/issue39984
<!-- /issue-number -->
