### PR TITLE
bpo-39946: Remove _PyThreadState_GetFrame

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -533,6 +533,10 @@ Build and C API Changes
   scheduled calls.
   (Contributed by Victor Stinner in :issue:`39984`.)
 
+* Remove ``_PyRuntime.getframe`` hook and remove ``_PyThreadState_GetFrame``
+  macro which was an alias to ``_PyRuntime.getframe``. They were only exposed
+  by the internal C API. Remove also ``PyThreadFrameGetter`` type.
+  (Contributed by Victor Stinner in :issue:`39946`.)
 
 Deprecated
 ==========

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -179,8 +179,6 @@ PyAPI_FUNC(PyThreadState *) PyInterpreterState_ThreadHead(PyInterpreterState *);
 PyAPI_FUNC(PyThreadState *) PyThreadState_Next(PyThreadState *);
 PyAPI_FUNC(void) PyThreadState_DeleteCurrent(void);
 
-typedef struct _frame *(*PyThreadFrameGetter)(PyThreadState *self_);
-
 /* Frame evaluation API */
 
 typedef PyObject* (*_PyFrameEvalFunction)(PyThreadState *tstate, struct _frame *, int);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -192,7 +192,6 @@ struct _gilstate_runtime_state {
     /* Assuming the current thread holds the GIL, this is the
        PyThreadState for the current thread. */
     _Py_atomic_address tstate_current;
-    PyThreadFrameGetter getframe;
     /* The single PyInterpreterState used by this process'
        GILState implementation
     */
@@ -200,9 +199,6 @@ struct _gilstate_runtime_state {
     PyInterpreterState *autoInterpreterState;
     Py_tss_t autoTSSkey;
 };
-
-/* hook for PyEval_GetFrame(), requested for Psyco */
-#define _PyThreadState_GetFrame _PyRuntime.gilstate.getframe
 
 /* Issue #26558: Flag to disable PyGILState_Check().
    If set to non-zero, PyGILState_Check() always return 1. */

--- a/Misc/NEWS.d/next/C API/2020-03-20-17-05-52.bpo-39946.3NS-Ls.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-20-17-05-52.bpo-39946.3NS-Ls.rst
@@ -1,0 +1,3 @@
+Remove ``_PyRuntime.getframe`` hook and remove ``_PyThreadState_GetFrame``
+macro which was an alias to ``_PyRuntime.getframe``. They were only exposed
+by the internal C API. Remove also ``PyThreadFrameGetter`` type.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4825,25 +4825,18 @@ _PyEval_GetAsyncGenFinalizer(void)
     return tstate->async_gen_finalizer;
 }
 
-static PyFrameObject *
-_PyEval_GetFrame(PyThreadState *tstate)
-{
-    _PyRuntimeState *runtime = tstate->interp->runtime;
-    return runtime->gilstate.getframe(tstate);
-}
-
 PyFrameObject *
 PyEval_GetFrame(void)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    return _PyEval_GetFrame(tstate);
+    return tstate->frame;
 }
 
 PyObject *
 PyEval_GetBuiltins(void)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    PyFrameObject *current_frame = _PyEval_GetFrame(tstate);
+    PyFrameObject *current_frame = tstate->frame;
     if (current_frame == NULL)
         return tstate->interp->builtins;
     else
@@ -4869,7 +4862,7 @@ PyObject *
 PyEval_GetLocals(void)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    PyFrameObject *current_frame = _PyEval_GetFrame(tstate);
+    PyFrameObject *current_frame = tstate->frame;
     if (current_frame == NULL) {
         _PyErr_SetString(tstate, PyExc_SystemError, "frame does not exist");
         return NULL;
@@ -4887,7 +4880,7 @@ PyObject *
 PyEval_GetGlobals(void)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    PyFrameObject *current_frame = _PyEval_GetFrame(tstate);
+    PyFrameObject *current_frame = tstate->frame;
     if (current_frame == NULL) {
         return NULL;
     }
@@ -4900,7 +4893,7 @@ int
 PyEval_MergeCompilerFlags(PyCompilerFlags *cf)
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    PyFrameObject *current_frame = _PyEval_GetFrame(tstate);
+    PyFrameObject *current_frame = tstate->frame;
     int result = cf->cf_flags != 0;
 
     if (current_frame != NULL) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -546,13 +546,6 @@ PyInterpreterState_GetDict(PyInterpreterState *interp)
     return interp->dict;
 }
 
-/* Default implementation for _PyThreadState_GetFrame */
-static struct _frame *
-threadstate_getframe(PyThreadState *self)
-{
-    return self->frame;
-}
-
 static PyThreadState *
 new_threadstate(PyInterpreterState *interp, int init)
 {
@@ -560,10 +553,6 @@ new_threadstate(PyInterpreterState *interp, int init)
     PyThreadState *tstate = (PyThreadState *)PyMem_RawMalloc(sizeof(PyThreadState));
     if (tstate == NULL) {
         return NULL;
-    }
-
-    if (_PyThreadState_GetFrame == NULL) {
-        _PyThreadState_GetFrame = threadstate_getframe;
     }
 
     tstate->interp = interp;
@@ -1000,9 +989,6 @@ PyInterpreterState *
 PyThreadState_GetInterpreter(PyThreadState *tstate)
 {
     assert(tstate != NULL);
-    if (tstate == NULL) {
-        return NULL;
-    }
     return tstate->interp;
 }
 
@@ -1011,7 +997,7 @@ struct _frame*
 PyThreadState_GetFrame(PyThreadState *tstate)
 {
     assert(tstate != NULL);
-    return _PyThreadState_GetFrame(tstate);
+    return tstate->frame;
 }
 
 

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -801,7 +801,7 @@ dump_traceback(int fd, PyThreadState *tstate, int write_header)
         PUTS(fd, "Stack (most recent call first):\n");
     }
 
-    frame = _PyThreadState_GetFrame(tstate);
+    frame = tstate->frame;
     if (frame == NULL) {
         PUTS(fd, "<no Python frame>\n");
         return;


### PR DESCRIPTION
Remove _PyRuntime.getframe hook and remove _PyThreadState_GetFrame
macro which was an alias to _PyRuntime.getframe. They were only
exposed by the internal C API. Remove also PyThreadFrameGetter type.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39946](https://bugs.python.org/issue39946) -->
https://bugs.python.org/issue39946
<!-- /issue-number -->
