### PR TITLE
Simplify set entry insertion logic.

### DIFF
--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -190,7 +190,7 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
             for (j = 0 ; j < LINEAR_PROBES ; j++) {
                 entry++;
                 if (entry->hash == 0 && entry->key == NULL)
-                    goto found_unused_;
+                    goto found_unused;
                 if (entry->hash == hash) {
                     PyObject *startkey = entry->key;
                     assert(startkey != dummy);
@@ -220,7 +220,7 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
 
         entry = &so->table[i];
         if (entry->key == NULL)
-            goto found_unused_;
+            goto found_unused;
     }
 
   found_unused:

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -137,7 +137,6 @@ static int
 set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
 {
     setentry *table;
-    setentry *freeslot;
     setentry *entry;
     size_t perturb;
     size_t mask;
@@ -158,7 +157,6 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
     if (entry->key == NULL)
         goto found_unused;
 
-    freeslot = NULL;
     perturb = hash;
 
     while (1) {
@@ -187,14 +185,12 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
                 goto restart;
             mask = so->mask;                 /* help avoid a register spill */
         }
-        else if (entry->hash == -1)
-            freeslot = entry;
 
         if (i + LINEAR_PROBES <= mask) {
             for (j = 0 ; j < LINEAR_PROBES ; j++) {
                 entry++;
                 if (entry->hash == 0 && entry->key == NULL)
-                    goto found_unused_or_dummy;
+                    goto found_unused_;
                 if (entry->hash == hash) {
                     PyObject *startkey = entry->key;
                     assert(startkey != dummy);
@@ -216,8 +212,6 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
                         goto restart;
                     mask = so->mask;
                 }
-                else if (entry->hash == -1)
-                    freeslot = entry;
             }
         }
 
@@ -226,16 +220,8 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
 
         entry = &so->table[i];
         if (entry->key == NULL)
-            goto found_unused_or_dummy;
+            goto found_unused_;
     }
-
-  found_unused_or_dummy:
-    if (freeslot == NULL)
-        goto found_unused;
-    so->used++;
-    freeslot->key = key;
-    freeslot->hash = hash;
-    return 0;
 
   found_unused:
     so->fill++;


### PR DESCRIPTION
[Dictionaries no longer reuse dummy entries](https://github.com/python/cpython/blob/master/Objects/dictobject.c#L758).  Instead, dummies accumulate until cleared by resizes.  That is a good strategy because it tightens the inner search loop and it makes the code cleaner.  Here, we do the same thing for sets.