### PR TITLE
[3.7] bpo-22490: Remove __PYVENV_LAUNCHER__ from environment during launch (GH-9516)

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -651,7 +651,6 @@ class ProcessTestCase(BaseTestCase):
             # on adding even when the environment in exec is empty.
             # Gentoo sandboxes also force LD_PRELOAD and SANDBOX_* to exist.
             return ('VERSIONER' in n or '__CF' in n or  # MacOS
-                    '__PYVENV_LAUNCHER__' in n or # MacOS framework build
                     n == 'LD_PRELOAD' or n.startswith('SANDBOX') or # Gentoo
                     n == 'LC_CTYPE') # Locale coercion triggered
 

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -345,6 +345,18 @@ class BasicTest(BaseTest):
         self.assertEqual(err, "".encode())
 
 
+    @unittest.skipUnless(sys.platform == 'darwin', 'only relevant on macOS')
+    def test_macos_env(self):
+        rmtree(self.env_dir)
+        builder = venv.EnvBuilder()
+        builder.create(self.env_dir)
+
+        envpy = os.path.join(os.path.realpath(self.env_dir),
+                             self.bindir, self.exe)
+        out, err = check_output([envpy, '-c',
+            'import os; print("__PYVENV_LAUNCHER__" in os.environ)'])
+        self.assertEqual(out.strip(), 'False'.encode())
+
 @requireVenvCreate
 class EnsurePipTest(BaseTest):
     """Test venv module installation of pip."""

--- a/Mac/Tools/pythonw.c
+++ b/Mac/Tools/pythonw.c
@@ -196,6 +196,15 @@ main(int argc, char **argv) {
             }
         }
 
+        /*
+         * The environment variable is used to pass the value of real_path
+         * to the actual python interpreter, and is read by code in
+         * Python/coreconfig.c.
+         *
+         * This way the real interpreter knows how the user invoked the
+         * interpreter and can behave as if this launcher is the real
+         * interpreter (looking for pyvenv configuration, ...)
+         */
         setenv("__PYVENV_LAUNCHER__", real_path, 1);
     }
 

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-23-16-32-58.bpo-22490.8e0YDf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-23-16-32-58.bpo-22490.8e0YDf.rst
@@ -1,0 +1,2 @@
+Don't leak environment variable ``__PYVENV_LAUNCHER__`` into the interpreter
+session on macOS.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1208,6 +1208,17 @@ config_init_program_name(_PyCoreConfig *config)
                                          "variable", (Py_ssize_t)len);
             }
             config->program_name = program_name;
+
+            /*
+             * This environment variable is used to communicate between
+             * the stub launcher and the real interpreter and isn't needed
+             * beyond this point.
+             *
+             * Clean up to avoid problems when launching other programs
+             * later on.
+             */
+            (void)unsetenv("__PYVENV_LAUNCHER__");
+
             return _Py_INIT_OK();
         }
     }


### PR DESCRIPTION
* [bpo-22490](https://bugs.python.org/issue22490): Remove "__PYVENV_LAUNCHER__" from the shell environment on macOS

This changeset removes the environment varialbe "__PYVENV_LAUNCHER__"
during interpreter launch as it is only needed to communicate between
the stub executable in framework installs and the actual interpreter.

Leaving the environment variable present may lead to misbehaviour when
launching other scripts.

* Actually commit the changes for issue 22490...

* Correct typo

Co-Authored-By: Nicola Soranzo <nicola.soranzo@gmail.com>

* Run make patchcheck

Co-authored-by: Jason R. Coombs <jaraco@jaraco.com>
Co-authored-by: Nicola Soranzo <nicola.soranzo@gmail.com>.
(cherry picked from commit 044cf94f610e831464a69a8e713dad89878824ce)

Co-authored-by: Ronald Oussoren <ronaldoussoren@mac.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-22490](https://bugs.python.org/issue22490) -->
https://bugs.python.org/issue22490
<!-- /issue-number -->
