### PR TITLE
bpo-40334: Add support for feature_version in new PEG parser

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -80,10 +80,14 @@ compound_stmt[stmt_ty]:
 # NOTE: annotated_rhs may start with 'yield'; yield_expr must start with 'yield'
 assignment:
     | a=NAME ':' b=expression c=['=' d=annotated_rhs { d }] {
-        _Py_AnnAssign(CHECK(_PyPegen_set_expr_context(p, a, Store)), b, c, 1, EXTRA) }
+        CHECK_VERSION(
+            6,
+            "Variable annotation syntax is",
+            _Py_AnnAssign(CHECK(_PyPegen_set_expr_context(p, a, Store)), b, c, 1, EXTRA)
+        ) }
     | a=('(' b=inside_paren_ann_assign_target ')' { b }
          | ann_assign_subscript_attribute_target) ':' b=expression c=['=' d=annotated_rhs { d }] {
-        _Py_AnnAssign(a, b, c, 0, EXTRA)}
+        CHECK_VERSION(6, "Variable annotations syntax is", _Py_AnnAssign(a, b, c, 0, EXTRA)) }
     | a=(z=star_targets '=' { z })+ b=(yield_expr | star_expressions) tc=[TYPE_COMMENT] {
          _Py_Assign(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
     | a=target b=augassign c=(yield_expr | star_expressions) {
@@ -91,19 +95,19 @@ assignment:
     | invalid_assignment
 
 augassign[AugOperator*]:
-    | '+=' {_PyPegen_augoperator(p, Add)}
-    | '-=' {_PyPegen_augoperator(p, Sub)}
-    | '*=' {_PyPegen_augoperator(p, Mult)}
-    | '@=' {_PyPegen_augoperator(p, MatMult)}
-    | '/=' {_PyPegen_augoperator(p, Div)}
-    | '%=' {_PyPegen_augoperator(p, Mod)}
-    | '&=' {_PyPegen_augoperator(p, BitAnd)}
-    | '|=' {_PyPegen_augoperator(p, BitOr)}
-    | '^=' {_PyPegen_augoperator(p, BitXor)}
-    | '<<=' {_PyPegen_augoperator(p, LShift)}
-    | '>>=' {_PyPegen_augoperator(p, RShift)}
-    | '**=' {_PyPegen_augoperator(p, Pow)}
-    | '//=' {_PyPegen_augoperator(p, FloorDiv)}
+    | '+=' { _PyPegen_augoperator(p, Add) }
+    | '-=' { _PyPegen_augoperator(p, Sub) }
+    | '*=' { _PyPegen_augoperator(p, Mult) }
+    | '@=' { CHECK_VERSION(5, "The '@' operator is", _PyPegen_augoperator(p, MatMult)) }
+    | '/=' { _PyPegen_augoperator(p, Div) }
+    | '%=' { _PyPegen_augoperator(p, Mod) }
+    | '&=' { _PyPegen_augoperator(p, BitAnd) }
+    | '|=' { _PyPegen_augoperator(p, BitOr) }
+    | '^=' { _PyPegen_augoperator(p, BitXor) }
+    | '<<=' { _PyPegen_augoperator(p, LShift) }
+    | '>>=' { _PyPegen_augoperator(p, RShift) }
+    | '**=' { _PyPegen_augoperator(p, Pow) }
+    | '//=' { _PyPegen_augoperator(p, FloorDiv) }
 
 global_stmt[stmt_ty]: 'global' a=','.NAME+ {
     _Py_Global(CHECK(_PyPegen_map_names_to_ids(p, a)), EXTRA) }
@@ -156,14 +160,20 @@ while_stmt[stmt_ty]:
     | 'while' a=named_expression ':' b=block c=[else_block] { _Py_While(a, b, c, EXTRA) }
 
 for_stmt[stmt_ty]:
-    | is_async=[ASYNC] 'for' t=star_targets 'in' ex=star_expressions ':' tc=[TYPE_COMMENT] b=block el=[else_block] {
-        (is_async ? _Py_AsyncFor : _Py_For)(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+    | 'for' t=star_targets 'in' ex=star_expressions ':' tc=[TYPE_COMMENT] b=block el=[else_block] {
+        _Py_For(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+    | ASYNC 'for' t=star_targets 'in' ex=star_expressions ':' tc=[TYPE_COMMENT] b=block el=[else_block] {
+        CHECK_VERSION(5, "Async for loops are", _Py_AsyncFor(t, ex, b, el, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
 
 with_stmt[stmt_ty]:
-    | is_async=[ASYNC] 'with' '(' a=','.with_item+ ')' ':' b=block {
-        (is_async ? _Py_AsyncWith : _Py_With)(a, b, NULL, EXTRA) }
-    | is_async=[ASYNC] 'with' a=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
-        (is_async ? _Py_AsyncWith : _Py_With)(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+    | 'with' '(' a=','.with_item+ ')' ':' b=block {
+        _Py_With(a, b, NULL, EXTRA) }
+    | 'with' a=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
+        _Py_With(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+    | ASYNC 'with' '(' a=','.with_item+ ')' ':' b=block {
+       CHECK_VERSION(5, "Async with statements are", _Py_AsyncWith(a, b, NULL, EXTRA)) }
+    | ASYNC 'with' a=','.with_item+ ':' tc=[TYPE_COMMENT] b=block {
+       CHECK_VERSION(5, "Async with statements are", _Py_AsyncWith(a, b, NEW_TYPE_COMMENT(p, tc), EXTRA)) }
 with_item[withitem_ty]:
     | e=expression o=['as' t=target { t }] { _Py_withitem(e, o, p->arena) }
 
@@ -188,10 +198,18 @@ function_def[stmt_ty]:
     | function_def_raw
 
 function_def_raw[stmt_ty]:
-    | is_async=[ASYNC] 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
-        (is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef)(n->v.Name.id,
-                             (params) ? params : CHECK(_PyPegen_empty_arguments(p)),
-                             b, NULL, a, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+    | 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
+        _Py_FunctionDef(n->v.Name.id,
+                        (params) ? params : CHECK(_PyPegen_empty_arguments(p)),
+                        b, NULL, a, NEW_TYPE_COMMENT(p, tc), EXTRA) }
+    | ASYNC 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] ':' tc=[func_type_comment] b=block {
+        CHECK_VERSION(
+            5,
+            "Async functions are",
+            _Py_AsyncFunctionDef(n->v.Name.id,
+                            (params) ? params : CHECK(_PyPegen_empty_arguments(p)),
+                            b, NULL, a, NEW_TYPE_COMMENT(p, tc), EXTRA)
+        ) }
 func_type_comment[PyObject*]:
     | NEWLINE t=TYPE_COMMENT &(NEWLINE INDENT) { t }  # Must be followed by indented block
     | invalid_double_type_comments
@@ -399,7 +417,7 @@ term[expr_ty]:
     | a=term '/' b=factor { _Py_BinOp(a, Div, b, EXTRA) }
     | a=term '//' b=factor { _Py_BinOp(a, FloorDiv, b, EXTRA) }
     | a=term '%' b=factor { _Py_BinOp(a, Mod, b, EXTRA) }
-    | a=term '@' b=factor { _Py_BinOp(a, MatMult, b, EXTRA) }
+    | a=term '@' b=factor { CHECK_VERSION(5, "The '@' operator is", _Py_BinOp(a, MatMult, b, EXTRA)) }
     | factor
 factor[expr_ty] (memo):
     | '+' a=factor { _Py_UnaryOp(UAdd, a, EXTRA) }
@@ -410,7 +428,7 @@ power[expr_ty]:
     | a=await_primary '**' b=factor { _Py_BinOp(a, Pow, b, EXTRA) }
     | await_primary
 await_primary[expr_ty] (memo):
-    | AWAIT a=primary { _Py_Await(a, EXTRA) }
+    | AWAIT a=primary { CHECK_VERSION(5, "Await expressions are", _Py_Await(a, EXTRA)) }
     | primary
 primary[expr_ty]:
     | a=primary '.' b=NAME { _Py_Attribute(a, b->v.Name.id, Load, EXTRA) }
@@ -469,8 +487,12 @@ kvpair[KeyValuePair*]:
     | '**' a=bitwise_or { _PyPegen_key_value_pair(p, NULL, a) }
     | a=expression ':' b=expression { _PyPegen_key_value_pair(p, a, b) }
 for_if_clauses[asdl_seq*]:
-    | a=(y=[ASYNC] 'for' a=star_targets 'in' b=disjunction c=('if' z=disjunction { z })*
-        { _Py_comprehension(a, b, c, y != NULL, p->arena) })+ { a }
+    | for_if_clause+
+for_if_clause[comprehension_ty]:
+    | ASYNC 'for' a=star_targets 'in' b=disjunction c=('if' z=disjunction { z })* {
+        CHECK_VERSION(6, "Async comprehensions are", _Py_comprehension(a, b, c, 1, p->arena)) }
+    | 'for' a=star_targets 'in' b=disjunction c=('if' z=disjunction { z })* {
+        _Py_comprehension(a, b, c, 0, p->arena) }
 
 yield_expr[expr_ty]:
     | 'yield' 'from' a=expression { _Py_YieldFrom(a, EXTRA) }

--- a/Lib/test/test_type_comments.py
+++ b/Lib/test/test_type_comments.py
@@ -252,7 +252,6 @@ class TypeCommentTests(unittest.TestCase):
         self.assertEqual(tree.body[0].type_comment, None)
         self.assertEqual(tree.body[1].type_comment, None)
 
-    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_asyncdef(self):
         for tree in self.parse_all(asyncdef, minver=5):
             self.assertEqual(tree.body[0].type_comment, "() -> int")
@@ -261,27 +260,22 @@ class TypeCommentTests(unittest.TestCase):
         self.assertEqual(tree.body[0].type_comment, None)
         self.assertEqual(tree.body[1].type_comment, None)
 
-    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_asyncvar(self):
         for tree in self.parse_all(asyncvar, maxver=6):
             pass
 
-    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_asynccomp(self):
         for tree in self.parse_all(asynccomp, minver=6):
             pass
 
-    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_matmul(self):
         for tree in self.parse_all(matmul, minver=5):
             pass
 
-    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_fstring(self):
         for tree in self.parse_all(fstring, minver=6):
             pass
 
-    @support.skip_if_new_parser("Pegen does not support feature_version yet")
     def test_underscorednumber(self):
         for tree in self.parse_all(underscorednumber, minver=6):
             pass

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -188,176 +188,183 @@ static KeywordToken *reserved_keywords[] = {
 #define kvpairs_type 1117
 #define kvpair_type 1118
 #define for_if_clauses_type 1119
-#define yield_expr_type 1120
-#define arguments_type 1121
-#define args_type 1122
-#define kwargs_type 1123
-#define starred_expression_type 1124
-#define kwarg_or_starred_type 1125
-#define kwarg_or_double_starred_type 1126
-#define star_targets_type 1127
-#define star_targets_seq_type 1128
-#define star_target_type 1129
-#define star_atom_type 1130
-#define inside_paren_ann_assign_target_type 1131
-#define ann_assign_subscript_attribute_target_type 1132
-#define del_targets_type 1133
-#define del_target_type 1134
-#define del_t_atom_type 1135
-#define targets_type 1136
-#define target_type 1137
-#define t_primary_type 1138  // Left-recursive
-#define t_lookahead_type 1139
-#define t_atom_type 1140
-#define incorrect_arguments_type 1141
-#define invalid_named_expression_type 1142
-#define invalid_assignment_type 1143
-#define invalid_block_type 1144
-#define invalid_comprehension_type 1145
-#define invalid_parameters_type 1146
-#define invalid_double_type_comments_type 1147
-#define _loop0_1_type 1148
-#define _loop0_2_type 1149
-#define _loop0_4_type 1150
-#define _gather_3_type 1151
-#define _loop0_6_type 1152
-#define _gather_5_type 1153
-#define _loop0_8_type 1154
-#define _gather_7_type 1155
-#define _loop0_10_type 1156
-#define _gather_9_type 1157
-#define _loop1_11_type 1158
-#define _loop0_13_type 1159
-#define _gather_12_type 1160
-#define _tmp_14_type 1161
-#define _tmp_15_type 1162
-#define _tmp_16_type 1163
-#define _tmp_17_type 1164
-#define _tmp_18_type 1165
-#define _tmp_19_type 1166
-#define _tmp_20_type 1167
-#define _tmp_21_type 1168
-#define _loop1_22_type 1169
-#define _tmp_23_type 1170
-#define _tmp_24_type 1171
-#define _loop0_26_type 1172
-#define _gather_25_type 1173
-#define _loop0_28_type 1174
-#define _gather_27_type 1175
-#define _tmp_29_type 1176
-#define _loop0_30_type 1177
-#define _loop1_31_type 1178
-#define _loop0_33_type 1179
-#define _gather_32_type 1180
-#define _tmp_34_type 1181
-#define _loop0_36_type 1182
-#define _gather_35_type 1183
-#define _tmp_37_type 1184
-#define _loop0_39_type 1185
-#define _gather_38_type 1186
-#define _loop0_41_type 1187
-#define _gather_40_type 1188
-#define _tmp_42_type 1189
-#define _loop1_43_type 1190
-#define _tmp_44_type 1191
-#define _tmp_45_type 1192
-#define _tmp_46_type 1193
-#define _tmp_47_type 1194
-#define _loop0_48_type 1195
-#define _loop0_49_type 1196
-#define _loop0_50_type 1197
-#define _loop1_51_type 1198
-#define _loop0_52_type 1199
-#define _loop1_53_type 1200
-#define _loop1_54_type 1201
-#define _loop1_55_type 1202
-#define _loop0_56_type 1203
-#define _loop1_57_type 1204
-#define _loop0_58_type 1205
-#define _loop1_59_type 1206
-#define _loop0_60_type 1207
-#define _loop1_61_type 1208
-#define _loop1_62_type 1209
-#define _tmp_63_type 1210
-#define _loop0_65_type 1211
-#define _gather_64_type 1212
-#define _loop1_66_type 1213
-#define _loop0_68_type 1214
-#define _gather_67_type 1215
-#define _loop1_69_type 1216
-#define _tmp_70_type 1217
-#define _tmp_71_type 1218
-#define _tmp_72_type 1219
-#define _tmp_73_type 1220
-#define _tmp_74_type 1221
-#define _tmp_75_type 1222
-#define _tmp_76_type 1223
-#define _tmp_77_type 1224
-#define _tmp_78_type 1225
-#define _loop0_79_type 1226
-#define _tmp_80_type 1227
-#define _loop1_81_type 1228
-#define _tmp_82_type 1229
-#define _tmp_83_type 1230
-#define _loop0_85_type 1231
-#define _gather_84_type 1232
-#define _loop0_87_type 1233
-#define _gather_86_type 1234
-#define _loop1_88_type 1235
-#define _loop1_89_type 1236
-#define _loop1_90_type 1237
-#define _tmp_91_type 1238
-#define _loop0_93_type 1239
-#define _gather_92_type 1240
-#define _tmp_94_type 1241
-#define _tmp_95_type 1242
-#define _tmp_96_type 1243
-#define _tmp_97_type 1244
-#define _loop1_98_type 1245
-#define _tmp_99_type 1246
-#define _tmp_100_type 1247
-#define _loop0_102_type 1248
-#define _gather_101_type 1249
-#define _loop1_103_type 1250
-#define _tmp_104_type 1251
-#define _tmp_105_type 1252
-#define _loop0_107_type 1253
-#define _gather_106_type 1254
-#define _loop0_109_type 1255
-#define _gather_108_type 1256
-#define _loop0_111_type 1257
-#define _gather_110_type 1258
-#define _loop0_113_type 1259
-#define _gather_112_type 1260
+#define for_if_clause_type 1120
+#define yield_expr_type 1121
+#define arguments_type 1122
+#define args_type 1123
+#define kwargs_type 1124
+#define starred_expression_type 1125
+#define kwarg_or_starred_type 1126
+#define kwarg_or_double_starred_type 1127
+#define star_targets_type 1128
+#define star_targets_seq_type 1129
+#define star_target_type 1130
+#define star_atom_type 1131
+#define inside_paren_ann_assign_target_type 1132
+#define ann_assign_subscript_attribute_target_type 1133
+#define del_targets_type 1134
+#define del_target_type 1135
+#define del_t_atom_type 1136
+#define targets_type 1137
+#define target_type 1138
+#define t_primary_type 1139  // Left-recursive
+#define t_lookahead_type 1140
+#define t_atom_type 1141
+#define incorrect_arguments_type 1142
+#define invalid_named_expression_type 1143
+#define invalid_assignment_type 1144
+#define invalid_block_type 1145
+#define invalid_comprehension_type 1146
+#define invalid_parameters_type 1147
+#define invalid_double_type_comments_type 1148
+#define _loop0_1_type 1149
+#define _loop0_2_type 1150
+#define _loop0_4_type 1151
+#define _gather_3_type 1152
+#define _loop0_6_type 1153
+#define _gather_5_type 1154
+#define _loop0_8_type 1155
+#define _gather_7_type 1156
+#define _loop0_10_type 1157
+#define _gather_9_type 1158
+#define _loop1_11_type 1159
+#define _loop0_13_type 1160
+#define _gather_12_type 1161
+#define _tmp_14_type 1162
+#define _tmp_15_type 1163
+#define _tmp_16_type 1164
+#define _tmp_17_type 1165
+#define _tmp_18_type 1166
+#define _tmp_19_type 1167
+#define _tmp_20_type 1168
+#define _tmp_21_type 1169
+#define _loop1_22_type 1170
+#define _tmp_23_type 1171
+#define _tmp_24_type 1172
+#define _loop0_26_type 1173
+#define _gather_25_type 1174
+#define _loop0_28_type 1175
+#define _gather_27_type 1176
+#define _tmp_29_type 1177
+#define _loop0_30_type 1178
+#define _loop1_31_type 1179
+#define _loop0_33_type 1180
+#define _gather_32_type 1181
+#define _tmp_34_type 1182
+#define _loop0_36_type 1183
+#define _gather_35_type 1184
+#define _tmp_37_type 1185
+#define _loop0_39_type 1186
+#define _gather_38_type 1187
+#define _loop0_41_type 1188
+#define _gather_40_type 1189
+#define _loop0_43_type 1190
+#define _gather_42_type 1191
+#define _loop0_45_type 1192
+#define _gather_44_type 1193
+#define _tmp_46_type 1194
+#define _loop1_47_type 1195
+#define _tmp_48_type 1196
+#define _tmp_49_type 1197
+#define _tmp_50_type 1198
+#define _tmp_51_type 1199
+#define _tmp_52_type 1200
+#define _loop0_53_type 1201
+#define _loop0_54_type 1202
+#define _loop0_55_type 1203
+#define _loop1_56_type 1204
+#define _loop0_57_type 1205
+#define _loop1_58_type 1206
+#define _loop1_59_type 1207
+#define _loop1_60_type 1208
+#define _loop0_61_type 1209
+#define _loop1_62_type 1210
+#define _loop0_63_type 1211
+#define _loop1_64_type 1212
+#define _loop0_65_type 1213
+#define _loop1_66_type 1214
+#define _loop1_67_type 1215
+#define _tmp_68_type 1216
+#define _loop0_70_type 1217
+#define _gather_69_type 1218
+#define _loop1_71_type 1219
+#define _loop0_73_type 1220
+#define _gather_72_type 1221
+#define _loop1_74_type 1222
+#define _tmp_75_type 1223
+#define _tmp_76_type 1224
+#define _tmp_77_type 1225
+#define _tmp_78_type 1226
+#define _tmp_79_type 1227
+#define _tmp_80_type 1228
+#define _tmp_81_type 1229
+#define _tmp_82_type 1230
+#define _tmp_83_type 1231
+#define _loop0_84_type 1232
+#define _tmp_85_type 1233
+#define _loop1_86_type 1234
+#define _tmp_87_type 1235
+#define _tmp_88_type 1236
+#define _loop0_90_type 1237
+#define _gather_89_type 1238
+#define _loop0_92_type 1239
+#define _gather_91_type 1240
+#define _loop1_93_type 1241
+#define _loop1_94_type 1242
+#define _loop1_95_type 1243
+#define _tmp_96_type 1244
+#define _loop0_98_type 1245
+#define _gather_97_type 1246
+#define _tmp_99_type 1247
+#define _tmp_100_type 1248
+#define _tmp_101_type 1249
+#define _tmp_102_type 1250
+#define _loop1_103_type 1251
+#define _tmp_104_type 1252
+#define _tmp_105_type 1253
+#define _loop0_107_type 1254
+#define _gather_106_type 1255
+#define _loop1_108_type 1256
+#define _loop0_109_type 1257
+#define _loop0_110_type 1258
+#define _tmp_111_type 1259
+#define _tmp_112_type 1260
 #define _loop0_114_type 1261
-#define _loop0_116_type 1262
-#define _gather_115_type 1263
-#define _tmp_117_type 1264
-#define _loop0_119_type 1265
-#define _gather_118_type 1266
-#define _loop0_121_type 1267
-#define _gather_120_type 1268
-#define _tmp_122_type 1269
-#define _tmp_123_type 1270
-#define _tmp_124_type 1271
-#define _tmp_125_type 1272
-#define _tmp_126_type 1273
-#define _loop0_127_type 1274
-#define _tmp_128_type 1275
-#define _tmp_129_type 1276
-#define _tmp_130_type 1277
-#define _tmp_131_type 1278
-#define _tmp_132_type 1279
-#define _tmp_133_type 1280
-#define _tmp_134_type 1281
-#define _tmp_135_type 1282
-#define _tmp_136_type 1283
-#define _tmp_137_type 1284
-#define _tmp_138_type 1285
-#define _tmp_139_type 1286
-#define _loop1_140_type 1287
-#define _loop0_141_type 1288
-#define _tmp_142_type 1289
+#define _gather_113_type 1262
+#define _loop0_116_type 1263
+#define _gather_115_type 1264
+#define _loop0_118_type 1265
+#define _gather_117_type 1266
+#define _loop0_120_type 1267
+#define _gather_119_type 1268
+#define _loop0_121_type 1269
+#define _loop0_123_type 1270
+#define _gather_122_type 1271
+#define _tmp_124_type 1272
+#define _loop0_126_type 1273
+#define _gather_125_type 1274
+#define _loop0_128_type 1275
+#define _gather_127_type 1276
+#define _tmp_129_type 1277
+#define _tmp_130_type 1278
+#define _tmp_131_type 1279
+#define _tmp_132_type 1280
+#define _tmp_133_type 1281
+#define _loop0_134_type 1282
+#define _tmp_135_type 1283
+#define _tmp_136_type 1284
+#define _tmp_137_type 1285
+#define _tmp_138_type 1286
+#define _tmp_139_type 1287
+#define _tmp_140_type 1288
+#define _tmp_141_type 1289
+#define _tmp_142_type 1290
+#define _tmp_143_type 1291
+#define _tmp_144_type 1292
+#define _tmp_145_type 1293
+#define _tmp_146_type 1294
+#define _tmp_147_type 1295
+#define _loop1_148_type 1296
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -479,6 +486,7 @@ static expr_ty dictcomp_rule(Parser *p);
 static asdl_seq* kvpairs_rule(Parser *p);
 static KeyValuePair* kvpair_rule(Parser *p);
 static asdl_seq* for_if_clauses_rule(Parser *p);
+static comprehension_ty for_if_clause_rule(Parser *p);
 static expr_ty yield_expr_rule(Parser *p);
 static expr_ty arguments_rule(Parser *p);
 static expr_ty args_rule(Parser *p);
@@ -548,107 +556,113 @@ static asdl_seq *_loop0_39_rule(Parser *p);
 static asdl_seq *_gather_38_rule(Parser *p);
 static asdl_seq *_loop0_41_rule(Parser *p);
 static asdl_seq *_gather_40_rule(Parser *p);
-static void *_tmp_42_rule(Parser *p);
-static asdl_seq *_loop1_43_rule(Parser *p);
-static void *_tmp_44_rule(Parser *p);
-static void *_tmp_45_rule(Parser *p);
+static asdl_seq *_loop0_43_rule(Parser *p);
+static asdl_seq *_gather_42_rule(Parser *p);
+static asdl_seq *_loop0_45_rule(Parser *p);
+static asdl_seq *_gather_44_rule(Parser *p);
 static void *_tmp_46_rule(Parser *p);
-static void *_tmp_47_rule(Parser *p);
-static asdl_seq *_loop0_48_rule(Parser *p);
-static asdl_seq *_loop0_49_rule(Parser *p);
-static asdl_seq *_loop0_50_rule(Parser *p);
-static asdl_seq *_loop1_51_rule(Parser *p);
-static asdl_seq *_loop0_52_rule(Parser *p);
-static asdl_seq *_loop1_53_rule(Parser *p);
-static asdl_seq *_loop1_54_rule(Parser *p);
-static asdl_seq *_loop1_55_rule(Parser *p);
-static asdl_seq *_loop0_56_rule(Parser *p);
-static asdl_seq *_loop1_57_rule(Parser *p);
-static asdl_seq *_loop0_58_rule(Parser *p);
+static asdl_seq *_loop1_47_rule(Parser *p);
+static void *_tmp_48_rule(Parser *p);
+static void *_tmp_49_rule(Parser *p);
+static void *_tmp_50_rule(Parser *p);
+static void *_tmp_51_rule(Parser *p);
+static void *_tmp_52_rule(Parser *p);
+static asdl_seq *_loop0_53_rule(Parser *p);
+static asdl_seq *_loop0_54_rule(Parser *p);
+static asdl_seq *_loop0_55_rule(Parser *p);
+static asdl_seq *_loop1_56_rule(Parser *p);
+static asdl_seq *_loop0_57_rule(Parser *p);
+static asdl_seq *_loop1_58_rule(Parser *p);
 static asdl_seq *_loop1_59_rule(Parser *p);
-static asdl_seq *_loop0_60_rule(Parser *p);
-static asdl_seq *_loop1_61_rule(Parser *p);
+static asdl_seq *_loop1_60_rule(Parser *p);
+static asdl_seq *_loop0_61_rule(Parser *p);
 static asdl_seq *_loop1_62_rule(Parser *p);
-static void *_tmp_63_rule(Parser *p);
+static asdl_seq *_loop0_63_rule(Parser *p);
+static asdl_seq *_loop1_64_rule(Parser *p);
 static asdl_seq *_loop0_65_rule(Parser *p);
-static asdl_seq *_gather_64_rule(Parser *p);
 static asdl_seq *_loop1_66_rule(Parser *p);
-static asdl_seq *_loop0_68_rule(Parser *p);
-static asdl_seq *_gather_67_rule(Parser *p);
-static asdl_seq *_loop1_69_rule(Parser *p);
-static void *_tmp_70_rule(Parser *p);
-static void *_tmp_71_rule(Parser *p);
-static void *_tmp_72_rule(Parser *p);
-static void *_tmp_73_rule(Parser *p);
-static void *_tmp_74_rule(Parser *p);
+static asdl_seq *_loop1_67_rule(Parser *p);
+static void *_tmp_68_rule(Parser *p);
+static asdl_seq *_loop0_70_rule(Parser *p);
+static asdl_seq *_gather_69_rule(Parser *p);
+static asdl_seq *_loop1_71_rule(Parser *p);
+static asdl_seq *_loop0_73_rule(Parser *p);
+static asdl_seq *_gather_72_rule(Parser *p);
+static asdl_seq *_loop1_74_rule(Parser *p);
 static void *_tmp_75_rule(Parser *p);
 static void *_tmp_76_rule(Parser *p);
 static void *_tmp_77_rule(Parser *p);
 static void *_tmp_78_rule(Parser *p);
-static asdl_seq *_loop0_79_rule(Parser *p);
+static void *_tmp_79_rule(Parser *p);
 static void *_tmp_80_rule(Parser *p);
-static asdl_seq *_loop1_81_rule(Parser *p);
+static void *_tmp_81_rule(Parser *p);
 static void *_tmp_82_rule(Parser *p);
 static void *_tmp_83_rule(Parser *p);
-static asdl_seq *_loop0_85_rule(Parser *p);
-static asdl_seq *_gather_84_rule(Parser *p);
-static asdl_seq *_loop0_87_rule(Parser *p);
-static asdl_seq *_gather_86_rule(Parser *p);
-static asdl_seq *_loop1_88_rule(Parser *p);
-static asdl_seq *_loop1_89_rule(Parser *p);
-static asdl_seq *_loop1_90_rule(Parser *p);
-static void *_tmp_91_rule(Parser *p);
-static asdl_seq *_loop0_93_rule(Parser *p);
-static asdl_seq *_gather_92_rule(Parser *p);
-static void *_tmp_94_rule(Parser *p);
-static void *_tmp_95_rule(Parser *p);
+static asdl_seq *_loop0_84_rule(Parser *p);
+static void *_tmp_85_rule(Parser *p);
+static asdl_seq *_loop1_86_rule(Parser *p);
+static void *_tmp_87_rule(Parser *p);
+static void *_tmp_88_rule(Parser *p);
+static asdl_seq *_loop0_90_rule(Parser *p);
+static asdl_seq *_gather_89_rule(Parser *p);
+static asdl_seq *_loop0_92_rule(Parser *p);
+static asdl_seq *_gather_91_rule(Parser *p);
+static asdl_seq *_loop1_93_rule(Parser *p);
+static asdl_seq *_loop1_94_rule(Parser *p);
+static asdl_seq *_loop1_95_rule(Parser *p);
 static void *_tmp_96_rule(Parser *p);
-static void *_tmp_97_rule(Parser *p);
-static asdl_seq *_loop1_98_rule(Parser *p);
+static asdl_seq *_loop0_98_rule(Parser *p);
+static asdl_seq *_gather_97_rule(Parser *p);
 static void *_tmp_99_rule(Parser *p);
 static void *_tmp_100_rule(Parser *p);
-static asdl_seq *_loop0_102_rule(Parser *p);
-static asdl_seq *_gather_101_rule(Parser *p);
+static void *_tmp_101_rule(Parser *p);
+static void *_tmp_102_rule(Parser *p);
 static asdl_seq *_loop1_103_rule(Parser *p);
 static void *_tmp_104_rule(Parser *p);
 static void *_tmp_105_rule(Parser *p);
 static asdl_seq *_loop0_107_rule(Parser *p);
 static asdl_seq *_gather_106_rule(Parser *p);
+static asdl_seq *_loop1_108_rule(Parser *p);
 static asdl_seq *_loop0_109_rule(Parser *p);
-static asdl_seq *_gather_108_rule(Parser *p);
-static asdl_seq *_loop0_111_rule(Parser *p);
-static asdl_seq *_gather_110_rule(Parser *p);
-static asdl_seq *_loop0_113_rule(Parser *p);
-static asdl_seq *_gather_112_rule(Parser *p);
+static asdl_seq *_loop0_110_rule(Parser *p);
+static void *_tmp_111_rule(Parser *p);
+static void *_tmp_112_rule(Parser *p);
 static asdl_seq *_loop0_114_rule(Parser *p);
+static asdl_seq *_gather_113_rule(Parser *p);
 static asdl_seq *_loop0_116_rule(Parser *p);
 static asdl_seq *_gather_115_rule(Parser *p);
-static void *_tmp_117_rule(Parser *p);
-static asdl_seq *_loop0_119_rule(Parser *p);
-static asdl_seq *_gather_118_rule(Parser *p);
+static asdl_seq *_loop0_118_rule(Parser *p);
+static asdl_seq *_gather_117_rule(Parser *p);
+static asdl_seq *_loop0_120_rule(Parser *p);
+static asdl_seq *_gather_119_rule(Parser *p);
 static asdl_seq *_loop0_121_rule(Parser *p);
-static asdl_seq *_gather_120_rule(Parser *p);
-static void *_tmp_122_rule(Parser *p);
-static void *_tmp_123_rule(Parser *p);
+static asdl_seq *_loop0_123_rule(Parser *p);
+static asdl_seq *_gather_122_rule(Parser *p);
 static void *_tmp_124_rule(Parser *p);
-static void *_tmp_125_rule(Parser *p);
-static void *_tmp_126_rule(Parser *p);
-static asdl_seq *_loop0_127_rule(Parser *p);
-static void *_tmp_128_rule(Parser *p);
+static asdl_seq *_loop0_126_rule(Parser *p);
+static asdl_seq *_gather_125_rule(Parser *p);
+static asdl_seq *_loop0_128_rule(Parser *p);
+static asdl_seq *_gather_127_rule(Parser *p);
 static void *_tmp_129_rule(Parser *p);
 static void *_tmp_130_rule(Parser *p);
 static void *_tmp_131_rule(Parser *p);
 static void *_tmp_132_rule(Parser *p);
 static void *_tmp_133_rule(Parser *p);
-static void *_tmp_134_rule(Parser *p);
+static asdl_seq *_loop0_134_rule(Parser *p);
 static void *_tmp_135_rule(Parser *p);
 static void *_tmp_136_rule(Parser *p);
 static void *_tmp_137_rule(Parser *p);
 static void *_tmp_138_rule(Parser *p);
 static void *_tmp_139_rule(Parser *p);
-static asdl_seq *_loop1_140_rule(Parser *p);
-static asdl_seq *_loop0_141_rule(Parser *p);
+static void *_tmp_140_rule(Parser *p);
+static void *_tmp_141_rule(Parser *p);
 static void *_tmp_142_rule(Parser *p);
+static void *_tmp_143_rule(Parser *p);
+static void *_tmp_144_rule(Parser *p);
+static void *_tmp_145_rule(Parser *p);
+static void *_tmp_146_rule(Parser *p);
+static void *_tmp_147_rule(Parser *p);
+static asdl_seq *_loop1_148_rule(Parser *p);
 
 
 // file: statements? $
@@ -1545,7 +1559,7 @@ assignment_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_AnnAssign ( CHECK ( _PyPegen_set_expr_context ( p , a , Store ) ) , b , c , 1 , EXTRA );
+            res = CHECK_VERSION ( 6 , "Variable annotation syntax is" , _Py_AnnAssign ( CHECK ( _PyPegen_set_expr_context ( p , a , Store ) ) , b , c , 1 , EXTRA ) );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -1577,7 +1591,7 @@ assignment_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_AnnAssign ( a , b , c , 0 , EXTRA );
+            res = CHECK_VERSION ( 6 , "Variable annotations syntax is" , _Py_AnnAssign ( a , b , c , 0 , EXTRA ) );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -1733,7 +1747,7 @@ augassign_rule(Parser *p)
             (literal = _PyPegen_expect_token(p, 50))
         )
         {
-            res = _PyPegen_augoperator ( p , MatMult );
+            res = CHECK_VERSION ( 5 , "The '@' operator is" , _PyPegen_augoperator ( p , MatMult ) );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -2836,7 +2850,8 @@ while_stmt_rule(Parser *p)
 }
 
 // for_stmt:
-//     | ASYNC? 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
+//     | 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
+//     | ASYNC 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
 static stmt_ty
 for_stmt_rule(Parser *p)
 {
@@ -2853,18 +2868,62 @@ for_stmt_rule(Parser *p)
     UNUSED(start_lineno); // Only used by EXTRA macro
     int start_col_offset = p->tokens[mark]->col_offset;
     UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // ASYNC? 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
+    { // 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
         asdl_seq* b;
         void *el;
         expr_ty ex;
-        void *is_async;
         void *keyword;
         void *keyword_1;
         void *literal;
         expr_ty t;
         void *tc;
         if (
-            (is_async = _PyPegen_expect_token(p, ASYNC), 1)
+            (keyword = _PyPegen_expect_token(p, 517))
+            &&
+            (t = star_targets_rule(p))
+            &&
+            (keyword_1 = _PyPegen_expect_token(p, 518))
+            &&
+            (ex = star_expressions_rule(p))
+            &&
+            (literal = _PyPegen_expect_token(p, 11))
+            &&
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            &&
+            (b = block_rule(p))
+            &&
+            (el = else_block_rule(p), 1)
+        )
+        {
+            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (token == NULL) {
+                return NULL;
+            }
+            int end_lineno = token->end_lineno;
+            UNUSED(end_lineno); // Only used by EXTRA macro
+            int end_col_offset = token->end_col_offset;
+            UNUSED(end_col_offset); // Only used by EXTRA macro
+            res = _Py_For ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // ASYNC 'for' star_targets 'in' star_expressions ':' TYPE_COMMENT? block else_block?
+        void *async_var;
+        asdl_seq* b;
+        void *el;
+        expr_ty ex;
+        void *keyword;
+        void *keyword_1;
+        void *literal;
+        expr_ty t;
+        void *tc;
+        if (
+            (async_var = _PyPegen_expect_token(p, ASYNC))
             &&
             (keyword = _PyPegen_expect_token(p, 517))
             &&
@@ -2891,7 +2950,7 @@ for_stmt_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncFor : _Py_For ) ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            res = CHECK_VERSION ( 5 , "Async for loops are" , _Py_AsyncFor ( t , ex , b , el , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -2906,8 +2965,10 @@ for_stmt_rule(Parser *p)
 }
 
 // with_stmt:
-//     | ASYNC? 'with' '(' ','.with_item+ ')' ':' block
-//     | ASYNC? 'with' ','.with_item+ ':' TYPE_COMMENT? block
+//     | 'with' '(' ','.with_item+ ')' ':' block
+//     | 'with' ','.with_item+ ':' TYPE_COMMENT? block
+//     | ASYNC 'with' '(' ','.with_item+ ')' ':' block
+//     | ASYNC 'with' ','.with_item+ ':' TYPE_COMMENT? block
 static stmt_ty
 with_stmt_rule(Parser *p)
 {
@@ -2924,17 +2985,14 @@ with_stmt_rule(Parser *p)
     UNUSED(start_lineno); // Only used by EXTRA macro
     int start_col_offset = p->tokens[mark]->col_offset;
     UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // ASYNC? 'with' '(' ','.with_item+ ')' ':' block
+    { // 'with' '(' ','.with_item+ ')' ':' block
         asdl_seq * a;
         asdl_seq* b;
-        void *is_async;
         void *keyword;
         void *literal;
         void *literal_1;
         void *literal_2;
         if (
-            (is_async = _PyPegen_expect_token(p, ASYNC), 1)
-            &&
             (keyword = _PyPegen_expect_token(p, 519))
             &&
             (literal = _PyPegen_expect_token(p, 7))
@@ -2956,7 +3014,7 @@ with_stmt_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncWith : _Py_With ) ( a , b , NULL , EXTRA );
+            res = _Py_With ( a , b , NULL , EXTRA );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -2965,16 +3023,13 @@ with_stmt_rule(Parser *p)
         }
         p->mark = mark;
     }
-    { // ASYNC? 'with' ','.with_item+ ':' TYPE_COMMENT? block
+    { // 'with' ','.with_item+ ':' TYPE_COMMENT? block
         asdl_seq * a;
         asdl_seq* b;
-        void *is_async;
         void *keyword;
         void *literal;
         void *tc;
         if (
-            (is_async = _PyPegen_expect_token(p, ASYNC), 1)
-            &&
             (keyword = _PyPegen_expect_token(p, 519))
             &&
             (a = _gather_40_rule(p))
@@ -2994,7 +3049,86 @@ with_stmt_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncWith : _Py_With ) ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            res = _Py_With ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // ASYNC 'with' '(' ','.with_item+ ')' ':' block
+        asdl_seq * a;
+        void *async_var;
+        asdl_seq* b;
+        void *keyword;
+        void *literal;
+        void *literal_1;
+        void *literal_2;
+        if (
+            (async_var = _PyPegen_expect_token(p, ASYNC))
+            &&
+            (keyword = _PyPegen_expect_token(p, 519))
+            &&
+            (literal = _PyPegen_expect_token(p, 7))
+            &&
+            (a = _gather_42_rule(p))
+            &&
+            (literal_1 = _PyPegen_expect_token(p, 8))
+            &&
+            (literal_2 = _PyPegen_expect_token(p, 11))
+            &&
+            (b = block_rule(p))
+        )
+        {
+            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (token == NULL) {
+                return NULL;
+            }
+            int end_lineno = token->end_lineno;
+            UNUSED(end_lineno); // Only used by EXTRA macro
+            int end_col_offset = token->end_col_offset;
+            UNUSED(end_col_offset); // Only used by EXTRA macro
+            res = CHECK_VERSION ( 5 , "Async with statements are" , _Py_AsyncWith ( a , b , NULL , EXTRA ) );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // ASYNC 'with' ','.with_item+ ':' TYPE_COMMENT? block
+        asdl_seq * a;
+        void *async_var;
+        asdl_seq* b;
+        void *keyword;
+        void *literal;
+        void *tc;
+        if (
+            (async_var = _PyPegen_expect_token(p, ASYNC))
+            &&
+            (keyword = _PyPegen_expect_token(p, 519))
+            &&
+            (a = _gather_44_rule(p))
+            &&
+            (literal = _PyPegen_expect_token(p, 11))
+            &&
+            (tc = _PyPegen_expect_token(p, TYPE_COMMENT), 1)
+            &&
+            (b = block_rule(p))
+        )
+        {
+            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (token == NULL) {
+                return NULL;
+            }
+            int end_lineno = token->end_lineno;
+            UNUSED(end_lineno); // Only used by EXTRA macro
+            int end_col_offset = token->end_col_offset;
+            UNUSED(end_col_offset); // Only used by EXTRA macro
+            res = CHECK_VERSION ( 5 , "Async with statements are" , _Py_AsyncWith ( a , b , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -3023,7 +3157,7 @@ with_item_rule(Parser *p)
         if (
             (e = expression_rule(p))
             &&
-            (o = _tmp_42_rule(p), 1)
+            (o = _tmp_46_rule(p), 1)
         )
         {
             res = _Py_withitem ( e , o , p -> arena );
@@ -3105,7 +3239,7 @@ try_stmt_rule(Parser *p)
             &&
             (b = block_rule(p))
             &&
-            (ex = _loop1_43_rule(p))
+            (ex = _loop1_47_rule(p))
             &&
             (el = else_block_rule(p), 1)
             &&
@@ -3162,7 +3296,7 @@ except_block_rule(Parser *p)
             &&
             (e = expression_rule(p))
             &&
-            (t = _tmp_44_rule(p), 1)
+            (t = _tmp_48_rule(p), 1)
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -3329,7 +3463,7 @@ raise_stmt_rule(Parser *p)
             &&
             (a = expression_rule(p))
             &&
-            (b = _tmp_45_rule(p), 1)
+            (b = _tmp_49_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -3421,7 +3555,8 @@ function_def_rule(Parser *p)
 }
 
 // function_def_raw:
-//     | ASYNC? 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
+//     | 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
+//     | ASYNC 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
 static stmt_ty
 function_def_raw_rule(Parser *p)
 {
@@ -3438,10 +3573,9 @@ function_def_raw_rule(Parser *p)
     UNUSED(start_lineno); // Only used by EXTRA macro
     int start_col_offset = p->tokens[mark]->col_offset;
     UNUSED(start_col_offset); // Only used by EXTRA macro
-    { // ASYNC? 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
+    { // 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
         void *a;
         asdl_seq* b;
-        void *is_async;
         void *keyword;
         void *literal;
         void *literal_1;
@@ -3450,8 +3584,6 @@ function_def_raw_rule(Parser *p)
         void *params;
         void *tc;
         if (
-            (is_async = _PyPegen_expect_token(p, ASYNC), 1)
-            &&
             (keyword = _PyPegen_expect_token(p, 522))
             &&
             (n = _PyPegen_name_token(p))
@@ -3462,7 +3594,7 @@ function_def_raw_rule(Parser *p)
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
             &&
-            (a = _tmp_46_rule(p), 1)
+            (a = _tmp_50_rule(p), 1)
             &&
             (literal_2 = _PyPegen_expect_token(p, 11))
             &&
@@ -3479,7 +3611,57 @@ function_def_raw_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = ( is_async ? _Py_AsyncFunctionDef : _Py_FunctionDef ) ( n -> v . Name . id , ( params ) ? params : CHECK ( _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            res = _Py_FunctionDef ( n -> v . Name . id , ( params ) ? params : CHECK ( _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // ASYNC 'def' NAME '(' params? ')' ['->' expression] ':' func_type_comment? block
+        void *a;
+        void *async_var;
+        asdl_seq* b;
+        void *keyword;
+        void *literal;
+        void *literal_1;
+        void *literal_2;
+        expr_ty n;
+        void *params;
+        void *tc;
+        if (
+            (async_var = _PyPegen_expect_token(p, ASYNC))
+            &&
+            (keyword = _PyPegen_expect_token(p, 522))
+            &&
+            (n = _PyPegen_name_token(p))
+            &&
+            (literal = _PyPegen_expect_token(p, 7))
+            &&
+            (params = params_rule(p), 1)
+            &&
+            (literal_1 = _PyPegen_expect_token(p, 8))
+            &&
+            (a = _tmp_51_rule(p), 1)
+            &&
+            (literal_2 = _PyPegen_expect_token(p, 11))
+            &&
+            (tc = func_type_comment_rule(p), 1)
+            &&
+            (b = block_rule(p))
+        )
+        {
+            Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (token == NULL) {
+                return NULL;
+            }
+            int end_lineno = token->end_lineno;
+            UNUSED(end_lineno); // Only used by EXTRA macro
+            int end_col_offset = token->end_col_offset;
+            UNUSED(end_col_offset); // Only used by EXTRA macro
+            res = CHECK_VERSION ( 5 , "Async functions are" , _Py_AsyncFunctionDef ( n -> v . Name . id , ( params ) ? params : CHECK ( _PyPegen_empty_arguments ( p ) ) , b , NULL , a , NEW_TYPE_COMMENT ( p , tc ) , EXTRA ) );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -3513,7 +3695,7 @@ func_type_comment_rule(Parser *p)
             &&
             (t = _PyPegen_expect_token(p, TYPE_COMMENT))
             &&
-            _PyPegen_lookahead(1, _tmp_47_rule, p)
+            _PyPegen_lookahead(1, _tmp_52_rule, p)
         )
         {
             res = t;
@@ -3610,9 +3792,9 @@ parameters_rule(Parser *p)
         if (
             (a = slash_no_default_rule(p))
             &&
-            (b = _loop0_48_rule(p))
+            (b = _loop0_53_rule(p))
             &&
-            (c = _loop0_49_rule(p))
+            (c = _loop0_54_rule(p))
             &&
             (d = star_etc_rule(p), 1)
         )
@@ -3633,7 +3815,7 @@ parameters_rule(Parser *p)
         if (
             (a = slash_with_default_rule(p))
             &&
-            (b = _loop0_50_rule(p))
+            (b = _loop0_55_rule(p))
             &&
             (c = star_etc_rule(p), 1)
         )
@@ -3652,9 +3834,9 @@ parameters_rule(Parser *p)
         asdl_seq * b;
         void *c;
         if (
-            (a = _loop1_51_rule(p))
+            (a = _loop1_56_rule(p))
             &&
-            (b = _loop0_52_rule(p))
+            (b = _loop0_57_rule(p))
             &&
             (c = star_etc_rule(p), 1)
         )
@@ -3672,7 +3854,7 @@ parameters_rule(Parser *p)
         asdl_seq * a;
         void *b;
         if (
-            (a = _loop1_53_rule(p))
+            (a = _loop1_58_rule(p))
             &&
             (b = star_etc_rule(p), 1)
         )
@@ -3720,7 +3902,7 @@ slash_no_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _loop1_54_rule(p))
+            (a = _loop1_59_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 17))
             &&
@@ -3740,7 +3922,7 @@ slash_no_default_rule(Parser *p)
         asdl_seq * a;
         void *literal;
         if (
-            (a = _loop1_55_rule(p))
+            (a = _loop1_60_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 17))
             &&
@@ -3778,9 +3960,9 @@ slash_with_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _loop0_56_rule(p))
+            (a = _loop0_61_rule(p))
             &&
-            (b = _loop1_57_rule(p))
+            (b = _loop1_62_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 17))
             &&
@@ -3801,9 +3983,9 @@ slash_with_default_rule(Parser *p)
         asdl_seq * b;
         void *literal;
         if (
-            (a = _loop0_58_rule(p))
+            (a = _loop0_63_rule(p))
             &&
-            (b = _loop1_59_rule(p))
+            (b = _loop1_64_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 17))
             &&
@@ -3846,7 +4028,7 @@ star_etc_rule(Parser *p)
             &&
             (a = param_no_default_rule(p))
             &&
-            (b = _loop0_60_rule(p))
+            (b = _loop0_65_rule(p))
             &&
             (c = kwds_rule(p), 1)
         )
@@ -3870,7 +4052,7 @@ star_etc_rule(Parser *p)
             &&
             (literal_1 = _PyPegen_expect_token(p, 12))
             &&
-            (b = _loop1_61_rule(p))
+            (b = _loop1_66_rule(p))
             &&
             (c = kwds_rule(p), 1)
         )
@@ -4239,7 +4421,7 @@ decorators_rule(Parser *p)
     { // (('@' named_expression NEWLINE))+
         asdl_seq * a;
         if (
-            (a = _loop1_62_rule(p))
+            (a = _loop1_67_rule(p))
         )
         {
             res = a;
@@ -4327,7 +4509,7 @@ class_def_raw_rule(Parser *p)
             &&
             (a = _PyPegen_name_token(p))
             &&
-            (b = _tmp_63_rule(p), 1)
+            (b = _tmp_68_rule(p), 1)
             &&
             (literal = _PyPegen_expect_token(p, 11))
             &&
@@ -4433,7 +4615,7 @@ expressions_list_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_64_rule(p))
+            (a = _gather_69_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4480,7 +4662,7 @@ star_expressions_rule(Parser *p)
         if (
             (a = star_expression_rule(p))
             &&
-            (b = _loop1_66_rule(p))
+            (b = _loop1_71_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4620,7 +4802,7 @@ star_named_expressions_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_67_rule(p))
+            (a = _gather_72_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -4834,7 +5016,7 @@ expressions_rule(Parser *p)
         if (
             (a = expression_rule(p))
             &&
-            (b = _loop1_69_rule(p))
+            (b = _loop1_74_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -5056,11 +5238,11 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_without_default_rule(p))
             &&
-            (b = _tmp_70_rule(p), 1)
+            (b = _tmp_75_rule(p), 1)
             &&
-            (c = _tmp_71_rule(p), 1)
+            (c = _tmp_76_rule(p), 1)
             &&
-            (d = _tmp_72_rule(p), 1)
+            (d = _tmp_77_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , a , NULL , b , c , d );
@@ -5079,9 +5261,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_slash_with_default_rule(p))
             &&
-            (b = _tmp_73_rule(p), 1)
+            (b = _tmp_78_rule(p), 1)
             &&
-            (c = _tmp_74_rule(p), 1)
+            (c = _tmp_79_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , a , NULL , b , c );
@@ -5100,9 +5282,9 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_plain_names_rule(p))
             &&
-            (b = _tmp_75_rule(p), 1)
+            (b = _tmp_80_rule(p), 1)
             &&
-            (c = _tmp_76_rule(p), 1)
+            (c = _tmp_81_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , a , b , c );
@@ -5120,7 +5302,7 @@ lambda_parameters_rule(Parser *p)
         if (
             (a = lambda_names_with_default_rule(p))
             &&
-            (b = _tmp_77_rule(p), 1)
+            (b = _tmp_82_rule(p), 1)
         )
         {
             res = _PyPegen_make_arguments ( p , NULL , NULL , NULL , a , b );
@@ -5202,7 +5384,7 @@ lambda_slash_with_default_rule(Parser *p)
         void *literal;
         void *literal_1;
         if (
-            (a = _tmp_78_rule(p), 1)
+            (a = _tmp_83_rule(p), 1)
             &&
             (b = lambda_names_with_default_rule(p))
             &&
@@ -5249,9 +5431,9 @@ lambda_star_etc_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _loop0_79_rule(p))
+            (b = _loop0_84_rule(p))
             &&
-            (c = _tmp_80_rule(p), 1)
+            (c = _tmp_85_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -5274,9 +5456,9 @@ lambda_star_etc_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (b = _loop1_81_rule(p))
+            (b = _loop1_86_rule(p))
             &&
-            (c = _tmp_82_rule(p), 1)
+            (c = _tmp_87_rule(p), 1)
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -5332,7 +5514,7 @@ lambda_name_with_optional_default_rule(Parser *p)
             &&
             (a = lambda_plain_name_rule(p))
             &&
-            (b = _tmp_83_rule(p), 1)
+            (b = _tmp_88_rule(p), 1)
         )
         {
             res = _PyPegen_name_default_pair ( p , a , b , NULL );
@@ -5361,7 +5543,7 @@ lambda_names_with_default_rule(Parser *p)
     { // ','.lambda_name_with_default+
         asdl_seq * a;
         if (
-            (a = _gather_84_rule(p))
+            (a = _gather_89_rule(p))
         )
         {
             res = a;
@@ -5425,7 +5607,7 @@ lambda_plain_names_rule(Parser *p)
     { // ','.(lambda_plain_name !'=')+
         asdl_seq * a;
         if (
-            (a = _gather_86_rule(p))
+            (a = _gather_91_rule(p))
         )
         {
             res = a;
@@ -5544,7 +5726,7 @@ disjunction_rule(Parser *p)
         if (
             (a = conjunction_rule(p))
             &&
-            (b = _loop1_88_rule(p))
+            (b = _loop1_93_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5606,7 +5788,7 @@ conjunction_rule(Parser *p)
         if (
             (a = inversion_rule(p))
             &&
-            (b = _loop1_89_rule(p))
+            (b = _loop1_94_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5728,7 +5910,7 @@ comparison_rule(Parser *p)
         if (
             (a = bitwise_or_rule(p))
             &&
-            (b = _loop1_90_rule(p))
+            (b = _loop1_95_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -5940,10 +6122,10 @@ noteq_bitwise_or_rule(Parser *p)
     CmpopExprPair* res = NULL;
     int mark = p->mark;
     { // ('!=') bitwise_or
-        void *_tmp_91_var;
+        void *_tmp_96_var;
         expr_ty a;
         if (
-            (_tmp_91_var = _tmp_91_rule(p))
+            (_tmp_96_var = _tmp_96_rule(p))
             &&
             (a = bitwise_or_rule(p))
         )
@@ -6901,7 +7083,7 @@ term_raw(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_BinOp ( a , MatMult , b , EXTRA );
+            res = CHECK_VERSION ( 5 , "The '@' operator is" , _Py_BinOp ( a , MatMult , b , EXTRA ) );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -7138,7 +7320,7 @@ await_primary_rule(Parser *p)
             UNUSED(end_lineno); // Only used by EXTRA macro
             int end_col_offset = token->end_col_offset;
             UNUSED(end_col_offset); // Only used by EXTRA macro
-            res = _Py_Await ( a , EXTRA );
+            res = CHECK_VERSION ( 5 , "Await expressions are" , _Py_Await ( a , EXTRA ) );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -7385,7 +7567,7 @@ slices_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_92_rule(p))
+            (a = _gather_97_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -7441,7 +7623,7 @@ slice_rule(Parser *p)
             &&
             (b = expression_rule(p), 1)
             &&
-            (c = _tmp_94_rule(p), 1)
+            (c = _tmp_99_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -7629,40 +7811,40 @@ atom_rule(Parser *p)
         p->mark = mark;
     }
     { // &'(' (tuple | group | genexp)
-        void *_tmp_95_var;
+        void *_tmp_100_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 7)
             &&
-            (_tmp_95_var = _tmp_95_rule(p))
+            (_tmp_100_var = _tmp_100_rule(p))
         )
         {
-            res = _tmp_95_var;
+            res = _tmp_100_var;
             goto done;
         }
         p->mark = mark;
     }
     { // &'[' (list | listcomp)
-        void *_tmp_96_var;
+        void *_tmp_101_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 9)
             &&
-            (_tmp_96_var = _tmp_96_rule(p))
+            (_tmp_101_var = _tmp_101_rule(p))
         )
         {
-            res = _tmp_96_var;
+            res = _tmp_101_var;
             goto done;
         }
         p->mark = mark;
     }
     { // &'{' (dict | set | dictcomp | setcomp)
-        void *_tmp_97_var;
+        void *_tmp_102_var;
         if (
             _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 25)
             &&
-            (_tmp_97_var = _tmp_97_rule(p))
+            (_tmp_102_var = _tmp_102_rule(p))
         )
         {
-            res = _tmp_97_var;
+            res = _tmp_102_var;
             goto done;
         }
         p->mark = mark;
@@ -7709,7 +7891,7 @@ strings_rule(Parser *p)
     { // STRING+
         asdl_seq * a;
         if (
-            (a = _loop1_98_rule(p))
+            (a = _loop1_103_rule(p))
         )
         {
             res = _PyPegen_concatenate_strings ( p , a );
@@ -7867,7 +8049,7 @@ tuple_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_99_rule(p), 1)
+            (a = _tmp_104_rule(p), 1)
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -7910,7 +8092,7 @@ group_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 7))
             &&
-            (a = _tmp_100_rule(p))
+            (a = _tmp_105_rule(p))
             &&
             (literal_1 = _PyPegen_expect_token(p, 8))
         )
@@ -8229,7 +8411,7 @@ kvpairs_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_101_rule(p))
+            (a = _gather_106_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8301,7 +8483,7 @@ kvpair_rule(Parser *p)
     return res;
 }
 
-// for_if_clauses: ((ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*))+
+// for_if_clauses: for_if_clause+
 static asdl_seq*
 for_if_clauses_rule(Parser *p)
 {
@@ -8310,13 +8492,82 @@ for_if_clauses_rule(Parser *p)
     }
     asdl_seq* res = NULL;
     int mark = p->mark;
-    { // ((ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*))+
-        asdl_seq * a;
+    { // for_if_clause+
+        asdl_seq * _loop1_108_var;
         if (
-            (a = _loop1_103_rule(p))
+            (_loop1_108_var = _loop1_108_rule(p))
         )
         {
-            res = a;
+            res = _loop1_108_var;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// for_if_clause:
+//     | ASYNC 'for' star_targets 'in' disjunction (('if' disjunction))*
+//     | 'for' star_targets 'in' disjunction (('if' disjunction))*
+static comprehension_ty
+for_if_clause_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    comprehension_ty res = NULL;
+    int mark = p->mark;
+    { // ASYNC 'for' star_targets 'in' disjunction (('if' disjunction))*
+        expr_ty a;
+        void *async_var;
+        expr_ty b;
+        asdl_seq * c;
+        void *keyword;
+        void *keyword_1;
+        if (
+            (async_var = _PyPegen_expect_token(p, ASYNC))
+            &&
+            (keyword = _PyPegen_expect_token(p, 517))
+            &&
+            (a = star_targets_rule(p))
+            &&
+            (keyword_1 = _PyPegen_expect_token(p, 518))
+            &&
+            (b = disjunction_rule(p))
+            &&
+            (c = _loop0_109_rule(p))
+        )
+        {
+            res = CHECK_VERSION ( 6 , "Async comprehensions are" , _Py_comprehension ( a , b , c , 1 , p -> arena ) );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // 'for' star_targets 'in' disjunction (('if' disjunction))*
+        expr_ty a;
+        expr_ty b;
+        asdl_seq * c;
+        void *keyword;
+        void *keyword_1;
+        if (
+            (keyword = _PyPegen_expect_token(p, 517))
+            &&
+            (a = star_targets_rule(p))
+            &&
+            (keyword_1 = _PyPegen_expect_token(p, 518))
+            &&
+            (b = disjunction_rule(p))
+            &&
+            (c = _loop0_110_rule(p))
+        )
+        {
+            res = _Py_comprehension ( a , b , c , 0 , p -> arena );
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -8479,7 +8730,7 @@ args_rule(Parser *p)
         if (
             (a = starred_expression_rule(p))
             &&
-            (b = _tmp_104_rule(p), 1)
+            (b = _tmp_111_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8528,7 +8779,7 @@ args_rule(Parser *p)
         if (
             (a = named_expression_rule(p))
             &&
-            (b = _tmp_105_rule(p), 1)
+            (b = _tmp_112_rule(p), 1)
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -8570,11 +8821,11 @@ kwargs_rule(Parser *p)
         asdl_seq * b;
         void *literal;
         if (
-            (a = _gather_106_rule(p))
+            (a = _gather_113_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (b = _gather_108_rule(p))
+            (b = _gather_115_rule(p))
         )
         {
             res = _PyPegen_join_sequences ( p , a , b );
@@ -8587,23 +8838,23 @@ kwargs_rule(Parser *p)
         p->mark = mark;
     }
     { // ','.kwarg_or_starred+
-        asdl_seq * _gather_110_var;
+        asdl_seq * _gather_117_var;
         if (
-            (_gather_110_var = _gather_110_rule(p))
+            (_gather_117_var = _gather_117_rule(p))
         )
         {
-            res = _gather_110_var;
+            res = _gather_117_var;
             goto done;
         }
         p->mark = mark;
     }
     { // ','.kwarg_or_double_starred+
-        asdl_seq * _gather_112_var;
+        asdl_seq * _gather_119_var;
         if (
-            (_gather_112_var = _gather_112_rule(p))
+            (_gather_119_var = _gather_119_rule(p))
         )
         {
-            res = _gather_112_var;
+            res = _gather_119_var;
             goto done;
         }
         p->mark = mark;
@@ -8846,7 +9097,7 @@ star_targets_rule(Parser *p)
         if (
             (a = star_target_rule(p))
             &&
-            (b = _loop0_114_rule(p))
+            (b = _loop0_121_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8887,7 +9138,7 @@ star_targets_seq_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_115_rule(p))
+            (a = _gather_122_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -8935,7 +9186,7 @@ star_target_rule(Parser *p)
         if (
             (literal = _PyPegen_expect_token(p, 16))
             &&
-            (a = _tmp_117_rule(p))
+            (a = _tmp_124_rule(p))
         )
         {
             Token *token = _PyPegen_get_last_nonnwhitespace_token(p);
@@ -9324,7 +9575,7 @@ del_targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_118_rule(p))
+            (a = _gather_125_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -9577,7 +9828,7 @@ targets_rule(Parser *p)
         void *opt_var;
         UNUSED(opt_var); // Silence compiler warnings
         if (
-            (a = _gather_120_rule(p))
+            (a = _gather_127_rule(p))
             &&
             (opt_var = _PyPegen_expect_token(p, 12), 1)
         )
@@ -10105,7 +10356,7 @@ incorrect_arguments_rule(Parser *p)
             &&
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (opt_var = _tmp_122_rule(p), 1)
+            (opt_var = _tmp_129_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "Generator expression must be parenthesized" );
@@ -10240,7 +10491,7 @@ invalid_assignment_rule(Parser *p)
             &&
             (expression_var_1 = expression_rule(p))
             &&
-            (opt_var = _tmp_123_rule(p), 1)
+            (opt_var = _tmp_130_rule(p), 1)
         )
         {
             res = RAISE_SYNTAX_ERROR ( "illegal target for annotation" );
@@ -10253,15 +10504,15 @@ invalid_assignment_rule(Parser *p)
         p->mark = mark;
     }
     { // expression ('=' | augassign) (yield_expr | star_expressions)
-        void *_tmp_124_var;
-        void *_tmp_125_var;
+        void *_tmp_131_var;
+        void *_tmp_132_var;
         expr_ty a;
         if (
             (a = expression_rule(p))
             &&
-            (_tmp_124_var = _tmp_124_rule(p))
+            (_tmp_131_var = _tmp_131_rule(p))
             &&
-            (_tmp_125_var = _tmp_125_rule(p))
+            (_tmp_132_var = _tmp_132_rule(p))
         )
         {
             res = RAISE_SYNTAX_ERROR ( "cannot assign to %s" , _PyPegen_get_expr_name ( a ) );
@@ -10319,12 +10570,12 @@ invalid_comprehension_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // ('[' | '(' | '{') '*' expression for_if_clauses
-        void *_tmp_126_var;
+        void *_tmp_133_var;
         expr_ty expression_var;
         asdl_seq* for_if_clauses_var;
         void *literal;
         if (
-            (_tmp_126_var = _tmp_126_rule(p))
+            (_tmp_133_var = _tmp_133_rule(p))
             &&
             (literal = _PyPegen_expect_token(p, 16))
             &&
@@ -10358,13 +10609,13 @@ invalid_parameters_rule(Parser *p)
     void * res = NULL;
     int mark = p->mark;
     { // param_no_default* (slash_with_default | param_with_default+) param_no_default
-        asdl_seq * _loop0_127_var;
-        void *_tmp_128_var;
+        asdl_seq * _loop0_134_var;
+        void *_tmp_135_var;
         arg_ty param_no_default_var;
         if (
-            (_loop0_127_var = _loop0_127_rule(p))
+            (_loop0_134_var = _loop0_134_rule(p))
             &&
-            (_tmp_128_var = _tmp_128_rule(p))
+            (_tmp_135_var = _tmp_135_rule(p))
             &&
             (param_no_default_var = param_no_default_rule(p))
         )
@@ -11319,12 +11570,12 @@ _loop1_22_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (star_targets '=')
-        void *_tmp_129_var;
+        void *_tmp_136_var;
         while (
-            (_tmp_129_var = _tmp_129_rule(p))
+            (_tmp_136_var = _tmp_136_rule(p))
         )
         {
-            res = _tmp_129_var;
+            res = _tmp_136_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -11646,12 +11897,12 @@ _loop0_30_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_130_var;
+        void *_tmp_137_var;
         while (
-            (_tmp_130_var = _tmp_130_rule(p))
+            (_tmp_137_var = _tmp_137_rule(p))
         )
         {
-            res = _tmp_130_var;
+            res = _tmp_137_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -11695,12 +11946,12 @@ _loop1_31_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_131_var;
+        void *_tmp_138_var;
         while (
-            (_tmp_131_var = _tmp_131_rule(p))
+            (_tmp_138_var = _tmp_138_rule(p))
         )
         {
-            res = _tmp_131_var;
+            res = _tmp_138_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12134,9 +12385,179 @@ _gather_40_rule(Parser *p)
     return res;
 }
 
-// _tmp_42: 'as' target
+// _loop0_43: ',' with_item
+static asdl_seq *
+_loop0_43_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' with_item
+        withitem_ty elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = with_item_rule(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_43");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_43_type, seq);
+    return seq;
+}
+
+// _gather_42: with_item _loop0_43
+static asdl_seq *
+_gather_42_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // with_item _loop0_43
+        withitem_ty elem;
+        asdl_seq * seq;
+        if (
+            (elem = with_item_rule(p))
+            &&
+            (seq = _loop0_43_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_45: ',' with_item
+static asdl_seq *
+_loop0_45_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' with_item
+        withitem_ty elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = with_item_rule(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_45");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_45_type, seq);
+    return seq;
+}
+
+// _gather_44: with_item _loop0_45
+static asdl_seq *
+_gather_44_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // with_item _loop0_45
+        withitem_ty elem;
+        asdl_seq * seq;
+        if (
+            (elem = with_item_rule(p))
+            &&
+            (seq = _loop0_45_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_46: 'as' target
 static void *
-_tmp_42_rule(Parser *p)
+_tmp_46_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12166,9 +12587,9 @@ _tmp_42_rule(Parser *p)
     return res;
 }
 
-// _loop1_43: except_block
+// _loop1_47: except_block
 static asdl_seq *
-_loop1_43_rule(Parser *p)
+_loop1_47_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12209,19 +12630,19 @@ _loop1_43_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_43");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_47");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_43_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_47_type, seq);
     return seq;
 }
 
-// _tmp_44: 'as' target
+// _tmp_48: 'as' target
 static void *
-_tmp_44_rule(Parser *p)
+_tmp_48_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12251,9 +12672,9 @@ _tmp_44_rule(Parser *p)
     return res;
 }
 
-// _tmp_45: 'from' expression
+// _tmp_49: 'from' expression
 static void *
-_tmp_45_rule(Parser *p)
+_tmp_49_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12283,9 +12704,9 @@ _tmp_45_rule(Parser *p)
     return res;
 }
 
-// _tmp_46: '->' expression
+// _tmp_50: '->' expression
 static void *
-_tmp_46_rule(Parser *p)
+_tmp_50_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12315,9 +12736,41 @@ _tmp_46_rule(Parser *p)
     return res;
 }
 
-// _tmp_47: NEWLINE INDENT
+// _tmp_51: '->' expression
 static void *
-_tmp_47_rule(Parser *p)
+_tmp_51_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // '->' expression
+        void *literal;
+        expr_ty z;
+        if (
+            (literal = _PyPegen_expect_token(p, 51))
+            &&
+            (z = expression_rule(p))
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_52: NEWLINE INDENT
+static void *
+_tmp_52_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12343,9 +12796,9 @@ _tmp_47_rule(Parser *p)
     return res;
 }
 
-// _loop0_48: param_no_default
+// _loop0_53: param_no_default
 static asdl_seq *
-_loop0_48_rule(Parser *p)
+_loop0_53_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12382,19 +12835,19 @@ _loop0_48_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_48");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_53");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_48_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_53_type, seq);
     return seq;
 }
 
-// _loop0_49: param_with_default
+// _loop0_54: param_with_default
 static asdl_seq *
-_loop0_49_rule(Parser *p)
+_loop0_54_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12431,19 +12884,19 @@ _loop0_49_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_49");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_54");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_49_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_54_type, seq);
     return seq;
 }
 
-// _loop0_50: param_with_default
+// _loop0_55: param_with_default
 static asdl_seq *
-_loop0_50_rule(Parser *p)
+_loop0_55_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12480,19 +12933,19 @@ _loop0_50_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_50");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_55");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_50_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_55_type, seq);
     return seq;
 }
 
-// _loop1_51: param_no_default
+// _loop1_56: param_no_default
 static asdl_seq *
-_loop1_51_rule(Parser *p)
+_loop1_56_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12533,19 +12986,19 @@ _loop1_51_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_51");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_56");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_51_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_56_type, seq);
     return seq;
 }
 
-// _loop0_52: param_with_default
+// _loop0_57: param_with_default
 static asdl_seq *
-_loop0_52_rule(Parser *p)
+_loop0_57_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12582,227 +13035,19 @@ _loop0_52_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_52");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_57");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_52_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_57_type, seq);
     return seq;
 }
 
-// _loop1_53: param_with_default
+// _loop1_58: param_with_default
 static asdl_seq *
-_loop1_53_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // param_with_default
-        NameDefaultPair* param_with_default_var;
-        while (
-            (param_with_default_var = param_with_default_rule(p))
-        )
-        {
-            res = param_with_default_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    if (n == 0) {
-        PyMem_Free(children);
-        return NULL;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_53");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_53_type, seq);
-    return seq;
-}
-
-// _loop1_54: param_no_default
-static asdl_seq *
-_loop1_54_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // param_no_default
-        arg_ty param_no_default_var;
-        while (
-            (param_no_default_var = param_no_default_rule(p))
-        )
-        {
-            res = param_no_default_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    if (n == 0) {
-        PyMem_Free(children);
-        return NULL;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_54");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_54_type, seq);
-    return seq;
-}
-
-// _loop1_55: param_no_default
-static asdl_seq *
-_loop1_55_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // param_no_default
-        arg_ty param_no_default_var;
-        while (
-            (param_no_default_var = param_no_default_rule(p))
-        )
-        {
-            res = param_no_default_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    if (n == 0) {
-        PyMem_Free(children);
-        return NULL;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_55");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_55_type, seq);
-    return seq;
-}
-
-// _loop0_56: param_no_default
-static asdl_seq *
-_loop0_56_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // param_no_default
-        arg_ty param_no_default_var;
-        while (
-            (param_no_default_var = param_no_default_rule(p))
-        )
-        {
-            res = param_no_default_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_56");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_56_type, seq);
-    return seq;
-}
-
-// _loop1_57: param_with_default
-static asdl_seq *
-_loop1_57_rule(Parser *p)
+_loop1_58_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12843,66 +13088,17 @@ _loop1_57_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_57");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_58");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_57_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_58_type, seq);
     return seq;
 }
 
-// _loop0_58: param_no_default
-static asdl_seq *
-_loop0_58_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // param_no_default
-        arg_ty param_no_default_var;
-        while (
-            (param_no_default_var = param_no_default_rule(p))
-        )
-        {
-            res = param_no_default_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_58");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_58_type, seq);
-    return seq;
-}
-
-// _loop1_59: param_with_default
+// _loop1_59: param_no_default
 static asdl_seq *
 _loop1_59_rule(Parser *p)
 {
@@ -12919,13 +13115,13 @@ _loop1_59_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // param_with_default
-        NameDefaultPair* param_with_default_var;
+    { // param_no_default
+        arg_ty param_no_default_var;
         while (
-            (param_with_default_var = param_with_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))
         )
         {
-            res = param_with_default_var;
+            res = param_no_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12955,9 +13151,9 @@ _loop1_59_rule(Parser *p)
     return seq;
 }
 
-// _loop0_60: param_maybe_default
+// _loop1_60: param_no_default
 static asdl_seq *
-_loop0_60_rule(Parser *p)
+_loop1_60_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -12972,62 +13168,13 @@ _loop0_60_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // param_maybe_default
-        NameDefaultPair* param_maybe_default_var;
+    { // param_no_default
+        arg_ty param_no_default_var;
         while (
-            (param_maybe_default_var = param_maybe_default_rule(p))
+            (param_no_default_var = param_no_default_rule(p))
         )
         {
-            res = param_maybe_default_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_60");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_60_type, seq);
-    return seq;
-}
-
-// _loop1_61: param_maybe_default
-static asdl_seq *
-_loop1_61_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // param_maybe_default
-        NameDefaultPair* param_maybe_default_var;
-        while (
-            (param_maybe_default_var = param_maybe_default_rule(p))
-        )
-        {
-            res = param_maybe_default_var;
+            res = param_no_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13047,17 +13194,66 @@ _loop1_61_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_61");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_60");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_61_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_60_type, seq);
     return seq;
 }
 
-// _loop1_62: ('@' named_expression NEWLINE)
+// _loop0_61: param_no_default
+static asdl_seq *
+_loop0_61_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_no_default
+        arg_ty param_no_default_var;
+        while (
+            (param_no_default_var = param_no_default_rule(p))
+        )
+        {
+            res = param_no_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_61");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_61_type, seq);
+    return seq;
+}
+
+// _loop1_62: param_with_default
 static asdl_seq *
 _loop1_62_rule(Parser *p)
 {
@@ -13074,13 +13270,13 @@ _loop1_62_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // ('@' named_expression NEWLINE)
-        void *_tmp_132_var;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
         while (
-            (_tmp_132_var = _tmp_132_rule(p))
+            (param_with_default_var = param_with_default_rule(p))
         )
         {
-            res = _tmp_132_var;
+            res = param_with_default_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13110,9 +13306,266 @@ _loop1_62_rule(Parser *p)
     return seq;
 }
 
-// _tmp_63: '(' arguments? ')'
+// _loop0_63: param_no_default
+static asdl_seq *
+_loop0_63_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_no_default
+        arg_ty param_no_default_var;
+        while (
+            (param_no_default_var = param_no_default_rule(p))
+        )
+        {
+            res = param_no_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_63");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_63_type, seq);
+    return seq;
+}
+
+// _loop1_64: param_with_default
+static asdl_seq *
+_loop1_64_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_with_default
+        NameDefaultPair* param_with_default_var;
+        while (
+            (param_with_default_var = param_with_default_rule(p))
+        )
+        {
+            res = param_with_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_64");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_64_type, seq);
+    return seq;
+}
+
+// _loop0_65: param_maybe_default
+static asdl_seq *
+_loop0_65_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_maybe_default
+        NameDefaultPair* param_maybe_default_var;
+        while (
+            (param_maybe_default_var = param_maybe_default_rule(p))
+        )
+        {
+            res = param_maybe_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_65");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_65_type, seq);
+    return seq;
+}
+
+// _loop1_66: param_maybe_default
+static asdl_seq *
+_loop1_66_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // param_maybe_default
+        NameDefaultPair* param_maybe_default_var;
+        while (
+            (param_maybe_default_var = param_maybe_default_rule(p))
+        )
+        {
+            res = param_maybe_default_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_66");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_66_type, seq);
+    return seq;
+}
+
+// _loop1_67: ('@' named_expression NEWLINE)
+static asdl_seq *
+_loop1_67_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ('@' named_expression NEWLINE)
+        void *_tmp_139_var;
+        while (
+            (_tmp_139_var = _tmp_139_rule(p))
+        )
+        {
+            res = _tmp_139_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    if (n == 0) {
+        PyMem_Free(children);
+        return NULL;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_67");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop1_67_type, seq);
+    return seq;
+}
+
+// _tmp_68: '(' arguments? ')'
 static void *
-_tmp_63_rule(Parser *p)
+_tmp_68_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13145,9 +13598,9 @@ _tmp_63_rule(Parser *p)
     return res;
 }
 
-// _loop0_65: ',' star_expression
+// _loop0_70: ',' star_expression
 static asdl_seq *
-_loop0_65_rule(Parser *p)
+_loop0_70_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13192,32 +13645,32 @@ _loop0_65_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_65");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_70");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_65_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_70_type, seq);
     return seq;
 }
 
-// _gather_64: star_expression _loop0_65
+// _gather_69: star_expression _loop0_70
 static asdl_seq *
-_gather_64_rule(Parser *p)
+_gather_69_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_expression _loop0_65
+    { // star_expression _loop0_70
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_expression_rule(p))
             &&
-            (seq = _loop0_65_rule(p))
+            (seq = _loop0_70_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13230,9 +13683,9 @@ _gather_64_rule(Parser *p)
     return res;
 }
 
-// _loop1_66: (',' star_expression)
+// _loop1_71: (',' star_expression)
 static asdl_seq *
-_loop1_66_rule(Parser *p)
+_loop1_71_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13248,12 +13701,12 @@ _loop1_66_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_expression)
-        void *_tmp_133_var;
+        void *_tmp_140_var;
         while (
-            (_tmp_133_var = _tmp_133_rule(p))
+            (_tmp_140_var = _tmp_140_rule(p))
         )
         {
-            res = _tmp_133_var;
+            res = _tmp_140_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13273,19 +13726,19 @@ _loop1_66_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_66");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_71");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_66_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_71_type, seq);
     return seq;
 }
 
-// _loop0_68: ',' star_named_expression
+// _loop0_73: ',' star_named_expression
 static asdl_seq *
-_loop0_68_rule(Parser *p)
+_loop0_73_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13330,32 +13783,32 @@ _loop0_68_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_68");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_73");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_68_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_73_type, seq);
     return seq;
 }
 
-// _gather_67: star_named_expression _loop0_68
+// _gather_72: star_named_expression _loop0_73
 static asdl_seq *
-_gather_67_rule(Parser *p)
+_gather_72_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_named_expression _loop0_68
+    { // star_named_expression _loop0_73
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_named_expression_rule(p))
             &&
-            (seq = _loop0_68_rule(p))
+            (seq = _loop0_73_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13368,9 +13821,9 @@ _gather_67_rule(Parser *p)
     return res;
 }
 
-// _loop1_69: (',' expression)
+// _loop1_74: (',' expression)
 static asdl_seq *
-_loop1_69_rule(Parser *p)
+_loop1_74_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13386,12 +13839,12 @@ _loop1_69_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' expression)
-        void *_tmp_134_var;
+        void *_tmp_141_var;
         while (
-            (_tmp_134_var = _tmp_134_rule(p))
+            (_tmp_141_var = _tmp_141_rule(p))
         )
         {
-            res = _tmp_134_var;
+            res = _tmp_141_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13411,19 +13864,19 @@ _loop1_69_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_69");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_74");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_69_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_74_type, seq);
     return seq;
 }
 
-// _tmp_70: ',' lambda_plain_names
+// _tmp_75: ',' lambda_plain_names
 static void *
-_tmp_70_rule(Parser *p)
+_tmp_75_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13453,167 +13906,7 @@ _tmp_70_rule(Parser *p)
     return res;
 }
 
-// _tmp_71: ',' lambda_names_with_default
-static void *
-_tmp_71_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = lambda_names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_72: ',' lambda_star_etc?
-static void *
-_tmp_72_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = lambda_star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_73: ',' lambda_names_with_default
-static void *
-_tmp_73_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = lambda_names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_74: ',' lambda_star_etc?
-static void *
-_tmp_74_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_star_etc?
-        void *literal;
-        void *z;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (z = lambda_star_etc_rule(p), 1)
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_75: ',' lambda_names_with_default
-static void *
-_tmp_75_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' lambda_names_with_default
-        void *literal;
-        asdl_seq* y;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (y = lambda_names_with_default_rule(p))
-        )
-        {
-            res = y;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_76: ',' lambda_star_etc?
+// _tmp_76: ',' lambda_names_with_default
 static void *
 _tmp_76_rule(Parser *p)
 {
@@ -13622,16 +13915,16 @@ _tmp_76_rule(Parser *p)
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ',' lambda_star_etc?
+    { // ',' lambda_names_with_default
         void *literal;
-        void *z;
+        asdl_seq* y;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (z = lambda_star_etc_rule(p), 1)
+            (y = lambda_names_with_default_rule(p))
         )
         {
-            res = z;
+            res = y;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -13677,9 +13970,169 @@ _tmp_77_rule(Parser *p)
     return res;
 }
 
-// _tmp_78: lambda_plain_names ','
+// _tmp_78: ',' lambda_names_with_default
 static void *
 _tmp_78_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_names_with_default
+        void *literal;
+        asdl_seq* y;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (y = lambda_names_with_default_rule(p))
+        )
+        {
+            res = y;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_79: ',' lambda_star_etc?
+static void *
+_tmp_79_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_star_etc?
+        void *literal;
+        void *z;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (z = lambda_star_etc_rule(p), 1)
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_80: ',' lambda_names_with_default
+static void *
+_tmp_80_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_names_with_default
+        void *literal;
+        asdl_seq* y;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (y = lambda_names_with_default_rule(p))
+        )
+        {
+            res = y;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_81: ',' lambda_star_etc?
+static void *
+_tmp_81_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_star_etc?
+        void *literal;
+        void *z;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (z = lambda_star_etc_rule(p), 1)
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_82: ',' lambda_star_etc?
+static void *
+_tmp_82_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' lambda_star_etc?
+        void *literal;
+        void *z;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (z = lambda_star_etc_rule(p), 1)
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_83: lambda_plain_names ','
+static void *
+_tmp_83_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13709,9 +14162,9 @@ _tmp_78_rule(Parser *p)
     return res;
 }
 
-// _loop0_79: lambda_name_with_optional_default
+// _loop0_84: lambda_name_with_optional_default
 static asdl_seq *
-_loop0_79_rule(Parser *p)
+_loop0_84_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13748,19 +14201,19 @@ _loop0_79_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_79");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_84");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_79_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_84_type, seq);
     return seq;
 }
 
-// _tmp_80: ',' lambda_kwds
+// _tmp_85: ',' lambda_kwds
 static void *
-_tmp_80_rule(Parser *p)
+_tmp_85_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13790,9 +14243,9 @@ _tmp_80_rule(Parser *p)
     return res;
 }
 
-// _loop1_81: lambda_name_with_optional_default
+// _loop1_86: lambda_name_with_optional_default
 static asdl_seq *
-_loop1_81_rule(Parser *p)
+_loop1_86_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13833,19 +14286,19 @@ _loop1_81_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_81");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_86");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_81_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_86_type, seq);
     return seq;
 }
 
-// _tmp_82: ',' lambda_kwds
+// _tmp_87: ',' lambda_kwds
 static void *
-_tmp_82_rule(Parser *p)
+_tmp_87_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13875,9 +14328,9 @@ _tmp_82_rule(Parser *p)
     return res;
 }
 
-// _tmp_83: '=' expression
+// _tmp_88: '=' expression
 static void *
-_tmp_83_rule(Parser *p)
+_tmp_88_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13907,9 +14360,9 @@ _tmp_83_rule(Parser *p)
     return res;
 }
 
-// _loop0_85: ',' lambda_name_with_default
+// _loop0_90: ',' lambda_name_with_default
 static asdl_seq *
-_loop0_85_rule(Parser *p)
+_loop0_90_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -13954,32 +14407,32 @@ _loop0_85_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_85");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_90");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_85_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_90_type, seq);
     return seq;
 }
 
-// _gather_84: lambda_name_with_default _loop0_85
+// _gather_89: lambda_name_with_default _loop0_90
 static asdl_seq *
-_gather_84_rule(Parser *p)
+_gather_89_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // lambda_name_with_default _loop0_85
+    { // lambda_name_with_default _loop0_90
         NameDefaultPair* elem;
         asdl_seq * seq;
         if (
             (elem = lambda_name_with_default_rule(p))
             &&
-            (seq = _loop0_85_rule(p))
+            (seq = _loop0_90_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -13992,9 +14445,9 @@ _gather_84_rule(Parser *p)
     return res;
 }
 
-// _loop0_87: ',' (lambda_plain_name !'=')
+// _loop0_92: ',' (lambda_plain_name !'=')
 static asdl_seq *
-_loop0_87_rule(Parser *p)
+_loop0_92_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14015,7 +14468,7 @@ _loop0_87_rule(Parser *p)
         while (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (elem = _tmp_135_rule(p))
+            (elem = _tmp_142_rule(p))
         )
         {
             res = elem;
@@ -14039,32 +14492,32 @@ _loop0_87_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_87");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_92");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_87_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_92_type, seq);
     return seq;
 }
 
-// _gather_86: (lambda_plain_name !'=') _loop0_87
+// _gather_91: (lambda_plain_name !'=') _loop0_92
 static asdl_seq *
-_gather_86_rule(Parser *p)
+_gather_91_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // (lambda_plain_name !'=') _loop0_87
+    { // (lambda_plain_name !'=') _loop0_92
         void *elem;
         asdl_seq * seq;
         if (
-            (elem = _tmp_135_rule(p))
+            (elem = _tmp_142_rule(p))
             &&
-            (seq = _loop0_87_rule(p))
+            (seq = _loop0_92_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14077,9 +14530,9 @@ _gather_86_rule(Parser *p)
     return res;
 }
 
-// _loop1_88: ('or' conjunction)
+// _loop1_93: ('or' conjunction)
 static asdl_seq *
-_loop1_88_rule(Parser *p)
+_loop1_93_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14095,12 +14548,12 @@ _loop1_88_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('or' conjunction)
-        void *_tmp_136_var;
+        void *_tmp_143_var;
         while (
-            (_tmp_136_var = _tmp_136_rule(p))
+            (_tmp_143_var = _tmp_143_rule(p))
         )
         {
-            res = _tmp_136_var;
+            res = _tmp_143_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14120,19 +14573,19 @@ _loop1_88_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_88");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_93");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_88_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_93_type, seq);
     return seq;
 }
 
-// _loop1_89: ('and' inversion)
+// _loop1_94: ('and' inversion)
 static asdl_seq *
-_loop1_89_rule(Parser *p)
+_loop1_94_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14148,12 +14601,12 @@ _loop1_89_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('and' inversion)
-        void *_tmp_137_var;
+        void *_tmp_144_var;
         while (
-            (_tmp_137_var = _tmp_137_rule(p))
+            (_tmp_144_var = _tmp_144_rule(p))
         )
         {
-            res = _tmp_137_var;
+            res = _tmp_144_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14173,19 +14626,19 @@ _loop1_89_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_89");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_94");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_89_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_94_type, seq);
     return seq;
 }
 
-// _loop1_90: compare_op_bitwise_or_pair
+// _loop1_95: compare_op_bitwise_or_pair
 static asdl_seq *
-_loop1_90_rule(Parser *p)
+_loop1_95_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14226,19 +14679,19 @@ _loop1_90_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_90");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_95");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_90_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_95_type, seq);
     return seq;
 }
 
-// _tmp_91: '!='
+// _tmp_96: '!='
 static void *
-_tmp_91_rule(Parser *p)
+_tmp_96_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14265,9 +14718,9 @@ _tmp_91_rule(Parser *p)
     return res;
 }
 
-// _loop0_93: ',' slice
+// _loop0_98: ',' slice
 static asdl_seq *
-_loop0_93_rule(Parser *p)
+_loop0_98_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14312,32 +14765,32 @@ _loop0_93_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_93");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_98");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_93_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_98_type, seq);
     return seq;
 }
 
-// _gather_92: slice _loop0_93
+// _gather_97: slice _loop0_98
 static asdl_seq *
-_gather_92_rule(Parser *p)
+_gather_97_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // slice _loop0_93
+    { // slice _loop0_98
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = slice_rule(p))
             &&
-            (seq = _loop0_93_rule(p))
+            (seq = _loop0_98_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14350,9 +14803,9 @@ _gather_92_rule(Parser *p)
     return res;
 }
 
-// _tmp_94: ':' expression?
+// _tmp_99: ':' expression?
 static void *
-_tmp_94_rule(Parser *p)
+_tmp_99_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14382,9 +14835,9 @@ _tmp_94_rule(Parser *p)
     return res;
 }
 
-// _tmp_95: tuple | group | genexp
+// _tmp_100: tuple | group | genexp
 static void *
-_tmp_95_rule(Parser *p)
+_tmp_100_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14429,9 +14882,9 @@ _tmp_95_rule(Parser *p)
     return res;
 }
 
-// _tmp_96: list | listcomp
+// _tmp_101: list | listcomp
 static void *
-_tmp_96_rule(Parser *p)
+_tmp_101_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14465,9 +14918,9 @@ _tmp_96_rule(Parser *p)
     return res;
 }
 
-// _tmp_97: dict | set | dictcomp | setcomp
+// _tmp_102: dict | set | dictcomp | setcomp
 static void *
-_tmp_97_rule(Parser *p)
+_tmp_102_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14523,9 +14976,9 @@ _tmp_97_rule(Parser *p)
     return res;
 }
 
