### PR TITLE
bpo-40094: CGIHTTPRequestHandler logs exit code

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1164,8 +1164,9 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
                 while select.select([self.rfile], [], [], 0)[0]:
                     if not self.rfile.read(1):
                         break
-                if sts:
-                    self.log_error("CGI script exit status %#x", sts)
+                exitcode = os.waitstatus_to_exitcode(sts)
+                if exitcode:
+                    self.log_error(f"CGI script exit code {exitcode}")
                 return
             # Child
             try:

--- a/Misc/NEWS.d/next/Library/2020-04-02-01-13-28.bpo-40094.AeZ34K.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-02-01-13-28.bpo-40094.AeZ34K.rst
@@ -1,0 +1,3 @@
+CGIHTTPRequestHandler of http.server now logs the CGI script exit code,
+rather than the CGI script exit status of os.waitpid(). For example, if the
+script is killed by signal 11, it now logs: "CGI script exit code -11."


### PR DESCRIPTION
CGIHTTPRequestHandler of http.server now logs the CGI script exit
code, rather than the CGI script exit status of os.waitpid().

For example, if the script is killed by signal 11, it now logs:
"CGI script exit code -11."

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40094](https://bugs.python.org/issue40094) -->
https://bugs.python.org/issue40094
<!-- /issue-number -->
