### PR TITLE
bpo-40108: Improve the error message in rumpy when importing a module including the extension

### DIFF
--- a/Lib/runpy.py
+++ b/Lib/runpy.py
@@ -133,6 +133,9 @@ def _get_module_details(mod_name, error=ImportError):
         # importlib, where the latter raises other errors for cases where
         # pkgutil previously raised ImportError
         msg = "Error while finding module specification for {!r} ({}: {})"
+        if mod_name.endswith(".py"):
+            msg += (f". Try using '{mod_name[:-3]}' instead of "
+                    f"'{mod_name}' as the module name.")
         raise error(msg.format(mod_name, type(ex).__name__, ex)) from ex
     if spec is None:
         raise error("No module named %s" % mod_name)

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -499,6 +499,16 @@ class CmdLineTest(unittest.TestCase):
             self.assertNotIn(b'is a package', err)
             self.assertNotIn(b'Traceback', err)
 
+    def test_hint_when_triying_to_import_a_py_file(self):
+        with support.temp_dir() as script_dir, \
+                support.change_cwd(path=script_dir):
+            # Create invalid *.pyc as empty file
+            with open('asyncio.py', 'wb'):
+                pass
+            err = self.check_dash_m_failure('asyncio.py')
+            self.assertIn(b"Try using 'asyncio' instead "
+                          b"of 'asyncio.py' as the module name", err)
+
     def test_dash_m_init_traceback(self):
         # These were wrapped in an ImportError and tracebacks were
         # suppressed; see Issue 14285

--- a/Misc/NEWS.d/next/Library/2020-03-31-01-11-20.bpo-40108.EGDVQ_.rst
+++ b/Misc/NEWS.d/next/Library/2020-03-31-01-11-20.bpo-40108.EGDVQ_.rst
@@ -1,0 +1,3 @@
+Improve the error message when triying to import a module using :mod:`runpy`
+and incorrently use the ".py" extension at the end of the module name. Patch
+by Pablo Galindo.


### PR DESCRIPTION


<!-- issue-number: [bpo-40108](https://bugs.python.org/issue40108) -->
https://bugs.python.org/issue40108
<!-- /issue-number -->
