### PR TITLE
bpo-18857: parse_qs*: Add flag to allow parsing NoneType values from serialized query-strings

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -190,8 +190,8 @@ or on combining URL components into a URL string.
    read. If set, then throws a :exc:`ValueError` if there are more than
    *max_num_fields* fields read.
 
-   To decode ``None`` as the result for keys which do not have a following
-   ``=`` present in *qs*, enable the *standalone_keys* parameter.
+   To decode ``None`` values for keys that do not have associated ``=``
+   characters in *qs*, enable the *standalone_keys* parameter.
 
    Use the :func:`urllib.parse.urlencode` function (with the ``doseq``
    parameter set to ``True``) to convert such dictionaries into query
@@ -229,8 +229,8 @@ or on combining URL components into a URL string.
    read. If set, then throws a :exc:`ValueError` if there are more than
    *max_num_fields* fields read.
 
-   To decode ``None`` as the result for keys which do not have a following
-   ``=`` present in *qs*, enable the *standalone_keys* parameter.
+   To decode ``None`` values for keys that do not have associated ``=``
+   characters in *qs*, enable the *standalone_keys* parameter.
 
    Use the :func:`urllib.parse.urlencode` function to convert such lists of pairs into
    query strings.

--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -190,6 +190,9 @@ or on combining URL components into a URL string.
    read. If set, then throws a :exc:`ValueError` if there are more than
    *max_num_fields* fields read.
 
+   To decode ``None`` as the result for keys which do not have a following
+   ``=`` present in *qs*, enable the *standalone_keys* parameter.
+
    Use the :func:`urllib.parse.urlencode` function (with the ``doseq``
    parameter set to ``True``) to convert such dictionaries into query
    strings.
@@ -225,6 +228,9 @@ or on combining URL components into a URL string.
    The optional argument *max_num_fields* is the maximum number of fields to
    read. If set, then throws a :exc:`ValueError` if there are more than
    *max_num_fields* fields read.
+
+   To decode ``None`` as the result for keys which do not have a following
+   ``=`` present in *qs*, enable the *standalone_keys* parameter.
 
    Use the :func:`urllib.parse.urlencode` function to convert such lists of pairs into
    query strings.

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -167,6 +167,13 @@ class UrlParseTestCase(unittest.TestCase):
             self.assertEqual(result, expect,
                             "Error parsing %r" % orig)
 
