### PR TITLE
bpo-40190: Add support for _SC_AIX_REALMEM in sysconf

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-04-05-02-58-17.bpo-40190.HF3OWo.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-05-02-58-17.bpo-40190.HF3OWo.rst
@@ -1,0 +1,1 @@
+Add support for ``_SC_AIX_REALMEM`` to :func:`posix.sysconf`.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11424,6 +11424,9 @@ static struct constdef posix_constants_sysconf[] = {
 #ifdef _SC_PAGE_SIZE
     {"SC_PAGE_SIZE",    _SC_PAGE_SIZE},
 #endif
+#ifdef _SC_AIX_REALMEM
+    {"SC_AIX_REALMEM", _SC_AIX_REALMEM},
+#endif
 #ifdef _SC_PASS_MAX
     {"SC_PASS_MAX",     _SC_PASS_MAX},
 #endif


### PR DESCRIPTION


<!-- issue-number: [bpo-40190](https://bugs.python.org/issue40190) -->
https://bugs.python.org/issue40190
<!-- /issue-number -->
