### PR TITLE
[WIP] bpo-40533: Make PyObject.ob_refcnt atomic in subinterpreters

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -104,7 +104,14 @@ typedef struct _typeobject PyTypeObject;
  */
 typedef struct _object {
     _PyObject_HEAD_EXTRA
+#ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
+    /* bpo-40533: Use an atomic variable for PyObject.ob_refcnt, to ensure that
+       Py_INCREF() and Py_DECREF() are safe when called in parallel, until
+       subinterpreters stop sharing Python objects. */
+    _Atomic Py_ssize_t ob_refcnt;
+#else
     Py_ssize_t ob_refcnt;
+#endif
     PyTypeObject *ob_type;
 } PyObject;
 

--- a/Objects/dict-common.h
+++ b/Objects/dict-common.h
@@ -20,7 +20,13 @@ typedef Py_ssize_t (*dict_lookup_func)
 
 /* See dictobject.c for actual layout of DictKeysObject */
 struct _dictkeysobject {
+#ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
+    /* bpo-40533: Use an atomic variables until subinterpreters stop sharing
+       Python dictionaries. */
+    _Atomic Py_ssize_t dk_refcnt;
+#else
     Py_ssize_t dk_refcnt;
+#endif
 
     /* Size of the hash table (dk_indices). It must be a power of 2. */
     Py_ssize_t dk_size;


### PR DESCRIPTION
When Python is built with experimental isolated interpreters, declare
PyObject.ob_refcnt and _dictkeysobject.dk_refcnt as atomic variables.

Temporary workaround until subinterpreters stop sharing Python
objects.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40533](https://bugs.python.org/issue40533) -->
https://bugs.python.org/issue40533
<!-- /issue-number -->
