### PR TITLE
bpo-35037 Fix issue in cython project: Cython files don't compile on Mingw-w64 64-bit 

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-01-24-09-15-41.bpo-8901.hVnhGO.rst
+++ b/Misc/NEWS.d/next/Windows/2020-01-24-09-15-41.bpo-8901.hVnhGO.rst
@@ -1,1 +1,3 @@
 Ignore the Windows registry when the ``-E`` option is used.
+Add Mingw-w64 64-bit windows machine, fix issue
+in https://bugs.python.org/issue40167

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -78,6 +78,11 @@ WIN32 is still required for the locale module.
 
 
 /* Compiler specific defines */
+#ifdef __MINGW32__
+#ifdef _WIN64
+#define MS_WIN64
+#endif
+#endif
 
 /* ------------------------------------------------------------------------*/
 /* Microsoft C defines _MSC_VER */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

#### Reference Issues/PRs
[bpo-40167](https://bugs.python.org/issue40167)  https://bugs.python.org/issue40167
fixes cython project issue in https://github.com/cython/cython/issues/3405

#### What does this implement/fix? Explain your changes.
fix Cython files don't compile on Mingw-w64 64-bit problem


<!-- issue-number: [bpo-40167](https://bugs.python.org/issue40167) -->
https://bugs.python.org/issue40167
<!-- /issue-number -->
