### PR TITLE
bpo-40158: Fix CPython MSBuild Properties in NuGet Package

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-04-03-17-54-33.bpo-40158.MWUTs4.rst
+++ b/Misc/NEWS.d/next/Build/2020-04-03-17-54-33.bpo-40158.MWUTs4.rst
@@ -1,0 +1,1 @@
+Fix CPython MSBuild Properties in NuGet Package (build/native/python.props)

--- a/PC/layout/support/props.py
+++ b/PC/layout/support/props.py
@@ -29,8 +29,7 @@ PROPS_DATA["PYTHON_TARGET"] = "_GetPythonRuntimeFilesDependsOn{}{}_{}".format(
 PROPS_TEMPLATE = r"""<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="$(Platform) == '{PYTHON_PLATFORM}'">
-    <PythonHome Condition="$(Configuration) == 'Debug'">$([msbuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), "python_d.exe")</PythonHome>
-    <PythonHome Condition="$(PythonHome) == ''">$([msbuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), "python.exe")</PythonHome>
+    <PythonHome Condition="$(PythonHome) == ''">$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)\..\..\tools"))</PythonHome>
     <PythonInclude>$(PythonHome)\include</PythonInclude>
     <PythonLibs>$(PythonHome)\libs</PythonLibs>
     <PythonTag>{PYTHON_TAG}</PythonTag>


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Fixes the resolution of the `<PythonHome>` build property.

### Summary of Changes

- The `[msbuild]::GetDirectoryNameOfFileAbove` expression was missing a closing `)`, which results in yielding the literal expression text instead of the expected path
- Upon further evaluation, the using of `[msbuild]::GetDirectoryNameOfFileAbove` will **never** resolve a path because **python.exe** is not in a parent folder; it's a _cousin_ in the folder `/tools`
- The use of **python_d.exe** was removed because it doesn't ship in the NuGet package
- `<PythonHome>` reverts back to the correct, but absolute path as seen in versions prior to 3.7.2

### Validation
Verification was performed by manually changing and testing the build property evaluation using the official 3.8.2 package. A review of the history shows that the same configuration and issue affects all versions from 3.7.2-3.9.0-a5.

<!-- issue-number: [bpo-40158](https://bugs.python.org/issue40158) -->
https://bugs.python.org/issue40158
<!-- /issue-number -->
