### PR TITLE
bpo-40126: Fix reverting multiple patches in unittest.mock.

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1551,7 +1551,9 @@ class _patch(object):
         entered_patchers = self._entered_patchers
         del self._entered_patchers
         for patcher in reversed(entered_patchers):
-            patcher.__exit__(*exc_info)
+            if patcher.__exit__(*exc_info):
+                exc_info = (None, None, None)
+        return exc_info[0] is None
 
 
     def start(self):
@@ -1567,9 +1569,9 @@ class _patch(object):
             self._active_patches.remove(self)
         except ValueError:
             # If the patch hasn't been started this will fail
-            return
+            return None
 
-        return self.__exit__()
+        return self.__exit__(None, None, None)
 
 
 
@@ -1869,9 +1871,9 @@ class _patch_dict(object):
             _patch._active_patches.remove(self)
         except ValueError:
             # If the patch hasn't been started this will fail
-            pass
+            return None
 
-        return self.__exit__()
+        return self.__exit__(None, None, None)
 
 
 def _clear_dict(in_dict):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1533,7 +1533,7 @@ class _patch(object):
         del self.target
         exit_stack = self._exit_stack
         del self._exit_stack
-        return exit_stack.__exit__(*sys.exc_info())
+        return exit_stack.__exit__(*exc_info)
 
 
     def start(self):

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -774,7 +774,7 @@ class PatchTest(unittest.TestCase):
         d = {'foo': 'bar'}
         original = d.copy()
         patcher = patch.dict(d, [('spam', 'eggs')], clear=True)
-        self.assertEqual(patcher.stop(), False)
+        self.assertFalse(patcher.stop())
         self.assertEqual(d, original)
 
 

--- a/Misc/NEWS.d/next/Library/2020-04-04-00-47-40.bpo-40126.Y-bTNP.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-04-00-47-40.bpo-40126.Y-bTNP.rst
@@ -1,0 +1,3 @@
+Fixed reverting multiple patches in unittest.mock. Patcher's ``__exit__()``
+is now never called if its ``__enter__()`` is failed. Returning true from
+``__exit__()`` silences now the exception.


### PR DESCRIPTION
Patcher's `__exit__()` is now never called if its `__enter__()` is failed.
Returning true from `__exit__()` silences now the exception.


<!-- issue-number: [bpo-40126](https://bugs.python.org/issue40126) -->
https://bugs.python.org/issue40126
<!-- /issue-number -->
