### PR TITLE
bpo-40520: Remove redundant comment in pydebug.h

### DIFF
--- a/Include/pydebug.h
+++ b/Include/pydebug.h
@@ -5,8 +5,6 @@
 extern "C" {
 #endif
 
-/* These global variable are defined in pylifecycle.c */
-/* XXX (ncoghlan): move these declarations to pylifecycle.h? */
 PyAPI_DATA(int) Py_DebugFlag;
 PyAPI_DATA(int) Py_VerboseFlag;
 PyAPI_DATA(int) Py_QuietFlag;


### PR DESCRIPTION


<!-- issue-number: [bpo-40520](https://bugs.python.org/issue40520) -->
https://bugs.python.org/issue40520
<!-- /issue-number -->


Automerge-Triggered-By: @corona10