### PR TITLE
gh-84350: Make dis.findlabels() accept a code object

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -318,7 +318,7 @@ def _get_instructions_bytes(code, varnames=None, names=None, constants=None,
     arguments.
 
     """
-    labels = findlabels(code)
+    labels = _findlabels_bytes(code)
     starts_line = None
     for offset, op, arg in _unpack_opargs(code):
         if linestarts is not None:
@@ -429,6 +429,14 @@ def _unpack_opargs(code):
 
 def findlabels(code):
     """Detect all offsets in a byte code which are jump targets.
+
+    Return the list of offsets.
+
+    """
+    return _findlabels_bytes(code.co_code)
+
+def _findlabels_bytes(code):
+    """Detect all offsets in a raw compiled bytecode string which are jump targets.
 
     Return the list of offsets.
 

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1202,5 +1202,12 @@ class BytecodeTests(unittest.TestCase):
         b = dis.Bytecode.from_traceback(tb)
         self.assertEqual(b.dis(), dis_traceback)
 
+    def test_findlabels(self):
+        self.assertEqual(
+            dis.findlabels(jumpy.__code__), [
+                44, 30, 8, 52, 94, 82, 102, 200, 118, 144, 142, 188, 172, 178, 210
+            ])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

<!-- issue-number: [bpo-40169](https://bugs.python.org/issue40169) -->
https://bugs.python.org/issue40169
<!-- /issue-number -->

Reasoning:
- The documentation of `dis` has always been "it accepts a code object".
- To keep it consistent with the other APIs in the `dis` module, which all accept a code object instead of raw byte code string.

<!-- gh-issue-number: gh-84350 -->
* Issue: gh-84350
<!-- /gh-issue-number -->
