### PR TITLE
bpo-40465: Deprecate the optional argument to random.shuffle().

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -208,8 +208,8 @@ Functions for sequences
    generated.  For example, a sequence of length 2080 is the largest that
    can fit within the period of the Mersenne Twister random number generator.
 
-   .. deprecated:: 3.9
-      In the future, the optional argument *random* will be removed.
+   .. deprecated-removed:: 3.9 3.11
+      The optional parameter *random*.
 
 
 .. function:: sample(population, k)

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -208,6 +208,9 @@ Functions for sequences
    generated.  For example, a sequence of length 2080 is the largest that
    can fit within the period of the Mersenne Twister random number generator.
 
+   .. deprecated:: 3.9
+      In the future, the optional argument *random* will be removed.
+
 
 .. function:: sample(population, k)
 

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -321,7 +321,7 @@ class Random(_random.Random):
                 j = randbelow(i+1)
                 x[i], x[j] = x[j], x[i]
         else:
-            _warn('The *random* parameter to shuffle() deprecated\n'
+            _warn('The *random* parameter to shuffle() has been deprecated\n'
                   'since Python 3.9 and will be removed in a subsequent '
                   'version.\n',
                   DeprecationWarning, 2)

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -323,7 +323,7 @@ class Random(_random.Random):
         else:
             _warn('The *random* parameter to shuffle() has been deprecated\n'
                   'since Python 3.9 and will be removed in a subsequent '
-                  'version.\n',
+                  'version.',
                   DeprecationWarning, 2)
             _int = int
             for i in reversed(range(1, len(x))):

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -321,6 +321,10 @@ class Random(_random.Random):
                 j = randbelow(i+1)
                 x[i], x[j] = x[j], x[i]
         else:
+            _warn('The *random* parameter to shuffle() deprecated\n'
+                  'since Python 3.9 and will be removed in a subsequent '
+                  'version.\n',
+                  DeprecationWarning, 2)
             _int = int
             for i in reversed(range(1, len(x))):
                 # pick an element in x[:i+1] with which to exchange x[i]

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -103,7 +103,8 @@ class TestBasicOps:
         shuffle = self.gen.shuffle
         mock_random = unittest.mock.Mock(return_value=0.5)
         seq = bytearray(b'abcdefghijk')
-        shuffle(seq, mock_random)
+        with self.assertWarns(DeprecationWarning):
+            shuffle(seq, mock_random)
         mock_random.assert_called_with()
 
     def test_choice(self):

--- a/Misc/NEWS.d/next/Library/2020-05-02-12-00-28.bpo-40465.qfCjOD.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-02-12-00-28.bpo-40465.qfCjOD.rst
@@ -1,0 +1,1 @@
+Deprecated the optional *random* argument to *random.shuffle()*.


### PR DESCRIPTION


<!-- issue-number: [bpo-40465](https://bugs.python.org/issue40465) -->
https://bugs.python.org/issue40465
<!-- /issue-number -->