-// _loop1_98: STRING
+// _loop1_103: STRING
 static asdl_seq *
-_loop1_98_rule(Parser *p)
+_loop1_103_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14566,19 +15019,19 @@ _loop1_98_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_98");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_103");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_98_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_103_type, seq);
     return seq;
 }
 
-// _tmp_99: star_named_expression ',' star_named_expressions?
+// _tmp_104: star_named_expression ',' star_named_expressions?
 static void *
-_tmp_99_rule(Parser *p)
+_tmp_104_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14611,9 +15064,9 @@ _tmp_99_rule(Parser *p)
     return res;
 }
 
-// _tmp_100: yield_expr | named_expression
+// _tmp_105: yield_expr | named_expression
 static void *
-_tmp_100_rule(Parser *p)
+_tmp_105_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14647,9 +15100,9 @@ _tmp_100_rule(Parser *p)
     return res;
 }
 
-// _loop0_102: ',' kvpair
+// _loop0_107: ',' kvpair
 static asdl_seq *
-_loop0_102_rule(Parser *p)
+_loop0_107_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14694,32 +15147,32 @@ _loop0_102_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_102");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_107");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_102_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_107_type, seq);
     return seq;
 }
 
-// _gather_101: kvpair _loop0_102
+// _gather_106: kvpair _loop0_107
 static asdl_seq *
