### PR TITLE
bpo-29587: Enable implicit exception chaining with gen.throw()

### DIFF
--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -316,6 +316,23 @@ class ExceptionTest(unittest.TestCase):
         self.assertEqual(cm.exception.value.value, 2)
 
 
+class GeneratorThrowTest(unittest.TestCase):
+
+    def test_exception_context_set(self):
+        def f():
+            try:
+                raise KeyError('a')
+            except Exception:
+                yield
+
+        gen = f()
+        gen.send(None)
+        with self.assertRaises(ValueError) as cm:
+            gen.throw(ValueError)
+        context = cm.exception.__context__
+        self.assertEqual((type(context), context.args), (KeyError, ('a',)))
+
+
 class YieldFromTests(unittest.TestCase):
     def test_generator_gi_yieldfrom(self):
         def a():

--- a/Misc/NEWS.d/next/Core and Builtins/2020-04-30-00-50-25.bpo-29587.oEwSq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2020-04-30-00-50-25.bpo-29587.oEwSq.rst
@@ -1,0 +1,1 @@
+Enable implicit exception chaining when calling :meth:`generator.throw`.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -512,6 +512,12 @@ throw_here:
     }
 
     PyErr_Restore(typ, val, tb);
+    if (gen->gi_exc_state.exc_type) {
+        Py_INCREF(gen->gi_exc_state.exc_type);
+        Py_XINCREF(gen->gi_exc_state.exc_value);
+        Py_XINCREF(gen->gi_exc_state.exc_traceback);
+        _PyErr_ChainExceptions(gen->gi_exc_state.exc_type, gen->gi_exc_state.exc_value, gen->gi_exc_state.exc_traceback);
+    }
     return gen_send_ex(gen, Py_None, 1, 0);
 
 failed_throw:

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -512,9 +512,11 @@ throw_here:
     }
 
     PyErr_Restore(typ, val, tb);
-    if (gen->gi_exc_state.exc_type) {
+    /* XXX Should we also handle the case where exc_type is true and
+       exc_value is false? */
+    if (gen->gi_exc_state.exc_type && gen->gi_exc_state.exc_value) {
         Py_INCREF(gen->gi_exc_state.exc_type);
-        Py_XINCREF(gen->gi_exc_state.exc_value);
+        Py_INCREF(gen->gi_exc_state.exc_value);
         Py_XINCREF(gen->gi_exc_state.exc_traceback);
         _PyErr_ChainExceptions(gen->gi_exc_state.exc_type,
             gen->gi_exc_state.exc_value, gen->gi_exc_state.exc_traceback);

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -516,7 +516,8 @@ throw_here:
         Py_INCREF(gen->gi_exc_state.exc_type);
         Py_XINCREF(gen->gi_exc_state.exc_value);
         Py_XINCREF(gen->gi_exc_state.exc_traceback);
-        _PyErr_ChainExceptions(gen->gi_exc_state.exc_type, gen->gi_exc_state.exc_value, gen->gi_exc_state.exc_traceback);
+        _PyErr_ChainExceptions(gen->gi_exc_state.exc_type,
+            gen->gi_exc_state.exc_value, gen->gi_exc_state.exc_traceback);
     }
     return gen_send_ex(gen, Py_None, 1, 0);
 


### PR DESCRIPTION
This is a new version of PR #19811 to sort out the buildbot failures.

It enables implicit exception chaining when calling `generator.throw(exc)` by setting `exc.__context__`.

<!-- issue-number: [bpo-29587](https://bugs.python.org/issue29587) -->
https://bugs.python.org/issue29587
<!-- /issue-number -->
