### PR TITLE
bpo-40170: PyObject_GET_WEAKREFS_LISTPTR() becomes a function

### DIFF
--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -138,8 +138,7 @@ PyAPI_FUNC(PyObject *) _PyObject_GC_Calloc(size_t size);
 /* Test if a type supports weak references */
 #define PyType_SUPPORTS_WEAKREFS(t) ((t)->tp_weaklistoffset > 0)
 
-#define PyObject_GET_WEAKREFS_LISTPTR(o) \
-    ((PyObject **) (((char *) (o)) + Py_TYPE(o)->tp_weaklistoffset))
+PyAPI_FUNC(PyObject **) PyObject_GET_WEAKREFS_LISTPTR(PyObject *op);
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -87,6 +87,13 @@ extern void _Py_PrintReferences(FILE *);
 extern void _Py_PrintReferenceAddresses(FILE *);
 #endif
 
+static inline PyObject **
+_PyObject_GET_WEAKREFS_LISTPTR(PyObject *op)
+{
+    Py_ssize_t offset = Py_TYPE(op)->tp_weaklistoffset;
+    return (PyObject **)((char *)op + offset);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C API/2020-04-05-00-10-45.bpo-40170.6nFYbY.rst
+++ b/Misc/NEWS.d/next/C API/2020-04-05-00-10-45.bpo-40170.6nFYbY.rst
@@ -1,0 +1,3 @@
+Convert the :c:func:`PyObject_GET_WEAKREFS_LISTPTR` macro to a function to hide
+implementation details: the macro accessed directly to the
+:c:member:`PyTypeObject.tp_weaklistoffset` member.

--- a/Modules/_weakref.c
+++ b/Modules/_weakref.c
@@ -1,8 +1,9 @@
 #include "Python.h"
+#include "pycore_object.h"   // _PyObject_GET_WEAKREFS_LISTPTR
 
 
 #define GET_WEAKREFS_LISTPTR(o) \
-        ((PyWeakReference **) PyObject_GET_WEAKREFS_LISTPTR(o))
+        ((PyWeakReference **) _PyObject_GET_WEAKREFS_LISTPTR(o))
 
 /*[clinic input]
 module _weakref

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -788,7 +788,7 @@ handle_weakrefs(PyGC_Head *unreachable, PyGC_Head *old)
 
         /* It supports weakrefs.  Does it have any? */
         wrlist = (PyWeakReference **)
-                                PyObject_GET_WEAKREFS_LISTPTR(op);
+                                _PyObject_GET_WEAKREFS_LISTPTR(op);
 
         /* `op` may have some weakrefs.  March over the list, clear
          * all the weakrefs, and move the weakrefs with callbacks

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2206,6 +2206,14 @@ _Py_Dealloc(PyObject *op)
     (*dealloc)(op);
 }
 
+
+PyObject **
+PyObject_GET_WEAKREFS_LISTPTR(PyObject *op)
+{
+    return _PyObject_GET_WEAKREFS_LISTPTR(op);
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1271,7 +1271,7 @@ subtype_dealloc(PyObject *self)
         if (type->tp_weaklistoffset && !base->tp_weaklistoffset) {
             /* Modeled after GET_WEAKREFS_LISTPTR() */
             PyWeakReference **list = (PyWeakReference **) \
-                PyObject_GET_WEAKREFS_LISTPTR(self);
+                _PyObject_GET_WEAKREFS_LISTPTR(self);
             while (*list)
                 _PyWeakref_ClearRef(*list);
         }

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -1,9 +1,10 @@
 #include "Python.h"
+#include "pycore_object.h"   // _PyObject_GET_WEAKREFS_LISTPTR
 #include "structmember.h"
 
 
 #define GET_WEAKREFS_LISTPTR(o) \
-        ((PyWeakReference **) PyObject_GET_WEAKREFS_LISTPTR(o))
+        ((PyWeakReference **) _PyObject_GET_WEAKREFS_LISTPTR(o))
 
 
 Py_ssize_t


### PR DESCRIPTION
Convert PyObject_GET_WEAKREFS_LISTPTR() macro to a function to hide
implementation details: the macro accessed directly to
PyTypeObject.tp_weaklistoffset member.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
