### PR TITLE
bpo-37207: Use PEP 590 vectorcall to speed up frozenset()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-17-22-35-29.bpo-37207.sBAV1j.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-17-22-35-29.bpo-37207.sBAV1j.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``frozenset()`` by using the :pep:`590` ``vectorcall``
+calling convention. Patch by Dong-hee Na.

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1066,14 +1066,15 @@ static PyObject *emptyfrozenset = NULL;
 static PyObject *
 make_new_frozenset(PyTypeObject *type, PyObject *iterable)
 {
+    assert(PyType_Check(type));
     if (iterable != NULL) {
-        /* frozenset(f) is idempotent */
         if (PyFrozenSet_CheckExact(iterable)) {
+            /* frozenset(f) is idempotent */
             Py_INCREF(iterable);
             return iterable;
         }
         PyObject *res = make_new_set((PyTypeObject *)type, iterable);
-        if (res == NULL || PySet_GET_SIZE(res)) {
+        if (res == NULL || PySet_GET_SIZE(res) != 0) {
             return res;
         }
         Py_DECREF(res);
@@ -1104,18 +1105,13 @@ frozenset_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return make_new_set(type, iterable);
     }
 
-    if (iterable != NULL) {
-        return make_new_frozenset(type, iterable);
-    }
-    return make_new_frozenset(type, NULL);
+    return make_new_frozenset(type, iterable);
 }
 
 static PyObject *
 frozenset_vectorcall(PyObject *type, PyObject * const*args,
                      size_t nargsf, PyObject *kwnames)
 {
-    assert(PyType_Check(type));
-
     if (!_PyArg_NoKwnames("frozenset", kwnames)) {
         return NULL;
     }
@@ -1125,11 +1121,8 @@ frozenset_vectorcall(PyObject *type, PyObject * const*args,
         return NULL;
     }
 
-    if (nargs) {
-        return make_new_frozenset((PyTypeObject *)type, args[0]);
-    }
-
-    return make_new_frozenset((PyTypeObject *)type, NULL);
+    PyObject *iterable = (nargs ? args[0] : NULL);
+    return make_new_frozenset((PyTypeObject *)type, iterable);
 }
 
 static PyObject *

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1133,41 +1133,6 @@ frozenset_vectorcall(PyObject *type, PyObject * const*args,
 }
 
 static PyObject *
-frozenset_vectorcall(PyObject *type, PyObject * const*args,
-                     size_t nargsf, PyObject *kwnames)
-{
-    assert(PyType_Check(type));
-
-    if (!_PyArg_NoKwnames("frozenset", kwnames)) {
-        return NULL;
-    }
-
-    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
-    if (!_PyArg_CheckPositional("frozenset", nargs, 0, 1)) {
-        return NULL;
-    }
-
-    if (nargs) {
-        if (PyFrozenSet_CheckExact(args[0])) {
-            Py_INCREF(args[0]);
-            return args[0];
-        }
-        PyObject *res = make_new_set((PyTypeObject *)type, args[0]);
-        if (res == NULL || PySet_GET_SIZE(res)) {
-            return res;
-        }
-        Py_DECREF(res);
-    }
-
-    // The empty frozenset is a singleton
-    if (emptyfrozenset == NULL) {
-        emptyfrozenset = make_new_set((PyTypeObject *)type, NULL);
-    }
-    Py_XINCREF(emptyfrozenset);
-    return emptyfrozenset;
-}
-
-static PyObject *
 set_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     return make_new_set(type, NULL);

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1133,6 +1133,41 @@ frozenset_vectorcall(PyObject *type, PyObject * const*args,
 }
 
 static PyObject *
+frozenset_vectorcall(PyObject *type, PyObject * const*args,
+                     size_t nargsf, PyObject *kwnames)
+{
+    assert(PyType_Check(type));
+
+    if (!_PyArg_NoKwnames("frozenset", kwnames)) {
+        return NULL;
+    }
+
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (!_PyArg_CheckPositional("frozenset", nargs, 0, 1)) {
+        return NULL;
+    }
+
+    if (nargs) {
+        if (PyFrozenSet_CheckExact(args[0])) {
+            Py_INCREF(args[0]);
+            return args[0];
+        }
+        PyObject *res = make_new_set((PyTypeObject *)type, args[0]);
+        if (res == NULL || PySet_GET_SIZE(res)) {
+            return res;
+        }
+        Py_DECREF(res);
+    }
+
+    // The empty frozenset is a singleton
+    if (emptyfrozenset == NULL) {
+        emptyfrozenset = make_new_set((PyTypeObject *)type, NULL);
+    }
+    Py_XINCREF(emptyfrozenset);
+    return emptyfrozenset;
+}
+
+static PyObject *
 set_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     return make_new_set(type, NULL);

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1077,6 +1077,7 @@ make_new_frozenset(PyTypeObject *type, PyObject *iterable)
         if (res == NULL || PySet_GET_SIZE(res) != 0) {
             return res;
         }
+        /* If the created frozenset is empty, return the empty frozenset singleton instead */
         Py_DECREF(res);
     }
 

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1024,6 +1024,7 @@ PyDoc_STRVAR(update_doc,
 static PyObject *
 make_new_set(PyTypeObject *type, PyObject *iterable)
 {
+    assert(PyType_Check(type));
     PySetObject *so;
 
     so = (PySetObject *)type->tp_alloc(type, 0);
@@ -1066,7 +1067,10 @@ static PyObject *emptyfrozenset = NULL;
 static PyObject *
 make_new_frozenset(PyTypeObject *type, PyObject *iterable)
 {
-    assert(PyType_Check(type));
+    if (type != &PyFrozenSet_Type) {
+        return make_new_set(type, iterable);
+    }
+
     if (iterable != NULL) {
         if (PyFrozenSet_CheckExact(iterable)) {
             /* frozenset(f) is idempotent */
@@ -1100,10 +1104,6 @@ frozenset_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     if (!PyArg_UnpackTuple(args, type->tp_name, 0, 1, &iterable)) {
         return NULL;
-    }
-
-    if (type != &PyFrozenSet_Type) {
-        return make_new_set(type, iterable);
     }
 
     return make_new_frozenset(type, iterable);


### PR DESCRIPTION
```
Mean +- std dev: [master] 2.26 us +- 0.06 us -> [pr] 2.06 us +- 0.05 us: 1.09x faster (-9%) 
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-37207](https://bugs.python.org/issue37207) -->
https://bugs.python.org/issue37207
<!-- /issue-number -->
