### PR TITLE
bpo-39966: Revert "bpo-25597: Ensure wraps' return value is used for magic methods in MagicMock (#16029)"

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2012,12 +2012,6 @@ _side_effect_methods = {
 
 
 def _set_return_value(mock, method, name):
-    # If _mock_wraps is present then attach it so that wrapped object
-    # is used for return value is used when called.
-    if mock._mock_wraps is not None:
-        method._mock_wraps = getattr(mock._mock_wraps, name)
-        return
-
     fixed = _return_values.get(name, DEFAULT)
     if fixed is not DEFAULT:
         method.return_value = fixed

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -715,53 +715,6 @@ class MockTest(unittest.TestCase):
         self.assertRaises(StopIteration, mock.method)
 
 
-    def test_magic_method_wraps_dict(self):
-        data = {'foo': 'bar'}
-
-        wrapped_dict = MagicMock(wraps=data)
-        self.assertEqual(wrapped_dict.get('foo'), 'bar')
-        self.assertEqual(wrapped_dict['foo'], 'bar')
-        self.assertTrue('foo' in wrapped_dict)
-
-        # return_value is non-sentinel and takes precedence over wrapped value.
-        wrapped_dict.get.return_value = 'return_value'
-        self.assertEqual(wrapped_dict.get('foo'), 'return_value')
-
-        # return_value is sentinel and hence wrapped value is returned.
-        wrapped_dict.get.return_value = sentinel.DEFAULT
-        self.assertEqual(wrapped_dict.get('foo'), 'bar')
-
-        self.assertEqual(wrapped_dict.get('baz'), None)
-        with self.assertRaises(KeyError):
-            wrapped_dict['baz']
-        self.assertFalse('bar' in wrapped_dict)
-
-        data['baz'] = 'spam'
-        self.assertEqual(wrapped_dict.get('baz'), 'spam')
-        self.assertEqual(wrapped_dict['baz'], 'spam')
-        self.assertTrue('baz' in wrapped_dict)
-
-        del data['baz']
-        self.assertEqual(wrapped_dict.get('baz'), None)
-
-
-    def test_magic_method_wraps_class(self):
-
-        class Foo:
-
-            def __getitem__(self, index):
-                return index
-
-            def __custom_method__(self):
-                return "foo"
-
-
-        klass = MagicMock(wraps=Foo)
-        obj = klass()
-        self.assertEqual(obj.__getitem__(2), 2)
-        self.assertEqual(obj.__custom_method__(), "foo")
-
-
     def test_exceptional_side_effect(self):
         mock = Mock(side_effect=AttributeError)
         self.assertRaises(AttributeError, mock)

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -715,6 +715,57 @@ class MockTest(unittest.TestCase):
         self.assertRaises(StopIteration, mock.method)
 
 
+    def test_magic_method_wraps_dict(self):
+        # bpo-25597: MagicMock with wrap doesn't call wrapped object's
+        # method for magic methods with default values.
+        data = {'foo': 'bar'}
+
+        wrapped_dict = MagicMock(wraps=data)
+        self.assertEqual(wrapped_dict.get('foo'), 'bar')
+        # Accessing key gives a MagicMock
+        self.assertIsInstance(wrapped_dict['foo'], MagicMock)
+        # __contains__ method has a default value of False
+        self.assertFalse('foo' in wrapped_dict)
+
+        # return_value is non-sentinel and takes precedence over wrapped value.
+        wrapped_dict.get.return_value = 'return_value'
+        self.assertEqual(wrapped_dict.get('foo'), 'return_value')
+
+        # return_value is sentinel and hence wrapped value is returned.
+        wrapped_dict.get.return_value = sentinel.DEFAULT
+        self.assertEqual(wrapped_dict.get('foo'), 'bar')
+
+        self.assertEqual(wrapped_dict.get('baz'), None)
+        self.assertIsInstance(wrapped_dict['baz'], MagicMock)
+        self.assertFalse('bar' in wrapped_dict)
+
+        data['baz'] = 'spam'
+        self.assertEqual(wrapped_dict.get('baz'), 'spam')
+        self.assertIsInstance(wrapped_dict['baz'], MagicMock)
+        self.assertFalse('bar' in wrapped_dict)
+
+        del data['baz']
+        self.assertEqual(wrapped_dict.get('baz'), None)
+
+
+    def test_magic_method_wraps_class(self):
+
+        class Foo:
+
+            def __getitem__(self, index):
+                return index
+
+            def __custom_method__(self):
+                return "foo"
+
+
+        klass = MagicMock(wraps=Foo)
+        obj = klass()
+        self.assertEqual(obj.__getitem__(2), 2)
+        self.assertEqual(obj[2], 2)
+        self.assertEqual(obj.__custom_method__(), "foo")
+
+
     def test_exceptional_side_effect(self):
         mock = Mock(side_effect=AttributeError)
         self.assertRaises(AttributeError, mock)

--- a/Misc/NEWS.d/3.9.0a4.rst
+++ b/Misc/NEWS.d/3.9.0a4.rst
@@ -583,6 +583,17 @@ asyncio.lock):``.  The same is correct for ``asyncio.Condition`` and
 
 ..
 
+.. bpo: 25597
+.. date: 2019-09-12-12-11-05
+.. nonce: mPMzVx
+.. section: Library
+
+Ensure, if ``wraps`` is supplied to :class:`unittest.mock.MagicMock`, it is
+used to calculate return values for the magic methods instead of using the
+default return values. Patch by Karthikeyan Singaravelan.
+
+..
+
 .. bpo: 36350
 .. date: 2019-03-18-16-17-59
 .. nonce: udRSWE

--- a/Misc/NEWS.d/3.9.0a4.rst
+++ b/Misc/NEWS.d/3.9.0a4.rst
@@ -583,17 +583,6 @@ asyncio.lock):``.  The same is correct for ``asyncio.Condition`` and
 
 ..
 
-.. bpo: 25597
-.. date: 2019-09-12-12-11-05
-.. nonce: mPMzVx
-.. section: Library
-
-Ensure, if ``wraps`` is supplied to :class:`unittest.mock.MagicMock`, it is
-used to calculate return values for the magic methods instead of using the
-default return values. Patch by Karthikeyan Singaravelan.
-
-..
-
 .. bpo: 36350
 .. date: 2019-03-18-16-17-59
 .. nonce: udRSWE

--- a/Misc/NEWS.d/next/Library/2020-04-27-14-48-43.bpo-39966.N5yXUe.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-27-14-48-43.bpo-39966.N5yXUe.rst
@@ -1,0 +1,2 @@
+Revert bpo-25597. :class:`unittest.mock.MagicMock` with wraps' set uses
+default return values for magic methods.


### PR DESCRIPTION
This reverts commit 72b1004657e60c900e4cd031b2635b587f4b280e.


<!-- issue-number: [bpo-39966](https://bugs.python.org/issue39966) -->
https://bugs.python.org/issue39966
<!-- /issue-number -->
