### PR TITLE
bpo-40334: Fix error location upon parsing an invalid string literal

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -648,7 +648,7 @@ class CmdLineTest(unittest.TestCase):
             self.assertEqual(
                 stderr.splitlines()[-3:],
                 [   b'    foo = """\\q"""',
-                    b'                 ^',
+                    b'          ^',
                     b'SyntaxError: invalid escape sequence \\q'
                 ],
             )

--- a/Lib/test/test_string_literals.py
+++ b/Lib/test/test_string_literals.py
@@ -118,8 +118,7 @@ class TestLiterals(unittest.TestCase):
             eval("'''\n\\z'''")
         self.assertEqual(len(w), 1)
         self.assertEqual(w[0].filename, '<string>')
-        if use_old_parser():
-            self.assertEqual(w[0].lineno, 1)
+        self.assertEqual(w[0].lineno, 1)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('error', category=DeprecationWarning)
@@ -128,8 +127,7 @@ class TestLiterals(unittest.TestCase):
             exc = cm.exception
         self.assertEqual(w, [])
         self.assertEqual(exc.filename, '<string>')
-        if use_old_parser():
-            self.assertEqual(exc.lineno, 1)
+        self.assertEqual(exc.lineno, 1)
 
     def test_eval_str_raw(self):
         self.assertEqual(eval(""" r'x' """), 'x')

--- a/Lib/test/test_string_literals.py
+++ b/Lib/test/test_string_literals.py
@@ -128,6 +128,7 @@ class TestLiterals(unittest.TestCase):
         self.assertEqual(w, [])
         self.assertEqual(exc.filename, '<string>')
         self.assertEqual(exc.lineno, 1)
+        self.assertEqual(exc.offset, 1)
 
     def test_eval_str_raw(self):
         self.assertEqual(eval(""" r'x' """), 'x')

--- a/Parser/pegen/parse_string.c
+++ b/Parser/pegen/parse_string.c
@@ -153,9 +153,14 @@ decode_bytes_with_escapes(Parser *p, const char *s, Py_ssize_t len, Token *t)
    If the string is an f-string, set *fstr and *fstrlen to the unparsed
    string object.  Return 0 if no errors occurred.  */
 int
-_PyPegen_parsestr(Parser *p, const char *s, int *bytesmode, int *rawmode, PyObject **result,
+_PyPegen_parsestr(Parser *p, int *bytesmode, int *rawmode, PyObject **result,
                   const char **fstr, Py_ssize_t *fstrlen, Token *t)
 {
+    const char *s = PyBytes_AsString(t->bytes);
+    if (s == NULL) {
+        return -1;
+    }
+
     size_t len;
     int quote = Py_CHARMASK(*s);
     int fmode = 0;

--- a/Parser/pegen/parse_string.c
+++ b/Parser/pegen/parse_string.c
@@ -26,13 +26,11 @@ warn_invalid_escape_sequence(Parser *p, unsigned char first_invalid_escape_char,
                to get a more accurate error report */
             PyErr_Clear();
 
-            /* This is a hack, in order for the SyntaxError to point to the token t,
-               since _PyPegen_raise_error always uses p->tokens[p->fill - 1] for the
-               error location. */
-            Token *old_end = p->tokens[p->fill - 1];
-            p->tokens[p->fill - 1] = t;
+            /* This is needed, in order for the SyntaxError to point to the token t,
+               since _PyPegen_raise_error uses p->tokens[p->fill - 1] for the
+               error location, if p->known_err_token is not set. */
+            p->known_err_token = t;
             RAISE_SYNTAX_ERROR("invalid escape sequence \\%c", first_invalid_escape_char);
-            p->tokens[p->fill - 1] = old_end;
         }
         Py_DECREF(msg);
         return -1;

--- a/Parser/pegen/parse_string.h
+++ b/Parser/pegen/parse_string.h
@@ -34,8 +34,8 @@ typedef struct {
 } FstringParser;
 
 void _PyPegen_FstringParser_Init(FstringParser *);
-int _PyPegen_parsestr(Parser *, const char *, int *, int *, PyObject **,
-             const char **, Py_ssize_t *, Token *);
+int _PyPegen_parsestr(Parser *, int *, int *, PyObject **,
+                      const char **, Py_ssize_t *, Token *);
 int _PyPegen_FstringParser_ConcatFstring(Parser *, FstringParser *, const char **,
                                 const char *, int, int, Token *, Token *,
                                 Token *);

--- a/Parser/pegen/parse_string.h
+++ b/Parser/pegen/parse_string.h
@@ -35,7 +35,7 @@ typedef struct {
 
 void _PyPegen_FstringParser_Init(FstringParser *);
 int _PyPegen_parsestr(Parser *, const char *, int *, int *, PyObject **,
-             const char **, Py_ssize_t *);
+             const char **, Py_ssize_t *, Token *);
 int _PyPegen_FstringParser_ConcatFstring(Parser *, FstringParser *, const char **,
                                 const char *, int, int, Token *, Token *,
                                 Token *);

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -383,7 +383,7 @@ _PyPegen_raise_error(Parser *p, PyObject *errtype, int with_col_number, const ch
     PyObject *errstr = NULL;
     PyObject *loc = NULL;
     PyObject *tmp = NULL;
-    Token *t = p->tokens[p->fill - 1];
+    Token *t = p->known_err_token != NULL ? p->known_err_token : p->tokens[p->fill - 1];
     Py_ssize_t col_number = !with_col_number;
     va_list va;
     p->error_indicator = 1;
@@ -1053,6 +1053,7 @@ _PyPegen_Parser_New(struct tok_state *tok, int start_rule, int flags,
     p->starting_col_offset = 0;
     p->flags = flags;
     p->feature_version = feature_version;
+    p->known_err_token = NULL;
 
     return p;
 }

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -1977,7 +1977,7 @@ _PyPegen_concatenate_strings(Parser *p, asdl_seq *strings)
             goto error;
         }
 
-        if (_PyPegen_parsestr(p, this_str, &this_bytesmode, &this_rawmode, &s, &fstr, &fstrlen) != 0) {
+        if (_PyPegen_parsestr(p, this_str, &this_bytesmode, &this_rawmode, &s, &fstr, &fstrlen, t) != 0) {
             goto error;
         }
 

--- a/Parser/pegen/pegen.c
+++ b/Parser/pegen/pegen.c
@@ -1972,12 +1972,7 @@ _PyPegen_concatenate_strings(Parser *p, asdl_seq *strings)
         const char *fstr;
         Py_ssize_t fstrlen = -1;
 
-        char *this_str = PyBytes_AsString(t->bytes);
-        if (!this_str) {
-            goto error;
-        }
-
-        if (_PyPegen_parsestr(p, this_str, &this_bytesmode, &this_rawmode, &s, &fstr, &fstrlen, t) != 0) {
+        if (_PyPegen_parsestr(p, &this_bytesmode, &this_rawmode, &s, &fstr, &fstrlen, t) != 0) {
             goto error;
         }
 

--- a/Parser/pegen/pegen.h
+++ b/Parser/pegen/pegen.h
@@ -71,6 +71,7 @@ typedef struct {
     int flags;
     int feature_version;
     growable_comment_array type_ignore_comments;
+    Token *known_err_token;
 } Parser;
 
 typedef struct {


### PR DESCRIPTION
When parsing a string with an invalid escape, the old parser used to
point to the beginning of the invalid string. This PR changes the new
parser to match that behavior, since it's currently pointing to the
end of the string (or to be more precise, to the beginning of the next
token).

Closes we-like-parsers/cpython#64.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-40334](https://bugs.python.org/issue40334) -->
https://bugs.python.org/issue40334
<!-- /issue-number -->
