### PR TITLE
bpo-18857: urlencode: Add flag to prevent rendering NoneType values as literal string 'None'

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -640,6 +640,10 @@ task isn't already covered by the URL parsing functions above.
    *quote_via* (the *encoding* and *errors* parameters are only passed
    when a query element is a :class:`str`).
 
+   To encode ``None`` values in a way that ensures that a reader can
+   distinguish them from empty strings, enable the *standalone_keys*
+   parameter.
+
    To reverse this encoding process, :func:`parse_qs` and :func:`parse_qsl` are
    provided in this module to parse query strings into Python data structures.
 

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -906,7 +906,6 @@ class UrlParseTestCase(unittest.TestCase):
         # Other tests incidentally urlencode things; test non-covered cases:
         # Sequence and object values.
         result = urllib.parse.urlencode({'a': [1, 2], 'b': (3, 4, 5), 'c': None}, True)
-        # we cannot rely on ordering here
         self.assertEqual(result, 'a=1&a=2&b=3&b=4&b=5&c=None')
 
     def test_urlencode_sequences_standalone_keys(self):

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -916,7 +916,7 @@ class UrlParseTestCase(unittest.TestCase):
         )
         self.assertEqual(result, 'a=1&a&b')
 
-    def test_urlencode_sequences_trivial(self):
+    def test_urlencode_sequences___str__(self):
         class Trivial:
             def __str__(self):
                 return 'trivial'

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -893,21 +893,21 @@ class UrlParseTestCase(unittest.TestCase):
     def test_urlencode(self):
         result = urllib.parse.urlencode({'a': 1, 'b': None})
         # bpo-18857: urlencode of a None value uses the string 'None'
-        assert set(result.split('&')) == {'a=1', 'b=None'}
+        self.assertEqual(result, 'a=1&b=None')
 
     def test_urlencode_standalone_keys(self):
         result = urllib.parse.urlencode(
             query={'a': 1, 'b': None},
             standalone_keys=True
         )
-        assert set(result.split('&')) == {'a=1', 'b'}
+        self.assertEqual(result, 'a=1&b')
 
     def test_urlencode_sequences(self):
         # Other tests incidentally urlencode things; test non-covered cases:
         # Sequence and object values.
         result = urllib.parse.urlencode({'a': [1, 2], 'b': (3, 4, 5), 'c': None}, True)
         # we cannot rely on ordering here
-        assert set(result.split('&')) == {'a=1', 'a=2', 'b=3', 'b=4', 'b=5', 'c=None'}
+        self.assertEqual(result, 'a=1&a=2&b=3&b=4&b=5&c=None')
 
     def test_urlencode_sequences_standalone_keys(self):
         result = urllib.parse.urlencode(
@@ -915,7 +915,7 @@ class UrlParseTestCase(unittest.TestCase):
             doseq=True,
             standalone_keys=True
         )
-        assert set(result.split('&')) == {'a=1', 'a', 'b'}
+        self.assertEqual(result, 'a=1&a&b')
 
     def test_urlencode_sequences_trivial(self):
         class Trivial:

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -905,9 +905,9 @@ class UrlParseTestCase(unittest.TestCase):
     def test_urlencode_sequences(self):
         # Other tests incidentally urlencode things; test non-covered cases:
         # Sequence and object values.
-        result = urllib.parse.urlencode({'a': [1, 2], 'b': (3, 4, 5)}, True)
+        result = urllib.parse.urlencode({'a': [1, 2], 'b': (3, 4, 5), 'c': None}, True)
         # we cannot rely on ordering here
