### PR TITLE
bpo-39481: Add GenericAlias support to ipaddress.py

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1446,6 +1446,8 @@ class IPv4Interface(IPv4Address):
         return '%s/%s' % (self._string_from_ip_int(self._ip),
                           self.hostmask)
 
+    __class_getitem__ = classmethod(types.GenericAlias)
+
 
 class IPv4Network(_BaseV4, _BaseNetwork):
 
@@ -2153,6 +2155,8 @@ class IPv6Interface(IPv6Address):
     @property
     def is_loopback(self):
         return self._ip == 1 and self.network.is_loopback
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
 
 class IPv6Network(_BaseV6, _BaseNetwork):

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -12,6 +12,7 @@ __version__ = '1.0'
 
 
 import functools
+import types
 
 IPV4LENGTH = 32
 IPV6LENGTH = 128
@@ -1124,6 +1125,7 @@ class _BaseNetwork(_IPAddressBase):
         return (self.network_address.is_loopback and
                 self.broadcast_address.is_loopback)
 
+    __class_getitem__ = classmethod(types.GenericAlias)
 
 class _BaseV4:
 

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -7,6 +7,7 @@ from collections import (
 )
 from collections.abc import *
 from contextlib import AbstractContextManager, AbstractAsyncContextManager
+from ipaddress import _BaseNetwork
 from os import DirEntry
 from re import Pattern, Match
 from types import GenericAlias, MappingProxyType
@@ -35,7 +36,7 @@ class BaseTest(unittest.TestCase):
                   Mapping, MutableMapping, MappingView,
                   KeysView, ItemsView, ValuesView,
                   Sequence, MutableSequence,
-                  MappingProxyType, DirEntry
+                  MappingProxyType, DirEntry, _BaseNetwork
                   ):
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -7,7 +7,7 @@ from collections import (
 )
 from collections.abc import *
 from contextlib import AbstractContextManager, AbstractAsyncContextManager
-from ipaddress import _BaseNetwork
+from ipaddress import IPv4Network, IPv4Interface, IPv6Network, IPv6Interface
 from os import DirEntry
 from re import Pattern, Match
 from types import GenericAlias, MappingProxyType
@@ -36,8 +36,11 @@ class BaseTest(unittest.TestCase):
                   Mapping, MutableMapping, MappingView,
                   KeysView, ItemsView, ValuesView,
                   Sequence, MutableSequence,
-                  MappingProxyType, DirEntry, _BaseNetwork
-                  ):
+                  MappingProxyType,
+                  DirEntry,
+                  IPv4Network, IPv4Interface,
+                  IPv6Network, IPv6Interface
+            ):
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):
                 alias = t[int]

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -39,7 +39,7 @@ class BaseTest(unittest.TestCase):
                   MappingProxyType,
                   DirEntry,
                   IPv4Network, IPv4Interface,
-                  IPv6Network, IPv6Interface
+                  IPv6Network, IPv6Interface,
             ):
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):


### PR DESCRIPTION


<!-- issue-number: [bpo-39481](https://bugs.python.org/issue39481) -->
https://bugs.python.org/issue39481
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum