### PR TITLE
bpo-40017: add CLOCK_TAI constant to the time module, if the constant is defined

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -776,10 +776,10 @@ These constants are used as parameters for :func:`clock_getres` and
 
 .. data:: CLOCK_TAI
 
-   `International Atomic Time. <https://www.nist.gov/pml/time-and-frequency-division/nist-time-frequently-asked-questions-faq#tai>`_
+   `International Atomic Time <https://www.nist.gov/pml/time-and-frequency-division/nist-time-frequently-asked-questions-faq#tai>`_
 
-   The system must have a current leap second table in order for this to give the correct answer.
-   You can configure ptp or ntp to maintain a leap second table.
+   The system must have a current leap second table in order for this to give
+   the correct answer.  PTP or NTP software can maintain a leap second table.
 
    .. availability:: Linux.
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -774,6 +774,16 @@ These constants are used as parameters for :func:`clock_getres` and
 
    .. versionadded:: 3.7
 
+.. data:: CLOCK_TAI
+
+   International atomic time, as seconds from the unix epoch.
+
+   Warning: your system must have a current leap second table in order for this to give the correct answer.
+   You can configure ptp or ntp to maintain a leap second table.
+
+   .. availability:: Linux.
+
+   .. versionadded:: 3.9
 
 .. data:: CLOCK_THREAD_CPUTIME_ID
 
@@ -804,7 +814,6 @@ These constants are used as parameters for :func:`clock_getres` and
    .. availability:: macOS 10.12 and newer.
 
    .. versionadded:: 3.8
-
 
 The following constant is the only parameter that can be sent to
 :func:`clock_settime`.

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -776,9 +776,9 @@ These constants are used as parameters for :func:`clock_getres` and
 
 .. data:: CLOCK_TAI
 
-   International atomic time, as seconds from the unix epoch.
+   `International Atomic Time. <https://www.nist.gov/pml/time-and-frequency-division/nist-time-frequently-asked-questions-faq#tai>`_
 
-   Warning: your system must have a current leap second table in order for this to give the correct answer.
+   The system must have a current leap second table in order for this to give the correct answer.
    You can configure ptp or ntp to maintain a leap second table.
 
    .. availability:: Linux.

--- a/Misc/NEWS.d/next/Library/2020-03-21-00-46-18.bpo-40017.HFpHZS.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-00-46-18.bpo-40017.HFpHZS.rst
@@ -1,0 +1,1 @@
+Added the CLOCK_TAI constant to the time library, if the operating system support is.

--- a/Misc/NEWS.d/next/Library/2020-03-21-00-46-18.bpo-40017.HFpHZS.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-00-46-18.bpo-40017.HFpHZS.rst
@@ -1,1 +1,1 @@
-Add :data:`time.CLOCK_TAI` constant, if the operating system support it: International Atomic Time.
+Add :data:`time.CLOCK_TAI` constant if the operating system support it.

--- a/Misc/NEWS.d/next/Library/2020-03-21-00-46-18.bpo-40017.HFpHZS.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-00-46-18.bpo-40017.HFpHZS.rst
@@ -1,1 +1,1 @@
-Added the CLOCK_TAI constant to the time library, if the operating system support is.
+Expose the CLOCK_TAI constant to the time library if the operating system support it.

--- a/Misc/NEWS.d/next/Library/2020-03-21-00-46-18.bpo-40017.HFpHZS.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-00-46-18.bpo-40017.HFpHZS.rst
@@ -1,1 +1,1 @@
-Expose the CLOCK_TAI constant to the time library if the operating system support it.
+Add :data:`time.CLOCK_TAI` constant, if the operating system support it: International Atomic Time.

--- a/Misc/NEWS.d/next/Library/2020-03-21-00-46-19.bpo-40017.HFpHZS.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-00-46-19.bpo-40017.HFpHZS.rst
@@ -1,0 +1,1 @@
+Added the CLOCK_TAI constant to the time library, if the operating system support is.

--- a/Misc/NEWS.d/next/Library/2020-03-21-00-46-19.bpo-40017.HFpHZS.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-00-46-19.bpo-40017.HFpHZS.rst
@@ -1,1 +1,0 @@
-Added the CLOCK_TAI constant to the time library, if the operating system support is.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1787,8 +1787,8 @@ time_exec(PyObject *module)
     }
 #endif
 #ifdef CLOCK_TAI
-    if (PyModule_AddIntMacro(m, CLOCK_TAI) < 0) {
-        goto error;
+    if (PyModule_AddIntMacro(module, CLOCK_TAI) < 0) {
+        return -1;
     }
 #endif
 #ifdef CLOCK_UPTIME

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1786,6 +1786,11 @@ time_exec(PyObject *module)
         return -1;
     }
 #endif
+#ifdef CLOCK_TAI
+    if (PyModule_AddIntMacro(m, CLOCK_TAI) < 0) {
+        goto error;
+    }
+#endif
 #ifdef CLOCK_UPTIME
     if (PyModule_AddIntMacro(module, CLOCK_UPTIME) < 0) {
         return -1;


### PR DESCRIPTION
Added the CLOCK_TAI constant to the time module, if present (and checked that it worked on ubuntu).

Added a description to the time module documentation.

I will gladly add a unit test if somebody can point me to the existing tests for these constants (a global search for CLOCK_BOOTTIME didn't turn up anything.

Would it make any sense to add this to the next Python 8.x as well?

<!-- issue-number: [bpo-40017](https://bugs.python.org/issue40017) -->
https://bugs.python.org/issue40017
<!-- /issue-number -->
