### PR TITLE
Deleted extra line

### DIFF
--- a/Lib/signal.py
+++ b/Lib/signal.py
@@ -1,4 +1,3 @@
-import _signal
 from _signal import *
 from functools import wraps as _wraps
 from enum import IntEnum as _IntEnum


### PR DESCRIPTION
In 3.8 Python,  multiprocessing does not work because the module signal is empty

My solution is:
in signal/__init__.py add line 
from _signal import *

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
