### PR TITLE
bpo-35967: Make test_platform.test_uname_processor more lenient to satisfy build bots.

### DIFF
--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -174,7 +174,7 @@ class PlatformTest(unittest.TestCase):
         if expect == 'unknown':
             return
 
-        self.assertEqual(expect, platform.uname().processor)
+        self.assertEqual(platform.uname().processor, expect)
 
     @unittest.skipUnless(sys.platform.startswith('win'), "windows only test")
     def test_uname_win32_ARCHITEW6432(self):

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -169,10 +169,12 @@ class PlatformTest(unittest.TestCase):
         of 'uname -p'. See Issue 35967 for rationale.
         """
         with contextlib.suppress(subprocess.CalledProcessError):
-            self.assertEqual(
-                platform.uname().processor,
-                subprocess.check_output(['uname', '-p'], text=True).strip(),
-            )
+            expect = subprocess.check_output(['uname', '-p'], text=True).strip()
+
+        if expect == 'unknown':
+            return
+
+        self.assertEqual(expect, platform.uname().processor)
 
     @unittest.skipUnless(sys.platform.startswith('win'), "windows only test")
     def test_uname_win32_ARCHITEW6432(self):

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -172,7 +172,7 @@ class PlatformTest(unittest.TestCase):
             expect = subprocess.check_output(['uname', '-p'], text=True).strip()
 
         if expect == 'unknown':
-            return
+            expect = ''
 
         self.assertEqual(platform.uname().processor, expect)
 


### PR DESCRIPTION
In GH-12824, I added a test to capture the status quo expectation of `platform.uname.processor`. Then sir bedevere informed me that the [buildbots are failing](https://buildbot.python.org/all/#builders/105/builds/779). This patch is intended to address that failure.

<!-- issue-number: [bpo-35967](https://bugs.python.org/issue35967) -->
https://bugs.python.org/issue35967
<!-- /issue-number -->
