### PR TITLE
[3.8] bpo-39435: Fix docs for pickle.loads (GH-18160)

### DIFF
--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -252,10 +252,10 @@ process more convenient:
    .. versionchanged:: 3.8
       The *buffers* argument was added.
 
-.. function:: loads(bytes_object, \*, fix_imports=True, encoding="ASCII", errors="strict", buffers=None)
+.. function:: loads(data, \*, fix_imports=True, encoding="ASCII", errors="strict", buffers=None)
 
    Return the reconstituted object hierarchy of the pickled representation
-   *bytes_object* of an object.
+   *data* of an object. *data* must be a :term:`bytes-like object`.
 
    The protocol version of the pickle is detected automatically, so no
    protocol argument is needed.  Bytes past the pickled representation

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -769,6 +769,7 @@ Manuel Jacob
 David Jacobs
 Kevin Jacobs
 Kjetil Jacobsen
+Shantanu Jain
 Bertrand Janin
 Geert Jansen
 Jack Jansen

--- a/Misc/NEWS.d/next/Documentation/2020-01-24-05-42-57.bpo-39435.EFcdFU.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-01-24-05-42-57.bpo-39435.EFcdFU.rst
@@ -1,0 +1,1 @@
+Fix an incorrect signature for :func:`pickle.loads` in the docs


### PR DESCRIPTION
(cherry picked from commit 289842a)

Co-authored-by: Shantanu <hauntsaninja@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39435](https://bugs.python.org/issue39435) -->
https://bugs.python.org/issue39435
<!-- /issue-number -->


Automerge-Triggered-By: @pitrou