### PR TITLE
gh-84709: rlcompleter with case insensitive

### DIFF
--- a/Doc/library/rlcompleter.rst
+++ b/Doc/library/rlcompleter.rst
@@ -69,7 +69,7 @@ Case Sensitivity
 You can change the Completer's default case sensitive selection to case insensitive using the following method:
 
 
-.. function:: rlcompleter.set_case_insensitive(option)
+.. function:: rlcompleter.set_ignore_case(option)
 
    Return the *None*.
 

--- a/Doc/library/rlcompleter.rst
+++ b/Doc/library/rlcompleter.rst
@@ -5,6 +5,7 @@
    :synopsis: Python identifier completion, suitable for the GNU readline library.
 
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
+.. sectionauthor:: Madhusudhan Kasula <kasula.madhusudhan@gmail.com>
 
 **Source code:** :source:`Lib/rlcompleter.py`
 
@@ -59,3 +60,19 @@ Completer objects have the following method:
    :func:`dir` function.  Any exception raised during the evaluation of the
    expression is caught, silenced and :const:`None` is returned.
 
+
+.. _case-sensitivity:
+
+Case Sensitivity
+-----------------
+
+You can change the Completer's default case sensitive selection to case insensitive using the following method:
+
+
+.. function:: rlcompleter.set_case_insensitive(option)
+
+   Return the *None*.
+
+   If called with *True*, it will set rlcompleter for case insensitive completions.
+
+   If called with *False*, it will set to default case sensitive completions.

--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -13,7 +13,7 @@ Tip: to use the tab key as the completion key, call
 
 And to make completion with case insensitive, call
 
-    rlcompleter.set_case_insensitive(True)
+    rlcompleter.set_ignore_case(True)
 
 Notes:
 
@@ -192,7 +192,7 @@ class Completer:
         return matches
 
 _re_ignorecase_flags = 0
-def set_case_insensitive(option):
+def set_ignore_case(option):
     import re
     global _re_ignorecase_flags
     _re_ignorecase_flags = re.IGNORECASE if option else 0

--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -11,6 +11,10 @@ Tip: to use the tab key as the completion key, call
 
     readline.parse_and_bind("tab: complete")
 
+And to make completion with case insensitive, call
+
+    rlcompleter.set_case_insensitive(True)
+
 Notes:
 
 - Exceptions raised by the completer function are *ignored* (and generally cause
@@ -166,7 +170,7 @@ class Completer:
             noprefix = None
         while True:
             for word in words:
-                if (word[:n] == attr and
+                if (re.match(attr, word[:n], flags=_re_ignorecase_flags) and
                     not (noprefix and word[:n+1] == noprefix)):
                     match = "%s.%s" % (expr, word)
                     try:
@@ -184,6 +188,12 @@ class Completer:
                 noprefix = None
         matches.sort()
         return matches
+
+_re_ignorecase_flags = 0
+def set_case_insensitive(option):
+    import re
+    global _re_ignorecase_flags
+    _re_ignorecase_flags = option and re.IGNORECASE or 0
 
 def get_class_members(klass):
     ret = dir(klass)

--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -110,12 +110,13 @@ class Completer:
         defined in self.namespace that match.
 
         """
+        import re
         import keyword
         matches = []
         seen = {"__builtins__"}
         n = len(text)
         for word in keyword.kwlist:
-            if word[:n] == text:
+            if re.match(text, word[:n], flags=_re_ignorecase_flags):
                 seen.add(word)
                 if word in {'finally', 'try'}:
                     word = word + ':'
@@ -126,7 +127,8 @@ class Completer:
                 matches.append(word)
         for nspace in [self.namespace, builtins.__dict__]:
             for word, val in nspace.items():
-                if word[:n] == text and word not in seen:
+                if (re.match(text, word[:n], flags=_re_ignorecase_flags) and
+                    word not in seen):
                     seen.add(word)
                     matches.append(self._callable_postfix(val, word))
         return matches
@@ -193,7 +195,7 @@ _re_ignorecase_flags = 0
 def set_case_insensitive(option):
     import re
     global _re_ignorecase_flags
-    _re_ignorecase_flags = option and re.IGNORECASE or 0
+    _re_ignorecase_flags = re.IGNORECASE if option else 0
 
 def get_class_members(klass):
     ret = dir(klass)

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -141,7 +141,7 @@ class TestRlcompleter(unittest.TestCase):
         # add an additional attr for testing
         CompleteMe.SpAm = 2
         # enable the case insensitive option
-        rlcompleter.set_case_insensitive(True)
+        rlcompleter.set_ignore_case(True)
         # test globals
         self.assertEqual(self.completer.global_matches('completem'),
                          ['CompleteMe('])
@@ -149,7 +149,7 @@ class TestRlcompleter(unittest.TestCase):
         self.assertNotEqual(self.completer.attr_matches('CompleteMe.spa'),
                          ['CompleteMe.spam', 'CompleteMe.SpAm'])
         # disable the case insensitive option
-        rlcompleter.set_case_insensitive(False)
+        rlcompleter.set_ignore_case(False)
         # test globals
         self.assertNotEqual(self.completer.global_matches('completem'),
                             ['CompleteMe('])

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -137,5 +137,31 @@ class TestRlcompleter(unittest.TestCase):
         self.assertEqual(completer.complete('Ellipsis', 0), 'Ellipsis(')
         self.assertIsNone(completer.complete('Ellipsis', 1))
 
+    def test_case_insentive_matches(self):
+        # add an additional attr for testing
+        CompleteMe.SpAm = 2
+        # enable the case insensitive option
+        rlcompleter.set_case_insensitive(True)
+        # test globals
+        self.assertEqual(self.completer.global_matches('completem'),
+                         ['CompleteMe('])
+        # test attr
+        self.assertNotEqual(self.completer.attr_matches('CompleteMe.spa'),
+                         ['CompleteMe.spam', 'CompleteMe.SpAm'])
+        # disable the case insensitive option
+        rlcompleter.set_case_insensitive(False)
+        # test globals
+        self.assertNotEqual(self.completer.global_matches('completem'),
+                            ['CompleteMe('])
+        self.assertEqual(self.completer.global_matches('CompleteM'),
+                         ['CompleteMe('])
+        # test attr
+        self.assertNotEqual(self.completer.attr_matches('CompleteMe.spa'),
+                            ['CompleteMe.spam', 'CompleteMe.SpAm'])
+        self.assertEqual(self.completer.attr_matches('CompleteMe.sp'),
+                         ['CompleteMe.spam'])
+        # delete the additional attr
+        del(CompleteMe.SpAm)
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2020-05-06-12-46-16.bpo-40529.cZSTKu.rst
+++ b/Misc/NEWS.d/next/Library/2020-05-06-12-46-16.bpo-40529.cZSTKu.rst
@@ -1,0 +1,1 @@
+Added an option to the user to make rl completions with case insensitive / sensitive.


### PR DESCRIPTION
Added an option to the user to make completions with case insensitive / sensitive.
rlcompleter.set_case_insensitive(True) # to enable case insensitive
Added documentation accordingly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40529](https://bugs.python.org/issue40529) -->
https://bugs.python.org/issue40529
<!-- /issue-number -->

<!-- gh-issue-number: gh-84709 -->
* Issue: gh-84709
<!-- /gh-issue-number -->
