### PR TITLE
bpo-40334: Support type comments

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -17,6 +17,8 @@ _PyPegen_parse(Parser *p)
         result = interactive_rule(p);
     } else if (p->start_rule == Py_eval_input) {
         result = eval_rule(p);
+    } else if (p->start_rule == Py_func_type_input) {
+        result = func_type_rule(p);
     } else if (p->start_rule == Py_fstring_input) {
         result = fstring_rule(p);
     }
@@ -29,7 +31,16 @@ _PyPegen_parse(Parser *p)
 file[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
 interactive[mod_ty]: a=statement_newline { Interactive(a, p->arena) }
 eval[mod_ty]: a=expressions NEWLINE* ENDMARKER { Expression(a, p->arena) }
+func_type[mod_ty]: '(' a=[type_expressions] ')' '->' b=expression { FunctionType(a, b, p->arena) }
 fstring[expr_ty]: star_expressions
+
+# type_expressions allow */** but ignore them
+type_expressions[asdl_seq*]:
+    | a=','.expression+ ',' '*' b=expression ',' '**' c=expression {
+        _PyPegen_seq_append_to_end(p, _PyPegen_seq_append_to_end(p, a, b), c) }
+    | a=','.expression+ ',' '*' b=expression { _PyPegen_seq_append_to_end(p, a, b) }
+    | a=','.expression+ ',' '**' b=expression { _PyPegen_seq_append_to_end(p, a, b) }
+    | ','.expression+
 
 statements[asdl_seq*]: a=statement+ { _PyPegen_seq_flatten(p, a) }
 statement[asdl_seq*]: a=compound_stmt { _PyPegen_singleton_seq(p, a) } | simple_stmt

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -28,7 +28,7 @@ _PyPegen_parse(Parser *p)
 
 // The end
 '''
-file[mod_ty]: a=[statements] ENDMARKER { Module(a, NULL, p->arena) }
+file[mod_ty]: a=[statements] ENDMARKER { _PyPegen_make_module(p, a) }
 interactive[mod_ty]: a=statement_newline { Interactive(a, p->arena) }
 eval[mod_ty]: a=expressions NEWLINE* ENDMARKER { Expression(a, p->arena) }
 func_type[mod_ty]: '(' a=[type_expressions] ')' '->' b=expression { FunctionType(a, b, p->arena) }

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -73,8 +73,8 @@ assignment:
     | a=('(' b=inside_paren_ann_assign_target ')' { b }
          | ann_assign_subscript_attribute_target) ':' b=expression c=['=' d=annotated_rhs { d }] {
         _Py_AnnAssign(a, b, c, 0, EXTRA)}
-    | a=(z=star_targets '=' { z })+ b=(yield_expr | star_expressions) {
-         _Py_Assign(a, b, NULL, EXTRA) }
+    | a=(z=star_targets '=' { z })+ b=(yield_expr | star_expressions) tc=[TYPE_COMMENT] {
+         _Py_Assign(a, b, NEW_TYPE_COMMENT(tc), EXTRA) }
     | a=target b=augassign c=(yield_expr | star_expressions) {
          _Py_AugAssign(a, b->kind, c, EXTRA) }
     | invalid_assignment
@@ -145,14 +145,14 @@ while_stmt[stmt_ty]:
     | 'while' a=named_expression ':' b=block c=[else_block] { _Py_While(a, b, c, EXTRA) }
 
 for_stmt[stmt_ty]:
-    | is_async=[ASYNC] 'for' t=star_targets 'in' ex=star_expressions ':' b=block el=[else_block] {
-        (is_async ? _Py_AsyncFor : _Py_For)(t, ex, b, el, NULL, EXTRA) }
+    | is_async=[ASYNC] 'for' t=star_targets 'in' ex=star_expressions ':' tc=[TYPE_COMMENT] b=block el=[else_block] {
+        (is_async ? _Py_AsyncFor : _Py_For)(t, ex, b, el, NEW_TYPE_COMMENT(tc), EXTRA) }
 
 with_stmt[stmt_ty]:
     | is_async=[ASYNC] 'with' '(' a=','.with_item+ ')' ':' b=block {
         (is_async ? _Py_AsyncWith : _Py_With)(a, b, NULL, EXTRA) }
-    | is_async=[ASYNC] 'with' a=','.with_item+ ':' b=block {
-        (is_async ? _Py_AsyncWith : _Py_With)(a, b, NULL, EXTRA) }
+    | is_async=[ASYNC] 'with' a=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
+        (is_async ? _Py_AsyncWith : _Py_With)(a, b, NEW_TYPE_COMMENT(tc), EXTRA) }
 with_item[withitem_ty]:
     | e=expression o=['as' t=target { t }] { _Py_withitem(e, o, p->arena) }
 
@@ -177,10 +177,14 @@ function_def[stmt_ty]:
     | function_def_raw
 
 function_def_raw[stmt_ty]:
-    | is_async=[ASYNC] 'def' n=NAME '(' params=[params] ')' a=['->' z=annotation { z }] ':' b=block {
+    | is_async=[ASYNC] 'def' n=NAME '(' params=[params] ')' a=['->' z=annotation { z }] ':' tc=[func_type_comment] b=block {
         (is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef)(n->v.Name.id,
                              (params) ? params : CHECK(_PyPegen_empty_arguments(p)),
-                             b, NULL, a, NULL, EXTRA) }
+                             b, NULL, a, NEW_TYPE_COMMENT(tc), EXTRA) }
+func_type_comment[PyObject *]:
+    | NEWLINE t=TYPE_COMMENT &(NEWLINE INDENT) { t }  # Must be followed by indented block
+    | invalid_double_type_comments
+    | TYPE_COMMENT
 
 params[arguments_ty]:
     | invalid_parameters
@@ -554,3 +558,6 @@ invalid_comprehension:
 invalid_parameters:
     | [plain_names ','] (slash_with_default | names_with_default) ',' plain_names {
         RAISE_SYNTAX_ERROR("non-default argument follows default argument") }
+invalid_double_type_comments:
+    | TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT {
+        RAISE_SYNTAX_ERROR("Cannot have two type comments on def") }

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -244,18 +244,18 @@ kwds[arg_ty]:
 # The latter form is for a final parameter without trailing comma.
 #
 param_no_default[arg_ty]:
-    | a=NAME b=annotation? ',' tc=TYPE_COMMENT? { _Py_arg(a->v.Name.id, b, tc, EXTRA) }
-    | a=NAME b=annotation? tc=TYPE_COMMENT? &')' { _Py_arg(a->v.Name.id, b, tc, EXTRA) }
+    | a=NAME b=annotation? ',' tc=TYPE_COMMENT? { _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA) }
+    | a=NAME b=annotation? tc=TYPE_COMMENT? &')' { _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA) }
 param_with_default[NameDefaultPair*]:
     | a=NAME b=annotation? c=default ',' tc=TYPE_COMMENT? {
-        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, tc, EXTRA), c) }
+        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA), c) }
     | a=NAME b=annotation? c=default tc=TYPE_COMMENT? &')' {
-        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, tc, EXTRA), c) }
+        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA), c) }
 param_maybe_default[NameDefaultPair*]:
     | a=NAME b=annotation? c=default? ',' tc=TYPE_COMMENT? {
-        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, tc, EXTRA), c) }
+        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA), c) }
     | a=NAME b=annotation? c=default? tc=TYPE_COMMENT? &')' {
-        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, tc, EXTRA), c) }
+        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA), c) }
 
 annotation[expr_ty]: ':' a=expression { a }
 default[expr_ty]: '=' a=expression { a }

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -244,18 +244,15 @@ kwds[arg_ty]:
 # The latter form is for a final parameter without trailing comma.
 #
 param_no_default[arg_ty]:
-    | a=NAME b=annotation? ',' tc=TYPE_COMMENT? { _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA) }
-    | a=NAME b=annotation? tc=TYPE_COMMENT? &')' { _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA) }
+    | a=param ',' tc=TYPE_COMMENT? { _PyPegen_add_type_comment(p, a, tc) }
+    | a=param tc=TYPE_COMMENT? &')' { _PyPegen_add_type_comment(p, a, tc) }
 param_with_default[NameDefaultPair*]:
-    | a=NAME b=annotation? c=default ',' tc=TYPE_COMMENT? {
-        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA), c) }
-    | a=NAME b=annotation? c=default tc=TYPE_COMMENT? &')' {
-        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA), c) }
+    | a=param c=default ',' tc=TYPE_COMMENT? { _PyPegen_name_default_pair(p, a, c, tc) }
+    | a=param c=default tc=TYPE_COMMENT? &')' { _PyPegen_name_default_pair(p, a, c, tc) }
 param_maybe_default[NameDefaultPair*]:
-    | a=NAME b=annotation? c=default? ',' tc=TYPE_COMMENT? {
-        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA), c) }
-    | a=NAME b=annotation? c=default? tc=TYPE_COMMENT? &')' {
-        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, NEW_TYPE_COMMENT(tc), EXTRA), c) }
+    | a=param c=default? ',' tc=TYPE_COMMENT? { _PyPegen_name_default_pair(p, a, c, tc) }
+    | a=param c=default? tc=TYPE_COMMENT? &')' { _PyPegen_name_default_pair(p, a, c, tc) }
+param[arg_ty]: a=NAME b=annotation? { _Py_arg(a->v.Name.id, b, NULL, EXTRA) }
 
 annotation[expr_ty]: ':' a=expression { a }
 default[expr_ty]: '=' a=expression { a }
@@ -329,10 +326,10 @@ lambda_star_etc[StarEtc*]:
         _PyPegen_star_etc(p, NULL, b, c) }
     | a=lambda_kwds [','] { _PyPegen_star_etc(p, NULL, NULL, a) }
 lambda_name_with_optional_default[NameDefaultPair*]:
-    | ',' a=lambda_plain_name b=['=' e=expression { e }] { _PyPegen_name_default_pair(p, a, b) }
+    | ',' a=lambda_plain_name b=['=' e=expression { e }] { _PyPegen_name_default_pair(p, a, b, NULL) }
 lambda_names_with_default[asdl_seq*]: a=','.lambda_name_with_default+ { a }
 lambda_name_with_default[NameDefaultPair*]:
-    | n=lambda_plain_name '=' e=expression { _PyPegen_name_default_pair(p, n, e) }
+    | n=lambda_plain_name '=' e=expression { _PyPegen_name_default_pair(p, n, e, NULL) }
 lambda_plain_names[asdl_seq*]: a=','.(lambda_plain_name !'=')+ { a }
 lambda_plain_name[arg_ty]: a=NAME { _Py_arg(a->v.Name.id, NULL, NULL, EXTRA) }
 lambda_kwds[arg_ty]: '**' a=lambda_plain_name { a }

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -37,7 +37,7 @@ fstring[expr_ty]: star_expressions
 # type_expressions allow */** but ignore them
 type_expressions[asdl_seq*]:
     | a=','.expression+ ',' '*' b=expression ',' '**' c=expression {
-        _PyPegen_seq_append_to_end(p, _PyPegen_seq_append_to_end(p, a, b), c) }
+        _PyPegen_seq_append_to_end(p, CHECK(_PyPegen_seq_append_to_end(p, a, b)), c) }
     | a=','.expression+ ',' '*' b=expression { _PyPegen_seq_append_to_end(p, a, b) }
     | a=','.expression+ ',' '**' b=expression { _PyPegen_seq_append_to_end(p, a, b) }
     | ','.expression+

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -85,7 +85,7 @@ assignment:
          | ann_assign_subscript_attribute_target) ':' b=expression c=['=' d=annotated_rhs { d }] {
         _Py_AnnAssign(a, b, c, 0, EXTRA)}
     | a=(z=star_targets '=' { z })+ b=(yield_expr | star_expressions) tc=[TYPE_COMMENT] {
-         _Py_Assign(a, b, NEW_TYPE_COMMENT(tc), EXTRA) }
+         _Py_Assign(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | a=target b=augassign c=(yield_expr | star_expressions) {
          _Py_AugAssign(a, b->kind, c, EXTRA) }
     | invalid_assignment
@@ -157,13 +157,13 @@ while_stmt[stmt_ty]:
 
 for_stmt[stmt_ty]:
     | is_async=[ASYNC] 'for' t=star_targets 'in' ex=star_expressions ':' tc=[TYPE_COMMENT] b=block el=[else_block] {
-        (is_async ? _Py_AsyncFor : _Py_For)(t, ex, b, el, NEW_TYPE_COMMENT(tc), EXTRA) }
+        (is_async ? _Py_AsyncFor : _Py_For)(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA) }
 
 with_stmt[stmt_ty]:
     | is_async=[ASYNC] 'with' '(' a=','.with_item+ ')' ':' b=block {
         (is_async ? _Py_AsyncWith : _Py_With)(a, b, NULL, EXTRA) }
     | is_async=[ASYNC] 'with' a=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
-        (is_async ? _Py_AsyncWith : _Py_With)(a, b, NEW_TYPE_COMMENT(tc), EXTRA) }
+        (is_async ? _Py_AsyncWith : _Py_With)(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
 with_item[withitem_ty]:
     | e=expression o=['as' t=target { t }] { _Py_withitem(e, o, p->arena) }
 
@@ -191,7 +191,7 @@ function_def_raw[stmt_ty]:
     | is_async=[ASYNC] 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
         (is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef)(n->v.Name.id,
                              (params) ? params : CHECK(_PyPegen_empty_arguments(p)),
-                             b, NULL, a, NEW_TYPE_COMMENT(tc), EXTRA) }
+                             b, NULL, a, NEW_TYPE_COMMENT(p, tc), EXTRA) }
 func_type_comment[PyObject*]:
     | NEWLINE t=TYPE_COMMENT &(NEWLINE INDENT) { t }  # Must be followed by indented block
     | invalid_double_type_comments

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -188,7 +188,7 @@ function_def[stmt_ty]:
     | function_def_raw
 
 function_def_raw[stmt_ty]:
-    | is_async=[ASYNC] 'def' n=NAME '(' params=[params] ')' a=['->' z=annotation { z }] ':' tc=[func_type_comment] b=block {
+    | is_async=[ASYNC] 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
         (is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef)(n->v.Name.id,
                              (params) ? params : CHECK(_PyPegen_empty_arguments(p)),
                              b, NULL, a, NEW_TYPE_COMMENT(tc), EXTRA) }
@@ -200,35 +200,65 @@ func_type_comment[PyObject *]:
 params[arguments_ty]:
     | invalid_parameters
     | parameters
+
 parameters[arguments_ty]:
-    | a=slash_without_default b=[',' x=plain_names { x }] c=[',' y=names_with_default { y }] d=[',' z=[star_etc] { z }] {
+    | a=slash_no_default b=param_no_default* c=param_with_default* d=[star_etc] {
         _PyPegen_make_arguments(p, a, NULL, b, c, d) }
-    | a=slash_with_default b=[',' y=names_with_default { y }] c=[',' z=[star_etc] { z }] {
+    | a=slash_with_default b=param_with_default* c=[star_etc] {
         _PyPegen_make_arguments(p, NULL, a, NULL, b, c) }
-    | a=plain_names b=[',' y=names_with_default { y }] c=[',' z=[star_etc] { z }] {
+    | a=param_no_default+ b=param_with_default* c=[star_etc] {
         _PyPegen_make_arguments(p, NULL, NULL, a, b, c) }
-    | a=names_with_default b=[',' z=[star_etc] { z }] { _PyPegen_make_arguments(p, NULL, NULL, NULL, a, b)}
+    | a=param_with_default+ b=[star_etc] { _PyPegen_make_arguments(p, NULL, NULL, NULL, a, b)}
     | a=star_etc { _PyPegen_make_arguments(p, NULL, NULL, NULL, NULL, a) }
-slash_without_default[asdl_seq*]: a=plain_names ',' '/' { a }
-slash_with_default[SlashWithDefault*]: a=[n=plain_names ',' { n }] b=names_with_default ',' '/' {
-    _PyPegen_slash_with_default(p, a, b) }
+
+# Some duplication here because we can't write (',' | &')'),
+# which is because we don't support empty alternatives (yet).
+#
+slash_no_default[asdl_seq*]:
+    | a=param_no_default+ '/' ',' { a }
+    | a=param_no_default+ '/' &')' { a }
+slash_with_default[SlashWithDefault*]:
+    | a=param_no_default* b=param_with_default+ '/' ',' { _PyPegen_slash_with_default(p, a, b) }
+    | a=param_no_default* b=param_with_default+ '/' &')' { _PyPegen_slash_with_default(p, a, b) }
+
 star_etc[StarEtc*]:
-    | '*' a=plain_name b=name_with_optional_default* c=[',' d=kwds { d }] [','] {
+    | '*' a=param_no_default b=param_maybe_default* c=[kwds] {
         _PyPegen_star_etc(p, a, b, c) }
-    | '*' b=name_with_optional_default+ c=[',' d=kwds { d }] [','] {
+    | '*' ',' b=param_maybe_default+ c=[kwds] {
         _PyPegen_star_etc(p, NULL, b, c) }
-    | a=kwds [','] { _PyPegen_star_etc(p, NULL, NULL, a) }
-name_with_optional_default[NameDefaultPair*]:
-    | ',' a=plain_name b=['=' e=expression { e }] { _PyPegen_name_default_pair(p, a, b) }
-names_with_default[asdl_seq*]: a=','.name_with_default+ { a }
-name_with_default[NameDefaultPair*]:
-    | n=plain_name '=' e=expression { _PyPegen_name_default_pair(p, n, e) }
-plain_names[asdl_seq*] (memo): a=','.(plain_name !'=')+ { a }
-plain_name[arg_ty]:
-    | a=NAME b=[':' z=annotation { z }] { _Py_arg(a->v.Name.id, b, NULL, EXTRA) }
+    | a=kwds { _PyPegen_star_etc(p, NULL, NULL, a) }
+
 kwds[arg_ty]:
-    | '**' a=plain_name { a }
-annotation[expr_ty]: expression
+    | '**' a=param_no_default { a }
+
+# One parameter.  This *includes* a following comma and type comment.
+#
+# There are three styles:
+# - No default
+# - With default
+# - Maybe with default
+#
+# There are two alternative forms of each, to deal with type comments:
+# - Ends in a comma followed by an optional type comment
+# - No comma, optional type comment, must be followed by close paren
+# The latter form is for a final parameter without trailing comma.
+#
+param_no_default[arg_ty]:
+    | a=NAME b=annotation? ',' tc=TYPE_COMMENT? { _Py_arg(a->v.Name.id, b, tc, EXTRA) }
+    | a=NAME b=annotation? tc=TYPE_COMMENT? &')' { _Py_arg(a->v.Name.id, b, tc, EXTRA) }
+param_with_default[NameDefaultPair*]:
+    | a=NAME b=annotation? c=default ',' tc=TYPE_COMMENT? {
+        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, tc, EXTRA), c) }
+    | a=NAME b=annotation? c=default tc=TYPE_COMMENT? &')' {
+        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, tc, EXTRA), c) }
+param_maybe_default[NameDefaultPair*]:
+    | a=NAME b=annotation? c=default? ',' tc=TYPE_COMMENT? {
+        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, tc, EXTRA), c) }
+    | a=NAME b=annotation? c=default? tc=TYPE_COMMENT? &')' {
+        _PyPegen_name_default_pair(p, _Py_arg(a->v.Name.id, b, tc, EXTRA), c) }
+
+annotation[expr_ty]: ':' a=expression { a }
+default[expr_ty]: '=' a=expression { a }
 
 decorators[asdl_seq*]: a=('@' f=named_expression NEWLINE { f })+ { a }
 
@@ -567,7 +597,7 @@ invalid_comprehension:
     | ('[' | '(' | '{') '*' expression for_if_clauses {
         RAISE_SYNTAX_ERROR("iterable unpacking cannot be used in comprehension") }
 invalid_parameters:
-    | [plain_names ','] (slash_with_default | names_with_default) ',' plain_names {
+    | param_no_default* (slash_with_default | param_with_default+) param_no_default {
         RAISE_SYNTAX_ERROR("non-default argument follows default argument") }
 invalid_double_type_comments:
     | TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT {

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -31,7 +31,7 @@ _PyPegen_parse(Parser *p)
 file[mod_ty]: a=[statements] ENDMARKER { _PyPegen_make_module(p, a) }
 interactive[mod_ty]: a=statement_newline { Interactive(a, p->arena) }
 eval[mod_ty]: a=expressions NEWLINE* ENDMARKER { Expression(a, p->arena) }
-func_type[mod_ty]: '(' a=[type_expressions] ')' '->' b=expression { FunctionType(a, b, p->arena) }
+func_type[mod_ty]: '(' a=[type_expressions] ')' '->' b=expression NEWLINE* ENDMARKER { FunctionType(a, b, p->arena) }
 fstring[expr_ty]: star_expressions
 
 # type_expressions allow */** but ignore them
@@ -192,7 +192,7 @@ function_def_raw[stmt_ty]:
         (is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef)(n->v.Name.id,
                              (params) ? params : CHECK(_PyPegen_empty_arguments(p)),
                              b, NULL, a, NEW_TYPE_COMMENT(tc), EXTRA) }
-func_type_comment[PyObject *]:
+func_type_comment[PyObject*]:
     | NEWLINE t=TYPE_COMMENT &(NEWLINE INDENT) { t }  # Must be followed by indented block
     | invalid_double_type_comments
     | TYPE_COMMENT
@@ -244,8 +244,8 @@ kwds[arg_ty]:
 # The latter form is for a final parameter without trailing comma.
 #
 param_no_default[arg_ty]:
-    | a=param ',' tc=TYPE_COMMENT? { _PyPegen_add_type_comment(p, a, tc) }
-    | a=param tc=TYPE_COMMENT? &')' { _PyPegen_add_type_comment(p, a, tc) }
+    | a=param ',' tc=TYPE_COMMENT? { _PyPegen_add_type_comment_to_arg(p, a, tc) }
+    | a=param tc=TYPE_COMMENT? &')' { _PyPegen_add_type_comment_to_arg(p, a, tc) }
 param_with_default[NameDefaultPair*]:
     | a=param c=default ',' tc=TYPE_COMMENT? { _PyPegen_name_default_pair(p, a, c, tc) }
     | a=param c=default tc=TYPE_COMMENT? &')' { _PyPegen_name_default_pair(p, a, c, tc) }

--- a/Lib/test/test_type_comments.py
+++ b/Lib/test/test_type_comments.py
@@ -219,7 +219,6 @@ def favk(
 """
 
 
-@support.skip_if_new_parser("Pegen does not support type comments yet")
 class TypeCommentTests(unittest.TestCase):
 
     lowest = 4  # Lowest minor version supported
@@ -253,6 +252,7 @@ class TypeCommentTests(unittest.TestCase):
         self.assertEqual(tree.body[0].type_comment, None)
         self.assertEqual(tree.body[1].type_comment, None)
 
+    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_asyncdef(self):
         for tree in self.parse_all(asyncdef, minver=5):
             self.assertEqual(tree.body[0].type_comment, "() -> int")
@@ -261,22 +261,27 @@ class TypeCommentTests(unittest.TestCase):
         self.assertEqual(tree.body[0].type_comment, None)
         self.assertEqual(tree.body[1].type_comment, None)
 
+    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_asyncvar(self):
         for tree in self.parse_all(asyncvar, maxver=6):
             pass
 
+    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_asynccomp(self):
         for tree in self.parse_all(asynccomp, minver=6):
             pass
 
+    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_matmul(self):
         for tree in self.parse_all(matmul, minver=5):
             pass
 
+    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_fstring(self):
         for tree in self.parse_all(fstring, minver=6):
             pass
 
+    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_underscorednumber(self):
         for tree in self.parse_all(underscorednumber, minver=6):
             pass
@@ -308,6 +313,7 @@ class TypeCommentTests(unittest.TestCase):
         tree = self.classic_parse(vardecl)
         self.assertEqual(tree.body[0].type_comment, None)
 
+    @support.skip_if_new_parser("Pegen does not support `# type: ignore` yet")
     def test_ignores(self):
         for tree in self.parse_all(ignores):
             self.assertEqual(
@@ -323,6 +329,7 @@ class TypeCommentTests(unittest.TestCase):
         tree = self.classic_parse(ignores)
         self.assertEqual(tree.type_ignores, [])
 
+    @support.skip_if_new_parser("Pegen does not support per-argument type comments yet")
     def test_longargs(self):
         for tree in self.parse_all(longargs):
             for t in tree.body:
@@ -377,6 +384,7 @@ class TypeCommentTests(unittest.TestCase):
         check_both_ways("pass  # type: ignorewhatever\n")
         check_both_ways("pass  # type: ignoreé\n")
 
+    @support.skip_if_new_parser("Pegen does not support func_type_input yet")
     def test_func_type_input(self):
 
         def parse_func_type_input(source):

--- a/Lib/test/test_type_comments.py
+++ b/Lib/test/test_type_comments.py
@@ -313,7 +313,6 @@ class TypeCommentTests(unittest.TestCase):
         tree = self.classic_parse(vardecl)
         self.assertEqual(tree.body[0].type_comment, None)
 
-    @support.skip_if_new_parser("Pegen does not support `# type: ignore` yet")
     def test_ignores(self):
         for tree in self.parse_all(ignores):
             self.assertEqual(

--- a/Lib/test/test_type_comments.py
+++ b/Lib/test/test_type_comments.py
@@ -384,7 +384,6 @@ class TypeCommentTests(unittest.TestCase):
         check_both_ways("pass  # type: ignorewhatever\n")
         check_both_ways("pass  # type: ignoreé\n")
 
-    @support.skip_if_new_parser("Pegen does not support func_type_input yet")
     def test_func_type_input(self):
 
         def parse_func_type_input(source):

--- a/Lib/test/test_type_comments.py
+++ b/Lib/test/test_type_comments.py
@@ -328,7 +328,6 @@ class TypeCommentTests(unittest.TestCase):
         tree = self.classic_parse(ignores)
         self.assertEqual(tree.type_ignores, [])
 
-    @support.skip_if_new_parser("Pegen does not support per-argument type comments yet")
     def test_longargs(self):
         for tree in self.parse_all(longargs):
             for t in tree.body:

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -108,247 +108,250 @@ static KeywordToken *reserved_keywords[] = {
 #define raise_stmt_type 1037
 #define function_def_type 1038
 #define function_def_raw_type 1039
-#define params_type 1040
-#define parameters_type 1041
-#define slash_without_default_type 1042
-#define slash_with_default_type 1043
-#define star_etc_type 1044
-#define name_with_optional_default_type 1045
-#define names_with_default_type 1046
-#define name_with_default_type 1047
-#define plain_names_type 1048
-#define plain_name_type 1049
-#define kwds_type 1050
-#define annotation_type 1051
-#define decorators_type 1052
-#define class_def_type 1053
-#define class_def_raw_type 1054
-#define block_type 1055
-#define expressions_list_type 1056
-#define star_expressions_type 1057
-#define star_expression_type 1058
-#define star_named_expressions_type 1059
-#define star_named_expression_type 1060
-#define named_expression_type 1061
-#define annotated_rhs_type 1062
-#define expressions_type 1063
-#define expression_type 1064
-#define lambdef_type 1065
-#define lambda_parameters_type 1066
-#define lambda_slash_without_default_type 1067
-#define lambda_slash_with_default_type 1068
-#define lambda_star_etc_type 1069
-#define lambda_name_with_optional_default_type 1070
-#define lambda_names_with_default_type 1071
-#define lambda_name_with_default_type 1072
-#define lambda_plain_names_type 1073
-#define lambda_plain_name_type 1074
-#define lambda_kwds_type 1075
-#define disjunction_type 1076
-#define conjunction_type 1077
-#define inversion_type 1078
-#define comparison_type 1079
-#define compare_op_bitwise_or_pair_type 1080
-#define eq_bitwise_or_type 1081
-#define noteq_bitwise_or_type 1082
-#define lte_bitwise_or_type 1083
-#define lt_bitwise_or_type 1084
-#define gte_bitwise_or_type 1085
-#define gt_bitwise_or_type 1086
-#define notin_bitwise_or_type 1087
-#define in_bitwise_or_type 1088
-#define isnot_bitwise_or_type 1089
-#define is_bitwise_or_type 1090
-#define bitwise_or_type 1091  // Left-recursive
-#define bitwise_xor_type 1092  // Left-recursive
-#define bitwise_and_type 1093  // Left-recursive
-#define shift_expr_type 1094  // Left-recursive
-#define sum_type 1095  // Left-recursive
-#define term_type 1096  // Left-recursive
-#define factor_type 1097
-#define power_type 1098
-#define await_primary_type 1099
-#define primary_type 1100  // Left-recursive
-#define slices_type 1101
-#define slice_type 1102
-#define atom_type 1103
-#define strings_type 1104
-#define list_type 1105
-#define listcomp_type 1106
-#define tuple_type 1107
-#define group_type 1108
-#define genexp_type 1109
-#define set_type 1110
-#define setcomp_type 1111
-#define dict_type 1112
-#define dictcomp_type 1113
-#define kvpairs_type 1114
-#define kvpair_type 1115
-#define for_if_clauses_type 1116
-#define yield_expr_type 1117
-#define arguments_type 1118
-#define args_type 1119
-#define kwargs_type 1120
-#define starred_expression_type 1121
-#define kwarg_or_starred_type 1122
-#define kwarg_or_double_starred_type 1123
-#define star_targets_type 1124
-#define star_targets_seq_type 1125
-#define star_target_type 1126
-#define star_atom_type 1127
-#define inside_paren_ann_assign_target_type 1128
-#define ann_assign_subscript_attribute_target_type 1129
-#define del_targets_type 1130
-#define del_target_type 1131
-#define del_t_atom_type 1132
-#define targets_type 1133
-#define target_type 1134
-#define t_primary_type 1135  // Left-recursive
-#define t_lookahead_type 1136
-#define t_atom_type 1137
-#define incorrect_arguments_type 1138
-#define invalid_named_expression_type 1139
-#define invalid_assignment_type 1140
-#define invalid_block_type 1141
-#define invalid_comprehension_type 1142
-#define invalid_parameters_type 1143
-#define _loop0_1_type 1144
-#define _loop1_2_type 1145
-#define _loop0_4_type 1146
-#define _gather_3_type 1147
-#define _tmp_5_type 1148
-#define _tmp_6_type 1149
-#define _tmp_7_type 1150
-#define _tmp_8_type 1151
-#define _tmp_9_type 1152
-#define _tmp_10_type 1153
-#define _tmp_11_type 1154
-#define _tmp_12_type 1155
-#define _loop1_13_type 1156
-#define _tmp_14_type 1157
-#define _tmp_15_type 1158
-#define _loop0_17_type 1159
-#define _gather_16_type 1160
-#define _loop0_19_type 1161
-#define _gather_18_type 1162
-#define _tmp_20_type 1163
-#define _loop0_21_type 1164
-#define _loop1_22_type 1165
-#define _loop0_24_type 1166
-#define _gather_23_type 1167
-#define _tmp_25_type 1168
-#define _loop0_27_type 1169
-#define _gather_26_type 1170
-#define _tmp_28_type 1171
-#define _loop0_30_type 1172
-#define _gather_29_type 1173
-#define _loop0_32_type 1174
-#define _gather_31_type 1175
-#define _tmp_33_type 1176
-#define _loop1_34_type 1177
-#define _tmp_35_type 1178
-#define _tmp_36_type 1179
-#define _tmp_37_type 1180
-#define _tmp_38_type 1181
-#define _tmp_39_type 1182
-#define _tmp_40_type 1183
-#define _tmp_41_type 1184
-#define _tmp_42_type 1185
-#define _tmp_43_type 1186
-#define _tmp_44_type 1187
-#define _tmp_45_type 1188
-#define _tmp_46_type 1189
-#define _loop0_47_type 1190
-#define _tmp_48_type 1191
-#define _loop1_49_type 1192
-#define _tmp_50_type 1193
-#define _tmp_51_type 1194
-#define _loop0_53_type 1195
-#define _gather_52_type 1196
-#define _loop0_55_type 1197
-#define _gather_54_type 1198
-#define _tmp_56_type 1199
-#define _loop1_57_type 1200
-#define _tmp_58_type 1201
-#define _loop0_60_type 1202
-#define _gather_59_type 1203
-#define _loop1_61_type 1204
-#define _loop0_63_type 1205
-#define _gather_62_type 1206
-#define _loop1_64_type 1207
-#define _tmp_65_type 1208
-#define _tmp_66_type 1209
-#define _tmp_67_type 1210
-#define _tmp_68_type 1211
-#define _tmp_69_type 1212
-#define _tmp_70_type 1213
-#define _tmp_71_type 1214
-#define _tmp_72_type 1215
-#define _tmp_73_type 1216
-#define _loop0_74_type 1217
-#define _tmp_75_type 1218
-#define _loop1_76_type 1219
-#define _tmp_77_type 1220
-#define _tmp_78_type 1221
-#define _loop0_80_type 1222
-#define _gather_79_type 1223
-#define _loop0_82_type 1224
-#define _gather_81_type 1225
-#define _loop1_83_type 1226
-#define _loop1_84_type 1227
-#define _loop1_85_type 1228
-#define _tmp_86_type 1229
-#define _loop0_88_type 1230
-#define _gather_87_type 1231
-#define _tmp_89_type 1232
-#define _tmp_90_type 1233
-#define _tmp_91_type 1234
-#define _tmp_92_type 1235
-#define _loop1_93_type 1236
-#define _tmp_94_type 1237
-#define _tmp_95_type 1238
-#define _loop0_97_type 1239
-#define _gather_96_type 1240
-#define _loop1_98_type 1241
-#define _tmp_99_type 1242
-#define _tmp_100_type 1243
-#define _loop0_102_type 1244
-#define _gather_101_type 1245
-#define _loop0_104_type 1246
-#define _gather_103_type 1247
-#define _loop0_106_type 1248
-#define _gather_105_type 1249
-#define _loop0_108_type 1250
-#define _gather_107_type 1251
-#define _loop0_109_type 1252
-#define _loop0_111_type 1253
-#define _gather_110_type 1254
-#define _tmp_112_type 1255
-#define _loop0_114_type 1256
-#define _gather_113_type 1257
-#define _loop0_116_type 1258
-#define _gather_115_type 1259
-#define _tmp_117_type 1260
-#define _tmp_118_type 1261
-#define _tmp_119_type 1262
-#define _tmp_120_type 1263
-#define _tmp_121_type 1264
-#define _tmp_122_type 1265
-#define _tmp_123_type 1266
-#define _tmp_124_type 1267
-#define _tmp_125_type 1268
-#define _tmp_126_type 1269
-#define _tmp_127_type 1270
-#define _tmp_128_type 1271
-#define _tmp_129_type 1272
-#define _tmp_130_type 1273
-#define _tmp_131_type 1274
-#define _tmp_132_type 1275
-#define _tmp_133_type 1276
-#define _tmp_134_type 1277
-#define _tmp_135_type 1278
-#define _loop0_136_type 1279
-#define _tmp_137_type 1280
+#define func_type_comment_type 1040
+#define params_type 1041
+#define parameters_type 1042
+#define slash_without_default_type 1043
+#define slash_with_default_type 1044
+#define star_etc_type 1045
+#define name_with_optional_default_type 1046
+#define names_with_default_type 1047
+#define name_with_default_type 1048
+#define plain_names_type 1049
+#define plain_name_type 1050
+#define kwds_type 1051
+#define annotation_type 1052
+#define decorators_type 1053
+#define class_def_type 1054
+#define class_def_raw_type 1055
+#define block_type 1056
+#define expressions_list_type 1057
+#define star_expressions_type 1058
+#define star_expression_type 1059
+#define star_named_expressions_type 1060
+#define star_named_expression_type 1061
+#define named_expression_type 1062
+#define annotated_rhs_type 1063
+#define expressions_type 1064
+#define expression_type 1065
+#define lambdef_type 1066
+#define lambda_parameters_type 1067
+#define lambda_slash_without_default_type 1068
+#define lambda_slash_with_default_type 1069
+#define lambda_star_etc_type 1070
+#define lambda_name_with_optional_default_type 1071
+#define lambda_names_with_default_type 1072
+#define lambda_name_with_default_type 1073
+#define lambda_plain_names_type 1074
+#define lambda_plain_name_type 1075
+#define lambda_kwds_type 1076
+#define disjunction_type 1077
+#define conjunction_type 1078
+#define inversion_type 1079
+#define comparison_type 1080
+#define compare_op_bitwise_or_pair_type 1081
+#define eq_bitwise_or_type 1082
+#define noteq_bitwise_or_type 1083
+#define lte_bitwise_or_type 1084
+#define lt_bitwise_or_type 1085
+#define gte_bitwise_or_type 1086
+#define gt_bitwise_or_type 1087
+#define notin_bitwise_or_type 1088
+#define in_bitwise_or_type 1089
+#define isnot_bitwise_or_type 1090
+#define is_bitwise_or_type 1091
+#define bitwise_or_type 1092  // Left-recursive
+#define bitwise_xor_type 1093  // Left-recursive
+#define bitwise_and_type 1094  // Left-recursive
+#define shift_expr_type 1095  // Left-recursive
+#define sum_type 1096  // Left-recursive
+#define term_type 1097  // Left-recursive
+#define factor_type 1098
+#define power_type 1099
+#define await_primary_type 1100
+#define primary_type 1101  // Left-recursive
+#define slices_type 1102
+#define slice_type 1103
+#define atom_type 1104
+#define strings_type 1105
+#define list_type 1106
+#define listcomp_type 1107
+#define tuple_type 1108
+#define group_type 1109
+#define genexp_type 1110
+#define set_type 1111
+#define setcomp_type 1112
+#define dict_type 1113
+#define dictcomp_type 1114
+#define kvpairs_type 1115
+#define kvpair_type 1116
+#define for_if_clauses_type 1117
+#define yield_expr_type 1118
+#define arguments_type 1119
+#define args_type 1120
+#define kwargs_type 1121
+#define starred_expression_type 1122
+#define kwarg_or_starred_type 1123
+#define kwarg_or_double_starred_type 1124
+#define star_targets_type 1125
+#define star_targets_seq_type 1126
+#define star_target_type 1127
+#define star_atom_type 1128
+#define inside_paren_ann_assign_target_type 1129
+#define ann_assign_subscript_attribute_target_type 1130
+#define del_targets_type 1131
+#define del_target_type 1132
+#define del_t_atom_type 1133
+#define targets_type 1134
+#define target_type 1135
+#define t_primary_type 1136  // Left-recursive
+#define t_lookahead_type 1137
+#define t_atom_type 1138
+#define incorrect_arguments_type 1139
+#define invalid_named_expression_type 1140
+#define invalid_assignment_type 1141
+#define invalid_block_type 1142
+#define invalid_comprehension_type 1143
+#define invalid_parameters_type 1144
+#define invalid_double_type_comments_type 1145
+#define _loop0_1_type 1146
+#define _loop1_2_type 1147
+#define _loop0_4_type 1148
+#define _gather_3_type 1149
+#define _tmp_5_type 1150
+#define _tmp_6_type 1151
+#define _tmp_7_type 1152
+#define _tmp_8_type 1153
+#define _tmp_9_type 1154
+#define _tmp_10_type 1155
+#define _tmp_11_type 1156
+#define _tmp_12_type 1157
+#define _loop1_13_type 1158
+#define _tmp_14_type 1159
+#define _tmp_15_type 1160
+#define _loop0_17_type 1161
+#define _gather_16_type 1162
+#define _loop0_19_type 1163
+#define _gather_18_type 1164
+#define _tmp_20_type 1165
+#define _loop0_21_type 1166
+#define _loop1_22_type 1167
+#define _loop0_24_type 1168
+#define _gather_23_type 1169
+#define _tmp_25_type 1170
+#define _loop0_27_type 1171
+#define _gather_26_type 1172
+#define _tmp_28_type 1173
+#define _loop0_30_type 1174
+#define _gather_29_type 1175
+#define _loop0_32_type 1176
+#define _gather_31_type 1177
+#define _tmp_33_type 1178
+#define _loop1_34_type 1179
+#define _tmp_35_type 1180
+#define _tmp_36_type 1181
+#define _tmp_37_type 1182
+#define _tmp_38_type 1183
+#define _tmp_39_type 1184
+#define _tmp_40_type 1185
+#define _tmp_41_type 1186
+#define _tmp_42_type 1187
+#define _tmp_43_type 1188
+#define _tmp_44_type 1189
+#define _tmp_45_type 1190
+#define _tmp_46_type 1191
+#define _tmp_47_type 1192
+#define _loop0_48_type 1193
+#define _tmp_49_type 1194
+#define _loop1_50_type 1195
+#define _tmp_51_type 1196
+#define _tmp_52_type 1197
+#define _loop0_54_type 1198
+#define _gather_53_type 1199
+#define _loop0_56_type 1200
+#define _gather_55_type 1201
+#define _tmp_57_type 1202
+#define _loop1_58_type 1203
+#define _tmp_59_type 1204
+#define _loop0_61_type 1205
+#define _gather_60_type 1206
+#define _loop1_62_type 1207
+#define _loop0_64_type 1208
+#define _gather_63_type 1209
+#define _loop1_65_type 1210
+#define _tmp_66_type 1211
+#define _tmp_67_type 1212
+#define _tmp_68_type 1213
+#define _tmp_69_type 1214
+#define _tmp_70_type 1215
+#define _tmp_71_type 1216
+#define _tmp_72_type 1217
+#define _tmp_73_type 1218
+#define _tmp_74_type 1219
+#define _loop0_75_type 1220
+#define _tmp_76_type 1221
+#define _loop1_77_type 1222
+#define _tmp_78_type 1223
+#define _tmp_79_type 1224
+#define _loop0_81_type 1225
+#define _gather_80_type 1226
+#define _loop0_83_type 1227
+#define _gather_82_type 1228
+#define _loop1_84_type 1229
+#define _loop1_85_type 1230
+#define _loop1_86_type 1231
+#define _tmp_87_type 1232
+#define _loop0_89_type 1233
+#define _gather_88_type 1234
+#define _tmp_90_type 1235
+#define _tmp_91_type 1236
+#define _tmp_92_type 1237
+#define _tmp_93_type 1238
+#define _loop1_94_type 1239
+#define _tmp_95_type 1240
+#define _tmp_96_type 1241
+#define _loop0_98_type 1242
+#define _gather_97_type 1243
+#define _loop1_99_type 1244
+#define _tmp_100_type 1245
+#define _tmp_101_type 1246
+#define _loop0_103_type 1247
+#define _gather_102_type 1248
+#define _loop0_105_type 1249
+#define _gather_104_type 1250
+#define _loop0_107_type 1251
+#define _gather_106_type 1252
+#define _loop0_109_type 1253
+#define _gather_108_type 1254
+#define _loop0_110_type 1255
+#define _loop0_112_type 1256
+#define _gather_111_type 1257
+#define _tmp_113_type 1258
+#define _loop0_115_type 1259
+#define _gather_114_type 1260
+#define _loop0_117_type 1261
+#define _gather_116_type 1262
+#define _tmp_118_type 1263
+#define _tmp_119_type 1264
+#define _tmp_120_type 1265
+#define _tmp_121_type 1266
+#define _tmp_122_type 1267
+#define _tmp_123_type 1268
+#define _tmp_124_type 1269
+#define _tmp_125_type 1270
+#define _tmp_126_type 1271
+#define _tmp_127_type 1272
+#define _tmp_128_type 1273
+#define _tmp_129_type 1274
+#define _tmp_130_type 1275
+#define _tmp_131_type 1276
+#define _tmp_132_type 1277
+#define _tmp_133_type 1278
+#define _tmp_134_type 1279
+#define _tmp_135_type 1280
+#define _tmp_136_type 1281
+#define _loop0_137_type 1282
+#define _tmp_138_type 1283
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -390,6 +393,7 @@ static stmt_ty return_stmt_rule(Parser *p);
 static stmt_ty raise_stmt_rule(Parser *p);
 static stmt_ty function_def_rule(Parser *p);
 static stmt_ty function_def_raw_rule(Parser *p);
+static PyObject* func_type_comment_rule(Parser *p);
 static arguments_ty params_rule(Parser *p);
 static arguments_ty parameters_rule(Parser *p);
 static asdl_seq* slash_without_default_rule(Parser *p);
@@ -494,6 +498,7 @@ static void *invalid_assignment_rule(Parser *p);
 static void *invalid_block_rule(Parser *p);
 static void *invalid_comprehension_rule(Parser *p);
 static void *invalid_parameters_rule(Parser *p);
+static void *invalid_double_type_comments_rule(Parser *p);
 static asdl_seq *_loop0_1_rule(Parser *p);
 static asdl_seq *_loop1_2_rule(Parser *p);
 static asdl_seq *_loop0_4_rule(Parser *p);
@@ -540,25 +545,25 @@ static void *_tmp_43_rule(Parser *p);
 static void *_tmp_44_rule(Parser *p);
 static void *_tmp_45_rule(Parser *p);
 static void *_tmp_46_rule(Parser *p);
-static asdl_seq *_loop0_47_rule(Parser *p);
-static void *_tmp_48_rule(Parser *p);
-static asdl_seq *_loop1_49_rule(Parser *p);
-static void *_tmp_50_rule(Parser *p);
+static void *_tmp_47_rule(Parser *p);
+static asdl_seq *_loop0_48_rule(Parser *p);
+static void *_tmp_49_rule(Parser *p);
+static asdl_seq *_loop1_50_rule(Parser *p);
 static void *_tmp_51_rule(Parser *p);
-static asdl_seq *_loop0_53_rule(Parser *p);
-static asdl_seq *_gather_52_rule(Parser *p);
-static asdl_seq *_loop0_55_rule(Parser *p);
-static asdl_seq *_gather_54_rule(Parser *p);
-static void *_tmp_56_rule(Parser *p);
-static asdl_seq *_loop1_57_rule(Parser *p);
-static void *_tmp_58_rule(Parser *p);
-static asdl_seq *_loop0_60_rule(Parser *p);
-static asdl_seq *_gather_59_rule(Parser *p);
-static asdl_seq *_loop1_61_rule(Parser *p);
-static asdl_seq *_loop0_63_rule(Parser *p);
-static asdl_seq *_gather_62_rule(Parser *p);
-static asdl_seq *_loop1_64_rule(Parser *p);
-static void *_tmp_65_rule(Parser *p);
+static void *_tmp_52_rule(Parser *p);
+static asdl_seq *_loop0_54_rule(Parser *p);
+static asdl_seq *_gather_53_rule(Parser *p);
+static asdl_seq *_loop0_56_rule(Parser *p);
+static asdl_seq *_gather_55_rule(Parser *p);
+static void *_tmp_57_rule(Parser *p);
+static asdl_seq *_loop1_58_rule(Parser *p);
+static void *_tmp_59_rule(Parser *p);
+static asdl_seq *_loop0_61_rule(Parser *p);
+static asdl_seq *_gather_60_rule(Parser *p);
+static asdl_seq *_loop1_62_rule(Parser *p);
+static asdl_seq *_loop0_64_rule(Parser *p);
+static asdl_seq *_gather_63_rule(Parser *p);
+static asdl_seq *_loop1_65_rule(Parser *p);
 static void *_tmp_66_rule(Parser *p);
 static void *_tmp_67_rule(Parser *p);
 static void *_tmp_68_rule(Parser *p);
@@ -567,50 +572,50 @@ static void *_tmp_70_rule(Parser *p);
 static void *_tmp_71_rule(Parser *p);
 static void *_tmp_72_rule(Parser *p);
 static void *_tmp_73_rule(Parser *p);
-static asdl_seq *_loop0_74_rule(Parser *p);
-static void *_tmp_75_rule(Parser *p);
-static asdl_seq *_loop1_76_rule(Parser *p);
-static void *_tmp_77_rule(Parser *p);
+static void *_tmp_74_rule(Parser *p);
+static asdl_seq *_loop0_75_rule(Parser *p);
+static void *_tmp_76_rule(Parser *p);
+static asdl_seq *_loop1_77_rule(Parser *p);
 static void *_tmp_78_rule(Parser *p);
-static asdl_seq *_loop0_80_rule(Parser *p);
-static asdl_seq *_gather_79_rule(Parser *p);
-static asdl_seq *_loop0_82_rule(Parser *p);
-static asdl_seq *_gather_81_rule(Parser *p);
-static asdl_seq *_loop1_83_rule(Parser *p);
+static void *_tmp_79_rule(Parser *p);
+static asdl_seq *_loop0_81_rule(Parser *p);
+static asdl_seq *_gather_80_rule(Parser *p);
+static asdl_seq *_loop0_83_rule(Parser *p);
+static asdl_seq *_gather_82_rule(Parser *p);
 static asdl_seq *_loop1_84_rule(Parser *p);
 static asdl_seq *_loop1_85_rule(Parser *p);
-static void *_tmp_86_rule(Parser *p);
-static asdl_seq *_loop0_88_rule(Parser *p);
-static asdl_seq *_gather_87_rule(Parser *p);
-static void *_tmp_89_rule(Parser *p);
+static asdl_seq *_loop1_86_rule(Parser *p);
+static void *_tmp_87_rule(Parser *p);
+static asdl_seq *_loop0_89_rule(Parser *p);
+static asdl_seq *_gather_88_rule(Parser *p);
 static void *_tmp_90_rule(Parser *p);
 static void *_tmp_91_rule(Parser *p);
 static void *_tmp_92_rule(Parser *p);
-static asdl_seq *_loop1_93_rule(Parser *p);
-static void *_tmp_94_rule(Parser *p);
+static void *_tmp_93_rule(Parser *p);
+static asdl_seq *_loop1_94_rule(Parser *p);
 static void *_tmp_95_rule(Parser *p);
-static asdl_seq *_loop0_97_rule(Parser *p);
-static asdl_seq *_gather_96_rule(Parser *p);
-static asdl_seq *_loop1_98_rule(Parser *p);
-static void *_tmp_99_rule(Parser *p);
+static void *_tmp_96_rule(Parser *p);
+static asdl_seq *_loop0_98_rule(Parser *p);
+static asdl_seq *_gather_97_rule(Parser *p);
+static asdl_seq *_loop1_99_rule(Parser *p);
 static void *_tmp_100_rule(Parser *p);
-static asdl_seq *_loop0_102_rule(Parser *p);
-static asdl_seq *_gather_101_rule(Parser *p);
-static asdl_seq *_loop0_104_rule(Parser *p);
-static asdl_seq *_gather_103_rule(Parser *p);
-static asdl_seq *_loop0_106_rule(Parser *p);
-static asdl_seq *_gather_105_rule(Parser *p);
-static asdl_seq *_loop0_108_rule(Parser *p);
-static asdl_seq *_gather_107_rule(Parser *p);
+static void *_tmp_101_rule(Parser *p);
+static asdl_seq *_loop0_103_rule(Parser *p);
+static asdl_seq *_gather_102_rule(Parser *p);
+static asdl_seq *_loop0_105_rule(Parser *p);
+static asdl_seq *_gather_104_rule(Parser *p);
+static asdl_seq *_loop0_107_rule(Parser *p);
+static asdl_seq *_gather_106_rule(Parser *p);
 static asdl_seq *_loop0_109_rule(Parser *p);
-static asdl_seq *_loop0_111_rule(Parser *p);
-static asdl_seq *_gather_110_rule(Parser *p);
-static void *_tmp_112_rule(Parser *p);
-static asdl_seq *_loop0_114_rule(Parser *p);
-static asdl_seq *_gather_113_rule(Parser *p);
-static asdl_seq *_loop0_116_rule(Parser *p);
-static asdl_seq *_gather_115_rule(Parser *p);
-static void *_tmp_117_rule(Parser *p);
+static asdl_seq *_gather_108_rule(Parser *p);
+static asdl_seq *_loop0_110_rule(Parser *p);
+static asdl_seq *_loop0_112_rule(Parser *p);
+static asdl_seq *_gather_111_rule(Parser *p);
+static void *_tmp_113_rule(Parser *p);
+static asdl_seq *_loop0_115_rule(Parser *p);
+static asdl_seq *_gather_114_rule(Parser *p);
+static asdl_seq *_loop0_117_rule(Parser *p);
+static asdl_seq *_gather_116_rule(Parser *p);
 static void *_tmp_118_rule(Parser *p);
 static void *_tmp_119_rule(Parser *p);
 static void *_tmp_120_rule(Parser *p);
@@ -629,8 +634,9 @@ static void *_tmp_132_rule(Parser *p);
 static void *_tmp_133_rule(Parser *p);
 static void *_tmp_134_rule(Parser *p);
 static void *_tmp_135_rule(Parser *p);
-static asdl_seq *_loop0_136_rule(Parser *p);
-static void *_tmp_137_rule(Parser *p);
+static void *_tmp_136_rule(Parser *p);
+static asdl_seq *_loop0_137_rule(Parser *p);
+static void *_tmp_138_rule(Parser *p);
 
 
 // file: statements? $
@@ -1328,7 +1334,7 @@ compound_stmt_rule(Parser *p)
 // assignment:
 //     | NAME ':' expression ['=' annotated_rhs]
 //     | ('(' inside_paren_ann_assign_target ')' | ann_assign_subscript_attribute_target) ':' expression ['=' annotated_rhs]
-//     | ((star_targets '='))+ (yield_expr | star_expressions)
+//     | ((star_targets '='))+ (yield_expr | star_expressions) TYPE_COMMENT?
 //     | target augassign (yield_expr | star_expressions)
 //     | invalid_assignment
 static void *
@@ -1411,13 +1417,16 @@ assignment_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // ((star_targets '='))+ (yield_expr | star_expressions)
+    { // ((star_targets '='))+ (yield_expr | star_expressions) TYPE_COMMENT?
         asdl_seq * a;
         void *b;
+        void *tc;
         if (
             (a = _loop1_13_rule(p))
             &&
             (b = _tmp_14_rule(p))
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1428,7 +1437,7 @@ assignment_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_Assign ( a , b , NULL , EXTRA );
+            res = _Py_Assign ( a , b , NEW_TYPE_COMMENT ( tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -2657,7 +2666,8 @@ while_stmt_rule(Parser *p)
     return res;
 }
 
-// for_stmt: ASYNC? 'for' star_targets 'in' star_expressions ':' block else_block?
+// for_stmt:
+//     | ASYNC? 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
 static stmt_ty
 for_stmt_rule(Parser *p)
 {
@@ -2674,7 +2684,7 @@ for_stmt_rule(Parser *p)
     UNUSED(start_lineno); // Only used by EXTRA macro
     int start_col_offset = p->tokens[mark]->col_offset;
     UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // ASYNC? 'for' star_targets 'in' star_expressions ':' block else_block?
+    { // ASYNC? 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
         asdl_seq* b;
         void *el;
         expr_ty ex;
@@ -2683,6 +2693,7 @@ for_stmt_rule(Parser *p)
         void *keyword_1;
         void *literal;
         expr_ty t;
+        void *tc;
         if (
             (is_async = _PyPegen_async_token(p), 1)
             &&
@@ -2695,6 +2706,8 @@ for_stmt_rule(Parser *p)
             (ex = star_expressions_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 11))
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
             &&
             (b = block_rule(p))
             &&
@@ -2709,7 +2722,7 @@ for_stmt_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncFor : _Py_For ) ( t , ex , b , el , NULL , EXTRA );
+            res = ( is_async ? _Py_AsyncFor : _Py_For ) ( t , ex , b , el , NEW_TYPE_COMMENT ( tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -2725,7 +2738,7 @@ for_stmt_rule(Parser *p)
 
 // with_stmt:
 //     | ASYNC? 'with' '(' ','.with_item+ ')' ':' block
-//     | ASYNC? 'with' ','.with_item+ ':' block
+//     | ASYNC? 'with' ','.with_item+ ':' TYPE_COMMENT? block
 static stmt_ty
 with_stmt_rule(Parser *p)
 {
@@ -2783,12 +2796,13 @@ with_stmt_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // ASYNC? 'with' ','.with_item+ ':' block
+    { // ASYNC? 'with' ','.with_item+ ':' TYPE_COMMENT? block
         asdl_seq * a;
         asdl_seq* b;
         void *is_async;
         void *keyword;
         void *literal;
+        void *tc;
         if (
             (is_async = _PyPegen_async_token(p), 1)
             &&
@@ -2797,6 +2811,8 @@ with_stmt_rule(Parser *p)
             (a = _gather_31_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 11))
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
             &&
             (b = block_rule(p))
         )
@@ -2809,7 +2825,7 @@ with_stmt_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncWith : _Py_With ) ( a , b , NULL , EXTRA );
+            res = ( is_async ? _Py_AsyncWith : _Py_With ) ( a , b , NEW_TYPE_COMMENT ( tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -3235,7 +3251,8 @@ function_def_rule(Parser *p)
     return res;
 }
 
-// function_def_raw: ASYNC? 'def' NAME '(' params? ')' ['->' annotation] ':' block
+// function_def_raw:
+//     | ASYNC? 'def' NAME '(' params? ')' ['->' annotation] ':' func_type_comment? block
 static stmt_ty
 function_def_raw_rule(Parser *p)
 {
@@ -3252,7 +3269,7 @@ function_def_raw_rule(Parser *p)
     UNUSED(start_lineno); // Only used by EXTRA macro
     int start_col_offset = p->tokens[mark]->col_offset;
     UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // ASYNC? 'def' NAME '(' params? ')' ['->' annotation] ':' block
+    { // ASYNC? 'def' NAME '(' params? ')' ['->' annotation] ':' func_type_comment? block
         void *a;
         asdl_seq* b;
         void *is_async;
@@ -3262,6 +3279,7 @@ function_def_raw_rule(Parser *p)
         void *literal_2;
         expr_ty n;
         void *params;
+        void *tc;
         if (
             (is_async = _PyPegen_async_token(p), 1)
             &&
@@ -3279,6 +3297,8 @@ function_def_raw_rule(Parser *p)
             &&
             (literal_2 = _PyPegen_expect_token(p, 11))
             &&
+            (tc = func_type_comment_rule(p), 1)
+            &&
             (b = block_rule(p))
         )
         {
@@ -3290,11 +3310,70 @@ function_def_raw_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef ) ( n -> v . Name . id , ( params ) ? params : CHECK ( _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NULL , EXTRA );
+            res = ( is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef ) ( n -> v . Name . id , ( params ) ? params : CHECK ( _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
             }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// func_type_comment:
+//     | NEWLINE TYPE_COMMENT &(NEWLINE INDENT)
+//     | invalid_double_type_comments
+//     | TYPE_COMMENT
+static PyObject*
+func_type_comment_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    PyObject* res = NULL;
+    int mark = p->mark;
+    { // NEWLINE TYPE_COMMENT &(NEWLINE INDENT)
+        void *newline_var;
+        void *t;
+        if (
+            (newline_var = _PyPegen_newline_token(p))
+            &&
+            (t = _PyPegen_type_comment_token(p))
+            &&
+            _PyPegen_lookahead(1, _tmp_38_rule, p)
+        )
+        {
+            res = t;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // invalid_double_type_comments
+        void *invalid_double_type_comments_var;
+        if (
+            (invalid_double_type_comments_var = invalid_double_type_comments_rule(p))
+        )
+        {
+            res = invalid_double_type_comments_var;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // TYPE_COMMENT
+        void *type_comment_var;
+        if (
+            (type_comment_var = _PyPegen_type_comment_token(p))
+        )
+        {
+            res = type_comment_var;
             goto done;
         }
         p->mark = mark;
@@ -3362,11 +3441,11 @@ parameters_rule(Parser *p)
         if (
             (a = slash_without_default_rule(p))
             &&
-            (b = _tmp_38_rule(p), 1)
+            (b = _tmp_39_rule(p), 1)
             &&
-            (c = _tmp_39_rule(p), 1)
+            (c = _tmp_40_rule(p), 1)
             &&
-            (d = _tmp_40_rule(p), 1)
+            (d = _tmp_41_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -3385,9 +3464,9 @@ parameters_rule(Parser *p)
         if (
             (a = slash_with_default_rule(p))
             &&
-            (b = _tmp_41_rule(p), 1)
+            (b = _tmp_42_rule(p), 1)
             &&
-            (c = _tmp_42_rule(p), 1)
+            (c = _tmp_43_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -3406,9 +3485,9 @@ parameters_rule(Parser *p)
         if (
             (a = plain_names_rule(p))
             &&
-            (b = _tmp_43_rule(p), 1)
+            (b = _tmp_44_rule(p), 1)
             &&
-            (c = _tmp_44_rule(p), 1)
+            (c = _tmp_45_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -3426,7 +3505,7 @@ parameters_rule(Parser *p)
         if (
             (a = names_with_default_rule(p))
             &&
-            (b = _tmp_45_rule(p), 1)
+            (b = _tmp_46_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -3508,7 +3587,7 @@ slash_with_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _tmp_46_rule(p), 1)
+            (a = _tmp_47_rule(p), 1)
             &&
             (b = names_with_default_rule(p))
             &&
@@ -3555,9 +3634,9 @@ star_etc_rule(Parser *p)
             &&
             (a = plain_name_rule(p))
             &&
-            (b = _loop0_47_rule(p))
+            (b = _loop0_48_rule(p))
             &&
-            (c = _tmp_48_rule(p), 1)
+            (c = _tmp_49_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -3580,9 +3659,9 @@ star_etc_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (b = _loop1_49_rule(p))
+            (b = _loop1_50_rule(p))
             &&
-            (c = _tmp_50_rule(p), 1)
+            (c = _tmp_51_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -3638,7 +3717,7 @@ name_with_optional_default_rule(Parser *p)
             &&
             (a = plain_name_rule(p))
             &&
-            (b = _tmp_51_rule(p), 1)
+            (b = _tmp_52_rule(p), 1)
         )
         {
             res = _PyPegen_name_default_pair ( p , a , b );
@@ -3667,7 +3746,7 @@ names_with_default_rule(Parser *p)
     { // ','.name_with_default+
         asdl_seq * a;
         if (
-            (a = _gather_52_rule(p))
+            (a = _gather_53_rule(p))
         )
         {
             res = a;
@@ -3733,7 +3812,7 @@ plain_names_rule(Parser *p)
     { // ','.(plain_name !'=')+
         asdl_seq * a;
         if (
-            (a = _gather_54_rule(p))
+            (a = _gather_55_rule(p))
         )
         {
             res = a;
@@ -3774,7 +3853,7 @@ plain_name_rule(Parser *p)
         if (
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_56_rule(p), 1)
+            (b = _tmp_57_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3868,7 +3947,7 @@ decorators_rule(Parser *p)
     { // (('@' named_expression NEWLINE))+
         asdl_seq * a;
         if (
-            (a = _loop1_57_rule(p))
+            (a = _loop1_58_rule(p))
         )
         {
             res = a;
@@ -3956,7 +4035,7 @@ class_def_raw_rule(Parser *p)
             &&
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_58_rule(p), 1)
+            (b = _tmp_59_rule(p), 1)
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -4062,7 +4141,7 @@ expressions_list_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_59_rule(p))
+            (a = _gather_60_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4109,7 +4188,7 @@ star_expressions_rule(Parser *p)
         if (
             (a = star_expression_rule(p))
             &&
-            (b = _loop1_61_rule(p))
+            (b = _loop1_62_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4249,7 +4328,7 @@ star_named_expressions_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_62_rule(p))
+            (a = _gather_63_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4463,7 +4542,7 @@ expressions_rule(Parser *p)
         if (
             (a = expression_rule(p))
             &&
-            (b = _loop1_64_rule(p))
+            (b = _loop1_65_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4685,11 +4764,11 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_without_default_rule(p))
             &&
-            (b = _tmp_65_rule(p), 1)
+            (b = _tmp_66_rule(p), 1)
             &&
-            (c = _tmp_66_rule(p), 1)
+            (c = _tmp_67_rule(p), 1)
             &&
-            (d = _tmp_67_rule(p), 1)
+            (d = _tmp_68_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -4708,9 +4787,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_with_default_rule(p))
             &&
-            (b = _tmp_68_rule(p), 1)
+            (b = _tmp_69_rule(p), 1)
             &&
-            (c = _tmp_69_rule(p), 1)
+            (c = _tmp_70_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -4729,9 +4808,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_plain_names_rule(p))
             &&
-            (b = _tmp_70_rule(p), 1)
+            (b = _tmp_71_rule(p), 1)
             &&
-            (c = _tmp_71_rule(p), 1)
+            (c = _tmp_72_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -4749,7 +4828,7 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_names_with_default_rule(p))
             &&
-            (b = _tmp_72_rule(p), 1)
+            (b = _tmp_73_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -4831,7 +4910,7 @@ lambda_slash_with_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _tmp_73_rule(p), 1)
+            (a = _tmp_74_rule(p), 1)
             &&
             (b = lambda_names_with_default_rule(p))
             &&
@@ -4878,9 +4957,9 @@ lambda_star_etc_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _loop0_74_rule(p))
+            (b = _loop0_75_rule(p))
             &&
-            (c = _tmp_75_rule(p), 1)
+            (c = _tmp_76_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4903,9 +4982,9 @@ lambda_star_etc_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (b = _loop1_76_rule(p))
+            (b = _loop1_77_rule(p))
             &&
-            (c = _tmp_77_rule(p), 1)
+            (c = _tmp_78_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4961,7 +5040,7 @@ lambda_name_with_optional_default_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _tmp_78_rule(p), 1)
+            (b = _tmp_79_rule(p), 1)
         )
         {
             res = _PyPegen_name_default_pair ( p , a , b );
@@ -4990,7 +5069,7 @@ lambda_names_with_default_rule(Parser *p)
     { // ','.lambda_name_with_default+
         asdl_seq * a;
         if (
-            (a = _gather_79_rule(p))
+            (a = _gather_80_rule(p))
         )
         {
             res = a;
@@ -5054,7 +5133,7 @@ lambda_plain_names_rule(Parser *p)
     { // ','.(lambda_plain_name !'=')+
         asdl_seq * a;
         if (
-            (a = _gather_81_rule(p))
+            (a = _gather_82_rule(p))
         )
         {
             res = a;
@@ -5173,7 +5252,7 @@ disjunction_rule(Parser *p)
         if (
             (a = conjunction_rule(p))
             &&
-            (b = _loop1_83_rule(p))
+            (b = _loop1_84_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5235,7 +5314,7 @@ conjunction_rule(Parser *p)
         if (
             (a = inversion_rule(p))
             &&
-            (b = _loop1_84_rule(p))
+            (b = _loop1_85_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5357,7 +5436,7 @@ comparison_rule(Parser *p)
         if (
             (a = bitwise_or_rule(p))
             &&
-            (b = _loop1_85_rule(p))
+            (b = _loop1_86_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5569,10 +5648,10 @@ noteq_bitwise_or_rule(Parser *p)
     CmpopExprPair* res = NULL;
     int mark = p->mark;
     { // ('!=') bitwise_or
-        void *_tmp_86_var;
+        void *_tmp_87_var;
         expr_ty a;
         if (
-            (_tmp_86_var = _tmp_86_rule(p))
+            (_tmp_87_var = _tmp_87_rule(p))
             &&
             (a = bitwise_or_rule(p))
         )
@@ -7014,7 +7093,7 @@ slices_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_87_rule(p))
+            (a = _gather_88_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -7070,7 +7149,7 @@ slice_rule(Parser *p)
             &&
             (b = expression_rule(p), 1)
             &&
-            (c = _tmp_89_rule(p), 1)
+            (c = _tmp_90_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7258,22 +7337,9 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // &'(' (tuple | group | genexp)
-        void *_tmp_90_var;
-        if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)
-            &&
-            (_tmp_90_var = _tmp_90_rule(p))
-        )
-        {
-            res = _tmp_90_var;
-            goto done;
-        }
-        p->mark = mark;
-    }
-    { // &'[' (list | listcomp)
         void *_tmp_91_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)
             &&
             (_tmp_91_var = _tmp_91_rule(p))
         )
@@ -7283,15 +7349,28 @@ atom_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // &'{' (dict | set | dictcomp | setcomp)
+    { // &'[' (list | listcomp)
         void *_tmp_92_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)
             &&
             (_tmp_92_var = _tmp_92_rule(p))
         )
         {
             res = _tmp_92_var;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // &'{' (dict | set | dictcomp | setcomp)
+        void *_tmp_93_var;
+        if (
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)
+            &&
+            (_tmp_93_var = _tmp_93_rule(p))
+        )
+        {
+            res = _tmp_93_var;
             goto done;
         }
         p->mark = mark;
@@ -7338,7 +7417,7 @@ strings_rule(Parser *p)
     { // STRING+
         asdl_seq * a;
         if (
-            (a = _loop1_93_rule(p))
+            (a = _loop1_94_rule(p))
         )
         {
             res = _PyPegen_concatenate_strings ( p , a );
@@ -7496,7 +7575,7 @@ tuple_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_94_rule(p), 1)
+            (a = _tmp_95_rule(p), 1)
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -7539,7 +7618,7 @@ group_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_95_rule(p))
+            (a = _tmp_96_rule(p))
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -7858,7 +7937,7 @@ kvpairs_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_96_rule(p))
+            (a = _gather_97_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -7942,7 +8021,7 @@ for_if_clauses_rule(Parser *p)
     { // ((ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*))+
         asdl_seq * a;
         if (
-            (a = _loop1_98_rule(p))
+            (a = _loop1_99_rule(p))
         )
         {
             res = a;
@@ -8108,7 +8187,7 @@ args_rule(Parser *p)
         if (
             (a = starred_expression_rule(p))
             &&
-            (b = _tmp_99_rule(p), 1)
+            (b = _tmp_100_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8157,7 +8236,7 @@ args_rule(Parser *p)
         if (
             (a = named_expression_rule(p))
             &&
-            (b = _tmp_100_rule(p), 1)
+            (b = _tmp_101_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8199,11 +8278,11 @@ kwargs_rule(Parser *p)
         asdl_seq * b;
         void *literal;
         if (
-            (a = _gather_101_rule(p))
+            (a = _gather_102_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (b = _gather_103_rule(p))
+            (b = _gather_104_rule(p))
         )
         {
             res = _PyPegen_join_sequences ( p , a , b );
@@ -8216,23 +8295,23 @@ kwargs_rule(Parser *p)
         p->mark = mark;
     }
     { // ','.kwarg_or_starred+
-        asdl_seq * _gather_105_var;
+        asdl_seq * _gather_106_var;
         if (
-            (_gather_105_var = _gather_105_rule(p))
+            (_gather_106_var = _gather_106_rule(p))
         )
         {
-            res = _gather_105_var;
+            res = _gather_106_var;
             goto done;
         }
         p->mark = mark;
     }
     { // ','.kwarg_or_double_starred+
-        asdl_seq * _gather_107_var;
+        asdl_seq * _gather_108_var;
         if (
-            (_gather_107_var = _gather_107_rule(p))
+            (_gather_108_var = _gather_108_rule(p))
         )
         {
-            res = _gather_107_var;
+            res = _gather_108_var;
             goto done;
         }
         p->mark = mark;
@@ -8475,7 +8554,7 @@ star_targets_rule(Parser *p)
         if (
             (a = star_target_rule(p))
             &&
-            (b = _loop0_109_rule(p))
+            (b = _loop0_110_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8516,7 +8595,7 @@ star_targets_seq_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_110_rule(p))
+            (a = _gather_111_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8564,7 +8643,7 @@ star_target_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (a = _tmp_112_rule(p))
+            (a = _tmp_113_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8953,7 +9032,7 @@ del_targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_113_rule(p))
+            (a = _gather_114_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -9206,7 +9285,7 @@ targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_115_rule(p))
+            (a = _gather_116_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -9734,7 +9813,7 @@ incorrect_arguments_rule(Parser *p)
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (opt_var = _tmp_117_rule(p), 1)
+            (opt_var = _tmp_118_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "Generator expression must be parenthesized" );
@@ -9869,7 +9948,7 @@ invalid_assignment_rule(Parser *p)
             &&
             (expression_var_1 = expression_rule(p))
             &&
-            (opt_var = _tmp_118_rule(p), 1)
+            (opt_var = _tmp_119_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "illegal target for annotation" );
@@ -9882,15 +9961,15 @@ invalid_assignment_rule(Parser *p)
         p->mark = mark;
     }
     { // expression ('=' | augassign) (yield_expr | star_expressions)
-        void *_tmp_119_var;
         void *_tmp_120_var;
+        void *_tmp_121_var;
         expr_ty a;
         if (
             (a = expression_rule(p))
             &&
-            (_tmp_119_var = _tmp_119_rule(p))
-            &&
             (_tmp_120_var = _tmp_120_rule(p))
+            &&
+            (_tmp_121_var = _tmp_121_rule(p))
         )
         {
             res = RAISE_SYNTAX_ERROR ( "cannot assign to %s" , _PyPegen_get_expr_name ( a ) );
@@ -9948,12 +10027,12 @@ invalid_comprehension_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ('[' | '(' | '{') '*' expression for_if_clauses
-        void *_tmp_121_var;
+        void *_tmp_122_var;
         expr_ty expression_var;
         asdl_seq* for_if_clauses_var;
         void *literal;
         if (
-            (_tmp_121_var = _tmp_121_rule(p))
+            (_tmp_122_var = _tmp_122_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -9987,15 +10066,15 @@ invalid_parameters_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // [plain_names ','] (slash_with_default | names_with_default) ',' plain_names
-        void *_tmp_123_var;
+        void *_tmp_124_var;
         void *literal;
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         asdl_seq* plain_names_var;
         if (
-            (opt_var = _tmp_122_rule(p), 1)
+            (opt_var = _tmp_123_rule(p), 1)
             &&
-            (_tmp_123_var = _tmp_123_rule(p))
+            (_tmp_124_var = _tmp_124_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -10003,6 +10082,47 @@ invalid_parameters_rule(Parser *p)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "non-default argument follows default argument" );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// invalid_double_type_comments: TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT
+static void *
+invalid_double_type_comments_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT
+        void *indent_var;
+        void *newline_var;
+        void *newline_var_1;
+        void *type_comment_var;
+        void *type_comment_var_1;
+        if (
+            (type_comment_var = _PyPegen_type_comment_token(p))
+            &&
+            (newline_var = _PyPegen_newline_token(p))
+            &&
+            (type_comment_var_1 = _PyPegen_type_comment_token(p))
+            &&
+            (newline_var_1 = _PyPegen_newline_token(p))
+            &&
+            (indent_var = _PyPegen_indent_token(p))
+        )
+        {
+            res = RAISE_SYNTAX_ERROR ( "Cannot have two type comments on def" );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -10522,12 +10642,12 @@ _loop1_13_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (star_targets '=')
-        void *_tmp_124_var;
+        void *_tmp_125_var;
         while (
-            (_tmp_124_var = _tmp_124_rule(p))
+            (_tmp_125_var = _tmp_125_rule(p))
         )
         {
-            res = _tmp_124_var;
+            res = _tmp_125_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -10849,12 +10969,12 @@ _loop0_21_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_125_var;
+        void *_tmp_126_var;
         while (
-            (_tmp_125_var = _tmp_125_rule(p))
+            (_tmp_126_var = _tmp_126_rule(p))
         )
         {
-            res = _tmp_125_var;
+            res = _tmp_126_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -10898,12 +11018,12 @@ _loop1_22_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_126_var;
+        void *_tmp_127_var;
         while (
-            (_tmp_126_var = _tmp_126_rule(p))
+            (_tmp_127_var = _tmp_127_rule(p))
         )
         {
-            res = _tmp_126_var;
+            res = _tmp_127_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -11518,9 +11638,37 @@ _tmp_37_rule(Parser *p)
     return res;
 }
 
-// _tmp_38: ',' plain_names
+// _tmp_38: NEWLINE INDENT
 static void *
 _tmp_38_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // NEWLINE INDENT
+        void *indent_var;
+        void *newline_var;
+        if (
+            (newline_var = _PyPegen_newline_token(p))
+            &&
+            (indent_var = _PyPegen_indent_token(p))
+        )
+        {
+            res = _PyPegen_dummy_name(p, newline_var, indent_var);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_39: ',' plain_names
+static void *
+_tmp_39_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11550,39 +11698,7 @@ _tmp_38_rule(Parser *p)
     return res;
 }
 
-// _tmp_39: ',' names_with_default
-static void *
-_tmp_39_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_40: ',' star_etc?
+// _tmp_40: ',' names_with_default
 static void *
 _tmp_40_rule(Parser *p)
 {
@@ -11591,16 +11707,16 @@ _tmp_40_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' star_etc?
+    { // ',' names_with_default
         void *literal;
-        void *z;
+        asdl_seq* y;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (z = star_etc_rule(p), 1)
+            (y = names_with_default_rule(p))
         )
         {
-            res = z;
+            res = y;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -11614,7 +11730,7 @@ _tmp_40_rule(Parser *p)
     return res;
 }
 
-// _tmp_41: ',' names_with_default
+// _tmp_41: ',' star_etc?
 static void *
 _tmp_41_rule(Parser *p)
 {
@@ -11623,16 +11739,16 @@ _tmp_41_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' names_with_default
+    { // ',' star_etc?
         void *literal;
-        asdl_seq* y;
+        void *z;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (y = names_with_default_rule(p))
+            (z = star_etc_rule(p), 1)
         )
         {
-            res = y;
+            res = z;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -11646,7 +11762,7 @@ _tmp_41_rule(Parser *p)
     return res;
 }
 
-// _tmp_42: ',' star_etc?
+// _tmp_42: ',' names_with_default
 static void *
 _tmp_42_rule(Parser *p)
 {
@@ -11655,38 +11771,6 @@ _tmp_42_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_43: ',' names_with_default
-static void *
-_tmp_43_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
     { // ',' names_with_default
         void *literal;
         asdl_seq* y;
@@ -11710,9 +11794,9 @@ _tmp_43_rule(Parser *p)
     return res;
 }
 
-// _tmp_44: ',' star_etc?
+// _tmp_43: ',' star_etc?
 static void *
-_tmp_44_rule(Parser *p)
+_tmp_43_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11729,6 +11813,38 @@ _tmp_44_rule(Parser *p)
         )
         {
             res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_44: ',' names_with_default
+static void *
+_tmp_44_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' names_with_default
+        void *literal;
+        asdl_seq* y;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (y = names_with_default_rule(p))
+        )
+        {
+            res = y;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -11774,9 +11890,41 @@ _tmp_45_rule(Parser *p)
     return res;
 }
 
-// _tmp_46: plain_names ','
+// _tmp_46: ',' star_etc?
 static void *
 _tmp_46_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' star_etc?
+        void *literal;
+        void *z;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (z = star_etc_rule(p), 1)
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_47: plain_names ','
+static void *
+_tmp_47_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11806,9 +11954,9 @@ _tmp_46_rule(Parser *p)
     return res;
 }
 
-// _loop0_47: name_with_optional_default
+// _loop0_48: name_with_optional_default
 static asdl_seq *
-_loop0_47_rule(Parser *p)
+_loop0_48_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11845,19 +11993,19 @@ _loop0_47_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_47");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_48");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_47_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_48_type, seq);
     return seq;
 }
 
-// _tmp_48: ',' kwds
+// _tmp_49: ',' kwds
 static void *
-_tmp_48_rule(Parser *p)
+_tmp_49_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11887,9 +12035,9 @@ _tmp_48_rule(Parser *p)
     return res;
 }
 
-// _loop1_49: name_with_optional_default
+// _loop1_50: name_with_optional_default
 static asdl_seq *
-_loop1_49_rule(Parser *p)
+_loop1_50_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11930,19 +12078,19 @@ _loop1_49_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_49");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_50");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_49_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_50_type, seq);
     return seq;
 }
 
-// _tmp_50: ',' kwds
+// _tmp_51: ',' kwds
 static void *
-_tmp_50_rule(Parser *p)
+_tmp_51_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11972,9 +12120,9 @@ _tmp_50_rule(Parser *p)
     return res;
 }
 
-// _tmp_51: '=' expression
+// _tmp_52: '=' expression
 static void *
-_tmp_51_rule(Parser *p)
+_tmp_52_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12004,9 +12152,9 @@ _tmp_51_rule(Parser *p)
     return res;
 }
 
-// _loop0_53: ',' name_with_default
+// _loop0_54: ',' name_with_default
 static asdl_seq *
-_loop0_53_rule(Parser *p)
+_loop0_54_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12051,32 +12199,32 @@ _loop0_53_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_53");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_54");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_53_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_54_type, seq);
     return seq;
 }
 
-// _gather_52: name_with_default _loop0_53
+// _gather_53: name_with_default _loop0_54
 static asdl_seq *
-_gather_52_rule(Parser *p)
+_gather_53_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // name_with_default _loop0_53
+    { // name_with_default _loop0_54
         NameDefaultPair* elem;
         asdl_seq * seq;
         if (
             (elem = name_with_default_rule(p))
             &&
-            (seq = _loop0_53_rule(p))
+            (seq = _loop0_54_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12089,9 +12237,9 @@ _gather_52_rule(Parser *p)
     return res;
 }
 
-// _loop0_55: ',' (plain_name !'=')
+// _loop0_56: ',' (plain_name !'=')
 static asdl_seq *
-_loop0_55_rule(Parser *p)
+_loop0_56_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12112,7 +12260,7 @@ _loop0_55_rule(Parser *p)
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (elem = _tmp_127_rule(p))
+            (elem = _tmp_128_rule(p))
         )
         {
             res = elem;
@@ -12136,32 +12284,32 @@ _loop0_55_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_55");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_56");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_55_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_56_type, seq);
     return seq;
 }
 
-// _gather_54: (plain_name !'=') _loop0_55
+// _gather_55: (plain_name !'=') _loop0_56
 static asdl_seq *
-_gather_54_rule(Parser *p)
+_gather_55_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // (plain_name !'=') _loop0_55
+    { // (plain_name !'=') _loop0_56
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_127_rule(p))
+            (elem = _tmp_128_rule(p))
             &&
-            (seq = _loop0_55_rule(p))
+            (seq = _loop0_56_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12174,9 +12322,9 @@ _gather_54_rule(Parser *p)
     return res;
 }
 
-// _tmp_56: ':' annotation
+// _tmp_57: ':' annotation
 static void *
-_tmp_56_rule(Parser *p)
+_tmp_57_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12206,9 +12354,9 @@ _tmp_56_rule(Parser *p)
     return res;
 }
 
-// _loop1_57: ('@' named_expression NEWLINE)
+// _loop1_58: ('@' named_expression NEWLINE)
 static asdl_seq *
-_loop1_57_rule(Parser *p)
+_loop1_58_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12224,12 +12372,12 @@ _loop1_57_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('@' named_expression NEWLINE)
-        void *_tmp_128_var;
+        void *_tmp_129_var;
         while (
-            (_tmp_128_var = _tmp_128_rule(p))
+            (_tmp_129_var = _tmp_129_rule(p))
         )
         {
-            res = _tmp_128_var;
+            res = _tmp_129_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12249,19 +12397,19 @@ _loop1_57_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_57");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_58");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_57_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_58_type, seq);
     return seq;
 }
 
-// _tmp_58: '(' arguments? ')'
+// _tmp_59: '(' arguments? ')'
 static void *
-_tmp_58_rule(Parser *p)
+_tmp_59_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12294,9 +12442,9 @@ _tmp_58_rule(Parser *p)
     return res;
 }
 
-// _loop0_60: ',' star_expression
+// _loop0_61: ',' star_expression
 static asdl_seq *
-_loop0_60_rule(Parser *p)
+_loop0_61_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12341,32 +12489,32 @@ _loop0_60_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_60");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_61");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_60_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_61_type, seq);
     return seq;
 }
 
-// _gather_59: star_expression _loop0_60
+// _gather_60: star_expression _loop0_61
 static asdl_seq *
-_gather_59_rule(Parser *p)
+_gather_60_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_expression _loop0_60
+    { // star_expression _loop0_61
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_expression_rule(p))
             &&
-            (seq = _loop0_60_rule(p))
+            (seq = _loop0_61_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12379,9 +12527,9 @@ _gather_59_rule(Parser *p)
     return res;
 }
 
-// _loop1_61: (',' star_expression)
+// _loop1_62: (',' star_expression)
 static asdl_seq *
-_loop1_61_rule(Parser *p)
+_loop1_62_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12397,12 +12545,12 @@ _loop1_61_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_expression)
-        void *_tmp_129_var;
+        void *_tmp_130_var;
         while (
-            (_tmp_129_var = _tmp_129_rule(p))
+            (_tmp_130_var = _tmp_130_rule(p))
         )
         {
-            res = _tmp_129_var;
+            res = _tmp_130_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12422,19 +12570,19 @@ _loop1_61_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_61");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_62");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_61_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_62_type, seq);
     return seq;
 }
 
-// _loop0_63: ',' star_named_expression
+// _loop0_64: ',' star_named_expression
 static asdl_seq *
-_loop0_63_rule(Parser *p)
+_loop0_64_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12479,32 +12627,32 @@ _loop0_63_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_63");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_64");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_63_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_64_type, seq);
     return seq;
 }
 
-// _gather_62: star_named_expression _loop0_63
+// _gather_63: star_named_expression _loop0_64
 static asdl_seq *
-_gather_62_rule(Parser *p)
+_gather_63_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_named_expression _loop0_63
+    { // star_named_expression _loop0_64
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_named_expression_rule(p))
             &&
-            (seq = _loop0_63_rule(p))
+            (seq = _loop0_64_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12517,9 +12665,9 @@ _gather_62_rule(Parser *p)
     return res;
 }
 
-// _loop1_64: (',' expression)
+// _loop1_65: (',' expression)
 static asdl_seq *
-_loop1_64_rule(Parser *p)
+_loop1_65_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12535,12 +12683,12 @@ _loop1_64_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' expression)
-        void *_tmp_130_var;
+        void *_tmp_131_var;
         while (
-            (_tmp_130_var = _tmp_130_rule(p))
+            (_tmp_131_var = _tmp_131_rule(p))
         )
         {
-            res = _tmp_130_var;
+            res = _tmp_131_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12560,19 +12708,19 @@ _loop1_64_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_64");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_65");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_64_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_65_type, seq);
     return seq;
 }
 
-// _tmp_65: ',' lambda_plain_names
+// _tmp_66: ',' lambda_plain_names
 static void *
-_tmp_65_rule(Parser *p)
+_tmp_66_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12602,39 +12750,7 @@ _tmp_65_rule(Parser *p)
     return res;
 }
 
-// _tmp_66: ',' lambda_names_with_default
-static void *
-_tmp_66_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = lambda_names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_67: ',' lambda_star_etc?
+// _tmp_67: ',' lambda_names_with_default
 static void *
 _tmp_67_rule(Parser *p)
 {
@@ -12643,16 +12759,16 @@ _tmp_67_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' lambda_star_etc?
+    { // ',' lambda_names_with_default
         void *literal;
-        void *z;
+        asdl_seq* y;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (z = lambda_star_etc_rule(p), 1)
+            (y = lambda_names_with_default_rule(p))
         )
         {
-            res = z;
+            res = y;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -12666,7 +12782,7 @@ _tmp_67_rule(Parser *p)
     return res;
 }
 
-// _tmp_68: ',' lambda_names_with_default
+// _tmp_68: ',' lambda_star_etc?
 static void *
 _tmp_68_rule(Parser *p)
 {
@@ -12675,16 +12791,16 @@ _tmp_68_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' lambda_names_with_default
+    { // ',' lambda_star_etc?
         void *literal;
-        asdl_seq* y;
+        void *z;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (y = lambda_names_with_default_rule(p))
+            (z = lambda_star_etc_rule(p), 1)
         )
         {
-            res = y;
+            res = z;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -12698,7 +12814,7 @@ _tmp_68_rule(Parser *p)
     return res;
 }
 
-// _tmp_69: ',' lambda_star_etc?
+// _tmp_69: ',' lambda_names_with_default
 static void *
 _tmp_69_rule(Parser *p)
 {
@@ -12707,38 +12823,6 @@ _tmp_69_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' lambda_star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = lambda_star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_70: ',' lambda_names_with_default
-static void *
-_tmp_70_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
     { // ',' lambda_names_with_default
         void *literal;
         asdl_seq* y;
@@ -12762,9 +12846,9 @@ _tmp_70_rule(Parser *p)
     return res;
 }
 
-// _tmp_71: ',' lambda_star_etc?
+// _tmp_70: ',' lambda_star_etc?
 static void *
-_tmp_71_rule(Parser *p)
+_tmp_70_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12781,6 +12865,38 @@ _tmp_71_rule(Parser *p)
         )
         {
             res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_71: ',' lambda_names_with_default
+static void *
+_tmp_71_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_names_with_default
+        void *literal;
+        asdl_seq* y;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (y = lambda_names_with_default_rule(p))
+        )
+        {
+            res = y;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -12826,9 +12942,41 @@ _tmp_72_rule(Parser *p)
     return res;
 }
 
-// _tmp_73: lambda_plain_names ','
+// _tmp_73: ',' lambda_star_etc?
 static void *
 _tmp_73_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_star_etc?
+        void *literal;
+        void *z;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (z = lambda_star_etc_rule(p), 1)
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_74: lambda_plain_names ','
+static void *
+_tmp_74_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12858,9 +13006,9 @@ _tmp_73_rule(Parser *p)
     return res;
 }
 
-// _loop0_74: lambda_name_with_optional_default
+// _loop0_75: lambda_name_with_optional_default
 static asdl_seq *
-_loop0_74_rule(Parser *p)
+_loop0_75_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12897,19 +13045,19 @@ _loop0_74_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_74");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_75");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_74_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_75_type, seq);
     return seq;
 }
 
-// _tmp_75: ',' lambda_kwds
+// _tmp_76: ',' lambda_kwds
 static void *
-_tmp_75_rule(Parser *p)
+_tmp_76_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12939,9 +13087,9 @@ _tmp_75_rule(Parser *p)
     return res;
 }
 
-// _loop1_76: lambda_name_with_optional_default
+// _loop1_77: lambda_name_with_optional_default
 static asdl_seq *
-_loop1_76_rule(Parser *p)
+_loop1_77_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12982,19 +13130,19 @@ _loop1_76_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_76");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_77");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_76_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_77_type, seq);
     return seq;
 }
 
-// _tmp_77: ',' lambda_kwds
+// _tmp_78: ',' lambda_kwds
 static void *
-_tmp_77_rule(Parser *p)
+_tmp_78_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13024,9 +13172,9 @@ _tmp_77_rule(Parser *p)
     return res;
 }
 
-// _tmp_78: '=' expression
+// _tmp_79: '=' expression
 static void *
-_tmp_78_rule(Parser *p)
+_tmp_79_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13056,9 +13204,9 @@ _tmp_78_rule(Parser *p)
     return res;
 }
 
-// _loop0_80: ',' lambda_name_with_default
+// _loop0_81: ',' lambda_name_with_default
 static asdl_seq *
-_loop0_80_rule(Parser *p)
+_loop0_81_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13103,32 +13251,32 @@ _loop0_80_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_80");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_81");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_80_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_81_type, seq);
     return seq;
 }
 
-// _gather_79: lambda_name_with_default _loop0_80
+// _gather_80: lambda_name_with_default _loop0_81
 static asdl_seq *
-_gather_79_rule(Parser *p)
+_gather_80_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // lambda_name_with_default _loop0_80
+    { // lambda_name_with_default _loop0_81
         NameDefaultPair* elem;
         asdl_seq * seq;
         if (
             (elem = lambda_name_with_default_rule(p))
             &&
-            (seq = _loop0_80_rule(p))
+            (seq = _loop0_81_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13141,9 +13289,9 @@ _gather_79_rule(Parser *p)
     return res;
 }
 
-// _loop0_82: ',' (lambda_plain_name !'=')
+// _loop0_83: ',' (lambda_plain_name !'=')
 static asdl_seq *
-_loop0_82_rule(Parser *p)
+_loop0_83_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13164,7 +13312,7 @@ _loop0_82_rule(Parser *p)
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (elem = _tmp_131_rule(p))
+            (elem = _tmp_132_rule(p))
         )
         {
             res = elem;
@@ -13188,32 +13336,32 @@ _loop0_82_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_82");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_83");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_82_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_83_type, seq);
     return seq;
 }
 
-// _gather_81: (lambda_plain_name !'=') _loop0_82
+// _gather_82: (lambda_plain_name !'=') _loop0_83
 static asdl_seq *
-_gather_81_rule(Parser *p)
+_gather_82_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // (lambda_plain_name !'=') _loop0_82
+    { // (lambda_plain_name !'=') _loop0_83
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_131_rule(p))
+            (elem = _tmp_132_rule(p))
             &&
-            (seq = _loop0_82_rule(p))
+            (seq = _loop0_83_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13226,60 +13374,7 @@ _gather_81_rule(Parser *p)
     return res;
 }
 
-// _loop1_83: ('or' conjunction)
-static asdl_seq *
-_loop1_83_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ('or' conjunction)
-        void *_tmp_132_var;
-        while (
-            (_tmp_132_var = _tmp_132_rule(p))
-        )
-        {
-            res = _tmp_132_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    if (n == 0) {
-        PyMem_Free(children);
-        return NULL;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_83");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_83_type, seq);
-    return seq;
-}
-
-// _loop1_84: ('and' inversion)
+// _loop1_84: ('or' conjunction)
 static asdl_seq *
 _loop1_84_rule(Parser *p)
 {
@@ -13296,7 +13391,7 @@ _loop1_84_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // ('and' inversion)
+    { // ('or' conjunction)
         void *_tmp_133_var;
         while (
             (_tmp_133_var = _tmp_133_rule(p))
@@ -13332,9 +13427,62 @@ _loop1_84_rule(Parser *p)
     return seq;
 }
 
-// _loop1_85: compare_op_bitwise_or_pair
+// _loop1_85: ('and' inversion)
 static asdl_seq *
 _loop1_85_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ('and' inversion)
+        void *_tmp_134_var;
+        while (
+            (_tmp_134_var = _tmp_134_rule(p))
+        )
+        {
+            res = _tmp_134_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_85");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_85_type, seq);
+    return seq;
+}
+
+// _loop1_86: compare_op_bitwise_or_pair
+static asdl_seq *
+_loop1_86_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13375,19 +13523,19 @@ _loop1_85_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_85");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_86");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_85_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_86_type, seq);
     return seq;
 }
 
-// _tmp_86: '!='
+// _tmp_87: '!='
 static void *
-_tmp_86_rule(Parser *p)
+_tmp_87_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13414,9 +13562,9 @@ _tmp_86_rule(Parser *p)
     return res;
 }
 
-// _loop0_88: ',' slice
+// _loop0_89: ',' slice
 static asdl_seq *
-_loop0_88_rule(Parser *p)
+_loop0_89_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13461,32 +13609,32 @@ _loop0_88_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_88");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_89");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_88_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_89_type, seq);
     return seq;
 }
 
-// _gather_87: slice _loop0_88
+// _gather_88: slice _loop0_89
 static asdl_seq *
-_gather_87_rule(Parser *p)
+_gather_88_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // slice _loop0_88
+    { // slice _loop0_89
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = slice_rule(p))
             &&
-            (seq = _loop0_88_rule(p))
+            (seq = _loop0_89_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13499,9 +13647,9 @@ _gather_87_rule(Parser *p)
     return res;
 }
 
-// _tmp_89: ':' expression?
+// _tmp_90: ':' expression?
 static void *
-_tmp_89_rule(Parser *p)
+_tmp_90_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13531,9 +13679,9 @@ _tmp_89_rule(Parser *p)
     return res;
 }
 
-// _tmp_90: tuple | group | genexp
+// _tmp_91: tuple | group | genexp
 static void *
-_tmp_90_rule(Parser *p)
+_tmp_91_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13578,9 +13726,9 @@ _tmp_90_rule(Parser *p)
     return res;
 }
 
-// _tmp_91: list | listcomp
+// _tmp_92: list | listcomp
 static void *
-_tmp_91_rule(Parser *p)
+_tmp_92_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13614,9 +13762,9 @@ _tmp_91_rule(Parser *p)
     return res;
 }
 
-// _tmp_92: dict | set | dictcomp | setcomp
+// _tmp_93: dict | set | dictcomp | setcomp
 static void *
-_tmp_92_rule(Parser *p)
+_tmp_93_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13672,9 +13820,9 @@ _tmp_92_rule(Parser *p)
     return res;
 }
 
-// _loop1_93: STRING
+// _loop1_94: STRING
 static asdl_seq *
-_loop1_93_rule(Parser *p)
+_loop1_94_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13715,19 +13863,19 @@ _loop1_93_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_93");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_94");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_93_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_94_type, seq);
     return seq;
 }
 
-// _tmp_94: star_named_expression ',' star_named_expressions?
+// _tmp_95: star_named_expression ',' star_named_expressions?
 static void *
-_tmp_94_rule(Parser *p)
+_tmp_95_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13760,9 +13908,9 @@ _tmp_94_rule(Parser *p)
     return res;
 }
 
-// _tmp_95: yield_expr | named_expression
+// _tmp_96: yield_expr | named_expression
 static void *
-_tmp_95_rule(Parser *p)
+_tmp_96_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13796,9 +13944,9 @@ _tmp_95_rule(Parser *p)
     return res;
 }
 
-// _loop0_97: ',' kvpair
+// _loop0_98: ',' kvpair
 static asdl_seq *
-_loop0_97_rule(Parser *p)
+_loop0_98_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13843,32 +13991,32 @@ _loop0_97_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_97");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_98");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_97_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_98_type, seq);
     return seq;
 }
 
-// _gather_96: kvpair _loop0_97
+// _gather_97: kvpair _loop0_98
 static asdl_seq *
-_gather_96_rule(Parser *p)
+_gather_97_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kvpair _loop0_97
+    { // kvpair _loop0_98
         KeyValuePair* elem;
         asdl_seq * seq;
         if (
             (elem = kvpair_rule(p))
             &&
-            (seq = _loop0_97_rule(p))
+            (seq = _loop0_98_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13881,9 +14029,9 @@ _gather_96_rule(Parser *p)
     return res;
 }
 
-// _loop1_98: (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
+// _loop1_99: (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
 static asdl_seq *
-_loop1_98_rule(Parser *p)
+_loop1_99_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13899,12 +14047,12 @@ _loop1_98_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
-        void *_tmp_134_var;
+        void *_tmp_135_var;
         while (
-            (_tmp_134_var = _tmp_134_rule(p))
+            (_tmp_135_var = _tmp_135_rule(p))
         )
         {
-            res = _tmp_134_var;
+            res = _tmp_135_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13924,46 +14072,14 @@ _loop1_98_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_98");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_99");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_98_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_99_type, seq);
     return seq;
-}
-
-// _tmp_99: ',' args
-static void *
-_tmp_99_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' args
-        expr_ty c;
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (c = args_rule(p))
-        )
-        {
-            res = c;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
 }
 
 // _tmp_100: ',' args
@@ -13998,9 +14114,41 @@ _tmp_100_rule(Parser *p)
     return res;
 }
 
-// _loop0_102: ',' kwarg_or_starred
+// _tmp_101: ',' args
+static void *
+_tmp_101_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' args
+        expr_ty c;
+        void *literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (c = args_rule(p))
+        )
+        {
+            res = c;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_103: ',' kwarg_or_starred
 static asdl_seq *
-_loop0_102_rule(Parser *p)
+_loop0_103_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14045,32 +14193,32 @@ _loop0_102_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_102");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_103");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_102_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_103_type, seq);
     return seq;
 }
 
-// _gather_101: kwarg_or_starred _loop0_102
+// _gather_102: kwarg_or_starred _loop0_103
 static asdl_seq *
-_gather_101_rule(Parser *p)
+_gather_102_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_starred _loop0_102
+    { // kwarg_or_starred _loop0_103
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_starred_rule(p))
             &&
-            (seq = _loop0_102_rule(p))
+            (seq = _loop0_103_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14083,9 +14231,9 @@ _gather_101_rule(Parser *p)
     return res;
 }
 
-// _loop0_104: ',' kwarg_or_double_starred
+// _loop0_105: ',' kwarg_or_double_starred
 static asdl_seq *
-_loop0_104_rule(Parser *p)
+_loop0_105_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14130,32 +14278,32 @@ _loop0_104_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_104");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_105");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_104_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_105_type, seq);
     return seq;
 }
 
-// _gather_103: kwarg_or_double_starred _loop0_104
+// _gather_104: kwarg_or_double_starred _loop0_105
 static asdl_seq *
-_gather_103_rule(Parser *p)
+_gather_104_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_104
+    { // kwarg_or_double_starred _loop0_105
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_double_starred_rule(p))
             &&
-            (seq = _loop0_104_rule(p))
+            (seq = _loop0_105_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14168,9 +14316,9 @@ _gather_103_rule(Parser *p)
     return res;
 }
 
-// _loop0_106: ',' kwarg_or_starred
+// _loop0_107: ',' kwarg_or_starred
 static asdl_seq *
-_loop0_106_rule(Parser *p)
+_loop0_107_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14215,32 +14363,32 @@ _loop0_106_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_106");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_107");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_106_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_107_type, seq);
     return seq;
 }
 
-// _gather_105: kwarg_or_starred _loop0_106
+// _gather_106: kwarg_or_starred _loop0_107
 static asdl_seq *
-_gather_105_rule(Parser *p)
+_gather_106_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_starred _loop0_106
+    { // kwarg_or_starred _loop0_107
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_starred_rule(p))
             &&
-            (seq = _loop0_106_rule(p))
+            (seq = _loop0_107_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14253,92 +14401,7 @@ _gather_105_rule(Parser *p)
     return res;
 }
 
-// _loop0_108: ',' kwarg_or_double_starred
-static asdl_seq *
-_loop0_108_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ',' kwarg_or_double_starred
-        KeywordOrStarred* elem;
-        void *literal;
-        while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = kwarg_or_double_starred_rule(p))
-        )
-        {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_108");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_108_type, seq);
-    return seq;
-}
-
-// _gather_107: kwarg_or_double_starred _loop0_108
-static asdl_seq *
-_gather_107_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_108
-        KeywordOrStarred* elem;
-        asdl_seq * seq;
-        if (
-            (elem = kwarg_or_double_starred_rule(p))
-            &&
-            (seq = _loop0_108_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_109: (',' star_target)
+// _loop0_109: ',' kwarg_or_double_starred
 static asdl_seq *
 _loop0_109_rule(Parser *p)
 {
@@ -14355,13 +14418,21 @@ _loop0_109_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // (',' star_target)
-        void *_tmp_135_var;
+    { // ',' kwarg_or_double_starred
+        KeywordOrStarred* elem;
+        void *literal;
         while (
-            (_tmp_135_var = _tmp_135_rule(p))
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = kwarg_or_double_starred_rule(p))
         )
         {
-            res = _tmp_135_var;
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14387,9 +14458,86 @@ _loop0_109_rule(Parser *p)
     return seq;
 }
 
-// _loop0_111: ',' star_target
+// _gather_108: kwarg_or_double_starred _loop0_109
 static asdl_seq *
-_loop0_111_rule(Parser *p)
+_gather_108_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // kwarg_or_double_starred _loop0_109
+        KeywordOrStarred* elem;
+        asdl_seq * seq;
+        if (
+            (elem = kwarg_or_double_starred_rule(p))
+            &&
+            (seq = _loop0_109_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_110: (',' star_target)
+static asdl_seq *
+_loop0_110_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // (',' star_target)
+        void *_tmp_136_var;
+        while (
+            (_tmp_136_var = _tmp_136_rule(p))
+        )
+        {
+            res = _tmp_136_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_110");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_110_type, seq);
+    return seq;
+}
+
+// _loop0_112: ',' star_target
+static asdl_seq *
+_loop0_112_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14434,32 +14582,32 @@ _loop0_111_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_111");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_112");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_111_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_112_type, seq);
     return seq;
 }
 
-// _gather_110: star_target _loop0_111
+// _gather_111: star_target _loop0_112
 static asdl_seq *
-_gather_110_rule(Parser *p)
+_gather_111_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_target _loop0_111
+    { // star_target _loop0_112
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_target_rule(p))
             &&
-            (seq = _loop0_111_rule(p))
+            (seq = _loop0_112_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14472,9 +14620,9 @@ _gather_110_rule(Parser *p)
     return res;
 }
 
-// _tmp_112: !'*' star_target
+// _tmp_113: !'*' star_target
 static void *
-_tmp_112_rule(Parser *p)
+_tmp_113_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14499,9 +14647,9 @@ _tmp_112_rule(Parser *p)
     return res;
 }
 
-// _loop0_114: ',' del_target
+// _loop0_115: ',' del_target
 static asdl_seq *
-_loop0_114_rule(Parser *p)
+_loop0_115_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14546,32 +14694,32 @@ _loop0_114_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_114");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_115");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_114_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_115_type, seq);
     return seq;
 }
 
-// _gather_113: del_target _loop0_114
+// _gather_114: del_target _loop0_115
 static asdl_seq *
-_gather_113_rule(Parser *p)
+_gather_114_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // del_target _loop0_114
+    { // del_target _loop0_115
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = del_target_rule(p))
             &&
-            (seq = _loop0_114_rule(p))
+            (seq = _loop0_115_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14584,9 +14732,9 @@ _gather_113_rule(Parser *p)
     return res;
 }
 
-// _loop0_116: ',' target
+// _loop0_117: ',' target
 static asdl_seq *
-_loop0_116_rule(Parser *p)
+_loop0_117_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14631,32 +14779,32 @@ _loop0_116_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_116");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_117");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_116_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_117_type, seq);
     return seq;
 }
 
-// _gather_115: target _loop0_116
+// _gather_116: target _loop0_117
 static asdl_seq *
-_gather_115_rule(Parser *p)
+_gather_116_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // target _loop0_116
+    { // target _loop0_117
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = target_rule(p))
             &&
-            (seq = _loop0_116_rule(p))
+            (seq = _loop0_117_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14669,9 +14817,9 @@ _gather_115_rule(Parser *p)
     return res;
 }
 
-// _tmp_117: args | expression for_if_clauses
+// _tmp_118: args | expression for_if_clauses
 static void *
-_tmp_117_rule(Parser *p)
+_tmp_118_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14708,9 +14856,9 @@ _tmp_117_rule(Parser *p)
     return res;
 }
 
-// _tmp_118: '=' annotated_rhs
+// _tmp_119: '=' annotated_rhs
 static void *
-_tmp_118_rule(Parser *p)
+_tmp_119_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14736,9 +14884,9 @@ _tmp_118_rule(Parser *p)
     return res;
 }
 
-// _tmp_119: '=' | augassign
+// _tmp_120: '=' | augassign
 static void *
-_tmp_119_rule(Parser *p)
+_tmp_120_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14772,9 +14920,9 @@ _tmp_119_rule(Parser *p)
     return res;
 }
 
-// _tmp_120: yield_expr | star_expressions
+// _tmp_121: yield_expr | star_expressions
 static void *
-_tmp_120_rule(Parser *p)
+_tmp_121_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14808,9 +14956,9 @@ _tmp_120_rule(Parser *p)
     return res;
 }
 
-// _tmp_121: '[' | '(' | '{'
+// _tmp_122: '[' | '(' | '{'
 static void *
-_tmp_121_rule(Parser *p)
+_tmp_122_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14855,9 +15003,9 @@ _tmp_121_rule(Parser *p)
     return res;
 }
 
-// _tmp_122: plain_names ','
+// _tmp_123: plain_names ','
 static void *
-_tmp_122_rule(Parser *p)
+_tmp_123_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14883,9 +15031,9 @@ _tmp_122_rule(Parser *p)
     return res;
 }
 
-// _tmp_123: slash_with_default | names_with_default
+// _tmp_124: slash_with_default | names_with_default
 static void *
-_tmp_123_rule(Parser *p)
+_tmp_124_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14919,9 +15067,9 @@ _tmp_123_rule(Parser *p)
     return res;
 }
 
-// _tmp_124: star_targets '='
+// _tmp_125: star_targets '='
 static void *
-_tmp_124_rule(Parser *p)
+_tmp_125_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14942,42 +15090,6 @@ _tmp_124_rule(Parser *p)
                 p->error_indicator = 1;
                 return NULL;
             }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_125: '.' | '...'
-static void *
-_tmp_125_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // '.'
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 23))
-        )
-        {
-            res = literal;
-            goto done;
-        }
-        p->mark = mark;
-    }
-    { // '...'
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 52))
-        )
-        {
-            res = literal;
             goto done;
         }
         p->mark = mark;
@@ -15023,9 +15135,45 @@ _tmp_126_rule(Parser *p)
     return res;
 }
 
-// _tmp_127: plain_name !'='
+// _tmp_127: '.' | '...'
 static void *
 _tmp_127_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // '.'
+        void *literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 23))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // '...'
+        void *literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 52))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_128: plain_name !'='
+static void *
+_tmp_128_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15050,9 +15198,9 @@ _tmp_127_rule(Parser *p)
     return res;
 }
 
-// _tmp_128: '@' named_expression NEWLINE
+// _tmp_129: '@' named_expression NEWLINE
 static void *
-_tmp_128_rule(Parser *p)
+_tmp_129_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15085,9 +15233,9 @@ _tmp_128_rule(Parser *p)
     return res;
 }
 
-// _tmp_129: ',' star_expression
+// _tmp_130: ',' star_expression
 static void *
-_tmp_129_rule(Parser *p)
+_tmp_130_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15117,9 +15265,9 @@ _tmp_129_rule(Parser *p)
     return res;
 }
 
-// _tmp_130: ',' expression
+// _tmp_131: ',' expression
 static void *
-_tmp_130_rule(Parser *p)
+_tmp_131_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15149,9 +15297,9 @@ _tmp_130_rule(Parser *p)
     return res;
 }
 
-// _tmp_131: lambda_plain_name !'='
+// _tmp_132: lambda_plain_name !'='
 static void *
-_tmp_131_rule(Parser *p)
+_tmp_132_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15176,9 +15324,9 @@ _tmp_131_rule(Parser *p)
     return res;
 }
 
-// _tmp_132: 'or' conjunction
+// _tmp_133: 'or' conjunction
 static void *
-_tmp_132_rule(Parser *p)
+_tmp_133_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15208,9 +15356,9 @@ _tmp_132_rule(Parser *p)
     return res;
 }
 
-// _tmp_133: 'and' inversion
+// _tmp_134: 'and' inversion
 static void *
-_tmp_133_rule(Parser *p)
+_tmp_134_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15240,9 +15388,9 @@ _tmp_133_rule(Parser *p)
     return res;
 }
 
-// _tmp_134: ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
+// _tmp_135: ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
 static void *
-_tmp_134_rule(Parser *p)
+_tmp_135_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15267,7 +15415,7 @@ _tmp_134_rule(Parser *p)
             &&
             (b = disjunction_rule(p))
             &&
-            (c = _loop0_136_rule(p))
+            (c = _loop0_137_rule(p))
         )
         {
             res = _Py_comprehension ( a , b , c , y != NULL , p -> arena );
@@ -15284,9 +15432,9 @@ _tmp_134_rule(Parser *p)
     return res;
 }
 
-// _tmp_135: ',' star_target
+// _tmp_136: ',' star_target
 static void *
-_tmp_135_rule(Parser *p)
+_tmp_136_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15316,9 +15464,9 @@ _tmp_135_rule(Parser *p)
     return res;
 }
 
-// _loop0_136: ('if' disjunction)
+// _loop0_137: ('if' disjunction)
 static asdl_seq *
-_loop0_136_rule(Parser *p)
+_loop0_137_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15334,12 +15482,12 @@ _loop0_136_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('if' disjunction)
-        void *_tmp_137_var;
+        void *_tmp_138_var;
         while (
-            (_tmp_137_var = _tmp_137_rule(p))
+            (_tmp_138_var = _tmp_138_rule(p))
         )
         {
-            res = _tmp_137_var;
+            res = _tmp_138_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15355,19 +15503,19 @@ _loop0_136_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_136");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_137");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_136_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_137_type, seq);
     return seq;
 }
 
-// _tmp_137: 'if' disjunction
+// _tmp_138: 'if' disjunction
 static void *
-_tmp_137_rule(Parser *p)
+_tmp_138_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -71,292 +71,304 @@ static KeywordToken *reserved_keywords[] = {
 #define file_type 1000
 #define interactive_type 1001
 #define eval_type 1002
-#define fstring_type 1003
-#define statements_type 1004
-#define statement_type 1005
-#define statement_newline_type 1006
-#define simple_stmt_type 1007
-#define small_stmt_type 1008
-#define compound_stmt_type 1009
-#define assignment_type 1010
-#define augassign_type 1011
-#define global_stmt_type 1012
-#define nonlocal_stmt_type 1013
-#define yield_stmt_type 1014
-#define assert_stmt_type 1015
-#define del_stmt_type 1016
-#define import_stmt_type 1017
-#define import_name_type 1018
-#define import_from_type 1019
-#define import_from_targets_type 1020
-#define import_from_as_names_type 1021
-#define import_from_as_name_type 1022
-#define dotted_as_names_type 1023
-#define dotted_as_name_type 1024
-#define dotted_name_type 1025  // Left-recursive
-#define if_stmt_type 1026
-#define elif_stmt_type 1027
-#define else_block_type 1028
-#define while_stmt_type 1029
-#define for_stmt_type 1030
-#define with_stmt_type 1031
-#define with_item_type 1032
-#define try_stmt_type 1033
-#define except_block_type 1034
-#define finally_block_type 1035
-#define return_stmt_type 1036
-#define raise_stmt_type 1037
-#define function_def_type 1038
-#define function_def_raw_type 1039
-#define func_type_comment_type 1040
-#define params_type 1041
-#define parameters_type 1042
-#define slash_without_default_type 1043
-#define slash_with_default_type 1044
-#define star_etc_type 1045
-#define name_with_optional_default_type 1046
-#define names_with_default_type 1047
-#define name_with_default_type 1048
-#define plain_names_type 1049
-#define plain_name_type 1050
-#define kwds_type 1051
-#define annotation_type 1052
-#define decorators_type 1053
-#define class_def_type 1054
-#define class_def_raw_type 1055
-#define block_type 1056
-#define expressions_list_type 1057
-#define star_expressions_type 1058
-#define star_expression_type 1059
-#define star_named_expressions_type 1060
-#define star_named_expression_type 1061
-#define named_expression_type 1062
-#define annotated_rhs_type 1063
-#define expressions_type 1064
-#define expression_type 1065
-#define lambdef_type 1066
-#define lambda_parameters_type 1067
-#define lambda_slash_without_default_type 1068
-#define lambda_slash_with_default_type 1069
-#define lambda_star_etc_type 1070
-#define lambda_name_with_optional_default_type 1071
-#define lambda_names_with_default_type 1072
-#define lambda_name_with_default_type 1073
-#define lambda_plain_names_type 1074
-#define lambda_plain_name_type 1075
-#define lambda_kwds_type 1076
-#define disjunction_type 1077
-#define conjunction_type 1078
-#define inversion_type 1079
-#define comparison_type 1080
-#define compare_op_bitwise_or_pair_type 1081
-#define eq_bitwise_or_type 1082
-#define noteq_bitwise_or_type 1083
-#define lte_bitwise_or_type 1084
-#define lt_bitwise_or_type 1085
-#define gte_bitwise_or_type 1086
-#define gt_bitwise_or_type 1087
-#define notin_bitwise_or_type 1088
-#define in_bitwise_or_type 1089
-#define isnot_bitwise_or_type 1090
-#define is_bitwise_or_type 1091
-#define bitwise_or_type 1092  // Left-recursive
-#define bitwise_xor_type 1093  // Left-recursive
-#define bitwise_and_type 1094  // Left-recursive
-#define shift_expr_type 1095  // Left-recursive
-#define sum_type 1096  // Left-recursive
-#define term_type 1097  // Left-recursive
-#define factor_type 1098
-#define power_type 1099
-#define await_primary_type 1100
-#define primary_type 1101  // Left-recursive
-#define slices_type 1102
-#define slice_type 1103
-#define atom_type 1104
-#define strings_type 1105
-#define list_type 1106
-#define listcomp_type 1107
-#define tuple_type 1108
-#define group_type 1109
-#define genexp_type 1110
-#define set_type 1111
-#define setcomp_type 1112
-#define dict_type 1113
-#define dictcomp_type 1114
-#define kvpairs_type 1115
-#define kvpair_type 1116
-#define for_if_clauses_type 1117
-#define yield_expr_type 1118
-#define arguments_type 1119
-#define args_type 1120
-#define kwargs_type 1121
-#define starred_expression_type 1122
-#define kwarg_or_starred_type 1123
-#define kwarg_or_double_starred_type 1124
-#define star_targets_type 1125
-#define star_targets_seq_type 1126
-#define star_target_type 1127
-#define star_atom_type 1128
-#define inside_paren_ann_assign_target_type 1129
-#define ann_assign_subscript_attribute_target_type 1130
-#define del_targets_type 1131
-#define del_target_type 1132
-#define del_t_atom_type 1133
-#define targets_type 1134
-#define target_type 1135
-#define t_primary_type 1136  // Left-recursive
-#define t_lookahead_type 1137
-#define t_atom_type 1138
-#define incorrect_arguments_type 1139
-#define invalid_named_expression_type 1140
-#define invalid_assignment_type 1141
-#define invalid_block_type 1142
-#define invalid_comprehension_type 1143
-#define invalid_parameters_type 1144
-#define invalid_double_type_comments_type 1145
-#define _loop0_1_type 1146
-#define _loop1_2_type 1147
-#define _loop0_4_type 1148
-#define _gather_3_type 1149
-#define _tmp_5_type 1150
-#define _tmp_6_type 1151
-#define _tmp_7_type 1152
-#define _tmp_8_type 1153
-#define _tmp_9_type 1154
-#define _tmp_10_type 1155
-#define _tmp_11_type 1156
-#define _tmp_12_type 1157
-#define _loop1_13_type 1158
-#define _tmp_14_type 1159
-#define _tmp_15_type 1160
-#define _loop0_17_type 1161
-#define _gather_16_type 1162
-#define _loop0_19_type 1163
-#define _gather_18_type 1164
-#define _tmp_20_type 1165
-#define _loop0_21_type 1166
-#define _loop1_22_type 1167
-#define _loop0_24_type 1168
-#define _gather_23_type 1169
-#define _tmp_25_type 1170
-#define _loop0_27_type 1171
-#define _gather_26_type 1172
-#define _tmp_28_type 1173
-#define _loop0_30_type 1174
-#define _gather_29_type 1175
-#define _loop0_32_type 1176
-#define _gather_31_type 1177
-#define _tmp_33_type 1178
-#define _loop1_34_type 1179
-#define _tmp_35_type 1180
-#define _tmp_36_type 1181
-#define _tmp_37_type 1182
-#define _tmp_38_type 1183
-#define _tmp_39_type 1184
-#define _tmp_40_type 1185
-#define _tmp_41_type 1186
-#define _tmp_42_type 1187
-#define _tmp_43_type 1188
-#define _tmp_44_type 1189
-#define _tmp_45_type 1190
-#define _tmp_46_type 1191
-#define _tmp_47_type 1192
-#define _loop0_48_type 1193
-#define _tmp_49_type 1194
-#define _loop1_50_type 1195
-#define _tmp_51_type 1196
-#define _tmp_52_type 1197
-#define _loop0_54_type 1198
-#define _gather_53_type 1199
-#define _loop0_56_type 1200
-#define _gather_55_type 1201
-#define _tmp_57_type 1202
-#define _loop1_58_type 1203
-#define _tmp_59_type 1204
-#define _loop0_61_type 1205
-#define _gather_60_type 1206
-#define _loop1_62_type 1207
-#define _loop0_64_type 1208
-#define _gather_63_type 1209
-#define _loop1_65_type 1210
-#define _tmp_66_type 1211
-#define _tmp_67_type 1212
-#define _tmp_68_type 1213
-#define _tmp_69_type 1214
-#define _tmp_70_type 1215
-#define _tmp_71_type 1216
-#define _tmp_72_type 1217
-#define _tmp_73_type 1218
-#define _tmp_74_type 1219
-#define _loop0_75_type 1220
-#define _tmp_76_type 1221
-#define _loop1_77_type 1222
-#define _tmp_78_type 1223
-#define _tmp_79_type 1224
-#define _loop0_81_type 1225
-#define _gather_80_type 1226
-#define _loop0_83_type 1227
-#define _gather_82_type 1228
-#define _loop1_84_type 1229
-#define _loop1_85_type 1230
-#define _loop1_86_type 1231
-#define _tmp_87_type 1232
-#define _loop0_89_type 1233
-#define _gather_88_type 1234
-#define _tmp_90_type 1235
-#define _tmp_91_type 1236
-#define _tmp_92_type 1237
-#define _tmp_93_type 1238
-#define _loop1_94_type 1239
-#define _tmp_95_type 1240
-#define _tmp_96_type 1241
-#define _loop0_98_type 1242
-#define _gather_97_type 1243
-#define _loop1_99_type 1244
-#define _tmp_100_type 1245
-#define _tmp_101_type 1246
-#define _loop0_103_type 1247
-#define _gather_102_type 1248
-#define _loop0_105_type 1249
-#define _gather_104_type 1250
-#define _loop0_107_type 1251
-#define _gather_106_type 1252
-#define _loop0_109_type 1253
-#define _gather_108_type 1254
-#define _loop0_110_type 1255
-#define _loop0_112_type 1256
-#define _gather_111_type 1257
-#define _tmp_113_type 1258
-#define _loop0_115_type 1259
-#define _gather_114_type 1260
-#define _loop0_117_type 1261
-#define _gather_116_type 1262
-#define _tmp_118_type 1263
-#define _tmp_119_type 1264
-#define _tmp_120_type 1265
-#define _tmp_121_type 1266
-#define _tmp_122_type 1267
-#define _tmp_123_type 1268
-#define _tmp_124_type 1269
-#define _tmp_125_type 1270
-#define _tmp_126_type 1271
-#define _tmp_127_type 1272
-#define _tmp_128_type 1273
-#define _tmp_129_type 1274
-#define _tmp_130_type 1275
-#define _tmp_131_type 1276
-#define _tmp_132_type 1277
-#define _tmp_133_type 1278
-#define _tmp_134_type 1279
-#define _tmp_135_type 1280
-#define _tmp_136_type 1281
-#define _loop0_137_type 1282
-#define _tmp_138_type 1283
+#define func_type_type 1003
+#define fstring_type 1004
+#define type_expressions_type 1005
+#define statements_type 1006
+#define statement_type 1007
+#define statement_newline_type 1008
+#define simple_stmt_type 1009
+#define small_stmt_type 1010
+#define compound_stmt_type 1011
+#define assignment_type 1012
+#define augassign_type 1013
+#define global_stmt_type 1014
+#define nonlocal_stmt_type 1015
+#define yield_stmt_type 1016
+#define assert_stmt_type 1017
+#define del_stmt_type 1018
+#define import_stmt_type 1019
+#define import_name_type 1020
+#define import_from_type 1021
+#define import_from_targets_type 1022
+#define import_from_as_names_type 1023
+#define import_from_as_name_type 1024
+#define dotted_as_names_type 1025
+#define dotted_as_name_type 1026
+#define dotted_name_type 1027  // Left-recursive
+#define if_stmt_type 1028
+#define elif_stmt_type 1029
+#define else_block_type 1030
+#define while_stmt_type 1031
+#define for_stmt_type 1032
+#define with_stmt_type 1033
+#define with_item_type 1034
+#define try_stmt_type 1035
+#define except_block_type 1036
+#define finally_block_type 1037
+#define return_stmt_type 1038
+#define raise_stmt_type 1039
+#define function_def_type 1040
+#define function_def_raw_type 1041
+#define func_type_comment_type 1042
+#define params_type 1043
+#define parameters_type 1044
+#define slash_without_default_type 1045
+#define slash_with_default_type 1046
+#define star_etc_type 1047
+#define name_with_optional_default_type 1048
+#define names_with_default_type 1049
+#define name_with_default_type 1050
+#define plain_names_type 1051
+#define plain_name_type 1052
+#define kwds_type 1053
+#define annotation_type 1054
+#define decorators_type 1055
+#define class_def_type 1056
+#define class_def_raw_type 1057
+#define block_type 1058
+#define expressions_list_type 1059
+#define star_expressions_type 1060
+#define star_expression_type 1061
+#define star_named_expressions_type 1062
+#define star_named_expression_type 1063
+#define named_expression_type 1064
+#define annotated_rhs_type 1065
+#define expressions_type 1066
+#define expression_type 1067
+#define lambdef_type 1068
+#define lambda_parameters_type 1069
+#define lambda_slash_without_default_type 1070
+#define lambda_slash_with_default_type 1071
+#define lambda_star_etc_type 1072
+#define lambda_name_with_optional_default_type 1073
+#define lambda_names_with_default_type 1074
+#define lambda_name_with_default_type 1075
+#define lambda_plain_names_type 1076
+#define lambda_plain_name_type 1077
+#define lambda_kwds_type 1078
+#define disjunction_type 1079
+#define conjunction_type 1080
+#define inversion_type 1081
+#define comparison_type 1082
+#define compare_op_bitwise_or_pair_type 1083
+#define eq_bitwise_or_type 1084
+#define noteq_bitwise_or_type 1085
+#define lte_bitwise_or_type 1086
+#define lt_bitwise_or_type 1087
+#define gte_bitwise_or_type 1088
+#define gt_bitwise_or_type 1089
+#define notin_bitwise_or_type 1090
+#define in_bitwise_or_type 1091
+#define isnot_bitwise_or_type 1092
+#define is_bitwise_or_type 1093
+#define bitwise_or_type 1094  // Left-recursive
+#define bitwise_xor_type 1095  // Left-recursive
+#define bitwise_and_type 1096  // Left-recursive
+#define shift_expr_type 1097  // Left-recursive
+#define sum_type 1098  // Left-recursive
+#define term_type 1099  // Left-recursive
+#define factor_type 1100
+#define power_type 1101
+#define await_primary_type 1102
+#define primary_type 1103  // Left-recursive
+#define slices_type 1104
+#define slice_type 1105
+#define atom_type 1106
+#define strings_type 1107
+#define list_type 1108
+#define listcomp_type 1109
+#define tuple_type 1110
+#define group_type 1111
+#define genexp_type 1112
+#define set_type 1113
+#define setcomp_type 1114
+#define dict_type 1115
+#define dictcomp_type 1116
+#define kvpairs_type 1117
+#define kvpair_type 1118
+#define for_if_clauses_type 1119
+#define yield_expr_type 1120
+#define arguments_type 1121
+#define args_type 1122
+#define kwargs_type 1123
+#define starred_expression_type 1124
+#define kwarg_or_starred_type 1125
+#define kwarg_or_double_starred_type 1126
+#define star_targets_type 1127
+#define star_targets_seq_type 1128
+#define star_target_type 1129
+#define star_atom_type 1130
+#define inside_paren_ann_assign_target_type 1131
+#define ann_assign_subscript_attribute_target_type 1132
+#define del_targets_type 1133
+#define del_target_type 1134
+#define del_t_atom_type 1135
+#define targets_type 1136
+#define target_type 1137
+#define t_primary_type 1138  // Left-recursive
+#define t_lookahead_type 1139
+#define t_atom_type 1140
+#define incorrect_arguments_type 1141
+#define invalid_named_expression_type 1142
+#define invalid_assignment_type 1143
+#define invalid_block_type 1144
+#define invalid_comprehension_type 1145
+#define invalid_parameters_type 1146
+#define invalid_double_type_comments_type 1147
+#define _loop0_1_type 1148
+#define _loop0_3_type 1149
+#define _gather_2_type 1150
+#define _loop0_5_type 1151
+#define _gather_4_type 1152
+#define _loop0_7_type 1153
+#define _gather_6_type 1154
+#define _loop0_9_type 1155
+#define _gather_8_type 1156
+#define _loop1_10_type 1157
+#define _loop0_12_type 1158
+#define _gather_11_type 1159
+#define _tmp_13_type 1160
+#define _tmp_14_type 1161
+#define _tmp_15_type 1162
+#define _tmp_16_type 1163
+#define _tmp_17_type 1164
+#define _tmp_18_type 1165
+#define _tmp_19_type 1166
+#define _tmp_20_type 1167
+#define _loop1_21_type 1168
+#define _tmp_22_type 1169
+#define _tmp_23_type 1170
+#define _loop0_25_type 1171
+#define _gather_24_type 1172
+#define _loop0_27_type 1173
+#define _gather_26_type 1174
+#define _tmp_28_type 1175
+#define _loop0_29_type 1176
+#define _loop1_30_type 1177
+#define _loop0_32_type 1178
+#define _gather_31_type 1179
+#define _tmp_33_type 1180
+#define _loop0_35_type 1181
+#define _gather_34_type 1182
+#define _tmp_36_type 1183
+#define _loop0_38_type 1184
+#define _gather_37_type 1185
+#define _loop0_40_type 1186
+#define _gather_39_type 1187
+#define _tmp_41_type 1188
+#define _loop1_42_type 1189
+#define _tmp_43_type 1190
+#define _tmp_44_type 1191
+#define _tmp_45_type 1192
+#define _tmp_46_type 1193
+#define _tmp_47_type 1194
+#define _tmp_48_type 1195
+#define _tmp_49_type 1196
+#define _tmp_50_type 1197
+#define _tmp_51_type 1198
+#define _tmp_52_type 1199
+#define _tmp_53_type 1200
+#define _tmp_54_type 1201
+#define _tmp_55_type 1202
+#define _loop0_56_type 1203
+#define _tmp_57_type 1204
+#define _loop1_58_type 1205
+#define _tmp_59_type 1206
+#define _tmp_60_type 1207
+#define _loop0_62_type 1208
+#define _gather_61_type 1209
+#define _loop0_64_type 1210
+#define _gather_63_type 1211
+#define _tmp_65_type 1212
+#define _loop1_66_type 1213
+#define _tmp_67_type 1214
+#define _loop0_69_type 1215
+#define _gather_68_type 1216
+#define _loop1_70_type 1217
+#define _loop0_72_type 1218
+#define _gather_71_type 1219
+#define _loop1_73_type 1220
+#define _tmp_74_type 1221
+#define _tmp_75_type 1222
+#define _tmp_76_type 1223
+#define _tmp_77_type 1224
+#define _tmp_78_type 1225
+#define _tmp_79_type 1226
+#define _tmp_80_type 1227
+#define _tmp_81_type 1228
+#define _tmp_82_type 1229
+#define _loop0_83_type 1230
+#define _tmp_84_type 1231
+#define _loop1_85_type 1232
+#define _tmp_86_type 1233
+#define _tmp_87_type 1234
+#define _loop0_89_type 1235
+#define _gather_88_type 1236
+#define _loop0_91_type 1237
+#define _gather_90_type 1238
+#define _loop1_92_type 1239
+#define _loop1_93_type 1240
+#define _loop1_94_type 1241
+#define _tmp_95_type 1242
+#define _loop0_97_type 1243
+#define _gather_96_type 1244
+#define _tmp_98_type 1245
+#define _tmp_99_type 1246
+#define _tmp_100_type 1247
+#define _tmp_101_type 1248
+#define _loop1_102_type 1249
+#define _tmp_103_type 1250
+#define _tmp_104_type 1251
+#define _loop0_106_type 1252
+#define _gather_105_type 1253
+#define _loop1_107_type 1254
+#define _tmp_108_type 1255
+#define _tmp_109_type 1256
+#define _loop0_111_type 1257
+#define _gather_110_type 1258
+#define _loop0_113_type 1259
+#define _gather_112_type 1260
+#define _loop0_115_type 1261
+#define _gather_114_type 1262
+#define _loop0_117_type 1263
+#define _gather_116_type 1264
+#define _loop0_118_type 1265
+#define _loop0_120_type 1266
+#define _gather_119_type 1267
+#define _tmp_121_type 1268
+#define _loop0_123_type 1269
+#define _gather_122_type 1270
+#define _loop0_125_type 1271
+#define _gather_124_type 1272
+#define _tmp_126_type 1273
+#define _tmp_127_type 1274
+#define _tmp_128_type 1275
+#define _tmp_129_type 1276
+#define _tmp_130_type 1277
+#define _tmp_131_type 1278
+#define _tmp_132_type 1279
+#define _tmp_133_type 1280
+#define _tmp_134_type 1281
+#define _tmp_135_type 1282
+#define _tmp_136_type 1283
+#define _tmp_137_type 1284
+#define _tmp_138_type 1285
+#define _tmp_139_type 1286
+#define _tmp_140_type 1287
+#define _tmp_141_type 1288
+#define _tmp_142_type 1289
+#define _tmp_143_type 1290
+#define _tmp_144_type 1291
+#define _loop0_145_type 1292
+#define _tmp_146_type 1293
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
 static mod_ty eval_rule(Parser *p);
+static mod_ty func_type_rule(Parser *p);
 static expr_ty fstring_rule(Parser *p);
+static asdl_seq* type_expressions_rule(Parser *p);
 static asdl_seq* statements_rule(Parser *p);
 static asdl_seq* statement_rule(Parser *p);
 static asdl_seq* statement_newline_rule(Parser *p);
@@ -500,130 +512,130 @@ static void *invalid_comprehension_rule(Parser *p);
 static void *invalid_parameters_rule(Parser *p);
 static void *invalid_double_type_comments_rule(Parser *p);
 static asdl_seq *_loop0_1_rule(Parser *p);
-static asdl_seq *_loop1_2_rule(Parser *p);
-static asdl_seq *_loop0_4_rule(Parser *p);
-static asdl_seq *_gather_3_rule(Parser *p);
-static void *_tmp_5_rule(Parser *p);
-static void *_tmp_6_rule(Parser *p);
-static void *_tmp_7_rule(Parser *p);
-static void *_tmp_8_rule(Parser *p);
-static void *_tmp_9_rule(Parser *p);
-static void *_tmp_10_rule(Parser *p);
-static void *_tmp_11_rule(Parser *p);
-static void *_tmp_12_rule(Parser *p);
-static asdl_seq *_loop1_13_rule(Parser *p);
+static asdl_seq *_loop0_3_rule(Parser *p);
+static asdl_seq *_gather_2_rule(Parser *p);
+static asdl_seq *_loop0_5_rule(Parser *p);
+static asdl_seq *_gather_4_rule(Parser *p);
+static asdl_seq *_loop0_7_rule(Parser *p);
+static asdl_seq *_gather_6_rule(Parser *p);
+static asdl_seq *_loop0_9_rule(Parser *p);
+static asdl_seq *_gather_8_rule(Parser *p);
+static asdl_seq *_loop1_10_rule(Parser *p);
+static asdl_seq *_loop0_12_rule(Parser *p);
+static asdl_seq *_gather_11_rule(Parser *p);
+static void *_tmp_13_rule(Parser *p);
 static void *_tmp_14_rule(Parser *p);
 static void *_tmp_15_rule(Parser *p);
-static asdl_seq *_loop0_17_rule(Parser *p);
-static asdl_seq *_gather_16_rule(Parser *p);
-static asdl_seq *_loop0_19_rule(Parser *p);
-static asdl_seq *_gather_18_rule(Parser *p);
+static void *_tmp_16_rule(Parser *p);
+static void *_tmp_17_rule(Parser *p);
+static void *_tmp_18_rule(Parser *p);
+static void *_tmp_19_rule(Parser *p);
 static void *_tmp_20_rule(Parser *p);
-static asdl_seq *_loop0_21_rule(Parser *p);
-static asdl_seq *_loop1_22_rule(Parser *p);
-static asdl_seq *_loop0_24_rule(Parser *p);
-static asdl_seq *_gather_23_rule(Parser *p);
-static void *_tmp_25_rule(Parser *p);
+static asdl_seq *_loop1_21_rule(Parser *p);
+static void *_tmp_22_rule(Parser *p);
+static void *_tmp_23_rule(Parser *p);
+static asdl_seq *_loop0_25_rule(Parser *p);
+static asdl_seq *_gather_24_rule(Parser *p);
 static asdl_seq *_loop0_27_rule(Parser *p);
 static asdl_seq *_gather_26_rule(Parser *p);
 static void *_tmp_28_rule(Parser *p);
-static asdl_seq *_loop0_30_rule(Parser *p);
-static asdl_seq *_gather_29_rule(Parser *p);
+static asdl_seq *_loop0_29_rule(Parser *p);
+static asdl_seq *_loop1_30_rule(Parser *p);
 static asdl_seq *_loop0_32_rule(Parser *p);
 static asdl_seq *_gather_31_rule(Parser *p);
 static void *_tmp_33_rule(Parser *p);
-static asdl_seq *_loop1_34_rule(Parser *p);
-static void *_tmp_35_rule(Parser *p);
+static asdl_seq *_loop0_35_rule(Parser *p);
+static asdl_seq *_gather_34_rule(Parser *p);
 static void *_tmp_36_rule(Parser *p);
-static void *_tmp_37_rule(Parser *p);
-static void *_tmp_38_rule(Parser *p);
-static void *_tmp_39_rule(Parser *p);
-static void *_tmp_40_rule(Parser *p);
+static asdl_seq *_loop0_38_rule(Parser *p);
+static asdl_seq *_gather_37_rule(Parser *p);
+static asdl_seq *_loop0_40_rule(Parser *p);
+static asdl_seq *_gather_39_rule(Parser *p);
 static void *_tmp_41_rule(Parser *p);
-static void *_tmp_42_rule(Parser *p);
+static asdl_seq *_loop1_42_rule(Parser *p);
 static void *_tmp_43_rule(Parser *p);
 static void *_tmp_44_rule(Parser *p);
 static void *_tmp_45_rule(Parser *p);
 static void *_tmp_46_rule(Parser *p);
 static void *_tmp_47_rule(Parser *p);
-static asdl_seq *_loop0_48_rule(Parser *p);
+static void *_tmp_48_rule(Parser *p);
 static void *_tmp_49_rule(Parser *p);
-static asdl_seq *_loop1_50_rule(Parser *p);
+static void *_tmp_50_rule(Parser *p);
 static void *_tmp_51_rule(Parser *p);
 static void *_tmp_52_rule(Parser *p);
-static asdl_seq *_loop0_54_rule(Parser *p);
-static asdl_seq *_gather_53_rule(Parser *p);
+static void *_tmp_53_rule(Parser *p);
+static void *_tmp_54_rule(Parser *p);
+static void *_tmp_55_rule(Parser *p);
 static asdl_seq *_loop0_56_rule(Parser *p);
-static asdl_seq *_gather_55_rule(Parser *p);
 static void *_tmp_57_rule(Parser *p);
 static asdl_seq *_loop1_58_rule(Parser *p);
 static void *_tmp_59_rule(Parser *p);
-static asdl_seq *_loop0_61_rule(Parser *p);
-static asdl_seq *_gather_60_rule(Parser *p);
-static asdl_seq *_loop1_62_rule(Parser *p);
+static void *_tmp_60_rule(Parser *p);
+static asdl_seq *_loop0_62_rule(Parser *p);
+static asdl_seq *_gather_61_rule(Parser *p);
 static asdl_seq *_loop0_64_rule(Parser *p);
 static asdl_seq *_gather_63_rule(Parser *p);
-static asdl_seq *_loop1_65_rule(Parser *p);
-static void *_tmp_66_rule(Parser *p);
+static void *_tmp_65_rule(Parser *p);
+static asdl_seq *_loop1_66_rule(Parser *p);
 static void *_tmp_67_rule(Parser *p);
-static void *_tmp_68_rule(Parser *p);
-static void *_tmp_69_rule(Parser *p);
-static void *_tmp_70_rule(Parser *p);
-static void *_tmp_71_rule(Parser *p);
-static void *_tmp_72_rule(Parser *p);
-static void *_tmp_73_rule(Parser *p);
+static asdl_seq *_loop0_69_rule(Parser *p);
+static asdl_seq *_gather_68_rule(Parser *p);
+static asdl_seq *_loop1_70_rule(Parser *p);
+static asdl_seq *_loop0_72_rule(Parser *p);
+static asdl_seq *_gather_71_rule(Parser *p);
+static asdl_seq *_loop1_73_rule(Parser *p);
 static void *_tmp_74_rule(Parser *p);
-static asdl_seq *_loop0_75_rule(Parser *p);
+static void *_tmp_75_rule(Parser *p);
 static void *_tmp_76_rule(Parser *p);
-static asdl_seq *_loop1_77_rule(Parser *p);
+static void *_tmp_77_rule(Parser *p);
 static void *_tmp_78_rule(Parser *p);
 static void *_tmp_79_rule(Parser *p);
-static asdl_seq *_loop0_81_rule(Parser *p);
-static asdl_seq *_gather_80_rule(Parser *p);
+static void *_tmp_80_rule(Parser *p);
+static void *_tmp_81_rule(Parser *p);
+static void *_tmp_82_rule(Parser *p);
 static asdl_seq *_loop0_83_rule(Parser *p);
-static asdl_seq *_gather_82_rule(Parser *p);
-static asdl_seq *_loop1_84_rule(Parser *p);
+static void *_tmp_84_rule(Parser *p);
 static asdl_seq *_loop1_85_rule(Parser *p);
-static asdl_seq *_loop1_86_rule(Parser *p);
+static void *_tmp_86_rule(Parser *p);
 static void *_tmp_87_rule(Parser *p);
 static asdl_seq *_loop0_89_rule(Parser *p);
 static asdl_seq *_gather_88_rule(Parser *p);
-static void *_tmp_90_rule(Parser *p);
-static void *_tmp_91_rule(Parser *p);
-static void *_tmp_92_rule(Parser *p);
-static void *_tmp_93_rule(Parser *p);
+static asdl_seq *_loop0_91_rule(Parser *p);
+static asdl_seq *_gather_90_rule(Parser *p);
+static asdl_seq *_loop1_92_rule(Parser *p);
+static asdl_seq *_loop1_93_rule(Parser *p);
 static asdl_seq *_loop1_94_rule(Parser *p);
 static void *_tmp_95_rule(Parser *p);
-static void *_tmp_96_rule(Parser *p);
-static asdl_seq *_loop0_98_rule(Parser *p);
-static asdl_seq *_gather_97_rule(Parser *p);
-static asdl_seq *_loop1_99_rule(Parser *p);
+static asdl_seq *_loop0_97_rule(Parser *p);
+static asdl_seq *_gather_96_rule(Parser *p);
+static void *_tmp_98_rule(Parser *p);
+static void *_tmp_99_rule(Parser *p);
 static void *_tmp_100_rule(Parser *p);
 static void *_tmp_101_rule(Parser *p);
-static asdl_seq *_loop0_103_rule(Parser *p);
-static asdl_seq *_gather_102_rule(Parser *p);
-static asdl_seq *_loop0_105_rule(Parser *p);
-static asdl_seq *_gather_104_rule(Parser *p);
-static asdl_seq *_loop0_107_rule(Parser *p);
-static asdl_seq *_gather_106_rule(Parser *p);
-static asdl_seq *_loop0_109_rule(Parser *p);
-static asdl_seq *_gather_108_rule(Parser *p);
-static asdl_seq *_loop0_110_rule(Parser *p);
-static asdl_seq *_loop0_112_rule(Parser *p);
-static asdl_seq *_gather_111_rule(Parser *p);
-static void *_tmp_113_rule(Parser *p);
+static asdl_seq *_loop1_102_rule(Parser *p);
+static void *_tmp_103_rule(Parser *p);
+static void *_tmp_104_rule(Parser *p);
+static asdl_seq *_loop0_106_rule(Parser *p);
+static asdl_seq *_gather_105_rule(Parser *p);
+static asdl_seq *_loop1_107_rule(Parser *p);
+static void *_tmp_108_rule(Parser *p);
+static void *_tmp_109_rule(Parser *p);
+static asdl_seq *_loop0_111_rule(Parser *p);
+static asdl_seq *_gather_110_rule(Parser *p);
+static asdl_seq *_loop0_113_rule(Parser *p);
+static asdl_seq *_gather_112_rule(Parser *p);
 static asdl_seq *_loop0_115_rule(Parser *p);
 static asdl_seq *_gather_114_rule(Parser *p);
 static asdl_seq *_loop0_117_rule(Parser *p);
 static asdl_seq *_gather_116_rule(Parser *p);
-static void *_tmp_118_rule(Parser *p);
-static void *_tmp_119_rule(Parser *p);
-static void *_tmp_120_rule(Parser *p);
+static asdl_seq *_loop0_118_rule(Parser *p);
+static asdl_seq *_loop0_120_rule(Parser *p);
+static asdl_seq *_gather_119_rule(Parser *p);
 static void *_tmp_121_rule(Parser *p);
-static void *_tmp_122_rule(Parser *p);
-static void *_tmp_123_rule(Parser *p);
-static void *_tmp_124_rule(Parser *p);
-static void *_tmp_125_rule(Parser *p);
+static asdl_seq *_loop0_123_rule(Parser *p);
+static asdl_seq *_gather_122_rule(Parser *p);
+static asdl_seq *_loop0_125_rule(Parser *p);
+static asdl_seq *_gather_124_rule(Parser *p);
 static void *_tmp_126_rule(Parser *p);
 static void *_tmp_127_rule(Parser *p);
 static void *_tmp_128_rule(Parser *p);
@@ -635,8 +647,16 @@ static void *_tmp_133_rule(Parser *p);
 static void *_tmp_134_rule(Parser *p);
 static void *_tmp_135_rule(Parser *p);
 static void *_tmp_136_rule(Parser *p);
-static asdl_seq *_loop0_137_rule(Parser *p);
+static void *_tmp_137_rule(Parser *p);
 static void *_tmp_138_rule(Parser *p);
+static void *_tmp_139_rule(Parser *p);
+static void *_tmp_140_rule(Parser *p);
+static void *_tmp_141_rule(Parser *p);
+static void *_tmp_142_rule(Parser *p);
+static void *_tmp_143_rule(Parser *p);
+static void *_tmp_144_rule(Parser *p);
+static asdl_seq *_loop0_145_rule(Parser *p);
+static void *_tmp_146_rule(Parser *p);
 
 
 // file: statements? $
@@ -735,6 +755,47 @@ eval_rule(Parser *p)
     return res;
 }
 
+// func_type: '(' type_expressions? ')' '->' expression
+static mod_ty
+func_type_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    mod_ty res = NULL;
+    int mark = p->mark;
+    { // '(' type_expressions? ')' '->' expression
+        void *a;
+        expr_ty b;
+        void *literal;
+        void *literal_1;
+        void *literal_2;
+        if (
+            (literal = _PyPegen_expect_token(p, 7))
+            &&
+            (a = type_expressions_rule(p), 1)
+            &&
+            (literal_1 = _PyPegen_expect_token(p, 8))
+            &&
+            (literal_2 = _PyPegen_expect_token(p, 51))
+            &&
+            (b = expression_rule(p))
+        )
+        {
+            res = FunctionType ( a , b , p -> arena );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
 // fstring: star_expressions
 static expr_ty
 fstring_rule(Parser *p)
@@ -760,6 +821,116 @@ fstring_rule(Parser *p)
     return res;
 }
 
+// type_expressions:
+//     | ','.expression+ ',' '*' expression ',' '**' expression
+//     | ','.expression+ ',' '*' expression
+//     | ','.expression+ ',' '**' expression
+//     | ','.expression+
+static asdl_seq*
+type_expressions_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq* res = NULL;
+    int mark = p->mark;
+    { // ','.expression+ ',' '*' expression ',' '**' expression
+        asdl_seq * a;
+        expr_ty b;
+        expr_ty c;
+        void *literal;
+        void *literal_1;
+        void *literal_2;
+        void *literal_3;
+        if (
+            (a = _gather_2_rule(p))
+            &&
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (literal_1 = _PyPegen_expect_token(p, 16))
+            &&
+            (b = expression_rule(p))
+            &&
+            (literal_2 = _PyPegen_expect_token(p, 12))
+            &&
+            (literal_3 = _PyPegen_expect_token(p, 35))
+            &&
+            (c = expression_rule(p))
+        )
+        {
+            res = _PyPegen_seq_append_to_end ( p , _PyPegen_seq_append_to_end ( p , a , b ) , c );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // ','.expression+ ',' '*' expression
+        asdl_seq * a;
+        expr_ty b;
+        void *literal;
+        void *literal_1;
+        if (
+            (a = _gather_4_rule(p))
+            &&
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (literal_1 = _PyPegen_expect_token(p, 16))
+            &&
+            (b = expression_rule(p))
+        )
+        {
+            res = _PyPegen_seq_append_to_end ( p , a , b );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // ','.expression+ ',' '**' expression
+        asdl_seq * a;
+        expr_ty b;
+        void *literal;
+        void *literal_1;
+        if (
+            (a = _gather_6_rule(p))
+            &&
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (literal_1 = _PyPegen_expect_token(p, 35))
+            &&
+            (b = expression_rule(p))
+        )
+        {
+            res = _PyPegen_seq_append_to_end ( p , a , b );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // ','.expression+
+        asdl_seq * _gather_8_var;
+        if (
+            (_gather_8_var = _gather_8_rule(p))
+        )
+        {
+            res = _gather_8_var;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
 // statements: statement+
 static asdl_seq*
 statements_rule(Parser *p)
@@ -772,7 +943,7 @@ statements_rule(Parser *p)
     { // statement+
         asdl_seq * a;
         if (
-            (a = _loop1_2_rule(p))
+            (a = _loop1_10_rule(p))
         )
         {
             res = _PyPegen_seq_flatten ( p , a );
@@ -953,7 +1124,7 @@ simple_stmt_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_3_rule(p))
+            (a = _gather_11_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 13), 1)
             &&
@@ -1056,7 +1227,7 @@ small_stmt_rule(Parser *p)
     { // &('import' | 'from') import_stmt
         stmt_ty import_stmt_var;
         if (
-            _PyPegen_lookahead(1, _tmp_5_rule, p)
+            _PyPegen_lookahead(1, _tmp_13_rule, p)
             &&
             (import_stmt_var = import_stmt_rule(p))
         )
@@ -1238,7 +1409,7 @@ compound_stmt_rule(Parser *p)
     { // &('def' | '@' | ASYNC) function_def
         stmt_ty function_def_var;
         if (
-            _PyPegen_lookahead(1, _tmp_6_rule, p)
+            _PyPegen_lookahead(1, _tmp_14_rule, p)
             &&
             (function_def_var = function_def_rule(p))
         )
@@ -1264,7 +1435,7 @@ compound_stmt_rule(Parser *p)
     { // &('class' | '@') class_def
         stmt_ty class_def_var;
         if (
-            _PyPegen_lookahead(1, _tmp_7_rule, p)
+            _PyPegen_lookahead(1, _tmp_15_rule, p)
             &&
             (class_def_var = class_def_rule(p))
         )
@@ -1277,7 +1448,7 @@ compound_stmt_rule(Parser *p)
     { // &('with' | ASYNC) with_stmt
         stmt_ty with_stmt_var;
         if (
-            _PyPegen_lookahead(1, _tmp_8_rule, p)
+            _PyPegen_lookahead(1, _tmp_16_rule, p)
             &&
             (with_stmt_var = with_stmt_rule(p))
         )
@@ -1290,7 +1461,7 @@ compound_stmt_rule(Parser *p)
     { // &('for' | ASYNC) for_stmt
         stmt_ty for_stmt_var;
         if (
-            _PyPegen_lookahead(1, _tmp_9_rule, p)
+            _PyPegen_lookahead(1, _tmp_17_rule, p)
             &&
             (for_stmt_var = for_stmt_rule(p))
         )
@@ -1365,7 +1536,7 @@ assignment_rule(Parser *p)
             &&
             (b = expression_rule(p))
             &&
-            (c = _tmp_10_rule(p), 1)
+            (c = _tmp_18_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1391,13 +1562,13 @@ assignment_rule(Parser *p)
         void *c;
         void *literal;
         if (
-            (a = _tmp_11_rule(p))
+            (a = _tmp_19_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
             (b = expression_rule(p))
             &&
-            (c = _tmp_12_rule(p), 1)
+            (c = _tmp_20_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1422,9 +1593,9 @@ assignment_rule(Parser *p)
         void *b;
         void *tc;
         if (
-            (a = _loop1_13_rule(p))
+            (a = _loop1_21_rule(p))
             &&
-            (b = _tmp_14_rule(p))
+            (b = _tmp_22_rule(p))
             &&
             (tc = _PyPegen_type_comment_token(p), 1)
         )
@@ -1455,7 +1626,7 @@ assignment_rule(Parser *p)
             &&
             (b = augassign_rule(p))
             &&
-            (c = _tmp_15_rule(p))
+            (c = _tmp_23_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1736,7 +1907,7 @@ global_stmt_rule(Parser *p)
         if (
             (keyword = _PyPegen_expect_token(p, 508))
             &&
-            (a = _gather_16_rule(p))
+            (a = _gather_24_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1784,7 +1955,7 @@ nonlocal_stmt_rule(Parser *p)
         if (
             (keyword = _PyPegen_expect_token(p, 509))
             &&
-            (a = _gather_18_rule(p))
+            (a = _gather_26_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1880,7 +2051,7 @@ assert_stmt_rule(Parser *p)
             &&
             (a = expression_rule(p))
             &&
-            (b = _tmp_20_rule(p), 1)
+            (b = _tmp_28_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2065,7 +2236,7 @@ import_from_rule(Parser *p)
         if (
             (keyword = _PyPegen_expect_token(p, 514))
             &&
-            (a = _loop0_21_rule(p))
+            (a = _loop0_29_rule(p))
             &&
             (b = dotted_name_rule(p))
             &&
@@ -2099,7 +2270,7 @@ import_from_rule(Parser *p)
         if (
             (keyword = _PyPegen_expect_token(p, 514))
             &&
-            (a = _loop1_22_rule(p))
+            (a = _loop1_30_rule(p))
             &&
             (keyword_1 = _PyPegen_expect_token(p, 513))
             &&
@@ -2205,7 +2376,7 @@ import_from_as_names_rule(Parser *p)
     { // ','.import_from_as_name+
         asdl_seq * a;
         if (
-            (a = _gather_23_rule(p))
+            (a = _gather_31_rule(p))
         )
         {
             res = a;
@@ -2237,7 +2408,7 @@ import_from_as_name_rule(Parser *p)
         if (
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_25_rule(p), 1)
+            (b = _tmp_33_rule(p), 1)
         )
         {
             res = _Py_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
@@ -2266,7 +2437,7 @@ dotted_as_names_rule(Parser *p)
     { // ','.dotted_as_name+
         asdl_seq * a;
         if (
-            (a = _gather_26_rule(p))
+            (a = _gather_34_rule(p))
         )
         {
             res = a;
@@ -2298,7 +2469,7 @@ dotted_as_name_rule(Parser *p)
         if (
             (a = dotted_name_rule(p))
             &&
-            (b = _tmp_28_rule(p), 1)
+            (b = _tmp_36_rule(p), 1)
         )
         {
             res = _Py_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
@@ -2770,7 +2941,7 @@ with_stmt_rule(Parser *p)
             &&
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _gather_29_rule(p))
+            (a = _gather_37_rule(p))
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
             &&
@@ -2808,7 +2979,7 @@ with_stmt_rule(Parser *p)
             &&
             (keyword = _PyPegen_expect_token(p, 519))
             &&
-            (a = _gather_31_rule(p))
+            (a = _gather_39_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -2854,7 +3025,7 @@ with_item_rule(Parser *p)
         if (
             (e = expression_rule(p))
             &&
-            (o = _tmp_33_rule(p), 1)
+            (o = _tmp_41_rule(p), 1)
         )
         {
             res = _Py_withitem ( e , o , p -> arena );
@@ -2936,7 +3107,7 @@ try_stmt_rule(Parser *p)
             &&
             (b = block_rule(p))
             &&
-            (ex = _loop1_34_rule(p))
+            (ex = _loop1_42_rule(p))
             &&
             (el = else_block_rule(p), 1)
             &&
@@ -2993,7 +3164,7 @@ except_block_rule(Parser *p)
             &&
             (e = expression_rule(p))
             &&
-            (t = _tmp_35_rule(p), 1)
+            (t = _tmp_43_rule(p), 1)
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -3160,7 +3331,7 @@ raise_stmt_rule(Parser *p)
             &&
             (a = expression_rule(p))
             &&
-            (b = _tmp_36_rule(p), 1)
+            (b = _tmp_44_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3293,7 +3464,7 @@ function_def_raw_rule(Parser *p)
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
             &&
-            (a = _tmp_37_rule(p), 1)
+            (a = _tmp_45_rule(p), 1)
             &&
             (literal_2 = _PyPegen_expect_token(p, 11))
             &&
@@ -3344,7 +3515,7 @@ func_type_comment_rule(Parser *p)
             &&
             (t = _PyPegen_type_comment_token(p))
             &&
-            _PyPegen_lookahead(1, _tmp_38_rule, p)
+            _PyPegen_lookahead(1, _tmp_46_rule, p)
         )
         {
             res = t;
@@ -3441,11 +3612,11 @@ parameters_rule(Parser *p)
         if (
             (a = slash_without_default_rule(p))
             &&
-            (b = _tmp_39_rule(p), 1)
+            (b = _tmp_47_rule(p), 1)
             &&
-            (c = _tmp_40_rule(p), 1)
+            (c = _tmp_48_rule(p), 1)
             &&
-            (d = _tmp_41_rule(p), 1)
+            (d = _tmp_49_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -3464,9 +3635,9 @@ parameters_rule(Parser *p)
         if (
             (a = slash_with_default_rule(p))
             &&
-            (b = _tmp_42_rule(p), 1)
+            (b = _tmp_50_rule(p), 1)
             &&
-            (c = _tmp_43_rule(p), 1)
+            (c = _tmp_51_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -3485,9 +3656,9 @@ parameters_rule(Parser *p)
         if (
             (a = plain_names_rule(p))
             &&
-            (b = _tmp_44_rule(p), 1)
+            (b = _tmp_52_rule(p), 1)
             &&
-            (c = _tmp_45_rule(p), 1)
+            (c = _tmp_53_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -3505,7 +3676,7 @@ parameters_rule(Parser *p)
         if (
             (a = names_with_default_rule(p))
             &&
-            (b = _tmp_46_rule(p), 1)
+            (b = _tmp_54_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -3587,7 +3758,7 @@ slash_with_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _tmp_47_rule(p), 1)
+            (a = _tmp_55_rule(p), 1)
             &&
             (b = names_with_default_rule(p))
             &&
@@ -3634,9 +3805,9 @@ star_etc_rule(Parser *p)
             &&
             (a = plain_name_rule(p))
             &&
-            (b = _loop0_48_rule(p))
+            (b = _loop0_56_rule(p))
             &&
-            (c = _tmp_49_rule(p), 1)
+            (c = _tmp_57_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -3659,9 +3830,9 @@ star_etc_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (b = _loop1_50_rule(p))
+            (b = _loop1_58_rule(p))
             &&
-            (c = _tmp_51_rule(p), 1)
+            (c = _tmp_59_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -3717,7 +3888,7 @@ name_with_optional_default_rule(Parser *p)
             &&
             (a = plain_name_rule(p))
             &&
-            (b = _tmp_52_rule(p), 1)
+            (b = _tmp_60_rule(p), 1)
         )
         {
             res = _PyPegen_name_default_pair ( p , a , b );
@@ -3746,7 +3917,7 @@ names_with_default_rule(Parser *p)
     { // ','.name_with_default+
         asdl_seq * a;
         if (
-            (a = _gather_53_rule(p))
+            (a = _gather_61_rule(p))
         )
         {
             res = a;
@@ -3812,7 +3983,7 @@ plain_names_rule(Parser *p)
     { // ','.(plain_name !'=')+
         asdl_seq * a;
         if (
-            (a = _gather_55_rule(p))
+            (a = _gather_63_rule(p))
         )
         {
             res = a;
@@ -3853,7 +4024,7 @@ plain_name_rule(Parser *p)
         if (
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_57_rule(p), 1)
+            (b = _tmp_65_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3947,7 +4118,7 @@ decorators_rule(Parser *p)
     { // (('@' named_expression NEWLINE))+
         asdl_seq * a;
         if (
-            (a = _loop1_58_rule(p))
+            (a = _loop1_66_rule(p))
         )
         {
             res = a;
@@ -4035,7 +4206,7 @@ class_def_raw_rule(Parser *p)
             &&
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_59_rule(p), 1)
+            (b = _tmp_67_rule(p), 1)
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -4141,7 +4312,7 @@ expressions_list_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_60_rule(p))
+            (a = _gather_68_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4188,7 +4359,7 @@ star_expressions_rule(Parser *p)
         if (
             (a = star_expression_rule(p))
             &&
-            (b = _loop1_62_rule(p))
+            (b = _loop1_70_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4328,7 +4499,7 @@ star_named_expressions_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_63_rule(p))
+            (a = _gather_71_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4542,7 +4713,7 @@ expressions_rule(Parser *p)
         if (
             (a = expression_rule(p))
             &&
-            (b = _loop1_65_rule(p))
+            (b = _loop1_73_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4764,11 +4935,11 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_without_default_rule(p))
             &&
-            (b = _tmp_66_rule(p), 1)
+            (b = _tmp_74_rule(p), 1)
             &&
-            (c = _tmp_67_rule(p), 1)
+            (c = _tmp_75_rule(p), 1)
             &&
-            (d = _tmp_68_rule(p), 1)
+            (d = _tmp_76_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -4787,9 +4958,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_with_default_rule(p))
             &&
-            (b = _tmp_69_rule(p), 1)
+            (b = _tmp_77_rule(p), 1)
             &&
-            (c = _tmp_70_rule(p), 1)
+            (c = _tmp_78_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -4808,9 +4979,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_plain_names_rule(p))
             &&
-            (b = _tmp_71_rule(p), 1)
+            (b = _tmp_79_rule(p), 1)
             &&
-            (c = _tmp_72_rule(p), 1)
+            (c = _tmp_80_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -4828,7 +4999,7 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_names_with_default_rule(p))
             &&
-            (b = _tmp_73_rule(p), 1)
+            (b = _tmp_81_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -4910,7 +5081,7 @@ lambda_slash_with_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _tmp_74_rule(p), 1)
+            (a = _tmp_82_rule(p), 1)
             &&
             (b = lambda_names_with_default_rule(p))
             &&
@@ -4957,9 +5128,9 @@ lambda_star_etc_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _loop0_75_rule(p))
+            (b = _loop0_83_rule(p))
             &&
-            (c = _tmp_76_rule(p), 1)
+            (c = _tmp_84_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4982,9 +5153,9 @@ lambda_star_etc_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (b = _loop1_77_rule(p))
+            (b = _loop1_85_rule(p))
             &&
-            (c = _tmp_78_rule(p), 1)
+            (c = _tmp_86_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -5040,7 +5211,7 @@ lambda_name_with_optional_default_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _tmp_79_rule(p), 1)
+            (b = _tmp_87_rule(p), 1)
         )
         {
             res = _PyPegen_name_default_pair ( p , a , b );
@@ -5069,7 +5240,7 @@ lambda_names_with_default_rule(Parser *p)
     { // ','.lambda_name_with_default+
         asdl_seq * a;
         if (
-            (a = _gather_80_rule(p))
+            (a = _gather_88_rule(p))
         )
         {
             res = a;
@@ -5133,7 +5304,7 @@ lambda_plain_names_rule(Parser *p)
     { // ','.(lambda_plain_name !'=')+
         asdl_seq * a;
         if (
-            (a = _gather_82_rule(p))
+            (a = _gather_90_rule(p))
         )
         {
             res = a;
@@ -5252,7 +5423,7 @@ disjunction_rule(Parser *p)
         if (
             (a = conjunction_rule(p))
             &&
-            (b = _loop1_84_rule(p))
+            (b = _loop1_92_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5314,7 +5485,7 @@ conjunction_rule(Parser *p)
         if (
             (a = inversion_rule(p))
             &&
-            (b = _loop1_85_rule(p))
+            (b = _loop1_93_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5436,7 +5607,7 @@ comparison_rule(Parser *p)
         if (
             (a = bitwise_or_rule(p))
             &&
-            (b = _loop1_86_rule(p))
+            (b = _loop1_94_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5648,10 +5819,10 @@ noteq_bitwise_or_rule(Parser *p)
     CmpopExprPair* res = NULL;
     int mark = p->mark;
     { // ('!=') bitwise_or
-        void *_tmp_87_var;
+        void *_tmp_95_var;
         expr_ty a;
         if (
-            (_tmp_87_var = _tmp_87_rule(p))
+            (_tmp_95_var = _tmp_95_rule(p))
             &&
             (a = bitwise_or_rule(p))
         )
@@ -7093,7 +7264,7 @@ slices_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_88_rule(p))
+            (a = _gather_96_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -7149,7 +7320,7 @@ slice_rule(Parser *p)
             &&
             (b = expression_rule(p), 1)
             &&
-            (c = _tmp_90_rule(p), 1)
+            (c = _tmp_98_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7337,40 +7508,40 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // &'(' (tuple | group | genexp)
-        void *_tmp_91_var;
+        void *_tmp_99_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)
             &&
-            (_tmp_91_var = _tmp_91_rule(p))
+            (_tmp_99_var = _tmp_99_rule(p))
         )
         {
-            res = _tmp_91_var;
+            res = _tmp_99_var;
             goto done;
         }
         p->mark = mark;
     }
     { // &'[' (list | listcomp)
-        void *_tmp_92_var;
+        void *_tmp_100_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)
             &&
-            (_tmp_92_var = _tmp_92_rule(p))
+            (_tmp_100_var = _tmp_100_rule(p))
         )
         {
-            res = _tmp_92_var;
+            res = _tmp_100_var;
             goto done;
         }
         p->mark = mark;
     }
     { // &'{' (dict | set | dictcomp | setcomp)
-        void *_tmp_93_var;
+        void *_tmp_101_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)
             &&
-            (_tmp_93_var = _tmp_93_rule(p))
+            (_tmp_101_var = _tmp_101_rule(p))
         )
         {
-            res = _tmp_93_var;
+            res = _tmp_101_var;
             goto done;
         }
         p->mark = mark;
@@ -7417,7 +7588,7 @@ strings_rule(Parser *p)
     { // STRING+
         asdl_seq * a;
         if (
-            (a = _loop1_94_rule(p))
+            (a = _loop1_102_rule(p))
         )
         {
             res = _PyPegen_concatenate_strings ( p , a );
@@ -7575,7 +7746,7 @@ tuple_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_95_rule(p), 1)
+            (a = _tmp_103_rule(p), 1)
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -7618,7 +7789,7 @@ group_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_96_rule(p))
+            (a = _tmp_104_rule(p))
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -7937,7 +8108,7 @@ kvpairs_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_97_rule(p))
+            (a = _gather_105_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8021,7 +8192,7 @@ for_if_clauses_rule(Parser *p)
     { // ((ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*))+
         asdl_seq * a;
         if (
-            (a = _loop1_99_rule(p))
+            (a = _loop1_107_rule(p))
         )
         {
             res = a;
@@ -8187,7 +8358,7 @@ args_rule(Parser *p)
         if (
             (a = starred_expression_rule(p))
             &&
-            (b = _tmp_100_rule(p), 1)
+            (b = _tmp_108_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8236,7 +8407,7 @@ args_rule(Parser *p)
         if (
             (a = named_expression_rule(p))
             &&
-            (b = _tmp_101_rule(p), 1)
+            (b = _tmp_109_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8278,11 +8449,11 @@ kwargs_rule(Parser *p)
         asdl_seq * b;
         void *literal;
         if (
-            (a = _gather_102_rule(p))
+            (a = _gather_110_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (b = _gather_104_rule(p))
+            (b = _gather_112_rule(p))
         )
         {
             res = _PyPegen_join_sequences ( p , a , b );
@@ -8295,23 +8466,23 @@ kwargs_rule(Parser *p)
         p->mark = mark;
     }
     { // ','.kwarg_or_starred+
-        asdl_seq * _gather_106_var;
+        asdl_seq * _gather_114_var;
         if (
-            (_gather_106_var = _gather_106_rule(p))
+            (_gather_114_var = _gather_114_rule(p))
         )
         {
-            res = _gather_106_var;
+            res = _gather_114_var;
             goto done;
         }
         p->mark = mark;
     }
     { // ','.kwarg_or_double_starred+
-        asdl_seq * _gather_108_var;
+        asdl_seq * _gather_116_var;
         if (
-            (_gather_108_var = _gather_108_rule(p))
+            (_gather_116_var = _gather_116_rule(p))
         )
         {
-            res = _gather_108_var;
+            res = _gather_116_var;
             goto done;
         }
         p->mark = mark;
@@ -8554,7 +8725,7 @@ star_targets_rule(Parser *p)
         if (
             (a = star_target_rule(p))
             &&
-            (b = _loop0_110_rule(p))
+            (b = _loop0_118_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8595,7 +8766,7 @@ star_targets_seq_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_111_rule(p))
+            (a = _gather_119_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8643,7 +8814,7 @@ star_target_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (a = _tmp_113_rule(p))
+            (a = _tmp_121_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9032,7 +9203,7 @@ del_targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_114_rule(p))
+            (a = _gather_122_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -9285,7 +9456,7 @@ targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_116_rule(p))
+            (a = _gather_124_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -9813,7 +9984,7 @@ incorrect_arguments_rule(Parser *p)
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (opt_var = _tmp_118_rule(p), 1)
+            (opt_var = _tmp_126_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "Generator expression must be parenthesized" );
@@ -9948,7 +10119,7 @@ invalid_assignment_rule(Parser *p)
             &&
             (expression_var_1 = expression_rule(p))
             &&
-            (opt_var = _tmp_119_rule(p), 1)
+            (opt_var = _tmp_127_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "illegal target for annotation" );
@@ -9961,15 +10132,15 @@ invalid_assignment_rule(Parser *p)
         p->mark = mark;
     }
     { // expression ('=' | augassign) (yield_expr | star_expressions)
-        void *_tmp_120_var;
-        void *_tmp_121_var;
+        void *_tmp_128_var;
+        void *_tmp_129_var;
         expr_ty a;
         if (
             (a = expression_rule(p))
             &&
-            (_tmp_120_var = _tmp_120_rule(p))
+            (_tmp_128_var = _tmp_128_rule(p))
             &&
-            (_tmp_121_var = _tmp_121_rule(p))
+            (_tmp_129_var = _tmp_129_rule(p))
         )
         {
             res = RAISE_SYNTAX_ERROR ( "cannot assign to %s" , _PyPegen_get_expr_name ( a ) );
@@ -10027,12 +10198,12 @@ invalid_comprehension_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ('[' | '(' | '{') '*' expression for_if_clauses
-        void *_tmp_122_var;
+        void *_tmp_130_var;
         expr_ty expression_var;
         asdl_seq* for_if_clauses_var;
         void *literal;
         if (
-            (_tmp_122_var = _tmp_122_rule(p))
+            (_tmp_130_var = _tmp_130_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -10066,15 +10237,15 @@ invalid_parameters_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // [plain_names ','] (slash_with_default | names_with_default) ',' plain_names
-        void *_tmp_124_var;
+        void *_tmp_132_var;
         void *literal;
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         asdl_seq* plain_names_var;
         if (
-            (opt_var = _tmp_123_rule(p), 1)
+            (opt_var = _tmp_131_rule(p), 1)
             &&
-            (_tmp_124_var = _tmp_124_rule(p))
+            (_tmp_132_var = _tmp_132_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -10185,9 +10356,349 @@ _loop0_1_rule(Parser *p)
     return seq;
 }
 
-// _loop1_2: statement
+// _loop0_3: ',' expression
 static asdl_seq *
-_loop1_2_rule(Parser *p)
+_loop0_3_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' expression
+        expr_ty elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = expression_rule(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_3");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_3_type, seq);
+    return seq;
+}
+
+// _gather_2: expression _loop0_3
+static asdl_seq *
+_gather_2_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // expression _loop0_3
+        expr_ty elem;
+        asdl_seq * seq;
+        if (
+            (elem = expression_rule(p))
+            &&
+            (seq = _loop0_3_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_5: ',' expression
+static asdl_seq *
+_loop0_5_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' expression
+        expr_ty elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = expression_rule(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_5");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_5_type, seq);
+    return seq;
+}
+
+// _gather_4: expression _loop0_5
+static asdl_seq *
+_gather_4_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // expression _loop0_5
+        expr_ty elem;
+        asdl_seq * seq;
+        if (
+            (elem = expression_rule(p))
+            &&
+            (seq = _loop0_5_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_7: ',' expression
+static asdl_seq *
+_loop0_7_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' expression
+        expr_ty elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = expression_rule(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_7");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_7_type, seq);
+    return seq;
+}
+
+// _gather_6: expression _loop0_7
+static asdl_seq *
+_gather_6_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // expression _loop0_7
+        expr_ty elem;
+        asdl_seq * seq;
+        if (
+            (elem = expression_rule(p))
+            &&
+            (seq = _loop0_7_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_9: ',' expression
+static asdl_seq *
+_loop0_9_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' expression
+        expr_ty elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = expression_rule(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_9");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_9_type, seq);
+    return seq;
+}
+
+// _gather_8: expression _loop0_9
+static asdl_seq *
+_gather_8_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // expression _loop0_9
+        expr_ty elem;
+        asdl_seq * seq;
+        if (
+            (elem = expression_rule(p))
+            &&
+            (seq = _loop0_9_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop1_10: statement
+static asdl_seq *
+_loop1_10_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10228,19 +10739,19 @@ _loop1_2_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_2");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_10");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_2_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_10_type, seq);
     return seq;
 }
 
-// _loop0_4: ';' small_stmt
+// _loop0_12: ';' small_stmt
 static asdl_seq *
-_loop0_4_rule(Parser *p)
+_loop0_12_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10285,32 +10796,32 @@ _loop0_4_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_4");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_12");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_4_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_12_type, seq);
     return seq;
 }
 
-// _gather_3: small_stmt _loop0_4
+// _gather_11: small_stmt _loop0_12
 static asdl_seq *
-_gather_3_rule(Parser *p)
+_gather_11_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // small_stmt _loop0_4
+    { // small_stmt _loop0_12
         stmt_ty elem;
         asdl_seq * seq;
         if (
             (elem = small_stmt_rule(p))
             &&
-            (seq = _loop0_4_rule(p))
+            (seq = _loop0_12_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -10323,9 +10834,9 @@ _gather_3_rule(Parser *p)
     return res;
 }
 
-// _tmp_5: 'import' | 'from'
+// _tmp_13: 'import' | 'from'
 static void *
-_tmp_5_rule(Parser *p)
+_tmp_13_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10359,9 +10870,9 @@ _tmp_5_rule(Parser *p)
     return res;
 }
 
-// _tmp_6: 'def' | '@' | ASYNC
+// _tmp_14: 'def' | '@' | ASYNC
 static void *
-_tmp_6_rule(Parser *p)
+_tmp_14_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10406,9 +10917,9 @@ _tmp_6_rule(Parser *p)
     return res;
 }
 
-// _tmp_7: 'class' | '@'
+// _tmp_15: 'class' | '@'
 static void *
-_tmp_7_rule(Parser *p)
+_tmp_15_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10442,9 +10953,9 @@ _tmp_7_rule(Parser *p)
     return res;
 }
 
-// _tmp_8: 'with' | ASYNC
+// _tmp_16: 'with' | ASYNC
 static void *
-_tmp_8_rule(Parser *p)
+_tmp_16_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10478,9 +10989,9 @@ _tmp_8_rule(Parser *p)
     return res;
 }
 
-// _tmp_9: 'for' | ASYNC
+// _tmp_17: 'for' | ASYNC
 static void *
-_tmp_9_rule(Parser *p)
+_tmp_17_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10514,9 +11025,9 @@ _tmp_9_rule(Parser *p)
     return res;
 }
 
-// _tmp_10: '=' annotated_rhs
+// _tmp_18: '=' annotated_rhs
 static void *
-_tmp_10_rule(Parser *p)
+_tmp_18_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10546,9 +11057,9 @@ _tmp_10_rule(Parser *p)
     return res;
 }
 
-// _tmp_11: '(' inside_paren_ann_assign_target ')' | ann_assign_subscript_attribute_target
+// _tmp_19: '(' inside_paren_ann_assign_target ')' | ann_assign_subscript_attribute_target
 static void *
-_tmp_11_rule(Parser *p)
+_tmp_19_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10592,9 +11103,9 @@ _tmp_11_rule(Parser *p)
     return res;
 }
 
-// _tmp_12: '=' annotated_rhs
+// _tmp_20: '=' annotated_rhs
 static void *
-_tmp_12_rule(Parser *p)
+_tmp_20_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10624,9 +11135,9 @@ _tmp_12_rule(Parser *p)
     return res;
 }
 
-// _loop1_13: (star_targets '=')
+// _loop1_21: (star_targets '=')
 static asdl_seq *
-_loop1_13_rule(Parser *p)
+_loop1_21_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10642,12 +11153,12 @@ _loop1_13_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (star_targets '=')
-        void *_tmp_125_var;
+        void *_tmp_133_var;
         while (
-            (_tmp_125_var = _tmp_125_rule(p))
+            (_tmp_133_var = _tmp_133_rule(p))
         )
         {
-            res = _tmp_125_var;
+            res = _tmp_133_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -10667,19 +11178,19 @@ _loop1_13_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_13");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_21");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_13_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_21_type, seq);
     return seq;
 }
 
-// _tmp_14: yield_expr | star_expressions
+// _tmp_22: yield_expr | star_expressions
 static void *
-_tmp_14_rule(Parser *p)
+_tmp_22_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10713,9 +11224,9 @@ _tmp_14_rule(Parser *p)
     return res;
 }
 
-// _tmp_15: yield_expr | star_expressions
+// _tmp_23: yield_expr | star_expressions
 static void *
-_tmp_15_rule(Parser *p)
+_tmp_23_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10749,9 +11260,9 @@ _tmp_15_rule(Parser *p)
     return res;
 }
 
-// _loop0_17: ',' NAME
+// _loop0_25: ',' NAME
 static asdl_seq *
-_loop0_17_rule(Parser *p)
+_loop0_25_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10796,32 +11307,32 @@ _loop0_17_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_17");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_25");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_17_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_25_type, seq);
     return seq;
 }
 
-// _gather_16: NAME _loop0_17
+// _gather_24: NAME _loop0_25
 static asdl_seq *
-_gather_16_rule(Parser *p)
+_gather_24_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // NAME _loop0_17
+    { // NAME _loop0_25
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = _PyPegen_name_token(p))
             &&
-            (seq = _loop0_17_rule(p))
+            (seq = _loop0_25_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -10834,9 +11345,9 @@ _gather_16_rule(Parser *p)
     return res;
 }
 
-// _loop0_19: ',' NAME
+// _loop0_27: ',' NAME
 static asdl_seq *
-_loop0_19_rule(Parser *p)
+_loop0_27_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10881,32 +11392,32 @@ _loop0_19_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_19");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_27");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_19_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_27_type, seq);
     return seq;
 }
 
-// _gather_18: NAME _loop0_19
+// _gather_26: NAME _loop0_27
 static asdl_seq *
-_gather_18_rule(Parser *p)
+_gather_26_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // NAME _loop0_19
+    { // NAME _loop0_27
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = _PyPegen_name_token(p))
             &&
-            (seq = _loop0_19_rule(p))
+            (seq = _loop0_27_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -10919,9 +11430,9 @@ _gather_18_rule(Parser *p)
     return res;
 }
 
-// _tmp_20: ',' expression
+// _tmp_28: ',' expression
 static void *
-_tmp_20_rule(Parser *p)
+_tmp_28_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10951,9 +11462,9 @@ _tmp_20_rule(Parser *p)
     return res;
 }
 
-// _loop0_21: ('.' | '...')
+// _loop0_29: ('.' | '...')
 static asdl_seq *
-_loop0_21_rule(Parser *p)
+_loop0_29_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10969,12 +11480,12 @@ _loop0_21_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_126_var;
+        void *_tmp_134_var;
         while (
-            (_tmp_126_var = _tmp_126_rule(p))
+            (_tmp_134_var = _tmp_134_rule(p))
         )
         {
-            res = _tmp_126_var;
+            res = _tmp_134_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -10990,19 +11501,19 @@ _loop0_21_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_21");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_29");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_21_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_29_type, seq);
     return seq;
 }
 
-// _loop1_22: ('.' | '...')
+// _loop1_30: ('.' | '...')
 static asdl_seq *
-_loop1_22_rule(Parser *p)
+_loop1_30_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11018,12 +11529,12 @@ _loop1_22_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_127_var;
+        void *_tmp_135_var;
         while (
-            (_tmp_127_var = _tmp_127_rule(p))
+            (_tmp_135_var = _tmp_135_rule(p))
         )
         {
-            res = _tmp_127_var;
+            res = _tmp_135_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -11043,19 +11554,19 @@ _loop1_22_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_22");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_30");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_22_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_30_type, seq);
     return seq;
 }
 
-// _loop0_24: ',' import_from_as_name
+// _loop0_32: ',' import_from_as_name
 static asdl_seq *
-_loop0_24_rule(Parser *p)
+_loop0_32_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11100,32 +11611,32 @@ _loop0_24_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_24");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_32");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_24_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_32_type, seq);
     return seq;
 }
 
-// _gather_23: import_from_as_name _loop0_24
+// _gather_31: import_from_as_name _loop0_32
 static asdl_seq *
-_gather_23_rule(Parser *p)
+_gather_31_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // import_from_as_name _loop0_24
+    { // import_from_as_name _loop0_32
         alias_ty elem;
         asdl_seq * seq;
         if (
             (elem = import_from_as_name_rule(p))
             &&
-            (seq = _loop0_24_rule(p))
+            (seq = _loop0_32_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11138,9 +11649,9 @@ _gather_23_rule(Parser *p)
     return res;
 }
 
-// _tmp_25: 'as' NAME
+// _tmp_33: 'as' NAME
 static void *
-_tmp_25_rule(Parser *p)
+_tmp_33_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11170,9 +11681,9 @@ _tmp_25_rule(Parser *p)
     return res;
 }
 
-// _loop0_27: ',' dotted_as_name
+// _loop0_35: ',' dotted_as_name
 static asdl_seq *
-_loop0_27_rule(Parser *p)
+_loop0_35_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11217,32 +11728,32 @@ _loop0_27_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_27");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_35");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_27_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_35_type, seq);
     return seq;
 }
 
-// _gather_26: dotted_as_name _loop0_27
+// _gather_34: dotted_as_name _loop0_35
 static asdl_seq *
-_gather_26_rule(Parser *p)
+_gather_34_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // dotted_as_name _loop0_27
+    { // dotted_as_name _loop0_35
         alias_ty elem;
         asdl_seq * seq;
         if (
             (elem = dotted_as_name_rule(p))
             &&
-            (seq = _loop0_27_rule(p))
+            (seq = _loop0_35_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11255,9 +11766,9 @@ _gather_26_rule(Parser *p)
     return res;
 }
 
-// _tmp_28: 'as' NAME
+// _tmp_36: 'as' NAME
 static void *
-_tmp_28_rule(Parser *p)
+_tmp_36_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11287,9 +11798,9 @@ _tmp_28_rule(Parser *p)
     return res;
 }
 
-// _loop0_30: ',' with_item
+// _loop0_38: ',' with_item
 static asdl_seq *
-_loop0_30_rule(Parser *p)
+_loop0_38_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11334,32 +11845,32 @@ _loop0_30_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_30");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_38");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_30_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_38_type, seq);
     return seq;
 }
 
-// _gather_29: with_item _loop0_30
+// _gather_37: with_item _loop0_38
 static asdl_seq *
-_gather_29_rule(Parser *p)
+_gather_37_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // with_item _loop0_30
+    { // with_item _loop0_38
         withitem_ty elem;
         asdl_seq * seq;
         if (
             (elem = with_item_rule(p))
             &&
-            (seq = _loop0_30_rule(p))
+            (seq = _loop0_38_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11372,9 +11883,9 @@ _gather_29_rule(Parser *p)
     return res;
 }
 
-// _loop0_32: ',' with_item
+// _loop0_40: ',' with_item
 static asdl_seq *
-_loop0_32_rule(Parser *p)
+_loop0_40_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11419,32 +11930,32 @@ _loop0_32_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_32");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_40");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_32_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_40_type, seq);
     return seq;
 }
 
-// _gather_31: with_item _loop0_32
+// _gather_39: with_item _loop0_40
 static asdl_seq *
-_gather_31_rule(Parser *p)
+_gather_39_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // with_item _loop0_32
+    { // with_item _loop0_40
         withitem_ty elem;
         asdl_seq * seq;
         if (
             (elem = with_item_rule(p))
             &&
-            (seq = _loop0_32_rule(p))
+            (seq = _loop0_40_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11457,9 +11968,9 @@ _gather_31_rule(Parser *p)
     return res;
 }
 
-// _tmp_33: 'as' target
+// _tmp_41: 'as' target
 static void *
-_tmp_33_rule(Parser *p)
+_tmp_41_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11489,9 +12000,9 @@ _tmp_33_rule(Parser *p)
     return res;
 }
 
-// _loop1_34: except_block
+// _loop1_42: except_block
 static asdl_seq *
-_loop1_34_rule(Parser *p)
+_loop1_42_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11532,19 +12043,19 @@ _loop1_34_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_34");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_42");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_34_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_42_type, seq);
     return seq;
 }
 
-// _tmp_35: 'as' target
+// _tmp_43: 'as' target
 static void *
-_tmp_35_rule(Parser *p)
+_tmp_43_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11574,9 +12085,9 @@ _tmp_35_rule(Parser *p)
     return res;
 }
 
-// _tmp_36: 'from' expression
+// _tmp_44: 'from' expression
 static void *
-_tmp_36_rule(Parser *p)
+_tmp_44_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11606,9 +12117,9 @@ _tmp_36_rule(Parser *p)
     return res;
 }
 
-// _tmp_37: '->' annotation
+// _tmp_45: '->' annotation
 static void *
-_tmp_37_rule(Parser *p)
+_tmp_45_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11638,9 +12149,9 @@ _tmp_37_rule(Parser *p)
     return res;
 }
 
-// _tmp_38: NEWLINE INDENT
+// _tmp_46: NEWLINE INDENT
 static void *
-_tmp_38_rule(Parser *p)
+_tmp_46_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11666,9 +12177,9 @@ _tmp_38_rule(Parser *p)
     return res;
 }
 
-// _tmp_39: ',' plain_names
+// _tmp_47: ',' plain_names
 static void *
-_tmp_39_rule(Parser *p)
+_tmp_47_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11698,9 +12209,9 @@ _tmp_39_rule(Parser *p)
     return res;
 }
 
-// _tmp_40: ',' names_with_default
+// _tmp_48: ',' names_with_default
 static void *
-_tmp_40_rule(Parser *p)
+_tmp_48_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11730,9 +12241,9 @@ _tmp_40_rule(Parser *p)
     return res;
 }
 
-// _tmp_41: ',' star_etc?
+// _tmp_49: ',' star_etc?
 static void *
-_tmp_41_rule(Parser *p)
+_tmp_49_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11762,9 +12273,9 @@ _tmp_41_rule(Parser *p)
     return res;
 }
 
-// _tmp_42: ',' names_with_default
+// _tmp_50: ',' names_with_default
 static void *
-_tmp_42_rule(Parser *p)
+_tmp_50_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11794,9 +12305,9 @@ _tmp_42_rule(Parser *p)
     return res;
 }
 
-// _tmp_43: ',' star_etc?
+// _tmp_51: ',' star_etc?
 static void *
-_tmp_43_rule(Parser *p)
+_tmp_51_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11826,9 +12337,9 @@ _tmp_43_rule(Parser *p)
     return res;
 }
 
-// _tmp_44: ',' names_with_default
+// _tmp_52: ',' names_with_default
 static void *
-_tmp_44_rule(Parser *p)
+_tmp_52_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11858,9 +12369,9 @@ _tmp_44_rule(Parser *p)
     return res;
 }
 
-// _tmp_45: ',' star_etc?
+// _tmp_53: ',' star_etc?
 static void *
-_tmp_45_rule(Parser *p)
+_tmp_53_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11890,9 +12401,9 @@ _tmp_45_rule(Parser *p)
     return res;
 }
 
-// _tmp_46: ',' star_etc?
+// _tmp_54: ',' star_etc?
 static void *
-_tmp_46_rule(Parser *p)
+_tmp_54_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11922,9 +12433,9 @@ _tmp_46_rule(Parser *p)
     return res;
 }
 
-// _tmp_47: plain_names ','
+// _tmp_55: plain_names ','
 static void *
-_tmp_47_rule(Parser *p)
+_tmp_55_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11954,9 +12465,9 @@ _tmp_47_rule(Parser *p)
     return res;
 }
 
-// _loop0_48: name_with_optional_default
+// _loop0_56: name_with_optional_default
 static asdl_seq *
-_loop0_48_rule(Parser *p)
+_loop0_56_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11993,19 +12504,19 @@ _loop0_48_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_48");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_56");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_48_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_56_type, seq);
     return seq;
 }
 
-// _tmp_49: ',' kwds
+// _tmp_57: ',' kwds
 static void *
-_tmp_49_rule(Parser *p)
+_tmp_57_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12035,9 +12546,9 @@ _tmp_49_rule(Parser *p)
     return res;
 }
 
-// _loop1_50: name_with_optional_default
+// _loop1_58: name_with_optional_default
 static asdl_seq *
-_loop1_50_rule(Parser *p)
+_loop1_58_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12078,19 +12589,19 @@ _loop1_50_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_50");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_58");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_50_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_58_type, seq);
     return seq;
 }
 
-// _tmp_51: ',' kwds
+// _tmp_59: ',' kwds
 static void *
-_tmp_51_rule(Parser *p)
+_tmp_59_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12120,9 +12631,9 @@ _tmp_51_rule(Parser *p)
     return res;
 }
 
-// _tmp_52: '=' expression
+// _tmp_60: '=' expression
 static void *
-_tmp_52_rule(Parser *p)
+_tmp_60_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12152,9 +12663,9 @@ _tmp_52_rule(Parser *p)
     return res;
 }
 
-// _loop0_54: ',' name_with_default
+// _loop0_62: ',' name_with_default
 static asdl_seq *
-_loop0_54_rule(Parser *p)
+_loop0_62_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12199,32 +12710,32 @@ _loop0_54_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_54");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_62");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_54_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_62_type, seq);
     return seq;
 }
 
-// _gather_53: name_with_default _loop0_54
+// _gather_61: name_with_default _loop0_62
 static asdl_seq *
-_gather_53_rule(Parser *p)
+_gather_61_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // name_with_default _loop0_54
+    { // name_with_default _loop0_62
         NameDefaultPair* elem;
         asdl_seq * seq;
         if (
             (elem = name_with_default_rule(p))
             &&
-            (seq = _loop0_54_rule(p))
+            (seq = _loop0_62_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12237,9 +12748,9 @@ _gather_53_rule(Parser *p)
     return res;
 }
 
-// _loop0_56: ',' (plain_name !'=')
+// _loop0_64: ',' (plain_name !'=')
 static asdl_seq *
-_loop0_56_rule(Parser *p)
+_loop0_64_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12260,7 +12771,7 @@ _loop0_56_rule(Parser *p)
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (elem = _tmp_128_rule(p))
+            (elem = _tmp_136_rule(p))
         )
         {
             res = elem;
@@ -12284,32 +12795,32 @@ _loop0_56_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_56");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_64");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_56_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_64_type, seq);
     return seq;
 }
 
-// _gather_55: (plain_name !'=') _loop0_56
+// _gather_63: (plain_name !'=') _loop0_64
 static asdl_seq *
-_gather_55_rule(Parser *p)
+_gather_63_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // (plain_name !'=') _loop0_56
+    { // (plain_name !'=') _loop0_64
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_128_rule(p))
+            (elem = _tmp_136_rule(p))
             &&
-            (seq = _loop0_56_rule(p))
+            (seq = _loop0_64_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12322,9 +12833,9 @@ _gather_55_rule(Parser *p)
     return res;
 }
 
-// _tmp_57: ':' annotation
+// _tmp_65: ':' annotation
 static void *
-_tmp_57_rule(Parser *p)
+_tmp_65_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12354,9 +12865,9 @@ _tmp_57_rule(Parser *p)
     return res;
 }
 
-// _loop1_58: ('@' named_expression NEWLINE)
+// _loop1_66: ('@' named_expression NEWLINE)
 static asdl_seq *
-_loop1_58_rule(Parser *p)
+_loop1_66_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12372,12 +12883,12 @@ _loop1_58_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('@' named_expression NEWLINE)
-        void *_tmp_129_var;
+        void *_tmp_137_var;
         while (
-            (_tmp_129_var = _tmp_129_rule(p))
+            (_tmp_137_var = _tmp_137_rule(p))
         )
         {
-            res = _tmp_129_var;
+            res = _tmp_137_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12397,19 +12908,19 @@ _loop1_58_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_58");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_66");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_58_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_66_type, seq);
     return seq;
 }
 
-// _tmp_59: '(' arguments? ')'
+// _tmp_67: '(' arguments? ')'
 static void *
-_tmp_59_rule(Parser *p)
+_tmp_67_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12442,9 +12953,9 @@ _tmp_59_rule(Parser *p)
     return res;
 }
 
-// _loop0_61: ',' star_expression
+// _loop0_69: ',' star_expression
 static asdl_seq *
-_loop0_61_rule(Parser *p)
+_loop0_69_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12489,32 +13000,32 @@ _loop0_61_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_61");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_69");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_61_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_69_type, seq);
     return seq;
 }
 
-// _gather_60: star_expression _loop0_61
+// _gather_68: star_expression _loop0_69
 static asdl_seq *
-_gather_60_rule(Parser *p)
+_gather_68_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_expression _loop0_61
+    { // star_expression _loop0_69
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_expression_rule(p))
             &&
-            (seq = _loop0_61_rule(p))
+            (seq = _loop0_69_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12527,9 +13038,9 @@ _gather_60_rule(Parser *p)
     return res;
 }
 
-// _loop1_62: (',' star_expression)
+// _loop1_70: (',' star_expression)
 static asdl_seq *
-_loop1_62_rule(Parser *p)
+_loop1_70_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12545,12 +13056,12 @@ _loop1_62_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_expression)
-        void *_tmp_130_var;
+        void *_tmp_138_var;
         while (
-            (_tmp_130_var = _tmp_130_rule(p))
+            (_tmp_138_var = _tmp_138_rule(p))
         )
         {
-            res = _tmp_130_var;
+            res = _tmp_138_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12570,19 +13081,19 @@ _loop1_62_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_62");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_70");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_62_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_70_type, seq);
     return seq;
 }
 
-// _loop0_64: ',' star_named_expression
+// _loop0_72: ',' star_named_expression
 static asdl_seq *
-_loop0_64_rule(Parser *p)
+_loop0_72_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12627,32 +13138,32 @@ _loop0_64_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_64");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_72");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_64_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_72_type, seq);
     return seq;
 }
 
-// _gather_63: star_named_expression _loop0_64
+// _gather_71: star_named_expression _loop0_72
 static asdl_seq *
-_gather_63_rule(Parser *p)
+_gather_71_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_named_expression _loop0_64
+    { // star_named_expression _loop0_72
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_named_expression_rule(p))
             &&
-            (seq = _loop0_64_rule(p))
+            (seq = _loop0_72_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12665,9 +13176,9 @@ _gather_63_rule(Parser *p)
     return res;
 }
 
-// _loop1_65: (',' expression)
+// _loop1_73: (',' expression)
 static asdl_seq *
-_loop1_65_rule(Parser *p)
+_loop1_73_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12683,12 +13194,12 @@ _loop1_65_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' expression)
-        void *_tmp_131_var;
+        void *_tmp_139_var;
         while (
-            (_tmp_131_var = _tmp_131_rule(p))
+            (_tmp_139_var = _tmp_139_rule(p))
         )
         {
-            res = _tmp_131_var;
+            res = _tmp_139_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12708,19 +13219,19 @@ _loop1_65_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_65");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_73");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_65_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_73_type, seq);
     return seq;
 }
 
-// _tmp_66: ',' lambda_plain_names
+// _tmp_74: ',' lambda_plain_names
 static void *
-_tmp_66_rule(Parser *p)
+_tmp_74_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12750,9 +13261,9 @@ _tmp_66_rule(Parser *p)
     return res;
 }
 
-// _tmp_67: ',' lambda_names_with_default
+// _tmp_75: ',' lambda_names_with_default
 static void *
-_tmp_67_rule(Parser *p)
+_tmp_75_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12782,9 +13293,9 @@ _tmp_67_rule(Parser *p)
     return res;
 }
 
-// _tmp_68: ',' lambda_star_etc?
+// _tmp_76: ',' lambda_star_etc?
 static void *
-_tmp_68_rule(Parser *p)
+_tmp_76_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12814,9 +13325,9 @@ _tmp_68_rule(Parser *p)
     return res;
 }
 
-// _tmp_69: ',' lambda_names_with_default
+// _tmp_77: ',' lambda_names_with_default
 static void *
-_tmp_69_rule(Parser *p)
+_tmp_77_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12846,9 +13357,9 @@ _tmp_69_rule(Parser *p)
     return res;
 }
 
-// _tmp_70: ',' lambda_star_etc?
+// _tmp_78: ',' lambda_star_etc?
 static void *
-_tmp_70_rule(Parser *p)
+_tmp_78_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12878,9 +13389,9 @@ _tmp_70_rule(Parser *p)
     return res;
 }
 
-// _tmp_71: ',' lambda_names_with_default
+// _tmp_79: ',' lambda_names_with_default
 static void *
-_tmp_71_rule(Parser *p)
+_tmp_79_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12910,9 +13421,9 @@ _tmp_71_rule(Parser *p)
     return res;
 }
 
-// _tmp_72: ',' lambda_star_etc?
+// _tmp_80: ',' lambda_star_etc?
 static void *
-_tmp_72_rule(Parser *p)
+_tmp_80_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12942,9 +13453,9 @@ _tmp_72_rule(Parser *p)
     return res;
 }
 
-// _tmp_73: ',' lambda_star_etc?
+// _tmp_81: ',' lambda_star_etc?
 static void *
-_tmp_73_rule(Parser *p)
+_tmp_81_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12974,9 +13485,9 @@ _tmp_73_rule(Parser *p)
     return res;
 }
 
-// _tmp_74: lambda_plain_names ','
+// _tmp_82: lambda_plain_names ','
 static void *
-_tmp_74_rule(Parser *p)
+_tmp_82_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13006,9 +13517,9 @@ _tmp_74_rule(Parser *p)
     return res;
 }
 
-// _loop0_75: lambda_name_with_optional_default
+// _loop0_83: lambda_name_with_optional_default
 static asdl_seq *
-_loop0_75_rule(Parser *p)
+_loop0_83_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13045,19 +13556,19 @@ _loop0_75_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_75");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_83");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_75_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_83_type, seq);
     return seq;
 }
 
-// _tmp_76: ',' lambda_kwds
+// _tmp_84: ',' lambda_kwds
 static void *
-_tmp_76_rule(Parser *p)
+_tmp_84_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13087,9 +13598,9 @@ _tmp_76_rule(Parser *p)
     return res;
 }
 
-// _loop1_77: lambda_name_with_optional_default
+// _loop1_85: lambda_name_with_optional_default
 static asdl_seq *
-_loop1_77_rule(Parser *p)
+_loop1_85_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13130,19 +13641,19 @@ _loop1_77_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_77");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_85");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_77_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_85_type, seq);
     return seq;
 }
 
-// _tmp_78: ',' lambda_kwds
+// _tmp_86: ',' lambda_kwds
 static void *
-_tmp_78_rule(Parser *p)
+_tmp_86_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13172,9 +13683,9 @@ _tmp_78_rule(Parser *p)
     return res;
 }
 
-// _tmp_79: '=' expression
+// _tmp_87: '=' expression
 static void *
-_tmp_79_rule(Parser *p)
+_tmp_87_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13204,9 +13715,9 @@ _tmp_79_rule(Parser *p)
     return res;
 }
 
-// _loop0_81: ',' lambda_name_with_default
+// _loop0_89: ',' lambda_name_with_default
 static asdl_seq *
-_loop0_81_rule(Parser *p)
+_loop0_89_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13251,32 +13762,32 @@ _loop0_81_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_81");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_89");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_81_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_89_type, seq);
     return seq;
 }
 
-// _gather_80: lambda_name_with_default _loop0_81
+// _gather_88: lambda_name_with_default _loop0_89
 static asdl_seq *
-_gather_80_rule(Parser *p)
+_gather_88_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // lambda_name_with_default _loop0_81
+    { // lambda_name_with_default _loop0_89
         NameDefaultPair* elem;
         asdl_seq * seq;
         if (
             (elem = lambda_name_with_default_rule(p))
             &&
-            (seq = _loop0_81_rule(p))
+            (seq = _loop0_89_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13289,9 +13800,9 @@ _gather_80_rule(Parser *p)
     return res;
 }
 
-// _loop0_83: ',' (lambda_plain_name !'=')
+// _loop0_91: ',' (lambda_plain_name !'=')
 static asdl_seq *
-_loop0_83_rule(Parser *p)
+_loop0_91_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13312,7 +13823,7 @@ _loop0_83_rule(Parser *p)
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (elem = _tmp_132_rule(p))
+            (elem = _tmp_140_rule(p))
         )
         {
             res = elem;
@@ -13336,32 +13847,32 @@ _loop0_83_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_83");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_91");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_83_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_91_type, seq);
     return seq;
 }
 
-// _gather_82: (lambda_plain_name !'=') _loop0_83
+// _gather_90: (lambda_plain_name !'=') _loop0_91
 static asdl_seq *
-_gather_82_rule(Parser *p)
+_gather_90_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // (lambda_plain_name !'=') _loop0_83
+    { // (lambda_plain_name !'=') _loop0_91
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_132_rule(p))
+            (elem = _tmp_140_rule(p))
             &&
-            (seq = _loop0_83_rule(p))
+            (seq = _loop0_91_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13374,9 +13885,9 @@ _gather_82_rule(Parser *p)
     return res;
 }
 
-// _loop1_84: ('or' conjunction)
+// _loop1_92: ('or' conjunction)
 static asdl_seq *
-_loop1_84_rule(Parser *p)
+_loop1_92_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13392,12 +13903,12 @@ _loop1_84_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('or' conjunction)
-        void *_tmp_133_var;
+        void *_tmp_141_var;
         while (
-            (_tmp_133_var = _tmp_133_rule(p))
+            (_tmp_141_var = _tmp_141_rule(p))
         )
         {
-            res = _tmp_133_var;
+            res = _tmp_141_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13417,19 +13928,19 @@ _loop1_84_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_84");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_92");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_84_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_92_type, seq);
     return seq;
 }
 
-// _loop1_85: ('and' inversion)
+// _loop1_93: ('and' inversion)
 static asdl_seq *
-_loop1_85_rule(Parser *p)
+_loop1_93_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13445,12 +13956,12 @@ _loop1_85_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('and' inversion)
-        void *_tmp_134_var;
+        void *_tmp_142_var;
         while (
-            (_tmp_134_var = _tmp_134_rule(p))
+            (_tmp_142_var = _tmp_142_rule(p))
         )
         {
-            res = _tmp_134_var;
+            res = _tmp_142_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13470,19 +13981,19 @@ _loop1_85_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_85");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_93");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_85_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_93_type, seq);
     return seq;
 }
 
-// _loop1_86: compare_op_bitwise_or_pair
+// _loop1_94: compare_op_bitwise_or_pair
 static asdl_seq *
-_loop1_86_rule(Parser *p)
+_loop1_94_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13523,19 +14034,19 @@ _loop1_86_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_86");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_94");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_86_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_94_type, seq);
     return seq;
 }
 
-// _tmp_87: '!='
+// _tmp_95: '!='
 static void *
-_tmp_87_rule(Parser *p)
+_tmp_95_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13562,9 +14073,9 @@ _tmp_87_rule(Parser *p)
     return res;
 }
 
-// _loop0_89: ',' slice
+// _loop0_97: ',' slice
 static asdl_seq *
-_loop0_89_rule(Parser *p)
+_loop0_97_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13609,32 +14120,32 @@ _loop0_89_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_89");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_97");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_89_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_97_type, seq);
     return seq;
 }
 
-// _gather_88: slice _loop0_89
+// _gather_96: slice _loop0_97
 static asdl_seq *
-_gather_88_rule(Parser *p)
+_gather_96_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // slice _loop0_89
+    { // slice _loop0_97
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = slice_rule(p))
             &&
-            (seq = _loop0_89_rule(p))
+            (seq = _loop0_97_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13647,9 +14158,9 @@ _gather_88_rule(Parser *p)
     return res;
 }
 
-// _tmp_90: ':' expression?
+// _tmp_98: ':' expression?
 static void *
-_tmp_90_rule(Parser *p)
+_tmp_98_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13679,9 +14190,9 @@ _tmp_90_rule(Parser *p)
     return res;
 }
 
-// _tmp_91: tuple | group | genexp
+// _tmp_99: tuple | group | genexp
 static void *
-_tmp_91_rule(Parser *p)
+_tmp_99_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13726,9 +14237,9 @@ _tmp_91_rule(Parser *p)
     return res;
 }
 
-// _tmp_92: list | listcomp
+// _tmp_100: list | listcomp
 static void *
-_tmp_92_rule(Parser *p)
+_tmp_100_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13762,9 +14273,9 @@ _tmp_92_rule(Parser *p)
     return res;
 }
 
-// _tmp_93: dict | set | dictcomp | setcomp
+// _tmp_101: dict | set | dictcomp | setcomp
 static void *
-_tmp_93_rule(Parser *p)
+_tmp_101_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13820,9 +14331,9 @@ _tmp_93_rule(Parser *p)
     return res;
 }
 
-// _loop1_94: STRING
+// _loop1_102: STRING
 static asdl_seq *
-_loop1_94_rule(Parser *p)
+_loop1_102_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13863,19 +14374,19 @@ _loop1_94_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_94");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_102");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_94_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_102_type, seq);
     return seq;
 }
 
-// _tmp_95: star_named_expression ',' star_named_expressions?
+// _tmp_103: star_named_expression ',' star_named_expressions?
 static void *
-_tmp_95_rule(Parser *p)
+_tmp_103_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13908,9 +14419,9 @@ _tmp_95_rule(Parser *p)
     return res;
 }
 
-// _tmp_96: yield_expr | named_expression
+// _tmp_104: yield_expr | named_expression
 static void *
-_tmp_96_rule(Parser *p)
+_tmp_104_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13944,9 +14455,9 @@ _tmp_96_rule(Parser *p)
     return res;
 }
 
-// _loop0_98: ',' kvpair
+// _loop0_106: ',' kvpair
 static asdl_seq *
-_loop0_98_rule(Parser *p)
+_loop0_106_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13991,32 +14502,32 @@ _loop0_98_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_98");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_106");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_98_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_106_type, seq);
     return seq;
 }
 
-// _gather_97: kvpair _loop0_98
+// _gather_105: kvpair _loop0_106
 static asdl_seq *
-_gather_97_rule(Parser *p)
+_gather_105_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kvpair _loop0_98
+    { // kvpair _loop0_106
         KeyValuePair* elem;
         asdl_seq * seq;
         if (
             (elem = kvpair_rule(p))
             &&
-            (seq = _loop0_98_rule(p))
+            (seq = _loop0_106_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14029,9 +14540,9 @@ _gather_97_rule(Parser *p)
     return res;
 }
 
-// _loop1_99: (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
+// _loop1_107: (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
 static asdl_seq *
-_loop1_99_rule(Parser *p)
+_loop1_107_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14047,12 +14558,12 @@ _loop1_99_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
-        void *_tmp_135_var;
+        void *_tmp_143_var;
         while (
-            (_tmp_135_var = _tmp_135_rule(p))
+            (_tmp_143_var = _tmp_143_rule(p))
         )
         {
-            res = _tmp_135_var;
+            res = _tmp_143_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14072,19 +14583,19 @@ _loop1_99_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_99");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_107");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_99_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_107_type, seq);
     return seq;
 }
 
-// _tmp_100: ',' args
+// _tmp_108: ',' args
 static void *
-_tmp_100_rule(Parser *p)
+_tmp_108_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14114,9 +14625,9 @@ _tmp_100_rule(Parser *p)
     return res;
 }
 
-// _tmp_101: ',' args
+// _tmp_109: ',' args
 static void *
-_tmp_101_rule(Parser *p)
+_tmp_109_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14146,9 +14657,9 @@ _tmp_101_rule(Parser *p)
     return res;
 }
 
-// _loop0_103: ',' kwarg_or_starred
+// _loop0_111: ',' kwarg_or_starred
 static asdl_seq *
-_loop0_103_rule(Parser *p)
+_loop0_111_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14193,32 +14704,32 @@ _loop0_103_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_103");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_111");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_103_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_111_type, seq);
     return seq;
 }
 
-// _gather_102: kwarg_or_starred _loop0_103
+// _gather_110: kwarg_or_starred _loop0_111
 static asdl_seq *
-_gather_102_rule(Parser *p)
+_gather_110_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_starred _loop0_103
+    { // kwarg_or_starred _loop0_111
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_starred_rule(p))
             &&
-            (seq = _loop0_103_rule(p))
+            (seq = _loop0_111_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14231,9 +14742,9 @@ _gather_102_rule(Parser *p)
     return res;
 }
 
-// _loop0_105: ',' kwarg_or_double_starred
+// _loop0_113: ',' kwarg_or_double_starred
 static asdl_seq *
-_loop0_105_rule(Parser *p)
+_loop0_113_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14278,32 +14789,32 @@ _loop0_105_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_105");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_113");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_105_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_113_type, seq);
     return seq;
 }
 
-// _gather_104: kwarg_or_double_starred _loop0_105
+// _gather_112: kwarg_or_double_starred _loop0_113
 static asdl_seq *
-_gather_104_rule(Parser *p)
+_gather_112_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_105
+    { // kwarg_or_double_starred _loop0_113
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_double_starred_rule(p))
             &&
-            (seq = _loop0_105_rule(p))
+            (seq = _loop0_113_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14316,9 +14827,9 @@ _gather_104_rule(Parser *p)
     return res;
 }
 
-// _loop0_107: ',' kwarg_or_starred
+// _loop0_115: ',' kwarg_or_starred
 static asdl_seq *
-_loop0_107_rule(Parser *p)
+_loop0_115_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14363,32 +14874,32 @@ _loop0_107_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_107");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_115");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_107_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_115_type, seq);
     return seq;
 }
 
-// _gather_106: kwarg_or_starred _loop0_107
+// _gather_114: kwarg_or_starred _loop0_115
 static asdl_seq *
-_gather_106_rule(Parser *p)
+_gather_114_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_starred _loop0_107
+    { // kwarg_or_starred _loop0_115
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_starred_rule(p))
             &&
-            (seq = _loop0_107_rule(p))
+            (seq = _loop0_115_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14401,9 +14912,9 @@ _gather_106_rule(Parser *p)
     return res;
 }
 
-// _loop0_109: ',' kwarg_or_double_starred
+// _loop0_117: ',' kwarg_or_double_starred
 static asdl_seq *
-_loop0_109_rule(Parser *p)
+_loop0_117_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14448,32 +14959,32 @@ _loop0_109_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_109");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_117");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_109_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_117_type, seq);
     return seq;
 }
 
-// _gather_108: kwarg_or_double_starred _loop0_109
+// _gather_116: kwarg_or_double_starred _loop0_117
 static asdl_seq *
-_gather_108_rule(Parser *p)
+_gather_116_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_109
+    { // kwarg_or_double_starred _loop0_117
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_double_starred_rule(p))
             &&
-            (seq = _loop0_109_rule(p))
+            (seq = _loop0_117_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14486,9 +14997,9 @@ _gather_108_rule(Parser *p)
     return res;
 }
 
-// _loop0_110: (',' star_target)
+// _loop0_118: (',' star_target)
 static asdl_seq *
-_loop0_110_rule(Parser *p)
+_loop0_118_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14504,12 +15015,12 @@ _loop0_110_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_target)
-        void *_tmp_136_var;
+        void *_tmp_144_var;
         while (
-            (_tmp_136_var = _tmp_136_rule(p))
+            (_tmp_144_var = _tmp_144_rule(p))
         )
         {
-            res = _tmp_136_var;
+            res = _tmp_144_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14525,19 +15036,19 @@ _loop0_110_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_110");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_118");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_110_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_118_type, seq);
     return seq;
 }
 
-// _loop0_112: ',' star_target
+// _loop0_120: ',' star_target
 static asdl_seq *
-_loop0_112_rule(Parser *p)
+_loop0_120_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14582,32 +15093,32 @@ _loop0_112_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_112");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_120");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_112_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_120_type, seq);
     return seq;
 }
 
-// _gather_111: star_target _loop0_112
+// _gather_119: star_target _loop0_120
 static asdl_seq *
-_gather_111_rule(Parser *p)
+_gather_119_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_target _loop0_112
+    { // star_target _loop0_120
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_target_rule(p))
             &&
-            (seq = _loop0_112_rule(p))
+            (seq = _loop0_120_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14620,9 +15131,9 @@ _gather_111_rule(Parser *p)
     return res;
 }
 
-// _tmp_113: !'*' star_target
+// _tmp_121: !'*' star_target
 static void *
-_tmp_113_rule(Parser *p)
+_tmp_121_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14647,9 +15158,9 @@ _tmp_113_rule(Parser *p)
     return res;
 }
 
-// _loop0_115: ',' del_target
+// _loop0_123: ',' del_target
 static asdl_seq *
-_loop0_115_rule(Parser *p)
+_loop0_123_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14694,32 +15205,32 @@ _loop0_115_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_115");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_123");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_115_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_123_type, seq);
     return seq;
 }
 
-// _gather_114: del_target _loop0_115
+// _gather_122: del_target _loop0_123
 static asdl_seq *
-_gather_114_rule(Parser *p)
+_gather_122_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // del_target _loop0_115
+    { // del_target _loop0_123
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = del_target_rule(p))
             &&
-            (seq = _loop0_115_rule(p))
+            (seq = _loop0_123_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14732,9 +15243,9 @@ _gather_114_rule(Parser *p)
     return res;
 }
 
-// _loop0_117: ',' target
+// _loop0_125: ',' target
 static asdl_seq *
-_loop0_117_rule(Parser *p)
+_loop0_125_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14779,32 +15290,32 @@ _loop0_117_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_117");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_125");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_117_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_125_type, seq);
     return seq;
 }
 
-// _gather_116: target _loop0_117
+// _gather_124: target _loop0_125
 static asdl_seq *
-_gather_116_rule(Parser *p)
+_gather_124_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // target _loop0_117
+    { // target _loop0_125
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = target_rule(p))
             &&
-            (seq = _loop0_117_rule(p))
+            (seq = _loop0_125_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14817,9 +15328,9 @@ _gather_116_rule(Parser *p)
     return res;
 }
 
-// _tmp_118: args | expression for_if_clauses
+// _tmp_126: args | expression for_if_clauses
 static void *
-_tmp_118_rule(Parser *p)
+_tmp_126_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14856,9 +15367,9 @@ _tmp_118_rule(Parser *p)
     return res;
 }
 
-// _tmp_119: '=' annotated_rhs
+// _tmp_127: '=' annotated_rhs
 static void *
-_tmp_119_rule(Parser *p)
+_tmp_127_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14884,9 +15395,9 @@ _tmp_119_rule(Parser *p)
     return res;
 }
 
-// _tmp_120: '=' | augassign
+// _tmp_128: '=' | augassign
 static void *
-_tmp_120_rule(Parser *p)
+_tmp_128_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14920,9 +15431,9 @@ _tmp_120_rule(Parser *p)
     return res;
 }
 
-// _tmp_121: yield_expr | star_expressions
+// _tmp_129: yield_expr | star_expressions
 static void *
-_tmp_121_rule(Parser *p)
+_tmp_129_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14956,9 +15467,9 @@ _tmp_121_rule(Parser *p)
     return res;
 }
 
-// _tmp_122: '[' | '(' | '{'
+// _tmp_130: '[' | '(' | '{'
 static void *
-_tmp_122_rule(Parser *p)
+_tmp_130_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15003,9 +15514,9 @@ _tmp_122_rule(Parser *p)
     return res;
 }
 
-// _tmp_123: plain_names ','
+// _tmp_131: plain_names ','
 static void *
-_tmp_123_rule(Parser *p)
+_tmp_131_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15031,9 +15542,9 @@ _tmp_123_rule(Parser *p)
     return res;
 }
 
-// _tmp_124: slash_with_default | names_with_default
+// _tmp_132: slash_with_default | names_with_default
 static void *
-_tmp_124_rule(Parser *p)
+_tmp_132_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15067,9 +15578,9 @@ _tmp_124_rule(Parser *p)
     return res;
 }
 
-// _tmp_125: star_targets '='
+// _tmp_133: star_targets '='
 static void *
-_tmp_125_rule(Parser *p)
+_tmp_133_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15099,9 +15610,9 @@ _tmp_125_rule(Parser *p)
     return res;
 }
 
-// _tmp_126: '.' | '...'
+// _tmp_134: '.' | '...'
 static void *
-_tmp_126_rule(Parser *p)
+_tmp_134_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15135,9 +15646,9 @@ _tmp_126_rule(Parser *p)
     return res;
 }
 
-// _tmp_127: '.' | '...'
+// _tmp_135: '.' | '...'
 static void *
-_tmp_127_rule(Parser *p)
+_tmp_135_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15171,9 +15682,9 @@ _tmp_127_rule(Parser *p)
     return res;
 }
 
-// _tmp_128: plain_name !'='
+// _tmp_136: plain_name !'='
 static void *
-_tmp_128_rule(Parser *p)
+_tmp_136_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15198,9 +15709,9 @@ _tmp_128_rule(Parser *p)
     return res;
 }
 
-// _tmp_129: '@' named_expression NEWLINE
+// _tmp_137: '@' named_expression NEWLINE
 static void *
-_tmp_129_rule(Parser *p)
+_tmp_137_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15233,9 +15744,9 @@ _tmp_129_rule(Parser *p)
     return res;
 }
 
-// _tmp_130: ',' star_expression
+// _tmp_138: ',' star_expression
 static void *
-_tmp_130_rule(Parser *p)
+_tmp_138_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15265,9 +15776,9 @@ _tmp_130_rule(Parser *p)
     return res;
 }
 
-// _tmp_131: ',' expression
+// _tmp_139: ',' expression
 static void *
-_tmp_131_rule(Parser *p)
+_tmp_139_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15297,9 +15808,9 @@ _tmp_131_rule(Parser *p)
     return res;
 }
 
-// _tmp_132: lambda_plain_name !'='
+// _tmp_140: lambda_plain_name !'='
 static void *
-_tmp_132_rule(Parser *p)
+_tmp_140_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15324,9 +15835,9 @@ _tmp_132_rule(Parser *p)
     return res;
 }
 
-// _tmp_133: 'or' conjunction
+// _tmp_141: 'or' conjunction
 static void *
-_tmp_133_rule(Parser *p)
+_tmp_141_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15356,9 +15867,9 @@ _tmp_133_rule(Parser *p)
     return res;
 }
 
-// _tmp_134: 'and' inversion
+// _tmp_142: 'and' inversion
 static void *
-_tmp_134_rule(Parser *p)
+_tmp_142_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15388,9 +15899,9 @@ _tmp_134_rule(Parser *p)
     return res;
 }
 
-// _tmp_135: ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
+// _tmp_143: ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
 static void *
-_tmp_135_rule(Parser *p)
+_tmp_143_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15415,7 +15926,7 @@ _tmp_135_rule(Parser *p)
             &&
             (b = disjunction_rule(p))
             &&
-            (c = _loop0_137_rule(p))
+            (c = _loop0_145_rule(p))
         )
         {
             res = _Py_comprehension ( a , b , c , y != NULL , p -> arena );
@@ -15432,9 +15943,9 @@ _tmp_135_rule(Parser *p)
     return res;
 }
 
-// _tmp_136: ',' star_target
+// _tmp_144: ',' star_target
 static void *
-_tmp_136_rule(Parser *p)
+_tmp_144_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15464,9 +15975,9 @@ _tmp_136_rule(Parser *p)
     return res;
 }
 
-// _loop0_137: ('if' disjunction)
+// _loop0_145: ('if' disjunction)
 static asdl_seq *
-_loop0_137_rule(Parser *p)
+_loop0_145_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15482,12 +15993,12 @@ _loop0_137_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('if' disjunction)
-        void *_tmp_138_var;
+        void *_tmp_146_var;
         while (
-            (_tmp_138_var = _tmp_138_rule(p))
+            (_tmp_146_var = _tmp_146_rule(p))
         )
         {
-            res = _tmp_138_var;
+            res = _tmp_146_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15503,19 +16014,19 @@ _loop0_137_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_137");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_145");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_137_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_145_type, seq);
     return seq;
 }
 
-// _tmp_138: 'if' disjunction
+// _tmp_146: 'if' disjunction
 static void *
-_tmp_138_rule(Parser *p)
+_tmp_146_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15560,6 +16071,8 @@ _PyPegen_parse(Parser *p)
         result = interactive_rule(p);
     } else if (p->start_rule == Py_eval_input) {
         result = eval_rule(p);
+    } else if (p->start_rule == Py_func_type_input) {
+        result = func_type_rule(p);
     } else if (p->start_rule == Py_fstring_input) {
         result = fstring_rule(p);
     }

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -677,7 +677,7 @@ file_rule(Parser *p)
             (endmarker_var = _PyPegen_endmarker_token(p))
         )
         {
-            res = Module ( a , NULL , p -> arena );
+            res = _PyPegen_make_module ( p , a );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -1606,7 +1606,7 @@ assignment_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_Assign ( a , b , NEW_TYPE_COMMENT ( tc ) , EXTRA );
+            res = _Py_Assign ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -2891,7 +2891,7 @@ for_stmt_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncFor : _Py_For ) ( t , ex , b , el , NEW_TYPE_COMMENT ( tc ) , EXTRA );
+            res = ( is_async ? _Py_AsyncFor : _Py_For ) ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -2994,7 +2994,7 @@ with_stmt_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncWith : _Py_With ) ( a , b , NEW_TYPE_COMMENT ( tc ) , EXTRA );
+            res = ( is_async ? _Py_AsyncWith : _Py_With ) ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -3479,7 +3479,7 @@ function_def_raw_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef ) ( n -> v . Name . id , ( params ) ? params : CHECK ( _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( tc ) , EXTRA );
+            res = ( is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef ) ( n -> v . Name . id , ( params ) ? params : CHECK ( _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -113,255 +113,249 @@ static KeywordToken *reserved_keywords[] = {
 #define func_type_comment_type 1042
 #define params_type 1043
 #define parameters_type 1044
-#define slash_without_default_type 1045
+#define slash_no_default_type 1045
 #define slash_with_default_type 1046
 #define star_etc_type 1047
-#define name_with_optional_default_type 1048
-#define names_with_default_type 1049
-#define name_with_default_type 1050
-#define plain_names_type 1051
-#define plain_name_type 1052
-#define kwds_type 1053
-#define annotation_type 1054
-#define decorators_type 1055
-#define class_def_type 1056
-#define class_def_raw_type 1057
-#define block_type 1058
-#define expressions_list_type 1059
-#define star_expressions_type 1060
-#define star_expression_type 1061
-#define star_named_expressions_type 1062
-#define star_named_expression_type 1063
-#define named_expression_type 1064
-#define annotated_rhs_type 1065
-#define expressions_type 1066
-#define expression_type 1067
-#define lambdef_type 1068
-#define lambda_parameters_type 1069
-#define lambda_slash_without_default_type 1070
-#define lambda_slash_with_default_type 1071
-#define lambda_star_etc_type 1072
-#define lambda_name_with_optional_default_type 1073
-#define lambda_names_with_default_type 1074
-#define lambda_name_with_default_type 1075
-#define lambda_plain_names_type 1076
-#define lambda_plain_name_type 1077
-#define lambda_kwds_type 1078
-#define disjunction_type 1079
-#define conjunction_type 1080
-#define inversion_type 1081
-#define comparison_type 1082
-#define compare_op_bitwise_or_pair_type 1083
-#define eq_bitwise_or_type 1084
-#define noteq_bitwise_or_type 1085
-#define lte_bitwise_or_type 1086
-#define lt_bitwise_or_type 1087
-#define gte_bitwise_or_type 1088
-#define gt_bitwise_or_type 1089
-#define notin_bitwise_or_type 1090
-#define in_bitwise_or_type 1091
-#define isnot_bitwise_or_type 1092
-#define is_bitwise_or_type 1093
-#define bitwise_or_type 1094  // Left-recursive
-#define bitwise_xor_type 1095  // Left-recursive
-#define bitwise_and_type 1096  // Left-recursive
-#define shift_expr_type 1097  // Left-recursive
-#define sum_type 1098  // Left-recursive
-#define term_type 1099  // Left-recursive
-#define factor_type 1100
-#define power_type 1101
-#define await_primary_type 1102
-#define primary_type 1103  // Left-recursive
-#define slices_type 1104
-#define slice_type 1105
-#define atom_type 1106
-#define strings_type 1107
-#define list_type 1108
-#define listcomp_type 1109
-#define tuple_type 1110
-#define group_type 1111
-#define genexp_type 1112
-#define set_type 1113
-#define setcomp_type 1114
-#define dict_type 1115
-#define dictcomp_type 1116
-#define kvpairs_type 1117
-#define kvpair_type 1118
-#define for_if_clauses_type 1119
-#define yield_expr_type 1120
-#define arguments_type 1121
-#define args_type 1122
-#define kwargs_type 1123
-#define starred_expression_type 1124
-#define kwarg_or_starred_type 1125
-#define kwarg_or_double_starred_type 1126
-#define star_targets_type 1127
-#define star_targets_seq_type 1128
-#define star_target_type 1129
-#define star_atom_type 1130
-#define inside_paren_ann_assign_target_type 1131
-#define ann_assign_subscript_attribute_target_type 1132
-#define del_targets_type 1133
-#define del_target_type 1134
-#define del_t_atom_type 1135
-#define targets_type 1136
-#define target_type 1137
-#define t_primary_type 1138  // Left-recursive
-#define t_lookahead_type 1139
-#define t_atom_type 1140
-#define incorrect_arguments_type 1141
-#define invalid_named_expression_type 1142
-#define invalid_assignment_type 1143
-#define invalid_block_type 1144
-#define invalid_comprehension_type 1145
-#define invalid_parameters_type 1146
-#define invalid_double_type_comments_type 1147
-#define _loop0_1_type 1148
-#define _loop0_3_type 1149
-#define _gather_2_type 1150
-#define _loop0_5_type 1151
-#define _gather_4_type 1152
-#define _loop0_7_type 1153
-#define _gather_6_type 1154
-#define _loop0_9_type 1155
-#define _gather_8_type 1156
-#define _loop1_10_type 1157
-#define _loop0_12_type 1158
-#define _gather_11_type 1159
-#define _tmp_13_type 1160
-#define _tmp_14_type 1161
-#define _tmp_15_type 1162
-#define _tmp_16_type 1163
-#define _tmp_17_type 1164
-#define _tmp_18_type 1165
-#define _tmp_19_type 1166
-#define _tmp_20_type 1167
-#define _loop1_21_type 1168
-#define _tmp_22_type 1169
-#define _tmp_23_type 1170
-#define _loop0_25_type 1171
-#define _gather_24_type 1172
-#define _loop0_27_type 1173
-#define _gather_26_type 1174
-#define _tmp_28_type 1175
-#define _loop0_29_type 1176
-#define _loop1_30_type 1177
-#define _loop0_32_type 1178
-#define _gather_31_type 1179
-#define _tmp_33_type 1180
-#define _loop0_35_type 1181
-#define _gather_34_type 1182
-#define _tmp_36_type 1183
-#define _loop0_38_type 1184
-#define _gather_37_type 1185
-#define _loop0_40_type 1186
-#define _gather_39_type 1187
-#define _tmp_41_type 1188
-#define _loop1_42_type 1189
-#define _tmp_43_type 1190
-#define _tmp_44_type 1191
-#define _tmp_45_type 1192
-#define _tmp_46_type 1193
-#define _tmp_47_type 1194
-#define _tmp_48_type 1195
-#define _tmp_49_type 1196
-#define _tmp_50_type 1197
-#define _tmp_51_type 1198
-#define _tmp_52_type 1199
-#define _tmp_53_type 1200
-#define _tmp_54_type 1201
-#define _tmp_55_type 1202
-#define _loop0_56_type 1203
-#define _tmp_57_type 1204
-#define _loop1_58_type 1205
-#define _tmp_59_type 1206
-#define _tmp_60_type 1207
-#define _loop0_62_type 1208
-#define _gather_61_type 1209
-#define _loop0_64_type 1210
-#define _gather_63_type 1211
-#define _tmp_65_type 1212
-#define _loop1_66_type 1213
-#define _tmp_67_type 1214
-#define _loop0_69_type 1215
-#define _gather_68_type 1216
-#define _loop1_70_type 1217
-#define _loop0_72_type 1218
-#define _gather_71_type 1219
-#define _loop1_73_type 1220
-#define _tmp_74_type 1221
-#define _tmp_75_type 1222
-#define _tmp_76_type 1223
-#define _tmp_77_type 1224
-#define _tmp_78_type 1225
-#define _tmp_79_type 1226
-#define _tmp_80_type 1227
-#define _tmp_81_type 1228
-#define _tmp_82_type 1229
-#define _loop0_83_type 1230
-#define _tmp_84_type 1231
-#define _loop1_85_type 1232
-#define _tmp_86_type 1233
-#define _tmp_87_type 1234
-#define _loop0_89_type 1235
-#define _gather_88_type 1236
-#define _loop0_91_type 1237
-#define _gather_90_type 1238
-#define _loop1_92_type 1239
-#define _loop1_93_type 1240
-#define _loop1_94_type 1241
-#define _tmp_95_type 1242
-#define _loop0_97_type 1243
-#define _gather_96_type 1244
-#define _tmp_98_type 1245
-#define _tmp_99_type 1246
-#define _tmp_100_type 1247
-#define _tmp_101_type 1248
-#define _loop1_102_type 1249
-#define _tmp_103_type 1250
-#define _tmp_104_type 1251
-#define _loop0_106_type 1252
-#define _gather_105_type 1253
-#define _loop1_107_type 1254
-#define _tmp_108_type 1255
-#define _tmp_109_type 1256
-#define _loop0_111_type 1257
-#define _gather_110_type 1258
+#define kwds_type 1048
+#define param_no_default_type 1049
+#define param_with_default_type 1050
+#define param_maybe_default_type 1051
+#define annotation_type 1052
+#define default_type 1053
+#define decorators_type 1054
+#define class_def_type 1055
+#define class_def_raw_type 1056
+#define block_type 1057
+#define expressions_list_type 1058
+#define star_expressions_type 1059
+#define star_expression_type 1060
+#define star_named_expressions_type 1061
+#define star_named_expression_type 1062
+#define named_expression_type 1063
+#define annotated_rhs_type 1064
+#define expressions_type 1065
+#define expression_type 1066
+#define lambdef_type 1067
+#define lambda_parameters_type 1068
+#define lambda_slash_without_default_type 1069
+#define lambda_slash_with_default_type 1070
+#define lambda_star_etc_type 1071
+#define lambda_name_with_optional_default_type 1072
+#define lambda_names_with_default_type 1073
+#define lambda_name_with_default_type 1074
+#define lambda_plain_names_type 1075
+#define lambda_plain_name_type 1076
+#define lambda_kwds_type 1077
+#define disjunction_type 1078
+#define conjunction_type 1079
+#define inversion_type 1080
+#define comparison_type 1081
+#define compare_op_bitwise_or_pair_type 1082
+#define eq_bitwise_or_type 1083
+#define noteq_bitwise_or_type 1084
+#define lte_bitwise_or_type 1085
+#define lt_bitwise_or_type 1086
+#define gte_bitwise_or_type 1087
+#define gt_bitwise_or_type 1088
+#define notin_bitwise_or_type 1089
+#define in_bitwise_or_type 1090
+#define isnot_bitwise_or_type 1091
+#define is_bitwise_or_type 1092
+#define bitwise_or_type 1093  // Left-recursive
+#define bitwise_xor_type 1094  // Left-recursive
+#define bitwise_and_type 1095  // Left-recursive
+#define shift_expr_type 1096  // Left-recursive
+#define sum_type 1097  // Left-recursive
+#define term_type 1098  // Left-recursive
+#define factor_type 1099
+#define power_type 1100
+#define await_primary_type 1101
+#define primary_type 1102  // Left-recursive
+#define slices_type 1103
+#define slice_type 1104
+#define atom_type 1105
+#define strings_type 1106
+#define list_type 1107
+#define listcomp_type 1108
+#define tuple_type 1109
+#define group_type 1110
+#define genexp_type 1111
+#define set_type 1112
+#define setcomp_type 1113
+#define dict_type 1114
+#define dictcomp_type 1115
+#define kvpairs_type 1116
+#define kvpair_type 1117
+#define for_if_clauses_type 1118
+#define yield_expr_type 1119
+#define arguments_type 1120
+#define args_type 1121
+#define kwargs_type 1122
+#define starred_expression_type 1123
+#define kwarg_or_starred_type 1124
+#define kwarg_or_double_starred_type 1125
+#define star_targets_type 1126
+#define star_targets_seq_type 1127
+#define star_target_type 1128
+#define star_atom_type 1129
+#define inside_paren_ann_assign_target_type 1130
+#define ann_assign_subscript_attribute_target_type 1131
+#define del_targets_type 1132
+#define del_target_type 1133
+#define del_t_atom_type 1134
+#define targets_type 1135
+#define target_type 1136
+#define t_primary_type 1137  // Left-recursive
+#define t_lookahead_type 1138
+#define t_atom_type 1139
+#define incorrect_arguments_type 1140
+#define invalid_named_expression_type 1141
+#define invalid_assignment_type 1142
+#define invalid_block_type 1143
+#define invalid_comprehension_type 1144
+#define invalid_parameters_type 1145
+#define invalid_double_type_comments_type 1146
+#define _loop0_1_type 1147
+#define _loop0_3_type 1148
+#define _gather_2_type 1149
+#define _loop0_5_type 1150
+#define _gather_4_type 1151
+#define _loop0_7_type 1152
+#define _gather_6_type 1153
+#define _loop0_9_type 1154
+#define _gather_8_type 1155
+#define _loop1_10_type 1156
+#define _loop0_12_type 1157
+#define _gather_11_type 1158
+#define _tmp_13_type 1159
+#define _tmp_14_type 1160
+#define _tmp_15_type 1161
+#define _tmp_16_type 1162
+#define _tmp_17_type 1163
+#define _tmp_18_type 1164
+#define _tmp_19_type 1165
+#define _tmp_20_type 1166
+#define _loop1_21_type 1167
+#define _tmp_22_type 1168
+#define _tmp_23_type 1169
+#define _loop0_25_type 1170
+#define _gather_24_type 1171
+#define _loop0_27_type 1172
+#define _gather_26_type 1173
+#define _tmp_28_type 1174
+#define _loop0_29_type 1175
+#define _loop1_30_type 1176
+#define _loop0_32_type 1177
+#define _gather_31_type 1178
+#define _tmp_33_type 1179
+#define _loop0_35_type 1180
+#define _gather_34_type 1181
+#define _tmp_36_type 1182
+#define _loop0_38_type 1183
+#define _gather_37_type 1184
+#define _loop0_40_type 1185
+#define _gather_39_type 1186
+#define _tmp_41_type 1187
+#define _loop1_42_type 1188
+#define _tmp_43_type 1189
+#define _tmp_44_type 1190
+#define _tmp_45_type 1191
+#define _tmp_46_type 1192
+#define _loop0_47_type 1193
+#define _loop0_48_type 1194
+#define _loop0_49_type 1195
+#define _loop1_50_type 1196
+#define _loop0_51_type 1197
+#define _loop1_52_type 1198
+#define _loop1_53_type 1199
+#define _loop1_54_type 1200
+#define _loop0_55_type 1201
+#define _loop1_56_type 1202
+#define _loop0_57_type 1203
+#define _loop1_58_type 1204
+#define _loop0_59_type 1205
+#define _loop1_60_type 1206
+#define _loop1_61_type 1207
+#define _tmp_62_type 1208
+#define _loop0_64_type 1209
+#define _gather_63_type 1210
+#define _loop1_65_type 1211
+#define _loop0_67_type 1212
+#define _gather_66_type 1213
+#define _loop1_68_type 1214
+#define _tmp_69_type 1215
+#define _tmp_70_type 1216
+#define _tmp_71_type 1217
+#define _tmp_72_type 1218
+#define _tmp_73_type 1219
+#define _tmp_74_type 1220
+#define _tmp_75_type 1221
+#define _tmp_76_type 1222
+#define _tmp_77_type 1223
+#define _loop0_78_type 1224
+#define _tmp_79_type 1225
+#define _loop1_80_type 1226
+#define _tmp_81_type 1227
+#define _tmp_82_type 1228
+#define _loop0_84_type 1229
+#define _gather_83_type 1230
+#define _loop0_86_type 1231
+#define _gather_85_type 1232
+#define _loop1_87_type 1233
+#define _loop1_88_type 1234
+#define _loop1_89_type 1235
+#define _tmp_90_type 1236
+#define _loop0_92_type 1237
+#define _gather_91_type 1238
+#define _tmp_93_type 1239
+#define _tmp_94_type 1240
+#define _tmp_95_type 1241
+#define _tmp_96_type 1242
+#define _loop1_97_type 1243
+#define _tmp_98_type 1244
+#define _tmp_99_type 1245
+#define _loop0_101_type 1246
+#define _gather_100_type 1247
+#define _loop1_102_type 1248
+#define _tmp_103_type 1249
+#define _tmp_104_type 1250
+#define _loop0_106_type 1251
+#define _gather_105_type 1252
+#define _loop0_108_type 1253
+#define _gather_107_type 1254
+#define _loop0_110_type 1255
+#define _gather_109_type 1256
+#define _loop0_112_type 1257
+#define _gather_111_type 1258
 #define _loop0_113_type 1259
-#define _gather_112_type 1260
-#define _loop0_115_type 1261
-#define _gather_114_type 1262
-#define _loop0_117_type 1263
-#define _gather_116_type 1264
-#define _loop0_118_type 1265
-#define _loop0_120_type 1266
-#define _gather_119_type 1267
-#define _tmp_121_type 1268
-#define _loop0_123_type 1269
-#define _gather_122_type 1270
-#define _loop0_125_type 1271
-#define _gather_124_type 1272
-#define _tmp_126_type 1273
-#define _tmp_127_type 1274
-#define _tmp_128_type 1275
-#define _tmp_129_type 1276
-#define _tmp_130_type 1277
-#define _tmp_131_type 1278
-#define _tmp_132_type 1279
-#define _tmp_133_type 1280
-#define _tmp_134_type 1281
-#define _tmp_135_type 1282
-#define _tmp_136_type 1283
-#define _tmp_137_type 1284
-#define _tmp_138_type 1285
-#define _tmp_139_type 1286
-#define _tmp_140_type 1287
-#define _tmp_141_type 1288
-#define _tmp_142_type 1289
-#define _tmp_143_type 1290
-#define _tmp_144_type 1291
-#define _loop0_145_type 1292
-#define _tmp_146_type 1293
+#define _loop0_115_type 1260
+#define _gather_114_type 1261
+#define _tmp_116_type 1262
+#define _loop0_118_type 1263
+#define _gather_117_type 1264
+#define _loop0_120_type 1265
+#define _gather_119_type 1266
+#define _tmp_121_type 1267
+#define _tmp_122_type 1268
+#define _tmp_123_type 1269
+#define _tmp_124_type 1270
+#define _tmp_125_type 1271
+#define _loop0_126_type 1272
+#define _tmp_127_type 1273
+#define _tmp_128_type 1274
+#define _tmp_129_type 1275
+#define _tmp_130_type 1276
+#define _tmp_131_type 1277
+#define _tmp_132_type 1278
+#define _tmp_133_type 1279
+#define _tmp_134_type 1280
+#define _tmp_135_type 1281
+#define _tmp_136_type 1282
+#define _tmp_137_type 1283
+#define _tmp_138_type 1284
+#define _loop1_139_type 1285
+#define _loop0_140_type 1286
+#define _tmp_141_type 1287
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -408,16 +402,15 @@ static stmt_ty function_def_raw_rule(Parser *p);
 static PyObject* func_type_comment_rule(Parser *p);
 static arguments_ty params_rule(Parser *p);
 static arguments_ty parameters_rule(Parser *p);
-static asdl_seq* slash_without_default_rule(Parser *p);
+static asdl_seq* slash_no_default_rule(Parser *p);
 static SlashWithDefault* slash_with_default_rule(Parser *p);
 static StarEtc* star_etc_rule(Parser *p);
-static NameDefaultPair* name_with_optional_default_rule(Parser *p);
-static asdl_seq* names_with_default_rule(Parser *p);
-static NameDefaultPair* name_with_default_rule(Parser *p);
-static asdl_seq* plain_names_rule(Parser *p);
-static arg_ty plain_name_rule(Parser *p);
 static arg_ty kwds_rule(Parser *p);
+static arg_ty param_no_default_rule(Parser *p);
+static NameDefaultPair* param_with_default_rule(Parser *p);
+static NameDefaultPair* param_maybe_default_rule(Parser *p);
 static expr_ty annotation_rule(Parser *p);
+static expr_ty default_rule(Parser *p);
 static asdl_seq* decorators_rule(Parser *p);
 static stmt_ty class_def_rule(Parser *p);
 static stmt_ty class_def_raw_rule(Parser *p);
@@ -557,86 +550,86 @@ static void *_tmp_43_rule(Parser *p);
 static void *_tmp_44_rule(Parser *p);
 static void *_tmp_45_rule(Parser *p);
 static void *_tmp_46_rule(Parser *p);
-static void *_tmp_47_rule(Parser *p);
-static void *_tmp_48_rule(Parser *p);
-static void *_tmp_49_rule(Parser *p);
-static void *_tmp_50_rule(Parser *p);
-static void *_tmp_51_rule(Parser *p);
-static void *_tmp_52_rule(Parser *p);
-static void *_tmp_53_rule(Parser *p);
-static void *_tmp_54_rule(Parser *p);
-static void *_tmp_55_rule(Parser *p);
-static asdl_seq *_loop0_56_rule(Parser *p);
-static void *_tmp_57_rule(Parser *p);
+static asdl_seq *_loop0_47_rule(Parser *p);
+static asdl_seq *_loop0_48_rule(Parser *p);
+static asdl_seq *_loop0_49_rule(Parser *p);
+static asdl_seq *_loop1_50_rule(Parser *p);
+static asdl_seq *_loop0_51_rule(Parser *p);
+static asdl_seq *_loop1_52_rule(Parser *p);
+static asdl_seq *_loop1_53_rule(Parser *p);
+static asdl_seq *_loop1_54_rule(Parser *p);
+static asdl_seq *_loop0_55_rule(Parser *p);
+static asdl_seq *_loop1_56_rule(Parser *p);
+static asdl_seq *_loop0_57_rule(Parser *p);
 static asdl_seq *_loop1_58_rule(Parser *p);
-static void *_tmp_59_rule(Parser *p);
-static void *_tmp_60_rule(Parser *p);
-static asdl_seq *_loop0_62_rule(Parser *p);
-static asdl_seq *_gather_61_rule(Parser *p);
+static asdl_seq *_loop0_59_rule(Parser *p);
+static asdl_seq *_loop1_60_rule(Parser *p);
+static asdl_seq *_loop1_61_rule(Parser *p);
+static void *_tmp_62_rule(Parser *p);
 static asdl_seq *_loop0_64_rule(Parser *p);
 static asdl_seq *_gather_63_rule(Parser *p);
-static void *_tmp_65_rule(Parser *p);
-static asdl_seq *_loop1_66_rule(Parser *p);
-static void *_tmp_67_rule(Parser *p);
-static asdl_seq *_loop0_69_rule(Parser *p);
-static asdl_seq *_gather_68_rule(Parser *p);
-static asdl_seq *_loop1_70_rule(Parser *p);
-static asdl_seq *_loop0_72_rule(Parser *p);
-static asdl_seq *_gather_71_rule(Parser *p);
-static asdl_seq *_loop1_73_rule(Parser *p);
+static asdl_seq *_loop1_65_rule(Parser *p);
+static asdl_seq *_loop0_67_rule(Parser *p);
+static asdl_seq *_gather_66_rule(Parser *p);
+static asdl_seq *_loop1_68_rule(Parser *p);
+static void *_tmp_69_rule(Parser *p);
+static void *_tmp_70_rule(Parser *p);
+static void *_tmp_71_rule(Parser *p);
+static void *_tmp_72_rule(Parser *p);
+static void *_tmp_73_rule(Parser *p);
 static void *_tmp_74_rule(Parser *p);
 static void *_tmp_75_rule(Parser *p);
 static void *_tmp_76_rule(Parser *p);
 static void *_tmp_77_rule(Parser *p);
-static void *_tmp_78_rule(Parser *p);
+static asdl_seq *_loop0_78_rule(Parser *p);
 static void *_tmp_79_rule(Parser *p);
-static void *_tmp_80_rule(Parser *p);
+static asdl_seq *_loop1_80_rule(Parser *p);
 static void *_tmp_81_rule(Parser *p);
 static void *_tmp_82_rule(Parser *p);
-static asdl_seq *_loop0_83_rule(Parser *p);
-static void *_tmp_84_rule(Parser *p);
-static asdl_seq *_loop1_85_rule(Parser *p);
-static void *_tmp_86_rule(Parser *p);
-static void *_tmp_87_rule(Parser *p);
-static asdl_seq *_loop0_89_rule(Parser *p);
-static asdl_seq *_gather_88_rule(Parser *p);
-static asdl_seq *_loop0_91_rule(Parser *p);
-static asdl_seq *_gather_90_rule(Parser *p);
-static asdl_seq *_loop1_92_rule(Parser *p);
-static asdl_seq *_loop1_93_rule(Parser *p);
-static asdl_seq *_loop1_94_rule(Parser *p);
+static asdl_seq *_loop0_84_rule(Parser *p);
+static asdl_seq *_gather_83_rule(Parser *p);
+static asdl_seq *_loop0_86_rule(Parser *p);
+static asdl_seq *_gather_85_rule(Parser *p);
+static asdl_seq *_loop1_87_rule(Parser *p);
+static asdl_seq *_loop1_88_rule(Parser *p);
+static asdl_seq *_loop1_89_rule(Parser *p);
+static void *_tmp_90_rule(Parser *p);
+static asdl_seq *_loop0_92_rule(Parser *p);
+static asdl_seq *_gather_91_rule(Parser *p);
+static void *_tmp_93_rule(Parser *p);
+static void *_tmp_94_rule(Parser *p);
 static void *_tmp_95_rule(Parser *p);
-static asdl_seq *_loop0_97_rule(Parser *p);
-static asdl_seq *_gather_96_rule(Parser *p);
+static void *_tmp_96_rule(Parser *p);
+static asdl_seq *_loop1_97_rule(Parser *p);
 static void *_tmp_98_rule(Parser *p);
 static void *_tmp_99_rule(Parser *p);
-static void *_tmp_100_rule(Parser *p);
-static void *_tmp_101_rule(Parser *p);
+static asdl_seq *_loop0_101_rule(Parser *p);
+static asdl_seq *_gather_100_rule(Parser *p);
 static asdl_seq *_loop1_102_rule(Parser *p);
 static void *_tmp_103_rule(Parser *p);
 static void *_tmp_104_rule(Parser *p);
 static asdl_seq *_loop0_106_rule(Parser *p);
 static asdl_seq *_gather_105_rule(Parser *p);
-static asdl_seq *_loop1_107_rule(Parser *p);
-static void *_tmp_108_rule(Parser *p);
-static void *_tmp_109_rule(Parser *p);
-static asdl_seq *_loop0_111_rule(Parser *p);
-static asdl_seq *_gather_110_rule(Parser *p);
+static asdl_seq *_loop0_108_rule(Parser *p);
+static asdl_seq *_gather_107_rule(Parser *p);
+static asdl_seq *_loop0_110_rule(Parser *p);
+static asdl_seq *_gather_109_rule(Parser *p);
+static asdl_seq *_loop0_112_rule(Parser *p);
+static asdl_seq *_gather_111_rule(Parser *p);
 static asdl_seq *_loop0_113_rule(Parser *p);
-static asdl_seq *_gather_112_rule(Parser *p);
 static asdl_seq *_loop0_115_rule(Parser *p);
 static asdl_seq *_gather_114_rule(Parser *p);
-static asdl_seq *_loop0_117_rule(Parser *p);
-static asdl_seq *_gather_116_rule(Parser *p);
+static void *_tmp_116_rule(Parser *p);
 static asdl_seq *_loop0_118_rule(Parser *p);
+static asdl_seq *_gather_117_rule(Parser *p);
 static asdl_seq *_loop0_120_rule(Parser *p);
 static asdl_seq *_gather_119_rule(Parser *p);
 static void *_tmp_121_rule(Parser *p);
-static asdl_seq *_loop0_123_rule(Parser *p);
-static asdl_seq *_gather_122_rule(Parser *p);
-static asdl_seq *_loop0_125_rule(Parser *p);
-static asdl_seq *_gather_124_rule(Parser *p);
-static void *_tmp_126_rule(Parser *p);
+static void *_tmp_122_rule(Parser *p);
+static void *_tmp_123_rule(Parser *p);
+static void *_tmp_124_rule(Parser *p);
+static void *_tmp_125_rule(Parser *p);
+static asdl_seq *_loop0_126_rule(Parser *p);
 static void *_tmp_127_rule(Parser *p);
 static void *_tmp_128_rule(Parser *p);
 static void *_tmp_129_rule(Parser *p);
@@ -649,14 +642,9 @@ static void *_tmp_135_rule(Parser *p);
 static void *_tmp_136_rule(Parser *p);
 static void *_tmp_137_rule(Parser *p);
 static void *_tmp_138_rule(Parser *p);
-static void *_tmp_139_rule(Parser *p);
-static void *_tmp_140_rule(Parser *p);
+static asdl_seq *_loop1_139_rule(Parser *p);
+static asdl_seq *_loop0_140_rule(Parser *p);
 static void *_tmp_141_rule(Parser *p);
-static void *_tmp_142_rule(Parser *p);
-static void *_tmp_143_rule(Parser *p);
-static void *_tmp_144_rule(Parser *p);
-static asdl_seq *_loop0_145_rule(Parser *p);
-static void *_tmp_146_rule(Parser *p);
 
 
 // file: statements? $
@@ -3423,7 +3411,7 @@ function_def_rule(Parser *p)
 }
 
 // function_def_raw:
-//     | ASYNC? 'def' NAME '(' params? ')' ['->' annotation] ':' func_type_comment? block
+//     | ASYNC? 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
 static stmt_ty
 function_def_raw_rule(Parser *p)
 {
@@ -3440,7 +3428,7 @@ function_def_raw_rule(Parser *p)
     UNUSED(start_lineno); // Only used by EXTRA macro
     int start_col_offset = p->tokens[mark]->col_offset;
     UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // ASYNC? 'def' NAME '(' params? ')' ['->' annotation] ':' func_type_comment? block
+    { // ASYNC? 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
         void *a;
         asdl_seq* b;
         void *is_async;
@@ -3591,10 +3579,10 @@ params_rule(Parser *p)
 }
 
 // parameters:
-//     | slash_without_default [',' plain_names] [',' names_with_default] [',' star_etc?]
-//     | slash_with_default [',' names_with_default] [',' star_etc?]
-//     | plain_names [',' names_with_default] [',' star_etc?]
-//     | names_with_default [',' star_etc?]
+//     | slash_no_default param_no_default* param_with_default* star_etc?
+//     | slash_with_default param_with_default* star_etc?
+//     | param_no_default+ param_with_default* star_etc?
+//     | param_with_default+ star_etc?
 //     | star_etc
 static arguments_ty
 parameters_rule(Parser *p)
@@ -3604,19 +3592,19 @@ parameters_rule(Parser *p)
     }
     arguments_ty res = NULL;
     int mark = p->mark;
-    { // slash_without_default [',' plain_names] [',' names_with_default] [',' star_etc?]
+    { // slash_no_default param_no_default* param_with_default* star_etc?
         asdl_seq* a;
-        void *b;
-        void *c;
+        asdl_seq * b;
+        asdl_seq * c;
         void *d;
         if (
-            (a = slash_without_default_rule(p))
+            (a = slash_no_default_rule(p))
             &&
-            (b = _tmp_47_rule(p), 1)
+            (b = _loop0_47_rule(p))
             &&
-            (c = _tmp_48_rule(p), 1)
+            (c = _loop0_48_rule(p))
             &&
-            (d = _tmp_49_rule(p), 1)
+            (d = star_etc_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -3628,16 +3616,16 @@ parameters_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // slash_with_default [',' names_with_default] [',' star_etc?]
+    { // slash_with_default param_with_default* star_etc?
         SlashWithDefault* a;
-        void *b;
+        asdl_seq * b;
         void *c;
         if (
             (a = slash_with_default_rule(p))
             &&
-            (b = _tmp_50_rule(p), 1)
+            (b = _loop0_49_rule(p))
             &&
-            (c = _tmp_51_rule(p), 1)
+            (c = star_etc_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -3649,16 +3637,16 @@ parameters_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // plain_names [',' names_with_default] [',' star_etc?]
-        asdl_seq* a;
-        void *b;
+    { // param_no_default+ param_with_default* star_etc?
+        asdl_seq * a;
+        asdl_seq * b;
         void *c;
         if (
-            (a = plain_names_rule(p))
+            (a = _loop1_50_rule(p))
             &&
-            (b = _tmp_52_rule(p), 1)
+            (b = _loop0_51_rule(p))
             &&
-            (c = _tmp_53_rule(p), 1)
+            (c = star_etc_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -3670,13 +3658,13 @@ parameters_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // names_with_default [',' star_etc?]
-        asdl_seq* a;
+    { // param_with_default+ star_etc?
+        asdl_seq * a;
         void *b;
         if (
-            (a = names_with_default_rule(p))
+            (a = _loop1_52_rule(p))
             &&
-            (b = _tmp_54_rule(p), 1)
+            (b = star_etc_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -3708,25 +3696,45 @@ parameters_rule(Parser *p)
     return res;
 }
 
-// slash_without_default: plain_names ',' '/'
+// slash_no_default: param_no_default+ '/' ',' | param_no_default+ '/' &')'
 static asdl_seq*
-slash_without_default_rule(Parser *p)
+slash_no_default_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq* res = NULL;
     int mark = p->mark;
-    { // plain_names ',' '/'
-        asdl_seq* a;
+    { // param_no_default+ '/' ','
+        asdl_seq * a;
         void *literal;
         void *literal_1;
         if (
-            (a = plain_names_rule(p))
+            (a = _loop1_53_rule(p))
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 17))
             &&
-            (literal_1 = _PyPegen_expect_token(p, 17))
+            (literal_1 = _PyPegen_expect_token(p, 12))
+        )
+        {
+            res = a;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // param_no_default+ '/' &')'
+        asdl_seq * a;
+        void *literal;
+        if (
+            (a = _loop1_54_rule(p))
+            &&
+            (literal = _PyPegen_expect_token(p, 17))
+            &&
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
         )
         {
             res = a;
@@ -3743,7 +3751,9 @@ slash_without_default_rule(Parser *p)
     return res;
 }
 
-// slash_with_default: [plain_names ','] names_with_default ',' '/'
+// slash_with_default:
+//     | param_no_default* param_with_default+ '/' ','
+//     | param_no_default* param_with_default+ '/' &')'
 static SlashWithDefault*
 slash_with_default_rule(Parser *p)
 {
@@ -3752,19 +3762,42 @@ slash_with_default_rule(Parser *p)
     }
     SlashWithDefault* res = NULL;
     int mark = p->mark;
-    { // [plain_names ','] names_with_default ',' '/'
-        void *a;
-        asdl_seq* b;
+    { // param_no_default* param_with_default+ '/' ','
+        asdl_seq * a;
+        asdl_seq * b;
         void *literal;
         void *literal_1;
         if (
-            (a = _tmp_55_rule(p), 1)
+            (a = _loop0_55_rule(p))
             &&
-            (b = names_with_default_rule(p))
+            (b = _loop1_56_rule(p))
             &&
-            (literal = _PyPegen_expect_token(p, 12))
+            (literal = _PyPegen_expect_token(p, 17))
             &&
-            (literal_1 = _PyPegen_expect_token(p, 17))
+            (literal_1 = _PyPegen_expect_token(p, 12))
+        )
+        {
+            res = _PyPegen_slash_with_default ( p , a , b );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // param_no_default* param_with_default+ '/' &')'
+        asdl_seq * a;
+        asdl_seq * b;
+        void *literal;
+        if (
+            (a = _loop0_57_rule(p))
+            &&
+            (b = _loop1_58_rule(p))
+            &&
+            (literal = _PyPegen_expect_token(p, 17))
+            &&
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
         )
         {
             res = _PyPegen_slash_with_default ( p , a , b );
@@ -3782,9 +3815,9 @@ slash_with_default_rule(Parser *p)
 }
 
 // star_etc:
-//     | '*' plain_name name_with_optional_default* [',' kwds] ','?
-//     | '*' name_with_optional_default+ [',' kwds] ','?
-//     | kwds ','?
+//     | '*' param_no_default param_maybe_default* kwds?
+//     | '*' ',' param_maybe_default+ kwds?
+//     | kwds
 static StarEtc*
 star_etc_rule(Parser *p)
 {
@@ -3793,23 +3826,19 @@ star_etc_rule(Parser *p)
     }
     StarEtc* res = NULL;
     int mark = p->mark;
-    { // '*' plain_name name_with_optional_default* [',' kwds] ','?
+    { // '*' param_no_default param_maybe_default* kwds?
         arg_ty a;
         asdl_seq * b;
         void *c;
         void *literal;
-        void *opt_var;
-        UNUSED(opt_var); // Silence compiler warnings
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (a = plain_name_rule(p))
+            (a = param_no_default_rule(p))
             &&
-            (b = _loop0_56_rule(p))
+            (b = _loop0_59_rule(p))
             &&
-            (c = _tmp_57_rule(p), 1)
-            &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (c = kwds_rule(p), 1)
         )
         {
             res = _PyPegen_star_etc ( p , a , b , c );
@@ -3821,20 +3850,19 @@ star_etc_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // '*' name_with_optional_default+ [',' kwds] ','?
+    { // '*' ',' param_maybe_default+ kwds?
         asdl_seq * b;
         void *c;
         void *literal;
-        void *opt_var;
-        UNUSED(opt_var); // Silence compiler warnings
+        void *literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (b = _loop1_58_rule(p))
+            (literal_1 = _PyPegen_expect_token(p, 12))
             &&
-            (c = _tmp_59_rule(p), 1)
+            (b = _loop1_60_rule(p))
             &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
+            (c = kwds_rule(p), 1)
         )
         {
             res = _PyPegen_star_etc ( p , NULL , b , c );
@@ -3846,14 +3874,10 @@ star_etc_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // kwds ','?
+    { // kwds
         arg_ty a;
-        void *opt_var;
-        UNUSED(opt_var); // Silence compiler warnings
         if (
             (a = kwds_rule(p))
-            &&
-            (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
         {
             res = _PyPegen_star_etc ( p , NULL , NULL , a );
@@ -3870,140 +3894,43 @@ star_etc_rule(Parser *p)
     return res;
 }
 
-// name_with_optional_default: ',' plain_name ['=' expression]
-static NameDefaultPair*
-name_with_optional_default_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    NameDefaultPair* res = NULL;
-    int mark = p->mark;
-    { // ',' plain_name ['=' expression]
-        arg_ty a;
-        void *b;
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (a = plain_name_rule(p))
-            &&
-            (b = _tmp_60_rule(p), 1)
-        )
-        {
-            res = _PyPegen_name_default_pair ( p , a , b );
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// names_with_default: ','.name_with_default+
-static asdl_seq*
-names_with_default_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq* res = NULL;
-    int mark = p->mark;
-    { // ','.name_with_default+
-        asdl_seq * a;
-        if (
-            (a = _gather_61_rule(p))
-        )
-        {
-            res = a;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// name_with_default: plain_name '=' expression
-static NameDefaultPair*
-name_with_default_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    NameDefaultPair* res = NULL;
-    int mark = p->mark;
-    { // plain_name '=' expression
-        expr_ty e;
-        void *literal;
-        arg_ty n;
-        if (
-            (n = plain_name_rule(p))
-            &&
-            (literal = _PyPegen_expect_token(p, 22))
-            &&
-            (e = expression_rule(p))
-        )
-        {
-            res = _PyPegen_name_default_pair ( p , n , e );
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// plain_names: ','.(plain_name !'=')+
-static asdl_seq*
-plain_names_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq* res = NULL;
-    if (_PyPegen_is_memoized(p, plain_names_type, &res))
-        return res;
-    int mark = p->mark;
-    { // ','.(plain_name !'=')+
-        asdl_seq * a;
-        if (
-            (a = _gather_63_rule(p))
-        )
-        {
-            res = a;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    _PyPegen_insert_memo(p, mark, plain_names_type, res);
-    return res;
-}
-
-// plain_name: NAME [':' annotation]
+// kwds: '**' param_no_default
 static arg_ty
-plain_name_rule(Parser *p)
+kwds_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    arg_ty res = NULL;
+    int mark = p->mark;
+    { // '**' param_no_default
+        arg_ty a;
+        void *literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 35))
+            &&
+            (a = param_no_default_rule(p))
+        )
+        {
+            res = a;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// param_no_default:
+//     | NAME annotation? ',' TYPE_COMMENT?
+//     | NAME annotation? TYPE_COMMENT? &')'
+static arg_ty
+param_no_default_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -4018,13 +3945,19 @@ plain_name_rule(Parser *p)
     UNUSED(start_lineno); // Only used by EXTRA macro
     int start_col_offset = p->tokens[mark]->col_offset;
     UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // NAME [':' annotation]
+    { // NAME annotation? ',' TYPE_COMMENT?
         expr_ty a;
         void *b;
+        void *literal;
+        void *tc;
         if (
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_65_rule(p), 1)
+            (b = annotation_rule(p), 1)
+            &&
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -4035,7 +3968,38 @@ plain_name_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_arg ( a -> v . Name . id , b , NULL , EXTRA );
+            res = _Py_arg ( a -> v . Name . id , b , tc , EXTRA );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // NAME annotation? TYPE_COMMENT? &')'
+        expr_ty a;
+        void *b;
+        void *tc;
+        if (
+            (a = _PyPegen_name_token(p))
+            &&
+            (b = annotation_rule(p), 1)
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
+            &&
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+        )
+        {
+            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (token == NULL) {
+                return NULL;
+            }
+            int end_lineno = token->end_lineno;
+            UNUSED(end_lineno); // Only used by EXTRA macro
+            int end_col_offset = token->end_col_offset;
+            UNUSED(end_col_offset); // Only used by EXTRA macro
+            res = _Py_arg ( a -> v . Name . id , b , tc , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -4049,22 +4013,208 @@ plain_name_rule(Parser *p)
     return res;
 }
 
-// kwds: '**' plain_name
-static arg_ty
-kwds_rule(Parser *p)
+// param_with_default:
+//     | NAME annotation? default ',' TYPE_COMMENT?
+//     | NAME annotation? default TYPE_COMMENT? &')'
+static NameDefaultPair*
+param_with_default_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
-    arg_ty res = NULL;
+    NameDefaultPair* res = NULL;
     int mark = p->mark;
-    { // '**' plain_name
-        arg_ty a;
+    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
+        p->error_indicator = 1;
+        return NULL;
+    }
+    int start_lineno = p->tokens[mark]->lineno;
+    UNUSED(start_lineno); // Only used by EXTRA macro
+    int start_col_offset = p->tokens[mark]->col_offset;
+    UNUSED(start_col_offset); // Only used by EXTRA macro
+    { // NAME annotation? default ',' TYPE_COMMENT?
+        expr_ty a;
+        void *b;
+        expr_ty c;
+        void *literal;
+        void *tc;
+        if (
+            (a = _PyPegen_name_token(p))
+            &&
+            (b = annotation_rule(p), 1)
+            &&
+            (c = default_rule(p))
+            &&
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
+        )
+        {
+            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (token == NULL) {
+                return NULL;
+            }
+            int end_lineno = token->end_lineno;
+            UNUSED(end_lineno); // Only used by EXTRA macro
+            int end_col_offset = token->end_col_offset;
+            UNUSED(end_col_offset); // Only used by EXTRA macro
+            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , tc , EXTRA ) , c );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // NAME annotation? default TYPE_COMMENT? &')'
+        expr_ty a;
+        void *b;
+        expr_ty c;
+        void *tc;
+        if (
+            (a = _PyPegen_name_token(p))
+            &&
+            (b = annotation_rule(p), 1)
+            &&
+            (c = default_rule(p))
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
+            &&
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+        )
+        {
+            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (token == NULL) {
+                return NULL;
+            }
+            int end_lineno = token->end_lineno;
+            UNUSED(end_lineno); // Only used by EXTRA macro
+            int end_col_offset = token->end_col_offset;
+            UNUSED(end_col_offset); // Only used by EXTRA macro
+            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , tc , EXTRA ) , c );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// param_maybe_default:
+//     | NAME annotation? default? ',' TYPE_COMMENT?
+//     | NAME annotation? default? TYPE_COMMENT? &')'
+static NameDefaultPair*
+param_maybe_default_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    NameDefaultPair* res = NULL;
+    int mark = p->mark;
+    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
+        p->error_indicator = 1;
+        return NULL;
+    }
+    int start_lineno = p->tokens[mark]->lineno;
+    UNUSED(start_lineno); // Only used by EXTRA macro
+    int start_col_offset = p->tokens[mark]->col_offset;
+    UNUSED(start_col_offset); // Only used by EXTRA macro
+    { // NAME annotation? default? ',' TYPE_COMMENT?
+        expr_ty a;
+        void *b;
+        void *c;
+        void *literal;
+        void *tc;
+        if (
+            (a = _PyPegen_name_token(p))
+            &&
+            (b = annotation_rule(p), 1)
+            &&
+            (c = default_rule(p), 1)
+            &&
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
+        )
+        {
+            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (token == NULL) {
+                return NULL;
+            }
+            int end_lineno = token->end_lineno;
+            UNUSED(end_lineno); // Only used by EXTRA macro
+            int end_col_offset = token->end_col_offset;
+            UNUSED(end_col_offset); // Only used by EXTRA macro
+            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , tc , EXTRA ) , c );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // NAME annotation? default? TYPE_COMMENT? &')'
+        expr_ty a;
+        void *b;
+        void *c;
+        void *tc;
+        if (
+            (a = _PyPegen_name_token(p))
+            &&
+            (b = annotation_rule(p), 1)
+            &&
+            (c = default_rule(p), 1)
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
+            &&
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+        )
+        {
+            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (token == NULL) {
+                return NULL;
+            }
+            int end_lineno = token->end_lineno;
+            UNUSED(end_lineno); // Only used by EXTRA macro
+            int end_col_offset = token->end_col_offset;
+            UNUSED(end_col_offset); // Only used by EXTRA macro
+            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , tc , EXTRA ) , c );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// annotation: ':' expression
+static expr_ty
+annotation_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    expr_ty res = NULL;
+    int mark = p->mark;
+    { // ':' expression
+        expr_ty a;
         void *literal;
         if (
-            (literal = _PyPegen_expect_token(p, 35))
+            (literal = _PyPegen_expect_token(p, 11))
             &&
-            (a = plain_name_rule(p))
+            (a = expression_rule(p))
         )
         {
             res = a;
@@ -4081,22 +4231,29 @@ kwds_rule(Parser *p)
     return res;
 }
 
-// annotation: expression
+// default: '=' expression
 static expr_ty
-annotation_rule(Parser *p)
+default_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     expr_ty res = NULL;
     int mark = p->mark;
-    { // expression
-        expr_ty expression_var;
+    { // '=' expression
+        expr_ty a;
+        void *literal;
         if (
-            (expression_var = expression_rule(p))
+            (literal = _PyPegen_expect_token(p, 22))
+            &&
+            (a = expression_rule(p))
         )
         {
-            res = expression_var;
+            res = a;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
             goto done;
         }
         p->mark = mark;
@@ -4118,7 +4275,7 @@ decorators_rule(Parser *p)
     { // (('@' named_expression NEWLINE))+
         asdl_seq * a;
         if (
-            (a = _loop1_66_rule(p))
+            (a = _loop1_61_rule(p))
         )
         {
             res = a;
@@ -4206,7 +4363,7 @@ class_def_raw_rule(Parser *p)
             &&
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_67_rule(p), 1)
+            (b = _tmp_62_rule(p), 1)
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -4312,7 +4469,7 @@ expressions_list_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_68_rule(p))
+            (a = _gather_63_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4359,7 +4516,7 @@ star_expressions_rule(Parser *p)
         if (
             (a = star_expression_rule(p))
             &&
-            (b = _loop1_70_rule(p))
+            (b = _loop1_65_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4499,7 +4656,7 @@ star_named_expressions_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_71_rule(p))
+            (a = _gather_66_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4713,7 +4870,7 @@ expressions_rule(Parser *p)
         if (
             (a = expression_rule(p))
             &&
-            (b = _loop1_73_rule(p))
+            (b = _loop1_68_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4935,11 +5092,11 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_without_default_rule(p))
             &&
-            (b = _tmp_74_rule(p), 1)
+            (b = _tmp_69_rule(p), 1)
             &&
-            (c = _tmp_75_rule(p), 1)
+            (c = _tmp_70_rule(p), 1)
             &&
-            (d = _tmp_76_rule(p), 1)
+            (d = _tmp_71_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -4958,9 +5115,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_with_default_rule(p))
             &&
-            (b = _tmp_77_rule(p), 1)
+            (b = _tmp_72_rule(p), 1)
             &&
-            (c = _tmp_78_rule(p), 1)
+            (c = _tmp_73_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -4979,9 +5136,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_plain_names_rule(p))
             &&
-            (b = _tmp_79_rule(p), 1)
+            (b = _tmp_74_rule(p), 1)
             &&
-            (c = _tmp_80_rule(p), 1)
+            (c = _tmp_75_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -4999,7 +5156,7 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_names_with_default_rule(p))
             &&
-            (b = _tmp_81_rule(p), 1)
+            (b = _tmp_76_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -5081,7 +5238,7 @@ lambda_slash_with_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _tmp_82_rule(p), 1)
+            (a = _tmp_77_rule(p), 1)
             &&
             (b = lambda_names_with_default_rule(p))
             &&
@@ -5128,9 +5285,9 @@ lambda_star_etc_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _loop0_83_rule(p))
+            (b = _loop0_78_rule(p))
             &&
-            (c = _tmp_84_rule(p), 1)
+            (c = _tmp_79_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -5153,9 +5310,9 @@ lambda_star_etc_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (b = _loop1_85_rule(p))
+            (b = _loop1_80_rule(p))
             &&
-            (c = _tmp_86_rule(p), 1)
+            (c = _tmp_81_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -5211,7 +5368,7 @@ lambda_name_with_optional_default_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _tmp_87_rule(p), 1)
+            (b = _tmp_82_rule(p), 1)
         )
         {
             res = _PyPegen_name_default_pair ( p , a , b );
@@ -5240,7 +5397,7 @@ lambda_names_with_default_rule(Parser *p)
     { // ','.lambda_name_with_default+
         asdl_seq * a;
         if (
-            (a = _gather_88_rule(p))
+            (a = _gather_83_rule(p))
         )
         {
             res = a;
@@ -5304,7 +5461,7 @@ lambda_plain_names_rule(Parser *p)
     { // ','.(lambda_plain_name !'=')+
         asdl_seq * a;
         if (
-            (a = _gather_90_rule(p))
+            (a = _gather_85_rule(p))
         )
         {
             res = a;
@@ -5423,7 +5580,7 @@ disjunction_rule(Parser *p)
         if (
             (a = conjunction_rule(p))
             &&
-            (b = _loop1_92_rule(p))
+            (b = _loop1_87_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5485,7 +5642,7 @@ conjunction_rule(Parser *p)
         if (
             (a = inversion_rule(p))
             &&
-            (b = _loop1_93_rule(p))
+            (b = _loop1_88_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5607,7 +5764,7 @@ comparison_rule(Parser *p)
         if (
             (a = bitwise_or_rule(p))
             &&
-            (b = _loop1_94_rule(p))
+            (b = _loop1_89_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5819,10 +5976,10 @@ noteq_bitwise_or_rule(Parser *p)
     CmpopExprPair* res = NULL;
     int mark = p->mark;
     { // ('!=') bitwise_or
-        void *_tmp_95_var;
+        void *_tmp_90_var;
         expr_ty a;
         if (
-            (_tmp_95_var = _tmp_95_rule(p))
+            (_tmp_90_var = _tmp_90_rule(p))
             &&
             (a = bitwise_or_rule(p))
         )
@@ -7264,7 +7421,7 @@ slices_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_96_rule(p))
+            (a = _gather_91_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -7320,7 +7477,7 @@ slice_rule(Parser *p)
             &&
             (b = expression_rule(p), 1)
             &&
-            (c = _tmp_98_rule(p), 1)
+            (c = _tmp_93_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7508,40 +7665,40 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // &'(' (tuple | group | genexp)
-        void *_tmp_99_var;
+        void *_tmp_94_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)
             &&
-            (_tmp_99_var = _tmp_99_rule(p))
+            (_tmp_94_var = _tmp_94_rule(p))
         )
         {
-            res = _tmp_99_var;
+            res = _tmp_94_var;
             goto done;
         }
         p->mark = mark;
     }
     { // &'[' (list | listcomp)
-        void *_tmp_100_var;
+        void *_tmp_95_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)
             &&
-            (_tmp_100_var = _tmp_100_rule(p))
+            (_tmp_95_var = _tmp_95_rule(p))
         )
         {
-            res = _tmp_100_var;
+            res = _tmp_95_var;
             goto done;
         }
         p->mark = mark;
     }
     { // &'{' (dict | set | dictcomp | setcomp)
-        void *_tmp_101_var;
+        void *_tmp_96_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)
             &&
-            (_tmp_101_var = _tmp_101_rule(p))
+            (_tmp_96_var = _tmp_96_rule(p))
         )
         {
-            res = _tmp_101_var;
+            res = _tmp_96_var;
             goto done;
         }
         p->mark = mark;
@@ -7588,7 +7745,7 @@ strings_rule(Parser *p)
     { // STRING+
         asdl_seq * a;
         if (
-            (a = _loop1_102_rule(p))
+            (a = _loop1_97_rule(p))
         )
         {
             res = _PyPegen_concatenate_strings ( p , a );
@@ -7746,7 +7903,7 @@ tuple_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_103_rule(p), 1)
+            (a = _tmp_98_rule(p), 1)
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -7789,7 +7946,7 @@ group_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_104_rule(p))
+            (a = _tmp_99_rule(p))
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -8108,7 +8265,7 @@ kvpairs_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_105_rule(p))
+            (a = _gather_100_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8192,7 +8349,7 @@ for_if_clauses_rule(Parser *p)
     { // ((ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*))+
         asdl_seq * a;
         if (
-            (a = _loop1_107_rule(p))
+            (a = _loop1_102_rule(p))
         )
         {
             res = a;
@@ -8358,7 +8515,7 @@ args_rule(Parser *p)
         if (
             (a = starred_expression_rule(p))
             &&
-            (b = _tmp_108_rule(p), 1)
+            (b = _tmp_103_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8407,7 +8564,7 @@ args_rule(Parser *p)
         if (
             (a = named_expression_rule(p))
             &&
-            (b = _tmp_109_rule(p), 1)
+            (b = _tmp_104_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8449,11 +8606,11 @@ kwargs_rule(Parser *p)
         asdl_seq * b;
         void *literal;
         if (
-            (a = _gather_110_rule(p))
+            (a = _gather_105_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (b = _gather_112_rule(p))
+            (b = _gather_107_rule(p))
         )
         {
             res = _PyPegen_join_sequences ( p , a , b );
@@ -8466,23 +8623,23 @@ kwargs_rule(Parser *p)
         p->mark = mark;
     }
     { // ','.kwarg_or_starred+
-        asdl_seq * _gather_114_var;
+        asdl_seq * _gather_109_var;
         if (
-            (_gather_114_var = _gather_114_rule(p))
+            (_gather_109_var = _gather_109_rule(p))
         )
         {
-            res = _gather_114_var;
+            res = _gather_109_var;
             goto done;
         }
         p->mark = mark;
     }
     { // ','.kwarg_or_double_starred+
-        asdl_seq * _gather_116_var;
+        asdl_seq * _gather_111_var;
         if (
-            (_gather_116_var = _gather_116_rule(p))
+            (_gather_111_var = _gather_111_rule(p))
         )
         {
-            res = _gather_116_var;
+            res = _gather_111_var;
             goto done;
         }
         p->mark = mark;
@@ -8725,7 +8882,7 @@ star_targets_rule(Parser *p)
         if (
             (a = star_target_rule(p))
             &&
-            (b = _loop0_118_rule(p))
+            (b = _loop0_113_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8766,7 +8923,7 @@ star_targets_seq_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_119_rule(p))
+            (a = _gather_114_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8814,7 +8971,7 @@ star_target_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (a = _tmp_121_rule(p))
+            (a = _tmp_116_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9203,7 +9360,7 @@ del_targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_122_rule(p))
+            (a = _gather_117_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -9456,7 +9613,7 @@ targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_124_rule(p))
+            (a = _gather_119_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -9984,7 +10141,7 @@ incorrect_arguments_rule(Parser *p)
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (opt_var = _tmp_126_rule(p), 1)
+            (opt_var = _tmp_121_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "Generator expression must be parenthesized" );
@@ -10119,7 +10276,7 @@ invalid_assignment_rule(Parser *p)
             &&
             (expression_var_1 = expression_rule(p))
             &&
-            (opt_var = _tmp_127_rule(p), 1)
+            (opt_var = _tmp_122_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "illegal target for annotation" );
@@ -10132,15 +10289,15 @@ invalid_assignment_rule(Parser *p)
         p->mark = mark;
     }
     { // expression ('=' | augassign) (yield_expr | star_expressions)
-        void *_tmp_128_var;
-        void *_tmp_129_var;
+        void *_tmp_123_var;
+        void *_tmp_124_var;
         expr_ty a;
         if (
             (a = expression_rule(p))
             &&
-            (_tmp_128_var = _tmp_128_rule(p))
+            (_tmp_123_var = _tmp_123_rule(p))
             &&
-            (_tmp_129_var = _tmp_129_rule(p))
+            (_tmp_124_var = _tmp_124_rule(p))
         )
         {
             res = RAISE_SYNTAX_ERROR ( "cannot assign to %s" , _PyPegen_get_expr_name ( a ) );
@@ -10198,12 +10355,12 @@ invalid_comprehension_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ('[' | '(' | '{') '*' expression for_if_clauses
-        void *_tmp_130_var;
+        void *_tmp_125_var;
         expr_ty expression_var;
         asdl_seq* for_if_clauses_var;
         void *literal;
         if (
-            (_tmp_130_var = _tmp_130_rule(p))
+            (_tmp_125_var = _tmp_125_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -10227,7 +10384,7 @@ invalid_comprehension_rule(Parser *p)
 }
 
 // invalid_parameters:
-//     | [plain_names ','] (slash_with_default | names_with_default) ',' plain_names
+//     | param_no_default* (slash_with_default | param_with_default+) param_no_default
 static void *
 invalid_parameters_rule(Parser *p)
 {
@@ -10236,20 +10393,16 @@ invalid_parameters_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // [plain_names ','] (slash_with_default | names_with_default) ',' plain_names
-        void *_tmp_132_var;
-        void *literal;
-        void *opt_var;
-        UNUSED(opt_var); // Silence compiler warnings
-        asdl_seq* plain_names_var;
+    { // param_no_default* (slash_with_default | param_with_default+) param_no_default
+        asdl_seq * _loop0_126_var;
+        void *_tmp_127_var;
+        arg_ty param_no_default_var;
         if (
-            (opt_var = _tmp_131_rule(p), 1)
+            (_loop0_126_var = _loop0_126_rule(p))
             &&
-            (_tmp_132_var = _tmp_132_rule(p))
+            (_tmp_127_var = _tmp_127_rule(p))
             &&
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (plain_names_var = plain_names_rule(p))
+            (param_no_default_var = param_no_default_rule(p))
         )
         {
             res = RAISE_SYNTAX_ERROR ( "non-default argument follows default argument" );
@@ -11153,12 +11306,12 @@ _loop1_21_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (star_targets '=')
-        void *_tmp_133_var;
+        void *_tmp_128_var;
         while (
-            (_tmp_133_var = _tmp_133_rule(p))
+            (_tmp_128_var = _tmp_128_rule(p))
         )
         {
-            res = _tmp_133_var;
+            res = _tmp_128_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -11480,12 +11633,12 @@ _loop0_29_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_134_var;
+        void *_tmp_129_var;
         while (
-            (_tmp_134_var = _tmp_134_rule(p))
+            (_tmp_129_var = _tmp_129_rule(p))
         )
         {
-            res = _tmp_134_var;
+            res = _tmp_129_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -11529,12 +11682,12 @@ _loop1_30_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_135_var;
+        void *_tmp_130_var;
         while (
-            (_tmp_135_var = _tmp_135_rule(p))
+            (_tmp_130_var = _tmp_130_rule(p))
         )
         {
-            res = _tmp_135_var;
+            res = _tmp_130_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12117,7 +12270,7 @@ _tmp_44_rule(Parser *p)
     return res;
 }
 
-// _tmp_45: '->' annotation
+// _tmp_45: '->' expression
 static void *
 _tmp_45_rule(Parser *p)
 {
@@ -12126,13 +12279,13 @@ _tmp_45_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // '->' annotation
+    { // '->' expression
         void *literal;
         expr_ty z;
         if (
             (literal = _PyPegen_expect_token(p, 51))
             &&
-            (z = annotation_rule(p))
+            (z = expression_rule(p))
         )
         {
             res = z;
@@ -12177,297 +12330,9 @@ _tmp_46_rule(Parser *p)
     return res;
 }
 
-// _tmp_47: ',' plain_names
-static void *
-_tmp_47_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' plain_names
-        void *literal;
-        asdl_seq* x;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (x = plain_names_rule(p))
-        )
-        {
-            res = x;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_48: ',' names_with_default
-static void *
-_tmp_48_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_49: ',' star_etc?
-static void *
-_tmp_49_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_50: ',' names_with_default
-static void *
-_tmp_50_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_51: ',' star_etc?
-static void *
-_tmp_51_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_52: ',' names_with_default
-static void *
-_tmp_52_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_53: ',' star_etc?
-static void *
-_tmp_53_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_54: ',' star_etc?
-static void *
-_tmp_54_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_55: plain_names ','
-static void *
-_tmp_55_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // plain_names ','
-        void *literal;
-        asdl_seq* n;
-        if (
-            (n = plain_names_rule(p))
-            &&
-            (literal = _PyPegen_expect_token(p, 12))
-        )
-        {
-            res = n;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_56: name_with_optional_default
+// _loop0_47: param_no_default
 static asdl_seq *
-_loop0_56_rule(Parser *p)
+_loop0_47_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12482,13 +12347,13 @@ _loop0_56_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // name_with_optional_default
-        NameDefaultPair* name_with_optional_default_var;
+    { // param_no_default
+        arg_ty param_no_default_var;
         while (
-            (name_with_optional_default_var = name_with_optional_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))
         )
         {
-            res = name_with_optional_default_var;
+            res = param_no_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12504,49 +12369,527 @@ _loop0_56_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_56");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_47");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_56_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_47_type, seq);
     return seq;
 }
 
-// _tmp_57: ',' kwds
-static void *
-_tmp_57_rule(Parser *p)
+// _loop0_48: param_with_default
+static asdl_seq *
+_loop0_48_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
-    void * res = NULL;
+    void *res = NULL;
     int mark = p->mark;
-    { // ',' kwds
-        arg_ty d;
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (d = kwds_rule(p))
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
+        while (
+            (param_with_default_var = param_with_default_rule(p))
         )
         {
-            res = d;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
+            res = param_with_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
             }
-            goto done;
+            children[n++] = res;
+            mark = p->mark;
         }
         p->mark = mark;
     }
-    res = NULL;
-  done:
-    return res;
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_48");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_48_type, seq);
+    return seq;
 }
 
-// _loop1_58: name_with_optional_default
+// _loop0_49: param_with_default
+static asdl_seq *
+_loop0_49_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
+        while (
+            (param_with_default_var = param_with_default_rule(p))
+        )
+        {
+            res = param_with_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_49");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_49_type, seq);
+    return seq;
+}
+
+// _loop1_50: param_no_default
+static asdl_seq *
+_loop1_50_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_no_default
+        arg_ty param_no_default_var;
+        while (
+            (param_no_default_var = param_no_default_rule(p))
+        )
+        {
+            res = param_no_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_50");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_50_type, seq);
+    return seq;
+}
+
+// _loop0_51: param_with_default
+static asdl_seq *
+_loop0_51_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
+        while (
+            (param_with_default_var = param_with_default_rule(p))
+        )
+        {
+            res = param_with_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_51");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_51_type, seq);
+    return seq;
+}
+
+// _loop1_52: param_with_default
+static asdl_seq *
+_loop1_52_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
+        while (
+            (param_with_default_var = param_with_default_rule(p))
+        )
+        {
+            res = param_with_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_52");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_52_type, seq);
+    return seq;
+}
+
+// _loop1_53: param_no_default
+static asdl_seq *
+_loop1_53_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_no_default
+        arg_ty param_no_default_var;
+        while (
+            (param_no_default_var = param_no_default_rule(p))
+        )
+        {
+            res = param_no_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_53");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_53_type, seq);
+    return seq;
+}
+
+// _loop1_54: param_no_default
+static asdl_seq *
+_loop1_54_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_no_default
+        arg_ty param_no_default_var;
+        while (
+            (param_no_default_var = param_no_default_rule(p))
+        )
+        {
+            res = param_no_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_54");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_54_type, seq);
+    return seq;
+}
+
+// _loop0_55: param_no_default
+static asdl_seq *
+_loop0_55_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_no_default
+        arg_ty param_no_default_var;
+        while (
+            (param_no_default_var = param_no_default_rule(p))
+        )
+        {
+            res = param_no_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_55");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_55_type, seq);
+    return seq;
+}
+
+// _loop1_56: param_with_default
+static asdl_seq *
+_loop1_56_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
+        while (
+            (param_with_default_var = param_with_default_rule(p))
+        )
+        {
+            res = param_with_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_56");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_56_type, seq);
+    return seq;
+}
+
+// _loop0_57: param_no_default
+static asdl_seq *
+_loop0_57_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_no_default
+        arg_ty param_no_default_var;
+        while (
+            (param_no_default_var = param_no_default_rule(p))
+        )
+        {
+            res = param_no_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_57");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_57_type, seq);
+    return seq;
+}
+
+// _loop1_58: param_with_default
 static asdl_seq *
 _loop1_58_rule(Parser *p)
 {
@@ -12563,13 +12906,13 @@ _loop1_58_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // name_with_optional_default
-        NameDefaultPair* name_with_optional_default_var;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
         while (
-            (name_with_optional_default_var = name_with_optional_default_rule(p))
+            (param_with_default_var = param_with_default_rule(p))
         )
         {
-            res = name_with_optional_default_var;
+            res = param_with_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12599,73 +12942,9 @@ _loop1_58_rule(Parser *p)
     return seq;
 }
 
-// _tmp_59: ',' kwds
-static void *
-_tmp_59_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' kwds
-        arg_ty d;
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (d = kwds_rule(p))
-        )
-        {
-            res = d;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_60: '=' expression
-static void *
-_tmp_60_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // '=' expression
-        expr_ty e;
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 22))
-            &&
-            (e = expression_rule(p))
-        )
-        {
-            res = e;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_62: ',' name_with_default
+// _loop0_59: param_maybe_default
 static asdl_seq *
-_loop0_62_rule(Parser *p)
+_loop0_59_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12680,21 +12959,13 @@ _loop0_62_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // ',' name_with_default
-        NameDefaultPair* elem;
-        void *literal;
+    { // param_maybe_default
+        NameDefaultPair* param_maybe_default_var;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = name_with_default_rule(p))
+            (param_maybe_default_var = param_maybe_default_rule(p))
         )
         {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
+            res = param_maybe_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12710,47 +12981,19 @@ _loop0_62_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_62");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_59");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_62_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_59_type, seq);
     return seq;
 }
 
-// _gather_61: name_with_default _loop0_62
+// _loop1_60: param_maybe_default
 static asdl_seq *
-_gather_61_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // name_with_default _loop0_62
-        NameDefaultPair* elem;
-        asdl_seq * seq;
-        if (
-            (elem = name_with_default_rule(p))
-            &&
-            (seq = _loop0_62_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_64: ',' (plain_name !'=')
-static asdl_seq *
-_loop0_64_rule(Parser *p)
+_loop1_60_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12765,130 +13008,13 @@ _loop0_64_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // ',' (plain_name !'=')
-        void *elem;
-        void *literal;
+    { // param_maybe_default
+        NameDefaultPair* param_maybe_default_var;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = _tmp_136_rule(p))
+            (param_maybe_default_var = param_maybe_default_rule(p))
         )
         {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_64");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_64_type, seq);
-    return seq;
-}
-
-// _gather_63: (plain_name !'=') _loop0_64
-static asdl_seq *
-_gather_63_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // (plain_name !'=') _loop0_64
-        void *elem;
-        asdl_seq * seq;
-        if (
-            (elem = _tmp_136_rule(p))
-            &&
-            (seq = _loop0_64_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_65: ':' annotation
-static void *
-_tmp_65_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ':' annotation
-        void *literal;
-        expr_ty z;
-        if (
-            (literal = _PyPegen_expect_token(p, 11))
-            &&
-            (z = annotation_rule(p))
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop1_66: ('@' named_expression NEWLINE)
-static asdl_seq *
-_loop1_66_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ('@' named_expression NEWLINE)
-        void *_tmp_137_var;
-        while (
-            (_tmp_137_var = _tmp_137_rule(p))
-        )
-        {
-            res = _tmp_137_var;
+            res = param_maybe_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12908,19 +13034,72 @@ _loop1_66_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_66");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_60");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_66_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_60_type, seq);
     return seq;
 }
 
-// _tmp_67: '(' arguments? ')'
+// _loop1_61: ('@' named_expression NEWLINE)
+static asdl_seq *
+_loop1_61_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ('@' named_expression NEWLINE)
+        void *_tmp_131_var;
+        while (
+            (_tmp_131_var = _tmp_131_rule(p))
+        )
+        {
+            res = _tmp_131_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_61");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_61_type, seq);
+    return seq;
+}
+
+// _tmp_62: '(' arguments? ')'
 static void *
-_tmp_67_rule(Parser *p)
+_tmp_62_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12953,9 +13132,9 @@ _tmp_67_rule(Parser *p)
     return res;
 }
 
-// _loop0_69: ',' star_expression
+// _loop0_64: ',' star_expression
 static asdl_seq *
-_loop0_69_rule(Parser *p)
+_loop0_64_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13000,32 +13179,32 @@ _loop0_69_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_69");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_64");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_69_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_64_type, seq);
     return seq;
 }
 
-// _gather_68: star_expression _loop0_69
+// _gather_63: star_expression _loop0_64
 static asdl_seq *
-_gather_68_rule(Parser *p)
+_gather_63_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_expression _loop0_69
+    { // star_expression _loop0_64
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_expression_rule(p))
             &&
-            (seq = _loop0_69_rule(p))
+            (seq = _loop0_64_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13038,9 +13217,9 @@ _gather_68_rule(Parser *p)
     return res;
 }
 
-// _loop1_70: (',' star_expression)
+// _loop1_65: (',' star_expression)
 static asdl_seq *
-_loop1_70_rule(Parser *p)
+_loop1_65_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13056,12 +13235,12 @@ _loop1_70_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_expression)
-        void *_tmp_138_var;
+        void *_tmp_132_var;
         while (
-            (_tmp_138_var = _tmp_138_rule(p))
+            (_tmp_132_var = _tmp_132_rule(p))
         )
         {
-            res = _tmp_138_var;
+            res = _tmp_132_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13081,19 +13260,19 @@ _loop1_70_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_70");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_65");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_70_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_65_type, seq);
     return seq;
 }
 
-// _loop0_72: ',' star_named_expression
+// _loop0_67: ',' star_named_expression
 static asdl_seq *
-_loop0_72_rule(Parser *p)
+_loop0_67_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13138,32 +13317,32 @@ _loop0_72_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_72");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_67");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_72_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_67_type, seq);
     return seq;
 }
 
-// _gather_71: star_named_expression _loop0_72
+// _gather_66: star_named_expression _loop0_67
 static asdl_seq *
-_gather_71_rule(Parser *p)
+_gather_66_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_named_expression _loop0_72
+    { // star_named_expression _loop0_67
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_named_expression_rule(p))
             &&
-            (seq = _loop0_72_rule(p))
+            (seq = _loop0_67_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13176,9 +13355,9 @@ _gather_71_rule(Parser *p)
     return res;
 }
 
-// _loop1_73: (',' expression)
+// _loop1_68: (',' expression)
 static asdl_seq *
-_loop1_73_rule(Parser *p)
+_loop1_68_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13194,12 +13373,12 @@ _loop1_73_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' expression)
-        void *_tmp_139_var;
+        void *_tmp_133_var;
         while (
-            (_tmp_139_var = _tmp_139_rule(p))
+            (_tmp_133_var = _tmp_133_rule(p))
         )
         {
-            res = _tmp_139_var;
+            res = _tmp_133_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13219,19 +13398,19 @@ _loop1_73_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_73");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_68");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_73_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_68_type, seq);
     return seq;
 }
 
-// _tmp_74: ',' lambda_plain_names
+// _tmp_69: ',' lambda_plain_names
 static void *
-_tmp_74_rule(Parser *p)
+_tmp_69_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13261,9 +13440,9 @@ _tmp_74_rule(Parser *p)
     return res;
 }
 
-// _tmp_75: ',' lambda_names_with_default
+// _tmp_70: ',' lambda_names_with_default
 static void *
-_tmp_75_rule(Parser *p)
+_tmp_70_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13280,6 +13459,166 @@ _tmp_75_rule(Parser *p)
         )
         {
             res = y;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_71: ',' lambda_star_etc?
+static void *
+_tmp_71_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_star_etc?
+        void *literal;
+        void *z;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (z = lambda_star_etc_rule(p), 1)
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_72: ',' lambda_names_with_default
+static void *
+_tmp_72_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_names_with_default
+        void *literal;
+        asdl_seq* y;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (y = lambda_names_with_default_rule(p))
+        )
+        {
+            res = y;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_73: ',' lambda_star_etc?
+static void *
+_tmp_73_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_star_etc?
+        void *literal;
+        void *z;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (z = lambda_star_etc_rule(p), 1)
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_74: ',' lambda_names_with_default
+static void *
+_tmp_74_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_names_with_default
+        void *literal;
+        asdl_seq* y;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (y = lambda_names_with_default_rule(p))
+        )
+        {
+            res = y;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_75: ',' lambda_star_etc?
+static void *
+_tmp_75_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_star_etc?
+        void *literal;
+        void *z;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (z = lambda_star_etc_rule(p), 1)
+        )
+        {
+            res = z;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -13325,169 +13664,9 @@ _tmp_76_rule(Parser *p)
     return res;
 }
 
-// _tmp_77: ',' lambda_names_with_default
+// _tmp_77: lambda_plain_names ','
 static void *
 _tmp_77_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = lambda_names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_78: ',' lambda_star_etc?
-static void *
-_tmp_78_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = lambda_star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_79: ',' lambda_names_with_default
-static void *
-_tmp_79_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = lambda_names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_80: ',' lambda_star_etc?
-static void *
-_tmp_80_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = lambda_star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_81: ',' lambda_star_etc?
-static void *
-_tmp_81_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = lambda_star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_82: lambda_plain_names ','
-static void *
-_tmp_82_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13517,9 +13696,9 @@ _tmp_82_rule(Parser *p)
     return res;
 }
 
-// _loop0_83: lambda_name_with_optional_default
+// _loop0_78: lambda_name_with_optional_default
 static asdl_seq *
-_loop0_83_rule(Parser *p)
+_loop0_78_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13556,19 +13735,19 @@ _loop0_83_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_83");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_78");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_83_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_78_type, seq);
     return seq;
 }
 
-// _tmp_84: ',' lambda_kwds
+// _tmp_79: ',' lambda_kwds
 static void *
-_tmp_84_rule(Parser *p)
+_tmp_79_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13598,9 +13777,9 @@ _tmp_84_rule(Parser *p)
     return res;
 }
 
-// _loop1_85: lambda_name_with_optional_default
+// _loop1_80: lambda_name_with_optional_default
 static asdl_seq *
-_loop1_85_rule(Parser *p)
+_loop1_80_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13641,19 +13820,19 @@ _loop1_85_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_85");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_80");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_85_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_80_type, seq);
     return seq;
 }
 
-// _tmp_86: ',' lambda_kwds
+// _tmp_81: ',' lambda_kwds
 static void *
-_tmp_86_rule(Parser *p)
+_tmp_81_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13683,9 +13862,9 @@ _tmp_86_rule(Parser *p)
     return res;
 }
 
-// _tmp_87: '=' expression
+// _tmp_82: '=' expression
 static void *
-_tmp_87_rule(Parser *p)
+_tmp_82_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13715,9 +13894,9 @@ _tmp_87_rule(Parser *p)
     return res;
 }
 
-// _loop0_89: ',' lambda_name_with_default
+// _loop0_84: ',' lambda_name_with_default
 static asdl_seq *
-_loop0_89_rule(Parser *p)
+_loop0_84_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13762,32 +13941,32 @@ _loop0_89_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_89");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_84");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_89_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_84_type, seq);
     return seq;
 }
 
-// _gather_88: lambda_name_with_default _loop0_89
+// _gather_83: lambda_name_with_default _loop0_84
 static asdl_seq *
-_gather_88_rule(Parser *p)
+_gather_83_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // lambda_name_with_default _loop0_89
+    { // lambda_name_with_default _loop0_84
         NameDefaultPair* elem;
         asdl_seq * seq;
         if (
             (elem = lambda_name_with_default_rule(p))
             &&
-            (seq = _loop0_89_rule(p))
+            (seq = _loop0_84_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13800,9 +13979,9 @@ _gather_88_rule(Parser *p)
     return res;
 }
 
-// _loop0_91: ',' (lambda_plain_name !'=')
+// _loop0_86: ',' (lambda_plain_name !'=')
 static asdl_seq *
-_loop0_91_rule(Parser *p)
+_loop0_86_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13823,7 +14002,7 @@ _loop0_91_rule(Parser *p)
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (elem = _tmp_140_rule(p))
+            (elem = _tmp_134_rule(p))
         )
         {
             res = elem;
@@ -13847,32 +14026,32 @@ _loop0_91_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_91");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_86");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_91_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_86_type, seq);
     return seq;
 }
 
-// _gather_90: (lambda_plain_name !'=') _loop0_91
+// _gather_85: (lambda_plain_name !'=') _loop0_86
 static asdl_seq *
-_gather_90_rule(Parser *p)
+_gather_85_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // (lambda_plain_name !'=') _loop0_91
+    { // (lambda_plain_name !'=') _loop0_86
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_140_rule(p))
+            (elem = _tmp_134_rule(p))
             &&
-            (seq = _loop0_91_rule(p))
+            (seq = _loop0_86_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13885,9 +14064,9 @@ _gather_90_rule(Parser *p)
     return res;
 }
 
-// _loop1_92: ('or' conjunction)
+// _loop1_87: ('or' conjunction)
 static asdl_seq *
-_loop1_92_rule(Parser *p)
+_loop1_87_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13903,12 +14082,12 @@ _loop1_92_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('or' conjunction)
-        void *_tmp_141_var;
+        void *_tmp_135_var;
         while (
-            (_tmp_141_var = _tmp_141_rule(p))
+            (_tmp_135_var = _tmp_135_rule(p))
         )
         {
-            res = _tmp_141_var;
+            res = _tmp_135_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13928,19 +14107,19 @@ _loop1_92_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_92");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_87");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_92_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_87_type, seq);
     return seq;
 }
 
-// _loop1_93: ('and' inversion)
+// _loop1_88: ('and' inversion)
 static asdl_seq *
-_loop1_93_rule(Parser *p)
+_loop1_88_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13956,12 +14135,12 @@ _loop1_93_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('and' inversion)
-        void *_tmp_142_var;
+        void *_tmp_136_var;
         while (
-            (_tmp_142_var = _tmp_142_rule(p))
+            (_tmp_136_var = _tmp_136_rule(p))
         )
         {
-            res = _tmp_142_var;
+            res = _tmp_136_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13981,19 +14160,19 @@ _loop1_93_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_93");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_88");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_93_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_88_type, seq);
     return seq;
 }
 
-// _loop1_94: compare_op_bitwise_or_pair
+// _loop1_89: compare_op_bitwise_or_pair
 static asdl_seq *
-_loop1_94_rule(Parser *p)
+_loop1_89_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14034,19 +14213,19 @@ _loop1_94_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_94");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_89");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_94_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_89_type, seq);
     return seq;
 }
 
-// _tmp_95: '!='
+// _tmp_90: '!='
 static void *
-_tmp_95_rule(Parser *p)
+_tmp_90_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14073,9 +14252,9 @@ _tmp_95_rule(Parser *p)
     return res;
 }
 
-// _loop0_97: ',' slice
+// _loop0_92: ',' slice
 static asdl_seq *
-_loop0_97_rule(Parser *p)
+_loop0_92_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14120,32 +14299,32 @@ _loop0_97_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_97");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_92");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_97_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_92_type, seq);
     return seq;
 }
 
-// _gather_96: slice _loop0_97
+// _gather_91: slice _loop0_92
 static asdl_seq *
-_gather_96_rule(Parser *p)
+_gather_91_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // slice _loop0_97
+    { // slice _loop0_92
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = slice_rule(p))
             &&
-            (seq = _loop0_97_rule(p))
+            (seq = _loop0_92_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14158,9 +14337,9 @@ _gather_96_rule(Parser *p)
     return res;
 }
 
-// _tmp_98: ':' expression?
+// _tmp_93: ':' expression?
 static void *
-_tmp_98_rule(Parser *p)
+_tmp_93_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14190,9 +14369,9 @@ _tmp_98_rule(Parser *p)
     return res;
 }
 
-// _tmp_99: tuple | group | genexp
+// _tmp_94: tuple | group | genexp
 static void *
-_tmp_99_rule(Parser *p)
+_tmp_94_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14237,9 +14416,9 @@ _tmp_99_rule(Parser *p)
     return res;
 }
 
-// _tmp_100: list | listcomp
+// _tmp_95: list | listcomp
 static void *
-_tmp_100_rule(Parser *p)
+_tmp_95_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14273,9 +14452,9 @@ _tmp_100_rule(Parser *p)
     return res;
 }
 
-// _tmp_101: dict | set | dictcomp | setcomp
+// _tmp_96: dict | set | dictcomp | setcomp
 static void *
-_tmp_101_rule(Parser *p)
+_tmp_96_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14331,9 +14510,9 @@ _tmp_101_rule(Parser *p)
     return res;
 }
 
-// _loop1_102: STRING
+// _loop1_97: STRING
 static asdl_seq *
-_loop1_102_rule(Parser *p)
+_loop1_97_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14374,19 +14553,19 @@ _loop1_102_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_102");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_97");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_102_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_97_type, seq);
     return seq;
 }
 
-// _tmp_103: star_named_expression ',' star_named_expressions?
+// _tmp_98: star_named_expression ',' star_named_expressions?
 static void *
-_tmp_103_rule(Parser *p)
+_tmp_98_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14419,9 +14598,9 @@ _tmp_103_rule(Parser *p)
     return res;
 }
 
-// _tmp_104: yield_expr | named_expression
+// _tmp_99: yield_expr | named_expression
 static void *
-_tmp_104_rule(Parser *p)
+_tmp_99_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14455,9 +14634,9 @@ _tmp_104_rule(Parser *p)
     return res;
 }
 
-// _loop0_106: ',' kvpair
+// _loop0_101: ',' kvpair
 static asdl_seq *
-_loop0_106_rule(Parser *p)
+_loop0_101_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14502,32 +14681,32 @@ _loop0_106_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_106");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_101");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_106_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_101_type, seq);
     return seq;
 }
 
-// _gather_105: kvpair _loop0_106
+// _gather_100: kvpair _loop0_101
 static asdl_seq *
-_gather_105_rule(Parser *p)
+_gather_100_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kvpair _loop0_106
+    { // kvpair _loop0_101
         KeyValuePair* elem;
         asdl_seq * seq;
         if (
             (elem = kvpair_rule(p))
             &&
-            (seq = _loop0_106_rule(p))
+            (seq = _loop0_101_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14540,9 +14719,9 @@ _gather_105_rule(Parser *p)
     return res;
 }
 
-// _loop1_107: (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
+// _loop1_102: (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
 static asdl_seq *
-_loop1_107_rule(Parser *p)
+_loop1_102_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14558,12 +14737,12 @@ _loop1_107_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
-        void *_tmp_143_var;
+        void *_tmp_137_var;
         while (
-            (_tmp_143_var = _tmp_143_rule(p))
+            (_tmp_137_var = _tmp_137_rule(p))
         )
         {
-            res = _tmp_143_var;
+            res = _tmp_137_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14583,19 +14762,19 @@ _loop1_107_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_107");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_102");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_107_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_102_type, seq);
     return seq;
 }
 
-// _tmp_108: ',' args
+// _tmp_103: ',' args
 static void *
-_tmp_108_rule(Parser *p)
+_tmp_103_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14625,9 +14804,9 @@ _tmp_108_rule(Parser *p)
     return res;
 }
 
-// _tmp_109: ',' args
+// _tmp_104: ',' args
 static void *
-_tmp_109_rule(Parser *p)
+_tmp_104_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14657,9 +14836,9 @@ _tmp_109_rule(Parser *p)
     return res;
 }
 
-// _loop0_111: ',' kwarg_or_starred
+// _loop0_106: ',' kwarg_or_starred
 static asdl_seq *
-_loop0_111_rule(Parser *p)
+_loop0_106_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14704,32 +14883,32 @@ _loop0_111_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_111");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_106");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_111_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_106_type, seq);
     return seq;
 }
 
-// _gather_110: kwarg_or_starred _loop0_111
+// _gather_105: kwarg_or_starred _loop0_106
 static asdl_seq *
-_gather_110_rule(Parser *p)
+_gather_105_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_starred _loop0_111
+    { // kwarg_or_starred _loop0_106
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_starred_rule(p))
             &&
-            (seq = _loop0_111_rule(p))
+            (seq = _loop0_106_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14742,9 +14921,9 @@ _gather_110_rule(Parser *p)
     return res;
 }
 
-// _loop0_113: ',' kwarg_or_double_starred
+// _loop0_108: ',' kwarg_or_double_starred
 static asdl_seq *
-_loop0_113_rule(Parser *p)
+_loop0_108_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14774,6 +14953,253 @@ _loop0_113_rule(Parser *p)
                 PyMem_Free(children);
                 return NULL;
             }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_108");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_108_type, seq);
+    return seq;
+}
+
+// _gather_107: kwarg_or_double_starred _loop0_108
+static asdl_seq *
+_gather_107_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // kwarg_or_double_starred _loop0_108
+        KeywordOrStarred* elem;
+        asdl_seq * seq;
+        if (
+            (elem = kwarg_or_double_starred_rule(p))
+            &&
+            (seq = _loop0_108_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_110: ',' kwarg_or_starred
+static asdl_seq *
+_loop0_110_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' kwarg_or_starred
+        KeywordOrStarred* elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = kwarg_or_starred_rule(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_110");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_110_type, seq);
+    return seq;
+}
+
+// _gather_109: kwarg_or_starred _loop0_110
+static asdl_seq *
+_gather_109_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // kwarg_or_starred _loop0_110
+        KeywordOrStarred* elem;
+        asdl_seq * seq;
+        if (
+            (elem = kwarg_or_starred_rule(p))
+            &&
+            (seq = _loop0_110_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_112: ',' kwarg_or_double_starred
+static asdl_seq *
+_loop0_112_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' kwarg_or_double_starred
+        KeywordOrStarred* elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = kwarg_or_double_starred_rule(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_112");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_112_type, seq);
+    return seq;
+}
+
+// _gather_111: kwarg_or_double_starred _loop0_112
+static asdl_seq *
+_gather_111_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // kwarg_or_double_starred _loop0_112
+        KeywordOrStarred* elem;
+        asdl_seq * seq;
+        if (
+            (elem = kwarg_or_double_starred_rule(p))
+            &&
+            (seq = _loop0_112_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_113: (',' star_target)
+static asdl_seq *
+_loop0_113_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // (',' star_target)
+        void *_tmp_138_var;
+        while (
+            (_tmp_138_var = _tmp_138_rule(p))
+        )
+        {
+            res = _tmp_138_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14799,256 +15225,9 @@ _loop0_113_rule(Parser *p)
     return seq;
 }
 
-// _gather_112: kwarg_or_double_starred _loop0_113
-static asdl_seq *
-_gather_112_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_113
-        KeywordOrStarred* elem;
-        asdl_seq * seq;
-        if (
-            (elem = kwarg_or_double_starred_rule(p))
-            &&
-            (seq = _loop0_113_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_115: ',' kwarg_or_starred
+// _loop0_115: ',' star_target
 static asdl_seq *
 _loop0_115_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ',' kwarg_or_starred
-        KeywordOrStarred* elem;
-        void *literal;
-        while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = kwarg_or_starred_rule(p))
-        )
-        {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_115");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_115_type, seq);
-    return seq;
-}
-
-// _gather_114: kwarg_or_starred _loop0_115
-static asdl_seq *
-_gather_114_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // kwarg_or_starred _loop0_115
-        KeywordOrStarred* elem;
-        asdl_seq * seq;
-        if (
-            (elem = kwarg_or_starred_rule(p))
-            &&
-            (seq = _loop0_115_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_117: ',' kwarg_or_double_starred
-static asdl_seq *
-_loop0_117_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ',' kwarg_or_double_starred
-        KeywordOrStarred* elem;
-        void *literal;
-        while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = kwarg_or_double_starred_rule(p))
-        )
-        {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_117");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_117_type, seq);
-    return seq;
-}
-
-// _gather_116: kwarg_or_double_starred _loop0_117
-static asdl_seq *
-_gather_116_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_117
-        KeywordOrStarred* elem;
-        asdl_seq * seq;
-        if (
-            (elem = kwarg_or_double_starred_rule(p))
-            &&
-            (seq = _loop0_117_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_118: (',' star_target)
-static asdl_seq *
-_loop0_118_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // (',' star_target)
-        void *_tmp_144_var;
-        while (
-            (_tmp_144_var = _tmp_144_rule(p))
-        )
-        {
-            res = _tmp_144_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_118");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_118_type, seq);
-    return seq;
-}
-
-// _loop0_120: ',' star_target
-static asdl_seq *
-_loop0_120_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15093,32 +15272,32 @@ _loop0_120_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_120");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_115");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_120_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_115_type, seq);
     return seq;
 }
 
-// _gather_119: star_target _loop0_120
+// _gather_114: star_target _loop0_115
 static asdl_seq *
-_gather_119_rule(Parser *p)
+_gather_114_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_target _loop0_120
+    { // star_target _loop0_115
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_target_rule(p))
             &&
-            (seq = _loop0_120_rule(p))
+            (seq = _loop0_115_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15131,9 +15310,9 @@ _gather_119_rule(Parser *p)
     return res;
 }
 
-// _tmp_121: !'*' star_target
+// _tmp_116: !'*' star_target
 static void *
-_tmp_121_rule(Parser *p)
+_tmp_116_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15158,9 +15337,9 @@ _tmp_121_rule(Parser *p)
     return res;
 }
 
-// _loop0_123: ',' del_target
+// _loop0_118: ',' del_target
 static asdl_seq *
-_loop0_123_rule(Parser *p)
+_loop0_118_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15205,32 +15384,32 @@ _loop0_123_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_123");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_118");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_123_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_118_type, seq);
     return seq;
 }
 
-// _gather_122: del_target _loop0_123
+// _gather_117: del_target _loop0_118
 static asdl_seq *
-_gather_122_rule(Parser *p)
+_gather_117_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // del_target _loop0_123
+    { // del_target _loop0_118
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = del_target_rule(p))
             &&
-            (seq = _loop0_123_rule(p))
+            (seq = _loop0_118_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15243,9 +15422,9 @@ _gather_122_rule(Parser *p)
     return res;
 }
 
-// _loop0_125: ',' target
+// _loop0_120: ',' target
 static asdl_seq *
-_loop0_125_rule(Parser *p)
+_loop0_120_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15290,32 +15469,32 @@ _loop0_125_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_125");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_120");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_125_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_120_type, seq);
     return seq;
 }
 
-// _gather_124: target _loop0_125
+// _gather_119: target _loop0_120
 static asdl_seq *
-_gather_124_rule(Parser *p)
+_gather_119_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // target _loop0_125
+    { // target _loop0_120
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = target_rule(p))
             &&
-            (seq = _loop0_125_rule(p))
+            (seq = _loop0_120_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15328,9 +15507,9 @@ _gather_124_rule(Parser *p)
     return res;
 }
 
-// _tmp_126: args | expression for_if_clauses
+// _tmp_121: args | expression for_if_clauses
 static void *
-_tmp_126_rule(Parser *p)
+_tmp_121_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15367,9 +15546,9 @@ _tmp_126_rule(Parser *p)
     return res;
 }
 
-// _tmp_127: '=' annotated_rhs
+// _tmp_122: '=' annotated_rhs
 static void *
-_tmp_127_rule(Parser *p)
+_tmp_122_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15395,9 +15574,9 @@ _tmp_127_rule(Parser *p)
     return res;
 }
 
-// _tmp_128: '=' | augassign
+// _tmp_123: '=' | augassign
 static void *
-_tmp_128_rule(Parser *p)
+_tmp_123_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15431,9 +15610,9 @@ _tmp_128_rule(Parser *p)
     return res;
 }
 
-// _tmp_129: yield_expr | star_expressions
+// _tmp_124: yield_expr | star_expressions
 static void *
-_tmp_129_rule(Parser *p)
+_tmp_124_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15467,9 +15646,9 @@ _tmp_129_rule(Parser *p)
     return res;
 }
 
-// _tmp_130: '[' | '(' | '{'
+// _tmp_125: '[' | '(' | '{'
 static void *
-_tmp_130_rule(Parser *p)
+_tmp_125_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15514,37 +15693,58 @@ _tmp_130_rule(Parser *p)
     return res;
 }
 
-// _tmp_131: plain_names ','
-static void *
-_tmp_131_rule(Parser *p)
+// _loop0_126: param_no_default
+static asdl_seq *
+_loop0_126_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
-    void * res = NULL;
+    void *res = NULL;
     int mark = p->mark;
-    { // plain_names ','
-        void *literal;
-        asdl_seq* plain_names_var;
-        if (
-            (plain_names_var = plain_names_rule(p))
-            &&
-            (literal = _PyPegen_expect_token(p, 12))
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_no_default
+        arg_ty param_no_default_var;
+        while (
+            (param_no_default_var = param_no_default_rule(p))
         )
         {
-            res = _PyPegen_dummy_name(p, plain_names_var, literal);
-            goto done;
+            res = param_no_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
         }
         p->mark = mark;
     }
-    res = NULL;
-  done:
-    return res;
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_126");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_126_type, seq);
+    return seq;
 }
 
-// _tmp_132: slash_with_default | names_with_default
+// _tmp_127: slash_with_default | param_with_default+
 static void *
-_tmp_132_rule(Parser *p)
+_tmp_127_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15562,13 +15762,13 @@ _tmp_132_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // names_with_default
-        asdl_seq* names_with_default_var;
+    { // param_with_default+
+        asdl_seq * _loop1_139_var;
         if (
-            (names_with_default_var = names_with_default_rule(p))
+            (_loop1_139_var = _loop1_139_rule(p))
         )
         {
-            res = names_with_default_var;
+            res = _loop1_139_var;
             goto done;
         }
         p->mark = mark;
@@ -15578,9 +15778,9 @@ _tmp_132_rule(Parser *p)
     return res;
 }
 
-// _tmp_133: star_targets '='
+// _tmp_128: star_targets '='
 static void *
-_tmp_133_rule(Parser *p)
+_tmp_128_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15610,9 +15810,9 @@ _tmp_133_rule(Parser *p)
     return res;
 }
 
-// _tmp_134: '.' | '...'
+// _tmp_129: '.' | '...'
 static void *
-_tmp_134_rule(Parser *p)
+_tmp_129_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15646,9 +15846,9 @@ _tmp_134_rule(Parser *p)
     return res;
 }
 
-// _tmp_135: '.' | '...'
+// _tmp_130: '.' | '...'
 static void *
-_tmp_135_rule(Parser *p)
+_tmp_130_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15682,36 +15882,9 @@ _tmp_135_rule(Parser *p)
     return res;
 }
 
-// _tmp_136: plain_name !'='
+// _tmp_131: '@' named_expression NEWLINE
 static void *
-_tmp_136_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // plain_name !'='
-        arg_ty plain_name_var;
-        if (
-            (plain_name_var = plain_name_rule(p))
-            &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 22)
-        )
-        {
-            res = plain_name_var;
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_137: '@' named_expression NEWLINE
-static void *
-_tmp_137_rule(Parser *p)
+_tmp_131_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15744,9 +15917,9 @@ _tmp_137_rule(Parser *p)
     return res;
 }
 
-// _tmp_138: ',' star_expression
+// _tmp_132: ',' star_expression
 static void *
-_tmp_138_rule(Parser *p)
+_tmp_132_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15776,9 +15949,9 @@ _tmp_138_rule(Parser *p)
     return res;
 }
 
-// _tmp_139: ',' expression
+// _tmp_133: ',' expression
 static void *
-_tmp_139_rule(Parser *p)
+_tmp_133_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15808,9 +15981,9 @@ _tmp_139_rule(Parser *p)
     return res;
 }
 
-// _tmp_140: lambda_plain_name !'='
+// _tmp_134: lambda_plain_name !'='
 static void *
-_tmp_140_rule(Parser *p)
+_tmp_134_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15835,9 +16008,9 @@ _tmp_140_rule(Parser *p)
     return res;
 }
 
-// _tmp_141: 'or' conjunction
+// _tmp_135: 'or' conjunction
 static void *
-_tmp_141_rule(Parser *p)
+_tmp_135_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15867,9 +16040,9 @@ _tmp_141_rule(Parser *p)
     return res;
 }
 
-// _tmp_142: 'and' inversion
+// _tmp_136: 'and' inversion
 static void *
-_tmp_142_rule(Parser *p)
+_tmp_136_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15899,9 +16072,9 @@ _tmp_142_rule(Parser *p)
     return res;
 }
 
-// _tmp_143: ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
+// _tmp_137: ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
 static void *
-_tmp_143_rule(Parser *p)
+_tmp_137_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15926,7 +16099,7 @@ _tmp_143_rule(Parser *p)
             &&
             (b = disjunction_rule(p))
             &&
-            (c = _loop0_145_rule(p))
+            (c = _loop0_140_rule(p))
         )
         {
             res = _Py_comprehension ( a , b , c , y != NULL , p -> arena );
@@ -15943,9 +16116,9 @@ _tmp_143_rule(Parser *p)
     return res;
 }
 
-// _tmp_144: ',' star_target
+// _tmp_138: ',' star_target
 static void *
-_tmp_144_rule(Parser *p)
+_tmp_138_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15975,9 +16148,62 @@ _tmp_144_rule(Parser *p)
     return res;
 }
 
-// _loop0_145: ('if' disjunction)
+// _loop1_139: param_with_default
 static asdl_seq *
-_loop0_145_rule(Parser *p)
+_loop1_139_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
+        while (
+            (param_with_default_var = param_with_default_rule(p))
+        )
+        {
+            res = param_with_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_139");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_139_type, seq);
+    return seq;
+}
+
+// _loop0_140: ('if' disjunction)
+static asdl_seq *
+_loop0_140_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15993,12 +16219,12 @@ _loop0_145_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('if' disjunction)
-        void *_tmp_146_var;
+        void *_tmp_141_var;
         while (
-            (_tmp_146_var = _tmp_146_rule(p))
+            (_tmp_141_var = _tmp_141_rule(p))
         )
         {
-            res = _tmp_146_var;
+            res = _tmp_141_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -16014,19 +16240,19 @@ _loop0_145_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_145");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_140");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_145_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_140_type, seq);
     return seq;
 }
 
-// _tmp_146: 'if' disjunction
+// _tmp_141: 'if' disjunction
 static void *
-_tmp_146_rule(Parser *p)
+_tmp_141_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -120,242 +120,243 @@ static KeywordToken *reserved_keywords[] = {
 #define param_no_default_type 1049
 #define param_with_default_type 1050
 #define param_maybe_default_type 1051
-#define annotation_type 1052
-#define default_type 1053
-#define decorators_type 1054
-#define class_def_type 1055
-#define class_def_raw_type 1056
-#define block_type 1057
-#define expressions_list_type 1058
-#define star_expressions_type 1059
-#define star_expression_type 1060
-#define star_named_expressions_type 1061
-#define star_named_expression_type 1062
-#define named_expression_type 1063
-#define annotated_rhs_type 1064
-#define expressions_type 1065
-#define expression_type 1066
-#define lambdef_type 1067
-#define lambda_parameters_type 1068
-#define lambda_slash_without_default_type 1069
-#define lambda_slash_with_default_type 1070
-#define lambda_star_etc_type 1071
-#define lambda_name_with_optional_default_type 1072
-#define lambda_names_with_default_type 1073
-#define lambda_name_with_default_type 1074
-#define lambda_plain_names_type 1075
-#define lambda_plain_name_type 1076
-#define lambda_kwds_type 1077
-#define disjunction_type 1078
-#define conjunction_type 1079
-#define inversion_type 1080
-#define comparison_type 1081
-#define compare_op_bitwise_or_pair_type 1082
-#define eq_bitwise_or_type 1083
-#define noteq_bitwise_or_type 1084
-#define lte_bitwise_or_type 1085
-#define lt_bitwise_or_type 1086
-#define gte_bitwise_or_type 1087
-#define gt_bitwise_or_type 1088
-#define notin_bitwise_or_type 1089
-#define in_bitwise_or_type 1090
-#define isnot_bitwise_or_type 1091
-#define is_bitwise_or_type 1092
-#define bitwise_or_type 1093  // Left-recursive
-#define bitwise_xor_type 1094  // Left-recursive
-#define bitwise_and_type 1095  // Left-recursive
-#define shift_expr_type 1096  // Left-recursive
-#define sum_type 1097  // Left-recursive
-#define term_type 1098  // Left-recursive
-#define factor_type 1099
-#define power_type 1100
-#define await_primary_type 1101
-#define primary_type 1102  // Left-recursive
-#define slices_type 1103
-#define slice_type 1104
-#define atom_type 1105
-#define strings_type 1106
-#define list_type 1107
-#define listcomp_type 1108
-#define tuple_type 1109
-#define group_type 1110
-#define genexp_type 1111
-#define set_type 1112
-#define setcomp_type 1113
-#define dict_type 1114
-#define dictcomp_type 1115
-#define kvpairs_type 1116
-#define kvpair_type 1117
-#define for_if_clauses_type 1118
-#define yield_expr_type 1119
-#define arguments_type 1120
-#define args_type 1121
-#define kwargs_type 1122
-#define starred_expression_type 1123
-#define kwarg_or_starred_type 1124
-#define kwarg_or_double_starred_type 1125
-#define star_targets_type 1126
-#define star_targets_seq_type 1127
-#define star_target_type 1128
-#define star_atom_type 1129
-#define inside_paren_ann_assign_target_type 1130
-#define ann_assign_subscript_attribute_target_type 1131
-#define del_targets_type 1132
-#define del_target_type 1133
-#define del_t_atom_type 1134
-#define targets_type 1135
-#define target_type 1136
-#define t_primary_type 1137  // Left-recursive
-#define t_lookahead_type 1138
-#define t_atom_type 1139
-#define incorrect_arguments_type 1140
-#define invalid_named_expression_type 1141
-#define invalid_assignment_type 1142
-#define invalid_block_type 1143
-#define invalid_comprehension_type 1144
-#define invalid_parameters_type 1145
-#define invalid_double_type_comments_type 1146
-#define _loop0_1_type 1147
-#define _loop0_3_type 1148
-#define _gather_2_type 1149
-#define _loop0_5_type 1150
-#define _gather_4_type 1151
-#define _loop0_7_type 1152
-#define _gather_6_type 1153
-#define _loop0_9_type 1154
-#define _gather_8_type 1155
-#define _loop1_10_type 1156
-#define _loop0_12_type 1157
-#define _gather_11_type 1158
-#define _tmp_13_type 1159
-#define _tmp_14_type 1160
-#define _tmp_15_type 1161
-#define _tmp_16_type 1162
-#define _tmp_17_type 1163
-#define _tmp_18_type 1164
-#define _tmp_19_type 1165
-#define _tmp_20_type 1166
-#define _loop1_21_type 1167
-#define _tmp_22_type 1168
-#define _tmp_23_type 1169
-#define _loop0_25_type 1170
-#define _gather_24_type 1171
-#define _loop0_27_type 1172
-#define _gather_26_type 1173
-#define _tmp_28_type 1174
-#define _loop0_29_type 1175
-#define _loop1_30_type 1176
-#define _loop0_32_type 1177
-#define _gather_31_type 1178
-#define _tmp_33_type 1179
-#define _loop0_35_type 1180
-#define _gather_34_type 1181
-#define _tmp_36_type 1182
-#define _loop0_38_type 1183
-#define _gather_37_type 1184
-#define _loop0_40_type 1185
-#define _gather_39_type 1186
-#define _tmp_41_type 1187
-#define _loop1_42_type 1188
-#define _tmp_43_type 1189
-#define _tmp_44_type 1190
-#define _tmp_45_type 1191
-#define _tmp_46_type 1192
-#define _loop0_47_type 1193
-#define _loop0_48_type 1194
-#define _loop0_49_type 1195
-#define _loop1_50_type 1196
-#define _loop0_51_type 1197
-#define _loop1_52_type 1198
-#define _loop1_53_type 1199
-#define _loop1_54_type 1200
-#define _loop0_55_type 1201
-#define _loop1_56_type 1202
-#define _loop0_57_type 1203
-#define _loop1_58_type 1204
-#define _loop0_59_type 1205
-#define _loop1_60_type 1206
-#define _loop1_61_type 1207
-#define _tmp_62_type 1208
-#define _loop0_64_type 1209
-#define _gather_63_type 1210
-#define _loop1_65_type 1211
-#define _loop0_67_type 1212
-#define _gather_66_type 1213
-#define _loop1_68_type 1214
-#define _tmp_69_type 1215
-#define _tmp_70_type 1216
-#define _tmp_71_type 1217
-#define _tmp_72_type 1218
-#define _tmp_73_type 1219
-#define _tmp_74_type 1220
-#define _tmp_75_type 1221
-#define _tmp_76_type 1222
-#define _tmp_77_type 1223
-#define _loop0_78_type 1224
-#define _tmp_79_type 1225
-#define _loop1_80_type 1226
-#define _tmp_81_type 1227
-#define _tmp_82_type 1228
-#define _loop0_84_type 1229
-#define _gather_83_type 1230
-#define _loop0_86_type 1231
-#define _gather_85_type 1232
-#define _loop1_87_type 1233
-#define _loop1_88_type 1234
-#define _loop1_89_type 1235
-#define _tmp_90_type 1236
-#define _loop0_92_type 1237
-#define _gather_91_type 1238
-#define _tmp_93_type 1239
-#define _tmp_94_type 1240
-#define _tmp_95_type 1241
-#define _tmp_96_type 1242
-#define _loop1_97_type 1243
-#define _tmp_98_type 1244
-#define _tmp_99_type 1245
-#define _loop0_101_type 1246
-#define _gather_100_type 1247
-#define _loop1_102_type 1248
-#define _tmp_103_type 1249
-#define _tmp_104_type 1250
-#define _loop0_106_type 1251
-#define _gather_105_type 1252
-#define _loop0_108_type 1253
-#define _gather_107_type 1254
-#define _loop0_110_type 1255
-#define _gather_109_type 1256
-#define _loop0_112_type 1257
-#define _gather_111_type 1258
-#define _loop0_113_type 1259
-#define _loop0_115_type 1260
-#define _gather_114_type 1261
-#define _tmp_116_type 1262
-#define _loop0_118_type 1263
-#define _gather_117_type 1264
-#define _loop0_120_type 1265
-#define _gather_119_type 1266
-#define _tmp_121_type 1267
-#define _tmp_122_type 1268
-#define _tmp_123_type 1269
-#define _tmp_124_type 1270
-#define _tmp_125_type 1271
-#define _loop0_126_type 1272
-#define _tmp_127_type 1273
-#define _tmp_128_type 1274
-#define _tmp_129_type 1275
-#define _tmp_130_type 1276
-#define _tmp_131_type 1277
-#define _tmp_132_type 1278
-#define _tmp_133_type 1279
-#define _tmp_134_type 1280
-#define _tmp_135_type 1281
-#define _tmp_136_type 1282
-#define _tmp_137_type 1283
-#define _tmp_138_type 1284
-#define _loop1_139_type 1285
-#define _loop0_140_type 1286
-#define _tmp_141_type 1287
+#define param_type 1052
+#define annotation_type 1053
+#define default_type 1054
+#define decorators_type 1055
+#define class_def_type 1056
+#define class_def_raw_type 1057
+#define block_type 1058
+#define expressions_list_type 1059
+#define star_expressions_type 1060
+#define star_expression_type 1061
+#define star_named_expressions_type 1062
+#define star_named_expression_type 1063
+#define named_expression_type 1064
+#define annotated_rhs_type 1065
+#define expressions_type 1066
+#define expression_type 1067
+#define lambdef_type 1068
+#define lambda_parameters_type 1069
+#define lambda_slash_without_default_type 1070
+#define lambda_slash_with_default_type 1071
+#define lambda_star_etc_type 1072
+#define lambda_name_with_optional_default_type 1073
+#define lambda_names_with_default_type 1074
+#define lambda_name_with_default_type 1075
+#define lambda_plain_names_type 1076
+#define lambda_plain_name_type 1077
+#define lambda_kwds_type 1078
+#define disjunction_type 1079
+#define conjunction_type 1080
+#define inversion_type 1081
+#define comparison_type 1082
+#define compare_op_bitwise_or_pair_type 1083
+#define eq_bitwise_or_type 1084
+#define noteq_bitwise_or_type 1085
+#define lte_bitwise_or_type 1086
+#define lt_bitwise_or_type 1087
+#define gte_bitwise_or_type 1088
+#define gt_bitwise_or_type 1089
+#define notin_bitwise_or_type 1090
+#define in_bitwise_or_type 1091
+#define isnot_bitwise_or_type 1092
+#define is_bitwise_or_type 1093
+#define bitwise_or_type 1094  // Left-recursive
+#define bitwise_xor_type 1095  // Left-recursive
+#define bitwise_and_type 1096  // Left-recursive
+#define shift_expr_type 1097  // Left-recursive
+#define sum_type 1098  // Left-recursive
+#define term_type 1099  // Left-recursive
+#define factor_type 1100
+#define power_type 1101
+#define await_primary_type 1102
+#define primary_type 1103  // Left-recursive
+#define slices_type 1104
+#define slice_type 1105
+#define atom_type 1106
+#define strings_type 1107
+#define list_type 1108
+#define listcomp_type 1109
+#define tuple_type 1110
+#define group_type 1111
+#define genexp_type 1112
+#define set_type 1113
+#define setcomp_type 1114
+#define dict_type 1115
+#define dictcomp_type 1116
+#define kvpairs_type 1117
+#define kvpair_type 1118
+#define for_if_clauses_type 1119
+#define yield_expr_type 1120
+#define arguments_type 1121
+#define args_type 1122
+#define kwargs_type 1123
+#define starred_expression_type 1124
+#define kwarg_or_starred_type 1125
+#define kwarg_or_double_starred_type 1126
+#define star_targets_type 1127
+#define star_targets_seq_type 1128
+#define star_target_type 1129
+#define star_atom_type 1130
+#define inside_paren_ann_assign_target_type 1131
+#define ann_assign_subscript_attribute_target_type 1132
+#define del_targets_type 1133
+#define del_target_type 1134
+#define del_t_atom_type 1135
+#define targets_type 1136
+#define target_type 1137
+#define t_primary_type 1138  // Left-recursive
+#define t_lookahead_type 1139
+#define t_atom_type 1140
+#define incorrect_arguments_type 1141
+#define invalid_named_expression_type 1142
+#define invalid_assignment_type 1143
+#define invalid_block_type 1144
+#define invalid_comprehension_type 1145
+#define invalid_parameters_type 1146
+#define invalid_double_type_comments_type 1147
+#define _loop0_1_type 1148
+#define _loop0_3_type 1149
+#define _gather_2_type 1150
+#define _loop0_5_type 1151
+#define _gather_4_type 1152
+#define _loop0_7_type 1153
+#define _gather_6_type 1154
+#define _loop0_9_type 1155
+#define _gather_8_type 1156
+#define _loop1_10_type 1157
+#define _loop0_12_type 1158
+#define _gather_11_type 1159
+#define _tmp_13_type 1160
+#define _tmp_14_type 1161
+#define _tmp_15_type 1162
+#define _tmp_16_type 1163
+#define _tmp_17_type 1164
+#define _tmp_18_type 1165
+#define _tmp_19_type 1166
+#define _tmp_20_type 1167
+#define _loop1_21_type 1168
+#define _tmp_22_type 1169
+#define _tmp_23_type 1170
+#define _loop0_25_type 1171
+#define _gather_24_type 1172
+#define _loop0_27_type 1173
+#define _gather_26_type 1174
+#define _tmp_28_type 1175
+#define _loop0_29_type 1176
+#define _loop1_30_type 1177
+#define _loop0_32_type 1178
+#define _gather_31_type 1179
+#define _tmp_33_type 1180
+#define _loop0_35_type 1181
+#define _gather_34_type 1182
+#define _tmp_36_type 1183
+#define _loop0_38_type 1184
+#define _gather_37_type 1185
+#define _loop0_40_type 1186
+#define _gather_39_type 1187
+#define _tmp_41_type 1188
+#define _loop1_42_type 1189
+#define _tmp_43_type 1190
+#define _tmp_44_type 1191
+#define _tmp_45_type 1192
+#define _tmp_46_type 1193
+#define _loop0_47_type 1194
+#define _loop0_48_type 1195
+#define _loop0_49_type 1196
+#define _loop1_50_type 1197
+#define _loop0_51_type 1198
+#define _loop1_52_type 1199
+#define _loop1_53_type 1200
+#define _loop1_54_type 1201
+#define _loop0_55_type 1202
+#define _loop1_56_type 1203
+#define _loop0_57_type 1204
+#define _loop1_58_type 1205
+#define _loop0_59_type 1206
+#define _loop1_60_type 1207
+#define _loop1_61_type 1208
+#define _tmp_62_type 1209
+#define _loop0_64_type 1210
+#define _gather_63_type 1211
+#define _loop1_65_type 1212
+#define _loop0_67_type 1213
+#define _gather_66_type 1214
+#define _loop1_68_type 1215
+#define _tmp_69_type 1216
+#define _tmp_70_type 1217
+#define _tmp_71_type 1218
+#define _tmp_72_type 1219
+#define _tmp_73_type 1220
+#define _tmp_74_type 1221
+#define _tmp_75_type 1222
+#define _tmp_76_type 1223
+#define _tmp_77_type 1224
+#define _loop0_78_type 1225
+#define _tmp_79_type 1226
+#define _loop1_80_type 1227
+#define _tmp_81_type 1228
+#define _tmp_82_type 1229
+#define _loop0_84_type 1230
+#define _gather_83_type 1231
+#define _loop0_86_type 1232
+#define _gather_85_type 1233
+#define _loop1_87_type 1234
+#define _loop1_88_type 1235
+#define _loop1_89_type 1236
+#define _tmp_90_type 1237
+#define _loop0_92_type 1238
+#define _gather_91_type 1239
+#define _tmp_93_type 1240
+#define _tmp_94_type 1241
+#define _tmp_95_type 1242
+#define _tmp_96_type 1243
+#define _loop1_97_type 1244
+#define _tmp_98_type 1245
+#define _tmp_99_type 1246
+#define _loop0_101_type 1247
+#define _gather_100_type 1248
+#define _loop1_102_type 1249
+#define _tmp_103_type 1250
+#define _tmp_104_type 1251
+#define _loop0_106_type 1252
+#define _gather_105_type 1253
+#define _loop0_108_type 1254
+#define _gather_107_type 1255
+#define _loop0_110_type 1256
+#define _gather_109_type 1257
+#define _loop0_112_type 1258
+#define _gather_111_type 1259
+#define _loop0_113_type 1260
+#define _loop0_115_type 1261
+#define _gather_114_type 1262
+#define _tmp_116_type 1263
+#define _loop0_118_type 1264
+#define _gather_117_type 1265
+#define _loop0_120_type 1266
+#define _gather_119_type 1267
+#define _tmp_121_type 1268
+#define _tmp_122_type 1269
+#define _tmp_123_type 1270
+#define _tmp_124_type 1271
+#define _tmp_125_type 1272
+#define _loop0_126_type 1273
+#define _tmp_127_type 1274
+#define _tmp_128_type 1275
+#define _tmp_129_type 1276
+#define _tmp_130_type 1277
+#define _tmp_131_type 1278
+#define _tmp_132_type 1279
+#define _tmp_133_type 1280
+#define _tmp_134_type 1281
+#define _tmp_135_type 1282
+#define _tmp_136_type 1283
+#define _tmp_137_type 1284
+#define _tmp_138_type 1285
+#define _loop1_139_type 1286
+#define _loop0_140_type 1287
+#define _tmp_141_type 1288
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -409,6 +410,7 @@ static arg_ty kwds_rule(Parser *p);
 static arg_ty param_no_default_rule(Parser *p);
 static NameDefaultPair* param_with_default_rule(Parser *p);
 static NameDefaultPair* param_maybe_default_rule(Parser *p);
+static arg_ty param_rule(Parser *p);
 static expr_ty annotation_rule(Parser *p);
 static expr_ty default_rule(Parser *p);
 static asdl_seq* decorators_rule(Parser *p);
@@ -3926,9 +3928,7 @@ kwds_rule(Parser *p)
     return res;
 }
 
-// param_no_default:
-//     | NAME annotation? ',' TYPE_COMMENT?
-//     | NAME annotation? TYPE_COMMENT? &')'
+// param_no_default: param ',' TYPE_COMMENT? | param TYPE_COMMENT? &')'
 static arg_ty
 param_no_default_rule(Parser *p)
 {
@@ -3937,38 +3937,19 @@ param_no_default_rule(Parser *p)
     }
     arg_ty res = NULL;
     int mark = p->mark;
-    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
-        p->error_indicator = 1;
-        return NULL;
-    }
-    int start_lineno = p->tokens[mark]->lineno;
-    UNUSED(start_lineno); // Only used by EXTRA macro
-    int start_col_offset = p->tokens[mark]->col_offset;
-    UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // NAME annotation? ',' TYPE_COMMENT?
-        expr_ty a;
-        void *b;
+    { // param ',' TYPE_COMMENT?
+        arg_ty a;
         void *literal;
         void *tc;
         if (
-            (a = _PyPegen_name_token(p))
-            &&
-            (b = annotation_rule(p), 1)
+            (a = param_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
             (tc = _PyPegen_type_comment_token(p), 1)
         )
         {
-            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
-            if (token == NULL) {
-                return NULL;
-            }
-            int end_lineno = token->end_lineno;
-            UNUSED(end_lineno); // Only used by EXTRA macro
-            int end_col_offset = token->end_col_offset;
-            UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA );
+            res = _PyPegen_add_type_comment ( p , a , tc );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -3977,29 +3958,18 @@ param_no_default_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // NAME annotation? TYPE_COMMENT? &')'
-        expr_ty a;
-        void *b;
+    { // param TYPE_COMMENT? &')'
+        arg_ty a;
         void *tc;
         if (
-            (a = _PyPegen_name_token(p))
-            &&
-            (b = annotation_rule(p), 1)
+            (a = param_rule(p))
             &&
             (tc = _PyPegen_type_comment_token(p), 1)
             &&
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
         )
         {
-            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
-            if (token == NULL) {
-                return NULL;
-            }
-            int end_lineno = token->end_lineno;
-            UNUSED(end_lineno); // Only used by EXTRA macro
-            int end_col_offset = token->end_col_offset;
-            UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA );
+            res = _PyPegen_add_type_comment ( p , a , tc );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -4013,9 +3983,7 @@ param_no_default_rule(Parser *p)
     return res;
 }
 
-// param_with_default:
-//     | NAME annotation? default ',' TYPE_COMMENT?
-//     | NAME annotation? default TYPE_COMMENT? &')'
+// param_with_default: param default ',' TYPE_COMMENT? | param default TYPE_COMMENT? &')'
 static NameDefaultPair*
 param_with_default_rule(Parser *p)
 {
@@ -4024,24 +3992,13 @@ param_with_default_rule(Parser *p)
     }
     NameDefaultPair* res = NULL;
     int mark = p->mark;
-    if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
-        p->error_indicator = 1;
-        return NULL;
-    }
-    int start_lineno = p->tokens[mark]->lineno;
-    UNUSED(start_lineno); // Only used by EXTRA macro
-    int start_col_offset = p->tokens[mark]->col_offset;
-    UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // NAME annotation? default ',' TYPE_COMMENT?
-        expr_ty a;
-        void *b;
+    { // param default ',' TYPE_COMMENT?
+        arg_ty a;
         expr_ty c;
         void *literal;
         void *tc;
         if (
-            (a = _PyPegen_name_token(p))
-            &&
-            (b = annotation_rule(p), 1)
+            (a = param_rule(p))
             &&
             (c = default_rule(p))
             &&
@@ -4050,15 +4007,7 @@ param_with_default_rule(Parser *p)
             (tc = _PyPegen_type_comment_token(p), 1)
         )
         {
-            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
-            if (token == NULL) {
-                return NULL;
-            }
-            int end_lineno = token->end_lineno;
-            UNUSED(end_lineno); // Only used by EXTRA macro
-            int end_col_offset = token->end_col_offset;
-            UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA ) , c );
+            res = _PyPegen_name_default_pair ( p , a , c , tc );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -4067,15 +4016,12 @@ param_with_default_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // NAME annotation? default TYPE_COMMENT? &')'
-        expr_ty a;
-        void *b;
+    { // param default TYPE_COMMENT? &')'
+        arg_ty a;
         expr_ty c;
         void *tc;
         if (
-            (a = _PyPegen_name_token(p))
-            &&
-            (b = annotation_rule(p), 1)
+            (a = param_rule(p))
             &&
             (c = default_rule(p))
             &&
@@ -4084,15 +4030,7 @@ param_with_default_rule(Parser *p)
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
         )
         {
-            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
-            if (token == NULL) {
-                return NULL;
-            }
-            int end_lineno = token->end_lineno;
-            UNUSED(end_lineno); // Only used by EXTRA macro
-            int end_col_offset = token->end_col_offset;
-            UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA ) , c );
+            res = _PyPegen_name_default_pair ( p , a , c , tc );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -4107,8 +4045,8 @@ param_with_default_rule(Parser *p)
 }
 
 // param_maybe_default:
-//     | NAME annotation? default? ',' TYPE_COMMENT?
-//     | NAME annotation? default? TYPE_COMMENT? &')'
+//     | param default? ',' TYPE_COMMENT?
+//     | param default? TYPE_COMMENT? &')'
 static NameDefaultPair*
 param_maybe_default_rule(Parser *p)
 {
@@ -4116,6 +4054,67 @@ param_maybe_default_rule(Parser *p)
         return NULL;
     }
     NameDefaultPair* res = NULL;
+    int mark = p->mark;
+    { // param default? ',' TYPE_COMMENT?
+        arg_ty a;
+        void *c;
+        void *literal;
+        void *tc;
+        if (
+            (a = param_rule(p))
+            &&
+            (c = default_rule(p), 1)
+            &&
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
+        )
+        {
+            res = _PyPegen_name_default_pair ( p , a , c , tc );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // param default? TYPE_COMMENT? &')'
+        arg_ty a;
+        void *c;
+        void *tc;
+        if (
+            (a = param_rule(p))
+            &&
+            (c = default_rule(p), 1)
+            &&
+            (tc = _PyPegen_type_comment_token(p), 1)
+            &&
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
+        )
+        {
+            res = _PyPegen_name_default_pair ( p , a , c , tc );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// param: NAME annotation?
+static arg_ty
+param_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    arg_ty res = NULL;
     int mark = p->mark;
     if (p->mark == p->fill && _PyPegen_fill_token(p) < 0) {
         p->error_indicator = 1;
@@ -4125,22 +4124,13 @@ param_maybe_default_rule(Parser *p)
     UNUSED(start_lineno); // Only used by EXTRA macro
     int start_col_offset = p->tokens[mark]->col_offset;
     UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // NAME annotation? default? ',' TYPE_COMMENT?
+    { // NAME annotation?
         expr_ty a;
         void *b;
-        void *c;
-        void *literal;
-        void *tc;
         if (
             (a = _PyPegen_name_token(p))
             &&
             (b = annotation_rule(p), 1)
-            &&
-            (c = default_rule(p), 1)
-            &&
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (tc = _PyPegen_type_comment_token(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -4151,41 +4141,7 @@ param_maybe_default_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA ) , c );
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    { // NAME annotation? default? TYPE_COMMENT? &')'
-        expr_ty a;
-        void *b;
-        void *c;
-        void *tc;
-        if (
-            (a = _PyPegen_name_token(p))
-            &&
-            (b = annotation_rule(p), 1)
-            &&
-            (c = default_rule(p), 1)
-            &&
-            (tc = _PyPegen_type_comment_token(p), 1)
-            &&
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
-        )
-        {
-            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
-            if (token == NULL) {
-                return NULL;
-            }
-            int end_lineno = token->end_lineno;
-            UNUSED(end_lineno); // Only used by EXTRA macro
-            int end_col_offset = token->end_col_offset;
-            UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA ) , c );
+            res = _Py_arg ( a -> v . Name . id , b , NULL , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -5371,7 +5327,7 @@ lambda_name_with_optional_default_rule(Parser *p)
             (b = _tmp_82_rule(p), 1)
         )
         {
-            res = _PyPegen_name_default_pair ( p , a , b );
+            res = _PyPegen_name_default_pair ( p , a , b , NULL );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -5435,7 +5391,7 @@ lambda_name_with_default_rule(Parser *p)
             (e = expression_rule(p))
         )
         {
-            res = _PyPegen_name_default_pair ( p , n , e );
+            res = _PyPegen_name_default_pair ( p , n , e , NULL );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -3968,7 +3968,7 @@ param_no_default_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_arg ( a -> v . Name . id , b , tc , EXTRA );
+            res = _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -3999,7 +3999,7 @@ param_no_default_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_arg ( a -> v . Name . id , b , tc , EXTRA );
+            res = _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -4058,7 +4058,7 @@ param_with_default_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , tc , EXTRA ) , c );
+            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA ) , c );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -4092,7 +4092,7 @@ param_with_default_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , tc , EXTRA ) , c );
+            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA ) , c );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -4151,7 +4151,7 @@ param_maybe_default_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , tc , EXTRA ) , c );
+            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA ) , c );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -4185,7 +4185,7 @@ param_maybe_default_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , tc , EXTRA ) , c );
+            res = _PyPegen_name_default_pair ( p , _Py_arg ( a -> v . Name . id , b , NEW_TYPE_COMMENT ( tc ) , EXTRA ) , c );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -217,18 +217,18 @@ static KeywordToken *reserved_keywords[] = {
 #define invalid_parameters_type 1146
 #define invalid_double_type_comments_type 1147
 #define _loop0_1_type 1148
-#define _loop0_3_type 1149
-#define _gather_2_type 1150
-#define _loop0_5_type 1151
-#define _gather_4_type 1152
-#define _loop0_7_type 1153
-#define _gather_6_type 1154
-#define _loop0_9_type 1155
-#define _gather_8_type 1156
-#define _loop1_10_type 1157
-#define _loop0_12_type 1158
-#define _gather_11_type 1159
-#define _tmp_13_type 1160
+#define _loop0_2_type 1149
+#define _loop0_4_type 1150
+#define _gather_3_type 1151
+#define _loop0_6_type 1152
+#define _gather_5_type 1153
+#define _loop0_8_type 1154
+#define _gather_7_type 1155
+#define _loop0_10_type 1156
+#define _gather_9_type 1157
+#define _loop1_11_type 1158
+#define _loop0_13_type 1159
+#define _gather_12_type 1160
 #define _tmp_14_type 1161
 #define _tmp_15_type 1162
 #define _tmp_16_type 1163
@@ -236,55 +236,55 @@ static KeywordToken *reserved_keywords[] = {
 #define _tmp_18_type 1165
 #define _tmp_19_type 1166
 #define _tmp_20_type 1167
-#define _loop1_21_type 1168
-#define _tmp_22_type 1169
+#define _tmp_21_type 1168
+#define _loop1_22_type 1169
 #define _tmp_23_type 1170
-#define _loop0_25_type 1171
-#define _gather_24_type 1172
-#define _loop0_27_type 1173
-#define _gather_26_type 1174
-#define _tmp_28_type 1175
-#define _loop0_29_type 1176
-#define _loop1_30_type 1177
-#define _loop0_32_type 1178
-#define _gather_31_type 1179
-#define _tmp_33_type 1180
-#define _loop0_35_type 1181
-#define _gather_34_type 1182
-#define _tmp_36_type 1183
-#define _loop0_38_type 1184
-#define _gather_37_type 1185
-#define _loop0_40_type 1186
-#define _gather_39_type 1187
-#define _tmp_41_type 1188
-#define _loop1_42_type 1189
-#define _tmp_43_type 1190
+#define _tmp_24_type 1171
+#define _loop0_26_type 1172
+#define _gather_25_type 1173
+#define _loop0_28_type 1174
+#define _gather_27_type 1175
+#define _tmp_29_type 1176
+#define _loop0_30_type 1177
+#define _loop1_31_type 1178
+#define _loop0_33_type 1179
+#define _gather_32_type 1180
+#define _tmp_34_type 1181
+#define _loop0_36_type 1182
+#define _gather_35_type 1183
+#define _tmp_37_type 1184
+#define _loop0_39_type 1185
+#define _gather_38_type 1186
+#define _loop0_41_type 1187
+#define _gather_40_type 1188
+#define _tmp_42_type 1189
+#define _loop1_43_type 1190
 #define _tmp_44_type 1191
 #define _tmp_45_type 1192
 #define _tmp_46_type 1193
-#define _loop0_47_type 1194
+#define _tmp_47_type 1194
 #define _loop0_48_type 1195
 #define _loop0_49_type 1196
-#define _loop1_50_type 1197
-#define _loop0_51_type 1198
-#define _loop1_52_type 1199
+#define _loop0_50_type 1197
+#define _loop1_51_type 1198
+#define _loop0_52_type 1199
 #define _loop1_53_type 1200
 #define _loop1_54_type 1201
-#define _loop0_55_type 1202
-#define _loop1_56_type 1203
-#define _loop0_57_type 1204
-#define _loop1_58_type 1205
-#define _loop0_59_type 1206
-#define _loop1_60_type 1207
+#define _loop1_55_type 1202
+#define _loop0_56_type 1203
+#define _loop1_57_type 1204
+#define _loop0_58_type 1205
+#define _loop1_59_type 1206
+#define _loop0_60_type 1207
 #define _loop1_61_type 1208
-#define _tmp_62_type 1209
-#define _loop0_64_type 1210
-#define _gather_63_type 1211
-#define _loop1_65_type 1212
-#define _loop0_67_type 1213
-#define _gather_66_type 1214
-#define _loop1_68_type 1215
-#define _tmp_69_type 1216
+#define _loop1_62_type 1209
+#define _tmp_63_type 1210
+#define _loop0_65_type 1211
+#define _gather_64_type 1212
+#define _loop1_66_type 1213
+#define _loop0_68_type 1214
+#define _gather_67_type 1215
+#define _loop1_69_type 1216
 #define _tmp_70_type 1217
 #define _tmp_71_type 1218
 #define _tmp_72_type 1219
@@ -293,56 +293,56 @@ static KeywordToken *reserved_keywords[] = {
 #define _tmp_75_type 1222
 #define _tmp_76_type 1223
 #define _tmp_77_type 1224
-#define _loop0_78_type 1225
-#define _tmp_79_type 1226
-#define _loop1_80_type 1227
-#define _tmp_81_type 1228
+#define _tmp_78_type 1225
+#define _loop0_79_type 1226
+#define _tmp_80_type 1227
+#define _loop1_81_type 1228
 #define _tmp_82_type 1229
-#define _loop0_84_type 1230
-#define _gather_83_type 1231
-#define _loop0_86_type 1232
-#define _gather_85_type 1233
-#define _loop1_87_type 1234
+#define _tmp_83_type 1230
+#define _loop0_85_type 1231
+#define _gather_84_type 1232
+#define _loop0_87_type 1233
+#define _gather_86_type 1234
 #define _loop1_88_type 1235
 #define _loop1_89_type 1236
-#define _tmp_90_type 1237
-#define _loop0_92_type 1238
-#define _gather_91_type 1239
-#define _tmp_93_type 1240
+#define _loop1_90_type 1237
+#define _tmp_91_type 1238
+#define _loop0_93_type 1239
+#define _gather_92_type 1240
 #define _tmp_94_type 1241
 #define _tmp_95_type 1242
 #define _tmp_96_type 1243
-#define _loop1_97_type 1244
-#define _tmp_98_type 1245
+#define _tmp_97_type 1244
+#define _loop1_98_type 1245
 #define _tmp_99_type 1246
-#define _loop0_101_type 1247
-#define _gather_100_type 1248
-#define _loop1_102_type 1249
-#define _tmp_103_type 1250
+#define _tmp_100_type 1247
+#define _loop0_102_type 1248
+#define _gather_101_type 1249
+#define _loop1_103_type 1250
 #define _tmp_104_type 1251
-#define _loop0_106_type 1252
-#define _gather_105_type 1253
-#define _loop0_108_type 1254
-#define _gather_107_type 1255
-#define _loop0_110_type 1256
-#define _gather_109_type 1257
-#define _loop0_112_type 1258
-#define _gather_111_type 1259
-#define _loop0_113_type 1260
-#define _loop0_115_type 1261
-#define _gather_114_type 1262
-#define _tmp_116_type 1263
-#define _loop0_118_type 1264
-#define _gather_117_type 1265
-#define _loop0_120_type 1266
-#define _gather_119_type 1267
-#define _tmp_121_type 1268
+#define _tmp_105_type 1252
+#define _loop0_107_type 1253
+#define _gather_106_type 1254
+#define _loop0_109_type 1255
+#define _gather_108_type 1256
+#define _loop0_111_type 1257
+#define _gather_110_type 1258
+#define _loop0_113_type 1259
+#define _gather_112_type 1260
+#define _loop0_114_type 1261
+#define _loop0_116_type 1262
+#define _gather_115_type 1263
+#define _tmp_117_type 1264
+#define _loop0_119_type 1265
+#define _gather_118_type 1266
+#define _loop0_121_type 1267
+#define _gather_120_type 1268
 #define _tmp_122_type 1269
 #define _tmp_123_type 1270
 #define _tmp_124_type 1271
 #define _tmp_125_type 1272
-#define _loop0_126_type 1273
-#define _tmp_127_type 1274
+#define _tmp_126_type 1273
+#define _loop0_127_type 1274
 #define _tmp_128_type 1275
 #define _tmp_129_type 1276
 #define _tmp_130_type 1277
@@ -354,9 +354,10 @@ static KeywordToken *reserved_keywords[] = {
 #define _tmp_136_type 1283
 #define _tmp_137_type 1284
 #define _tmp_138_type 1285
-#define _loop1_139_type 1286
-#define _loop0_140_type 1287
-#define _tmp_141_type 1288
+#define _tmp_139_type 1286
+#define _loop1_140_type 1287
+#define _loop0_141_type 1288
+#define _tmp_142_type 1289
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -507,18 +508,18 @@ static void *invalid_comprehension_rule(Parser *p);
 static void *invalid_parameters_rule(Parser *p);
 static void *invalid_double_type_comments_rule(Parser *p);
 static asdl_seq *_loop0_1_rule(Parser *p);
-static asdl_seq *_loop0_3_rule(Parser *p);
-static asdl_seq *_gather_2_rule(Parser *p);
-static asdl_seq *_loop0_5_rule(Parser *p);
-static asdl_seq *_gather_4_rule(Parser *p);
-static asdl_seq *_loop0_7_rule(Parser *p);
-static asdl_seq *_gather_6_rule(Parser *p);
-static asdl_seq *_loop0_9_rule(Parser *p);
-static asdl_seq *_gather_8_rule(Parser *p);
-static asdl_seq *_loop1_10_rule(Parser *p);
-static asdl_seq *_loop0_12_rule(Parser *p);
-static asdl_seq *_gather_11_rule(Parser *p);
-static void *_tmp_13_rule(Parser *p);
+static asdl_seq *_loop0_2_rule(Parser *p);
+static asdl_seq *_loop0_4_rule(Parser *p);
+static asdl_seq *_gather_3_rule(Parser *p);
+static asdl_seq *_loop0_6_rule(Parser *p);
+static asdl_seq *_gather_5_rule(Parser *p);
+static asdl_seq *_loop0_8_rule(Parser *p);
+static asdl_seq *_gather_7_rule(Parser *p);
+static asdl_seq *_loop0_10_rule(Parser *p);
+static asdl_seq *_gather_9_rule(Parser *p);
+static asdl_seq *_loop1_11_rule(Parser *p);
+static asdl_seq *_loop0_13_rule(Parser *p);
+static asdl_seq *_gather_12_rule(Parser *p);
 static void *_tmp_14_rule(Parser *p);
 static void *_tmp_15_rule(Parser *p);
 static void *_tmp_16_rule(Parser *p);
@@ -526,55 +527,55 @@ static void *_tmp_17_rule(Parser *p);
 static void *_tmp_18_rule(Parser *p);
 static void *_tmp_19_rule(Parser *p);
 static void *_tmp_20_rule(Parser *p);
-static asdl_seq *_loop1_21_rule(Parser *p);
-static void *_tmp_22_rule(Parser *p);
+static void *_tmp_21_rule(Parser *p);
+static asdl_seq *_loop1_22_rule(Parser *p);
 static void *_tmp_23_rule(Parser *p);
-static asdl_seq *_loop0_25_rule(Parser *p);
-static asdl_seq *_gather_24_rule(Parser *p);
-static asdl_seq *_loop0_27_rule(Parser *p);
-static asdl_seq *_gather_26_rule(Parser *p);
-static void *_tmp_28_rule(Parser *p);
-static asdl_seq *_loop0_29_rule(Parser *p);
-static asdl_seq *_loop1_30_rule(Parser *p);
-static asdl_seq *_loop0_32_rule(Parser *p);
-static asdl_seq *_gather_31_rule(Parser *p);
-static void *_tmp_33_rule(Parser *p);
-static asdl_seq *_loop0_35_rule(Parser *p);
-static asdl_seq *_gather_34_rule(Parser *p);
-static void *_tmp_36_rule(Parser *p);
-static asdl_seq *_loop0_38_rule(Parser *p);
-static asdl_seq *_gather_37_rule(Parser *p);
-static asdl_seq *_loop0_40_rule(Parser *p);
-static asdl_seq *_gather_39_rule(Parser *p);
-static void *_tmp_41_rule(Parser *p);
-static asdl_seq *_loop1_42_rule(Parser *p);
-static void *_tmp_43_rule(Parser *p);
+static void *_tmp_24_rule(Parser *p);
+static asdl_seq *_loop0_26_rule(Parser *p);
+static asdl_seq *_gather_25_rule(Parser *p);
+static asdl_seq *_loop0_28_rule(Parser *p);
+static asdl_seq *_gather_27_rule(Parser *p);
+static void *_tmp_29_rule(Parser *p);
+static asdl_seq *_loop0_30_rule(Parser *p);
+static asdl_seq *_loop1_31_rule(Parser *p);
+static asdl_seq *_loop0_33_rule(Parser *p);
+static asdl_seq *_gather_32_rule(Parser *p);
+static void *_tmp_34_rule(Parser *p);
+static asdl_seq *_loop0_36_rule(Parser *p);
+static asdl_seq *_gather_35_rule(Parser *p);
+static void *_tmp_37_rule(Parser *p);
+static asdl_seq *_loop0_39_rule(Parser *p);
+static asdl_seq *_gather_38_rule(Parser *p);
+static asdl_seq *_loop0_41_rule(Parser *p);
+static asdl_seq *_gather_40_rule(Parser *p);
+static void *_tmp_42_rule(Parser *p);
+static asdl_seq *_loop1_43_rule(Parser *p);
 static void *_tmp_44_rule(Parser *p);
 static void *_tmp_45_rule(Parser *p);
 static void *_tmp_46_rule(Parser *p);
-static asdl_seq *_loop0_47_rule(Parser *p);
+static void *_tmp_47_rule(Parser *p);
 static asdl_seq *_loop0_48_rule(Parser *p);
 static asdl_seq *_loop0_49_rule(Parser *p);
-static asdl_seq *_loop1_50_rule(Parser *p);
-static asdl_seq *_loop0_51_rule(Parser *p);
-static asdl_seq *_loop1_52_rule(Parser *p);
+static asdl_seq *_loop0_50_rule(Parser *p);
+static asdl_seq *_loop1_51_rule(Parser *p);
+static asdl_seq *_loop0_52_rule(Parser *p);
 static asdl_seq *_loop1_53_rule(Parser *p);
 static asdl_seq *_loop1_54_rule(Parser *p);
-static asdl_seq *_loop0_55_rule(Parser *p);
-static asdl_seq *_loop1_56_rule(Parser *p);
-static asdl_seq *_loop0_57_rule(Parser *p);
-static asdl_seq *_loop1_58_rule(Parser *p);
-static asdl_seq *_loop0_59_rule(Parser *p);
-static asdl_seq *_loop1_60_rule(Parser *p);
+static asdl_seq *_loop1_55_rule(Parser *p);
+static asdl_seq *_loop0_56_rule(Parser *p);
+static asdl_seq *_loop1_57_rule(Parser *p);
+static asdl_seq *_loop0_58_rule(Parser *p);
+static asdl_seq *_loop1_59_rule(Parser *p);
+static asdl_seq *_loop0_60_rule(Parser *p);
 static asdl_seq *_loop1_61_rule(Parser *p);
-static void *_tmp_62_rule(Parser *p);
-static asdl_seq *_loop0_64_rule(Parser *p);
-static asdl_seq *_gather_63_rule(Parser *p);
-static asdl_seq *_loop1_65_rule(Parser *p);
-static asdl_seq *_loop0_67_rule(Parser *p);
-static asdl_seq *_gather_66_rule(Parser *p);
-static asdl_seq *_loop1_68_rule(Parser *p);
-static void *_tmp_69_rule(Parser *p);
+static asdl_seq *_loop1_62_rule(Parser *p);
+static void *_tmp_63_rule(Parser *p);
+static asdl_seq *_loop0_65_rule(Parser *p);
+static asdl_seq *_gather_64_rule(Parser *p);
+static asdl_seq *_loop1_66_rule(Parser *p);
+static asdl_seq *_loop0_68_rule(Parser *p);
+static asdl_seq *_gather_67_rule(Parser *p);
+static asdl_seq *_loop1_69_rule(Parser *p);
 static void *_tmp_70_rule(Parser *p);
 static void *_tmp_71_rule(Parser *p);
 static void *_tmp_72_rule(Parser *p);
@@ -583,56 +584,56 @@ static void *_tmp_74_rule(Parser *p);
 static void *_tmp_75_rule(Parser *p);
 static void *_tmp_76_rule(Parser *p);
 static void *_tmp_77_rule(Parser *p);
-static asdl_seq *_loop0_78_rule(Parser *p);
-static void *_tmp_79_rule(Parser *p);
-static asdl_seq *_loop1_80_rule(Parser *p);
-static void *_tmp_81_rule(Parser *p);
+static void *_tmp_78_rule(Parser *p);
+static asdl_seq *_loop0_79_rule(Parser *p);
+static void *_tmp_80_rule(Parser *p);
+static asdl_seq *_loop1_81_rule(Parser *p);
 static void *_tmp_82_rule(Parser *p);
-static asdl_seq *_loop0_84_rule(Parser *p);
-static asdl_seq *_gather_83_rule(Parser *p);
-static asdl_seq *_loop0_86_rule(Parser *p);
-static asdl_seq *_gather_85_rule(Parser *p);
-static asdl_seq *_loop1_87_rule(Parser *p);
+static void *_tmp_83_rule(Parser *p);
+static asdl_seq *_loop0_85_rule(Parser *p);
+static asdl_seq *_gather_84_rule(Parser *p);
+static asdl_seq *_loop0_87_rule(Parser *p);
+static asdl_seq *_gather_86_rule(Parser *p);
 static asdl_seq *_loop1_88_rule(Parser *p);
 static asdl_seq *_loop1_89_rule(Parser *p);
-static void *_tmp_90_rule(Parser *p);
-static asdl_seq *_loop0_92_rule(Parser *p);
-static asdl_seq *_gather_91_rule(Parser *p);
-static void *_tmp_93_rule(Parser *p);
+static asdl_seq *_loop1_90_rule(Parser *p);
+static void *_tmp_91_rule(Parser *p);
+static asdl_seq *_loop0_93_rule(Parser *p);
+static asdl_seq *_gather_92_rule(Parser *p);
 static void *_tmp_94_rule(Parser *p);
 static void *_tmp_95_rule(Parser *p);
 static void *_tmp_96_rule(Parser *p);
-static asdl_seq *_loop1_97_rule(Parser *p);
-static void *_tmp_98_rule(Parser *p);
+static void *_tmp_97_rule(Parser *p);
+static asdl_seq *_loop1_98_rule(Parser *p);
 static void *_tmp_99_rule(Parser *p);
-static asdl_seq *_loop0_101_rule(Parser *p);
-static asdl_seq *_gather_100_rule(Parser *p);
-static asdl_seq *_loop1_102_rule(Parser *p);
-static void *_tmp_103_rule(Parser *p);
+static void *_tmp_100_rule(Parser *p);
+static asdl_seq *_loop0_102_rule(Parser *p);
+static asdl_seq *_gather_101_rule(Parser *p);
+static asdl_seq *_loop1_103_rule(Parser *p);
 static void *_tmp_104_rule(Parser *p);
-static asdl_seq *_loop0_106_rule(Parser *p);
-static asdl_seq *_gather_105_rule(Parser *p);
-static asdl_seq *_loop0_108_rule(Parser *p);
-static asdl_seq *_gather_107_rule(Parser *p);
-static asdl_seq *_loop0_110_rule(Parser *p);
-static asdl_seq *_gather_109_rule(Parser *p);
-static asdl_seq *_loop0_112_rule(Parser *p);
-static asdl_seq *_gather_111_rule(Parser *p);
+static void *_tmp_105_rule(Parser *p);
+static asdl_seq *_loop0_107_rule(Parser *p);
+static asdl_seq *_gather_106_rule(Parser *p);
+static asdl_seq *_loop0_109_rule(Parser *p);
+static asdl_seq *_gather_108_rule(Parser *p);
+static asdl_seq *_loop0_111_rule(Parser *p);
+static asdl_seq *_gather_110_rule(Parser *p);
 static asdl_seq *_loop0_113_rule(Parser *p);
-static asdl_seq *_loop0_115_rule(Parser *p);
-static asdl_seq *_gather_114_rule(Parser *p);
-static void *_tmp_116_rule(Parser *p);
-static asdl_seq *_loop0_118_rule(Parser *p);
-static asdl_seq *_gather_117_rule(Parser *p);
-static asdl_seq *_loop0_120_rule(Parser *p);
-static asdl_seq *_gather_119_rule(Parser *p);
-static void *_tmp_121_rule(Parser *p);
+static asdl_seq *_gather_112_rule(Parser *p);
+static asdl_seq *_loop0_114_rule(Parser *p);
+static asdl_seq *_loop0_116_rule(Parser *p);
+static asdl_seq *_gather_115_rule(Parser *p);
+static void *_tmp_117_rule(Parser *p);
+static asdl_seq *_loop0_119_rule(Parser *p);
+static asdl_seq *_gather_118_rule(Parser *p);
+static asdl_seq *_loop0_121_rule(Parser *p);
+static asdl_seq *_gather_120_rule(Parser *p);
 static void *_tmp_122_rule(Parser *p);
 static void *_tmp_123_rule(Parser *p);
 static void *_tmp_124_rule(Parser *p);
 static void *_tmp_125_rule(Parser *p);
-static asdl_seq *_loop0_126_rule(Parser *p);
-static void *_tmp_127_rule(Parser *p);
+static void *_tmp_126_rule(Parser *p);
+static asdl_seq *_loop0_127_rule(Parser *p);
 static void *_tmp_128_rule(Parser *p);
 static void *_tmp_129_rule(Parser *p);
 static void *_tmp_130_rule(Parser *p);
@@ -644,9 +645,10 @@ static void *_tmp_135_rule(Parser *p);
 static void *_tmp_136_rule(Parser *p);
 static void *_tmp_137_rule(Parser *p);
 static void *_tmp_138_rule(Parser *p);
-static asdl_seq *_loop1_139_rule(Parser *p);
-static asdl_seq *_loop0_140_rule(Parser *p);
-static void *_tmp_141_rule(Parser *p);
+static void *_tmp_139_rule(Parser *p);
+static asdl_seq *_loop1_140_rule(Parser *p);
+static asdl_seq *_loop0_141_rule(Parser *p);
+static void *_tmp_142_rule(Parser *p);
 
 
 // file: statements? $
@@ -745,7 +747,7 @@ eval_rule(Parser *p)
     return res;
 }
 
-// func_type: '(' type_expressions? ')' '->' expression
+// func_type: '(' type_expressions? ')' '->' expression NEWLINE* $
 static mod_ty
 func_type_rule(Parser *p)
 {
@@ -754,9 +756,11 @@ func_type_rule(Parser *p)
     }
     mod_ty res = NULL;
     int mark = p->mark;
-    { // '(' type_expressions? ')' '->' expression
+    { // '(' type_expressions? ')' '->' expression NEWLINE* $
+        asdl_seq * _loop0_2_var;
         void *a;
         expr_ty b;
+        void *endmarker_var;
         void *literal;
         void *literal_1;
         void *literal_2;
@@ -770,6 +774,10 @@ func_type_rule(Parser *p)
             (literal_2 = _PyPegen_expect_token(p, 51))
             &&
             (b = expression_rule(p))
+            &&
+            (_loop0_2_var = _loop0_2_rule(p))
+            &&
+            (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))
         )
         {
             res = FunctionType ( a , b , p -> arena );
@@ -833,7 +841,7 @@ type_expressions_rule(Parser *p)
         void *literal_2;
         void *literal_3;
         if (
-            (a = _gather_2_rule(p))
+            (a = _gather_3_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -863,7 +871,7 @@ type_expressions_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _gather_4_rule(p))
+            (a = _gather_5_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -887,7 +895,7 @@ type_expressions_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _gather_6_rule(p))
+            (a = _gather_7_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -906,12 +914,12 @@ type_expressions_rule(Parser *p)
         p->mark = mark;
     }
     { // ','.expression+
-        asdl_seq * _gather_8_var;
+        asdl_seq * _gather_9_var;
         if (
-            (_gather_8_var = _gather_8_rule(p))
+            (_gather_9_var = _gather_9_rule(p))
         )
         {
-            res = _gather_8_var;
+            res = _gather_9_var;
             goto done;
         }
         p->mark = mark;
@@ -933,7 +941,7 @@ statements_rule(Parser *p)
     { // statement+
         asdl_seq * a;
         if (
-            (a = _loop1_10_rule(p))
+            (a = _loop1_11_rule(p))
         )
         {
             res = _PyPegen_seq_flatten ( p , a );
@@ -1114,7 +1122,7 @@ simple_stmt_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_11_rule(p))
+            (a = _gather_12_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 13), 1)
             &&
@@ -1217,7 +1225,7 @@ small_stmt_rule(Parser *p)
     { // &('import' | 'from') import_stmt
         stmt_ty import_stmt_var;
         if (
-            _PyPegen_lookahead(1, _tmp_13_rule, p)
+            _PyPegen_lookahead(1, _tmp_14_rule, p)
             &&
             (import_stmt_var = import_stmt_rule(p))
         )
@@ -1399,7 +1407,7 @@ compound_stmt_rule(Parser *p)
     { // &('def' | '@' | ASYNC) function_def
         stmt_ty function_def_var;
         if (
-            _PyPegen_lookahead(1, _tmp_14_rule, p)
+            _PyPegen_lookahead(1, _tmp_15_rule, p)
             &&
             (function_def_var = function_def_rule(p))
         )
@@ -1425,7 +1433,7 @@ compound_stmt_rule(Parser *p)
     { // &('class' | '@') class_def
         stmt_ty class_def_var;
         if (
-            _PyPegen_lookahead(1, _tmp_15_rule, p)
+            _PyPegen_lookahead(1, _tmp_16_rule, p)
             &&
             (class_def_var = class_def_rule(p))
         )
@@ -1438,7 +1446,7 @@ compound_stmt_rule(Parser *p)
     { // &('with' | ASYNC) with_stmt
         stmt_ty with_stmt_var;
         if (
-            _PyPegen_lookahead(1, _tmp_16_rule, p)
+            _PyPegen_lookahead(1, _tmp_17_rule, p)
             &&
             (with_stmt_var = with_stmt_rule(p))
         )
@@ -1451,7 +1459,7 @@ compound_stmt_rule(Parser *p)
     { // &('for' | ASYNC) for_stmt
         stmt_ty for_stmt_var;
         if (
-            _PyPegen_lookahead(1, _tmp_17_rule, p)
+            _PyPegen_lookahead(1, _tmp_18_rule, p)
             &&
             (for_stmt_var = for_stmt_rule(p))
         )
@@ -1526,7 +1534,7 @@ assignment_rule(Parser *p)
             &&
             (b = expression_rule(p))
             &&
-            (c = _tmp_18_rule(p), 1)
+            (c = _tmp_19_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1552,13 +1560,13 @@ assignment_rule(Parser *p)
         void *c;
         void *literal;
         if (
-            (a = _tmp_19_rule(p))
+            (a = _tmp_20_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
             (b = expression_rule(p))
             &&
-            (c = _tmp_20_rule(p), 1)
+            (c = _tmp_21_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1583,9 +1591,9 @@ assignment_rule(Parser *p)
         void *b;
         void *tc;
         if (
-            (a = _loop1_21_rule(p))
+            (a = _loop1_22_rule(p))
             &&
-            (b = _tmp_22_rule(p))
+            (b = _tmp_23_rule(p))
             &&
             (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
         )
@@ -1616,7 +1624,7 @@ assignment_rule(Parser *p)
             &&
             (b = augassign_rule(p))
             &&
-            (c = _tmp_23_rule(p))
+            (c = _tmp_24_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1897,7 +1905,7 @@ global_stmt_rule(Parser *p)
         if (
             (keyword = _PyPegen_expect_token(p, 508))
             &&
-            (a = _gather_24_rule(p))
+            (a = _gather_25_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -1945,7 +1953,7 @@ nonlocal_stmt_rule(Parser *p)
         if (
             (keyword = _PyPegen_expect_token(p, 509))
             &&
-            (a = _gather_26_rule(p))
+            (a = _gather_27_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2041,7 +2049,7 @@ assert_stmt_rule(Parser *p)
             &&
             (a = expression_rule(p))
             &&
-            (b = _tmp_28_rule(p), 1)
+            (b = _tmp_29_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -2226,7 +2234,7 @@ import_from_rule(Parser *p)
         if (
             (keyword = _PyPegen_expect_token(p, 514))
             &&
-            (a = _loop0_29_rule(p))
+            (a = _loop0_30_rule(p))
             &&
             (b = dotted_name_rule(p))
             &&
@@ -2260,7 +2268,7 @@ import_from_rule(Parser *p)
         if (
             (keyword = _PyPegen_expect_token(p, 514))
             &&
-            (a = _loop1_30_rule(p))
+            (a = _loop1_31_rule(p))
             &&
             (keyword_1 = _PyPegen_expect_token(p, 513))
             &&
@@ -2366,7 +2374,7 @@ import_from_as_names_rule(Parser *p)
     { // ','.import_from_as_name+
         asdl_seq * a;
         if (
-            (a = _gather_31_rule(p))
+            (a = _gather_32_rule(p))
         )
         {
             res = a;
@@ -2398,7 +2406,7 @@ import_from_as_name_rule(Parser *p)
         if (
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_33_rule(p), 1)
+            (b = _tmp_34_rule(p), 1)
         )
         {
             res = _Py_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
@@ -2427,7 +2435,7 @@ dotted_as_names_rule(Parser *p)
     { // ','.dotted_as_name+
         asdl_seq * a;
         if (
-            (a = _gather_34_rule(p))
+            (a = _gather_35_rule(p))
         )
         {
             res = a;
@@ -2459,7 +2467,7 @@ dotted_as_name_rule(Parser *p)
         if (
             (a = dotted_name_rule(p))
             &&
-            (b = _tmp_36_rule(p), 1)
+            (b = _tmp_37_rule(p), 1)
         )
         {
             res = _Py_alias ( a -> v . Name . id , ( b ) ? ( ( expr_ty ) b ) -> v . Name . id : NULL , p -> arena );
@@ -2931,7 +2939,7 @@ with_stmt_rule(Parser *p)
             &&
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _gather_37_rule(p))
+            (a = _gather_38_rule(p))
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
             &&
@@ -2969,7 +2977,7 @@ with_stmt_rule(Parser *p)
             &&
             (keyword = _PyPegen_expect_token(p, 519))
             &&
-            (a = _gather_39_rule(p))
+            (a = _gather_40_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -3015,7 +3023,7 @@ with_item_rule(Parser *p)
         if (
             (e = expression_rule(p))
             &&
-            (o = _tmp_41_rule(p), 1)
+            (o = _tmp_42_rule(p), 1)
         )
         {
             res = _Py_withitem ( e , o , p -> arena );
@@ -3097,7 +3105,7 @@ try_stmt_rule(Parser *p)
             &&
             (b = block_rule(p))
             &&
-            (ex = _loop1_42_rule(p))
+            (ex = _loop1_43_rule(p))
             &&
             (el = else_block_rule(p), 1)
             &&
@@ -3154,7 +3162,7 @@ except_block_rule(Parser *p)
             &&
             (e = expression_rule(p))
             &&
-            (t = _tmp_43_rule(p), 1)
+            (t = _tmp_44_rule(p), 1)
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -3321,7 +3329,7 @@ raise_stmt_rule(Parser *p)
             &&
             (a = expression_rule(p))
             &&
-            (b = _tmp_44_rule(p), 1)
+            (b = _tmp_45_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3454,7 +3462,7 @@ function_def_raw_rule(Parser *p)
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
             &&
-            (a = _tmp_45_rule(p), 1)
+            (a = _tmp_46_rule(p), 1)
             &&
             (literal_2 = _PyPegen_expect_token(p, 11))
             &&
@@ -3505,7 +3513,7 @@ func_type_comment_rule(Parser *p)
             &&
             (t = _PyPegen_expect_token(p, TYPE_COMMENT))
             &&
-            _PyPegen_lookahead(1, _tmp_46_rule, p)
+            _PyPegen_lookahead(1, _tmp_47_rule, p)
         )
         {
             res = t;
@@ -3602,9 +3610,9 @@ parameters_rule(Parser *p)
         if (
             (a = slash_no_default_rule(p))
             &&
-            (b = _loop0_47_rule(p))
+            (b = _loop0_48_rule(p))
             &&
-            (c = _loop0_48_rule(p))
+            (c = _loop0_49_rule(p))
             &&
             (d = star_etc_rule(p), 1)
         )
@@ -3625,7 +3633,7 @@ parameters_rule(Parser *p)
         if (
             (a = slash_with_default_rule(p))
             &&
-            (b = _loop0_49_rule(p))
+            (b = _loop0_50_rule(p))
             &&
             (c = star_etc_rule(p), 1)
         )
@@ -3644,9 +3652,9 @@ parameters_rule(Parser *p)
         asdl_seq * b;
         void *c;
         if (
-            (a = _loop1_50_rule(p))
+            (a = _loop1_51_rule(p))
             &&
-            (b = _loop0_51_rule(p))
+            (b = _loop0_52_rule(p))
             &&
             (c = star_etc_rule(p), 1)
         )
@@ -3664,7 +3672,7 @@ parameters_rule(Parser *p)
         asdl_seq * a;
         void *b;
         if (
-            (a = _loop1_52_rule(p))
+            (a = _loop1_53_rule(p))
             &&
             (b = star_etc_rule(p), 1)
         )
@@ -3712,7 +3720,7 @@ slash_no_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _loop1_53_rule(p))
+            (a = _loop1_54_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 17))
             &&
@@ -3732,7 +3740,7 @@ slash_no_default_rule(Parser *p)
         asdl_seq * a;
         void *literal;
         if (
-            (a = _loop1_54_rule(p))
+            (a = _loop1_55_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 17))
             &&
@@ -3770,9 +3778,9 @@ slash_with_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _loop0_55_rule(p))
+            (a = _loop0_56_rule(p))
             &&
-            (b = _loop1_56_rule(p))
+            (b = _loop1_57_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 17))
             &&
@@ -3793,9 +3801,9 @@ slash_with_default_rule(Parser *p)
         asdl_seq * b;
         void *literal;
         if (
-            (a = _loop0_57_rule(p))
+            (a = _loop0_58_rule(p))
             &&
-            (b = _loop1_58_rule(p))
+            (b = _loop1_59_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 17))
             &&
@@ -3838,7 +3846,7 @@ star_etc_rule(Parser *p)
             &&
             (a = param_no_default_rule(p))
             &&
-            (b = _loop0_59_rule(p))
+            (b = _loop0_60_rule(p))
             &&
             (c = kwds_rule(p), 1)
         )
@@ -3862,7 +3870,7 @@ star_etc_rule(Parser *p)
             &&
             (literal_1 = _PyPegen_expect_token(p, 12))
             &&
-            (b = _loop1_60_rule(p))
+            (b = _loop1_61_rule(p))
             &&
             (c = kwds_rule(p), 1)
         )
@@ -3949,7 +3957,7 @@ param_no_default_rule(Parser *p)
             (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
         )
         {
-            res = _PyPegen_add_type_comment ( p , a , tc );
+            res = _PyPegen_add_type_comment_to_arg ( p , a , tc );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -3969,7 +3977,7 @@ param_no_default_rule(Parser *p)
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 8)
         )
         {
-            res = _PyPegen_add_type_comment ( p , a , tc );
+            res = _PyPegen_add_type_comment_to_arg ( p , a , tc );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -4231,7 +4239,7 @@ decorators_rule(Parser *p)
     { // (('@' named_expression NEWLINE))+
         asdl_seq * a;
         if (
-            (a = _loop1_61_rule(p))
+            (a = _loop1_62_rule(p))
         )
         {
             res = a;
@@ -4319,7 +4327,7 @@ class_def_raw_rule(Parser *p)
             &&
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_62_rule(p), 1)
+            (b = _tmp_63_rule(p), 1)
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -4425,7 +4433,7 @@ expressions_list_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_63_rule(p))
+            (a = _gather_64_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4472,7 +4480,7 @@ star_expressions_rule(Parser *p)
         if (
             (a = star_expression_rule(p))
             &&
-            (b = _loop1_65_rule(p))
+            (b = _loop1_66_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4612,7 +4620,7 @@ star_named_expressions_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_66_rule(p))
+            (a = _gather_67_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4826,7 +4834,7 @@ expressions_rule(Parser *p)
         if (
             (a = expression_rule(p))
             &&
-            (b = _loop1_68_rule(p))
+            (b = _loop1_69_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -5048,11 +5056,11 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_without_default_rule(p))
             &&
-            (b = _tmp_69_rule(p), 1)
+            (b = _tmp_70_rule(p), 1)
             &&
-            (c = _tmp_70_rule(p), 1)
+            (c = _tmp_71_rule(p), 1)
             &&
-            (d = _tmp_71_rule(p), 1)
+            (d = _tmp_72_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -5071,9 +5079,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_with_default_rule(p))
             &&
-            (b = _tmp_72_rule(p), 1)
+            (b = _tmp_73_rule(p), 1)
             &&
-            (c = _tmp_73_rule(p), 1)
+            (c = _tmp_74_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -5092,9 +5100,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_plain_names_rule(p))
             &&
-            (b = _tmp_74_rule(p), 1)
+            (b = _tmp_75_rule(p), 1)
             &&
-            (c = _tmp_75_rule(p), 1)
+            (c = _tmp_76_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -5112,7 +5120,7 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_names_with_default_rule(p))
             &&
-            (b = _tmp_76_rule(p), 1)
+            (b = _tmp_77_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -5194,7 +5202,7 @@ lambda_slash_with_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _tmp_77_rule(p), 1)
+            (a = _tmp_78_rule(p), 1)
             &&
             (b = lambda_names_with_default_rule(p))
             &&
@@ -5241,9 +5249,9 @@ lambda_star_etc_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _loop0_78_rule(p))
+            (b = _loop0_79_rule(p))
             &&
-            (c = _tmp_79_rule(p), 1)
+            (c = _tmp_80_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -5266,9 +5274,9 @@ lambda_star_etc_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (b = _loop1_80_rule(p))
+            (b = _loop1_81_rule(p))
             &&
-            (c = _tmp_81_rule(p), 1)
+            (c = _tmp_82_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -5324,7 +5332,7 @@ lambda_name_with_optional_default_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _tmp_82_rule(p), 1)
+            (b = _tmp_83_rule(p), 1)
         )
         {
             res = _PyPegen_name_default_pair ( p , a , b , NULL );
@@ -5353,7 +5361,7 @@ lambda_names_with_default_rule(Parser *p)
     { // ','.lambda_name_with_default+
         asdl_seq * a;
         if (
-            (a = _gather_83_rule(p))
+            (a = _gather_84_rule(p))
         )
         {
             res = a;
@@ -5417,7 +5425,7 @@ lambda_plain_names_rule(Parser *p)
     { // ','.(lambda_plain_name !'=')+
         asdl_seq * a;
         if (
-            (a = _gather_85_rule(p))
+            (a = _gather_86_rule(p))
         )
         {
             res = a;
@@ -5536,7 +5544,7 @@ disjunction_rule(Parser *p)
         if (
             (a = conjunction_rule(p))
             &&
-            (b = _loop1_87_rule(p))
+            (b = _loop1_88_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5598,7 +5606,7 @@ conjunction_rule(Parser *p)
         if (
             (a = inversion_rule(p))
             &&
-            (b = _loop1_88_rule(p))
+            (b = _loop1_89_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5720,7 +5728,7 @@ comparison_rule(Parser *p)
         if (
             (a = bitwise_or_rule(p))
             &&
-            (b = _loop1_89_rule(p))
+            (b = _loop1_90_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5932,10 +5940,10 @@ noteq_bitwise_or_rule(Parser *p)
     CmpopExprPair* res = NULL;
     int mark = p->mark;
     { // ('!=') bitwise_or
-        void *_tmp_90_var;
+        void *_tmp_91_var;
         expr_ty a;
         if (
-            (_tmp_90_var = _tmp_90_rule(p))
+            (_tmp_91_var = _tmp_91_rule(p))
             &&
             (a = bitwise_or_rule(p))
         )
@@ -7377,7 +7385,7 @@ slices_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_91_rule(p))
+            (a = _gather_92_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -7433,7 +7441,7 @@ slice_rule(Parser *p)
             &&
             (b = expression_rule(p), 1)
             &&
-            (c = _tmp_93_rule(p), 1)
+            (c = _tmp_94_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7621,22 +7629,9 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // &'(' (tuple | group | genexp)
-        void *_tmp_94_var;
-        if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)
-            &&
-            (_tmp_94_var = _tmp_94_rule(p))
-        )
-        {
-            res = _tmp_94_var;
-            goto done;
-        }
-        p->mark = mark;
-    }
-    { // &'[' (list | listcomp)
         void *_tmp_95_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)
             &&
             (_tmp_95_var = _tmp_95_rule(p))
         )
@@ -7646,15 +7641,28 @@ atom_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // &'{' (dict | set | dictcomp | setcomp)
+    { // &'[' (list | listcomp)
         void *_tmp_96_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)
             &&
             (_tmp_96_var = _tmp_96_rule(p))
         )
         {
             res = _tmp_96_var;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // &'{' (dict | set | dictcomp | setcomp)
+        void *_tmp_97_var;
+        if (
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)
+            &&
+            (_tmp_97_var = _tmp_97_rule(p))
+        )
+        {
+            res = _tmp_97_var;
             goto done;
         }
         p->mark = mark;
@@ -7701,7 +7709,7 @@ strings_rule(Parser *p)
     { // STRING+
         asdl_seq * a;
         if (
-            (a = _loop1_97_rule(p))
+            (a = _loop1_98_rule(p))
         )
         {
             res = _PyPegen_concatenate_strings ( p , a );
@@ -7859,7 +7867,7 @@ tuple_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_98_rule(p), 1)
+            (a = _tmp_99_rule(p), 1)
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -7902,7 +7910,7 @@ group_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_99_rule(p))
+            (a = _tmp_100_rule(p))
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -8221,7 +8229,7 @@ kvpairs_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_100_rule(p))
+            (a = _gather_101_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8305,7 +8313,7 @@ for_if_clauses_rule(Parser *p)
     { // ((ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*))+
         asdl_seq * a;
         if (
-            (a = _loop1_102_rule(p))
+            (a = _loop1_103_rule(p))
         )
         {
             res = a;
@@ -8471,7 +8479,7 @@ args_rule(Parser *p)
         if (
             (a = starred_expression_rule(p))
             &&
-            (b = _tmp_103_rule(p), 1)
+            (b = _tmp_104_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8520,7 +8528,7 @@ args_rule(Parser *p)
         if (
             (a = named_expression_rule(p))
             &&
-            (b = _tmp_104_rule(p), 1)
+            (b = _tmp_105_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8562,11 +8570,11 @@ kwargs_rule(Parser *p)
         asdl_seq * b;
         void *literal;
         if (
-            (a = _gather_105_rule(p))
+            (a = _gather_106_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (b = _gather_107_rule(p))
+            (b = _gather_108_rule(p))
         )
         {
             res = _PyPegen_join_sequences ( p , a , b );
@@ -8579,23 +8587,23 @@ kwargs_rule(Parser *p)
         p->mark = mark;
     }
     { // ','.kwarg_or_starred+
-        asdl_seq * _gather_109_var;
+        asdl_seq * _gather_110_var;
         if (
-            (_gather_109_var = _gather_109_rule(p))
+            (_gather_110_var = _gather_110_rule(p))
         )
         {
-            res = _gather_109_var;
+            res = _gather_110_var;
             goto done;
         }
         p->mark = mark;
     }
     { // ','.kwarg_or_double_starred+
-        asdl_seq * _gather_111_var;
+        asdl_seq * _gather_112_var;
         if (
-            (_gather_111_var = _gather_111_rule(p))
+            (_gather_112_var = _gather_112_rule(p))
         )
         {
-            res = _gather_111_var;
+            res = _gather_112_var;
             goto done;
         }
         p->mark = mark;
@@ -8838,7 +8846,7 @@ star_targets_rule(Parser *p)
         if (
             (a = star_target_rule(p))
             &&
-            (b = _loop0_113_rule(p))
+            (b = _loop0_114_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8879,7 +8887,7 @@ star_targets_seq_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_114_rule(p))
+            (a = _gather_115_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8927,7 +8935,7 @@ star_target_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (a = _tmp_116_rule(p))
+            (a = _tmp_117_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9316,7 +9324,7 @@ del_targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_117_rule(p))
+            (a = _gather_118_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -9569,7 +9577,7 @@ targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_119_rule(p))
+            (a = _gather_120_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -10097,7 +10105,7 @@ incorrect_arguments_rule(Parser *p)
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (opt_var = _tmp_121_rule(p), 1)
+            (opt_var = _tmp_122_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "Generator expression must be parenthesized" );
@@ -10232,7 +10240,7 @@ invalid_assignment_rule(Parser *p)
             &&
             (expression_var_1 = expression_rule(p))
             &&
-            (opt_var = _tmp_122_rule(p), 1)
+            (opt_var = _tmp_123_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "illegal target for annotation" );
@@ -10245,15 +10253,15 @@ invalid_assignment_rule(Parser *p)
         p->mark = mark;
     }
     { // expression ('=' | augassign) (yield_expr | star_expressions)
-        void *_tmp_123_var;
         void *_tmp_124_var;
+        void *_tmp_125_var;
         expr_ty a;
         if (
             (a = expression_rule(p))
             &&
-            (_tmp_123_var = _tmp_123_rule(p))
-            &&
             (_tmp_124_var = _tmp_124_rule(p))
+            &&
+            (_tmp_125_var = _tmp_125_rule(p))
         )
         {
             res = RAISE_SYNTAX_ERROR ( "cannot assign to %s" , _PyPegen_get_expr_name ( a ) );
@@ -10311,12 +10319,12 @@ invalid_comprehension_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ('[' | '(' | '{') '*' expression for_if_clauses
-        void *_tmp_125_var;
+        void *_tmp_126_var;
         expr_ty expression_var;
         asdl_seq* for_if_clauses_var;
         void *literal;
         if (
-            (_tmp_125_var = _tmp_125_rule(p))
+            (_tmp_126_var = _tmp_126_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -10350,13 +10358,13 @@ invalid_parameters_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // param_no_default* (slash_with_default | param_with_default+) param_no_default
-        asdl_seq * _loop0_126_var;
-        void *_tmp_127_var;
+        asdl_seq * _loop0_127_var;
+        void *_tmp_128_var;
         arg_ty param_no_default_var;
         if (
-            (_loop0_126_var = _loop0_126_rule(p))
+            (_loop0_127_var = _loop0_127_rule(p))
             &&
-            (_tmp_127_var = _tmp_127_rule(p))
+            (_tmp_128_var = _tmp_128_rule(p))
             &&
             (param_no_default_var = param_no_default_rule(p))
         )
@@ -10465,9 +10473,58 @@ _loop0_1_rule(Parser *p)
     return seq;
 }
 
-// _loop0_3: ',' expression
+// _loop0_2: NEWLINE
 static asdl_seq *
-_loop0_3_rule(Parser *p)
+_loop0_2_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // NEWLINE
+        void *newline_var;
+        while (
+            (newline_var = _PyPegen_expect_token(p, NEWLINE))
+        )
+        {
+            res = newline_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_2");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_2_type, seq);
+    return seq;
+}
+
+// _loop0_4: ',' expression
+static asdl_seq *
+_loop0_4_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10512,32 +10569,32 @@ _loop0_3_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_3");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_4");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_3_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_4_type, seq);
     return seq;
 }
 
-// _gather_2: expression _loop0_3
+// _gather_3: expression _loop0_4
 static asdl_seq *
-_gather_2_rule(Parser *p)
+_gather_3_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // expression _loop0_3
+    { // expression _loop0_4
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = expression_rule(p))
             &&
-            (seq = _loop0_3_rule(p))
+            (seq = _loop0_4_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -10550,9 +10607,9 @@ _gather_2_rule(Parser *p)
     return res;
 }
 
-// _loop0_5: ',' expression
+// _loop0_6: ',' expression
 static asdl_seq *
-_loop0_5_rule(Parser *p)
+_loop0_6_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10597,32 +10654,32 @@ _loop0_5_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_5");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_6");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_5_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_6_type, seq);
     return seq;
 }
 
-// _gather_4: expression _loop0_5
+// _gather_5: expression _loop0_6
 static asdl_seq *
-_gather_4_rule(Parser *p)
+_gather_5_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // expression _loop0_5
+    { // expression _loop0_6
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = expression_rule(p))
             &&
-            (seq = _loop0_5_rule(p))
+            (seq = _loop0_6_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -10635,9 +10692,9 @@ _gather_4_rule(Parser *p)
     return res;
 }
 
-// _loop0_7: ',' expression
+// _loop0_8: ',' expression
 static asdl_seq *
-_loop0_7_rule(Parser *p)
+_loop0_8_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10682,32 +10739,32 @@ _loop0_7_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_7");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_8");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_7_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_8_type, seq);
     return seq;
 }
 
-// _gather_6: expression _loop0_7
+// _gather_7: expression _loop0_8
 static asdl_seq *
-_gather_6_rule(Parser *p)
+_gather_7_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // expression _loop0_7
+    { // expression _loop0_8
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = expression_rule(p))
             &&
-            (seq = _loop0_7_rule(p))
+            (seq = _loop0_8_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -10720,9 +10777,9 @@ _gather_6_rule(Parser *p)
     return res;
 }
 
-// _loop0_9: ',' expression
+// _loop0_10: ',' expression
 static asdl_seq *
-_loop0_9_rule(Parser *p)
+_loop0_10_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10767,32 +10824,32 @@ _loop0_9_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_9");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_10");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_9_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_10_type, seq);
     return seq;
 }
 
-// _gather_8: expression _loop0_9
+// _gather_9: expression _loop0_10
 static asdl_seq *
-_gather_8_rule(Parser *p)
+_gather_9_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // expression _loop0_9
+    { // expression _loop0_10
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = expression_rule(p))
             &&
-            (seq = _loop0_9_rule(p))
+            (seq = _loop0_10_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -10805,9 +10862,9 @@ _gather_8_rule(Parser *p)
     return res;
 }
 
-// _loop1_10: statement
+// _loop1_11: statement
 static asdl_seq *
-_loop1_10_rule(Parser *p)
+_loop1_11_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10848,19 +10905,19 @@ _loop1_10_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_10");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_11");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_10_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_11_type, seq);
     return seq;
 }
 
-// _loop0_12: ';' small_stmt
+// _loop0_13: ';' small_stmt
 static asdl_seq *
-_loop0_12_rule(Parser *p)
+_loop0_13_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10905,32 +10962,32 @@ _loop0_12_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_12");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_13");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_12_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_13_type, seq);
     return seq;
 }
 
-// _gather_11: small_stmt _loop0_12
+// _gather_12: small_stmt _loop0_13
 static asdl_seq *
-_gather_11_rule(Parser *p)
+_gather_12_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // small_stmt _loop0_12
+    { // small_stmt _loop0_13
         stmt_ty elem;
         asdl_seq * seq;
         if (
             (elem = small_stmt_rule(p))
             &&
-            (seq = _loop0_12_rule(p))
+            (seq = _loop0_13_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -10943,9 +11000,9 @@ _gather_11_rule(Parser *p)
     return res;
 }
 
-// _tmp_13: 'import' | 'from'
+// _tmp_14: 'import' | 'from'
 static void *
-_tmp_13_rule(Parser *p)
+_tmp_14_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -10979,9 +11036,9 @@ _tmp_13_rule(Parser *p)
     return res;
 }
 
-// _tmp_14: 'def' | '@' | ASYNC
+// _tmp_15: 'def' | '@' | ASYNC
 static void *
-_tmp_14_rule(Parser *p)
+_tmp_15_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11026,9 +11083,9 @@ _tmp_14_rule(Parser *p)
     return res;
 }
 
-// _tmp_15: 'class' | '@'
+// _tmp_16: 'class' | '@'
 static void *
-_tmp_15_rule(Parser *p)
+_tmp_16_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11062,9 +11119,9 @@ _tmp_15_rule(Parser *p)
     return res;
 }
 
-// _tmp_16: 'with' | ASYNC
+// _tmp_17: 'with' | ASYNC
 static void *
-_tmp_16_rule(Parser *p)
+_tmp_17_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11098,9 +11155,9 @@ _tmp_16_rule(Parser *p)
     return res;
 }
 
-// _tmp_17: 'for' | ASYNC
+// _tmp_18: 'for' | ASYNC
 static void *
-_tmp_17_rule(Parser *p)
+_tmp_18_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11134,9 +11191,9 @@ _tmp_17_rule(Parser *p)
     return res;
 }
 
-// _tmp_18: '=' annotated_rhs
+// _tmp_19: '=' annotated_rhs
 static void *
-_tmp_18_rule(Parser *p)
+_tmp_19_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11166,9 +11223,9 @@ _tmp_18_rule(Parser *p)
     return res;
 }
 
-// _tmp_19: '(' inside_paren_ann_assign_target ')' | ann_assign_subscript_attribute_target
+// _tmp_20: '(' inside_paren_ann_assign_target ')' | ann_assign_subscript_attribute_target
 static void *
-_tmp_19_rule(Parser *p)
+_tmp_20_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11212,9 +11269,9 @@ _tmp_19_rule(Parser *p)
     return res;
 }
 
-// _tmp_20: '=' annotated_rhs
+// _tmp_21: '=' annotated_rhs
 static void *
-_tmp_20_rule(Parser *p)
+_tmp_21_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11244,9 +11301,9 @@ _tmp_20_rule(Parser *p)
     return res;
 }
 
-// _loop1_21: (star_targets '=')
+// _loop1_22: (star_targets '=')
 static asdl_seq *
-_loop1_21_rule(Parser *p)
+_loop1_22_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11262,12 +11319,12 @@ _loop1_21_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (star_targets '=')
-        void *_tmp_128_var;
+        void *_tmp_129_var;
         while (
-            (_tmp_128_var = _tmp_128_rule(p))
+            (_tmp_129_var = _tmp_129_rule(p))
         )
         {
-            res = _tmp_128_var;
+            res = _tmp_129_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -11287,50 +11344,14 @@ _loop1_21_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_21");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_22");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_21_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_22_type, seq);
     return seq;
-}
-
-// _tmp_22: yield_expr | star_expressions
-static void *
-_tmp_22_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // yield_expr
-        expr_ty yield_expr_var;
-        if (
-            (yield_expr_var = yield_expr_rule(p))
-        )
-        {
-            res = yield_expr_var;
-            goto done;
-        }
-        p->mark = mark;
-    }
-    { // star_expressions
-        expr_ty star_expressions_var;
-        if (
-            (star_expressions_var = star_expressions_rule(p))
-        )
-        {
-            res = star_expressions_var;
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
 }
 
 // _tmp_23: yield_expr | star_expressions
@@ -11369,179 +11390,215 @@ _tmp_23_rule(Parser *p)
     return res;
 }
 
-// _loop0_25: ',' NAME
-static asdl_seq *
-_loop0_25_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ',' NAME
-        expr_ty elem;
-        void *literal;
-        while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = _PyPegen_name_token(p))
-        )
-        {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_25");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_25_type, seq);
-    return seq;
-}
-
-// _gather_24: NAME _loop0_25
-static asdl_seq *
-_gather_24_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // NAME _loop0_25
-        expr_ty elem;
-        asdl_seq * seq;
-        if (
-            (elem = _PyPegen_name_token(p))
-            &&
-            (seq = _loop0_25_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_27: ',' NAME
-static asdl_seq *
-_loop0_27_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ',' NAME
-        expr_ty elem;
-        void *literal;
-        while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = _PyPegen_name_token(p))
-        )
-        {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_27");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_27_type, seq);
-    return seq;
-}
-
-// _gather_26: NAME _loop0_27
-static asdl_seq *
-_gather_26_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // NAME _loop0_27
-        expr_ty elem;
-        asdl_seq * seq;
-        if (
-            (elem = _PyPegen_name_token(p))
-            &&
-            (seq = _loop0_27_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_28: ',' expression
+// _tmp_24: yield_expr | star_expressions
 static void *
-_tmp_28_rule(Parser *p)
+_tmp_24_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // yield_expr
+        expr_ty yield_expr_var;
+        if (
+            (yield_expr_var = yield_expr_rule(p))
+        )
+        {
+            res = yield_expr_var;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // star_expressions
+        expr_ty star_expressions_var;
+        if (
+            (star_expressions_var = star_expressions_rule(p))
+        )
+        {
+            res = star_expressions_var;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_26: ',' NAME
+static asdl_seq *
+_loop0_26_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' NAME
+        expr_ty elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = _PyPegen_name_token(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_26");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_26_type, seq);
+    return seq;
+}
+
+// _gather_25: NAME _loop0_26
+static asdl_seq *
+_gather_25_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // NAME _loop0_26
+        expr_ty elem;
+        asdl_seq * seq;
+        if (
+            (elem = _PyPegen_name_token(p))
+            &&
+            (seq = _loop0_26_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_28: ',' NAME
+static asdl_seq *
+_loop0_28_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' NAME
+        expr_ty elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = _PyPegen_name_token(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_28");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_28_type, seq);
+    return seq;
+}
+
+// _gather_27: NAME _loop0_28
+static asdl_seq *
+_gather_27_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // NAME _loop0_28
+        expr_ty elem;
+        asdl_seq * seq;
+        if (
+            (elem = _PyPegen_name_token(p))
+            &&
+            (seq = _loop0_28_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_29: ',' expression
+static void *
+_tmp_29_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11571,58 +11628,9 @@ _tmp_28_rule(Parser *p)
     return res;
 }
 
-// _loop0_29: ('.' | '...')
+// _loop0_30: ('.' | '...')
 static asdl_seq *
-_loop0_29_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ('.' | '...')
-        void *_tmp_129_var;
-        while (
-            (_tmp_129_var = _tmp_129_rule(p))
-        )
-        {
-            res = _tmp_129_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_29");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_29_type, seq);
-    return seq;
-}
-
-// _loop1_30: ('.' | '...')
-static asdl_seq *
-_loop1_30_rule(Parser *p)
+_loop0_30_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11657,25 +11665,74 @@ _loop1_30_rule(Parser *p)
         }
         p->mark = mark;
     }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_30");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_30_type, seq);
+    return seq;
+}
+
+// _loop1_31: ('.' | '...')
+static asdl_seq *
+_loop1_31_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ('.' | '...')
+        void *_tmp_131_var;
+        while (
+            (_tmp_131_var = _tmp_131_rule(p))
+        )
+        {
+            res = _tmp_131_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
     if (n == 0) {
         PyMem_Free(children);
         return NULL;
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_30");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_31");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_30_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_31_type, seq);
     return seq;
 }
 
-// _loop0_32: ',' import_from_as_name
+// _loop0_33: ',' import_from_as_name
 static asdl_seq *
-_loop0_32_rule(Parser *p)
+_loop0_33_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11720,32 +11777,32 @@ _loop0_32_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_32");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_33");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_32_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_33_type, seq);
     return seq;
 }
 
-// _gather_31: import_from_as_name _loop0_32
+// _gather_32: import_from_as_name _loop0_33
 static asdl_seq *
-_gather_31_rule(Parser *p)
+_gather_32_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // import_from_as_name _loop0_32
+    { // import_from_as_name _loop0_33
         alias_ty elem;
         asdl_seq * seq;
         if (
             (elem = import_from_as_name_rule(p))
             &&
-            (seq = _loop0_32_rule(p))
+            (seq = _loop0_33_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11758,9 +11815,9 @@ _gather_31_rule(Parser *p)
     return res;
 }
 
-// _tmp_33: 'as' NAME
+// _tmp_34: 'as' NAME
 static void *
-_tmp_33_rule(Parser *p)
+_tmp_34_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11790,9 +11847,9 @@ _tmp_33_rule(Parser *p)
     return res;
 }
 
-// _loop0_35: ',' dotted_as_name
+// _loop0_36: ',' dotted_as_name
 static asdl_seq *
-_loop0_35_rule(Parser *p)
+_loop0_36_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11837,32 +11894,32 @@ _loop0_35_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_35");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_36");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_35_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_36_type, seq);
     return seq;
 }
 
-// _gather_34: dotted_as_name _loop0_35
+// _gather_35: dotted_as_name _loop0_36
 static asdl_seq *
-_gather_34_rule(Parser *p)
+_gather_35_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // dotted_as_name _loop0_35
+    { // dotted_as_name _loop0_36
         alias_ty elem;
         asdl_seq * seq;
         if (
             (elem = dotted_as_name_rule(p))
             &&
-            (seq = _loop0_35_rule(p))
+            (seq = _loop0_36_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11875,9 +11932,9 @@ _gather_34_rule(Parser *p)
     return res;
 }
 
-// _tmp_36: 'as' NAME
+// _tmp_37: 'as' NAME
 static void *
-_tmp_36_rule(Parser *p)
+_tmp_37_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11907,9 +11964,9 @@ _tmp_36_rule(Parser *p)
     return res;
 }
 
-// _loop0_38: ',' with_item
+// _loop0_39: ',' with_item
 static asdl_seq *
-_loop0_38_rule(Parser *p)
+_loop0_39_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -11954,32 +12011,32 @@ _loop0_38_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_38");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_39");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_38_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_39_type, seq);
     return seq;
 }
 
-// _gather_37: with_item _loop0_38
+// _gather_38: with_item _loop0_39
 static asdl_seq *
-_gather_37_rule(Parser *p)
+_gather_38_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // with_item _loop0_38
+    { // with_item _loop0_39
         withitem_ty elem;
         asdl_seq * seq;
         if (
             (elem = with_item_rule(p))
             &&
-            (seq = _loop0_38_rule(p))
+            (seq = _loop0_39_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -11992,9 +12049,9 @@ _gather_37_rule(Parser *p)
     return res;
 }
 
-// _loop0_40: ',' with_item
+// _loop0_41: ',' with_item
 static asdl_seq *
-_loop0_40_rule(Parser *p)
+_loop0_41_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12039,32 +12096,32 @@ _loop0_40_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_40");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_41");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_40_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_41_type, seq);
     return seq;
 }
 
-// _gather_39: with_item _loop0_40
+// _gather_40: with_item _loop0_41
 static asdl_seq *
-_gather_39_rule(Parser *p)
+_gather_40_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // with_item _loop0_40
+    { // with_item _loop0_41
         withitem_ty elem;
         asdl_seq * seq;
         if (
             (elem = with_item_rule(p))
             &&
-            (seq = _loop0_40_rule(p))
+            (seq = _loop0_41_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -12077,9 +12134,9 @@ _gather_39_rule(Parser *p)
     return res;
 }
 
-// _tmp_41: 'as' target
+// _tmp_42: 'as' target
 static void *
-_tmp_41_rule(Parser *p)
+_tmp_42_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12109,9 +12166,9 @@ _tmp_41_rule(Parser *p)
     return res;
 }
 
-// _loop1_42: except_block
+// _loop1_43: except_block
 static asdl_seq *
-_loop1_42_rule(Parser *p)
+_loop1_43_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12152,19 +12209,19 @@ _loop1_42_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_42");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_43");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_42_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_43_type, seq);
     return seq;
 }
 
-// _tmp_43: 'as' target
+// _tmp_44: 'as' target
 static void *
-_tmp_43_rule(Parser *p)
+_tmp_44_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12194,9 +12251,9 @@ _tmp_43_rule(Parser *p)
     return res;
 }
 
-// _tmp_44: 'from' expression
+// _tmp_45: 'from' expression
 static void *
-_tmp_44_rule(Parser *p)
+_tmp_45_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12226,9 +12283,9 @@ _tmp_44_rule(Parser *p)
     return res;
 }
 
-// _tmp_45: '->' expression
+// _tmp_46: '->' expression
 static void *
-_tmp_45_rule(Parser *p)
+_tmp_46_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12258,9 +12315,9 @@ _tmp_45_rule(Parser *p)
     return res;
 }
 
-// _tmp_46: NEWLINE INDENT
+// _tmp_47: NEWLINE INDENT
 static void *
-_tmp_46_rule(Parser *p)
+_tmp_47_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12286,9 +12343,9 @@ _tmp_46_rule(Parser *p)
     return res;
 }
 
-// _loop0_47: param_no_default
+// _loop0_48: param_no_default
 static asdl_seq *
-_loop0_47_rule(Parser *p)
+_loop0_48_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12310,55 +12367,6 @@ _loop0_47_rule(Parser *p)
         )
         {
             res = param_no_default_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_47");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_47_type, seq);
-    return seq;
-}
-
-// _loop0_48: param_with_default
-static asdl_seq *
-_loop0_48_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // param_with_default
-        NameDefaultPair* param_with_default_var;
-        while (
-            (param_with_default_var = param_with_default_rule(p))
-        )
-        {
-            res = param_with_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12433,9 +12441,58 @@ _loop0_49_rule(Parser *p)
     return seq;
 }
 
-// _loop1_50: param_no_default
+// _loop0_50: param_with_default
 static asdl_seq *
-_loop1_50_rule(Parser *p)
+_loop0_50_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
+        while (
+            (param_with_default_var = param_with_default_rule(p))
+        )
+        {
+            res = param_with_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_50");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_50_type, seq);
+    return seq;
+}
+
+// _loop1_51: param_no_default
+static asdl_seq *
+_loop1_51_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12476,19 +12533,19 @@ _loop1_50_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_50");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_51");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_50_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_51_type, seq);
     return seq;
 }
 
-// _loop0_51: param_with_default
+// _loop0_52: param_with_default
 static asdl_seq *
-_loop0_51_rule(Parser *p)
+_loop0_52_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12525,70 +12582,17 @@ _loop0_51_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_51");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_52");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_51_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_52_type, seq);
     return seq;
 }
 
-// _loop1_52: param_with_default
-static asdl_seq *
-_loop1_52_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // param_with_default
-        NameDefaultPair* param_with_default_var;
-        while (
-            (param_with_default_var = param_with_default_rule(p))
-        )
-        {
-            res = param_with_default_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    if (n == 0) {
-        PyMem_Free(children);
-        return NULL;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_52");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_52_type, seq);
-    return seq;
-}
-
-// _loop1_53: param_no_default
+// _loop1_53: param_with_default
 static asdl_seq *
 _loop1_53_rule(Parser *p)
 {
@@ -12605,13 +12609,13 @@ _loop1_53_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // param_no_default
-        arg_ty param_no_default_var;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
         while (
-            (param_no_default_var = param_no_default_rule(p))
+            (param_with_default_var = param_with_default_rule(p))
         )
         {
-            res = param_no_default_var;
+            res = param_with_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12694,9 +12698,62 @@ _loop1_54_rule(Parser *p)
     return seq;
 }
 
-// _loop0_55: param_no_default
+// _loop1_55: param_no_default
 static asdl_seq *
-_loop0_55_rule(Parser *p)
+_loop1_55_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_no_default
+        arg_ty param_no_default_var;
+        while (
+            (param_no_default_var = param_no_default_rule(p))
+        )
+        {
+            res = param_no_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_55");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_55_type, seq);
+    return seq;
+}
+
+// _loop0_56: param_no_default
+static asdl_seq *
+_loop0_56_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12733,19 +12790,19 @@ _loop0_55_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_55");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_56");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_55_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_56_type, seq);
     return seq;
 }
 
-// _loop1_56: param_with_default
+// _loop1_57: param_with_default
 static asdl_seq *
-_loop1_56_rule(Parser *p)
+_loop1_57_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12786,19 +12843,19 @@ _loop1_56_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_56");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_57");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_56_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_57_type, seq);
     return seq;
 }
 
-// _loop0_57: param_no_default
+// _loop0_58: param_no_default
 static asdl_seq *
-_loop0_57_rule(Parser *p)
+_loop0_58_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12835,19 +12892,19 @@ _loop0_57_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_57");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_58");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_57_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_58_type, seq);
     return seq;
 }
 
-// _loop1_58: param_with_default
+// _loop1_59: param_with_default
 static asdl_seq *
-_loop1_58_rule(Parser *p)
+_loop1_59_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12888,19 +12945,19 @@ _loop1_58_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_58");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_59");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_58_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_59_type, seq);
     return seq;
 }
 
-// _loop0_59: param_maybe_default
+// _loop0_60: param_maybe_default
 static asdl_seq *
-_loop0_59_rule(Parser *p)
+_loop0_60_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12937,70 +12994,17 @@ _loop0_59_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_59");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_60");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_59_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_60_type, seq);
     return seq;
 }
 
-// _loop1_60: param_maybe_default
-static asdl_seq *
-_loop1_60_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // param_maybe_default
-        NameDefaultPair* param_maybe_default_var;
-        while (
-            (param_maybe_default_var = param_maybe_default_rule(p))
-        )
-        {
-            res = param_maybe_default_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    if (n == 0) {
-        PyMem_Free(children);
-        return NULL;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_60");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_60_type, seq);
-    return seq;
-}
-
-// _loop1_61: ('@' named_expression NEWLINE)
+// _loop1_61: param_maybe_default
 static asdl_seq *
 _loop1_61_rule(Parser *p)
 {
@@ -13017,13 +13021,13 @@ _loop1_61_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // ('@' named_expression NEWLINE)
-        void *_tmp_131_var;
+    { // param_maybe_default
+        NameDefaultPair* param_maybe_default_var;
         while (
-            (_tmp_131_var = _tmp_131_rule(p))
+            (param_maybe_default_var = param_maybe_default_rule(p))
         )
         {
-            res = _tmp_131_var;
+            res = param_maybe_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13053,9 +13057,62 @@ _loop1_61_rule(Parser *p)
     return seq;
 }
 
-// _tmp_62: '(' arguments? ')'
+// _loop1_62: ('@' named_expression NEWLINE)
+static asdl_seq *
+_loop1_62_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ('@' named_expression NEWLINE)
+        void *_tmp_132_var;
+        while (
+            (_tmp_132_var = _tmp_132_rule(p))
+        )
+        {
+            res = _tmp_132_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_62");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_62_type, seq);
+    return seq;
+}
+
+// _tmp_63: '(' arguments? ')'
 static void *
-_tmp_62_rule(Parser *p)
+_tmp_63_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13088,9 +13145,9 @@ _tmp_62_rule(Parser *p)
     return res;
 }
 
-// _loop0_64: ',' star_expression
+// _loop0_65: ',' star_expression
 static asdl_seq *
-_loop0_64_rule(Parser *p)
+_loop0_65_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13135,32 +13192,32 @@ _loop0_64_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_64");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_65");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_64_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_65_type, seq);
     return seq;
 }
 
-// _gather_63: star_expression _loop0_64
+// _gather_64: star_expression _loop0_65
 static asdl_seq *
-_gather_63_rule(Parser *p)
+_gather_64_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_expression _loop0_64
+    { // star_expression _loop0_65
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_expression_rule(p))
             &&
-            (seq = _loop0_64_rule(p))
+            (seq = _loop0_65_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13173,9 +13230,9 @@ _gather_63_rule(Parser *p)
     return res;
 }
 
-// _loop1_65: (',' star_expression)
+// _loop1_66: (',' star_expression)
 static asdl_seq *
-_loop1_65_rule(Parser *p)
+_loop1_66_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13191,12 +13248,12 @@ _loop1_65_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_expression)
-        void *_tmp_132_var;
+        void *_tmp_133_var;
         while (
-            (_tmp_132_var = _tmp_132_rule(p))
+            (_tmp_133_var = _tmp_133_rule(p))
         )
         {
-            res = _tmp_132_var;
+            res = _tmp_133_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13216,19 +13273,19 @@ _loop1_65_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_65");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_66");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_65_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_66_type, seq);
     return seq;
 }
 
-// _loop0_67: ',' star_named_expression
+// _loop0_68: ',' star_named_expression
 static asdl_seq *
-_loop0_67_rule(Parser *p)
+_loop0_68_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13273,32 +13330,32 @@ _loop0_67_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_67");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_68");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_67_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_68_type, seq);
     return seq;
 }
 
-// _gather_66: star_named_expression _loop0_67
+// _gather_67: star_named_expression _loop0_68
 static asdl_seq *
-_gather_66_rule(Parser *p)
+_gather_67_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_named_expression _loop0_67
+    { // star_named_expression _loop0_68
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_named_expression_rule(p))
             &&
-            (seq = _loop0_67_rule(p))
+            (seq = _loop0_68_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13311,9 +13368,9 @@ _gather_66_rule(Parser *p)
     return res;
 }
 
-// _loop1_68: (',' expression)
+// _loop1_69: (',' expression)
 static asdl_seq *
-_loop1_68_rule(Parser *p)
+_loop1_69_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13329,12 +13386,12 @@ _loop1_68_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' expression)
-        void *_tmp_133_var;
+        void *_tmp_134_var;
         while (
-            (_tmp_133_var = _tmp_133_rule(p))
+            (_tmp_134_var = _tmp_134_rule(p))
         )
         {
-            res = _tmp_133_var;
+            res = _tmp_134_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13354,19 +13411,19 @@ _loop1_68_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_68");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_69");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_68_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_69_type, seq);
     return seq;
 }
 
-// _tmp_69: ',' lambda_plain_names
+// _tmp_70: ',' lambda_plain_names
 static void *
-_tmp_69_rule(Parser *p)
+_tmp_70_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13396,39 +13453,7 @@ _tmp_69_rule(Parser *p)
     return res;
 }
 
-// _tmp_70: ',' lambda_names_with_default
-static void *
-_tmp_70_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = lambda_names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_71: ',' lambda_star_etc?
+// _tmp_71: ',' lambda_names_with_default
 static void *
 _tmp_71_rule(Parser *p)
 {
@@ -13437,16 +13462,16 @@ _tmp_71_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' lambda_star_etc?
+    { // ',' lambda_names_with_default
         void *literal;
-        void *z;
+        asdl_seq* y;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (z = lambda_star_etc_rule(p), 1)
+            (y = lambda_names_with_default_rule(p))
         )
         {
-            res = z;
+            res = y;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -13460,7 +13485,7 @@ _tmp_71_rule(Parser *p)
     return res;
 }
 
-// _tmp_72: ',' lambda_names_with_default
+// _tmp_72: ',' lambda_star_etc?
 static void *
 _tmp_72_rule(Parser *p)
 {
@@ -13469,16 +13494,16 @@ _tmp_72_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' lambda_names_with_default
+    { // ',' lambda_star_etc?
         void *literal;
-        asdl_seq* y;
+        void *z;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (y = lambda_names_with_default_rule(p))
+            (z = lambda_star_etc_rule(p), 1)
         )
         {
-            res = y;
+            res = z;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -13492,7 +13517,7 @@ _tmp_72_rule(Parser *p)
     return res;
 }
 
-// _tmp_73: ',' lambda_star_etc?
+// _tmp_73: ',' lambda_names_with_default
 static void *
 _tmp_73_rule(Parser *p)
 {
@@ -13501,38 +13526,6 @@ _tmp_73_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' lambda_star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = lambda_star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_74: ',' lambda_names_with_default
-static void *
-_tmp_74_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
     { // ',' lambda_names_with_default
         void *literal;
         asdl_seq* y;
@@ -13556,9 +13549,9 @@ _tmp_74_rule(Parser *p)
     return res;
 }
 
-// _tmp_75: ',' lambda_star_etc?
+// _tmp_74: ',' lambda_star_etc?
 static void *
-_tmp_75_rule(Parser *p)
+_tmp_74_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13575,6 +13568,38 @@ _tmp_75_rule(Parser *p)
         )
         {
             res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_75: ',' lambda_names_with_default
+static void *
+_tmp_75_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_names_with_default
+        void *literal;
+        asdl_seq* y;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (y = lambda_names_with_default_rule(p))
+        )
+        {
+            res = y;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -13620,9 +13645,41 @@ _tmp_76_rule(Parser *p)
     return res;
 }
 
-// _tmp_77: lambda_plain_names ','
+// _tmp_77: ',' lambda_star_etc?
 static void *
 _tmp_77_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_star_etc?
+        void *literal;
+        void *z;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (z = lambda_star_etc_rule(p), 1)
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_78: lambda_plain_names ','
+static void *
+_tmp_78_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13652,9 +13709,9 @@ _tmp_77_rule(Parser *p)
     return res;
 }
 
-// _loop0_78: lambda_name_with_optional_default
+// _loop0_79: lambda_name_with_optional_default
 static asdl_seq *
-_loop0_78_rule(Parser *p)
+_loop0_79_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13691,19 +13748,19 @@ _loop0_78_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_78");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_79");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_78_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_79_type, seq);
     return seq;
 }
 
-// _tmp_79: ',' lambda_kwds
+// _tmp_80: ',' lambda_kwds
 static void *
-_tmp_79_rule(Parser *p)
+_tmp_80_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13733,9 +13790,9 @@ _tmp_79_rule(Parser *p)
     return res;
 }
 
-// _loop1_80: lambda_name_with_optional_default
+// _loop1_81: lambda_name_with_optional_default
 static asdl_seq *
-_loop1_80_rule(Parser *p)
+_loop1_81_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13776,19 +13833,19 @@ _loop1_80_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_80");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_81");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_80_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_81_type, seq);
     return seq;
 }
 
-// _tmp_81: ',' lambda_kwds
+// _tmp_82: ',' lambda_kwds
 static void *
-_tmp_81_rule(Parser *p)
+_tmp_82_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13818,9 +13875,9 @@ _tmp_81_rule(Parser *p)
     return res;
 }
 
-// _tmp_82: '=' expression
+// _tmp_83: '=' expression
 static void *
-_tmp_82_rule(Parser *p)
+_tmp_83_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13850,9 +13907,9 @@ _tmp_82_rule(Parser *p)
     return res;
 }
 
-// _loop0_84: ',' lambda_name_with_default
+// _loop0_85: ',' lambda_name_with_default
 static asdl_seq *
-_loop0_84_rule(Parser *p)
+_loop0_85_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13897,32 +13954,32 @@ _loop0_84_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_84");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_85");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_84_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_85_type, seq);
     return seq;
 }
 
-// _gather_83: lambda_name_with_default _loop0_84
+// _gather_84: lambda_name_with_default _loop0_85
 static asdl_seq *
-_gather_83_rule(Parser *p)
+_gather_84_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // lambda_name_with_default _loop0_84
+    { // lambda_name_with_default _loop0_85
         NameDefaultPair* elem;
         asdl_seq * seq;
         if (
             (elem = lambda_name_with_default_rule(p))
             &&
-            (seq = _loop0_84_rule(p))
+            (seq = _loop0_85_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13935,9 +13992,9 @@ _gather_83_rule(Parser *p)
     return res;
 }
 
-// _loop0_86: ',' (lambda_plain_name !'=')
+// _loop0_87: ',' (lambda_plain_name !'=')
 static asdl_seq *
-_loop0_86_rule(Parser *p)
+_loop0_87_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13958,7 +14015,7 @@ _loop0_86_rule(Parser *p)
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (elem = _tmp_134_rule(p))
+            (elem = _tmp_135_rule(p))
         )
         {
             res = elem;
@@ -13982,32 +14039,32 @@ _loop0_86_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_86");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_87");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_86_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_87_type, seq);
     return seq;
 }
 
-// _gather_85: (lambda_plain_name !'=') _loop0_86
+// _gather_86: (lambda_plain_name !'=') _loop0_87
 static asdl_seq *
-_gather_85_rule(Parser *p)
+_gather_86_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // (lambda_plain_name !'=') _loop0_86
+    { // (lambda_plain_name !'=') _loop0_87
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_134_rule(p))
+            (elem = _tmp_135_rule(p))
             &&
-            (seq = _loop0_86_rule(p))
+            (seq = _loop0_87_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14020,60 +14077,7 @@ _gather_85_rule(Parser *p)
     return res;
 }
 
-// _loop1_87: ('or' conjunction)
-static asdl_seq *
-_loop1_87_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ('or' conjunction)
-        void *_tmp_135_var;
-        while (
-            (_tmp_135_var = _tmp_135_rule(p))
-        )
-        {
-            res = _tmp_135_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    if (n == 0) {
-        PyMem_Free(children);
-        return NULL;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_87");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_87_type, seq);
-    return seq;
-}
-
-// _loop1_88: ('and' inversion)
+// _loop1_88: ('or' conjunction)
 static asdl_seq *
 _loop1_88_rule(Parser *p)
 {
@@ -14090,7 +14094,7 @@ _loop1_88_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // ('and' inversion)
+    { // ('or' conjunction)
         void *_tmp_136_var;
         while (
             (_tmp_136_var = _tmp_136_rule(p))
@@ -14126,9 +14130,62 @@ _loop1_88_rule(Parser *p)
     return seq;
 }
 
-// _loop1_89: compare_op_bitwise_or_pair
+// _loop1_89: ('and' inversion)
 static asdl_seq *
 _loop1_89_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ('and' inversion)
+        void *_tmp_137_var;
+        while (
+            (_tmp_137_var = _tmp_137_rule(p))
+        )
+        {
+            res = _tmp_137_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_89");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_89_type, seq);
+    return seq;
+}
+
+// _loop1_90: compare_op_bitwise_or_pair
+static asdl_seq *
+_loop1_90_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14169,19 +14226,19 @@ _loop1_89_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_89");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_90");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_89_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_90_type, seq);
     return seq;
 }
 
-// _tmp_90: '!='
+// _tmp_91: '!='
 static void *
-_tmp_90_rule(Parser *p)
+_tmp_91_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14208,9 +14265,9 @@ _tmp_90_rule(Parser *p)
     return res;
 }
 
-// _loop0_92: ',' slice
+// _loop0_93: ',' slice
 static asdl_seq *
-_loop0_92_rule(Parser *p)
+_loop0_93_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14255,32 +14312,32 @@ _loop0_92_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_92");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_93");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_92_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_93_type, seq);
     return seq;
 }
 
-// _gather_91: slice _loop0_92
+// _gather_92: slice _loop0_93
 static asdl_seq *
-_gather_91_rule(Parser *p)
+_gather_92_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // slice _loop0_92
+    { // slice _loop0_93
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = slice_rule(p))
             &&
-            (seq = _loop0_92_rule(p))
+            (seq = _loop0_93_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14293,9 +14350,9 @@ _gather_91_rule(Parser *p)
     return res;
 }
 
-// _tmp_93: ':' expression?
+// _tmp_94: ':' expression?
 static void *
-_tmp_93_rule(Parser *p)
+_tmp_94_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14325,9 +14382,9 @@ _tmp_93_rule(Parser *p)
     return res;
 }
 
-// _tmp_94: tuple | group | genexp
+// _tmp_95: tuple | group | genexp
 static void *
-_tmp_94_rule(Parser *p)
+_tmp_95_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14372,9 +14429,9 @@ _tmp_94_rule(Parser *p)
     return res;
 }
 
-// _tmp_95: list | listcomp
+// _tmp_96: list | listcomp
 static void *
-_tmp_95_rule(Parser *p)
+_tmp_96_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14408,9 +14465,9 @@ _tmp_95_rule(Parser *p)
     return res;
 }
 
-// _tmp_96: dict | set | dictcomp | setcomp
+// _tmp_97: dict | set | dictcomp | setcomp
 static void *
-_tmp_96_rule(Parser *p)
+_tmp_97_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14466,9 +14523,9 @@ _tmp_96_rule(Parser *p)
     return res;
 }
 
-// _loop1_97: STRING
+// _loop1_98: STRING
 static asdl_seq *
-_loop1_97_rule(Parser *p)
+_loop1_98_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14509,19 +14566,19 @@ _loop1_97_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_97");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_98");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_97_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_98_type, seq);
     return seq;
 }
 
-// _tmp_98: star_named_expression ',' star_named_expressions?
+// _tmp_99: star_named_expression ',' star_named_expressions?
 static void *
-_tmp_98_rule(Parser *p)
+_tmp_99_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14554,9 +14611,9 @@ _tmp_98_rule(Parser *p)
     return res;
 }
 
-// _tmp_99: yield_expr | named_expression
+// _tmp_100: yield_expr | named_expression
 static void *
-_tmp_99_rule(Parser *p)
+_tmp_100_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14590,9 +14647,9 @@ _tmp_99_rule(Parser *p)
     return res;
 }
 
-// _loop0_101: ',' kvpair
+// _loop0_102: ',' kvpair
 static asdl_seq *
-_loop0_101_rule(Parser *p)
+_loop0_102_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14637,32 +14694,32 @@ _loop0_101_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_101");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_102");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_101_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_102_type, seq);
     return seq;
 }
 
-// _gather_100: kvpair _loop0_101
+// _gather_101: kvpair _loop0_102
 static asdl_seq *
-_gather_100_rule(Parser *p)
+_gather_101_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kvpair _loop0_101
+    { // kvpair _loop0_102
         KeyValuePair* elem;
         asdl_seq * seq;
         if (
             (elem = kvpair_rule(p))
             &&
-            (seq = _loop0_101_rule(p))
+            (seq = _loop0_102_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14675,9 +14732,9 @@ _gather_100_rule(Parser *p)
     return res;
 }
 
-// _loop1_102: (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
+// _loop1_103: (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
 static asdl_seq *
-_loop1_102_rule(Parser *p)
+_loop1_103_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14693,12 +14750,12 @@ _loop1_102_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
-        void *_tmp_137_var;
+        void *_tmp_138_var;
         while (
-            (_tmp_137_var = _tmp_137_rule(p))
+            (_tmp_138_var = _tmp_138_rule(p))
         )
         {
-            res = _tmp_137_var;
+            res = _tmp_138_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14718,46 +14775,14 @@ _loop1_102_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_102");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_103");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_102_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_103_type, seq);
     return seq;
-}
-
-// _tmp_103: ',' args
-static void *
-_tmp_103_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' args
-        expr_ty c;
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (c = args_rule(p))
-        )
-        {
-            res = c;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
 }
 
 // _tmp_104: ',' args
@@ -14792,9 +14817,41 @@ _tmp_104_rule(Parser *p)
     return res;
 }
 
-// _loop0_106: ',' kwarg_or_starred
+// _tmp_105: ',' args
+static void *
+_tmp_105_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' args
+        expr_ty c;
+        void *literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (c = args_rule(p))
+        )
+        {
+            res = c;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_107: ',' kwarg_or_starred
 static asdl_seq *
-_loop0_106_rule(Parser *p)
+_loop0_107_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14839,32 +14896,32 @@ _loop0_106_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_106");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_107");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_106_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_107_type, seq);
     return seq;
 }
 
-// _gather_105: kwarg_or_starred _loop0_106
+// _gather_106: kwarg_or_starred _loop0_107
 static asdl_seq *
-_gather_105_rule(Parser *p)
+_gather_106_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_starred _loop0_106
+    { // kwarg_or_starred _loop0_107
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_starred_rule(p))
             &&
-            (seq = _loop0_106_rule(p))
+            (seq = _loop0_107_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14877,9 +14934,9 @@ _gather_105_rule(Parser *p)
     return res;
 }
 
-// _loop0_108: ',' kwarg_or_double_starred
+// _loop0_109: ',' kwarg_or_double_starred
 static asdl_seq *
-_loop0_108_rule(Parser *p)
+_loop0_109_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14924,32 +14981,32 @@ _loop0_108_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_108");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_109");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_108_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_109_type, seq);
     return seq;
 }
 
-// _gather_107: kwarg_or_double_starred _loop0_108
+// _gather_108: kwarg_or_double_starred _loop0_109
 static asdl_seq *
-_gather_107_rule(Parser *p)
+_gather_108_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_108
+    { // kwarg_or_double_starred _loop0_109
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_double_starred_rule(p))
             &&
-            (seq = _loop0_108_rule(p))
+            (seq = _loop0_109_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14962,9 +15019,9 @@ _gather_107_rule(Parser *p)
     return res;
 }
 
-// _loop0_110: ',' kwarg_or_starred
+// _loop0_111: ',' kwarg_or_starred
 static asdl_seq *
-_loop0_110_rule(Parser *p)
+_loop0_111_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15009,32 +15066,32 @@ _loop0_110_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_110");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_111");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_110_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_111_type, seq);
     return seq;
 }
 
-// _gather_109: kwarg_or_starred _loop0_110
+// _gather_110: kwarg_or_starred _loop0_111
 static asdl_seq *
-_gather_109_rule(Parser *p)
+_gather_110_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_starred _loop0_110
+    { // kwarg_or_starred _loop0_111
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_starred_rule(p))
             &&
-            (seq = _loop0_110_rule(p))
+            (seq = _loop0_111_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15047,92 +15104,7 @@ _gather_109_rule(Parser *p)
     return res;
 }
 
-// _loop0_112: ',' kwarg_or_double_starred
-static asdl_seq *
-_loop0_112_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ',' kwarg_or_double_starred
-        KeywordOrStarred* elem;
-        void *literal;
-        while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = kwarg_or_double_starred_rule(p))
-        )
-        {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_112");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_112_type, seq);
-    return seq;
-}
-
-// _gather_111: kwarg_or_double_starred _loop0_112
-static asdl_seq *
-_gather_111_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_112
-        KeywordOrStarred* elem;
-        asdl_seq * seq;
-        if (
-            (elem = kwarg_or_double_starred_rule(p))
-            &&
-            (seq = _loop0_112_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_113: (',' star_target)
+// _loop0_113: ',' kwarg_or_double_starred
 static asdl_seq *
 _loop0_113_rule(Parser *p)
 {
@@ -15149,13 +15121,21 @@ _loop0_113_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // (',' star_target)
-        void *_tmp_138_var;
+    { // ',' kwarg_or_double_starred
+        KeywordOrStarred* elem;
+        void *literal;
         while (
-            (_tmp_138_var = _tmp_138_rule(p))
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = kwarg_or_double_starred_rule(p))
         )
         {
-            res = _tmp_138_var;
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15181,9 +15161,86 @@ _loop0_113_rule(Parser *p)
     return seq;
 }
 
-// _loop0_115: ',' star_target
+// _gather_112: kwarg_or_double_starred _loop0_113
 static asdl_seq *
-_loop0_115_rule(Parser *p)
+_gather_112_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // kwarg_or_double_starred _loop0_113
+        KeywordOrStarred* elem;
+        asdl_seq * seq;
+        if (
+            (elem = kwarg_or_double_starred_rule(p))
+            &&
+            (seq = _loop0_113_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_114: (',' star_target)
+static asdl_seq *
+_loop0_114_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // (',' star_target)
+        void *_tmp_139_var;
+        while (
+            (_tmp_139_var = _tmp_139_rule(p))
+        )
+        {
+            res = _tmp_139_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_114");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_114_type, seq);
+    return seq;
+}
+
+// _loop0_116: ',' star_target
+static asdl_seq *
+_loop0_116_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15228,32 +15285,32 @@ _loop0_115_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_115");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_116");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_115_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_116_type, seq);
     return seq;
 }
 
-// _gather_114: star_target _loop0_115
+// _gather_115: star_target _loop0_116
 static asdl_seq *
-_gather_114_rule(Parser *p)
+_gather_115_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_target _loop0_115
+    { // star_target _loop0_116
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_target_rule(p))
             &&
-            (seq = _loop0_115_rule(p))
+            (seq = _loop0_116_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15266,9 +15323,9 @@ _gather_114_rule(Parser *p)
     return res;
 }
 
-// _tmp_116: !'*' star_target
+// _tmp_117: !'*' star_target
 static void *
-_tmp_116_rule(Parser *p)
+_tmp_117_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15293,9 +15350,9 @@ _tmp_116_rule(Parser *p)
     return res;
 }
 
-// _loop0_118: ',' del_target
+// _loop0_119: ',' del_target
 static asdl_seq *
-_loop0_118_rule(Parser *p)
+_loop0_119_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15340,32 +15397,32 @@ _loop0_118_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_118");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_119");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_118_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_119_type, seq);
     return seq;
 }
 
-// _gather_117: del_target _loop0_118
+// _gather_118: del_target _loop0_119
 static asdl_seq *
-_gather_117_rule(Parser *p)
+_gather_118_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // del_target _loop0_118
+    { // del_target _loop0_119
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = del_target_rule(p))
             &&
-            (seq = _loop0_118_rule(p))
+            (seq = _loop0_119_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15378,9 +15435,9 @@ _gather_117_rule(Parser *p)
     return res;
 }
 
-// _loop0_120: ',' target
+// _loop0_121: ',' target
 static asdl_seq *
-_loop0_120_rule(Parser *p)
+_loop0_121_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15425,32 +15482,32 @@ _loop0_120_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_120");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_121");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_120_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_121_type, seq);
     return seq;
 }
 
-// _gather_119: target _loop0_120
+// _gather_120: target _loop0_121
 static asdl_seq *
-_gather_119_rule(Parser *p)
+_gather_120_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // target _loop0_120
+    { // target _loop0_121
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = target_rule(p))
             &&
-            (seq = _loop0_120_rule(p))
+            (seq = _loop0_121_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15463,9 +15520,9 @@ _gather_119_rule(Parser *p)
     return res;
 }
 
-// _tmp_121: args | expression for_if_clauses
+// _tmp_122: args | expression for_if_clauses
 static void *
-_tmp_121_rule(Parser *p)
+_tmp_122_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15502,9 +15559,9 @@ _tmp_121_rule(Parser *p)
     return res;
 }
 
-// _tmp_122: '=' annotated_rhs
+// _tmp_123: '=' annotated_rhs
 static void *
-_tmp_122_rule(Parser *p)
+_tmp_123_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15530,9 +15587,9 @@ _tmp_122_rule(Parser *p)
     return res;
 }
 
-// _tmp_123: '=' | augassign
+// _tmp_124: '=' | augassign
 static void *
-_tmp_123_rule(Parser *p)
+_tmp_124_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15566,9 +15623,9 @@ _tmp_123_rule(Parser *p)
     return res;
 }
 
-// _tmp_124: yield_expr | star_expressions
+// _tmp_125: yield_expr | star_expressions
 static void *
-_tmp_124_rule(Parser *p)
+_tmp_125_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15602,9 +15659,9 @@ _tmp_124_rule(Parser *p)
     return res;
 }
 
-// _tmp_125: '[' | '(' | '{'
+// _tmp_126: '[' | '(' | '{'
 static void *
-_tmp_125_rule(Parser *p)
+_tmp_126_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15649,9 +15706,9 @@ _tmp_125_rule(Parser *p)
     return res;
 }
 
-// _loop0_126: param_no_default
+// _loop0_127: param_no_default
 static asdl_seq *
-_loop0_126_rule(Parser *p)
+_loop0_127_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15688,19 +15745,19 @@ _loop0_126_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_126");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_127");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_126_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_127_type, seq);
     return seq;
 }
 
-// _tmp_127: slash_with_default | param_with_default+
+// _tmp_128: slash_with_default | param_with_default+
 static void *
-_tmp_127_rule(Parser *p)
+_tmp_128_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15719,12 +15776,12 @@ _tmp_127_rule(Parser *p)
         p->mark = mark;
     }
     { // param_with_default+
-        asdl_seq * _loop1_139_var;
+        asdl_seq * _loop1_140_var;
         if (
-            (_loop1_139_var = _loop1_139_rule(p))
+            (_loop1_140_var = _loop1_140_rule(p))
         )
         {
-            res = _loop1_139_var;
+            res = _loop1_140_var;
             goto done;
         }
         p->mark = mark;
@@ -15734,9 +15791,9 @@ _tmp_127_rule(Parser *p)
     return res;
 }
 
-// _tmp_128: star_targets '='
+// _tmp_129: star_targets '='
 static void *
-_tmp_128_rule(Parser *p)
+_tmp_129_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15757,42 +15814,6 @@ _tmp_128_rule(Parser *p)
                 p->error_indicator = 1;
                 return NULL;
             }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_129: '.' | '...'
-static void *
-_tmp_129_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // '.'
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 23))
-        )
-        {
-            res = literal;
-            goto done;
-        }
-        p->mark = mark;
-    }
-    { // '...'
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 52))
-        )
-        {
-            res = literal;
             goto done;
         }
         p->mark = mark;
@@ -15838,9 +15859,45 @@ _tmp_130_rule(Parser *p)
     return res;
 }
 
-// _tmp_131: '@' named_expression NEWLINE
+// _tmp_131: '.' | '...'
 static void *
 _tmp_131_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // '.'
+        void *literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 23))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // '...'
+        void *literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 52))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_132: '@' named_expression NEWLINE
+static void *
+_tmp_132_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15873,9 +15930,9 @@ _tmp_131_rule(Parser *p)
     return res;
 }
 
-// _tmp_132: ',' star_expression
+// _tmp_133: ',' star_expression
 static void *
-_tmp_132_rule(Parser *p)
+_tmp_133_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15905,9 +15962,9 @@ _tmp_132_rule(Parser *p)
     return res;
 }
 
-// _tmp_133: ',' expression
+// _tmp_134: ',' expression
 static void *
-_tmp_133_rule(Parser *p)
+_tmp_134_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15937,9 +15994,9 @@ _tmp_133_rule(Parser *p)
     return res;
 }
 
-// _tmp_134: lambda_plain_name !'='
+// _tmp_135: lambda_plain_name !'='
 static void *
-_tmp_134_rule(Parser *p)
+_tmp_135_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15964,9 +16021,9 @@ _tmp_134_rule(Parser *p)
     return res;
 }
 
-// _tmp_135: 'or' conjunction
+// _tmp_136: 'or' conjunction
 static void *
-_tmp_135_rule(Parser *p)
+_tmp_136_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15996,9 +16053,9 @@ _tmp_135_rule(Parser *p)
     return res;
 }
 
-// _tmp_136: 'and' inversion
+// _tmp_137: 'and' inversion
 static void *
-_tmp_136_rule(Parser *p)
+_tmp_137_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16028,9 +16085,9 @@ _tmp_136_rule(Parser *p)
     return res;
 }
 
-// _tmp_137: ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
+// _tmp_138: ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
 static void *
-_tmp_137_rule(Parser *p)
+_tmp_138_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16055,7 +16112,7 @@ _tmp_137_rule(Parser *p)
             &&
             (b = disjunction_rule(p))
             &&
-            (c = _loop0_140_rule(p))
+            (c = _loop0_141_rule(p))
         )
         {
             res = _Py_comprehension ( a , b , c , y != NULL , p -> arena );
@@ -16072,9 +16129,9 @@ _tmp_137_rule(Parser *p)
     return res;
 }
 
-// _tmp_138: ',' star_target
+// _tmp_139: ',' star_target
 static void *
-_tmp_138_rule(Parser *p)
+_tmp_139_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16104,9 +16161,9 @@ _tmp_138_rule(Parser *p)
     return res;
 }
 
-// _loop1_139: param_with_default
+// _loop1_140: param_with_default
 static asdl_seq *
-_loop1_139_rule(Parser *p)
+_loop1_140_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16147,19 +16204,19 @@ _loop1_139_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_139");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_140");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_139_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_140_type, seq);
     return seq;
 }
 
-// _loop0_140: ('if' disjunction)
+// _loop0_141: ('if' disjunction)
 static asdl_seq *
-_loop0_140_rule(Parser *p)
+_loop0_141_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16175,12 +16232,12 @@ _loop0_140_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('if' disjunction)
-        void *_tmp_141_var;
+        void *_tmp_142_var;
         while (
-            (_tmp_141_var = _tmp_141_rule(p))
+            (_tmp_142_var = _tmp_142_rule(p))
         )
         {
-            res = _tmp_141_var;
+            res = _tmp_142_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -16196,19 +16253,19 @@ _loop0_140_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_140");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_141");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_140_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_141_type, seq);
     return seq;
 }
 
-// _tmp_141: 'if' disjunction
+// _tmp_142: 'if' disjunction
 static void *
-_tmp_141_rule(Parser *p)
+_tmp_142_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -856,7 +856,7 @@ type_expressions_rule(Parser *p)
             (c = expression_rule(p))
         )
         {
-            res = _PyPegen_seq_append_to_end ( p , _PyPegen_seq_append_to_end ( p , a , b ) , c );
+            res = _PyPegen_seq_append_to_end ( p , CHECK ( _PyPegen_seq_append_to_end ( p , a , b ) ) , c );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -1181,6 +1181,27 @@ _PyPegen_seq_insert_in_front(Parser *p, void *a, asdl_seq *seq)
     return new_seq;
 }
 
+/* Creates a copy of seq and appends a to it */
+asdl_seq *
+_PyPegen_seq_append_to_end(Parser *p, asdl_seq *seq, void *a)
+{
+    assert(a != NULL);
+    if (!seq) {
+        return _PyPegen_singleton_seq(p, a);
+    }
+
+    asdl_seq *new_seq = _Py_asdl_seq_new(asdl_seq_LEN(seq) + 1, p->arena);
+    if (!new_seq) {
+        return NULL;
+    }
+
+    for (Py_ssize_t i = 0, l = asdl_seq_LEN(new_seq); i + 1 < l; i++) {
+        asdl_seq_SET(new_seq, i, asdl_seq_GET(seq, i));
+    }
+    asdl_seq_SET(new_seq, asdl_seq_LEN(new_seq) - 1, a);
+    return new_seq;
+}
+
 static Py_ssize_t
 _get_flattened_seq_size(asdl_seq *seqs)
 {

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -553,14 +553,63 @@ _get_keyword_or_name_type(Parser *p, const char *name, int name_len)
     return NAME;
 }
 
+static int
+growable_comment_array_init(growable_comment_array *arr, size_t initial_size) {
+    assert(initial_size > 0);
+    arr->items = PyMem_Malloc(initial_size * sizeof(*arr->items));
+    arr->size = initial_size;
+    arr->num_items = 0;
+
+    return arr->items != NULL;
+}
+
+static int
+growable_comment_array_add(growable_comment_array *arr, int lineno, char *comment) {
+    if (arr->num_items >= arr->size) {
+        size_t new_size = arr->size * 2;
+        void *new_items_array = PyMem_Realloc(arr->items, new_size * sizeof(*arr->items));
+        if (!new_items_array) {
+            return 0;
+        }
+        arr->items = new_items_array;
+        arr->size = new_size;
+    }
+
+    arr->items[arr->num_items].lineno = lineno;
+    arr->items[arr->num_items].comment = comment;  // Take ownership
+    arr->num_items++;
+    return 1;
+}
+
+static void
+growable_comment_array_deallocate(growable_comment_array *arr) {
+    for (unsigned i = 0; i < arr->num_items; i++) {
+        PyMem_Free(arr->items[i].comment);
+    }
+    PyMem_Free(arr->items);
+}
+
 int
 _PyPegen_fill_token(Parser *p)
 {
     const char *start, *end;
     int type = PyTokenizer_Get(p->tok, &start, &end);
 
-    // Skip '# type: ignore'; TODO: collect these like parsetok.c
+    // Record and skip '# type: ignore' comments
     while (type == TYPE_IGNORE) {
+        Py_ssize_t len = end - start;
+        char *tag = PyMem_Malloc(len + 1);
+        if (tag == NULL) {
+            PyErr_NoMemory();
+            return -1;
+        }
+        strncpy(tag, start, len);
+        tag[len] = '\0';
+        // Ownership of tag passes to the growable array
+        if (!growable_comment_array_add(&p->type_ignore_comments, p->tok->lineno, tag)) {
+            PyErr_NoMemory();
+            return -1;
+        }
         type = PyTokenizer_Get(p->tok, &start, &end);
     }
 
@@ -945,6 +994,7 @@ _PyPegen_Parser_Free(Parser *p)
         PyMem_Free(p->tokens[i]);
     }
     PyMem_Free(p->tokens);
+    growable_comment_array_deallocate(&p->type_ignore_comments);
     PyMem_Free(p);
 }
 
@@ -987,13 +1037,19 @@ _PyPegen_Parser_New(struct tok_state *tok, int start_rule, int flags,
         PyMem_Free(p);
         return (Parser *) PyErr_NoMemory();
     }
-    p->tokens[0] = PyMem_Malloc(sizeof(Token));
+    p->tokens[0] = PyMem_Calloc(1, sizeof(Token));
     if (!p->tokens) {
         PyMem_Free(p->tokens);
         PyMem_Free(p);
         return (Parser *) PyErr_NoMemory();
     }
-    memset(p->tokens[0], '\0', sizeof(Token));
+    if (!growable_comment_array_init(&p->type_ignore_comments, 10)) {
+        PyMem_Free(p->tokens[0]);
+        PyMem_Free(p->tokens);
+        PyMem_Free(p);
+        return (Parser *) PyErr_NoMemory();
+    }
+
     p->mark = 0;
     p->fill = 0;
     p->size = 1;
@@ -1992,4 +2048,29 @@ error:
         raise_decode_error(p);
     }
     return NULL;
+}
+
+mod_ty
+_PyPegen_make_module(Parser *p, asdl_seq *a) {
+    asdl_seq *type_ignores = NULL;
+    Py_ssize_t num = p->type_ignore_comments.num_items;
+    if (num > 0) {
+        // Turn the raw (comment, lineno) pairs into TypeIgnore objects in the arena
+        type_ignores = _Py_asdl_seq_new(num, p->arena);
+        if (type_ignores == NULL) {
+            return NULL;
+        }
+        for (int i = 0; i < num; i++) {
+            PyObject *tag = _PyPegen_new_type_comment(p, p->type_ignore_comments.items[i].comment);
+            if (tag == NULL) {
+                return NULL;
+            }
+            type_ignore_ty ti = TypeIgnore(p->type_ignore_comments.items[i].lineno, tag, p->arena);
+            if (ti == NULL) {
+                return NULL;
+            }
+            asdl_seq_SET(type_ignores, i, ti);
+        }
+    }
+    return Module(a, type_ignores, p->arena);
 }

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -25,7 +25,7 @@ _PyPegen_add_type_comment(Parser *p, arg_ty a, char *tc)
     if (tc == NULL) {
         return a;
     }
-    PyObject *tco = _PyPegen_new_type_comment(p, tc);
+    PyObject *tco = NEW_TYPE_COMMENT(tc);
     if (tco == NULL) {
         return NULL;
     }

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -6,9 +6,9 @@
 #include "parse_string.h"
 
 PyObject *
-_PyPegen_new_type_comment(Parser *p, char *tc)
+_PyPegen_new_type_comment(Parser *p, char *s)
 {
-    PyObject *res = PyUnicode_DecodeUTF8(tc, strlen(tc), NULL);
+    PyObject *res = PyUnicode_DecodeUTF8(s, strlen(s), NULL);
     if (res == NULL) {
         return NULL;
     }
@@ -20,12 +20,12 @@ _PyPegen_new_type_comment(Parser *p, char *tc)
 }
 
 arg_ty
-_PyPegen_add_type_comment_to_arg(Parser *p, arg_ty a, char *tc)
+_PyPegen_add_type_comment_to_arg(Parser *p, arg_ty a, Token *tc)
 {
     if (tc == NULL) {
         return a;
     }
-    PyObject *tco = NEW_TYPE_COMMENT(tc);
+    PyObject *tco = NEW_TYPE_COMMENT(p, tc);
     if (tco == NULL) {
         return NULL;
     }
@@ -1597,7 +1597,7 @@ _PyPegen_get_values(Parser *p, asdl_seq *seq)
 
 /* Constructs a NameDefaultPair */
 NameDefaultPair *
-_PyPegen_name_default_pair(Parser *p, arg_ty arg, expr_ty value, char *tc)
+_PyPegen_name_default_pair(Parser *p, arg_ty arg, expr_ty value, Token *tc)
 {
     NameDefaultPair *a = PyArena_Malloc(p->arena, sizeof(NameDefaultPair));
     if (!a) {

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -25,7 +25,11 @@ _PyPegen_add_type_comment_to_arg(Parser *p, arg_ty a, Token *tc)
     if (tc == NULL) {
         return a;
     }
-    PyObject *tco = NEW_TYPE_COMMENT(p, tc);
+    char *bytes = PyBytes_AsString(tc->bytes);
+    if (bytes == NULL) {
+        return NULL;
+    }
+    PyObject *tco = _PyPegen_new_type_comment(p, bytes);
     if (tco == NULL) {
         return NULL;
     }

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -20,7 +20,7 @@ _PyPegen_new_type_comment(Parser *p, char *tc)
 }
 
 arg_ty
-_PyPegen_add_type_comment(Parser *p, arg_ty a, char *tc)
+_PyPegen_add_type_comment_to_arg(Parser *p, arg_ty a, char *tc)
 {
     if (tc == NULL) {
         return a;
@@ -1190,10 +1190,7 @@ _PyPegen_run_parser_from_string(const char *str, int start_rule, PyObject *filen
     mod_ty result = NULL;
 
     int parser_flags = compute_parser_flags(flags);
-
-    if (parser_flags & PyPARSE_TYPE_COMMENTS) {
-        tok->type_comments = 1;
-    }
+    tok->type_comments = (parser_flags & PyPARSE_TYPE_COMMENTS) > 0;
 
     Parser *p = _PyPegen_Parser_New(tok, start_rule, parser_flags, NULL, arena);
     if (p == NULL) {
@@ -1606,7 +1603,7 @@ _PyPegen_name_default_pair(Parser *p, arg_ty arg, expr_ty value, char *tc)
     if (!a) {
         return NULL;
     }
-    a->arg = _PyPegen_add_type_comment(p, arg, tc);
+    a->arg = _PyPegen_add_type_comment_to_arg(p, arg, tc);
     a->value = value;
     return a;
 }

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -6,9 +6,9 @@
 #include "parse_string.h"
 
 PyObject *
-_PyPegen_new_type_comment(Parser *p, char *s)
+_PyPegen_new_type_comment(Parser *p, char *tc)
 {
-    PyObject *res = PyUnicode_DecodeUTF8(s, strlen(s), NULL);
+    PyObject *res = PyUnicode_DecodeUTF8(tc, strlen(tc), NULL);
     if (res == NULL) {
         return NULL;
     }
@@ -17,6 +17,21 @@ _PyPegen_new_type_comment(Parser *p, char *s)
         return NULL;
     }
     return res;
+}
+
+arg_ty
+_PyPegen_add_type_comment(Parser *p, arg_ty a, char *tc)
+{
+    if (tc == NULL) {
+        return a;
+    }
+    PyObject *tco = _PyPegen_new_type_comment(p, tc);
+    if (tco == NULL) {
+        return NULL;
+    }
+    return arg(a->arg, a->annotation, tco,
+               a->lineno, a->col_offset, a->end_lineno, a->end_col_offset,
+               p->arena);
 }
 
 static int
@@ -1586,13 +1601,13 @@ _PyPegen_get_values(Parser *p, asdl_seq *seq)
 
 /* Constructs a NameDefaultPair */
 NameDefaultPair *
-_PyPegen_name_default_pair(Parser *p, arg_ty arg, expr_ty value)
+_PyPegen_name_default_pair(Parser *p, arg_ty arg, expr_ty value, char *tc)
 {
     NameDefaultPair *a = PyArena_Malloc(p->arena, sizeof(NameDefaultPair));
     if (!a) {
         return NULL;
     }
-    a->arg = arg;
+    a->arg = _PyPegen_add_type_comment(p, arg, tc);
     a->value = value;
     return a;
 }

--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -169,6 +169,7 @@ mod_ty _PyPegen_run_parser_from_string(const char *, int, PyObject *, PyCompiler
 void *_PyPegen_interactive_exit(Parser *);
 asdl_seq *_PyPegen_singleton_seq(Parser *, void *);
 asdl_seq *_PyPegen_seq_insert_in_front(Parser *, void *, asdl_seq *);
+asdl_seq *_PyPegen_seq_append_to_end(Parser *, asdl_seq *, void *);
 asdl_seq *_PyPegen_seq_flatten(Parser *, asdl_seq *);
 expr_ty _PyPegen_join_names_with_dot(Parser *, expr_ty, expr_ty);
 int _PyPegen_seq_count_dots(asdl_seq *);

--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -120,6 +120,7 @@ void *_PyPegen_indent_token(Parser *p);
 void *_PyPegen_dedent_token(Parser *p);
 expr_ty _PyPegen_number_token(Parser *p);
 void *_PyPegen_string_token(Parser *p);
+void *_PyPegen_type_comment_token(Parser *p);
 const char *_PyPegen_get_expr_name(expr_ty);
 void *_PyPegen_raise_error(Parser *p, PyObject *, const char *errmsg, ...);
 void *_PyPegen_dummy_name(Parser *p, ...);
@@ -154,6 +155,9 @@ CHECK_CALL_NULL_ALLOWED(Parser *p, void *result)
 #define CHECK(result) CHECK_CALL(p, result)
 #define CHECK_NULL_ALLOWED(result) CHECK_CALL_NULL_ALLOWED(p, result)
 
+#define NEW_TYPE_COMMENT(tc) (tc==NULL ? NULL : _PyPegen_new_type_comment(p, PyBytes_AsString(((Token *)tc)->bytes)))
+
+PyObject *_PyPegen_new_type_comment(Parser *, char *);
 PyObject *_PyPegen_new_identifier(Parser *, char *);
 Parser *_PyPegen_Parser_New(struct tok_state *, int, int, int *, PyArena *);
 void _PyPegen_Parser_Free(Parser *);

--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -43,6 +43,16 @@ typedef struct {
     int type;
 } KeywordToken;
 
+
+typedef struct {
+    struct {
+        int lineno;
+        char *comment;  // The " <tag>" in "# type: ignore <tag>"
+    } *items;
+    size_t size;
+    size_t num_items;
+} growable_comment_array;
+
 typedef struct {
     struct tok_state *tok;
     Token **tokens;
@@ -59,6 +69,7 @@ typedef struct {
     int starting_col_offset;
     int error_indicator;
     int flags;
+    growable_comment_array type_ignore_comments;
 } Parser;
 
 typedef struct {
@@ -198,6 +209,7 @@ expr_ty _PyPegen_concatenate_strings(Parser *p, asdl_seq *);
 asdl_seq *_PyPegen_join_sequences(Parser *, asdl_seq *, asdl_seq *);
 void *_PyPegen_arguments_parsing_error(Parser *, expr_ty);
 int _PyPegen_check_barry_as_flufl(Parser *);
+mod_ty _PyPegen_make_module(Parser *, asdl_seq *);
 
 void *_PyPegen_parse(Parser *);
 

--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -158,10 +158,18 @@ CHECK_CALL_NULL_ALLOWED(Parser *p, void *result)
 #define CHECK(result) CHECK_CALL(p, result)
 #define CHECK_NULL_ALLOWED(result) CHECK_CALL_NULL_ALLOWED(p, result)
 
-#define NEW_TYPE_COMMENT(tc) (tc == NULL ? NULL : _PyPegen_new_type_comment(p, PyBytes_AsString(((Token *)tc)->bytes)))
-
 PyObject *_PyPegen_new_type_comment(Parser *, char *);
-arg_ty _PyPegen_add_type_comment_to_arg(Parser *, arg_ty, char *);
+
+Py_LOCAL_INLINE(PyObject *)
+NEW_TYPE_COMMENT(Parser *p, Token *tc)
+{
+    if (tc == NULL) {
+        return NULL;
+    }
+    return CHECK_CALL_NULL_ALLOWED(p, _PyPegen_new_type_comment(p, PyBytes_AsString(tc->bytes)));
+}
+
+arg_ty _PyPegen_add_type_comment_to_arg(Parser *, arg_ty, Token *);
 PyObject *_PyPegen_new_identifier(Parser *, char *);
 Parser *_PyPegen_Parser_New(struct tok_state *, int, int, int *, PyArena *);
 void _PyPegen_Parser_Free(Parser *);
@@ -186,7 +194,7 @@ expr_ty _PyPegen_set_expr_context(Parser *, expr_ty, expr_context_ty);
 KeyValuePair *_PyPegen_key_value_pair(Parser *, expr_ty, expr_ty);
 asdl_seq *_PyPegen_get_keys(Parser *, asdl_seq *);
 asdl_seq *_PyPegen_get_values(Parser *, asdl_seq *);
-NameDefaultPair *_PyPegen_name_default_pair(Parser *, arg_ty, expr_ty, char *);
+NameDefaultPair *_PyPegen_name_default_pair(Parser *, arg_ty, expr_ty, Token *);
 SlashWithDefault *_PyPegen_slash_with_default(Parser *, asdl_seq *, asdl_seq *);
 StarEtc *_PyPegen_star_etc(Parser *, arg_ty, asdl_seq *, arg_ty);
 arguments_ty _PyPegen_make_arguments(Parser *, asdl_seq *, SlashWithDefault *,

--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -121,16 +121,9 @@ int _PyPegen_lookahead(int, void *(func)(Parser *), Parser *);
 Token *_PyPegen_expect_token(Parser *p, int type);
 Token *_PyPegen_get_last_nonnwhitespace_token(Parser *);
 int _PyPegen_fill_token(Parser *p);
-void *_PyPegen_async_token(Parser *p);
-void *_PyPegen_await_token(Parser *p);
-void *_PyPegen_endmarker_token(Parser *p);
 expr_ty _PyPegen_name_token(Parser *p);
-void *_PyPegen_newline_token(Parser *p);
-void *_PyPegen_indent_token(Parser *p);
-void *_PyPegen_dedent_token(Parser *p);
 expr_ty _PyPegen_number_token(Parser *p);
 void *_PyPegen_string_token(Parser *p);
-void *_PyPegen_type_comment_token(Parser *p);
 const char *_PyPegen_get_expr_name(expr_ty);
 void *_PyPegen_raise_error(Parser *p, PyObject *, const char *errmsg, ...);
 void *_PyPegen_dummy_name(Parser *p, ...);
@@ -165,10 +158,10 @@ CHECK_CALL_NULL_ALLOWED(Parser *p, void *result)
 #define CHECK(result) CHECK_CALL(p, result)
 #define CHECK_NULL_ALLOWED(result) CHECK_CALL_NULL_ALLOWED(p, result)
 
-#define NEW_TYPE_COMMENT(tc) (tc==NULL ? NULL : _PyPegen_new_type_comment(p, PyBytes_AsString(((Token *)tc)->bytes)))
+#define NEW_TYPE_COMMENT(tc) (tc == NULL ? NULL : _PyPegen_new_type_comment(p, PyBytes_AsString(((Token *)tc)->bytes)))
 
 PyObject *_PyPegen_new_type_comment(Parser *, char *);
-arg_ty _PyPegen_add_type_comment(Parser *, arg_ty, char *);
+arg_ty _PyPegen_add_type_comment_to_arg(Parser *, arg_ty, char *);
 PyObject *_PyPegen_new_identifier(Parser *, char *);
 Parser *_PyPegen_Parser_New(struct tok_state *, int, int, int *, PyArena *);
 void _PyPegen_Parser_Free(Parser *);

--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -169,6 +169,7 @@ CHECK_CALL_NULL_ALLOWED(Parser *p, void *result)
 #define NEW_TYPE_COMMENT(tc) (tc==NULL ? NULL : _PyPegen_new_type_comment(p, PyBytes_AsString(((Token *)tc)->bytes)))
 
 PyObject *_PyPegen_new_type_comment(Parser *, char *);
+arg_ty _PyPegen_add_type_comment(Parser *, arg_ty, char *);
 PyObject *_PyPegen_new_identifier(Parser *, char *);
 Parser *_PyPegen_Parser_New(struct tok_state *, int, int, int *, PyArena *);
 void _PyPegen_Parser_Free(Parser *);
@@ -193,7 +194,7 @@ expr_ty _PyPegen_set_expr_context(Parser *, expr_ty, expr_context_ty);
 KeyValuePair *_PyPegen_key_value_pair(Parser *, expr_ty, expr_ty);
 asdl_seq *_PyPegen_get_keys(Parser *, asdl_seq *);
 asdl_seq *_PyPegen_get_values(Parser *, asdl_seq *);
-NameDefaultPair *_PyPegen_name_default_pair(Parser *, arg_ty, expr_ty);
+NameDefaultPair *_PyPegen_name_default_pair(Parser *, arg_ty, expr_ty, char *);
 SlashWithDefault *_PyPegen_slash_with_default(Parser *, asdl_seq *, asdl_seq *);
 StarEtc *_PyPegen_star_etc(Parser *, arg_ty, asdl_seq *, arg_ty);
 arguments_ty _PyPegen_make_arguments(Parser *, asdl_seq *, SlashWithDefault *,

--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -166,7 +166,18 @@ NEW_TYPE_COMMENT(Parser *p, Token *tc)
     if (tc == NULL) {
         return NULL;
     }
-    return CHECK_CALL_NULL_ALLOWED(p, _PyPegen_new_type_comment(p, PyBytes_AsString(tc->bytes)));
+    char *bytes = PyBytes_AsString(tc->bytes);
+    if (bytes == NULL) {
+        goto error;
+    }
+    PyObject *tco = _PyPegen_new_type_comment(p, bytes);
+    if (tco == NULL) {
+        goto error;
+    }
+    return tco;
+ error:
+    p->error_indicator = 1;  // Inline CHECK_CALL
+    return NULL;
 }
 
 arg_ty _PyPegen_add_type_comment_to_arg(Parser *, arg_ty, Token *);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -816,12 +816,8 @@ builtin_compile_impl(PyObject *module, PyObject *source, PyObject *filename,
     if (str == NULL)
         goto error;
 
-    int current_use_peg = PyInterpreterState_Get()->config._use_peg_parser;
-    if (flags & PyCF_TYPE_COMMENTS || feature_version >= 0 || compile_mode == 3) {
-        PyInterpreterState_Get()->config._use_peg_parser = 0;
-    }
     result = Py_CompileStringObject(str, filename, start[compile_mode], &cf, optimize);
-    PyInterpreterState_Get()->config._use_peg_parser = current_use_peg;
+
     Py_XDECREF(source_copy);
     goto finally;
 


### PR DESCRIPTION
This implements full support for `# type: <type>` comments, `# type: ignore <stuff>` comments, and the `func_type` parsing mode for `ast.parse()` and `compile()`.

Closes https://github.com/we-like-parsers/cpython/issues/95

<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
