### PR TITLE
bpo-40325: Deprecate set object support in random.sample()

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -230,6 +230,13 @@ Functions for sequences
    If the sample size is larger than the population size, a :exc:`ValueError`
    is raised.
 
+   .. deprecated:: 3.9
+   In the future, the *population* must be a sequence.  Instances of
+   :class:`set` are no longer supported.  They must first be converted
+   to a :class:`list` or :class:`tuple`, preferably in a deterministic
+   order so that the sample is reproducible.
+
+
 Real-valued distributions
 -------------------------
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -231,10 +231,10 @@ Functions for sequences
    is raised.
 
    .. deprecated:: 3.9
-   In the future, the *population* must be a sequence.  Instances of
-   :class:`set` are no longer supported.  They must first be converted
-   to a :class:`list` or :class:`tuple`, preferably in a deterministic
-   order so that the sample is reproducible.
+      In the future, the *population* must be a sequence.  Instances of
+      :class:`set` are no longer supported.  The set must first be converted
+      to a :class:`list` or :class:`tuple`, preferably in a deterministic
+      order so that the sample is reproducible.
 
 
 Real-valued distributions

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -367,9 +367,12 @@ class Random(_random.Random):
         # causing them to eat more entropy than necessary.
 
         if isinstance(population, _Set):
+            _warn('Sampling from a set deprecated\n'
+                  'since Python 3.9 and will be removed in a subsequent version.',
+                  DeprecationWarning, 2)
             population = tuple(population)
         if not isinstance(population, _Sequence):
-            raise TypeError("Population must be a sequence or set.  For dicts, use list(d).")
+            raise TypeError("Population must be a sequence.  For dicts or sets, use sorted(d).")
         randbelow = self._randbelow
         n = len(population)
         if not 0 <= k <= n:

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -147,7 +147,6 @@ class TestBasicOps:
 
     def test_sample_inputs(self):
         # SF bug #801342 -- population can be any iterable defining __len__()
-        self.gen.sample(set(range(20)), 2)
         self.gen.sample(range(20), 2)
         self.gen.sample(range(20), 2)
         self.gen.sample(str('abcdefghijklmnopqrst'), 2)
@@ -155,6 +154,11 @@ class TestBasicOps:
 
     def test_sample_on_dicts(self):
         self.assertRaises(TypeError, self.gen.sample, dict.fromkeys('abcdef'), 2)
+
+    def test_sample_on_sets(self):
+        with self.assertWarns(DeprecationWarning):
+            population = {10, 20, 30, 40, 50, 60, 70}
+            self.gen.sample(population, k=5)
 
     def test_choices(self):
         choices = self.gen.choices

--- a/Misc/NEWS.d/next/Library/2020-04-18-19-40-00.bpo-40325.KWSvix.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-18-19-40-00.bpo-40325.KWSvix.rst
@@ -1,0 +1,1 @@
+Deprecatated support for set objects in random.sample().

--- a/Misc/NEWS.d/next/Library/2020-04-18-19-40-00.bpo-40325.KWSvix.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-18-19-40-00.bpo-40325.KWSvix.rst
@@ -1,1 +1,1 @@
-Deprecatated support for set objects in random.sample().
+Deprecated support for set objects in random.sample().


### PR DESCRIPTION


<!-- issue-number: [bpo-40325](https://bugs.python.org/issue40325) -->
https://bugs.python.org/issue40325
<!-- /issue-number -->
