### PR TITLE
bpo-36543: Restore cElementTree and mark it for removal in 3.10

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -17,6 +17,8 @@ for parsing and creating XML data.
    This module will use a fast implementation whenever available.
    The :mod:`xml.etree.cElementTree` module is deprecated.
 
+.. versionchanged:: 3.9
+   The :mod:`xml.etree.cElementTree` will be removed in Python 3.10.
 
 .. warning::
 

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -626,6 +626,10 @@ Deprecated
   `parso`_.
   (Contributed by Carl Meyer in :issue:`40360`.)
 
+* The :mod:`xml.etree.cElementTree` module has been deprecated since Python
+  3.3 and is scheduled to be removed in Python 3.10.
+  (Contributed by Serhiy Storchaka and Christian Heimes in :issue:`36543`)
+
 .. _LibCST: https://libcst.readthedocs.io/
 .. _parso: https://parso.readthedocs.io/
 

--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -8,6 +8,9 @@ import unittest
 
 cET = import_fresh_module('xml.etree.ElementTree',
                           fresh=['_elementtree'])
+cET_alias = import_fresh_module('xml.etree.cElementTree',
+                                fresh=['_elementtree', 'xml.etree'],
+                                deprecated=True)
 
 
 @unittest.skipUnless(cET, 'requires _elementtree')
@@ -168,12 +171,23 @@ class MiscTests(unittest.TestCase):
 
 
 @unittest.skipUnless(cET, 'requires _elementtree')
+class TestAliasWorking(unittest.TestCase):
+    # Test that the cET alias module is alive
+    def test_alias_working(self):
+        e = cET_alias.Element('foo')
+        self.assertEqual(e.tag, 'foo')
+
+
+@unittest.skipUnless(cET, 'requires _elementtree')
 @support.cpython_only
 class TestAcceleratorImported(unittest.TestCase):
     # Test that the C accelerator was imported, as expected
     def test_correct_import_cET(self):
         # SubElement is a function so it retains _elementtree as its module.
         self.assertEqual(cET.SubElement.__module__, '_elementtree')
+
+    def test_correct_import_cET_alias(self):
+        self.assertEqual(cET_alias.SubElement.__module__, '_elementtree')
 
     def test_parser_comes_from_C(self):
         # The type of methods defined in Python code is types.FunctionType,
@@ -214,6 +228,7 @@ def test_main():
     # Run the tests specific to the C implementation
     support.run_unittest(
         MiscTests,
+        TestAliasWorking,
         TestAcceleratorImported,
         SizeofTest,
         )

--- a/Lib/xml/etree/cElementTree.py
+++ b/Lib/xml/etree/cElementTree.py
@@ -1,0 +1,3 @@
+# Deprecated alias for xml.etree.ElementTree
+
+from xml.etree.ElementTree import *

--- a/Lib/xml/etree/cElementTree.py
+++ b/Lib/xml/etree/cElementTree.py
@@ -1,3 +1,12 @@
 # Deprecated alias for xml.etree.ElementTree
 
 from xml.etree.ElementTree import *
+
+from warnings import warn as _warn
+
+_warn(
+    "xml.etree.cElementTree is deprecated, use xml.etree.ElementTree instead",
+    PendingDeprecationWarning
+)
+
+del _warn

--- a/Misc/NEWS.d/next/Library/2020-05-05-13-51-07.bpo-36543.4j7Rn3.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-05-13-51-07.bpo-36543.4j7Rn3.rst
@@ -1,0 +1,2 @@
+Re-add :mod:`xml.etree.cElementTree`, deprecate it in 3.9, and schedule it
+for removal in 3.10.


### PR DESCRIPTION
* Restore ``xml.etree.cElementTree``
* Schedule the module for removal in 3.10
* Add a ``PendingDeprecationWarning``

<!-- issue-number: [bpo-36543](https://bugs.python.org/issue36543) -->
https://bugs.python.org/issue36543
<!-- /issue-number -->
