### PR TITLE
bpo-39943: Keep constness of pointer objects.

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2850,19 +2850,19 @@ PyObject *
 PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 {
     PyHeapTypeObject *res;
-    PyMemberDef *memb;
     PyObject *modname;
     PyTypeObject *type, *base;
 
-    PyType_Slot *slot;
+    const PyType_Slot *slot;
     Py_ssize_t nmembers, weaklistoffset, dictoffset;
-    char *s, *res_start;
+    const char *s;
+    char *res_start;
 
     nmembers = weaklistoffset = dictoffset = 0;
     for (slot = spec->slots; slot->slot; slot++) {
         if (slot->slot == Py_tp_members) {
             nmembers = 0;
-            for (memb = slot->pfunc; memb->name != NULL; memb++) {
+            for (const PyMemberDef *memb = slot->pfunc; memb->name != NULL; memb++) {
                 nmembers++;
                 if (strcmp(memb->name, "__weaklistoffset__") == 0) {
                     // The PyMemberDef must be a Py_ssize_t and readonly
@@ -2894,7 +2894,7 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
     /* Set the type name and qualname */
     s = strrchr(spec->name, '.');
     if (s == NULL)
-        s = (char*)spec->name;
+        s = spec->name;
     else
         s++;
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2855,7 +2855,6 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 
     const PyType_Slot *slot;
     Py_ssize_t nmembers, weaklistoffset, dictoffset;
-    const char *s;
     char *res_start;
 
     nmembers = weaklistoffset = dictoffset = 0;
@@ -2892,7 +2891,7 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
     }
 
     /* Set the type name and qualname */
-    s = strrchr(spec->name, '.');
+    const char *s = strrchr(spec->name, '.');
     if (s == NULL)
         s = spec->name;
     else


### PR DESCRIPTION
Also moved an auto variable that got consted into its innermost necessary scope.


<!-- issue-number: [bpo-39943](https://bugs.python.org/issue39943) -->
https://bugs.python.org/issue39943
<!-- /issue-number -->
