### PR TITLE
[2.7] closes bpo-38576: Disallow control characters in hostnames in http.client.

### DIFF
--- a/Lib/httplib.py
+++ b/Lib/httplib.py
@@ -745,6 +745,8 @@ class HTTPConnection:
 
         (self.host, self.port) = self._get_hostport(host, port)
 
+        self._validate_host(self.host)
+
         # This is stored as an instance variable to allow unittests
         # to replace with a suitable mock
         self._create_connection = socket.create_connection
@@ -1027,6 +1029,17 @@ class HTTPConnection:
                 "URL can't contain control characters. {url!r} "
                 "(found at least {matched!r})"
             ).format(matched=match.group(), url=url)
+            raise InvalidURL(msg)
+
+    def _validate_host(self, host):
+        """Validate a host so it doesn't contain control characters."""
+        # Prevent CVE-2019-18348.
+        match = _contains_disallowed_url_pchar_re.search(host)
+        if match:
+            msg = (
+                "URL can't contain control characters. {host!r} "
+                "(found at least {matched!r})"
+            ).format(matched=match.group(), host=host)
             raise InvalidURL(msg)
 
     def putheader(self, header, *values):

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -702,7 +702,7 @@ class BasicTest(TestCase):
         with self.assertRaisesRegexp(socket.error, "Invalid response"):
             conn._tunnel()
 
