### PR TITLE
bpo-40513: _xxsubinterpreters.run_string() releases the GIL

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1939,6 +1939,20 @@ _run_script_in_interpreter(PyInterpreterState *interp, const char *codestr,
         return -1;
     }
 
+#ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
+    // Switch to interpreter.
+    PyThreadState *new_tstate = PyInterpreterState_ThreadHead(interp);
+    PyThreadState *save1 = PyEval_SaveThread();
+
+    (void)PyThreadState_Swap(new_tstate);
+
+    // Run the script.
+    _sharedexception *exc = NULL;
+    int result = _run_script(interp, codestr, shared, &exc);
+
+    // Switch back.
+    PyEval_RestoreThread(save1);
+#else
     // Switch to interpreter.
     PyThreadState *save_tstate = NULL;
     if (interp != PyInterpreterState_Get()) {
@@ -1956,6 +1970,7 @@ _run_script_in_interpreter(PyInterpreterState *interp, const char *codestr,
     if (save_tstate != NULL) {
         PyThreadState_Swap(save_tstate);
     }
+#endif
 
     // Propagate any exception out to the caller.
     if (exc != NULL) {


### PR DESCRIPTION
In the experimental isolated subinterpreters build mode,
_xxsubinterpreters.run_string() now releases the GIL.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40513](https://bugs.python.org/issue40513) -->
https://bugs.python.org/issue40513
<!-- /issue-number -->
