### PR TITLE
bpo-40429: PyThreadState_GetFrame() returns a strong ref

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1074,10 +1074,10 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
 
 .. c:function:: PyFrameObject* PyThreadState_GetFrame(PyThreadState *tstate)
 
-   Get a borrowed reference to the current frame of the Python thread state
-   *tstate*.
+   Get the current frame of the Python thread state *tstate*.
 
-   Return ``NULL`` if no frame is currently executing.
+   Return a strong reference. Return ``NULL`` if no frame is currently
+   executing.
 
    See also :c:func:`PyEval_GetFrame`.
 

--- a/Misc/NEWS.d/next/C API/2020-04-29-01-39-41.bpo-40429.VQfvta.rst
+++ b/Misc/NEWS.d/next/C API/2020-04-29-01-39-41.bpo-40429.VQfvta.rst
@@ -1,0 +1,2 @@
+The :c:func:`PyThreadState_GetFrame` function now returns a strong reference
+to the frame.

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -425,10 +425,7 @@ traceback_hash(traceback_t *traceback)
 static void
 traceback_get_frames(traceback_t *traceback)
 {
-    PyThreadState *tstate;
-    PyFrameObject *pyframe;
-
-    tstate = PyGILState_GetThisThreadState();
+    PyThreadState *tstate = PyGILState_GetThisThreadState();
     if (tstate == NULL) {
 #ifdef TRACE_DEBUG
         tracemalloc_error("failed to get the current thread state");
@@ -436,7 +433,8 @@ traceback_get_frames(traceback_t *traceback)
         return;
     }
 
-    pyframe = PyThreadState_GetFrame(tstate);
+    PyFrameObject *pyframe = PyThreadState_GetFrame(tstate);
+    Py_XDECREF(pyframe); // use a borrowed reference
     for (; pyframe != NULL; pyframe = pyframe->f_back) {
         if (traceback->nframe < _Py_tracemalloc_config.max_nframe) {
             tracemalloc_get_frame(pyframe, &traceback->frames[traceback->nframe]);

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1840,14 +1840,17 @@ _is_running(PyInterpreterState *interp)
                         "interpreter has more than one thread");
         return -1;
     }
+
+    assert(!PyErr_Occurred());
     PyFrameObject *frame = PyThreadState_GetFrame(tstate);
     if (frame == NULL) {
-        if (PyErr_Occurred() != NULL) {
-            return -1;
-        }
         return 0;
     }
-    return (int)(frame->f_executing);
+
+    int executing = (int)(frame->f_executing);
+    Py_DECREF(frame);
+
+    return executing;
 }
 
 static int

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8108,15 +8108,16 @@ super_init(PyObject *self, PyObject *args, PyObject *kwds)
         /* Call super(), without args -- fill in from __class__
            and first local variable on the stack. */
         PyThreadState *tstate = _PyThreadState_GET();
-        PyFrameObject *f = PyThreadState_GetFrame(tstate);
-        if (f == NULL) {
+        PyFrameObject *frame = PyThreadState_GetFrame(tstate);
+        if (frame == NULL) {
             PyErr_SetString(PyExc_RuntimeError,
                             "super(): no current frame");
             return -1;
         }
 
-        PyCodeObject *code = PyFrame_GetCode(f);
-        int res = super_init_without_args(f, code, &type, &obj);
+        PyCodeObject *code = PyFrame_GetCode(frame);
+        int res = super_init_without_args(frame, code, &type, &obj);
+        Py_DECREF(frame);
         Py_DECREF(code);
 
         if (res < 0) {

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -1372,7 +1372,7 @@ _PyErr_WriteUnraisableMsg(const char *err_msg_str, PyObject *obj)
     }
 
     if (exc_tb == NULL) {
-        struct _frame *frame = tstate->frame;
+        PyFrameObject *frame = tstate->frame;
         if (frame != NULL) {
             exc_tb = _PyTraceBack_FromFrame(NULL, frame);
             if (exc_tb == NULL) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1042,11 +1042,13 @@ PyThreadState_GetInterpreter(PyThreadState *tstate)
 }
 
 
-struct _frame*
+PyFrameObject*
 PyThreadState_GetFrame(PyThreadState *tstate)
 {
     assert(tstate != NULL);
-    return tstate->frame;
+    PyFrameObject *frame = tstate->frame;
+    Py_XINCREF(frame);
+    return frame;
 }
 
 
@@ -1165,7 +1167,7 @@ _PyThread_CurrentFrames(void)
     for (i = runtime->interpreters.head; i != NULL; i = i->next) {
         PyThreadState *t;
         for (t = i->tstate_head; t != NULL; t = t->next) {
-            struct _frame *frame = t->frame;
+            PyFrameObject *frame = t->frame;
             if (frame == NULL) {
                 continue;
             }


### PR DESCRIPTION
The PyThreadState_GetFrame() function now returns a strong reference
to the frame.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40429](https://bugs.python.org/issue40429) -->
https://bugs.python.org/issue40429
<!-- /issue-number -->
