### PR TITLE
bpo-40182: Remove the _field_types attribute of the NamedTuple class

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -960,12 +960,13 @@ The module defines the following classes, functions and decorators:
       Added support for default values, methods, and docstrings.
 
    .. versionchanged:: 3.8
-      Deprecated the ``_field_types`` attribute in favor of the more
-      standard ``__annotations__`` attribute which has the same information.
-
-   .. versionchanged:: 3.8
       The ``_field_types`` and ``__annotations__`` attributes are
       now regular dictionaries instead of instances of ``OrderedDict``.
+
+   .. versionchanged:: 3.9
+      Removed the ``_field_types`` attribute in favor of the more
+      standard ``__annotations__`` attribute which has the same information.
+
 
 .. class:: TypedDict(dict)
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -734,6 +734,11 @@ Removed
   defining ``COUNT_ALLOCS`` macro.
   (Contributed by Victor Stinner in :issue:`39489`.)
 
+* The ``_field_types`` attribute of the :class:`typing.NamedTuple` class
+  has been removed.  It was deprecated deprecated since Python 3.8.  Use
+  the ``__annotations__`` attribute instead.
+  (Contributed by Serhiy Storchaka in :issue:`40182`.)
+
 
 Porting to Python 3.9
 =====================

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3561,7 +3561,6 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(Emp._fields, ('name', 'id'))
         self.assertEqual(Emp.__annotations__,
                          collections.OrderedDict([('name', str), ('id', int)]))
-        self.assertIs(Emp._field_types, Emp.__annotations__)
 
     def test_namedtuple_pyversion(self):
         if sys.version_info[:2] < (3, 6):
@@ -3581,7 +3580,6 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(CoolEmployee._fields, ('name', 'cool'))
         self.assertEqual(CoolEmployee.__annotations__,
                          collections.OrderedDict(name=str, cool=int))
-        self.assertIs(CoolEmployee._field_types, CoolEmployee.__annotations__)
 
     def test_annotation_usage_with_default(self):
         jelle = CoolEmployeeWithDefault('Jelle')
@@ -3594,7 +3592,8 @@ class NamedTupleTests(BaseTestCase):
 
         self.assertEqual(CoolEmployeeWithDefault.__name__, 'CoolEmployeeWithDefault')
         self.assertEqual(CoolEmployeeWithDefault._fields, ('name', 'cool'))
-        self.assertEqual(CoolEmployeeWithDefault._field_types, dict(name=str, cool=int))
+        self.assertEqual(CoolEmployeeWithDefault.__annotations__,
+                         dict(name=str, cool=int))
         self.assertEqual(CoolEmployeeWithDefault._field_defaults, dict(cool=0))
 
         with self.assertRaises(TypeError):
@@ -3641,7 +3640,6 @@ class XMethBad2(NamedTuple):
         self.assertEqual(LocalEmployee.__name__, 'LocalEmployee')
         self.assertEqual(LocalEmployee._fields, ('name', 'age'))
         self.assertEqual(LocalEmployee.__annotations__, dict(name=str, age=int))
-        self.assertIs(LocalEmployee._field_types, LocalEmployee.__annotations__)
         with self.assertRaises(TypeError):
             NamedTuple('Name', [('x', int)], y=str)
         with self.assertRaises(TypeError):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1705,9 +1705,7 @@ def _make_nmtuple(name, types):
     msg = "NamedTuple('Name', [(f0, t0), (f1, t1), ...]); each t must be a type"
     types = [(n, _type_check(t, msg)) for n, t in types]
     nm_tpl = collections.namedtuple(name, [n for n, t in types])
-    # Prior to PEP 526, only _field_types attribute was assigned.
-    # Now __annotations__ are used and _field_types is deprecated (remove in 3.9)
-    nm_tpl.__annotations__ = nm_tpl._field_types = dict(types)
+    nm_tpl.__annotations__ = dict(types)
     try:
         nm_tpl.__module__ = sys._getframe(2).f_globals.get('__name__', '__main__')
     except (AttributeError, ValueError):
@@ -1717,7 +1715,7 @@ def _make_nmtuple(name, types):
 
 # attributes prohibited to set in NamedTuple class syntax
 _prohibited = {'__new__', '__init__', '__slots__', '__getnewargs__',
-               '_fields', '_field_defaults', '_field_types',
+               '_fields', '_field_defaults',
                '_make', '_replace', '_asdict', '_source'}
 
 _special = {'__module__', '__name__', '__annotations__'}

--- a/Misc/NEWS.d/next/Library/2020-04-04-23-44-09.bpo-40182.Bf_kFN.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-04-23-44-09.bpo-40182.Bf_kFN.rst
@@ -1,0 +1,2 @@
+Removed the ``_field_types`` attribute of the :class:`typing.NamedTuple`
+class.


### PR DESCRIPTION


<!-- issue-number: [bpo-40182](https://bugs.python.org/issue40182) -->
https://bugs.python.org/issue40182
<!-- /issue-number -->
