### PR TITLE
Handle when IOCTL_VM_SOCKETS_GET_LOCAL_CID does not exist in "socket"

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -49,6 +49,8 @@ except ImportError:
 def get_cid():
     if fcntl is None:
         return None
+    if not hasattr(socket, 'IOCTL_VM_SOCKETS_GET_LOCAL_CID'):
+        return None
     try:
         with open("/dev/vsock", "rb") as f:
             r = fcntl.ioctl(f, socket.IOCTL_VM_SOCKETS_GET_LOCAL_CID, "    ")


### PR DESCRIPTION
Running `test_socket` or anything that depends on it (like python -m
test.pythoninfo) crashes if IOCTL_VM_SOCKETS_GET_LOCAL_CID does not
exist in the socket module.

Automerge-Triggered-By: @pablogsal