### PR TITLE
bpo-40330: Fix utf-8 size check in ShareableList

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4006,6 +4006,10 @@ class _TestSharedMemory(BaseTestCase):
                                     "exceeds available storage"):
             sl[0] = 'encodées'  # Exactly 9 bytes of UTF-8 data
         self.assertEqual(sl[1], b'HoWdY')
+        with self.assertRaisesRegex(ValueError,
+                                    "exceeds available storage"):
+            sl[1] = b'123456789'
+        self.assertEqual(sl[1], b'HoWdY')
 
         # Exercise count().
         with warnings.catch_warnings():

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3995,9 +3995,17 @@ class _TestSharedMemory(BaseTestCase):
         sl[4] = 'some'  # Change type at a given position.
         self.assertEqual(sl[4], 'some')
         self.assertEqual(sl.format, '8s8sdq8sxxxxxxx?q')
-        with self.assertRaises(ValueError):
-            sl[4] = 'far too many'  # Exceeds available storage.
+        with self.assertRaisesRegex(ValueError,
+                                    "exceeds available storage"):
+            sl[4] = 'far too many'
         self.assertEqual(sl[4], 'some')
+        sl[0] = 'encodés'  # Exactly 8 bytes of UTF-8 data
+        self.assertEqual(sl[0], 'encodés')
+        self.assertEqual(sl[1], b'HoWdY')  # no spillage
+        with self.assertRaisesRegex(ValueError,
+                                    "exceeds available storage"):
+            sl[0] = 'encodées'  # Exactly 9 bytes of UTF-8 data
+        self.assertEqual(sl[1], b'HoWdY')
 
         # Exercise count().
         with warnings.catch_warnings():

--- a/Misc/NEWS.d/next/Library/2020-04-19-17-31-29.bpo-40330.DGjoIS.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-19-17-31-29.bpo-40330.DGjoIS.rst
@@ -1,0 +1,2 @@
+In :meth:`ShareableList.__setitem__`, check the size of a new string item
+after encoding it to utf-8, not before.


### PR DESCRIPTION
The item size must be checked after encoding to bytes, not before.


<!-- issue-number: [bpo-40330](https://bugs.python.org/issue40330) -->
https://bugs.python.org/issue40330
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou