### PR TITLE
bpo-40208: Remove deprecated has_exec method of SymbolTable

### DIFF
--- a/Doc/library/symtable.rst
+++ b/Doc/library/symtable.rst
@@ -67,10 +67,6 @@ Examining Symbol Tables
       Return ``True`` if the block has nested namespaces within it.  These can
       be obtained with :meth:`get_children`.
 
-   .. method:: has_exec()
-
-      Return ``True`` if the block uses ``exec``.
-
    .. method:: get_identifiers()
 
       Return a list of names of symbols in this table.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -739,6 +739,9 @@ Removed
   the ``__annotations__`` attribute instead.
   (Contributed by Serhiy Storchaka in :issue:`40182`.)
 
+* The :meth:`symtable.SymbolTable.has_exec` method has been removed. It was
+  deprecated since 2006. (Contributed by Batuhan Taskaya in :issue:`40208`)
+
 
 Porting to Python 3.9
 =====================

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -740,7 +740,8 @@ Removed
   (Contributed by Serhiy Storchaka in :issue:`40182`.)
 
 * The :meth:`symtable.SymbolTable.has_exec` method has been removed. It was
-  deprecated since 2006. (Contributed by Batuhan Taskaya in :issue:`40208`)
+  deprecated since 2006, and only returning ``False`` when it's called.
+  (Contributed by Batuhan Taskaya in :issue:`40208`)
 
 
 Porting to Python 3.9

--- a/Lib/symtable.py
+++ b/Lib/symtable.py
@@ -82,10 +82,6 @@ class SymbolTable(object):
     def has_children(self):
         return bool(self._table.children)
 
-    def has_exec(self):
-        """Return true if the scope uses exec.  Deprecated method."""
-        return False
-
     def get_identifiers(self):
         return self._table.symbols.keys()
 

--- a/Lib/test/test_symtable.py
+++ b/Lib/test/test_symtable.py
@@ -65,7 +65,6 @@ class SymtableTest(unittest.TestCase):
 
     def test_optimized(self):
         self.assertFalse(self.top.is_optimized())
-        self.assertFalse(self.top.has_exec())
 
         self.assertTrue(self.spam.is_optimized())
 

--- a/Misc/NEWS.d/next/Library/2020-04-06-20-09-33.bpo-40208.3rO_q7.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-06-20-09-33.bpo-40208.3rO_q7.rst
@@ -1,1 +1,1 @@
-Remove deprecated :meth:`SymbolTable.has_exec`.
+Remove deprecated :meth:`symtable.SymbolTable.has_exec`.

--- a/Misc/NEWS.d/next/Library/2020-04-06-20-09-33.bpo-40208.3rO_q7.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-06-20-09-33.bpo-40208.3rO_q7.rst
@@ -1,0 +1,1 @@
+Remove deprecated :meth:`SymbolTable.has_exec`.


### PR DESCRIPTION


<!-- issue-number: [bpo-40208](https://bugs.python.org/issue40208) -->
https://bugs.python.org/issue40208
<!-- /issue-number -->
