### PR TITLE
bpo-38237: Fix "versionchanged" for pow named arguments

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1311,7 +1311,7 @@ are always available.  They are listed here in alphabetical order.
       the second argument to be negative, permitting computation of modular
       inverses.
 
-   .. versionchanged:: 3.9
+   .. versionchanged:: 3.8
       Allow keyword arguments.  Formerly, only positional arguments were
       supported.
 


### PR DESCRIPTION
The ability to use named arguments in "pow" was introduced in Python 3.8, not Python 3.9.


<!-- issue-number: [bpo-38237](https://bugs.python.org/issue38237) -->
https://bugs.python.org/issue38237
<!-- /issue-number -->
