### PR TITLE
bpo-40334: Simplify type handling in the PEG c_generator

### DIFF
--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -676,7 +676,7 @@ file_rule(Parser *p)
     int mark = p->mark;
     { // statements? $
         void *a;
-        void *endmarker_var;
+        Token * endmarker_var;
         if (
             (a = statements_rule(p), 1)
             &&
@@ -738,7 +738,7 @@ eval_rule(Parser *p)
     { // expressions NEWLINE* $
         asdl_seq * _loop0_1_var;
         expr_ty a;
-        void *endmarker_var;
+        Token * endmarker_var;
         if (
             (a = expressions_rule(p))
             &&
@@ -774,10 +774,10 @@ func_type_rule(Parser *p)
         asdl_seq * _loop0_2_var;
         void *a;
         expr_ty b;
-        void *endmarker_var;
-        void *literal;
-        void *literal_1;
-        void *literal_2;
+        Token * endmarker_var;
+        Token * literal;
+        Token * literal_1;
+        Token * literal_2;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -850,10 +850,10 @@ type_expressions_rule(Parser *p)
         asdl_seq * a;
         expr_ty b;
         expr_ty c;
-        void *literal;
-        void *literal_1;
-        void *literal_2;
-        void *literal_3;
+        Token * literal;
+        Token * literal_1;
+        Token * literal_2;
+        Token * literal_3;
         if (
             (a = _gather_3_rule(p))
             &&
@@ -882,8 +882,8 @@ type_expressions_rule(Parser *p)
     { // ','.expression+ ',' '*' expression
         asdl_seq * a;
         expr_ty b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = _gather_5_rule(p))
             &&
@@ -906,8 +906,8 @@ type_expressions_rule(Parser *p)
     { // ','.expression+ ',' '**' expression
         asdl_seq * a;
         expr_ty b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = _gather_7_rule(p))
             &&
@@ -1031,7 +1031,7 @@ statement_newline_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // compound_stmt NEWLINE
         stmt_ty a;
-        void *newline_var;
+        Token * newline_var;
         if (
             (a = compound_stmt_rule(p))
             &&
@@ -1059,7 +1059,7 @@ statement_newline_rule(Parser *p)
         p->mark = mark;
     }
     { // NEWLINE
-        void *newline_var;
+        Token * newline_var;
         if (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))
         )
@@ -1082,7 +1082,7 @@ statement_newline_rule(Parser *p)
         p->mark = mark;
     }
     { // $
-        void *endmarker_var;
+        Token * endmarker_var;
         if (
             (endmarker_var = _PyPegen_expect_token(p, ENDMARKER))
         )
@@ -1112,7 +1112,7 @@ simple_stmt_rule(Parser *p)
     int mark = p->mark;
     { // small_stmt !';' NEWLINE
         stmt_ty a;
-        void *newline_var;
+        Token * newline_var;
         if (
             (a = small_stmt_rule(p))
             &&
@@ -1132,7 +1132,7 @@ simple_stmt_rule(Parser *p)
     }
     { // ';'.small_stmt+ ';'? NEWLINE
         asdl_seq * a;
-        void *newline_var;
+        Token * newline_var;
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
@@ -1263,7 +1263,7 @@ small_stmt_rule(Parser *p)
         p->mark = mark;
     }
     { // 'pass'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 502))
         )
@@ -1325,7 +1325,7 @@ small_stmt_rule(Parser *p)
         p->mark = mark;
     }
     { // 'break'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 506))
         )
@@ -1348,7 +1348,7 @@ small_stmt_rule(Parser *p)
         p->mark = mark;
     }
     { // 'continue'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 507))
         )
@@ -1540,7 +1540,7 @@ assignment_rule(Parser *p)
         expr_ty a;
         expr_ty b;
         void *c;
-        void *literal;
+        Token * literal;
         if (
             (a = _PyPegen_name_token(p))
             &&
@@ -1572,7 +1572,7 @@ assignment_rule(Parser *p)
         void *a;
         expr_ty b;
         void *c;
-        void *literal;
+        Token * literal;
         if (
             (a = _tmp_20_rule(p))
             &&
@@ -1697,7 +1697,7 @@ augassign_rule(Parser *p)
     AugOperator* res = NULL;
     int mark = p->mark;
     { // '+='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 36))
         )
@@ -1712,7 +1712,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '-='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 37))
         )
@@ -1727,7 +1727,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '*='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 38))
         )
@@ -1742,7 +1742,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '@='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 50))
         )
@@ -1757,7 +1757,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '/='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 39))
         )
@@ -1772,7 +1772,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '%='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 40))
         )
@@ -1787,7 +1787,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '&='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 41))
         )
@@ -1802,7 +1802,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '|='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 42))
         )
@@ -1817,7 +1817,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '^='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 43))
         )
@@ -1832,7 +1832,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '<<='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 44))
         )
@@ -1847,7 +1847,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '>>='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 45))
         )
@@ -1862,7 +1862,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '**='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 46))
         )
@@ -1877,7 +1877,7 @@ augassign_rule(Parser *p)
         p->mark = mark;
     }
     { // '//='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 48))
         )
@@ -1915,7 +1915,7 @@ global_stmt_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // 'global' ','.NAME+
         asdl_seq * a;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 508))
             &&
@@ -1963,7 +1963,7 @@ nonlocal_stmt_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // 'nonlocal' ','.NAME+
         asdl_seq * a;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 509))
             &&
@@ -2057,7 +2057,7 @@ assert_stmt_rule(Parser *p)
     { // 'assert' expression [',' expression]
         expr_ty a;
         void *b;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 505))
             &&
@@ -2107,7 +2107,7 @@ del_stmt_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // 'del' del_targets
         asdl_seq* a;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 503))
             &&
@@ -2191,7 +2191,7 @@ import_name_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // 'import' dotted_as_names
         asdl_seq* a;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 513))
             &&
@@ -2243,8 +2243,8 @@ import_from_rule(Parser *p)
         asdl_seq * a;
         expr_ty b;
         asdl_seq* c;
