### PR TITLE
gh-84176: CLN remove some locks in ProcessPoolExecutor

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -89,17 +89,24 @@ def _python_exit():
     global _global_shutdown
     _global_shutdown = True
     items = list(_threads_wakeups.items())
-    for _, thread_wakeup in items:
-        # call not protected by ProcessPoolExecutor._shutdown_lock
-        thread_wakeup.wakeup()
+    for _, (shutdown_lock, thread_wakeup) in items:
+        with shutdown_lock:
+            thread_wakeup.wakeup()
     for t, _ in items:
         t.join()
+
 
 # Register for `_python_exit()` to be called just before joining all
 # non-daemon threads. This is used instead of `atexit.register()` for
 # compatibility with subinterpreters, which no longer support daemon threads.
 # See bpo-39812 for context.
 threading._register_atexit(_python_exit)
+
+
+# With the fork context, _thread_wakeups is propagated to children.
+# Clear it after fork to avoid some situation that can cause some
+# freeze when joining the workers.
+mp.util.register_after_fork(_threads_wakeups, lambda obj: obj.clear())
 
 # Controls how many more calls than processes will be queued in the call queue.
 # A smaller number will mean that processes spend more time idle waiting for
@@ -653,7 +660,8 @@ class ProcessPoolExecutor(_base.Executor):
             self._executor_manager_thread = _ExecutorManagerThread(self)
             self._executor_manager_thread.start()
             _threads_wakeups[self._executor_manager_thread] = \
-                self._executor_manager_thread_wakeup
+                (self._shutdown_lock,
+                 self._executor_manager_thread_wakeup)
 
     def _adjust_process_count(self):
         # if there's an idle process, we don't need to spawn a new one.


### PR DESCRIPTION
Follow-up of #19760 to try to remove some locks.

Actually, the only one that matters in term of perf is probably the one in Lib/concurrent/futures/process.py#L171 which would be concurrent with the job submission. It can be removed because this lock is here to protect against concurrent call to `close` which is only called in the same thread as `clear` so the protection is unecesary.

We can also remove the one in `SafeQueue` because the queue is closed (and thus the queue feeder thread join) before we call `thread_wakeup.close`. But this is not really changing the perf so maybe we could leave it. Let me know what you prefer.

Finally, the call to `wakeup` in `_python_exit` was indeed not protected and this could lead to the same race condition. I added a lock here to make sure we avoid this. (A bit more complicated than expected as the `_python_exit` was leaking in the workers).

I launched 50times the tests with @vstinner [patch](https://bugs.python.org/issue39995#msg367463) and did not observed the failure so I think this is working.

<!-- issue-number: [bpo-39995](https://bugs.python.org/issue39995) -->
https://bugs.python.org/issue39995
<!-- /issue-number -->

<!-- gh-issue-number: gh-84176 -->
* Issue: gh-84176
<!-- /gh-issue-number -->
