### PR TITLE
bpo-40160: update to os.walk documentation example

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3048,14 +3048,16 @@ features:
    walking the tree bottom-up is essential, :func:`rmdir` doesn't allow
    deleting a directory before the directory is empty::
 
-      # Output everything reachable from the directory named in "top",
+      # Delete everything reachable from the directory named in "top",
       # assuming there are no symbolic links.
+      # CAUTION:  This is dangerous!  For example, if top == '/', it
+      # could delete all your disk files.
       import os
       for root, dirs, files in os.walk(top, topdown=False):
           for name in files:
-              print("file:", os.path.join(root, name))
+              print(f"os.remove('{os.path.join(root, name)}')")
           for name in dirs:
-              print("directory:", os.path.join(root, name))
+              print(f"os.remove('{os.path.join(root, name)}')")
 
    .. audit-event:: os.walk top,topdown,onerror,followlinks os.walk
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3048,16 +3048,14 @@ features:
    walking the tree bottom-up is essential, :func:`rmdir` doesn't allow
    deleting a directory before the directory is empty::
 
-      # Delete everything reachable from the directory named in "top",
+      # Output everything reachable from the directory named in "top",
       # assuming there are no symbolic links.
-      # CAUTION:  This is dangerous!  For example, if top == '/', it
-      # could delete all your disk files.
       import os
       for root, dirs, files in os.walk(top, topdown=False):
           for name in files:
-              os.remove(os.path.join(root, name))
+              print("file:", os.path.join(root, name))
           for name in dirs:
-              os.rmdir(os.path.join(root, name))
+              print("directory:", os.path.join(root, name))
 
    .. audit-event:: os.walk top,topdown,onerror,followlinks os.walk
 

--- a/Misc/NEWS.d/next/Documentation/2020-04-02-21-34-35.bpo-40160.8AGXVv.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-04-02-21-34-35.bpo-40160.8AGXVv.rst
@@ -1,1 +1,0 @@
-skip news

--- a/Misc/NEWS.d/next/Documentation/2020-04-02-21-34-35.bpo-40160.8AGXVv.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-04-02-21-34-35.bpo-40160.8AGXVv.rst
@@ -1,0 +1,1 @@
+skip news


### PR DESCRIPTION
The example for os.walkdir should be less destructive. It currently recursively removes all files and directories. I think it is a good idea to change this in case someone does a copy / paste from the documentation.

https://bugs.python.org/issue40160


<!-- issue-number: [bpo-40160](https://bugs.python.org/issue40160) -->
https://bugs.python.org/issue40160
<!-- /issue-number -->