-        void *keyword;
-        void *keyword_1;
+        Token * keyword;
+        Token * keyword_1;
         if (
             (keyword = _PyPegen_expect_token(p, 514))
             &&
@@ -2277,8 +2277,8 @@ import_from_rule(Parser *p)
     { // 'from' (('.' | '...'))+ 'import' import_from_targets
         asdl_seq * a;
         asdl_seq* b;
-        void *keyword;
-        void *keyword_1;
+        Token * keyword;
+        Token * keyword_1;
         if (
             (keyword = _PyPegen_expect_token(p, 514))
             &&
@@ -2322,8 +2322,8 @@ import_from_targets_rule(Parser *p)
     int mark = p->mark;
     { // '(' import_from_as_names ','? ')'
         asdl_seq* a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
@@ -2357,7 +2357,7 @@ import_from_targets_rule(Parser *p)
         p->mark = mark;
     }
     { // '*'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 16))
         )
@@ -2535,7 +2535,7 @@ dotted_name_raw(Parser *p)
     { // dotted_name '.' NAME
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = dotted_name_rule(p))
             &&
@@ -2592,8 +2592,8 @@ if_stmt_rule(Parser *p)
         expr_ty a;
         asdl_seq* b;
         stmt_ty c;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 510))
             &&
@@ -2627,8 +2627,8 @@ if_stmt_rule(Parser *p)
         expr_ty a;
         asdl_seq* b;
         void *c;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 510))
             &&
@@ -2686,8 +2686,8 @@ elif_stmt_rule(Parser *p)
         expr_ty a;
         asdl_seq* b;
         stmt_ty c;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 515))
             &&
@@ -2721,8 +2721,8 @@ elif_stmt_rule(Parser *p)
         expr_ty a;
         asdl_seq* b;
         void *c;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 515))
             &&
@@ -2768,8 +2768,8 @@ else_block_rule(Parser *p)
     int mark = p->mark;
     { // 'else' ':' block
         asdl_seq* b;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 516))
             &&
@@ -2813,8 +2813,8 @@ while_stmt_rule(Parser *p)
         expr_ty a;
         asdl_seq* b;
         void *c;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 512))
             &&
@@ -2872,9 +2872,9 @@ for_stmt_rule(Parser *p)
         asdl_seq* b;
         void *el;
         expr_ty ex;
-        void *keyword;
-        void *keyword_1;
-        void *literal;
+        Token * keyword;
+        Token * keyword_1;
+        Token * literal;
         expr_ty t;
         void *tc;
         if (
@@ -2913,13 +2913,13 @@ for_stmt_rule(Parser *p)
         p->mark = mark;
     }
     { // ASYNC 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
-        void *async_var;
+        Token * async_var;
         asdl_seq* b;
         void *el;
         expr_ty ex;
-        void *keyword;
-        void *keyword_1;
-        void *literal;
+        Token * keyword;
+        Token * keyword_1;
+        Token * literal;
         expr_ty t;
         void *tc;
         if (
@@ -2988,10 +2988,10 @@ with_stmt_rule(Parser *p)
     { // 'with' '(' ','.with_item+ ')' ':' block
         asdl_seq * a;
         asdl_seq* b;
-        void *keyword;
-        void *literal;
-        void *literal_1;
-        void *literal_2;
+        Token * keyword;
+        Token * literal;
+        Token * literal_1;
+        Token * literal_2;
         if (
             (keyword = _PyPegen_expect_token(p, 519))
             &&
@@ -3026,8 +3026,8 @@ with_stmt_rule(Parser *p)
     { // 'with' ','.with_item+ ':' TYPE_COMMENT? block
         asdl_seq * a;
         asdl_seq* b;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         void *tc;
         if (
             (keyword = _PyPegen_expect_token(p, 519))
@@ -3060,12 +3060,12 @@ with_stmt_rule(Parser *p)
     }
     { // ASYNC 'with' '(' ','.with_item+ ')' ':' block
         asdl_seq * a;
-        void *async_var;
+        Token * async_var;
         asdl_seq* b;
-        void *keyword;
-        void *literal;
-        void *literal_1;
-        void *literal_2;
+        Token * keyword;
+        Token * literal;
+        Token * literal_1;
+        Token * literal_2;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))
             &&
@@ -3101,10 +3101,10 @@ with_stmt_rule(Parser *p)
     }
     { // ASYNC 'with' ','.with_item+ ':' TYPE_COMMENT? block
         asdl_seq * a;
-        void *async_var;
+        Token * async_var;
         asdl_seq* b;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         void *tc;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))
@@ -3196,8 +3196,8 @@ try_stmt_rule(Parser *p)
     { // 'try' ':' block finally_block
         asdl_seq* b;
         asdl_seq* f;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 511))
             &&
@@ -3230,8 +3230,8 @@ try_stmt_rule(Parser *p)
         void *el;
         asdl_seq * ex;
         void *f;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 511))
             &&
@@ -3288,8 +3288,8 @@ except_block_rule(Parser *p)
     { // 'except' expression ['as' target] ':' block
         asdl_seq* b;
         expr_ty e;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         void *t;
         if (
             (keyword = _PyPegen_expect_token(p, 520))
@@ -3322,8 +3322,8 @@ except_block_rule(Parser *p)
     }
     { // 'except' ':' block
         asdl_seq* b;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 520))
             &&
@@ -3365,8 +3365,8 @@ finally_block_rule(Parser *p)
     int mark = p->mark;
     { // 'finally' ':' block
         asdl_seq* a;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 521))
             &&
@@ -3408,7 +3408,7 @@ return_stmt_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // 'return' star_expressions?
         void *a;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 500))
             &&
@@ -3457,7 +3457,7 @@ raise_stmt_rule(Parser *p)
     { // 'raise' expression ['from' expression]
         expr_ty a;
         void *b;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 501))
             &&
@@ -3484,7 +3484,7 @@ raise_stmt_rule(Parser *p)
         p->mark = mark;
     }
     { // 'raise'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 501))
         )
