### PR TITLE
bpo-33129: Add kwarg support for dataclass' generated init method

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -526,7 +526,7 @@ def _init_fn(fields, frozen, has_post_init, self_name, globals):
         body_lines = ['pass']
 
     return _create_fn('__init__',
-                      [self_name] + [_init_param(f) for f in fields if f.init],
+                      [self_name] + [_init_param(f) for f in fields if f.init] + ['**kwargs'],
                       body_lines,
                       locals=locals,
                       globals=globals,

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3162,9 +3162,9 @@ class TestReplace(unittest.TestCase):
         #  if we're also replacing one that does exist.  Test this
         #  here, because setting attributes on frozen instances is
         #  handled slightly differently from non-frozen ones.
-        with self.assertRaisesRegex(TypeError, r"__init__\(\) got an unexpected "
-                                             "keyword argument 'a'"):
+        with self.assertRaisesRegex(AttributeError, r"'C' object has no attribute 'a'"):
             c1 = replace(c, x=20, a=5)
+            result = c1.a
 
     def test_invalid_field_name(self):
         @dataclass(frozen=True)
@@ -3222,9 +3222,8 @@ class TestReplace(unittest.TestCase):
         self.assertEqual(c.y, 1000)
 
         # Trying to replace y is an error: can't replace ClassVars.
-        with self.assertRaisesRegex(TypeError, r"__init__\(\) got an "
-                                    "unexpected keyword argument 'y'"):
-            replace(c, y=30)
+        c1 = replace(c, y=30)
+        self.assertEqual(c, c1)
 
         replace(c, x=5)
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -3173,9 +3173,9 @@ class TestReplace(unittest.TestCase):
             y: int
 
         c = C(1, 2)
-        with self.assertRaisesRegex(TypeError, r"__init__\(\) got an unexpected "
-                                    "keyword argument 'z'"):
+        with self.assertRaisesRegex(AttributeError, r"'C' object has no attribute 'z'"):
             c1 = replace(c, z=3)
+            result = c1.z
 
     def test_invalid_object(self):
         @dataclass(frozen=True)

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -794,6 +794,8 @@ class TestCase(unittest.TestCase):
             self.assertIs   (param.annotation, float)
             # Don't test for the default, since it's set to MISSING.
             self.assertEqual(param.kind, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            param = next(params)
+            self.assertEqual(param.name, 'kwargs')
             self.assertRaises(StopIteration, next, params)
 
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1992,14 +1992,14 @@ class TestDocString(unittest.TestCase):
         class C:
             pass
 
-        self.assertDocStrEqual(C.__doc__, "C()")
+        self.assertDocStrEqual(C.__doc__, "C(**kwargs)")
 
     def test_docstring_one_field(self):
         @dataclass
         class C:
             x: int
 
-        self.assertDocStrEqual(C.__doc__, "C(x:int)")
+        self.assertDocStrEqual(C.__doc__, "C(x:int, **kwargs)")
 
     def test_docstring_two_fields(self):
         @dataclass
@@ -2007,7 +2007,7 @@ class TestDocString(unittest.TestCase):
             x: int
             y: int
 
-        self.assertDocStrEqual(C.__doc__, "C(x:int, y:int)")
+        self.assertDocStrEqual(C.__doc__, "C(x:int, y:int, **kwargs)")
 
     def test_docstring_three_fields(self):
         @dataclass
@@ -2016,49 +2016,49 @@ class TestDocString(unittest.TestCase):
             y: int
             z: str
 
-        self.assertDocStrEqual(C.__doc__, "C(x:int, y:int, z:str)")
+        self.assertDocStrEqual(C.__doc__, "C(x:int, y:int, z:str, **kwargs)")
 
     def test_docstring_one_field_with_default(self):
         @dataclass
         class C:
             x: int = 3
 
-        self.assertDocStrEqual(C.__doc__, "C(x:int=3)")
+        self.assertDocStrEqual(C.__doc__, "C(x:int=3, **kwargs)")
 
     def test_docstring_one_field_with_default_none(self):
         @dataclass
         class C:
             x: Union[int, type(None)] = None
 
-        self.assertDocStrEqual(C.__doc__, "C(x:Union[int, NoneType]=None)")
+        self.assertDocStrEqual(C.__doc__, "C(x:Union[int, NoneType]=None, **kwargs)")
 
     def test_docstring_list_field(self):
         @dataclass
         class C:
             x: List[int]
 
-        self.assertDocStrEqual(C.__doc__, "C(x:List[int])")
+        self.assertDocStrEqual(C.__doc__, "C(x:List[int], **kwargs)")
 
     def test_docstring_list_field_with_default_factory(self):
         @dataclass
         class C:
             x: List[int] = field(default_factory=list)
 
-        self.assertDocStrEqual(C.__doc__, "C(x:List[int]=<factory>)")
+        self.assertDocStrEqual(C.__doc__, "C(x:List[int]=<factory>, **kwargs)")
 
     def test_docstring_deque_field(self):
         @dataclass
         class C:
             x: deque
 
-        self.assertDocStrEqual(C.__doc__, "C(x:collections.deque)")
+        self.assertDocStrEqual(C.__doc__, "C(x:collections.deque, **kwargs)")
 
     def test_docstring_deque_field_with_default_factory(self):
         @dataclass
         class C:
             x: deque = field(default_factory=deque)
 
-        self.assertDocStrEqual(C.__doc__, "C(x:collections.deque=<factory>)")
+        self.assertDocStrEqual(C.__doc__, "C(x:collections.deque=<factory>, **kwargs)")
 
 
 class TestInit(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2020-03-28-20-10-52.bpo-33129.owLqbD.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-03-28-20-10-52.bpo-33129.owLqbD.rst
@@ -1,0 +1,1 @@
+Added kwargs support for dataclass' generated init method so that we can more expressively interact with HTTP response body objects by extracting the object members we want and ignoring the rest without raising an TypeError exception.


### PR DESCRIPTION
Hello there! Thanks for reviewing my PR.

### Context
The `@dataclass` feature shines brightly in the context of web development because we _need_ to have a consistent expectation from our many APIs about the shape of their response JSONs for things like **[DTOs](https://en.wikipedia.org/wiki/Data_transfer_object)**. In a microservice or monorepo architecture, consistency with our DTOs is a _must_.

For example, consider an API endpoint that returns a user object such as:
```
@dataclass
class GetUserResponse:
  id: int
  first_name: str
```
This now allows us to interact with an API response object as though it were any other class!
```
def get_user(id: int) -> GetUserResponse:
  response_body: dict = request('get', f'http://foo.bar/api/user/{id}').json()
  return GetUserResponse(**response_body)
```
This feature is _incredibly_ useful in the context of front-end and back-end web development because we can know what exactly we're working with when we interact with other services and apps, such as a microservice in your company's Kubernetes cluster or perhaps a third party API that handles user authentication and feature permissions.

### Use Case
However, there is currently a limitation to this _wonderful_ feature: what if we are only concerned with _some subset_ of the returned data from that API? Or, alternatively, what if the API we are consuming suddenly includes new members in its JSON object (e.g. `last_name`)?

```
TypeError: __init__() got an unexpected keyword argument 'last_name'
```

If we attempt to run our hypothetical software again, we find that because the `@dataclass` members do not _perfectly_ align with what was promised... suddenly our program crashes, integration tests fail, acceptance tests fail, the microservice is unable to perform in the production environment, people get paged, et cetera.

At time of writing, one workaround we _could_ do is to leverage the `field(init=False)` feature, like so:
```
@dataclass
class GetUserResponse:
  ...
  last_name: str = field(init=False)
```
However, this does not address the pain point because we still have to go back and account for changes in the response object _preemptively_ every time something changes in how microservices or APIs interact with our software, in order to prevent future runtime crashes! It's not realistic to predict these breaking external changes, even if those changes come from another team within the same company.

Wouldn't it be great if a `@dataclass` could just work with only the information we want, without having to specify _every single_ object member in our response body?

### Implementation

This pain point can be healed with just a **one line** change in `dataclasses.py` by adding `**kwargs` to allow for unaccounted data members! 

After incorporating this one-line change, we can now use `@dataclass` in a much more robust fashion. In the above example, we are now able to create a `GetUserResponse` object that does not save the `last_name` member.  We can still include it in our class specification, but our program will no longer _crash_ at runtime just because of the sudden change in our signature!

### Alternatives

If writing this directly into the generated `__init__` method is a blocker, we could instead add a layer of indirection with a new `@dataclass` signature flag (e.g. `@dataclass(strict=False)`) that will only add `**kwargs` to the generated `__init__` method if the flag is set appropriately. I'll be happy to accomodate that if you guys want to go in that direction instead.



Well, that's my PR. Thanks for reading!

<!-- issue-number: [bpo-33129](https://bugs.python.org/issue33129) -->
https://bugs.python.org/issue33129
<!-- /issue-number -->
