### PR TITLE
bpo-40164: Update macOS installer builds to use OpenSSL 1.1.1g.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -215,9 +215,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.1.1d",
-              url="https://www.openssl.org/source/openssl-1.1.1d.tar.gz",
-              checksum='3be209000dbc7e1b95bcdf47980a3baa',
+              name="OpenSSL 1.1.1g",
+              url="https://www.openssl.org/source/openssl-1.1.1g.tar.gz",
+              checksum='76766e98997660138cdaf13a187bd234',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2020-04-21-19-46-35.bpo-40164.6HA6IC.rst
+++ b/Misc/NEWS.d/next/macOS/2020-04-21-19-46-35.bpo-40164.6HA6IC.rst
@@ -1,0 +1,1 @@
+Update macOS installer builds to use OpenSSL 1.1.1g.


### PR DESCRIPTION


<!-- issue-number: [bpo-40164](https://bugs.python.org/issue40164) -->
https://bugs.python.org/issue40164
<!-- /issue-number -->
