### PR TITLE
bpo-40268: Remove unused structmember.h includes

### DIFF
--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -1,7 +1,6 @@
 /* ABCMeta implementation */
 
 #include "Python.h"
-#include "structmember.h"
 #include "clinic/_abc.c.h"
 
 /*[clinic input]

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1,5 +1,5 @@
 #include "Python.h"
-#include "structmember.h"
+#include <stddef.h>               // offsetof()
 
 
 /*[clinic input]

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -3,7 +3,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #include <bzlib.h>
 #include <stdio.h>

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1,10 +1,10 @@
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #ifdef STDC_HEADERS
 #include <stddef.h>
 #else
-#include <sys/types.h>          /* For size_t */
+#include <sys/types.h>            // size_t
 #endif
 
 /*[clinic input]

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -11,7 +11,7 @@ module instead.
 #define MODULE_VERSION "1.0"
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include <stdbool.h>
 
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -102,7 +102,7 @@ bytes(cdata)
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #include <ffi.h>
 #ifdef MS_WIN32

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -55,7 +55,7 @@
  */
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #ifdef MS_WIN32
 #include <windows.h>
@@ -751,7 +751,7 @@ static int ConvParam(PyObject *obj, Py_ssize_t index, struct argument *pa)
 #if defined(MS_WIN32) && !defined(_WIN32_WCE)
 /*
 Per: https://msdn.microsoft.com/en-us/library/7572ztz4.aspx
-To be returned by value in RAX, user-defined types must have a length 
+To be returned by value in RAX, user-defined types must have a length
 of 1, 2, 4, 8, 16, 32, or 64 bits
 */
 int can_return_struct_as_int(size_t s)

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -9,7 +9,7 @@
 
 #include "Python.h"
 #include "datetime.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #include <time.h>
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -28,7 +28,6 @@
 
 #include <Python.h>
 #include "longintrepr.h"
-#include "structmember.h"
 #include "complexobject.h"
 #include "mpdecimal.h"
 

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -14,7 +14,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 /* -------------------------------------------------------------------- */
 /* configuration */

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1,8 +1,8 @@
 #include "Python.h"
 #include "pycore_pymem.h"
-#include "pycore_pystate.h"      // _PyThreadState_GET()
+#include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_tupleobject.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 /* _functools module written and maintained
    by Hye-Shik Chang <perky@FreeBSD.org>

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -14,7 +14,6 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"
 #include "hashlib.h"
 #include "pystrhex.h"
 

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -9,7 +9,6 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"
 #include "_iomodule.h"
 
 #ifdef HAVE_SYS_TYPES_H

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -10,7 +10,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pycore_object.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "_iomodule.h"
 
 /*[clinic input]

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -1,6 +1,6 @@
 #include "Python.h"
 #include "pycore_object.h"
-#include "structmember.h"       /* for offsetof() */
+#include <stddef.h>               // offsetof()
 #include "_iomodule.h"
 
 /*[clinic input]

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -3,7 +3,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pycore_object.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include <stdbool.h>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -11,7 +11,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pycore_object.h"
-#include "structmember.h"
+#include <stddef.h>               // offsetof()
 #include "_iomodule.h"
 
 /*[clinic input]

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"
+#include <stddef.h>               // offsetof()
 #include "pycore_accu.h"
 #include "pycore_object.h"
 #include "_iomodule.h"

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -8,10 +8,10 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "pycore_interp.h"      // PyInterpreterState.fs_codec
+#include "pycore_interp.h"        // PyInterpreterState.fs_codec
 #include "pycore_object.h"
-#include "pycore_pystate.h"     // _PyInterpreterState_GET()
-#include "structmember.h"
+#include "pycore_pystate.h"       // _PyInterpreterState_GET()
+#include "structmember.h"         // PyMemberDef
 #include "_iomodule.h"
 
 /*[clinic input]

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -12,7 +12,7 @@
 
 #ifdef MS_WINDOWS
 
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -9,7 +9,7 @@
 #endif
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "pycore_accu.h"
 
 typedef struct {

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -8,7 +8,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #include <stdarg.h>
 #include <string.h>

--- a/Modules/_multiprocessing/posixshmem.c
+++ b/Modules/_multiprocessing/posixshmem.c
@@ -5,7 +5,6 @@ posixshmem - A Python extension that provides shm_open() and shm_unlink()
 #define PY_SSIZE_T_CLEAN
 
 #include <Python.h>
-#include "structmember.h"
 
 // for shm_open() and shm_unlink()
 #ifdef HAVE_SYS_MMAN_H

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -9,7 +9,7 @@
 #endif
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 PyDoc_STRVAR(pickle_module_doc,
 "Optimized C implementation for the Python pickle module.");

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -1,5 +1,5 @@
 #include "Python.h"
-#include "structmember.h" /* offsetof */
+#include <stddef.h>               // offsetof()
 
 /*[clinic input]
 module _queue

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -23,7 +23,7 @@
 
 #include "cache.h"
 #include "module.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "connection.h"
 #include "statement.h"
 #include "cursor.h"

--- a/Modules/_sqlite/microprotocols.c
+++ b/Modules/_sqlite/microprotocols.c
@@ -24,7 +24,6 @@
  */
 
 #include <Python.h>
