### PR TITLE
Add note in docs regarding uppercase 'X' specifier

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -463,6 +463,8 @@ The available integer presentation types are:
    +---------+----------------------------------------------------------+
    | ``'X'`` | Hex format. Outputs the number in base 16, using         |
    |         | upper-case letters for the digits above 9.               |
+   |         | Note: In case # is specified, the prefix '0x' will be    |
+   |         | uppercased as well.                                      |
    +---------+----------------------------------------------------------+
    | ``'n'`` | Number. This is the same as ``'d'``, except that it uses |
    |         | the current locale setting to insert the appropriate     |


### PR DESCRIPTION
I noticed that when using string format to print hexadecimal numbers like the following:

>>> '{:#X}'.format(1234)
'0X4D2'

I get an uppercase 'X', this is worth mentioning in the docs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
