### PR TITLE
[3.8] closes bpo-40184: Only define pysiphash if the hash algorithm is SIPHASH24.

### DIFF
--- a/Python/pyhash.c
+++ b/Python/pyhash.c
@@ -412,13 +412,6 @@ siphash24(uint64_t k0, uint64_t k1, const void *src, Py_ssize_t src_sz) {
     return t;
 }
 
-static Py_hash_t
-pysiphash(const void *src, Py_ssize_t src_sz) {
-    return (Py_hash_t)siphash24(
-        _le64toh(_Py_HashSecret.siphash.k0), _le64toh(_Py_HashSecret.siphash.k1),
-        src, src_sz);
-}
-
 uint64_t
 _Py_KeyedHash(uint64_t key, const void *src, Py_ssize_t src_sz)
 {
@@ -427,6 +420,13 @@ _Py_KeyedHash(uint64_t key, const void *src, Py_ssize_t src_sz)
 
 
 #if Py_HASH_ALGORITHM == Py_HASH_SIPHASH24
+static Py_hash_t
+pysiphash(const void *src, Py_ssize_t src_sz) {
+    return (Py_hash_t)siphash24(
+        _le64toh(_Py_HashSecret.siphash.k0), _le64toh(_Py_HashSecret.siphash.k1),
+        src, src_sz);
+}
+
 static PyHash_FuncDef PyHash_Func = {pysiphash, "siphash24", 64, 128};
 #endif
 


### PR DESCRIPTION
(cherry picked from commit 1b21573)

Co-authored-by: Batuhan Taşkaya <batuhanosmantaskaya@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40184](https://bugs.python.org/issue40184) -->
https://bugs.python.org/issue40184
<!-- /issue-number -->
