### PR TITLE
bpo-40454: asyncio.run() no longer overrides asyncio debug mode

### DIFF
--- a/Lib/asyncio/runners.py
+++ b/Lib/asyncio/runners.py
@@ -5,7 +5,10 @@ from . import events
 from . import tasks
 
 
-def run(main, *, debug=False):
+_marker = object()
+
+
+def run(main, *, debug=_marker):
     """Execute the coroutine and return the result.
 
     This function runs the passed coroutine, taking care of
@@ -39,7 +42,8 @@ def run(main, *, debug=False):
     loop = events.new_event_loop()
     try:
         events.set_event_loop(loop)
-        loop.set_debug(debug or coroutines._DEBUG)
+        if debug is not _marker:
+            loop.set_debug(debug)
         return loop.run_until_complete(main)
     finally:
         try:

--- a/Lib/asyncio/runners.py
+++ b/Lib/asyncio/runners.py
@@ -39,7 +39,7 @@ def run(main, *, debug=False):
     loop = events.new_event_loop()
     try:
         events.set_event_loop(loop)
-        loop.set_debug(debug)
+        loop.set_debug(debug or coroutines._DEBUG)
         return loop.run_until_complete(main)
     finally:
         try:

--- a/Misc/NEWS.d/next/Library/2020-05-03-23-38-59.bpo-40454.NMfPYZ.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-03-23-38-59.bpo-40454.NMfPYZ.rst
@@ -1,0 +1,2 @@
+The :func:`asyncio.run` function no longer overrides :mod:`asyncio` debug
+mode.


### PR DESCRIPTION


<!-- issue-number: [bpo-40454](https://bugs.python.org/issue40454) -->
https://bugs.python.org/issue40454
<!-- /issue-number -->
