### PR TITLE
bpo-40302: Optimize UTF-32 encoder SWAB4()

### DIFF
--- a/Objects/stringlib/codecs.h
+++ b/Objects/stringlib/codecs.h
@@ -743,7 +743,7 @@ STRINGLIB(SWAB4)(STRINGLIB_CHAR ch)
     return (word << 24);
 #elif STRINGLIB_SIZEOF_CHAR == 2
     /* high bytes are zero */
-    return ((word & 0x00FFu) << 24) + ((word & 0xFF00u) << 8);
+    return ((word & 0x00FFu) << 24) | ((word & 0xFF00u) << 8);
 #else
     return _Py_bswap32(word);
 #endif


### PR DESCRIPTION
Use a | b instead of a + b in  UCS-2 implementation of SWAB4().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40302](https://bugs.python.org/issue40302) -->
https://bugs.python.org/issue40302
<!-- /issue-number -->
