### PR TITLE
bpo-27807: Skip test_site.test_startup_imports() if pth file

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -10,16 +10,17 @@ from test import support
 from test.support import (captured_stderr, TESTFN, EnvironmentVarGuard,
                           change_cwd)
 import builtins
-import os
-import sys
-import re
 import encodings
-import urllib.request
-import urllib.error
+import glob
+import os
+import re
 import shutil
 import subprocess
+import sys
 import sysconfig
 import tempfile
+import urllib.error
+import urllib.request
 from unittest import mock
 from copy import copy
 
@@ -519,6 +520,23 @@ class ImportSideEffectTests(unittest.TestCase):
 class StartupImportTests(unittest.TestCase):
 
     def test_startup_imports(self):
+        # Get sys.path in isolated mode (python3 -I)
+        popen = subprocess.Popen([sys.executable, '-I', '-c',
+                                  'import sys; print(repr(sys.path))'],
+                                 stdout=subprocess.PIPE,
+                                 encoding='utf-8')
+        stdout = popen.communicate()[0]
+        self.assertEqual(popen.returncode, 0, repr(stdout))
+        isolated_paths = eval(stdout)
+
+        # bpo-27807: Even with -I, the site module executes all .pth files
+        # found in sys.path (see site.addpackage()). Skip the file if at least
+        # one .pth file is found.
+        for path in isolated_paths:
+            pth_files = glob.glob(os.path.join(path, "*.pth"))
+            if pth_files:
+                self.skipTest(f"found {len(pth_files)} .pth files in: {path}")
+
         # This tests checks which modules are loaded by Python when it
         # initially starts upon startup.
         popen = subprocess.Popen([sys.executable, '-I', '-v', '-c',
@@ -527,6 +545,7 @@ class StartupImportTests(unittest.TestCase):
                                  stderr=subprocess.PIPE,
                                  encoding='utf-8')
         stdout, stderr = popen.communicate()
+        self.assertEqual(popen.returncode, 0, (stdout, stderr))
         modules = eval(stdout)
 
         self.assertIn('site', modules)

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -530,7 +530,7 @@ class StartupImportTests(unittest.TestCase):
         isolated_paths = eval(stdout)
 
         # bpo-27807: Even with -I, the site module executes all .pth files
-        # found in sys.path (see site.addpackage()). Skip the file if at least
+        # found in sys.path (see site.addpackage()). Skip the test if at least
         # one .pth file is found.
         for path in isolated_paths:
             pth_files = glob.glob(os.path.join(path, "*.pth"))

--- a/Misc/NEWS.d/next/Tests/2020-03-18-16-04-33.bpo-27807.9gKjET.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-18-16-04-33.bpo-27807.9gKjET.rst
@@ -1,0 +1,2 @@
+``test_site.test_startup_imports()`` is now skipped if a path of
+:data:`sys.path` contains a ``.pth`` file.


### PR DESCRIPTION
test_site.test_startup_imports() is now skipped if a path of sys.path
contains a .pth file.

Sort test_site imports.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-27807](https://bugs.python.org/issue27807) -->
https://bugs.python.org/issue27807
<!-- /issue-number -->
