### PR TITLE
[3.7] gdbinit: Use proper define syntax (GH-19557)

### DIFF
--- a/Misc/gdbinit
+++ b/Misc/gdbinit
@@ -149,7 +149,7 @@ define pystackv
 end
 
 # generally useful macro to print a Unicode string
-def pu
+define pu
   set $uni = $arg0
   set $i = 0
   while (*$uni && $i++<100)


### PR DESCRIPTION
Using `def` rather than `define` results in:

    Ambiguous command "def pu": define, define-prefix.

Automerge-Triggered-By: @csabella.
(cherry picked from commit 1221135289306333d11db25ab20cbbd21ceec630)

Co-authored-by: Florian Bruhin <me@the-compiler.org>

Automerge-Triggered-By: @csabella