### PR TITLE
gh-82909: Update PC/pyconfig.h to allow disabling pragma based auto-linking

### DIFF
--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -96,6 +96,13 @@ gives you access to spam's names, but does not create a separate copy.  On Unix,
 linking with a library is more like ``from spam import *``; it does create a
 separate copy.
 
+.. c:macro:: PY_NO_LINK_LIB
+
+   Turn off the implicit, ``#pragma``-based linkage with the Python
+   library, performed inside CPython header files.
+
+   .. versionadded:: 3.14
+
 
 .. _win-dlls:
 
@@ -108,21 +115,46 @@ Using DLLs in Practice
 Windows Python is built in Microsoft Visual C++; using other compilers may or
 may not work.  The rest of this section is MSVC++ specific.
 
-When creating DLLs in Windows, you must pass :file:`pythonXY.lib` to the linker.
-To build two DLLs, spam and ni (which uses C functions found in spam), you could
-use these commands::
+When creating DLLs in Windows, you can use the CPython library in two ways::
 
-   cl /LD /I/python/include spam.c ../libs/pythonXY.lib
-   cl /LD /I/python/include ni.c spam.lib ../libs/pythonXY.lib
+1. By default, inclusion of :file:`PC/pyconfig.h` directly or via
+   :file:`Python.h` triggers an implicit, configure-aware link with the
+   library.  The header file chooses :file:`pythonXY_d.lib` for Debug,
+   :file:`pythonXY.lib` for Release, and :file:`pythonX.lib` for Release with
+   the `Limited API <stable-application-binary-interface>`_ enabled.
 
-The first command created three files: :file:`spam.obj`, :file:`spam.dll` and
-:file:`spam.lib`.  :file:`Spam.dll` does not contain any Python functions (such
-as :c:func:`PyArg_ParseTuple`), but it does know how to find the Python code
-thanks to :file:`pythonXY.lib`.
+   To build two DLLs, spam and ni (which uses C functions found in spam), you
+   could use these commands::
 
-The second command created :file:`ni.dll` (and :file:`.obj` and :file:`.lib`),
-which knows how to find the necessary functions from spam, and also from the
-Python executable.
+       cl /LD /I/python/include spam.c
+       cl /LD /I/python/include ni.c spam.lib
+
+   The first command created three files: :file:`spam.obj`, :file:`spam.dll`
+   and :file:`spam.lib`.  :file:`Spam.dll` does not contain any Python
+   functions (such as :c:func:`PyArg_ParseTuple`), but it does know how to find
+   the Python code thanks to the implicitly linked :file:`pythonXY.lib`.
+
+   The second command created :file:`ni.dll` (and :file:`.obj` and
+   :file:`.lib`), which knows how to find the necessary functions from spam,
+   and also from the Python executable.
+
+2. Manually by defining :c:macro:`PY_NO_LINK_LIB` macro before including
+   :file:`Python.h`. You must pass :file:`pythonXY.lib` to the linker.
+
+   To build two DLLs, spam and ni (which uses C functions found in spam), you
+   could use these commands::
+
+      cl /LD /DPY_NO_LINK_LIB /I/python/include spam.c ../libs/pythonXY.lib
+      cl /LD /DPY_NO_LINK_LIB /I/python/include ni.c spam.lib ../libs/pythonXY.lib
+
+   The first command created three files: :file:`spam.obj`, :file:`spam.dll`
+   and :file:`spam.lib`.  :file:`Spam.dll` does not contain any Python
+   functions (such as :c:func:`PyArg_ParseTuple`), but it does know how to find
+   the Python code thanks to :file:`pythonXY.lib`.
+
+   The second command created :file:`ni.dll` (and :file:`.obj` and
+   :file:`.lib`), which knows how to find the necessary functions from spam,
+   and also from the Python executable.
 
 Not every identifier is exported to the lookup table.  If you want any other
 modules (including Python) to be able to see your identifiers, you have to say

--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -115,7 +115,7 @@ Using DLLs in Practice
 Windows Python is built in Microsoft Visual C++; using other compilers may or
 may not work.  The rest of this section is MSVC++ specific.
 
-When creating DLLs in Windows, you can use the CPython library in two ways::
+When creating DLLs in Windows, you can use the CPython library in two ways:
 
 1. By default, inclusion of :file:`PC/pyconfig.h` directly or via
    :file:`Python.h` triggers an implicit, configure-aware link with the

--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -96,7 +96,7 @@ gives you access to spam's names, but does not create a separate copy.  On Unix,
 linking with a library is more like ``from spam import *``; it does create a
 separate copy.
 
-.. c:macro:: PY_NO_LINK_LIB
+.. c:macro:: Py_NO_LINK_LIB
 
    Turn off the implicit, ``#pragma``-based linkage with the Python
    library, performed inside CPython header files.
@@ -138,14 +138,14 @@ When creating DLLs in Windows, you can use the CPython library in two ways::
    :file:`.lib`), which knows how to find the necessary functions from spam,
    and also from the Python executable.
 
-2. Manually by defining :c:macro:`PY_NO_LINK_LIB` macro before including
+2. Manually by defining :c:macro:`Py_NO_LINK_LIB` macro before including
    :file:`Python.h`. You must pass :file:`pythonXY.lib` to the linker.
 
    To build two DLLs, spam and ni (which uses C functions found in spam), you
    could use these commands::
 
