### PR TITLE
bpo-39481: Generic alias support to mp.ValueProxy, mp.ApplyResult, mp…

### DIFF
--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -7,6 +7,7 @@ import collections
 import logging
 import threading
 import time
+import types
 
 FIRST_COMPLETED = 'FIRST_COMPLETED'
 FIRST_EXCEPTION = 'FIRST_EXCEPTION'
@@ -543,6 +544,8 @@ class Future(object):
                 waiter.add_exception(self)
             self._condition.notify_all()
         self._invoke_callbacks()
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
 class Executor(object):
     """This is an abstract base class for concrete asynchronous executors."""

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -10,6 +10,7 @@ from concurrent.futures import _base
 import itertools
 import queue
 import threading
+import types
 import weakref
 import os
 
@@ -56,6 +57,8 @@ class _WorkItem(object):
             self = None
         else:
             self.future.set_result(result)
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
 
 def _worker(executor_reference, work_queue, initializer, initargs):

--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -131,6 +131,7 @@ Finis.
 #
 import re
 import string
+import types
 
 __all__ = ["CookieError", "BaseCookie", "SimpleCookie"]
 
@@ -418,6 +419,8 @@ class Morsel(dict):
 
         # Return the result
         return _semispacejoin(result)
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
 
 #

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -21,6 +21,7 @@ import signal
 import array
 import queue
 import time
+import types
 import os
 from os import getpid
 
@@ -1128,6 +1129,8 @@ class ValueProxy(BaseProxy):
     def set(self, value):
         return self._callmethod('set', (value,))
     value = property(get, set)
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
 
 BaseListProxy = MakeProxyType('BaseListProxy', (

--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -20,6 +20,7 @@ import queue
 import threading
 import time
 import traceback
+import types
 import warnings
 from queue import Empty
 
@@ -779,6 +780,8 @@ class ApplyResult(object):
         self._event.set()
         del self._cache[self._job]
         self._pool = None
+
+    __class_getitem__ = classmethod(types.GenericAlias)
 
 AsyncResult = ApplyResult       # create alias -- see #17805
 

--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -14,6 +14,7 @@ import os
 import threading
 import collections
 import time
+import types
 import weakref
 import errno
 
@@ -366,3 +367,5 @@ class SimpleQueue(object):
         else:
             with self._wlock:
                 self._writer.send_bytes(obj)
+
+    __class_getitem__ = classmethod(types.GenericAlias)

--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -14,6 +14,7 @@ import os
 import errno
 import struct
 import secrets
+import types
 
 if os.name == "nt":
     import _winapi
@@ -508,3 +509,5 @@ class ShareableList:
                 return position
         else:
             raise ValueError(f"{value!r} not in this container")
+
+    __class_getitem__ = classmethod(types.GenericAlias)

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -6,7 +6,14 @@ from collections import (
     defaultdict, deque, OrderedDict, Counter, UserDict, UserList
 )
 from collections.abc import *
+from concurrent.futures import Future
+from concurrent.futures.thread import _WorkItem
 from contextlib import AbstractContextManager, AbstractAsyncContextManager
+from http.cookies import Morsel
+from multiprocessing.managers import ValueProxy
+from multiprocessing.pool import ApplyResult
+from multiprocessing.shared_memory import ShareableList
+from multiprocessing.queues import SimpleQueue
 from os import DirEntry
 from re import Pattern, Match
 from types import GenericAlias, MappingProxyType
@@ -35,7 +42,11 @@ class BaseTest(unittest.TestCase):
                   Mapping, MutableMapping, MappingView,
                   KeysView, ItemsView, ValuesView,
                   Sequence, MutableSequence,
-                  MappingProxyType, DirEntry
+                  MappingProxyType, DirEntry,
+                  ValueProxy, ApplyResult,
+                  ShareableList, SimpleQueue,
+                  Future, _WorkItem,
+                  Morsel
                   ):
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):


### PR DESCRIPTION
- `multiprocessing.pool.ApplyResult`
- `multiprocessing.managers.ValueProxy`
- `multiprocessing.shared_memory.ShareableList`
- `multiprocessing.queues.SimpleQueue`
- `concurrent.futures.Future` 
- `concurrent.futures.thread._WorkItem`
- `http.cookies.Morsel`

<!-- issue-number: [bpo-39481](https://bugs.python.org/issue39481) -->
https://bugs.python.org/issue39481
<!-- /issue-number -->
