### PR TITLE
bpo-40177: Fix misinformation about NaN != NaN comparison

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1422,8 +1422,9 @@ built-in types.
   The not-a-number values ``float('NaN')`` and ``decimal.Decimal('NaN')`` are
   special.  Any ordered comparison of a number to a not-a-number value is false.
   A counter-intuitive implication is that not-a-number values are not equal to
-  themselves.  For example, if ``x = float('NaN')``, ``3 < x``, ``x < 3``, ``x
-  == x``, ``x != x`` are all false.  This behavior is compliant with IEEE 754.
+  themselves.  For example, if ``x = float('NaN')``, ``3 < x``, ``x < 3`` and
+  ``x == x`` are all false, while ``x != x`` is true.  This behavior is
+  compliant with IEEE 754.
 
 * ``None`` and ``NotImplemented`` are singletons.  :PEP:`8` advises that
   comparisons for singletons should always be done with ``is`` or ``is not``,


### PR DESCRIPTION
The documentation incorrectly states that `x != x` is false for a NaN value `x`. This PR fixes that.

<!-- issue-number: [bpo-40177](https://bugs.python.org/issue40177) -->
https://bugs.python.org/issue40177
<!-- /issue-number -->
