### PR TITLE
bpo-40297: Fix test_socket.CANTest.testSendFrame

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -209,7 +209,7 @@ class SocketCANTest(unittest.TestCase):
     the following commands:
     # modprobe vcan
     # ip link add dev vcan0 type vcan
-    # ifconfig vcan0 up
+    # ip link set up vcan0
     """
     interface = 'vcan0'
     bufsize = 128
@@ -2004,7 +2004,6 @@ class CANTest(ThreadedCANSocketTest):
         cf, addr = self.s.recvfrom(self.bufsize)
         self.assertEqual(self.cf, cf)
         self.assertEqual(addr[0], self.interface)
-        self.assertEqual(addr[1], socket.AF_CAN)
 
     def _testSendFrame(self):
         self.cf = self.build_can_frame(0x00, b'\x01\x02\x03\x04\x05')


### PR DESCRIPTION
The address tuple for CAN_RAW no longer returns the address family
after the introduction of CAN ISO-TP support in a30f6d45ac3. However,
updating test_socket.CANTest.testSendFrame was missed as part of the
change, so the test incorrectly attempts to index past the last tuple
item to retrieve the address family.

This removes the now-redundant check for equality against socket.AF_CAN,
as the tuple will not contain the address family.

<!-- issue-number: [bpo-40297](https://bugs.python.org/issue40297) -->
https://bugs.python.org/issue40297
<!-- /issue-number -->
