### PR TITLE
bpo-39943: Keep constness of pointer objects.

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -625,7 +625,7 @@ type_get_bases(PyTypeObject *type, void *context)
 
 static PyTypeObject *best_base(PyObject *);
 static int mro_internal(PyTypeObject *, PyObject **);
-static int type_is_subtype_base_chain(PyTypeObject *, PyTypeObject *);
+static int type_is_subtype_base_chain(const PyTypeObject *, const PyTypeObject *);
 static int compatible_for_assignment(PyTypeObject *, PyTypeObject *, const char *);
 static int add_subclass(PyTypeObject*, PyTypeObject*);
 static int add_all_subclasses(PyTypeObject *type, PyObject *bases);
@@ -1362,7 +1362,7 @@ static PyTypeObject *solid_base(PyTypeObject *type);
 /* type test with subclassing support */
 
 static int
-type_is_subtype_base_chain(PyTypeObject *a, PyTypeObject *b)
+type_is_subtype_base_chain(const PyTypeObject *a, const PyTypeObject *b)
 {
     do {
         if (a == b)
@@ -2850,17 +2850,18 @@ PyObject *
 PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 {
     PyHeapTypeObject *res;
-    PyMemberDef *memb;
     PyObject *modname;
     PyTypeObject *type, *base;
 
-    PyType_Slot *slot;
+    const PyType_Slot *slot;
     Py_ssize_t nmembers, weaklistoffset, dictoffset;
-    char *s, *res_start;
+    const char *s;
+    char *res_start;
 
     nmembers = weaklistoffset = dictoffset = 0;
     for (slot = spec->slots; slot->slot; slot++) {
         if (slot->slot == Py_tp_members) {
+            const PyMemberDef *memb;
             nmembers = 0;
             for (memb = slot->pfunc; memb->name != NULL; memb++) {
                 nmembers++;
@@ -2894,7 +2895,7 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
     /* Set the type name and qualname */
     s = strrchr(spec->name, '.');
     if (s == NULL)
-        s = (char*)spec->name;
+        s = spec->name;
     else
         s++;
 


### PR DESCRIPTION
Also moved an auto variable that got consted into its innermost
necessary scope.

Note that this is the same type of patch as #19185, but in a different source file.  If it's easier for the folks that go through these patches to have similar changes to multiple source files put together in one PR, let me know and I'll do that going forward.

<!-- issue-number: [bpo-39943](https://bugs.python.org/issue39943) -->
https://bugs.python.org/issue39943
<!-- /issue-number -->
