### PR TITLE
[3.8] bpo-40112: distutils test_search_cpp: Fix logic to determine if C compiler is xlc on AIX (GH-19225)

### DIFF
--- a/Lib/distutils/tests/test_config_cmd.py
+++ b/Lib/distutils/tests/test_config_cmd.py
@@ -47,8 +47,7 @@ class ConfigTestCase(support.LoggingSilencer,
         cmd = config(dist)
         cmd._check_compiler()
         compiler = cmd.compiler
-        is_xlc = shutil.which(compiler.preprocessor[0]).startswith("/usr/vac")
-        if is_xlc:
+        if sys.platform[:3] == "aix" and "xlc" in compiler.preprocessor[0].lower():
             self.skipTest('xlc: The -E option overrides the -P, -o, and -qsyntaxonly options')
 
         # simple pattern searches


### PR DESCRIPTION
(cherry picked from commit 76db37b1d37a9daadd9e5b320f2d5a53cd1352ec)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40112](https://bugs.python.org/issue40112) -->
https://bugs.python.org/issue40112
<!-- /issue-number -->
