### PR TITLE
bpo-40515: Require OPENSSL_THREADS

### DIFF
--- a/Misc/NEWS.d/next/Library/2020-05-06-13-51-19.bpo-40515.TUCvYB.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-06-13-51-19.bpo-40515.TUCvYB.rst
@@ -1,0 +1,3 @@
+The :mod:`ssl` and :mod:`hashlib` modules now actively check that OpenSSL is
+build with thread support. Python 3.7.0 made thread support mandatory and no
+longer works safely with a no-thread builds.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -27,6 +27,10 @@
 
 #include <openssl/crypto.h>       // FIPS_mode()
 
+#ifndef OPENSSL_THREADS
+#  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"
+#endif
+
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 /* OpenSSL < 1.1.0 */
 #define EVP_MD_CTX_new EVP_MD_CTX_create

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -73,6 +73,10 @@ static PySocketModule_APIObject PySocketModule;
 #  endif
 #endif
 
+#ifndef OPENSSL_THREADS
+#  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"
+#endif
+
 /* SSL error object */
 static PyObject *PySSLErrorObject;
 static PyObject *PySSLCertVerificationErrorObject;
@@ -6005,7 +6009,7 @@ PyInit__ssl(void)
     if (!_setup_ssl_threads()) {
         return NULL;
     }
-#elif OPENSSL_VERSION_1_1 && defined(OPENSSL_THREADS)
+#elif OPENSSL_VERSION_1_1
     /* OpenSSL 1.1.0 builtin thread support is enabled */
     _ssl_locks_count++;
 #endif


### PR DESCRIPTION
The ``ssl`` and ``hashlib`` modules now actively check that OpenSSL is
build with thread support. Python 3.7.0 made thread support mandatory and no
longer works safely with a no-thread builds.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40515](https://bugs.python.org/issue40515) -->
https://bugs.python.org/issue40515
<!-- /issue-number -->
