### PR TITLE
bpo-36543: Remove the xml.etree.cElementTree module.

### DIFF
--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -8,9 +8,6 @@ import unittest
 
 cET = import_fresh_module('xml.etree.ElementTree',
                           fresh=['_elementtree'])
-cET_alias = import_fresh_module('xml.etree.cElementTree',
-                                fresh=['_elementtree', 'xml.etree'],
-                                deprecated=True)
 
 
 @unittest.skipUnless(cET, 'requires _elementtree')
@@ -156,23 +153,12 @@ class MiscTests(unittest.TestCase):
 
 
 @unittest.skipUnless(cET, 'requires _elementtree')
-class TestAliasWorking(unittest.TestCase):
-    # Test that the cET alias module is alive
-    def test_alias_working(self):
-        e = cET_alias.Element('foo')
-        self.assertEqual(e.tag, 'foo')
-
-
-@unittest.skipUnless(cET, 'requires _elementtree')
 @support.cpython_only
 class TestAcceleratorImported(unittest.TestCase):
     # Test that the C accelerator was imported, as expected
     def test_correct_import_cET(self):
         # SubElement is a function so it retains _elementtree as its module.
         self.assertEqual(cET.SubElement.__module__, '_elementtree')
-
-    def test_correct_import_cET_alias(self):
-        self.assertEqual(cET_alias.SubElement.__module__, '_elementtree')
 
     def test_parser_comes_from_C(self):
         # The type of methods defined in Python code is types.FunctionType,
@@ -213,7 +199,6 @@ def test_main():
     # Run the tests specific to the C implementation
     support.run_unittest(
         MiscTests,
-        TestAliasWorking,
         TestAcceleratorImported,
         SizeofTest,
         )

--- a/Lib/xml/etree/cElementTree.py
+++ b/Lib/xml/etree/cElementTree.py
@@ -1,3 +1,0 @@
-# Deprecated alias for xml.etree.ElementTree
-
-from xml.etree.ElementTree import *


### PR DESCRIPTION


<!-- issue-number: [bpo-36543](https://bugs.python.org/issue36543) -->
https://bugs.python.org/issue36543
<!-- /issue-number -->
