### PR TITLE
[WIP] bpo-40068: test_reinit_tls_after_fork() detects crashes

### DIFF
--- a/Misc/NEWS.d/next/Tests/2020-03-27-20-23-31.bpo-40068.HucS3F.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-27-20-23-31.bpo-40068.HucS3F.rst
@@ -1,0 +1,2 @@
+test_reinit_tls_after_fork() of test_threading now checks if a child process
+crashed in os.fork().


### PR DESCRIPTION
test_reinit_tls_after_fork() of test_threading now checks if a child
process crashed in os.fork().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40068](https://bugs.python.org/issue40068) -->
https://bugs.python.org/issue40068
<!-- /issue-number -->
