### PR TITLE
[WIP] bpo-40091: Fix a crash in logging after fork

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -257,8 +257,8 @@ else:
                 # Similar to what PyErr_WriteUnraisable does.
                 print("Ignoring exception from logging atfork", instance,
                       "._reinit_lock() method:", err, file=sys.stderr)
-        _releaseLock()  # Acquired by os.register_at_fork(before=.
 
+        _lock = threading.RLock()
 
     os.register_at_fork(before=_acquireLock,
                         after_in_child=_after_at_fork_child_reinit_locks,

--- a/Misc/NEWS.d/next/Library/2020-03-27-18-03-12.bpo-40091.ZIh4oL.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-27-18-03-12.bpo-40091.ZIh4oL.rst
@@ -1,0 +1,2 @@
+Fix a crash in the :mod:`logging` module after fork in the process process:
+reset the main logging lock.


### PR DESCRIPTION
Fix a crash in the logging module after fork in the process process:
reset the main logging lock.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40091](https://bugs.python.org/issue40091) -->
https://bugs.python.org/issue40091
<!-- /issue-number -->
