### PR TITLE
bpo-40334: Spacialized error message for invalid args after bare '*'

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -245,6 +245,7 @@ star_etc[StarEtc*]:
     | '*' ',' b=param_maybe_default+ c=[kwds] {
         _PyPegen_star_etc(p, NULL, b, c) }
     | a=kwds { _PyPegen_star_etc(p, NULL, NULL, a) }
+    | invalid_star_etc
 
 kwds[arg_ty]: '**' a=param_no_default { a }
 
@@ -632,6 +633,8 @@ invalid_comprehension:
 invalid_parameters:
     | param_no_default* (slash_with_default | param_with_default+) param_no_default {
         RAISE_SYNTAX_ERROR("non-default argument follows default argument") }
+invalid_star_etc:
+    | '*' (')' | ',' (')' | '**')) { RAISE_SYNTAX_ERROR("named arguments must follow bare *") }
 invalid_double_type_comments:
     | TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT {
         RAISE_SYNTAX_ERROR("Cannot have two type comments on def") }

--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -353,6 +353,7 @@ lambda_star_etc[StarEtc*]:
     | '*' ',' b=lambda_param_maybe_default+ c=[lambda_kwds] {
         _PyPegen_star_etc(p, NULL, b, c) }
     | a=lambda_kwds { _PyPegen_star_etc(p, NULL, NULL, a) }
+    | invalid_lambda_star_etc
 
 lambda_kwds[arg_ty]: '**' a=lambda_param_no_default { a }
 
@@ -635,6 +636,8 @@ invalid_parameters:
         RAISE_SYNTAX_ERROR("non-default argument follows default argument") }
 invalid_star_etc:
     | '*' (')' | ',' (')' | '**')) { RAISE_SYNTAX_ERROR("named arguments must follow bare *") }
+invalid_lambda_star_etc:
+    | '*' (':' | ',' (':' | '**')) { RAISE_SYNTAX_ERROR("named arguments must follow bare *") }
 invalid_double_type_comments:
     | TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT {
         RAISE_SYNTAX_ERROR("Cannot have two type comments on def") }

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -242,11 +242,11 @@ class ExceptionTests(unittest.TestCase):
         check('from __future__ import doesnt_exist', 1, 1)
         check('from __future__ import braces', 1, 1)
         check('x=1\nfrom __future__ import division', 2, 1)
+        check('def f(*):\n  pass', 1, 7 if support.use_old_parser() else 8)
 
     @support.skip_if_new_parser("Pegen column offsets might be different")
     def testSyntaxErrorOffsetCustom(self):
         self.check('for 1 in []: pass', 1, 5)
-        self.check('def f(*):\n  pass', 1, 7)
         self.check('[*x for x in xs]', 1, 2)
         self.check('def f():\n  x, y: int', 2, 3)
         self.check('(yield i) = 2', 1, 1)

