### PR TITLE
bpo-1635741: Fix compiler warning in _stat.c

### DIFF
--- a/Modules/_stat.c
+++ b/Modules/_stat.c
@@ -563,7 +563,7 @@ stat_exec(PyObject *module)
         "ST_CTIME"
     };
 
-    for (int i = 0; i < Py_ARRAY_LENGTH(st_constants); i++) {
+    for (int i = 0; i < (int)Py_ARRAY_LENGTH(st_constants); i++) {
         if (PyModule_AddIntConstant(module, st_constants[i], i) < 0) {
             return -1;
         }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-1635741](https://bugs.python.org/issue1635741) -->
https://bugs.python.org/issue1635741
<!-- /issue-number -->
