### PR TITLE
bpo-40499: Mention that asyncio.wait() needs a non-empty aws set

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -498,6 +498,8 @@ Waiting Primitives
    set concurrently and block until the condition specified
    by *return_when*.
 
+   The *aws* set must not be empty.
+
    Returns two sets of Tasks/Futures: ``(done, pending)``.
 
    Usage::

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1443,6 +1443,7 @@ Mike Romberg
 Armin Ronacher
 Case Roole
 Timothy Roscoe
+Joel Rosdahl
 Erik Rose
 Mark Roseman
 Josh Rosenberg

--- a/Misc/NEWS.d/next/Documentation/2020-05-04-14-20-02.bpo-40499.tjLSo8.rst
+++ b/Misc/NEWS.d/next/Documentation/2020-05-04-14-20-02.bpo-40499.tjLSo8.rst
@@ -1,0 +1,1 @@
+Mention that :func:`asyncio.wait` requires a non-empty set of awaitables.


### PR DESCRIPTION
A similar formulation was added in [bpo-21596](https://bugs.python.org/issue21596)
(db74d982d43d98040e38665d843cbc8de4a082b1) but was lost in [bpo-33649](https://bugs.python.org/issue33649)
(3faaa8857a42a36383bb18425444e597fc876797).

<!-- issue-number: [bpo-40499](https://bugs.python.org/issue40499) -->
https://bugs.python.org/issue40499
<!-- /issue-number -->