-    def test_putrequest_override_validation(self):
+    def test_putrequest_override_domain_validation(self):
         """
         It should be possible to override the default validation
         behavior in putrequest (bpo-38216).
@@ -714,6 +714,17 @@ class BasicTest(TestCase):
         conn = UnsafeHTTPConnection('example.com')
         conn.sock = FakeSocket('')
         conn.putrequest('GET', '/\x00')
+
+    def test_putrequest_override_host_validation(self):
+        class UnsafeHTTPConnection(httplib.HTTPConnection):
+            def _validate_host(self, url):
+                pass
+
+        conn = UnsafeHTTPConnection('example.com\r\n')
+        conn.sock = FakeSocket('')
+        # set skip_host so a ValueError is not raised upon adding the
+        # invalid URL as the value of the "Host:" header
+        conn.putrequest('GET', '/', skip_host=1)
 
 
 class OfflineTest(TestCase):

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1373,7 +1373,7 @@ class MiscTests(unittest.TestCase, FakeHTTPMixin):
             self.fakehttp(b"HTTP/1.1 200 OK\r\n\r\nHello.")
             try:
                 escaped_char_repr = repr(char).replace('\\', r'\\')
-                InvalidURL = http.client.InvalidURL
+                InvalidURL = httplib.InvalidURL
                 with self.assertRaisesRegex(
                     InvalidURL, "contain control.*{escaped_char_repr}".format(escaped_char_repr=escaped_char_repr)):
                     urlopen("http:{schemeless_url}".format(schemeless_url=schemeless_url))

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1374,10 +1374,10 @@ class MiscTests(unittest.TestCase, FakeHTTPMixin):
             try:
                 escaped_char_repr = repr(char).replace('\\', r'\\')
                 InvalidURL = httplib.InvalidURL
-                with self.assertRaisesRegex(
+                with self.assertRaisesRegexp(
                     InvalidURL, "contain control.*{escaped_char_repr}".format(escaped_char_repr=escaped_char_repr)):
                     urlopen("http:{schemeless_url}".format(schemeless_url=schemeless_url))
-                with self.assertRaisesRegex(InvalidURL, "contain control.*{escaped_char_repr}".format(escaped_char_repr=escaped_char_repr)):
+                with self.assertRaisesRegexp(InvalidURL, "contain control.*{escaped_char_repr}".format(escaped_char_repr=escaped_char_repr)):
                     urlopen("https:{schemeless_url}".format(schemeless_url=schemeless_url))
             finally:
                 self.unfakehttp()

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1321,7 +1321,7 @@ class MiscTests(unittest.TestCase, FakeHTTPMixin):
         )
 
     @unittest.skipUnless(ssl, "ssl module required")
-    def test_url_with_control_char_rejected(self):
+    def test_url_path_with_control_char_rejected(self):
         for char_no in range(0, 0x21) + range(0x7f, 0x100):
             char = chr(char_no)
             schemeless_url = "//localhost:7777/test%s/" % char
@@ -1345,7 +1345,7 @@ class MiscTests(unittest.TestCase, FakeHTTPMixin):
                 self.unfakehttp()
 
     @unittest.skipUnless(ssl, "ssl module required")
-    def test_url_with_newline_header_injection_rejected(self):
+    def test_url_path_with_newline_header_injection_rejected(self):
         self.fakehttp(b"HTTP/1.1 200 OK\r\n\r\nHello.")
         host = "localhost:7777?a=1 HTTP/1.1\r\nX-injected: header\r\nTEST: 123"
         schemeless_url = "//" + host + ":8080/test/?test=a"
@@ -1365,6 +1365,22 @@ class MiscTests(unittest.TestCase, FakeHTTPMixin):
         finally:
             self.unfakehttp()
 
+    @unittest.skipUnless(ssl, "ssl module required")
+    def test_url_host_with_control_char_rejected(self):
+        for char_no in list(range(0, 0x21)) + [0x7f]:
+            char = chr(char_no)
+            schemeless_url = "//localhost{char}/test/".format(char=char)
+            self.fakehttp(b"HTTP/1.1 200 OK\r\n\r\nHello.")
+            try:
+                escaped_char_repr = repr(char).replace('\\', r'\\')
+                InvalidURL = http.client.InvalidURL
+                with self.assertRaisesRegex(
+                    InvalidURL, "contain control.*{escaped_char_repr}".format(escaped_char_repr=escaped_char_repr)):
+                    urlopen("http:{schemeless_url}".format(schemeless_url=schemeless_url))
+                with self.assertRaisesRegex(InvalidURL, "contain control.*{escaped_char_repr}".format(escaped_char_repr=escaped_char_repr)):
+                    urlopen("https:{schemeless_url}".format(schemeless_url=schemeless_url))
+            finally:
+                self.unfakehttp()
 
 
 class RequestTests(unittest.TestCase):

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1357,11 +1357,12 @@ class MiscTests(unittest.TestCase, FakeHTTPMixin):
             # calls urllib.parse.quote() on the URL which makes all of the
             # above attempts at injection within the url _path_ safe.
             InvalidURL = httplib.InvalidURL
-            with self.assertRaisesRegexp(
-                InvalidURL, r"contain control.*\\r.*(found at least . .)"):
-                urllib2.urlopen("http:" + schemeless_url)
-            with self.assertRaisesRegexp(InvalidURL, r"contain control.*\\n"):
-                urllib2.urlopen("https:" + schemeless_url)
+            with self.assertRaisesRegexp(InvalidURL,
+                    r"contain control.*\\r.*(found at least . .)"):
+                urllib2.urlopen("http:{}".format(schemeless_url))
+            with self.assertRaisesRegexp(InvalidURL,
+                    r"contain control.*\\n"):
+                urllib2.urlopen("https:{}".format(schemeless_url))
         finally:
             self.unfakehttp()
 
@@ -1369,16 +1370,17 @@ class MiscTests(unittest.TestCase, FakeHTTPMixin):
     def test_url_host_with_control_char_rejected(self):
         for char_no in list(range(0, 0x21)) + [0x7f]:
             char = chr(char_no)
-            schemeless_url = "//localhost{char}/test/".format(char=char)
+            schemeless_url = "//localhost{}/test/".format(char)
             self.fakehttp(b"HTTP/1.1 200 OK\r\n\r\nHello.")
             try:
                 escaped_char_repr = repr(char).replace('\\', r'\\')
                 InvalidURL = httplib.InvalidURL
-                with self.assertRaisesRegexp(
-                    InvalidURL, "contain control.*{escaped_char_repr}".format(escaped_char_repr=escaped_char_repr)):
-                    urlopen("http:{schemeless_url}".format(schemeless_url=schemeless_url))
-                with self.assertRaisesRegexp(InvalidURL, "contain control.*{escaped_char_repr}".format(escaped_char_repr=escaped_char_repr)):
-                    urlopen("https:{schemeless_url}".format(schemeless_url=schemeless_url))
+                with self.assertRaisesRegexp(InvalidURL,
+                    "contain control.*{}".format(escaped_char_repr)):
+                        urllib2.urlopen("http:{}".format(schemeless_url))
+                with self.assertRaisesRegexp(InvalidURL,
+                    "contain control.*{}".format(escaped_char_repr)):
+                        urllib2.urlopen("https:{}".format(schemeless_url))
             finally:
                 self.unfakehttp()
 

--- a/Misc/NEWS.d/next/Library/2020-03-18-01-30-50.bpo-38576.cvI68q.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-18-01-30-50.bpo-38576.cvI68q.rst
@@ -1,0 +1,3 @@
+Disallow control characters in hostnames in http.client, addressing
+CVE-2019-18348. Such potentially malicious header injection URLs now cause a
+InvalidURL to be raised.


### PR DESCRIPTION
Add host validation for control characters for more
CVE-2019-18348 protection.
(cherry picked from commit 83fc70159b24)

Co-authored-by: Ashwin Ramaswami <aramaswamis@gmail.com>

<!-- issue-number: [bpo-38576](https://bugs.python.org/issue38576) -->
https://bugs.python.org/issue38576
<!-- /issue-number -->
