### PR TITLE
bpo-40034: Fix cgi.parse() does not work with multipart POST requests.

### DIFF
--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -154,6 +154,8 @@ def parse(fp=None, environ=os.environ, keep_blank_values=0, strict_parsing=0):
     if environ['REQUEST_METHOD'] == 'POST':
         ctype, pdict = parse_header(environ['CONTENT_TYPE'])
         if ctype == 'multipart/form-data':
+            pdict['boundary'] = pdict['boundary'].encode(encoding)
+            pdict['CONTENT-LENGTH'] = environ['CONTENT_LENGTH']
             return parse_multipart(fp, pdict)
         elif ctype == 'application/x-www-form-urlencoded':
             clength = int(environ['CONTENT_LENGTH'])

--- a/Lib/test/test_cgi.py
+++ b/Lib/test/test_cgi.py
@@ -161,6 +161,19 @@ Content-Length: 3
         fs = cgi.FieldStorage(headers={'content-type':'text/plain'})
         self.assertRaises(TypeError, bool, fs)
 
+    def test_cgi_parse_multipart_post(self):
+        fp = BytesIO(   b'--------------------------c70158ae56918981\r\n'
+                        b'Content-Disposition: form-data; name="example_key"'
+                        b'\r\n\r\nexample_value\r\n'
+                        b'--------------------------c70158ae56918981--\r\n')
+        env = { "REQUEST_METHOD": "POST",
+                "CONTENT_LENGTH": "159",
+                "CONTENT_TYPE": "multipart/form-data; boundary=-----------"
+                                "-------------c70158ae56918981"}
+        result = cgi.parse(fp, env)
+        expected = {'example_key': ['example_value']}
+        self.assertEqual(result, expected)
+
     def test_strict(self):
         for orig, expect in parse_strict_test_cases:
             # Test basic parsing

--- a/Misc/NEWS.d/next/Library/2020-03-23-18-07-00.bpo-40034.nUTh33.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-23-18-07-00.bpo-40034.nUTh33.rst
@@ -1,0 +1,5 @@
+Fix :func:`cgi.parse` for multipart POST requests.
+
+For applications that check CONTENT_TYPE and REQUEST_METHOD and then directly
+call :func:`urlparse.parse_qs` or :func:`cgi.parse_multipart` this should
+allow them to just call :func:`cgi.parse` and have it do the right thing.


### PR DESCRIPTION
cgi.parse calls parse_multipart() but does not set up pdict in the way
parse_multipart() expects.  Specifically 'boundary' needs to be bytes
(not str) and 'CONTENT-LENGTH' needs to be set.

<!-- issue-number: [bpo-40034](https://bugs.python.org/issue40034) -->
https://bugs.python.org/issue40034
<!-- /issue-number -->
