### PR TITLE
bpo-29587: Enable exception chaining for gen.throw() with "yield from"

### DIFF
--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -318,7 +318,7 @@ class ExceptionTest(unittest.TestCase):
 
 class GeneratorThrowTest(unittest.TestCase):
 
-    def test_exception_context_set(self):
+    def test_exception_context_with_yield(self):
         def f():
             try:
                 raise KeyError('a')
@@ -326,6 +326,23 @@ class GeneratorThrowTest(unittest.TestCase):
                 yield
 
         gen = f()
+        gen.send(None)
+        with self.assertRaises(ValueError) as cm:
+            gen.throw(ValueError)
+        context = cm.exception.__context__
+        self.assertEqual((type(context), context.args), (KeyError, ('a',)))
+
+    def test_exception_context_with_yield_from(self):
+        def f():
+            yield
+
+        def g():
+            try:
+                raise KeyError('a')
+            except Exception:
+                yield from f()
+
+        gen = g()
         gen.send(None)
         with self.assertRaises(ValueError) as cm:
             gen.throw(ValueError)


### PR DESCRIPTION
This is a follow-up to https://bugs.python.org/issue29587 (PR's #19823 and #19877) that gets exception chaining working for `gen.throw()` in the `yield from` case.

(The previous work got the `yield` case working.)


<!-- issue-number: [bpo-29587](https://bugs.python.org/issue29587) -->
https://bugs.python.org/issue29587
<!-- /issue-number -->
