### PR TITLE
bpo-39481: Generic alias for itertools.chain

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -7,6 +7,7 @@ from collections import (
 )
 from collections.abc import *
 from contextlib import AbstractContextManager, AbstractAsyncContextManager
+from itertools import chain
 from os import DirEntry
 from re import Pattern, Match
 from types import GenericAlias, MappingProxyType
@@ -35,7 +36,8 @@ class BaseTest(unittest.TestCase):
                   Mapping, MutableMapping, MappingView,
                   KeysView, ItemsView, ValuesView,
                   Sequence, MutableSequence,
-                  MappingProxyType, DirEntry
+                  MappingProxyType, DirEntry,
+                  chain,
                   ):
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -2028,6 +2028,8 @@ static PyMethodDef chain_methods[] = {
      reduce_doc},
     {"__setstate__",    (PyCFunction)chain_setstate,    METH_O,
      setstate_doc},
+    {"__class_getitem__",    (PyCFunction)Py_GenericAlias,
+    METH_O|METH_CLASS,       PyDoc_STR("See PEP 585")},
     {NULL,              NULL}           /* sentinel */
 };
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39481](https://bugs.python.org/issue39481) -->
https://bugs.python.org/issue39481
<!-- /issue-number -->