-_gather_101_rule(Parser *p)
+_gather_106_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kvpair _loop0_102
+    { // kvpair _loop0_107
         KeyValuePair* elem;
         asdl_seq * seq;
         if (
             (elem = kvpair_rule(p))
             &&
-            (seq = _loop0_102_rule(p))
+            (seq = _loop0_107_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -14732,9 +15185,9 @@ _gather_101_rule(Parser *p)
     return res;
 }
 
-// _loop1_103: (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
+// _loop1_108: for_if_clause
 static asdl_seq *
-_loop1_103_rule(Parser *p)
+_loop1_108_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -14749,13 +15202,13 @@ _loop1_103_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // (ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*)
-        void *_tmp_138_var;
+    { // for_if_clause
+        comprehension_ty for_if_clause_var;
         while (
-            (_tmp_138_var = _tmp_138_rule(p))
+            (for_if_clause_var = for_if_clause_rule(p))
         )
         {
-            res = _tmp_138_var;
+            res = for_if_clause_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14775,166 +15228,17 @@ _loop1_103_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_103");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_108");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_103_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_108_type, seq);
     return seq;
 }
 
-// _tmp_104: ',' args
-static void *
-_tmp_104_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' args
-        expr_ty c;
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (c = args_rule(p))
-        )
-        {
-            res = c;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_105: ',' args
-static void *
-_tmp_105_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // ',' args
-        expr_ty c;
-        void *literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (c = args_rule(p))
-        )
-        {
-            res = c;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_107: ',' kwarg_or_starred
-static asdl_seq *
-_loop0_107_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ',' kwarg_or_starred
-        KeywordOrStarred* elem;
-        void *literal;
-        while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = kwarg_or_starred_rule(p))
-        )
-        {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_107");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_107_type, seq);
-    return seq;
-}
-
-// _gather_106: kwarg_or_starred _loop0_107
-static asdl_seq *
-_gather_106_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    asdl_seq * res = NULL;
-    int mark = p->mark;
-    { // kwarg_or_starred _loop0_107
-        KeywordOrStarred* elem;
-        asdl_seq * seq;
-        if (
-            (elem = kwarg_or_starred_rule(p))
-            &&
-            (seq = _loop0_107_rule(p))
-        )
-        {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _loop0_109: ',' kwarg_or_double_starred
+// _loop0_109: ('if' disjunction)
 static asdl_seq *
 _loop0_109_rule(Parser *p)
 {
@@ -14951,21 +15255,13 @@ _loop0_109_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // ',' kwarg_or_double_starred
-        KeywordOrStarred* elem;
-        void *literal;
+    { // ('if' disjunction)
+        void *_tmp_145_var;
         while (
-            (literal = _PyPegen_expect_token(p, 12))
-            &&
-            (elem = kwarg_or_double_starred_rule(p))
+            (_tmp_145_var = _tmp_145_rule(p))
         )
         {
-            res = elem;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                PyMem_Free(children);
-                return NULL;
-            }
+            res = _tmp_145_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14991,25 +15287,78 @@ _loop0_109_rule(Parser *p)
     return seq;
 }
 
-// _gather_108: kwarg_or_double_starred _loop0_109
+// _loop0_110: ('if' disjunction)
 static asdl_seq *
-_gather_108_rule(Parser *p)
+_loop0_110_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
-    asdl_seq * res = NULL;
+    void *res = NULL;
     int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_109
-        KeywordOrStarred* elem;
-        asdl_seq * seq;
-        if (
-            (elem = kwarg_or_double_starred_rule(p))
-            &&
-            (seq = _loop0_109_rule(p))
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ('if' disjunction)
+        void *_tmp_146_var;
+        while (
+            (_tmp_146_var = _tmp_146_rule(p))
         )
         {
-            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            res = _tmp_146_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_110");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_110_type, seq);
+    return seq;
+}
+
+// _tmp_111: ',' args
+static void *
+_tmp_111_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' args
+        expr_ty c;
+        void *literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (c = args_rule(p))
+        )
+        {
+            res = c;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
             goto done;
         }
         p->mark = mark;
@@ -15019,9 +15368,41 @@ _gather_108_rule(Parser *p)
     return res;
 }
 
-// _loop0_111: ',' kwarg_or_starred
+// _tmp_112: ',' args
+static void *
+_tmp_112_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ',' args
+        expr_ty c;
+        void *literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (c = args_rule(p))
+        )
+        {
+            res = c;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_114: ',' kwarg_or_starred
 static asdl_seq *
-_loop0_111_rule(Parser *p)
+_loop0_114_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15066,32 +15447,32 @@ _loop0_111_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_111");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_114");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_111_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_114_type, seq);
     return seq;
 }
 
