### PR TITLE
bpo-37207: Use PEP 590 vectorcall to speed up dict()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-02-00-25-19.bpo-37207.ZTPmKJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-02-00-25-19.bpo-37207.ZTPmKJ.rst
@@ -1,0 +1,2 @@
+Speed up calls to ``dict()`` by using the :pep:`590` ``vectorcall`` calling
+convention.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3363,14 +3363,12 @@ dict_vectorcall(PyObject *type, PyObject * const*args,
         }
         args++;
     }
-    if (kwnames == NULL) {
-        return self;
-    }
-
-    for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(kwnames); i++) {
-        if (PyDict_SetItem(self, PyTuple_GET_ITEM(kwnames, i), args[i]) < 0) {
-            Py_DECREF(self);
-            return NULL;
+    if (kwnames != NULL) {
+        for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(kwnames); i++) {
+            if (PyDict_SetItem(self, PyTuple_GET_ITEM(kwnames, i), args[i]) < 0) {
+                Py_DECREF(self);
+                return NULL;
+            }
         }
     }
     return self;

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3343,6 +3343,40 @@ dict_init(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
+dict_vectorcall(PyObject *type, PyObject * const*args,
+                size_t nargsf, PyObject *kwnames)
+{
+    assert(PyType_Check(type));
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (!_PyArg_CheckPositional("dict", nargs, 0, 1)) {
+        return NULL;
+    }
+
+    PyObject *self = dict_new((PyTypeObject *)type, NULL, NULL);
+    if (self == NULL) {
+        return NULL;
+    }
+    if (nargs == 1) {
+        if (dict_update_arg(self, args[0]) < 0) {
+            Py_DECREF(self);
+            return NULL;
+        }
+        args++;
+    }
+    if (kwnames == NULL) {
+        return self;
+    }
+
+    for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(kwnames); i++) {
+        if (PyDict_SetItem(self, PyTuple_GET_ITEM(kwnames, i), args[i]) < 0) {
+            Py_DECREF(self);
+            return NULL;
+        }
+    }
+    return self;
+}
+
+static PyObject *
 dict_iter(PyDictObject *dict)
 {
     return dictiter_new(dict, &PyDictIterKey_Type);
@@ -3400,6 +3434,7 @@ PyTypeObject PyDict_Type = {
     PyType_GenericAlloc,                        /* tp_alloc */
     dict_new,                                   /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
+    .tp_vectorcall = dict_vectorcall,
 };
 
 PyObject *


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37207](https://bugs.python.org/issue37207) -->
https://bugs.python.org/issue37207
<!-- /issue-number -->
