### PR TITLE
bpo-40184: Only define pysiphash if the hash algorithm is SIPHASH24

### DIFF
--- a/Python/pyhash.c
+++ b/Python/pyhash.c
@@ -412,13 +412,6 @@ siphash24(uint64_t k0, uint64_t k1, const void *src, Py_ssize_t src_sz) {
     return t;
 }
 
-static Py_hash_t
-pysiphash(const void *src, Py_ssize_t src_sz) {
-    return (Py_hash_t)siphash24(
-        _le64toh(_Py_HashSecret.siphash.k0), _le64toh(_Py_HashSecret.siphash.k1),
-        src, src_sz);
-}
-
 uint64_t
 _Py_KeyedHash(uint64_t key, const void *src, Py_ssize_t src_sz)
 {
@@ -427,6 +420,13 @@ _Py_KeyedHash(uint64_t key, const void *src, Py_ssize_t src_sz)
 
 
 #if Py_HASH_ALGORITHM == Py_HASH_SIPHASH24
+static Py_hash_t
+pysiphash(const void *src, Py_ssize_t src_sz) {
+    return (Py_hash_t)siphash24(
+        _le64toh(_Py_HashSecret.siphash.k0), _le64toh(_Py_HashSecret.siphash.k1),
+        src, src_sz);
+}
+
 static PyHash_FuncDef PyHash_Func = {pysiphash, "siphash24", 64, 128};
 #endif
 


### PR DESCRIPTION


<!-- issue-number: [bpo-40184](https://bugs.python.org/issue40184) -->
https://bugs.python.org/issue40184
<!-- /issue-number -->
