### PR TITLE
WIP: bpo-31046: ensurepip should honour the value of $(prefix)

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -59,12 +59,12 @@ def _disable_pip_configuration_settings():
     os.environ['PIP_CONFIG_FILE'] = os.devnull
 
 
-def bootstrap(*, root=None, upgrade=False, user=False,
+def bootstrap(*, root=None, prefix=None, upgrade=False, user=False,
               altinstall=False, default_pip=False,
               verbosity=0):
     """
     Bootstrap pip into the current Python installation (or the given root
-    directory).
+    and prefix directory).
 
     Note that calling this function will alter both sys.path and os.environ.
     """
@@ -122,6 +122,8 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         args = ["install", "--no-index", "--find-links", tmpdir]
         if root:
             args += ["--root", root]
+        if prefix:
+            args += ["--prefix", prefix]
         if upgrade:
             args += ["--upgrade"]
         if user:
@@ -194,6 +196,11 @@ def _main(argv=None):
         help="Install everything relative to this alternate root directory.",
     )
     parser.add_argument(
+        "--prefix",
+        default=None,
+        help="Install everything using this prefix.",
+    )
+    parser.add_argument(
         "--altinstall",
         action="store_true",
         default=False,
@@ -212,6 +219,7 @@ def _main(argv=None):
 
     return _bootstrap(
         root=args.root,
+        prefix=args.prefix,
         upgrade=args.upgrade,
         user=args.user,
         verbosity=args.verbosity,

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1188,7 +1188,7 @@ install: @FRAMEWORKINSTALLFIRST@ commoninstall bininstall maninstall @FRAMEWORKI
 			install|*) ensurepip="" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --root=$(DESTDIR)/ ; \
+			$$ensurepip --root=$(DESTDIR)/ --prefix=$(prefix) ; \
 	fi
 
 altinstall: commoninstall
@@ -1198,7 +1198,7 @@ altinstall: commoninstall
 			install|*) ensurepip="--altinstall" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --root=$(DESTDIR)/ ; \
+			$$ensurepip --root=$(DESTDIR)/ --prefix=$(prefix) ; \
 	fi
 
 commoninstall:  check-clean-src @FRAMEWORKALTINSTALLFIRST@ \


### PR DESCRIPTION
(patch attached by Xavier de Gaye xdegaye@gmail.com to the ticket)

When cross-compiling, the local Python interpreter that is used to run ensurepip may not have the same value of sys.prefix as the value of the 'prefix' variable that is set in the Makefile.

With the following values used to install Python locally for a later copy to the files hierarchy owned by the 'termux' application on an Android device:

```
    DESTDIR=/tmp/android
    prefix=/data/data/com.termux/files/usr/local
```
'make install' causes ensurepip to install pip in $(DESTDIR)/usr/local instead of the expected $(DESTDIR)/$(prefix) where is installed the standard library.

The attached patch fixes the problem. The patch was implemented assuming that pip uses distutils for the installation (note that setup.py also uses the --prefix option in the Makefile), but I know nothing about pip so forgive me if the patch is wrong and please just assume it is just a way to demonstrate the problem.

<!-- issue-number: [bpo-31046](https://bugs.python.org/issue31046) -->
https://bugs.python.org/issue31046
<!-- /issue-number -->
