### PR TITLE
bpo-40112: Fix logic to determine if xlc is ccompiler

### DIFF
--- a/Lib/distutils/tests/test_config_cmd.py
+++ b/Lib/distutils/tests/test_config_cmd.py
@@ -47,8 +47,7 @@ class ConfigTestCase(support.LoggingSilencer,
         cmd = config(dist)
         cmd._check_compiler()
         compiler = cmd.compiler
-        is_xlc = "xlc" in compiler.preprocessor[0].lower()
-        if is_xlc:
+        if sys.platform[:3] == "aix" and "xlc" in compiler.preprocessor[0].lower():
             self.skipTest('xlc: The -E option overrides the -P, -o, and -qsyntaxonly options')
 
         # simple pattern searches

--- a/Lib/distutils/tests/test_config_cmd.py
+++ b/Lib/distutils/tests/test_config_cmd.py
@@ -47,7 +47,7 @@ class ConfigTestCase(support.LoggingSilencer,
         cmd = config(dist)
         cmd._check_compiler()
         compiler = cmd.compiler
-        is_xlc = shutil.which(compiler.preprocessor[0]).startswith("/usr/vac")
+        is_xlc = "xlc" in compiler.preprocessor[0].lower()
         if is_xlc:
             self.skipTest('xlc: The -E option overrides the -P, -o, and -qsyntaxonly options')
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40112](https://bugs.python.org/issue40112) -->
https://bugs.python.org/issue40112
<!-- /issue-number -->

No need for a NEWS entry - I think.