### PR TITLE
bpo-40374: Including ``__reversed__`` as Mapping mixin

### DIFF
--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -72,7 +72,7 @@ ABC                        Inherits from          Abstract Methods        Mixin 
                                                   ``discard``
 
 :class:`Mapping`           :class:`Collection`    ``__getitem__``,        ``__contains__``, ``keys``, ``items``, ``values``,
-                                                  ``__iter__``,           ``get``, ``__eq__``, and ``__ne__``
+                                                  ``__iter__``,           ``get``, ``__reversed__``, ``__eq__``, and ``__ne__``
                                                   ``__len__``
 
 :class:`MutableMapping`    :class:`Mapping`       ``__getitem__``,        Inherited :class:`Mapping` methods and

--- a/Misc/NEWS.d/next/Documentation/2020-04-23-19-52-55.bpo-40374.u2yD8b.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-04-23-19-52-55.bpo-40374.u2yD8b.rst
@@ -1,0 +1,1 @@
+`Mapping` has a `__reversed__` method, but is not listed under Mixin Methods in the Abstract Base Classes table.


### PR DESCRIPTION
``Mapping.__reversed__`` exists, but is not listed under Mixin Methods in the Abstract Base Classes table. Including.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40374](https://bugs.python.org/issue40374) -->
https://bugs.python.org/issue40374
<!-- /issue-number -->
