### PR TITLE
bpo-40020: fix realloc leak on failure in growable_comment_array_add

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-19-21-53-41.bpo-40020.n-26G7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-19-21-53-41.bpo-40020.n-26G7.rst
@@ -1,0 +1,1 @@
+Fix a leak and subsequent crash in parsetok.c caused by realloc misuse on a rare codepath.

--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -37,12 +37,13 @@ growable_comment_array_init(growable_comment_array *arr, size_t initial_size) {
 static int
 growable_comment_array_add(growable_comment_array *arr, int lineno, char *comment) {
     if (arr->num_items >= arr->size) {
-        arr->size *= 2;
-        void *new_items_array = realloc(arr->items, arr->size * sizeof(*arr->items));
+        size_t new_size = arr->size * 2;
+        void *new_items_array = realloc(arr->items, new_size * sizeof(*arr->items));
         if (!new_items_array) {
             return 0;
         }
         arr->items = new_items_array;
+        arr->size = new_size;
     }
 
     arr->items[arr->num_items].lineno = lineno;

--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -38,7 +38,7 @@ static int
 growable_comment_array_add(growable_comment_array *arr, int lineno, char *comment) {
     if (arr->num_items >= arr->size) {
         arr->size *= 2;
-        void *const new_items_array = realloc(arr->items, arr->size * sizeof(*arr->items));
+        void *new_items_array = realloc(arr->items, arr->size * sizeof(*arr->items));
         if (!new_items_array) {
             return 0;
         }

--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -38,10 +38,11 @@ static int
 growable_comment_array_add(growable_comment_array *arr, int lineno, char *comment) {
     if (arr->num_items >= arr->size) {
         arr->size *= 2;
-        arr->items = realloc(arr->items, arr->size * sizeof(*arr->items));
-        if (!arr->items) {
+        void *const new_items_array = realloc(arr->items, arr->size * sizeof(*arr->items));
+        if (!new_items_array) {
             return 0;
         }
+        arr->items = new_items_array;
     }
 
     arr->items[arr->num_items].lineno = lineno;


### PR DESCRIPTION
Fixes [bpo-40020](https://bugs.python.org/issue40020). I have signed the CLA, but I don't know if it's active yet. 

I don't have make installed on this machine, but I'm setting it up right now to get the patchcheck run. Will update.

realloc returns a null pointer on failure, and then growable_comment_array_deallocate crashes later when it dereferences it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40020](https://bugs.python.org/issue40020) -->
https://bugs.python.org/issue40020
<!-- /issue-number -->
