### PR TITLE
bpo-34951 Updated regex in pattern for finding cookie (rfc2616)

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -441,7 +441,7 @@ _CookiePattern = re.compile(r"""
     (?P<val>                         # Start of group 'val'
     "(?:[^\\"]|\\.)*"                  # Any doublequoted string
     |                                  # or
-    \w{3},\s[\w\d\s-]{9,11}\s[\d:]{8}\sGMT  # Special case for "expires" attr
+    \w{3,9},\s[\w\d\s-]{9,11}\s[\d:]{8}\sGMT  # Special case for "expires" attr
     |                                  # or
     [""" + _LegalValueChars + r"""]*      # Any word or empty string
     )                                # End of group 'val'


### PR DESCRIPTION
Updated regex for special case for "expires" attr in pattern for finding cookie if day of week is specified in deprecated format (rfc2616).

According to https://tools.ietf.org/html/rfc2616#section-3.3.1, clients and servers that parse the date value MUST accept all three formats (for compatibility with HTTP/1.0).

But the current regular expression does not match dates in the following format:

      Sunday, 06-Nov-94 08:49:37 GMT

<!-- issue-number: [bpo-34951](https://bugs.python.org/issue34951) -->
https://bugs.python.org/issue34951
<!-- /issue-number -->
