### PR TITLE
bpo-40334: Fix test_peg_parser to actually use the old parser

### DIFF
--- a/Lib/test/test_peg_parser.py
+++ b/Lib/test/test_peg_parser.py
@@ -699,7 +699,7 @@ class ASTGenerationTest(unittest.TestCase):
         self.maxDiff = None
         for source in TEST_SOURCES:
             actual_ast = peg_parser.parse_string(source)
-            expected_ast = ast.parse(source)
+            expected_ast = peg_parser.parse_string(source, oldparser=True)
             self.assertEqual(
                 ast.dump(actual_ast, include_attributes=True),
                 ast.dump(expected_ast, include_attributes=True),
@@ -721,12 +721,11 @@ class ASTGenerationTest(unittest.TestCase):
                 f"Actual error message does not match expexted for {source}"
             )
 
-    @support.skip_if_new_parser("This tests nothing for now, since compile uses pegen as well")
     @unittest.expectedFailure
     def test_correct_but_known_to_fail_ast_generation_on_source_files(self) -> None:
         for source in GOOD_BUT_FAIL_SOURCES:
             actual_ast = peg_parser.parse_string(source)
-            expected_ast = ast.parse(source)
+            expected_ast = peg_parser.parse_string(source, oldparser=True)
             self.assertEqual(
                 ast.dump(actual_ast, include_attributes=True),
                 ast.dump(expected_ast, include_attributes=True),
@@ -736,7 +735,7 @@ class ASTGenerationTest(unittest.TestCase):
     def test_correct_ast_generation_without_pos_info(self) -> None:
         for source in GOOD_BUT_FAIL_SOURCES:
             actual_ast = peg_parser.parse_string(source)
-            expected_ast = ast.parse(source)
+            expected_ast = peg_parser.parse_string(source, oldparser=True)
             self.assertEqual(
                 ast.dump(actual_ast),
                 ast.dump(expected_ast),
@@ -752,7 +751,7 @@ class ASTGenerationTest(unittest.TestCase):
     def test_correct_ast_generatrion_eval(self) -> None:
         for source in EXPRESSIONS_TEST_SOURCES:
             actual_ast = peg_parser.parse_string(source, mode='eval')
-            expected_ast = ast.parse(source, mode='eval')
+            expected_ast = peg_parser.parse_string(source, mode='eval', oldparser=True)
             self.assertEqual(
                 ast.dump(actual_ast, include_attributes=True),
                 ast.dump(expected_ast, include_attributes=True),

--- a/Modules/_peg_parser.c
+++ b/Modules/_peg_parser.c
@@ -45,11 +45,13 @@ error:
 PyObject *
 _Py_parse_string(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    static char *keywords[] = {"string", "mode", NULL};
+    static char *keywords[] = {"string", "mode", "oldparser", NULL};
     char *the_string;
     char *mode_str = "exec";
+    int oldparser = 0;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|s", keywords, &the_string, &mode_str)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|sp", keywords,
+            &the_string, &mode_str, &oldparser)) {
         return NULL;
     }
 
@@ -77,7 +79,13 @@ _Py_parse_string(PyObject *self, PyObject *args, PyObject *kwds)
     PyCompilerFlags flags = _PyCompilerFlags_INIT;
     flags.cf_flags = PyCF_IGNORE_COOKIE;
 
-    mod_ty res = PyPegen_ASTFromString(the_string, mode, &flags, arena);
+    mod_ty res;
+    if (oldparser) {
+        res = PyParser_ASTFromString(the_string, "<string>", mode, &flags, arena);
+    }
+    else {
+        res = PyPegen_ASTFromString(the_string, mode, &flags, arena);
+    }
     if (res == NULL) {
         goto error;
     }


### PR DESCRIPTION
Now that the default parser is the new PEG parser, ast.parse uses
it, which means that we don't actually test something in
test_peg_parser. This PR introduces a new kwarg `oldparser` for
`_peg_parser.parse_string` for specifying that a string needs to
be parsed with the old parser. This kwarg is used in the tests to
actually compare the ASTs the new parser generates with those
generated by the old parser.

Closes we-like-parsers/cpyhton#93.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
