### PR TITLE
bpo-40094: mailcap.test() uses waitstatus_to_exitcode()

### DIFF
--- a/Lib/mailcap.py
+++ b/Lib/mailcap.py
@@ -251,6 +251,7 @@ def test():
         else:
             print("Executing:", command)
             sts = os.system(command)
+            sts = os.waitstatus_to_exitcode(sts)
             if sts:
                 print("Exit status:", sts)
 


### PR DESCRIPTION
mailcap.test() now uses os.waitstatus_to_exitcode() to convert
os.system() exit status into an exit code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40094](https://bugs.python.org/issue40094) -->
https://bugs.python.org/issue40094
<!-- /issue-number -->
