### PR TITLE
bpo-40346: Random subclass randbytes uses getrandbits

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -39,7 +39,7 @@ basic generator of your own devising: in that case, override the :meth:`~Random.
 Optionally, a new generator can supply a :meth:`~Random.getrandbits` method --- this
 allows :meth:`randrange` to produce selections over an arbitrarily large range.
 In subclasses, :meth:`randbytes` is implemented with the
-:meth:`~Random.getrandbits` method.
+:meth:`~Random.getrandbits` method, unless :meth:`randbytes` is overriden.
 
 The :mod:`random` module also provides the :class:`SystemRandom` class which
 uses the system function :func:`os.urandom` to generate random numbers

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -38,6 +38,8 @@ basic generator of your own devising: in that case, override the :meth:`~Random.
 :meth:`~Random.seed`, :meth:`~Random.getstate`, and :meth:`~Random.setstate` methods.
 Optionally, a new generator can supply a :meth:`~Random.getrandbits` method --- this
 allows :meth:`randrange` to produce selections over an arbitrarily large range.
+In subclasses, :meth:`randbytes` is implemented with the
+:meth:`~Random.getrandbits` method.
 
 The :mod:`random` module also provides the :class:`SystemRandom` class which
 uses the system function :func:`os.urandom` to generate random numbers

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -750,7 +750,7 @@ class SystemRandom(Random):
     """
 
     def __init_subclass__(cls, /, **kwargs):
-        super.__init_subclass__(**kwargs)
+        super().__init_subclass__(**kwargs)
 
         if (cls.randbytes == SystemRandom.randbytes
            and cls.getrandbits != _random.Random.getrandbits):

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -198,13 +198,9 @@ class Random(_random.Random):
 ## -------------------- bytes -----------------------------
 
     # Implementation used by Random and SystemRandom subclasses
-    def randbytes(self, n):
+    def _randbytes_getrandbits (self, n):
         """Generate n random bytes."""
         return self.getrandbits(n * 8).to_bytes(n, 'little')
-    # Declare the function as "randbytes" to set __name__ and __qualname__
-    # to "randbytes"
-    _randbytes_getrandbits = randbytes
-    del randbytes
 
 ## ---- Methods below this point do not need to be overridden when
 ## ---- subclassing for the purpose of using a different core generator.

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -120,9 +120,10 @@ class Random(_random.Random):
                 cls._randbelow = cls._randbelow_without_getrandbits
                 break
 
-        if cls.randbytes == _random.Random.randbytes:
+        if (cls.randbytes == _random.Random.randbytes
+           and cls.getrandbits != _random.Random.getrandbits):
             # Subclasses of random.Random implement randbytes()
-            # using getrandbits()
+            # using getrandbits() if getrandbits() is overriden.
             cls.randbytes = cls._randbytes_getrandbits
 
     def seed(self, a=None, version=2):
@@ -747,9 +748,10 @@ class SystemRandom(Random):
     def __init_subclass__(cls, /, **kwargs):
         super.__init_subclass__(**kwargs)
 
-        if cls.randbytes == SystemRandom.randbytes:
+        if (cls.randbytes == SystemRandom.randbytes
+           and cls.getrandbits != _random.Random.getrandbits):
             # Subclasses of random.SystemRandom implement randbytes()
-            # using getrandbits()
+            # using getrandbits() if getrandbits() is overriden.
             cls.randbytes = cls._randbytes_getrandbits
 
     def random(self):

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -753,7 +753,7 @@ class SystemRandom(Random):
         super().__init_subclass__(**kwargs)
 
         if (cls.randbytes == SystemRandom.randbytes
-           and cls.getrandbits != _random.Random.getrandbits):
+           and cls.getrandbits != SystemRandom.getrandbits):
             # Subclasses of random.SystemRandom implement randbytes()
             # using getrandbits() if getrandbits() is overriden.
             cls.randbytes = cls._randbytes_getrandbits

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -198,9 +198,13 @@ class Random(_random.Random):
 ## -------------------- bytes -----------------------------
 
     # Implementation used by Random and SystemRandom subclasses
-    def _randbytes_getrandbits(self, n):
+    def randbytes(self, n):
         """Generate n random bytes."""
         return self.getrandbits(n * 8).to_bytes(n, 'little')
+    # Declare the function as "randbytes" to set __name__ and __qualname__
+    # to "randbytes"
+    _randbytes_getrandbits = randbytes
+    del randbytes
 
 ## ---- Methods below this point do not need to be overridden when
 ## ---- subclassing for the purpose of using a different core generator.

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -368,6 +368,10 @@ class TestBasicOps:
         self.assertEqual(subclass.getrandbits_calls,
                          [n * 8 for n in range(10)])
 
+        # Check the method name in a subclass
+        self.assertEqual(subclass.randbytes.__name__, "randbytes")
+        self.assertEqual(subclass.randbytes.__qualname__, "Random.randbytes")
+
         class Subclass2(type(self.gen)):
             getrandbits_calls = []
             def getrandbits(self, n):

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -355,9 +355,6 @@ class TestBasicOps:
         self.assertEqual(subclass.getrandbits_calls,
                          [n * 8 for n in range(10)])
 
-        self.assertEqual(subclass.randbytes.__name__, "randbytes")
-        self.assertEqual(subclass.randbytes.__qualname__, "Random.randbytes")
-
         # SubSubclass override explicitly randbytes():
         # getrandbits() implemented in Subclass is not called.
         class SubSubclass(Subclass):

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -338,42 +338,50 @@ class TestBasicOps:
     def test_randbytes_subclass(self):
         # For random.Random and random.SystemRandom subclasses,
         # randbytes() is implemented with getrandbits()
+
+        # Subclass implements getrandbits() but not randbytes()
         class Subclass(type(self.gen)):
-            getrandbits_calls = []
+            def __init__(self):
+                super().__init__()
+                self.getrandbits_calls = []
+
             def getrandbits(self, n):
                 self.getrandbits_calls.append(n)
                 return 0
 
-        class SubSubclass(Subclass):
-            randbytes_calls = []
-            def randbytes(self, n):
-                self.randbytes_calls.append(n)
-                return b'\x04' * n
-
-        # SubSubclass override explicitly randbytes():
-        # getrandbits() implemented in Subclass is not called.
-        #
-        # Test SubSubclass first, since it shares randbytes_calls
-        # and getrandbits_calls lists with Subclass.
-        subsubclass = SubSubclass()
-        for n in range(10):
-            self.assertEqual(subsubclass.randbytes(n), b'\x04' * n)
-        self.assertEqual(subsubclass.randbytes_calls, list(range(10)))
-        self.assertEqual(subsubclass.getrandbits_calls, [])
-
-        # Subclass implements getrandbits() but not randbytes()
         subclass = Subclass()
         for n in range(10):
             self.assertEqual(subclass.randbytes(n), b'\0' * n)
         self.assertEqual(subclass.getrandbits_calls,
                          [n * 8 for n in range(10)])
 
-        # Check the method name in a subclass
         self.assertEqual(subclass.randbytes.__name__, "randbytes")
         self.assertEqual(subclass.randbytes.__qualname__, "Random.randbytes")
 
+        # SubSubclass override explicitly randbytes():
+        # getrandbits() implemented in Subclass is not called.
+        class SubSubclass(Subclass):
+            def __init__(self):
+                super().__init__()
+                self.randbytes_calls = []
+
+            def randbytes(self, n):
+                self.randbytes_calls.append(n)
+                return b'\x04' * n
+
+        subsubclass = SubSubclass()
+        for n in range(10):
+            self.assertEqual(subsubclass.randbytes(n), b'\x04' * n)
+        self.assertEqual(subsubclass.randbytes_calls, list(range(10)))
+        self.assertEqual(subsubclass.getrandbits_calls, [])
+
+        # Subclass2 implements getrandbits() and randbytes():
+        # randbytes() doesn't use getrandbits().
         class Subclass2(type(self.gen)):
-            getrandbits_calls = []
+            def __init__(self):
+                super().__init__()
+                self.getrandbits_calls = []
+
             def getrandbits(self, n):
                 self.getrandbits_calls.append(n)
                 return 0
@@ -381,13 +389,11 @@ class TestBasicOps:
             randbytes_calls = []
             def randbytes(self, n):
                 self.randbytes_calls.append(n)
-                return b'\x04' * n
+                return b'\x07' * n
 
-        # Subclass implements getrandbits() and randbytes():
-        # randbytes() doesn't use getrandbits().
         subclass2 = Subclass2()
         for n in range(10):
-            self.assertEqual(subclass2.randbytes(n), b'\x04' * n)
+            self.assertEqual(subclass2.randbytes(n), b'\x07' * n)
         self.assertEqual(subclass2.randbytes_calls, list(range(10)))
         self.assertEqual(subclass2.getrandbits_calls, [])
 

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -335,6 +335,20 @@ class TestBasicOps:
         self.assertRaises(ValueError, self.gen.randbytes, -1)
         self.assertRaises(TypeError, self.gen.randbytes, 1.0)
 
+    def test_randbytes_subclass(self):
+        # For random.Random and random.SystemRandom subclasses,
+        # randbytes() is implemented with getrandbits()
+        class Subclass(type(self.gen)):
+            calls = []
+            def getrandbits(self, n):
+                self.calls.append(n)
+                return 0
+
+        subclass = Subclass()
+        for n in range(10):
+            self.assertEqual(subclass.randbytes(n), b'\0' * n)
+        self.assertEqual(subclass.calls, [n * 8 for n in range(10)])
+
 
 try:
     random.SystemRandom().random()

--- a/Misc/NEWS.d/next/Library/2020-04-24-11-22-10.bpo-40346.viRmGr.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-24-11-22-10.bpo-40346.viRmGr.rst
@@ -1,0 +1,3 @@
+Subclasses of the :class:`random.Random` and :class:`random.SystemRandom`
+classes now get a ``randbytes()`` method implementation which uses the
+``getrandbits()`` method.


### PR DESCRIPTION
Subclass of the random.Random class now get a randbytes() method
implementation which uses the getrandbits() method.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40346](https://bugs.python.org/issue40346) -->
https://bugs.python.org/issue40346
<!-- /issue-number -->
