### PR TITLE
bpo-40202: Show the number of values in the too-many-to-unpack error

### DIFF
--- a/Lib/test/test_unpack.py
+++ b/Lib/test/test_unpack.py
@@ -62,14 +62,14 @@ Unpacking tuple of wrong size
     >>> a, b = t
     Traceback (most recent call last):
       ...
-    ValueError: too many values to unpack (expected 2)
+    ValueError: too many values to unpack (expected 2, got 3)
 
 Unpacking tuple of wrong size
 
     >>> a, b = l
     Traceback (most recent call last):
       ...
-    ValueError: too many values to unpack (expected 2)
+    ValueError: too many values to unpack (expected 2, got 3)
 
 Unpacking sequence too short
 
@@ -136,7 +136,7 @@ Unpacking to an empty iterable should raise ValueError
     >>> () = [42]
     Traceback (most recent call last):
       ...
-    ValueError: too many values to unpack (expected 0)
+    ValueError: too many values to unpack (expected 0, got 1)
 
 """
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-09-02-32-27.bpo-40202.UMVW4Q.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-09-02-32-27.bpo-40202.UMVW4Q.rst
@@ -1,0 +1,3 @@
+Improve the error message when unpacking too many values from an iterable.
+We now show both the expected number of elements and the actual number of
+elements when possible.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4513,6 +4513,20 @@ unpack_iterable(PyThreadState *tstate, PyObject *v,
             return 1;
         }
         Py_DECREF(w);
+        /* Get the length of the iterable for better diagnostics message. */
+        Py_ssize_t length = PySequence_Length(v);
+        if (length != -1) {
+            _PyErr_Format(tstate, PyExc_ValueError,
+                "too many values to unpack (expected %d, got %zi)",
+                argcnt, length);
+            goto Error;
+        }
+        else {
+            /* Ignore any errors from the len() call, if we can't call it
+               then no harm. We just try to provide it best-effort. */
+            PyErr_Clear();
+        }
+
         _PyErr_Format(tstate, PyExc_ValueError,
                       "too many values to unpack (expected %d)",
                       argcnt);


### PR DESCRIPTION
I think the current tests provide okay coverage for this, there's a custom `Seq` object in `test_unpack.py` that throws a `TypeError` so that path is covered as well.

This currently just drops any errors from the `PyObject_Length` call which seems like the right thing to do. We can try best-effort to use the size in the error message but I don't think there's any point in propagating the error upwards.

<!-- issue-number: [bpo-40202](https://bugs.python.org/issue40202) -->
https://bugs.python.org/issue40202
<!-- /issue-number -->
