### PR TITLE
bpo-29753: fix merging packed bitfields in ctypes struct/union

### DIFF
--- a/Lib/ctypes/test/test_bitfields.py
+++ b/Lib/ctypes/test/test_bitfields.py
@@ -233,6 +233,69 @@ class BitFieldTest(unittest.TestCase):
         else:
             self.assertEqual(sizeof(X), sizeof(c_int) * 2)
 
+    @unittest.skipIf(os.name == 'nt', reason='Posix only')
+    def test_packed_posix(self):
+        test_cases = {
+            (
+                ("a", c_uint8, 4),
+                ("b", c_uint8, 4),
+            ): 1,
+            (
+                ("a", c_uint8, 1),
+                ("b", c_uint16, 1),
+                ("c", c_uint32, 1),
+                ("d", c_uint64, 1),
+            ): 1,
+            (
+                ("a", c_uint8, 8),
+                ("b", c_uint16, 1),
+                ("c", c_uint32, 1),
+                ("d", c_uint64, 1),
+            ): 2,
+            (
+                ("a", c_uint32, 9),
+                ("b", c_uint16, 10),
+                ("c", c_uint32, 25),
+                ("d", c_uint64, 1),
+            ): 6,
+            (
+                ("a", c_uint32, 9),
+                ("b", c_uint16, 10),
+                ("c", c_uint32, 25),
+                ("d", c_uint64, 5),
+            ): 7,
+            (
+                ("a", c_uint16),
+                ("b", c_uint16, 9),
+                ("c", c_uint16, 1),
+                ("d", c_uint16, 1),
+                ("e", c_uint16, 1),
+                ("f", c_uint16, 1),
+                ("g", c_uint16, 3),
+                ("h", c_uint32, 10),
+                ("i", c_uint32, 20),
+                ("j", c_uint32, 2),
+            ): 8,
+            (
+                ("a", c_uint16, 9),
+                ("b", c_uint16, 10),
+                ("d", c_uint16),
+                ("c", c_uint8, 8),
+            ): 6,
+            (
+                ("a", c_uint32, 9),
+                ("b", c_uint32),
+                ("c", c_uint32, 8),
+            ): 7,
+        }
+
+        for fields, size in test_cases.items():
+            with self.subTest(fields=fields):
+                class X(Structure):
+                    _pack_ = 1
+                    _fields_ = list(fields)
+                self.assertEqual(sizeof(X), size)
+
     def test_anon_bitfields(self):
         # anonymous bit-fields gave a strange error message
         class X(Structure):

--- a/Misc/NEWS.d/next/Library/2020-05-02-01-01-30.bpo-29753.n2M-AF.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-02-01-01-30.bpo-29753.n2M-AF.rst
@@ -1,1 +1,1 @@
-In ctypes, now packed bitfields are calculated properly.
+In ctypes, now packed bitfields are calculated properly and the first item of packed bitfields is now shrank correctly.

--- a/Misc/NEWS.d/next/Library/2020-05-02-01-01-30.bpo-29753.n2M-AF.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-02-01-01-30.bpo-29753.n2M-AF.rst
@@ -1,0 +1,1 @@
+In ctypes, now packed bitfields are calculated properly.

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -74,9 +74,7 @@ PyCField_FromDesc(PyObject *desc, Py_ssize_t index,
 
 #ifndef MS_WIN32
     if (pack && bitsize) { /* packed bitfield */
-        size = 1;
-        while(size * 8 < bitsize)
-            size += 1;
+        size = (bitsize - 1) / 8 + 1;
     } else
 #endif
         size = dict->size;
@@ -180,8 +178,7 @@ PyCField_FromDesc(PyObject *desc, Py_ssize_t index,
 
     case EXPAND_BITFIELD:
         if (pack)
-            while(size * 8 < (*pbitofs + bitsize))
-                size += 1;
+            size = (*pbitofs + bitsize - 1) / 8 + 1;
 
         *poffset += size - *pfield_size/8;
         *psize += size - *pfield_size/8;


### PR DESCRIPTION
From the commit message:

> When the structure is packed we should always expand when needed,
> otherwise we will add some padding between the fields. This patch makes
> sure we always merge bitfields together. It also changes the field merging
> algorithm so that it handles bitfields correctly.


<!-- issue-number: [bpo-29753](https://bugs.python.org/issue29753) -->
https://bugs.python.org/issue29753
<!-- /issue-number -->

Automerge-Triggered-By: GH:jaraco