--- a/Lib/test/test_peg_parser.py
+++ b/Lib/test/test_peg_parser.py
@@ -606,6 +606,9 @@ FAIL_SPECIALIZED_MESSAGE_CASES = [
     ("def f(*): pass", "named arguments must follow bare *"),
     ("def f(*,): pass", "named arguments must follow bare *"),
     ("def f(*, **a): pass", "named arguments must follow bare *"),
+    ("lambda *: pass", "named arguments must follow bare *"),
+    ("lambda *,: pass", "named arguments must follow bare *"),
+    ("lambda *, **a: pass", "named arguments must follow bare *"),
 ]
 
 GOOD_BUT_FAIL_TEST_CASES = [

--- a/Lib/test/test_peg_parser.py
+++ b/Lib/test/test_peg_parser.py
@@ -603,6 +603,9 @@ FAIL_SPECIALIZED_MESSAGE_CASES = [
     ("1 += 1", "cannot assign to literal"),
     ("pass\n    pass", "unexpected indent"),
     ("def f():\npass", "expected an indented block"),
+    ("def f(*): pass", "named arguments must follow bare *"),
+    ("def f(*,): pass", "named arguments must follow bare *"),
+    ("def f(*, **a): pass", "named arguments must follow bare *"),
 ]
 
 GOOD_BUT_FAIL_TEST_CASES = [

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -627,9 +627,9 @@ Corner-cases that used to fail to raise the correct error:
     Traceback (most recent call last):
     SyntaxError: cannot assign to __debug__
 
-    # >>> with (lambda *:0): pass
-    # Traceback (most recent call last):
-    # SyntaxError: named arguments must follow bare *
+    >>> with (lambda *:0): pass
+    Traceback (most recent call last):
+    SyntaxError: named arguments must follow bare *
 
 Corner-cases that used to crash:
 

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -215,150 +215,153 @@ static KeywordToken *reserved_keywords[] = {
 #define invalid_block_type 1144
 #define invalid_comprehension_type 1145
 #define invalid_parameters_type 1146
-#define invalid_double_type_comments_type 1147
-#define _loop0_1_type 1148
-#define _loop0_2_type 1149
-#define _loop0_4_type 1150
-#define _gather_3_type 1151
-#define _loop0_6_type 1152
-#define _gather_5_type 1153
-#define _loop0_8_type 1154
-#define _gather_7_type 1155
-#define _loop0_10_type 1156
-#define _gather_9_type 1157
-#define _loop1_11_type 1158
-#define _loop0_13_type 1159
-#define _gather_12_type 1160
-#define _tmp_14_type 1161
-#define _tmp_15_type 1162
-#define _tmp_16_type 1163
-#define _tmp_17_type 1164
-#define _tmp_18_type 1165
-#define _tmp_19_type 1166
-#define _tmp_20_type 1167
-#define _tmp_21_type 1168
-#define _loop1_22_type 1169
-#define _tmp_23_type 1170
-#define _tmp_24_type 1171
-#define _loop0_26_type 1172
-#define _gather_25_type 1173
-#define _loop0_28_type 1174
-#define _gather_27_type 1175
-#define _tmp_29_type 1176
-#define _loop0_30_type 1177
-#define _loop1_31_type 1178
-#define _loop0_33_type 1179
-#define _gather_32_type 1180
-#define _tmp_34_type 1181
-#define _loop0_36_type 1182
-#define _gather_35_type 1183
-#define _tmp_37_type 1184
-#define _loop0_39_type 1185
-#define _gather_38_type 1186
-#define _loop0_41_type 1187
-#define _gather_40_type 1188
-#define _loop0_43_type 1189
-#define _gather_42_type 1190
-#define _loop0_45_type 1191
-#define _gather_44_type 1192
-#define _tmp_46_type 1193
-#define _loop1_47_type 1194
-#define _tmp_48_type 1195
-#define _tmp_49_type 1196
-#define _tmp_50_type 1197
-#define _tmp_51_type 1198
-#define _tmp_52_type 1199
-#define _loop0_53_type 1200
-#define _loop0_54_type 1201
-#define _loop0_55_type 1202
-#define _loop1_56_type 1203
-#define _loop0_57_type 1204
-#define _loop1_58_type 1205
-#define _loop1_59_type 1206
-#define _loop1_60_type 1207
-#define _loop0_61_type 1208
-#define _loop1_62_type 1209
-#define _loop0_63_type 1210
-#define _loop1_64_type 1211
-#define _loop0_65_type 1212
-#define _loop1_66_type 1213
-#define _loop1_67_type 1214
-#define _tmp_68_type 1215
-#define _loop0_70_type 1216
-#define _gather_69_type 1217
-#define _loop1_71_type 1218
-#define _loop0_73_type 1219
-#define _gather_72_type 1220
-#define _loop1_74_type 1221
-#define _loop0_75_type 1222
-#define _loop0_76_type 1223
-#define _loop0_77_type 1224
-#define _loop1_78_type 1225
-#define _loop0_79_type 1226
-#define _loop1_80_type 1227
-#define _loop1_81_type 1228
-#define _loop1_82_type 1229
-#define _loop0_83_type 1230
-#define _loop1_84_type 1231
-#define _loop0_85_type 1232
-#define _loop1_86_type 1233
-#define _loop0_87_type 1234
-#define _loop1_88_type 1235
-#define _loop1_89_type 1236
-#define _loop1_90_type 1237
-#define _loop1_91_type 1238
-#define _tmp_92_type 1239
-#define _loop0_94_type 1240
-#define _gather_93_type 1241
-#define _tmp_95_type 1242
-#define _tmp_96_type 1243
-#define _tmp_97_type 1244
-#define _tmp_98_type 1245
-#define _loop1_99_type 1246
-#define _tmp_100_type 1247
-#define _tmp_101_type 1248
-#define _loop0_103_type 1249
-#define _gather_102_type 1250
-#define _loop1_104_type 1251
-#define _loop0_105_type 1252
-#define _loop0_106_type 1253
-#define _tmp_107_type 1254
-#define _tmp_108_type 1255
-#define _loop0_110_type 1256
-#define _gather_109_type 1257
-#define _loop0_112_type 1258
-#define _gather_111_type 1259
-#define _loop0_114_type 1260
-#define _gather_113_type 1261
-#define _loop0_116_type 1262
-#define _gather_115_type 1263
-#define _loop0_117_type 1264
-#define _loop0_119_type 1265
-#define _gather_118_type 1266
-#define _tmp_120_type 1267
-#define _loop0_122_type 1268
-#define _gather_121_type 1269
-#define _loop0_124_type 1270
-#define _gather_123_type 1271
-#define _tmp_125_type 1272
-#define _tmp_126_type 1273
-#define _tmp_127_type 1274
-#define _tmp_128_type 1275
-#define _tmp_129_type 1276
-#define _loop0_130_type 1277
-#define _tmp_131_type 1278
-#define _tmp_132_type 1279
-#define _tmp_133_type 1280
-#define _tmp_134_type 1281
-#define _tmp_135_type 1282
-#define _tmp_136_type 1283
-#define _tmp_137_type 1284
-#define _tmp_138_type 1285
-#define _tmp_139_type 1286
-#define _tmp_140_type 1287
-#define _tmp_141_type 1288
-#define _tmp_142_type 1289
-#define _loop1_143_type 1290
+#define invalid_star_etc_type 1147
+#define invalid_double_type_comments_type 1148
+#define _loop0_1_type 1149
+#define _loop0_2_type 1150
+#define _loop0_4_type 1151
+#define _gather_3_type 1152
+#define _loop0_6_type 1153
+#define _gather_5_type 1154
+#define _loop0_8_type 1155
+#define _gather_7_type 1156
+#define _loop0_10_type 1157
+#define _gather_9_type 1158
+#define _loop1_11_type 1159
+#define _loop0_13_type 1160
+#define _gather_12_type 1161
+#define _tmp_14_type 1162
+#define _tmp_15_type 1163
+#define _tmp_16_type 1164
+#define _tmp_17_type 1165
+#define _tmp_18_type 1166
+#define _tmp_19_type 1167
+#define _tmp_20_type 1168
+#define _tmp_21_type 1169
+#define _loop1_22_type 1170
+#define _tmp_23_type 1171
+#define _tmp_24_type 1172
+#define _loop0_26_type 1173
+#define _gather_25_type 1174
+#define _loop0_28_type 1175
+#define _gather_27_type 1176
+#define _tmp_29_type 1177
+#define _loop0_30_type 1178
+#define _loop1_31_type 1179
+#define _loop0_33_type 1180
+#define _gather_32_type 1181
+#define _tmp_34_type 1182
+#define _loop0_36_type 1183
+#define _gather_35_type 1184
+#define _tmp_37_type 1185
+#define _loop0_39_type 1186
+#define _gather_38_type 1187
+#define _loop0_41_type 1188
+#define _gather_40_type 1189
+#define _loop0_43_type 1190
+#define _gather_42_type 1191
+#define _loop0_45_type 1192
+#define _gather_44_type 1193
+#define _tmp_46_type 1194
+#define _loop1_47_type 1195
+#define _tmp_48_type 1196
+#define _tmp_49_type 1197
+#define _tmp_50_type 1198
+#define _tmp_51_type 1199
+#define _tmp_52_type 1200
+#define _loop0_53_type 1201
+#define _loop0_54_type 1202
+#define _loop0_55_type 1203
+#define _loop1_56_type 1204
+#define _loop0_57_type 1205
+#define _loop1_58_type 1206
+#define _loop1_59_type 1207
+#define _loop1_60_type 1208
+#define _loop0_61_type 1209
+#define _loop1_62_type 1210
+#define _loop0_63_type 1211
+#define _loop1_64_type 1212
+#define _loop0_65_type 1213
+#define _loop1_66_type 1214
+#define _loop1_67_type 1215
+#define _tmp_68_type 1216
+#define _loop0_70_type 1217
+#define _gather_69_type 1218
+#define _loop1_71_type 1219
+#define _loop0_73_type 1220
+#define _gather_72_type 1221
+#define _loop1_74_type 1222
+#define _loop0_75_type 1223
+#define _loop0_76_type 1224
+#define _loop0_77_type 1225
+#define _loop1_78_type 1226
+#define _loop0_79_type 1227
+#define _loop1_80_type 1228
+#define _loop1_81_type 1229
+#define _loop1_82_type 1230
+#define _loop0_83_type 1231
+#define _loop1_84_type 1232
+#define _loop0_85_type 1233
+#define _loop1_86_type 1234
+#define _loop0_87_type 1235
+#define _loop1_88_type 1236
+#define _loop1_89_type 1237
+#define _loop1_90_type 1238
+#define _loop1_91_type 1239
+#define _tmp_92_type 1240
+#define _loop0_94_type 1241
+#define _gather_93_type 1242
+#define _tmp_95_type 1243
+#define _tmp_96_type 1244
+#define _tmp_97_type 1245
+#define _tmp_98_type 1246
+#define _loop1_99_type 1247
+#define _tmp_100_type 1248
+#define _tmp_101_type 1249
+#define _loop0_103_type 1250
+#define _gather_102_type 1251
+#define _loop1_104_type 1252
+#define _loop0_105_type 1253
+#define _loop0_106_type 1254
+#define _tmp_107_type 1255
+#define _tmp_108_type 1256
+#define _loop0_110_type 1257
+#define _gather_109_type 1258
+#define _loop0_112_type 1259
+#define _gather_111_type 1260
+#define _loop0_114_type 1261
+#define _gather_113_type 1262
+#define _loop0_116_type 1263
+#define _gather_115_type 1264
+#define _loop0_117_type 1265
+#define _loop0_119_type 1266
+#define _gather_118_type 1267
+#define _tmp_120_type 1268
+#define _loop0_122_type 1269
+#define _gather_121_type 1270
+#define _loop0_124_type 1271
+#define _gather_123_type 1272
+#define _tmp_125_type 1273
+#define _tmp_126_type 1274
+#define _tmp_127_type 1275
+#define _tmp_128_type 1276
+#define _tmp_129_type 1277
+#define _loop0_130_type 1278
+#define _tmp_131_type 1279
+#define _tmp_132_type 1280
+#define _tmp_133_type 1281
+#define _tmp_134_type 1282
+#define _tmp_135_type 1283
+#define _tmp_136_type 1284
+#define _tmp_137_type 1285
+#define _tmp_138_type 1286
+#define _tmp_139_type 1287
+#define _tmp_140_type 1288
+#define _tmp_141_type 1289
+#define _tmp_142_type 1290
+#define _tmp_143_type 1291
+#define _loop1_144_type 1292
+#define _tmp_145_type 1293
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -507,6 +510,7 @@ static void *invalid_assignment_rule(Parser *p);
 static void *invalid_block_rule(Parser *p);
 static void *invalid_comprehension_rule(Parser *p);
 static void *invalid_parameters_rule(Parser *p);
+static void *invalid_star_etc_rule(Parser *p);
 static void *invalid_double_type_comments_rule(Parser *p);
 static asdl_seq *_loop0_1_rule(Parser *p);
 static asdl_seq *_loop0_2_rule(Parser *p);
@@ -650,7 +654,9 @@ static void *_tmp_139_rule(Parser *p);
 static void *_tmp_140_rule(Parser *p);
 static void *_tmp_141_rule(Parser *p);
 static void *_tmp_142_rule(Parser *p);
-static asdl_seq *_loop1_143_rule(Parser *p);
+static void *_tmp_143_rule(Parser *p);
+static asdl_seq *_loop1_144_rule(Parser *p);
+static void *_tmp_145_rule(Parser *p);
 
 
 // file: statements? $
@@ -3998,6 +4004,7 @@ slash_with_default_rule(Parser *p)
 //     | '*' param_no_default param_maybe_default* kwds?
 //     | '*' ',' param_maybe_default+ kwds?
 //     | kwds
+//     | invalid_star_etc
 static StarEtc*
 star_etc_rule(Parser *p)
 {
@@ -4065,6 +4072,17 @@ star_etc_rule(Parser *p)
                 p->error_indicator = 1;
                 return NULL;
             }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // invalid_star_etc
+        void *invalid_star_etc_var;
+        if (
+            (invalid_star_etc_var = invalid_star_etc_rule(p))
+        )
+        {
+            res = invalid_star_etc_var;
             goto done;
         }
         p->mark = mark;
@@ -10691,6 +10709,38 @@ invalid_parameters_rule(Parser *p)
     return res;
 }
 
+// invalid_star_etc: '*' (')' | ',' (')' | '**'))
+static void *
+invalid_star_etc_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // '*' (')' | ',' (')' | '**'))
+        void *_tmp_132_var;
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 16))
+            &&
+            (_tmp_132_var = _tmp_132_rule(p))
+        )
+        {
+            res = RAISE_SYNTAX_ERROR ( "named arguments must follow bare *" );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
 // invalid_double_type_comments: TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT
 static void *
 invalid_double_type_comments_rule(Parser *p)
@@ -11627,12 +11677,12 @@ _loop1_22_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (star_targets '=')
-        void *_tmp_132_var;
+        void *_tmp_133_var;
         while (
-            (_tmp_132_var = _tmp_132_rule(p))
+            (_tmp_133_var = _tmp_133_rule(p))
         )
         {
-            res = _tmp_132_var;
+            res = _tmp_133_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -11954,12 +12004,12 @@ _loop0_30_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_133_var;
+        void *_tmp_134_var;
         while (
-            (_tmp_133_var = _tmp_133_rule(p))
+            (_tmp_134_var = _tmp_134_rule(p))
         )
         {
-            res = _tmp_133_var;
+            res = _tmp_134_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12003,12 +12053,12 @@ _loop1_31_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_134_var;
+        void *_tmp_135_var;
         while (
-            (_tmp_134_var = _tmp_134_rule(p))
+            (_tmp_135_var = _tmp_135_rule(p))
         )
         {
-            res = _tmp_134_var;
+            res = _tmp_135_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13585,12 +13635,12 @@ _loop1_67_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('@' named_expression NEWLINE)
-        void *_tmp_135_var;
+        void *_tmp_136_var;
         while (
-            (_tmp_135_var = _tmp_135_rule(p))
+            (_tmp_136_var = _tmp_136_rule(p))
         )
         {
-            res = _tmp_135_var;
+            res = _tmp_136_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13758,12 +13808,12 @@ _loop1_71_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_expression)
-        void *_tmp_136_var;
+        void *_tmp_137_var;
         while (
-            (_tmp_136_var = _tmp_136_rule(p))
+            (_tmp_137_var = _tmp_137_rule(p))
         )
         {
-            res = _tmp_136_var;
+            res = _tmp_137_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13896,12 +13946,12 @@ _loop1_74_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' expression)
-        void *_tmp_137_var;
+        void *_tmp_138_var;
         while (
-            (_tmp_137_var = _tmp_137_rule(p))
+            (_tmp_138_var = _tmp_138_rule(p))
         )
         {
-            res = _tmp_137_var;
+            res = _tmp_138_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14663,12 +14713,12 @@ _loop1_89_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('or' conjunction)
-        void *_tmp_138_var;
+        void *_tmp_139_var;
         while (
-            (_tmp_138_var = _tmp_138_rule(p))
+            (_tmp_139_var = _tmp_139_rule(p))
         )
         {
-            res = _tmp_138_var;
+            res = _tmp_139_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14716,12 +14766,12 @@ _loop1_90_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('and' inversion)
-        void *_tmp_139_var;
+        void *_tmp_140_var;
         while (
-            (_tmp_139_var = _tmp_139_rule(p))
+            (_tmp_140_var = _tmp_140_rule(p))
         )
         {
-            res = _tmp_139_var;
+            res = _tmp_140_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15371,12 +15421,12 @@ _loop0_105_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('if' disjunction)
-        void *_tmp_140_var;
+        void *_tmp_141_var;
         while (
-            (_tmp_140_var = _tmp_140_rule(p))
+            (_tmp_141_var = _tmp_141_rule(p))
         )
         {
-            res = _tmp_140_var;
+            res = _tmp_141_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15420,12 +15470,12 @@ _loop0_106_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('if' disjunction)
-        void *_tmp_141_var;
+        void *_tmp_142_var;
         while (
-            (_tmp_141_var = _tmp_141_rule(p))
+            (_tmp_142_var = _tmp_142_rule(p))
         )
         {
-            res = _tmp_141_var;
+            res = _tmp_142_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15873,12 +15923,12 @@ _loop0_117_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_target)
-        void *_tmp_142_var;
+        void *_tmp_143_var;
         while (
-            (_tmp_142_var = _tmp_142_rule(p))
+            (_tmp_143_var = _tmp_143_rule(p))
         )
         {
-            res = _tmp_142_var;
+            res = _tmp_143_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -16442,12 +16492,12 @@ _tmp_131_rule(Parser *p)
         p->mark = mark;
     }
     { // param_with_default+
-        asdl_seq * _loop1_143_var;
+        asdl_seq * _loop1_144_var;
         if (
-            (_loop1_143_var = _loop1_143_rule(p))
+            (_loop1_144_var = _loop1_144_rule(p))
         )
         {
-            res = _loop1_143_var;
+            res = _loop1_144_var;
             goto done;
         }
         p->mark = mark;
@@ -16457,9 +16507,48 @@ _tmp_131_rule(Parser *p)
     return res;
 }
 
-// _tmp_132: star_targets '='
+// _tmp_132: ')' | ',' (')' | '**')
 static void *
 _tmp_132_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ')'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 8))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // ',' (')' | '**')
+        void *_tmp_145_var;
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (_tmp_145_var = _tmp_145_rule(p))
+        )
+        {
+            res = _PyPegen_dummy_name(p, literal, _tmp_145_var);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_133: star_targets '='
+static void *
+_tmp_133_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16480,42 +16569,6 @@ _tmp_132_rule(Parser *p)
                 p->error_indicator = 1;
                 return NULL;
             }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_133: '.' | '...'
-static void *
-_tmp_133_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // '.'
-        Token * literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 23))
-        )
-        {
-            res = literal;
-            goto done;
-        }
-        p->mark = mark;
-    }
-    { // '...'
-        Token * literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 52))
-        )
-        {
-            res = literal;
             goto done;
         }
         p->mark = mark;
