### PR TITLE
bpo-39984: Add PyInterpreterState.ceval

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -15,9 +15,10 @@ struct _frame;
 
 #include "pycore_pystate.h"   /* PyInterpreterState.eval_frame */
 
-PyAPI_FUNC(void) _Py_FinishPendingCalls(PyThreadState *tstate);
-PyAPI_FUNC(void) _PyEval_Initialize(struct _ceval_runtime_state *);
-PyAPI_FUNC(void) _PyEval_FiniThreads(
+extern void _Py_FinishPendingCalls(PyThreadState *tstate);
+extern void _PyEval_InitRuntimeState(struct _ceval_runtime_state *);
+extern void _PyEval_InitState(struct _ceval_state *);
+extern void _PyEval_FiniThreads(
     struct _ceval_runtime_state *ceval);
 PyAPI_FUNC(void) _PyEval_SignalReceived(
     struct _ceval_runtime_state *ceval);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -35,12 +35,6 @@ struct _pending_calls {
 
 struct _ceval_runtime_state {
     int recursion_limit;
-    /* Records whether tracing is on for any thread.  Counts the number
-       of threads for which tstate->c_tracefunc is non-NULL, so if the
-       value is 0, we know we don't have to check this thread's
-       c_tracefunc.  This speeds up the if statement in
-       PyEval_EvalFrameEx() after fast_next_opcode. */
-    int tracing_possible;
     /* This single variable consolidates all requests to break out of
        the fast path in the eval loop. */
     _Py_atomic_int eval_breaker;
@@ -50,6 +44,15 @@ struct _ceval_runtime_state {
     /* Request for checking signals. */
     _Py_atomic_int signals_pending;
     struct _gil_runtime_state gil;
+};
+
+struct _ceval_state {
+    /* Records whether tracing is on for any thread.  Counts the number
+       of threads for which tstate->c_tracefunc is non-NULL, so if the
+       value is 0, we know we don't have to check this thread's
+       c_tracefunc.  This speeds up the if statement in
+       _PyEval_EvalFrameDefault() after fast_next_opcode. */
+    int tracing_possible;
 };
 
 /* interpreter state */
@@ -75,6 +78,7 @@ struct _is {
 
     int finalizing;
 
+    struct _ceval_state ceval;
     struct _gc_runtime_state gc;
 
     PyObject *modules;

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-17-01-55-33.bpo-39984.y5Chgb.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-17-01-55-33.bpo-39984.y5Chgb.rst
@@ -1,0 +1,3 @@
+subinterpreters: Move ``_PyRuntimeState.ceval.tracing_possible`` to
+``PyInterpreterState.ceval.tracing_possible``: each interpreter now has its own
+variable.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -58,7 +58,7 @@ _PyRuntimeState_Init_impl(_PyRuntimeState *runtime)
     runtime->open_code_userdata = open_code_userdata;
     runtime->audit_hook_head = audit_hook_head;
 
-    _PyEval_Initialize(&runtime->ceval);
+    _PyEval_InitRuntimeState(&runtime->ceval);
 
     PyPreConfig_InitPythonConfig(&runtime->preconfig);
 
@@ -213,6 +213,7 @@ PyInterpreterState_New(void)
     _PyRuntimeState *runtime = &_PyRuntime;
     interp->runtime = runtime;
 
+    _PyEval_InitState(&interp->ceval);
     _PyGC_InitState(&interp->gc);
     PyConfig_InitPythonConfig(&interp->config);
 


### PR DESCRIPTION
subinterpreters: Move _PyRuntimeState.ceval.tracing_possible to
PyInterpreterState.ceval.tracing_possible: each interpreter now has
its own variable.

Changes:

* Add _ceval_state structure.
* Add PyInterpreterState.ceval field.
* _PyEval_EvalFrameDefault(): add ceval2 variable (struct _ceval_state*).
* Rename _PyEval_Initialize() to _PyEval_InitRuntimeState()
* Add _PyEval_InitState()
* Don't export internal _Py_FinishPendingCalls() and
  _PyEval_FiniThreads() functions anymore.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39984](https://bugs.python.org/issue39984) -->
https://bugs.python.org/issue39984
<!-- /issue-number -->
