### PR TITLE
bpo-40014: Fix os.getgrouplist() failure on macOS with many groups

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-03-23-17-52-00.bpo-40014.Ya70VG.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-23-17-52-00.bpo-40014.Ya70VG.rst
@@ -1,0 +1,3 @@
+Fix ``os.getgrouplist()``: on macOS, the ``getgrouplist()`` function returns a
+non-zero value without setting ``errno`` if the group list is too small. Double
+the list size and call it again in this case.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6999,10 +6999,29 @@ posix_getgrouplist(PyObject *self, PyObject *args)
     if (groups == NULL)
         return PyErr_NoMemory();
 
+#ifdef __APPLE__
+    while (getgrouplist(user, basegid, groups, &ngroups)) {
+        /* On macOS, getgrouplist() returns a non-zero value without setting
+           errno if the group list is too small. Double the list size and call
+           it again in this case. */
+        PyMem_Free(groups);
+
+        if (ngroups > INT_MAX / 2) {
+            return PyErr_NoMemory();
+        }
+        ngroups *= 2;
+
+        groups = PyMem_New(int, ngroups);
+        if (groups == NULL) {
+            return PyErr_NoMemory();
+        }
+    }
+#else
     if (getgrouplist(user, basegid, groups, &ngroups) == -1) {
         PyMem_Del(groups);
         return posix_error();
     }
+#endif
 
 #ifdef _Py_MEMORY_SANITIZER
     /* Clang memory sanitizer libc intercepts don't know getgrouplist. */


### PR DESCRIPTION
On Darwin 19.3 (macOS 10.15 Catalina), getgrouplist() returns a
non-zero value without setting errno if the group list is too small.
Double the list size and call it again in this case.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40014](https://bugs.python.org/issue40014) -->
https://bugs.python.org/issue40014
<!-- /issue-number -->
