### PR TITLE
bpo-39481: Generic alias to os.DirEntry

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -7,6 +7,7 @@ from collections import (
 )
 from collections.abc import *
 from contextlib import AbstractContextManager, AbstractAsyncContextManager
+from os import DirEntry
 from re import Pattern, Match
 from types import GenericAlias, MappingProxyType
 import typing
@@ -34,7 +35,7 @@ class BaseTest(unittest.TestCase):
                   Mapping, MutableMapping, MappingView,
                   KeysView, ItemsView, ValuesView,
                   Sequence, MutableSequence,
-                  MappingProxyType,
+                  MappingProxyType, DirEntry
                   ):
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12975,6 +12975,8 @@ static PyMethodDef DirEntry_methods[] = {
     OS_DIRENTRY_STAT_METHODDEF
     OS_DIRENTRY_INODE_METHODDEF
     OS_DIRENTRY___FSPATH___METHODDEF
+    {"__class_getitem__",       (PyCFunction)Py_GenericAlias,
+    METH_O|METH_CLASS,          PyDoc_STR("See PEP 585")},
     {NULL}
 };
 


### PR DESCRIPTION
Add generic alias to DirEntry

<!-- issue-number: [bpo-39481](https://bugs.python.org/issue39481) -->
https://bugs.python.org/issue39481
<!-- /issue-number -->
