### PR TITLE
bpo-40305: Fix server_close implementation for class ThreadingHTTPServer and TCPServer

### DIFF
--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -487,6 +487,8 @@ class TCPServer(BaseServer):
         May be overridden.
 
         """
+        # stop infinite loop BaseServer.serve_forever method
+        super().shutdown()
         self.socket.close()
 
     def fileno(self):

--- a/Misc/NEWS.d/next/Library/2020-04-16-18-54-28.bpo-40305.YJnO3x.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-16-18-54-28.bpo-40305.YJnO3x.rst
@@ -1,0 +1,2 @@
+Fix ``server_close()`` method implementation of :class:`TCPServer`.
+Now call parent method ``shutdown()`` to stop :class:`BaseServer` ``server_forever()`` infinite loop.


### PR DESCRIPTION
<!-- issue-number: [bpo-40305](https://bugs.python.org/issue40305) -->
https://bugs.python.org/issue40305
<!-- /issue-number -->
* #84485
