### PR TITLE
bpo-40361: Updated condition for darwin/win to fix NotADirectoryError 'xdg-settings' error

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -516,7 +516,7 @@ def register_standard_browsers():
         # OS X can use below Unix support (but we prefer using the OS X
         # specific stuff)
 
-    if sys.platform[:3] == "win":
+    elif sys.platform[:3] == "win":
         # First try to use the default Windows browser
         register("windows-default", WindowsDefault)
 

--- a/Misc/NEWS.d/next/Library/2020-04-23-01-59-00.bpo-40361.5rgn4b.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-23-01-59-00.bpo-40361.5rgn4b.rst
@@ -1,0 +1,3 @@
+When loading Jupyter Notebook, a NotADirectoryError: [Errno 20] Not a directory: 'xdg-settings' error was showing. This seems to be because Darwin systems were using Win settings. 
+
+The pull request has addressed this by modifying the webbrowser.py code.


### PR DESCRIPTION
when loading jupyter notebook, NotADirectoryError: [Errno 20] Not a directory: 'xdg-settings' was coming. This was because darwin system were using win settings

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40361](https://bugs.python.org/issue40361) -->
https://bugs.python.org/issue40361
<!-- /issue-number -->
