### PR TITLE
bpo-40424: allow makexp_aix to manage parallel build requests

### DIFF
--- a/Misc/NEWS.d/next/Build/2020-06-02-21-35-11.bpo-40424.lns33S.rst
+++ b/Misc/NEWS.d/next/Build/2020-06-02-21-35-11.bpo-40424.lns33S.rst
@@ -1,0 +1,2 @@
+AIX Build: fix a race condition with `makexp_aix` when calling make with -jNN.
+Patch by M. Felt

--- a/Misc/NEWS.d/next/Build/2020-06-02-21-35-11.bpo-40424.lns33S.rst
+++ b/Misc/NEWS.d/next/Build/2020-06-02-21-35-11.bpo-40424.lns33S.rst
@@ -1,2 +1,6 @@
-AIX Build: fix a race condition with `makexp_aix` when calling make with -jNN.
-Patch by M. Felt
+Fix inter-mixed output when run in a multi-job build caused by the first
+job overwriting the file with the first echo and all subsequent echos appending
+to the end. This causes the symbol list to be defined twice leading to errant
+"ld: 0711-224 WARNING: Duplicate symbol" messages from the linker.
+
+Patch by M. Felt and Kevin (kadler).

--- a/Modules/makexp_aix
+++ b/Modules/makexp_aix
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # ===========================================================================
 # FILE:         makexp_aix
 # TYPE:         standalone executable
-# SYSTEM:	AIX
+# SYSTEM: AIX 3.2.5 and AIX 4
 #
 # DESCRIPTION:  This script creates an export list of ALL global symbols
 #               from a list of object or archive files.
@@ -18,11 +18,8 @@
 #                      <InputFile> is an object (.o) or an archive file (.a).
 #
 # HISTORY:
-#               15-Apr-2020 -- Do not run in parallel to same expFileName
-#               Michael Felt
-#
-#		3-Apr-1998  -- remove C++ entries of the form Class::method
-#		Vladimir Marangozov
+#  3-Apr-1998  -- remove C++ entries of the form Class::method
+#  Vladimir Marangozov
 #
 #               1-Jul-1996  -- added header information
 #               Vladimir Marangozov
@@ -35,33 +32,18 @@
 expFileName=$1
 toAppendStr=$2
 shift; shift;
-inputFiles=$*
 
-# if lock file exists - file is already being made.
-# wait for lock file to be removed, and then exit
-if [[ -e ${expFileName}.lck ]]; then
-  while [[ -e ${expFileName}.lck ]]; do
-     sleep 3
-  done
-  exit 0
-else
-  touch ${expFileName}.lck
-fi
-
-automsg="Generated automatically by makexp_aix"
-notemsg="NOTE: lists _all_ global symbols defined in the above file(s)."
-curwdir=`pwd`
-
+# run in a sub-shell so the output is written atomically
+(
 # Create the export file and setup the header info
-echo "#!"$toAppendStr > $expFileName
-echo "*" >> $expFileName
-echo "* $automsg  (`date -u`)" >> $expFileName
-echo "*" >> $expFileName
-echo "* Base Directory: $curwdir" >> $expFileName
-echo "* Input File(s) : $inputFiles" >> $expFileName
-echo "*" >> $expFileName
-echo "* $notemsg" >> $expFileName
-echo "*" >> $expFileName
+echo "#!"$toAppendStr
+echo "*"
+echo "* Generated automatically by makexp_aix  (`date -u`)"
+echo "*"
+echo "* Input File(s) : $*"
+echo "*"
+echo "* NOTE: lists _all_ global symbols defined in the above file(s)."
+echo "*"
 
 # Extract the symbol list using 'nm' which produces quite
 # different output under AIX 4 than under AIX 3.2.5.
@@ -86,13 +68,7 @@ echo "*" >> $expFileName
 # 7. Eliminate all entries containing two colons, like Class::method
 #
 
-# Use -X32_64 if it appears to be implemented in this version of 'nm'.
-NM=/usr/ccs/bin/nm
-xopt=-X32_64
-$NM -e $xopt $1 >/dev/null 2>&1 || xopt=""
-
-$NM -Bex $xopt $inputFiles					\
-| sed -e '/ [^BDT] /d' -e '/\./d' -e 's/.* [BDT] //' -e '/::/d'	\
-| sort | uniq >> $expFileName
-
-rm ${expFileName}.lck
+/usr/bin/nm -Bex -X32_64 $* \
+| sed -e '/ [^BDT] /d' -e '/\./d' -e 's/.* [BDT] //' -e '/::/d' \
+| sort | uniq
+) > $expFileName

--- a/Modules/makexp_aix
+++ b/Modules/makexp_aix
@@ -3,7 +3,7 @@
 # ===========================================================================
 # FILE:         makexp_aix
 # TYPE:         standalone executable
-# SYSTEM:	AIX 3.2.5 and AIX 4
+# SYSTEM:	AIX
 #
 # DESCRIPTION:  This script creates an export list of ALL global symbols
 #               from a list of object or archive files.
@@ -18,6 +18,9 @@
 #                      <InputFile> is an object (.o) or an archive file (.a).
 #
 # HISTORY:
+#               15-Apr-2020 -- Do not run in parallel to same expFileName
+#               Michael Felt
+#
 #		3-Apr-1998  -- remove C++ entries of the form Class::method
 #		Vladimir Marangozov
 #
@@ -33,6 +36,18 @@ expFileName=$1
 toAppendStr=$2
 shift; shift;
 inputFiles=$*
+
+# if lock file exists - file is already being made.
+# wait for lock file to be removed, and then exit
+if [[ -e ${expFileName}.lck ]]; then
+  while [[ -e ${expFileName}.lck ]]; do
+     sleep 3
+  done
+  exit 0
+else
+  touch ${expFileName}.lck
+fi
+
 automsg="Generated automatically by makexp_aix"
 notemsg="NOTE: lists _all_ global symbols defined in the above file(s)."
 curwdir=`pwd`
@@ -79,3 +94,5 @@ $NM -e $xopt $1 >/dev/null 2>&1 || xopt=""
 $NM -Bex $xopt $inputFiles					\
 | sed -e '/ [^BDT] /d' -e '/\./d' -e 's/.* [BDT] //' -e '/::/d'	\
 | sort | uniq >> $expFileName
+
+rm ${expFileName}.lck


### PR DESCRIPTION
Make the build utility `makexp_aix` able to deal with parallel build `make (-jNN)`
Patch by M. Felt.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40424](https://bugs.python.org/issue40424) -->
https://bugs.python.org/issue40424
<!-- /issue-number -->
