### PR TITLE
bpo-40421: Add PyFrame_GetLastInstr() function

### DIFF
--- a/Doc/c-api/reflection.rst
+++ b/Doc/c-api/reflection.rst
@@ -40,6 +40,17 @@ Reflection
    .. versionadded:: 3.9
 
 
+.. c:function:: int PyFrame_GetLastInstr(PyFrameObject *frame)
+
+   Get the index of last attempted instruction in bytecode of *frame*.
+
+   Return ``-1`` for new frame (not run yet).
+
+   *frame* must not be ``NULL``.
+
+   .. versionadded:: 3.9
+
+
 .. c:function:: int PyFrame_GetLineNumber(PyFrameObject *frame)
 
    Return the line number that *frame* is currently executing.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -539,6 +539,8 @@ Build and C API Changes
 
 * New :c:func:`PyFrame_GetCode` function: return a borrowed reference to the
   frame code.
+  New :c:func:`PyFrame_GetLastInstr` function: get the index of last attempted
+  instruction in bytecode of a frame.
   (Contributed by Victor Stinner in :issue:`40421`.)
 
 * Add :c:func:`PyFrame_GetLineNumber` to the limited C API.

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -79,6 +79,8 @@ PyAPI_FUNC(int) PyFrame_ClearFreeList(void);
 
 PyAPI_FUNC(void) _PyFrame_DebugMallocStats(FILE *out);
 
+PyAPI_FUNC(int) PyFrame_GetLastInstr(PyFrameObject *frame);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C API/2020-04-28-19-25-20.bpo-40421.iHT9OE.rst
+++ b/Misc/NEWS.d/next/C API/2020-04-28-19-25-20.bpo-40421.iHT9OE.rst
@@ -1,0 +1,2 @@
+New :c:func:`PyFrame_GetLastInstr` function: get the index of last attempted
+instruction in bytecode of a frame.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1229,3 +1229,11 @@ PyFrame_GetCode(PyFrameObject *frame)
     assert(frame != NULL);
     return frame->f_code;
 }
+
+
+int
+PyFrame_GetLastInstr(PyFrameObject *frame)
+{
+    assert(frame != NULL);
+    return frame->f_lasti;
+}

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -233,7 +233,8 @@ _PyTraceBack_FromFrame(PyObject *tb_next, PyFrameObject *frame)
     assert(tb_next == NULL || PyTraceBack_Check(tb_next));
     assert(frame != NULL);
 
-    return tb_create_raw((PyTracebackObject *)tb_next, frame, frame->f_lasti,
+    return tb_create_raw((PyTracebackObject *)tb_next, frame,
+                         PyFrame_GetLastInstr(frame),
                          PyFrame_GetLineNumber(frame));
 }
 
@@ -767,8 +768,7 @@ dump_frame(int fd, PyFrameObject *frame)
         PUTS(fd, "???");
     }
 
-    /* PyFrame_GetLineNumber() was introduced in Python 2.7.0 and 3.2.0 */
-    lineno = PyCode_Addr2Line(code, frame->f_lasti);
+    lineno = PyCode_Addr2Line(code, PyFrame_GetLastInstr(frame));
     PUTS(fd, ", line ");
     if (lineno >= 0) {
         _Py_DumpDecimal(fd, (unsigned long)lineno);


### PR DESCRIPTION
New PyFrame_GetLastInstr() function: get the index of last attempted
instruction in bytecode of a frame.

Replace frame->f_lasti with PyFrame_GetLastInstr(frame).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40421](https://bugs.python.org/issue40421) -->
https://bugs.python.org/issue40421
<!-- /issue-number -->
