### PR TITLE
bpo-40277: Add a repr() to namedtuple's _tuplegetter to aid with introspection

### DIFF
--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -411,6 +411,12 @@ class TestNamedTuple(unittest.TestCase):
         self.assertIs(P.m.__doc__, Q.o.__doc__)
         self.assertIs(P.n.__doc__, Q.p.__doc__)
 
+    @support.cpython_only
+    def test_field_repr(self):
+        Point = namedtuple('Point', 'x y')
+        self.assertEqual(repr(Point.x), "_tuplegetter(0, 'Alias for field number 0')")
+        self.assertEqual(repr(Point.y), "_tuplegetter(1, 'Alias for field number 1')")
+
     def test_name_fixer(self):
         for spec, renamed in [
             [('efg', 'g%hi'),  ('efg', '_1')],                              # field with non-alpha char

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -417,6 +417,12 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(repr(Point.x), "_tuplegetter(0, 'Alias for field number 0')")
         self.assertEqual(repr(Point.y), "_tuplegetter(1, 'Alias for field number 1')")
 
+        Point.x.__doc__ = 'The x-coordinate'
+        Point.y.__doc__ = 'The y-coordinate'
+
+        self.assertEqual(repr(Point.x), "_tuplegetter(0, 'The x-coordinate')")
+        self.assertEqual(repr(Point.y), "_tuplegetter(1, 'The y-coordinate')")
+
     def test_name_fixer(self):
         for spec, renamed in [
             [('efg', 'g%hi'),  ('efg', '_1')],                              # field with non-alpha char

--- a/Misc/NEWS.d/next/Library/2020-04-14-21-53-18.bpo-40277.NknSaf.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-14-21-53-18.bpo-40277.NknSaf.rst
@@ -1,0 +1,2 @@
+:func:`collections.namedtuple` now provides a human-readable repr for its
+field accessors.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2489,6 +2489,14 @@ tuplegetter_reduce(_tuplegetterobject *self, PyObject *Py_UNUSED(ignored))
     return Py_BuildValue("(O(nO))", (PyObject*) Py_TYPE(self), self->index, self->doc);
 }
 
+static PyObject*
+tuplegetter_repr(_tuplegetterobject *self)
+{
+    return PyUnicode_FromFormat("%s(%zd, %R)",
+                                _PyType_Name(Py_TYPE(self)),
+                                self->index, self->doc);
+}
+
 
 static PyMemberDef tuplegetter_members[] = {
     {"__doc__",  T_OBJECT, offsetof(_tuplegetterobject, doc), 0},
@@ -2511,7 +2519,7 @@ static PyTypeObject tuplegetter_type = {
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
-    0,                                          /* tp_repr */
+    (reprfunc)tuplegetter_repr,                 /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */


### PR DESCRIPTION
Added some basic tests through `namedtuple`, doesn't seem like anything else uses `_tuplegetter`. Not sure if this change warrants a NEWS entry.

<!-- issue-number: [bpo-40277](https://bugs.python.org/issue40277) -->
https://bugs.python.org/issue40277
<!-- /issue-number -->
