### PR TITLE
bpo-40170: Remove PyIndex_Check() macro

### DIFF
--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -335,12 +335,6 @@ PyAPI_FUNC(void) PyBuffer_Release(Py_buffer *view);
     (Py_TYPE(obj)->tp_iternext != NULL && \
      Py_TYPE(obj)->tp_iternext != &_PyObject_NextNotImplemented)
 
-/* === Number Protocol ================================================== */
-
-#define PyIndex_Check(obj)                              \
-    (Py_TYPE(obj)->tp_as_number != NULL &&            \
-     Py_TYPE(obj)->tp_as_number->nb_index != NULL)
-
 /* === Sequence protocol ================================================ */
 
 /* Assume tp_as_sequence and sq_item exist and that 'i' does not

--- a/Misc/NEWS.d/next/C API/2020-04-04-23-51-59.bpo-40170.uXQ701.rst
+++ b/Misc/NEWS.d/next/C API/2020-04-04-23-51-59.bpo-40170.uXQ701.rst
@@ -1,0 +1,3 @@
+Always declare :c:func:`PyIndex_Check` as an opaque function to hide
+implementation details: remove ``PyIndex_Check()`` macro. The macro accessed
+directly the :c:member:`PyTypeObject.tp_as_number` member.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -1309,8 +1309,6 @@ PyNumber_Absolute(PyObject *o)
 }
 
 
-#undef PyIndex_Check
-
 int
 PyIndex_Check(PyObject *obj)
 {


### PR DESCRIPTION
Always declare PyIndex_Check() as an opaque function to hide
implementation details: remove PyIndex_Check() macro. The macro
accessed directly the PyTypeObject.tp_as_number member.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40170](https://bugs.python.org/issue40170) -->
https://bugs.python.org/issue40170
<!-- /issue-number -->
