### PR TITLE
bpo-40174: clock_gettime always needed under POSIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3606,7 +3606,7 @@ fi
 
 # checks for library functions
 AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
- clock confstr copy_file_range ctermid dup3 execv explicit_bzero explicit_memset \
+ clock clock_gettime confstr copy_file_range ctermid dup3 execv explicit_bzero explicit_memset \
  faccessat fchmod fchmodat fchown fchownat \
  fdwalk fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
  futimens futimes gai_strerror getentropy \
@@ -3712,6 +3712,10 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
 ])
+
+if test "x${ac_cv_func_clock_gettime}" = xno; then
+  AC_MSG_ERROR([could not find clock_gettime (see https://bugs.python.org/issue40174)])
+fi
 
 AC_MSG_CHECKING(for memfd_create)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[


### PR DESCRIPTION
Indicate that clock_gettime is always needed under POSIX.

<!-- issue-number: [bpo-40174](https://bugs.python.org/issue40174) -->
https://bugs.python.org/issue40174
<!-- /issue-number -->
