### PR TITLE
bpo-38972: Link to instructions to change PowerShell execution policy…

### DIFF
--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -88,7 +88,7 @@ The command, if run with ``-h``, will show the available options::
    script by setting the execution policy for the user. You can do this by
    issuing the following Powershell command from a Powershell command window:
 
-   PS C:\Users\user> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+   PS C:\> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
    See `About Execution Policies 
    <https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7>`_

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -90,7 +90,7 @@ The command, if run with ``-h``, will show the available options::
 
    PS C:\> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
-   See `About Execution Policies 
+   See `About Execution Policies
    <https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7>`_
    for more information.
 

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -83,6 +83,17 @@ The command, if run with ``-h``, will show the available options::
    particular note is that double-clicking ``python.exe`` in File Explorer
    will resolve the symlink eagerly and ignore the virtual environment.
 
+.. note::
+   On Microsoft Windows, it may be required to enable the ``Activate.ps1``
+   script by setting the execution policy for the user. You can do this by
+   issuing the following Powershell command from a Powershell command window:
+
+   PS C:\Users\user> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+   See `About Execution Policies 
+   <https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7>`_
+   for more information.
+
 The created ``pyvenv.cfg`` file also includes the
 ``include-system-site-packages`` key, set to ``true`` if ``venv`` is
 run with the ``--system-site-packages`` option, ``false`` otherwise.

--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -86,12 +86,12 @@ The command, if run with ``-h``, will show the available options::
 .. note::
    On Microsoft Windows, it may be required to enable the ``Activate.ps1``
    script by setting the execution policy for the user. You can do this by
-   issuing the following Powershell command from a Powershell command window:
+   issuing the following PowerShell command:
 
    PS C:\> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
    See `About Execution Policies
-   <https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7>`_
+   <ttps:/go.microsoft.com/fwlink/?LinkID=135170>`_
    for more information.
 
 The created ``pyvenv.cfg`` file also includes the

--- a/Lib/venv/scripts/common/Activate.ps1
+++ b/Lib/venv/scripts/common/Activate.ps1
@@ -42,7 +42,7 @@ On Windows, it may be required to enable this Activate.ps1 script by setting the
 execution policy for the user. You can do this by issuing the following Powershell
 command from a Powershell command window:
 
-PS C:\Users\user> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+PS C:\> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
 Please see About Execution Policies: 
 https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7

--- a/Lib/venv/scripts/common/Activate.ps1
+++ b/Lib/venv/scripts/common/Activate.ps1
@@ -1,6 +1,6 @@
 <#
 .Synopsis
-Activate a Python virtual environment for the current Powershell session.
+Activate a Python virtual environment for the current PowerShell session.
 
 .Description
 Pushes the python executable for a virtual environment to the front of the
@@ -39,14 +39,13 @@ parentheses) while the virtual environment is active.
 
 .Notes
 On Windows, it may be required to enable this Activate.ps1 script by setting the
-execution policy for the user. You can do this by issuing the following Powershell
-command from a Powershell command window:
+execution policy for the user. You can do this by issuing the following PowerShell
+command:
 
 PS C:\> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
-Please see About Execution Policies: 
-https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7
-for more information.
+For more information on Execution Policies: 
+ttps:/go.microsoft.com/fwlink/?LinkID=135170
 
 #>
 Param(

--- a/Lib/venv/scripts/common/Activate.ps1
+++ b/Lib/venv/scripts/common/Activate.ps1
@@ -37,6 +37,16 @@ Activates the Python virtual environment that contains the Activate.ps1 script,
 and prefixes the current prompt with the specified string (surrounded in
 parentheses) while the virtual environment is active.
 
+.Notes
+On Windows, it may be required to enable this Activate.ps1 script by setting the
+execution policy for the user. You can do this by issuing the following Powershell
+command from a Powershell command window:
+
+PS C:\Users\user> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+Please see About Execution Policies: 
+https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7
+for more information.
 
 #>
 Param(
@@ -137,7 +147,7 @@ function Get-PyVenvConfig(
                 $val = $keyval[1]
 
                 # Remove extraneous quotations around a string value.
-                if ("'""".Contains($val.Substring(0,1))) {
+                if ("'""".Contains($val.Substring(0, 1))) {
                     $val = $val.Substring(1, $val.Length - 2)
                 }
 
@@ -165,7 +175,8 @@ Write-Verbose "VenvExecDir Name: '$($VenvExecDir.Name)"
 # VenvExecDir if specified on the command line.
 if ($VenvDir) {
     Write-Verbose "VenvDir given as parameter, using '$VenvDir' to determine values"
-} else {
+}
+else {
     Write-Verbose "VenvDir not given as a parameter, using parent directory name as VenvDir."
     $VenvDir = $VenvExecDir.Parent.FullName.TrimEnd("\\/")
     Write-Verbose "VenvDir=$VenvDir"
@@ -179,7 +190,8 @@ $pyvenvCfg = Get-PyVenvConfig -ConfigDir $VenvDir
 # just use the name of the virtual environment folder.
 if ($Prompt) {
     Write-Verbose "Prompt specified as argument, using '$Prompt'"
-} else {
+}
+else {
     Write-Verbose "Prompt not specified as argument to script, checking pyvenv.cfg value"
     if ($pyvenvCfg -and $pyvenvCfg['prompt']) {
         Write-Verbose "  Setting based on value in pyvenv.cfg='$($pyvenvCfg['prompt'])'"


### PR DESCRIPTION
… for venv activation

Add proposed documentation for `venv` + Windows + Powershell.

This change:
- Adds details on `Set-ExecutionPolicy` to venv site documenation.
- Also adds the same detail to the Activate.ps1 script itself as a `.Note`. You can see this if you use `Get-Help Activation.ps1 -Full`.



<!-- issue-number: [bpo-38972](https://bugs.python.org/issue38972) -->
https://bugs.python.org/issue38972
<!-- /issue-number -->
