### PR TITLE
bpo-39998: Remove PyEval_AcquireLock() and PyEval_ReleaseLock()

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1208,39 +1208,6 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    available (even when threads have not been initialized).
 
 
-.. c:function:: void PyEval_AcquireLock()
-
-   Acquire the global interpreter lock.  The lock must have been created earlier.
-   If this thread already has the lock, a deadlock ensues.
-
-   .. deprecated:: 3.2
-      This function does not update the current thread state.  Please use
-      :c:func:`PyEval_RestoreThread` or :c:func:`PyEval_AcquireThread`
-      instead.
-
-   .. note::
-      Calling this function from a thread when the runtime is finalizing
-      will terminate the thread, even if the thread was not created by Python.
-      You can use :c:func:`_Py_IsFinalizing` or :func:`sys.is_finalizing` to
-      check if the interpreter is in process of being finalized before calling
-      this function to avoid unwanted termination.
-
-   .. versionchanged:: 3.8
-      Updated to be consistent with :c:func:`PyEval_RestoreThread`,
-      :c:func:`Py_END_ALLOW_THREADS`, and :c:func:`PyGILState_Ensure`,
-      and terminate the current thread if called while the interpreter is finalizing.
-
-
-.. c:function:: void PyEval_ReleaseLock()
-
-   Release the global interpreter lock.  The lock must have been created earlier.
-
-   .. deprecated:: 3.2
-      This function does not update the current thread state.  Please use
-      :c:func:`PyEval_SaveThread` or :c:func:`PyEval_ReleaseThread`
-      instead.
-
-
 .. _sub-interpreter-support:
 
 Sub-interpreter support

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -761,8 +761,6 @@ PyErr_WarnFormat::...::
 PyErr_WriteUnraisable:void:::
 PyErr_WriteUnraisable:PyObject*:obj:0:
 
-PyEval_AcquireLock:void:::
-
 PyEval_AcquireThread:void:::
 PyEval_AcquireThread:PyThreadState*:tstate::
 
@@ -781,8 +779,6 @@ PyEval_GetFuncName:const char*:::
 PyEval_GetFuncName:PyObject*:func:0:
 
 PyEval_InitThreads:void:::
-
-PyEval_ReleaseLock:void:::
 
 PyEval_ReleaseThread:void:::
 PyEval_ReleaseThread:PyThreadState*:tstate::

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -533,6 +533,14 @@ Build and C API Changes
   scheduled calls.
   (Contributed by Victor Stinner in :issue:`39984`.)
 
+* The misleading ``PyEval_AcquireLock()`` and ``PyEval_ReleaseLock()``
+  functions have been removed. These functions were deprecated since Python 3.2
+  and did not update the current thread state. Instead, use
+  :c:func:`PyEval_SaveThread` with :c:func:`PyEval_RestoreThread`,
+  or :c:func:`PyEval_AcquireThread` with :c:func:`PyEval_ReleaseThread`,
+  which are thread-state aware APIs.
+  (Contributed by Victor Stinner in :issue:`39998`.)
+
 
 Deprecated
 ==========

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -130,8 +130,6 @@ PyAPI_FUNC(void) PyEval_RestoreThread(PyThreadState *);
 
 Py_DEPRECATED(3.9) PyAPI_FUNC(int) PyEval_ThreadsInitialized(void);
 Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
-Py_DEPRECATED(3.2) PyAPI_FUNC(void) PyEval_AcquireLock(void);
-/* Py_DEPRECATED(3.2) */ PyAPI_FUNC(void) PyEval_ReleaseLock(void);
 PyAPI_FUNC(void) PyEval_AcquireThread(PyThreadState *tstate);
 PyAPI_FUNC(void) PyEval_ReleaseThread(PyThreadState *tstate);
 

--- a/Misc/NEWS.d/next/C API/2020-03-18-00-26-54.bpo-39998.fTQmn0.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-18-00-26-54.bpo-39998.fTQmn0.rst
@@ -1,0 +1,6 @@
+The misleading ``PyEval_AcquireLock()`` and ``PyEval_ReleaseLock()``
+functions have been removed. These functions were deprecated since Python 3.2
+and did not update the current thread state. Instead, use
+:c:func:`PyEval_SaveThread` with :c:func:`PyEval_RestoreThread`, or
+:c:func:`PyEval_AcquireThread` with :c:func:`PyEval_ReleaseThread`, which
+are thread-state aware APIs.

--- a/PC/python3.def
+++ b/PC/python3.def
@@ -158,7 +158,6 @@ EXPORTS
   PyErr_WarnExplicit=python39.PyErr_WarnExplicit
   PyErr_WarnFormat=python39.PyErr_WarnFormat
   PyErr_WriteUnraisable=python39.PyErr_WriteUnraisable
-  PyEval_AcquireLock=python39.PyEval_AcquireLock
   PyEval_AcquireThread=python39.PyEval_AcquireThread
   PyEval_CallFunction=python39.PyEval_CallFunction
   PyEval_CallMethod=python39.PyEval_CallMethod
@@ -176,7 +175,6 @@ EXPORTS
   PyEval_GetLocals=python39.PyEval_GetLocals
   PyEval_InitThreads=python39.PyEval_InitThreads
   PyEval_ReInitThreads=python39.PyEval_ReInitThreads
-  PyEval_ReleaseLock=python39.PyEval_ReleaseLock
   PyEval_ReleaseThread=python39.PyEval_ReleaseThread
   PyEval_RestoreThread=python39.PyEval_RestoreThread
   PyEval_SaveThread=python39.PyEval_SaveThread

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -352,26 +352,6 @@ _PyEval_Fini(void)
 #endif
 }
 
-void
-PyEval_AcquireLock(void)
-{
-    _PyRuntimeState *runtime = &_PyRuntime;
-    PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);
-    ensure_tstate_not_null(__func__, tstate);
-
-    take_gil(tstate);
-}
-
-void
-PyEval_ReleaseLock(void)
-{
-    _PyRuntimeState *runtime = &_PyRuntime;
-    PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);
-    /* This function must succeed when the current thread state is NULL.
-       We therefore avoid PyThreadState_Get() which dumps a fatal error
-       in debug mode. */
-    drop_gil(&runtime->ceval, tstate);
-}
 
 void
 _PyEval_ReleaseLock(PyThreadState *tstate)


### PR DESCRIPTION
Remove PyEval_AcquireLock() and PyEval_ReleaseLock() functions which
were deprecated since Python 3.2.

Rename PyEval_ReleaseLock() to _PyEval_ReleaseLock() and move it to
the internal C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39998](https://bugs.python.org/issue39998) -->
https://bugs.python.org/issue39998
<!-- /issue-number -->
