### PR TITLE
Fix compiler warning building with GCC on Windows

### DIFF
--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -355,7 +355,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #define HAVE_COPYSIGN 1
 
 /* Define to 1 if you have the `round' function. */
-#if _MSC_VER >= 1800
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 #define HAVE_ROUND 1
 #endif
 


### PR DESCRIPTION
First contribution here. Let me know if this fix is trivial enough or needs a bug to be open.

The warning can be reproduced when building with GCC on Windows:
```
C:\Python37\Include/pyconfig.h:360:5: warning: "_MSC_VER" is not defined, evaluates to 0 [-Wundef]
 #if _MSC_VER >= 1800
```