-        assert set(result.split('&')) == {'a=1', 'a=2', 'b=3', 'b=4', 'b=5'}
+        assert set(result.split('&')) == {'a=1', 'a=2', 'b=3', 'b=4', 'b=5', 'c=None'}
 
     def test_urlencode_sequences_standalone_keys(self):
         result = urllib.parse.urlencode(

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -897,6 +897,7 @@ class UrlParseTestCase(unittest.TestCase):
         # we cannot rely on ordering here
         assert set(result.split('&')) == {'a=1', 'a=2', 'b=3', 'b=4', 'b=5'}
 
+    def test_urlencode_sequences_trivial(self):
         class Trivial:
             def __str__(self):
                 return 'trivial'

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -890,6 +890,11 @@ class UrlParseTestCase(unittest.TestCase):
             urllib.parse.parse_qs(';'.join(['a=a']*11), max_num_fields=10)
         urllib.parse.parse_qs('&'.join(['a=a']*10), max_num_fields=10)
 
+    def test_urlencode(self):
+        result = urllib.parse.urlencode({'a': 1, 'b': None})
+        # bpo-18857: urlencode of a None value uses the string 'None'
+        assert set(result.split('&')) == {'a=1', 'b=None'}
+
     def test_urlencode_sequences(self):
         # Other tests incidentally urlencode things; test non-covered cases:
         # Sequence and object values.

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -895,12 +895,27 @@ class UrlParseTestCase(unittest.TestCase):
         # bpo-18857: urlencode of a None value uses the string 'None'
         assert set(result.split('&')) == {'a=1', 'b=None'}
 
+    def test_urlencode_standalone_keys(self):
+        result = urllib.parse.urlencode(
+            query={'a': 1, 'b': None},
+            standalone_keys=True
+        )
+        assert set(result.split('&')) == {'a=1', 'b'}
+
     def test_urlencode_sequences(self):
         # Other tests incidentally urlencode things; test non-covered cases:
         # Sequence and object values.
         result = urllib.parse.urlencode({'a': [1, 2], 'b': (3, 4, 5)}, True)
         # we cannot rely on ordering here
         assert set(result.split('&')) == {'a=1', 'a=2', 'b=3', 'b=4', 'b=5'}
+
+    def test_urlencode_sequences_standalone_keys(self):
+        result = urllib.parse.urlencode(
+            query={'a': [1, None], 'b': None},
+            doseq=True,
+            standalone_keys=True
+        )
+        assert set(result.split('&')) == {'a=1', 'a', 'b'}
 
     def test_urlencode_sequences_trivial(self):
         class Trivial:

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -935,11 +935,14 @@ def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
             else:
                 k = quote_via(str(k), safe, encoding, errors)
 
-            if isinstance(v, bytes):
+            if v is None and standalone_keys:
+                l.append(k)
+            elif isinstance(v, bytes):
                 v = quote_via(v, safe)
+                l.append(k + '=' + v)
             else:
                 v = quote_via(str(v), safe, encoding, errors)
-            l.append(k + '=' + v)
+                l.append(k + '=' + v)
     else:
         for k, v in query:
             if isinstance(k, bytes):
@@ -947,7 +950,9 @@ def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
             else:
                 k = quote_via(str(k), safe, encoding, errors)
 
-            if isinstance(v, bytes):
+            if v is None and standalone_keys:
+                l.append(k)
+            elif isinstance(v, bytes):
                 v = quote_via(v, safe)
                 l.append(k + '=' + v)
             elif isinstance(v, str):
@@ -964,11 +969,14 @@ def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
                 else:
                     # loop over the sequence
                     for elt in v:
-                        if isinstance(elt, bytes):
+                        if elt is None and standalone_keys:
+                            l.append(k)
+                        elif isinstance(elt, bytes):
                             elt = quote_via(elt, safe)
+                            l.append(k + '=' + elt)
                         else:
                             elt = quote_via(str(elt), safe, encoding, errors)
-                        l.append(k + '=' + elt)
+                            l.append(k + '=' + elt)
     return '&'.join(l)
 
 

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -892,7 +892,7 @@ def quote_from_bytes(bs, safe='/'):
     return ''.join([quoter(char) for char in bs])
 
 def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
-              quote_via=quote_plus):
+              quote_via=quote_plus, standalone_keys=False):
     """Encode a dict or sequence of two-element tuples into a URL query string.
 
     If any values in the query arg are sequences and doseq is true, each

--- a/Misc/NEWS.d/next/Library/2020-05-05-20-55-31.bpo-18857.jFahmw.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-05-20-55-31.bpo-18857.jFahmw.rst
@@ -1,5 +1,5 @@
-Added ``standalone_keys`` flag (disabled-by-default) to
-``urllib.parse.urlencode``.
+Added ``standalone_keys`` flag (disabled by default) to
+:meth:`urllib.parse.urlencode`.
 
 This flag allows developers to unambiguously render ``None`` values (as
 opposed to empty strings) when serializing query-string parameters.

--- a/Misc/NEWS.d/next/Library/2020-05-05-20-55-31.bpo-18857.jFahmw.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-05-20-55-31.bpo-18857.jFahmw.rst
@@ -1,0 +1,5 @@
+Added ``standalone_keys`` flag (disabled-by-default) to
+``urllib.parse.urlencode``.
+
+This flag allows developers to unambiguously render ``None`` values (as
+opposed to empty strings) when serializing query-string parameters.


### PR DESCRIPTION
When a dictionary-like object with value(s) `None` is passed to [urllib.parse.urlencode](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode), query-string elements are generated containing the string literal 'None'.

For example (credit: [Joshua Johnston](https://bugs.python.org/issue18857#msg196314)):

```python
>>> from urllib import urlencode
>>> urlencode({'josh': None})
'josh=None'
```

This can cause recipients of query-string data generated in this manner to misinterpret and potentially store parsed 'None' string values as data, when in fact a null/absent value was intended.

This pull request introduces an optional (default-disabled) flag called `standalone_keys`; a developer may optionally set this flag to allow query-string parameters to be unambiguously serialized as 'standalone keys' -- indicating that no value is present.

https://bugs.python.org/issue18857

<!-- issue-number: [bpo-18857](https://bugs.python.org/issue18857) -->
https://bugs.python.org/issue18857
<!-- /issue-number -->
