### PR TITLE
bpo-40229 tty unblocking setraw and save-restore features

### DIFF
--- a/Doc/library/tty.rst
+++ b/Doc/library/tty.rst
@@ -20,11 +20,16 @@ Because it requires the :mod:`termios` module, it will work only on Unix.
 The :mod:`tty` module defines the following functions:
 
 
-.. function:: setraw(fd, when=termios.TCSAFLUSH)
+.. function:: setraw(fd, when=termios.TCSAFLUSH, block=True)
 
    Change the mode of the file descriptor *fd* to raw. If *when* is omitted, it
    defaults to :const:`termios.TCSAFLUSH`, and is passed to
    :func:`termios.tcsetattr`.
+
+   *block* specifies whether reading from the file with the descriptor *fd* will be blocking.
+   If *block* is ``True`` (which is the default), reading from the file will expect a minimum of 1 character and no timeout;
+   if *block* is ``False``, reading from the file has no minimum expectation and times out after 1 millisecond,
+   which comes in handy when you want to have a mainloop or something that keeps running when there is no input.
 
 
 .. function:: setcbreak(fd, when=termios.TCSAFLUSH)
@@ -34,8 +39,47 @@ The :mod:`tty` module defines the following functions:
    :func:`termios.tcsetattr`.
 
 
+.. function:: save(fd=None, key=None)
+
+   Save the mode of file descriptor *fd*, either with or without a key (which is typically a string but can be anything that is not ``None``).
+
+   *fd* can be omitted in the case that you have set a default file descriptor using :func:`setdefaultfd`.
+   If you have not set a default file descriptor, calling :func:`save` without *fd* will result in a :exc:`ValueError`.
+   If you have set a default file descriptor, calling :func:`save` with another file descriptor *fd* will use the one that is provided as argument.
+
+   If *key* is omitted, the save will be accessible only when using :func:`restore` with *key* omitted as well.
+   No matter if you provide or omit *key*, :func:`save` always creates one step forward in history.
+
+   Historical modes are stored internally in the module during the runtime.
+
+
+.. function:: restore(fd=None, key=None, when=termios.TCSAFLUSH)
+
+   Save the mode of file descriptor *fd*, either with or without a key (which is typically a string but can be anything that is not ``None``).
+
+   *fd* can be omitted in the case that you have set a default file descriptor using :func:`setdefaultfd`.
+   If you have not set a default file descriptor, calling :func:`restore` without *fd* will result in a :exc:`ValueError`.
+   If you have set a default file descriptor, calling :func:`restore` with another file descriptor *fd* will use the one that is provided as argument.
+
+   If *key* is omitted, the mode one step back in the history will be restored;
+   sequential calls of :func:`restore` without *key* will go back in the mode history one step at a time.
+   If *key* is provided, the mode saved with the specified key will be restored (if a mode has been saved with that key using :func:`save`),
+   and this modification creates one step forward in the history.
+
+   If *when* is omitted, it defaults to :const:`termios.TCSAFLUSH`, and is passed to :func:`termios.tcsetattr`.
+
+   Historical modes are stored internally in the module during the runtime.
+
+
+.. function:: setdefaultfd(fd)
+
+   Set the default file descriptor *fd* for :func:`save` and :func:`restore`.
+   This is especially useful when you just want to build something that runs on your terminal and all whose mode you care about is :attr:`sys.stdin`.
+
+   The default file descriptor does not apply to :func:`setraw` or :func:`setcbreak`, in order to maintain compatibility.
+
+
 .. seealso::
 
    Module :mod:`termios`
       Low-level terminal control interface.
-

--- a/Lib/tty.py
+++ b/Lib/tty.py
@@ -15,7 +15,7 @@ ISPEED = 4
 OSPEED = 5
 CC = 6
 
-def setraw(fd, when=TCSAFLUSH):
+def setraw(fd, when=TCSAFLUSH, block=True):
     """Put terminal into a raw mode."""
     mode = tcgetattr(fd)
     mode[IFLAG] = mode[IFLAG] & ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON)
@@ -23,8 +23,12 @@ def setraw(fd, when=TCSAFLUSH):
     mode[CFLAG] = mode[CFLAG] & ~(CSIZE | PARENB)
     mode[CFLAG] = mode[CFLAG] | CS8
     mode[LFLAG] = mode[LFLAG] & ~(ECHO | ICANON | IEXTEN | ISIG)
-    mode[CC][VMIN] = 1
-    mode[CC][VTIME] = 0
+    if block:
+        mode[CC][VMIN] = 1
+        mode[CC][VTIME] = 0
+    else:
+        mode[CC][VMIN] = 0
+        mode[CC][VTIME] = 1
     tcsetattr(fd, when, mode)
 
 def setcbreak(fd, when=TCSAFLUSH):
