### PR TITLE
bpo-39740: Early declare devpoll_methods to support old compilers

### DIFF
--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -764,6 +764,8 @@ poll_dealloc(pollObject *self)
 
 
 #ifdef HAVE_SYS_DEVPOLL_H
+static PyMethodDef devpoll_methods[];
+
 typedef struct {
     PyObject_HEAD
     int fd_devpoll;


### PR DESCRIPTION
Compilers like solaris studio's cc are throwing errors when compiling select module.

<!-- issue-number: [bpo-39740](https://bugs.python.org/issue39740) -->
https://bugs.python.org/issue39740
<!-- /issue-number -->
