### PR TITLE
bpo-40334: Correct return value of func_type_comment

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -210,7 +210,7 @@ function_def_raw[stmt_ty]:
                             (params) ? params : CHECK(_PyPegen_empty_arguments(p)),
                             b, NULL, a, NEW_TYPE_COMMENT(p, tc), EXTRA)
         ) }
-func_type_comment[PyObject*]:
+func_type_comment[Token*]:
     | NEWLINE t=TYPE_COMMENT &(NEWLINE INDENT) { t }  # Must be followed by indented block
     | invalid_double_type_comments
     | TYPE_COMMENT

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -408,7 +408,7 @@ static stmt_ty return_stmt_rule(Parser *p);
 static stmt_ty raise_stmt_rule(Parser *p);
 static stmt_ty function_def_rule(Parser *p);
 static stmt_ty function_def_raw_rule(Parser *p);
-static PyObject* func_type_comment_rule(Parser *p);
+static Token* func_type_comment_rule(Parser *p);
 static arguments_ty params_rule(Parser *p);
 static arguments_ty parameters_rule(Parser *p);
 static asdl_seq* slash_no_default_rule(Parser *p);
@@ -3679,13 +3679,13 @@ function_def_raw_rule(Parser *p)
 //     | NEWLINE TYPE_COMMENT &(NEWLINE INDENT)
 //     | invalid_double_type_comments
 //     | TYPE_COMMENT
-static PyObject*
+static Token*
 func_type_comment_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
     }
-    PyObject* res = NULL;
+    Token* res = NULL;
     int mark = p->mark;
     { // NEWLINE TYPE_COMMENT &(NEWLINE INDENT)
         void *newline_var;


### PR DESCRIPTION
Minor correction caught with #19818

<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
