### PR TITLE
bpo-39849: Fix compiler warning in _testcapimodule

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -6831,6 +6831,7 @@ test_buildvalue_issue38913(PyObject *self, PyObject *Py_UNUSED(ignored))
         return NULL;
     }
 
+    (void) res; /* silence unused-but-set-variable warning */
     PyErr_Clear();
     Py_RETURN_NONE;
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-39849](https://bugs.python.org/issue39849) -->
https://bugs.python.org/issue39849
<!-- /issue-number -->
