### PR TITLE
bpo-40521: Disable list free list in subinterpreters

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -98,8 +98,15 @@ list_preallocate_exact(PyListObject *self, Py_ssize_t size)
 
 /* Empty list reuse scheme to save calls to malloc and free */
 #ifndef PyList_MAXFREELIST
-#define PyList_MAXFREELIST 80
+#  define PyList_MAXFREELIST 80
 #endif
+
+/* bpo-40521: tuple free lists are shared by all interpreters. */
+#ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
+#  undef PyList_MAXFREELIST
+#  define PyList_MAXFREELIST 0
+#endif
+
 static PyListObject *free_list[PyList_MAXFREELIST];
 static int numfree = 0;
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -101,7 +101,7 @@ list_preallocate_exact(PyListObject *self, Py_ssize_t size)
 #  define PyList_MAXFREELIST 80
 #endif
 
-/* bpo-40521: tuple free lists are shared by all interpreters. */
+/* bpo-40521: list free lists are shared by all interpreters. */
 #ifdef EXPERIMENTAL_ISOLATED_SUBINTERPRETERS
 #  undef PyList_MAXFREELIST
 #  define PyList_MAXFREELIST 0


### PR DESCRIPTION
When Python is built with experimental isolated interpreters, disable
list free list.

Temporary workaround until this cache is made per-interpreter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40521](https://bugs.python.org/issue40521) -->
https://bugs.python.org/issue40521
<!-- /issue-number -->
