### PR TITLE
bpo-40428: Remove references to Py*_ClearFreeList in the docs

### DIFF
--- a/Doc/c-api/contextvars.rst
+++ b/Doc/c-api/contextvars.rst
@@ -101,11 +101,6 @@ Context object management functions:
    current context for the current thread.  Returns ``0`` on success,
    and ``-1`` on error.
 
-.. c:function:: int PyContext_ClearFreeList()
-
-   Clear the context variable free list. Return the total number of
-   freed items.  This function always succeeds.
-
 
 Context variable functions:
 

--- a/Doc/c-api/dict.rst
+++ b/Doc/c-api/dict.rst
@@ -232,10 +232,3 @@ Dictionary Objects
           for key, value in seq2:
               if override or key not in a:
                   a[key] = value
-
-
-.. c:function:: int PyDict_ClearFreeList()
-
-   Clear the free list. Return the total number of freed items.
-
-   .. versionadded:: 3.3

--- a/Doc/c-api/float.rst
+++ b/Doc/c-api/float.rst
@@ -76,8 +76,3 @@ Floating Point Objects
 .. c:function:: double PyFloat_GetMin()
 
    Return the minimum normalized positive float *DBL_MIN* as C :c:type:`double`.
-
-.. c:function:: int PyFloat_ClearFreeList()
-
-   Clear the float free list. Return the number of items that could not
-   be freed.

--- a/Doc/c-api/list.rst
+++ b/Doc/c-api/list.rst
@@ -142,10 +142,3 @@ List Objects
 
    Return a new tuple object containing the contents of *list*; equivalent to
    ``tuple(list)``.
-
-
-.. c:function:: int PyList_ClearFreeList()
-
-   Clear the free list. Return the total number of freed items.
-
-   .. versionadded:: 3.3

--- a/Doc/c-api/method.rst
+++ b/Doc/c-api/method.rst
@@ -92,9 +92,3 @@ no longer available.
 .. c:function:: PyObject* PyMethod_GET_SELF(PyObject *meth)
 
    Macro version of :c:func:`PyMethod_Self` which avoids error checking.
-
-
-.. c:function:: int PyMethod_ClearFreeList()
-
-   Clear the free list. Return the total number of freed items.
-

--- a/Doc/c-api/set.rst
+++ b/Doc/c-api/set.rst
@@ -157,10 +157,3 @@ subtypes but not for instances of :class:`frozenset` or its subtypes.
 .. c:function:: int PySet_Clear(PyObject *set)
 
    Empty an existing set of all elements.
-
-
-.. c:function:: int PySet_ClearFreeList()
-
-   Clear the free list. Return the total number of freed items.
-
-   .. versionadded:: 3.3

--- a/Doc/c-api/tuple.rst
+++ b/Doc/c-api/tuple.rst
@@ -111,11 +111,6 @@ Tuple Objects
    raises :exc:`MemoryError` or :exc:`SystemError`.
 
 
-.. c:function:: int PyTuple_ClearFreeList()
-
-   Clear the free list. Return the total number of freed items.
-
-
 Struct Sequence Objects
 -----------------------
 


### PR DESCRIPTION
They were removed from the public C API in ae00a5a.



<!-- issue-number: [bpo-40428](https://bugs.python.org/issue40428) -->
https://bugs.python.org/issue40428
<!-- /issue-number -->
