### PR TITLE
bpo-40286: Add randbytes() method to random.Random

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -112,6 +112,13 @@ Bookkeeping functions
    :meth:`randrange` to handle arbitrarily large ranges.
 
 
+.. function:: randbytes(n)
+
+   Generate *n* random bytes.
+
+   .. versionadded:: 3.9
+
+
 Functions for integers
 ----------------------
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -353,6 +353,12 @@ The documentation string is now shown not only for class, function,
 method etc, but for any object that has its own ``__doc__`` attribute.
 (Contributed by Serhiy Storchaka in :issue:`40257`.)
 
+random
+------
+
+Add a new :attr:`random.Random.randbytes` method: generate random bytes.
+(Contributed by Victor Stinner in :issue:`40286`.)
+
 signal
 ------
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -739,6 +739,12 @@ class SystemRandom(Random):
         x = int.from_bytes(_urandom(numbytes), 'big')
         return x >> (numbytes * 8 - k)                # trim excess bits
 
+    def randbytes(self, n):
+        """Generate n random bytes."""
+        # os.urandom(n) fails with ValueError for n < 0
+        # and returns an empty bytes string for n == 0.
+        return _urandom(n)
+
     def seed(self, *args, **kwds):
         "Stub method.  Not used for a system random number generator."
         return None
@@ -819,6 +825,7 @@ weibullvariate = _inst.weibullvariate
 getstate = _inst.getstate
 setstate = _inst.setstate
 getrandbits = _inst.getrandbits
+randbytes = _inst.randbytes
 
 if hasattr(_os, "fork"):
     _os.register_at_fork(after_in_child=_inst.seed)

--- a/Lib/secrets.py
+++ b/Lib/secrets.py
@@ -14,7 +14,6 @@ __all__ = ['choice', 'randbelow', 'randbits', 'SystemRandom',
 
 import base64
 import binascii
-import os
 
 from hmac import compare_digest
 from random import SystemRandom
@@ -44,7 +43,7 @@ def token_bytes(nbytes=None):
     """
     if nbytes is None:
         nbytes = DEFAULT_ENTROPY
-    return os.urandom(nbytes)
+    return _sysrand.randbytes(nbytes)
 
 def token_hex(nbytes=None):
     """Return a random text string, in hexadecimal.

--- a/Misc/NEWS.d/next/Library/2020-04-15-00-39-25.bpo-40286.ai80FA.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-15-00-39-25.bpo-40286.ai80FA.rst
@@ -1,0 +1,2 @@
+Add :func:`random.randbytes` function and
+:meth:`random.Random.randbytes` method to generate random bytes.

--- a/Modules/Setup
+++ b/Modules/Setup
@@ -174,7 +174,7 @@ _symtable symtablemodule.c
 #_weakref _weakref.c	# basic weak reference support
 #_testcapi _testcapimodule.c    # Python C API test module
 #_testinternalcapi _testinternalcapi.c -I$(srcdir)/Include/internal -DPy_BUILD_CORE_MODULE  # Python internal C API test module
-#_random _randommodule.c	# Random number generator
+#_random _randommodule.c -DPy_BUILD_CORE_MODULE	# Random number generator
 #_elementtree -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DUSE_PYEXPAT_CAPI _elementtree.c	# elementtree accelerator
 #_pickle _pickle.c	# pickle accelerator
 #_datetime _datetimemodule.c	# datetime accelerator

--- a/Modules/clinic/_randommodule.c.h
+++ b/Modules/clinic/_randommodule.c.h
@@ -114,4 +114,45 @@ _random_Random_getrandbits(RandomObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a7feb0c9c8d1b627 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(_random_Random_randbytes__doc__,
+"randbytes($self, n, /)\n"
+"--\n"
+"\n"
+"Generate n random bytes.");
+
+#define _RANDOM_RANDOM_RANDBYTES_METHODDEF    \
+    {"randbytes", (PyCFunction)_random_Random_randbytes, METH_O, _random_Random_randbytes__doc__},
+
+static PyObject *
+_random_Random_randbytes_impl(RandomObject *self, Py_ssize_t n);
+
+static PyObject *
+_random_Random_randbytes(RandomObject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    Py_ssize_t n;
+
+    if (PyFloat_Check(arg)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "integer argument expected, got float" );
+        goto exit;
+    }
+    {
+        Py_ssize_t ival = -1;
+        PyObject *iobj = PyNumber_Index(arg);
+        if (iobj != NULL) {
+            ival = PyLong_AsSsize_t(iobj);
+            Py_DECREF(iobj);
+        }
+        if (ival == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        n = ival;
+    }
+    return_value = _random_Random_randbytes_impl(self, n);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=e515c651860c4001 input=a9049054013a1b77]*/

--- a/setup.py
+++ b/setup.py
@@ -808,7 +808,8 @@ class PyBuildExt(build_ext):
         self.add(Extension('_datetime', ['_datetimemodule.c'],
                            libraries=['m']))
         # random number generator implemented in C
-        self.add(Extension("_random", ["_randommodule.c"]))
+        self.add(Extension("_random", ["_randommodule.c"],
+                           extra_compile_args=['-DPy_BUILD_CORE_MODULE']))
         # bisect
         self.add(Extension("_bisect", ["_bisectmodule.c"]))
         # heapq


### PR DESCRIPTION
Add random.randbytes() function and random.Random.randbytes()
method to generate random bytes.

Modify secrets.token_bytes() to use SystemRandom.randbytes()
rather than calling directly os.urandom().

Rename also genrand_int32() to genrand_uint32(), since it returns an
unsigned 32-bit integer, not a signed integer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40286](https://bugs.python.org/issue40286) -->
https://bugs.python.org/issue40286
<!-- /issue-number -->
