### PR TITLE
bpo-40000: Improve AST validation for invalid constant nodes

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -588,7 +588,7 @@ class AST_Tests(unittest.TestCase):
             ast.fix_missing_locations(e)
             with self.assertRaisesRegex(
                 TypeError, "invalid type in Constant: type"
-            ) as cm:
+            ):
                 compile(e, "<test>", "eval")
 
     def test_empty_yield_from(self):

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -582,6 +582,19 @@ class AST_Tests(unittest.TestCase):
             compile(m, "<test>", "exec")
         self.assertIn("identifier must be of type str", str(cm.exception))
 
+    def test_invalid_constant(self):
+        for invalid_constant in (int, (1, 2, int), frozenset((1, 2, int))):
+            e = ast.Expression(value=ast.Constant(invalid_constant))
+            ast.fix_missing_locations(e)
+            self.assertRaises(
+                TypeError,
+                compile,
+                e,
+                "<test>",
+                "eval",
+                msg="TypeError: got an invalid type in Constant: type",
+            )
+
     def test_empty_yield_from(self):
         # Issue 16546: yield from value is not optional.
         empty_yield_from = ast.parse("def f():\n yield from g()")

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -583,17 +583,13 @@ class AST_Tests(unittest.TestCase):
         self.assertIn("identifier must be of type str", str(cm.exception))
 
     def test_invalid_constant(self):
-        for invalid_constant in (int, (1, 2, int), frozenset((1, 2, int))):
-            e = ast.Expression(value=ast.Constant(invalid_constant))
+        for invalid_constant in int, (1, 2, int), frozenset((1, 2, int)):
+            e = ast.Expression(body=ast.Constant(invalid_constant))
             ast.fix_missing_locations(e)
-            self.assertRaises(
-                TypeError,
-                compile,
-                e,
-                "<test>",
-                "eval",
-                msg="TypeError: got an invalid type in Constant: type",
-            )
+            with self.assertRaisesRegex(
+                TypeError, "invalid type in Constant: type"
+            ) as cm:
+                compile(e, "<test>", "eval")
 
     def test_empty_yield_from(self):
         # Issue 16546: yield from value is not optional.

--- a/Misc/NEWS.d/next/Library/2020-03-18-12-54-25.bpo-40000.FnsPZC.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-18-12-54-25.bpo-40000.FnsPZC.rst
@@ -1,0 +1,2 @@
+Improved error messages for Constant node validation in AST. Patch by
+Batuhan Taskaya.

--- a/Misc/NEWS.d/next/Library/2020-03-18-12-54-25.bpo-40000.FnsPZC.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-18-12-54-25.bpo-40000.FnsPZC.rst
@@ -1,2 +1,2 @@
-Improved error messages for Constant node validation in AST. Patch by
+Improved error messages for validation of ``ast.Constant`` nodes. Patch by
 Batuhan Taskaya.


### PR DESCRIPTION


<!-- issue-number: [bpo-40000](https://bugs.python.org/issue40000) -->
https://bugs.python.org/issue40000
<!-- /issue-number -->
