### PR TITLE
bpo-40049: Check if symlink exists when extracting from tarfile

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2232,6 +2232,8 @@ class TarFile(object):
         try:
             # For systems that support symbolic and hard links.
             if tarinfo.issym():
+                if os.path.lexists(targetpath):
+                    os.unlink(targetpath)
                 os.symlink(tarinfo.linkname, targetpath)
             else:
                 # See extract().

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -755,6 +755,18 @@ class StreamReadTest(CommonReadTest, unittest.TestCase):
         finally:
             tar1.close()
 
+    @support.skip_unless_symlink
+    def test_symlink_overwrite(self):
+        # Test for issue #40049: Extracting a symlink over an existing file
+        # in stream mode causes a backwards seek
+        sympath = os.path.join(TEMPDIR, 'symtype2')
+        pathlib.Path(sympath).touch()
+        try:
+            self.tar.extract('symtype2', TEMPDIR)
+            self.assertTrue(os.path.islink(sympath))
+        finally:
+            pathlib.Path(sympath).unlink(missing_ok=True)
+
 class GzipStreamReadTest(GzipTest, StreamReadTest):
     pass
 

--- a/Misc/NEWS.d/next/Library/2020-03-27-20-49-32.bpo-40049.8079ca.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-27-20-49-32.bpo-40049.8079ca.rst
@@ -1,3 +1,3 @@
-The tarfile module now checks for an existing symlink before creating a
+The :mod:`tarfile` module now checks for an existing symlink before creating a
 new one during extraction. This prevents premature scanning of the  
 archive and errors when extracting from a stream.

--- a/Misc/NEWS.d/next/Library/2020-03-27-20-49-32.bpo-40049.8079ca.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-27-20-49-32.bpo-40049.8079ca.rst
@@ -1,0 +1,3 @@
+The tarfile module now checks for an existing symlink before creating a
+new one during extraction. This prevents premature scanning of the  
+archive and errors when extracting from a stream.


### PR DESCRIPTION
When extracting a tarfile, os.symlink() will raise an exception if the symlink already exists. This will cause the entire tarfile to be scanned for the destination files, thinking that the platform does not support symlinks. On a normal file this goes unnoticed, but when processing stream data it will raise a StreamError because it needs to seek backwards to resume extraction where it left off.

<!-- issue-number: [bpo-40049](https://bugs.python.org/issue40049) -->
https://bugs.python.org/issue40049
<!-- /issue-number -->
