### PR TITLE
[3.7] bpo-40126: Fix attribute out of scope during error handling in mock

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1244,6 +1244,7 @@ class _patch(object):
         def patched(*args, **keywargs):
             extra_args = []
             entered_patchers = []
+            patching = None
 
             exc_info = tuple()
             try:

--- a/Misc/NEWS.d/next/Library/2020-04-03-21-15-27.bpo-40126.ggpdKD.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-03-21-15-27.bpo-40126.ggpdKD.rst
@@ -1,0 +1,4 @@
+Fixed an issue in unittest.mock where an unhandled exception can be raised
+by decorate_callable if patched.patchings is cleared during cleanup of
+another decorator. This causes the patching variable to be undefined in the
+exception handler, leading to an UnboundLocalError being raised.


### PR DESCRIPTION
Resolves an issue where the `patching` attribute raises `UnboundLocalError` as it can be out of scope if there is an error before assignment in loop execution (e.g. if `patched.patchings is None`). This can happen if a library clears `patchings` in its own decorator cleanup.

<!-- issue-number: [bpo-40126](https://bugs.python.org/issue40126) -->
https://bugs.python.org/issue40126
<!-- /issue-number -->
