### PR TITLE
bpo-40294: Fix use-after-free in _asynciomodule.c when module is loaded/unloaded multiple times

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3271,6 +3271,8 @@ module_free(void *m)
     Py_CLEAR(context_kwname);
 
     module_free_freelists();
+
+    module_initialized = 0;
 }
 
 static int


### PR DESCRIPTION
GH-16598 added  the static variable `module_initialized` to `_asynciomodule.c` to guard against multiple initializations and instead re-use the resources from the first initialization. However, the variable isn't cleared in `module_free()`. If the module is again initialized after `module_free` is called, the program will crash. In particular, `Py_INCREF(all_tasks);` in `PyInit__asyncio()` will access invalid memory.

The fix seems straightforward: simply clear the flag in `module_free()`. This seems symmetric with it being set in `module_init()`.

<!-- issue-number: [bpo-40294](https://bugs.python.org/issue40294) -->
https://bugs.python.org/issue40294
<!-- /issue-number -->
