### PR TITLE
bpo-40370: Pass the same compile args and link args as the interpreter in test_peg_generator

### DIFF
--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -8,6 +8,7 @@ import sys
 
 from test import test_tools
 from test.test_peg_generator.ast_dump import ast_dump
+from test import support
 from pathlib import PurePath, Path
 from typing import Sequence
 
@@ -23,6 +24,9 @@ with test_tools.imports_under_tool('peg_generator'):
 
 class TestCParser(unittest.TestCase):
     def setUp(self):
+        cmd = support.missing_compiler_executable()
+        if cmd is not None:
+            self.skipTest('The %r command is not found' % cmd)
         self.tmp_path = tempfile.mkdtemp()
 
     def tearDown(self):

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -25,13 +25,15 @@ MOD_DIR = pathlib.Path(__file__).parent
 def get_extra_flags(compiler_flags, compiler_py_flags_nodist):
     flags = sysconfig.get_config_var(compiler_flags)
     py_flags_nodist = sysconfig.get_config_var(compiler_py_flags_nodist)
+    if flags is None or py_flags_nodist is None:
+        return []
     return f'{flags} {py_flags_nodist}'.split()
 
 
 def compile_c_extension(
     generated_source_path: str,
     build_dir: Optional[str] = None,
-    verbose: bool = True,
+    verbose: bool = False,
     keep_asserts: bool = True,
 ) -> str:
     """Compile the generated source for a parser generator into an extension module.
@@ -47,12 +49,10 @@ def compile_c_extension(
     if verbose:
         distutils.log.set_verbosity(distutils.log.DEBUG)
 
-
     source_file_path = pathlib.Path(generated_source_path)
     extension_name = source_file_path.stem
     extra_compile_args = get_extra_flags('CFLAGS', 'PY_CFLAGS_NODIST')
     extra_link_args = get_extra_flags('LDFLAGS', 'PY_LDFLAGS_NODIST')
-    print(extra_compile_args, extra_link_args)
     if keep_asserts:
         extra_compile_args.append("-UNDEBUG")
     extension = [

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -2,6 +2,7 @@ import pathlib
 import shutil
 import tokenize
 import sys
+import sysconfig
 
 from typing import Optional, Tuple
 
@@ -19,6 +20,12 @@ from pegen.python_generator import PythonParserGenerator
 from pegen.tokenizer import Tokenizer
 
 MOD_DIR = pathlib.Path(__file__).parent
+
+
+def get_extra_flags(compiler_flags, compiler_py_flags_nodist):
+    flags = sysconfig.get_config_var(compiler_flags)
+    py_flags_nodist = sysconfig.get_config_var(compiler_py_flags_nodist)
+    return (flags + ' ' + py_flags_nodist).split()
 
 
 def compile_c_extension(
@@ -40,11 +47,11 @@ def compile_c_extension(
     if verbose:
         distutils.log.set_verbosity(distutils.log.DEBUG)
 
+
     source_file_path = pathlib.Path(generated_source_path)
     extension_name = source_file_path.stem
-    extra_compile_args = []
-    if not sys.platform.startswith('win'):
-        extra_compile_args.append("-std=c99")
+    extra_compile_args = get_extra_flags('CFLAGS', 'PY_CFLAGS_NODIST')
+    extra_link_args = get_extra_flags('LDFLAGS', 'PY_LDFLAGS_NODIST')
     if keep_asserts:
         extra_compile_args.append("-UNDEBUG")
     extension = [
@@ -65,6 +72,7 @@ def compile_c_extension(
                 str(MOD_DIR.parent.parent.parent / "Parser" / "pegen"),
             ],
             extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args,
         )
     ]
     dist = Distribution({"name": extension_name, "ext_modules": extension})

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -25,7 +25,7 @@ MOD_DIR = pathlib.Path(__file__).parent
 def get_extra_flags(compiler_flags, compiler_py_flags_nodist):
     flags = sysconfig.get_config_var(compiler_flags)
     py_flags_nodist = sysconfig.get_config_var(compiler_py_flags_nodist)
-    return (flags + ' ' + py_flags_nodist).split()
+    return f'{flags} {py_flags_nodist}'.split()
 
 
 def compile_c_extension(

--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -31,7 +31,7 @@ def get_extra_flags(compiler_flags, compiler_py_flags_nodist):
 def compile_c_extension(
     generated_source_path: str,
     build_dir: Optional[str] = None,
-    verbose: bool = False,
+    verbose: bool = True,
     keep_asserts: bool = True,
 ) -> str:
     """Compile the generated source for a parser generator into an extension module.
@@ -52,6 +52,7 @@ def compile_c_extension(
     extension_name = source_file_path.stem
     extra_compile_args = get_extra_flags('CFLAGS', 'PY_CFLAGS_NODIST')
     extra_link_args = get_extra_flags('LDFLAGS', 'PY_LDFLAGS_NODIST')
+    print(extra_compile_args, extra_link_args)
     if keep_asserts:
         extra_compile_args.append("-UNDEBUG")
     extension = [


### PR DESCRIPTION


<!-- issue-number: [bpo-40370](https://bugs.python.org/issue40370) -->
https://bugs.python.org/issue40370
<!-- /issue-number -->
