### PR TITLE
Fix typo in Lib/traceback.py

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -551,7 +551,7 @@ class TracebackException:
         The return value is a generator of strings, each ending in a newline.
 
         Normally, the generator emits a single string; however, for
-        SyntaxError exceptions, it emites several lines that (when
+        SyntaxError exceptions, it emits several lines that (when
         printed) display detailed information about where the syntax
         error occurred.
 


### PR DESCRIPTION
Typo fix: "emites" -> "emit".


Automerge-Triggered-By: @aeros