### PR TITLE
bpo-39865: Don't lose exception context when __getattr__ is present

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -78,6 +78,10 @@ PyAPI_FUNC(void) _PyErr_SetKeyError(PyObject *);
 _PyErr_StackItem *_PyErr_GetTopmostException(PyThreadState *tstate);
 PyAPI_FUNC(void) _PyErr_GetExcInfo(PyThreadState *, PyObject **, PyObject **, PyObject **);
 
+/* Cause manipulation (PEP 3134) */
+
+PyAPI_FUNC(void) _PyErr_ChainExceptionCause(PyObject *, PyObject *, PyObject *);
+
 /* Context manipulation (PEP 3134) */
 
 PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);

--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-02-03-24-05.bpo-39865.C01OR6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-02-03-24-05.bpo-39865.C01OR6.rst
@@ -1,0 +1,3 @@
+AttributeError exceptions thrown when getting an attribute before falling
+back to __getattr__ are now shown as the cause. This can prevent some
+important context from being accidentally surpressed.


### PR DESCRIPTION
When a class has a `__getattr__` hook, it attempts to retrieve the attribute (e.g through a descriptor or the `__dict__`). If this initial attempt fails with `AttributeError` then a fallback is attempted on `__getattr__`. In turn, if the `__getattr__` raises another `AttributeError`, then the original exception that caused the fallback is lost. This PR attempts to surface that information to avoid subtle bugs that might be caused by this.

The motivating example for this, as taken from the test is:

```python
class A:
    @property
    def foo(self):
        a = 0
        a.accidental_attribute_error
        return 42
    def __getattr__(self, attr):
        if attr == 'foo':
            raise AttributeError("foo not supported in getattr")
        else:
            return 'fallback'
```

In this case, this class supports `a.foo` through a descriptor/property but has a bug in it. Previously attempting to access `a.foo` would lead to this traceback:

```
Traceback (most recent call last):
  File "lib\test\test_descr.py", line 2301, in test_property_fallback_exception
    a.foo
  File "lib\test\test_descr.py", line 2294, in __getattr__
    raise AttributeError("foo not supported in getattr")
AttributeError: foo not supported in getattr
```

This masks the original exception that caused the lookup to be delegated to `__getattr__`. However with the right cause set, the error message now looks like:

```
  File "lib\test\test_descr.py", line 2290, in foo
    a.accidental_attribute_error
AttributeError: 'int' object has no attribute 'accidental_attribute_error'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "lib\test\test_descr.py", line 2301, in test_property_fallback_exception
    a.foo
  File "lib\test\test_descr.py", line 2294, in __getattr__
    raise AttributeError("foo not supported in getattr")
AttributeError: foo not supported in getattr
```

which makes the real root cause of the bug a lot easier to diagnose. There's also external reason to believe that this might be a problem:

* https://stackoverflow.com/a/24260979/11365663
* https://github.com/davidhalter/jedi/blob/28c1ba6c1c757aa36ebc6a53d58115ba88e6c4f4/jedi/inference/utils.py#L52-L79

-----

The code to set the cause could definitely use a helper in the `PyErr_` namespace. It's pretty ugly as it stands now.

<!-- issue-number: [bpo-39865](https://bugs.python.org/issue39865) -->
https://bugs.python.org/issue39865
<!-- /issue-number -->
