### PR TITLE
[WIP] bpo-38865: Py_FinalizeEx() cannot be called in a subinterpreter

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -290,6 +290,8 @@ Initializing and finalizing the interpreter
    developer might want to free all memory allocated by Python before exiting from
    the application.
 
+   This function cannot be called in a subinterpreter.
+
    **Bugs and caveats:** The destruction of modules and objects in modules is done
    in random order; this may cause destructors (:meth:`__del__` methods) to fail
    when they depend on other objects (even functions) or modules.  Dynamically
@@ -304,6 +306,9 @@ Initializing and finalizing the interpreter
    .. audit-event:: cpython._PySys_ClearAuditHooks "" c.Py_FinalizeEx
 
    .. versionadded:: 3.6
+
+   .. versionchanged:: 3.9
+      This function cannot be called in a subinterpreter anymore.
 
 .. c:function:: void Py_Finalize()
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -514,6 +514,9 @@ Build and C API Changes
 
   Extension modules without module state (``m_size <= 0``) are not affected.
 
+* :c:func:`Py_FinalizeEx` cannot be called in a subinterpreter anymore.
+  (Contributed by Victor Stinner in :issue:`38865`.)
+
 
 Deprecated
 ==========

--- a/Misc/NEWS.d/next/C API/2020-03-18-22-52-27.bpo-38865.KeRYAu.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-18-22-52-27.bpo-38865.KeRYAu.rst
@@ -1,0 +1,1 @@
+:c:func:`Py_FinalizeEx` cannot be called in a subinterpreter anymore.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1340,6 +1340,10 @@ Py_FinalizeEx(void)
     PyThreadState *tstate = _PyRuntimeState_GetThreadState(runtime);
     PyInterpreterState *interp = tstate->interp;
 
+    if (!_Py_IsMainInterpreter(tstate)) {
+        Py_FatalError("Py_FinalizeEx cannot be called in a subinterpreter");
+    }
+
     // Wrap up existing "threading"-module-created, non-daemon threads.
     wait_for_thread_shutdown(tstate);
 


### PR DESCRIPTION
Py_FinalizeEx() cannot be called in a subinterpreter anymore.

Fix test_embed.test_audit_subinterpreter(): end subinterpreters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38865](https://bugs.python.org/issue38865) -->
https://bugs.python.org/issue38865
<!-- /issue-number -->
