### PR TITLE
bpo-40192: Use thread_cputime for time.thread_time to improve resolution

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -371,6 +371,12 @@ finalization crashed with a Python fatal error if a daemon thread was still
 running.
 (Contributed by Victor Stinner in :issue:`37266`.)
 
+time
+----
+
+:func:`~time.thread_time` now output in nanosecond resolution via
+``thread_cputime`` on AIX. (Contributed by Batuhan Taskaya in :issue:`40192`)
+
 sys
 ---
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -374,8 +374,10 @@ running.
 time
 ----
 
-:func:`~time.thread_time` now output in nanosecond resolution via
-``thread_cputime`` on AIX. (Contributed by Batuhan Taskaya in :issue:`40192`)
+On AIX, :func:`~time.thread_time` is now implemented with ``thread_cputime()``
+which has nanosecond resolution, rather than
+``clock_gettime(CLOCK_THREAD_CPUTIME_ID)`` which has a resolution of 10 ms.
+(Contributed by Batuhan Taskaya in :issue:`40192`)
 
 sys
 ---

--- a/Misc/NEWS.d/next/Library/2020-04-05-04-16-14.bpo-40192.nk8uRJ.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-05-04-16-14.bpo-40192.nk8uRJ.rst
@@ -1,0 +1,2 @@
+Improve :func:`time.thread_time` in AIX to output in nanoseconds and use
+`thread_cputime` backend. Patch by Batuhan Taskaya.

--- a/Misc/NEWS.d/next/Library/2020-04-05-04-16-14.bpo-40192.nk8uRJ.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-05-04-16-14.bpo-40192.nk8uRJ.rst
@@ -1,2 +1,4 @@
-Improve :func:`time.thread_time` in AIX to output in nanoseconds and use
-``thread_cputime`` backend. Patch by Batuhan Taskaya.
+On AIX, :func:`~time.thread_time` is now implemented with ``thread_cputime()``
+which has nanosecond resolution, rather than
+``clock_gettime(CLOCK_THREAD_CPUTIME_ID)`` which has a resolution of 10 ms.
+Patch by Batuhan Taskaya.

--- a/Misc/NEWS.d/next/Library/2020-04-05-04-16-14.bpo-40192.nk8uRJ.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-05-04-16-14.bpo-40192.nk8uRJ.rst
@@ -1,2 +1,2 @@
 Improve :func:`time.thread_time` in AIX to output in nanoseconds and use
-`thread_cputime` backend. Patch by Batuhan Taskaya.
+``thread_cputime`` backend. Patch by Batuhan Taskaya.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -24,6 +24,10 @@
 #  include <pthread.h>
 #endif
 
+#if defined(_AIX)
+#   include <sys/thread.h>
+#endif
+
 #if defined(__WATCOMC__) && !defined(__QNX__)
 #include <i86.h>
 #else
@@ -1341,6 +1345,26 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
     /* ktime and utime have a resolution of 100 nanoseconds */
     t = _PyTime_FromNanoseconds((ktime + utime) * 100);
     *tp = t;
+    return 0;
+}
+#elif defined(_AIX)
+#define HAVE_THREAD_TIME
+static int
+_PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
+{
+    thread_cputime_t tc;
+    if (thread_cputime(-1, &tc) != 0) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return -1;
+    }
+
+    if (info) {
+        info->implementation = "thread_cputime()";
+        info->monotonic = 1;
+        info->adjustable = 0;
+        info->resolution = 1e-9;
+    }
+    *tp = _PyTime_FromNanoseconds(tc.stime);
     return 0;
 }
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1353,9 +1353,9 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 static int
 _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
 {
-    /* bpo-40192: On AIX, thread_cputime is preffered because
-    it is using nano-second time resolution (compared to 10ms)
-    resolution of clock_gettime(CLOCK_THREAD_CPUTIME_ID) */
+    /* bpo-40192: On AIX, thread_cputime() is preferred: it has nanosecond
+       resolution, whereas clock_gettime(CLOCK_THREAD_CPUTIME_ID)
+       has a resolution of 10 ms. */
     thread_cputime_t tc;
     if (thread_cputime(-1, &tc) != 0) {
         PyErr_SetFromErrno(PyExc_OSError);


### PR DESCRIPTION


<!-- issue-number: [bpo-40192](https://bugs.python.org/issue40192) -->
https://bugs.python.org/issue40192
<!-- /issue-number -->
