### PR TITLE
bpo-40124: Explain an assert when waiting on a asyncio stream drain

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -191,7 +191,9 @@ class FlowControlMixin(protocols.Protocol):
         if not self._paused:
             return
         waiter = self._drain_waiter
-        assert waiter is None or waiter.cancelled()
+        assert waiter is None or waiter.cancelled(), (
+            'Another task is waiting for this stream to drain'
+        )
         waiter = self._loop.create_future()
         self._drain_waiter = waiter
         await waiter


### PR DESCRIPTION
If a task is waiting on a stream to drain and another task tries to
this assertion will fail. It wasn't clear at first glance why the
assertion failed, but I hope with this message it will be.


<!-- issue-number: [bpo-40124](https://bugs.python.org/issue40124) -->
https://bugs.python.org/issue40124
<!-- /issue-number -->
