### PR TITLE
bpo-26317: GH Action Test

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,40 @@
+name: macOS w/ clang or GCC
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  # this needs the fix in
+  # https://github.com/python/cpython/pull/13306
+  install_gcc9_autotools:
+    name: install with gcc@9.3.0 (Autotools)
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+    - name: install GCC with brew
+      run: |
+        brew install automake
+        brew install gcc
+        gcc-9 --version
+    - name: compile
+      run: |
+        export CC=$(which gcc-9)
+        export CXX=$(which g++-9)
+        ./configure
+        make -j 2
+        make buildbottest
+
+  install_clang_autotools:
+    name: install with AppleClang 11.0 (Autotools)
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+    - name: install autotools with brew
+      run: |
+        brew install automake
+    - name: compile
+      run: |
+        ./configure
+        make -j 2
+        make buildbottest


### PR DESCRIPTION
Add test coverage for macOS builds via free and fast GitHub Action runs:
- macOS 10.15 + AppleClang 11.0
- macOS 10.15 + Homebrew GCC (atm 9.3)

This needs the fix in #13306 to land first.

Refs.:
- #13306 (fixes this error: https://github.com/ax3l/cpython/runs/612544626?check_suite_focus=true)
- https://bugs.python.org/issue26317

<!-- issue-number: [bpo-26317](https://bugs.python.org/issue26317) -->
https://bugs.python.org/issue26317
<!-- /issue-number -->
