### PR TITLE
bpo-40166: Change Unicode Howto so that it does not have a specific number of assigned code points.

### DIFF
--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -41,9 +41,9 @@ but these are two different characters that have different meanings.
 
 The Unicode standard describes how characters are represented by
 **code points**.  A code point value is an integer in the range 0 to
-0x10FFFF (about 1.1 million values, the actual number assigned is
-`less <http://www.unicode.org/versions/latest/#Summary>`_ than that).
-In the standard and in this document, a code point is written
+0x10FFFF (about 1.1 million values, the
+`actual number assigned <https://www.unicode.org/versions/latest/#Summary>`_
+is less than that). In the standard and in this document, a code point is written
 using the notation ``U+265E`` to mean the character with value
 ``0x265e`` (9,822 in decimal).
 

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,7 +157,7 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <https://www.unicode.org>`_ has character charts, a
+The `Unicode Consortium site <http://unicode.org/main.html>`_ has character charts, a
 glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -41,8 +41,9 @@ but these are two different characters that have different meanings.
 
 The Unicode standard describes how characters are represented by
 **code points**.  A code point value is an integer in the range 0 to
-0x10FFFF (about 1.1 million values, with some 110 thousand assigned so
-far).  In the standard and in this document, a code point is written
+0x10FFFF (about 1.1 million values, the actual number assigned is
+`less <http://www.unicode.org/versions/latest/#Summary>`_ than that).
+In the standard and in this document, a code point is written
 using the notation ``U+265E`` to mean the character with value
 ``0x265e`` (9,822 in decimal).
 

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,7 +157,7 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <https://unicode.org/main.html>`_ has character charts, a
+The `Unicode Consortium site <https://www.unicode.org/main.html>`_ has character charts, a
 glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,7 +157,7 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <http://unicode.org/main.html>`_ has character charts, a
+The `Unicode Consortium site <https://unicode.org/main.html>`_ has character charts, a
 glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,8 +157,8 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <https://www.unicode.org/main.html>`_ has character charts, a
-glossary, and PDF versions of the Unicode specification.  Be prepared for some
+The `Unicode Consortium site <https://www.unicode.org/main.html>`_ has character charts,
+a glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.
 

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,8 +157,8 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <https://www.unicode.org/main.html>`_ has character charts,
-a glossary, and PDF versions of the Unicode specification.  Be prepared for some
+The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts, a
+glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.
 

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,7 +157,7 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts, a
+The `Unicode Consortium site <https://www.unicode.org>`_ has character charts, a
 glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,8 +157,8 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts, a
-glossary, and PDF versions of the Unicode specification.  Be prepared for some
+The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts,
+a glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.
 

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,7 +157,7 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts, a
+The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts, 
 glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,8 +157,8 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts,
-a glossary, and PDF versions of the Unicode specification.  Be prepared for some
+The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts, a
+glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.
 

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -157,7 +157,7 @@ UTF-8 has several convenient properties:
 References
 ----------
 
-The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts, 
+The `Unicode Consortium site <https://www.unicode.org/>`_ has character charts, a
 glossary, and PDF versions of the Unicode specification.  Be prepared for some
 difficult reading.  `A chronology <https://www.unicode.org/history/>`_ of the
 origin and development of Unicode is also available on the site.


### PR DESCRIPTION
The link http://www.unicode.org/versions/latest/#Summary redirects to the summary section of the summary page of the latest version of the Unicode Standard. The current latest version is version 13.0.0 .

The last few versions of the page have had the following sort of Summary opening (latest standard)

![image](https://user-images.githubusercontent.com/32741226/78321707-64bdb880-7575-11ea-9560-e7a88f6d1cc5.png)

This could be better than writing the number 110 thousand characters which is currently not true.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40166](https://bugs.python.org/issue40166) -->
https://bugs.python.org/issue40166
<!-- /issue-number -->
