### PR TITLE
bpo-32117: Updated Simpsons names in docs

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -428,8 +428,8 @@ Other Language Changes
             lastname, *members = family.split()
             return lastname.upper(), *members
 
-    >>> parse('simpsons homer marge bart lisa sally')
-    ('SIMPSONS', 'homer', 'marge', 'bart', 'lisa', 'sally')
+    >>> parse('simpsons homer marge bart lisa maggie')
+    ('SIMPSONS', 'homer', 'marge', 'bart', 'lisa', 'maggie')
 
   (Contributed by David Cuthbert and Jordan Chapman in :issue:`32117`.)
 


### PR DESCRIPTION
`sally` is not a Simpsons character 

<!-- issue-number: [bpo-32117](https://bugs.python.org/issue32117) -->
https://bugs.python.org/issue32117
<!-- /issue-number -->


Automerge-Triggered-By: @gvanrossum