@@ -34,3 +38,82 @@ def setcbreak(fd, when=TCSAFLUSH):
     mode[CC][VMIN] = 1
     mode[CC][VTIME] = 0
     tcsetattr(fd, when, mode)
+
+# New: utilities for backing up and restoring modes
+
+__all__.extend(["save", "restore", "setdefaultfd"])
+
+default_fd = None
+
+def _checkfd(fd):
+    if fd is None:
+        if default_fd is None:
+            raise ValueError("fd unset")
+        return default_fd
+    return fd
+
+modeStorage = ({}, [])
+modeStack = []
+modeStackPos = 0
+
+def _modeStackPush(way, key):
+    """Save mode change history to stack"""
+    global modeStack, modeStackPos
+    if modeStackPos < len(modeStack):
+        modeStack[modeStackPos] = (way, key)
+    else:
+        modeStack.append((way, key))
+    modeStackPos += 1
+
+def _modeStackPop():
+    """Pop from back of mode history stack"""
+    global modeStack, modeStackPos
+    if modeStackPos <= 0:
+        return None
+    modeStackPos -= 1
+    return modeStack[modeStackPos]
+
+def save(fd=None, key=None):
+    """
+    Save terminal mode.
+    
+    Saves without keys can only be accessed through restores without keys.
+    
+    Saves with keys can be accessed both ways.
+    """
+    fd = _checkfd(fd)
+    if key is None:
+        way = 1  # Where this goes to: keyword storage (0) or list space (1)
+        key = len(modeStorage[1])
+        modeStorage[1].append(tcgetattr(fd))
+    else:
+        way = 0
+        modeStorage[0][key] = tcgetattr(fd)
+    _modeStackPush(way, key)
+
+def restore(fd=None, key=None, when=TCSAFLUSH):
+    """
+    Restore terminal mode.
+    
+    Any restoration with keys will be ONE NEW STEP in history;
+    
+    Sequential restoration without keys go BACK in history ONE STEP a time.
+    """
+    fd = _checkfd(fd)
+    way = 0
+    if key is None:
+        way, key = _modeStackPop()
+    else:
+        _modeStackPush(way, key)
+    tcsetattr(fd, when, modeStorage[way][key])
+
+def setdefaultfd(fd):
+    """
+    Set default fd.
+    
+    This affects ONLY `save` and `restore`
+    
+    This does NOT affect `setraw` and `setcbreak` for compatibility.
+    """
+    global default_fd
+    default_fd = fd

--- a/Lib/tty.py
+++ b/Lib/tty.py
@@ -76,9 +76,7 @@ def _modeStackPop():
 def save(fd=None, key=None):
     """
     Save terminal mode.
-    
     Saves without keys can only be accessed through restores without keys.
-    
     Saves with keys can be accessed both ways.
     """
     fd = _checkfd(fd)
@@ -94,9 +92,7 @@ def save(fd=None, key=None):
 def restore(fd=None, key=None, when=TCSAFLUSH):
     """
     Restore terminal mode.
-    
     Any restoration with keys will be ONE NEW STEP in history;
-    
     Sequential restoration without keys go BACK in history ONE STEP a time.
     """
     fd = _checkfd(fd)
@@ -110,9 +106,7 @@ def restore(fd=None, key=None, when=TCSAFLUSH):
 def setdefaultfd(fd):
     """
     Set default fd.
-    
     This affects ONLY `save` and `restore`
-    
     This does NOT affect `setraw` and `setcbreak` for compatibility.
     """
     global default_fd

--- a/Misc/NEWS.d/next/Library/2020-04-08-18-00-25.bpo-40229.ShLdUB.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-08-18-00-25.bpo-40229.ShLdUB.rst
@@ -1,0 +1,9 @@
+I modified tty.setraw() a bit to support choosing between a blocking (default) and an unblocking terminal raw mode. I personally find it very useful when I want a mainloop to continue running even if I'm not typing.
+
+Also, I added save and restore features to the tty module, because I usually find saving terminal modes and restoring the right one at the right time a bit of pain for me.
+
+I changed the documentation reST to match my changes in the code. You can see that below.
+
+Oh, and I created that issue for this pull request, but since this is my first time doing this, I was pretty confused and might have got things wrong. I apologize here if I did get something messed up.
+
+Thank you!


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

I modified `tty.setraw()` a bit to support choosing between a blocking (default) and an unblocking terminal raw mode. I personally find it very useful when I want a mainloop to continue running even if I'm not typing.

Also, I added save and restore features to the `tty` module, because I usually find saving terminal modes and restoring the right one at the right time a bit of pain for me.

I changed the documentation reST to match my changes in the code. You can see that below.

Oh, and I created that issue for this pull request, but since this is my first time doing this, I was pretty confused and might have got things wrong. I apologize here if I did get something messed up.

Thank you!

<!-- issue-number: [bpo-40229](https://bugs.python.org/issue40229) -->
https://bugs.python.org/issue40229
<!-- /issue-number -->
