### PR TITLE
bpo-39522: Correctly unparse unicode prefix in ast_unparse.c

### DIFF
--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -153,6 +153,7 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         eq = self.assertAnnotationEqual
         eq('...')
         eq("'some_string'")
+        eq("u'some_string'")
         eq("b'\\xa3'")
         eq('Name')
         eq('None')

--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-14-18-47-00.bpo-39522.uVeIV_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-14-18-47-00.bpo-39522.uVeIV_.rst
@@ -1,0 +1,2 @@
+Correctly unparse explicit ``u`` prefix for strings when postponed
+evaluation for annotations activated. Patch by Batuhan Taskaya.

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -875,6 +875,8 @@ append_ast_expr(_PyUnicodeWriter *writer, expr_ty e, int level)
         if (e->v.Constant.value == Py_Ellipsis) {
             APPEND_STR_FINISH("...");
         }
+        APPEND_STR_IF(e->v.Constant.kind != NULL,
+                      PyUnicode_AS_DATA(e->v.Constant.kind));
         return append_ast_constant(writer, e->v.Constant.value);
     case JoinedStr_kind:
         return append_joinedstr(writer, e, false);


### PR DESCRIPTION


<!-- issue-number: [bpo-39522](https://bugs.python.org/issue39522) -->
https://bugs.python.org/issue39522
<!-- /issue-number -->
