### PR TITLE
[3.7] bpo-39932: Fix multiprocessing test_heap()

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3424,6 +3424,16 @@ class _TestHeap(BaseTestCase):
 
     ALLOWED_TYPES = ('processes',)
 
+    def setUp(self):
+        super().setUp()
+        # Make pristine heap for these tests
+        self.old_heap = multiprocessing.heap.BufferWrapper._heap
+        multiprocessing.heap.BufferWrapper._heap = multiprocessing.heap.Heap()
+
+    def tearDown(self):
+        multiprocessing.heap.BufferWrapper._heap = self.old_heap
+        super().tearDown()
+
     def test_heap(self):
         iterations = 5000
         maxblocks = 50

--- a/Misc/NEWS.d/next/Tests/2020-04-23-23-46-08.bpo-39932.6G8rRN.rst
+++ b/Misc/NEWS.d/next/Tests/2020-04-23-23-46-08.bpo-39932.6G8rRN.rst
@@ -1,0 +1,2 @@
+Fix multiprocessing test_heap(): a new Heap object is now created for each test
+run.


### PR DESCRIPTION
_TestHeap now creates a new Heap() object for each test run.
Partial backport of commit e4679cd644aa19f9d9df9beb1326625cf2b02c15
by Antoine Pitrou.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39932](https://bugs.python.org/issue39932) -->
https://bugs.python.org/issue39932
<!-- /issue-number -->