@@ -3576,10 +3576,10 @@ function_def_raw_rule(Parser *p)
     { // 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
         void *a;
         asdl_seq* b;
-        void *keyword;
-        void *literal;
-        void *literal_1;
-        void *literal_2;
+        Token * keyword;
+        Token * literal;
+        Token * literal_1;
+        Token * literal_2;
         expr_ty n;
         void *params;
         void *tc;
@@ -3622,12 +3622,12 @@ function_def_raw_rule(Parser *p)
     }
     { // ASYNC 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
         void *a;
-        void *async_var;
+        Token * async_var;
         asdl_seq* b;
-        void *keyword;
-        void *literal;
-        void *literal_1;
-        void *literal_2;
+        Token * keyword;
+        Token * literal;
+        Token * literal_1;
+        Token * literal_2;
         expr_ty n;
         void *params;
         void *tc;
@@ -3688,8 +3688,8 @@ func_type_comment_rule(Parser *p)
     PyObject* res = NULL;
     int mark = p->mark;
     { // NEWLINE TYPE_COMMENT &(NEWLINE INDENT)
-        void *newline_var;
-        void *t;
+        Token * newline_var;
+        Token * t;
         if (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))
             &&
@@ -3719,7 +3719,7 @@ func_type_comment_rule(Parser *p)
         p->mark = mark;
     }
     { // TYPE_COMMENT
-        void *type_comment_var;
+        Token * type_comment_var;
         if (
             (type_comment_var = _PyPegen_expect_token(p, TYPE_COMMENT))
         )
@@ -3899,8 +3899,8 @@ slash_no_default_rule(Parser *p)
     int mark = p->mark;
     { // param_no_default+ '/' ','
         asdl_seq * a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = _loop1_59_rule(p))
             &&
@@ -3920,7 +3920,7 @@ slash_no_default_rule(Parser *p)
     }
     { // param_no_default+ '/' &')'
         asdl_seq * a;
-        void *literal;
+        Token * literal;
         if (
             (a = _loop1_60_rule(p))
             &&
@@ -3957,8 +3957,8 @@ slash_with_default_rule(Parser *p)
     { // param_no_default* param_with_default+ '/' ','
         asdl_seq * a;
         asdl_seq * b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = _loop0_61_rule(p))
             &&
@@ -3981,7 +3981,7 @@ slash_with_default_rule(Parser *p)
     { // param_no_default* param_with_default+ '/' &')'
         asdl_seq * a;
         asdl_seq * b;
-        void *literal;
+        Token * literal;
         if (
             (a = _loop0_63_rule(p))
             &&
@@ -4022,7 +4022,7 @@ star_etc_rule(Parser *p)
         arg_ty a;
         asdl_seq * b;
         void *c;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -4045,8 +4045,8 @@ star_etc_rule(Parser *p)
     { // '*' ',' param_maybe_default+ kwds?
         asdl_seq * b;
         void *c;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -4097,7 +4097,7 @@ kwds_rule(Parser *p)
     int mark = p->mark;
     { // '**' param_no_default
         arg_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 35))
             &&
@@ -4129,7 +4129,7 @@ param_no_default_rule(Parser *p)
     int mark = p->mark;
     { // param ',' TYPE_COMMENT?
         arg_ty a;
-        void *literal;
+        Token * literal;
         void *tc;
         if (
             (a = param_rule(p))
@@ -4185,7 +4185,7 @@ param_with_default_rule(Parser *p)
     { // param default ',' TYPE_COMMENT?
         arg_ty a;
         expr_ty c;
-        void *literal;
+        Token * literal;
         void *tc;
         if (
             (a = param_rule(p))
@@ -4248,7 +4248,7 @@ param_maybe_default_rule(Parser *p)
     { // param default? ',' TYPE_COMMENT?
         arg_ty a;
         void *c;
-        void *literal;
+        Token * literal;
         void *tc;
         if (
             (a = param_rule(p))
@@ -4356,7 +4356,7 @@ annotation_rule(Parser *p)
     int mark = p->mark;
     { // ':' expression
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -4388,7 +4388,7 @@ default_rule(Parser *p)
     int mark = p->mark;
     { // '=' expression
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 22))
             &&
@@ -4502,8 +4502,8 @@ class_def_raw_rule(Parser *p)
         expr_ty a;
         void *b;
         asdl_seq* c;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 523))
             &&
@@ -4551,9 +4551,9 @@ block_rule(Parser *p)
     int mark = p->mark;
     { // NEWLINE INDENT statements DEDENT
         asdl_seq* a;
-        void *dedent_var;
-        void *indent_var;
-        void *newline_var;
+        Token * dedent_var;
+        Token * indent_var;
+        Token * newline_var;
         if (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))
             &&
@@ -4686,7 +4686,7 @@ star_expressions_rule(Parser *p)
     }
     { // star_expression ','
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (a = star_expression_rule(p))
             &&
@@ -4747,7 +4747,7 @@ star_expression_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // '*' bitwise_or
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -4840,7 +4840,7 @@ star_named_expression_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // '*' bitwise_or
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -4900,7 +4900,7 @@ named_expression_rule(Parser *p)
     { // NAME ':=' expression
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = _PyPegen_name_token(p))
             &&
@@ -5040,7 +5040,7 @@ expressions_rule(Parser *p)
     }
     { // expression ','
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (a = expression_rule(p))
             &&
@@ -5103,8 +5103,8 @@ expression_rule(Parser *p)
         expr_ty a;
         expr_ty b;
         expr_ty c;
-        void *keyword;
-        void *keyword_1;
+        Token * keyword;
+        Token * keyword_1;
         if (
             (a = disjunction_rule(p))
             &&
@@ -5182,8 +5182,8 @@ lambdef_rule(Parser *p)
     { // 'lambda' lambda_parameters? ':' expression
         void *a;
         expr_ty b;
-        void *keyword;
-        void *literal;
+        Token * keyword;
+        Token * literal;
         if (
             (keyword = _PyPegen_expect_token(p, 524))
             &&
@@ -5345,8 +5345,8 @@ lambda_slash_without_default_rule(Parser *p)
     int mark = p->mark;
     { // lambda_plain_names ',' '/'
         asdl_seq* a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = lambda_plain_names_rule(p))
             &&
@@ -5381,8 +5381,8 @@ lambda_slash_with_default_rule(Parser *p)
     { // [lambda_plain_names ','] lambda_names_with_default ',' '/'
         void *a;
         asdl_seq* b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = _tmp_83_rule(p), 1)
             &&
@@ -5423,7 +5423,7 @@ lambda_star_etc_rule(Parser *p)
         arg_ty a;
         asdl_seq * b;
         void *c;
-        void *literal;
+        Token * literal;
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
@@ -5450,7 +5450,7 @@ lambda_star_etc_rule(Parser *p)
     { // '*' lambda_name_with_optional_default+ [',' lambda_kwds] ','?
         asdl_seq * b;
         void *c;
-        void *literal;
+        Token * literal;
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
@@ -5508,7 +5508,7 @@ lambda_name_with_optional_default_rule(Parser *p)
     { // ',' lambda_plain_name ['=' expression]
         arg_ty a;
         void *b;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -5571,7 +5571,7 @@ lambda_name_with_default_rule(Parser *p)
     int mark = p->mark;
     { // lambda_plain_name '=' expression
         expr_ty e;
-        void *literal;
+        Token * literal;
         arg_ty n;
         if (
             (n = lambda_plain_name_rule(p))
@@ -5680,7 +5680,7 @@ lambda_kwds_rule(Parser *p)
     int mark = p->mark;
     { // '**' lambda_plain_name
         arg_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 35))
             &&
@@ -5846,7 +5846,7 @@ inversion_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // 'not' inversion
         expr_ty a;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 525))
             &&
@@ -6091,7 +6091,7 @@ eq_bitwise_or_rule(Parser *p)
     int mark = p->mark;
     { // '==' bitwise_or
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 27))
             &&
@@ -6155,7 +6155,7 @@ lte_bitwise_or_rule(Parser *p)
     int mark = p->mark;
     { // '<=' bitwise_or
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 29))
             &&
@@ -6187,7 +6187,7 @@ lt_bitwise_or_rule(Parser *p)
     int mark = p->mark;
     { // '<' bitwise_or
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 20))
             &&
@@ -6219,7 +6219,7 @@ gte_bitwise_or_rule(Parser *p)
     int mark = p->mark;
     { // '>=' bitwise_or
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 30))
             &&
@@ -6251,7 +6251,7 @@ gt_bitwise_or_rule(Parser *p)
     int mark = p->mark;
     { // '>' bitwise_or
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 21))
             &&
@@ -6283,8 +6283,8 @@ notin_bitwise_or_rule(Parser *p)
     int mark = p->mark;
     { // 'not' 'in' bitwise_or
         expr_ty a;
-        void *keyword;
-        void *keyword_1;
+        Token * keyword;
+        Token * keyword_1;
         if (
             (keyword = _PyPegen_expect_token(p, 525))
             &&
@@ -6318,7 +6318,7 @@ in_bitwise_or_rule(Parser *p)
     int mark = p->mark;
     { // 'in' bitwise_or
         expr_ty a;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 518))
             &&
@@ -6350,8 +6350,8 @@ isnot_bitwise_or_rule(Parser *p)
     int mark = p->mark;
     { // 'is' 'not' bitwise_or
         expr_ty a;
-        void *keyword;
-        void *keyword_1;
+        Token * keyword;
+        Token * keyword_1;
         if (
             (keyword = _PyPegen_expect_token(p, 526))
             &&
@@ -6385,7 +6385,7 @@ is_bitwise_or_rule(Parser *p)
     int mark = p->mark;
     { // 'is' bitwise_or
         expr_ty a;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 526))
             &&
@@ -6451,7 +6451,7 @@ bitwise_or_raw(Parser *p)
     { // bitwise_or '|' bitwise_xor
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = bitwise_or_rule(p))
             &&
@@ -6538,7 +6538,7 @@ bitwise_xor_raw(Parser *p)
     { // bitwise_xor '^' bitwise_and
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = bitwise_xor_rule(p))
             &&
@@ -6625,7 +6625,7 @@ bitwise_and_raw(Parser *p)
     { // bitwise_and '&' shift_expr
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = bitwise_and_rule(p))
             &&
@@ -6712,7 +6712,7 @@ shift_expr_raw(Parser *p)
     { // shift_expr '<<' sum
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = shift_expr_rule(p))
             &&
@@ -6741,7 +6741,7 @@ shift_expr_raw(Parser *p)
     { // shift_expr '>>' sum
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = shift_expr_rule(p))
             &&
@@ -6828,7 +6828,7 @@ sum_raw(Parser *p)
     { // sum '+' term
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = sum_rule(p))
             &&
@@ -6857,7 +6857,7 @@ sum_raw(Parser *p)
     { // sum '-' term
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = sum_rule(p))
             &&
@@ -6950,7 +6950,7 @@ term_raw(Parser *p)
     { // term '*' factor
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = term_rule(p))
             &&
@@ -6979,7 +6979,7 @@ term_raw(Parser *p)
     { // term '/' factor
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = term_rule(p))
             &&
@@ -7008,7 +7008,7 @@ term_raw(Parser *p)
     { // term '//' factor
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = term_rule(p))
             &&
@@ -7037,7 +7037,7 @@ term_raw(Parser *p)
     { // term '%' factor
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = term_rule(p))
             &&
@@ -7066,7 +7066,7 @@ term_raw(Parser *p)
     { // term '@' factor
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = term_rule(p))
             &&
@@ -7129,7 +7129,7 @@ factor_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // '+' factor
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 14))
             &&
@@ -7155,7 +7155,7 @@ factor_rule(Parser *p)
     }
     { // '-' factor
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 15))
             &&
@@ -7181,7 +7181,7 @@ factor_rule(Parser *p)
     }
     { // '~' factor
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 31))
             &&
@@ -7242,7 +7242,7 @@ power_rule(Parser *p)
     { // await_primary '**' factor
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = await_primary_rule(p))
             &&
@@ -7305,7 +7305,7 @@ await_primary_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // AWAIT primary
         expr_ty a;
-        void *await_var;
+        Token * await_var;
         if (
             (await_var = _PyPegen_expect_token(p, AWAIT))
             &&
@@ -7396,7 +7396,7 @@ primary_raw(Parser *p)
     { // primary '.' NAME
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = primary_rule(p))
             &&
@@ -7451,8 +7451,8 @@ primary_raw(Parser *p)
     { // primary '(' arguments? ')'
         expr_ty a;
         void *b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = primary_rule(p))
             &&
@@ -7483,8 +7483,8 @@ primary_raw(Parser *p)
     { // primary '[' slices ']'
         expr_ty a;
         expr_ty b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = primary_rule(p))
             &&
@@ -7615,7 +7615,7 @@ slice_rule(Parser *p)
         void *a;
         void *b;
         void *c;
-        void *literal;
+        Token * literal;
         if (
             (a = expression_rule(p), 1)
             &&
@@ -7703,7 +7703,7 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // 'True'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 527))
         )
@@ -7726,7 +7726,7 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // 'False'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 528))
         )
@@ -7749,7 +7749,7 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // 'None'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 529))
         )
@@ -7772,7 +7772,7 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // '__new_parser__'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 530))
         )
@@ -7850,7 +7850,7 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // '...'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 52))
         )
