### PR TITLE
bpo-40071: Fix potential crash in _functoolsmodule.c

### DIFF
--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1413,7 +1413,10 @@ static PyMethodDef _functools_methods[] = {
 static void
 _functools_free(void *m)
 {
-    Py_CLEAR(kwd_mark);
+    // FIXME: Do not clear kwd_mark to avoid NULL pointer dereferencing if we have
+    //        other modules instances that could use it. Will fix when PEP-573 land
+    //        and we could move kwd_mark to a per-module state.
+    // Py_CLEAR(kwd_mark);
 }
 
 static int


### PR DESCRIPTION
Changes on 7dd549e made _functools compatible with
PEP-489 and we could have multiple modules instances loaded.

But, right now there is no way to make `kwd_mark` global into
a per module instance variable. kwd_mark is used on lru_cache_new
which does not have a reference to a PyModule*, necessary to use
PyModule_GetState.

PEP-573 will solve this problem and will allow us to move the global
state to per-module data and properly clear the state when unloading
a module instance.

This change temporarily disable cleaning of kwd_mark to avoid NULL
pointer dereference if we clear kwd_mark and other module instances
still alive use it.

<!-- issue-number: [bpo-40071](https://bugs.python.org/issue40071) -->
https://bugs.python.org/issue40071
<!-- /issue-number -->
