### PR TITLE
PEP 617: Use Py_ssize_t instead of ssize_t

### DIFF
--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -1161,7 +1161,7 @@ _PyPegen_join_names_with_dot(Parser *p, expr_ty first_name, expr_ty second_name)
     if (!second_str) {
         return NULL;
     }
-    ssize_t len = strlen(first_str) + strlen(second_str) + 1;  // +1 for the dot
+    Py_ssize_t len = strlen(first_str) + strlen(second_str) + 1;  // +1 for the dot
 
     PyObject *str = PyBytes_FromStringAndSize(NULL, len);
     if (!str) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
