### PR TITLE
bpo-40334: Fix broken mkdir -p call in regen-pegen

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -822,7 +822,7 @@ regen-grammar: regen-token
 
 .PHONY: regen-pegen
 regen-pegen:
-	@$(MKDIR_P) -p $(srcdir)/Parser/pegen
+	@$(MKDIR_P) $(srcdir)/Parser/pegen
 	PYTHONPATH=$(srcdir)/Tools/peg_generator $(PYTHON_FOR_REGEN) -m pegen -c -q $(srcdir)/Grammar/python.gram \
 		-o $(srcdir)/Parser/pegen/parse.new.c
 	$(UPDATE_FILE) $(srcdir)/Parser/pegen/parse.c $(srcdir)/Parser/pegen/parse.new.c


### PR DESCRIPTION
This caused problems on platforms (like macOS) where MKDIR_P is set to `./install-sh -c -d`.

<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
