### PR TITLE
bpo-40077: Remove redundant cast in _json extension module

### DIFF
--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1818,7 +1818,7 @@ _json_exec(PyObject *module)
     }
     Py_INCREF(state->PyScannerType);
     if (PyModule_AddObject(module, "make_scanner", state->PyScannerType) < 0) {
-        Py_DECREF((PyObject*)state->PyScannerType);
+        Py_DECREF(state->PyScannerType);
         return -1;
     }
 
@@ -1828,7 +1828,7 @@ _json_exec(PyObject *module)
     }
     Py_INCREF(state->PyEncoderType);
     if (PyModule_AddObject(module, "make_encoder", state->PyEncoderType) < 0) {
-        Py_DECREF((PyObject*)state->PyEncoderType);
+        Py_DECREF(state->PyEncoderType);
         return -1;
     }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-40077](https://bugs.python.org/issue40077) -->
https://bugs.python.org/issue40077
<!-- /issue-number -->
