### PR TITLE
list.reverse(): add slice support

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -85,10 +85,18 @@ objects:
    customization, see :func:`sorted` for their explanation).
 
 
-.. method:: list.reverse()
+.. method:: list.reverse([start[, end]])
    :noindex:
 
    Reverse the elements of the list in place.
+
+   The optional arguments *start* and *end* are interpreted as in the slice
+   notation and are used to limit the reverse to a particular subsequence of
+   the list.
+
+   If *start* only provided, it is interpreted as delimiter. In this case, if
+   *start* is non-negative, only first *start* elements of the list are reversed.
+   If *start* is negative, last *start* elements are reversed, accordingly.
 
 
 .. method:: list.copy()

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -403,7 +403,15 @@ class CommonTest(seq_tests.CommonTest):
         u.reverse()
         self.assertEqual(u, u2)
 
-        self.assertRaises(TypeError, u.reverse, 42)
+        u.reverse(2)
+        self.assertEqual(u, [-1, -2, 0, 1, 2])
+        u.reverse(2)
+        self.assertEqual(u, u2)
+
+        u.reverse(-2)
+        self.assertEqual(u, [-2, -1, 0, 2, 1])
+        u.reverse(-2)
+        self.assertEqual(u, u2)
 
     def test_clear(self):
         u = self.type2test([2, 3, 4])

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1211,6 +1211,7 @@ Gregory Nofi
 Jesse Noller
 Bill Noon
 Stefan Norberg
+Yury Norov
 Tim Northover
 Joe Norton
 Neal Norwitz

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-26-09-25-37.bpo-111.W8cuFs.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-26-09-25-37.bpo-111.W8cuFs.rst
@@ -1,0 +1,3 @@
+Extend list.reverse() interface with .reverse([start,[end]]) notation. It
+allows to reverse continuous sublist of a list in-place without performance
+decrease.

--- a/Objects/clinic/listobject.c.h
+++ b/Objects/clinic/listobject.c.h
@@ -213,21 +213,72 @@ exit:
 }
 
 PyDoc_STRVAR(list_reverse__doc__,
-"reverse($self, /)\n"
+"reverse($self, start=0, stop=sys.maxsize, /)\n"
 "--\n"
 "\n"
 "Reverse *IN PLACE*.");
 
 #define LIST_REVERSE_METHODDEF    \
-    {"reverse", (PyCFunction)list_reverse, METH_NOARGS, list_reverse__doc__},
+    {"reverse", (PyCFunction)(void(*)(void))list_reverse, METH_FASTCALL, list_reverse__doc__},
 
 static PyObject *
-list_reverse_impl(PyListObject *self);
+list_reverse_impl(PyListObject *self, Py_ssize_t start, Py_ssize_t stop);
 
 static PyObject *
