### PR TITLE
bpo-40334: Compile extensions in test_peg_generator with C99

### DIFF
--- a/Parser/pegen/parse_string.c
+++ b/Parser/pegen/parse_string.c
@@ -275,8 +275,7 @@ static inline void shift_arg(expr_ty parent, arg_ty n, int line, int col) {
 }
 
 static void fstring_shift_seq_locations(expr_ty parent, asdl_seq *seq, int lineno, int col_offset) {
-    Py_ssize_t i;
-    for (i = 0; i < asdl_seq_LEN(seq); i++) {
+    for (Py_ssize_t i = 0, l = asdl_seq_LEN(seq); i < l; i++) {
         expr_ty expr = asdl_seq_GET(seq, i);
         if (expr == NULL){
             continue;
@@ -323,13 +322,12 @@ static void fstring_shift_argument(expr_ty parent, arg_ty arg, int lineno, int c
 }
 
 static void fstring_shift_arguments(expr_ty parent, arguments_ty args, int lineno, int col_offset) {
-    Py_ssize_t i;
-    for (i = 0; i < asdl_seq_LEN(args->posonlyargs); i++) {
+    for (Py_ssize_t i = 0, l = asdl_seq_LEN(args->posonlyargs); i < l; i++) {
        arg_ty arg = asdl_seq_GET(args->posonlyargs, i);
        shift_arg(parent, arg, lineno, col_offset);
     }
 
-    for (i = 0; i < asdl_seq_LEN(args->args); i++) {
+    for (Py_ssize_t i = 0, l = asdl_seq_LEN(args->args); i < l; i++) {
        arg_ty arg = asdl_seq_GET(args->args, i);
        shift_arg(parent, arg, lineno, col_offset);
     }
@@ -338,7 +336,7 @@ static void fstring_shift_arguments(expr_ty parent, arguments_ty args, int linen
         shift_arg(parent, args->vararg, lineno, col_offset);
     }
 
-    for (i = 0; i < asdl_seq_LEN(args->kwonlyargs); i++) {
+    for (Py_ssize_t i = 0, l = asdl_seq_LEN(args->kwonlyargs); i < l; i++) {
        arg_ty arg = asdl_seq_GET(args->kwonlyargs, i);
        shift_arg(parent, arg, lineno, col_offset);
     }
@@ -353,7 +351,6 @@ static void fstring_shift_arguments(expr_ty parent, arguments_ty args, int linen
 }
 
 static void fstring_shift_children_locations(expr_ty n, int lineno, int col_offset) {
-    Py_ssize_t i;
     switch (n->kind) {
         case BoolOp_kind:
             fstring_shift_seq_locations(n, n->v.BoolOp.values, lineno, col_offset);
@@ -387,14 +384,14 @@ static void fstring_shift_children_locations(expr_ty n, int lineno, int col_offs
             break;
         case ListComp_kind:
             shift_expr(n, n->v.ListComp.elt, lineno, col_offset);
-            for (i = 0; i < asdl_seq_LEN(n->v.ListComp.generators); i++) {
+            for (Py_ssize_t i = 0, l = asdl_seq_LEN(n->v.ListComp.generators); i < l; i++) {
                 comprehension_ty comp = asdl_seq_GET(n->v.ListComp.generators, i);
                 fstring_shift_comprehension(n, comp, lineno, col_offset);
             }
             break;
         case SetComp_kind:
             shift_expr(n, n->v.SetComp.elt, lineno, col_offset);
-            for (i = 0; i < asdl_seq_LEN(n->v.SetComp.generators); i++) {
+            for (Py_ssize_t i = 0, l = asdl_seq_LEN(n->v.SetComp.generators); i < l; i++) {
                 comprehension_ty comp = asdl_seq_GET(n->v.SetComp.generators, i);
                 fstring_shift_comprehension(n, comp, lineno, col_offset);
             }
@@ -402,14 +399,14 @@ static void fstring_shift_children_locations(expr_ty n, int lineno, int col_offs
         case DictComp_kind:
             shift_expr(n, n->v.DictComp.key, lineno, col_offset);
             shift_expr(n, n->v.DictComp.value, lineno, col_offset);
-            for (i = 0; i < asdl_seq_LEN(n->v.DictComp.generators); i++) {
+            for (Py_ssize_t i = 0, l = asdl_seq_LEN(n->v.DictComp.generators); i < l; i++) {
                 comprehension_ty comp = asdl_seq_GET(n->v.DictComp.generators, i);
                 fstring_shift_comprehension(n, comp, lineno, col_offset);
             }
             break;
         case GeneratorExp_kind:
             shift_expr(n, n->v.GeneratorExp.elt, lineno, col_offset);
-            for (i = 0; i < asdl_seq_LEN(n->v.GeneratorExp.generators); i++) {
+            for (Py_ssize_t i = 0, l = asdl_seq_LEN(n->v.GeneratorExp.generators); i < l; i++) {
                 comprehension_ty comp = asdl_seq_GET(n->v.GeneratorExp.generators, i);
                 fstring_shift_comprehension(n, comp, lineno, col_offset);
             }
@@ -430,7 +427,7 @@ static void fstring_shift_children_locations(expr_ty n, int lineno, int col_offs
         case Call_kind:
             shift_expr(n, n->v.Call.func, lineno, col_offset);
             fstring_shift_seq_locations(n, n->v.Call.args, lineno, col_offset);
-            for (i = 0; i < asdl_seq_LEN(n->v.Call.keywords); i++) {
+            for (Py_ssize_t i = 0, l = asdl_seq_LEN(n->v.Call.keywords); i < l; i++) {
                 keyword_ty keyword = asdl_seq_GET(n->v.Call.keywords, i);
                 shift_expr(n, keyword->value, lineno, col_offset);
             }
@@ -521,8 +518,7 @@ fstring_fix_expr_location(Token *parent, expr_ty n, char *expr_str)
             }
             /* adjust the start based on the number of newlines encountered
                before the f-string expression */
-            char *p;
-            for (p = parent_str; p < substr; p++) {
+            for (char* p = parent_str; p < substr; p++) {
                 if (*p == '\n') {
                     lines++;
                 }

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -1,6 +1,7 @@
 import pathlib
 import shutil
 import tokenize
+import sys
 
 from typing import Optional, Tuple
 
@@ -42,6 +43,8 @@ def compile_c_extension(
     source_file_path = pathlib.Path(generated_source_path)
     extension_name = source_file_path.stem
     extra_compile_args = []
+    if not sys.platform.startswith('win'):
+        extra_compile_args.append("-std=c99")
     if keep_asserts:
         extra_compile_args.append("-UNDEBUG")
     extension = [


### PR DESCRIPTION
This PR restores the C99 stuff that we removed from `Parser/pegen/parse_string.c` and fixes the remaining buildbot issues.

<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
