### PR TITLE
bpo-40090: change of documentation for json library module to update for the correct rfc.

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -12,8 +12,7 @@
 --------------
 
 `JSON (JavaScript Object Notation) <http://json.org>`_, specified by
-`STD 90 <https://tools.ietf.org/html/std90>`_ or :rfc:`8259` (which obsoletes :rfc:`4627`
-and :rfc:`7159`) and by
+:rfc:`8259` (which obsoletes :rfc:`4627` and :rfc:`7159`) and by
 `ECMA-404 <http://www.ecma-international.org/publications/standards/Ecma-404.htm>`_,
 is a lightweight data interchange format inspired by
 `JavaScript <https://en.wikipedia.org/wiki/JavaScript>`_ object literal syntax
@@ -753,5 +752,4 @@ Command line options
 .. cmdoption:: -h, --help
 
    Show the help message.
-
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -12,11 +12,12 @@
 --------------
 
 `JSON (JavaScript Object Notation) <http://json.org>`_, specified by
-:rfc:`7159` (which obsoletes :rfc:`4627`) and by
+`STD 90 <https://tools.ietf.org/html/std90>`_ or :rfc:`8259` (which obsoletes :rfc:`4627`
+and :rfc:`7159`) and by
 `ECMA-404 <http://www.ecma-international.org/publications/standards/Ecma-404.htm>`_,
 is a lightweight data interchange format inspired by
 `JavaScript <https://en.wikipedia.org/wiki/JavaScript>`_ object literal syntax
-(although it is not a strict subset of JavaScript [#rfc-errata]_ ).
+(although it is not a strict subset of JavaScript [#rfc-security]_ ).
 
 :mod:`json` exposes an API familiar to users of the standard library
 :mod:`marshal` and :mod:`pickle` modules.
@@ -544,7 +545,7 @@ Exceptions
 Standard Compliance and Interoperability
 ----------------------------------------
 
-The JSON format is specified by :rfc:`7159` and by
+The JSON format is specified by :rfc:`8259` and by
 `ECMA-404 <http://www.ecma-international.org/publications/standards/Ecma-404.htm>`_.
 This section details this module's level of compliance with the RFC.
 For simplicity, :class:`JSONEncoder` and :class:`JSONDecoder` subclasses, and
@@ -633,7 +634,7 @@ Top-level Non-Object, Non-Array Values
 The old version of JSON specified by the obsolete :rfc:`4627` required that
 the top-level value of a JSON text must be either a JSON object or array
 (Python :class:`dict` or :class:`list`), and could not be a JSON null,
-boolean, number, or string value.  :rfc:`7159` removed that restriction, and
+boolean, number, or string value.  :rfc:`8259` does not have that restriction, and
 this module does not and has never implemented that restriction in either its
 serializer or its deserializer.
 
@@ -756,8 +757,8 @@ Command line options
 
 .. rubric:: Footnotes
 
-.. [#rfc-errata] As noted in `the errata for RFC 7159
-   <https://www.rfc-editor.org/errata_search.php?rfc=7159>`_,
+.. [#rfc-security] As noted in `the security section of RFC 8259
+   <https://tools.ietf.org/html/rfc8259#section-12>`_,
    JSON permits literal U+2028 (LINE SEPARATOR) and
    U+2029 (PARAGRAPH SEPARATOR) characters in strings, whereas JavaScript
    (as of ECMAScript Edition 5.1) does not.

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -17,7 +17,7 @@ and :rfc:`7159`) and by
 `ECMA-404 <http://www.ecma-international.org/publications/standards/Ecma-404.htm>`_,
 is a lightweight data interchange format inspired by
 `JavaScript <https://en.wikipedia.org/wiki/JavaScript>`_ object literal syntax
-(although it is not a strict subset of JavaScript [#rfc-security]_ ).
+(although it is not a strict subset of JavaScript  ).
 
 :mod:`json` exposes an API familiar to users of the standard library
 :mod:`marshal` and :mod:`pickle` modules.
@@ -755,10 +755,3 @@ Command line options
    Show the help message.
 
 
-.. rubric:: Footnotes
-
-.. [#rfc-security] As noted in `the security section of RFC 8259
-   <https://tools.ietf.org/html/rfc8259#section-12>`_,
-   JSON permits literal U+2028 (LINE SEPARATOR) and
-   U+2029 (PARAGRAPH SEPARATOR) characters in strings, whereas JavaScript
-   (as of ECMAScript Edition 5.1) does not.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
This is a Pull Request to correct for the RFC in the [documentation for the json module](https://docs.python.org/dev/library/json.html). Currently the documentation refers to [RFC 7159](https://tools.ietf.org/html/rfc7159) which has been obsoleted by [RFC 8259](https://tools.ietf.org/html/rfc8259)

Furthermore it removes the footnotes in the documentation because the latest edition of ECMAScript makes the footnote irrelevant. Edition 5.1 of ECMAScript did not allow for U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) in [string literals](https://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4) but [ECMAScript edition 10.0](https://www.ecma-international.org/ecma-262/10.0/index.html#sec-intro) does.
![image](https://user-images.githubusercontent.com/32741226/77786241-83501b00-706e-11ea-861b-75745f6e2eac.png)


<!-- issue-number: [bpo-40090](https://bugs.python.org/issue40090) -->
https://bugs.python.org/issue40090
<!-- /issue-number -->
