### PR TITLE
bpo-39966: Fix wrapped objects exception mockunittest

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2036,7 +2036,7 @@ _side_effect_methods = {
 def _set_return_value(mock, method, name):
     # If _mock_wraps is present then attach it so that wrapped object
     # is used for return value is used when called.
-    if mock._mock_wraps is not None:
+    if mock._mock_wraps is not None and hasattr(mock._mock_wraps, name):
         method._mock_wraps = getattr(mock._mock_wraps, name)
         return
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -772,8 +772,7 @@ class MockTest(unittest.TestCase):
 
         # use __bool__ attribute if it is present in the wrapped object
         klass1 = MagicMock(wraps=Foo)
-        obj1 = klass1()
-        self.assertEqual(bool(obj1), False)
+        self.assertFalse(klass1())
 
         # use the default value if the attribute is not present
         klass2 = MagicMock(wraps=Bar)

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -777,8 +777,7 @@ class MockTest(unittest.TestCase):
 
         # use the default value if the attribute is not present
         klass2 = MagicMock(wraps=Bar)
-        obj2 = klass2()
-        self.assertEqual(bool(obj2), True)
+        self.assertTrue(klass2())
 
 
     def test_exceptional_side_effect(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -775,7 +775,7 @@ class MockTest(unittest.TestCase):
         obj1 = klass1()
         self.assertEqual(bool(obj1), False)
 
-        # use the default value if the attribute is not present 
+        # use the default value if the attribute is not present
         klass2 = MagicMock(wraps=Bar)
         obj2 = klass2()
         self.assertEqual(bool(obj2), True)

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -762,6 +762,25 @@ class MockTest(unittest.TestCase):
         self.assertEqual(obj.__custom_method__(), "foo")
 
 
+    def test_magic_method_wraps_with_and_without_default_value(self):
+        class Foo:
+            def __bool__(self):
+                return False
+
+        class Bar:
+            pass
+
+        # use __bool__ attribute if it is present in the wrapped object
+        klass1 = MagicMock(wraps=Foo)
+        obj1 = klass1()
+        self.assertEqual(bool(obj1), False)
+
+        # use the default value if the attribute is not present 
+        klass2 = MagicMock(wraps=Bar)
+        obj2 = klass2()
+        self.assertEqual(bool(obj2), True)
+
+
     def test_exceptional_side_effect(self):
         mock = Mock(side_effect=AttributeError)
         self.assertRaises(AttributeError, mock)

--- a/Misc/NEWS.d/next/Library/2020-03-21-17-16-51.bpo-39966.3cRQmc.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-17-16-51.bpo-39966.3cRQmc.rst
@@ -1,2 +1,2 @@
-Return default value when the magic method is not present in the wrapped
-object.
+:mod:`unittest.mock` objects return a suitable default value when a magic
+method is not defined on the mocked object.

--- a/Misc/NEWS.d/next/Library/2020-03-21-17-16-51.bpo-39966.3cRQmc.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-21-17-16-51.bpo-39966.3cRQmc.rst
@@ -1,0 +1,2 @@
+Return default value when the magic method is not present in the wrapped
+object.


### PR DESCRIPTION
the wrapped value of magic methods will be used **when present** or falls back to the default value.
@brandtbucher
<!-- issue-number: [bpo-39966](https://bugs.python.org/issue39966) -->
https://bugs.python.org/issue39966
<!-- /issue-number -->
