### PR TITLE
bpo-37388: Don't check encoding/errors during finalization

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-07-15-44-29.bpo-37388.stlxBq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-07-15-44-29.bpo-37388.stlxBq.rst
@@ -1,0 +1,4 @@
+str.encode() and str.decode() no longer check the encoding and errors in
+development mode or in debug mode during Python finalization. The codecs
+machinery can no longer work on very late calls to str.encode() and
+str.decode().

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -451,6 +451,12 @@ unicode_check_encoding_errors(const char *encoding, const char *errors)
         return 0;
     }
 
+    /* Disable checks during Python finalization. For example, it allows to
+       call _PyObject_Dump() during finalization for debugging purpose. */
+    if (interp->finalizing) {
+        return 0;
+    }
+
     if (encoding != NULL) {
         PyObject *handler = _PyCodec_Lookup(encoding);
         if (handler == NULL) {


### PR DESCRIPTION
str.encode() and str.decode() no longer check the encoding and errors
in development mode or in debug mode during Python finalization. The
codecs machinery can no longer work on very late calls to
str.encode() and str.decode().

This change should help to call _PyObject_Dump() to debug during late
Python finalization.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-37388](https://bugs.python.org/issue37388) -->
https://bugs.python.org/issue37388
<!-- /issue-number -->
