### PR TITLE
bpo-40366: Remove support for passing obsolete flags into compile

### DIFF
--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -22,10 +22,13 @@
   can be inspected programmatically via importing :mod:`__future__` and examining
   its contents.
 
-Each statement in :file:`__future__.py` is of the form::
+Each statement in :file:`__future__.py` is in one of these forms::
 
    FeatureName = _Feature(OptionalRelease, MandatoryRelease,
                           CompilerFlag)
+
+   FeatureName = _ObsoletedFeature(OptionalRelease, MandatoryRelease,
+                                   CompilerFlag)
 
 
 where, normally, *OptionalRelease* is less than *MandatoryRelease*, and both are

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -791,6 +791,9 @@ Removed
   deprecated since 2006, and only returning ``False`` when it's called.
   (Contributed by Batuhan Taskaya in :issue:`40208`)
 
+* Support for passing ``CO_NESTED`` flag to :func:`compile` has been removed.
+  It was obsolete and the default behavior since Python 2.2, 19 years.
+  (Contributed by Batuhan Taskaya in :issue:`40366`)
 
 Porting to Python 3.9
 =====================

--- a/Include/compile.h
+++ b/Include/compile.h
@@ -17,7 +17,6 @@ PyAPI_FUNC(PyCodeObject *) PyNode_Compile(struct _node *, const char *);
                    CO_FUTURE_WITH_STATEMENT | CO_FUTURE_PRINT_FUNCTION | \
                    CO_FUTURE_UNICODE_LITERALS | CO_FUTURE_BARRY_AS_BDFL | \
                    CO_FUTURE_GENERATOR_STOP | CO_FUTURE_ANNOTATIONS)
-#define PyCF_MASK_OBSOLETE (CO_NESTED)
 
 /* bpo-39562: CO_FUTURE_ and PyCF_ constants must be kept unique.
    PyCF_ constants can use bits from 0x0100 to 0x10000.

--- a/Lib/__future__.py
+++ b/Lib/__future__.py
@@ -105,11 +105,14 @@ class _Feature:
                                   self.mandatory,
                                   self.compiler_flag))
 
-nested_scopes = _Feature((2, 1, 0, "beta",  1),
+class _ObsoletedFuture(_Feature):
+    pass
+
+nested_scopes = _ObsoletedFuture((2, 1, 0, "beta",  1),
                          (2, 2, 0, "alpha", 0),
                          CO_NESTED)
 
-generators = _Feature((2, 2, 0, "alpha", 1),
+generators = _ObsoletedFuture((2, 2, 0, "alpha", 1),
                       (2, 3, 0, "final", 0),
                       CO_GENERATOR_ALLOWED)
 

--- a/Lib/test/test___future__.py
+++ b/Lib/test/test___future__.py
@@ -51,8 +51,19 @@ class FutureTest(unittest.TestCase):
 
             a(hasattr(value, "compiler_flag"),
                    "feature is missing a .compiler_flag attr")
-            # Make sure the compile accepts the flag.
-            compile("", "<test>", "exec", value.compiler_flag)
+
+            if isinstance(value, __future__._ObsoletedFuture) and value.compiler_flag:
+                self.assertRaises(
+                    ValueError,
+                    compile,
+                    "",
+                    "<test>",
+                    "exec",
+                    value.compiler_flag
+                )
+            else:
+                # Make sure the compile accepts the flag.
+                compile("", "<test>", "exec", value.compiler_flag)
             a(isinstance(getattr(value, "compiler_flag"), int),
                    ".compiler_flag isn't int")
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -20,7 +20,7 @@ import unittest
 import warnings
 from contextlib import ExitStack
 from functools import partial
-from inspect import CO_COROUTINE
+from inspect import CO_COROUTINE, CO_NESTED
 from itertools import product
 from textwrap import dedent
 from types import AsyncGeneratorType, FunctionType
@@ -339,6 +339,7 @@ class BuiltinTest(unittest.TestCase):
         compile('print("\xe5")\n', '', 'exec')
         self.assertRaises(ValueError, compile, chr(0), 'f', 'exec')
         self.assertRaises(ValueError, compile, str('a = 1'), 'f', 'bad')
+        self.assertRaises(ValueError, compile, 'obsolote_flag', 'f', 'exec', CO_NESTED)
 
         # test the optimize argument
 

--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-23-02-28-33.bpo-40366.pDs7Zh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-23-02-28-33.bpo-40366.pDs7Zh.rst
@@ -1,0 +1,1 @@
+Removed support for ``CO_NESTED`` flag in :func:`compile`.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -738,14 +738,11 @@ builtin_compile_impl(PyObject *module, PyObject *source, PyObject *filename,
         cf.cf_feature_version = feature_version;
     }
 
-    if (flags &
-        ~(PyCF_MASK | PyCF_MASK_OBSOLETE | PyCF_COMPILE_MASK))
-    {
+    if (flags & ~(PyCF_MASK | PyCF_COMPILE_MASK)) {
         PyErr_SetString(PyExc_ValueError,
                         "compile(): unrecognised flags");
         goto error;
     }
-    /* XXX Warn if (supplied_flags & PyCF_MASK_OBSOLETE) != 0? */
 
     if (optimize < -1 || optimize > 2) {
         PyErr_SetString(PyExc_ValueError,

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4913,12 +4913,6 @@ PyEval_MergeCompilerFlags(PyCompilerFlags *cf)
             result = 1;
             cf->cf_flags |= compilerflags;
         }
-#if 0 /* future keyword */
-        if (codeflags & CO_GENERATOR_ALLOWED) {
-            result = 1;
-            cf->cf_flags |= CO_GENERATOR_ALLOWED;
-        }
-#endif
     }
     return result;
 }


### PR DESCRIPTION
This PR also removes a case related `CO_GENERATOR_ALLOWED` (which was also unusable, and totally purged in #19230)

<!-- issue-number: [bpo-40366](https://bugs.python.org/issue40366) -->
https://bugs.python.org/issue40366
<!-- /issue-number -->