@@ -7928,8 +7928,8 @@ list_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // '[' star_named_expressions? ']'
         void *a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 9))
             &&
@@ -7980,8 +7980,8 @@ listcomp_rule(Parser *p)
     { // '[' named_expression for_if_clauses ']'
         expr_ty a;
         asdl_seq* b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 9))
             &&
@@ -8044,8 +8044,8 @@ tuple_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // '(' [star_named_expression ',' star_named_expressions?] ')'
         void *a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -8087,8 +8087,8 @@ group_rule(Parser *p)
     int mark = p->mark;
     { // '(' (yield_expr | named_expression) ')'
         void *a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -8131,8 +8131,8 @@ genexp_rule(Parser *p)
     { // '(' expression for_if_clauses ')'
         expr_ty a;
         asdl_seq* b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -8195,8 +8195,8 @@ set_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // '{' expressions_list '}'
         asdl_seq* a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 25))
             &&
@@ -8247,8 +8247,8 @@ setcomp_rule(Parser *p)
     { // '{' expression for_if_clauses '}'
         expr_ty a;
         asdl_seq* b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 25))
             &&
@@ -8311,8 +8311,8 @@ dict_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // '{' kvpairs? '}'
         void *a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 25))
             &&
@@ -8363,8 +8363,8 @@ dictcomp_rule(Parser *p)
     { // '{' kvpair for_if_clauses '}'
         KeyValuePair* a;
         asdl_seq* b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 25))
             &&
