### PR TITLE
bpo-40334: Make the PyPegen* and PyParser* APIs more consistent

### DIFF
--- a/Include/internal/pegen_interface.h
+++ b/Include/internal/pegen_interface.h
@@ -11,25 +11,34 @@ extern "C" {
 #include "Python.h"
 #include "Python-ast.h"
 
-PyAPI_FUNC(mod_ty) PyPegen_ASTFromFile(const char *filename, int mode, PyCompilerFlags*, PyArena *arena);
-PyAPI_FUNC(mod_ty) PyPegen_ASTFromString(const char *str, int mode, PyCompilerFlags *flags,
-                                         PyArena *arena);
-PyAPI_FUNC(mod_ty) PyPegen_ASTFromStringObject(const char *str, PyObject* filename, int mode,
-                                               PyCompilerFlags *flags, PyArena *arena);
-PyAPI_FUNC(mod_ty) PyPegen_ASTFromFileObject(FILE *fp, PyObject *filename_ob,
-                                             int mode, const char *enc, const char *ps1,
-                                             const char *ps2, PyCompilerFlags *flags,
-                                             int *errcode, PyArena *arena);
-PyAPI_FUNC(PyCodeObject *) PyPegen_CodeObjectFromFile(const char *filename, int mode, PyCompilerFlags *flags);
-PyAPI_FUNC(PyCodeObject *) PyPegen_CodeObjectFromString(const char *str, int mode,
-                                                        PyCompilerFlags *flags);
-PyAPI_FUNC(PyCodeObject *) PyPegen_CodeObjectFromFileObject(FILE *, PyObject *filename_ob,
-                                                            int mode,
-                                                            const char *ps1,
-                                                            const char *ps2,
-                                                            PyCompilerFlags *flags,
-                                                            const char *enc,
-                                                            int *errcode);
+PyAPI_FUNC(mod_ty) PyPegen_ASTFromString(
+    const char *str,
+    const char *filename,
+    int mode,
+    PyCompilerFlags *flags,
+    PyArena *arena);
+PyAPI_FUNC(mod_ty) PyPegen_ASTFromStringObject(
+    const char *str,
+    PyObject* filename,
+    int mode,
+    PyCompilerFlags *flags,
+    PyArena *arena);
+PyAPI_FUNC(mod_ty) PyPegen_ASTFromFileObject(
+    FILE *fp,
+    PyObject *filename_ob,
+    int mode,
+    const char *enc,
+    const char *ps1,
+    const char *ps2,
+    PyCompilerFlags *flags,
+    int *errcode,
+    PyArena *arena);
+PyAPI_FUNC(mod_ty) PyPegen_ASTFromFilename(
+    const char *filename,
+    int mode,
+    PyCompilerFlags *flags,
+    PyArena *arena);
+
 
 #ifdef __cplusplus
 }

--- a/Modules/_peg_parser.c
+++ b/Modules/_peg_parser.c
@@ -31,7 +31,7 @@ _Py_parse_file(PyObject *self, PyObject *args, PyObject *kwds)
     PyCompilerFlags flags = _PyCompilerFlags_INIT;
     PyObject *result = NULL;
 
-    mod_ty res = PyPegen_ASTFromFile(filename, mode, &flags, arena);
+    mod_ty res = PyPegen_ASTFromFilename(filename, mode, &flags, arena);
     if (res == NULL) {
         goto error;
     }
@@ -80,12 +80,8 @@ _Py_parse_string(PyObject *self, PyObject *args, PyObject *kwds)
     flags.cf_flags = PyCF_IGNORE_COOKIE;
 
     mod_ty res;
-    if (oldparser) {
-        res = PyParser_ASTFromString(the_string, "<string>", mode, &flags, arena);
-    }
-    else {
-        res = PyPegen_ASTFromString(the_string, mode, &flags, arena);
-    }
+    res = (oldparser ? PyParser_ASTFromString : PyPegen_ASTFromString)
+        (the_string, "<string>", mode, &flags, arena);
     if (res == NULL) {
         goto error;
     }

--- a/Modules/_peg_parser.c
+++ b/Modules/_peg_parser.c
@@ -80,8 +80,12 @@ _Py_parse_string(PyObject *self, PyObject *args, PyObject *kwds)
     flags.cf_flags = PyCF_IGNORE_COOKIE;
 
     mod_ty res;
-    res = (oldparser ? PyParser_ASTFromString : PyPegen_ASTFromString)
-        (the_string, "<string>", mode, &flags, arena);
+    if (oldparser) {
+        res = PyParser_ASTFromString(the_string, "<string>", mode, &flags, arena);
+    }
+    else {
+        res = PyPegen_ASTFromString(the_string, "<string>", mode, &flags, arena);
+    }
     if (res == NULL) {
         goto error;
     }

--- a/Parser/pegen/peg_api.c
+++ b/Parser/pegen/peg_api.c
@@ -4,9 +4,10 @@
 #include "pegen.h"
 
 mod_ty
