### PR TITLE
bpo-39481: fix test_genericalias on Android

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -19,7 +19,11 @@ from itertools import chain
 from http.cookies import Morsel
 from multiprocessing.managers import ValueProxy
 from multiprocessing.pool import ApplyResult
-from multiprocessing.shared_memory import ShareableList
+try:
+    from multiprocessing.shared_memory import ShareableList
+except ImportError:
+    # multiprocessing.shared_memory is not available on e.g. Android
+    ShareableList = None
 from multiprocessing.queues import SimpleQueue
 from os import DirEntry
 from re import Pattern, Match
@@ -71,6 +75,8 @@ class BaseTest(unittest.TestCase):
                   Future, _WorkItem,
                   Morsel,
                   ):
+            if t is None:
+                continue
             tname = t.__name__
             with self.subTest(f"Testing {tname}"):
                 alias = t[int]


### PR DESCRIPTION
(I'm not sure if it's correct to refer [bpo-39481](https://bugs.python.org/issue39481) or not. Sorry if I did it wrong.)

Android bionic does not implement `shm_open`/`shm_unlink` [1]. As a
result `_posixshmem` extension does not exist and
`multiprocessing.shared_memory` cannot be imported.
```
0:01:48 load avg: 1.53 [159/421/7] test_genericalias failed
test test_genericalias crashed -- Traceback (most recent call last):
  File "/data/local/tmp/lib/python3.9/test/libregrtest/runtest.py", line 270, in _runtest_inner
    refleak = _runtest_inner2(ns, test_name)
  File "/data/local/tmp/lib/python3.9/test/libregrtest/runtest.py", line 221, in _runtest_inner2
    the_module = importlib.import_module(abstest)
  File "/data/local/tmp/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/data/local/tmp/lib/python3.9/test/test_genericalias.py", line 22, in <module>
    from multiprocessing.shared_memory import ShareableList
  File "/data/local/tmp/lib/python3.9/multiprocessing/shared_memory.py", line 23, in <module>
    import _posixshmem
ModuleNotFoundError: No module named '_posixshmem'
```
[1] https://android.googlesource.com/platform/bionic/+/master/docs/status.md

<!-- issue-number: [bpo-39481](https://bugs.python.org/issue39481) -->
https://bugs.python.org/issue39481
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum