### PR TITLE
bpo-40071: Fix refleak in _functools module.

### DIFF
--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1424,9 +1424,11 @@ _functools_exec(PyObject *module)
         &lru_cache_type
     };
 
-    kwd_mark = _PyObject_CallNoArg((PyObject *)&PyBaseObject_Type);
     if (!kwd_mark) {
-        return -1;
+        kwd_mark = _PyObject_CallNoArg((PyObject *)&PyBaseObject_Type);
+        if (!kwd_mark) {
+            return -1;
+        }
     }
 
     for (size_t i = 0; i < Py_ARRAY_LENGTH(typelist); i++) {


### PR DESCRIPTION


<!-- issue-number: [bpo-40071](https://bugs.python.org/issue40071) -->
https://bugs.python.org/issue40071
<!-- /issue-number -->
