### PR TITLE
bpo-39986: Make test_listdir from test_os more robust

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2206,8 +2206,11 @@ class Pep383Tests(unittest.TestCase):
         # test listdir without arguments
         current_directory = os.getcwd()
         try:
-            os.chdir(os.sep)
-            self.assertEqual(set(os.listdir()), set(os.listdir(os.sep)))
+            with tempfile.TemporaryDirectory() as tmpdir:
+                os.chdir(tmpdir)
+                open("a.txt", "w").close()
+                open("test_file.foo", "w").close()
+                self.assertEqual(set(os.listdir()), set(os.listdir(tmpdir)))
         finally:
             os.chdir(current_directory)
 

--- a/Misc/NEWS.d/next/Tests/2020-03-16-19-38-15.bpo-39986.xK3wOi.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-16-19-38-15.bpo-39986.xK3wOi.rst
@@ -1,0 +1,2 @@
+Make test_os test_listdir test robust against root directory changing while
+the test runs.


### PR DESCRIPTION
The test_listdir test of test_os assumed that calling listdir on the
root directory twice gives the same results, however this can fail if
unrelated process create files in the root directory in between the two
calls. This changes the test to create a temporary directory with two
files inside and call listdir on this temporary directory instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39986](https://bugs.python.org/issue39986) -->
https://bugs.python.org/issue39986
<!-- /issue-number -->
