### PR TITLE
bpo-35967: Skip test with `uname -p` on Android

### DIFF
--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -167,8 +167,11 @@ class PlatformTest(unittest.TestCase):
         On some systems, the processor must match the output
         of 'uname -p'. See Issue 35967 for rationale.
         """
-        proc_res = subprocess.check_output(['uname', '-p'], text=True).strip()
-        expect = platform._unknown_as_blank(proc_res)
+        try:
+            proc_res = subprocess.check_output(['uname', '-p'], text=True).strip()
+            expect = platform._unknown_as_blank(proc_res)
+        except (OSError, subprocess.CalledProcessError):
+            expect = ''
         self.assertEqual(platform.uname().processor, expect)
 
     @unittest.skipUnless(sys.platform.startswith('win'), "windows only test")


### PR DESCRIPTION
The uname binary on Android does not support -p [1]. Here is a sample
log:
```
0:06:03 load avg: 0.56 [254/421/8] test_platform failed -- running: test_asyncio (5 min 53 sec)
uname: Unknown option p (see "uname --help")
test test_platform failed -- Traceback (most recent call last):
  File "/data/local/tmp/lib/python3.9/test/test_platform.py", line 170, in test_uname_processor
    proc_res = subprocess.check_output(['uname', '-p'], text=True).strip()
  File "/data/local/tmp/lib/python3.9/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/data/local/tmp/lib/python3.9/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['uname', '-p']' returned non-zero exit status 1.
```
[1] https://android.googlesource.com/platform/external/toybox/+/refs/heads/master/toys/posix/uname.c

<!-- issue-number: [bpo-35967](https://bugs.python.org/issue35967) -->
https://bugs.python.org/issue35967
<!-- /issue-number -->


Automerge-Triggered-By: @jaraco