### PR TITLE
bpo-39285: Clarify example for PurePath.match

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -528,8 +528,10 @@ Pure paths provide the following methods and properties:
       >>> PurePath('a/b.py').match('/*.py')
       False
 
-   As with other methods, case-sensitivity is observed::
+   As with other methods, case-sensitivity follows platform defaults::
 
+      >>> PurePosixPath('b.py').match('*.PY')
+      False
       >>> PureWindowsPath('b.py').match('*.PY')
       True
 


### PR DESCRIPTION
Fixes Issue39285

The example incorrectly returned True for match.

Furthermore the example is ambiguous in its usage of PureWindowsPath.
Windows is case-insensitve, however the underlying match functionality
utilizes fnmatch.fnmatchcase.

https://bugs.python.org/issue39285

<!-- issue-number: [bpo-39285](https://bugs.python.org/issue39285) -->
https://bugs.python.org/issue39285
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou