### PR TITLE
bpo-40334: Fix shifting of nested fstrings

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -207,8 +207,7 @@ f'{a * f"-{x()}-"}'"""
         call = binop.right.values[1].value
         self.assertEqual(type(call), ast.Call)
         self.assertEqual(call.lineno, 3)
-        if support.use_old_parser():
-            self.assertEqual(call.col_offset, 11)
+        self.assertEqual(call.col_offset, 11)
 
     def test_ast_line_numbers_duplicate_expression(self):
         """Duplicate expression

--- a/Parser/pegen/parse_string.c
+++ b/Parser/pegen/parse_string.c
@@ -449,6 +449,15 @@ static void fstring_shift_children_locations(expr_ty n, int lineno, int col_offs
         case Tuple_kind:
             fstring_shift_seq_locations(n, n->v.Tuple.elts, lineno, col_offset);
             break;
+        case JoinedStr_kind:
+            fstring_shift_seq_locations(n, n->v.JoinedStr.values, lineno, col_offset);
+            break;
+        case FormattedValue_kind:
+            shift_expr(n, n->v.FormattedValue.value, lineno, col_offset);
+            if (n->v.FormattedValue.format_spec) {
+                shift_expr(n, n->v.FormattedValue.format_spec, lineno, col_offset);
+            }
+            break;
         default:
             return;
     }


### PR DESCRIPTION
`JoinedStr`s and `FormattedValue`s also need to be shifted, in order
to correctly compute the location of nested fstrings.

Closes we-like-parsers/cpython#114.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
