### PR TITLE
bpo-40060 Expose socket.TCP_NOTSENT_LOWAT on macOS in official builds

### DIFF
--- a/Misc/NEWS.d/next/macOS/2020-04-07-01-39-52.bpo-40060.9Y0s-a.rst
+++ b/Misc/NEWS.d/next/macOS/2020-04-07-01-39-52.bpo-40060.9Y0s-a.rst
@@ -1,0 +1,1 @@
+Expose socket.TCP_NOTSENT_LOWAT on macOS in official builds

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -8228,6 +8228,11 @@ PyInit__socket(void)
 #ifdef  TCP_USER_TIMEOUT
     PyModule_AddIntMacro(m, TCP_USER_TIMEOUT);
 #endif
+#ifndef TCP_NOTSENT_LOWAT
+# ifdef __APPLE__
+#  define TCP_NOTSENT_LOWAT 0x201
+# endif
+#endif
 #ifdef  TCP_NOTSENT_LOWAT
     PyModule_AddIntMacro(m, TCP_NOTSENT_LOWAT);
 #endif


### PR DESCRIPTION
Somehow, it turns out that `TCP_NOTSENT_LOWAT` that's available since 3.7.x is not available in the official macOS builds 🙀
This change exports the constant even if cpython is built against very old header files, as it's presumed to be the case for official macOS builds.
https://bugs.python.org/issue40060

<!-- issue-number: [bpo-40060](https://bugs.python.org/issue40060) -->
https://bugs.python.org/issue40060
<!-- /issue-number -->
