### PR TITLE
Improved documentation for `BUILD_CONST_KEY_MAP`

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -844,8 +844,8 @@ All of the following opcodes use their arguments.
 
 .. opcode:: BUILD_CONST_KEY_MAP (count)
 
-   The version of :opcode:`BUILD_MAP` specialized for constant keys. Pops the 
-   top element on the stack which contains a tuple of keys, then starting from 
+   The version of :opcode:`BUILD_MAP` specialized for constant keys. Pops the
+   top element on the stack which contains a tuple of keys, then starting from
    ``TOS1``, pops *count* values to form values in the built dictionary.
 
    .. versionadded:: 3.6

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -844,9 +844,9 @@ All of the following opcodes use their arguments.
 
 .. opcode:: BUILD_CONST_KEY_MAP (count)
 
-   The version of :opcode:`BUILD_MAP` specialized for constant keys.  *count*
-   values are consumed from the stack.  The top element on the stack contains
-   a tuple of keys.
+   The version of :opcode:`BUILD_MAP` specialized for constant keys. Pops the 
+   top element on the stack which contains a tuple of keys, then starting from 
+   ``TOS1``, pops *count* values to form values in the built dictionary.
 
    .. versionadded:: 3.6
 


### PR DESCRIPTION
Example

```python
>>> dis.dis("{1: a, 2: b, 3: c}")
  1           0 LOAD_NAME                0 (a)
              2 LOAD_NAME                1 (b)
              4 LOAD_NAME                2 (c)
              6 LOAD_CONST               0 ((1, 2, 3))
              8 BUILD_CONST_KEY_MAP      3
             10 RETURN_VALUE
```

Automerge-Triggered-By: @zhangyangyu