### PR TITLE
[3.8] bpo-36320: Use the deprecated-removed directive for _field_types

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -959,7 +959,7 @@ The module defines the following classes, functions and decorators:
    .. versionchanged:: 3.6.1
       Added support for default values, methods, and docstrings.
 
-   .. versionchanged:: 3.8
+   .. deprecated-removed:: 3.8 3.9
       Deprecated the ``_field_types`` attribute in favor of the more
       standard ``__annotations__`` attribute which has the same information.
 


### PR DESCRIPTION


<!-- issue-number: [bpo-36320](https://bugs.python.org/issue36320) -->
https://bugs.python.org/issue36320
<!-- /issue-number -->
