### PR TITLE
bpo-40149: Implement traverse in _abc._abc_data

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-04-07-18-06-38.bpo-40149.mMU2iu.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-07-18-06-38.bpo-40149.mMU2iu.rst
@@ -1,0 +1,1 @@
+Implement traverse and clear slots in _abc._abc_data type.

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -51,13 +51,29 @@ typedef struct {
     unsigned long long _abc_negative_cache_version;
 } _abc_data;
 
+static int
+abc_data_traverse(_abc_data *self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->_abc_registry);
+    Py_VISIT(self->_abc_cache);
+    Py_VISIT(self->_abc_negative_cache);
+    return 0;
+}
+
+static int
+abc_data_clear(_abc_data *self)
+{
+    Py_CLEAR(self->_abc_registry);
+    Py_CLEAR(self->_abc_cache);
+    Py_CLEAR(self->_abc_negative_cache);
+    return 0;
+}
+
 static void
 abc_data_dealloc(_abc_data *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
-    Py_XDECREF(self->_abc_registry);
-    Py_XDECREF(self->_abc_cache);
-    Py_XDECREF(self->_abc_negative_cache);
+    (void)abc_data_clear(self);
     tp->tp_free(self);
     Py_DECREF(tp);
 }
@@ -84,13 +100,15 @@ static PyType_Slot _abc_data_type_spec_slots[] = {
     {Py_tp_doc, (void *)abc_data_doc},
     {Py_tp_new, abc_data_new},
     {Py_tp_dealloc, abc_data_dealloc},
+    {Py_tp_traverse, abc_data_traverse},
+    {Py_tp_clear, abc_data_clear},
     {0, 0}
 };
 
 static PyType_Spec _abc_data_type_spec = {
     .name = "_abc._abc_data",
     .basicsize = sizeof(_abc_data),
-    .flags = Py_TPFLAGS_DEFAULT,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = _abc_data_type_spec_slots,
 };
 


### PR DESCRIPTION
Implement tp_traverse and tp_clear slots in _abc._abc_data type.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40149](https://bugs.python.org/issue40149) -->
https://bugs.python.org/issue40149
<!-- /issue-number -->
