### PR TITLE
 bpo-39990: try resolving type hints in pydoc

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -559,7 +559,7 @@ The Signature object represents the call signature of a callable object and its
 return annotation.  To retrieve a Signature object, use the :func:`signature`
 function.
 
-.. function:: signature(callable, \*, follow_wrapped=True)
+.. function:: signature(callable, \*, follow_wrapped=True, resolve_type_hints=False)
 
    Return a :class:`Signature` object for the given ``callable``::
 
@@ -587,6 +587,9 @@ function.
    A slash(/) in the signature of a function denotes that the parameters prior
    to it are positional-only. For more info, see
    :ref:`the FAQ entry on positional-only parameters <faq-positional-only-arguments>`.
+
+   .. versionadded:: 3.9
+      ``resolve_type_hints`` parameter. Pass ``True`` to resolve the type annotations.
 
    .. versionadded:: 3.5
       ``follow_wrapped`` parameter. Pass ``False`` to get a signature of
@@ -671,7 +674,7 @@ function.
          >>> str(new_sig)
          "(a, b) -> 'new return anno'"
 
-   .. classmethod:: Signature.from_callable(obj, \*, follow_wrapped=True)
+   .. classmethod:: Signature.from_callable(obj, \*, follow_wrapped=True, resolve_type_hints=False)
 
        Return a :class:`Signature` (or its subclass) object for a given callable
        ``obj``.  Pass ``follow_wrapped=False`` to get a signature of ``obj``
@@ -683,6 +686,9 @@ function.
              pass
          sig = MySignature.from_callable(min)
          assert isinstance(sig, MySignature)
+
+       .. versionadded:: 3.9
+          ``resolve_type_hints`` parameter. Pass ``True`` to resolve the type annotations.
 
        .. versionadded:: 3.5
 

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -907,9 +907,12 @@ class HTMLDoc(Doc):
 
         decl = ''
         try:
-            signature = inspect.signature(object)
-        except (ValueError, TypeError):
-            signature = None
+            signature = inspect.signature(object, resolve_type_hints=True)
+        except (NameError, AttributeError, SyntaxError, TypeError, ValueError):
+            try:
+                signature = inspect.signature(object, resolve_type_hints=False)
+            except (ValueError, TypeError):
+                signature = None
         if signature:
             argspec = str(signature)
             if argspec and argspec != '()':
@@ -967,9 +970,12 @@ class HTMLDoc(Doc):
         argspec = None
         if inspect.isroutine(object):
             try:
-                signature = inspect.signature(object)
-            except (ValueError, TypeError):
-                signature = None
+                signature = inspect.signature(object, resolve_type_hints=True)
+            except (NameError, AttributeError, SyntaxError, TypeError, ValueError):
+                try:
+                    signature = inspect.signature(object, resolve_type_hints=False)
+                except (ValueError, TypeError):
+                    signature = None
             if signature:
                 argspec = str(signature)
                 if realname == '<lambda>':
@@ -1226,9 +1232,12 @@ location listed above.
         push = contents.append
 
         try:
-            signature = inspect.signature(object)
-        except (ValueError, TypeError):
-            signature = None
+            signature = inspect.signature(object, resolve_type_hints=True)
+        except (NameError, AttributeError, SyntaxError, TypeError, ValueError):
+            try:
+                signature = inspect.signature(object, resolve_type_hints=False)
+            except (ValueError, TypeError):
+                signature = None
         if signature:
             argspec = str(signature)
             if argspec and argspec != '()':
@@ -1397,9 +1406,12 @@ location listed above.
 
         if inspect.isroutine(object):
             try:
-                signature = inspect.signature(object)
-            except (ValueError, TypeError):
-                signature = None
+                signature = inspect.signature(object, resolve_type_hints=True)
+            except (NameError, AttributeError, SyntaxError, TypeError, ValueError):
+                try:
+                    signature = inspect.signature(object, resolve_type_hints=False)
+                except (ValueError, TypeError):
+                    signature = None
             if signature:
                 argspec = str(signature)
                 if realname == '<lambda>':

--- a/Misc/NEWS.d/next/Documentation/2020-05-03-00-47-47.bpo-39990.Qz_45W.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-05-03-00-47-47.bpo-39990.Qz_45W.rst
@@ -1,0 +1,1 @@
+Add option to resolve annotation strings when creating a inspect.Signature from function/callable.


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-39990](https://bugs.python.org/issue39990) -->
https://bugs.python.org/issue39990
<!-- /issue-number -->
