### PR TITLE
bpo-30966: concurrent.futures.Process.shutdown() closes queue

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -728,6 +728,8 @@ class ProcessPoolExecutor(_base.Executor):
         # objects that use file descriptors.
         self._executor_manager_thread = None
         self._call_queue = None
+        if self._result_queue is not None and wait:
+            self._result_queue.close()
         self._result_queue = None
         self._processes = None
 

--- a/Misc/NEWS.d/next/Library/2020-04-27-20-27-39.bpo-30966.Xmtlqu.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-27-20-27-39.bpo-30966.Xmtlqu.rst
@@ -1,0 +1,2 @@
+``Process.shutdown(wait=True)`` of :mod:`concurrent.futures` now closes
+explicitly the result queue.


### PR DESCRIPTION
Process.shutdown(wait=True) of concurrent.futures now closes
explicitly the result queue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-30966](https://bugs.python.org/issue30966) -->
https://bugs.python.org/issue30966
<!-- /issue-number -->