-// _gather_110: kwarg_or_starred _loop0_111
+// _gather_113: kwarg_or_starred _loop0_114
 static asdl_seq *
-_gather_110_rule(Parser *p)
+_gather_113_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_starred _loop0_111
+    { // kwarg_or_starred _loop0_114
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_starred_rule(p))
             &&
-            (seq = _loop0_111_rule(p))
+            (seq = _loop0_114_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15104,9 +15485,9 @@ _gather_110_rule(Parser *p)
     return res;
 }
 
-// _loop0_113: ',' kwarg_or_double_starred
+// _loop0_116: ',' kwarg_or_double_starred
 static asdl_seq *
-_loop0_113_rule(Parser *p)
+_loop0_116_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15151,32 +15532,32 @@ _loop0_113_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_113");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_116");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_113_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_116_type, seq);
     return seq;
 }
 
-// _gather_112: kwarg_or_double_starred _loop0_113
+// _gather_115: kwarg_or_double_starred _loop0_116
 static asdl_seq *
-_gather_112_rule(Parser *p)
+_gather_115_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // kwarg_or_double_starred _loop0_113
+    { // kwarg_or_double_starred _loop0_116
         KeywordOrStarred* elem;
         asdl_seq * seq;
         if (
             (elem = kwarg_or_double_starred_rule(p))
             &&
-            (seq = _loop0_113_rule(p))
+            (seq = _loop0_116_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15189,9 +15570,9 @@ _gather_112_rule(Parser *p)
     return res;
 }
 
-// _loop0_114: (',' star_target)
+// _loop0_118: ',' kwarg_or_starred
 static asdl_seq *
-_loop0_114_rule(Parser *p)
+_loop0_118_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15206,13 +15587,21 @@ _loop0_114_rule(Parser *p)
     }
     ssize_t children_capacity = 1;
     ssize_t n = 0;
-    { // (',' star_target)
-        void *_tmp_139_var;
+    { // ',' kwarg_or_starred
+        KeywordOrStarred* elem;
+        void *literal;
         while (
-            (_tmp_139_var = _tmp_139_rule(p))
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = kwarg_or_starred_rule(p))
         )
         {
-            res = _tmp_139_var;
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15228,19 +15617,181 @@ _loop0_114_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_114");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_118");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_114_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_118_type, seq);
     return seq;
 }
 
