### PR TITLE
bpo-40025:The behavior is the same when `_generate_next_value_` is defined afte…

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -273,10 +273,6 @@ overridden::
     the next :class:`int` in sequence with the last :class:`int` provided, but
     the way it does this is an implementation detail and may change.
 
-.. note::
-
-    The :meth:`_generate_next_value_` method must be defined before any members.
-
 Iteration
 ---------
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1,5 +1,4 @@
 import sys
-import operator
 from types import MappingProxyType, DynamicClassAttribute
 
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -79,12 +79,12 @@ class _EnumDict(dict):
                 raise ValueError('_names_ are reserved for future Enum use')
             if key == '_generate_next_value_':
                 setattr(self, '_generate_next_value', value)
-                if value.__qualname__ != 'Enum._generate_next_value':
+                if value is not getattr(Enum, '_generate_next_value_', None):
                     # subclass define _generate_next_value_, recalculate auto()
                     self._subclass_define_generate_next_value = True
                     for i, origin_value in self._maybe_recalculate_auto_obj.items():
                         name, _value = self._member_names[i], self._last_values[i]
-                        if _value == origin_value.value:
+                        if _value is origin_value.value:
                             origin_value.value = self._generate_next_value(name, 1, len(self._member_names[:i]),
                                                                            self._last_values[:i])
                         super().__setitem__(name, origin_value.value)

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -110,7 +110,6 @@ class _EnumDict(dict):
                 # enum overwriting a descriptor?
                 raise TypeError('%r already defined as: %r' % (key, self[key]))
             if isinstance(value, auto):
-                # if self._subclass_define_generate_next_value:
                 self._maybe_recalculate_auto_obj[len(self._member_names)] = value
                 if value.value == _auto_null:
                     value.value = self._generate_next_value(key, 1, len(self._member_names), self._last_values[:])

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -78,9 +78,6 @@ class _EnumDict(dict):
                     ):
                 raise ValueError('_names_ are reserved for future Enum use')
             if key == '_generate_next_value_':
-                # check if members already defined as auto()
-                if self._auto_called:
-                    raise TypeError("_generate_next_value_ must be defined before members")
                 setattr(self, '_generate_next_value', value)
             elif key == '_ignore_':
                 if isinstance(value, str):
@@ -104,10 +101,12 @@ class _EnumDict(dict):
                 # enum overwriting a descriptor?
                 raise TypeError('%r already defined as: %r' % (key, self[key]))
             if isinstance(value, auto):
-                self._auto_called = True
-                if value.value == _auto_null:
-                    value.value = self._generate_next_value(key, 1, len(self._member_names), self._last_values[:])
-                value = value.value
+                _value = value.value
+                if _value == _auto_null and self._auto_called:
+                    _value = self._generate_next_value(key, 1, len(self._member_names), self._last_values[:])
+                else:
+                    _value = value
+                value = _value
             self._member_names.append(key)
             self._last_values.append(value)
         super().__setitem__(key, value)
@@ -148,6 +147,14 @@ class EnumMeta(type):
 
         # save enum items into separate mapping so they don't get baked into
         # the new class
+        for i,name in enumerate(classdict._member_names):
+            value = classdict[name]
+            if isinstance(value, auto):
+                if value.value == _auto_null:
+                    value.value = classdict._generate_next_value(name, 1, len(classdict._member_names[:i]), classdict._last_values[:i])
+                super(type(classdict), classdict).__setitem__(name, value.value)
+                classdict._last_values[i] = value.value
+        super(type(classdict), classdict).__setitem__('_auto_called', True)
         enum_members = {k: classdict[k] for k in classdict._member_names}
         for name in classdict._member_names:
             del classdict[name]

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -47,72 +47,6 @@ class auto:
     Instances are replaced with an appropriate value in Enum class suites.
     """
     value = _auto_null
-    operate = op1 = op2 = _auto_null
-
-    def _create_operate(self, operate, op1, op2):
-        ret = auto()
-        ret.operate = operate
-        ret.op1 = op1
-        ret.op2 = op2
-        return ret
-
-    def __add__(self, other):
-        return self._create_operate(operator.add, self, other)
-
-    def __sub__(self, other):
-        return self._create_operate(operator.sub, self, other)
-
-    def __mul__(self, other):
-        return self._create_operate(operator.mul, self, other)
-
-    def __truediv__(self, other):
-        return self._create_operate(operator.truediv, self, other)
-
-    def __floordiv__(self, other):
-        return self._create_operate(operator.floordiv, self, other)
-
-    def __neg__(self):
-        return self._create_operate(operator.neg, self, _auto_null)
-
-    def __and__(self, other):
-        return self._create_operate(operator.and_, self, other)
-
-    def __or__(self, other):
-        return self._create_operate(operator.or_, self, other)
-
-    def __xor__(self, other):
-        return self._create_operate(operator.xor, self, other)
-
-    def __invert__(self):
-        return self._create_operate(operator.invert, self, _auto_null)
-
-    def __lshift__(self, other):
-        return self._create_operate(operator.lshift, self, other)
-
-    def __rshift__(self, other):
-        return self._create_operate(operator.rshift, self, other)
-
-    def __call__(self, generate_next_value, name, start, count, last_values):
-        if self.value is _auto_null:
-            if self.operate is _auto_null:
-                self.value = generate_next_value(name, start, count, last_values)
-            else:
-                op1, op2 = self.op1, self.op2
-                if isinstance(op1, auto):
-                    if op1.value is _auto_null:
-                        op1(generate_next_value, name, start, count, last_values)
-                    op1 = op1.value
-                if isinstance(op2, auto):
-                    if op2.value is _auto_null:
-                        op2(generate_next_value, name, start, count, last_values)
-                    op2 = op2.value
-                if op2 is not _auto_null:
-                    self.value = self.operate(op1, op2)
-                else:
-                    self.value = self.operate(op1)
-                self.operate = self.op1 = self.op2 = None
-
-        return self.value
 
 
 class _EnumDict(dict):
@@ -127,6 +61,7 @@ class _EnumDict(dict):
         self._member_names = []
         self._last_values = []
         self._ignore = []
+        self._subclass_define_generate_next_value = False
 
     def __setitem__(self, key, value):
         """Changes anything not dundered or not a descriptor.
@@ -145,6 +80,8 @@ class _EnumDict(dict):
                 raise ValueError('_names_ are reserved for future Enum use')
             if key == '_generate_next_value_':
                 setattr(self, '_generate_next_value', value)
+                if value is not getattr(Enum, '_generate_next_value_', None):
+                    self._subclass_define_generate_next_value = True
             elif key == '_ignore_':
                 if isinstance(value, str):
                     value = value.replace(',',' ').split()
@@ -166,6 +103,10 @@ class _EnumDict(dict):
             if key in self:
                 # enum overwriting a descriptor?
                 raise TypeError('%r already defined as: %r' % (key, self[key]))
+            if isinstance(value, auto):
+                if value.value is _auto_null and self._subclass_define_generate_next_value:
+                    value.value = self._generate_next_value(key, 1, len(self._member_names), self._last_values[:])
+                    value = value.value
             self._member_names.append(key)
             self._last_values.append(value)
         super().__setitem__(key, value)
@@ -209,8 +150,8 @@ class EnumMeta(type):
             _value = classdict._last_values[i]
             if isinstance(_value, auto):
                 if _value.value is _auto_null:
-                    _value(classdict._generate_next_value, name, 1, i, classdict._last_values[:i])
-                classdict._last_values[i] = _value.value
+                    _value.value = classdict._generate_next_value(name, 1, i, classdict._last_values[:i])
+                    classdict._last_values[i] = _value.value
                 super(type(classdict), classdict).__setitem__(name, _value.value)
 
         # save enum items into separate mapping so they don't get baked into

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1765,63 +1765,21 @@ class TestEnum(unittest.TestCase):
             B = auto()
 
         class G(Enum):
