### PR TITLE
bpo-39991: uuid._netstat_getnode() ignores IPv6 addresses

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -456,7 +456,10 @@ def _find_mac_under_heading(command, args, heading):
         try:
             words = line.rstrip().split()
             word = words[column_index]
-            if len(word) == 17:
+            # Accept 'HH:HH:HH:HH:HH:HH' MAC address (ex: '52:54:00:9d:0e:67'),
+            # but reject IPv6 address (ex: 'fe80::5054:ff:fe9') detected
+            # by '::' pattern.
+            if len(word) == 17 and b'::' not in word:
                 mac = int(word.replace(_MAC_DELIM, b''), 16)
             elif _MAC_OMITS_LEADING_ZEROES:
                 # (Only) on AIX the macaddr value given is not prefixed by 0, e.g.

--- a/Misc/NEWS.d/next/Library/2020-03-17-12-40-38.bpo-39991.hLPPs4.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-17-12-40-38.bpo-39991.hLPPs4.rst
@@ -1,0 +1,2 @@
+:func:`uuid.getnode` now skips IPv6 addresses with the same string length
+than a MAC address (17 characters): only use MAC addresses.


### PR DESCRIPTION
uuid.getnode() now skips IPv6 addresses with the same string length
than a MAC address (17 characters): only use MAC addresses.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39991](https://bugs.python.org/issue39991) -->
https://bugs.python.org/issue39991
<!-- /issue-number -->
