### PR TITLE
bpo-38237: Use divmod for positional arguments whatsnew example

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -142,12 +142,11 @@ However, these are invalid calls::
 
 One use case for this notation is that it allows pure Python functions
 to fully emulate behaviors of existing C coded functions.  For example,
-the built-in :func:`pow` function does not accept keyword arguments::
+the built-in :func:`divmod` function does not accept keyword arguments::
 
-  def pow(x, y, z=None, /):
-      "Emulate the built in pow() function"
-      r = x ** y
-      return r if z is None else r%z
+  def divmod(a, b, /):
+      "Emulate the built in divmod() function"
+      return (a // b, a % b)
 
 Another use case is to preclude keyword arguments when the parameter
 name is not helpful.  For example, the builtin :func:`len` function has


### PR DESCRIPTION
Since the change to have `pow` accept keyword arguments was backported to 3.8, this example is no longer accurate.

The reason I chose `divmod` is because that's what I used in the programming FAQ: https://docs.python.org/3/faq/programming.html#what-does-the-slash-in-the-parameter-list-of-a-function-mean

@serhiy-storchaka pointed out on the bug tracker that this method is not a truly accurate Python version of `divmod` because it doesn't dispatch to `__divmod__` and `__rdivmod__` but I don't think this really matters. The example is just supposed to serve as a simple illustration and the original example didn't dispatch to the three-argument version of `__pow__`.

@pablogsal Do you have any thoughts on this?

<!-- issue-number: [bpo-38237](https://bugs.python.org/issue38237) -->
https://bugs.python.org/issue38237
<!-- /issue-number -->
