### PR TITLE
bpo-40334: Suppress all output in test_peg_generator

### DIFF
--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -295,7 +295,6 @@ class TestCParser(unittest.TestCase):
         expr: NAME
         """
         grammar = parse_string(grammar_source, GrammarParser)
-        print(list(Path(self.tmp_path).iterdir()))
         extension = generate_parser_c_extension(grammar, Path(self.tmp_path))
         for text in ("a b 42 b a", "名 名 42 名 名"):
             try:

--- a/Lib/test/test_peg_generator/test_pegen.py
+++ b/Lib/test/test_peg_generator/test_pegen.py
@@ -81,7 +81,6 @@ class TestPegen(unittest.TestCase):
         """
         rules = parse_string(grammar, GrammarParser).rules
         self.assertEqual(str(rules["start"]), "start: ','.thing+ NEWLINE")
-        print(repr(rules["start"]))
         self.assertTrue(repr(rules["start"]).startswith(
             "Rule('start', None, Rhs([Alt([NamedItem(None, Gather(StringLeaf(\"','\"), NameLeaf('thing'"
         ))
@@ -511,7 +510,7 @@ class TestPegen(unittest.TestCase):
         expr: NUMBER
         """
         parser_class = make_parser(grammar)
-        node = parse_string("(1)", parser_class, verbose=True)
+        node = parse_string("(1)", parser_class)
         self.assertEqual(node, [
             TokenInfo(OP, string="(", start=(1, 0), end=(1, 1), line="(1)"),
             [TokenInfo(NUMBER, string="1", start=(1, 1), end=(1, 2), line="(1)")],
@@ -695,8 +694,6 @@ class TestGrammarVisualizer(unittest.TestCase):
         printer.print_grammar_ast(rules, printer=lines.append)
 
         output = "\n".join(lines)
-        print()
-        print(output)
         expected_output = textwrap.dedent(
             """\
         └──Rule


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
