### PR TITLE
gdbinit: Use proper define syntax

### DIFF
--- a/Misc/gdbinit
+++ b/Misc/gdbinit
@@ -160,7 +160,7 @@ document pystackv
   Print the entire Python call stack - verbose mode
 end
 
-def pu
+define pu
   set $uni = $arg0
   set $i = 0
   while (*$uni && $i++<100)


### PR DESCRIPTION
Using `def` rather than `define` results in:

    Ambiguous command "def pu": define, define-prefix.

Automerge-Triggered-By: @csabella