### PR TITLE
bpo-40114 support maxsize argument for lru_cache user_function option

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -560,6 +560,7 @@ def lru_cache(*args, maxsize=object(), typed=object()):
         return decorating_function(user_function)
     return decorating_function
 
+lru_cache.__text_signature__ = "(maxsize=128, typed=False)"
 
 def _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo):
     # Constants shared by all lru cache instances:

--- a/Misc/NEWS.d/next/Library/2020-03-30-12-03-46.bpo-40114.QIbPaD.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-30-12-03-46.bpo-40114.QIbPaD.rst
@@ -1,0 +1,1 @@
+functools.lru_cache() user_function option now supports optional maxsize argument


### PR DESCRIPTION
<!-- issue-number: [bpo-40114](https://bugs.python.org/issue40114) -->
https://bugs.python.org/issue40114
<!-- /issue-number -->