-// _loop0_116: ',' star_target
+// _gather_117: kwarg_or_starred _loop0_118
 static asdl_seq *
-_loop0_116_rule(Parser *p)
+_gather_117_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // kwarg_or_starred _loop0_118
+        KeywordOrStarred* elem;
+        asdl_seq * seq;
+        if (
+            (elem = kwarg_or_starred_rule(p))
+            &&
+            (seq = _loop0_118_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_120: ',' kwarg_or_double_starred
+static asdl_seq *
+_loop0_120_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // ',' kwarg_or_double_starred
+        KeywordOrStarred* elem;
+        void *literal;
+        while (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (elem = kwarg_or_double_starred_rule(p))
+        )
+        {
+            res = elem;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                PyMem_Free(children);
+                return NULL;
+            }
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_120");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_120_type, seq);
+    return seq;
+}
+
+// _gather_119: kwarg_or_double_starred _loop0_120
+static asdl_seq *
+_gather_119_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    asdl_seq * res = NULL;
+    int mark = p->mark;
+    { // kwarg_or_double_starred _loop0_120
+        KeywordOrStarred* elem;
+        asdl_seq * seq;
+        if (
+            (elem = kwarg_or_double_starred_rule(p))
+            &&
+            (seq = _loop0_120_rule(p))
+        )
+        {
+            res = _PyPegen_seq_insert_in_front(p, elem, seq);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _loop0_121: (',' star_target)
+static asdl_seq *
+_loop0_121_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void *res = NULL;
+    int mark = p->mark;
+    int start_mark = p->mark;
+    void **children = PyMem_Malloc(sizeof(void *));
+    if (!children) {
+        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
+        return NULL;
+    }
+    ssize_t children_capacity = 1;
+    ssize_t n = 0;
+    { // (',' star_target)
+        void *_tmp_147_var;
+        while (
+            (_tmp_147_var = _tmp_147_rule(p))
+        )
+        {
+            res = _tmp_147_var;
+            if (n == children_capacity) {
+                children_capacity *= 2;
+                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
+                if (!children) {
+                    PyErr_Format(PyExc_MemoryError, "realloc None");
+                    return NULL;
+                }
+            }
+            children[n++] = res;
+            mark = p->mark;
+        }
+        p->mark = mark;
+    }
+    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
+    if (!seq) {
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_121");
+        PyMem_Free(children);
+        return NULL;
+    }
+    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
+    PyMem_Free(children);
+    _PyPegen_insert_memo(p, start_mark, _loop0_121_type, seq);
+    return seq;
+}
+
+// _loop0_123: ',' star_target
+static asdl_seq *
+_loop0_123_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15285,32 +15836,32 @@ _loop0_116_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_116");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_123");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_116_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_123_type, seq);
     return seq;
 }
 
