### PR TITLE
bpo-40225: Don't raise an exception on normal return from generator.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-11-13-07-49.bpo-4022.Ctpn_F.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-11-13-07-49.bpo-4022.Ctpn_F.rst
@@ -1,0 +1,1 @@
+Improve performance of generators by not raising internal StopIteration.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -231,7 +231,8 @@ gen_send_ex(PyGenObject *gen, PyObject *arg, int exc, int closing)
             if (PyAsyncGen_CheckExact(gen)) {
                 PyErr_SetNone(PyExc_StopAsyncIteration);
             }
-            else {
+            else if (arg) {
+                /* Set exception if not called by gen_iternext() */
                 PyErr_SetNone(PyExc_StopIteration);
             }
         }


### PR DESCRIPTION
Reducing runtime on the example program in [bpo-40225](https://bugs.python.org/issue40225) on my machine from 2.427s to 0.142s. (With a non PGO, LTO build).



<!-- issue-number: [bpo-40225](https://bugs.python.org/issue40225) -->
https://bugs.python.org/issue40225
<!-- /issue-number -->
