### PR TITLE
Revert "bpo-29587: Enable implicit exception chaining with gen.throw()"

### DIFF
--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -316,23 +316,6 @@ class ExceptionTest(unittest.TestCase):
         self.assertEqual(cm.exception.value.value, 2)
 
 
-class GeneratorThrowTest(unittest.TestCase):
-
-    def test_exception_context_set(self):
-        def f():
-            try:
-                raise KeyError('a')
-            except Exception:
-                yield
-
-        gen = f()
-        gen.send(None)
-        with self.assertRaises(ValueError) as cm:
-            gen.throw(ValueError)
-        context = cm.exception.__context__
-        self.assertEqual((type(context), context.args), (KeyError, ('a',)))
-
-
 class YieldFromTests(unittest.TestCase):
     def test_generator_gi_yieldfrom(self):
         def a():

--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-30-00-50-25.bpo-29587.oEwSq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-30-00-50-25.bpo-29587.oEwSq.rst
@@ -1,1 +1,0 @@
-Enable implicit exception chaining when calling :meth:`generator.throw`.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -512,12 +512,6 @@ throw_here:
     }
 
     PyErr_Restore(typ, val, tb);
-    if (gen->gi_exc_state.exc_type) {
-        Py_INCREF(gen->gi_exc_state.exc_type);
-        Py_XINCREF(gen->gi_exc_state.exc_value);
-        Py_XINCREF(gen->gi_exc_state.exc_traceback);
-        _PyErr_ChainExceptions(gen->gi_exc_state.exc_type, gen->gi_exc_state.exc_value, gen->gi_exc_state.exc_traceback);
-    }
     return gen_send_ex(gen, Py_None, 1, 0);
 
 failed_throw:


### PR DESCRIPTION
Reverts python/cpython#19811

<!-- issue-number: [bpo-29587](https://bugs.python.org/issue29587) -->
https://bugs.python.org/issue29587
<!-- /issue-number -->
