### PR TITLE
bpo-40025: Require _generate_next_value_ to be defined before members

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -274,7 +274,7 @@ overridden::
     the way it does this is an implementation detail and may change.
 
 .. note::
-    
+
     The :meth:`_generate_next_value_` method must be defined before any members.
 
 Iteration

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -273,6 +273,10 @@ overridden::
     the next :class:`int` in sequence with the last :class:`int` provided, but
     the way it does this is an implementation detail and may change.
 
+.. note::
+    
+    The :meth:`_generate_next_value_` method must be defined before any members.
+
 Iteration
 ---------
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -77,6 +77,9 @@ class _EnumDict(dict):
                     ):
                 raise ValueError('_names_ are reserved for future Enum use')
             if key == '_generate_next_value_':
+                # check if members already defined
+                if len(self._member_names) > len(dir(super)):
+                    raise TypeError("_generate_next_value_ must be defined before members")
                 setattr(self, '_generate_next_value', value)
             elif key == '_ignore_':
                 if isinstance(value, str):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -78,7 +78,7 @@ class _EnumDict(dict):
                 raise ValueError('_names_ are reserved for future Enum use')
             if key == '_generate_next_value_':
                 # check if members already defined
-                if len(self._member_names) > len(dir(super)):
+                if self._member_names:
                     raise TypeError("_generate_next_value_ must be defined before members")
                 setattr(self, '_generate_next_value', value)
             elif key == '_ignore_':

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -60,6 +60,7 @@ class _EnumDict(dict):
         self._member_names = []
         self._last_values = []
         self._ignore = []
+        self.auto_called = False
 
     def __setitem__(self, key, value):
         """Changes anything not dundered or not a descriptor.
@@ -77,8 +78,8 @@ class _EnumDict(dict):
                     ):
                 raise ValueError('_names_ are reserved for future Enum use')
             if key == '_generate_next_value_':
-                # check if members already defined
-                if self._member_names:
+                # check if members already defined as auto()
+                if self.auto_called:
                     raise TypeError("_generate_next_value_ must be defined before members")
                 setattr(self, '_generate_next_value', value)
             elif key == '_ignore_':
@@ -103,6 +104,9 @@ class _EnumDict(dict):
                 # enum overwriting a descriptor?
                 raise TypeError('%r already defined as: %r' % (key, self[key]))
             if isinstance(value, auto):
+                # on first call to auto set auto_called to True
+                if not self.auto_called:
+                    self.auto_called = True
                 if value.value == _auto_null:
                     value.value = self._generate_next_value(key, 1, len(self._member_names), self._last_values[:])
                 value = value.value

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -60,7 +60,7 @@ class _EnumDict(dict):
         self._member_names = []
         self._last_values = []
         self._ignore = []
-        self.auto_called = False
+        self._auto_called = False
 
     def __setitem__(self, key, value):
         """Changes anything not dundered or not a descriptor.
@@ -79,7 +79,7 @@ class _EnumDict(dict):
                 raise ValueError('_names_ are reserved for future Enum use')
             if key == '_generate_next_value_':
                 # check if members already defined as auto()
-                if self.auto_called:
+                if self._auto_called:
                     raise TypeError("_generate_next_value_ must be defined before members")
                 setattr(self, '_generate_next_value', value)
             elif key == '_ignore_':
@@ -104,9 +104,7 @@ class _EnumDict(dict):
                 # enum overwriting a descriptor?
                 raise TypeError('%r already defined as: %r' % (key, self[key]))
             if isinstance(value, auto):
-                # on first call to auto set auto_called to True
-                if not self.auto_called:
-                    self.auto_called = True
+                self._auto_called = True
                 if value.value == _auto_null:
                     value.value = self._generate_next_value(key, 1, len(self._member_names), self._last_values[:])
                 value = value.value

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1751,6 +1751,16 @@ class TestEnum(unittest.TestCase):
         self.assertEqual(Color.blue.value, 2)
         self.assertEqual(Color.green.value, 3)
 
+    def test_auto_order(self):
+        with self.assertRaises(TypeError):
+            class Color(Enum):
+                red = auto()
+                green = auto()
+                blue = auto()
+                def _generate_next_value_(name, start, count, last):
+                    return name
+
+
     def test_duplicate_auto(self):
         class Dupes(Enum):
             first = primero = auto()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1236,6 +1236,7 @@ Adam Olsen
 Bryan Olson
 Grant Olson
 Koray Oner
+Ethan Onstott
 Piet van Oostrum
 Tomas Oppelstrup
 Jason Orendorff

--- a/Misc/NEWS.d/next/Library/2020-03-21-05-26-38.bpo-40025.DTLtyq.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-05-26-38.bpo-40025.DTLtyq.rst
@@ -1,1 +1,1 @@
-Throw error when _generate_next_value_ is defined after members. Patch by Ethan Onstott.
+Raise TypeError when _generate_next_value_ is defined after members. Patch by Ethan Onstott.

--- a/Misc/NEWS.d/next/Library/2020-03-21-05-26-38.bpo-40025.DTLtyq.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-05-26-38.bpo-40025.DTLtyq.rst
@@ -1,0 +1,1 @@
+Throw error when _generate_next_value_ is defined after members. Patch by Ethan Onstott.


### PR DESCRIPTION
<!-- issue-number: [bpo-40025](https://bugs.python.org/issue40025) -->
https://bugs.python.org/issue40025
<!-- /issue-number -->
