### PR TITLE
bpo-40286: Remove C implementation of Random.randbytes()

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -192,6 +192,12 @@ class Random(_random.Random):
 ## ---- Methods below this point do not need to be overridden when
 ## ---- subclassing for the purpose of using a different core generator.
 
+## -------------------- bytes methods ---------------------
+
+    def randbytes(self, n):
+        """Generate n random bytes."""
+        return self.getrandbits(n * 8).to_bytes(n, 'little')
+
 ## -------------------- pickle support  -------------------
 
     # Issue 17489: Since __reduce__ was defined to fix #759889 this is no

--- a/Misc/NEWS.d/next/Library/2020-04-29-18-02-16.bpo-40286.txbQNx.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-29-18-02-16.bpo-40286.txbQNx.rst
@@ -1,0 +1,3 @@
+Remove ``_random.Random.randbytes()``: the C implementation of
+``randbytes()``. Implement the method in Python to ease subclassing:
+``randbytes()`` now directly reuses ``getrandbits()``.

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -513,50 +513,6 @@ _random_Random_getrandbits_impl(RandomObject *self, int k)
     return result;
 }
 
-/*[clinic input]
-
-_random.Random.randbytes
-
-  self: self(type="RandomObject *")
-  n: Py_ssize_t
-  /
-
-Generate n random bytes.
-[clinic start generated code]*/
-
-static PyObject *
-_random_Random_randbytes_impl(RandomObject *self, Py_ssize_t n)
-/*[clinic end generated code: output=67a28548079a17ea input=7ba658a24150d233]*/
-{
-    if (n < 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "number of bytes must be non-negative");
-        return NULL;
-    }
-
-    PyObject *bytes = PyBytes_FromStringAndSize(NULL, n);
-    if (bytes == NULL) {
-        return NULL;
-    }
-    uint8_t *ptr = (uint8_t *)PyBytes_AS_STRING(bytes);
-
-    for (; n; ptr += 4, n -= 4) {
-        uint32_t word = genrand_uint32(self);
-#if PY_BIG_ENDIAN
-        /* Convert to little endian */
-        word = _Py_bswap32(word);
-#endif
-        if (n < 4) {
-            /* Drop least significant bits */
-            memcpy(ptr, (uint8_t *)&word + (4 - n), n);
-            break;
-        }
-        memcpy(ptr, &word, 4);
-    }
-
-    return bytes;
-}
-
 static PyObject *
 random_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
@@ -586,7 +542,6 @@ static PyMethodDef random_methods[] = {
     _RANDOM_RANDOM_GETSTATE_METHODDEF
     _RANDOM_RANDOM_SETSTATE_METHODDEF
     _RANDOM_RANDOM_GETRANDBITS_METHODDEF
-    _RANDOM_RANDOM_RANDBYTES_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/Modules/clinic/_randommodule.c.h
+++ b/Modules/clinic/_randommodule.c.h
@@ -114,45 +114,4 @@ _random_Random_getrandbits(RandomObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-
-PyDoc_STRVAR(_random_Random_randbytes__doc__,
-"randbytes($self, n, /)\n"
-"--\n"
-"\n"
-"Generate n random bytes.");
-
-#define _RANDOM_RANDOM_RANDBYTES_METHODDEF    \
-    {"randbytes", (PyCFunction)_random_Random_randbytes, METH_O, _random_Random_randbytes__doc__},
-
-static PyObject *
-_random_Random_randbytes_impl(RandomObject *self, Py_ssize_t n);
-
-static PyObject *
-_random_Random_randbytes(RandomObject *self, PyObject *arg)
-{
-    PyObject *return_value = NULL;
-    Py_ssize_t n;
-
-    if (PyFloat_Check(arg)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
-    {
-        Py_ssize_t ival = -1;
-        PyObject *iobj = PyNumber_Index(arg);
-        if (iobj != NULL) {
-            ival = PyLong_AsSsize_t(iobj);
-            Py_DECREF(iobj);
-        }
-        if (ival == -1 && PyErr_Occurred()) {
-            goto exit;
-        }
-        n = ival;
-    }
-    return_value = _random_Random_randbytes_impl(self, n);
-
-exit:
-    return return_value;
-}
-/*[clinic end generated code: output=e515c651860c4001 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a7feb0c9c8d1b627 input=a9049054013a1b77]*/


### PR DESCRIPTION
Remove _random.Random.randbytes(): the C implementation of
randbytes(). Implement the method in Python to ease subclassing:
randbytes() now directly reuses getrandbits().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40286](https://bugs.python.org/issue40286) -->
https://bugs.python.org/issue40286
<!-- /issue-number -->
