### PR TITLE
bpo-40014: test.pythoninfo catchs os.getgrouplist() error

### DIFF
--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -333,8 +333,13 @@ def collect_pwd(info_add):
         return
 
     if hasattr(os, 'getgrouplist'):
-        groups = os.getgrouplist(entry.pw_name, entry.pw_gid)
-        groups = ', '.join(map(str, groups))
+        try:
+            groups = os.getgrouplist(entry.pw_name, entry.pw_gid)
+        except OSError as exc:
+            # bpo-40014: os.getgrouplist() can fail on macOS 10.15 (Catalina)
+            groups = f'<ERROR: {exc!r}>'
+        else:
+            groups = ', '.join(map(str, groups))
         info_add('os.getgrouplist', groups)
 
 

--- a/Misc/NEWS.d/next/Tests/2020-03-23-17-11-43.bpo-40014.MZdRMI.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-23-17-11-43.bpo-40014.MZdRMI.rst
@@ -1,0 +1,2 @@
+``test.pythoninfo`` now catchs and handles :exc:`OSError` when calling
+:func:`os.getgrouplist`.


### PR DESCRIPTION
test.pythoninfo now catchs and handles OSError when calling
os.getgrouplist().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40014](https://bugs.python.org/issue40014) -->
https://bugs.python.org/issue40014
<!-- /issue-number -->
