### PR TITLE
bpo-40075: Use PyGILState_Ensure in _tkinter PythonCmd

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-26-16-38-39.bpo-40075.HZGN4e.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-26-16-38-39.bpo-40075.HZGN4e.rst
@@ -1,0 +1,1 @@
+Fix a crash in ``_tkinter`` on Windows where ``ENTER_PYTHON`` may try to restore a NULL state.


### PR DESCRIPTION
In the `PythonCmd` function in `_tkinter.c`, use `PyGILState_Ensure` instead of `ENTER_PYTHON` which may try to restore a NULL state and lead to a crash.

This is implemented with two new macros: `ENTER_PYTHON_GIL_STATE` and `LEAVE_PYTHON_GIL_STATE`

<!-- issue-number: [bpo-40075](https://bugs.python.org/issue40075) -->
https://bugs.python.org/issue40075
<!-- /issue-number -->
