### PR TITLE
bpo-40334: Disallow invalid single statements in the new parser

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -501,7 +501,6 @@ if 1:
         self.compile_single("if x:\n   f(x)\nelse:\n   g(x)")
         self.compile_single("class T:\n   pass")
 
-    @support.skip_if_new_parser('Pegen does not disallow multiline single stmts')
     def test_bad_single_statement(self):
         self.assertInvalidSingle('1\n2')
         self.assertInvalidSingle('def f(): pass')

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -912,10 +912,24 @@ _PyPegen_number_token(Parser *p)
 }
 
 static int // bool
+newline_in_string(Parser *p, const char *cur)
+{
+    for (char c = *cur; cur >= p->tok->buf; c = *--cur) {
+        if (c == '\'' || c == '"') {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int // bool
 bad_single_statement(Parser *p)
 {
     const char *cur = strchr(p->tok->buf, '\n');
-    if (!cur) {
+
+    /* Newlines are allowed if preceded by a line continuation character
+       or if they appear inside a string. */
+    if (!cur || *(cur - 1) == '\\' || newline_in_string(p, cur)) {
         return 0;
     }
     char c = *cur;

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -938,16 +938,18 @@ bad_single_statement(Parser *p)
         while (c == ' ' || c == '\t' || c == '\n' || c == '\014')
             c = *++cur;
 
-        if (!c)
+        if (!c) {
             return 0;
+        }
 
         if (c != '#') {
             return 1;
         }
 
         /* Suck up comment. */
-        while (c && c != '\n')
+        while (c && c != '\n') {
             c = *++cur;
+        }
     }
 }
 

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -935,8 +935,9 @@ bad_single_statement(Parser *p)
     char c = *cur;
 
     for (;;) {
-        while (c == ' ' || c == '\t' || c == '\n' || c == '\014')
+        while (c == ' ' || c == '\t' || c == '\n' || c == '\014') {
             c = *++cur;
+        }
 
         if (!c) {
             return 0;

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -922,6 +922,9 @@ newline_in_string(Parser *p, const char *cur)
     return 0;
 }
 
+/* Check that the source for a single input statement really is a single
+   statement by looking at what is left in the buffer after parsing.
+   Trailing whitespace and comments are OK. */
 static int // bool
 bad_single_statement(Parser *p)
 {


### PR DESCRIPTION
After parsing is done, a single statement has to be checked for
additional lines and a `SyntaxError` must be raised, in case there
are any.

Closes we-like-parsers/cpython#99.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
