### PR TITLE
bpo-40055: distutils tests now disable docutils import

### DIFF
--- a/Lib/distutils/tests/__init__.py
+++ b/Lib/distutils/tests/__init__.py
@@ -18,6 +18,12 @@ import unittest
 from test.support import run_unittest
 
 
+# bpo-40055: Prevent docutils from being imported to avoid depending on
+# docutils. Import docutils can have side effects. For example, docutils
+# imports pkg_resources which changes warnings filters.
+sys.modules['docutils'] = None
+
+
 here = os.path.dirname(__file__) or os.curdir
 
 

--- a/Lib/distutils/tests/test_check.py
+++ b/Lib/distutils/tests/test_check.py
@@ -4,6 +4,7 @@ import textwrap
 import unittest
 from test.support import run_unittest
 
+# bpo-40055: distutils.tests prevents docutils from being imported
 from distutils.command.check import check, HAS_DOCUTILS
 from distutils.tests import support
 from distutils.errors import DistutilsSetupError

--- a/Lib/distutils/tests/test_register.py
+++ b/Lib/distutils/tests/test_register.py
@@ -14,10 +14,8 @@ from distutils.log import INFO
 
 from distutils.tests.test_config import BasePyPIRCCommandTestCase
 
-try:
-    import docutils
-except ImportError:
-    docutils = None
+# bpo-40055: distutils.tests prevents docutils from being imported
+from distutils.command.check import HAS_DOCUTILS
 
 PYPIRC_NOPASSWORD = """\
 [distutils]
@@ -204,7 +202,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         self.assertEqual(headers['Content-length'], '290')
         self.assertIn(b'tarek', req.data)
 
-    @unittest.skipUnless(docutils is not None, 'needs docutils')
+    @unittest.skipUnless(HAS_DOCUTILS, 'needs docutils')
     def test_strict(self):
         # testing the script option
         # when on, the register command stops if
@@ -270,7 +268,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         finally:
             del register_module.input
 
-    @unittest.skipUnless(docutils is not None, 'needs docutils')
+    @unittest.skipUnless(HAS_DOCUTILS, 'needs docutils')
     def test_register_invalid_long_description(self):
         description = ':funkie:`str`'  # mimic Sphinx-specific markup
         metadata = {'url': 'xxx', 'author': 'xxx',

--- a/Misc/NEWS.d/next/Tests/2020-03-24-17-54-08.bpo-40055.AKINUq.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-24-17-54-08.bpo-40055.AKINUq.rst
@@ -1,0 +1,3 @@
+Distutils tests now prevent docutils from being imported since "import
+docutils" can have side effects on tests. For example, it imports
+pkg_resources which alters warnings filters.


### PR DESCRIPTION
Prevent docutils from being imported since "import docutils" can have
side effects on tests. For example, it imports pkg_resources which
alters warnings filters.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40055](https://bugs.python.org/issue40055) -->
https://bugs.python.org/issue40055
<!-- /issue-number -->
