### PR TITLE
bpo-40052: Fix alignment issue in PyVectorcall_Function()

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -67,7 +67,10 @@ PyVectorcall_Function(PyObject *callable)
 {
     PyTypeObject *tp;
     Py_ssize_t offset;
-    vectorcallfunc *ptr;
+    union {
+        char *data;
+        vectorcallfunc *ptr;
+    } vc;
 
     assert(callable != NULL);
     tp = Py_TYPE(callable);
@@ -77,8 +80,8 @@ PyVectorcall_Function(PyObject *callable)
     assert(PyCallable_Check(callable));
     offset = tp->tp_vectorcall_offset;
     assert(offset > 0);
-    ptr = (vectorcallfunc *)(((char *)callable) + offset);
-    return *ptr;
+    vc.data = (char *)callable + offset;
+    return *vc.ptr;
 }
 
 /* Call the callable object 'callable' with the "vectorcall" calling

--- a/Misc/NEWS.d/next/C API/2020-03-24-09-27-10.bpo-40052.27P2KG.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-24-09-27-10.bpo-40052.27P2KG.rst
@@ -1,0 +1,1 @@
+Fix an alignment build warning/error in function ``PyVectorcall_Function()`` publicly exposed by ``abstract.h``.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -205,6 +205,10 @@ PyObject *
 PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *kwargs)
 {
     PyThreadState *tstate = _PyThreadState_GET();
+    union {
+        char *data;
+        vectorcallfunc *ptr;
+    } vc;
 
     /* get vectorcallfunc as in PyVectorcall_Function, but without
      * the Py_TPFLAGS_HAVE_VECTORCALL check */
@@ -215,7 +219,8 @@ PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *kwargs)
                       Py_TYPE(callable)->tp_name);
         return NULL;
     }
-    vectorcallfunc func = *(vectorcallfunc *)(((char *)callable) + offset);
+    vc.data = (char *)callable + offset;
+    vectorcallfunc func = *vc.ptr;
     if (func == NULL) {
         _PyErr_Format(tstate, PyExc_TypeError,
                       "'%.200s' object does not support vectorcall",


### PR DESCRIPTION
```
In file included from /usr/include/python3.8/Python.h:147:
In file included from /usr/include/python3.8/abstract.h:837:
/usr/include/python3.8/cpython/abstract.h:91:11: error: cast from 'char *' to 'vectorcallfunc *'
(aka 'struct _object *(**)(struct _object *, struct _object *const *, unsigned long, struct _object *)')
increases required alignment from 1 to 8 [-Werror,-Wcast-align]

    ptr = (vectorcallfunc*)(((char *)callable) + offset);
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

<!-- issue-number: [bpo-40052](https://bugs.python.org/issue40052) -->
https://bugs.python.org/issue40052
<!-- /issue-number -->
