### PR TITLE
bpo-40360: Add a What's new entry for lib2to3 pending deprecation

### DIFF
--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -608,6 +608,16 @@ Deprecated
 * Passing ``None`` as the first argument to the :func:`shlex.split` function
   has been deprecated.  (Contributed by Zackery Spytz in :issue:`33262`.)
 
+* The :mod:`lib2to3` module now emits a :exc:`PendingDeprecationWarning`.
+  Python 3.9 switched to a PEG parser (see :pep:`617`), and Python 3.10 may
+  include new language syntax that is not parsable by lib2to3's LL(1) parser.
+  The ``lib2to3`` module may be removed from the standard library in a future
+  Python version. Consider third-party alternatives such as `LibCST`_ or
+  `parso`_.
+  (Contributed by Carl Meyer in :issue:`40360`.)
+
+.. _LibCST: https://libcst.readthedocs.io/
+.. _parso: https://parso.readthedocs.io/
 
 Removed
 =======


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

(I don't think what's new entries deserve their own changelog entries, hence not adding it.)

<!-- issue-number: [bpo-40360](https://bugs.python.org/issue40360) -->
https://bugs.python.org/issue40360
<!-- /issue-number -->
