### PR TITLE
bpo-39481: Generic alias support to ctypes.Array, LibraryLoader...

### DIFF
--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -1,6 +1,7 @@
 """create and manipulate C data types in Python"""
 
 import os as _os, sys as _sys
+import types as _types
 
 __version__ = "1.1.0"
 
@@ -449,6 +450,8 @@ class LibraryLoader(object):
 
     def LoadLibrary(self, name):
         return self._dlltype(name)
+
+    __class_getitem__ = classmethod(_types.GenericAlias)
 
 cdll = LibraryLoader(CDLL)
 pydll = LibraryLoader(PyDLL)

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -7,9 +7,11 @@ from collections import (
 )
 from collections.abc import *
 from contextlib import AbstractContextManager, AbstractAsyncContextManager
+from ctypes import Array, LibraryLoader
 from os import DirEntry
 from re import Pattern, Match
 from types import GenericAlias, MappingProxyType
+from urllib.parse import SplitResult, ParseResult
 import typing
 
 from typing import TypeVar
@@ -35,7 +37,9 @@ class BaseTest(unittest.TestCase):
                   Mapping, MutableMapping, MappingView,
                   KeysView, ItemsView, ValuesView,
                   Sequence, MutableSequence,
-                  MappingProxyType, DirEntry
+                  MappingProxyType, DirEntry,
+                  Array, LibraryLoader,
+                  SplitResult, ParseResult
                   ):
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -29,6 +29,7 @@ test_urlparse.py provides a good indicator of parsing behavior.
 
 import re
 import sys
+import types
 import collections
 import warnings
 
@@ -175,6 +176,8 @@ class _NetlocResultMixinBase(object):
             if not ( 0 <= port <= 65535):
                 raise ValueError("Port out of range 0-65535")
         return port
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
 
 class _NetlocResultMixinStr(_NetlocResultMixinBase, _ResultMixinStr):

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -4798,6 +4798,12 @@ Array_length(PyObject *myself)
     return self->b_length;
 }
 
+static PyMethodDef Array_methods[] = {
+    {"__class_getitem__",    (PyCFunction)Py_GenericAlias,
+    METH_O|METH_CLASS,       PyDoc_STR("See PEP 585")},
+    { NULL, NULL }
+};
+
 static PySequenceMethods Array_as_sequence = {
     Array_length,                               /* sq_length; */
     0,                                          /* sq_concat; */
@@ -4846,7 +4852,7 @@ PyTypeObject PyCArray_Type = {
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */
     0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
+    Array_methods,                              /* tp_methods */
     0,                                          /* tp_members */
     0,                                          /* tp_getset */
     0,                                          /* tp_base */


### PR DESCRIPTION
- `ctypes.Array`
- `ctypes.LibraryLoader`
- `urllib.parse._NetlocResultMixinBase` (`SplitResult`, `ParseResult`)

<!-- issue-number: [bpo-39481](https://bugs.python.org/issue39481) -->
https://bugs.python.org/issue39481
<!-- /issue-number -->
