### PR TITLE
bpo-40038: pathlib: remove partial support for preserving accessor when modifying a path

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -692,7 +692,7 @@ class PurePath(object):
         return cls._flavour.parse_parts(parts)
 
     @classmethod
-    def _from_parts(cls, args, init=True):
+    def _from_parts(cls, args):
         # We need to call _parse_args on the instance, so as to get the
         # right flavour.
         self = object.__new__(cls)
@@ -700,18 +700,14 @@ class PurePath(object):
         self._drv = drv
         self._root = root
         self._parts = parts
-        if init:
-            self._init()
         return self
 
     @classmethod
-    def _from_parsed_parts(cls, drv, root, parts, init=True):
+    def _from_parsed_parts(cls, drv, root, parts):
         self = object.__new__(cls)
         self._drv = drv
         self._root = root
         self._parts = parts
-        if init:
-            self._init()
         return self
 
     @classmethod
@@ -720,10 +716,6 @@ class PurePath(object):
             return drv + root + cls._flavour.join(parts[1:])
         else:
             return cls._flavour.join(parts)
-
-    def _init(self):
-        # Overridden in concrete Path
-        pass
 
     def _make_child(self, args):
         drv, root, parts = self._parse_args(args)
@@ -1064,28 +1056,17 @@ class Path(PurePath):
     object. You can also instantiate a PosixPath or WindowsPath directly,
     but cannot instantiate a WindowsPath on a POSIX system or vice versa.
     """
-    __slots__ = (
-        '_accessor',
-    )
+    _accessor = _normal_accessor
+    __slots__ = ()
 
     def __new__(cls, *args, **kwargs):
         if cls is Path:
             cls = WindowsPath if os.name == 'nt' else PosixPath
-        self = cls._from_parts(args, init=False)
+        self = cls._from_parts(args)
         if not self._flavour.is_supported:
             raise NotImplementedError("cannot instantiate %r on your system"
                                       % (cls.__name__,))
-        self._init()
         return self
-
-    def _init(self,
-              # Private non-constructor arguments
-              template=None,
-              ):
-        if template is not None:
-            self._accessor = template._accessor
-        else:
-            self._accessor = _normal_accessor
 
     def _make_child_relpath(self, part):
         # This is an optimization used for dir walking.  `part` must be
@@ -1194,9 +1175,7 @@ class Path(PurePath):
             return self
         # FIXME this must defer to the specific flavour (and, under Windows,
         # use nt._getfullpathname())
-        obj = self._from_parts([os.getcwd()] + self._parts, init=False)
-        obj._init(template=self)
-        return obj
+        return self._from_parts([os.getcwd()] + self._parts)
 
     def resolve(self, strict=False):
         """
@@ -1212,9 +1191,7 @@ class Path(PurePath):
             s = str(self.absolute())
         # Now we have no symlinks in the path, it's safe to normalize it.
         normed = self._flavour.pathmod.normpath(s)
-        obj = self._from_parts((normed,), init=False)
-        obj._init(template=self)
-        return obj
+        return self._from_parts((normed,))
 
     def stat(self):
         """
@@ -1282,9 +1259,7 @@ class Path(PurePath):
         Return the path to which the symbolic link points.
         """
         path = self._accessor.readlink(self)
-        obj = self._from_parts((path,), init=False)
-        obj._init(template=self)
-        return obj
+        return self._from_parts((path,))
 
     def touch(self, mode=0o666, exist_ok=True):
         """


### PR DESCRIPTION
Now #18846 has landed, `pathlib.Path._init()` does nothing useful and can be removed.

A long time ago, `_init()` helped preserve the current accessor when creating new paths from an existing path (e.g. by calling `q = p.resolve()`). But this has only ever worked for a small handful of methods, was never documented, and we currently don't support anything other than `_NormalAccessor` anyway.

More info in the bug report.

<!-- issue-number: [bpo-40038](https://bugs.python.org/issue40038) -->
https://bugs.python.org/issue40038
<!-- /issue-number -->
