### PR TITLE
bpo-39942:Fix `TypeVar` fails when missing `__name__`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -222,10 +222,10 @@ class TypeVarTests(BaseTestCase):
             TypeVar('X', str, float, bound=Employee)
 
     def test_missing__name__(self):
-        code = """if 1:
-        import typing
-        T = typing.TypeVar("T")
-        """
+        # See bpo-39942
+        code = ("import typing\n"
+                "T = typing.TypeVar('T')\n"
+                )
         exec(code, {})
 
     def test_no_bivariant(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -221,6 +221,13 @@ class TypeVarTests(BaseTestCase):
         with self.assertRaises(TypeError):
             TypeVar('X', str, float, bound=Employee)
 
+    def test_missing__name__(self):
+        code = """if 1:
+        import typing
+        T = typing.TypeVar("T")
+        """
+        exec(code, {})
+
     def test_no_bivariant(self):
         with self.assertRaises(ValueError):
             TypeVar('T', covariant=True, contravariant=True)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -606,9 +606,12 @@ class TypeVar(_Final, _Immutable, _root=True):
             self.__bound__ = _type_check(bound, "Bound must be a type.")
         else:
             self.__bound__ = None
-        def_mod = sys._getframe(1).f_globals['__name__']  # for pickling
-        if def_mod != 'typing':
-            self.__module__ = def_mod
+        try:
+            def_mod = sys._getframe(1).f_globals.get('__name__', '__main__')  # for pickling
+            if def_mod != 'typing':
+                self.__module__ = def_mod
+        except (AttributeError, ValueError):
+            pass
 
     def __repr__(self):
         if self.__covariant__:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -608,10 +608,10 @@ class TypeVar(_Final, _Immutable, _root=True):
             self.__bound__ = None
         try:
             def_mod = sys._getframe(1).f_globals.get('__name__', '__main__')  # for pickling
-            if def_mod != 'typing':
-                self.__module__ = def_mod
         except (AttributeError, ValueError):
-            pass
+            def_mod = None
+        if def_mod != 'typing':
+            self.__module__ = def_mod
 
     def __repr__(self):
         if self.__covariant__:

--- a/Misc/NEWS.d/next/Library/2020-04-20-20-16-02.bpo-39942.NvGnTc.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-20-20-16-02.bpo-39942.NvGnTc.rst
@@ -1,0 +1,2 @@
+Set "__main__" as the default module name when "__name__" is missing in
+:class:`typing.TypeVar`. Patch by Weipeng Hong.


### PR DESCRIPTION


<!-- issue-number: [bpo-39942](https://bugs.python.org/issue39942) -->
https://bugs.python.org/issue39942
<!-- /issue-number -->
