### PR TITLE
bpo-38061: subprocess uses closefrom() on FreeBSD

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -471,6 +471,10 @@ Optimizations
   until the main thread handles signals.
   (Contributed by Victor Stinner in :issue:`40010`.)
 
+* Optimize the :mod:`subprocess` module on FreeBSD using ``closefrom()``.
+  (Contributed by Ed Maste, Conrad Meyer, Kyle Evans, Kubilay Kocak and Victor
+  Stinner in :issue:`38061`.)
+
 
 Build and C API Changes
 =======================

--- a/Misc/NEWS.d/next/Library/2020-04-24-01-55-00.bpo-38061.XmULB3.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-24-01-55-00.bpo-38061.XmULB3.rst
@@ -1,0 +1,11 @@
+Optimize the :mod:`subprocess` module on FreeBSD using ``closefrom()``.
+A single ``close(fd)`` syscall is cheap, but when ``sysconf(_SC_OPEN_MAX)`` is
+high, the loop calling ``close(fd)`` on each file descriptor can take several
+milliseconds.
+
+The workaround on FreeBSD to improve performance was to load and mount the
+fdescfs kernel module, but this is not enabled by default.
+
+Initial patch by Ed Maste (emaste), Conrad Meyer (cem), Kyle Evans (kevans) and
+Kubilay Kocak (koobs):
+https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242274

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -264,9 +264,15 @@ _close_fds_by_brute_force(long start_fd, PyObject *py_fds_to_keep)
         start_fd = keep_fd + 1;
     }
     if (start_fd <= end_fd) {
+#if defined(__FreeBSD__)
+        /* Any errors encountered while closing file descriptors are ignored */
+        closefrom(start_fd);
+#else
         for (fd_num = start_fd; fd_num < end_fd; ++fd_num) {
-            close(fd_num);
+            /* Ignore errors */
+            (void)close(fd_num);
         }
+#endif
     }
 }
 


### PR DESCRIPTION
Optimize the subprocess module on FreeBSD using closefrom().
A single close(fd) syscall is cheap, but when sysconf(_SC_OPEN_MAX)
is high, the loop calling close(fd) on each file descriptor can take
several milliseconds.

The workaround on FreeBSD to improve performance was to load and
mount the fdescfs kernel module, but this is not enabled by default.

Initial patch by Kyle Evans with the help of Kubilay Kocak:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242274

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38061](https://bugs.python.org/issue38061) -->
https://bugs.python.org/issue38061
<!-- /issue-number -->