@@ -16561,9 +16614,45 @@ _tmp_134_rule(Parser *p)
     return res;
 }
 
-// _tmp_135: '@' named_expression NEWLINE
+// _tmp_135: '.' | '...'
 static void *
 _tmp_135_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // '.'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 23))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // '...'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 52))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_136: '@' named_expression NEWLINE
+static void *
+_tmp_136_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16596,9 +16685,9 @@ _tmp_135_rule(Parser *p)
     return res;
 }
 
-// _tmp_136: ',' star_expression
+// _tmp_137: ',' star_expression
 static void *
-_tmp_136_rule(Parser *p)
+_tmp_137_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16628,9 +16717,9 @@ _tmp_136_rule(Parser *p)
     return res;
 }
 
-// _tmp_137: ',' expression
+// _tmp_138: ',' expression
 static void *
-_tmp_137_rule(Parser *p)
+_tmp_138_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16660,9 +16749,9 @@ _tmp_137_rule(Parser *p)
     return res;
 }
 
-// _tmp_138: 'or' conjunction
+// _tmp_139: 'or' conjunction
 static void *
-_tmp_138_rule(Parser *p)
+_tmp_139_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16692,9 +16781,9 @@ _tmp_138_rule(Parser *p)
     return res;
 }
 
-// _tmp_139: 'and' inversion
+// _tmp_140: 'and' inversion
 static void *
