### PR TITLE
bpo-40275: Avoid importing asyncio in test.support

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3,7 +3,6 @@
 if __name__ != 'test.support':
     raise ImportError('support must be imported from the test package')
 
-import asyncio.events
 import collections.abc
 import contextlib
 import errno
@@ -3257,6 +3256,7 @@ SMALLEST = _SMALLEST()
 
 def maybe_get_event_loop_policy():
     """Return the global event loop policy if one is set, else return None."""
+    import asyncio.events
     return asyncio.events._event_loop_policy
 
 # Helpers for testing hashing.

--- a/Lib/unittest/__init__.py
+++ b/Lib/unittest/__init__.py
@@ -78,8 +78,13 @@ def load_tests(loader, tests, pattern):
     this_dir = os.path.dirname(__file__)
     return loader.discover(start_dir=this_dir, pattern=pattern)
 
+
+def __dir__():
+    return globals().keys() | {'IsolatedAsyncioTestCase'}
+
 def __getattr__(name):
     if name == 'IsolatedAsyncioTestCase':
         global IsolatedAsyncioTestCase
         from .async_case import IsolatedAsyncioTestCase
+        return IsolatedAsyncioTestCase
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/unittest/__init__.py
+++ b/Lib/unittest/__init__.py
@@ -57,7 +57,6 @@ __all__.extend(['getTestCaseNames', 'makeSuite', 'findTestCases'])
 __unittest = True
 
 from .result import TestResult
-from .async_case import IsolatedAsyncioTestCase
 from .case import (addModuleCleanup, TestCase, FunctionTestCase, SkipTest, skip,
                    skipIf, skipUnless, expectedFailure)
 from .suite import BaseTestSuite, TestSuite
@@ -78,3 +77,9 @@ def load_tests(loader, tests, pattern):
     # top level directory cached on loader instance
     this_dir = os.path.dirname(__file__)
     return loader.discover(start_dir=this_dir, pattern=pattern)
+
+def __getattr__(name):
+    if name == 'IsolatedAsyncioTestCase':
+        global IsolatedAsyncioTestCase
+        from .async_case import IsolatedAsyncioTestCase
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/unittest/__init__.py
+++ b/Lib/unittest/__init__.py
@@ -65,6 +65,7 @@ from .loader import (TestLoader, defaultTestLoader, makeSuite, getTestCaseNames,
 from .main import TestProgram, main
 from .runner import TextTestRunner, TextTestResult
 from .signals import installHandler, registerResult, removeResult, removeHandler
+# IsolatedAsyncioTestCase will be imported lazily.
 
 # deprecated
 _TextTestResult = TextTestResult
@@ -78,6 +79,10 @@ def load_tests(loader, tests, pattern):
     this_dir = os.path.dirname(__file__)
     return loader.discover(start_dir=this_dir, pattern=pattern)
 
+
+# Lazy import of IsolatedAsyncioTestCase from .async_case
+# It imports asyncio, which is relatively heavy, but most tests
+# do not need it.
 
 def __dir__():
     return globals().keys() | {'IsolatedAsyncioTestCase'}

--- a/Misc/NEWS.d/next/Library/2020-04-20-18-50-25.bpo-40275.Ofk6J8.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-20-18-50-25.bpo-40275.Ofk6J8.rst
@@ -1,2 +1,2 @@
-The :class:`unittest.IsolatedAsyncioTestCase` class is now imported lazily
-to avoid importing a large :mod:`asyncio` package when tests do not need it.
+The :mod:`asyncio` package is now imported lazily in :mod:`unittest` only
+when the :class:`~unittest.IsolatedAsyncioTestCase` class is used.

--- a/Misc/NEWS.d/next/Library/2020-04-20-18-50-25.bpo-40275.Ofk6J8.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-20-18-50-25.bpo-40275.Ofk6J8.rst
@@ -1,0 +1,2 @@
+The :class:`unittest.IsolatedAsyncioTestCase` class is now imported lazily
+to avoid importing a large :mod:`asyncio` package when tests do not need it.


### PR DESCRIPTION
* Import `IsolatedAsyncioTestCase` lazily in `unittest`.
* Import `asyncio.events` lazily in `test.support`.


<!-- issue-number: [bpo-40275](https://bugs.python.org/issue40275) -->
https://bugs.python.org/issue40275
<!-- /issue-number -->