-            first = auto()
             def _generate_next_value_(name, *args):
                 return 12
+            first = auto()
             second = first + 9
 
-        class H(Enum):
-            first = auto()
-            second = first + 9
-            def _generate_next_value_(name, *args):
-                return 12
+        with self.assertRaises(TypeError):
+            class H(Enum):
+                first = auto()
+                def _generate_next_value_(name, *args):
+                    return 12
+                second = first + 9
 
         self.assertEqual(E.B.value, F.B.value)
-        self.assertEqual(G.first.value, 12)
         self.assertEqual(G.second.value, 21)
-        self.assertEqual(H.first.value, 12)
-        self.assertEqual(H.second.value, 21)
 
-    def test_operate_auto_with_generate_next_value(self):
-        class E(Enum):
-            first = auto()
-            second = first + 3 - 1
-            third = auto() * (first + second + auto())
-            fourth = third / 5
-            fifth = third // 6
-            sixth = -auto()
-        self.assertEqual(E.first.value, 1)
-        self.assertEqual(E.second.value, 3)
-        self.assertEqual(E.third.value, 4 * (1 + 3 + 4))
-        self.assertEqual(E.fourth.value, 6.4)
-        self.assertEqual(E.fifth.value, 5)
-        self.assertEqual(E.sixth.value, -6)
-
-        class F(Enum):
-            first = auto()
-            second = first + 3 - 1
-            third = auto() * (first + second + auto())
-            fourth = third / 5
-            fifth = third // 6
-            sixth = -auto()
-            def _generate_next_value_(name, *args):
-                return 12
-        self.assertEqual(F.first.value, 12)
-        self.assertEqual(F.second.value, 14)
-        self.assertEqual(F.third.value, 12 * (12 + 14 + 12))
-        self.assertEqual(F.fourth.value, 91.2)
-        self.assertEqual(F.fifth.value, 76)
-        self.assertEqual(F.sixth.value, -12)
-
-        class Color(Flag):
-            BLACK = 0
-            RED = auto()
-            GREEN = auto()
-            BLUE = auto()
-            PURPLE = RED|BLUE
-            YELLOW = RED<<19
-        self.assertEqual(Color.PURPLE.value, 5)
-        self.assertEqual(Color.YELLOW.value, 1<<19)
 
     def test_duplicate_auto(self):
         class Dupes(Enum):
@@ -2343,16 +2301,6 @@ class TestFlag(unittest.TestCase):
             first = primero = auto()
             second = auto()
             third = auto()
-        self.assertEqual([Dupes.first, Dupes.second, Dupes.third], list(Dupes))
-
-    def test_duplicate_auto_generate_next_value(self):
-        class Dupes(Enum):
-            first = primero = auto()
-            second = auto()
-            def _generate_next_value_(name, *args):
-                return name
-            third = primero2 = auto()
-
         self.assertEqual([Dupes.first, Dupes.second, Dupes.third], list(Dupes))
 
     def test_bizarre(self):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1770,10 +1770,58 @@ class TestEnum(unittest.TestCase):
                 return 12
             second = first + 9
 
+        class H(Enum):
+            first = auto()
+            second = first + 9
+            def _generate_next_value_(name, *args):
+                return 12
+
         self.assertEqual(E.B.value, F.B.value)
         self.assertEqual(G.first.value, 12)
         self.assertEqual(G.second.value, 21)
+        self.assertEqual(H.first.value, 12)
+        self.assertEqual(H.second.value, 21)
 
