### PR TITLE
bpo-40101: Fix parser's assumption about the return value of convert

### DIFF
--- a/Lib/lib2to3/pgen2/parse.py
+++ b/Lib/lib2to3/pgen2/parse.py
@@ -201,4 +201,7 @@ class Parser(object):
                 node[-1].append(newnode)
             else:
                 self.rootnode = newnode
-                self.rootnode.used_names = self.used_names
+                try:
+                    self.rootnode.used_names = self.used_names
+                except AttributeError:
+                    pass # skip if an attribute can't be assigned

--- a/Lib/lib2to3/pgen2/parse.py
+++ b/Lib/lib2to3/pgen2/parse.py
@@ -10,6 +10,8 @@ how this parsing engine works.
 
 """
 
+import contextlib
+
 # Local imports
 from . import token
 
@@ -201,7 +203,5 @@ class Parser(object):
                 node[-1].append(newnode)
             else:
                 self.rootnode = newnode
-                try:
+                with contextlib.suppress(AttributeError):
                     self.rootnode.used_names = self.used_names
-                except AttributeError:
-                    pass # skip if an attribute can't be assigned

--- a/Lib/lib2to3/tests/test_parser.py
+++ b/Lib/lib2to3/tests/test_parser.py
@@ -23,6 +23,7 @@ import tempfile
 import unittest
 
 # Local imports
+from lib2to3 import pytree
 from lib2to3.pgen2 import driver as pgen2_driver
 from lib2to3.pgen2 import tokenize
 from ..pgen2.parse import ParseError
@@ -37,6 +38,11 @@ class TestDriver(support.TestCase):
         self.assertEqual(t.children[0].children[0].type, syms.print_stmt)
         self.assertEqual(t.children[1].children[0].type, syms.print_stmt)
 
+    def test_driver_with_default_convert(self):
+        driver = pgen2_driver.Driver(grammar=support.grammar)
+        driver.parse_string("test\n")
+        driver = pgen2_driver.Driver(grammar=support.grammar, convert=pytree.convert)
+        self.assertEqual(driver.parse_string("test\n").used_names, {"test"})
 
 class TestPgen2Caching(support.TestCase):
     def test_load_grammar_from_txt_file(self):

--- a/Misc/NEWS.d/next/Library/2020-03-29-18-27-06.bpo-40101.iWJqAe.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-29-18-27-06.bpo-40101.iWJqAe.rst
@@ -1,0 +1,3 @@
+Allow usages of Driver/Parser from :mod:`lib2to3` without a convert
+functionality or a converter that would return unassignable objects. Patch
+by Batuhan Taskaya.


### PR DESCRIPTION

<!-- issue-number: [bpo-40101](https://bugs.python.org/issue40101) -->
https://bugs.python.org/issue40101
<!-- /issue-number -->
