### PR TITLE
bpo-13097: fix segfault in ctypes callback invocation

### DIFF
--- a/Lib/ctypes/test/test_callbacks.py
+++ b/Lib/ctypes/test/test_callbacks.py
@@ -292,12 +292,12 @@ class SampleCallbacksTestCase(unittest.TestCase):
             return len(args)
 
         CTYPES_MAX_ARGCOUNT = 1024
-        proto = CFUNCTYPE(None, *(c_int,) * nargs)
+        proto = CFUNCTYPE(c_int, *(c_int,) * CTYPES_MAX_ARGCOUNT)
         cb = proto(func)
-        args1 = (None,) * CTYPES_MAX_ARGCOUNT
+        args1 = (1,) * CTYPES_MAX_ARGCOUNT
         self.assertEqual(cb(*args1), CTYPES_MAX_ARGCOUNT)
         
-        args2 = (None,) * (CTYPES_MAX_ARGCOUNT + 1)
+        args2 = (1,) * (CTYPES_MAX_ARGCOUNT + 1)
         with self.assertRaises(ArgumentError):
             cb(*args2)
 

--- a/Lib/ctypes/test/test_callbacks.py
+++ b/Lib/ctypes/test/test_callbacks.py
@@ -289,13 +289,17 @@ class SampleCallbacksTestCase(unittest.TestCase):
 
     def test_callback_too_many_args(self):
         def func(*args):
-            return (1, "abc", None)
+            return len(args)
 
-        nargs = 2 ** 20
+        CTYPES_MAX_ARGCOUNT = 1024
         proto = CFUNCTYPE(None, *(c_int,) * nargs)
         cb = proto(func)
+        args1 = (None,) * CTYPES_MAX_ARGCOUNT
+        self.assertEqual(cb(*args1), CTYPES_MAX_ARGCOUNT)
+        
+        args2 = (None,) * (CTYPES_MAX_ARGCOUNT + 1)
         with self.assertRaises(ArgumentError):
-            cb(*(1,) * nargs)
+            cb(*args2)
 
 
 ################################################################

--- a/Lib/ctypes/test/test_callbacks.py
+++ b/Lib/ctypes/test/test_callbacks.py
@@ -296,7 +296,7 @@ class SampleCallbacksTestCase(unittest.TestCase):
         cb = proto(func)
         args1 = (1,) * CTYPES_MAX_ARGCOUNT
         self.assertEqual(cb(*args1), CTYPES_MAX_ARGCOUNT)
-        
+
         args2 = (1,) * (CTYPES_MAX_ARGCOUNT + 1)
         with self.assertRaises(ArgumentError):
             cb(*args2)

--- a/Lib/ctypes/test/test_callbacks.py
+++ b/Lib/ctypes/test/test_callbacks.py
@@ -287,6 +287,17 @@ class SampleCallbacksTestCase(unittest.TestCase):
         self.assertEqual(s.second, check.second)
         self.assertEqual(s.third, check.third)
 
+    def test_callback_too_many_args(self):
+        def func(*args):
+            return (1, "abc", None)
+
+        nargs = 2 ** 20
+        proto = CFUNCTYPE(None, *(c_int,) * nargs)
+        cb = proto(func)
+        with self.assertRaises(ArgumentError):
+            cb(*(1,) * nargs)
+
+
 ################################################################
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2020-05-06-02-01-25.bpo-13097.Wh5xSK.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-06-02-01-25.bpo-13097.Wh5xSK.rst
@@ -1,0 +1,1 @@
+``ctypes`` now raises an ``ArgumentError`` when a callback is invoked with more than 1024 arguments.

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1114,7 +1114,8 @@ PyObject *_ctypes_callproc(PPROC pProc,
 
     if (argcount > CTYPES_MAX_ARGCOUNT)
     {
-        PyErr_SetString(PyExc_ArgError, "too many arguments");
+        PyErr_Format(PyExc_ArgError, "too many arguments (%zi), maximum is %i",
+                     argcount, CTYPES_MAX_ARGCOUNT);
         return NULL;
     }
 

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1073,6 +1073,11 @@ GetComError(HRESULT errcode, GUID *riid, IUnknown *pIunk)
 #endif
 
 /*
+ * Max number of arguments _ctypes_callproc will accept.
+ */
+#define CTYPES_MAX_ARGCOUNT 1024
+
+/*
  * Requirements, must be ensured by the caller:
  * - argtuple is tuple of arguments
  * - argtypes is either NULL, or a tuple of the same size as argtuple
@@ -1106,6 +1111,12 @@ PyObject *_ctypes_callproc(PPROC pProc,
     if (pIunk)
         ++argcount;
 #endif
+
+    if (argcount > CTYPES_MAX_ARGCOUNT)
+    {
+        PyErr_SetString(PyExc_ArgError, "too many arguments");
+        return NULL;
+    }
 
     args = (struct argument *)alloca(sizeof(struct argument) * argcount);
     if (!args) {

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1073,7 +1073,10 @@ GetComError(HRESULT errcode, GUID *riid, IUnknown *pIunk)
 #endif
 
 /*
- * Max number of arguments _ctypes_callproc will accept.
+ * bpo-13097: Max number of arguments _ctypes_callproc will accept.
+ *
+ * This limit is enforced for the `alloca()` call in `_ctypes_callproc`,
+ * to avoid allocating a massive buffer on the stack.
  */
 #define CTYPES_MAX_ARGCOUNT 1024
 


### PR DESCRIPTION
The ctypes module allocates arguments on the stack in
`ctypes_callproc` using alloca, which is problematic
when large numbers of parameters are passed. Instead
of crashing, this commit raises an ArgumentError if
more than 1024 parameters are passed.


<!-- issue-number: [bpo-13097](https://bugs.python.org/issue13097) -->
https://bugs.python.org/issue13097
<!-- /issue-number -->
