### PR TITLE
bpo-40421: Add PyFrame_GetBack() function

### DIFF
--- a/Doc/c-api/reflection.rst
+++ b/Doc/c-api/reflection.rst
@@ -31,6 +31,17 @@ Reflection
    See also :c:func:`PyThreadState_GetFrame`.
 
 
+.. c:function:: int PyFrame_GetBack(PyFrameObject *frame)
+
+   Get the *frame* next outer frame.
+
+   Return a strong reference, or ``NULL`` if *frame* has no outer frame.
+
+   *frame* must not be ``NULL``.
+
+   .. versionadded:: 3.9
+
+
 .. c:function:: int PyFrame_GetCode(PyFrameObject *frame)
 
    Get the *frame* code.

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -538,6 +538,7 @@ Build and C API Changes
 =======================
 
 * New :c:func:`PyFrame_GetCode` function: get a frame code.
+  New :c:func:`PyFrame_GetBack` function: get the frame next outer frame.
   (Contributed by Victor Stinner in :issue:`40421`.)
 
 * Add :c:func:`PyFrame_GetLineNumber` to the limited C API.

--- a/Include/cpython/frameobject.h
+++ b/Include/cpython/frameobject.h
@@ -77,6 +77,8 @@ PyAPI_FUNC(void) PyFrame_FastToLocals(PyFrameObject *);
 
 PyAPI_FUNC(void) _PyFrame_DebugMallocStats(FILE *out);
 
+PyAPI_FUNC(PyFrameObject *) PyFrame_GetBack(PyFrameObject *frame);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C API/2020-04-28-19-29-36.bpo-40421.3uIIaB.rst
+++ b/Misc/NEWS.d/next/C API/2020-04-28-19-29-36.bpo-40421.3uIIaB.rst
@@ -1,0 +1,1 @@
+New :c:func:`PyFrame_GetBack` function: get the frame next outer frame.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1237,3 +1237,13 @@ PyFrame_GetCode(PyFrameObject *frame)
     Py_INCREF(code);
     return code;
 }
+
+
+PyFrameObject*
+PyFrame_GetBack(PyFrameObject *frame)
+{
+    assert(frame != NULL);
+    PyFrameObject *back = frame->f_back;
+    Py_XINCREF(back);
+    return back;
+}


### PR DESCRIPTION
New PyFrame_GetBack() function: return a borrowed reference to the
frame next outer frame.

Replace frame->f_back with PyFrame_GetBack(frame) in most code but
frameobject.c, ceval.c and genobject.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40421](https://bugs.python.org/issue40421) -->
https://bugs.python.org/issue40421
<!-- /issue-number -->