-// _gather_115: star_target _loop0_116
+// _gather_122: star_target _loop0_123
 static asdl_seq *
-_gather_115_rule(Parser *p)
+_gather_122_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // star_target _loop0_116
+    { // star_target _loop0_123
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = star_target_rule(p))
             &&
-            (seq = _loop0_116_rule(p))
+            (seq = _loop0_123_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15323,9 +15874,9 @@ _gather_115_rule(Parser *p)
     return res;
 }
 
-// _tmp_117: !'*' star_target
+// _tmp_124: !'*' star_target
 static void *
-_tmp_117_rule(Parser *p)
+_tmp_124_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15350,9 +15901,9 @@ _tmp_117_rule(Parser *p)
     return res;
 }
 
-// _loop0_119: ',' del_target
+// _loop0_126: ',' del_target
 static asdl_seq *
-_loop0_119_rule(Parser *p)
+_loop0_126_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15397,32 +15948,32 @@ _loop0_119_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_119");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_126");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_119_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_126_type, seq);
     return seq;
 }
 
-// _gather_118: del_target _loop0_119
+// _gather_125: del_target _loop0_126
 static asdl_seq *
-_gather_118_rule(Parser *p)
+_gather_125_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // del_target _loop0_119
+    { // del_target _loop0_126
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = del_target_rule(p))
             &&
