### PR TITLE
[3.8] bpo-40164: Update Windows to OpenSSL 1.1.1f (GH-19359)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-04-04-13-13-44.bpo-40164.SPrSn5.rst
+++ b/Misc/NEWS.d/next/Windows/2020-04-04-13-13-44.bpo-40164.SPrSn5.rst
@@ -1,0 +1,1 @@
+Updates Windows to OpenSSL 1.1.1f

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.6
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.3.0-rc0-r1
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1d
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.1f
 set libraries=%libraries%                                       sqlite-3.31.1.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.9.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.9.0
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1d
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.1f
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.9.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -62,8 +62,8 @@
     <libffiDir>$(ExternalsDir)libffi\</libffiDir>
     <libffiOutDir>$(ExternalsDir)libffi\$(ArchName)\</libffiOutDir>
     <libffiIncludeDir>$(libffiOutDir)include</libffiIncludeDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.1d\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1d\$(ArchName)\</opensslOutDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.1f\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.1f\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>


### PR DESCRIPTION


<!-- issue-number: [bpo-40164](https://bugs.python.org/issue40164) -->
https://bugs.python.org/issue40164
<!-- /issue-number -->
