### PR TITLE
bpo-40417: Fix deprecation warning in PyImport_ReloadModule

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-01-19-04-52.bpo-40417.Sti2lJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-01-19-04-52.bpo-40417.Sti2lJ.rst
@@ -1,0 +1,1 @@
+Fix "imp" module deprecation warning when PyImport_ReloadModule is called

--- a/Misc/NEWS.d/next/Core and Builtins/2020-05-01-19-04-52.bpo-40417.Sti2lJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-05-01-19-04-52.bpo-40417.Sti2lJ.rst
@@ -1,1 +1,1 @@
-Fix "imp" module deprecation warning when PyImport_ReloadModule is called
+Fix imp module deprecation warning when PyImport_ReloadModule is called. Patch by Robert Rouhani.

--- a/Python/import.c
+++ b/Python/import.c
@@ -1980,20 +1980,20 @@ PyImport_ReloadModule(PyObject *m)
     _Py_IDENTIFIER(importlib);
     _Py_IDENTIFIER(reload);
     PyObject *reloaded_module = NULL;
-    PyObject *imp = _PyImport_GetModuleId(&PyId_importlib);
-    if (imp == NULL) {
+    PyObject *importlib = _PyImport_GetModuleId(&PyId_importlib);
+    if (importlib == NULL) {
         if (PyErr_Occurred()) {
             return NULL;
         }
 
-        imp = PyImport_ImportModule("importlib");
-        if (imp == NULL) {
+        importlib = PyImport_ImportModule("importlib");
+        if (importlib == NULL) {
             return NULL;
         }
     }
 
-    reloaded_module = _PyObject_CallMethodIdOneArg(imp, &PyId_reload, m);
-    Py_DECREF(imp);
+    reloaded_module = _PyObject_CallMethodIdOneArg(importlib, &PyId_reload, m);
+    Py_DECREF(importlib);
     return reloaded_module;
 }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -1977,16 +1977,16 @@ PyImport_ImportModuleLevel(const char *name, PyObject *globals, PyObject *locals
 PyObject *
 PyImport_ReloadModule(PyObject *m)
 {
-    _Py_IDENTIFIER(imp);
+    _Py_IDENTIFIER(importlib);
     _Py_IDENTIFIER(reload);
     PyObject *reloaded_module = NULL;
-    PyObject *imp = _PyImport_GetModuleId(&PyId_imp);
+    PyObject *imp = _PyImport_GetModuleId(&PyId_importlib);
     if (imp == NULL) {
         if (PyErr_Occurred()) {
             return NULL;
         }
 
-        imp = PyImport_ImportModule("imp");
+        imp = PyImport_ImportModule("importlib");
         if (imp == NULL) {
             return NULL;
         }


### PR DESCRIPTION
I can add another commit with the new test case I wrote to verify that the warning was being printed before my change, stopped printing after my change, and that the function does not return null after my change.

https://bugs.python.org/issue40417


<!-- issue-number: [bpo-40417](https://bugs.python.org/issue40417) -->
https://bugs.python.org/issue40417
<!-- /issue-number -->


Automerge-Triggered-By: @brettcannon