-_tmp_139_rule(Parser *p)
+_tmp_140_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16711,38 +16800,6 @@ _tmp_139_rule(Parser *p)
         )
         {
             res = c;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_140: 'if' disjunction
-static void *
-_tmp_140_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // 'if' disjunction
-        Token * keyword;
-        expr_ty z;
-        if (
-            (keyword = _PyPegen_expect_token(p, 510))
-            &&
-            (z = disjunction_rule(p))
-        )
-        {
-            res = z;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -16788,9 +16845,41 @@ _tmp_141_rule(Parser *p)
     return res;
 }
 
-// _tmp_142: ',' star_target
+// _tmp_142: 'if' disjunction
 static void *
 _tmp_142_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // 'if' disjunction
+        Token * keyword;
+        expr_ty z;
+        if (
+            (keyword = _PyPegen_expect_token(p, 510))
+            &&
+            (z = disjunction_rule(p))
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_143: ',' star_target
+static void *
+_tmp_143_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16820,9 +16909,9 @@ _tmp_142_rule(Parser *p)
     return res;
 }
 
-// _loop1_143: param_with_default
+// _loop1_144: param_with_default
 static asdl_seq *
-_loop1_143_rule(Parser *p)
+_loop1_144_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16863,14 +16952,50 @@ _loop1_143_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_143");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_144");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_143_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_144_type, seq);
     return seq;
