### PR TITLE
bpo-37973: Improve the docstrings of sys.float_info

### DIFF
--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -59,12 +59,14 @@ static PyStructSequence_Field floatinfo_fields[] = {
                     "is a normalized float"},
     {"min_10_exp",      "DBL_MIN_10_EXP -- minimum int e such that 10**e is "
                     "a normalized"},
-    {"dig",             "DBL_DIG -- digits"},
+    {"dig",             "DBL_DIG -- maximum number of decimal digits that "
+                    "can be faithfully represented in a float"},
     {"mant_dig",        "DBL_MANT_DIG -- mantissa digits"},
     {"epsilon",         "DBL_EPSILON -- Difference between 1 and the next "
                     "representable float"},
     {"radix",           "FLT_RADIX -- radix of exponent"},
-    {"rounds",          "FLT_ROUNDS -- rounding mode"},
+    {"rounds",          "FLT_ROUNDS -- rounding mode used for arithmetic "
+                    "operations"},
     {0}
 };
 


### PR DESCRIPTION
Taken from https://docs.python.org/3/library/sys.html#sys.float_info


<!-- issue-number: [bpo-37973](https://bugs.python.org/issue37973) -->
https://bugs.python.org/issue37973
<!-- /issue-number -->
