### PR TITLE
bpo-39148: enable ipv6 for datagrams in Proactor

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1207,7 +1207,7 @@ class EventLoopTestsMixin:
             ConnectionRefusedError, client.connect, ('127.0.0.1', port))
         client.close()
 
-    def test_create_datagram_endpoint(self):
+    def _test_create_datagram_endpoint(self, local_addr, family):
         class TestMyDatagramProto(MyDatagramProto):
             def __init__(inner_self):
                 super().__init__(loop=self.loop)
@@ -1217,9 +1217,11 @@ class EventLoopTestsMixin:
                 self.transport.sendto(b'resp:'+data, addr)
 
         coro = self.loop.create_datagram_endpoint(
-            TestMyDatagramProto, local_addr=('127.0.0.1', 0))
+            TestMyDatagramProto, local_addr=local_addr, family=family)
         s_transport, server = self.loop.run_until_complete(coro)
-        host, port = s_transport.get_extra_info('sockname')
+        sockname = s_transport.get_extra_info('sockname')
+        host, port = socket.getnameinfo(
+            sockname, socket.NI_NUMERICHOST|socket.NI_NUMERICSERV)
 
         self.assertIsInstance(s_transport, asyncio.Transport)
         self.assertIsInstance(server, TestMyDatagramProto)
@@ -1252,6 +1254,13 @@ class EventLoopTestsMixin:
         self.loop.run_until_complete(client.done)
         self.assertEqual('CLOSED', client.state)
         server.transport.close()
+
+    def test_create_datagram_endpoint(self):
+        self._test_create_datagram_endpoint(('127.0.0.1', 0), socket.AF_INET)
+
+    @unittest.skipUnless(support.IPV6_ENABLED, 'IPv6 not supported or enabled')
+    def test_create_datagram_endpoint_ipv6(self):
+        self._test_create_datagram_endpoint(('::1', 0), socket.AF_INET6)
 
     def test_create_datagram_endpoint_sock(self):
         sock = None

--- a/Misc/NEWS.d/next/Windows/2020-03-23-19-07-55.bpo-39148.W1YJEb.rst
+++ b/Misc/NEWS.d/next/Windows/2020-03-23-19-07-55.bpo-39148.W1YJEb.rst
@@ -1,0 +1,3 @@
+Add IPv6 support to :mod:`asyncio` datagram endpoints in ProactorEventLoop.
+Change the raised exception for unknown address families to ValueError
+as it's not coming from Windows API.

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -670,7 +670,6 @@ make_ipv4_addr(const struct sockaddr_in *addr)
         return PyUnicode_FromString(buf);
 }
 
-#ifdef ENABLE_IPV6
 /* Convert IPv6 sockaddr to a Python str. */
 
 static PyObject *
@@ -683,7 +682,6 @@ make_ipv6_addr(const struct sockaddr_in6 *addr)
         }
         return PyUnicode_FromString(buf);
 }
-#endif
 
 static PyObject*
 unparse_address(LPSOCKADDR Address, DWORD Length)
@@ -701,7 +699,6 @@ unparse_address(LPSOCKADDR Address, DWORD Length)
             }
             return ret;
         }
-#ifdef ENABLE_IPV6
         case AF_INET6: {
             const struct sockaddr_in6 *a = (const struct sockaddr_in6 *)Address;
             PyObject *addrobj = make_ipv6_addr(a);
@@ -716,9 +713,9 @@ unparse_address(LPSOCKADDR Address, DWORD Length)
             }
             return ret;
         }
-#endif /* ENABLE_IPV6 */
         default: {
-            return SetFromWindowsErr(ERROR_INVALID_PARAMETER);
+            PyErr_SetString(PyExc_ValueError, "recvfrom returned unsupported address family");
+            return NULL;
         }
     }
 }


### PR DESCRIPTION
Ifdef is not necessary, as AF_INET6 is supported from Windows Vista, and other code in overlapped.c uses AF_INET6 and is not ifdef'd.
Change the raised exception so users are not fooled to think it comes from Windows API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39148](https://bugs.python.org/issue39148) -->
https://bugs.python.org/issue39148
<!-- /issue-number -->


Automerge-Triggered-By: @njsmith