-#include <structmember.h>
 
 #include "cursor.h"
 #include "microprotocols.h"

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -41,7 +41,7 @@ static const char copyright[] =
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h" /* offsetof */
+#include "structmember.h"         // PyMemberDef
 
 #include "sre.h"
 

--- a/Modules/_statisticsmodule.c
+++ b/Modules/_statisticsmodule.c
@@ -1,7 +1,6 @@
 /* statistics accelerator C extension: _statistics module. */
 
 #include "Python.h"
-#include "structmember.h"
 #include "clinic/_statisticsmodule.c.h"
 
 /*[clinic input]

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -6,7 +6,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include <ctype.h>
 
 /*[clinic input]

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -17,7 +17,7 @@
 #include "Python.h"
 #include "datetime.h"
 #include "marshal.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include <float.h>
 #include <signal.h>
 

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -4,9 +4,9 @@
 
 #include "Python.h"
 #include "pycore_pylifecycle.h"
-#include "pycore_interp.h"       // _PyInterpreterState.num_threads
-#include "pycore_pystate.h"      // _PyThreadState_Init()
-#include <stddef.h>              // offsetof()
+#include "pycore_interp.h"        // _PyInterpreterState.num_threads
+#include "pycore_pystate.h"       // _PyThreadState_Init()
+#include <stddef.h>               // offsetof()
 
 static PyObject *ThreadError;
 static PyObject *str_dict;
@@ -586,8 +586,6 @@ newlockobject(void)
 }
 
 /* Thread-local objects */
-
-#include "structmember.h"
 
 /* Quick overview:
 

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -35,7 +35,7 @@
 /* See http://www.python.org/2.4/license for licensing details. */
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #define WINDOWS_LEAN_AND_MEAN
 #include "windows.h"