@@ -8441,7 +8441,7 @@ kvpair_rule(Parser *p)
     int mark = p->mark;
     { // '**' bitwise_or
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 35))
             &&
@@ -8460,7 +8460,7 @@ kvpair_rule(Parser *p)
     { // expression ':' expression
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = expression_rule(p))
             &&
@@ -8521,11 +8521,11 @@ for_if_clause_rule(Parser *p)
     int mark = p->mark;
     { // ASYNC 'for' star_targets 'in' disjunction (('if' disjunction))*
         expr_ty a;
-        void *async_var;
+        Token * async_var;
         expr_ty b;
         asdl_seq * c;
-        void *keyword;
-        void *keyword_1;
+        Token * keyword;
+        Token * keyword_1;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))
             &&
@@ -8553,8 +8553,8 @@ for_if_clause_rule(Parser *p)
         expr_ty a;
         expr_ty b;
         asdl_seq * c;
-        void *keyword;
-        void *keyword_1;
+        Token * keyword;
+        Token * keyword_1;
         if (
             (keyword = _PyPegen_expect_token(p, 517))
             &&
@@ -8600,8 +8600,8 @@ yield_expr_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // 'yield' 'from' expression
         expr_ty a;
-        void *keyword;
-        void *keyword_1;
+        Token * keyword;
+        Token * keyword_1;
         if (
             (keyword = _PyPegen_expect_token(p, 504))
             &&
@@ -8629,7 +8629,7 @@ yield_expr_rule(Parser *p)
     }
     { // 'yield' star_expressions?
         void *a;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 504))
             &&
@@ -8819,7 +8819,7 @@ kwargs_rule(Parser *p)
     { // ','.kwarg_or_starred+ ',' ','.kwarg_or_double_starred+
         asdl_seq * a;
         asdl_seq * b;
-        void *literal;
+        Token * literal;
         if (
             (a = _gather_113_rule(p))
             &&
@@ -8883,7 +8883,7 @@ starred_expression_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // '*' expression
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -8932,7 +8932,7 @@ kwarg_or_starred_rule(Parser *p)
     { // NAME '=' expression
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = _PyPegen_name_token(p))
             &&
@@ -8998,7 +8998,7 @@ kwarg_or_double_starred_rule(Parser *p)
     { // NAME '=' expression
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = _PyPegen_name_token(p))
             &&
@@ -9026,7 +9026,7 @@ kwarg_or_double_starred_rule(Parser *p)
     }
     { // '**' expression
         expr_ty a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 35))
             &&
@@ -9182,7 +9182,7 @@ star_target_rule(Parser *p)
     UNUSED(start_col_offset); // Only used by EXTRA macro
     { // '*' (!'*' star_target)
         void *a;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -9209,7 +9209,7 @@ star_target_rule(Parser *p)
     { // t_primary '.' NAME !t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = t_primary_rule(p))
             &&
@@ -9240,8 +9240,8 @@ star_target_rule(Parser *p)
     { // t_primary '[' slices ']' !t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = t_primary_rule(p))
             &&
@@ -9326,8 +9326,8 @@ star_atom_rule(Parser *p)
     }
     { // '(' star_target ')'
         expr_ty a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -9347,8 +9347,8 @@ star_atom_rule(Parser *p)
     }
     { // '(' star_targets_seq? ')'
         void *a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -9376,8 +9376,8 @@ star_atom_rule(Parser *p)
     }
     { // '[' star_targets_seq? ']'
         void *a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 9))
             &&
@@ -9448,8 +9448,8 @@ inside_paren_ann_assign_target_rule(Parser *p)
     }
     { // '(' inside_paren_ann_assign_target ')'
         expr_ty a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -9494,7 +9494,7 @@ ann_assign_subscript_attribute_target_rule(Parser *p)
     { // t_primary '.' NAME !t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = t_primary_rule(p))
             &&
@@ -9525,8 +9525,8 @@ ann_assign_subscript_attribute_target_rule(Parser *p)
     { // t_primary '[' slices ']' !t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = t_primary_rule(p))
             &&
@@ -9619,7 +9619,7 @@ del_target_rule(Parser *p)
     { // t_primary '.' NAME !t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = t_primary_rule(p))
             &&
@@ -9650,8 +9650,8 @@ del_target_rule(Parser *p)
     { // t_primary '[' slices ']' !t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = t_primary_rule(p))
             &&
@@ -9732,8 +9732,8 @@ del_t_atom_rule(Parser *p)
     }
     { // '(' del_target ')'
         expr_ty a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -9753,8 +9753,8 @@ del_t_atom_rule(Parser *p)
     }
     { // '(' del_targets? ')'
         void *a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -9782,8 +9782,8 @@ del_t_atom_rule(Parser *p)
     }
     { // '[' del_targets? ']'
         void *a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 9))
             &&
@@ -9872,7 +9872,7 @@ target_rule(Parser *p)
     { // t_primary '.' NAME !t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = t_primary_rule(p))
             &&
@@ -9903,8 +9903,8 @@ target_rule(Parser *p)
     { // t_primary '[' slices ']' !t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = t_primary_rule(p))
             &&
@@ -10001,7 +10001,7 @@ t_primary_raw(Parser *p)
     { // t_primary '.' NAME &t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
+        Token * literal;
         if (
             (a = t_primary_rule(p))
             &&
@@ -10032,8 +10032,8 @@ t_primary_raw(Parser *p)
     { // t_primary '[' slices ']' &t_lookahead
         expr_ty a;
         expr_ty b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = t_primary_rule(p))
             &&
@@ -10094,8 +10094,8 @@ t_primary_raw(Parser *p)
     { // t_primary '(' arguments? ')' &t_lookahead
         expr_ty a;
         void *b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (a = t_primary_rule(p))
             &&
@@ -10157,7 +10157,7 @@ t_lookahead_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // '('
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 7))
         )
@@ -10168,7 +10168,7 @@ t_lookahead_rule(Parser *p)
         p->mark = mark;
     }
     { // '['
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 9))
         )
@@ -10179,7 +10179,7 @@ t_lookahead_rule(Parser *p)
         p->mark = mark;
     }
     { // '.'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 23))
         )
@@ -10228,8 +10228,8 @@ t_atom_rule(Parser *p)
     }
     { // '(' target ')'
         expr_ty a;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -10249,8 +10249,8 @@ t_atom_rule(Parser *p)
     }
     { // '(' targets? ')'
         void *b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -10278,8 +10278,8 @@ t_atom_rule(Parser *p)
     }
     { // '[' targets? ']'
         void *b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 9))
             &&
