### PR TITLE
Simplify choice()'s interaction with the private _randbelow() method

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -265,7 +265,7 @@ class Random(_random.Random):
         return self.randrange(a, b+1)
 
     def _randbelow_with_getrandbits(self, n):
-        "Return a random int in the range [0,n).  Returns if n==0."
+        "Return a random int in the range [0,n).  Returns 0 if n==0."
 
         if not n:
             return 0

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -265,10 +265,10 @@ class Random(_random.Random):
         return self.randrange(a, b+1)
 
     def _randbelow_with_getrandbits(self, n):
-        "Return a random int in the range [0,n).  Raises ValueError if n==0."
+        "Return a random int in the range [0,n).  Returns if n==0."
 
         if not n:
-            raise ValueError("Boundary cannot be zero")
+            return 0
         getrandbits = self.getrandbits
         k = n.bit_length()  # don't use (n-1) here because n can be 1
         r = getrandbits(k)          # 0 <= r < 2**k
@@ -277,7 +277,7 @@ class Random(_random.Random):
         return r
 
     def _randbelow_without_getrandbits(self, n, int=int, maxsize=1<<BPF):
-        """Return a random int in the range [0,n).  Raises ValueError if n==0.
+        """Return a random int in the range [0,n).  Returns 0 if n==0.
 
         The implementation does not use getrandbits, but only random.
         """
@@ -289,7 +289,7 @@ class Random(_random.Random):
                 "To remove the range limitation, add a getrandbits() method.")
             return int(random() * n)
         if n == 0:
-            raise ValueError("Boundary cannot be zero")
+            return 0
         rem = maxsize % n
         limit = (maxsize - rem) / maxsize   # int(limit * maxsize) % n == 0
         r = random()
@@ -303,10 +303,7 @@ class Random(_random.Random):
 
     def choice(self, seq):
         """Choose a random element from a non-empty sequence."""
-        try:
-            i = self._randbelow(len(seq))
-        except ValueError:
-            raise IndexError('Cannot choose from an empty sequence') from None
+        i = self._randbelow(len(seq))
         return seq[i]
 
     def shuffle(self, x, random=None):

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -303,8 +303,7 @@ class Random(_random.Random):
 
     def choice(self, seq):
         """Choose a random element from a non-empty sequence."""
-        i = self._randbelow(len(seq))
-        return seq[i]
+        return seq[self._randbelow(len(seq))] # raises IndexError if seq is empty
 
     def shuffle(self, x, random=None):
         """Shuffle list x in place, and return None.

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -688,7 +688,7 @@ class MersenneTwister_TestBasicOps(TestBasicOps, unittest.TestCase):
                 maxsize+1, maxsize=maxsize
             )
         self.gen._randbelow_without_getrandbits(5640, maxsize=maxsize)
-        # issue 33203: test that _randbelow raises returns zero on
+        # issue 33203: test that _randbelow returns zero on
         # n == 0 also in its getrandbits-independent branch.
         x = self.gen._randbelow_without_getrandbits(0, maxsize=maxsize)
         self.assertEqual(x, 0)

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -688,10 +688,10 @@ class MersenneTwister_TestBasicOps(TestBasicOps, unittest.TestCase):
                 maxsize+1, maxsize=maxsize
             )
         self.gen._randbelow_without_getrandbits(5640, maxsize=maxsize)
-        # issue 33203: test that _randbelow raises ValueError on
+        # issue 33203: test that _randbelow raises returns zero on
         # n == 0 also in its getrandbits-independent branch.
-        with self.assertRaises(ValueError):
-            self.gen._randbelow_without_getrandbits(0, maxsize=maxsize)
+        x = self.gen._randbelow_without_getrandbits(0, maxsize=maxsize)
+        self.assertEqual(x, 0)
 
         # This might be going too far to test a single line, but because of our
         # noble aim of achieving 100% test coverage we need to write a case in


### PR DESCRIPTION
The `https://github.com/python/cpython/blob/2.7/Lib/random.py#L275` just let the indexing raise an IndexError.  An intermediate trip through a ValueError isn't necessary.