### PR TITLE
bpo-39947: Use PyThreadState_GetFrame()

### DIFF
--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -445,7 +445,8 @@ traceback_get_frames(traceback_t *traceback)
         return;
     }
 
-    for (pyframe = tstate->frame; pyframe != NULL; pyframe = pyframe->f_back) {
+    pyframe = PyThreadState_GetFrame(tstate);
+    for (; pyframe != NULL; pyframe = pyframe->f_back) {
         if (traceback->nframe < _Py_tracemalloc_config.max_nframe) {
             tracemalloc_get_frame(pyframe, &traceback->frames[traceback->nframe]);
             assert(traceback->frames[traceback->nframe].filename != NULL);

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1830,7 +1830,7 @@ _is_running(PyInterpreterState *interp)
                         "interpreter has more than one thread");
         return -1;
     }
-    PyFrameObject *frame = tstate->frame;
+    PyFrameObject *frame = PyThreadState_GetFrame(tstate);
     if (frame == NULL) {
         if (PyErr_Occurred() != NULL) {
             return -1;
@@ -2004,7 +2004,8 @@ interp_create(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_RuntimeError, "interpreter creation failed");
         return NULL;
     }
-    PyObject *idobj = _PyInterpreterState_GetIDObject(tstate->interp);
+    PyInterpreterState *interp = PyThreadState_GetInterpreter(tstate);
+    PyObject *idobj = _PyInterpreterState_GetIDObject(interp);
     if (idobj == NULL) {
         // XXX Possible GILState issues?
         save_tstate = PyThreadState_Swap(tstate);
@@ -2012,7 +2013,7 @@ interp_create(PyObject *self, PyObject *args)
         PyThreadState_Swap(save_tstate);
         return NULL;
     }
-    _PyInterpreterState_RequireIDRef(tstate->interp, 1);
+    _PyInterpreterState_RequireIDRef(interp, 1);
     return idobj;
 }
 


### PR DESCRIPTION
_tracemalloc.c and _xxsubinterpretersmodule.c use
PyThreadState_GetFrame() and PyThreadState_GetInterpreter() to no
longer depend on the PyThreadState structure.

<!-- issue-number: [bpo-39947](https://bugs.python.org/issue39947) -->
https://bugs.python.org/issue39947
<!-- /issue-number -->
