### PR TITLE
bpo-40165: Suppress stderr from the user on skip for test_stty_match

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3453,7 +3453,11 @@ class TermsizeTests(unittest.TestCase):
         should work too.
         """
         try:
-            size = subprocess.check_output(['stty', 'size']).decode().split()
+            size = (
+                subprocess.check_output(
+                    ["stty", "size"], stderr=subprocess.DEVNULL, text=True
+                ).split()
+            )
         except (FileNotFoundError, subprocess.CalledProcessError,
                 PermissionError):
             self.skipTest("stty invocation failed")


### PR DESCRIPTION


<!-- issue-number: [bpo-40165](https://bugs.python.org/issue40165) -->
https://bugs.python.org/issue40165
<!-- /issue-number -->
