### PR TITLE
bpo-42065: Fix incorrectly formatted _codecs.charmap_decode error message

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -2183,6 +2183,18 @@ class CharmapTest(unittest.TestCase):
             ("", len(allbytes))
         )
 
+        self.assertRaisesRegex(TypeError,
+            "character mapping must be in range\\(0x110000\\)",
+            codecs.charmap_decode,
+            b"\x00\x01\x02", "strict", {0: "A", 1: 'Bb', 2: -2}
+        )
+
+        self.assertRaisesRegex(TypeError,
+            "character mapping must be in range\\(0x110000\\)",
+            codecs.charmap_decode,
+            b"\x00\x01\x02", "strict", {0: "A", 1: 'Bb', 2: 999999999}
+        )
+
     def test_decode_with_int2int_map(self):
         a = ord('a')
         b = ord('b')

--- a/Misc/NEWS.d/next/Library/2020-10-17-23-17-18.bpo-42065.85BsRA.rst
+++ b/Misc/NEWS.d/next/Library/2020-10-17-23-17-18.bpo-42065.85BsRA.rst
@@ -1,0 +1,3 @@
+Fix an incorrectly formatted error from :meth:`_codecs.charmap_decode` when
+called with a mapped value outside the range of valid Unicode code points.
+PR by Max Bernstein.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8147,7 +8147,7 @@ charmap_decode_mapping(const char *s,
                 goto Undefined;
             if (value < 0 || value > MAX_UNICODE) {
                 PyErr_Format(PyExc_TypeError,
-                             "character mapping must be in range(0x%lx)",
+                             "character mapping must be in range(0x%x)",
                              (unsigned long)MAX_UNICODE + 1);
                 goto onError;
             }


### PR DESCRIPTION
The formatter does not support `%lx`. Add previously failing tests.

<!-- issue-number: [bpo-42065](https://bugs.python.org/issue42065) -->
https://bugs.python.org/issue42065
<!-- /issue-number -->