@@ -10324,8 +10324,8 @@ incorrect_arguments_rule(Parser *p)
     int mark = p->mark;
     { // args ',' '*'
         expr_ty args_var;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (args_var = args_rule(p))
             &&
@@ -10346,7 +10346,7 @@ incorrect_arguments_rule(Parser *p)
     { // expression for_if_clauses ',' [args | expression for_if_clauses]
         expr_ty expression_var;
         asdl_seq* for_if_clauses_var;
-        void *literal;
+        Token * literal;
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
@@ -10371,7 +10371,7 @@ incorrect_arguments_rule(Parser *p)
     { // args ',' args
         expr_ty a;
         expr_ty args_var;
-        void *literal;
+        Token * literal;
         if (
             (a = args_rule(p))
             &&
@@ -10406,7 +10406,7 @@ invalid_named_expression_rule(Parser *p)
     { // expression ':=' expression
         expr_ty a;
         expr_ty expression_var;
-        void *literal;
+        Token * literal;
         if (
             (a = expression_rule(p))
             &&
@@ -10444,7 +10444,7 @@ invalid_assignment_rule(Parser *p)
     int mark = p->mark;
     { // list ':'
         expr_ty list_var;
-        void *literal;
+        Token * literal;
         if (
             (list_var = list_rule(p))
             &&
@@ -10461,7 +10461,7 @@ invalid_assignment_rule(Parser *p)
         p->mark = mark;
     }
     { // tuple ':'
-        void *literal;
+        Token * literal;
         expr_ty tuple_var;
         if (
             (tuple_var = tuple_rule(p))
@@ -10481,7 +10481,7 @@ invalid_assignment_rule(Parser *p)
     { // expression ':' expression ['=' annotated_rhs]
         expr_ty expression_var;
         expr_ty expression_var_1;
-        void *literal;
+        Token * literal;
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
@@ -10539,7 +10539,7 @@ invalid_block_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // NEWLINE !INDENT
-        void *newline_var;
+        Token * newline_var;
         if (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))
             &&
@@ -10573,7 +10573,7 @@ invalid_comprehension_rule(Parser *p)
         void *_tmp_133_var;
         expr_ty expression_var;
         asdl_seq* for_if_clauses_var;
-        void *literal;
+        Token * literal;
         if (
             (_tmp_133_var = _tmp_133_rule(p))
             &&
@@ -10644,11 +10644,11 @@ invalid_double_type_comments_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT
-        void *indent_var;
-        void *newline_var;
-        void *newline_var_1;
-        void *type_comment_var;
-        void *type_comment_var_1;
+        Token * indent_var;
+        Token * newline_var;
+        Token * newline_var_1;
+        Token * type_comment_var;
+        Token * type_comment_var_1;
         if (
             (type_comment_var = _PyPegen_expect_token(p, TYPE_COMMENT))
             &&
@@ -10693,7 +10693,7 @@ _loop0_1_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // NEWLINE
-        void *newline_var;
+        Token * newline_var;
         while (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))
         )
@@ -10742,7 +10742,7 @@ _loop0_2_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // NEWLINE
-        void *newline_var;
+        Token * newline_var;
         while (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))
         )
@@ -10792,7 +10792,7 @@ _loop0_4_rule(Parser *p)
     ssize_t n = 0;
     { // ',' expression
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -10877,7 +10877,7 @@ _loop0_6_rule(Parser *p)
     ssize_t n = 0;
     { // ',' expression
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -10962,7 +10962,7 @@ _loop0_8_rule(Parser *p)
     ssize_t n = 0;
     { // ',' expression
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -11047,7 +11047,7 @@ _loop0_10_rule(Parser *p)
     ssize_t n = 0;
     { // ',' expression
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -11185,7 +11185,7 @@ _loop0_13_rule(Parser *p)
     ssize_t n = 0;
     { // ';' small_stmt
         stmt_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 13))
             &&
@@ -11261,7 +11261,7 @@ _tmp_14_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'import'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 513))
         )
@@ -11272,7 +11272,7 @@ _tmp_14_rule(Parser *p)
         p->mark = mark;
     }
     { // 'from'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 514))
         )
@@ -11297,7 +11297,7 @@ _tmp_15_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'def'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 522))
         )
@@ -11308,7 +11308,7 @@ _tmp_15_rule(Parser *p)
         p->mark = mark;
     }
     { // '@'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 49))
         )
@@ -11319,7 +11319,7 @@ _tmp_15_rule(Parser *p)
         p->mark = mark;
     }
     { // ASYNC
-        void *async_var;
+        Token * async_var;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))
         )
@@ -11344,7 +11344,7 @@ _tmp_16_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'class'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 523))
         )
@@ -11355,7 +11355,7 @@ _tmp_16_rule(Parser *p)
         p->mark = mark;
     }
     { // '@'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 49))
         )
@@ -11380,7 +11380,7 @@ _tmp_17_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'with'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 519))
         )
@@ -11391,7 +11391,7 @@ _tmp_17_rule(Parser *p)
         p->mark = mark;
     }
     { // ASYNC
-        void *async_var;
+        Token * async_var;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))
         )
@@ -11416,7 +11416,7 @@ _tmp_18_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'for'
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 517))
         )
@@ -11427,7 +11427,7 @@ _tmp_18_rule(Parser *p)
         p->mark = mark;
     }
     { // ASYNC
-        void *async_var;
+        Token * async_var;
         if (
             (async_var = _PyPegen_expect_token(p, ASYNC))
         )
@@ -11453,7 +11453,7 @@ _tmp_19_rule(Parser *p)
     int mark = p->mark;
     { // '=' annotated_rhs
         expr_ty d;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 22))
             &&
@@ -11485,8 +11485,8 @@ _tmp_20_rule(Parser *p)
     int mark = p->mark;
     { // '(' inside_paren_ann_assign_target ')'
         expr_ty b;
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
@@ -11531,7 +11531,7 @@ _tmp_21_rule(Parser *p)
     int mark = p->mark;
     { // '=' annotated_rhs
         expr_ty d;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 22))
             &&
