### PR TITLE
bpo-29255: Wait in KqueueSelector when no fds are registered

### DIFF
--- a/Lib/selectors.py
+++ b/Lib/selectors.py
@@ -552,7 +552,10 @@ if hasattr(select, 'kqueue'):
 
         def select(self, timeout=None):
             timeout = None if timeout is None else max(timeout, 0)
-            max_ev = len(self._fd_to_key)
+            # If max_ev is 0, kqueue will ignore the timeout. For consistent
+            # behavior with the other selector classes, we prevent that here
+            # (using max). See https://bugs.python.org/issue29255
+            max_ev = max(len(self._fd_to_key), 1)
             ready = []
             try:
                 kev_list = self._selector.control(None, max_ev, timeout)

--- a/Lib/test/test_selectors.py
+++ b/Lib/test/test_selectors.py
@@ -543,6 +543,19 @@ class KqueueSelectorTestCase(BaseSelectorTestCase, ScalableSelectorMixIn):
         with self.assertRaises(KeyError):
             s.get_key(bad_f)
 
+    def test_empty_select_timeout(self):
+        # Issues #23009, #29255: Make sure timeout is applied when no fds
+        # are registered.
+        s = self.SELECTOR()
+        self.addCleanup(s.close)
+
+        t0 = time()
+        self.assertEqual(s.select(1), [])
+        t1 = time()
+        dt = t1 - t0
+        # Tolerate 2.0 seconds for very slow buildbots
+        self.assertTrue(0.8 <= dt <= 2.0, dt)
+
 
 @unittest.skipUnless(hasattr(selectors, 'DevpollSelector'),
                      "Test needs selectors.DevpollSelector")

--- a/Misc/NEWS.d/next/Library/2020-04-14-11-31-07.bpo-29255.4EcyIN.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-14-11-31-07.bpo-29255.4EcyIN.rst
@@ -1,0 +1,1 @@
+Wait in `KqueueSelector.select` when no fds are registered


### PR DESCRIPTION
Also partially fixes [bpo-25680](https://bugs.python.org/issue25680) (there's still a discrepancy in behavior on Windows that needs to be fixed).


<!-- issue-number: [bpo-29255](https://bugs.python.org/issue29255) -->
https://bugs.python.org/issue29255
<!-- /issue-number -->
