### PR TITLE
bpo-40096: Support no return on xlc

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -832,6 +832,7 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 
    PyAPI_FUNC(void) _Py_NO_RETURN PyThread_exit_thread(void); */
 #if defined(__clang__) || \
+    defined(__xlc__) || \
     (defined(__GNUC__) && \
      ((__GNUC__ >= 3) || \
       (__GNUC__ == 2) && (__GNUC_MINOR__ >= 5)))


### PR DESCRIPTION


<!-- issue-number: [bpo-40096](https://bugs.python.org/issue40096) -->
https://bugs.python.org/issue40096
<!-- /issue-number -->
