### PR TITLE
bpo-39995: Fix concurrent.futures._ThreadWakeup race condition

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-04-28-17-57-47.bpo-39995.4cGpi8.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-28-17-57-47.bpo-39995.4cGpi8.rst
@@ -1,0 +1,3 @@
+Fix a race condition in concurrent.futures._ThreadWakeup: it now uses an
+internal threading event to ensure that the pipe is not closed while sending or
+receiving bytes. Patch by Kyle Stanley and Victor Stinner.


### PR DESCRIPTION
Fix a race condition in concurrent.futures._ThreadWakeup: it now uses
an internal threading event to ensure pipe is not closed while
sending or receiving bytes.

Co-Authored-by: Kyle Stanley <aeros167@gmail.com>


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39995](https://bugs.python.org/issue39995) -->
https://bugs.python.org/issue39995
<!-- /issue-number -->
