### PR TITLE
bpo-36144: Add union operators to WeakKeyDictionary

### DIFF
--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -171,6 +171,9 @@ Extension types can easily be made to support weak references; see
       performed by the program during iteration may cause items in the
       dictionary to vanish "by magic" (as a side effect of garbage collection).
 
+   .. versionchanged:: 3.9
+      Added support for ``|`` and ``|=`` operators, specified in :pep:`584`.
+
 :class:`WeakKeyDictionary` objects have an additional method that
 exposes the internal references directly.  The references are not guaranteed to
 be "live" at the time they are used, so the result of calling the references

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1625,10 +1625,10 @@ class MappingTestCase(TestBase):
         self.assertEqual(list(d.keys()), [o2])
 
     def test_weak_keyed_union_operators(self):
-        o1 = Object('1')
-        wkd1 = weakref.WeakKeyDictionary({o1: '1', C(): '2'})
-        wkd2 = weakref.WeakKeyDictionary({C(): '3', o1: '4'})
-        d1 = {C(): '5', o1: '6'}
+        o = Object('1')
+        wkd1 = weakref.WeakKeyDictionary({o: '1', C(): '2'})
+        wkd2 = weakref.WeakKeyDictionary({C(): '3', o: '4'})
+        d1 = {C(): '5', o: '6'}
 
         tmp = wkd1 | wkd2 # Between two WeakKeyDictionaries
         self.assertEqual(dict(tmp), dict(wkd1) | dict(wkd2))

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1629,7 +1629,7 @@ class MappingTestCase(TestBase):
         c1 = C()
         c2 = C()
         c3 = C()
-        
+
         wvd1 = weakref.WeakKeyDictionary({c1: '1', c2: '2'})
         wvd2 = weakref.WeakKeyDictionary({c3: '3', c1: '4'})
 

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1625,22 +1625,41 @@ class MappingTestCase(TestBase):
         self.assertEqual(list(d.keys()), [o2])
 
     def test_weak_keyed_union_operators(self):
-        o = Object('1')
-        wkd1 = weakref.WeakKeyDictionary({o: '1', C(): '2'})
-        wkd2 = weakref.WeakKeyDictionary({C(): '3', o: '4'})
-        d1 = {C(): '5', o: '6'}
+        o1 = C()
+        o2 = C()
+        o3 = C()
+        wkd1 = weakref.WeakKeyDictionary({o1: 1, o2: 2})
+        wkd2 = weakref.WeakKeyDictionary({o3: 3, o1: 4})
+        wkd3 = wkd1.copy()
+        d1 = {o2: '5', o3: '6'}
+        pairs = [(o2, 7), (o3, 8)]
 
-        tmp = wkd1 | wkd2 # Between two WeakKeyDictionaries
-        self.assertEqual(dict(tmp), dict(wkd1) | dict(wkd2))
-        self.assertIsInstance(tmp, weakref.WeakKeyDictionary)
+        tmp1 = wkd1 | wkd2 # Between two WeakKeyDictionaries
+        self.assertEqual(dict(tmp1), dict(wkd1) | dict(wkd2))
+        self.assertIs(type(tmp1), weakref.WeakKeyDictionary)
         wkd1 |= wkd2
-        self.assertEqual(wkd1, tmp)
+        self.assertEqual(wkd1, tmp1)
 
-        tmp = wkd2 | d1 # Between WeakKeyDictionary and mapping
-        self.assertEqual(dict(tmp), dict(wkd2) | d1)
-        self.assertIsInstance(tmp, weakref.WeakKeyDictionary)
+        tmp2 = wkd2 | d1 # Between WeakKeyDictionary and mapping
+        self.assertEqual(dict(tmp2), dict(wkd2) | d1)
+        self.assertIs(type(tmp2), weakref.WeakKeyDictionary)
         wkd2 |= d1
