### PR TITLE
bpo-34990: Treat the pyc header's mtime in compileall as an unsigned int

### DIFF
--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -206,8 +206,8 @@ def compile_file(fullname, ddir=None, force=False, rx=None, quiet=0,
             if not force:
                 try:
                     mtime = int(os.stat(fullname).st_mtime)
-                    expect = struct.pack('<4sll', importlib.util.MAGIC_NUMBER,
-                                         0, mtime)
+                    expect = struct.pack('<4sLL', importlib.util.MAGIC_NUMBER,
+                                         0, mtime & 0xFFFF_FFFF)
                     for cfile in opt_cfiles.values():
                         with open(cfile, 'rb') as chandle:
                             actual = chandle.read(12)

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -62,7 +62,10 @@ class CompileallTestsBase:
     def test_year_2038_mtime_compilation(self):
         # Test to make sure we can handle mtimes larger than what a 32-bit
         # signed number can hold as part of bpo-34990
-        os.utime(self.source_path, (2**32 - 1, 2**32 - 1))
+        try:
+            os.utime(self.source_path, (2**32 - 1, 2**32 - 1))
+        except (OverflowError, OSError):
+            self.skipTest("filesystem doesn't support timestamps near 2**32")
         self.assertTrue(compileall.compile_file(self.source_path))
 
     def test_larger_than_32_bit_times(self):

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -55,8 +55,20 @@ class CompileallTestsBase:
         with open(self.bc_path, 'rb') as file:
             data = file.read(12)
         mtime = int(os.stat(self.source_path).st_mtime)
-        compare = struct.pack('<4sll', importlib.util.MAGIC_NUMBER, 0, mtime)
+        compare = struct.pack('<4sLL', importlib.util.MAGIC_NUMBER, 0,
+                              mtime & 0xFFFF_FFFF)
         return data, compare
+
+    def test_year_2038_mtime_compilation(self):
+        # Test to make sure we can handle mtimes larger than what a 32-bit
+        # signed number can hold as part of bpo-34990
+        with open(self.source_path, 'r') as f:
+            os.utime(f.name, (2**32 - 1, 2**32 - 1))
+        self.assertTrue(compileall.compile_file(self.source_path))
+
+        with open(self.source_path, 'r') as f:
+            os.utime(f.name, (2**35, 2**35))
+        self.assertTrue(compileall.compile_file(self.source_path))
 
     def recreation_check(self, metadata):
         """Check that compileall recreates bytecode when the new metadata is
@@ -76,7 +88,7 @@ class CompileallTestsBase:
 
     def test_mtime(self):
         # Test a change in mtime leads to a new .pyc.
-        self.recreation_check(struct.pack('<4sll', importlib.util.MAGIC_NUMBER,
+        self.recreation_check(struct.pack('<4sLL', importlib.util.MAGIC_NUMBER,
                                           0, 1))
 
     def test_magic_number(self):

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -62,12 +62,16 @@ class CompileallTestsBase:
     def test_year_2038_mtime_compilation(self):
         # Test to make sure we can handle mtimes larger than what a 32-bit
         # signed number can hold as part of bpo-34990
-        with open(self.source_path, 'r') as f:
-            os.utime(f.name, (2**32 - 1, 2**32 - 1))
+        os.utime(self.source_path, (2**32 - 1, 2**32 - 1))
         self.assertTrue(compileall.compile_file(self.source_path))
 
-        with open(self.source_path, 'r') as f:
-            os.utime(f.name, (2**35, 2**35))
+    def test_larger_than_32_bit_times(self):
+        # This is similar to the test above but we skip it if the OS doesn't
+        # support modification times larger than 32-bits.
+        try:
+            os.utime(self.source_path, (2**35, 2**35))
+        except (OverflowError, OSError):
+            self.skipTest("filesystem doesn't support large timestamps")
         self.assertTrue(compileall.compile_file(self.source_path))
 
     def recreation_check(self, metadata):

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -41,7 +41,8 @@ def make_pyc(co, mtime, size):
         else:
             mtime = int(-0x100000000 + int(mtime))
     pyc = (importlib.util.MAGIC_NUMBER +
-        struct.pack("<iii", 0, int(mtime), size & 0xFFFFFFFF) + data)
+        struct.pack("<iLL", 0,
+                    int(mtime) & 0xFFFF_FFFF, size & 0xFFFF_FFFF) + data)
     return pyc
 
 def module_path_to_dotted_name(path):
@@ -251,6 +252,19 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         badtime_pyc[11] ^= 0x02
         files = {TESTMOD + ".py": (NOW, test_src),
                  TESTMOD + pyc_ext: (NOW, badtime_pyc)}
+        self.doTest(".py", files, TESTMOD)
+
+    def test2038MTime(self):
+        # Make sure we can handle mtimes larger than what a 32-bit signed number
+        # can hold.
+        twenty_thirty_eight_pyc = make_pyc(test_co, 2**32 - 1, len(test_src))
+        files = {TESTMOD + ".py": (NOW, test_src),
+                 TESTMOD + pyc_ext: (NOW, twenty_thirty_eight_pyc)}
+        self.doTest(".py", files, TESTMOD)
+
+        larger_than_32_bit = make_pyc(test_co, 2**35, len(test_src))
+        files = {TESTMOD + ".py": (NOW, test_src),
+                 TESTMOD + pyc_ext: (NOW, twenty_thirty_eight_pyc)}
         self.doTest(".py", files, TESTMOD)
 
     def testPackage(self):

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -34,12 +34,6 @@ raise_src = 'def do_raise(): raise TypeError\n'
 
 def make_pyc(co, mtime, size):
     data = marshal.dumps(co)
-    if type(mtime) is type(0.0):
-        # Mac mtimes need a bit of special casing
-        if mtime < 0x7fffffff:
-            mtime = int(mtime)
-        else:
-            mtime = int(-0x100000000 + int(mtime))
     pyc = (importlib.util.MAGIC_NUMBER +
         struct.pack("<iLL", 0,
                     int(mtime) & 0xFFFF_FFFF, size & 0xFFFF_FFFF) + data)
@@ -258,11 +252,6 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         # Make sure we can handle mtimes larger than what a 32-bit signed number
         # can hold.
         twenty_thirty_eight_pyc = make_pyc(test_co, 2**32 - 1, len(test_src))
-        files = {TESTMOD + ".py": (NOW, test_src),
-                 TESTMOD + pyc_ext: (NOW, twenty_thirty_eight_pyc)}
-        self.doTest(".py", files, TESTMOD)
-
-        larger_than_32_bit = make_pyc(test_co, 2**35, len(test_src))
         files = {TESTMOD + ".py": (NOW, test_src),
                  TESTMOD + pyc_ext: (NOW, twenty_thirty_eight_pyc)}
         self.doTest(".py", files, TESTMOD)

--- a/Misc/NEWS.d/next/Library/2020-04-24-20-39-38.bpo-34990.3SmL9M.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-24-20-39-38.bpo-34990.3SmL9M.rst
@@ -1,2 +1,2 @@
 Fixed a Y2k38 bug in the compileall module where it would fail to compile
-files created after 2038.
+files with a modification time after the year 2038.

--- a/Misc/NEWS.d/next/Library/2020-04-24-20-39-38.bpo-34990.3SmL9M.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-24-20-39-38.bpo-34990.3SmL9M.rst
@@ -1,0 +1,2 @@
+Fixed a Y2k38 bug in the compileall module where it would fail to compile
+files created after 2038.


### PR DESCRIPTION
Created with @matrixise's blessing to continue their work. This is an alternative to [changing the timestamps to 64-bit](https://github.com/python/cpython/pull/19651). Should last for a while.

I didn't update `Tools/checkpyc.py` like the original PR there pending a decision on a [bug I made to remove it](https://bugs.python.org/issue40385)

<!-- issue-number: [bpo-34990](https://bugs.python.org/issue34990) -->
https://bugs.python.org/issue34990
<!-- /issue-number -->
