### PR TITLE
bpo-40334: Use old compiler when compile mode is func_type

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -817,7 +817,7 @@ builtin_compile_impl(PyObject *module, PyObject *source, PyObject *filename,
         goto error;
 
     int current_use_peg = PyInterpreterState_Get()->config._use_peg_parser;
-    if (flags & PyCF_TYPE_COMMENTS || feature_version >= 0) {
+    if (flags & PyCF_TYPE_COMMENTS || feature_version >= 0 || compile_mode == 3) {
         PyInterpreterState_Get()->config._use_peg_parser = 0;
     }
     result = Py_CompileStringObject(str, filename, start[compile_mode], &cf, optimize);


### PR DESCRIPTION
This is invoked by mypy, using `ast.parse(source, "<func_type>", "func_type")`. Since the new grammar doesn't yet support the `func_type_input` start symbol we must use the old compiler in this case to prevent a crash.

<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
