### PR TITLE
bpo-40163: Fix multissltest download of old OpenSSL (GH-19329)

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2020-04-03-08-32-31.bpo-40163.lX8K4B.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-04-03-08-32-31.bpo-40163.lX8K4B.rst
@@ -1,0 +1,3 @@
+Fix multissltest tool. OpenSSL has changed download URL for old releases.
+The multissltest tool now tries to download from current and old download
+URLs.


### PR DESCRIPTION
OpenSSL has changed download URLs of old releases. The multitestssl tool
now tries to download from current and old URLs.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-40163](https://bugs.python.org/issue40163) -->
https://bugs.python.org/issue40163
<!-- /issue-number -->


Automerge-Triggered-By: @tiran