### PR TITLE
bpo-40094: Fix which.py script exit code

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2020-04-02-01-22-21.bpo-40094.1XQQF6.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-04-02-01-22-21.bpo-40094.1XQQF6.rst
@@ -1,0 +1,3 @@
+Fix ``which.py`` script exit code: it now uses
+:func:`os.waitstatus_to_exitcode` to convert :func:`os.system` exit status
+into an exit code.

--- a/Tools/scripts/which.py
+++ b/Tools/scripts/which.py
@@ -49,6 +49,7 @@ def main():
                     msg(filename + ': not executable')
             if longlist:
                 sts = os.system('ls ' + longlist + ' ' + filename)
+                sts = os.waitstatus_to_exitcode(sts)
                 if sts: msg('"ls -l" exit status: ' + repr(sts))
         if not ident:
             msg(prog + ': not found')


### PR DESCRIPTION
It now uses os.waitstatus_to_exitcode() to convert os.system() exit
status into an exit code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40094](https://bugs.python.org/issue40094) -->
https://bugs.python.org/issue40094
<!-- /issue-number -->
