### PR TITLE
bpo-40127: SSL library documentation

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -128,8 +128,9 @@ purposes.
    *cafile*, *capath*, *cadata* represent optional CA certificates to
    trust for certificate verification, as in
    :meth:`SSLContext.load_verify_locations`.  If all three are
-   :const:`None`, this function trusts the system's default
-   CA certificates instead.
+   :const:`None` and :attr:`SSLContext.verify_mode` is not set to
+   :data:`CERT_NONE`, this function uses the system's default CA
+   certificates.
 
    The settings are: :data:`PROTOCOL_TLS`, :data:`OP_NO_SSLv2`, and
    :data:`OP_NO_SSLv3` with high encryption cipher suites without RC4 and

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -128,7 +128,7 @@ purposes.
    *cafile*, *capath*, *cadata* represent optional CA certificates to
    trust for certificate verification, as in
    :meth:`SSLContext.load_verify_locations`.  If all three are
-   :const:`None`, this function can choose to trust the system's default
+   :const:`None`, this function trusts the system's default
    CA certificates instead.
 
    The settings are: :data:`PROTOCOL_TLS`, :data:`OP_NO_SSLv2`, and


### PR DESCRIPTION
Remove *can choose* statement as there is no choice when no cafile, capath, cadata are given.

<!-- issue-number: [bpo-40127](https://bugs.python.org/issue40127) -->
https://bugs.python.org/issue40127
<!-- /issue-number -->
