### PR TITLE
bpo-39984: Pass tstate to _PyEval_SignalAsyncExc()

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -18,8 +18,7 @@ struct _frame;
 extern void _Py_FinishPendingCalls(PyThreadState *tstate);
 extern void _PyEval_InitRuntimeState(struct _ceval_runtime_state *);
 extern void _PyEval_InitState(struct _ceval_state *);
-extern void _PyEval_FiniThreads(
-    struct _ceval_runtime_state *ceval);
+extern void _PyEval_FiniThreads(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyEval_SignalReceived(
     struct _ceval_runtime_state *ceval);
 PyAPI_FUNC(int) _PyEval_AddPendingCall(
@@ -27,8 +26,7 @@ PyAPI_FUNC(int) _PyEval_AddPendingCall(
     struct _ceval_runtime_state *ceval,
     int (*func)(void *),
     void *arg);
-PyAPI_FUNC(void) _PyEval_SignalAsyncExc(
-    struct _ceval_runtime_state *ceval);
+PyAPI_FUNC(void) _PyEval_SignalAsyncExc(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyEval_ReInitThreads(
     struct pyruntimestate *runtime);
 PyAPI_FUNC(void) _PyEval_SetCoroutineOriginTrackingDepth(

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -246,8 +246,9 @@ PyEval_InitThreads(void)
 }
 
 void
-_PyEval_FiniThreads(struct _ceval_runtime_state *ceval)
+_PyEval_FiniThreads(PyThreadState *tstate)
 {
+    struct _ceval_runtime_state *ceval = &tstate->interp->runtime->ceval;
     struct _gil_runtime_state *gil = &ceval->gil;
     if (!gil_created(gil)) {
         return;
@@ -356,10 +357,11 @@ void
 _PyEval_ReInitThreads(_PyRuntimeState *runtime)
 {
     struct _ceval_runtime_state *ceval = &runtime->ceval;
-    if (!gil_created(&ceval->gil)) {
+    struct _gil_runtime_state *gil = &runtime->ceval.gil;
+    if (!gil_created(gil)) {
         return;
     }
-    recreate_gil(&ceval->gil);
+    recreate_gil(gil);
     PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);
     ensure_tstate_not_null(__func__, tstate);
 
@@ -379,8 +381,9 @@ _PyEval_ReInitThreads(_PyRuntimeState *runtime)
    raised. */
 
 void
-_PyEval_SignalAsyncExc(struct _ceval_runtime_state *ceval)
+_PyEval_SignalAsyncExc(PyThreadState *tstate)
 {
+    struct _ceval_runtime_state *ceval = &tstate->interp->runtime->ceval;
     SIGNAL_ASYNC_EXC(ceval);
 }
 

--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -286,7 +286,7 @@ _ready:
 
     /* Don't access tstate if the thread must exit */
     if (!must_exit && tstate->async_exc != NULL) {
-        _PyEval_SignalAsyncExc(ceval);
+        _PyEval_SignalAsyncExc(tstate);
     }
 
     MUTEX_UNLOCK(gil->mutex);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -548,7 +548,7 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
        another running thread (see issue #9901).
        Instead we destroy the previously created GIL here, which ensures
        that we can call Py_Initialize / Py_FinalizeEx multiple times. */
-    _PyEval_FiniThreads(&runtime->ceval);
+    _PyEval_FiniThreads(tstate);
 
     /* Auto-thread-state API */
     status = _PyGILState_Init(tstate);


### PR DESCRIPTION
_PyEval_SignalAsyncExc() and _PyEval_FiniThreads() now expect
tstate, instead of ceval.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39984](https://bugs.python.org/issue39984) -->
https://bugs.python.org/issue39984
<!-- /issue-number -->
