### PR TITLE
bpo-40270: Enable json extension in windows sqlite extension

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-04-14-16-18-49.bpo-40270.XVJzeG.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-14-16-18-49.bpo-40270.XVJzeG.rst
@@ -1,0 +1,2 @@
+The in-built sqlite extension on Windows is now compiled with the json
+extension. This allows the use of functions such as ``json_object``.

--- a/Misc/NEWS.d/next/Library/2020-04-14-16-18-49.bpo-40270.XVJzeG.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-14-16-18-49.bpo-40270.XVJzeG.rst
@@ -1,2 +1,2 @@
-The in-built sqlite extension on Windows is now compiled with the json
+The included copy of sqlite3 on Windows is now compiled with the json
 extension. This allows the use of functions such as ``json_object``.

--- a/PCbuild/sqlite3.vcxproj
+++ b/PCbuild/sqlite3.vcxproj
@@ -98,7 +98,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(sqlite3Dir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>SQLITE_ENABLE_FTS4;SQLITE_ENABLE_FTS5;SQLITE_API=__declspec(dllexport);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SQLITE_ENABLE_JSON1;SQLITE_ENABLE_FTS4;SQLITE_ENABLE_FTS5;SQLITE_API=__declspec(dllexport);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level1</WarningLevel>
     </ClCompile>
     <ResourceCompile>


### PR DESCRIPTION
Here's the change in the size of the compiled sqlite library:

**Before**:
```
λ du -h win32\sqlite3.dll
1008K   win32\sqlite3.dll
```

**After**:
```
1.1M    win32\sqlite3.dll
```

<!-- issue-number: [bpo-40270](https://bugs.python.org/issue40270) -->
https://bugs.python.org/issue40270
<!-- /issue-number -->
