### PR TITLE
bpo-40334: Add tests/test_peg_generator to the install files target

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1426,6 +1426,7 @@ LIBSUBDIRS=	tkinter tkinter/test tkinter/test/test_tkinter \
 		ctypes ctypes/test ctypes/macholib \
 		idlelib idlelib/Icons idlelib/idle_test \
 		distutils distutils/command distutils/tests $(XMLLIBSUBDIRS) \
+		test/test_peg_generator \
 		test/test_tools test/test_warnings test/test_warnings/data \
 		turtledemo \
 		multiprocessing multiprocessing/dummy \

--- a/PCbuild/lib.pyproj
+++ b/PCbuild/lib.pyproj
@@ -1207,6 +1207,12 @@
     <Compile Include="test\test_pathlib.py" />
     <Compile Include="test\test_pdb.py" />
     <Compile Include="test\test_peepholer.py" />
+    <Compile Include="test\test_peg_generator\__init__.py" />
+    <Compile Include="test\test_peg_generator\__main__.py" />
+    <Compile Include="test\test_peg_generator\ast_dump.py" />
+    <Compile Include="test\test_peg_generator\test_c_parser.py" />
+    <Compile Include="test\test_peg_generator\test_first_sets.py" />
+    <Compile Include="test\test_peg_generator\test_pegen.py" />
     <Compile Include="test\test_pickle.py" />
     <Compile Include="test\test_pickletools.py" />
     <Compile Include="test\test_pipes.py" />
@@ -1787,6 +1793,7 @@
     <Folder Include="test\test_import\data\package" />
     <Folder Include="test\test_import\data\package2" />
     <Folder Include="test\test_json" />
+    <Folder Include="test\test_peg_generator" />
     <Folder Include="test\test_tools" />
     <Folder Include="test\test_warnings" />
     <Folder Include="test\test_warnings\data" />


### PR DESCRIPTION
We forgot to add the `test/test_peg_generator` folder to `LIBSUBDIRS` in the Makefile and the windows files.

<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
