### PR TITLE
bpo-40334: Set error_indicator in _PyPegen_raise_error

### DIFF
--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -389,6 +389,7 @@ _PyPegen_raise_error(Parser *p, PyObject *errtype, int with_col_number, const ch
     Token *t = p->tokens[p->fill - 1];
     Py_ssize_t col_number = !with_col_number;
     va_list va;
+    p->error_indicator = 1;
 
     va_start(va, errmsg);
     errstr = PyUnicode_FromFormatV(errmsg, va);


### PR DESCRIPTION
Due to PyErr_Occurred not being called at the beginning of each rule
(too expensive), we need to set the error indicator, so that
rules do not get expanded, after an exception has been thrown.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
