### PR TITLE
[3.8] bpo-40398: Fix typing.get_args() for special generic aliases. (GH-19720)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2913,6 +2913,9 @@ class GetUtilitiesTestCase(TestCase):
         self.assertIs(get_origin(Generic), Generic)
         self.assertIs(get_origin(Generic[T]), Generic)
         self.assertIs(get_origin(List[Tuple[T, T]][int]), list)
+        self.assertIs(get_origin(List), list)
+        self.assertIs(get_origin(Tuple), tuple)
+        self.assertIs(get_origin(Callable), collections.abc.Callable)
 
     def test_get_args(self):
         T = TypeVar('T')
@@ -2928,11 +2931,15 @@ class GetUtilitiesTestCase(TestCase):
                          (int, Tuple[str, int]))
         self.assertEqual(get_args(typing.Dict[int, Tuple[T, T]][Optional[int]]),
                          (int, Tuple[Optional[int], Optional[int]]))
-        self.assertEqual(get_args(Callable[[], T][int]), ([], int,))
+        self.assertEqual(get_args(Callable[[], T][int]), ([], int))
+        self.assertEqual(get_args(Callable[..., int]), (..., int))
         self.assertEqual(get_args(Union[int, Callable[[Tuple[T, ...]], str]]),
                          (int, Callable[[Tuple[T, ...]], str]))
         self.assertEqual(get_args(Tuple[int, ...]), (int, ...))
         self.assertEqual(get_args(Tuple[()]), ((),))
+        self.assertEqual(get_args(List), ())
+        self.assertEqual(get_args(Tuple), ())
+        self.assertEqual(get_args(Callable), ())
 
 
 class CollectionsAbcTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1300,7 +1300,7 @@ def get_args(tp):
         get_args(Union[int, Tuple[T, int]][str]) == (int, Tuple[str, int])
         get_args(Callable[[], T][int]) == ([], int)
     """
-    if isinstance(tp, _GenericAlias):
+    if isinstance(tp, _GenericAlias) and not tp._special:
         res = tp.__args__
         if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:
             res = (list(res[:-1]), res[-1])

--- a/Misc/NEWS.d/next/Library/2020-04-26-22-25-36.bpo-40398.OdXnR3.rst
+++ b/Misc/NEWS.d/next/Library/2020-04-26-22-25-36.bpo-40398.OdXnR3.rst
@@ -1,0 +1,2 @@
+:func:`typing.get_args` now always returns an empty tuple for special
+generic aliases.


### PR DESCRIPTION
(cherry picked from commit 6292be7adf247589bbf03524f8883cb4cb61f3e9)


<!-- issue-number: [bpo-40398](https://bugs.python.org/issue40398) -->
https://bugs.python.org/issue40398
<!-- /issue-number -->
