### PR TITLE
bpo-31904: Increase LOOPBACK_TIMEOUT to 10 for VxWorks RTOS

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -138,6 +138,8 @@ if sys.platform == 'win32' and platform.machine() == 'ARM':
     # bpo-37553: test_socket.SendfileUsingSendTest is taking longer than 2
     # seconds on Windows ARM32 buildbot
     LOOPBACK_TIMEOUT = 10
+elif sys.platform == 'vxworks':
+    LOOPBACK_TIMEOUT = 10
 
 # Timeout in seconds for network requests going to the Internet. The timeout is
 # short enough to prevent a test to wait for too long if the Internet request

--- a/Misc/NEWS.d/next/Tests/2020-04-09-15-40-03.bpo-31904.TJ4k3d.rst
+++ b/Misc/NEWS.d/next/Tests/2020-04-09-15-40-03.bpo-31904.TJ4k3d.rst
@@ -1,0 +1,1 @@
+Increase LOOPBACK_TIMEOUT to 10 for VxWorks RTOS.


### PR DESCRIPTION
VxWorks might run on some low-performance board. If TLS is enabled with ftp, it needs bigger LOOPBACK_TIMEOUT value. Otherwise, some test cases under test.test_ftplib.TestTLS_FTPClassMixin will fail. The value 10 is enough to prevent test failure.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
