### PR TITLE
bpo-39481: Make weakref and WeakSet generic

### DIFF
--- a/Lib/_weakrefset.py
+++ b/Lib/_weakrefset.py
@@ -3,6 +3,7 @@
 # by abc.py to load everything else at startup.
 
 from _weakref import ref
+from types import GenericAlias
 
 __all__ = ['WeakSet']
 
@@ -197,3 +198,5 @@ class WeakSet:
 
     def __repr__(self):
         return repr(self.data)
+
+    __class_getitem__ = classmethod(GenericAlias)

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -28,6 +28,7 @@ from tempfile import TemporaryDirectory, SpooledTemporaryFile
 from urllib.parse import SplitResult, ParseResult
 from unittest.case import _AssertRaisesContext
 from queue import Queue, SimpleQueue
+from weakref import WeakSet, ReferenceType, ref
 import typing
 
 from typing import TypeVar
@@ -67,6 +68,7 @@ class BaseTest(unittest.TestCase):
                   Array, LibraryLoader,
                   SplitResult, ParseResult,
                   ValueProxy, ApplyResult,
+                  WeakSet, ReferenceType, ref,
                   ShareableList, SimpleQueue,
                   Future, _WorkItem,
                   Morsel,

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -362,6 +362,12 @@ static PyMemberDef weakref_members[] = {
     {NULL} /* Sentinel */
 };
 
+static PyMethodDef weakref_methods[] = {
+    {"__class_getitem__",    (PyCFunction)Py_GenericAlias,
+    METH_O|METH_CLASS,       PyDoc_STR("See PEP 585")},
+    {NULL} /* Sentinel */
+};
+
 PyTypeObject
 _PyWeakref_RefType = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
@@ -392,7 +398,7 @@ _PyWeakref_RefType = {
     0,                          /*tp_weaklistoffset*/
     0,                          /*tp_iter*/
     0,                          /*tp_iternext*/
-    0,                          /*tp_methods*/
+    weakref_methods,             /*tp_methods*/
     weakref_members,            /*tp_members*/
     0,                          /*tp_getset*/
     0,                          /*tp_base*/

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -398,7 +398,7 @@ _PyWeakref_RefType = {
     0,                          /*tp_weaklistoffset*/
     0,                          /*tp_iter*/
     0,                          /*tp_iternext*/
-    weakref_methods,             /*tp_methods*/
+    weakref_methods,            /*tp_methods*/
     weakref_members,            /*tp_members*/
     0,                          /*tp_getset*/
     0,                          /*tp_base*/


### PR DESCRIPTION


<!-- issue-number: [bpo-39481](https://bugs.python.org/issue39481) -->
https://bugs.python.org/issue39481
<!-- /issue-number -->
