### PR TITLE
bpo-39812: Remove daemon threads in concurrent.futures

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -195,6 +195,11 @@ which have not started running, instead of waiting for them to complete before
 shutting down the executor.
 (Contributed by Kyle Stanley in :issue:`39349`.)
 
+Removed daemon threads from :class:`~concurrent.futures.ThreadPoolExecutor`
+and :class:`~concurrent.futures.ProcessPoolExecutor`. This improves
+compatibility with subinterpreters and predictability in their shutdown
+processes. (Contributed by Kyle Stanley in :issue:`39812`.)
+
 curses
 ------
 

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -59,20 +59,6 @@ import itertools
 import sys
 import traceback
 
-# Workers are created as daemon threads and processes. This is done to allow the
-# interpreter to exit when there are still idle processes in a
-# ProcessPoolExecutor's process pool (i.e. shutdown() was not called). However,
-# allowing workers to die with the interpreter has two undesirable properties:
-#   - The workers would still be running during interpreter shutdown,
-#     meaning that they would fail in unpredictable ways.
-#   - The workers could be killed while evaluating a work item, which could
-#     be bad if the callable being evaluated has external side-effects e.g.
-#     writing to a file.
-#
-# To work around this problem, an exit handler is installed which tells the
-# workers to exit when their work queues are empty and then waits until the
-# threads/processes finish.
-
 _threads_wakeups = weakref.WeakKeyDictionary()
 _global_shutdown = False
 
@@ -106,6 +92,12 @@ def _python_exit():
         thread_wakeup.wakeup()
     for t, _ in items:
         t.join()
+
+# Register for `_python_exit()` to be called just before joining all
+# non-daemon threads. This is used instead of `atexit.register()` for
+# compatibility with subinterpreters, which no longer support daemon threads.
+# See bpo-39812 for context.
+threading._register_atexit(_python_exit)
 
 # Controls how many more calls than processes will be queued in the call queue.
 # A smaller number will mean that processes spend more time idle waiting for
@@ -306,9 +298,7 @@ class _ExecutorManagerThread(threading.Thread):
         #     {5: <_WorkItem...>, 6: <_WorkItem...>, ...}
         self.pending_work_items = executor._pending_work_items
 
-        # Set this thread to be daemonized
         super().__init__()
-        self.daemon = True
 
     def run(self):
         # Main loop for the executor manager thread.
@@ -732,5 +722,3 @@ class ProcessPoolExecutor(_base.Executor):
             self._executor_manager_thread_wakeup = None
 
     shutdown.__doc__ = _base.Executor.shutdown.__doc__
-
-atexit.register(_python_exit)

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -59,6 +59,7 @@ import itertools
 import sys
 import traceback
 
+
 _threads_wakeups = weakref.WeakKeyDictionary()
 _global_shutdown = False
 

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -13,6 +13,7 @@ import threading
 import weakref
 import os
 
+
 _threads_queues = weakref.WeakKeyDictionary()
 _shutdown = False
 # Lock that ensures that new workers are not created while the interpreter is

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -13,20 +13,6 @@ import threading
 import weakref
 import os
 
-# Workers are created as daemon threads. This is done to allow the interpreter
-# to exit when there are still idle threads in a ThreadPoolExecutor's thread
-# pool (i.e. shutdown() was not called). However, allowing workers to die with
-# the interpreter has two undesirable properties:
-#   - The workers would still be running during interpreter shutdown,
-#     meaning that they would fail in unpredictable ways.
-#   - The workers could be killed while evaluating a work item, which could
-#     be bad if the callable being evaluated has external side-effects e.g.
-#     writing to a file.
-#
-# To work around this problem, an exit handler is installed which tells the
-# workers to exit when their work queues are empty and then waits until the
-# threads finish.
-
 _threads_queues = weakref.WeakKeyDictionary()
 _shutdown = False
 # Lock that ensures that new workers are not created while the interpreter is
@@ -43,7 +29,11 @@ def _python_exit():
     for t, q in items:
         t.join()
 
-atexit.register(_python_exit)
+# Register for `_python_exit()` to be called just before joining all
+# non-daemon threads. This is used instead of `atexit.register()` for
+# compatibility with subinterpreters, which no longer support daemon threads.
+# See bpo-39812 for context.
+threading._register_atexit(_python_exit)
 
 
 class _WorkItem(object):
@@ -197,7 +187,6 @@ class ThreadPoolExecutor(_base.Executor):
                                        self._work_queue,
                                        self._initializer,
                                        self._initargs))
-            t.daemon = True
             t.start()
             self._threads.add(t)
             _threads_queues[t] = self._work_queue

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1358,7 +1358,7 @@ def _register_atexit(func, *arg, **kwargs):
     purpose to `atexit.register()`, but its functions are called prior to
     threading shutdown instead of interpreter shutdown.
 
-    For similarity to atexit, the registed functions are called in reverse.
+    For similarity to atexit, the registered functions are called in reverse.
     """
     global _threading_atexits
     if _threading_atexits is None:

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1348,7 +1348,7 @@ def enumerate():
         return list(_active.values()) + list(_limbo.values())
 
 
-_threading_atexits = None
+_threading_atexits = []
 
 def _register_atexit(func, *arg, **kwargs):
     """CPython internal: register *func* to be called before joining threads.
@@ -1360,9 +1360,6 @@ def _register_atexit(func, *arg, **kwargs):
 
     For similarity to atexit, the registered functions are called in reverse.
     """
-    global _threading_atexits
-    if _threading_atexits is None:
-        _threading_atexits = []
     call = functools.partial(func, *arg, **kwargs)
     _threading_atexits.append(call)
 
@@ -1397,11 +1394,10 @@ def _shutdown():
     tlock.release()
     _main_thread._stop()
 
-    # Call registered threading atexit functions before threads are joined
-    if _threading_atexits is not None:
-        # Order is reversed, similar to atexit.
-        for atexit_call in reversed(_threading_atexits):
-            atexit_call()
+    # Call registered threading atexit functions before threads are joined.
+    # Order is reversed, similar to atexit.
+    for atexit_call in reversed(_threading_atexits):
+        atexit_call()
 
     # Join all non-deamon threads
     while True:

--- a/Misc/NEWS.d/next/Library/2020-03-25-00-35-48.bpo-39812.rIKnms.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-25-00-35-48.bpo-39812.rIKnms.rst
@@ -1,0 +1,4 @@
+Removed daemon threads from :mod:`concurrent.futures` by adding
+an internal `threading._register_atexit()`, which calls registered functions
+prior to joining all non-daemon threads. This allows for compatibility
+with subinterpreters, which don't support daemon threads.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Removes daemon threads from the Executor internals in concurrent.futures to allow for compatibility with subinterpreters (since they no longer support daemon threads with https://bugs.python.org/issue37266).

/cc @pitrou 

<!-- issue-number: [bpo-39812](https://bugs.python.org/issue39812) -->
https://bugs.python.org/issue39812
<!-- /issue-number -->
