### PR TITLE
bpo-40246: Report a different error message for invalid string prefixes

### DIFF
--- a/Include/errcode.h
+++ b/Include/errcode.h
@@ -31,6 +31,7 @@ extern "C" {
 #define E_LINECONT      25      /* Unexpected characters after a line continuation */
 #define E_IDENTIFIER    26      /* Invalid characters in identifier */
 #define E_BADSINGLE     27      /* Ill-formed single statement input */
+#define E_BADPREFIX     28      /* Bad string prefixes */
 
 #ifdef __cplusplus
 }

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -841,7 +841,7 @@ non-important content
         self.assertEqual(f'{f"{y}"*3}', '555')
 
     def test_invalid_string_prefixes(self):
-        self.assertAllRaise(SyntaxError, 'unexpected EOF while parsing',
+        self.assertAllRaise(SyntaxError, 'invalid string prefix',
                             ["fu''",
                              "uf''",
                              "Fu''",

--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-11-17-52-03.bpo-40246.vXPze5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-11-17-52-03.bpo-40246.vXPze5.rst
@@ -1,0 +1,1 @@
+Report a specialized error message, `invalid string prefix`, when the tokenizer encounters a string with an invalid prefix.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1392,6 +1392,10 @@ tok_get(struct tok_state *tok, const char **p_start, const char **p_end)
         if (nonascii && !verify_identifier(tok)) {
             return ERRORTOKEN;
         }
+        if (c == '"' || c == '\'') {
+            tok->done = E_BADPREFIX;
+            return ERRORTOKEN;
+        }
         *p_start = tok->start;
         *p_end = tok->cur;
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1574,6 +1574,9 @@ err_input(perrdetail *err)
     case E_BADSINGLE:
         msg = "multiple statements found while compiling a single statement";
         break;
+    case E_BADPREFIX:
+        msg = "invalid string prefix";
+        break;
     default:
         fprintf(stderr, "error=%d\n", err->error);
         msg = "unknown parsing error";


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40246](https://bugs.python.org/issue40246) -->
https://bugs.python.org/issue40246
<!-- /issue-number -->
