### PR TITLE
bpo-40288: atexit supports more than once loading per interpreter 

### DIFF
--- a/Include/cpython/pylifecycle.h
+++ b/Include/cpython/pylifecycle.h
@@ -42,7 +42,7 @@ PyAPI_FUNC(void) _Py_NO_RETURN Py_ExitStatusException(PyStatus err);
 /* Py_PyAtExit is for the atexit module, Py_AtExit is for low-level
  * exit functions.
  */
-PyAPI_FUNC(void) _Py_PyAtExit(void (*func)(PyObject *), PyObject *);
+PyAPI_FUNC(int) _Py_PyAtExit(void (*func)(PyObject *), PyObject *);
 
 /* Restore signals that the interpreter has called SIG_IGN on to SIG_DFL. */
 PyAPI_FUNC(void) _Py_RestoreSignals(void);

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -121,8 +121,11 @@ struct _is {
     PyObject *after_forkers_child;
 #endif
     /* AtExit module */
-    void (*pyexitfunc)(PyObject *);
-    PyObject *pyexitmodule;
+
+#define NEXITMODULE 32
+    void (*pyexitfunc[NEXITMODULE])(PyObject *);
+    PyObject *pyexitmodule[NEXITMODULE];
+    int nexitmodule;
 
     uint64_t tstate_next_unique_id;
 

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -222,6 +222,29 @@ class SubinterpreterTest(unittest.TestCase):
         self.assertEqual(os.read(r, len(expected)), expected)
         os.close(r)
 
+    def test_multiple_loading_on_subinterpreter(self):
+        expected = b"atexit2 callback\natexit1 callback\n"
+        r, w = os.pipe()
+
+        code = r"""if 1:
+            import sys
+            import os
+            def callback(msg):
+                os.write({:d}, msg)
+            atexit1 = sys.modules.pop('atexit', None)
+            if atexit1 is None:
+                import atexit as atexit1
+                del sys.modules['atexit']
+
+            import atexit as atexit2
+            atexit1.register(callback, b"atexit1 callback\n")
+            atexit2.register(callback, b"atexit2 callback\n")
+        """.format(w)
+        ret = support.run_in_subinterp(code)
+        os.close(w)
+        self.assertEqual(os.read(r, len(expected)), expected)
+        os.close(r)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-17-10-02-36.bpo-40288.twb5Dx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-17-10-02-36.bpo-40288.twb5Dx.rst
@@ -1,0 +1,2 @@
+:mod:`atexit` now supports more than once loading per interpreter. Patch by
+Dong-hee Na.

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -327,7 +327,9 @@ atexit_exec(PyObject *m) {
     if (modstate->atexit_callbacks == NULL)
         return -1;
 
-    _Py_PyAtExit(atexit_callfuncs, m);
+    if (_Py_PyAtExit(atexit_callfuncs, m) < 0) {
+        return -1;
+    }
     return 0;
 }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2354,7 +2354,7 @@ int _Py_PyAtExit(void (*func)(PyObject *), PyObject *module)
 
     is->pyexitfunc[n] = func;
     is->pyexitmodule[n] = module;
-    return 0;
+    return is->nexitmodule;
 }
 
 static void

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -267,6 +267,7 @@ PyInterpreterState_New(void)
         return NULL;
     }
 
+    interp->nexitmodule = 0;
     interp->tstate_next_unique_id = 0;
 
     interp->audit_hooks = NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40288](https://bugs.python.org/issue40288) -->
https://bugs.python.org/issue40288
<!-- /issue-number -->
