### PR TITLE
bpo-40431: Fix syntax typo in turtledemo

### DIFF
--- a/Lib/turtledemo/__main__.py
+++ b/Lib/turtledemo/__main__.py
@@ -272,7 +272,7 @@ class DemoWindow(object):
         self.stop_btn.config(state=stop,
                              bg="#d00" if stop == NORMAL else "#fca")
         self.clear_btn.config(state=clear,
-                              bg="#d00" if clear == NORMAL else"#fca")
+                              bg="#d00" if clear == NORMAL else "#fca")
         self.output_lbl.config(text=txt, fg=color)
 
     def makeLoadDemoMenu(self, master):

--- a/Misc/NEWS.d/next/Tools-Demos/2020-04-29-01-32-17.bpo-40431.B_aEZ0.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-04-29-01-32-17.bpo-40431.B_aEZ0.rst
@@ -1,0 +1,1 @@
+Fix a syntax typo in ``turtledemo`` that now raises a ``SyntaxError``.


### PR DESCRIPTION
    ***   File "/usr/lib64/python3.9/turtledemo/__main__.py", line 275
        bg="#d00" if clear == NORMAL else"#fca")
                                        ^
    SyntaxError: invalid string prefix

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40431](https://bugs.python.org/issue40431) -->
https://bugs.python.org/issue40431
<!-- /issue-number -->
