### PR TITLE
bpo-40421: Add PyFrame_GetCode() function

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1074,8 +1074,10 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
 
 .. c:function:: PyFrameObject* PyThreadState_GetFrame(PyThreadState *tstate)
 
-   Get the current frame of the Python thread state *tstate*. It can be
-   ``NULL`` if no frame is currently executing.
+   Get a borrowed reference to the current frame of the Python thread state
+   *tstate*.
+
+   Return ``NULL`` if no frame is currently executing.
 
    See also :c:func:`PyEval_GetFrame`.
 

--- a/Doc/c-api/reflection.rst
+++ b/Doc/c-api/reflection.rst
@@ -31,6 +31,15 @@ Reflection
    See also :c:func:`PyThreadState_GetFrame`.
 
 
+.. c:function:: int PyFrame_GetCode(PyFrameObject *frame)
+
+   Return a borrowed reference to the *frame* code.
+
+   *frame* must not be ``NULL``.
+
+   .. versionadded:: 3.9
+
+
 .. c:function:: int PyFrame_GetLineNumber(PyFrameObject *frame)
 
    Return the line number that *frame* is currently executing.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -537,6 +537,10 @@ Optimizations
 Build and C API Changes
 =======================
 
+* New :c:func:`PyFrame_GetCode` function: return a borrowed reference to the
+  frame code.
+  (Contributed by Victor Stinner in :issue:`40421`.)
+
 * Add :c:func:`PyFrame_GetLineNumber` to the limited C API.
   (Contributed by Victor Stinner in :issue:`40421`.)
 

--- a/Include/pyframe.h
+++ b/Include/pyframe.h
@@ -14,6 +14,8 @@ typedef struct _frame PyFrameObject;
 /* Return the line of code the frame is currently executing. */
 PyAPI_FUNC(int) PyFrame_GetLineNumber(PyFrameObject *);
 
+PyAPI_FUNC(PyCodeObject *) PyFrame_GetCode(PyFrameObject *frame);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C API/2020-04-28-15-47-58.bpo-40421.ZIzOV0.rst
+++ b/Misc/NEWS.d/next/C API/2020-04-28-15-47-58.bpo-40421.ZIzOV0.rst
@@ -1,0 +1,2 @@
+New :c:func:`PyFrame_GetCode` function: return a borrowed reference to the
+frame code.

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -1,5 +1,4 @@
 #include "Python.h"
-#include "frameobject.h"
 #include "rotatingtree.h"
 
 /************************************************************/
@@ -388,14 +387,16 @@ profiler_callback(PyObject *self, PyFrameObject *frame, int what,
 
     /* the 'frame' of a called function is about to start its execution */
     case PyTrace_CALL:
-        ptrace_enter_call(self, (void *)frame->f_code,
-                                (PyObject *)frame->f_code);
+    {
+        PyCodeObject *code = PyFrame_GetCode(frame);
+        ptrace_enter_call(self, (void *)code, (PyObject *)code);
         break;
+    }
 
     /* the 'frame' of a called function is about to finish
        (either normally or with an exception) */
     case PyTrace_RETURN:
-        ptrace_leave_call(self, (void *)frame->f_code);
+        ptrace_leave_call(self, (void *)PyFrame_GetCode(frame));
         break;
 
     /* case PyTrace_EXCEPTION:

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -346,7 +346,7 @@ tracemalloc_get_frame(PyFrameObject *pyframe, frame_t *frame)
         lineno = 0;
     frame->lineno = (unsigned int)lineno;
 
-    code = pyframe->f_code;
+    code = PyFrame_GetCode(pyframe);
     if (code == NULL) {
 #ifdef TRACE_DEBUG
         tracemalloc_error("failed to get the code object of the frame");

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1222,3 +1222,10 @@ _PyFrame_DebugMallocStats(FILE *out)
                            numfree, sizeof(PyFrameObject));
 }
 
+
+PyCodeObject *
+PyFrame_GetCode(PyFrameObject *frame)
+{
+    assert(frame != NULL);
+    return frame->f_code;
+}

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8033,13 +8033,13 @@ super_init(PyObject *self, PyObject *args, PyObject *kwds)
         PyFrameObject *f;
         PyCodeObject *co;
         Py_ssize_t i, n;
-        f = _PyThreadState_GET()->frame;
+        f = PyThreadState_GetFrame(_PyThreadState_GET());
         if (f == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
                             "super(): no current frame");
             return -1;
         }
-        co = f->f_code;
+        co = PyFrame_GetCode(f);
         if (co == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
                             "super(): no code object");

--- a/Python/import.c
+++ b/Python/import.c
@@ -15,7 +15,6 @@
 #include "errcode.h"
 #include "marshal.h"
 #include "code.h"
-#include "frameobject.h"
 #include "importdl.h"
 #include "pydtrace.h"
 
@@ -1536,7 +1535,7 @@ remove_importlib_frames(PyThreadState *tstate)
         PyTracebackObject *traceback = (PyTracebackObject *)tb;
         PyObject *next = (PyObject *) traceback->tb_next;
         PyFrameObject *frame = traceback->tb_frame;
-        PyCodeObject *code = frame->f_code;
+        PyCodeObject *code = PyFrame_GetCode(frame);
         int now_in_importlib;
 
         assert(PyTraceBack_Check(tb));

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -560,24 +560,23 @@ tb_printinternal(PyTracebackObject *tb, PyObject *f, long limit)
         tb = tb->tb_next;
     }
     while (tb != NULL && err == 0) {
+        PyCodeObject *code = PyFrame_GetCode(tb->tb_frame);
         if (last_file == NULL ||
-            tb->tb_frame->f_code->co_filename != last_file ||
+            code->co_filename != last_file ||
             last_line == -1 || tb->tb_lineno != last_line ||
-            last_name == NULL || tb->tb_frame->f_code->co_name != last_name) {
+            last_name == NULL || code->co_name != last_name) {
             if (cnt > TB_RECURSIVE_CUTOFF) {
                 err = tb_print_line_repeated(f, cnt);
             }
-            last_file = tb->tb_frame->f_code->co_filename;
+            last_file = code->co_filename;
             last_line = tb->tb_lineno;
-            last_name = tb->tb_frame->f_code->co_name;
+            last_name = code->co_name;
             cnt = 0;
         }
         cnt++;
         if (err == 0 && cnt <= TB_RECURSIVE_CUTOFF) {
-            err = tb_displayline(f,
-                                 tb->tb_frame->f_code->co_filename,
-                                 tb->tb_lineno,
-                                 tb->tb_frame->f_code->co_name);
+            err = tb_displayline(f, code->co_filename, tb->tb_lineno,
+                                 code->co_name);
             if (err == 0) {
                 err = PyErr_CheckSignals();
             }
@@ -756,7 +755,7 @@ dump_frame(int fd, PyFrameObject *frame)
     PyCodeObject *code;
     int lineno;
 
-    code = frame->f_code;
+    code = PyFrame_GetCode(frame);
     PUTS(fd, "  File ");
     if (code != NULL && code->co_filename != NULL
         && PyUnicode_Check(code->co_filename))


### PR DESCRIPTION
PyFrame_GetCode(frame): return a borrowed reference to the frame
code.

Replace frame->f_code with PyFrame_GetCode(frame) in most code,
except in frameobject.c and ceval.c.

Also add PyFrame_GetLineNumber() to the limited C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40421](https://bugs.python.org/issue40421) -->
https://bugs.python.org/issue40421
<!-- /issue-number -->
