### PR TITLE
Change 'exception happened' to 'exception occurred' in two places

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -67,7 +67,7 @@ The rest of the line provides detail based on the type of exception and what
 caused it.
 
 The preceding part of the error message shows the context where the exception
-happened, in the form of a stack traceback. In general it contains a stack
+occurred, in the form of a stack traceback. In general it contains a stack
 traceback listing source lines; however, it will not display lines read from
 standard input.
 

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -374,7 +374,7 @@ class BaseServer:
 
         """
         print('-'*40, file=sys.stderr)
-        print('Exception happened during processing of request from',
+        print('Exception occurred during processing of request from',
             client_address, file=sys.stderr)
         import traceback
         traceback.print_exc()


### PR DESCRIPTION
Justification: The phrase "Exception happened" occurs [twice](https://github.com/python/cpython/search?q=%22Exception+happened%22&unscoped_q=%22Exception+happened%22) in the code base, while "Exception occurred" occurs [30 times](https://github.com/python/cpython/search?q=%22Exception+occurred%22&type=Code).

Since this is really only a cosmetic change akin to a typo fix, I didn't file an issue.