+}
+
+// _tmp_145: ')' | '**'
+static void *
+_tmp_145_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ')'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 8))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // '**'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 35))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
 }
 
 void *

--- a/Parser/pegen/parse.c
+++ b/Parser/pegen/parse.c
@@ -216,152 +216,155 @@ static KeywordToken *reserved_keywords[] = {
 #define invalid_comprehension_type 1145
 #define invalid_parameters_type 1146
 #define invalid_star_etc_type 1147
-#define invalid_double_type_comments_type 1148
-#define _loop0_1_type 1149
-#define _loop0_2_type 1150
-#define _loop0_4_type 1151
-#define _gather_3_type 1152
-#define _loop0_6_type 1153
-#define _gather_5_type 1154
-#define _loop0_8_type 1155
-#define _gather_7_type 1156
-#define _loop0_10_type 1157
-#define _gather_9_type 1158
-#define _loop1_11_type 1159
-#define _loop0_13_type 1160
-#define _gather_12_type 1161
-#define _tmp_14_type 1162
-#define _tmp_15_type 1163
-#define _tmp_16_type 1164
-#define _tmp_17_type 1165
-#define _tmp_18_type 1166
-#define _tmp_19_type 1167
-#define _tmp_20_type 1168
-#define _tmp_21_type 1169
-#define _loop1_22_type 1170
-#define _tmp_23_type 1171
-#define _tmp_24_type 1172
-#define _loop0_26_type 1173
-#define _gather_25_type 1174
-#define _loop0_28_type 1175
-#define _gather_27_type 1176
-#define _tmp_29_type 1177
-#define _loop0_30_type 1178
-#define _loop1_31_type 1179
-#define _loop0_33_type 1180
-#define _gather_32_type 1181
-#define _tmp_34_type 1182
-#define _loop0_36_type 1183
-#define _gather_35_type 1184
-#define _tmp_37_type 1185
-#define _loop0_39_type 1186
-#define _gather_38_type 1187
-#define _loop0_41_type 1188
-#define _gather_40_type 1189
-#define _loop0_43_type 1190
-#define _gather_42_type 1191
-#define _loop0_45_type 1192
-#define _gather_44_type 1193
-#define _tmp_46_type 1194
-#define _loop1_47_type 1195
-#define _tmp_48_type 1196
-#define _tmp_49_type 1197
-#define _tmp_50_type 1198
-#define _tmp_51_type 1199
-#define _tmp_52_type 1200
-#define _loop0_53_type 1201
-#define _loop0_54_type 1202
-#define _loop0_55_type 1203
-#define _loop1_56_type 1204
-#define _loop0_57_type 1205
-#define _loop1_58_type 1206
-#define _loop1_59_type 1207
-#define _loop1_60_type 1208
-#define _loop0_61_type 1209
-#define _loop1_62_type 1210
-#define _loop0_63_type 1211
-#define _loop1_64_type 1212
-#define _loop0_65_type 1213
-#define _loop1_66_type 1214
-#define _loop1_67_type 1215
-#define _tmp_68_type 1216
-#define _loop0_70_type 1217
-#define _gather_69_type 1218
-#define _loop1_71_type 1219
-#define _loop0_73_type 1220
-#define _gather_72_type 1221
-#define _loop1_74_type 1222
-#define _loop0_75_type 1223
-#define _loop0_76_type 1224
-#define _loop0_77_type 1225
-#define _loop1_78_type 1226
-#define _loop0_79_type 1227
-#define _loop1_80_type 1228
-#define _loop1_81_type 1229
-#define _loop1_82_type 1230
-#define _loop0_83_type 1231
-#define _loop1_84_type 1232
-#define _loop0_85_type 1233
-#define _loop1_86_type 1234
-#define _loop0_87_type 1235
-#define _loop1_88_type 1236
-#define _loop1_89_type 1237
-#define _loop1_90_type 1238
-#define _loop1_91_type 1239
-#define _tmp_92_type 1240
-#define _loop0_94_type 1241
-#define _gather_93_type 1242
-#define _tmp_95_type 1243
-#define _tmp_96_type 1244
-#define _tmp_97_type 1245
-#define _tmp_98_type 1246
-#define _loop1_99_type 1247
-#define _tmp_100_type 1248
-#define _tmp_101_type 1249
-#define _loop0_103_type 1250
-#define _gather_102_type 1251
-#define _loop1_104_type 1252
-#define _loop0_105_type 1253
-#define _loop0_106_type 1254
-#define _tmp_107_type 1255
-#define _tmp_108_type 1256
-#define _loop0_110_type 1257
-#define _gather_109_type 1258
-#define _loop0_112_type 1259
-#define _gather_111_type 1260
-#define _loop0_114_type 1261
-#define _gather_113_type 1262
-#define _loop0_116_type 1263
-#define _gather_115_type 1264
-#define _loop0_117_type 1265
-#define _loop0_119_type 1266
-#define _gather_118_type 1267
-#define _tmp_120_type 1268
-#define _loop0_122_type 1269
-#define _gather_121_type 1270
-#define _loop0_124_type 1271
-#define _gather_123_type 1272
-#define _tmp_125_type 1273
-#define _tmp_126_type 1274
-#define _tmp_127_type 1275
-#define _tmp_128_type 1276
-#define _tmp_129_type 1277
-#define _loop0_130_type 1278
-#define _tmp_131_type 1279
-#define _tmp_132_type 1280
-#define _tmp_133_type 1281
-#define _tmp_134_type 1282
-#define _tmp_135_type 1283
-#define _tmp_136_type 1284
-#define _tmp_137_type 1285
-#define _tmp_138_type 1286
-#define _tmp_139_type 1287
-#define _tmp_140_type 1288
-#define _tmp_141_type 1289
-#define _tmp_142_type 1290
-#define _tmp_143_type 1291
-#define _loop1_144_type 1292
-#define _tmp_145_type 1293
+#define invalid_lambda_star_etc_type 1148
+#define invalid_double_type_comments_type 1149
+#define _loop0_1_type 1150
+#define _loop0_2_type 1151
+#define _loop0_4_type 1152
+#define _gather_3_type 1153
+#define _loop0_6_type 1154
+#define _gather_5_type 1155
+#define _loop0_8_type 1156
+#define _gather_7_type 1157
+#define _loop0_10_type 1158
+#define _gather_9_type 1159
+#define _loop1_11_type 1160
+#define _loop0_13_type 1161
+#define _gather_12_type 1162
+#define _tmp_14_type 1163
+#define _tmp_15_type 1164
+#define _tmp_16_type 1165
+#define _tmp_17_type 1166
+#define _tmp_18_type 1167
+#define _tmp_19_type 1168
+#define _tmp_20_type 1169
+#define _tmp_21_type 1170
+#define _loop1_22_type 1171
+#define _tmp_23_type 1172
+#define _tmp_24_type 1173
+#define _loop0_26_type 1174
+#define _gather_25_type 1175
+#define _loop0_28_type 1176
+#define _gather_27_type 1177
+#define _tmp_29_type 1178
+#define _loop0_30_type 1179
+#define _loop1_31_type 1180
+#define _loop0_33_type 1181
+#define _gather_32_type 1182
+#define _tmp_34_type 1183
+#define _loop0_36_type 1184
+#define _gather_35_type 1185
+#define _tmp_37_type 1186
+#define _loop0_39_type 1187
+#define _gather_38_type 1188
+#define _loop0_41_type 1189
+#define _gather_40_type 1190
+#define _loop0_43_type 1191
+#define _gather_42_type 1192
+#define _loop0_45_type 1193
+#define _gather_44_type 1194
+#define _tmp_46_type 1195
+#define _loop1_47_type 1196
+#define _tmp_48_type 1197
+#define _tmp_49_type 1198
+#define _tmp_50_type 1199
+#define _tmp_51_type 1200
+#define _tmp_52_type 1201
+#define _loop0_53_type 1202
+#define _loop0_54_type 1203
+#define _loop0_55_type 1204
+#define _loop1_56_type 1205
+#define _loop0_57_type 1206
+#define _loop1_58_type 1207
+#define _loop1_59_type 1208
+#define _loop1_60_type 1209
+#define _loop0_61_type 1210
+#define _loop1_62_type 1211
+#define _loop0_63_type 1212
+#define _loop1_64_type 1213
+#define _loop0_65_type 1214
+#define _loop1_66_type 1215
+#define _loop1_67_type 1216
+#define _tmp_68_type 1217
+#define _loop0_70_type 1218
+#define _gather_69_type 1219
+#define _loop1_71_type 1220
+#define _loop0_73_type 1221
+#define _gather_72_type 1222
+#define _loop1_74_type 1223
+#define _loop0_75_type 1224
+#define _loop0_76_type 1225
+#define _loop0_77_type 1226
+#define _loop1_78_type 1227
+#define _loop0_79_type 1228
+#define _loop1_80_type 1229
+#define _loop1_81_type 1230
+#define _loop1_82_type 1231
+#define _loop0_83_type 1232
+#define _loop1_84_type 1233
+#define _loop0_85_type 1234
+#define _loop1_86_type 1235
+#define _loop0_87_type 1236
+#define _loop1_88_type 1237
+#define _loop1_89_type 1238
+#define _loop1_90_type 1239
+#define _loop1_91_type 1240
+#define _tmp_92_type 1241
+#define _loop0_94_type 1242
+#define _gather_93_type 1243
+#define _tmp_95_type 1244
+#define _tmp_96_type 1245
+#define _tmp_97_type 1246
+#define _tmp_98_type 1247
+#define _loop1_99_type 1248
+#define _tmp_100_type 1249
+#define _tmp_101_type 1250
+#define _loop0_103_type 1251
+#define _gather_102_type 1252
+#define _loop1_104_type 1253
+#define _loop0_105_type 1254
+#define _loop0_106_type 1255
+#define _tmp_107_type 1256
+#define _tmp_108_type 1257
+#define _loop0_110_type 1258
+#define _gather_109_type 1259
+#define _loop0_112_type 1260
+#define _gather_111_type 1261
+#define _loop0_114_type 1262
+#define _gather_113_type 1263
+#define _loop0_116_type 1264
+#define _gather_115_type 1265
+#define _loop0_117_type 1266
+#define _loop0_119_type 1267
+#define _gather_118_type 1268
+#define _tmp_120_type 1269
+#define _loop0_122_type 1270
+#define _gather_121_type 1271
+#define _loop0_124_type 1272
+#define _gather_123_type 1273
+#define _tmp_125_type 1274
+#define _tmp_126_type 1275
+#define _tmp_127_type 1276
+#define _tmp_128_type 1277
+#define _tmp_129_type 1278
+#define _loop0_130_type 1279
+#define _tmp_131_type 1280
+#define _tmp_132_type 1281
+#define _tmp_133_type 1282
+#define _tmp_134_type 1283
+#define _tmp_135_type 1284
+#define _tmp_136_type 1285
+#define _tmp_137_type 1286
+#define _tmp_138_type 1287
+#define _tmp_139_type 1288
+#define _tmp_140_type 1289
+#define _tmp_141_type 1290
+#define _tmp_142_type 1291
+#define _tmp_143_type 1292
+#define _tmp_144_type 1293
+#define _loop1_145_type 1294
+#define _tmp_146_type 1295
+#define _tmp_147_type 1296
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -511,6 +514,7 @@ static void *invalid_block_rule(Parser *p);
 static void *invalid_comprehension_rule(Parser *p);
 static void *invalid_parameters_rule(Parser *p);
 static void *invalid_star_etc_rule(Parser *p);
+static void *invalid_lambda_star_etc_rule(Parser *p);
 static void *invalid_double_type_comments_rule(Parser *p);
 static asdl_seq *_loop0_1_rule(Parser *p);
 static asdl_seq *_loop0_2_rule(Parser *p);
@@ -655,8 +659,10 @@ static void *_tmp_140_rule(Parser *p);
 static void *_tmp_141_rule(Parser *p);
 static void *_tmp_142_rule(Parser *p);
 static void *_tmp_143_rule(Parser *p);
-static asdl_seq *_loop1_144_rule(Parser *p);
-static void *_tmp_145_rule(Parser *p);
+static void *_tmp_144_rule(Parser *p);
+static asdl_seq *_loop1_145_rule(Parser *p);
+static void *_tmp_146_rule(Parser *p);
+static void *_tmp_147_rule(Parser *p);
 
 
 // file: statements? $
@@ -5464,6 +5470,7 @@ lambda_slash_with_default_rule(Parser *p)
 //     | '*' lambda_param_no_default lambda_param_maybe_default* lambda_kwds?
 //     | '*' ',' lambda_param_maybe_default+ lambda_kwds?
 //     | lambda_kwds
+//     | invalid_lambda_star_etc
 static StarEtc*
 lambda_star_etc_rule(Parser *p)
 {
@@ -5531,6 +5538,17 @@ lambda_star_etc_rule(Parser *p)
                 p->error_indicator = 1;
                 return NULL;
             }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // invalid_lambda_star_etc
+        void *invalid_lambda_star_etc_var;
+        if (
+            (invalid_lambda_star_etc_var = invalid_lambda_star_etc_rule(p))
+        )
+        {
+            res = invalid_lambda_star_etc_var;
             goto done;
         }
         p->mark = mark;
@@ -10741,6 +10759,38 @@ invalid_star_etc_rule(Parser *p)
     return res;
 }
 
