### PR TITLE
bpo-31160: Fix test_builtin.test_input_no_stdout_fileno()

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -831,11 +831,14 @@ The :mod:`test.support` module defines the following functions:
    *exitcode*.
 
    Raise an :exc:`AssertionError` if the process exit code is not equal to
-   *exitcode*.
+   *exitcode*. Use ``exitcode=None`` to not check the process exit code. The
+   returned process exit code can be used to check it in the caller.
 
    If the process runs longer than *timeout* seconds (:data:`SHORT_TIMEOUT` by
    default), kill the process and raise an :exc:`AssertionError`. The timeout
    feature is not available on Windows.
+
+    Return the process exit code.
 
    .. versionadded:: 3.9
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3407,11 +3407,15 @@ def wait_process(pid, *, exitcode, timeout=None):
     Wait until process pid completes and check that the process exit code is
     exitcode.
 
-    Raise an AssertionError if the process exit code is not equal to exitcode.
+    Raise an AssertionError if the process exit code is not equal to
+    exitcode. Use exitcode=None to not check the process exit code. The
+    returned process exit code can be used to check it in the caller.
 
-    If the process runs longer than timeout seconds (SHORT_TIMEOUT by default),
-    kill the process (if signal.SIGKILL is available) and raise an
-    AssertionError. The timeout feature is not available on Windows.
+    If the process runs longer than *timeout* seconds (SHORT_TIMEOUT by
+    default), kill the process and raise an AssertionError. The timeout feature
+    is not available on Windows.
+
+    Return the process exit code.
     """
     if os.name != "nt":
         import signal
@@ -3447,10 +3451,12 @@ def wait_process(pid, *, exitcode, timeout=None):
         pid2, status = os.waitpid(pid, 0)
 
     exitcode2 = os.waitstatus_to_exitcode(status)
-    if exitcode2 != exitcode:
+    if exitcode is not None and exitcode2 != exitcode:
         raise AssertionError(f"process {pid} exited with code {exitcode2}, "
                              f"but exit code {exitcode} is expected")
 
     # sanity check: it should not fail in practice
     if pid2 != pid:
         raise AssertionError(f"pid {pid2} != pid {pid}")
+
+    return exitcode2


### PR DESCRIPTION
[bpo-31160](https://bugs.python.org/issue31160), [bpo-40140](https://bugs.python.org/issue40140), [bpo-40155](https://bugs.python.org/issue40155): Fix test_input_no_stdout_fileno() of
test_builtin.

test.support.wait_process() can now be called with exitcode=None to
not check the exit code. Moreover, it now returns the child process
exit code, so it can be checked in the caller.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-31160](https://bugs.python.org/issue31160) -->
https://bugs.python.org/issue31160
<!-- /issue-number -->
