### PR TITLE
bpo-39985: Make string.Formatter with empty field name default to 0

### DIFF
--- a/Lib/string.py
+++ b/Lib/string.py
@@ -222,8 +222,13 @@ class Formatter:
 
     def get_value(self, key, args, kwargs):
         if isinstance(key, int):
+            # "1234[x]"
             return args[key]
+        elif key == "":
+            # "[x]"
+            return args[0]
         else:
+            # "abcd[x]"
             return kwargs[key]
 
 

--- a/Lib/test/test_string.py
+++ b/Lib/test/test_string.py
@@ -96,6 +96,7 @@ class ModuleTest(unittest.TestCase):
         fmt = string.Formatter()
         lookup = ["eggs", "and", "spam"]
         self.assertEqual(fmt.format("{0[2]}{0[0]}", lookup), 'spameggs')
+        self.assertEqual(fmt.format("{[2]}{1[0]}", lookup, (1, 2, 3)), 'spam1')
         with self.assertRaises(IndexError):
             fmt.format("{0[2]}{0[0]}", [])
         with self.assertRaises(KeyError):

--- a/Misc/NEWS.d/next/Library/2020-03-19-00-20-28.bpo-39985.4ki_Ed.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-19-00-20-28.bpo-39985.4ki_Ed.rst
@@ -1,0 +1,1 @@
+Make string.Formatter behave like str.format with anonymous subscripts.


### PR DESCRIPTION
This causes string.Formatter to behave like str.format in cases like
`"[0]".format((1, 2, 3))`, where `[0]` implicitly refers to the first
argument to `str.format`.


<!-- issue-number: [bpo-39985](https://bugs.python.org/issue39985) -->
https://bugs.python.org/issue39985
<!-- /issue-number -->
