### PR TITLE
bpo-39849: Enable assertions in _testcapimodule.c and _testinternalcapi.c

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -11,6 +11,8 @@
    The Visual Studio projects builds _testcapi with Py_BUILD_CORE_MODULE
    macro defined, but only the public C API must be tested here. */
 #undef Py_BUILD_CORE_MODULE
+/* Always enable assertions */
+#undef NDEBUG
 
 #define PY_SSIZE_T_CLEAN
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -10,6 +10,7 @@
 
    The Visual Studio projects builds _testcapi with Py_BUILD_CORE_MODULE
    macro defined, but only the public C API must be tested here. */
+
 #undef Py_BUILD_CORE_MODULE
 /* Always enable assertions */
 #undef NDEBUG

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -6,6 +6,9 @@
 #  error "Py_BUILD_CORE_BUILTIN or Py_BUILD_CORE_MODULE must be defined"
 #endif
 
+/* Always enable assertions */
+#undef NDEBUG
+
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"


### PR DESCRIPTION


<!-- issue-number: [bpo-39849](https://bugs.python.org/issue39849) -->
https://bugs.python.org/issue39849
<!-- /issue-number -->
