### PR TITLE
bpo-30966: Add multiprocessing.SimpleQueue.close()

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -878,6 +878,12 @@ For an example of the usage of queues for interprocess communication see
 
    It is a simplified :class:`Queue` type, very close to a locked :class:`Pipe`.
 
+   .. method:: close()
+
+      Close the queue.
+
+      .. versionadded:: 3.9
+
    .. method:: empty()
 
       Return ``True`` if the queue is empty, ``False`` otherwise.

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -880,7 +880,11 @@ For an example of the usage of queues for interprocess communication see
 
    .. method:: close()
 
-      Close the queue.
+      Close the queue: release internal resources.
+
+      A queue must not be used anymore after it is closed. For example,
+      :meth:`get`, :meth:`put` and :meth:`empty` methods must no longer be
+      called.
 
       .. versionadded:: 3.9
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -376,6 +376,14 @@ nntplib
 if the given timeout for their constructor is zero to prevent the creation of
 a non-blocking socket. (Contributed by Dong-hee Na in :issue:`39259`.)
 
+multiprocessing
+---------------
+
+The :class:`multiprocessing.SimpleQueue` class has a new
+:meth:`~multiprocessing.SimpleQueue.close` method to explicitly close the
+queue.
+(Contributed by Victor Stinner in :issue:`30966`.)
+
 os
 --
 

--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -346,6 +346,10 @@ class SimpleQueue(object):
         else:
             self._wlock = ctx.Lock()
 
+    def close(self):
+        self._reader.close()
+        self._writer.close()
+
     def empty(self):
         return not self._poll()
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5244,6 +5244,20 @@ class TestSimpleQueue(unittest.TestCase):
 
         proc.join()
 
+    def test_close(self):
+        queue = multiprocessing.SimpleQueue()
+        queue.close()
+        # closing a queue twice should not fail
+        queue.close()
+
+    # Test specific to CPython since it tests private attributes
+    @test.support.cpython_only
+    def test_closed(self):
+        queue = multiprocessing.SimpleQueue()
+        queue.close()
+        self.assertTrue(queue._reader.closed)
+        self.assertTrue(queue._writer.closed)
+
 
 class TestPoolNotLeakOnFailure(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2020-04-27-17-19-09.bpo-30966._5lDx-.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-27-17-19-09.bpo-30966._5lDx-.rst
@@ -1,0 +1,2 @@
+Add a new :meth:`~multiprocessing.SimpleQueue.close` method to the
+:class:`~multiprocessing.SimpleQueue` class to explicitly close the queue.


### PR DESCRIPTION
Add a new close() method to multiprocessing.SimpleQueue to explicitly
close the queue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-30966](https://bugs.python.org/issue30966) -->
https://bugs.python.org/issue30966
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou