### PR TITLE
bpo-40057: Document some class attributes not mentioned in socketserver doc

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -436,6 +436,14 @@ Request Handler Objects
    :attr:`DatagramRequestHandler.wfile` supports the
    :class:`io.BufferedIOBase` writable interface.
 
+   The :class:`StreamRequestHandler` class also provides the
+   :attr:`self.connection` attribute which is set to :attr:`self.request`, thus
+   acting as an alias for that attribute.
+
+   The :class:`DatagramRequestHandler` class also provides the
+   :attr:`self.packet` and :attr:`self.socket` attributes into which it unpacks
+   the :attr:`self.request` attribute.
+
    .. versionchanged:: 3.6
       :attr:`StreamRequestHandler.wfile` also supports the
       :class:`io.BufferedIOBase` writable interface.


### PR DESCRIPTION
Document the following class attributes, which were previously not mentioned in the documentation of the `socketserver` module despite of their existence:

`StreamRequestHandler.connection` (currently defined at [line 764 of `socketserver.py`](https://github.com/python/cpython/blob/master/Lib/socketserver.py#L764))
`DatagramRequestHandler.packet` (currently defined at [line 812 of `socketserver.py`](https://github.com/python/cpython/tree/master/Lib/socketserver.py#L812))
`DatagramRequestHandler.socket` (currently defined at [line 812 of `socketserver.py`](https://github.com/python/cpython/tree/master/Lib/socketserver.py#L812))

EDIT:

Perhaps this is poorly worded, as those are actually _instance_ attributes. However, `StreamRequestHandler` also defines 4 actual class (static) attributes that do not appear anywhere in the docs either, although they are preceded by a comment that describes them in `socketserver.py`:
`rbufsize`, `wbufsize`, `timeout` and `disable_nagle_algorithm`.

`ForkingMixIn` also defines 3 class (static) attributes that do not appear in the docs either and are not preceded by a comment describing them in `socketserver.py`:
`timeout`, `active_children` and `max_children`

<!-- issue-number: [bpo-40057](https://bugs.python.org/issue40057) -->
https://bugs.python.org/issue40057
<!-- /issue-number -->
