### PR TITLE
bpo-31033:  Make traceback for cancelled asyncio tasks more useful

### DIFF
--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -14,6 +14,20 @@ static inline PyObject* _PyErr_Occurred(PyThreadState *tstate)
     return tstate->curexc_type;
 }
 
+static inline void _PyErr_ClearExcState(_PyErr_StackItem *exc_state)
+{
+    PyObject *t, *v, *tb;
+    t = exc_state->exc_type;
+    v = exc_state->exc_value;
+    tb = exc_state->exc_traceback;
+    exc_state->exc_type = NULL;
+    exc_state->exc_value = NULL;
+    exc_state->exc_traceback = NULL;
+    Py_XDECREF(t);
+    Py_XDECREF(v);
+    Py_XDECREF(tb);
+}
+
 
 PyAPI_FUNC(void) _PyErr_Fetch(
     PyThreadState *tstate,

--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -50,6 +50,9 @@ PyAPI_FUNC(void) _PyErr_SetObject(
     PyObject *type,
     PyObject *value);
 
+PyAPI_FUNC(void) _PyErr_ChainStackItem(
+    _PyErr_StackItem *exc_state);
+
 PyAPI_FUNC(void) _PyErr_Clear(PyThreadState *tstate);
 
 PyAPI_FUNC(void) _PyErr_SetNone(PyThreadState *tstate, PyObject *exception);

--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -52,7 +52,7 @@ class Future:
     _loop = None
     _source_traceback = None
     _cancel_message = None
-    # A saved CancelledError for later chaining.
+    # A saved CancelledError for later chaining as an exception context.
     _cancelled_exc = None
 
     # This field is used for a dual purpose:
@@ -128,14 +128,15 @@ class Future:
 
     def _make_cancelled_error(self):
         """
-        Create a CancelledError for raising purposes.
+        Create the CancelledError to raise if the Future is cancelled.
 
-        This should only be called once since it erases self._cancelled_exc.
+        This should only be called once when handling a cancellation since
+        it erases self._cancelled_exc.
         """
         exc = exceptions.CancelledError(
             '' if self._cancel_message is None else self._cancel_message)
         exc.__context__ = self._cancelled_exc
-        # Remove a reference since we don't need this anymore.
+        # Remove the reference since we don't need this anymore.
         self._cancelled_exc = None
         return exc
 

--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -126,6 +126,12 @@ class Future:
             raise RuntimeError("Future object is not initialized.")
         return loop
 
+    def _make_cancelled_error(self):
+        exc = exceptions.CancelledError(
+            '' if self._cancel_message is None else self._cancel_message)
+        exc.__context__ = self._cancelled_exc
+        return exc
+
     def cancel(self, msg=None):
         """Cancel the future and schedule callbacks.
 
@@ -177,9 +183,7 @@ class Future:
         the future is done and has an exception set, this exception is raised.
         """
         if self._state == _CANCELLED:
-            exc = exceptions.CancelledError(
-                '' if self._cancel_message is None else self._cancel_message)
-            exc.__context__ = self._cancelled_exc
+            exc = self._make_cancelled_error()
             raise exc
         if self._state != _FINISHED:
             raise exceptions.InvalidStateError('Result is not ready.')
@@ -197,9 +201,7 @@ class Future:
         InvalidStateError.
         """
         if self._state == _CANCELLED:
-            exc = exceptions.CancelledError(
-                '' if self._cancel_message is None else self._cancel_message)
-            exc.__context__ = self._cancelled_exc
+            exc = self._make_cancelled_error()
             raise exc
         if self._state != _FINISHED:
             raise exceptions.InvalidStateError('Exception is not set.')

--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -127,14 +127,15 @@ class Future:
         return loop
 
     def _make_cancelled_error(self):
-        """
-        Create the CancelledError to raise if the Future is cancelled.
+        """Create the CancelledError to raise if the Future is cancelled.
 
         This should only be called once when handling a cancellation since
-        it erases self._cancelled_exc.
+        it erases the saved context exception value.
         """
-        exc = exceptions.CancelledError(
-            '' if self._cancel_message is None else self._cancel_message)
+        if self._cancel_message is None:
+            exc = exceptions.CancelledError()
+        else:
+            exc = exceptions.CancelledError(self._cancel_message)
         exc.__context__ = self._cancelled_exc
         # Remove the reference since we don't need this anymore.
         self._cancelled_exc = None

--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -127,9 +127,16 @@ class Future:
         return loop
 
     def _make_cancelled_error(self):
+        """
+        Create a CancelledError for raising purposes.
+
+        This should only be called once since it erases self._cancelled_exc.
+        """
         exc = exceptions.CancelledError(
             '' if self._cancel_message is None else self._cancel_message)
         exc.__context__ = self._cancelled_exc
+        # Remove a reference since we don't need this anymore.
+        self._cancelled_exc = None
         return exc
 
     def cancel(self, msg=None):

--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -197,8 +197,10 @@ class Future:
         InvalidStateError.
         """
         if self._state == _CANCELLED:
-            raise exceptions.CancelledError(
+            exc = exceptions.CancelledError(
                 '' if self._cancel_message is None else self._cancel_message)
+            exc.__context__ = self._cancelled_exc
+            raise exc
         if self._state != _FINISHED:
             raise exceptions.InvalidStateError('Exception is not set.')
         self.__log_traceback = False

--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -52,6 +52,8 @@ class Future:
     _loop = None
     _source_traceback = None
     _cancel_message = None
+    # A saved CancelledError for later chaining.
+    _cancelled_exc = None
 
     # This field is used for a dual purpose:
     # - Its presence is a marker to declare that a class implements
@@ -175,9 +177,10 @@ class Future:
         the future is done and has an exception set, this exception is raised.
         """
         if self._state == _CANCELLED:
-            raise exceptions.CancelledError(
+            exc = exceptions.CancelledError(
                 '' if self._cancel_message is None else self._cancel_message)
-
+            exc.__context__ = self._cancelled_exc
+            raise exc
         if self._state != _FINISHED:
             raise exceptions.InvalidStateError('Result is not ready.')
         self.__log_traceback = False

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -293,6 +293,8 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
             else:
                 super().set_result(exc.value)
         except exceptions.CancelledError as exc:
+            # Save the original exception so we can chain it later.
+            self._cancelled_exc = exc
             if exc.args:
                 cancel_msg = exc.args[0]
             else:

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -800,10 +800,15 @@ def gather(*coros_or_futures, loop=None, return_exceptions=False):
 
             for fut in children:
                 if fut.cancelled():
-                    # Check if 'fut' is cancelled first, as
-                    # 'fut.exception()' will *raise* a CancelledError
-                    # instead of returning it.
-                    res = fut._make_cancelled_error()
+                    # Check if 'fut' is cancelled first, as 'fut.exception()'
+                    # will *raise* a CancelledError instead of returning it.
+                    # Also, since we're adding the exception return value
+                    # to 'results' instead of raising it, don't bother
+                    # setting __context__.  This also lets us preserve
+                    # calling '_make_cancelled_error()' at most once.
+                    res = exceptions.CancelledError(
+                        '' if fut._cancel_message is None else
+                        fut._cancel_message)
                 else:
                     res = fut.exception()
                     if res is None:

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -564,8 +564,8 @@ class BaseTaskTests:
     def test_cancel_with_message_then_future_result(self):
         # Test Future.result() after calling cancel() with a message.
         cases = [
-            ((), ('',)),
-            ((None,), ('',)),
+            ((), ()),
+            ((None,), ()),
             (('my message',), ('my message',)),
             # Non-string values should roundtrip.
             ((5,), (5,)),
@@ -589,7 +589,7 @@ class BaseTaskTests:
                 with self.assertRaises(asyncio.CancelledError) as cm:
                     loop.run_until_complete(task)
                 exc = cm.exception
-                self.assertEqual(exc.args, ('',))
+                self.assertEqual(exc.args, ())
 
                 actual = get_innermost_context(exc)
                 self.assertEqual(actual,
@@ -598,8 +598,8 @@ class BaseTaskTests:
     def test_cancel_with_message_then_future_exception(self):
         # Test Future.exception() after calling cancel() with a message.
         cases = [
-            ((), ('',)),
-            ((None,), ('',)),
+            ((), ()),
+            ((None,), ()),
             (('my message',), ('my message',)),
             # Non-string values should roundtrip.
             ((5,), (5,)),
@@ -623,7 +623,7 @@ class BaseTaskTests:
                 with self.assertRaises(asyncio.CancelledError) as cm:
                     loop.run_until_complete(task)
                 exc = cm.exception
-                self.assertEqual(exc.args, ('',))
+                self.assertEqual(exc.args, ())
 
                 actual = get_innermost_context(exc)
                 self.assertEqual(actual,
@@ -647,7 +647,7 @@ class BaseTaskTests:
         with self.assertRaises(asyncio.CancelledError) as cm:
             loop.run_until_complete(task)
         exc = cm.exception
-        self.assertEqual(exc.args, ('',))
+        self.assertEqual(exc.args, ())
 
         actual = get_innermost_context(exc)
         self.assertEqual(actual,
@@ -2479,8 +2479,8 @@ class BaseTaskTests:
 
     def test_cancel_gather_2(self):
         cases = [
-            ((), ('',)),
-            ((None,), ('',)),
+            ((), ()),
+            ((None,), ()),
             (('my message',), ('my message',)),
             # Non-string values should roundtrip.
             ((5,), (5,)),
@@ -2509,7 +2509,7 @@ class BaseTaskTests:
                 try:
                     loop.run_until_complete(main())
                 except asyncio.CancelledError as exc:
-                    self.assertEqual(exc.args, ('',))
+                    self.assertEqual(exc.args, ())
                     exc_type, exc_args, depth = get_innermost_context(exc)
                     self.assertEqual((exc_type, exc_args),
                         (asyncio.CancelledError, expected_args))

--- a/Misc/NEWS.d/next/Library/2020-05-06-02-33-00.bpo-31033.aX12pw.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-06-02-33-00.bpo-31033.aX12pw.rst
@@ -1,0 +1,2 @@
+When a :class:`asyncio.Task` is cancelled, the exception traceback
+now chains all the way back to where the task was first interrupted.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -604,9 +604,7 @@ create_cancelled_error(PyObject *msg)
 {
     PyObject *exc;
     if (msg == NULL || msg == Py_None) {
-        msg = PyUnicode_FromString("");
-        exc = PyObject_CallOneArg(asyncio_CancelledError, msg);
-        Py_DECREF(msg);
+        exc = PyObject_CallNoArgs(asyncio_CancelledError);
     } else {
         exc = PyObject_CallOneArg(asyncio_CancelledError, msg);
     }

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1350,17 +1350,22 @@ FutureObj_get_state(FutureObj *fut, void *Py_UNUSED(ignored))
 /*[clinic input]
 _asyncio.Future._make_cancelled_error
 
-Create the CancelledError to raise if the Future is cancelled.
+Create a CancelledError for raising purposes.
+
+This should only be called once since it erases the context exception value.
 [clinic start generated code]*/
 
 static PyObject *
 _asyncio_Future__make_cancelled_error_impl(FutureObj *self)
-/*[clinic end generated code: output=a5df276f6c1213de input=374e7bf8dd6edc60]*/
+/*[clinic end generated code: output=a5df276f6c1213de input=b0a790c6d0c33e9c]*/
 {
     PyObject *exc = create_cancelled_error(self->fut_cancel_msg);
     _PyErr_StackItem *exc_state = &self->fut_cancelled_exc_state;
-    Py_XINCREF(exc_state->exc_value);
+    /* Transfer ownership of exc_value from exc_state to exc since we are
+       done with it. */
     PyException_SetContext(exc, exc_state->exc_value);
+    exc_state->exc_value = NULL;
+
     return exc;
 }
 

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -869,6 +869,7 @@ _asyncio_Future_exception_impl(FutureObj *self)
 
     if (self->fut_state == STATE_CANCELLED) {
         set_cancelled_error(self->fut_cancel_msg);
+        _PyErr_ChainStackItem(&self->fut_cancelled_exc_state);
         return NULL;
     }
 

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1350,14 +1350,15 @@ FutureObj_get_state(FutureObj *fut, void *Py_UNUSED(ignored))
 /*[clinic input]
 _asyncio.Future._make_cancelled_error
 
-Create a CancelledError for raising purposes.
+Create the CancelledError to raise if the Future is cancelled.
 
-This should only be called once since it erases the context exception value.
+This should only be called once when handling a cancellation since
+it erases the context exception value.
 [clinic start generated code]*/
 
 static PyObject *
 _asyncio_Future__make_cancelled_error_impl(FutureObj *self)
-/*[clinic end generated code: output=a5df276f6c1213de input=b0a790c6d0c33e9c]*/
+/*[clinic end generated code: output=a5df276f6c1213de input=ac6effe4ba795ecc]*/
 {
     PyObject *exc = create_cancelled_error(self->fut_cancel_msg);
     _PyErr_StackItem *exc_state = &self->fut_cancelled_exc_state;
@@ -2271,11 +2272,14 @@ _asyncio_Task_all_tasks_impl(PyTypeObject *type, PyObject *loop)
 _asyncio.Task._make_cancelled_error
 
 Create the CancelledError to raise if the Task is cancelled.
+
+This should only be called once when handling a cancellation since
+it erases the context exception value.
 [clinic start generated code]*/
 
 static PyObject *
 _asyncio_Task__make_cancelled_error_impl(TaskObj *self)
-/*[clinic end generated code: output=55a819e8b4276fab input=fc5485bb07d5c36b]*/
+/*[clinic end generated code: output=55a819e8b4276fab input=52c0e32de8e2f840]*/
 {
     FutureObj *fut = (FutureObj*)self;
     return _asyncio_Future__make_cancelled_error_impl(fut);

--- a/Modules/clinic/_asynciomodule.c.h
+++ b/Modules/clinic/_asynciomodule.c.h
@@ -271,6 +271,24 @@ _asyncio_Future_get_loop(FutureObj *self, PyObject *Py_UNUSED(ignored))
     return _asyncio_Future_get_loop_impl(self);
 }
 
+PyDoc_STRVAR(_asyncio_Future__make_cancelled_error__doc__,
+"_make_cancelled_error($self, /)\n"
+"--\n"
+"\n"
+"Create the CancelledError to raise if the Future is cancelled.");
+
+#define _ASYNCIO_FUTURE__MAKE_CANCELLED_ERROR_METHODDEF    \
+    {"_make_cancelled_error", (PyCFunction)_asyncio_Future__make_cancelled_error, METH_NOARGS, _asyncio_Future__make_cancelled_error__doc__},
+
+static PyObject *
+_asyncio_Future__make_cancelled_error_impl(FutureObj *self);
+
+static PyObject *
+_asyncio_Future__make_cancelled_error(FutureObj *self, PyObject *Py_UNUSED(ignored))
+{
+    return _asyncio_Future__make_cancelled_error_impl(self);
+}
+
 PyDoc_STRVAR(_asyncio_Future__repr_info__doc__,
 "_repr_info($self, /)\n"
 "--\n"
@@ -412,6 +430,24 @@ skip_optional_pos:
 
 exit:
     return return_value;
+}
+
+PyDoc_STRVAR(_asyncio_Task__make_cancelled_error__doc__,
+"_make_cancelled_error($self, /)\n"
+"--\n"
+"\n"
+"Create the CancelledError to raise if the Task is cancelled.");
+
+#define _ASYNCIO_TASK__MAKE_CANCELLED_ERROR_METHODDEF    \
+    {"_make_cancelled_error", (PyCFunction)_asyncio_Task__make_cancelled_error, METH_NOARGS, _asyncio_Task__make_cancelled_error__doc__},
+
+static PyObject *
+_asyncio_Task__make_cancelled_error_impl(TaskObj *self);
+
+static PyObject *
+_asyncio_Task__make_cancelled_error(TaskObj *self, PyObject *Py_UNUSED(ignored))
+{
+    return _asyncio_Task__make_cancelled_error_impl(self);
 }
 
 PyDoc_STRVAR(_asyncio_Task__repr_info__doc__,
@@ -870,4 +906,4 @@ _asyncio__leave_task(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6ed4cfda8fc516ad input=a9049054013a1b77]*/
+/*[clinic end generated code: output=96c960a1c42cea41 input=a9049054013a1b77]*/

--- a/Modules/clinic/_asynciomodule.c.h
+++ b/Modules/clinic/_asynciomodule.c.h
@@ -275,7 +275,9 @@ PyDoc_STRVAR(_asyncio_Future__make_cancelled_error__doc__,
 "_make_cancelled_error($self, /)\n"
 "--\n"
 "\n"
-"Create the CancelledError to raise if the Future is cancelled.");
+"Create a CancelledError for raising purposes.\n"
+"\n"
+"This should only be called once since it erases the context exception value.");
 
 #define _ASYNCIO_FUTURE__MAKE_CANCELLED_ERROR_METHODDEF    \
     {"_make_cancelled_error", (PyCFunction)_asyncio_Future__make_cancelled_error, METH_NOARGS, _asyncio_Future__make_cancelled_error__doc__},
@@ -906,4 +908,4 @@ _asyncio__leave_task(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=96c960a1c42cea41 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f6e561a44879afd9 input=a9049054013a1b77]*/

--- a/Modules/clinic/_asynciomodule.c.h
+++ b/Modules/clinic/_asynciomodule.c.h
@@ -275,9 +275,10 @@ PyDoc_STRVAR(_asyncio_Future__make_cancelled_error__doc__,
 "_make_cancelled_error($self, /)\n"
 "--\n"
 "\n"
-"Create a CancelledError for raising purposes.\n"
+"Create the CancelledError to raise if the Future is cancelled.\n"
 "\n"
-"This should only be called once since it erases the context exception value.");
+"This should only be called once when handling a cancellation since\n"
+"it erases the context exception value.");
 
 #define _ASYNCIO_FUTURE__MAKE_CANCELLED_ERROR_METHODDEF    \
     {"_make_cancelled_error", (PyCFunction)_asyncio_Future__make_cancelled_error, METH_NOARGS, _asyncio_Future__make_cancelled_error__doc__},
@@ -438,7 +439,10 @@ PyDoc_STRVAR(_asyncio_Task__make_cancelled_error__doc__,
 "_make_cancelled_error($self, /)\n"
 "--\n"
 "\n"
-"Create the CancelledError to raise if the Task is cancelled.");
+"Create the CancelledError to raise if the Task is cancelled.\n"
+"\n"
+"This should only be called once when handling a cancellation since\n"
+"it erases the context exception value.");
 
 #define _ASYNCIO_TASK__MAKE_CANCELLED_ERROR_METHODDEF    \
     {"_make_cancelled_error", (PyCFunction)_asyncio_Task__make_cancelled_error, METH_NOARGS, _asyncio_Task__make_cancelled_error__doc__},
@@ -908,4 +912,4 @@ _asyncio__leave_task(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f6e561a44879afd9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=0e5c1eb8b692977b input=a9049054013a1b77]*/

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -512,6 +512,20 @@ _PyErr_ChainExceptions(PyObject *exc, PyObject *val, PyObject *tb)
     }
 }
 
+void
+_PyErr_ChainStackItem(_PyErr_StackItem *exc_state)
+{
+    if (exc_state->exc_type == NULL || exc_state->exc_type == Py_None) {
+        return;
+    }
+    Py_INCREF(exc_state->exc_type);
+    Py_XINCREF(exc_state->exc_value);
+    Py_XINCREF(exc_state->exc_traceback);
+    _PyErr_ChainExceptions(exc_state->exc_type,
+                           exc_state->exc_value,
+                           exc_state->exc_traceback);
+}
+
 static PyObject *
 _PyErr_FormatVFromCause(PyThreadState *tstate, PyObject *exception,
                         const char *format, va_list vargs)

--- a/setup.py
+++ b/setup.py
@@ -840,7 +840,8 @@ class PyBuildExt(build_ext):
         # _opcode module
         self.add(Extension('_opcode', ['_opcode.c']))
         # asyncio speedups
-        self.add(Extension("_asyncio", ["_asynciomodule.c"]))
+        self.add(Extension("_asyncio", ["_asynciomodule.c"],
+                           extra_compile_args=['-DPy_BUILD_CORE_MODULE']))
         # _abc speedups
         self.add(Extension("_abc", ["_abc.c"]))
         # _queue module


### PR DESCRIPTION
When an asyncio.Task is cancelled, the exception traceback now starts with where the task was first interrupted.

Previously, the traceback only had "depth one," which wasn't too useful.

<!-- issue-number: [bpo-31033](https://bugs.python.org/issue31033) -->
https://bugs.python.org/issue31033
<!-- /issue-number -->
