### PR TITLE
bpo-38329: python.org macOS installers now update Current symlink

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -1309,12 +1309,6 @@ def buildPython():
 
     os.chdir(curdir)
 
-    if PYTHON_3:
-        # Remove the 'Current' link, that way we don't accidentally mess
-        # with an already installed version of python 2
-        os.unlink(os.path.join(rootDir, 'Library', 'Frameworks',
-                            'Python.framework', 'Versions', 'Current'))
-
 def patchFile(inPath, outPath):
     data = fileContents(inPath)
     data = data.replace('$FULL_VERSION', getFullVersion())

--- a/Misc/NEWS.d/next/macOS/2020-04-22-03-39-22.bpo-38329.H0a8JV.rst
+++ b/Misc/NEWS.d/next/macOS/2020-04-22-03-39-22.bpo-38329.H0a8JV.rst
@@ -1,0 +1,4 @@
+python.org macOS installers now update the Current version symlink of
+/Library/Frameworks/Python.framework/Versions for 3.9 installs. Previously,
+Current was only updated for Python 2.x installs. This should make it easier
+to embed Python 3 into other macOS applications.


### PR DESCRIPTION
Previously, python.org macOS installers did not alter the Current version
symlink in /Library/Frameworks/Python.framework/Versions when installing
a version of Python 3.x, only when installing 2.x.  Now that Python 2 is
retired, it's time to change that.  This should make it a bit easier
to embed Python 3 into other macOS applications.


<!-- issue-number: [bpo-38329](https://bugs.python.org/issue38329) -->
https://bugs.python.org/issue38329
<!-- /issue-number -->
