### PR TITLE
bpo-40170: Convert PyObject_CheckBuffer() macro to a function

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -264,9 +264,7 @@ PyAPI_FUNC(Py_ssize_t) PyObject_LengthHint(PyObject *o, Py_ssize_t);
 /* === New Buffer API ============================================ */
 
 /* Return 1 if the getbuffer function is available, otherwise return 0. */
-#define PyObject_CheckBuffer(obj) \
-    ((Py_TYPE(obj)->tp_as_buffer != NULL) &&  \
-     (Py_TYPE(obj)->tp_as_buffer->bf_getbuffer != NULL))
+PyAPI_FUNC(int) PyObject_CheckBuffer(PyObject *obj);
 
 /* This is a C-API version of the getbuffer function call.  It checks
    to make sure object has the required function pointer and issues the

--- a/Misc/NEWS.d/next/C API/2020-04-05-00-02-13.bpo-40170.IFsGZ-.rst
+++ b/Misc/NEWS.d/next/C API/2020-04-05-00-02-13.bpo-40170.IFsGZ-.rst
@@ -1,0 +1,3 @@
+Convert :c:func:`PyObject_CheckBuffer` macro to a function to hide
+implementation details: the macro accessed directly the
+:c:member:`PyTypeObject.tp_as_buffer` member.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -277,6 +277,16 @@ PyObject_DelItemString(PyObject *o, const char *key)
     return ret;
 }
 
+
+/* Return 1 if the getbuffer function is available, otherwise return 0. */
+int
+PyObject_CheckBuffer(PyObject *obj)
+{
+    PyBufferProcs *tp_as_buffer = Py_TYPE(obj)->tp_as_buffer;
+    return (tp_as_buffer != NULL && tp_as_buffer->bf_getbuffer != NULL);
+}
+
+
 /* We release the buffer right after use of this function which could
    cause issues later on.  Don't use these functions in new code.
  */


### PR DESCRIPTION
Convert PyObject_CheckBuffer() macro to a function to hide
implementation details: the macro accessed directly
PyTypeObject.tp_as_buffer field.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
