### PR TITLE
bpo-40260: Remove unnecessary newline in compile() call

### DIFF
--- a/Lib/modulefinder.py
+++ b/Lib/modulefinder.py
@@ -339,7 +339,7 @@ class ModuleFinder:
             self.msgout(2, "load_module ->", m)
             return m
         if type == _PY_SOURCE:
-            co = compile(fp.read()+b'\n', pathname, 'exec')
+            co = compile(fp.read(), pathname, 'exec')
         elif type == _PY_COMPILED:
             try:
                 data = fp.read()


### PR DESCRIPTION
this _should_ fix debian's modulefinder subclass

I didn't have a great way to test this unfortunately :(

<!-- issue-number: [bpo-40260](https://bugs.python.org/issue40260) -->
https://bugs.python.org/issue40260
<!-- /issue-number -->
