### PR TITLE
bpo-40052: Replace misaligned type casting with proper unions.

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -68,6 +68,10 @@ PyVectorcall_Function(PyObject *callable)
     PyTypeObject *tp;
     Py_ssize_t offset;
     vectorcallfunc *ptr;
+    union {
+        char *data;
+        vectorcallfunc *ptr;
+    } vc;
 
     assert(callable != NULL);
     tp = Py_TYPE(callable);
@@ -77,8 +81,8 @@ PyVectorcall_Function(PyObject *callable)
     assert(PyCallable_Check(callable));
     offset = tp->tp_vectorcall_offset;
     assert(offset > 0);
-    ptr = (vectorcallfunc *)(((char *)callable) + offset);
-    return *ptr;
+    vc.data = (char *)callable + offset;
+    return *vc.ptr;
 }
 
 /* Call the callable object 'callable' with the "vectorcall" calling

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -206,6 +206,11 @@ PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *kwargs)
 {
     PyThreadState *tstate = _PyThreadState_GET();
 
+    union {
+        char *data;
+        vectorcallfunc *ptr;
+    } vc;
+
     /* get vectorcallfunc as in PyVectorcall_Function, but without
      * the Py_TPFLAGS_HAVE_VECTORCALL check */
     Py_ssize_t offset = Py_TYPE(callable)->tp_vectorcall_offset;
@@ -215,7 +220,9 @@ PyVectorcall_Call(PyObject *callable, PyObject *tuple, PyObject *kwargs)
                       Py_TYPE(callable)->tp_name);
         return NULL;
     }
-    vectorcallfunc func = *(vectorcallfunc *)(((char *)callable) + offset);
+    vc.data = (char *)callable + offset;
+    vectorcallfunc func = *vc.ptr;
+
     if (func == NULL) {
         _PyErr_Format(tstate, PyExc_TypeError,
                       "'%.200s' object does not support vectorcall",


### PR DESCRIPTION
Fixes #40052

Thank you, Andreas Schneider (@cryptomilk), for providing [the guidance](https://bugzilla.suse.com/show_bug.cgi?id=1167501) for creating this patch.

<!-- issue-number: [bpo-40052](https://bugs.python.org/issue40052) -->
https://bugs.python.org/issue40052
<!-- /issue-number -->
