### PR TITLE
bpo-39947: Add PyThreadState_GetID() function

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1084,6 +1084,15 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    .. versionadded:: 3.9
 
 
+.. c:function:: uint64_t PyThreadState_GetID(PyThreadState *tstate)
+
+   Get the unique thread state identifier of the Python thread state *tstate*.
+
+   *tstate* must not be ``NULL``.
+
+   .. versionadded:: 3.9
+
+
 .. c:function:: PyInterpreterState* PyThreadState_GetInterpreter(PyThreadState *tstate)
 
    Get the interpreter of the Python thread state *tstate*.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -429,6 +429,8 @@ Build and C API Changes
   :c:func:`PyInterpreterState_Get` functions to get the interpreter.
   New :c:func:`PyThreadState_GetFrame` function to get the current frame of a
   Python thread state.
+  New :c:func:`PyThreadState_GetID` function: get the unique identifier of a
+  Python thread state.
   (Contributed by Victor Stinner in :issue:`39947`.)
 
 * Add ``--with-platlibdir`` option to the ``configure`` script: name of the

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -91,6 +91,7 @@ PyAPI_FUNC(int) PyThreadState_SetAsyncExc(unsigned long, PyObject *);
 /* New in 3.9 */
 PyAPI_FUNC(PyInterpreterState*) PyThreadState_GetInterpreter(PyThreadState *tstate);
 PyAPI_FUNC(struct _frame*) PyThreadState_GetFrame(PyThreadState *tstate);
+PyAPI_FUNC(uint64_t) PyThreadState_GetID(PyThreadState *tstate);
 #endif
 
 typedef

--- a/Misc/NEWS.d/next/C API/2020-03-25-19-44-55.bpo-39947.2OxvPt.rst
+++ b/Misc/NEWS.d/next/C API/2020-03-25-19-44-55.bpo-39947.2OxvPt.rst
@@ -1,0 +1,2 @@
+Add :c:func:`PyThreadState_GetID` function: get the unique identifier of a
+Python thread state.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -231,7 +231,8 @@ get_running_loop(PyObject **loop)
     PyObject *rl;
 
     PyThreadState *ts = PyThreadState_Get();
-    if (ts->id == cached_running_holder_tsid && cached_running_holder != NULL) {
+    uint64_t ts_id = PyThreadState_GetID(ts);
+    if (ts_id == cached_running_holder_tsid && cached_running_holder != NULL) {
         // Fast path, check the cache.
         rl = cached_running_holder;  // borrowed
     }
@@ -252,7 +253,7 @@ get_running_loop(PyObject **loop)
         }
 
         cached_running_holder = rl;  // borrowed
-        cached_running_holder_tsid = ts->id;
+        cached_running_holder_tsid = ts_id;
     }
 
     assert(Py_IS_TYPE(rl, &PyRunningLoopHolder_Type));

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1012,6 +1012,14 @@ PyThreadState_GetFrame(PyThreadState *tstate)
 }
 
 
+uint64_t
+PyThreadState_GetID(PyThreadState *tstate)
+{
+    assert(tstate != NULL);
+    return tstate->id;
+}
+
+
 /* Asynchronously raise an exception in a thread.
    Requested by Just van Rossum and Alex Martelli.
    To prevent naive misuse, you must write your own extension


### PR DESCRIPTION
Add PyThreadState_GetID() function: get the unique identifier of a
Python thread state.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39947](https://bugs.python.org/issue39947) -->
https://bugs.python.org/issue39947
<!-- /issue-number -->
