### PR TITLE
bpo-40003: test.bisect_cmd copies Python options

### DIFF
--- a/Lib/test/bisect_cmd.py
+++ b/Lib/test/bisect_cmd.py
@@ -47,8 +47,16 @@ def format_shell_args(args):
     return ' '.join(args)
 
 
+def python_cmd():
+    cmd = [sys.executable]
+    cmd.extend(subprocess._args_from_interpreter_flags())
+    cmd.extend(subprocess._optim_args_from_interpreter_flags())
+    return cmd
+
+
 def list_cases(args):
-    cmd = [sys.executable, '-m', 'test', '--list-cases']
+    cmd = python_cmd()
+    cmd.extend(['-m', 'test', '--list-cases'])
     cmd.extend(args.test_args)
     proc = subprocess.run(cmd,
                           stdout=subprocess.PIPE,
@@ -68,7 +76,8 @@ def run_tests(args, tests, huntrleaks=None):
     try:
         write_tests(tmp, tests)
 
-        cmd = [sys.executable, '-m', 'test', '--matchfile', tmp]
+        cmd = python_cmd()
+        cmd.extend(['-m', 'test', '--matchfile', tmp])
         cmd.extend(args.test_args)
         print("+ %s" % format_shell_args(cmd))
         proc = subprocess.run(cmd)
@@ -100,6 +109,9 @@ def parse_args():
 
 def main():
     args = parse_args()
+    if '-w' in args.test_args or '--verbose2' in args.test_args:
+        print("WARNING: -w/--verbose2 option should not be used to bisect!")
+        print()
 
     if args.input:
         with open(args.input) as fp:

--- a/Misc/NEWS.d/next/Tests/2020-03-31-16-07-15.bpo-40003.SOruLY.rst
+++ b/Misc/NEWS.d/next/Tests/2020-03-31-16-07-15.bpo-40003.SOruLY.rst
@@ -1,0 +1,3 @@
+``test.bisect_cmd`` now copies Python command line options like ``-O`` or
+``-W``. Moreover, emit a warning if ``test.bisect_cmd`` is used with
+``-w``/``--verbose2`` option.


### PR DESCRIPTION
test.bisect_cmd now copies Python command line options like -O or -W.
Moreover, emit a warning if test.bisect_cmd is used with
-w/--verbose2 option.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40003](https://bugs.python.org/issue40003) -->
https://bugs.python.org/issue40003
<!-- /issue-number -->
