### PR TITLE
bpo-40509: Enable REMAINDER argparse arguments to be used in mutually exclusive …

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1516,7 +1516,7 @@ class _ActionsContainer(object):
 
         # mark positional arguments as required if at least one is
         # always required
-        if kwargs.get('nargs') not in [OPTIONAL, ZERO_OR_MORE]:
+        if kwargs.get('nargs') not in [OPTIONAL, ZERO_OR_MORE, REMAINDER]:
             kwargs['required'] = True
         if kwargs.get('nargs') == ZERO_OR_MORE and 'default' not in kwargs:
             kwargs['required'] = True
@@ -1915,6 +1915,10 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             # error if this argument is not allowed with other previously
             # seen arguments, assuming that actions that use the default
             # value don't really count as "present"
+            if action.nargs in [REMAINDER]:
+                if argument_values == []:
+                    action.default = argument_values
+
             if argument_values is not action.default:
                 seen_non_default_actions.add(action)
                 for conflict_action in action_conflicts.get(action, []):

--- a/Misc/NEWS.d/next/Library/2020-05-06-14-31-07.bpo-40509.PgYRgH.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-06-14-31-07.bpo-40509.PgYRgH.rst
@@ -1,0 +1,1 @@
+Allow REMAINDER positional arguments in argparse mutually exclusive groups.


### PR DESCRIPTION



<!-- issue-number: [bpo-40509](https://bugs.python.org/issue40509) -->
https://bugs.python.org/issue40509
<!-- /issue-number -->