-        self.assertEqual(wkd2, tmp)
+        self.assertEqual(wkd2, tmp2)
+
+        tmp3 = wkd3.copy() # Between WeakKeyDictionary and iterable key, value
+        tmp3 |= pairs
+        self.assertEqual(dict(tmp3), dict(wkd3) | dict(pairs))
+        self.assertIs(type(tmp3), weakref.WeakKeyDictionary)
+
+        tmp4 = d1 | wkd3 # Testing .__ror__
+        self.assertEqual(dict(tmp4), d1 | dict(wkd3))
+        self.assertIs(type(tmp4), weakref.WeakKeyDictionary)
+
+        del o1
+        self.assertNotIn(4, tmp1.values())
+        self.assertNotIn(4, tmp2.values())
+        self.assertNotIn(1, tmp3.values())
+        self.assertNotIn(1, tmp4.values())
 
     def test_weak_valued_delitem(self):
         d = weakref.WeakValueDictionary()

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1630,14 +1630,14 @@ class MappingTestCase(TestBase):
         c2 = C()
         c3 = C()
 
-        wvd1 = weakref.WeakKeyDictionary({c1: '1', c2: '2'})
-        wvd2 = weakref.WeakKeyDictionary({c3: '3', c1: '4'})
+        wkd1 = weakref.WeakKeyDictionary({c1: '1', c2: '2'})
+        wkd2 = weakref.WeakKeyDictionary({c3: '3', c1: '4'})
 
-        wvd3 = wvd1 | wvd2
-        self.assertEqual(dict(wvd3), dict(wvd1) | dict(wvd2))
+        wkd3 = wkd1 | wkd2
+        self.assertEqual(dict(wkd3), dict(wkd1) | dict(wkd2))
 
-        wvd1 |= wvd2
-        self.assertEqual(wvd1, wvd3)
+        wkd1 |= wkd2
+        self.assertEqual(wkd1, wkd3)
 
     def test_weak_valued_delitem(self):
         d = weakref.WeakValueDictionary()

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1624,6 +1624,21 @@ class MappingTestCase(TestBase):
         self.assertEqual(len(d), 1)
         self.assertEqual(list(d.keys()), [o2])
 
+    def test_weak_keyed_union_operators(self):
+        class C: pass
+        c1 = C()
+        c2 = C()
+        c3 = C()
+        
+        wvd1 = weakref.WeakKeyDictionary({c1: '1', c2: '2'})
+        wvd2 = weakref.WeakKeyDictionary({c3: '3', c1: '4'})
+
+        wvd3 = wvd1 | wvd2
+        self.assertEqual(dict(wvd3), dict(wvd1) | dict(wvd2))
+
+        wvd1 |= wvd2
+        self.assertEqual(wvd1, wvd3)
+
     def test_weak_valued_delitem(self):
         d = weakref.WeakValueDictionary()
         o1 = Object('1')

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1625,19 +1625,22 @@ class MappingTestCase(TestBase):
         self.assertEqual(list(d.keys()), [o2])
 
     def test_weak_keyed_union_operators(self):
-        class C: pass
-        c1 = C()
-        c2 = C()
-        c3 = C()
+        o1 = Object('1')
+        wkd1 = weakref.WeakKeyDictionary({o1: '1', C(): '2'})
+        wkd2 = weakref.WeakKeyDictionary({C(): '3', o1: '4'})
+        d1 = {C(): '5', o1: '6'}
 
-        wkd1 = weakref.WeakKeyDictionary({c1: '1', c2: '2'})
-        wkd2 = weakref.WeakKeyDictionary({c3: '3', c1: '4'})
-
-        wkd3 = wkd1 | wkd2
-        self.assertEqual(dict(wkd3), dict(wkd1) | dict(wkd2))
-
+        tmp = wkd1 | wkd2 # Between two WeakKeyDictionaries
+        self.assertEqual(dict(tmp), dict(wkd1) | dict(wkd2))
+        self.assertIsInstance(tmp, weakref.WeakKeyDictionary)
         wkd1 |= wkd2