-list_reverse(PyListObject *self, PyObject *Py_UNUSED(ignored))
+list_reverse(PyListObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
-    return list_reverse_impl(self);
+    PyObject *return_value = NULL;
+    Py_ssize_t start = 0;
+    Py_ssize_t stop = PY_SSIZE_T_MAX;
+
+    if (!_PyArg_CheckPositional("reverse", nargs, 0, 2)) {
+        goto exit;
+    }
+    if (nargs < 1) {
+        goto skip_optional;
+    }
+    if (PyFloat_Check(args[0])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    {
+        Py_ssize_t ival = -1;
+        PyObject *iobj = PyNumber_Index(args[0]);
+        if (iobj != NULL) {
+            ival = PyLong_AsSsize_t(iobj);
+            Py_DECREF(iobj);
+        }
+        if (ival == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        start = ival;
+    }
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    if (PyFloat_Check(args[1])) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    {
+        Py_ssize_t ival = -1;
+        PyObject *iobj = PyNumber_Index(args[1]);
+        if (iobj != NULL) {
+            ival = PyLong_AsSsize_t(iobj);
+            Py_DECREF(iobj);
+        }
+        if (ival == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        stop = ival;
+    }
+skip_optional:
+    return_value = list_reverse_impl(self, start, stop);
+
+exit:
+    return return_value;
 }
 
 PyDoc_STRVAR(list_index__doc__,
@@ -367,4 +418,4 @@ list___reversed__(PyListObject *self, PyObject *Py_UNUSED(ignored))
 {
     return list___reversed___impl(self);
 }
-/*[clinic end generated code: output=1ff61490c091d165 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c99fc49621112919 input=a9049054013a1b77]*/

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2457,15 +2457,41 @@ PyList_Sort(PyObject *v)
 /*[clinic input]
 list.reverse
 
+    start: Py_ssize_t = 0
+    stop: Py_ssize_t(c_default="PY_SSIZE_T_MAX") = sys.maxsize
+    /
+
 Reverse *IN PLACE*.
 [clinic start generated code]*/
 
 static PyObject *
-list_reverse_impl(PyListObject *self)
-/*[clinic end generated code: output=482544fc451abea9 input=eefd4c3ae1bc9887]*/
+list_reverse_impl(PyListObject *self, Py_ssize_t start,
+                  Py_ssize_t stop)
+/*[clinic end generated code: output=902a1009dd649d65 input=6d23a5491e12c398]*/
 {
-    if (Py_SIZE(self) > 1)
-        reverse_slice(self->ob_item, self->ob_item + Py_SIZE(self));
+    Py_ssize_t len = Py_SIZE(self);
+
+    if (stop == PY_SSIZE_T_MAX) {
+        if (start == 0) {
+                stop = len;
+        } else if (start > 0) {
+            stop = start < len ? start : len;
+            start = 0;
+        } else {
+            stop = len;
+            start = len + start > 0 ? len + start : 0;
+        }
+    } else {
+        if (start < 0 || stop < 0 ||
+                    stop > Py_SIZE(self) || start > stop) {
+            PyErr_Format(PyExc_ValueError, "range invalid: %d, %d", start, stop);
+            return NULL;
+        }
+    }
+
+    if (stop - start > 1)
+        reverse_slice(self->ob_item + start, self->ob_item + stop);
+
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Hi all,

In Python, I need a tool to reverse part of a list (tail) quickly.
I expected that

	nums[start:end].reverse()

would do it inplace with the performance similar to nums.reverse().
However, it doesn't work at all. The fastest way to reverse a part of
the list that I found is like this:

	nums[start:end] = nums[end:start-1:-1]

But it is 30 times slower than pure reverse(). The patch below adds
a region support for the reverse(). It works as fast as I expect.

The test script and results are like this:
>>> exec(open('test.py').read())
nums.reverse()				 0.006764888763427734
nums = nums[::-1]			 0.10066413879394531
nums.reverse(-L/2)			 0.003548145294189453
nums.reverse(L/2, L)			 0.003538370132446289
nums = nums[:L/2] + nums[L:L/2-1:-1]	 0.19934582710266113
nums[L/2:L] = nums[L:L/2-1:-1]		 0.11419057846069336

import time

nums = list(range(10000000))
L = len(nums)
LL = int(L/2)

t = time.time()
nums.reverse()
print('nums.reverse()\t\t\t\t', str(time.time() - t))

t = time.time()
nums = nums[::-1]
print('nums = nums[::-1]\t\t\t', str(time.time() - t))

t = time.time()
nums.reverse(-LL)
print('nums.reverse(-L/2)\t\t\t', time.time() - t)

t = time.time()
nums.reverse(LL, L)
print('nums.reverse(L/2, L)\t\t\t', time.time() - t)

t = time.time()
nums = nums[:LL] + nums[L : LL - 1 : -1]
print('nums = nums[:L/2] + nums[L:L/2-1:-1]\t', time.time() - t)

t = time.time()
nums[LL:L] = nums[L:LL-1:-1]
print('nums[L/2:L] = nums[L:L/2-1:-1]\t\t', time.time() - t)

If there is better way to reverse lists, can someone point me at the right
direction? If not, I'll be happy to fix all existing issues and upstream
this approach.

Thanks,
Yury

Signed-off-by: Yury Norov <yury.norov@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