@@ -1110,8 +1110,8 @@ _winapi_CreateProcess_impl(PyObject *module,
         }
     }
     else if (command_line != Py_None) {
-        PyErr_Format(PyExc_TypeError, 
-                     "CreateProcess() argument 2 must be str or None, not %s", 
+        PyErr_Format(PyExc_TypeError,
+                     "CreateProcess() argument 2 must be str or None, not %s",
                      Py_TYPE(command_line)->tp_name);
         goto cleanup;
     }

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -5,7 +5,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"
+#include <stddef.h>               // offsetof()
 
 #ifdef STDC_HEADERS
 #include <stddef.h>

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -6,7 +6,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "multibytecodec.h"
 #include "clinic/multibytecodec.c.h"
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -2,7 +2,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pycore_tupleobject.h"
-#include "structmember.h"
+#include <stddef.h>               // offsetof()
 
 /* Itertools module written and maintained
    by Raymond D. Hettinger <python@rcn.com>

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -20,7 +20,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <stddef.h>               // offsetof()
 
 #ifndef MS_WINDOWS
 #define UNIX

--- a/Modules/ossaudiodev.c
+++ b/Modules/ossaudiodev.c
@@ -19,7 +19,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -8,7 +8,7 @@
    Check itemsize */
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #define WINDOWS_LEAN_AND_MEAN
 #include <winsock2.h>

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -35,10 +35,10 @@
 #  include <windows.h>
 #endif
 
-#include "pycore_ceval.h"     /* _PyEval_ReInitThreads() */
-#include "pycore_import.h"    /* _PyImport_ReInitLock() */
-#include "pycore_pystate.h"   /* _PyInterpreterState_GET() */
-#include "structmember.h"
+#include "pycore_ceval.h"         // _PyEval_ReInitThreads()
+#include "pycore_import.h"        // _PyImport_ReInitLock()
+#include "pycore_pystate.h"       // _PyInterpreterState_GET()
+#include "structmember.h"         // PyMemberDef
 #ifndef MS_WINDOWS
 #  include "posixmodule.h"
 #else

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1,7 +1,7 @@
 #include "Python.h"
 #include <ctype.h>
 
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "frameobject.h"
 #include "expat.h"
 

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -9,7 +9,7 @@
 #endif
 
 #include "Python.h"
-#include <structmember.h>
+#include "structmember.h"         // PyMemberDef
 
 #ifdef HAVE_SYS_DEVPOLL_H
 #include <sys/resource.h>

--- a/Modules/sha256module.c
+++ b/Modules/sha256module.c
@@ -17,7 +17,7 @@
 /* SHA objects */
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "hashlib.h"
 #include "pystrhex.h"
 

--- a/Modules/sha512module.c
+++ b/Modules/sha512module.c
@@ -17,7 +17,7 @@
 /* SHA objects */
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "hashlib.h"
 #include "pystrhex.h"
 

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -101,7 +101,7 @@ Local naming conventions:
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #ifdef _Py_MEMORY_SANITIZER
 # include <sanitizer/msan_interface.h>

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -17,7 +17,7 @@
 
 #include "Python.h"
 #include "ucnhash.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #include <stdbool.h>
 

--- a/Modules/xxsubtype.c
+++ b/Modules/xxsubtype.c
@@ -1,5 +1,5 @@
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 PyDoc_STRVAR(xxsubtype__doc__,
 "xxsubtype is an example module showing how to subtype builtin types from C.\n"

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -6,7 +6,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "zlib.h"
 
 

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -1,12 +1,12 @@
 /* Abstract Object Interface (many thanks to Jim Fulton) */
 
 #include "Python.h"
-#include "pycore_abstract.h"   // _PyIndex_Check()
-#include "pycore_ceval.h"      // _Py_EnterRecursiveCall()
+#include "pycore_abstract.h"      // _PyIndex_Check()
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "pycore_pyerrors.h"
-#include "pycore_pystate.h"    // _PyThreadState_GET()
+#include "pycore_pystate.h"       // _PyThreadState_GET()
 #include <ctype.h>
-#include "structmember.h" /* we need the offsetof() macro from there */
+#include <stddef.h>               // offsetof()
 #include "longintrepr.h"
 
 

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2,11 +2,10 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "pycore_abstract.h"   // _PyIndex_Check()
+#include "pycore_abstract.h"      // _PyIndex_Check()
 #include "pycore_bytes_methods.h"
 #include "pycore_object.h"
 #include "pycore_pymem.h"
-#include "structmember.h"
 #include "bytesobject.h"
 #include "pystrhex.h"
 

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -4,8 +4,8 @@
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pymem.h"
-#include "pycore_pystate.h"   // _PyThreadState_GET()
-#include "structmember.h"
+#include "pycore_pystate.h"       // _PyThreadState_GET()
+#include "structmember.h"         // PyMemberDef
 
 #define TP_DESCR_GET(t) ((t)->tp_descr_get)
 

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -3,7 +3,7 @@
 #include "Python.h"
 #include "code.h"
 #include "opcode.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "pycore_code.h"
 #include "pycore_interp.h"        // PyInterpreterState.co_extra_freefuncs
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -6,7 +6,7 @@
 /* Submitted by Jim Hugunin */
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 /*[clinic input]
 class complex "PyComplexObject *" "&PyComplex_Type"

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -5,7 +5,7 @@
 #include "pycore_object.h"
 #include "pycore_pystate.h"      // _PyThreadState_GET()
 #include "pycore_tupleobject.h"
-#include "structmember.h" /* Why is this not included in Python.h? */
+#include "structmember.h"         // PyMemberDef
 
 _Py_IDENTIFIER(getattr);
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -9,7 +9,7 @@
 #include "pycore_initconfig.h"
 #include "pycore_object.h"
 #include "pycore_pymem.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "osdefs.h"
 
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -7,7 +7,7 @@
 #include "code.h"
 #include "frameobject.h"
 #include "opcode.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #define OFF(x) offsetof(PyFrameObject, x)
 

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -6,7 +6,7 @@
 #include "pycore_pymem.h"
 #include "pycore_tupleobject.h"
 #include "code.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 PyObject *
 PyFunction_NewWithQualName(PyObject *code, PyObject *globals, PyObject *qualname)

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -2,7 +2,7 @@
 
 #include "Python.h"
 #include "pycore_object.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 typedef struct {
     PyObject_HEAD
@@ -118,7 +118,7 @@ ga_repr(PyObject *self)
 
     _PyUnicodeWriter writer;
     _PyUnicodeWriter_Init(&writer);
-    
+
     if (ga_repr_item(&writer, alias->origin) < 0) {
         goto error;
     }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1,11 +1,11 @@
 /* Generator object implementation */
 
 #include "Python.h"
-#include "pycore_ceval.h"     // _PyEval_EvalFrame()
+#include "pycore_ceval.h"         // _PyEval_EvalFrame()
 #include "pycore_object.h"
-#include "pycore_pystate.h"   // _PyThreadState_GET()
+#include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "frameobject.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "opcode.h"
 
 static PyObject *gen_close(PyGenObject *, PyObject *);

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -2,12 +2,12 @@
 /* Method object implementation */
 
 #include "Python.h"
-#include "pycore_ceval.h"     // _Py_EnterRecursiveCall()
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pymem.h"
-#include "pycore_pystate.h"   // _PyThreadState_GET()
-#include "structmember.h"
+#include "pycore_pystate.h"       // _PyThreadState_GET()
+#include "structmember.h"         // PyMemberDef
 
 /* undefine macro trampoline to PyCFunction_NewEx */
 #undef PyCFunction_New

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -2,9 +2,9 @@
 /* Module object implementation */
 
 #include "Python.h"
-#include "pycore_interp.h"    // PyInterpreterState.importlib
-#include "pycore_pystate.h"   // _PyInterpreterState_GET()
-#include "structmember.h"
+#include "pycore_interp.h"        // PyInterpreterState.importlib
+#include "pycore_pystate.h"       // _PyInterpreterState_GET()
+#include "structmember.h"         // PyMemberDef
 
 static Py_ssize_t max_module_number;
 

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -1,7 +1,7 @@
 // namespace object implementation
 
 #include "Python.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 
 typedef struct {

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -466,7 +466,7 @@ later:
 
 #include "Python.h"
 #include "pycore_object.h"
-#include "structmember.h"
+#include <stddef.h>               // offsetof()
 #include "dict-common.h"
 #include <stddef.h>
 

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -3,7 +3,7 @@
 #include "Python.h"
 #include "pycore_abstract.h"   // _PyIndex_Check()
 #include "pycore_tupleobject.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 /* Support objects whose length is > PY_SSIZE_T_MAX.
 

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -32,8 +32,8 @@
 */
 
 #include "Python.h"
-#include "pycore_object.h"   // _PyObject_GC_UNTRACK()
-#include "structmember.h"
+#include "pycore_object.h"        // _PyObject_GC_UNTRACK()
+#include <stddef.h>               // offsetof()
 
 /* Object used as dummy key to fill deleted entries */
 static PyObject _dummy_struct;

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -14,10 +14,10 @@ this type and there is exactly one in existence.
 */
 
 #include "Python.h"
-#include "pycore_abstract.h"   // _PyIndex_Check()
+#include "pycore_abstract.h"      // _PyIndex_Check()
 #include "pycore_object.h"
 #include "pycore_pymem.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 static PyObject *
 ellipsis_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -10,7 +10,7 @@
 #include "Python.h"
 #include "pycore_tupleobject.h"
 #include "pycore_object.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 static const char visible_length_key[] = "n_sequence_fields";
 static const char real_length_key[] = "n_fields";

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5,9 +5,9 @@
 #include "pycore_initconfig.h"
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
-#include "pycore_pystate.h"     // _PyThreadState_GET()
+#include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "frameobject.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 #include <ctype.h>
 

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -1,6 +1,6 @@
 #include "Python.h"
-#include "pycore_object.h"   // _PyObject_GET_WEAKREFS_LISTPTR
-#include "structmember.h"
+#include "pycore_object.h"        // _PyObject_GET_WEAKREFS_LISTPTR()
+#include "structmember.h"         // PyMemberDef
 
 
 #define GET_WEAKREFS_LISTPTR(o) \

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -14,8 +14,8 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "structmember.h"
-#include "windows.h"
+#include "structmember.h"         // PyMemberDef
+#include <windows.h>
 
 static BOOL PyHKEY_AsHKEY(PyObject *ob, HKEY *pRes, BOOL bNoneOK);
 static BOOL clinic_HKEY_converter(PyObject *ob, void *p);

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1428,7 +1428,7 @@ def main(srcfile, dump_module=False):
             f.write('\n')
             f.write('#include "Python.h"\n')
             f.write('#include "%s-ast.h"\n' % mod.name)
-            f.write('#include "structmember.h"\n')
+            f.write('#include "structmember.h"         // PyMemberDef\n')
             f.write('\n')
 
             generate_module_def(f, mod)

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -4,7 +4,7 @@
 
 #include "Python.h"
 #include "Python-ast.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 typedef struct {
     int initialized;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -29,7 +29,6 @@
 #include "opcode.h"
 #include "pydtrace.h"
 #include "setobject.h"
-#include "structmember.h"
 
 #include <ctype.h>
 

--- a/Python/context.c
+++ b/Python/context.c
@@ -6,7 +6,7 @@
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"
 #include "pycore_pystate.h"       // _PyThreadState_GET()
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 
 #define CONTEXT_FREELIST_MAXLEN 255

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -1,8 +1,8 @@
 #include "Python.h"
 
 #include "pycore_hamt.h"
-#include "pycore_object.h"   // _PyObject_GC_TRACK()
-#include "structmember.h"
+#include "pycore_object.h"        // _PyObject_GC_TRACK()
+#include <stddef.h>               // offsetof()
 
 /*
 This file provides an implementation of an immutable mapping using the

--- a/Python/structmember.c
+++ b/Python/structmember.c
@@ -2,8 +2,7 @@
 /* Map C struct members to Python object attributes */
 
 #include "Python.h"
-
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 PyObject *
 PyMember_GetOne(const char *addr, PyMemberDef *l)

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -2,7 +2,7 @@
 #include "pycore_pystate.h"   // _PyThreadState_GET()
 #include "symtable.h"
 #undef Yield   /* undefine macro conflicting with <winbase.h> */
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 
 /* error strings used for warnings */
 #define GLOBAL_PARAM \

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -5,7 +5,7 @@
 
 #include "code.h"
 #include "frameobject.h"
-#include "structmember.h"
+#include "structmember.h"         // PyMemberDef
 #include "osdefs.h"
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>


### PR DESCRIPTION
If only offsetof() is needed: include stddef.h instead.

When structmember.h is used, add a comment explaining that
PyMemberDef is used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40268](https://bugs.python.org/issue40268) -->
https://bugs.python.org/issue40268
<!-- /issue-number -->
