### PR TITLE
bpo-40103: Ensuring that `ZipFile`s with overlapping directories can be extracted simultaneously from multiple processes.

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1677,11 +1677,11 @@ class ZipFile:
         # Create all upper directories if necessary.
         upperdirs = os.path.dirname(targetpath)
         if upperdirs and not os.path.exists(upperdirs):
-            os.makedirs(upperdirs)
+            os.makedirs(upperdirs, exist_ok=True)
 
         if member.is_dir():
             if not os.path.isdir(targetpath):
-                os.mkdir(targetpath)
+                os.makedirs(targetpath, exist_ok=True)
             return targetpath
 
         with self.open(member, pwd=pwd) as source, \

--- a/Misc/NEWS.d/next/Library/2020-04-20-13-51-24.bpo-40103.7e8Bld.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-20-13-51-24.bpo-40103.7e8Bld.rst
@@ -1,0 +1,1 @@
+Ensuring that Python can unzip into the same directories from multiple processes at the same time.


### PR DESCRIPTION
When multiple processes are extracting `ZipFile`s, if the files being extracted share parent directories, they may collide on the `os.makedir` calls which will result in an error. For example:

```
zip0.zip: [parent/filename0.txt]
zip1.zip: [parent/filename1.txt]
```
If the two zips are extracted by separate processes, they may both attempt to check for, and create, `parent` at the same time.

https://bugs.python.org/issue40103

<!-- issue-number: [bpo-40103](https://bugs.python.org/issue40103) -->
https://bugs.python.org/issue40103
<!-- /issue-number -->
