### PR TITLE
bpo-40419: timeit CLI docs now mention 1,2,5,10,... trials instead of powers of 10

### DIFF
--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -251,7 +251,8 @@ quotes and using leading spaces.  Multiple :option:`-s` options are treated
 similarly.
 
 If :option:`-n` is not given, a suitable number of loops is calculated by trying
-successive powers of 10 until the total time is at least 0.2 seconds.
+increasing numbers from the sequence 1, 2, 5, 10, 20, 50, ... until the total
+time is at least 0.2 seconds.
 
 :func:`default_timer` measurements can be affected by other programs running on
 the same machine, so the best thing to do when accurate timing is necessary is

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -29,7 +29,8 @@ argument in quotes and using leading spaces.  Multiple -s options are
 treated similarly.
 
 If -n is not given, a suitable number of loops is calculated by trying
-successive powers of 10 until the total time is at least 0.2 seconds.
+increasing numbers from the sequence 1, 2, 5, 10, 20, 50, ... until the
+total time is at least 0.2 seconds.
 
 Note: there is a certain baseline overhead associated with executing a
 pass statement.  It differs between versions.  The code here doesn't try


### PR DESCRIPTION
Docs updated both in the `Lib/timeit.py` and `Doc/library/timeit.rst` files

<!-- issue-number: [bpo-40419](https://bugs.python.org/issue40419) -->
https://bugs.python.org/issue40419
<!-- /issue-number -->
