### PR TITLE
bpo-40268: pythread.h is always included by Python.h

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -131,6 +131,7 @@
 #include "pyerrors.h"
 
 #include "cpython/initconfig.h"
+#include "pythread.h"
 #include "pystate.h"
 #include "context.h"
 

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -7,8 +7,6 @@
 extern "C" {
 #endif
 
-#include "pythread.h"
-
 /* This limitation is for performance and simplicity. If needed it can be
 removed (with effort). */
 #define MAX_CO_EXTRA_USERS 255

--- a/Modules/_blake2/blake2b_impl.c
+++ b/Modules/_blake2/blake2b_impl.c
@@ -15,7 +15,6 @@
 
 #include "Python.h"
 #include "pystrhex.h"
-#include "pythread.h"
 
 #include "../hashlib.h"
 #include "blake2ns.h"

--- a/Modules/_blake2/blake2s_impl.c
+++ b/Modules/_blake2/blake2s_impl.c
@@ -15,7 +15,6 @@
 
 #include "Python.h"
 #include "pystrhex.h"
-#include "pythread.h"
 
 #include "../hashlib.h"
 #include "blake2ns.h"

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -5,8 +5,6 @@
 #include "Python.h"
 #include "structmember.h"
 
-#include "pythread.h"
-
 #include <bzlib.h>
 #include <stdio.h>
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -28,7 +28,6 @@
 
 #include <Python.h>
 #include "longintrepr.h"
-#include "pythread.h"
 #include "structmember.h"
 #include "complexobject.h"
 #include "mpdecimal.h"

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -11,7 +11,6 @@
 #include "Python.h"
 #include "pycore_object.h"
 #include "structmember.h"
-#include "pythread.h"
 #include "_iomodule.h"
 
 /*[clinic input]

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -9,7 +9,6 @@
 
 #include "Python.h"
 #include "structmember.h"
-#include "pythread.h"
 
 #include <stdarg.h>
 #include <string.h>

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -1,6 +1,5 @@
 #include "Python.h"
 #include "structmember.h" /* offsetof */
-#include "pythread.h"
 
 /*[clinic input]
 module _queue

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -30,8 +30,6 @@
 #include "prepare_protocol.h"
 #include "util.h"
 
-#include "pythread.h"
-
 #define ACTION_FINALIZE 1
 #define ACTION_RESET 2
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -18,8 +18,6 @@
 
 #include "Python.h"
 
-#include "pythread.h"
-
 /* Redefined below for Windows debug builds after important #includes */
 #define _PySSL_FIX_ERRNO
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -17,7 +17,6 @@
 #include "Python.h"
 #include "datetime.h"
 #include "marshal.h"
-#include "pythread.h"
 #include "structmember.h"
 #include <float.h>
 #include <signal.h>

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -6,7 +6,6 @@
 #include "pycore_pylifecycle.h"
 #include "pycore_interp.h"       // _PyInterpreterState.num_threads
 #include "pycore_pystate.h"      // _PyThreadState_Init()
-#include "pythread.h"
 #include <stddef.h>              // offsetof()
 
 static PyObject *ThreadError;

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -26,8 +26,6 @@ Copyright (C) 1994 Steen Lumholt.
 #include "Python.h"
 #include <ctype.h>
 
-#include "pythread.h"
-
 #ifdef MS_WINDOWS
 #include <windows.h>
 #endif

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -4,7 +4,6 @@
 #include "pycore_traceback.h"
 #include "hashtable.h"
 #include "frameobject.h"
-#include "pythread.h"
 #include "osdefs.h"
 
 #include "clinic/_tracemalloc.c.h"

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1,7 +1,6 @@
 #include "Python.h"
 #include "pycore_initconfig.h"
 #include "pycore_traceback.h"
-#include "pythread.h"
 #include <signal.h>
 #include <object.h>
 #include <frameobject.h>

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -38,7 +38,6 @@
 #include "pycore_ceval.h"     /* _PyEval_ReInitThreads() */
 #include "pycore_import.h"    /* _PyImport_ReInitLock() */
 #include "pycore_pystate.h"   /* _PyInterpreterState_GET() */
-#include "pythread.h"
 #include "structmember.h"
 #ifndef MS_WINDOWS
 #  include "posixmodule.h"

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -104,8 +104,6 @@ class sigset_t_converter(CConverter):
    may not be the thread that received the signal.
 */
 
-#include "pythread.h"
-
 static volatile struct {
     _Py_atomic_int tripped;
     PyObject *func;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -234,13 +234,8 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
 #define RELEASE_GETADDRINFO_LOCK
 #endif
 
-#if defined(USE_GETHOSTBYNAME_LOCK) || defined(USE_GETADDRINFO_LOCK)
-# include "pythread.h"
-#endif
-
-
 #if defined(__APPLE__) || defined(__CYGWIN__) || defined(__NetBSD__)
-# include <sys/ioctl.h>
+#  include <sys/ioctl.h>
 #endif
 
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -25,13 +25,12 @@
 #endif
 
 #if defined(__WATCOMC__) && !defined(__QNX__)
-#include <i86.h>
+#  include <i86.h>
 #else
-#ifdef MS_WINDOWS
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include "pythread.h"
-#endif /* MS_WINDOWS */
+#  ifdef MS_WINDOWS
+#    define WIN32_LEAN_AND_MEAN
+#    include <windows.h>
+#  endif /* MS_WINDOWS */
 #endif /* !__WATCOMC__ || __QNX__ */
 
 #ifdef _Py_MEMORY_SANITIZER

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -10,7 +10,6 @@
 #include "zlib.h"
 
 
-#include "pythread.h"
 #define ENTER_ZLIB(obj) \
     Py_BEGIN_ALLOW_THREADS; \
     PyThread_acquire_lock((obj)->lock, 1); \

--- a/Parser/myreadline.c
+++ b/Parser/myreadline.c
@@ -19,7 +19,6 @@
 
 PyThreadState* _PyOS_ReadlineTState = NULL;
 
-#include "pythread.h"
 static PyThread_type_lock _PyOS_ReadlineLock = NULL;
 
 int (*PyOS_InputHook)(void) = NULL;

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -9,7 +9,6 @@
 #include "pycore_initconfig.h"    // _PyConfig_InitCompatConfig()
 #include "pycore_runtime.h"       // _PyRuntime
 #include <Python.h>
-#include "pythread.h"
 #include <inttypes.h>
 #include <stdio.h>
 #include <wchar.h>

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -240,7 +240,6 @@ UNSIGNAL_ASYNC_EXC(PyInterpreterState *interp)
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
-#include "pythread.h"
 #include "ceval_gil.h"
 
 static void

--- a/Python/import.c
+++ b/Python/import.c
@@ -150,8 +150,6 @@ _PyImportZip_Init(PyThreadState *tstate)
    in different threads to return with a partially loaded module.
    These calls are serialized by the global interpreter lock. */
 
-#include "pythread.h"
-
 static PyThread_type_lock import_lock = 0;
 static unsigned long import_lock_thread = PYTHREAD_INVALID_THREAD_ID;
 static int import_lock_level = 0;

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2350,8 +2350,6 @@ Py_ExitStatusException(PyStatus status)
 
 /* Clean up and exit */
 
-#  include "pythread.h"
-
 /* For the atexit module. */
 void _Py_PyAtExit(void (*func)(PyObject *), PyObject *module)
 {

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -26,7 +26,6 @@ Data members:
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"      // _PyThreadState_GET()
 #include "pycore_tupleobject.h"
-#include "pythread.h"
 #include "pydtrace.h"
 
 #include "osdefs.h"

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -23,8 +23,6 @@
 
 #include <stdlib.h>
 
-#include "pythread.h"
-
 #ifndef _POSIX_THREADS
 
 /* Check if we're running on HP-UX and _SC_THREADS is defined. If so, then


### PR DESCRIPTION
Remove explicit pythread.h includes: it is always included
by Python.h.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40268](https://bugs.python.org/issue40268) -->
https://bugs.python.org/issue40268
<!-- /issue-number -->