+// invalid_lambda_star_etc: '*' (':' | ',' (':' | '**'))
+static void *
+invalid_lambda_star_etc_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // '*' (':' | ',' (':' | '**'))
+        void *_tmp_133_var;
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 16))
+            &&
+            (_tmp_133_var = _tmp_133_rule(p))
+        )
+        {
+            res = RAISE_SYNTAX_ERROR ( "named arguments must follow bare *" );
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
 // invalid_double_type_comments: TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT
 static void *
 invalid_double_type_comments_rule(Parser *p)
@@ -11677,12 +11727,12 @@ _loop1_22_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (star_targets '=')
-        void *_tmp_133_var;
+        void *_tmp_134_var;
         while (
-            (_tmp_133_var = _tmp_133_rule(p))
+            (_tmp_134_var = _tmp_134_rule(p))
         )
         {
-            res = _tmp_133_var;
+            res = _tmp_134_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12004,12 +12054,12 @@ _loop0_30_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_134_var;
+        void *_tmp_135_var;
         while (
-            (_tmp_134_var = _tmp_134_rule(p))
+            (_tmp_135_var = _tmp_135_rule(p))
         )
         {
-            res = _tmp_134_var;
+            res = _tmp_135_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -12053,12 +12103,12 @@ _loop1_31_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('.' | '...')
-        void *_tmp_135_var;
+        void *_tmp_136_var;
         while (
-            (_tmp_135_var = _tmp_135_rule(p))
+            (_tmp_136_var = _tmp_136_rule(p))
         )
         {
-            res = _tmp_135_var;
+            res = _tmp_136_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13635,12 +13685,12 @@ _loop1_67_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('@' named_expression NEWLINE)
-        void *_tmp_136_var;
+        void *_tmp_137_var;
         while (
-            (_tmp_136_var = _tmp_136_rule(p))
+            (_tmp_137_var = _tmp_137_rule(p))
         )
         {
-            res = _tmp_136_var;
+            res = _tmp_137_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13808,12 +13858,12 @@ _loop1_71_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_expression)
-        void *_tmp_137_var;
+        void *_tmp_138_var;
         while (
-            (_tmp_137_var = _tmp_137_rule(p))
+            (_tmp_138_var = _tmp_138_rule(p))
         )
         {
-            res = _tmp_137_var;
+            res = _tmp_138_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -13946,12 +13996,12 @@ _loop1_74_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' expression)
-        void *_tmp_138_var;
+        void *_tmp_139_var;
         while (
-            (_tmp_138_var = _tmp_138_rule(p))
+            (_tmp_139_var = _tmp_139_rule(p))
         )
         {
-            res = _tmp_138_var;
+            res = _tmp_139_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14713,12 +14763,12 @@ _loop1_89_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('or' conjunction)
-        void *_tmp_139_var;
+        void *_tmp_140_var;
         while (
-            (_tmp_139_var = _tmp_139_rule(p))
+            (_tmp_140_var = _tmp_140_rule(p))
         )
         {
-            res = _tmp_139_var;
+            res = _tmp_140_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -14766,12 +14816,12 @@ _loop1_90_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('and' inversion)
-        void *_tmp_140_var;
+        void *_tmp_141_var;
         while (
-            (_tmp_140_var = _tmp_140_rule(p))
+            (_tmp_141_var = _tmp_141_rule(p))
         )
         {
-            res = _tmp_140_var;
+            res = _tmp_141_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15421,12 +15471,12 @@ _loop0_105_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('if' disjunction)
-        void *_tmp_141_var;
+        void *_tmp_142_var;
         while (
-            (_tmp_141_var = _tmp_141_rule(p))
+            (_tmp_142_var = _tmp_142_rule(p))
         )
         {
-            res = _tmp_141_var;
+            res = _tmp_142_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15470,12 +15520,12 @@ _loop0_106_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // ('if' disjunction)
-        void *_tmp_142_var;
+        void *_tmp_143_var;
         while (
-            (_tmp_142_var = _tmp_142_rule(p))
+            (_tmp_143_var = _tmp_143_rule(p))
         )
         {
-            res = _tmp_142_var;
+            res = _tmp_143_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -15923,12 +15973,12 @@ _loop0_117_rule(Parser *p)
     ssize_t children_capacity = 1;
     ssize_t n = 0;
     { // (',' star_target)
-        void *_tmp_143_var;
+        void *_tmp_144_var;
         while (
-            (_tmp_143_var = _tmp_143_rule(p))
+            (_tmp_144_var = _tmp_144_rule(p))
         )
         {
-            res = _tmp_143_var;
+            res = _tmp_144_var;
             if (n == children_capacity) {
                 children_capacity *= 2;
                 children = PyMem_Realloc(children, children_capacity*sizeof(void *));
@@ -16492,12 +16542,12 @@ _tmp_131_rule(Parser *p)
         p->mark = mark;
     }
     { // param_with_default+
-        asdl_seq * _loop1_144_var;
+        asdl_seq * _loop1_145_var;
         if (
-            (_loop1_144_var = _loop1_144_rule(p))
+            (_loop1_145_var = _loop1_145_rule(p))
         )
         {
-            res = _loop1_144_var;
+            res = _loop1_145_var;
             goto done;
         }
         p->mark = mark;
@@ -16528,15 +16578,15 @@ _tmp_132_rule(Parser *p)
         p->mark = mark;
     }
     { // ',' (')' | '**')
-        void *_tmp_145_var;
+        void *_tmp_146_var;
         Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 12))
             &&
-            (_tmp_145_var = _tmp_145_rule(p))
+            (_tmp_146_var = _tmp_146_rule(p))
         )
         {
-            res = _PyPegen_dummy_name(p, literal, _tmp_145_var);
+            res = _PyPegen_dummy_name(p, literal, _tmp_146_var);
             goto done;
         }
         p->mark = mark;
@@ -16546,9 +16596,48 @@ _tmp_132_rule(Parser *p)
     return res;
 }
 
-// _tmp_133: star_targets '='
+// _tmp_133: ':' | ',' (':' | '**')
 static void *
 _tmp_133_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ':'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 11))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // ',' (':' | '**')
+        void *_tmp_147_var;
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 12))
+            &&
+            (_tmp_147_var = _tmp_147_rule(p))
+        )
+        {
+            res = _PyPegen_dummy_name(p, literal, _tmp_147_var);
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_134: star_targets '='
+static void *
+_tmp_134_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16569,42 +16658,6 @@ _tmp_133_rule(Parser *p)
                 p->error_indicator = 1;
                 return NULL;
             }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_134: '.' | '...'
-static void *
-_tmp_134_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // '.'
-        Token * literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 23))
-        )
-        {
-            res = literal;
-            goto done;
-        }
-        p->mark = mark;
-    }
-    { // '...'
-        Token * literal;
-        if (
-            (literal = _PyPegen_expect_token(p, 52))
-        )
-        {
-            res = literal;
             goto done;
         }
         p->mark = mark;
@@ -16650,9 +16703,45 @@ _tmp_135_rule(Parser *p)
     return res;
 }
 
