### PR TITLE
Issue40104: Fix issue with usage of a default namespace with child element lookup

### DIFF
--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -89,6 +89,8 @@ def xpath_tokenizer(pattern, namespaces=None):
             else:
                 yield token
             parsing_attribute = False
+        elif namespaces and '' in namespaces:
+            yield '', "{%s}%s" % (namespaces[''], token[1])
         else:
             yield token
             parsing_attribute = ttype == '@'


### PR DESCRIPTION
This fixes an issue with default namespace lookups of elements.  Here is some python test code that verifies the issue.

```
from xml.etree.ElementTree import fromstring as parse_xml_fromstring
from xml.etree.ElementTree import ElementTree

SAMPLEXML = """<?xml version="1.0" encoding="utf-8"?>
<root xmlns="urn:schemas-upnp-org:device-1-0">
    <specVersion><major>1</major><minor>0</minor></specVersion>
    <device>
        <deviceType>urn:schemas-wifialliance-org:device:WFADevice:1</deviceType>
        <friendlyName>R7400 (Wireless AP)</friendlyName>
    </device>
</root>

rootNode = parse_xml_fromstring(SAMPLEXML)
# Create a namespaces map like { '': 'urn:schemas-upnp-org:device-1-0' }
defaultns = {"": docNode.tag.split("}")[0][1:]}

specVerNode = docNode.find("specVersion", namespaces=defaultns)
```
Results should look like this

```
docNode.find("specVersion", namespaces=defaultns)
<Element '{urn:schemas-upnp-org:device-1-0}specVersion' at 0x7f18030e32f0>
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
