### PR TITLE
bpo-38870: Don't start generated output with newlines

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -669,7 +669,7 @@ class _Unparser(NodeVisitor):
         else:
             self.interleave(lambda: self.write(", "), traverser, items)
 
-    def newline(self):
+    def maybe_newline(self):
         """Adds a newline if it isn't the start of generated source"""
         if self._source:
             self.write("\n")
@@ -677,7 +677,7 @@ class _Unparser(NodeVisitor):
     def fill(self, text=""):
         """Indent a piece of text and append it, according to the current
         indentation level"""
-        self.newline()
+        self.maybe_newline()
         self.write("    " * self._indent + text)
 
     def write(self, text):
@@ -922,7 +922,7 @@ class _Unparser(NodeVisitor):
             self.traverse(node.body)
 
     def visit_ClassDef(self, node):
-        self.newline()
+        self.maybe_newline()
         for deco in node.decorator_list:
             self.fill("@")
             self.traverse(deco)
@@ -952,7 +952,7 @@ class _Unparser(NodeVisitor):
         self._function_helper(node, "async def")
 
     def _function_helper(self, node, fill_suffix):
-        self.newline()
+        self.maybe_newline()
         for deco in node.decorator_list:
             self.fill("@")
             self.traverse(deco)

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -669,10 +669,16 @@ class _Unparser(NodeVisitor):
         else:
             self.interleave(lambda: self.write(", "), traverser, items)
 
+    def newline(self):
+        """Adds a newline if it isn't the start of generated source"""
+        if self._source:
+            self.write("\n")
+
     def fill(self, text=""):
         """Indent a piece of text and append it, according to the current
         indentation level"""
-        self.write("\n" + "    " * self._indent + text)
+        self.newline()
+        self.write("    " * self._indent + text)
 
     def write(self, text):
         """Append a piece of text"""
@@ -916,7 +922,7 @@ class _Unparser(NodeVisitor):
             self.traverse(node.body)
 
     def visit_ClassDef(self, node):
-        self.write("\n")
+        self.newline()
         for deco in node.decorator_list:
             self.fill("@")
             self.traverse(deco)
@@ -946,7 +952,7 @@ class _Unparser(NodeVisitor):
         self._function_helper(node, "async def")
 
     def _function_helper(self, node, fill_suffix):
-        self.write("\n")
+        self.newline()
         for deco in node.decorator_list:
             self.fill("@")
             self.traverse(deco)
@@ -1043,7 +1049,7 @@ class _Unparser(NodeVisitor):
         write("{")
         unparser = type(self)()
         unparser.set_precedence(_Precedence.TEST.next(), node.value)
-        expr = unparser.visit(node.value).rstrip("\n")
+        expr = unparser.visit(node.value)
         if expr.startswith("{"):
             write(" ")  # Separate pair of opening brackets as "{ {"
         write(expr)

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -128,19 +128,17 @@ class ASTTestCase(unittest.TestCase):
     def check_invalid(self, node, raises=ValueError):
         self.assertRaises(raises, ast.unparse, node)
 
-    def get_source(self, code1, code2=None, strip=True):
+    def get_source(self, code1, code2=None):
         code2 = code2 or code1
         code1 = ast.unparse(ast.parse(code1))
-        if strip:
-            code1 = code1.strip()
         return code1, code2
 
-    def check_src_roundtrip(self, code1, code2=None, strip=True):
-        code1, code2 = self.get_source(code1, code2, strip)
+    def check_src_roundtrip(self, code1, code2=None):
+        code1, code2 = self.get_source(code1, code2)
         self.assertEqual(code2, code1)
 
-    def check_src_dont_roundtrip(self, code1, code2=None, strip=True):
-        code1, code2 = self.get_source(code1, code2, strip)
+    def check_src_dont_roundtrip(self, code1, code2=None):
+        code1, code2 = self.get_source(code1, code2)
         self.assertNotEqual(code2, code1)
 
 class UnparseTestCase(ASTTestCase):


### PR DESCRIPTION
This is a small nit that can cause too much unnecessary nose when using ast.unparse for comparisons. Examples
```py
 $ python
Python 3.9.0a5+ (heads/master:5565c30f0b, Apr 17 2020, 16:56:39) 
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ast
>>> ast.unparse(ast.parse("compile"))
'\ncompile'
>>> ast.unparse(ast.parse("compile")) == "compile"
False
>>> ast.unparse(ast.parse("class compile: pass"))
'\n\nclass compile():\n    pass'
```


<!-- issue-number: [bpo-38870](https://bugs.python.org/issue38870) -->
https://bugs.python.org/issue38870
<!-- /issue-number -->
