### PR TITLE
bpo-38061: os.closerange() uses closefrom() on FreeBSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-04-24-01-27-08.bpo-38061.cdlkMz.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-24-01-27-08.bpo-38061.cdlkMz.rst
@@ -1,0 +1,6 @@
+On FreeBSD, ``os.closerange(fd_low, fd_high)`` now calls ``closefrom(fd_low)``
+if *fd_high* is greater than or equal to ``sysconf(_SC_OPEN_MAX)``.
+
+Initial patch by Ed Maste (emaste), Conrad Meyer (cem), Kyle Evans (kevans)
+and Kubilay Kocak (koobs):
+https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242274


### PR DESCRIPTION
On FreeBSD, os.closerange(fd_low, fd_high) now calls
closefrom(fd_low) if fd_high is greater than or equal to
sysconf(_SC_OPEN_MAX).

Initial patch by Kyle Evans with the help of Kubilay Kocak:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242274

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38061](https://bugs.python.org/issue38061) -->
https://bugs.python.org/issue38061
<!-- /issue-number -->
