### PR TITLE
bpo-40263: Fix off-by-one-error in _winapi_WaitForMultipleObjects_impl

### DIFF
--- a/Misc/NEWS.d/next/Windows/2020-04-13-15-20-28.bpo-40263.1KKEbu.rst
+++ b/Misc/NEWS.d/next/Windows/2020-04-13-15-20-28.bpo-40263.1KKEbu.rst
@@ -1,0 +1,3 @@
+This is a follow-on bug from https://bugs.python.org/issue26903. Once that
+is applied we run into an off-by-one assertion problem. The assert was not
+correct.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1705,7 +1705,7 @@ _winapi_WaitForMultipleObjects_impl(PyObject *module, PyObject *handle_seq,
     nhandles = PySequence_Length(handle_seq);
     if (nhandles == -1)
         return NULL;
-    if (nhandles < 0 || nhandles >= MAXIMUM_WAIT_OBJECTS - 1) {
+    if (nhandles < 0 || nhandles > MAXIMUM_WAIT_OBJECTS - 1) {
         PyErr_Format(PyExc_ValueError,
                      "need at most %zd handles, got a sequence of length %zd",
                      MAXIMUM_WAIT_OBJECTS - 1, nhandles);


### PR DESCRIPTION
Fix off-by-one-error in _winapi_WaitForMultipleObjects_impl

<!-- issue-number: [bpo-40263](https://bugs.python.org/issue40263) -->
https://bugs.python.org/issue40263
<!-- /issue-number -->