-        self.assertEqual(wkd1, wkd3)
+        self.assertEqual(wkd1, tmp)
+
+        tmp = wkd2 | d1 # Between WeakKeyDictionary and mapping
+        self.assertEqual(dict(tmp), dict(wkd2) | d1)
+        self.assertIsInstance(tmp, weakref.WeakKeyDictionary)
+        wkd2 |= d1
+        self.assertEqual(wkd2, tmp)
 
     def test_weak_valued_delitem(self):
         d = weakref.WeakValueDictionary()

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -489,10 +489,8 @@ class WeakKeyDictionary(_collections_abc.MutableMapping):
             self.update(kwargs)
 
     def __ior__(self, other):
-        if isinstance(other, (dict, WeakKeyDictionary, WeakValueDictionary)):
-            self.update(other)
-            return self
-        return NotImplemented
+        self.update(other)
+        return self
 
     def __or__(self, other):
         if isinstance(other, (dict, WeakKeyDictionary, WeakValueDictionary)):

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -489,18 +489,24 @@ class WeakKeyDictionary(_collections_abc.MutableMapping):
             self.update(kwargs)
 
     def __ior__(self, other):
-        self.update(other)
-        return self
+        if isinstance(other, (dict, WeakKeyDictionary, WeakValueDictionary)):
+            self.update(other)
+            return self
+        return NotImplemented
 
     def __or__(self, other):
-        c = self.copy()
-        c.update(other)
-        return c
+        if isinstance(other, (dict, WeakKeyDictionary, WeakValueDictionary)):
+            c = self.copy()
+            c.update(other)
+            return c
+        return NotImplemented
 
     def __ror__(self, other):
-        c = other.copy()
-        c.update(self)
-        return c
+        if isinstance(other, (dict, WeakKeyDictionary, WeakValueDictionary)):
+            c = other.copy()
+            c.update(self)
+            return c
+        return NotImplemented
 
 
 class finalize:

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -488,6 +488,20 @@ class WeakKeyDictionary(_collections_abc.MutableMapping):
         if len(kwargs):
             self.update(kwargs)
 
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
+    def __or__(self, other):
+        c = self.copy()
+        c.update(other)
+        return c
+
+    def __ror__(self, other):
+        c = other.copy()
+        c.update(self)
+        return c
+    
 
 class finalize:
     """Class for finalization of weakrefable objects

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -501,7 +501,7 @@ class WeakKeyDictionary(_collections_abc.MutableMapping):
         c = other.copy()
         c.update(self)
         return c
-    
+
 
 class finalize:
     """Class for finalization of weakrefable objects

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -501,7 +501,8 @@ class WeakKeyDictionary(_collections_abc.MutableMapping):
 
     def __ror__(self, other):
         if isinstance(other, (dict, WeakKeyDictionary, WeakValueDictionary)):
-            c = other.copy()
+            c = self.__class__()
+            c.update(other)
             c.update(self)
             return c
         return NotImplemented

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -493,14 +493,14 @@ class WeakKeyDictionary(_collections_abc.MutableMapping):
         return self
 
     def __or__(self, other):
-        if isinstance(other, (dict, WeakKeyDictionary, WeakValueDictionary)):
+        if isinstance(other, _collections_abc.Mapping):
             c = self.copy()
             c.update(other)
             return c
         return NotImplemented
 
     def __ror__(self, other):
-        if isinstance(other, (dict, WeakKeyDictionary, WeakValueDictionary)):
+        if isinstance(other, _collections_abc.Mapping):
             c = self.__class__()
             c.update(other)
             c.update(self)

--- a/Misc/NEWS.d/next/Library/2020-03-18-14-02-58.bpo-36144.ooyn6Z.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-18-14-02-58.bpo-36144.ooyn6Z.rst
@@ -1,0 +1,1 @@
+Added :pep:`584` operators to :class:`weakref.WeakKeyDictionary`.


### PR DESCRIPTION
The `__ror__` implementation was a little tricky, because we can't assume that a subclass will have the same constructor signature as the parent class, since we don't do that anywhere else.
@brandtbucher 

<!-- issue-number: [bpo-36144](https://bugs.python.org/issue36144) -->
https://bugs.python.org/issue36144
<!-- /issue-number -->
