### PR TITLE
bpo-32494: Add gdbm.count()

### DIFF
--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -237,6 +237,13 @@ supported.
 
       Close the ``gdbm`` database.
 
+   .. method:: gdbm.count()
+
+      Count the number of records in the database.  This method requires GNU
+      DBM version 1.11 or greater.
+
+      .. versionadded:: 3.9
+
 :mod:`dbm.ndbm` --- Interface based on ndbm
 -------------------------------------------
 

--- a/Misc/NEWS.d/next/Library/2020-04-17-08-28-08.bpo-32494.k4zxIG.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-17-08-28-08.bpo-32494.k4zxIG.rst
@@ -1,0 +1,2 @@
+Add :meth:`gdbm.count` to wrap the ``gdbm_count()`` function added in GDBM
+1.11.

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -486,6 +486,32 @@ _gdbm_gdbm_sync_impl(dbmobject *self)
     Py_RETURN_NONE;
 }
 
+#if GDBM_VERSION_MAJOR >= 1 && GDBM_VERSION_MINOR >= 11
+/*[clinic input]
+_gdbm.gdbm.count
+
+Count the number of records in the database.
+[clinic start generated code]*/
+
+static PyObject *
+_gdbm_gdbm_count_impl(dbmobject *self)
+/*[clinic end generated code: output=8b62b02ae4c2fcee input=1b9d3f0877315a04]*/
+{
+    gdbm_count_t count;
+    check_dbmobject_open(self);
+    if (gdbm_count(self->di_dbm, &count) == -1) {
+        if (errno != 0) {
+            PyErr_SetFromErrno(DbmError);
+        }
+        else {
+            PyErr_SetString(DbmError, gdbm_strerror(gdbm_errno));
+        }
+        return NULL;
+    }
+    return PyLong_FromUnsignedLongLong(count);
+}
+#endif
+
 static PyObject *
 dbm__enter__(PyObject *self, PyObject *args)
 {
@@ -509,6 +535,7 @@ static PyMethodDef dbm_methods[] = {
     _GDBM_GDBM_SYNC_METHODDEF
     _GDBM_GDBM_GET_METHODDEF
     _GDBM_GDBM_SETDEFAULT_METHODDEF
+    _GDBM_GDBM_COUNT_METHODDEF
     {"__enter__", dbm__enter__, METH_NOARGS, NULL},
     {"__exit__",  dbm__exit__, METH_VARARGS, NULL},
     {NULL,              NULL}           /* sentinel */

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -211,6 +211,28 @@ _gdbm_gdbm_sync(dbmobject *self, PyObject *Py_UNUSED(ignored))
     return _gdbm_gdbm_sync_impl(self);
 }
 
+#if (GDBM_VERSION_MAJOR >= 1 && GDBM_VERSION_MINOR >= 11)
+
+PyDoc_STRVAR(_gdbm_gdbm_count__doc__,
+"count($self, /)\n"
+"--\n"
+"\n"
+"Count the number of records in the database.");
+
+#define _GDBM_GDBM_COUNT_METHODDEF    \
+    {"count", (PyCFunction)_gdbm_gdbm_count, METH_NOARGS, _gdbm_gdbm_count__doc__},
+
+static PyObject *
+_gdbm_gdbm_count_impl(dbmobject *self);
+
+static PyObject *
+_gdbm_gdbm_count(dbmobject *self, PyObject *Py_UNUSED(ignored))
+{
+    return _gdbm_gdbm_count_impl(self);
+}
+
+#endif /* (GDBM_VERSION_MAJOR >= 1 && GDBM_VERSION_MINOR >= 11) */
+
 PyDoc_STRVAR(dbmopen__doc__,
 "open($module, filename, flags=\'r\', mode=0o666, /)\n"
 "--\n"
@@ -298,4 +320,8 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2766471b2fa1a816 input=a9049054013a1b77]*/
+
+#ifndef _GDBM_GDBM_COUNT_METHODDEF
+    #define _GDBM_GDBM_COUNT_METHODDEF
+#endif /* !defined(_GDBM_GDBM_COUNT_METHODDEF) */
+/*[clinic end generated code: output=0373bfdb5c23b602 input=a9049054013a1b77]*/


### PR DESCRIPTION
gdbm_count() was added in GDBM 1.11.



<!-- issue-number: [bpo-32494](https://bugs.python.org/issue32494) -->
https://bugs.python.org/issue32494
<!-- /issue-number -->
