### PR TITLE
bpo-40196: Fix a bug in the symtable when reporting inspecting global variables

### DIFF
--- a/Lib/symtable.py
+++ b/Lib/symtable.py
@@ -197,7 +197,7 @@ class Symbol(object):
         return bool(self.__scope == GLOBAL_EXPLICIT)
 
     def is_local(self):
-        return bool(self.__flags & DEF_BOUND)
+        return bool(self.__scope in (LOCAL, CELL))
 
     def is_annotated(self):
         return bool(self.__flags & DEF_ANNOT)

--- a/Lib/test/test_symtable.py
+++ b/Lib/test/test_symtable.py
@@ -99,6 +99,7 @@ class SymtableTest(unittest.TestCase):
         self.assertTrue(self.spam.lookup("bar").is_declared_global())
         self.assertFalse(self.internal.lookup("x").is_global())
         self.assertFalse(self.Mine.lookup("instance_var").is_global())
+        self.assertTrue(self.spam.lookup("bar").is_global())
 
     def test_nonlocal(self):
         self.assertFalse(self.spam.lookup("some_var").is_nonlocal())
@@ -108,7 +109,10 @@ class SymtableTest(unittest.TestCase):
 
     def test_local(self):
         self.assertTrue(self.spam.lookup("x").is_local())
-        self.assertFalse(self.internal.lookup("x").is_local())
+        self.assertFalse(self.spam.lookup("bar").is_local())
+
+    def test_free(self):
+        self.assertTrue(self.internal.lookup("x").is_free())
 
     def test_referenced(self):
         self.assertTrue(self.internal.lookup("x").is_referenced())

--- a/Misc/NEWS.d/next/Library/2020-04-06-11-05-13.bpo-40196.Jqowse.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-06-11-05-13.bpo-40196.Jqowse.rst
@@ -1,2 +1,2 @@
-Fix a bug in the ``symtable`` module that was causing incorrectly report
+Fix a bug in the :mod:`symtable` module that was causing incorrectly report
 global variables as local. Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Library/2020-04-06-11-05-13.bpo-40196.Jqowse.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-06-11-05-13.bpo-40196.Jqowse.rst
@@ -1,0 +1,2 @@
+Fix a bug in the ``symtable`` module that was causing incorrectly report
+global variables as local. Patch by Pablo Galindo.


### PR DESCRIPTION


<!-- issue-number: [bpo-40196](https://bugs.python.org/issue40196) -->
https://bugs.python.org/issue40196
<!-- /issue-number -->