+    def test_operate_auto_with_generate_next_value(self):
+        class E(Enum):
+            first = auto()
+            second = first + 3 - 1
+            third = auto() * (first + second + auto())
+            fourth = third / 5
+            fifth = third // 6
+            sixth = -auto()
+        self.assertEqual(E.first.value, 1)
+        self.assertEqual(E.second.value, 3)
+        self.assertEqual(E.third.value, 4 * (1 + 3 + 4))
+        self.assertEqual(E.fourth.value, 6.4)
+        self.assertEqual(E.fifth.value, 5)
+        self.assertEqual(E.sixth.value, -6)
+
+        class F(Enum):
+            first = auto()
+            second = first + 3 - 1
+            third = auto() * (first + second + auto())
+            fourth = third / 5
+            fifth = third // 6
+            sixth = -auto()
+            def _generate_next_value_(name, *args):
+                return 12
+        self.assertEqual(F.first.value, 12)
+        self.assertEqual(F.second.value, 14)
+        self.assertEqual(F.third.value, 12 * (12 + 14 + 12))
+        self.assertEqual(F.fourth.value, 91.2)
+        self.assertEqual(F.fifth.value, 76)
+        self.assertEqual(F.sixth.value, -12)
+
+        class Color(Flag):
+            BLACK = 0
+            RED = auto()
+            GREEN = auto()
+            BLUE = auto()
+            PURPLE = RED|BLUE
+            YELLOW = RED<<19
+        self.assertEqual(Color.PURPLE.value, 5)
+        self.assertEqual(Color.YELLOW.value, 1<<19)
 
     def test_duplicate_auto(self):
         class Dupes(Enum):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1764,7 +1764,15 @@ class TestEnum(unittest.TestCase):
             A = auto()
             B = auto()
 
+        class G(Enum):
+            first = auto()
+            def _generate_next_value_(name, *args):
+                return 12
+            second = first + 9
+
         self.assertEqual(E.B.value, F.B.value)
+        self.assertEqual(G.first.value, 12)
+        self.assertEqual(G.second.value, 21)
 
 
     def test_duplicate_auto(self):
@@ -2287,6 +2295,16 @@ class TestFlag(unittest.TestCase):
             first = primero = auto()
             second = auto()
             third = auto()
+        self.assertEqual([Dupes.first, Dupes.second, Dupes.third], list(Dupes))
+
+    def test_duplicate_auto_generate_next_value(self):
+        class Dupes(Enum):
+            first = primero = auto()
+            second = auto()
+            def _generate_next_value_(name, *args):
+                return name
+            third = primero2 = auto()
+
         self.assertEqual([Dupes.first, Dupes.second, Dupes.third], list(Dupes))
 
     def test_bizarre(self):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1751,14 +1751,20 @@ class TestEnum(unittest.TestCase):
         self.assertEqual(Color.blue.value, 2)
         self.assertEqual(Color.green.value, 3)
 
-    def test_auto_order(self):
-        with self.assertRaises(TypeError):
-            class Color(Enum):
-                red = auto()
-                green = auto()
-                blue = auto()
-                def _generate_next_value_(name, start, count, last):
-                    return name
+    def test_auto_generate_next_value(self):
+        class E(Enum):
+            A = auto()
+            B = auto()
+            def _generate_next_value_(name, *args):
+                return name
+
+        class F(Enum):
+            def _generate_next_value_(name, *args):
+                return name
+            A = auto()
+            B = auto()
+
+        self.assertEqual(E.B.value, F.B.value)
 
 
     def test_duplicate_auto(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -732,6 +732,7 @@ Thomas Holmes
 Craig Holmquist
 Philip Homburg
 Naofumi Honda
+Weipeng Hong
 Jeffrey Honig
 Rob Hooft
 Michiel de Hoon

--- a/Misc/NEWS.d/next/Library/2020-05-05-00-29-29.bpo-40025.Divf9C.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-05-00-29-29.bpo-40025.Divf9C.rst
@@ -1,0 +1,2 @@
+The behavior is the same when `_generate_next_value_` is defined after or
+before members. Patch by Weipeng Hong.


### PR DESCRIPTION
…r or before members

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40025](https://bugs.python.org/issue40025) -->
https://bugs.python.org/issue40025
<!-- /issue-number -->
