### PR TITLE
bpo-40355: ast.literal_eval rejects malformed Dict nodes

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -88,6 +88,8 @@ def literal_eval(node_or_string):
               node.func.id == 'set' and node.args == node.keywords == []):
             return set()
         elif isinstance(node, Dict):
+            if len(node.keys) != len(node.values):
+                raise ValueError(f'malformed node or string: {node!r}')
             return dict(zip(map(_convert, node.keys),
                             map(_convert, node.values)))
         elif isinstance(node, BinOp) and isinstance(node.op, (Add, Sub)):

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -62,11 +62,13 @@ def literal_eval(node_or_string):
         node_or_string = parse(node_or_string, mode='eval')
     if isinstance(node_or_string, Expression):
         node_or_string = node_or_string.body
+    def _malformed(node):
+        raise ValueError(f'malformed node or string: {node!r}')
     def _convert_num(node):
         if isinstance(node, Constant):
             if type(node.value) in (int, float, complex):
                 return node.value
-        raise ValueError('malformed node or string: ' + repr(node))
+        _malformed(node)
     def _convert_signed_num(node):
         if isinstance(node, UnaryOp) and isinstance(node.op, (UAdd, USub)):
             operand = _convert_num(node.operand)
@@ -89,7 +91,7 @@ def literal_eval(node_or_string):
             return set()
         elif isinstance(node, Dict):
             if len(node.keys) != len(node.values):
-                raise ValueError(f'malformed node or string: {node!r}')
+                _malformed(node)
             return dict(zip(map(_convert, node.keys),
                             map(_convert, node.values)))
         elif isinstance(node, BinOp) and isinstance(node.op, (Add, Sub)):

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -62,13 +62,12 @@ def literal_eval(node_or_string):
         node_or_string = parse(node_or_string, mode='eval')
     if isinstance(node_or_string, Expression):
         node_or_string = node_or_string.body
-    def _malformed(node):
+    def _raise_malformed_node(node):
         raise ValueError(f'malformed node or string: {node!r}')
     def _convert_num(node):
-        if isinstance(node, Constant):
-            if type(node.value) in (int, float, complex):
-                return node.value
-        _malformed(node)
+        if not isinstance(node, Constant) or type(node.value) not in (int, float, complex):
+            _raise_malformed_node(node)
+        return node.value
     def _convert_signed_num(node):
         if isinstance(node, UnaryOp) and isinstance(node.op, (UAdd, USub)):
             operand = _convert_num(node.operand)
@@ -91,7 +90,7 @@ def literal_eval(node_or_string):
             return set()
         elif isinstance(node, Dict):
             if len(node.keys) != len(node.values):
-                _malformed(node)
+                _raise_malformed_node(node)
             return dict(zip(map(_convert, node.keys),
                             map(_convert, node.values)))
         elif isinstance(node, BinOp) and isinstance(node.op, (Add, Sub)):

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -965,6 +965,12 @@ Module(
         self.assertRaises(ValueError, ast.literal_eval, '3+(0+6j)')
         self.assertRaises(ValueError, ast.literal_eval, '-(3+6j)')
 
+    def test_literal_eval_malformed(self):
+        malformed = ast.Dict(keys=[ast.Constant(1), ast.Constant(2)], values=[ast.Constant(3)])
+        self.assertRaises(ValueError, ast.literal_eval, malformed)
+        malformed = ast.Dict(keys=[ast.Constant(1)], values=[ast.Constant(2), ast.Constant(3)])
+        self.assertRaises(ValueError, ast.literal_eval, malformed)
+
     def test_bad_integer(self):
         # issue13436: Bad error message with invalid numeric values
         body = [ast.ImportFrom(module='time',

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -965,7 +965,7 @@ Module(
         self.assertRaises(ValueError, ast.literal_eval, '3+(0+6j)')
         self.assertRaises(ValueError, ast.literal_eval, '-(3+6j)')
 
-    def test_literal_eval_malformed(self):
+    def test_literal_eval_malformed_dict_nodes(self):
         malformed = ast.Dict(keys=[ast.Constant(1), ast.Constant(2)], values=[ast.Constant(3)])
         self.assertRaises(ValueError, ast.literal_eval, malformed)
         malformed = ast.Dict(keys=[ast.Constant(1)], values=[ast.Constant(2), ast.Constant(3)])

--- a/Misc/NEWS.d/next/Library/2020-05-02-14-24-48.bpo-40355.xTujaB.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-02-14-24-48.bpo-40355.xTujaB.rst
@@ -1,2 +1,2 @@
-Fixed case where malformed :class:`ast.Dict` nodes could have keys or values
-thrown away by :func:`ast.literal_eval`. Patch by Curtis Bucher.
+Improve error reporting in :func:`ast.literal_eval` in the presence of malformed :class:`ast.Dict`
+nodes instead of silently ignoring any non-conforming elements. Patch by Curtis Bucher.

--- a/Misc/NEWS.d/next/Library/2020-05-02-14-24-48.bpo-40355.xTujaB.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-02-14-24-48.bpo-40355.xTujaB.rst
@@ -1,0 +1,2 @@
+Fixed case where malformed :class:`ast.Dict` nodes could have keys or values
+thrown away by :func:`ast.literal_eval`. Patch by Curtis Bucher.


### PR DESCRIPTION
This doesn't fix `ast.unparse`.

@brandtbucher 


<!-- issue-number: [bpo-40355](https://bugs.python.org/issue40355) -->
https://bugs.python.org/issue40355
<!-- /issue-number -->