-            (seq = _loop0_119_rule(p))
+            (seq = _loop0_126_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15435,9 +15986,9 @@ _gather_118_rule(Parser *p)
     return res;
 }
 
-// _loop0_121: ',' target
+// _loop0_128: ',' target
 static asdl_seq *
-_loop0_121_rule(Parser *p)
+_loop0_128_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15482,32 +16033,32 @@ _loop0_121_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_121");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_128");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_121_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_128_type, seq);
     return seq;
 }
 
-// _gather_120: target _loop0_121
+// _gather_127: target _loop0_128
 static asdl_seq *
-_gather_120_rule(Parser *p)
+_gather_127_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     asdl_seq * res = NULL;
     int mark = p->mark;
-    { // target _loop0_121
+    { // target _loop0_128
         expr_ty elem;
         asdl_seq * seq;
         if (
             (elem = target_rule(p))
             &&
-            (seq = _loop0_121_rule(p))
+            (seq = _loop0_128_rule(p))
         )
         {
             res = _PyPegen_seq_insert_in_front(p, elem, seq);
@@ -15520,9 +16071,9 @@ _gather_120_rule(Parser *p)
     return res;
 }
 
-// _tmp_122: args | expression for_if_clauses
+// _tmp_129: args | expression for_if_clauses
 static void *
-_tmp_122_rule(Parser *p)
+_tmp_129_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15559,9 +16110,9 @@ _tmp_122_rule(Parser *p)
     return res;
 }
 
-// _tmp_123: '=' annotated_rhs
+// _tmp_130: '=' annotated_rhs
 static void *
-_tmp_123_rule(Parser *p)
+_tmp_130_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15587,9 +16138,9 @@ _tmp_123_rule(Parser *p)
     return res;
 }
 
