### PR TITLE
bpo-39816: More descriptive error msg than "too many values to unpack"

### DIFF
--- a/Lib/test/test_unpack.py
+++ b/Lib/test/test_unpack.py
@@ -62,28 +62,28 @@ Unpacking tuple of wrong size
     >>> a, b = t
     Traceback (most recent call last):
       ...
-    ValueError: too many values to unpack (expected 2)
+    ValueError: too many values to unpack (expected 2) from object of type 'tuple'
 
-Unpacking tuple of wrong size
+Unpacking list of wrong size
 
     >>> a, b = l
     Traceback (most recent call last):
       ...
-    ValueError: too many values to unpack (expected 2)
+    ValueError: too many values to unpack (expected 2) from object of type 'list'
 
 Unpacking sequence too short
 
     >>> a, b, c, d = Seq()
     Traceback (most recent call last):
       ...
-    ValueError: not enough values to unpack (expected 4, got 3)
+    ValueError: not enough values to unpack (expected 4, got 3) from object of type 'Seq'
 
 Unpacking sequence too long
 
     >>> a, b = Seq()
     Traceback (most recent call last):
       ...
-    ValueError: too many values to unpack (expected 2)
+    ValueError: too many values to unpack (expected 2) from object of type 'Seq'
 
 Unpacking a sequence where the test for too long raises a different kind of
 error
@@ -136,7 +136,7 @@ Unpacking to an empty iterable should raise ValueError
     >>> () = [42]
     Traceback (most recent call last):
       ...
-    ValueError: too many values to unpack (expected 0)
+    ValueError: too many values to unpack (expected 0) from object of type 'list'
 
 """
 

--- a/Lib/test/test_unpack_ex.py
+++ b/Lib/test/test_unpack_ex.py
@@ -270,14 +270,14 @@ Unpacking sequence too short
     >>> a, *b, c, d, e = Seq()
     Traceback (most recent call last):
       ...
-    ValueError: not enough values to unpack (expected at least 4, got 3)
+    ValueError: not enough values to unpack (expected at least 4, got 3) from object of type 'Seq'
 
 Unpacking sequence too short and target appears last
 
     >>> a, b, c, d, *e = Seq()
     Traceback (most recent call last):
       ...
-    ValueError: not enough values to unpack (expected at least 4, got 3)
+    ValueError: not enough values to unpack (expected at least 4, got 3) from object of type 'Seq'
 
 Unpacking a sequence where the test for too long raises a different kind of
 error

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4387,14 +4387,17 @@ unpack_iterable(PyThreadState *tstate, PyObject *v,
                 if (argcntafter == -1) {
                     _PyErr_Format(tstate, PyExc_ValueError,
                                   "not enough values to unpack "
-                                  "(expected %d, got %d)",
-                                  argcnt, i);
+                                  "(expected %d, got %d) from object of type "
+                                  "'%.200s'",
+                                  argcnt, i, Py_TYPE(v)->tp_name);
                 }
                 else {
                     _PyErr_Format(tstate, PyExc_ValueError,
                                   "not enough values to unpack "
-                                  "(expected at least %d, got %d)",
-                                  argcnt + argcntafter, i);
+                                  "(expected at least %d, got %d) from "
+                                  "object of type '%.200s'",
+                                  argcnt + argcntafter, i,
+                                  Py_TYPE(v)->tp_name);
                 }
             }
             goto Error;
@@ -4413,8 +4416,9 @@ unpack_iterable(PyThreadState *tstate, PyObject *v,
         }
         Py_DECREF(w);
         _PyErr_Format(tstate, PyExc_ValueError,
-                      "too many values to unpack (expected %d)",
-                      argcnt);
+                      "too many values to unpack (expected %d) from object "
+                      "of type '%.200s'",
+                      argcnt, Py_TYPE(v)->tp_name);
         goto Error;
     }
 
@@ -4427,8 +4431,9 @@ unpack_iterable(PyThreadState *tstate, PyObject *v,
     ll = PyList_GET_SIZE(l);
     if (ll < argcntafter) {
         _PyErr_Format(tstate, PyExc_ValueError,
-            "not enough values to unpack (expected at least %d, got %zd)",
-            argcnt + argcntafter, argcnt + ll);
+            "not enough values to unpack (expected at least %d, got %zd) "
+            "from object of type '%.200s'",
+            argcnt + argcntafter, argcnt + ll, Py_TYPE(v)->tp_name);
         goto Error;
     }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39816](https://bugs.python.org/issue39816) -->
https://bugs.python.org/issue39816
<!-- /issue-number -->
