### PR TITLE
bpo-29587: Remove the exc_value NULL check in _gen_throw()

### DIFF
--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -332,6 +332,25 @@ class GeneratorThrowTest(unittest.TestCase):
         context = cm.exception.__context__
         self.assertEqual((type(context), context.args), (KeyError, ('a',)))
 
+    def test_throw_after_none_exc_type(self):
+        def g():
+            try:
+                raise KeyError
+            except KeyError:
+                pass
+
+            try:
+                yield
+            except Exception:
+                # This line causes a crash ("Segmentation fault (core dumped)")
+                # on e.g. Fedora 32.
+                raise RuntimeError
+
+        gen = g()
+        gen.send(None)
+        with self.assertRaises(RuntimeError) as cm:
+            gen.throw(ValueError)
+
 
 class YieldFromTests(unittest.TestCase):
     def test_generator_gi_yieldfrom(self):

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -342,8 +342,9 @@ class GeneratorThrowTest(unittest.TestCase):
             try:
                 yield
             except Exception:
-                # This line causes a crash ("Segmentation fault (core dumped)")
-                # on e.g. Fedora 32.
+                # Without the `gi_exc_state.exc_type != Py_None` in
+                # _gen_throw(), this line was causing a crash ("Segmentation
+                # fault (core dumped)") on e.g. Fedora 32.
                 raise RuntimeError
 
         gen = g()

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -512,7 +512,10 @@ throw_here:
     }
 
     PyErr_Restore(typ, val, tb);
-    if (gen->gi_exc_state.exc_type) {
+    /* XXX It seems like we shouldn't have to check not equal to Py_None
+       here because exc_type should only ever be a class.  But not including
+       this check was causing crashes on certain tests e.g. on Fedora. */
+    if (gen->gi_exc_state.exc_type && gen->gi_exc_state.exc_type != Py_None) {
         Py_INCREF(gen->gi_exc_state.exc_type);
         Py_XINCREF(gen->gi_exc_state.exc_value);
         Py_XINCREF(gen->gi_exc_state.exc_traceback);

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -512,11 +512,9 @@ throw_here:
     }
 
     PyErr_Restore(typ, val, tb);
-    /* XXX Should we also handle the case where exc_type is true and
-       exc_value is false? */
-    if (gen->gi_exc_state.exc_type && gen->gi_exc_state.exc_value) {
+    if (gen->gi_exc_state.exc_type) {
         Py_INCREF(gen->gi_exc_state.exc_type);
-        Py_INCREF(gen->gi_exc_state.exc_value);
+        Py_XINCREF(gen->gi_exc_state.exc_value);
         Py_XINCREF(gen->gi_exc_state.exc_traceback);
         _PyErr_ChainExceptions(gen->gi_exc_state.exc_type,
             gen->gi_exc_state.exc_value, gen->gi_exc_state.exc_traceback);


### PR DESCRIPTION
This is another follow-up to PR #19823, removing the check that `exc_value` isn't `NULL` prior to calling `_PyErr_ChainExceptions()`. This makes it so that exception chaining can occur in more cases.

<!-- issue-number: [bpo-29587](https://bugs.python.org/issue29587) -->
https://bugs.python.org/issue29587
<!-- /issue-number -->