@@ -11696,7 +11696,7 @@ _loop0_26_rule(Parser *p)
     ssize_t n = 0;
     { // ',' NAME
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -11781,7 +11781,7 @@ _loop0_28_rule(Parser *p)
     ssize_t n = 0;
     { // ',' NAME
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -11857,7 +11857,7 @@ _tmp_29_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ',' expression
-        void *literal;
+        Token * literal;
         expr_ty z;
         if (
             (literal = _PyPegen_expect_token(p, 12))
@@ -12000,7 +12000,7 @@ _loop0_33_rule(Parser *p)
     ssize_t n = 0;
     { // ',' import_from_as_name
         alias_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -12076,7 +12076,7 @@ _tmp_34_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'as' NAME
-        void *keyword;
+        Token * keyword;
         expr_ty z;
         if (
             (keyword = _PyPegen_expect_token(p, 531))
@@ -12117,7 +12117,7 @@ _loop0_36_rule(Parser *p)
     ssize_t n = 0;
     { // ',' dotted_as_name
         alias_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -12193,7 +12193,7 @@ _tmp_37_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'as' NAME
-        void *keyword;
+        Token * keyword;
         expr_ty z;
         if (
             (keyword = _PyPegen_expect_token(p, 531))
@@ -12234,7 +12234,7 @@ _loop0_39_rule(Parser *p)
     ssize_t n = 0;
     { // ',' with_item
         withitem_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -12319,7 +12319,7 @@ _loop0_41_rule(Parser *p)
     ssize_t n = 0;
     { // ',' with_item
         withitem_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -12404,7 +12404,7 @@ _loop0_43_rule(Parser *p)
     ssize_t n = 0;
     { // ',' with_item
         withitem_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -12489,7 +12489,7 @@ _loop0_45_rule(Parser *p)
     ssize_t n = 0;
     { // ',' with_item
         withitem_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -12565,7 +12565,7 @@ _tmp_46_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'as' target
-        void *keyword;
+        Token * keyword;
         expr_ty t;
         if (
             (keyword = _PyPegen_expect_token(p, 531))
@@ -12650,7 +12650,7 @@ _tmp_48_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'as' target
-        void *keyword;
+        Token * keyword;
         expr_ty z;
         if (
             (keyword = _PyPegen_expect_token(p, 531))
@@ -12682,7 +12682,7 @@ _tmp_49_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'from' expression
-        void *keyword;
+        Token * keyword;
         expr_ty z;
         if (
             (keyword = _PyPegen_expect_token(p, 514))
@@ -12714,7 +12714,7 @@ _tmp_50_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // '->' expression
-        void *literal;
+        Token * literal;
         expr_ty z;
         if (
             (literal = _PyPegen_expect_token(p, 51))
@@ -12746,7 +12746,7 @@ _tmp_51_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // '->' expression
-        void *literal;
+        Token * literal;
         expr_ty z;
         if (
             (literal = _PyPegen_expect_token(p, 51))
@@ -12778,8 +12778,8 @@ _tmp_52_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // NEWLINE INDENT
-        void *indent_var;
-        void *newline_var;
+        Token * indent_var;
+        Token * newline_var;
         if (
             (newline_var = _PyPegen_expect_token(p, NEWLINE))
             &&
@@ -13573,8 +13573,8 @@ _tmp_68_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // '(' arguments? ')'
-        void *literal;
-        void *literal_1;
+        Token * literal;
+        Token * literal_1;
         void *z;
         if (
             (literal = _PyPegen_expect_token(p, 7))
@@ -13617,7 +13617,7 @@ _loop0_70_rule(Parser *p)
     ssize_t n = 0;
     { // ',' star_expression
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -13755,7 +13755,7 @@ _loop0_73_rule(Parser *p)
     ssize_t n = 0;
     { // ',' star_named_expression
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -13884,7 +13884,7 @@ _tmp_75_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ',' lambda_plain_names
-        void *literal;
+        Token * literal;
         asdl_seq* x;
         if (
             (literal = _PyPegen_expect_token(p, 12))
@@ -13916,7 +13916,7 @@ _tmp_76_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ',' lambda_names_with_default
-        void *literal;
+        Token * literal;
         asdl_seq* y;
         if (
             (literal = _PyPegen_expect_token(p, 12))
@@ -13948,7 +13948,7 @@ _tmp_77_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ',' lambda_star_etc?
-        void *literal;
+        Token * literal;
         void *z;
         if (
             (literal = _PyPegen_expect_token(p, 12))
@@ -13980,7 +13980,7 @@ _tmp_78_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ',' lambda_names_with_default
-        void *literal;
+        Token * literal;
         asdl_seq* y;
         if (
             (literal = _PyPegen_expect_token(p, 12))
@@ -14012,7 +14012,7 @@ _tmp_79_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ',' lambda_star_etc?
-        void *literal;
+        Token * literal;
         void *z;
         if (
             (literal = _PyPegen_expect_token(p, 12))
@@ -14044,7 +14044,7 @@ _tmp_80_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ',' lambda_names_with_default
-        void *literal;
+        Token * literal;
         asdl_seq* y;
         if (
             (literal = _PyPegen_expect_token(p, 12))
@@ -14076,7 +14076,7 @@ _tmp_81_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ',' lambda_star_etc?
-        void *literal;
+        Token * literal;
         void *z;
         if (
             (literal = _PyPegen_expect_token(p, 12))
@@ -14108,7 +14108,7 @@ _tmp_82_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ',' lambda_star_etc?
-        void *literal;
+        Token * literal;
         void *z;
         if (
             (literal = _PyPegen_expect_token(p, 12))
@@ -14140,7 +14140,7 @@ _tmp_83_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // lambda_plain_names ','
-        void *literal;
+        Token * literal;
         asdl_seq* n;
         if (
             (n = lambda_plain_names_rule(p))
@@ -14222,7 +14222,7 @@ _tmp_85_rule(Parser *p)
     int mark = p->mark;
     { // ',' lambda_kwds
         arg_ty d;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -14307,7 +14307,7 @@ _tmp_87_rule(Parser *p)
     int mark = p->mark;
     { // ',' lambda_kwds
         arg_ty d;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -14339,7 +14339,7 @@ _tmp_88_rule(Parser *p)
     int mark = p->mark;
     { // '=' expression
         expr_ty e;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 22))
             &&
@@ -14379,7 +14379,7 @@ _loop0_90_rule(Parser *p)
     ssize_t n = 0;
     { // ',' lambda_name_with_default
         NameDefaultPair* elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -14464,7 +14464,7 @@ _loop0_92_rule(Parser *p)
     ssize_t n = 0;
     { // ',' (lambda_plain_name !'=')
         void *elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -14699,7 +14699,7 @@ _tmp_96_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // '!='
-        void *tok;
+        Token * tok;
         if (
             (tok = _PyPegen_expect_token(p, 28))
         )
@@ -14737,7 +14737,7 @@ _loop0_98_rule(Parser *p)
     ssize_t n = 0;
     { // ',' slice
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -14814,7 +14814,7 @@ _tmp_99_rule(Parser *p)
     int mark = p->mark;
     { // ':' expression?
         void *d;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -15039,7 +15039,7 @@ _tmp_104_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // star_named_expression ',' star_named_expressions?
-        void *literal;
+        Token * literal;
         expr_ty y;
         void *z;
         if (
@@ -15119,7 +15119,7 @@ _loop0_107_rule(Parser *p)
     ssize_t n = 0;
     { // ',' kvpair
         KeyValuePair* elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -15347,7 +15347,7 @@ _tmp_111_rule(Parser *p)
     int mark = p->mark;
     { // ',' args
         expr_ty c;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -15379,7 +15379,7 @@ _tmp_112_rule(Parser *p)
     int mark = p->mark;
     { // ',' args
         expr_ty c;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -15419,7 +15419,7 @@ _loop0_114_rule(Parser *p)
     ssize_t n = 0;
     { // ',' kwarg_or_starred
         KeywordOrStarred* elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -15504,7 +15504,7 @@ _loop0_116_rule(Parser *p)
     ssize_t n = 0;
     { // ',' kwarg_or_double_starred
         KeywordOrStarred* elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -15589,7 +15589,7 @@ _loop0_118_rule(Parser *p)
     ssize_t n = 0;
     { // ',' kwarg_or_starred
         KeywordOrStarred* elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -15674,7 +15674,7 @@ _loop0_120_rule(Parser *p)
     ssize_t n = 0;
     { // ',' kwarg_or_double_starred
         KeywordOrStarred* elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -15808,7 +15808,7 @@ _loop0_123_rule(Parser *p)
     ssize_t n = 0;
     { // ',' star_target
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -15920,7 +15920,7 @@ _loop0_126_rule(Parser *p)
     ssize_t n = 0;
     { // ',' del_target
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -16005,7 +16005,7 @@ _loop0_128_rule(Parser *p)
     ssize_t n = 0;
     { // ',' target
         expr_ty elem;
-        void *literal;
+        Token * literal;
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -16121,7 +16121,7 @@ _tmp_130_rule(Parser *p)
     int mark = p->mark;
     { // '=' annotated_rhs
         expr_ty annotated_rhs_var;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 22))
             &&
@@ -16148,7 +16148,7 @@ _tmp_131_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // '='
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 22))
         )
@@ -16220,7 +16220,7 @@ _tmp_133_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // '['
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 9))
         )
@@ -16231,7 +16231,7 @@ _tmp_133_rule(Parser *p)
         p->mark = mark;
     }
     { // '('
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 7))
         )
@@ -16242,7 +16242,7 @@ _tmp_133_rule(Parser *p)
         p->mark = mark;
     }
     { // '{'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 25))
         )
@@ -16352,7 +16352,7 @@ _tmp_136_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // star_targets '='
-        void *literal;
+        Token * literal;
         expr_ty z;
         if (
             (z = star_targets_rule(p))
@@ -16384,7 +16384,7 @@ _tmp_137_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // '.'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 23))
         )
@@ -16395,7 +16395,7 @@ _tmp_137_rule(Parser *p)
         p->mark = mark;
     }
     { // '...'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 52))
         )
@@ -16420,7 +16420,7 @@ _tmp_138_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // '.'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 23))
         )
@@ -16431,7 +16431,7 @@ _tmp_138_rule(Parser *p)
         p->mark = mark;
     }
     { // '...'
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 52))
         )
@@ -16457,8 +16457,8 @@ _tmp_139_rule(Parser *p)
     int mark = p->mark;
     { // '@' named_expression NEWLINE
         expr_ty f;
-        void *literal;
-        void *newline_var;
+        Token * literal;
+        Token * newline_var;
         if (
             (literal = _PyPegen_expect_token(p, 49))
             &&
@@ -16492,7 +16492,7 @@ _tmp_140_rule(Parser *p)
     int mark = p->mark;
     { // ',' star_expression
         expr_ty c;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -16524,7 +16524,7 @@ _tmp_141_rule(Parser *p)
     int mark = p->mark;
     { // ',' expression
         expr_ty c;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
@@ -16583,7 +16583,7 @@ _tmp_143_rule(Parser *p)
     int mark = p->mark;
     { // 'or' conjunction
         expr_ty c;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 532))
             &&
@@ -16615,7 +16615,7 @@ _tmp_144_rule(Parser *p)
     int mark = p->mark;
     { // 'and' inversion
         expr_ty c;
-        void *keyword;
+        Token * keyword;
         if (
             (keyword = _PyPegen_expect_token(p, 533))
             &&
@@ -16646,7 +16646,7 @@ _tmp_145_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'if' disjunction
-        void *keyword;
+        Token * keyword;
         expr_ty z;
         if (
             (keyword = _PyPegen_expect_token(p, 510))
@@ -16678,7 +16678,7 @@ _tmp_146_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // 'if' disjunction
-        void *keyword;
+        Token * keyword;
         expr_ty z;
         if (
             (keyword = _PyPegen_expect_token(p, 510))
@@ -16711,7 +16711,7 @@ _tmp_147_rule(Parser *p)
     int mark = p->mark;
     { // ',' star_target
         expr_ty c;
-        void *literal;
+        Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&

--- a/Tools/peg_generator/pegen/parser_generator.py
+++ b/Tools/peg_generator/pegen/parser_generator.py
@@ -47,7 +47,7 @@ class ParserGenerator:
         self.todo = self.rules.copy()  # Rules to generate
         self.counter = 0  # For name_rule()/name_loop()
         self.keyword_counter = 499  # For keyword_type()
-        self.all_rules: Optional[Dict[str, Rule]] = None  # Rules + temporal rules
+        self.all_rules: Dict[str, Rule] = {}  # Rules + temporal rules
         self._local_variable_stack: List[List[str]] = []
 
     @contextlib.contextmanager
@@ -87,13 +87,13 @@ class ParserGenerator:
         done: Set[str] = set()
         while True:
             alltodo = list(self.todo)
+            self.all_rules.update(self.todo)
             todo = [i for i in alltodo if i not in done]
             if not todo:
                 break
             for rulename in todo:
                 self.todo[rulename].collect_todo(self)
             done = set(alltodo)
-        self.all_rules = self.todo.copy()
 
     def keyword_type(self) -> int:
         self.keyword_counter += 1


### PR DESCRIPTION
Follow up of #19775. With this PR almost all the type-deducing code in `add_var` can be eliminated :)

As a bonus, this PR eliminates some extra `void*` in the generated code :)

<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