+            # Ensure that standalone_keys parsing remains stable when the
+            # keep_blank_values flag is enabled
+            result = urllib.parse.parse_qs(orig, keep_blank_values=True,
+                                           standalone_keys=True)
+            self.assertEqual(result, expect,
+                            "Error parsing %r" % orig)
+
     def test_roundtrips(self):
         str_cases = [
             ('file:///tmp/junk.txt',

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -163,10 +163,6 @@ class UrlParseTestCase(unittest.TestCase):
             self.assertEqual(result, expect_without_blanks,
                             "Error parsing %r" % orig)
 
-            result = urllib.parse.parse_qs(orig, standalone_keys=True)
-            self.assertEqual(result, expect,
-                            "Error parsing %r" % orig)
-
     def test_roundtrips(self):
         str_cases = [
             ('file:///tmp/junk.txt',

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -150,14 +150,21 @@ class UrlParseTestCase(unittest.TestCase):
 
     def test_qs(self):
         for orig, expect in parse_qs_test_cases:
-            expect = {v: self._coalesce_empty(orig, expect[v]) for v in expect}
+            expect_with_blanks = {v: self._coalesce_empty(orig, expect[v])
+                                  for v in expect}
             result = urllib.parse.parse_qs(orig, keep_blank_values=True)
-            self.assertEqual(result, expect, "Error parsing %r" % orig)
+            self.assertEqual(result, expect_with_blanks,
+                            "Error parsing %r" % orig)
 
-            expect_without_blanks = {v: expect[v]
-                                     for v in expect if len(expect[v][0])}
+            expect_without_blanks = {v: self._coalesce_empty(orig, expect[v])
+                                     for v in expect_with_blanks
+                                     if expect[v][0]}
             result = urllib.parse.parse_qs(orig, keep_blank_values=False)
             self.assertEqual(result, expect_without_blanks,
+                            "Error parsing %r" % orig)
+
+            result = urllib.parse.parse_qs(orig, standalone_keys=True)
+            self.assertEqual(result, expect,
                             "Error parsing %r" % orig)
 
     def test_roundtrips(self):

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -161,18 +161,18 @@ class UrlParseTestCase(unittest.TestCase):
                                      if expect[v][0]}
             result = urllib.parse.parse_qs(orig, keep_blank_values=False)
             self.assertEqual(result, expect_without_blanks,
-                            "Error parsing %r" % orig)
+                             "Error parsing %r" % orig)
 
             result = urllib.parse.parse_qs(orig, standalone_keys=True)
             self.assertEqual(result, expect,
-                            "Error parsing %r" % orig)
+                             "Error parsing %r" % orig)
 
             # Ensure that standalone_keys parsing remains stable when the
             # keep_blank_values flag is enabled
             result = urllib.parse.parse_qs(orig, keep_blank_values=True,
                                            standalone_keys=True)
             self.assertEqual(result, expect,
-                            "Error parsing %r" % orig)
+                             "Error parsing %r" % orig)
 
     def test_roundtrips(self):
         str_cases = [

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -163,6 +163,10 @@ class UrlParseTestCase(unittest.TestCase):
             self.assertEqual(result, expect_without_blanks,
                             "Error parsing %r" % orig)
 
+            result = urllib.parse.parse_qs(orig, standalone_keys=True)
+            self.assertEqual(result, expect,
+                            "Error parsing %r" % orig)
+
     def test_roundtrips(self):
         str_cases = [
             ('file:///tmp/junk.txt',

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -760,9 +760,9 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
 
         result = []
         for token in [name, value]:
-            if len(token) or keep_blank_values:
+            if token is not None:
                 token = unquote_plus(token, encoding=encoding, errors=errors)
-            token = _coerce_result(token)
+                token = _coerce_result(token)
             result.append(token)
         results.append(tuple(result))
     return results

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -742,7 +742,7 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
             raise ValueError('Max number of fields exceeded')
 
     pairs = [s2 for s1 in qs.split('&') for s2 in s1.split(';')]
-    r = []
+    results = []
     for name_value in pairs:
         if not name_value and not strict_parsing:
             continue
@@ -765,8 +765,8 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
             name = _coerce_result(name)
             value = unquote_plus(value, encoding=encoding, errors=errors)
             value = _coerce_result(value)
-            r.append((name, value))
-    return r
+            results.append((name, value))
+    return results
 
 def unquote_plus(string, encoding='utf-8', errors='replace'):
     """Like unquote(), but also replace plus signs by spaces, as required for

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -747,18 +747,16 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         if not name_value and not strict_parsing:
             continue
 
+        default_value = '' if keep_blank_values else None
         name_value = iter(name_value.split('=', 1))
         name = next(name_value)
-        value = next(name_value, None)
+        value = next(name_value, default_value)
 
-        if not value:
-            if strict_parsing:
-                raise ValueError("bad query field: %r" % (name_value,))
-            # Handle case of a control-name with no equal sign
-            if keep_blank_values:
-                value = ''
-            else:
-                continue
+        if strict_parsing and not value:
+            raise ValueError("bad query field: %r" % (name_value,))
+
+        if not value and not keep_blank_values:
+            continue
 
         result = []
         for token in [name, value]:

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -750,26 +750,24 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         if not name_value and not strict_parsing:
             continue
 
+        empty_value = name_value.endswith('=')
         tokens = iter(name_value.split('=', 1))
         name = next(tokens)
-        value = next(tokens, None)
+        value = '' if empty_value else next(tokens, None)
 
-        if value is None:
-            if strict_parsing:
-                raise ValueError("bad query field: %r" % (name_value,))
-            elif keep_blank_values:
-                pass
+        if value is None and strict_parsing:
+            raise ValueError("bad query field: %r" % (name_value,))
+
+        if not value:
+            if keep_blank_values:
+                value = ''
             elif standalone_keys:
                 pass
             else:
                 continue
 
-        default_value = None
-        if keep_blank_values:
-            default_value = ''
-        if standalone_keys and name_value.endswith('='):
-            default_value = ''
-        value = value or default_value
+        if value is None and not standalone_keys:
+            continue
 
         result = []
         for token in [name, value]:

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -756,9 +756,9 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         if standalone_keys and name_value.endswith('='):
             default_value = ''
 
-        name_value = iter(name_value.split('=', 1))
-        name = next(name_value)
-        value = next(name_value, default_value)
+        tokens = iter(name_value.split('=', 1))
+        name = next(tokens)
+        value = next(tokens, default_value)
 
         if not value:
             if strict_parsing:

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -760,12 +760,13 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
             else:
                 continue
 
-        if len(value) or keep_blank_values:
-            name = unquote_plus(name, encoding=encoding, errors=errors)
-            name = _coerce_result(name)
-            value = unquote_plus(value, encoding=encoding, errors=errors)
-            value = _coerce_result(value)
-            results.append((name, value))
+        result = []
+        for token in [name, value]:
+            if len(token) or keep_blank_values:
+                token = unquote_plus(token, encoding=encoding, errors=errors)
+            token = _coerce_result(token)
+            result.append(token)
+        results.append(tuple(result))
     return results
 
 def unquote_plus(string, encoding='utf-8', errors='replace'):

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -750,17 +750,11 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         if not name_value and not strict_parsing:
             continue
 
-        default_value = None
-        if keep_blank_values:
-            default_value = ''
-        if standalone_keys and name_value.endswith('='):
-            default_value = ''
-
         tokens = iter(name_value.split('=', 1))
         name = next(tokens)
-        value = next(tokens, default_value)
+        value = next(tokens, None)
 
-        if not value:
+        if value is None:
             if strict_parsing:
                 raise ValueError("bad query field: %r" % (name_value,))
             elif keep_blank_values:
@@ -769,6 +763,13 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
                 pass
             else:
                 continue
+
+        default_value = None
+        if keep_blank_values:
+            default_value = ''
+        if standalone_keys and name_value.endswith('='):
+            default_value = ''
+        value = value or default_value
 
         result = []
         for token in [name, value]:

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -689,9 +689,14 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
         Returns a dictionary.
     """
     parsed_result = {}
-    pairs = parse_qsl(qs, keep_blank_values, strict_parsing,
-                      encoding=encoding, errors=errors,
-                      max_num_fields=max_num_fields)
+    pairs = parse_qsl(
+        qs=qs,
+        keep_blank_values=keep_blank_values,
+        strict_parsing=strict_parsing,
+        encoding=encoding,
+        errors=errors,
+        max_num_fields=max_num_fields,
+    )
     for name, value in pairs:
         if name in parsed_result:
             parsed_result[name].append(value)

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -750,10 +750,10 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         if not name_value and not strict_parsing:
             continue
 
-        empty_value = name_value.endswith('=')
+        empty_value = '' if name_value.endswith('=') else None
         tokens = iter(name_value.split('=', 1))
         name = next(tokens)
-        value = '' if empty_value else next(tokens, None)
+        value = next(tokens, empty_value)
 
         if value is None and strict_parsing:
             raise ValueError("bad query field: %r" % (name_value,))

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -761,11 +761,9 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
                 continue
 
         if len(value) or keep_blank_values:
-            name = name.replace('+', ' ')
-            name = unquote(name, encoding=encoding, errors=errors)
+            name = unquote_plus(name, encoding=encoding, errors=errors)
             name = _coerce_result(name)
-            value = value.replace('+', ' ')
-            value = unquote(value, encoding=encoding, errors=errors)
+            value = unquote_plus(value, encoding=encoding, errors=errors)
             value = _coerce_result(value)
             r.append((name, value))
     return r

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -752,11 +752,11 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         name = next(name_value)
         value = next(name_value, default_value)
 
-        if strict_parsing and not value:
-            raise ValueError("bad query field: %r" % (name_value,))
-
-        if not value and not keep_blank_values:
-            continue
+        if not value:
+            if strict_parsing:
+                raise ValueError("bad query field: %r" % (name_value,))
+            if not keep_blank_values:
+                continue
 
         result = []
         for token in [name, value]:

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -746,20 +746,25 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
     for name_value in pairs:
         if not name_value and not strict_parsing:
             continue
-        nv = name_value.split('=', 1)
-        if len(nv) != 2:
+
+        name_value = iter(name_value.split('=', 1))
+        name = next(name_value)
+        value = next(name_value, None)
+
+        if not value:
             if strict_parsing:
                 raise ValueError("bad query field: %r" % (name_value,))
             # Handle case of a control-name with no equal sign
             if keep_blank_values:
-                nv.append('')
+                value = ''
             else:
                 continue
-        if len(nv[1]) or keep_blank_values:
-            name = nv[0].replace('+', ' ')
+
+        if len(value) or keep_blank_values:
+            name = name.replace('+', ' ')
             name = unquote(name, encoding=encoding, errors=errors)
             name = _coerce_result(name)
-            value = nv[1].replace('+', ' ')
+            value = value.replace('+', ' ')
             value = unquote(value, encoding=encoding, errors=errors)
             value = _coerce_result(value)
             r.append((name, value))

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -662,7 +662,8 @@ def unquote(string, encoding='utf-8', errors='replace'):
 
 
 def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
-             encoding='utf-8', errors='replace', max_num_fields=None):
+             encoding='utf-8', errors='replace', max_num_fields=None,
+             standalone_keys=False):
     """Parse a query given as a string argument.
 
         Arguments:
@@ -696,6 +697,7 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
         encoding=encoding,
         errors=errors,
         max_num_fields=max_num_fields,
+        standalone_keys=standalone_keys,
     )
     for name, value in pairs:
         if name in parsed_result:
@@ -706,7 +708,8 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
 
 
 def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
-              encoding='utf-8', errors='replace', max_num_fields=None):
+              encoding='utf-8', errors='replace', max_num_fields=None,
+              standalone_keys=False):
     """Parse a query given as a string argument.
 
         Arguments:
@@ -747,7 +750,12 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         if not name_value and not strict_parsing:
             continue
 
-        default_value = '' if keep_blank_values else None
+        default_value = None
+        if keep_blank_values:
+            default_value = ''
+        if standalone_keys and name_value.endswith('='):
+            default_value = ''
+
         name_value = iter(name_value.split('=', 1))
         name = next(name_value)
         value = next(name_value, default_value)
@@ -755,7 +763,11 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
         if not value:
             if strict_parsing:
                 raise ValueError("bad query field: %r" % (name_value,))
-            if not keep_blank_values:
+            elif keep_blank_values:
+                pass
+            elif standalone_keys:
+                pass
+            else:
                 continue
 
         result = []

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -759,10 +759,10 @@ def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
             raise ValueError("bad query field: %r" % (name_value,))
 
         if not value:
-            if keep_blank_values:
-                value = ''
-            elif standalone_keys:
+            if standalone_keys:
                 pass
+            elif keep_blank_values:
+                value = ''
             else:
                 continue
 

--- a/Misc/NEWS.d/next/Library/2020-05-06-01-17-10.bpo-18857._Ev13u.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-06-01-17-10.bpo-18857._Ev13u.rst
@@ -1,5 +1,5 @@
 Added ``standalone_keys`` flag (disabled by default) to
-``urllib.parse.parse_qs`` and ``urllib.parse.parse_qsl``.
+:meth:`urllib.parse.parse_qs` and :meth:`urllib.parse.parse_qsl`.
 
 This flag allows developers to unambiguously read ``None`` values (as
 opposed to empty strings) when deserializing query-strings.

--- a/Misc/NEWS.d/next/Library/2020-05-06-01-17-10.bpo-18857._Ev13u.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-06-01-17-10.bpo-18857._Ev13u.rst
@@ -1,4 +1,4 @@
-Added ``standalone_keys`` flag (disabled-by-default) to
+Added ``standalone_keys`` flag (disabled by default) to
 ``urllib.parse.parse_qs`` and ``urllib.parse.parse_qsl``.
 
 This flag allows developers to unambiguously read ``None`` values (as

--- a/Misc/NEWS.d/next/Library/2020-05-06-01-17-10.bpo-18857._Ev13u.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-06-01-17-10.bpo-18857._Ev13u.rst
@@ -1,0 +1,5 @@
+Added ``standalone_keys`` flag (disabled-by-default) to
+``urllib.parse.parse_qs`` and ``urllib.parse.parse_qsl``.
+
+This flag allows developers to unambiguously read ``None`` values (as
+opposed to empty strings) when deserializing query-strings.


### PR DESCRIPTION
In #19945, a (default-disabled) flag is added to serialize dictionary-like objects into query-strings with an unambiguous format for `None` values.

In this pull request, the same (again, default-disabled) flag is added to the [urllib.parse.parse_qs*](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.parse_qs) methods, allowing corresponding deserialization of `None` values.

<!-- issue-number: [bpo-18857](https://bugs.python.org/issue18857) -->
https://bugs.python.org/issue18857
<!-- /issue-number -->