-PyPegen_ASTFromString(const char *str, int mode, PyCompilerFlags *flags, PyArena *arena)
+PyPegen_ASTFromString(const char *str, const char *filename, int mode,
+                      PyCompilerFlags *flags, PyArena *arena)
 {
-    PyObject *filename_ob = PyUnicode_FromString("<string>");
+    PyObject *filename_ob = PyUnicode_FromString(filename);
     if (filename_ob == NULL) {
         return NULL;
     }
@@ -16,7 +17,8 @@ PyPegen_ASTFromString(const char *str, int mode, PyCompilerFlags *flags, PyArena
 }
 
 mod_ty
-PyPegen_ASTFromStringObject(const char *str, PyObject* filename, int mode, PyCompilerFlags *flags, PyArena *arena)
+PyPegen_ASTFromStringObject(const char *str, PyObject* filename, int mode,
+                            PyCompilerFlags *flags, PyArena *arena)
 {
     if (PySys_Audit("compile", "yO", str, filename) < 0) {
         return NULL;
@@ -27,7 +29,7 @@ PyPegen_ASTFromStringObject(const char *str, PyObject* filename, int mode, PyCom
 }
 
 mod_ty
-PyPegen_ASTFromFile(const char *filename, int mode, PyCompilerFlags *flags, PyArena *arena)
+PyPegen_ASTFromFilename(const char *filename, int mode, PyCompilerFlags *flags, PyArena *arena)
 {
     PyObject *filename_ob = PyUnicode_FromString(filename);
     if (filename_ob == NULL) {
@@ -49,85 +51,4 @@ PyPegen_ASTFromFileObject(FILE *fp, PyObject *filename_ob, int mode,
     }
     return _PyPegen_run_parser_from_file_pointer(fp, mode, filename_ob, enc, ps1, ps2,
                                         flags, errcode, arena);
-}
-
-PyCodeObject *
-PyPegen_CodeObjectFromString(const char *str, int mode, PyCompilerFlags *flags)
-{
-    PyArena *arena = PyArena_New();
-    if (arena == NULL) {
-        return NULL;
-    }
-
-    PyCodeObject *result = NULL;
-
-    PyObject *filename_ob = PyUnicode_FromString("<string>");
-    if (filename_ob == NULL) {
-        goto error;
-    }
-
-    mod_ty res = PyPegen_ASTFromString(str, mode, flags, arena);
-    if (res == NULL) {
-        goto error;
-    }
-
-    result = PyAST_CompileObject(res, filename_ob, NULL, -1, arena);
-
-error:
-    Py_XDECREF(filename_ob);
-    PyArena_Free(arena);
-    return result;
-}
-
-PyCodeObject *
-PyPegen_CodeObjectFromFile(const char *filename, int mode, PyCompilerFlags* flags)
-{
-    PyArena *arena = PyArena_New();
-    if (arena == NULL) {
-        return NULL;
-    }
-
-    PyCodeObject *result = NULL;
-
-    PyObject *filename_ob = PyUnicode_FromString(filename);
-    if (filename_ob == NULL) {
-        goto error;
-    }
-
-    mod_ty res = PyPegen_ASTFromFile(filename, mode, flags, arena);
-    if (res == NULL) {
-        goto error;
-    }
-
-    result = PyAST_CompileObject(res, filename_ob, NULL, -1, arena);
-
-error:
-    Py_XDECREF(filename_ob);
-    PyArena_Free(arena);
-    return result;
-}
-
-PyCodeObject *
-PyPegen_CodeObjectFromFileObject(FILE *fp, PyObject *filename_ob, int mode,
-                                 const char *ps1, const char *ps2, 
-                                 PyCompilerFlags *flags, const char *enc, int *errcode)
-{
-    PyArena *arena = PyArena_New();
-    if (arena == NULL) {
-        return NULL;
-    }
-
-    PyCodeObject *result = NULL;
-
-    mod_ty res = PyPegen_ASTFromFileObject(fp, filename_ob, mode, enc, ps1, ps2,
-                                           flags, errcode, arena);
-    if (res == NULL) {
-        goto error;
-    }
-
-    result = PyAST_CompileObject(res, filename_ob, NULL, -1, arena);
-
-error:
-    PyArena_Free(arena);
-    return result;
 }


### PR DESCRIPTION
This PR tries to make both APIs more consistent by doing the following:
- Remove the `PyPegen_CodeObjectFrom*` functions, which weren't used
  and will probably not be needed. Functions like
  `Py_CompileStringObject` can be used instead.
- Include a `const char *filename` parameter in `PyPegen_ASTFromString`.
- Rename `PyPegen_ASTFromFile` to `PyPegen_ASTFromFilename`, because
  its signature is not the same with `PyParser_ASTFromFile`.

Closes we-like-parsers/cpython#104.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
