### PR TITLE
gh-84530: Introduce a new type for namespace packages

### DIFF
--- a/Lib/modulefinder.py
+++ b/Lib/modulefinder.py
@@ -73,9 +73,11 @@ def _find_module(name, path=None):
     if spec.loader is importlib.machinery.FrozenImporter:
         return None, None, ("", "", _PY_FROZEN)
 
-    if spec.loader is None:
-        # A namespace package has no loader
-        return None, None, ("", "", _NSP_DIRECTORY)
+    if spec.loader is None and spec.submodule_search_locations:
+        return (
+            None, os.path.dirname(str(spec.submodule_search_locations)),
+            ("", "", _NSP_DIRECTORY)
+        )
 
     file_path = spec.origin
 

--- a/Lib/modulefinder.py
+++ b/Lib/modulefinder.py
@@ -25,6 +25,7 @@ _C_EXTENSION = 3
 _PKG_DIRECTORY = 5
 _C_BUILTIN = 6
 _PY_FROZEN = 7
+_NSP_DIRECTORY = 8
 
 # Modulefinder does a good job at simulating Python's, but it can not
 # handle __path__ modifications packages make at runtime.  Therefore there
@@ -71,6 +72,10 @@ def _find_module(name, path=None):
 
     if spec.loader is importlib.machinery.FrozenImporter:
         return None, None, ("", "", _PY_FROZEN)
+
+    if spec.loader is None:
+        # A namespace package has no loader
+        return None, None, ("", "", _NSP_DIRECTORY)
 
     file_path = spec.origin
 

--- a/Lib/test/test_modulefinder.py
+++ b/Lib/test/test_modulefinder.py
@@ -79,6 +79,18 @@ a/c.py
                                 from sys import version_info
 """]
 
+namespace_pkg_test = [
+    "a.module",
+    ["a", "a.module", "b"],
+    [], [],
+    """\
+a/__init__.py
+a/module.py
+                                from b import c
+b/c.py
+                                import sys
+"""]
+
 absolute_import_test = [
     "a.module",
     ["a", "a.module",
@@ -351,6 +363,9 @@ class ModuleFinderTest(unittest.TestCase):
 
     def test_package(self):
         self._do_test(package_test)
+
+    def test_namespace_pkg(self):
+        self._do_test(namespace_pkg_test)
 
     def test_maybe(self):
         self._do_test(maybe_test)

--- a/Misc/NEWS.d/next/Library/2020-07-11-09-57-55.bpo-40350.vg5vTq.rst
+++ b/Misc/NEWS.d/next/Library/2020-07-11-09-57-55.bpo-40350.vg5vTq.rst
@@ -1,0 +1,1 @@
+Add a new constant `_NSP_DIRECTORY` to help `modulefinder.py` distinguish namespace packages.


### PR DESCRIPTION
This PR fixes `modulefinder.py`'s module-loader to handle namespace packages differently than regular packages, and in doing so introduces a separate type for namespace packages.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40350](https://bugs.python.org/issue40350) -->
https://bugs.python.org/issue40350
<!-- /issue-number -->


<!-- gh-issue-number: gh-84530 -->
* Issue: gh-84530
<!-- /gh-issue-number -->
