### PR TITLE
bpo-31904: set expected default encoding in test_c_locale_coercion.py for VxWorks RTOS

### DIFF
--- a/Lib/test/test_c_locale_coercion.py
+++ b/Lib/test/test_c_locale_coercion.py
@@ -49,6 +49,10 @@ elif sys.platform == "cygwin":
     # TODO: Work out a robust dynamic test for this that doesn't rely on
     #       CPython's own locale handling machinery
     EXPECT_COERCION_IN_DEFAULT_LOCALE = False
+elif sys.platform == "vxworks":
+    # VxWorks defaults to using UTF-8 for all system interfaces
+    EXPECTED_C_LOCALE_STREAM_ENCODING = "utf-8"
+    EXPECTED_C_LOCALE_FS_ENCODING = "utf-8"
 
 # Note that the above expectations are still wrong in some cases, such as:
 # * Windows when PYTHONLEGACYWINDOWSFSENCODING is set

--- a/Misc/NEWS.d/next/Tests/2020-04-09-16-29-18.bpo-31904.ej348T.rst
+++ b/Misc/NEWS.d/next/Tests/2020-04-09-16-29-18.bpo-31904.ej348T.rst
@@ -1,0 +1,1 @@
+Set expected default encoding in test_c_locale_coercion.py for VxWorks RTOS.


### PR DESCRIPTION
So far VxWorks RTOS only supports "C" locale and always use utf-8 encoding for the "C" locale.

<!-- issue-number: [bpo-31904](https://bugs.python.org/issue31904) -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
