### PR TITLE
bpo-40372: Make doctest example programs exit with code 1 if any test fails

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -83,7 +83,10 @@ Here's a complete but small example module::
 
    if __name__ == "__main__":
        import doctest
-       doctest.testmod()
+       import sys
+       fail, _ = doctest.testmod()
+       if fail:
+           sys.exit(1)
 
 If you run :file:`example.py` directly from the command line, :mod:`doctest`
 works its magic:
@@ -147,9 +150,13 @@ continue to do it) is to end each module :mod:`M` with::
 
    if __name__ == "__main__":
        import doctest
-       doctest.testmod()
+       import sys
+       fail, _ = doctest.testmod()
+       if fail:
+           sys.exit(1)
 
-:mod:`doctest` then examines docstrings in module :mod:`M`.
+:mod:`doctest` then examines docstrings in module :mod:`M`, and the program
+exits with an unsuccessful code if any test fails.
 
 Running the module as a script causes the examples in the docstrings to get
 executed and verified::

--- a/Misc/NEWS.d/next/Documentation/2020-04-23-10-42-20.bpo-40372.LXiCcc.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-04-23-10-42-20.bpo-40372.LXiCcc.rst
@@ -1,0 +1,2 @@
+``doctest`` program examples now exit with a non-successful code if any test
+fails


### PR DESCRIPTION
Build commands should fail on test error. That includes calling files' __main__ block by executing them directly.

Therefore, the documented examples are changed to return an error code if any single test has failed (but still succeeds even if no tests are found, which is probably overkill here and not always desired).

<!-- issue-number: [bpo-40372](https://bugs.python.org/issue40372) -->
https://bugs.python.org/issue40372
<!-- /issue-number -->
