### PR TITLE
Add note about IntEnum gotcha

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -591,6 +591,9 @@ However, they still can't be compared to standard :class:`Enum` enumerations::
     [0, 1]
 
 
+Note that the :class:`IntEnum` class is defined by mixing in :class:`int` to :class:`Enum`, which has some surprising
+ramifications; see `Others`_ for details.
+
 IntFlag
 ^^^^^^^
 


### PR DESCRIPTION
I discovered that `"{}".format(s)` on an IntEnum returned a different string than `str(s)`.  
This behavior surprised me (and at least one other person on the Python discord); I figured it'd be good to draw attention to it.