-      cl /LD /DPY_NO_LINK_LIB /I/python/include spam.c ../libs/pythonXY.lib
-      cl /LD /DPY_NO_LINK_LIB /I/python/include ni.c spam.lib ../libs/pythonXY.lib
+      cl /LD /DPy_NO_LINK_LIB /I/python/include spam.c ../libs/pythonXY.lib
+      cl /LD /DPy_NO_LINK_LIB /I/python/include ni.c spam.lib ../libs/pythonXY.lib
 
    The first command created three files: :file:`spam.obj`, :file:`spam.dll`
    and :file:`spam.lib`.  :file:`Spam.dll` does not contain any Python

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1381,6 +1381,10 @@ Build changes
 * GNU Autoconf 2.72 is now required to generate :file:`configure`.
   (Contributed by Erlend Aasland in :gh:`115765`.)
 
+* ``#pragma``-based linking with ``python3*.lib`` can now be switched off
+  with :c:expr:`Py_NO_LINK_LIB`. (Contributed by Jean-Christophe
+  Fillion-Robin in :gh:`82909`.)
+
 .. _whatsnew314-pep761:
 
 PEP 761: Discontinuation of PGP signatures

--- a/Misc/NEWS.d/next/Build/2023-04-02-14-20-29.gh-issue-82909.LGcZJy.rst
+++ b/Misc/NEWS.d/next/Build/2023-04-02-14-20-29.gh-issue-82909.LGcZJy.rst
@@ -1,2 +1,2 @@
 ``#pragma``-based linking with ``python3*.lib`` can now be switched off with
-:c:expr:`PY_NO_LINK_LIB`. Patch by Jean-Christophe Fillion-Robin.
+:c:expr:`Py_NO_LINK_LIB`. Patch by Jean-Christophe Fillion-Robin.

--- a/Misc/NEWS.d/next/Build/2023-04-02-14-20-29.gh-issue-82909.LGcZJy.rst
+++ b/Misc/NEWS.d/next/Build/2023-04-02-14-20-29.gh-issue-82909.LGcZJy.rst
@@ -1,0 +1,2 @@
+``#pragma``-based linking with ``python3*.lib`` can now be switched off with
+:c:expr:`PY_NO_LINK_LIB`. Patch by Jean-Christophe Fillion-Robin.

--- a/PC/pyconfig.h.in
+++ b/PC/pyconfig.h.in
@@ -311,10 +311,10 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #ifdef MS_COREDLL
 #       if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
                 /* not building the core - must be an ext */
-#               if defined(_MSC_VER) && !defined(PY_NO_LINK_LIB)
+#               if defined(_MSC_VER) && !defined(Py_NO_LINK_LIB)
                         /* So MSVC users need not specify the .lib
                         file in their Makefile */
-                        /* Define PY_NO_LINK_LIB to build extension disabling pragma
+                        /* Define Py_NO_LINK_LIB to build extension disabling pragma
                         based auto-linking.
                         This is relevant when using build-system generator (e.g CMake) where
                         the linking is explicitly handled */
@@ -335,7 +335,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #                               pragma comment(lib,"python314.lib")
 #                       endif /* _DEBUG */
 #                       endif /* Py_GIL_DISABLED */
-#               endif /* _MSC_VER && !PY_NO_LINK_LIB */
+#               endif /* _MSC_VER && !Py_NO_LINK_LIB */
 #       endif /* Py_BUILD_CORE */
 #endif /* MS_COREDLL */
 

--- a/PC/pyconfig.h.in
+++ b/PC/pyconfig.h.in
@@ -311,9 +311,13 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #ifdef MS_COREDLL
 #       if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
                 /* not building the core - must be an ext */
-#               if defined(_MSC_VER)
+#               if defined(_MSC_VER) && !defined(PY_NO_LINK_LIB)
                         /* So MSVC users need not specify the .lib
                         file in their Makefile */
+                        /* Define PY_NO_LINK_LIB to build extension disabling pragma
+                        based auto-linking.
+                        This is relevant when using build-system generator (e.g CMake) where
+                        the linking is explicitly handled */
 #                       if defined(Py_GIL_DISABLED)
 #                       if defined(_DEBUG)
 #                               pragma comment(lib,"python314t_d.lib")
@@ -331,7 +335,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #                               pragma comment(lib,"python314.lib")
 #                       endif /* _DEBUG */
 #                       endif /* Py_GIL_DISABLED */
-#               endif /* _MSC_VER */
+#               endif /* _MSC_VER && !PY_NO_LINK_LIB */
 #       endif /* Py_BUILD_CORE */
 #endif /* MS_COREDLL */
 


### PR DESCRIPTION
Define `PY_NO_LINK_LIB` to build extension disabling pragma based
auto-linking. This is relevant when using build-system generator
(e.g CMake) where the linking is explicitly handled

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-38728](https://bugs.python.org/issue38728) -->
https://bugs.python.org/issue38728
<!-- /issue-number -->


<!-- gh-issue-number: gh-82909 -->
* Issue: gh-82909
<!-- /gh-issue-number -->
