### PR TITLE
bpo-39943: Use calloc-based functions, not malloc+memset

### DIFF
--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -156,10 +156,9 @@ _ctypes_get_errobj(int **pspace)
         Py_INCREF(errobj);
     }
     else if (!PyErr_Occurred()) {
-        void *space = PyMem_Malloc(sizeof(int) * 2);
+        void *space = PyMem_Calloc(2, sizeof(int));
         if (space == NULL)
             return NULL;
-        memset(space, 0, sizeof(int) * 2);
         errobj = PyCapsule_New(space, CTYPES_CAPSULE_NAME_PYMEM, pymem_destructor);
         if (errobj == NULL) {
             PyMem_Free(space);
@@ -1712,10 +1711,9 @@ resize(PyObject *self, PyObject *args)
     if (!_CDataObject_HasExternalBuffer(obj)) {
         /* We are currently using the objects default buffer, but it
            isn't large enough any more. */
-        void *ptr = PyMem_Malloc(size);
+        void *ptr = PyMem_Calloc(1, size);
         if (ptr == NULL)
             return PyErr_NoMemory();
-        memset(ptr, 0, size);
         memmove(ptr, obj->b_ptr, obj->b_size);
         obj->b_ptr = ptr;
         obj->b_size = size;

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -212,10 +212,9 @@ parse_filter_spec_lzma(PyObject *spec)
             return NULL;
     }
 
-    options = (lzma_options_lzma *)PyMem_Malloc(sizeof *options);
+    options = (lzma_options_lzma *)PyMem_Calloc(1, sizeof *options);
     if (options == NULL)
         return PyErr_NoMemory();
-    memset(options, 0, sizeof *options);
 
     if (lzma_lzma_preset(options, preset)) {
         PyMem_Free(options);
@@ -257,10 +256,9 @@ parse_filter_spec_delta(PyObject *spec)
         return NULL;
     }
 
-    options = (lzma_options_delta *)PyMem_Malloc(sizeof *options);
+    options = (lzma_options_delta *)PyMem_Calloc(1, sizeof *options);
     if (options == NULL)
         return PyErr_NoMemory();
-    memset(options, 0, sizeof *options);
     options->type = LZMA_DELTA_TYPE_BYTE;
     options->dist = dist;
     return options;
@@ -281,10 +279,9 @@ parse_filter_spec_bcj(PyObject *spec)
         return NULL;
     }
 
-    options = (lzma_options_bcj *)PyMem_Malloc(sizeof *options);
+    options = (lzma_options_bcj *)PyMem_Calloc(1, sizeof *options);
     if (options == NULL)
         return PyErr_NoMemory();
-    memset(options, 0, sizeof *options);
     options->start_offset = start_offset;
     return options;
 }

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -603,11 +603,10 @@ _winapi_CreateJunction_impl(PyObject *module, LPWSTR src_path,
         sizeof(rdb->MountPointReparseBuffer.PathBuffer) +
         /* Two +1's for NUL terminators. */
         (prefix_len + print_len + 1 + print_len + 1) * sizeof(WCHAR);
-    rdb = (_Py_PREPARSE_DATA_BUFFER)PyMem_RawMalloc(rdb_size);
+    rdb = (_Py_PREPARSE_DATA_BUFFER)PyMem_RawCalloc(1, rdb_size);
     if (rdb == NULL)
         goto cleanup;
 
-    memset(rdb, 0, rdb_size);
     rdb->ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
     rdb->ReparseDataLength = rdb_size - _Py_REPARSE_DATA_BUFFER_HEADER_SIZE;
     rdb->MountPointReparseBuffer.SubstituteNameOffset = 0;

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -1311,15 +1311,12 @@ binascii_a2b_qp_impl(PyObject *module, Py_buffer *data, int header)
     datalen = data->len;
 
     /* We allocate the output same size as input, this is overkill.
-     * The previous implementation used calloc() so we'll zero out the
-     * memory here too, since PyMem_Malloc() does not guarantee that.
      */
-    odata = (unsigned char *) PyMem_Malloc(datalen);
+    odata = (unsigned char *) PyMem_Calloc(1, datalen);
     if (odata == NULL) {
         PyErr_NoMemory();
         return NULL;
     }
-    memset(odata, 0, datalen);
 
     in = out = 0;
     while (in < datalen) {
@@ -1499,15 +1496,12 @@ binascii_b2a_qp_impl(PyObject *module, Py_buffer *data, int quotetabs,
     }
 
     /* We allocate the output same size as input, this is overkill.
-     * The previous implementation used calloc() so we'll zero out the
-     * memory here too, since PyMem_Malloc() does not guarantee that.
      */
-    odata = (unsigned char *) PyMem_Malloc(odatalen);
+    odata = (unsigned char *) PyMem_Calloc(1, odatalen);
     if (odata == NULL) {
         PyErr_NoMemory();
         return NULL;
     }
-    memset(odata, 0, odatalen);
 
     in = out = linelen = 0;
     while (in < datalen) {

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -911,10 +911,9 @@ faulthandler_register_py(PyObject *self,
         return NULL;
 
     if (user_signals == NULL) {
-        user_signals = PyMem_Malloc(NSIG * sizeof(user_signal_t));
+        user_signals = PyMem_Calloc(NSIG, sizeof(user_signal_t));
         if (user_signals == NULL)
             return PyErr_NoMemory();
-        memset(user_signals, 0, NSIG * sizeof(user_signal_t));
     }
     user = &user_signals[signum];
 

--- a/PC/_testconsole.c
+++ b/PC/_testconsole.c
@@ -55,10 +55,9 @@ _testconsole_write_input_impl(PyObject *module, PyObject *file,
     const wchar_t *p = (const wchar_t *)PyBytes_AS_STRING(s);
     DWORD size = (DWORD)PyBytes_GET_SIZE(s) / sizeof(wchar_t);
 
-    rec = (INPUT_RECORD*)PyMem_Malloc(sizeof(INPUT_RECORD) * size);
+    rec = (INPUT_RECORD*)PyMem_Calloc(size, sizeof(INPUT_RECORD));
     if (!rec)
         goto error;
-    memset(rec, 0, sizeof(INPUT_RECORD) * size);
 
     INPUT_RECORD *prec = rec;
     for (DWORD i = 0; i < size; ++i, ++p, ++prec) {

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -370,11 +370,10 @@ getpythonregpath(HKEY keyBase, int skipcore)
     /* Allocate a temp array of char buffers, so we only need to loop
        reading the registry once
     */
-    ppPaths = PyMem_RawMalloc( sizeof(WCHAR *) * numKeys );
+    ppPaths = PyMem_RawCalloc(numKeys, sizeof(WCHAR *));
     if (ppPaths==NULL) {
         goto done;
     }
-    memset(ppPaths, 0, sizeof(WCHAR *) * numKeys);
     /* Loop over all subkeys, allocating a temp sub-buffer. */
     for(index=0;index<numKeys;index++) {
         WCHAR keyBuf[MAX_PATH+1];

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -561,13 +561,12 @@ compiler_enter_scope(struct compiler *c, identifier name,
     struct compiler_unit *u;
     basicblock *block;
 
-    u = (struct compiler_unit *)PyObject_Malloc(sizeof(
+    u = (struct compiler_unit *)PyObject_Calloc(1, sizeof(
                                             struct compiler_unit));
     if (!u) {
         PyErr_NoMemory();
         return 0;
     }
-    memset(u, 0, sizeof(struct compiler_unit));
     u->u_scope_type = scope_type;
     u->u_argcount = 0;
     u->u_posonlyargcount = 0;
@@ -770,12 +769,11 @@ compiler_new_block(struct compiler *c)
     struct compiler_unit *u;
 
     u = c->u;
-    b = (basicblock *)PyObject_Malloc(sizeof(basicblock));
+    b = (basicblock *)PyObject_Calloc(1, sizeof(basicblock));
     if (b == NULL) {
         PyErr_NoMemory();
         return NULL;
     }
-    memset((void *)b, 0, sizeof(basicblock));
     /* Extend the singly linked list of blocks with new block. */
     b->b_list = u->u_blocks;
     u->u_blocks = b;
@@ -812,15 +810,13 @@ compiler_next_instr(basicblock *b)
 {
     assert(b != NULL);
     if (b->b_instr == NULL) {
-        b->b_instr = (struct instr *)PyObject_Malloc(
-                         sizeof(struct instr) * DEFAULT_BLOCK_SIZE);
+        b->b_instr = (struct instr *)PyObject_Calloc(
+                         DEFAULT_BLOCK_SIZE, sizeof(struct instr));
         if (b->b_instr == NULL) {
             PyErr_NoMemory();
             return -1;
         }
         b->b_ialloc = DEFAULT_BLOCK_SIZE;
-        memset((char *)b->b_instr, 0,
-               sizeof(struct instr) * DEFAULT_BLOCK_SIZE);
     }
     else if (b->b_iused == b->b_ialloc) {
         struct instr *tmp;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -206,12 +206,11 @@ PyInterpreterState_New(void)
         return NULL;
     }
 
-    PyInterpreterState *interp = PyMem_RawMalloc(sizeof(PyInterpreterState));
+    PyInterpreterState *interp = PyMem_RawCalloc(1, sizeof(PyInterpreterState));
     if (interp == NULL) {
         return NULL;
     }
 
-    memset(interp, 0, sizeof(*interp));
     interp->id_refcount = -1;
 
     _PyRuntimeState *runtime = &_PyRuntime;

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -547,9 +547,8 @@ PyThread_allocate_lock(void)
     if (!initialized)
         PyThread_init_thread();
 
-    lock = (pthread_lock *) PyMem_RawMalloc(sizeof(pthread_lock));
+    lock = (pthread_lock *) PyMem_RawCalloc(1, sizeof(pthread_lock));
     if (lock) {
-        memset((void *)lock, '\0', sizeof(pthread_lock));
         lock->locked = 0;
 
         status = pthread_mutex_init(&lock->mut, NULL);


### PR DESCRIPTION
This consolidates a number of malloc+memset function calls to use their calloc-based equivalents.

<!-- issue-number: [bpo-39943](https://bugs.python.org/issue39943) -->
https://bugs.python.org/issue39943
<!-- /issue-number -->
