### PR TITLE
bpo-40300: Allow empty logging.Formatter.default_msec_format. (GH-19551)

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -608,6 +608,9 @@ The useful mapping keys in a :class:`LogRecord` are given in the section on
          attributes are ``default_time_format`` (for the strptime format string)
          and ``default_msec_format`` (for appending the millisecond value).
 
+      .. versionchanged:: 3.9
+         The ``default_msec_format`` can be ``None``.
+
    .. method:: formatException(exc_info)
 
       Formats the specified exception information (a standard exception tuple as

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -597,8 +597,9 @@ class Formatter(object):
         if datefmt:
             s = time.strftime(datefmt, ct)
         else:
-            t = time.strftime(self.default_time_format, ct)
-            s = self.default_msec_format % (t, record.msecs)
+            s = time.strftime(self.default_time_format, ct)
+            if self.default_msec_format:
+                s = self.default_msec_format % (s, record.msecs)
         return s
 
     def formatException(self, ei):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3941,6 +3941,19 @@ class FormatterTest(unittest.TestCase):
         f.format(r)
         self.assertEqual(r.asctime, '1993-04-21 08:03:00,123')
 
+    def test_default_msec_format_none(self):
+        class NoMsecFormatter(logging.Formatter):
+            default_msec_format = None
+            default_time_format = '%d/%m/%Y %H:%M:%S'
+
+        r = self.get_record()
+        dt = datetime.datetime(1993, 4, 21, 8, 3, 0, 123, utc)
+        r.created = time.mktime(dt.astimezone(None).timetuple())
+        f = NoMsecFormatter()
+        f.converter = time.gmtime
+        self.assertEqual(f.formatTime(r), '21/04/1993 08:03:00')
+
+
 class TestBufferingFormatter(logging.BufferingFormatter):
     def formatHeader(self, records):
         return '[(%d)' % len(records)


### PR DESCRIPTION
I will add tests if this is an acceptable change.

<!-- issue-number: [bpo-40300](https://bugs.python.org/issue40300) -->
https://bugs.python.org/issue40300
<!-- /issue-number -->