-// _tmp_136: '@' named_expression NEWLINE
+// _tmp_136: '.' | '...'
 static void *
 _tmp_136_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // '.'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 23))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // '...'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 52))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_137: '@' named_expression NEWLINE
+static void *
+_tmp_137_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16685,9 +16774,9 @@ _tmp_136_rule(Parser *p)
     return res;
 }
 
-// _tmp_137: ',' star_expression
+// _tmp_138: ',' star_expression
 static void *
-_tmp_137_rule(Parser *p)
+_tmp_138_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16717,9 +16806,9 @@ _tmp_137_rule(Parser *p)
     return res;
 }
 
-// _tmp_138: ',' expression
+// _tmp_139: ',' expression
 static void *
-_tmp_138_rule(Parser *p)
+_tmp_139_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16749,9 +16838,9 @@ _tmp_138_rule(Parser *p)
     return res;
 }
 
-// _tmp_139: 'or' conjunction
+// _tmp_140: 'or' conjunction
 static void *
-_tmp_139_rule(Parser *p)
+_tmp_140_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16781,9 +16870,9 @@ _tmp_139_rule(Parser *p)
     return res;
 }
 
-// _tmp_140: 'and' inversion
+// _tmp_141: 'and' inversion
 static void *
-_tmp_140_rule(Parser *p)
+_tmp_141_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16800,38 +16889,6 @@ _tmp_140_rule(Parser *p)
         )
         {
             res = c;
-            if (res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = mark;
-    }
-    res = NULL;
-  done:
-    return res;
-}
-
-// _tmp_141: 'if' disjunction
-static void *
-_tmp_141_rule(Parser *p)
-{
-    if (p->error_indicator) {
-        return NULL;
-    }
-    void * res = NULL;
-    int mark = p->mark;
-    { // 'if' disjunction
-        Token * keyword;
-        expr_ty z;
-        if (
-            (keyword = _PyPegen_expect_token(p, 510))
-            &&
-            (z = disjunction_rule(p))
-        )
-        {
-            res = z;
             if (res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 return NULL;
@@ -16877,9 +16934,41 @@ _tmp_142_rule(Parser *p)
     return res;
 }
 
-// _tmp_143: ',' star_target
+// _tmp_143: 'if' disjunction
 static void *
 _tmp_143_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // 'if' disjunction
+        Token * keyword;
+        expr_ty z;
+        if (
+            (keyword = _PyPegen_expect_token(p, 510))
+            &&
+            (z = disjunction_rule(p))
+        )
+        {
+            res = z;
+            if (res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_144: ',' star_target
+static void *
+_tmp_144_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16909,9 +16998,9 @@ _tmp_143_rule(Parser *p)
     return res;
 }
 
-// _loop1_144: param_with_default
+// _loop1_145: param_with_default
 static asdl_seq *
-_loop1_144_rule(Parser *p)
+_loop1_145_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16952,19 +17041,19 @@ _loop1_144_rule(Parser *p)
     }
     asdl_seq *seq = _Py_asdl_seq_new(n, p->arena);
     if (!seq) {
-        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_144");
+        PyErr_Format(PyExc_MemoryError, "asdl_seq_new _loop1_145");
         PyMem_Free(children);
         return NULL;
     }
     for (int i = 0; i < n; i++) asdl_seq_SET(seq, i, children[i]);
     PyMem_Free(children);
-    _PyPegen_insert_memo(p, start_mark, _loop1_144_type, seq);
+    _PyPegen_insert_memo(p, start_mark, _loop1_145_type, seq);
     return seq;
 }
 
-// _tmp_145: ')' | '**'
+// _tmp_146: ')' | '**'
 static void *
-_tmp_145_rule(Parser *p)
+_tmp_146_rule(Parser *p)
 {
     if (p->error_indicator) {
         return NULL;
@@ -16975,6 +17064,42 @@ _tmp_145_rule(Parser *p)
         Token * literal;
         if (
             (literal = _PyPegen_expect_token(p, 8))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    { // '**'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 35))
+        )
+        {
+            res = literal;
+            goto done;
+        }
+        p->mark = mark;
+    }
+    res = NULL;
+  done:
+    return res;
+}
+
+// _tmp_147: ':' | '**'
+static void *
+_tmp_147_rule(Parser *p)
+{
+    if (p->error_indicator) {
+        return NULL;
+    }
+    void * res = NULL;
+    int mark = p->mark;
+    { // ':'
+        Token * literal;
+        if (
+            (literal = _PyPegen_expect_token(p, 11))
         )
         {
             res = literal;


### PR DESCRIPTION
When parsing things like `def f(*): pass` or `lambda *: pass` the old parser used to
output `SyntaxError: named arguments must follow bare *`, which the
new parser wasn't able to do.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
