### PR TITLE
bpo-40214: Temporarily disable a ctypes test

### DIFF
--- a/Lib/ctypes/test/test_loading.py
+++ b/Lib/ctypes/test/test_loading.py
@@ -158,8 +158,11 @@ class LoaderTest(unittest.TestCase):
             # Relative path (but not just filename) should succeed
             should_pass("WinDLL('./_sqlite3.dll')")
 
-            # Insecure load flags should succeed
-            should_pass("WinDLL('_sqlite3.dll', winmode=0)")
+            # XXX: This test has started failing on Azure Pipelines CI.  See
+            #      bpo-40214 for more information.
+            if 0:
+                # Insecure load flags should succeed
+                should_pass("WinDLL('_sqlite3.dll', winmode=0)")
 
             # Full path load without DLL_LOAD_DIR shouldn't find dependency
             should_fail("WinDLL(nt._getfullpathname('_sqlite3.dll'), " +


### PR DESCRIPTION
Only one particular sub-test of
ctypes.test.test_loading.test_load_dll_with_flags is disabled.

<!-- issue-number: [bpo-40214](https://bugs.python.org/issue40214) -->
https://bugs.python.org/issue40214
<!-- /issue-number -->
