### PR TITLE
bpo-40174: Check when clock_gettime is necessary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3606,7 +3606,7 @@ fi
 
 # checks for library functions
 AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
- clock confstr copy_file_range ctermid dup3 execv explicit_bzero explicit_memset \
+ clock clock_gettime confstr copy_file_range ctermid dup3 execv explicit_bzero explicit_memset \
  faccessat fchmod fchmodat fchown fchownat \
  fdwalk fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
  futimens futimes gai_strerror getentropy \
@@ -3725,6 +3725,21 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   [AC_DEFINE(HAVE_MEMFD_CREATE, 1, Define if you have the 'memfd_create' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
+])
+
+AC_MSG_CHECKING(if clock_gettime is mandatory but missing)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[
+#if defined(MS_WINDOWS)
+#elif defined(__APPLE__)
+#elif defined(__hpux)
+#else
+#if !defined(HAVE_CLOCK_GETTIME)
+It's just a flesh wound!
+#endif
+#endif
+]])],
+  [AC_MSG_RESULT(no)],
+  [AC_MSG_ERROR([could not find clock_gettime (see https://bugs.python.org/issue40174)])
 ])
 
 # On some systems (eg. FreeBSD 5), we would find a definition of the


### PR DESCRIPTION
Detect and announces cases when clock_gettime is necessary but not found.

<!-- issue-number: [bpo-40174](https://bugs.python.org/issue40174) -->
https://bugs.python.org/issue40174
<!-- /issue-number -->
