### PR TITLE
bpo-40302: Replace PY_INT64_T with int64_t

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1114,7 +1114,7 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
    .. versionadded:: 3.9
 
 
-.. c:function:: PY_INT64_T PyInterpreterState_GetID(PyInterpreterState *interp)
+.. c:function:: int64_t PyInterpreterState_GetID(PyInterpreterState *interp)
 
    Return the interpreter's unique ID.  If there was any error in doing
    so then ``-1`` is returned and an error is set.

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -170,7 +170,7 @@ struct _xidregitem {
     struct _xidregitem *next;
 };
 
-PyAPI_FUNC(struct _is*) _PyInterpreterState_LookUpID(PY_INT64_T);
+PyAPI_FUNC(struct _is*) _PyInterpreterState_LookUpID(int64_t);
 
 PyAPI_FUNC(int) _PyInterpreterState_IDInitref(struct _is *);
 PyAPI_FUNC(void) _PyInterpreterState_IDIncref(struct _is *);

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -234,7 +234,7 @@ init_by_array(RandomObject *self, uint32_t init_key[], size_t key_length)
 static int
 random_seed_urandom(RandomObject *self)
 {
-    PY_UINT32_T key[N];
+    uint32_t key[N];
 
     if (_PyOS_URandomNonblock(key, sizeof(key)) < 0) {
         return -1;
@@ -250,14 +250,14 @@ random_seed_time_pid(RandomObject *self)
     uint32_t key[5];
 
     now = _PyTime_GetSystemClock();
-    key[0] = (PY_UINT32_T)(now & 0xffffffffU);
-    key[1] = (PY_UINT32_T)(now >> 32);
+    key[0] = (uint32_t)(now & 0xffffffffU);
+    key[1] = (uint32_t)(now >> 32);
 
-    key[2] = (PY_UINT32_T)getpid();
+    key[2] = (uint32_t)getpid();
 
     now = _PyTime_GetMonotonicClock();
-    key[3] = (PY_UINT32_T)(now & 0xffffffffU);
-    key[4] = (PY_UINT32_T)(now >> 32);
+    key[3] = (uint32_t)(now & 0xffffffffU);
+    key[4] = (uint32_t)(now >> 32);
 
     init_by_array(self, key, Py_ARRAY_LENGTH(key));
 }

--- a/Modules/_sha3/sha3module.c
+++ b/Modules/_sha3/sha3module.c
@@ -40,7 +40,7 @@
 #elif PY_BIG_ENDIAN
   /* opt64 is not yet supported on big endian platforms */
   #define KeccakOpt 32
-#elif SIZEOF_VOID_P == 8 && defined(PY_UINT64_T)
+#elif SIZEOF_VOID_P == 8
   /* opt64 works only on little-endian 64bit platforms with unsigned int64 */
   #define KeccakOpt 64
 #else
@@ -48,9 +48,9 @@
   #define KeccakOpt 32
 #endif
 
-#if KeccakOpt == 64 && defined(PY_UINT64_T)
+#if KeccakOpt == 64
   /* 64bit platforms with unsigned int64 */
-  typedef PY_UINT64_T UINT64;
+  typedef uint64_t UINT64;
   typedef unsigned char UINT8;
 #endif
 

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2135,7 +2135,7 @@ static PyObject *
 interp_get_main(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     // Currently, 0 is always the main interpreter.
-    PY_INT64_T id = 0;
+    int64_t id = 0;
     return _PyInterpreterID_New(id);
 }
 

--- a/Objects/interpreteridobject.c
+++ b/Objects/interpreteridobject.c
@@ -270,7 +270,7 @@ _PyInterpreterState_GetIDObject(PyInterpreterState *interp)
     if (_PyInterpreterState_IDInitref(interp) != 0) {
         return NULL;
     };
-    PY_INT64_T id = PyInterpreterState_GetID(interp);
+    int64_t id = PyInterpreterState_GetID(interp);
     if (id < 0) {
         return NULL;
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -452,11 +452,11 @@ PyInterpreterState_GetID(PyInterpreterState *interp)
 
 
 static PyInterpreterState *
-interp_look_up_id(_PyRuntimeState *runtime, PY_INT64_T requested_id)
+interp_look_up_id(_PyRuntimeState *runtime, int64_t requested_id)
 {
     PyInterpreterState *interp = runtime->interpreters.head;
     while (interp != NULL) {
-        PY_INT64_T id = PyInterpreterState_GetID(interp);
+        int64_t id = PyInterpreterState_GetID(interp);
         if (id < 0) {
             return NULL;
         }
@@ -469,7 +469,7 @@ interp_look_up_id(_PyRuntimeState *runtime, PY_INT64_T requested_id)
 }
 
 PyInterpreterState *
-_PyInterpreterState_LookUpID(PY_INT64_T requested_id)
+_PyInterpreterState_LookUpID(int64_t requested_id)
 {
     PyInterpreterState *interp = NULL;
     if (requested_id >= 0) {


### PR DESCRIPTION
* Replace PY_INT64_T with int64_t
* Replace PY_UINT32_T with uint32_t
* Replace PY_UINT64_T with uint64_t

sha3module.c no longer checks if PY_UINT64_T is defined since it's
always defined and uint64_t is always available on platforms
supported by Python.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40302](https://bugs.python.org/issue40302) -->
https://bugs.python.org/issue40302
<!-- /issue-number -->
