### PR TITLE
bpo-36310: Allow ``pygettext.py`` to detect calls to ``gettext`` in f-strings.

### DIFF
--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -266,17 +266,17 @@ class Test_pygettext(unittest.TestCase):
         msgids = self.extract_docstrings_from_str(dedent('''\
         f"{_(1)}"
         '''))
-        self.assertNotIn(1)
+        self.assertNotIn(1, msgids)
 
     def test_calls_in_fstring_with_multiple_args(self):
-        msgids = self.extract.docstrings_from_str(dedent('''\
+        msgids = self.extract_docstrings_from_str(dedent('''\
         f"{_('foo', 'bar')}"
         '''))
         self.assertNotIn('foo', msgids)
         self.assertNotIn('bar', msgids)
 
     def test_calls_in_fstring_with_keyword_args(self):
-        msgids = self.extract.docstrings_from_str(dedent('''\
+        msgids = self.extract_docstrings_from_str(dedent('''\
         f"{_('foo', bar='baz')}"
         '''))
         self.assertNotIn('foo', msgids)
@@ -284,7 +284,7 @@ class Test_pygettext(unittest.TestCase):
         self.assertNotIn('baz', msgids)
 
     def test_calls_in_fstring_with_partially_wrong_expression(self):
-        msgids = self.extract.docstrings_from_str(dedent('''\
+        msgids = self.extract_docstrings_from_str(dedent('''\
         f"{_(f'foo') + _('bar')}"
         '''))
         self.assertNotIn('foo', msgids)

--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -248,7 +248,7 @@ class Test_pygettext(unittest.TestCase):
         msgids = self.extract_docstrings_from_str(dedent('''\
         f"{type(str)('foo bar')}"
         '''))
-        self.assertFalse([msgid for msgid in msgids if 'foo bar' in msgid])
+        self.assertNotIn('foo bar', msgids)
 
     def test_calls_in_fstrings_with_format(self):
         msgids = self.extract_docstrings_from_str(dedent('''\

--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -220,6 +220,48 @@ class Test_pygettext(unittest.TestCase):
         '''))
         self.assertIn('doc', msgids)
 
+    def test_calls_in_fstrings(self):
+        msgids = self.extract_docstrings_from_str(dedent('''\
+        f"{_('foo bar')}"
+        '''))
+        self.assertIn('foo bar', msgids)
+
+    def test_calls_in_fstrings_raw(self):
+        msgids = self.extract_docstrings_from_str(dedent('''\
+        rf"{_('foo bar')}"
+        '''))
+        self.assertIn('foo bar', msgids)
+
+    def test_calls_in_fstrings_nested(self):
+        msgids = self.extract_docstrings_from_str(dedent('''\
+        f"""{f'{_("foo bar")}'}"""
+        '''))
+        self.assertIn('foo bar', msgids)
+
+    def test_calls_in_fstrings_attribute(self):
+        msgids = self.extract_docstrings_from_str(dedent('''\
+        f"{obj._('foo bar')}"
+        '''))
+        self.assertIn('foo bar', msgids)
+
+    def test_calls_in_fstrings_with_call_on_call(self):
+        msgids = self.extract_docstrings_from_str(dedent('''\
+        f"{type(str)('foo bar')}"
+        '''))
+        self.assertFalse([msgid for msgid in msgids if 'foo bar' in msgid])
+
+    def test_calls_in_fstrings_with_format(self):
+        msgids = self.extract_docstrings_from_str(dedent('''\
+        f"{_('foo {bar}').format(bar='baz')}"
+        '''))
+        self.assertIn('foo {bar}', msgids)
+
+    def test_calls_in_fstrings_with_wrong_input(self):
+        msgids = self.extract_docstrings_from_str(dedent('''\
+        f"{_(f'foo {bar}')}"
+        '''))
+        self.assertFalse([msgid for msgid in msgids if 'foo {bar}' in msgid])
+
     def test_files_list(self):
         """Make sure the directories are inspected for source files
            bpo-31920

--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -256,11 +256,39 @@ class Test_pygettext(unittest.TestCase):
         '''))
         self.assertIn('foo {bar}', msgids)
 
-    def test_calls_in_fstrings_with_wrong_input(self):
+    def test_calls_in_fstrings_with_wrong_input_1(self):
         msgids = self.extract_docstrings_from_str(dedent('''\
         f"{_(f'foo {bar}')}"
         '''))
         self.assertFalse([msgid for msgid in msgids if 'foo {bar}' in msgid])
+
+    def test_calls_in_fstrings_with_wrong_input_2(self):
+        msgids = self.extract_docstrings_from_str(dedent('''\
+        f"{_(1)}"
+        '''))
+        self.assertNotIn(1)
+
+    def test_calls_in_fstring_with_multiple_args(self):
+        msgids = self.extract.docstrings_from_str(dedent('''\
+        f"{_('foo', 'bar')}"
+        '''))
+        self.assertNotIn('foo', msgids)
+        self.assertNotIn('bar', msgids)
+
+    def test_calls_in_fstring_with_keyword_args(self):
+        msgids = self.extract.docstrings_from_str(dedent('''\
+        f"{_('foo', bar='baz')}"
+        '''))
+        self.assertNotIn('foo', msgids)
+        self.assertNotIn('bar', msgids)
+        self.assertNotIn('baz', msgids)
+
+    def test_calls_in_fstring_with_partially_wrong_expression(self):
+        msgids = self.extract.docstrings_from_str(dedent('''\
+        f"{_(f'foo') + _('bar')}"
+        '''))
+        self.assertNotIn('foo', msgids)
+        self.assertIn('bar', msgids)
 
     def test_files_list(self):
         """Make sure the directories are inspected for source files

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -933,6 +933,7 @@ Ivan Krstić
 Anselm Kruis
 Steven Kryskalla
 Andrew Kuchling
+Jakub Kuczys
 Dave Kuhlman
 Jon Kuhn
 Ilya Kulakov

--- a/Misc/NEWS.d/next/Tools-Demos/2020-05-03-01-30-46.bpo-36310.xDxxwY.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-05-03-01-30-46.bpo-36310.xDxxwY.rst
@@ -1,1 +1,2 @@
-Allow ``pygettext.py`` to detect calls to ``gettext`` in f-strings.
+Allow :file:`Tools/i18n/pygettext.py` to detect calls to ``gettext`` in
+f-strings.

--- a/Misc/NEWS.d/next/Tools-Demos/2020-05-03-01-30-46.bpo-36310.xDxxwY.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2020-05-03-01-30-46.bpo-36310.xDxxwY.rst
@@ -1,0 +1,1 @@
+Allow ``pygettext.py`` to detect calls to ``gettext`` in f-strings.

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -366,9 +366,9 @@ class TokenEater:
                     if len(call.args) != 1:
                         print(_(
                             '*** %(file)s:%(lineno)s: Seen unexpected amount of'
-                            ' positional arguments in gettext call: %(tstring)s'
+                            ' positional arguments in gettext call: %(source_segment)s'
                             ) % {
-                            'tstring': tstring,
+                            'source_segment': ast.get_source_segment(tstring, call) or tstring,
                             'file': self.__curfile,
                             'lineno': lineno
                             }, file=sys.stderr)
@@ -376,9 +376,9 @@ class TokenEater:
                     if call.keywords:
                         print(_(
                             '*** %(file)s:%(lineno)s: Seen unexpected keyword arguments'
-                            ' in gettext call: %(tstring)s'
+                            ' in gettext call: %(source_segment)s'
                             ) % {
-                            'tstring': tstring,
+                            'source_segment': ast.get_source_segment(tstring, call) or tstring,
                             'file': self.__curfile,
                             'lineno': lineno
                             }, file=sys.stderr)
@@ -387,9 +387,9 @@ class TokenEater:
                     if not isinstance(arg, ast.Constant):
                         print(_(
                             '*** %(file)s:%(lineno)s: Seen unexpected argument type'
-                            ' in gettext call: %(tstring)s'
+                            ' in gettext call: %(source_segment)s'
                             ) % {
-                            'tstring': tstring,
+                            'source_segment': ast.get_source_segment(tstring, call) or tstring,
                             'file': self.__curfile,
                             'lineno': lineno
                             }, file=sys.stderr)

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -363,12 +363,36 @@ class TokenEater:
 
                     if func_name not in opts.keywords:
                         continue
-                    if len(call.args) != 1 or call.keywords:
-                        # what warning should I print when this happens?
+                    if len(call.args) != 1:
+                        print(_(
+                            '*** %(file)s:%(lineno)s: Seen unexpected amount of'
+                            ' positional arguments in gettext call: %(tstring)s'
+                            ) % {
+                            'tstring': tstring,
+                            'file': self.__curfile,
+                            'lineno': lineno
+                            }, file=sys.stderr)
+                        continue
+                    if call.keywords:
+                        print(_(
+                            '*** %(file)s:%(lineno)s: Seen unexpected keyword arguments'
+                            ' in gettext call: %(tstring)s'
+                            ) % {
+                            'tstring': tstring,
+                            'file': self.__curfile,
+                            'lineno': lineno
+                            }, file=sys.stderr)
                         continue
                     arg = call.args[0]
                     if not isinstance(arg, ast.Constant):
-                        # what warning should I print when this happens?
+                        print(_(
+                            '*** %(file)s:%(lineno)s: Seen unexpected argument type'
+                            ' in gettext call: %(tstring)s'
+                            ) % {
+                            'tstring': tstring,
+                            'file': self.__curfile,
+                            'lineno': lineno
+                            }, file=sys.stderr)
                         continue
                     if isinstance(arg.value, str):
                         self.__addentry(arg.value, lineno)

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -369,7 +369,7 @@ class TokenEater:
                     arg = call.args[0]
                     if not isinstance(arg, ast.Constant):
                         # what warning should I print when this happens?
-                        break
+                        continue
                     if isinstance(arg.value, str):
                         self.__addentry(arg.value, lineno)
 

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -354,8 +354,13 @@ class TokenEater:
                 for call in filter(lambda node: isinstance(node, ast.Call),
                                    ast.walk(value)):
                     func = call.func
-                    # Name.id or Attribute.attr
-                    func_name = getattr(func, "id", None) or func.attr
+                    if isinstance(func, ast.Name):
+                        func_name = func.id
+                    elif isinstance(func, ast.Attribute):
+                        func_name = func.attr
+                    else:
+                        continue
+
                     if func_name not in opts.keywords:
                         continue
                     if len(call.args) != 1 or call.keywords:


### PR DESCRIPTION
Adds support for `gettext` calls in f-strings. This was implemented using AST to parse the f-string since it seems like the simplest way to do this.

There are two places in which we should probably print a warning (I put a comment in each) but I'm not sure what the warning should be as unlike for regular string cases, there's no specific unexpected token I can print warning about.

<!-- issue-number: [bpo-36310](https://bugs.python.org/issue36310) -->
https://bugs.python.org/issue36310
<!-- /issue-number -->
