### PR TITLE
bpo-40287: Fix SpooledTemporaryFile.seek() return value

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -738,7 +738,7 @@ class SpooledTemporaryFile:
         return self._file.readlines(*args)
 
     def seek(self, *args):
-        self._file.seek(*args)
+        return self._file.seek(*args)
 
     def tell(self):
         return self._file.tell()

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1018,7 +1018,8 @@ class TestSpooledTemporaryFile(BaseTestCase):
         # Verify writelines with a SpooledTemporaryFile
         f = self.do_create()
         f.writelines((b'x', b'y', b'z'))
-        f.seek(0)
+        pos = f.seek(0)
+        self.assertEqual(pos, 0)
         buf = f.read()
         self.assertEqual(buf, b'xyz')
 
@@ -1036,7 +1037,8 @@ class TestSpooledTemporaryFile(BaseTestCase):
         # when that occurs
         f = self.do_create(max_size=30)
         self.assertFalse(f._rolled)
-        f.seek(100, 0)
+        pos = f.seek(100, 0)
+        self.assertEqual(pos, 100)
         self.assertFalse(f._rolled)
         f.write(b'x')
         self.assertTrue(f._rolled)

--- a/Misc/NEWS.d/next/Library/2020-04-15-17-21-48.bpo-40287.-mkEJH.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-15-17-21-48.bpo-40287.-mkEJH.rst
@@ -1,1 +1,1 @@
-Fixed ``SpooledTemporaryFile.seek()`` did not return the position.
+Fixed ``SpooledTemporaryFile.seek()`` to return the position.

--- a/Misc/NEWS.d/next/Library/2020-04-15-17-21-48.bpo-40287.-mkEJH.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-15-17-21-48.bpo-40287.-mkEJH.rst
@@ -1,0 +1,1 @@
+Fixed ``SpooledTemporaryFile.seek()`` did not return the position.


### PR DESCRIPTION


<!-- issue-number: [bpo-40287](https://bugs.python.org/issue40287) -->
https://bugs.python.org/issue40287
<!-- /issue-number -->
