### PR TITLE
bpo-39943: Add the const qualifier to pointers on non-mutable PyBytes data.

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1310,7 +1310,7 @@ CharArray_get_value(CDataObject *self, void *Py_UNUSED(ignored))
 static int
 CharArray_set_value(CDataObject *self, PyObject *value, void *Py_UNUSED(ignored))
 {
-    char *ptr;
+    const char *ptr;
     Py_ssize_t size;
 
     if (value == NULL) {

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1384,7 +1384,7 @@ copy_com_pointer(PyObject *self, PyObject *args)
 static PyObject *py_dl_open(PyObject *self, PyObject *args)
 {
     PyObject *name, *name2;
-    char *name_str;
+    const char *name_str;
     void * handle;
 #if HAVE_DECL_RTLD_LOCAL
     int mode = RTLD_NOW | RTLD_LOCAL;

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -1283,7 +1283,7 @@ s_get(void *ptr, Py_ssize_t size)
 static PyObject *
 s_set(void *ptr, PyObject *value, Py_ssize_t length)
 {
-    char *data;
+    const char *data;
     Py_ssize_t size;
 
     if(!PyBytes_Check(value)) {
@@ -1321,7 +1321,7 @@ z_set(void *ptr, PyObject *value, Py_ssize_t size)
         return value;
     }
     if (PyBytes_Check(value)) {
-        *(char **)ptr = PyBytes_AsString(value);
+        *(const char **)ptr = PyBytes_AsString(value);
         Py_INCREF(value);
         return value;
     } else if (PyLong_Check(value)) {

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -709,7 +709,7 @@ _curses_window_addstr_impl(PyCursesWindowObject *self, int group_left_1,
     else
 #endif
     {
-        char *str = PyBytes_AS_STRING(bytesobj);
+        const char *str = PyBytes_AS_STRING(bytesobj);
         funcname = "addstr";
         if (use_xy)
             rtn = mvwaddstr(self->win,y,x,str);
@@ -792,7 +792,7 @@ _curses_window_addnstr_impl(PyCursesWindowObject *self, int group_left_1,
     else
 #endif
     {
-        char *str = PyBytes_AS_STRING(bytesobj);
+        const char *str = PyBytes_AS_STRING(bytesobj);
         funcname = "addnstr";
         if (use_xy)
             rtn = mvwaddnstr(self->win,y,x,str,n);
@@ -1710,7 +1710,7 @@ _curses_window_insstr_impl(PyCursesWindowObject *self, int group_left_1,
     else
 #endif
     {
-        char *str = PyBytes_AS_STRING(bytesobj);
+        const char *str = PyBytes_AS_STRING(bytesobj);
         funcname = "insstr";
         if (use_xy)
             rtn = mvwinsstr(self->win,y,x,str);
@@ -1795,7 +1795,7 @@ _curses_window_insnstr_impl(PyCursesWindowObject *self, int group_left_1,
     else
 #endif
     {
-        char *str = PyBytes_AS_STRING(bytesobj);
+        const char *str = PyBytes_AS_STRING(bytesobj);
         funcname = "insnstr";
         if (use_xy)
             rtn = mvwinsnstr(self->win,y,x,str,n);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1153,7 +1153,7 @@ checkpath(PyObject* tag)
         return 0;
     }
     if (PyBytes_Check(tag)) {
-        char *p = PyBytes_AS_STRING(tag);
+        const char *p = PyBytes_AS_STRING(tag);
         const Py_ssize_t len = PyBytes_GET_SIZE(tag);
         if (len >= 3 && p[0] == '{' && (
                 p[1] == '}' || (p[1] == '*' && p[2] == '}'))) {

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -393,7 +393,7 @@ _io_BytesIO_tell_impl(bytesio *self)
 static PyObject *
 read_bytes(bytesio *self, Py_ssize_t size)
 {
-    char *output;
+    const char *output;
 
     assert(self->buf != NULL);
     assert(size <= self->string_size);
@@ -502,7 +502,7 @@ _io_BytesIO_readlines_impl(bytesio *self, PyObject *arg)
 {
     Py_ssize_t maxsize, size, n;
     PyObject *result, *line;
-    char *output;
+    const char *output;
 
     CHECK_CLOSED(self);
 

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2640,7 +2640,7 @@ _io_TextIOWrapper_tell_impl(textio *self)
     Py_ssize_t chars_to_skip, chars_decoded;
     Py_ssize_t skip_bytes, skip_back;
     PyObject *saved_state = NULL;
-    char *input, *input_end;
+    const char *input, *input_end;
     Py_ssize_t dec_buffer_len;
     int dec_flags;
 

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -637,7 +637,7 @@ PyDoc_STRVAR(bindtextdomain__doc__,
 static PyObject*
 PyIntl_bindtextdomain(PyObject* self, PyObject*args)
 {
-    char *domain, *dirname, *current_dirname;
+    const char *domain, *dirname, *current_dirname;
     PyObject *dirname_obj, *dirname_bytes = NULL, *result;
 
     if (!PyArg_ParseTuple(args, "sO", &domain, &dirname_obj))

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -79,7 +79,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
         NULL
     };
 
-    char* database;
+    const char* database;
     PyObject* database_obj;
     int detect_types = 0;
     PyObject* isolation_level = NULL;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4037,7 +4037,7 @@ error:
 /* internal helper function, returns -1 on error
  */
 static int
-_add_ca_certs(PySSLContext *self, void *data, Py_ssize_t len,
+_add_ca_certs(PySSLContext *self, const void *data, Py_ssize_t len,
               int filetype)
 {
     BIO *biobuf = NULL;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1785,7 +1785,7 @@ s_pack_internal(PyStructObject *soself, PyObject *const *args, int offset, char*
             if (e->format == 's') {
                 Py_ssize_t n;
                 int isstring;
-                void *p;
+                const void *p;
                 isstring = PyBytes_Check(v);
                 if (!isstring && !PyByteArray_Check(v)) {
                     PyErr_SetString(_structmodulestate_global->StructError,
@@ -1807,7 +1807,7 @@ s_pack_internal(PyStructObject *soself, PyObject *const *args, int offset, char*
             } else if (e->format == 'p') {
                 Py_ssize_t n;
                 int isstring;
-                void *p;
+                const void *p;
                 isstring = PyBytes_Check(v);
                 if (!isstring && !PyByteArray_Check(v)) {
                     PyErr_SetString(_structmodulestate_global->StructError,

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -574,9 +574,9 @@ SplitObj(PyObject *arg)
     else if (PyBytes_Check(arg)) {
         int argc;
         const char **argv;
-        char *list = PyBytes_AS_STRING(arg);
+        const char *list = PyBytes_AS_STRING(arg);
 
-        if (Tcl_SplitList((Tcl_Interp *)NULL, list, &argc, &argv) != TCL_OK) {
+        if (Tcl_SplitList((Tcl_Interp *)NULL, (char *)list, &argc, &argv) != TCL_OK) {
             Py_INCREF(arg);
             return arg;
         }

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -1246,7 +1246,7 @@ _multibytecodec_MultibyteIncrementalDecoder_setstate_impl(MultibyteIncrementalDe
     PyObject *buffer;
     PyLongObject *statelong;
     Py_ssize_t buffersize;
-    char *bufferstr;
+    const char *bufferstr;
     unsigned char statebytes[8];
 
     if (!PyArg_ParseTuple(state, "SO!;setstate(): illegal state argument",

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -234,7 +234,7 @@ static PyObject *
 write_history_file(PyObject *self, PyObject *args)
 {
     PyObject *filename_obj = Py_None, *filename_bytes;
-    char *filename;
+    const char *filename;
     int err;
     if (!PyArg_ParseTuple(args, "|O:write_history_file", &filename_obj))
         return NULL;
@@ -270,7 +270,7 @@ append_history_file(PyObject *self, PyObject *args)
 {
     int nelements;
     PyObject *filename_obj = Py_None, *filename_bytes;
-    char *filename;
+    const char *filename;
     int err;
     if (!PyArg_ParseTuple(args, "i|O:append_history_file", &nelements, &filename_obj))
         return NULL;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1598,7 +1598,7 @@ bytes_subscript(PyBytesObject* self, PyObject* item)
     else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelength, i;
         size_t cur;
-        char* source_buf;
+        const char* source_buf;
         char* result_buf;
         PyObject* result;
 
@@ -1863,7 +1863,7 @@ Py_LOCAL_INLINE(PyObject *)
 do_xstrip(PyBytesObject *self, int striptype, PyObject *sepobj)
 {
     Py_buffer vsep;
-    char *s = PyBytes_AS_STRING(self);
+    const char *s = PyBytes_AS_STRING(self);
     Py_ssize_t len = PyBytes_GET_SIZE(self);
     char *sep;
     Py_ssize_t seplen;
@@ -1903,7 +1903,7 @@ do_xstrip(PyBytesObject *self, int striptype, PyObject *sepobj)
 Py_LOCAL_INLINE(PyObject *)
 do_strip(PyBytesObject *self, int striptype)
 {
-    char *s = PyBytes_AS_STRING(self);
+    const char *s = PyBytes_AS_STRING(self);
     Py_ssize_t len = PyBytes_GET_SIZE(self), i, j;
 
     i = 0;
@@ -2020,7 +2020,8 @@ bytes_translate_impl(PyBytesObject *self, PyObject *table,
                      PyObject *deletechars)
 /*[clinic end generated code: output=43be3437f1956211 input=0ecdf159f654233c]*/
 {
-    char *input, *output;
+    const char *input;
+    char *output;
     Py_buffer table_view = {NULL, NULL};
     Py_buffer del_table_view = {NULL, NULL};
     const char *table_chars;
@@ -2371,7 +2372,7 @@ static PyObject *
 bytes_hex_impl(PyBytesObject *self, PyObject *sep, int bytes_per_sep)
 /*[clinic end generated code: output=1f134da504064139 input=f1238d3455990218]*/
 {
-    char* argbuf = PyBytes_AS_STRING(self);
+    const char *argbuf = PyBytes_AS_STRING(self);
     Py_ssize_t arglen = PyBytes_GET_SIZE(self);
     return _Py_strhex_with_sep(argbuf, arglen, sep, bytes_per_sep);
 }
@@ -3188,7 +3189,7 @@ _PyBytesWriter_AsString(_PyBytesWriter *writer)
 Py_LOCAL_INLINE(Py_ssize_t)
 _PyBytesWriter_GetSize(_PyBytesWriter *writer, char *str)
 {
-    char *start = _PyBytesWriter_AsString(writer);
+    const char *start = _PyBytesWriter_AsString(writer);
     assert(str != NULL);
     assert(str >= start);
     assert(str - start <= writer->allocated);
@@ -3199,7 +3200,7 @@ _PyBytesWriter_GetSize(_PyBytesWriter *writer, char *str)
 Py_LOCAL_INLINE(int)
 _PyBytesWriter_CheckConsistency(_PyBytesWriter *writer, char *str)
 {
-    char *start, *end;
+    const char *start, *end;
 
     if (writer->use_small_buffer) {
         assert(writer->buffer == NULL);

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -76,7 +76,7 @@ PyFile_GetLine(PyObject *f, int n)
     }
 
     if (n < 0 && result != NULL && PyBytes_Check(result)) {
-        char *s = PyBytes_AS_STRING(result);
+        const char *s = PyBytes_AS_STRING(result);
         Py_ssize_t len = PyBytes_GET_SIZE(result);
         if (len == 0) {
             Py_DECREF(result);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5071,7 +5071,7 @@ long_new_impl(PyTypeObject *type, PyObject *x, PyObject *obase)
     if (PyUnicode_Check(x))
         return PyLong_FromUnicodeObject(x, (int)base);
     else if (PyByteArray_Check(x) || PyBytes_Check(x)) {
-        char *string;
+        const char *string;
         if (PyByteArray_Check(x))
             string = PyByteArray_AS_STRING(x);
         else

--- a/Objects/stringlib/join.h
+++ b/Objects/stringlib/join.h
@@ -7,8 +7,8 @@
 Py_LOCAL_INLINE(PyObject *)
 STRINGLIB(bytes_join)(PyObject *sep, PyObject *iterable)
 {
-    char *sepstr = STRINGLIB_STR(sep);
-    const Py_ssize_t seplen = STRINGLIB_LEN(sep);
+    const char *sepstr = STRINGLIB_STR(sep);
+    Py_ssize_t seplen = STRINGLIB_LEN(sep);
     PyObject *res = NULL;
     char *p;
     Py_ssize_t seqlen = 0;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3887,7 +3887,7 @@ PyUnicode_FSConverter(PyObject* arg, void* addr)
     PyObject *path = NULL;
     PyObject *output = NULL;
     Py_ssize_t size;
-    void *data;
+    const char *data;
     if (arg == NULL) {
         Py_DECREF(*(PyObject**)addr);
         *(PyObject**)addr = NULL;
@@ -4718,7 +4718,7 @@ _PyUnicode_EncodeUTF7(PyObject *str,
     unsigned int base64bits = 0;
     unsigned long base64buffer = 0;
     char * out;
-    char * start;
+    const char * start;
 
     if (PyUnicode_READY(str) == -1)
         return NULL;
@@ -5446,7 +5446,7 @@ unicode_fill_utf8(PyObject *unicode)
         return -1;
     }
 
-    char *start = writer.use_small_buffer ? writer.small_buffer :
+    const char *start = writer.use_small_buffer ? writer.small_buffer :
                     PyBytes_AS_STRING(writer.buffer);
     Py_ssize_t len = end - start;
 

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1452,7 +1452,7 @@ _Py_fopen_obj(PyObject *path, const char *mode)
              && errno == EINTR && !(async_err = PyErr_CheckSignals()));
 #else
     PyObject *bytes;
-    char *path_bytes;
+    const char *path_bytes;
 
     assert(PyGILState_Check());
 


### PR DESCRIPTION


<!-- issue-number: [bpo-39943](https://bugs.python.org/issue39943) -->
https://bugs.python.org/issue39943
<!-- /issue-number -->