-// _tmp_124: '=' | augassign
+// _tmp_131: '=' | augassign
 static void *
-_tmp_124_rule(Parser *p)
+_tmp_131_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15623,9 +16174,9 @@ _tmp_124_rule(Parser *p)
     return res;
 }
 
-// _tmp_125: yield_expr | star_expressions
+// _tmp_132: yield_expr | star_expressions
 static void *
-_tmp_125_rule(Parser *p)
+_tmp_132_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15659,9 +16210,9 @@ _tmp_125_rule(Parser *p)
     return res;
 }
 
-// _tmp_126: '[' | '(' | '{'
+// _tmp_133: '[' | '(' | '{'
 static void *
-_tmp_126_rule(Parser *p)
+_tmp_133_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15706,9 +16257,9 @@ _tmp_126_rule(Parser *p)
     return res;
 }
 
-// _loop0_127: param_no_default
+// _loop0_134: param_no_default
 static asdl_seq *
-_loop0_127_rule(Parser *p)
+_loop0_134_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15745,19 +16296,19 @@ _loop0_127_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_127");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_134");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_127_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop0_134_type, seq);
     return seq;
 }
 
-// _tmp_128: slash_with_default | param_with_default+
+// _tmp_135: slash_with_default | param_with_default+
 static void *
-_tmp_128_rule(Parser *p)
+_tmp_135_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15776,12 +16327,12 @@ _tmp_128_rule(Parser *p)
         p->mark = mark;
     }
     { // param_with_default+
-        asdl_seq * _loop1_140_var;
+        asdl_seq * _loop1_148_var;
         if (
-            (_loop1_140_var = _loop1_140_rule(p))
+            (_loop1_148_var = _loop1_148_rule(p))
         )
         {
-            res = _loop1_140_var;
+            res = _loop1_148_var;
             goto done;
         }
         p->mark = mark;
@@ -15791,9 +16342,9 @@ _tmp_128_rule(Parser *p)
     return res;
 }
 
-// _tmp_129: star_targets '='
+// _tmp_136: star_targets '='
 static void *
-_tmp_129_rule(Parser *p)
+_tmp_136_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15823,9 +16374,9 @@ _tmp_129_rule(Parser *p)
     return res;
 }
 
-// _tmp_130: '.' | '...'
+// _tmp_137: '.' | '...'
 static void *
-_tmp_130_rule(Parser *p)
+_tmp_137_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15859,9 +16410,9 @@ _tmp_130_rule(Parser *p)
     return res;
 }
 
-// _tmp_131: '.' | '...'
+// _tmp_138: '.' | '...'
 static void *
-_tmp_131_rule(Parser *p)
+_tmp_138_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15895,9 +16446,9 @@ _tmp_131_rule(Parser *p)
     return res;
 }
 
-// _tmp_132: '@' named_expression NEWLINE
+// _tmp_139: '@' named_expression NEWLINE
 static void *
-_tmp_132_rule(Parser *p)
+_tmp_139_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15930,9 +16481,9 @@ _tmp_132_rule(Parser *p)
     return res;
 }
 
-// _tmp_133: ',' star_expression
+// _tmp_140: ',' star_expression
 static void *
-_tmp_133_rule(Parser *p)
+_tmp_140_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15962,9 +16513,9 @@ _tmp_133_rule(Parser *p)
     return res;
 }
 
-// _tmp_134: ',' expression
+// _tmp_141: ',' expression
 static void *
-_tmp_134_rule(Parser *p)
+_tmp_141_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -15994,9 +16545,9 @@ _tmp_134_rule(Parser *p)
     return res;
 }
 
-// _tmp_135: lambda_plain_name !'='
+// _tmp_142: lambda_plain_name !'='
 static void *
-_tmp_135_rule(Parser *p)
+_tmp_142_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16021,9 +16572,9 @@ _tmp_135_rule(Parser *p)
     return res;
 }
 
-// _tmp_136: 'or' conjunction
+// _tmp_143: 'or' conjunction
 static void *
-_tmp_136_rule(Parser *p)
+_tmp_143_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16053,9 +16604,9 @@ _tmp_136_rule(Parser *p)
     return res;
 }
 
-// _tmp_137: 'and' inversion
+// _tmp_144: 'and' inversion
 static void *
-_tmp_137_rule(Parser *p)
+_tmp_144_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16085,37 +16636,25 @@ _tmp_137_rule(Parser *p)
     return res;
 }
 
-// _tmp_138: ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
+// _tmp_145: 'if' disjunction
 static void *
-_tmp_138_rule(Parser *p)
+_tmp_145_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
     void * res = NULL;
     int mark = p->mark;
-    { // ASYNC? 'for' star_targets 'in' disjunction (('if' disjunction))*
-        expr_ty a;
-        expr_ty b;
-        asdl_seq * c;
+    { // 'if' disjunction
         void *keyword;
-        void *keyword_1;
-        void *y;
+        expr_ty z;
         if (
-            (y = _PyPegen_expect_token(p, ASYNC), 1)
+            (keyword = _PyPegen_expect_token(p, 510))
             &&
-            (keyword = _PyPegen_expect_token(p, 517))
-            &&
-            (a = star_targets_rule(p))
-            &&
-            (keyword_1 = _PyPegen_expect_token(p, 518))
-            &&
-            (b = disjunction_rule(p))
-            &&
-            (c = _loop0_141_rule(p))
+            (z = disjunction_rule(p))
         )
         {
-            res = _Py_comprehension ( a , b , c , y != NULL , p -> arena );
+            res = z;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -16129,9 +16668,41 @@ _tmp_138_rule(Parser *p)
     return res;
 }
 
-// _tmp_139: ',' star_target
+// _tmp_146: 'if' disjunction
 static void *
-_tmp_139_rule(Parser *p)
+_tmp_146_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // 'if' disjunction
+        void *keyword;
+        expr_ty z;
+        if (
+            (keyword = _PyPegen_expect_token(p, 510))
+            &&
+            (z = disjunction_rule(p))
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_147: ',' star_target
+static void *
+_tmp_147_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16161,9 +16732,9 @@ _tmp_139_rule(Parser *p)
     return res;
 }
 
-// _loop1_140: param_with_default
+// _loop1_148: param_with_default
 static asdl_seq *
-_loop1_140_rule(Parser *p)
+_loop1_148_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16204,95 +16775,14 @@ _loop1_140_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_140");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_148");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_140_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_148_type, seq);
     return seq;
-}
-
-// _loop0_141: ('if' disjunction)
-static asdl_seq *
-_loop0_141_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void *res = NULL;
-    int mark = p->mark;
-    int start_mark = p->mark;
-    void **children = PyMem_Malloc(sizeof(void *));
-    if (!children) {
-        PyErr_Format(PyExc_MemoryError, "Parser out of memory");
-        return NULL;
-    }
-    ssize_t children_capacity = 1;
-    ssize_t n = 0;
-    { // ('if' disjunction)
-        void *_tmp_142_var;
-        while (
-            (_tmp_142_var = _tmp_142_rule(p))
-        )
-        {
-            res = _tmp_142_var;
-            if (n == children_capacity) {
-                children_capacity *= 2;
-                children = PyMem_Realloc(children, children_capacity*sizeof(void *));
-                if (!children) {
-                    PyErr_Format(PyExc_MemoryError, "realloc None");
-                    return NULL;
-                }
-            }
-            children[n++] = res;
-            mark = p->mark;
-        }
-        p->mark = mark;
-    }
-    asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
-    if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop0_141");
-        PyMem_Free(children);
-        return NULL;
-    }
-    for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
-    PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop0_141_type, seq);
-    return seq;
-}
-
-// _tmp_142: 'if' disjunction
-static void *
-_tmp_142_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // 'if' disjunction
-        void *keyword;
-        expr_ty z;
-        if (
-            (keyword = _PyPegen_expect_token(p, 510))
-            &&
-            (z = disjunction_rule(p))
-        )
-        {
-            res = z;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
 }
 
 void *

--- a/Parser/pegen/parse_string.c
+++ b/Parser/pegen/parse_string.c
@@ -179,6 +179,13 @@ _PyPegen_parsestr(Parser *p, const char *s, int *bytesmode, int *rawmode, PyObje
         }
     }
 
+    /* fstrings are only allowed in Python 3.6 and greater */
+    if (fmode && p->feature_version < 6) {
+        p->error_indicator = 1;
+        RAISE_SYNTAX_ERROR("Format strings are only supported in Python 3.6 and greater");
+        return -1;
+    }
+
     if (fmode && *bytesmode) {
         PyErr_BadInternalCall();
         return -1;
@@ -595,7 +602,8 @@ fstring_compile_expr(Parser *p, const char *expr_start, const char *expr_end,
         return NULL;
     }
 
-    Parser *p2 = _PyPegen_Parser_New(tok, Py_fstring_input, p->flags, NULL, p->arena);
+    Parser *p2 = _PyPegen_Parser_New(tok, Py_fstring_input, p->flags, p->feature_version,
+                                     NULL, p->arena);
     p2->starting_lineno = p->starting_lineno + p->tok->first_lineno - 1;
     p2->starting_col_offset = p->tok->first_lineno == p->tok->lineno
                               ? p->starting_col_offset + t->col_offset : 0;

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -933,9 +933,14 @@ _PyPegen_number_token(Parser *p)
     }
 
     char *num_raw = PyBytes_AsString(t->bytes);
-
     if (num_raw == NULL) {
         return NULL;
+    }
+
+    if (p->feature_version < 6 && strchr(num_raw, '_') != NULL) {
+        p->error_indicator = 1;
+        return RAISE_SYNTAX_ERROR("Underscores in numeric literals are only supported"
+                                  "in Python 3.6 and greater");
     }
 
     PyObject *c = parsenumber(num_raw);
@@ -1030,12 +1035,15 @@ compute_parser_flags(PyCompilerFlags *flags)
     if (flags->cf_flags & PyCF_TYPE_COMMENTS) {
         parser_flags |= PyPARSE_TYPE_COMMENTS;
     }
+    if (flags->cf_feature_version < 7) {
+        parser_flags |= PyPARSE_ASYNC_HACKS;
+    }
     return parser_flags;
 }
 
 Parser *
 _PyPegen_Parser_New(struct tok_state *tok, int start_rule, int flags,
-                    int *errcode, PyArena *arena)
+                    int feature_version, int *errcode, PyArena *arena)
 {
     Parser *p = PyMem_Malloc(sizeof(Parser));
     if (p == NULL) {
@@ -1077,6 +1085,7 @@ _PyPegen_Parser_New(struct tok_state *tok, int start_rule, int flags,
     p->starting_lineno = 0;
     p->starting_col_offset = 0;
     p->flags = flags;
+    p->feature_version = feature_version;
 
     return p;
 }
@@ -1138,7 +1147,8 @@ _PyPegen_run_parser_from_file_pointer(FILE *fp, int start_rule, PyObject *filena
     mod_ty result = NULL;
 
     int parser_flags = compute_parser_flags(flags);
-    Parser *p = _PyPegen_Parser_New(tok, start_rule, parser_flags, errcode, arena);
+    Parser *p = _PyPegen_Parser_New(tok, start_rule, parser_flags, flags->cf_feature_version,
+                                    errcode, arena);
     if (p == NULL) {
         goto error;
     }
@@ -1195,8 +1205,10 @@ _PyPegen_run_parser_from_string(const char *str, int start_rule, PyObject *filen
 
     int parser_flags = compute_parser_flags(flags);
     tok->type_comments = (parser_flags & PyPARSE_TYPE_COMMENTS) > 0;
+    tok->async_hacks = (parser_flags & PyPARSE_ASYNC_HACKS) > 0;
 
-    Parser *p = _PyPegen_Parser_New(tok, start_rule, parser_flags, NULL, arena);
+    Parser *p = _PyPegen_Parser_New(tok, start_rule, parser_flags, flags->cf_feature_version,
+                                    NULL, arena);
     if (p == NULL) {
         goto error;
     }

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -1147,7 +1147,7 @@ _PyPegen_run_parser_from_file_pointer(FILE *fp, int start_rule, PyObject *filena
     mod_ty result = NULL;
 
     int parser_flags = compute_parser_flags(flags);
-    Parser *p = _PyPegen_Parser_New(tok, start_rule, parser_flags, flags->cf_feature_version,
+    Parser *p = _PyPegen_Parser_New(tok, start_rule, parser_flags, PY_MINOR_VERSION,
                                     errcode, arena);
     if (p == NULL) {
         goto error;
@@ -1204,10 +1204,11 @@ _PyPegen_run_parser_from_string(const char *str, int start_rule, PyObject *filen
     mod_ty result = NULL;
 
     int parser_flags = compute_parser_flags(flags);
+    int feature_version = flags ? flags->cf_feature_version : PY_MINOR_VERSION;
     tok->type_comments = (parser_flags & PyPARSE_TYPE_COMMENTS) > 0;
     tok->async_hacks = (parser_flags & PyPARSE_ASYNC_HACKS) > 0;
 
-    Parser *p = _PyPegen_Parser_New(tok, start_rule, parser_flags, flags->cf_feature_version,
+    Parser *p = _PyPegen_Parser_New(tok, start_rule, parser_flags, feature_version,
                                     NULL, arena);
     if (p == NULL) {
         goto error;


### PR DESCRIPTION
`ast.parse` and `compile` support a `feature_version` parameter that
tells the parser to parse the input string, as if it were written in
an older Python version.
The `feature_version` is propagated to the tokenizer, which uses it
to handle the three different stages of support for `async` and
`await`. Additionally, it disallows the following at parser level:
- The '@' operator in < 3.5
- Async functions in < 3.5
- Async comprehensions in < 3.6
- Underscores in numeric literals in < 3.6
- Await expression in < 3.5
- Variable annotations in < 3.6
- Async for-loops in < 3.5
- Async with-statements in < 3.5
- F-strings in < 3.6

Closes we-like-parsers/cpython#124.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
